### PR TITLE
fix(amazon-bedrock-mantle): add discovery.enabled config gate

### DIFF
--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -24,7 +24,7 @@
     },
     "discovery.enabled": {
       "label": "Enable Discovery",
-      "help": "When false, OpenClaw keeps the Amazon Bedrock Mantle plugin available but skips implicit startup discovery. When true, discovery can run even without AWS auth env markers."
+      "help": "When false, OpenClaw keeps the Amazon Bedrock Mantle plugin available but skips implicit startup discovery. Leave unset for default auto-detect behavior using available AWS credentials."
     }
   },
   "providers": ["amazon-bedrock-mantle"]

--- a/extensions/amazon-bedrock-mantle/openclaw.plugin.json
+++ b/extensions/amazon-bedrock-mantle/openclaw.plugin.json
@@ -4,7 +4,28 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "discovery": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "When false, skip implicit Mantle discovery on startup. Defaults to undefined (auto-detect from credentials)."
+          }
+        }
+      }
+    }
+  },
+  "uiHints": {
+    "discovery": {
+      "label": "Model Discovery",
+      "help": "Plugin-owned controls for Amazon Bedrock Mantle model auto-discovery."
+    },
+    "discovery.enabled": {
+      "label": "Enable Discovery",
+      "help": "When false, OpenClaw keeps the Amazon Bedrock Mantle plugin available but skips implicit startup discovery. When true, discovery can run even without AWS auth env markers."
+    }
   },
   "providers": ["amazon-bedrock-mantle"]
 }

--- a/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock-mantle/register.sync.runtime.ts
@@ -5,8 +5,15 @@ import {
   resolveMantleBearerToken,
 } from "./discovery.js";
 
+type BedrockMantlePluginConfig = {
+  discovery?: {
+    enabled?: boolean;
+  };
+};
+
 export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
   const providerId = "amazon-bedrock-mantle";
+  const pluginConfig = (api.pluginConfig ?? {}) as BedrockMantlePluginConfig;
 
   api.registerProvider({
     id: providerId,
@@ -16,6 +23,9 @@ export function registerBedrockMantlePlugin(api: OpenClawPluginApi): void {
     catalog: {
       order: "simple",
       run: async (ctx) => {
+        if (pluginConfig.discovery?.enabled === false) {
+          return null;
+        }
         const implicit = await resolveImplicitMantleProvider({
           env: ctx.env,
         });


### PR DESCRIPTION
## Summary
- The `amazon-bedrock-mantle` plugin ran IAM token discovery on every request even when Bedrock Mantle was not in use
- Added `config.discovery.enabled` option (matching the existing pattern in `amazon-bedrock`) to allow users to suppress discovery without disabling the entire plugin
- Gate checks `pluginConfig.discovery.enabled === false` in the catalog handler before calling `resolveImplicitMantleProvider`

Fixes #67288

## Test plan
- [ ] Set `plugins.entries.amazon-bedrock-mantle.config.discovery.enabled: false` and verify no `[bedrock-mantle-discovery]` log messages
- [ ] Set `discovery.enabled: true` with valid AWS creds and verify Mantle models are discovered
- [ ] Leave `discovery.enabled` unset (default) and verify existing auto-detect behavior unchanged

Note: `check-additional` CI failure is pre-existing — `qa-matrix` references `openclaw/plugin-sdk/qa-runtime` which is missing from exports. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)