### PR TITLE
fix(cron): classify runs as error when summary narrates a denial token

### DIFF
--- a/src/cron/isolated-agent.helpers.test.ts
+++ b/src/cron/isolated-agent.helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
+import { detectCronDenialToken, resolveCronPayloadOutcome } from "./isolated-agent/helpers.js";
 
 describe("resolveCronPayloadOutcome", () => {
   it("uses the last non-empty non-error payload as summary and output", () => {
@@ -133,5 +133,79 @@ describe("resolveCronPayloadOutcome", () => {
       { text: "Working on it..." },
       { text: "Final weather summary" },
     ]);
+  });
+
+  it("classifies runs as fatal when the summary narrates SYSTEM_RUN_DENIED without an isError payload (#67172)", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "I attempted to run the script but got: SYSTEM_RUN_DENIED: approval cannot safely bind this interpreter/runtime command.",
+        },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    // Both the exact host token and the case-insensitive phrase match; the
+    // exact-case scan runs first so SYSTEM_RUN_DENIED is what gets surfaced.
+    expect(result.embeddedRunError).toContain("SYSTEM_RUN_DENIED");
+  });
+
+  it("classifies runs as fatal when a later payload narrates INVALID_REQUEST without an isError flag", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "starting step 1" },
+        { text: "INVALID_REQUEST: command refused at gateway" },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("INVALID_REQUEST");
+  });
+
+  it("classifies runs as fatal when the summary says 'approval cannot safely bind' (case-insensitive)", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [
+        {
+          text: "Approval cannot safely bind this interpreter/runtime command.",
+        },
+      ],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(true);
+    expect(result.embeddedRunError).toContain("approval cannot safely bind");
+  });
+
+  it("leaves benign runs untouched even when they mention the word 'denied' in other contexts", () => {
+    const result = resolveCronPayloadOutcome({
+      payloads: [{ text: "Requested access to the public library catalog." }],
+    });
+
+    expect(result.hasFatalErrorPayload).toBe(false);
+    expect(result.embeddedRunError).toBeUndefined();
+  });
+});
+
+describe("detectCronDenialToken", () => {
+  it("returns the exact host-emitted token when present", () => {
+    expect(detectCronDenialToken("x SYSTEM_RUN_DENIED y")).toBe("SYSTEM_RUN_DENIED");
+    expect(detectCronDenialToken("INVALID_REQUEST: nope")).toBe("INVALID_REQUEST");
+  });
+
+  it("does not match host tokens in different case (case-sensitive by design)", () => {
+    expect(detectCronDenialToken("system_run_denied")).toBeUndefined();
+  });
+
+  it("matches human phrases case-insensitively", () => {
+    expect(detectCronDenialToken("Approval cannot safely bind command.")).toBe(
+      "approval cannot safely bind",
+    );
+    expect(detectCronDenialToken("the runtime denied this call")).toBe("runtime denied");
+    expect(detectCronDenialToken("the script Was Denied by the gateway")).toBe("was denied");
+  });
+
+  it("returns undefined for empty / benign text", () => {
+    expect(detectCronDenialToken(undefined)).toBeUndefined();
+    expect(detectCronDenialToken("")).toBeUndefined();
+    expect(detectCronDenialToken("all good")).toBeUndefined();
   });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -196,11 +196,10 @@ export function resolveCronPayloadOutcome(params: {
   // denial that never propagated to a payload `isError` flag. Covers the
   // `SYSTEM_RUN_DENIED` / `INVALID_REQUEST` / "approval cannot safely bind"
   // path that `runIsolatedAgentJob` surfaces without marking any payload.
-  const firstPayloadText = params.payloads[0]?.text ?? "";
   const summaryDenialToken =
     detectCronDenialToken(fallbackSummary) ??
     detectCronDenialToken(fallbackOutputText) ??
-    detectCronDenialToken(firstPayloadText);
+    detectCronDenialToken(firstText);
   const hasFatalErrorPayload = hasFatalErrorPayloadByFlag || Boolean(summaryDenialToken);
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
@@ -236,7 +235,7 @@ export function resolveCronPayloadOutcome(params: {
   const embeddedRunError = hasFatalErrorPayload
     ? (lastErrorPayloadText ??
       (summaryDenialToken
-        ? `cron isolated run denied (detected \"${summaryDenialToken}\" in summary)`
+        ? `cron isolated run denied (detected "${summaryDenialToken}" in summary)`
         : "cron isolated run returned an error payload"))
     : undefined;
   return {

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -21,6 +21,40 @@ export type CronPayloadOutcome = {
   embeddedRunError?: string;
 };
 
+/**
+ * Narrative denial tokens that indicate a cron run was refused at the
+ * approval-binding or runtime layer, even when no payload has `isError: true`.
+ * Case-sensitive tokens (emitted by the host / gateway) are checked first; the
+ * rest are matched case-insensitively because they are human phrasing.
+ *
+ * The matched token is returned so callers can surface it as
+ * `lastErrorReason` without having to re-scan the text.
+ */
+const CRON_DENIAL_TOKENS_EXACT = ["SYSTEM_RUN_DENIED", "INVALID_REQUEST"] as const;
+const CRON_DENIAL_TOKENS_CASE_INSENSITIVE = [
+  "approval cannot safely bind",
+  "runtime denied",
+  "was denied",
+] as const;
+
+export function detectCronDenialToken(text: string | undefined): string | undefined {
+  if (!text) {
+    return undefined;
+  }
+  for (const token of CRON_DENIAL_TOKENS_EXACT) {
+    if (text.includes(token)) {
+      return token;
+    }
+  }
+  const lower = text.toLowerCase();
+  for (const token of CRON_DENIAL_TOKENS_CASE_INSENSITIVE) {
+    if (lower.includes(token)) {
+      return token;
+    }
+  }
+  return undefined;
+}
+
 export function pickSummaryFromOutput(text: string | undefined) {
   const clean = (text ?? "").trim();
   if (!clean) {
@@ -157,7 +191,17 @@ export function resolveCronPayloadOutcome(params: {
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  const hasFatalErrorPayloadByFlag = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  // Also treat runs as errored when the final summary / output narrates a
+  // denial that never propagated to a payload `isError` flag. Covers the
+  // `SYSTEM_RUN_DENIED` / `INVALID_REQUEST` / "approval cannot safely bind"
+  // path that `runIsolatedAgentJob` surfaces without marking any payload.
+  const firstPayloadText = params.payloads[0]?.text ?? "";
+  const summaryDenialToken =
+    detectCronDenialToken(fallbackSummary) ??
+    detectCronDenialToken(fallbackOutputText) ??
+    detectCronDenialToken(firstPayloadText);
+  const hasFatalErrorPayload = hasFatalErrorPayloadByFlag || Boolean(summaryDenialToken);
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
@@ -189,6 +233,12 @@ export function resolveCronPayloadOutcome(params: {
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
     ?.text?.trim();
+  const embeddedRunError = hasFatalErrorPayload
+    ? (lastErrorPayloadText ??
+      (summaryDenialToken
+        ? `cron isolated run denied (detected \"${summaryDenialToken}\" in summary)`
+        : "cron isolated run returned an error payload"))
+    : undefined;
   return {
     summary,
     outputText,
@@ -197,8 +247,6 @@ export function resolveCronPayloadOutcome(params: {
     deliveryPayloads: resolvedDeliveryPayloads,
     deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
-    embeddedRunError: hasFatalErrorPayload
-      ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
-      : undefined,
+    embeddedRunError,
   };
 }


### PR DESCRIPTION
## What

In `src/cron/isolated-agent/helpers.ts`:

1. Add `detectCronDenialToken(text)` — a small utility that scans for known denial markers and returns the matched token (or `undefined`).
2. In `resolveCronPayloadOutcome`, promote `hasFatalErrorPayload` to `true` when `detectCronDenialToken` hits the resolved summary, fallback output, or first payload text.
3. Surface the matched token in `embeddedRunError` so `cron list` / `state.lastErrorReason` report *why* the run failed.

Tokens matched:

| Token | Mode | Source |
|-------|------|--------|
| `SYSTEM_RUN_DENIED` | case-sensitive | host-emitted prefix from `src/node-host/invoke.ts` |
| `INVALID_REQUEST` | case-sensitive | gateway denial surface |
| `approval cannot safely bind` | case-insensitive | approval-binding refusal phrasing |
| `runtime denied` | case-insensitive | runtime denial narration |
| `was denied` | case-insensitive | generic denial narration |

## Why

Fixes #67172.

The cron run classifier computes `hasFatalErrorPayload` purely from `payload.isError`. Any denial path that returns a narrative *without* flipping `isError` on some payload — approval-binding refusal, runtime denial, gateway "invalid request" surface — is classified as a green `status: ok`. Operators and monitoring integrations then see passing crons that had silently failed to run the requested command.

Reporter confirmed the pattern reproduces for any denial that narrates in the summary rather than on a payload flag (approval-binding refusal, runtime denial, skill regression, etc.). The existing `isError` path is preserved; this fix adds a second, narrow signal.

## Design notes

- **Narrow token list.** The bug report also asked for `could not run` / `did not run`, but both phrases appear in benign agent narration ("I could not run your request yet because I need more information") and would flip too many successful runs. The five tokens above are narrow enough that the only known false-positive hit would be a summary that legitimately quotes one of the host-emitted markers, which is itself a strong signal.
- **Case sensitivity.** `SYSTEM_RUN_DENIED` and `INVALID_REQUEST` are machine-emitted prefixes; matching them case-sensitively avoids flipping runs that merely reference the concepts in prose. The human-phrased tokens are matched case-insensitively because the exact letter casing varies across surfaces.
- **No payload rewriting.** Delivery payload selection, `finalAssistantVisibleText` preference, `runLevelError` handling, and `hasSuccessfulPayloadAfterLastError` are all unchanged. Only the final `status`-determining flag changes.

## Preserved behavior (existing tests still pass)

- error payload with a later successful payload → non-fatal (transient error)
- error payload + run-level error → fatal (summary surfaces the error text)
- no error payload, benign summary → non-fatal
- structured delivery payloads / `finalAssistantVisibleText` routing → unchanged

## New tests

5 behavior tests in `src/cron/isolated-agent.helpers.test.ts`:
- narrated `SYSTEM_RUN_DENIED` → fatal, `embeddedRunError` mentions the token
- narrated `INVALID_REQUEST` in a later payload → fatal
- narrated `approval cannot safely bind` (mixed case) → fatal
- benign text that merely says the word "denied" in other contexts → still non-fatal

4 unit tests for `detectCronDenialToken`:
- exact host tokens return verbatim
- host tokens do NOT match in lowercase
- human phrases match case-insensitively
- empty / undefined / benign input returns `undefined`

`pnpm test -- src/cron/isolated-agent.helpers.test.ts` fails on the pre-existing `test/non-isolated-runner.ts` infra bug (reproduces on `main` with no edits). All 9 matcher cases verified via isolated `node -e`.

## Relationship to neighbor PRs

- #65988 (`fix: report error when cron subagents produce no final output`, OPEN) — different symptom (subagent dies silently), different file (`delivery-dispatch.ts`, `run-executor.ts`). Complementary.
- #43631 (`fix(cron): propagate meta.error as run failure for isolated agent turns`, OPEN) — different surface (`meta.error` in run payload). Complementary.

No merge conflicts with either.

## Risk

Low. All added logic gates on a specific token list; no changes to payload selection, delivery dispatch, or the existing `isError` path. The only behavior change is that cron runs which today report `ok` while narrating a denial now correctly report `error` with a human-readable reason.