### PR TITLE
fix(amazon-bedrock-mantle): add discovery.enabled gate to suppress implicit provider

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -495,4 +495,68 @@ describe("bedrock mantle discovery", () => {
 
     expect(result.models?.map((m) => m.id)).toEqual(["custom-model"]);
   });
+
+  // ---------------------------------------------------------------------------
+  // Discovery gate (#67288)
+  // ---------------------------------------------------------------------------
+
+  it("returns null without hitting the network when discovery.enabled === false (#67288)", async () => {
+    const mockFetch = vi.fn();
+    const tokenProvider = vi.fn(async () => "bedrock-api-key-iam"); // pragma: allowlist secret
+    mocks.getTokenProvider.mockReturnValue(tokenProvider);
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      pluginConfig: { discovery: { enabled: false } },
+    });
+
+    expect(provider).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(tokenProvider).not.toHaveBeenCalled();
+  });
+
+  it("still resolves when discovery.enabled is undefined (preserves auto-detect)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      pluginConfig: { discovery: {} },
+    });
+
+    expect(provider).not.toBeNull();
+    expect(provider?.baseUrl).toBe("https://bedrock-mantle.us-east-1.api.aws/v1");
+  });
+
+  it("still resolves when discovery.enabled === true", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],
+      }),
+    });
+
+    const provider = await resolveImplicitMantleProvider({
+      env: {
+        AWS_BEARER_TOKEN_BEDROCK: "my-token", // pragma: allowlist secret
+        AWS_REGION: "us-east-1",
+      } as NodeJS.ProcessEnv,
+      fetchFn: mockFetch as unknown as typeof fetch,
+      pluginConfig: { discovery: { enabled: true } },
+    });
+
+    expect(provider).not.toBeNull();
+  });
 });

--- a/extensions/amazon-bedrock-mantle/discovery.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.ts
@@ -246,6 +246,24 @@ export async function discoverMantleModels(params: {
 // ---------------------------------------------------------------------------
 
 /**
+ * Plugin-level config shape recognised by `resolveImplicitMantleProvider`.
+ * Mirrors the equivalent `config.discovery.enabled` gate in amazon-bedrock
+ * so operators can disable Mantle's implicit discovery / IAM token generation
+ * without having to turn the whole plugin off.
+ */
+export interface MantlePluginConfig {
+  discovery?: {
+    /**
+     * Explicit opt-out. When `false`, `resolveImplicitMantleProvider` returns
+     * `null` without attempting to resolve a bearer token or hit `/v1/models`.
+     * Any other value (including `undefined`) preserves the existing
+     * auto-detect behavior.
+     */
+    enabled?: boolean;
+  };
+}
+
+/**
  * Resolve an implicit Bedrock Mantle provider if authentication is available.
  *
  * Detection priority:
@@ -253,11 +271,20 @@ export async function discoverMantleModels(params: {
  * 2. IAM credentials → generate bearer token via `@aws/bedrock-token-generator`
  * - Region from AWS_REGION / AWS_DEFAULT_REGION / default us-east-1
  * - Models discovered from `/v1/models`
+ *
+ * When `pluginConfig.discovery.enabled === false`, returns `null` before any
+ * token resolution or network call runs, which suppresses the
+ * `[bedrock-mantle-discovery] Mantle IAM token generation unavailable` log
+ * spam for operators who aren't using Mantle. See #67288.
  */
 export async function resolveImplicitMantleProvider(params: {
   env?: NodeJS.ProcessEnv;
   fetchFn?: typeof fetch;
+  pluginConfig?: MantlePluginConfig;
 }): Promise<ModelProviderConfig | null> {
+  if (params.pluginConfig?.discovery?.enabled === false) {
+    return null;
+  }
   const env = params.env ?? process.env;
   const region = env.AWS_REGION ?? env.AWS_DEFAULT_REGION ?? "us-east-1";
   const explicitBearerToken = resolveMantleBearerToken(env);

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -3,10 +3,12 @@ import {
   mergeImplicitMantleProvider,
   resolveImplicitMantleProvider,
   resolveMantleBearerToken,
+  type MantlePluginConfig,
 } from "./discovery.js";
 
 export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
   const providerId = "amazon-bedrock-mantle";
+  const pluginConfig = (api.pluginConfig ?? {}) as MantlePluginConfig;
 
   api.registerProvider({
     id: providerId,
@@ -18,6 +20,7 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
       run: async (ctx) => {
         const implicit = await resolveImplicitMantleProvider({
           env: ctx.env,
+          pluginConfig,
         });
         if (!implicit) {
           return null;


### PR DESCRIPTION
## What

Mirror the existing `config.discovery.enabled` opt-out that `amazon-bedrock` already ships, so `amazon-bedrock-mantle` can be held in the plugin registry without probing IAM on every request.

- `extensions/amazon-bedrock-mantle/discovery.ts`
  - export `MantlePluginConfig` describing the optional `discovery.enabled` field
  - `resolveImplicitMantleProvider` accepts `pluginConfig`; returns `null` when `discovery.enabled === false` **before** touching the bearer-token resolver or the `/v1/models` endpoint
- `extensions/amazon-bedrock-mantle/register.sync.runtime.ts`
  - read `api.pluginConfig` once (same idiom as `amazon-bedrock`'s registration at `register.sync.runtime.ts:78`) and forward it into each `resolveImplicitMantleProvider` call
- `extensions/amazon-bedrock-mantle/discovery.test.ts`
  - new test: gate=false returns `null` and does not touch `fetch` or the IAM token provider
  - new test: gate=true still resolves normally
  - new test: empty `discovery` object preserves auto-detect

## Why

Fixes #67288.

Reporter (@kanekoh) set `plugins.entries.amazon-bedrock.enabled: false` and `plugins.entries.amazon-bedrock.config.discovery.enabled: false` — but the Mantle plugin has no equivalent gate. On every request the Mantle path tries to resolve a bearer token, falls back to the IAM token generator, and emits `[bedrock-mantle-discovery] Mantle IAM token generation unavailable` at debug level. The only way to silence it today is `plugins.entries.amazon-bedrock-mantle.enabled: false`, which disables the whole plugin.

The amazon-bedrock side already handles this cleanly in `resolveImplicitBedrockProvider` (`discovery.ts:442-449`):

```ts
const enabled = discoveryConfig?.enabled;
if (enabled === false) {
  return null;
}
```

This PR adds the mirrored gate to Mantle at the earliest point in `resolveImplicitMantleProvider`, so no AWS SDK initialization, token generation, or HTTP request happens when the user has opted out.

## Behavior

| `pluginConfig.discovery.enabled` | Before | After |
|----------------------------------|--------|-------|
| `false` | probes + logs every request | returns `null`, zero fetch/IAM calls |
| `true` | probes | probes (unchanged) |
| `undefined` / omitted | probes | probes (unchanged) |
| `discovery` object omitted | probes | probes (unchanged) |

## Test

3 new cases in `discovery.test.ts`:
- gate=false: `fetch` not called, token provider not called, returns `null`
- gate=true: resolves with correct baseUrl
- gate missing entirely: resolves (auto-detect preserved)

`pnpm test -- extensions/amazon-bedrock-mantle/discovery.test.ts` fails on the pre-existing `test/non-isolated-runner.ts` infra bug (reproduces on `main` unchanged). Logic independently verified against 5 `pluginConfig` shapes via an isolated `node -e` script (5/5 pass). `tsc --noEmit` reports no new errors on the three changed files.

## Risk

Low. Three files, 94 insertions (most are test code). The only runtime behavior change is the explicit `enabled === false` opt-out: every other code path — including the default-enabled behavior — is byte-for-byte preserved because the `pluginConfig` parameter is optional and the gate checks a strict `=== false` equality.