### PR TITLE
agents: standardize fs permission_denied and harden file mutations

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -39,7 +39,9 @@ async function expectOutsideWriteRejected(params: {
   outsidePath: string;
 }) {
   const patch = buildAddFilePatch(params.patchTargetPath);
-  await expect(applyPatch(patch, { cwd: params.dir })).rejects.toThrow(/Path escapes sandbox root/);
+  await expect(applyPatch(patch, { cwd: params.dir })).rejects.toThrow(
+    /permission_denied reason=workspace_boundary/i,
+  );
   await expect(fs.readFile(params.outsidePath, "utf8")).rejects.toBeDefined();
 }
 
@@ -183,7 +185,9 @@ describe("applyPatch", () => {
 +pwned
 *** End Patch`;
 
-      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(/Symlink escapes sandbox root/);
+      await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+        /permission_denied reason=path_alias_escape/i,
+      );
       const outsideContents = await fs.readFile(outside, "utf8");
       expect(outsideContents).toBe("initial\n");
       await fs.rm(outside, { force: true });
@@ -208,7 +212,7 @@ describe("applyPatch", () => {
 
       try {
         await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
-          /Symlink escapes sandbox root/,
+          /permission_denied reason=path_alias_escape/i,
         );
         await expect(fs.readFile(outsideFile, "utf8")).rejects.toBeDefined();
       } finally {
@@ -243,7 +247,9 @@ describe("applyPatch", () => {
 -initial
 +pwned
 *** End Patch`;
-        await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(/hardlink|sandbox/i);
+        await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
+          /permission_denied reason=path_alias_escape/i,
+        );
         const outsideContents = await fs.readFile(outside, "utf8");
         expect(outsideContents).toBe("initial\n");
       } finally {
@@ -297,7 +303,7 @@ describe("applyPatch", () => {
 
       try {
         await expect(applyPatch(patch, { cwd: dir })).rejects.toThrow(
-          /Symlink escapes sandbox root/,
+          /permission_denied reason=path_alias_escape/i,
         );
         const stillThere = await fs.readFile(outsideFile, "utf8");
         expect(stillThere).toBe("victim\n");

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -11,6 +11,7 @@ import {
 } from "../infra/fs-safe.js";
 import { PATH_ALIAS_POLICIES, type PathAliasPolicy } from "../infra/path-alias-guards.js";
 import { applyUpdateHunk } from "./apply-patch-update.js";
+import { createFsPermissionDeniedError } from "./fs-permission-denied.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
@@ -319,13 +320,21 @@ async function resolvePatchPath(
       cwd: options.cwd,
     });
     if (options.workspaceOnly !== false && resolved.hostPath) {
-      await assertSandboxPath({
-        filePath: resolved.hostPath,
-        cwd: options.cwd,
-        root: options.cwd,
-        allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
-        allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
-      });
+      try {
+        await assertSandboxPath({
+          filePath: resolved.hostPath,
+          cwd: options.cwd,
+          root: options.cwd,
+          allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
+          allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
+        });
+      } catch (error) {
+        throw createFsPermissionDeniedError({
+          action: "apply_patch:path_guard",
+          path: filePath,
+          cause: error,
+        });
+      }
     }
     return {
       resolved: resolved.hostPath ?? resolved.containerPath,
@@ -334,8 +343,10 @@ async function resolvePatchPath(
   }
 
   const workspaceOnly = options.workspaceOnly !== false;
-  const resolved = workspaceOnly
-    ? (
+  let resolved: string;
+  if (workspaceOnly) {
+    try {
+      resolved = (
         await assertSandboxPath({
           filePath,
           cwd: options.cwd,
@@ -343,8 +354,17 @@ async function resolvePatchPath(
           allowFinalSymlinkForUnlink: aliasPolicy.allowFinalSymlinkForUnlink,
           allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
         })
-      ).resolved
-    : resolvePathFromInput(filePath, options.cwd);
+      ).resolved;
+    } catch (error) {
+      throw createFsPermissionDeniedError({
+        action: "apply_patch:path_guard",
+        path: filePath,
+        cause: error,
+      });
+    }
+  } else {
+    resolved = resolvePathFromInput(filePath, options.cwd);
+  }
   return {
     resolved,
     display: toDisplayPath(resolved, options.cwd),
@@ -359,6 +379,13 @@ function assertBoundaryRead(
     return;
   }
   const reason = opened.reason === "validation" ? "unsafe path" : "path not found";
+  if (opened.reason === "validation") {
+    throw createFsPermissionDeniedError({
+      action: "apply_patch:read_boundary",
+      path: targetPath,
+      cause: new Error(`Failed boundary read for ${targetPath} (${reason})`),
+    });
+  }
   throw new Error(`Failed boundary read for ${targetPath} (${reason})`);
 }
 

--- a/src/agents/fs-permission-denied.test.ts
+++ b/src/agents/fs-permission-denied.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyFsPermissionDeniedReason,
+  createFsPermissionDeniedError,
+} from "./fs-permission-denied.js";
+
+describe("fs-permission-denied", () => {
+  it("classifies workspace boundary violations", () => {
+    expect(
+      classifyFsPermissionDeniedReason(new Error("Path escapes sandbox root (/tmp/workspace): ../x")),
+    ).toBe("workspace_boundary");
+    expect(
+      classifyFsPermissionDeniedReason(new Error("file is outside workspace root")),
+    ).toBe("workspace_boundary");
+  });
+
+  it("classifies symlink/hardlink violations as path alias escapes", () => {
+    expect(
+      classifyFsPermissionDeniedReason(new Error("Symlink escapes sandbox root")),
+    ).toBe("path_alias_escape");
+    expect(
+      classifyFsPermissionDeniedReason(new Error("hardlinked path not allowed")),
+    ).toBe("path_alias_escape");
+  });
+
+  it("classifies read-only filesystem violations", () => {
+    expect(
+      classifyFsPermissionDeniedReason(new Error("Sandbox path is read-only; cannot write")),
+    ).toBe("readonly_filesystem");
+  });
+
+  it("creates standardized permission_denied error payload", () => {
+    const error = createFsPermissionDeniedError({
+      action: "apply_patch:path_guard",
+      path: "../secrets.txt",
+      cause: new Error("Path escapes sandbox root"),
+    }) as Error & { code?: string; reason?: string };
+
+    expect(error.code).toBe("E_FS_PERMISSION_DENIED");
+    expect(error.reason).toBe("workspace_boundary");
+    expect(error.message).toContain("permission_denied");
+    expect(error.message).toContain("action=apply_patch:path_guard");
+    expect(error.message).toContain("reason=workspace_boundary");
+  });
+});
+

--- a/src/agents/fs-permission-denied.ts
+++ b/src/agents/fs-permission-denied.ts
@@ -1,0 +1,50 @@
+export type FsPermissionDeniedReason =
+  | "workspace_boundary"
+  | "path_alias_escape"
+  | "readonly_filesystem"
+  | "unknown";
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error && typeof error.message === "string") {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  return String(error ?? "unknown error");
+}
+
+export function classifyFsPermissionDeniedReason(error: unknown): FsPermissionDeniedReason {
+  const message = normalizeErrorMessage(error).toLowerCase();
+  if (message.includes("symlink") || message.includes("hardlink") || message.includes("alias")) {
+    return "path_alias_escape";
+  }
+  if (
+    message.includes("escapes sandbox root") ||
+    message.includes("outside workspace root") ||
+    message.includes("outside sandbox root")
+  ) {
+    return "workspace_boundary";
+  }
+  if (message.includes("read-only")) {
+    return "readonly_filesystem";
+  }
+  return "unknown";
+}
+
+export function createFsPermissionDeniedError(params: {
+  action: string;
+  path?: string;
+  cause: unknown;
+}): Error {
+  const reason = classifyFsPermissionDeniedReason(params.cause);
+  const causeMessage = normalizeErrorMessage(params.cause);
+  const pathPart = params.path ? ` path=${JSON.stringify(params.path)}` : "";
+  const error = new Error(
+    `permission_denied reason=${reason} action=${params.action}${pathPart}: ${causeMessage}`,
+  );
+  (error as Error & { code?: string; reason?: FsPermissionDeniedReason }).code =
+    "E_FS_PERMISSION_DENIED";
+  (error as Error & { code?: string; reason?: FsPermissionDeniedReason }).reason = reason;
+  return error;
+}

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -15,6 +15,7 @@ import { hasEncodedFileUrlSeparator, trySafeFileURLToPath } from "../infra/local
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
+import { createFsPermissionDeniedError } from "./fs-permission-denied.js";
 import { toRelativeWorkspacePath } from "./path-policy.js";
 import { wrapEditToolWithRecovery } from "./pi-tools.host-edit.js";
 import {
@@ -46,6 +47,8 @@ const MAX_ADAPTIVE_READ_MAX_BYTES = 512 * 1024;
 const ADAPTIVE_READ_CONTEXT_SHARE = 0.2;
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const MAX_ADAPTIVE_READ_PAGES = 8;
+const MAX_TOOL_WRITE_CONTENT_BYTES = 2 * 1024 * 1024;
+const MAX_TOOL_EDIT_CONTENT_BYTES = 2 * 1024 * 1024;
 
 type OpenClawReadToolOptions = {
   modelContextWindowTokens?: number;
@@ -88,6 +91,90 @@ function formatBytes(bytes: number): string {
     return `${Math.round(bytes / 1024)}KB`;
   }
   return `${bytes}B`;
+}
+
+function assertSafeMutationTextPayload(params: {
+  toolName: "write" | "edit";
+  field: string;
+  value: string;
+  maxBytes: number;
+}): void {
+  const bytes = Buffer.byteLength(params.value, "utf-8");
+  if (bytes > params.maxBytes) {
+    throw new Error(
+      `${params.toolName}: ${params.field} exceeds max size (${formatBytes(params.maxBytes)}). Got ${formatBytes(bytes)}.`,
+    );
+  }
+  if (params.value.includes("\0")) {
+    throw new Error(
+      `${params.toolName}: ${params.field} contains NUL bytes; binary payloads are not supported.`,
+    );
+  }
+}
+
+function wrapFsMutationPayloadGuard(tool: AnyAgentTool): AnyAgentTool {
+  if (tool.name !== "write" && tool.name !== "edit") {
+    return tool;
+  }
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+      if (tool.name === "write") {
+        if (typeof record?.content === "string") {
+          assertSafeMutationTextPayload({
+            toolName: "write",
+            field: "content",
+            value: record.content,
+            maxBytes: MAX_TOOL_WRITE_CONTENT_BYTES,
+          });
+        }
+      } else if (tool.name === "edit") {
+        if (typeof record?.oldText === "string") {
+          assertSafeMutationTextPayload({
+            toolName: "edit",
+            field: "oldText",
+            value: record.oldText,
+            maxBytes: MAX_TOOL_EDIT_CONTENT_BYTES,
+          });
+        }
+        if (typeof record?.newText === "string") {
+          assertSafeMutationTextPayload({
+            toolName: "edit",
+            field: "newText",
+            value: record.newText,
+            maxBytes: MAX_TOOL_EDIT_CONTENT_BYTES,
+          });
+        }
+        if (Array.isArray(record?.edits)) {
+          for (const [index, edit] of record.edits.entries()) {
+            if (!edit || typeof edit !== "object") {
+              continue;
+            }
+            const oldText = (edit as { oldText?: unknown }).oldText;
+            if (typeof oldText === "string") {
+              assertSafeMutationTextPayload({
+                toolName: "edit",
+                field: `edits[${index}].oldText`,
+                value: oldText,
+                maxBytes: MAX_TOOL_EDIT_CONTENT_BYTES,
+              });
+            }
+            const newText = (edit as { newText?: unknown }).newText;
+            if (typeof newText === "string") {
+              assertSafeMutationTextPayload({
+                toolName: "edit",
+                field: `edits[${index}].newText`,
+                value: newText,
+                maxBytes: MAX_TOOL_EDIT_CONTENT_BYTES,
+              });
+            }
+          }
+        }
+      }
+      return tool.execute(toolCallId, args, signal, onUpdate);
+    },
+  };
 }
 
 function getToolResultText(result: AgentToolResult<unknown>): string | undefined {
@@ -609,7 +696,16 @@ export function wrapToolWorkspaceRootGuardWithOptions(
           root,
           containerWorkdir: options?.containerWorkdir,
         });
-        const sandboxResult = await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        let sandboxResult: { resolved: string; relative: string };
+        try {
+          sandboxResult = await assertSandboxPath({ filePath: sandboxPath, cwd: root, root });
+        } catch (error) {
+          throw createFsPermissionDeniedError({
+            action: `${tool.name}:path_guard`,
+            path: filePath,
+            cause: error,
+          });
+        }
         if (options?.normalizeGuardedPathParams && record) {
           normalizedRecord ??= { ...record };
           normalizedRecord[key] = sandboxResult.resolved;
@@ -641,7 +737,7 @@ export function createSandboxedWriteTool(params: SandboxToolParams) {
   const base = createWriteTool(params.root, {
     operations: createSandboxWriteOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapFsMutationPayloadGuard(wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write));
 }
 
 export function createSandboxedEditTool(params: SandboxToolParams) {
@@ -653,14 +749,16 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
     readFile: async (absolutePath: string) =>
       (await params.bridge.readFile({ filePath: absolutePath, cwd: params.root })).toString("utf8"),
   });
-  return wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit);
+  return wrapFsMutationPayloadGuard(
+    wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit),
+  );
 }
 
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapFsMutationPayloadGuard(wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write));
 }
 
 export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {
@@ -671,7 +769,9 @@ export function createHostWorkspaceEditTool(root: string, options?: { workspaceO
     root,
     readFile: (absolutePath: string) => fs.readFile(absolutePath, "utf-8"),
   });
-  return wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit);
+  return wrapFsMutationPayloadGuard(
+    wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit),
+  );
 }
 
 export function createOpenClawReadTool(

--- a/src/agents/pi-tools.workspace-paths.test.ts
+++ b/src/agents/pi-tools.workspace-paths.test.ts
@@ -175,7 +175,7 @@ describe("workspace path resolution", () => {
       const outsideAbsolute = path.resolve(path.parse(workspaceDir).root, "outside-openclaw.txt");
       await expect(
         readTool.execute("ws-read-at-prefix", { path: `@${outsideAbsolute}` }),
-      ).rejects.toThrow(/Path escapes sandbox root/i);
+      ).rejects.toThrow(/permission_denied reason=workspace_boundary|Path escapes sandbox root/i);
     });
   });
 
@@ -203,19 +203,79 @@ describe("workspace path resolution", () => {
           throw err;
         }
         await expect(readTool.execute("ws-read-hardlink", { path: "linked.txt" })).rejects.toThrow(
-          /hardlink|sandbox/i,
+          /permission_denied reason=path_alias_escape|hardlink|sandbox/i,
         );
         await expect(
           writeTool.execute("ws-write-hardlink", {
             path: "linked.txt",
             content: "pwned",
           }),
-        ).rejects.toThrow(/hardlink|sandbox/i);
+        ).rejects.toThrow(/permission_denied reason=path_alias_escape|hardlink|sandbox/i);
         expect(await fs.readFile(outsidePath, "utf8")).toBe("top-secret");
       } finally {
         await fs.rm(hardlinkPath, { force: true });
         await fs.rm(outsidePath, { force: true });
       }
+    });
+  });
+
+  it("returns standardized permission_denied errors for workspace boundary violations", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const cfg: OpenClawConfig = { tools: { fs: { workspaceOnly: true } } };
+      const tools = createOpenClawCodingTools({ workspaceDir, config: cfg });
+      const { writeTool } = expectReadWriteEditTools(tools);
+      const outsideAbsolute = path.resolve(path.parse(workspaceDir).root, "outside-openclaw.txt");
+      await expect(
+        writeTool.execute("ws-write-at-prefix", {
+          path: `@${outsideAbsolute}`,
+          content: "blocked",
+        }),
+      ).rejects.toThrow(/permission_denied reason=workspace_boundary/i);
+    });
+  });
+
+  it("rejects oversized write payloads before mutation", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const { writeTool } = expectReadWriteEditTools(tools);
+      const oversized = "x".repeat(2 * 1024 * 1024 + 1);
+      await expect(
+        writeTool.execute("ws-write-too-large", {
+          path: "too-large.txt",
+          content: oversized,
+        }),
+      ).rejects.toThrow(/content exceeds max size/i);
+      await expect(fs.stat(path.join(workspaceDir, "too-large.txt"))).rejects.toBeDefined();
+    });
+  });
+
+  it("rejects write payloads containing NUL bytes", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const { writeTool } = expectReadWriteEditTools(tools);
+      await expect(
+        writeTool.execute("ws-write-binary-like", {
+          path: "binary-like.txt",
+          content: "abc\0def",
+        }),
+      ).rejects.toThrow(/NUL bytes/i);
+      await expect(fs.stat(path.join(workspaceDir, "binary-like.txt"))).rejects.toBeDefined();
+    });
+  });
+
+  it("rejects edit payloads containing NUL bytes", async () => {
+    await withTempDir("openclaw-ws-", async (workspaceDir) => {
+      const tools = createOpenClawCodingTools({ workspaceDir });
+      const { editTool } = expectReadWriteEditTools(tools);
+      const target = path.join(workspaceDir, "edit-target.txt");
+      await fs.writeFile(target, "hello world", "utf8");
+      await expect(
+        editTool.execute("ws-edit-binary-like", {
+          path: "edit-target.txt",
+          edits: [{ oldText: "world", newText: "wor\0ld" }],
+        }),
+      ).rejects.toThrow(/NUL bytes/i);
+      await expect(fs.readFile(target, "utf8")).resolves.toBe("hello world");
     });
   });
 });

--- a/src/agents/sandbox/fs-bridge-path-safety.ts
+++ b/src/agents/sandbox/fs-bridge-path-safety.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { PathAliasPolicy } from "../../infra/path-alias-guards.js";
 import type { SafeOpenSyncAllowedType } from "../../infra/safe-open-sync.js";
+import { createFsPermissionDeniedError } from "../fs-permission-denied.js";
 import { openBoundaryFile, type BoundaryFileOpenResult } from "./fs-bridge-path-safety.runtime.js";
 import type { SandboxResolvedFsPath, SandboxFsMount } from "./fs-paths.js";
 import { isPathInsideContainerRoot, normalizeContainerPath } from "./path-utils.js";
@@ -72,9 +73,15 @@ export class SandboxFsPathGuard {
   ): Promise<BoundaryFileOpenResult & { ok: true }> {
     const opened = await this.openBoundaryWithinRequiredMount(target, "read files");
     if (!opened.ok) {
-      throw opened.error instanceof Error
-        ? opened.error
-        : new Error(`Sandbox boundary checks failed; cannot read files: ${target.containerPath}`);
+      const cause =
+        opened.error instanceof Error
+          ? opened.error
+          : new Error(`Sandbox boundary checks failed; cannot read files: ${target.containerPath}`);
+      throw createFsPermissionDeniedError({
+        action: "sandbox_fs_bridge:read files",
+        path: target.containerPath,
+        cause,
+      });
     }
     return opened;
   }
@@ -82,7 +89,11 @@ export class SandboxFsPathGuard {
   private resolveRequiredMount(containerPath: string, action: string): SandboxFsMount {
     const lexicalMount = this.resolveMountByContainerPath(containerPath);
     if (!lexicalMount) {
-      throw new Error(`Sandbox path escapes allowed mounts; cannot ${action}: ${containerPath}`);
+      throw createFsPermissionDeniedError({
+        action: `sandbox_fs_bridge:${action}`,
+        path: containerPath,
+        cause: new Error(`Sandbox path escapes allowed mounts; cannot ${action}: ${containerPath}`),
+      });
     }
     return lexicalMount;
   }
@@ -96,9 +107,13 @@ export class SandboxFsPathGuard {
   }): PinnedSandboxEntry {
     const relativeParentPath = path.posix.relative(params.mount.containerRoot, params.parentPath);
     if (relativeParentPath.startsWith("..") || path.posix.isAbsolute(relativeParentPath)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.targetPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `sandbox_fs_bridge:${params.action}`,
+        path: params.targetPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.targetPath}`,
+        ),
+      });
     }
     return {
       mountRootPath: params.mount.containerRoot,
@@ -117,11 +132,17 @@ export class SandboxFsPathGuard {
         const canFallbackToDirectoryStat =
           options.allowedType === "directory" && this.pathIsExistingDirectory(target.hostPath);
         if (!canFallbackToDirectoryStat) {
-          throw guarded.error instanceof Error
-            ? guarded.error
-            : new Error(
-                `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
-              );
+          const cause =
+            guarded.error instanceof Error
+              ? guarded.error
+              : new Error(
+                  `Sandbox boundary checks failed; cannot ${options.action}: ${target.containerPath}`,
+                );
+          throw createFsPermissionDeniedError({
+            action: `sandbox_fs_bridge:${options.action}`,
+            path: target.containerPath,
+            cause,
+          });
         }
       }
     } else {
@@ -134,9 +155,13 @@ export class SandboxFsPathGuard {
     });
     const canonicalMount = this.resolveRequiredMount(canonicalContainerPath, options.action);
     if (options.requireWritable && !canonicalMount.writable) {
-      throw new Error(
-        `Sandbox path is read-only; cannot ${options.action}: ${target.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `sandbox_fs_bridge:${options.action}`,
+        path: target.containerPath,
+        cause: new Error(
+          `Sandbox path is read-only; cannot ${options.action}: ${target.containerPath}`,
+        ),
+      });
     }
   }
 
@@ -217,9 +242,13 @@ export class SandboxFsPathGuard {
     const mount = this.resolveRequiredMount(target.containerPath, action);
     const relativePath = path.posix.relative(mount.containerRoot, target.containerPath);
     if (relativePath.startsWith("..") || path.posix.isAbsolute(relativePath)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${action}: ${target.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `sandbox_fs_bridge:${action}`,
+        path: target.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot ${action}: ${target.containerPath}`,
+        ),
+      });
     }
     return {
       mountRootPath: mount.containerRoot,
@@ -272,7 +301,11 @@ export class SandboxFsPathGuard {
     });
     const canonical = result.stdout.toString("utf8").trim();
     if (!canonical.startsWith("/")) {
-      throw new Error(`Failed to resolve canonical sandbox path: ${params.containerPath}`);
+      throw createFsPermissionDeniedError({
+        action: "sandbox_fs_bridge:resolve_canonical_path",
+        path: params.containerPath,
+        cause: new Error(`Failed to resolve canonical sandbox path: ${params.containerPath}`),
+      });
     }
     return normalizeContainerPath(canonical);
   }

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -19,6 +19,7 @@ import {
   resolveSandboxFsPathWithMounts,
   type SandboxResolvedFsPath,
 } from "./fs-paths.js";
+import { createFsPermissionDeniedError } from "../fs-permission-denied.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 type RunCommandOptions = {
@@ -273,7 +274,11 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 
   private ensureWriteAccess(target: SandboxResolvedFsPath, action: string) {
     if (!allowsWrites(this.sandbox.workspaceAccess) || !target.writable) {
-      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+      throw createFsPermissionDeniedError({
+        action: `sandbox_fs_bridge:${action}`,
+        path: target.containerPath,
+        cause: new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`),
+      });
     }
   }
 

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -8,6 +8,7 @@ import type {
 import { SANDBOX_PINNED_MUTATION_PYTHON } from "./fs-bridge-mutation-helper.js";
 import { createWritableRenameTargetResolver } from "./fs-bridge-rename-targets.js";
 import type { SandboxFsBridge, SandboxFsStat, SandboxResolvedPath } from "./fs-bridge.types.js";
+import { createFsPermissionDeniedError } from "../fs-permission-denied.js";
 import {
   isPathInsideContainerRoot,
   normalizeContainerPath as normalizeSandboxContainerPath,
@@ -125,9 +126,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     this.ensureWritable(target, "create directories");
     const relativePath = path.posix.relative(target.mountRootPath, target.containerPath);
     if (relativePath.startsWith("..") || path.posix.isAbsolute(relativePath)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot create directories: ${target.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: "remote_sandbox_fs_bridge:create directories",
+        path: target.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot create directories: ${target.containerPath}`,
+        ),
+      });
     }
     await this.runMutation({
       args: ["mkdirp", target.mountRootPath, relativePath === "." ? "" : relativePath],
@@ -314,15 +319,23 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       }
     }
 
-    throw new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.filePath}`);
+    throw createFsPermissionDeniedError({
+      action: "remote_sandbox_fs_bridge:access",
+      path: params.filePath,
+      cause: new Error(`Sandbox path escapes allowed mounts; cannot access: ${params.filePath}`),
+    });
   }
 
   private toResolvedPath(params: { mount: MountInfo; containerPath: string }): ResolvedRemotePath {
     const relative = path.posix.relative(params.mount.containerRoot, params.containerPath);
     if (relative.startsWith("..") || path.posix.isAbsolute(relative)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot access: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: "remote_sandbox_fs_bridge:access",
+        path: params.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot access: ${params.containerPath}`,
+        ),
+      });
     }
     return {
       relativePath:
@@ -355,7 +368,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
 
   private ensureWritable(target: ResolvedRemotePath, action: string) {
     if (this.sandbox.workspaceAccess !== "rw" || !target.writable) {
-      throw new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`);
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${action}`,
+        path: target.containerPath,
+        cause: new Error(`Sandbox path is read-only; cannot ${action}: ${target.containerPath}`),
+      });
     }
   }
 
@@ -399,9 +416,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
     const canonical = normalizeContainerPath(result.stdout.toString("utf8").trim());
     if (!this.resolveMountByContainerPath(this.getMounts(), canonical)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${params.action}`,
+        path: params.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+        ),
+      });
     }
     return canonical;
   }
@@ -427,9 +448,13 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     }
     const [kind = "", linksRaw = "1"] = output.split("|");
     if (kind === "regular file" && Number(linksRaw) > 1) {
-      throw new Error(
-        `Hardlinked path is not allowed under sandbox mount root: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${params.action}`,
+        path: params.containerPath,
+        cause: new Error(
+          `Hardlinked path is not allowed under sandbox mount root: ${params.containerPath}`,
+        ),
+      });
     }
   }
 
@@ -450,20 +475,32 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
     });
     const mount = this.resolveMountByContainerPath(this.getMounts(), canonicalParent);
     if (!mount) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${params.action}`,
+        path: params.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+        ),
+      });
     }
     if (params.requireWritable && !mount.writable) {
-      throw new Error(
-        `Sandbox path is read-only; cannot ${params.action}: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${params.action}`,
+        path: params.containerPath,
+        cause: new Error(
+          `Sandbox path is read-only; cannot ${params.action}: ${params.containerPath}`,
+        ),
+      });
     }
     const relativeParentPath = path.posix.relative(mount.containerRoot, canonicalParent);
     if (relativeParentPath.startsWith("..") || path.posix.isAbsolute(relativeParentPath)) {
-      throw new Error(
-        `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
-      );
+      throw createFsPermissionDeniedError({
+        action: `remote_sandbox_fs_bridge:${params.action}`,
+        path: params.containerPath,
+        cause: new Error(
+          `Sandbox path escapes allowed mounts; cannot ${params.action}: ${params.containerPath}`,
+        ),
+      });
     }
     return {
       mountRootPath: mount.containerRoot,


### PR DESCRIPTION
## Summary\n- standardize fs permission_denied handling for parity with claw-code\n- harden file mutation paths and error mapping\n\n## Validation\n- lint:parity:claw-code\n- key test suite: 10 files / 55 tests