### PR TITLE
fix(browser): expand ~ in executablePath so spawn() can find the binary

### DIFF
--- a/extensions/browser/src/browser/config.test.ts
+++ b/extensions/browser/src/browser/config.test.ts
@@ -459,4 +459,29 @@ describe("browser config", () => {
       expect(resolved.defaultProfile).toBe("custom");
     });
   });
+
+  describe("executablePath tilde expansion (#67264)", () => {
+    it("expands a leading ~ in executablePath so spawn() can find the binary", () => {
+      withEnv({ HOME: "/home/og_mr_claw" }, () => {
+        const resolved = resolveBrowserConfig({
+          executablePath: "~/.local/chromium/linux-1615071/chrome-linux/chrome",
+        } as BrowserConfig);
+        expect(resolved.executablePath).toBe(
+          "/home/og_mr_claw/.local/chromium/linux-1615071/chrome-linux/chrome",
+        );
+      });
+    });
+
+    it("leaves an absolute executablePath untouched", () => {
+      const resolved = resolveBrowserConfig({
+        executablePath: "/opt/chromium/chrome-linux/chrome",
+      } as BrowserConfig);
+      expect(resolved.executablePath).toBe("/opt/chromium/chrome-linux/chrome");
+    });
+
+    it("omits executablePath when the config leaves it empty", () => {
+      const resolved = resolveBrowserConfig({ executablePath: "" } as BrowserConfig);
+      expect(resolved.executablePath).toBeUndefined();
+    });
+  });
 });

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -244,7 +244,12 @@ export function resolveBrowserConfig(
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
-  const executablePath = normalizeOptionalString(cfg?.executablePath);
+  // Expand `~` / `~user` / `$HOME` style paths so Node's child_process.spawn()
+  // can resolve executables stored under the user's home. Node does not expand
+  // `~` itself, so leaving the raw tilde in place causes ENOENT at spawn time.
+  // See #67264.
+  const rawExecutablePath = normalizeOptionalString(cfg?.executablePath);
+  const executablePath = rawExecutablePath ? resolveUserPath(rawExecutablePath) : undefined;
   const defaultProfileFromConfig = normalizeOptionalString(cfg?.defaultProfile);
 
   const legacyCdpPort = rawCdpUrl ? cdpInfo.port : undefined;


### PR DESCRIPTION
## What

`extensions/browser/src/browser/config.ts` — in `resolveBrowserConfig`, route the user-supplied `browser.executablePath` through `resolveUserPath` (already imported) so `~/path` / `~` / `$HOME`-style values are expanded to absolute paths before they leave the config layer.

```diff
-  const executablePath = normalizeOptionalString(cfg?.executablePath);
+  const rawExecutablePath = normalizeOptionalString(cfg?.executablePath);
+  const executablePath = rawExecutablePath ? resolveUserPath(rawExecutablePath) : undefined;
```

## Why

Fixes #67264.

Node's `child_process.spawn()` does NOT expand `~`. `resolveBrowserConfig` normalized `executablePath` with only `normalizeOptionalString` (whitespace trimming), so a config value like `~/.local/chromium/chrome-linux/chrome` — either written directly by the user, or produced by a round-trip through a path shortener that collapsed `$HOME` — reached `spawn()` unchanged. Spawn then failed with `ENOENT`, the browser never started, and `openclaw browser status` reported `running: false`.

Reporter (@KG-To) reproduced this on Ubuntu 24.04 + a custom Chromium under `$HOME/.local/chromium/`. Workaround was to move Chromium to `/opt/chromium/`.

`resolveUserPath` is the existing helper used elsewhere for home-relative paths (config/paths, state-dir, OAuth client secrets). It was already imported at line 17 of `config.ts`, so the fix is a single chained call.

## Behavior

| Input | Before | After |
|-------|--------|-------|
| `"~/.local/chromium/.../chrome"` | passed to spawn as-is → ENOENT | expanded to `${HOME}/.local/chromium/.../chrome` |
| `"~"` | as-is → ENOENT | expanded to `${HOME}` |
| `"  ~/.chrome  "` | trimmed only | trimmed + expanded |
| `"/opt/chromium/.../chrome"` | unchanged | unchanged |
| `""` / undefined / unset | undefined | undefined |

## Test

Three new cases in `config.test.ts` under a new describe block:

- leading `~/` is expanded against `HOME`
- absolute paths are left untouched
- empty / unset paths still resolve to `undefined`

`pnpm test -- extensions/browser/src/browser/config.test.ts` currently fails on the pre-existing `test/non-isolated-runner.ts` `Class extends value undefined` infra bug (reproduces on `main` with no edits). Behavior verified against six input shapes via an isolated `node -e` script:

```
6/6 passed
```

## Risk

Low. Single-file runtime change, two lines. `resolveUserPath` on a non-tilde absolute path is a no-op, so absolute `executablePath` values continue to work byte-for-byte. The only behavior change is that `~`-prefixed values now resolve instead of erroring at spawn time.