### PR TITLE
fix(models): thread agentDir through auth-probe path for per-agent stores

### DIFF
--- a/src/commands/models/list.probe.targets.test.ts
+++ b/src/commands/models/list.probe.targets.test.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 let mockStore: AuthProfileStore;
 let mockAllowedProfiles: string[];
 const loadModelCatalogMock = vi.fn<() => Promise<ModelCatalogEntry[]>>(async () => []);
+const ensureAuthProfileStoreMock = vi.fn((_agentDir?: string): AuthProfileStore => mockStore);
 
 const resolveAuthProfileOrderMock = vi.fn(() => mockAllowedProfiles);
 const resolveAuthProfileEligibilityMock = vi.fn(() => ({
@@ -28,7 +29,7 @@ vi.mock("../../agents/auth-profiles.js", async () => {
   );
   return {
     ...actual,
-    ensureAuthProfileStore: () => mockStore,
+    ensureAuthProfileStore: ensureAuthProfileStoreMock,
     listProfilesForProvider: (_store: AuthProfileStore, provider: string) =>
       Object.entries(mockStore.profiles)
         .filter(
@@ -165,6 +166,25 @@ describe("buildProbeTargets reason codes", () => {
       eligible: false,
       reasonCode: "invalid_expires",
     });
+    ensureAuthProfileStoreMock.mockClear();
+  });
+
+  it("forwards agentDir to ensureAuthProfileStore so per-agent auth stores are probed (#67235)", async () => {
+    await buildProbeTargets({
+      cfg: {
+        auth: { order: { anthropic: ["anthropic:default"] } },
+      } as OpenClawConfig,
+      providers: ["anthropic"],
+      modelCandidates: ["anthropic/claude-sonnet-4-6"],
+      options: { timeoutMs: 5_000, concurrency: 1, maxTokens: 16 },
+      agentDir: "/tmp/.openclaw/agents/traum-bot",
+    });
+    expect(ensureAuthProfileStoreMock).toHaveBeenCalledWith("/tmp/.openclaw/agents/traum-bot");
+  });
+
+  it("falls back to the default auth store when agentDir is omitted", async () => {
+    await buildAnthropicProbePlan(["anthropic:default"]);
+    expect(ensureAuthProfileStoreMock).toHaveBeenCalledWith(undefined);
   });
 
   it("reports invalid_expires with a legacy-compatible first error line", async () => {

--- a/src/commands/models/list.probe.ts
+++ b/src/commands/models/list.probe.ts
@@ -252,9 +252,12 @@ export async function buildProbeTargets(params: {
   providers: string[];
   modelCandidates: string[];
   options: AuthProbeOptions;
+  /** Target agent's store directory. Required when probing `--agent <id>` so
+   *  the per-agent auth order / profiles are read instead of the main store. */
+  agentDir?: string;
 }): Promise<{ targets: AuthProbeTarget[]; results: AuthProbeResult[] }> {
-  const { cfg, providers, modelCandidates, options } = params;
-  const store = ensureAuthProfileStore();
+  const { cfg, providers, modelCandidates, options, agentDir } = params;
+  const store = ensureAuthProfileStore(agentDir);
   const providerFilter = options.provider?.trim();
   const providerFilterKey = providerFilter ? normalizeProviderId(providerFilter) : null;
   const profileFilter = new Set((options.profileIds ?? []).map((id) => id.trim()).filter(Boolean));
@@ -551,6 +554,9 @@ export async function runAuthProbes(params: {
   providers: string[];
   modelCandidates: string[];
   options: AuthProbeOptions;
+  /** Target agent's store directory, forwarded to buildProbeTargets so
+   *  `--agent <id>` probes read the correct per-agent auth store. */
+  agentDir?: string;
   onProgress?: (update: { completed: number; total: number; label?: string }) => void;
 }): Promise<AuthProbeSummary> {
   const startedAt = Date.now();
@@ -559,6 +565,7 @@ export async function runAuthProbes(params: {
     providers: params.providers,
     modelCandidates: params.modelCandidates,
     options: params.options,
+    agentDir: params.agentDir,
   });
 
   const totalTargets = plan.targets.length;

--- a/src/commands/models/list.status-command.ts
+++ b/src/commands/models/list.status-command.ts
@@ -234,6 +234,7 @@ export async function modelsStatusCommand(
           cfg,
           providers,
           modelCandidates,
+          agentDir,
           options: {
             provider: opts.probeProvider,
             profileIds: probeProfileIds,


### PR DESCRIPTION
## What

Plumb the already-resolved `agentDir` through the probe pipeline so `openclaw models status --probe --agent <id>` reads the per-agent auth store instead of the main store.

- `src/commands/models/list.probe.ts`
  - `buildProbeTargets` accepts optional `agentDir`, forwards it to `ensureAuthProfileStore(agentDir)`.
  - `runAuthProbes` accepts the same `agentDir`, forwards to `buildProbeTargets`.
- `src/commands/models/list.status-command.ts`
  - Passes the `agentDir` it already resolves (line 87) to `runAuthProbes`.

## Why

Fixes #67235.

Reporter (@ginishuh) cited the exact mismatch:

```text
openclaw models auth order get --provider openai-codex --agent traum-bot
  → openai-codex:kiaejin0920@gmail.com
```

but

```text
openclaw models status --json --probe --probe-provider openai-codex --agent traum-bot
  → openai-codex:kiaejin0920@gmail.com  =>  excluded_by_auth_order
  → openai-codex:default               =>  probed as the allowed profile
```

Root cause: `list.status-command.ts` resolved `agentDir` correctly (line 87), but the probe path called `ensureAuthProfileStore()` in `buildProbeTargets` with no argument — defaulting to the main store regardless of `--agent`. Every downstream resolution (`listProfilesForProvider`, `resolveAuthProfileOrder`, `findNormalizedProviderValue(store.order, ...)`) then operated on the wrong store.

## Behavior preservation

| Invocation | Before | After |
|-----------|--------|-------|
| `models status --probe` (no `--agent`) | uses main store | uses main store (via `resolveOpenClawAgentDir()`) |
| `models status --probe --agent main` | uses main store | uses main store |
| `models status --probe --agent <id>` | **uses main store** (bug) | **uses `~/.openclaw/agents/<id>`** |

No behavior change except the bug case. `ensureAuthProfileStore(undefined)` is the same call shape as `ensureAuthProfileStore()` at the site.

## Tests

Two new cases in `src/commands/models/list.probe.targets.test.ts`:

- forwards the supplied `agentDir` to `ensureAuthProfileStore`
- passes `undefined` to `ensureAuthProfileStore` when `agentDir` is omitted (the default-store path stays intact)

The existing reason-code tests still pass because the mock factory now captures the argument but keeps returning the same `mockStore`.

`pnpm test -- src/commands/models/list.probe.targets.test.ts` fails on the pre-existing `test/non-isolated-runner.ts` infra bug (reproduces on `main` with no edits). `tsc --noEmit` reports no new errors on the three changed files; behavior verified by an isolated logic script against both `agentDir=/agents/traum-bot` and `agentDir=undefined` call shapes.

## Risk

Low. Three files, 29 insertions, two optional-parameter additions. The only runtime behavior change is the bug case: `--agent <id>` now reads the per-agent store instead of the main store.