### PR TITLE
feat(plugins): add OPENCLAW_JITI_CACHE_DIR env var for jiti fsCache [AI]

### DIFF
--- a/extensions/matrix/src/plugin-entry.runtime.js
+++ b/extensions/matrix/src/plugin-entry.runtime.js
@@ -173,6 +173,7 @@ const jiti = createJiti(import.meta.url, {
   alias: buildPluginSdkAliasMap(import.meta.url),
   interopDefault: true,
   tryNative: false,
+  fsCache: process.env.OPENCLAW_JITI_CACHE_DIR?.trim() || true,
   extensions: JITI_EXTENSIONS,
 });
 

--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -175,6 +175,7 @@ function getJiti(tryNative) {
     // Prefer Node's native sync ESM loader for built dist/plugin-sdk/*.js files
     // so local plugins do not create a second transpiled OpenClaw core graph.
     tryNative: effectiveTryNative,
+    fsCache: process.env.OPENCLAW_JITI_CACHE_DIR?.trim() || true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
   jitiLoaders.set(effectiveTryNative, jitiLoader);

--- a/src/plugins/loader.git-path-regression.test.ts
+++ b/src/plugins/loader.git-path-regression.test.ts
@@ -62,6 +62,7 @@ export const copiedRuntimeMarker = {
       const withoutAlias = createJiti(${JSON.stringify(jitiBaseFile)}, {
         interopDefault: true,
         tryNative: false,
+        fsCache: false,
         extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
       });
       let withoutAliasThrew = false;
@@ -73,6 +74,7 @@ export const copiedRuntimeMarker = {
       const withAlias = createJiti(${JSON.stringify(jitiBaseFile)}, {
         interopDefault: true,
         tryNative: false,
+        fsCache: false,
         extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
         alias: {
           "openclaw/plugin-sdk/infra-runtime": ${JSON.stringify(copiedChannelRuntimeShim)},

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -452,12 +452,18 @@ export function resolvePluginRuntimeModulePath(
   return null;
 }
 
+export function resolveJitiFsCache(): boolean | string {
+  const dir = process.env.OPENCLAW_JITI_CACHE_DIR?.trim();
+  return dir || true;
+}
+
 export function buildPluginLoaderJitiOptions(aliasMap: Record<string, string>) {
   return {
     interopDefault: true,
     // Prefer Node's native sync ESM loader for built dist/*.js modules so
     // bundled plugins and plugin-sdk subpaths stay on the canonical module graph.
     tryNative: true,
+    fsCache: resolveJitiFsCache(),
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
     ...(Object.keys(aliasMap).length > 0
       ? {


### PR DESCRIPTION
## Summary

- Problem: There was no way to customize the Jiti filesystem cache directory across all plugin loading paths.
- Why it matters: Users running OpenClaw in environments with restricted or slow default temp directories (e.g., CI, containers, or read-only filesystems) need control over where Jiti writes its transpiled module cache.
- What changed:
  - Added `resolveJitiFsCache()` in `src/plugins/sdk-alias.ts` that reads `OPENCLAW_JITI_CACHE_DIR` and returns the path, or `true` by default.
  - Wired `fsCache: resolveJitiFsCache()` into `buildPluginLoaderJitiOptions()`, covering all core/plugin createJiti calls that use this helper.
  - Added `fsCache` directly to independent createJiti calls in `src/plugin-sdk/root-alias.cjs` and `extensions/matrix/src/plugin-entry.runtime.js`.
  - Added `fsCache: false` to inline test createJiti calls in `src/plugins/loader.git-path-regression.test.ts` to keep tests deterministic.
- What did NOT change (scope boundary): No changes to existing default behavior when `OPENCLAW_JITI_CACHE_DIR` is unset. No changes to `scripts/load-channel-config-surface.ts`, which explicitly keeps `fsCache: false`.

## Change Type

- [x] Feature

## Scope

- [x] Skills / tool execution
- [x] API / contracts

## Linked Issue/PR

- N/A

## User-visible / Behavior Changes

- New environment variable: `OPENCLAW_JITI_CACHE_DIR`. When set to a non-empty path, all Jiti loaders in core/plugin runtime will use that directory for filesystem caching. When unset, behavior remains unchanged (`fsCache: true`).

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

- OS: Linux
- Runtime/container: Local dev

Steps:
1. Run `pnpm test -- src/plugins/sdk-alias.test.ts src/plugins/loader.git-path-regression.test.ts`
2. Run `npx vitest run --config test/vitest/vitest.contracts.config.ts src/plugins/contracts/plugin-sdk-root-alias.test.ts`

Expected: Tests pass.
Actual: Tests pass.

## Evidence

- [x] Existing coverage already sufficient

## Human Verification

- Verified scenarios:
  - Scoped plugin tests (`sdk-alias.test.ts`, `loader.git-path-regression.test.ts`) pass.
  - Contracts test (`plugin-sdk-root-alias.test.ts`) passes.
- Edge cases checked:
  - `OPENCLAW_JITI_CACHE_DIR=""` falls back to `true`.
  - `OPENCLAW_JITI_CACHE_DIR="/tmp/custom"` returns the trimmed path.
- What I did **not** verify:
  - Full `pnpm test` suite (tsgo/madge checks time out in this environment).

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)

## Risks and Mitigations

- Risk: If `OPENCLAW_JITI_CACHE_DIR` points to a non-writable path, Jiti may throw at runtime.
  - Mitigation: This is standard behavior for any custom cache directory; users are expected to provide a valid, writable path.
