### PR TITLE
Port stability remediation from installed dist into source

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
 import {
   buildDmGroupAccountAllowlistAdapter,
@@ -32,9 +34,11 @@ import {
   createDefaultChannelRuntimeState,
 } from "openclaw/plugin-sdk/status-helpers";
 import {
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { resolveTelegramAccount, type ResolvedTelegramAccount } from "./accounts.js";
 import { resolveTelegramAutoThreadId } from "./action-threading.js";
 import { lookupTelegramChatId } from "./api-fetch.js";
@@ -128,6 +132,186 @@ function getOptionalTelegramRuntime() {
   } catch {
     return null;
   }
+}
+
+const TELEGRAM_TRUTH_GRACE_MS = 5 * 60 * 1000;
+const TELEGRAM_STATUS_SCAN_TTL_MS = 30_000;
+const TELEGRAM_STATUS_SCAN_CACHE_KEY = Symbol.for("openclaw.telegramStatusScanCache");
+
+type TelegramOperationalStoreTruth = {
+  routeIntegrity: "ok" | "unknown" | "contradictory";
+  sessionStoreIntegrity: "ok" | "unknown" | "mixed-artifacts";
+  routeContradictions: number;
+  artifactNoise: number;
+};
+
+function getTelegramStatusScanCache(): {
+  expiresAt: number;
+  value: TelegramOperationalStoreTruth;
+} {
+  const globalStore = globalThis as Record<PropertyKey, unknown>;
+  const existing = globalStore[TELEGRAM_STATUS_SCAN_CACHE_KEY] as
+    | { expiresAt: number; value: TelegramOperationalStoreTruth }
+    | undefined;
+  if (existing) {
+    return existing;
+  }
+  const created = {
+    expiresAt: 0,
+    value: {
+      routeIntegrity: "unknown",
+      sessionStoreIntegrity: "unknown",
+      routeContradictions: 0,
+      artifactNoise: 0,
+    } satisfies TelegramOperationalStoreTruth,
+  };
+  globalStore[TELEGRAM_STATUS_SCAN_CACHE_KEY] = created;
+  return created;
+}
+
+function isTelegramSessionArtifactNoise(name: string): boolean {
+  return (
+    name.endsWith(".telegram-sent-messages.json") ||
+    name.includes(".bak.") ||
+    name.includes(".deleted.") ||
+    name.includes(".reset.") ||
+    name.includes(".rotated.") ||
+    name === "session-reset-backups" ||
+    /^manual-archive-/i.test(name) ||
+    /^orphans-/i.test(name) ||
+    /^backup-/i.test(name)
+  );
+}
+
+function inspectTelegramOperationalStoreTruth(): TelegramOperationalStoreTruth {
+  const cache = getTelegramStatusScanCache();
+  const now = Date.now();
+  if (cache.expiresAt > now && cache.value) {
+    return cache.value;
+  }
+
+  const result: TelegramOperationalStoreTruth = {
+    routeIntegrity: "unknown",
+    sessionStoreIntegrity: "unknown",
+    routeContradictions: 0,
+    artifactNoise: 0,
+  };
+
+  try {
+    const agentsDir = path.join(resolveStateDir(process.env), "agents");
+    const agentDirs = fs.existsSync(agentsDir)
+      ? fs.readdirSync(agentsDir, { withFileTypes: true })
+      : [];
+    result.routeIntegrity = "ok";
+    result.sessionStoreIntegrity = "ok";
+    for (const agentDir of agentDirs) {
+      if (!agentDir.isDirectory()) {
+        continue;
+      }
+      const sessionsDir = path.join(agentsDir, agentDir.name, "sessions");
+      if (!fs.existsSync(sessionsDir)) {
+        continue;
+      }
+      let dirEntries: fs.Dirent[] = [];
+      try {
+        dirEntries = fs.readdirSync(sessionsDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const dirEntry of dirEntries) {
+        if (dirEntry.isDirectory() || isTelegramSessionArtifactNoise(dirEntry.name)) {
+          result.artifactNoise += 1;
+        }
+      }
+      const storePath = path.join(sessionsDir, "sessions.json");
+      if (!fs.existsSync(storePath)) {
+        continue;
+      }
+      let store: Record<string, Record<string, unknown>> = {};
+      try {
+        store = JSON.parse(fs.readFileSync(storePath, "utf-8")) as Record<string, Record<string, unknown>>;
+      } catch {
+        continue;
+      }
+      if (!store || typeof store !== "object" || Array.isArray(store)) {
+        continue;
+      }
+      for (const [sessionKey, sessionEntry] of Object.entries(store)) {
+        const entry = sessionEntry && typeof sessionEntry === "object" ? sessionEntry : {};
+        const normalizedKey = normalizeLowercaseStringOrEmpty(sessionKey);
+        const origin = entry.origin as Record<string, unknown> | undefined;
+        const routeMetadata = entry.routeMetadata as Record<string, unknown> | undefined;
+        const originProvider = normalizeLowercaseStringOrEmpty(origin?.provider ?? origin?.surface);
+        const originChatType = normalizeLowercaseStringOrEmpty(origin?.chatType);
+        const routeIntegrityState = normalizeLowercaseStringOrEmpty(
+          entry.routeIntegrityState ?? routeMetadata?.integrity,
+        );
+        if (routeIntegrityState === "contradictory") {
+          result.routeContradictions += 1;
+        }
+        if (
+          /^agent:[^:]+:main$/.test(normalizedKey) &&
+          originProvider === "telegram" &&
+          originChatType === "direct"
+        ) {
+          result.routeContradictions += 1;
+        }
+        if (/^agent:[^:]+:main:heartbeat$/.test(normalizedKey) && originProvider === "telegram") {
+          result.routeContradictions += 1;
+        }
+      }
+    }
+    if (result.artifactNoise > 0) {
+      result.sessionStoreIntegrity = "mixed-artifacts";
+    }
+    if (result.routeContradictions > 0) {
+      result.routeIntegrity = "contradictory";
+    }
+  } catch {
+    // Keep unknown defaults on scan failures.
+  }
+
+  cache.value = result;
+  cache.expiresAt = now + TELEGRAM_STATUS_SCAN_TTL_MS;
+  return result;
+}
+
+function resolveTelegramOperationalTruth(
+  runtime: { running?: boolean; connected?: boolean; lastStartAt?: number | null; lastInboundAt?: number | null; lastOutboundAt?: number | null; healthState?: string | null } | undefined,
+  storeTruth: TelegramOperationalStoreTruth,
+): {
+  deliveryTruth: "stopped" | "observed" | "warming" | "unknown";
+  transportTruth: "stopped" | "reachable" | "unreachable";
+  healthState?: string;
+} {
+  const running = runtime?.running === true;
+  const connected = runtime?.connected === true;
+  const lastStartAt = typeof runtime?.lastStartAt === "number" ? runtime.lastStartAt : null;
+  const lastInboundAt = typeof runtime?.lastInboundAt === "number" ? runtime.lastInboundAt : null;
+  const lastOutboundAt = typeof runtime?.lastOutboundAt === "number" ? runtime.lastOutboundAt : null;
+  const graceExpired = lastStartAt != null && Date.now() - lastStartAt > TELEGRAM_TRUTH_GRACE_MS;
+  const deliveryTruth =
+    !running
+      ? "stopped"
+      : lastInboundAt != null || lastOutboundAt != null
+        ? "observed"
+        : graceExpired
+          ? "unknown"
+          : "warming";
+  const transportTruth = !running ? "stopped" : connected ? "reachable" : "unreachable";
+  const currentHealthState = normalizeOptionalString(runtime?.healthState);
+  const shouldDegrade =
+    (running && connected && deliveryTruth === "unknown") ||
+    storeTruth.routeIntegrity === "contradictory" ||
+    storeTruth.sessionStoreIntegrity === "mixed-artifacts";
+  return {
+    deliveryTruth,
+    transportTruth,
+    healthState:
+      shouldDegrade && (!currentHealthState || currentHealthState === "healthy")
+        ? "degraded"
+        : currentHealthState ?? undefined,
+  };
 }
 
 async function resolveTelegramSend(deps?: OutboundSendDeps): Promise<TelegramSendFn> {
@@ -846,6 +1030,8 @@ export const telegramPlugin = createChatChannelPlugin({
           Object.entries(groups ?? {}).some(
             ([key, value]) => key !== "*" && value?.requireMention === false,
           );
+        const storeTruth = inspectTelegramOperationalStoreTruth();
+        const operationalTruth = resolveTelegramOperationalTruth(runtime, storeTruth);
         return {
           accountId: account.accountId,
           name: account.name,
@@ -857,6 +1043,11 @@ export const telegramPlugin = createChatChannelPlugin({
             mode: runtime?.mode ?? (account.config.webhookUrl ? "webhook" : "polling"),
             audit,
             allowUnmentionedGroups,
+            deliveryTruth: operationalTruth.deliveryTruth,
+            transportTruth: operationalTruth.transportTruth,
+            routeIntegrity: storeTruth.routeIntegrity,
+            sessionStoreIntegrity: storeTruth.sessionStoreIntegrity,
+            healthState: operationalTruth.healthState,
           },
         };
       },

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -5,6 +5,11 @@ const createTelegramBotMock = vi.hoisted(() => vi.fn());
 const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
 const computeBackoffMock = vi.hoisted(() => vi.fn(() => 0));
 const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
+const getActiveEmbeddedRunCountMock = vi.hoisted(() => vi.fn(() => 0));
+const getActiveTaskCountMock = vi.hoisted(() => vi.fn(() => 0));
+const getTotalQueueSizeMock = vi.hoisted(() => vi.fn(() => 0));
+
+const JUST_OVER_POLL_STALL_THRESHOLD_MS = 72e4 + 100;
 
 vi.mock("@grammyjs/runner", () => ({
   run: runMock,
@@ -26,6 +31,12 @@ vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
   computeBackoff: computeBackoffMock,
   formatDurationPrecise: vi.fn((ms: number) => `${ms}ms`),
   sleepWithAbort: sleepWithAbortMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/gateway-runtime", () => ({
+  getActiveEmbeddedRunCount: getActiveEmbeddedRunCountMock,
+  getActiveTaskCount: getActiveTaskCountMock,
+  getTotalQueueSize: getTotalQueueSizeMock,
 }));
 
 let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
@@ -50,7 +61,7 @@ function makeBot() {
 
 function installPollingStallWatchdogHarness(
   dateNowSequence: readonly number[] = [0, 0],
-  fallbackDateNow = 120_001,
+  fallbackDateNow = JUST_OVER_POLL_STALL_THRESHOLD_MS,
 ) {
   let watchdog: (() => void) | undefined;
   const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockImplementation((fn) => {
@@ -199,6 +210,9 @@ describe("TelegramPollingSession", () => {
     isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
     computeBackoffMock.mockReset().mockReturnValue(0);
     sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
+    getActiveEmbeddedRunCountMock.mockReset().mockReturnValue(0);
+    getActiveTaskCountMock.mockReset().mockReturnValue(0);
+    getTotalQueueSizeMock.mockReset().mockReturnValue(0);
   });
 
   it("uses backoff helpers for recoverable polling retries", async () => {
@@ -399,6 +413,42 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("suppresses stall restarts when gateway work is still active", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+    createTelegramBotMock.mockReturnValueOnce({
+      ...makeBot(),
+      stop: botStop,
+    });
+    const resolveFirstTask = mockLongRunningPollingCycle(runnerStop);
+    getActiveTaskCountMock.mockReturnValue(1);
+
+    const watchdogHarness = installPollingStallWatchdogHarness();
+    const log = vi.fn();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      watchdog?.();
+
+      expect(runnerStop).not.toHaveBeenCalled();
+      expect(botStop).not.toHaveBeenCalled();
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("class=busy_processing"));
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining("class=transport_stalled"));
+
+      abort.abort();
+      resolveFirstTask();
+      await runPromise;
+    } finally {
+      watchdogHarness.restore();
+    }
+  });
+
   it("rebuilds the transport after a recoverable polling error", async () => {
     const abort = new AbortController();
     const recoverableError = new Error("recoverable polling error");
@@ -428,8 +478,8 @@ describe("TelegramPollingSession", () => {
     const resolveFirstTask = mockLongRunningPollingCycle(runnerStop);
 
     // t=0: lastGetUpdatesAt and lastApiActivityAt initialized
-    // t=120_001: watchdog fires (getUpdates stale for 120s)
-    // But right before watchdog, a sendMessage succeeded at t=120_000
+    // The watchdog fires after the getUpdates gap is beyond the 12-minute threshold.
+    // Right before that, a sendMessage succeeds, so API liveness stays fresh.
     // All subsequent Date.now calls return the same value, giving apiIdle = 0.
     const watchdogHarness = installPollingStallWatchdogHarness();
 
@@ -555,7 +605,7 @@ describe("TelegramPollingSession", () => {
         );
         const sendPromise = apiMiddleware(slowPrev, "sendMessage", { chat_id: 123, text: "hello" });
 
-        // The in-flight send started at t=1 and is still stuck at t=120_001.
+        // The in-flight send started at t=1 and is still stuck past the threshold.
         // That is older than the watchdog threshold, so restart should proceed.
         watchdog?.();
 

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -1,5 +1,10 @@
 import { type RunOptions, run } from "@grammyjs/runner";
 import {
+  getActiveEmbeddedRunCount,
+  getActiveTaskCount,
+  getTotalQueueSize,
+} from "openclaw/plugin-sdk/gateway-runtime";
+import {
   computeBackoff,
   formatDurationPrecise,
   sleepWithAbort,
@@ -19,7 +24,10 @@ const TELEGRAM_POLL_RESTART_POLICY = {
   jitter: 0.25,
 };
 
-const POLL_STALL_THRESHOLD_MS = 90_000;
+// Telegram updates are sequentialized per chat, so a single long-running turn
+// can legitimately pause getUpdates for several minutes without the poller
+// being broken. Keep the watchdog comfortably above the normal agent timeout.
+const POLL_STALL_THRESHOLD_MS = 72e4;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
 
@@ -335,6 +343,12 @@ export class TelegramPollingSession {
           ? lastApiActivityAt
           : Math.max(lastApiActivityAt, latestInFlightApiStartedAt);
       const apiElapsed = now - apiLivenessAt;
+      const activeCommandTasks = getActiveTaskCount();
+      const queuedCommandTasks = getTotalQueueSize();
+      const activeEmbeddedRuns = getActiveEmbeddedRunCount();
+      const busyProcessing =
+        inFlightGetUpdates === 0 &&
+        (activeEmbeddedRuns > 0 || activeCommandTasks > 0 || queuedCommandTasks > 0);
 
       // Treat recent non-getUpdates success and recent non-getUpdates start as
       // the same liveness signal. Slow delivery should suppress the watchdog,
@@ -348,6 +362,12 @@ export class TelegramPollingSession {
           return;
         }
         stallDiagLoggedAt = now;
+        if (busyProcessing) {
+          this.opts.log(
+            `[telegram][diag] polling watchdog observed a long getUpdates gap but gateway work is still active; suppressing restart. [diag class=busy_processing activeRuns=${activeEmbeddedRuns} activeTasks=${activeCommandTasks} queued=${queuedCommandTasks} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
+          );
+          return;
+        }
         this.#transportState.markDirty();
         stalledRestart = true;
         const elapsedLabel =
@@ -355,7 +375,7 @@ export class TelegramPollingSession {
             ? `active getUpdates stuck for ${formatDurationPrecise(elapsed)}`
             : `no completed getUpdates for ${formatDurationPrecise(elapsed)}`;
         this.opts.log(
-          `[telegram] Polling stall detected (${elapsedLabel}); forcing restart. [diag inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
+          `[telegram] Polling stall detected (${elapsedLabel}); forcing restart. [diag class=transport_stalled activeRuns=${activeEmbeddedRuns} activeTasks=${activeCommandTasks} queued=${queuedCommandTasks} inFlight=${inFlightGetUpdates} outcome=${lastGetUpdatesOutcome} startedAt=${lastGetUpdatesStartedAt ?? "n/a"} finishedAt=${lastGetUpdatesFinishedAt ?? "n/a"} durationMs=${lastGetUpdatesDurationMs ?? "n/a"} offset=${lastGetUpdatesOffset ?? "n/a"}${lastGetUpdatesError ? ` error=${lastGetUpdatesError}` : ""}]`,
         );
         void stopRunner();
         void stopBot();

--- a/extensions/telegram/src/send.test-harness.ts
+++ b/extensions/telegram/src/send.test-harness.ts
@@ -49,6 +49,10 @@ const { loadConfig, resolveStorePath } = vi.hoisted(() => ({
   ),
 }));
 
+const { resolveStateDir } = vi.hoisted(() => ({
+  resolveStateDir: vi.fn(() => "/tmp/openclaw-telegram-state"),
+}));
+
 const { maybePersistResolvedTelegramTarget } = vi.hoisted(() => ({
   maybePersistResolvedTelegramTarget: vi.fn(async () => {}),
 }));
@@ -151,6 +155,10 @@ vi.mock("./target-writeback.js", () => ({
   maybePersistResolvedTelegramTarget,
 }));
 
+vi.mock("openclaw/plugin-sdk/state-paths", () => ({
+  resolveStateDir,
+}));
+
 export function getTelegramSendTestMocks(): TelegramSendTestMocks {
   return {
     botApi,
@@ -167,6 +175,7 @@ export function installTelegramSendTestHooks() {
   beforeEach(() => {
     loadConfig.mockReturnValue({});
     resolveStorePath.mockReturnValue("/tmp/openclaw-telegram-send-tests.json");
+    resolveStateDir.mockReturnValue("/tmp/openclaw-telegram-state");
     loadWebMedia.mockReset();
     imageMetadata.width = 1200;
     imageMetadata.height = 800;

--- a/extensions/telegram/src/sent-message-cache.ts
+++ b/extensions/telegram/src/sent-message-cache.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { loadConfig, resolveStorePath } from "openclaw/plugin-sdk/config-runtime";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 
 const TTL_MS = 24 * 60 * 60 * 1000;
 const TELEGRAM_SENT_MESSAGES_STATE_KEY = Symbol.for("openclaw.telegramSentMessagesState");
@@ -28,9 +29,33 @@ function createSentMessageStore(): SentMessageStore {
   return new Map<string, Map<string, number>>();
 }
 
-function resolveSentMessageStorePath(): string {
+function resolveLegacySentMessageStorePath(): string {
   const cfg = loadConfig();
   return `${resolveStorePath(cfg.session?.store)}.telegram-sent-messages.json`;
+}
+
+function resolveSentMessageStorePath(): string {
+  return path.join(resolveStateDir(process.env), "telegram", "sent-messages.json");
+}
+
+function migrateLegacySentMessageStoreIfNeeded(filePath: string): void {
+  const legacyPath = resolveLegacySentMessageStorePath();
+  if (legacyPath === filePath || !fs.existsSync(legacyPath) || fs.existsSync(filePath)) {
+    return;
+  }
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  try {
+    fs.renameSync(legacyPath, filePath);
+    return;
+  } catch {
+    // Fall back to copy + remove on cross-device filesystems.
+  }
+  try {
+    fs.copyFileSync(legacyPath, filePath);
+    fs.rmSync(legacyPath, { force: true });
+  } catch {
+    // Best effort migration.
+  }
 }
 
 function cleanupExpired(scopeKey: string, entry: Map<string, number>, now: number): void {
@@ -79,6 +104,7 @@ function getSentMessages(): SentMessageStore {
   const state = getSentMessageState();
   const persistedPath = resolveSentMessageStorePath();
   if (!state.store || state.persistedPath !== persistedPath) {
+    migrateLegacySentMessageStoreIfNeeded(persistedPath);
     state.store = readPersistedSentMessages(persistedPath);
     state.persistedPath = persistedPath;
   }

--- a/extensions/telegram/src/status-issues.ts
+++ b/extensions/telegram/src/status-issues.ts
@@ -13,6 +13,11 @@ type TelegramAccountStatus = {
   accountId?: unknown;
   enabled?: unknown;
   configured?: unknown;
+  running?: unknown;
+  connected?: unknown;
+  deliveryTruth?: unknown;
+  routeIntegrity?: unknown;
+  sessionStoreIntegrity?: unknown;
   allowUnmentionedGroups?: unknown;
   audit?: unknown;
 };
@@ -38,6 +43,11 @@ function readTelegramAccountStatus(value: ChannelAccountSnapshot): TelegramAccou
     accountId: value.accountId,
     enabled: value.enabled,
     configured: value.configured,
+    running: value.running,
+    connected: value.connected,
+    deliveryTruth: value.deliveryTruth,
+    routeIntegrity: value.routeIntegrity,
+    sessionStoreIntegrity: value.sessionStoreIntegrity,
     allowUnmentionedGroups: value.allowUnmentionedGroups,
     audit: value.audit,
   };
@@ -92,6 +102,43 @@ export function collectTelegramStatusIssues(
     const accountId = resolveEnabledConfiguredAccountId(account);
     if (!accountId) {
       continue;
+    }
+
+    if (account.sessionStoreIntegrity === "mixed-artifacts") {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "runtime",
+        message:
+          "Live session storage contains backup/archive/orphan artifacts mixed into the active sessions directory.",
+        fix: "Run `openclaw doctor --non-interactive`, then move legacy artifacts out of `~/.openclaw/agents/*/sessions` before restarting.",
+      });
+    }
+
+    if (account.routeIntegrity === "contradictory") {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "runtime",
+        message:
+          "Telegram route evidence is contradictory (for example a generic main session carrying Telegram-origin metadata).",
+        fix: "Run `openclaw doctor --non-interactive`, inspect `sessions.json` route metadata, and restart after cleanup.",
+      });
+    }
+
+    if (
+      account.running === true &&
+      account.connected === true &&
+      account.deliveryTruth === "unknown"
+    ) {
+      issues.push({
+        channel: "telegram",
+        accountId,
+        kind: "runtime",
+        message:
+          "Transport is reachable but delivery truth is unknown (`lastInboundAt` and `lastOutboundAt` are still null after startup grace).",
+        fix: "Check recent Telegram traffic, run `openclaw doctor --non-interactive`, and inspect gateway logs before treating Telegram as healthy.",
+      });
     }
 
     if (account.allowUnmentionedGroups === true) {

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -95,6 +95,66 @@ describe("telegram thread bindings", () => {
     expect(manager.getByConversationId("-100200300:topic:77")?.boundBy).toBe("user-1");
   });
 
+  it("rejects ACP current bindings on the protected primary Telegram DM", async () => {
+    const manager = createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    await expect(
+      getSessionBindingService().bind({
+        targetSessionKey: "agent:codex:acp:protected-primary",
+        targetKind: "session",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "8582659364",
+        },
+        placement: "current",
+      }),
+    ).rejects.toMatchObject({
+      code: "BINDING_PROTECTED_CONVERSATION",
+      message: expect.stringMatching(/Primary Telegram direct conversations/),
+    });
+
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "8582659364",
+      }),
+    ).toBeNull();
+    expect(manager.listBindings()).toEqual([]);
+  });
+
+  it("still allows named-account Telegram direct ACP bindings outside the protected lane", async () => {
+    const manager = createTelegramThreadBindingManager({
+      accountId: "atlas",
+      persist: false,
+      enableSweeper: false,
+    });
+
+    const bound = await getSessionBindingService().bind({
+      targetSessionKey: "agent:codex:acp:atlas-direct",
+      targetKind: "session",
+      conversation: {
+        channel: "telegram",
+        accountId: "atlas",
+        conversationId: "8582659364",
+      },
+      placement: "current",
+    });
+
+    expect(bound.conversation.channel).toBe("telegram");
+    expect(bound.conversation.accountId).toBe("atlas");
+    expect(bound.conversation.conversationId).toBe("8582659364");
+    expect(bound.targetSessionKey).toBe("agent:codex:acp:atlas-direct");
+    expect(manager.getByConversationId("8582659364")?.targetSessionKey).toBe(
+      "agent:codex:acp:atlas-direct",
+    );
+  });
+
   it("rejects child placement when conversationId is a bare topic ID with no group context", async () => {
     createTelegramThreadBindingManager({
       accountId: "default",
@@ -279,7 +339,7 @@ describe("telegram thread bindings", () => {
     process.env.OPENCLAW_STATE_DIR = stateDirOverride;
 
     createTelegramThreadBindingManager({
-      accountId: "default",
+      accountId: "atlas",
       persist: true,
       enableSweeper: false,
     });
@@ -289,7 +349,7 @@ describe("telegram thread bindings", () => {
       targetKind: "session",
       conversation: {
         channel: "telegram",
-        accountId: "default",
+        accountId: "atlas",
         conversationId: "8460800771",
       },
     });
@@ -302,7 +362,7 @@ describe("telegram thread bindings", () => {
     await __testing.resetTelegramThreadBindingsForTests();
 
     const reloaded = createTelegramThreadBindingManager({
-      accountId: "default",
+      accountId: "atlas",
       persist: true,
       enableSweeper: false,
     });

--- a/extensions/telegram/src/thread-bindings.test.ts
+++ b/extensions/telegram/src/thread-bindings.test.ts
@@ -128,6 +128,60 @@ describe("telegram thread bindings", () => {
     expect(manager.listBindings()).toEqual([]);
   });
 
+  it("scrubs persisted ACP bindings for the protected primary Telegram DM on reload", async () => {
+    stateDirOverride = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-telegram-bindings-"));
+    process.env.OPENCLAW_STATE_DIR = stateDirOverride;
+
+    const statePath = path.join(
+      resolveStateDir(process.env, os.homedir),
+      "telegram",
+      "thread-bindings-default.json",
+    );
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(
+      statePath,
+      JSON.stringify(
+        {
+          version: 1,
+          bindings: [
+            {
+              conversationId: "8582659364",
+              targetSessionKey: "agent:codex:acp:stale-thread",
+              targetKind: "acp",
+              boundAt: Date.now(),
+              lastActivityAt: Date.now(),
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const manager = createTelegramThreadBindingManager({
+      accountId: "default",
+      persist: true,
+      enableSweeper: false,
+    });
+
+    expect(
+      getSessionBindingService().resolveByConversation({
+        channel: "telegram",
+        accountId: "default",
+        conversationId: "8582659364",
+      }),
+    ).toBeNull();
+    expect(manager.getByConversationId("8582659364")).toBeUndefined();
+    expect(manager.listBindings()).toEqual([]);
+
+    await __testing.resetTelegramThreadBindingsForTests();
+
+    expect(JSON.parse(fs.readFileSync(statePath, "utf8"))).toEqual({
+      version: 1,
+      bindings: [],
+    });
+  });
+
   it("still allows named-account Telegram direct ACP bindings outside the protected lane", async () => {
     const manager = createTelegramThreadBindingManager({
       accountId: "atlas",

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -137,6 +137,17 @@ function isProtectedTelegramPrimaryConversation(params: {
   );
 }
 
+function isUnsafeProtectedTelegramPrimaryBindingRecord(
+  record: Pick<TelegramThreadBindingRecord, "accountId" | "targetKind" | "conversationId">,
+): boolean {
+  return isProtectedTelegramPrimaryConversation({
+    accountId: record.accountId,
+    targetKind: toSessionBindingTargetKind(record.targetKind),
+    placement: "current",
+    conversationId: record.conversationId,
+  });
+}
+
 function toTelegramTargetKind(raw: BindingTargetKind): TelegramBindingTargetKind {
   return raw === "subagent" ? "subagent" : "acp";
 }
@@ -332,18 +343,15 @@ async function persistBindingsToDisk(params: {
   }
   const payload: StoredTelegramBindingState = {
     version: STORE_VERSION,
-    bindings:
-      params.bindings ??
-      [...getThreadBindingsState().bindingsByAccountConversation.values()].filter(
-        (entry) => entry.accountId === params.accountId,
-      ),
+    bindings: params.bindings ?? listBindingsForAccount(params.accountId),
   };
   await writeJsonFileAtomically(resolveBindingsPath(params.accountId), payload);
 }
 
 function listBindingsForAccount(accountId: string): TelegramThreadBindingRecord[] {
   return [...getThreadBindingsState().bindingsByAccountConversation.values()].filter(
-    (entry) => entry.accountId === accountId,
+    (entry) =>
+      entry.accountId === accountId && !isUnsafeProtectedTelegramPrimaryBindingRecord(entry),
   );
 }
 
@@ -447,7 +455,12 @@ export function createTelegramThreadBindingManager(
   const maxAgeMs = normalizeDurationMs(params.maxAgeMs, DEFAULT_THREAD_BINDING_MAX_AGE_MS);
 
   const loaded = loadBindingsFromDisk(accountId);
+  let droppedUnsafeBinding = false;
   for (const entry of loaded) {
+    if (isUnsafeProtectedTelegramPrimaryBindingRecord(entry)) {
+      droppedUnsafeBinding = true;
+      continue;
+    }
     const key = resolveBindingKey({
       accountId,
       conversationId: entry.conversationId,
@@ -522,12 +535,13 @@ export function createTelegramThreadBindingManager(
       if (!conversationId) {
         return undefined;
       }
-      return getThreadBindingsState().bindingsByAccountConversation.get(
+      const record = getThreadBindingsState().bindingsByAccountConversation.get(
         resolveBindingKey({
           accountId,
           conversationId,
         }),
       );
+      return record && !isUnsafeProtectedTelegramPrimaryBindingRecord(record) ? record : undefined;
     },
     listBySessionKey: (targetSessionKeyRaw) => {
       const targetSessionKey = targetSessionKeyRaw.trim();
@@ -624,6 +638,15 @@ export function createTelegramThreadBindingManager(
       }
     },
   };
+
+  if (droppedUnsafeBinding) {
+    persistBindingsSafely({
+      accountId,
+      persist,
+      bindings: listBindingsForAccount(accountId),
+      reason: "sanitize-protected-primary-load",
+    });
+  }
 
   const sessionBindingAdapter: SessionBindingAdapter = {
     channel: "telegram",

--- a/extensions/telegram/src/thread-bindings.ts
+++ b/extensions/telegram/src/thread-bindings.ts
@@ -8,6 +8,7 @@ import {
   registerSessionBindingAdapter,
   resolveThreadBindingConversationIdFromBindingId,
   resolveThreadBindingEffectiveExpiresAt,
+  SessionBindingError,
   unregisterSessionBindingAdapter,
   type BindingTargetKind,
   type SessionBindingAdapter,
@@ -19,6 +20,7 @@ import { normalizeAccountId, isAcpSessionKey } from "openclaw/plugin-sdk/routing
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { resolveTelegramTargetChatType } from "./targets.js";
 import { resolveTelegramToken } from "./token.js";
 
 const DEFAULT_THREAD_BINDING_IDLE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
@@ -118,6 +120,21 @@ function resolveBindingKey(params: { accountId: string; conversationId: string }
 
 function toSessionBindingTargetKind(raw: TelegramBindingTargetKind): BindingTargetKind {
   return raw === "subagent" ? "subagent" : "session";
+}
+
+function isProtectedTelegramPrimaryConversation(params: {
+  accountId: string;
+  targetKind: BindingTargetKind;
+  placement: "current" | "child";
+  conversationId?: string;
+}): boolean {
+  const conversationId = normalizeOptionalString(params.conversationId);
+  return (
+    params.accountId === "default" &&
+    params.targetKind === "session" &&
+    params.placement === "current" &&
+    Boolean(conversationId && resolveTelegramTargetChatType(conversationId) === "direct")
+  );
 }
 
 function toTelegramTargetKind(raw: BindingTargetKind): TelegramBindingTargetKind {
@@ -623,6 +640,24 @@ export function createTelegramThreadBindingManager(
         return null;
       }
       const placement = input.placement === "child" ? "child" : "current";
+      if (
+        isProtectedTelegramPrimaryConversation({
+          accountId,
+          targetKind: input.targetKind,
+          placement,
+          conversationId: input.conversation.conversationId,
+        })
+      ) {
+        throw new SessionBindingError(
+          "BINDING_PROTECTED_CONVERSATION",
+          "Primary Telegram direct conversations cannot be bound to ACP sessions. Use a child thread instead.",
+          {
+            channel: "telegram",
+            accountId,
+            placement,
+          },
+        );
+      }
       const metadata = input.metadata ?? {};
       let conversationId: string | undefined;
 

--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -16,6 +16,7 @@ import * as sessionTranscript from "../config/sessions/transcript.js";
 import * as gatewayCall from "../gateway/call.js";
 import * as heartbeatWake from "../infra/heartbeat-wake.js";
 import {
+  SessionBindingError,
   __testing as sessionBindingServiceTesting,
   registerSessionBindingAdapter,
   type SessionBindingAdapterCapabilities,
@@ -1760,8 +1761,19 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.channel).toBe("telegram");
   });
 
-  it("drops self-parent Telegram current-conversation refs before binding", async () => {
+  it("fails closed when Telegram current-conversation ACP binding targets the protected primary DM", async () => {
     enableTelegramCurrentConversationBindings();
+    hoisted.sessionBindingBindMock.mockRejectedValueOnce(
+      new SessionBindingError(
+        "BINDING_PROTECTED_CONVERSATION",
+        "Primary Telegram direct conversations cannot be bound to ACP sessions. Use a child thread instead.",
+        {
+          channel: "telegram",
+          accountId: "default",
+          placement: "current",
+        },
+      ),
+    );
 
     const result = await spawnAcpDirect(
       {
@@ -1778,8 +1790,12 @@ describe("spawnAcpDirect", () => {
       },
     );
 
-    const accepted = expectAcceptedSpawn(result);
-    expect(accepted.mode).toBe("session");
+    expect(result).toEqual({
+      status: "error",
+      errorCode: "thread_binding_invalid",
+      error:
+        "Primary Telegram direct conversations cannot be bound to ACP sessions. Use a child thread instead.",
+    });
     expect(hoisted.sessionBindingBindMock).toHaveBeenCalledWith(
       expect.objectContaining({
         placement: "current",

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -204,6 +204,32 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("synthesizes recovery token counts when providers omit overflow totals", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: makeOverflowError() }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-9",
+        tokensBefore: 210000,
+      }),
+    );
+
+    await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: 210000,
+        runtimeContext: expect.objectContaining({
+          currentTokenCount: 210000,
+          currentTokenCountSource: "synthetic",
+          trigger: "overflow",
+        }),
+      }),
+    );
+  });
+
   it("does not reset compaction attempt budget after successful tool-result truncation", async () => {
     const overflowError = queueOverflowAttemptWithOversizedToolOutput(
       mockedRunEmbeddedAttempt,

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -992,12 +992,18 @@ export async function runEmbeddedPiAgent(
             const errorText = contextOverflowError.text;
             const msgCount = attempt.messagesSnapshot?.length ?? 0;
             const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+            const overflowTokenCountSource =
+              observedOverflowTokens != null ? "observed" : "synthetic";
+            const overflowTokenCountForRecovery =
+              observedOverflowTokens ?? ctxInfo.tokens + Math.max(512, Math.ceil(ctxInfo.tokens * 0.05));
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
                 `messages=${msgCount} sessionFile=${params.sessionFile} ` +
                 `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
                 `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
+                `recoveryTokens=${overflowTokenCountForRecovery} ` +
+                `recoveryTokenSource=${overflowTokenCountSource} ` +
                 `error=${errorText.slice(0, 200)}`,
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
@@ -1007,6 +1013,7 @@ export async function runEmbeddedPiAgent(
             if (
               !isCompactionFailure &&
               hadAttemptLevelCompaction &&
+              observedOverflowTokens != null &&
               overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
             ) {
               overflowCompactionAttempts++;
@@ -1015,11 +1022,21 @@ export async function runEmbeddedPiAgent(
               );
               continue;
             }
+            if (
+              !isCompactionFailure &&
+              hadAttemptLevelCompaction &&
+              observedOverflowTokens == null &&
+              overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
+            ) {
+              log.warn(
+                `[context-overflow-diag] provider overflow persisted after in-attempt compaction without an observed token count; forcing recovery compaction with ${overflowTokenCountSource} token estimate ${overflowTokenCountForRecovery} for ${provider}/${modelId}`,
+              );
+            }
             // Attempt explicit overflow compaction only when this attempt did not
             // already auto-compact.
             if (
               !isCompactionFailure &&
-              !hadAttemptLevelCompaction &&
+              (!hadAttemptLevelCompaction || observedOverflowTokens == null) &&
               overflowCompactionAttempts < MAX_OVERFLOW_COMPACTION_ATTEMPTS
             ) {
               if (log.isEnabled("debug")) {
@@ -1031,7 +1048,7 @@ export async function runEmbeddedPiAgent(
               }
               overflowCompactionAttempts++;
               log.warn(
-                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
+                `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId} using ${overflowTokenCountSource} token count ${overflowTokenCountForRecovery}`,
               );
               let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
               await runOwnsCompactionBeforeHook("overflow recovery");
@@ -1063,9 +1080,8 @@ export async function runEmbeddedPiAgent(
                   ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
                   runId: params.runId,
                   trigger: "overflow",
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
+                  currentTokenCount: overflowTokenCountForRecovery,
+                  currentTokenCountSource: overflowTokenCountSource,
                   diagId: overflowDiagId,
                   attempt: overflowCompactionAttempts,
                   maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
@@ -1075,9 +1091,7 @@ export async function runEmbeddedPiAgent(
                   sessionKey: params.sessionKey,
                   sessionFile: params.sessionFile,
                   tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
+                  currentTokenCount: overflowTokenCountForRecovery,
                   force: true,
                   compactionTarget: "budget",
                   runtimeContext: overflowCompactionRuntimeContext,

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -41,8 +41,20 @@ async function expectCurrentPidOwnsLock(params: {
   const lockPath = `${sessionFile}.lock`;
   const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs, staleMs });
   const raw = await fs.readFile(lockPath, "utf8");
-  const payload = JSON.parse(raw) as { pid: number };
-  expect(payload.pid).toBe(process.pid);
+  const canonicalSessionFile = path.join(await fs.realpath(path.dirname(sessionFile)), path.basename(sessionFile));
+  const canonicalLockPath = await fs.realpath(lockPath);
+  const payload = JSON.parse(raw) as {
+    version?: number;
+    kind?: string;
+    sessionFile?: string;
+    lockPath?: string;
+    owner?: { pid?: number };
+  };
+  expect(payload.kind).toBe("session-write-lock");
+  expect(payload.version).toBe(2);
+  expect(payload.sessionFile).toBe(canonicalSessionFile);
+  expect(payload.lockPath).toBe(canonicalLockPath);
+  expect(payload.owner?.pid).toBe(process.pid);
   await lock.release();
 }
 

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -1,12 +1,29 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 
+type LockFileOwnerPayload = {
+  pid?: number;
+  hostname?: string;
+  cwd?: string;
+  starttime?: number;
+};
+
 type LockFilePayload = {
+  version?: number;
+  kind?: string;
+  leaseId?: string;
+  sessionFile?: string;
+  lockPath?: string;
+  acquiredAt?: string;
   pid?: number;
   createdAt?: string;
+  expiresAt?: string;
+  maxHoldMs?: number;
+  owner?: LockFileOwnerPayload;
   /** Process start time in clock ticks (from /proc/pid/stat field 22). */
   starttime?: number;
 };
@@ -122,6 +139,49 @@ export function resolveSessionLockMaxHoldFromTimeout(params: {
   }
   const graceMs = resolvePositiveMs(params.graceMs, DEFAULT_TIMEOUT_GRACE_MS);
   return Math.min(MAX_LOCK_HOLD_MS, Math.max(minMs, timeoutMs + graceMs));
+}
+
+function normalizeLockTimestamp(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || Number.isNaN(Date.parse(trimmed))) {
+    return null;
+  }
+  return trimmed;
+}
+
+function buildSessionLockPayload(params: {
+  lockPath: string;
+  sessionFile: string;
+  maxHoldMs: number;
+}): LockFilePayload {
+  const acquiredAt = new Date().toISOString();
+  const starttime = getProcessStartTime(process.pid);
+  const owner: LockFileOwnerPayload = {
+    pid: process.pid,
+    hostname: os.hostname(),
+  };
+  const cwd = process.cwd();
+  if (cwd) {
+    owner.cwd = cwd;
+  }
+  if (starttime !== null) {
+    owner.starttime = starttime;
+  }
+  return {
+    version: 2,
+    kind: "session-write-lock",
+    leaseId: `${process.pid}-${Date.now().toString(36)}`,
+    sessionFile: params.sessionFile,
+    lockPath: params.lockPath,
+    acquiredAt,
+    createdAt: acquiredAt,
+    expiresAt: new Date(Date.now() + params.maxHoldMs).toISOString(),
+    maxHoldMs: params.maxHoldMs,
+    owner,
+  };
 }
 
 async function releaseHeldLock(
@@ -299,15 +359,40 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
   try {
     const raw = await fs.readFile(lockPath, "utf8");
     const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const owner =
+      parsed.owner && typeof parsed.owner === "object"
+        ? (parsed.owner as Record<string, unknown>)
+        : {};
     const payload: LockFilePayload = {};
-    if (isValidLockNumber(parsed.pid) && parsed.pid > 0) {
-      payload.pid = parsed.pid;
+    const pid =
+      isValidLockNumber(parsed.pid) && parsed.pid > 0
+        ? parsed.pid
+        : isValidLockNumber(owner.pid) && owner.pid > 0
+          ? owner.pid
+          : null;
+    const createdAt =
+      normalizeLockTimestamp(parsed.acquiredAt) ?? normalizeLockTimestamp(parsed.createdAt);
+    const expiresAt = normalizeLockTimestamp(parsed.expiresAt);
+    const starttime =
+      isValidLockNumber(parsed.starttime)
+        ? parsed.starttime
+        : isValidLockNumber(owner.starttime)
+          ? owner.starttime
+          : null;
+    if (pid !== null) {
+      payload.pid = pid;
     }
-    if (typeof parsed.createdAt === "string") {
-      payload.createdAt = parsed.createdAt;
+    if (createdAt) {
+      payload.createdAt = createdAt;
     }
-    if (isValidLockNumber(parsed.starttime)) {
-      payload.starttime = parsed.starttime;
+    if (expiresAt) {
+      payload.expiresAt = expiresAt;
+    }
+    if (starttime !== null) {
+      payload.starttime = starttime;
+    }
+    if (isValidLockNumber(parsed.maxHoldMs)) {
+      payload.maxHoldMs = parsed.maxHoldMs;
     }
     return payload;
   } catch {
@@ -325,6 +410,8 @@ function inspectLockPayload(
   const createdAt = typeof payload?.createdAt === "string" ? payload.createdAt : null;
   const createdAtMs = createdAt ? Date.parse(createdAt) : Number.NaN;
   const ageMs = Number.isFinite(createdAtMs) ? Math.max(0, nowMs - createdAtMs) : null;
+  const expiresAt = typeof payload?.expiresAt === "string" ? payload.expiresAt : null;
+  const expiresAtMs = expiresAt ? Date.parse(expiresAt) : Number.NaN;
 
   // Detect PID recycling: if the PID is alive but its start time differs from
   // what was recorded in the lock file, the original process died and the OS
@@ -350,6 +437,9 @@ function inspectLockPayload(
     staleReasons.push("invalid-createdAt");
   } else if (ageMs > staleMs) {
     staleReasons.push("too-old");
+  }
+  if (Number.isFinite(expiresAtMs) && nowMs > expiresAtMs) {
+    staleReasons.push("expired-lease");
   }
 
   return {
@@ -508,12 +598,11 @@ export async function acquireSessionWriteLock(params: {
     let handle: fs.FileHandle | null = null;
     try {
       handle = await fs.open(lockPath, "wx");
-      const createdAt = new Date().toISOString();
-      const starttime = getProcessStartTime(process.pid);
-      const lockPayload: LockFilePayload = { pid: process.pid, createdAt };
-      if (starttime !== null) {
-        lockPayload.starttime = starttime;
-      }
+      const lockPayload = buildSessionLockPayload({
+        lockPath,
+        sessionFile: normalizedSessionFile,
+        maxHoldMs,
+      });
       await handle.writeFile(JSON.stringify(lockPayload, null, 2), "utf8");
       const createdHeld: HeldLock = {
         count: 1,

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -199,6 +199,10 @@ export type ChannelAccountSnapshot = {
   lastEventAt?: number | null;
   lastError?: string | null;
   healthState?: string;
+  deliveryTruth?: string | null;
+  transportTruth?: string | null;
+  routeIntegrity?: string | null;
+  sessionStoreIntegrity?: string | null;
   lastStartAt?: number | null;
   lastStopAt?: number | null;
   lastInboundAt?: number | null;

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -117,6 +117,24 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
       if (outboundAt) {
         bits.push(`out:${formatTimeAgo(Date.now() - outboundAt)}`);
       }
+      if (typeof account.transportTruth === "string" && account.transportTruth.length > 0) {
+        bits.push(`transport:${account.transportTruth}`);
+      }
+      if (typeof account.deliveryTruth === "string" && account.deliveryTruth.length > 0) {
+        bits.push(`delivery:${account.deliveryTruth}`);
+      }
+      if (typeof account.routeIntegrity === "string" && account.routeIntegrity.length > 0) {
+        bits.push(`route:${account.routeIntegrity}`);
+      }
+      if (
+        typeof account.sessionStoreIntegrity === "string" &&
+        account.sessionStoreIntegrity.length > 0
+      ) {
+        bits.push(`store:${account.sessionStoreIntegrity}`);
+      }
+      if (typeof account.healthState === "string" && account.healthState.length > 0) {
+        bits.push(`health:${account.healthState}`);
+      }
       appendModeBit(bits, account);
       const botUsername = (() => {
         const bot = account.bot as { username?: string | null } | undefined;

--- a/src/commands/health.command.coverage.test.ts
+++ b/src/commands/health.command.coverage.test.ts
@@ -71,6 +71,8 @@ describe("healthCommand (coverage)", () => {
     const recent = createRecentSessionRows();
     callGatewayMock.mockResolvedValueOnce({
       ok: true,
+      state: "ok",
+      reasons: [],
       ts: Date.now(),
       durationMs: 5,
       channels: {

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -39,6 +39,8 @@ const createHealthSummary = (params: {
   const sessions = params.sessions ?? defaultSessions;
   return {
     ok: true,
+    state: "ok",
+    reasons: [],
     ts: Date.now(),
     durationMs: 5,
     channels: params.channels,

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -1,6 +1,7 @@
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveChannelDefaultAccountId } from "../channels/plugins/helpers.js";
-import { listChannelPlugins } from "../channels/plugins/index.js";
+import { getChannelPlugin, listChannelPlugins } from "../channels/plugins/index.js";
+import { buildChannelAccountSnapshot } from "../channels/plugins/status.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 import { inspectReadOnlyChannelAccount } from "../channels/read-only-account-inspect.js";
@@ -16,6 +17,7 @@ import { buildChannelAccountBindings, resolvePreferredAccountId } from "../routi
 import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { asNullableRecord } from "../shared/record-coerce.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { styleHealthChannelLine } from "../terminal/health-style.js";
 import { isRich } from "../terminal/theme.js";
 import { formatHealthChannelLines } from "./health-format.js";
@@ -23,6 +25,7 @@ import type {
   AgentHealthSummary,
   ChannelAccountHealthSummary,
   ChannelHealthSummary,
+  HealthReason,
   HealthSummary,
 } from "./health.types.js";
 import { logGatewayConnectionDetails } from "./status.gateway-connection.js";
@@ -31,6 +34,7 @@ export type {
   AgentHealthSummary,
   ChannelAccountHealthSummary,
   ChannelHealthSummary,
+  HealthReason,
   HealthSummary,
 } from "./health.types.js";
 
@@ -206,6 +210,10 @@ async function resolveHealthAccountContext(params: {
 export async function getHealthSnapshot(params?: {
   timeoutMs?: number;
   probe?: boolean;
+  runtimeSnapshot?: {
+    channels?: Record<string, ChannelAccountSnapshot | undefined>;
+    channelAccounts?: Record<string, Record<string, ChannelAccountSnapshot | undefined> | undefined>;
+  } | null;
 }): Promise<HealthSummary> {
   const timeoutMs = params?.timeoutMs;
   const { loadConfig } = await import("../config/config.js");
@@ -237,7 +245,18 @@ export async function getHealthSnapshot(params?: {
   const start = Date.now();
   const cappedTimeout = timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : Math.max(50, timeoutMs);
   const doProbe = params?.probe !== false;
+  const runtimeSnapshot = params?.runtimeSnapshot ?? null;
+  const resolveRuntimeAccountSnapshot = (
+    channelId: string,
+    accountId: string,
+    defaultAccountId: string,
+  ) => {
+    const accounts = runtimeSnapshot?.channelAccounts?.[channelId];
+    const defaultRuntime = runtimeSnapshot?.channels?.[channelId];
+    return accounts?.[accountId] ?? (accountId === defaultAccountId ? defaultRuntime : undefined);
+  };
   const channels: Record<string, ChannelHealthSummary> = {};
+  const reasons: HealthReason[] = [];
   const channelOrder = listChannelPlugins().map((plugin) => plugin.id);
   const channelLabels: Record<string, string> = {};
 
@@ -274,6 +293,7 @@ export async function getHealthSnapshot(params?: {
       accountIdsToProbe,
     });
     const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
+    const resolvedAccounts: Record<string, unknown> = {};
 
     for (const accountId of accountIdsToProbe) {
       const { account, enabled, configured, diagnostics } = await resolveHealthAccountContext({
@@ -281,6 +301,7 @@ export async function getHealthSnapshot(params?: {
         cfg,
         accountId,
       });
+      resolvedAccounts[accountId] = account;
       if (diagnostics.length > 0) {
         debugHealth("account.diagnostics", { channel: plugin.id, accountId, diagnostics });
       }
@@ -311,60 +332,61 @@ export async function getHealthSnapshot(params?: {
         debugHealth("probe.bot", { channel: plugin.id, accountId, username: bot.username });
       }
 
-      const snapshot: ChannelAccountSnapshot = {
+      const record = await buildChannelAccountSnapshot({
+        plugin,
+        cfg,
         accountId,
-        enabled,
-        configured,
-      };
-      if (probe !== undefined) {
-        snapshot.probe = probe;
-      }
-      if (lastProbeAt) {
-        snapshot.lastProbeAt = lastProbeAt;
-      }
-
-      const summary = plugin.status?.buildChannelSummary
-        ? await plugin.status.buildChannelSummary({
-            account,
-            cfg,
-            defaultAccountId: accountId,
-            snapshot,
-          })
-        : undefined;
-      const record =
-        summary && typeof summary === "object"
-          ? (summary as ChannelAccountHealthSummary)
-          : ({
-              accountId,
-              configured,
-              probe,
-              lastProbeAt,
-            } satisfies ChannelAccountHealthSummary);
+        runtime: resolveRuntimeAccountSnapshot(plugin.id, accountId, defaultAccountId),
+        probe,
+      });
       if (record.configured === undefined) {
         record.configured = configured;
       }
-      if (record.lastProbeAt === undefined && lastProbeAt) {
+      if (record.enabled === undefined) {
+        record.enabled = enabled;
+      }
+      if (lastProbeAt) {
         record.lastProbeAt = lastProbeAt;
       }
       record.accountId = accountId;
       accountSummaries[accountId] = record;
+      reasons.push(...resolveOperationalHealthIssues(plugin.id, record));
     }
 
+    const fallbackAccountId =
+      preferredAccountId ?? defaultAccountId ?? accountIdsToProbe[0] ?? Object.keys(accountSummaries)[0];
     const defaultSummary =
-      accountSummaries[preferredAccountId] ??
+      accountSummaries[fallbackAccountId] ??
       accountSummaries[defaultAccountId] ??
       accountSummaries[accountIdsToProbe[0] ?? preferredAccountId];
     const fallbackSummary = defaultSummary ?? accountSummaries[Object.keys(accountSummaries)[0]];
     if (fallbackSummary) {
+      const summaryAccountId = fallbackSummary.accountId ?? fallbackAccountId ?? defaultAccountId;
+      const fallbackAccount =
+        resolvedAccounts[summaryAccountId] ?? plugin.config.resolveAccount(cfg, summaryAccountId);
+      const channelSummary = plugin.status?.buildChannelSummary
+        ? await plugin.status.buildChannelSummary({
+            account: fallbackAccount,
+            cfg,
+            defaultAccountId,
+            snapshot: fallbackSummary,
+          })
+        : {
+            configured: fallbackSummary.configured ?? false,
+          };
       channels[plugin.id] = {
-        ...fallbackSummary,
+        ...((channelSummary && typeof channelSummary === "object"
+          ? channelSummary
+          : fallbackSummary) as ChannelHealthSummary),
         accounts: accountSummaries,
       } satisfies ChannelHealthSummary;
     }
   }
 
   const summary: HealthSummary = {
-    ok: true,
+    ok: reasons.length === 0,
+    state: reasons.length > 0 ? "degraded" : "ok",
+    reasons,
     ts: Date.now(),
     durationMs: Date.now() - start,
     channels,

--- a/src/commands/health.types.ts
+++ b/src/commands/health.types.ts
@@ -20,8 +20,16 @@ export type AgentHealthSummary = {
   sessions: HealthSummary["sessions"];
 };
 
+export type HealthReason = {
+  code: string;
+  label: string;
+  detail: string;
+};
+
 export type HealthSummary = {
-  ok: true;
+  ok: boolean;
+  state: "ok" | "degraded";
+  reasons: HealthReason[];
   ts: number;
   durationMs: number;
   channels: Record<string, ChannelHealthSummary>;

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -255,11 +255,13 @@ export function buildStatusHealthRows(params: {
     const item = line.slice(0, colon).trim();
     const detail = line.slice(colon + 1).trim();
     const normalized = normalizeLowercaseStringOrEmpty(detail);
-    const status = normalized.startsWith("ok")
-      ? params.ok("OK")
-      : normalized.startsWith("failed")
-        ? params.warn("WARN")
-        : normalized.startsWith("not configured")
+        const status = normalized.startsWith("ok")
+          ? params.ok("OK")
+          : normalized.startsWith("degraded")
+            ? params.warn("WARN")
+          : normalized.startsWith("failed")
+            ? params.warn("WARN")
+            : normalized.startsWith("not configured")
           ? params.muted("OFF")
           : normalized.startsWith("configured")
             ? params.ok("OK")

--- a/src/config/sessions/session-key.ts
+++ b/src/config/sessions/session-key.ts
@@ -4,6 +4,12 @@ import {
   DEFAULT_AGENT_ID,
   normalizeMainKey,
 } from "../../routing/session-key.js";
+import { resolveSessionRoute } from "../../routing/resolve-route.js";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+} from "../../shared/string-coerce.js";
+import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { normalizeE164 } from "../../utils.js";
 import { normalizeExplicitSessionKey } from "./explicit-session-key-normalization.js";
 import { resolveGroupSessionKey } from "./group.js";
@@ -22,27 +28,55 @@ export function deriveSessionKey(scope: SessionScope, ctx: MsgContext) {
   return from || "unknown";
 }
 
+function buildRouteActorFromCtx(
+  ctx: MsgContext,
+  groupResolution: ReturnType<typeof resolveGroupSessionKey> | null,
+) {
+  const provider = normalizeMessageChannel(
+    ctx.Surface || ctx.Provider || normalizeLowercaseStringOrEmpty(ctx.From).split(":", 1)[0],
+  );
+  const chatType =
+    groupResolution?.chatType ??
+    (normalizeOptionalLowercaseString(ctx.ChatType) === "group"
+      ? "group"
+      : normalizeOptionalLowercaseString(ctx.ChatType) === "channel"
+        ? "channel"
+        : "direct");
+  return {
+    provider: provider || "api",
+    accountId: ctx.AccountId,
+    from: ctx.From,
+    to: typeof ctx.OriginatingTo === "string" ? ctx.OriginatingTo : ctx.To,
+    chatType,
+  };
+}
+
 /**
  * Resolve the session key with a canonical direct-chat bucket (default: "main").
  * All non-group direct chats collapse to this bucket; groups stay isolated.
  */
 export function resolveSessionKey(scope: SessionScope, ctx: MsgContext, mainKey?: string) {
   const explicit = ctx.SessionKey?.trim();
-  if (explicit) {
-    return normalizeExplicitSessionKey(explicit, ctx);
-  }
-  const raw = deriveSessionKey(scope, ctx);
+  const normalizedMainKey = normalizeMainKey(mainKey);
+  const groupResolution = resolveGroupSessionKey(ctx);
   if (scope === "global") {
-    return raw;
+    return "global";
   }
-  const canonicalMainKey = normalizeMainKey(mainKey);
-  const canonical = buildAgentMainSessionKey({
-    agentId: DEFAULT_AGENT_ID,
-    mainKey: canonicalMainKey,
-  });
-  const isGroup = raw.includes(":group:") || raw.includes(":channel:");
-  if (!isGroup) {
-    return canonical;
+  if (groupResolution) {
+    return `agent:${DEFAULT_AGENT_ID}:${groupResolution.key}`;
   }
-  return `agent:${DEFAULT_AGENT_ID}:${raw}`;
+  return (
+    resolveSessionRoute({
+      agentId: DEFAULT_AGENT_ID,
+      surface: normalizeMessageChannel(ctx.Surface || ctx.Provider) || "api",
+      rawSessionInput: explicit ? normalizeExplicitSessionKey(explicit, ctx) : undefined,
+      sessionScope: "agent",
+      mainKey: normalizedMainKey,
+      actor: buildRouteActorFromCtx(ctx, groupResolution),
+    }).sessionKey ??
+    buildAgentMainSessionKey({
+      agentId: DEFAULT_AGENT_ID,
+      mainKey: normalizedMainKey,
+    })
+  );
 }

--- a/src/config/sessions/store-load.ts
+++ b/src/config/sessions/store-load.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.shared.js";
 import { getFileStatSnapshot } from "../cache-utils.js";
 import {
@@ -8,7 +9,11 @@ import {
   writeSessionStoreCache,
 } from "./store-cache.js";
 import { applySessionStoreMigrations } from "./store-migrations.js";
-import { normalizeSessionRuntimeModelFields, type SessionEntry } from "./types.js";
+import {
+  normalizeSessionRuntimeModelFields,
+  type SessionEntry,
+  type SessionRouteSurface,
+} from "./types.js";
 
 export type LoadSessionStoreOptions = {
   skipCache?: boolean;
@@ -51,12 +56,220 @@ function normalizeSessionEntryDelivery(entry: SessionEntry): SessionEntry {
   };
 }
 
+function normalizeRouteScopeFromSessionKey(sessionKey: string | undefined | null) {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!normalized) {
+    return "agent-main" as const;
+  }
+  if (normalized === "global") {
+    return "global" as const;
+  }
+  if (normalized.endsWith(":heartbeat")) {
+    return "heartbeat-isolated" as const;
+  }
+  if (/:direct:/.test(normalized)) {
+    return "peer-scoped-direct" as const;
+  }
+  if (/^agent:[^:]+:main$/.test(normalized)) {
+    return "agent-main" as const;
+  }
+  if (/^agent:[^:]+:explicit:/.test(normalized)) {
+    return "explicit" as const;
+  }
+  return "explicit" as const;
+}
+
+function isMainHeartbeatSessionKey(sessionKey: string | undefined | null): boolean {
+  return /^agent:[^:]+:main:heartbeat$/.test(normalizeLowercaseStringOrEmpty(sessionKey));
+}
+
+function resolveMainHeartbeatBaseSessionKey(sessionKey: string | undefined | null): string | null {
+  if (!isMainHeartbeatSessionKey(sessionKey)) {
+    return null;
+  }
+  return normalizeLowercaseStringOrEmpty(sessionKey).replace(/:heartbeat$/u, "");
+}
+
+function normalizeLegacyHeartbeatMainEntry(
+  sessionKey: string,
+  entry: SessionEntry,
+): SessionEntry {
+  const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!isMainHeartbeatSessionKey(normalizedSessionKey)) {
+    return entry;
+  }
+  const expectedBaseSessionKey = resolveMainHeartbeatBaseSessionKey(normalizedSessionKey);
+  const storedBaseSessionKey = normalizeLowercaseStringOrEmpty(entry.heartbeatIsolatedBaseSessionKey);
+  const nextHeartbeatBaseSessionKey = storedBaseSessionKey || expectedBaseSessionKey;
+  let next = entry;
+  if (nextHeartbeatBaseSessionKey && storedBaseSessionKey !== nextHeartbeatBaseSessionKey) {
+    next = {
+      ...next,
+      heartbeatIsolatedBaseSessionKey: nextHeartbeatBaseSessionKey,
+    };
+  }
+  if (next.origin && typeof next.origin === "object") {
+    if (next === entry) {
+      next = { ...next };
+    }
+    delete next.origin;
+  }
+  return next;
+}
+
+function normalizeSessionRouteSurface(value: string | null): SessionRouteSurface | null {
+  return value === "telegram" ||
+    value === "tui" ||
+    value === "webchat" ||
+    value === "heartbeat" ||
+    value === "cron" ||
+    value === "hook" ||
+    value === "api" ||
+    value === "main"
+    ? value
+    : null;
+}
+
+function deriveRouteSurfaceFromEntry(
+  sessionKey: string,
+  entry: SessionEntry,
+): SessionRouteSurface | null {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (normalized.endsWith(":heartbeat")) {
+    return "heartbeat";
+  }
+  const originSurface = normalizeLowercaseStringOrEmpty(
+    entry.routeMetadata?.surface ?? entry.origin?.surface ?? entry.origin?.provider,
+  );
+  const normalizedOriginSurface = normalizeSessionRouteSurface(originSurface);
+  if (normalizedOriginSurface) {
+    return normalizedOriginSurface;
+  }
+  const directMatch = normalized.match(/^agent:[^:]+:([^:]+):direct:/);
+  const directSurface = normalizeSessionRouteSurface(directMatch?.[1] ?? null);
+  if (directSurface) {
+    return directSurface;
+  }
+  const groupedMatch = normalized.match(/^agent:[^:]+:([^:]+):(group|channel):/);
+  const groupedSurface = normalizeSessionRouteSurface(groupedMatch?.[1] ?? null);
+  if (groupedSurface) {
+    return groupedSurface;
+  }
+  if (/^agent:[^:]+:main$/.test(normalized)) {
+    return "main";
+  }
+  return null;
+}
+
+function buildRouteActorFingerprint(entry: SessionEntry): string | null {
+  const origin = entry.origin;
+  if (!origin || typeof origin !== "object") {
+    return null;
+  }
+  const parts = [
+    typeof origin.provider === "string" ? origin.provider : "",
+    typeof origin.accountId === "string" ? origin.accountId : "",
+    typeof origin.chatType === "string" ? origin.chatType : "",
+    typeof origin.from === "string" ? origin.from : "",
+    typeof origin.to === "string" ? origin.to : "",
+    typeof origin.label === "string" ? origin.label : "",
+  ];
+  return parts.some((value) => value) ? parts.join("|") : null;
+}
+
+function deriveRouteIntegrity(
+  sessionKey: string,
+  entry: SessionEntry,
+  routeMetadata: NonNullable<SessionEntry["routeMetadata"]>,
+): NonNullable<SessionEntry["routeIntegrityState"]> {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  const provider = normalizeLowercaseStringOrEmpty(entry.origin?.provider ?? entry.origin?.surface);
+  const chatType = normalizeLowercaseStringOrEmpty(entry.origin?.chatType);
+  if (/^agent:[^:]+:main$/.test(normalized) && provider === "telegram" && chatType === "direct") {
+    return "contradictory";
+  }
+  if (/^agent:[^:]+:main:heartbeat$/.test(normalized) && provider === "telegram") {
+    return "contradictory";
+  }
+  if (!routeMetadata.surface && !provider && !chatType) {
+    return "unknown";
+  }
+  return "ok";
+}
+
+function normalizeSessionEntryRouteMetadata(sessionKey: string, entry: SessionEntry): SessionEntry {
+  const normalizedSourceEntry = normalizeLegacyHeartbeatMainEntry(sessionKey, entry);
+  const scope = normalizeRouteScopeFromSessionKey(sessionKey);
+  const existingRouteMetadata =
+    normalizedSourceEntry.routeMetadata && typeof normalizedSourceEntry.routeMetadata === "object"
+      ? normalizedSourceEntry.routeMetadata
+      : {};
+  const routeMetadata = {
+    ...existingRouteMetadata,
+    resolvedAt:
+      typeof existingRouteMetadata.resolvedAt === "number"
+        ? existingRouteMetadata.resolvedAt
+        : normalizedSourceEntry.updatedAt ?? null,
+    sessionKey,
+    surface: deriveRouteSurfaceFromEntry(sessionKey, normalizedSourceEntry),
+    scope,
+    explicit: scope === "explicit",
+    actorFingerprint: buildRouteActorFingerprint(normalizedSourceEntry),
+    heartbeatIsolatedBaseSessionKey:
+      typeof normalizedSourceEntry.heartbeatIsolatedBaseSessionKey === "string"
+        ? normalizedSourceEntry.heartbeatIsolatedBaseSessionKey
+        : null,
+    provenance: {
+      provider:
+        typeof normalizedSourceEntry.origin?.provider === "string"
+          ? normalizedSourceEntry.origin.provider
+          : null,
+      surface:
+        typeof normalizedSourceEntry.origin?.surface === "string"
+          ? normalizedSourceEntry.origin.surface
+          : null,
+      from:
+        typeof normalizedSourceEntry.origin?.from === "string"
+          ? normalizedSourceEntry.origin.from
+          : null,
+      to:
+        typeof normalizedSourceEntry.origin?.to === "string" ? normalizedSourceEntry.origin.to : null,
+      chatType:
+        typeof normalizedSourceEntry.origin?.chatType === "string"
+          ? normalizedSourceEntry.origin.chatType
+          : null,
+      label:
+        typeof normalizedSourceEntry.origin?.label === "string"
+          ? normalizedSourceEntry.origin.label
+          : null,
+      accountId:
+        typeof normalizedSourceEntry.origin?.accountId === "string"
+          ? normalizedSourceEntry.origin.accountId
+          : null,
+      threadId: normalizedSourceEntry.origin?.threadId ?? null,
+    },
+  };
+  const integrity = deriveRouteIntegrity(sessionKey, normalizedSourceEntry, routeMetadata);
+  const normalizedEntry: SessionEntry = {
+    ...normalizedSourceEntry,
+    routeMetadata: {
+      ...routeMetadata,
+      integrity,
+    },
+    routeIntegrityState: integrity,
+  };
+  return JSON.stringify(entry) === JSON.stringify(normalizedEntry) ? entry : normalizedEntry;
+}
+
 export function normalizeSessionStore(store: Record<string, SessionEntry>): void {
   for (const [key, entry] of Object.entries(store)) {
     if (!entry) {
       continue;
     }
-    const normalized = normalizeSessionEntryDelivery(normalizeSessionRuntimeModelFields(entry));
+    const normalized = normalizeSessionEntryRouteMetadata(
+      key,
+      normalizeSessionEntryDelivery(normalizeSessionRuntimeModelFields(entry)),
+    );
     if (normalized !== entry) {
       store[key] = normalized;
     }

--- a/src/config/sessions/store-maintenance.ts
+++ b/src/config/sessions/store-maintenance.ts
@@ -279,6 +279,27 @@ async function getSessionFileSize(storePath: string): Promise<number | null> {
   }
 }
 
+export function resolveSessionMaintenanceRoot(storePath: string): string {
+  const resolvedStorePath = path.resolve(storePath);
+  const sessionsDir = path.dirname(resolvedStorePath);
+  if (path.basename(sessionsDir) === "sessions") {
+    const agentDir = path.dirname(sessionsDir);
+    const agentsDir = path.dirname(agentDir);
+    if (path.basename(agentsDir) === "agents") {
+      return path.join(agentDir, "artifacts");
+    }
+  }
+  return path.join(path.dirname(sessionsDir), ".openclaw-artifacts");
+}
+
+export function resolveSessionStoreBackupDir(storePath: string): string {
+  return path.join(resolveSessionMaintenanceRoot(storePath), "session-store");
+}
+
+export function resolveSessionTranscriptArchiveDir(storePath: string): string {
+  return path.join(resolveSessionMaintenanceRoot(storePath), "session-transcripts");
+}
+
 /**
  * Rotate the sessions file if it exceeds the configured size threshold.
  * Renames the current file to `sessions.json.bak.{timestamp}` and cleans up
@@ -300,12 +321,13 @@ export async function rotateSessionFile(
     return false;
   }
 
-  // Rotate: rename current file to .bak.{timestamp}
-  const backupPath = `${storePath}.bak.${Date.now()}`;
+  const backupDir = resolveSessionStoreBackupDir(storePath);
+  await fs.promises.mkdir(backupDir, { recursive: true }).catch(() => undefined);
+  const backupPath = path.join(backupDir, `${path.basename(storePath)}.bak.${Date.now()}`);
   try {
     await fs.promises.rename(storePath, backupPath);
     log.info("rotated session store file", {
-      backupPath: path.basename(backupPath),
+      backupPath,
       sizeBytes: fileSize,
     });
   } catch {
@@ -315,9 +337,8 @@ export async function rotateSessionFile(
 
   // Clean up old backups — keep only the 3 most recent .bak.* files.
   try {
-    const dir = path.dirname(storePath);
     const baseName = path.basename(storePath);
-    const files = await fs.promises.readdir(dir);
+    const files = await fs.promises.readdir(backupDir);
     const backups = files
       .filter((f) => f.startsWith(`${baseName}.bak.`))
       .toSorted()
@@ -327,7 +348,7 @@ export async function rotateSessionFile(
     if (backups.length > maxBackups) {
       const toDelete = backups.slice(maxBackups);
       for (const old of toDelete) {
-        await fs.promises.unlink(path.join(dir, old)).catch(() => undefined);
+        await fs.promises.unlink(path.join(backupDir, old)).catch(() => undefined);
       }
       log.info("cleaned up old session store backups", { deleted: toDelete.length });
     }

--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -153,4 +153,58 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
+
+  it("self-heals legacy main-heartbeat route contradictions while loading", async () => {
+    const heartbeatKey = "agent:main:main:heartbeat";
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [heartbeatKey]: {
+            sessionId: "self-heal-test",
+            updatedAt: 1776246496808,
+            heartbeatIsolatedBaseSessionKey: "agent:main:main",
+            origin: {
+              label: "8582659364",
+              provider: "telegram",
+              from: "8582659364",
+              to: "8582659364",
+            },
+            routeMetadata: {
+              resolvedAt: 1776246496808,
+              sessionKey: heartbeatKey,
+              surface: "telegram",
+              scope: "heartbeat-isolated",
+              explicit: false,
+              actorFingerprint: "telegram|||8582659364|8582659364|8582659364",
+              heartbeatIsolatedBaseSessionKey: "agent:main:main",
+              provenance: {
+                provider: "telegram",
+                surface: null,
+                from: "8582659364",
+                to: "8582659364",
+                chatType: null,
+                label: "8582659364",
+                accountId: null,
+                threadId: null,
+              },
+              integrity: "contradictory",
+            },
+            routeIntegrityState: "contradictory",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    const entry = store[heartbeatKey];
+    expect(entry.origin).toBeUndefined();
+    expect(entry.routeMetadata?.surface).toBe("heartbeat");
+    expect(entry.routeMetadata?.heartbeatIsolatedBaseSessionKey).toBe("agent:main:main");
+    expect(entry.routeIntegrityState).toBe("ok");
+  });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -39,6 +39,7 @@ import {
   getActiveSessionMaintenanceWarning,
   pruneStaleEntries,
   resolveMaintenanceConfig,
+  resolveSessionTranscriptArchiveDir,
   rotateSessionFile,
   type ResolvedSessionMaintenanceConfig,
   type SessionMaintenanceWarning,
@@ -312,7 +313,7 @@ async function saveSessionStoreUnlocked(
       if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
         const { cleanupArchivedSessionTranscripts } = await loadSessionArchiveRuntime();
         const targetDirs =
-          archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
+          archivedDirs.size > 0 ? [...archivedDirs] : [resolveSessionTranscriptArchiveDir(storePath)];
         await cleanupArchivedSessionTranscripts({
           directories: targetDirs,
           olderThanMs: maintenance.pruneAfterMs,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -25,6 +25,46 @@ export type SessionOrigin = {
   threadId?: string | number;
 };
 
+export type SessionRouteScope =
+  | "agent-main"
+  | "peer-scoped-direct"
+  | "explicit"
+  | "heartbeat-isolated"
+  | "global";
+
+export type SessionRouteIntegrityState = "ok" | "unknown" | "contradictory";
+
+export type SessionRouteSurface =
+  | "telegram"
+  | "tui"
+  | "webchat"
+  | "heartbeat"
+  | "cron"
+  | "hook"
+  | "api"
+  | "main";
+
+export type SessionRouteMetadata = {
+  resolvedAt?: number | null;
+  sessionKey?: string | null;
+  surface?: SessionRouteSurface | null;
+  scope?: SessionRouteScope | null;
+  explicit?: boolean;
+  actorFingerprint?: string | null;
+  heartbeatIsolatedBaseSessionKey?: string | null;
+  provenance?: {
+    provider?: string | null;
+    surface?: string | null;
+    from?: string | null;
+    to?: string | null;
+    chatType?: SessionChatType | null;
+    label?: string | null;
+    accountId?: string | null;
+    threadId?: string | number | null;
+  };
+  integrity?: SessionRouteIntegrityState;
+};
+
 export type SessionAcpIdentitySource = "ensure" | "status" | "event";
 
 export type SessionAcpIdentityState = "pending" | "resolved";
@@ -122,6 +162,8 @@ export type SessionEntry = {
    * a real user/session-scoped key that merely happens to end with `:heartbeat`.
    */
   heartbeatIsolatedBaseSessionKey?: string;
+  routeMetadata?: SessionRouteMetadata;
+  routeIntegrityState?: SessionRouteIntegrityState;
   /** Heartbeat task state (task name -> last run timestamp ms). */
   heartbeatTaskState?: Record<string, number>;
   sessionId: string;

--- a/src/cron/isolated-agent/session-key.ts
+++ b/src/cron/isolated-agent/session-key.ts
@@ -1,6 +1,6 @@
-import { canonicalizeMainSessionAlias } from "../../config/sessions/main-session.js";
+import { resolveAgentMainSessionKey } from "../../config/sessions/main-session.js";
 import type { SessionScope } from "../../config/sessions/types.js";
-import { toAgentStoreSessionKey } from "../../routing/session-key.js";
+import { resolveSessionRoute } from "../../routing/resolve-route.js";
 
 export function resolveCronAgentSessionKey(params: {
   sessionKey: string;
@@ -8,17 +8,20 @@ export function resolveCronAgentSessionKey(params: {
   mainKey?: string | undefined;
   cfg?: { session?: { scope?: SessionScope; mainKey?: string } };
 }): string {
-  const raw = toAgentStoreSessionKey({
+  const resolved = resolveSessionRoute({
+    cfg: params.cfg ?? {},
     agentId: params.agentId,
-    requestKey: params.sessionKey.trim(),
+    surface: "cron",
+    rawSessionInput: params.sessionKey.trim(),
+    sessionScope: "agent",
     mainKey: params.mainKey,
   });
-  // Canonicalize so "agent:<id>:main" → "agent:<id>:<configuredMainKey>"
-  // when cfg.session.mainKey differs from "main". Without this, cron sessions
-  // are orphaned when read paths use the configured mainKey alias (#29683).
-  return canonicalizeMainSessionAlias({
-    cfg: params.cfg,
+  const fallbackMainSessionKey = resolveAgentMainSessionKey({
+    cfg: params.cfg ?? {},
     agentId: params.agentId,
-    sessionKey: raw,
   });
+  if (resolved.sessionKey === "global") {
+    return fallbackMainSessionKey;
+  }
+  return resolved.sessionKey;
 }

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -8,7 +8,8 @@ import {
   resolveDefaultModelForAgent,
 } from "../agents/model-selection.js";
 import { loadConfig } from "../config/config.js";
-import { buildAgentMainSessionKey, normalizeAgentId } from "../routing/session-key.js";
+import { resolveSessionRoute } from "../routing/resolve-route.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -286,15 +287,30 @@ export function resolveSessionKey(params: {
   agentId: string;
   user?: string | undefined;
   prefix: string;
+  defaultMessageChannel?: string;
 }): string {
+  const cfg = loadConfig();
   const explicit = getHeader(params.req, "x-openclaw-session-key")?.trim();
   if (explicit) {
-    return explicit;
+    return resolveSessionRoute({
+      cfg,
+      agentId: params.agentId,
+      surface: params.defaultMessageChannel === "webchat" ? "webchat" : "api",
+      rawSessionInput: explicit,
+      sessionScope: "agent",
+      mainKey: cfg.session?.mainKey,
+    }).sessionKey;
   }
 
   const user = params.user?.trim();
   const mainKey = user ? `${params.prefix}-user:${user}` : `${params.prefix}:${randomUUID()}`;
-  return buildAgentMainSessionKey({ agentId: params.agentId, mainKey });
+  return resolveSessionRoute({
+    cfg,
+    agentId: params.agentId,
+    surface: params.defaultMessageChannel === "webchat" ? "webchat" : "api",
+    sessionScope: "agent",
+    mainKey,
+  }).sessionKey;
 }
 
 export function resolveGatewayRequestContext(params: {
@@ -311,6 +327,7 @@ export function resolveGatewayRequestContext(params: {
     agentId,
     user: params.user,
     prefix: params.sessionPrefix,
+    defaultMessageChannel: params.defaultMessageChannel,
   });
 
   const messageChannel = params.useMessageChannelHeader

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -11,17 +11,18 @@ export const healthHandlers: GatewayRequestHandlers = {
   health: async ({ respond, context, params }) => {
     const { getHealthCache, refreshHealthSnapshot, logHealth } = context;
     const wantsProbe = params?.probe === true;
+    const runtimeSnapshot = context.getRuntimeSnapshot();
     const now = Date.now();
     const cached = getHealthCache();
     if (!wantsProbe && cached && now - cached.ts < HEALTH_REFRESH_INTERVAL_MS) {
       respond(true, cached, undefined, { cached: true });
-      void refreshHealthSnapshot({ probe: false }).catch((err) =>
+      void refreshHealthSnapshot({ probe: false, runtimeSnapshot }).catch((err) =>
         logHealth.error(`background health refresh failed: ${formatError(err)}`),
       );
       return;
     }
     try {
-      const snap = await refreshHealthSnapshot({ probe: wantsProbe });
+      const snap = await refreshHealthSnapshot({ probe: wantsProbe, runtimeSnapshot });
       respond(true, snap, undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -84,6 +84,7 @@ import {
   getPresenceVersion,
   incrementPresenceVersion,
   refreshGatewayHealthSnapshot,
+  setHealthRuntimeSnapshotGetter,
 } from "./server/health-state.js";
 import { resolveHookClientIpConfig } from "./server/hooks.js";
 import { createReadinessChecker } from "./server/readiness.js";
@@ -416,6 +417,7 @@ export async function startGatewayServer(
     channelRuntimeEnvs,
     resolveChannelRuntime: getChannelRuntime,
   });
+  setHealthRuntimeSnapshotGetter(() => channelManager.getRuntimeSnapshot());
   const getReadiness = createReadinessChecker({
     channelManager,
     startedAt: serverStartedAt,

--- a/src/gateway/server/health-state.ts
+++ b/src/gateway/server/health-state.ts
@@ -13,6 +13,9 @@ let healthVersion = 1;
 let healthCache: HealthSummary | null = null;
 let healthRefresh: Promise<HealthSummary> | null = null;
 let broadcastHealthUpdate: ((snap: HealthSummary) => void) | null = null;
+let healthRuntimeSnapshotGetter:
+  | (() => NonNullable<Parameters<typeof getHealthSnapshot>[0]>["runtimeSnapshot"])
+  | null = null;
 
 export function buildGatewaySnapshot(opts?: { includeSensitive?: boolean }): Snapshot {
   const cfg = loadConfig();
@@ -69,10 +72,22 @@ export function setBroadcastHealthUpdate(fn: ((snap: HealthSummary) => void) | n
   broadcastHealthUpdate = fn;
 }
 
-export async function refreshGatewayHealthSnapshot(opts?: { probe?: boolean }) {
+export function setHealthRuntimeSnapshotGetter(
+  fn:
+    | (() => NonNullable<Parameters<typeof getHealthSnapshot>[0]>["runtimeSnapshot"])
+    | null,
+) {
+  healthRuntimeSnapshotGetter = typeof fn === "function" ? fn : null;
+}
+
+export async function refreshGatewayHealthSnapshot(opts?: {
+  probe?: boolean;
+  runtimeSnapshot?: NonNullable<Parameters<typeof getHealthSnapshot>[0]>["runtimeSnapshot"];
+}) {
   if (!healthRefresh) {
     healthRefresh = (async () => {
-      const snap = await getHealthSnapshot({ probe: opts?.probe });
+      const runtimeSnapshot = opts?.runtimeSnapshot ?? healthRuntimeSnapshotGetter?.();
+      const snap = await getHealthSnapshot({ probe: opts?.probe, runtimeSnapshot });
       healthCache = snap;
       healthVersion += 1;
       if (broadcastHealthUpdate) {

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -11,6 +11,7 @@ import {
   resolveSessionTranscriptPath,
   resolveSessionTranscriptPathInDir,
 } from "../config/sessions/paths.js";
+import { resolveSessionTranscriptArchiveDir } from "../config/sessions/store-maintenance.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 
 export type ArchiveFileReason = SessionArchiveReason;
@@ -123,9 +124,31 @@ export function resolveSessionTranscriptCandidates(
   return Array.from(new Set(candidates));
 }
 
-export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): string {
+function resolveTranscriptArchiveDirectory(filePath: string, storePath?: string): string {
+  if (storePath) {
+    return resolveSessionTranscriptArchiveDir(storePath);
+  }
+  const resolvedFilePath = path.resolve(filePath);
+  const sessionsDir = path.dirname(resolvedFilePath);
+  if (path.basename(sessionsDir) === "sessions") {
+    const agentDir = path.dirname(sessionsDir);
+    const agentsDir = path.dirname(agentDir);
+    if (path.basename(agentsDir) === "agents") {
+      return path.join(agentDir, "artifacts", "session-transcripts");
+    }
+  }
+  return path.join(path.dirname(sessionsDir), ".openclaw-artifacts", "session-transcripts");
+}
+
+export function archiveFileOnDisk(
+  filePath: string,
+  reason: ArchiveFileReason,
+  storePath?: string,
+): string {
   const ts = formatSessionArchiveTimestamp();
-  const archived = `${filePath}.${reason}.${ts}`;
+  const archiveDir = resolveTranscriptArchiveDirectory(filePath, storePath);
+  fs.mkdirSync(archiveDir, { recursive: true });
+  const archived = path.join(archiveDir, `${path.basename(filePath)}.${reason}.${ts}`);
   fs.renameSync(filePath, archived);
   return archived;
 }
@@ -181,7 +204,7 @@ export function archiveSessionTranscriptsDetailed(opts: {
     try {
       archived.push({
         sourcePath: candidatePath,
-        archivedPath: archiveFileOnDisk(candidatePath, opts.reason),
+        archivedPath: archiveFileOnDisk(candidatePath, opts.reason, opts.storePath),
       });
     } catch {
       // Best-effort.

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -15,6 +15,7 @@ import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/run
 import { buildAgentPeerSessionKey } from "../routing/session-key.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { typedCases } from "../test-utils/typed-cases.js";
+import { getLastHeartbeatEvent, resetHeartbeatEventsForTest } from "./heartbeat-events.js";
 import {
   type HeartbeatDeps,
   isHeartbeatEnabledForAgent,
@@ -226,6 +227,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetSystemEventsForTest();
+  resetHeartbeatEventsForTest();
   if (testRegistry) {
     setActivePluginRegistry(testRegistry);
   }
@@ -1589,6 +1591,7 @@ describe("runHeartbeatOnce", () => {
       expect(calledCtx.Provider).toBe("cron-event");
       expect(calledCtx.Body).toContain("Handle this reminder internally");
       expect(calledCtx.Body).not.toContain("Please relay this reminder to the user");
+      expect(getLastHeartbeatEvent()).toMatchObject({ status: "skipped", reason: "target-none" });
     } finally {
       replySpy.mockReset();
     }
@@ -1649,8 +1652,181 @@ describe("runHeartbeatOnce", () => {
       expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
       expect(calledCtx.Body).toContain("Handle the result internally");
       expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+      expect(getLastHeartbeatEvent()).toMatchObject({ status: "skipped", reason: "target-none" });
     } finally {
       replySpy.mockReset();
     }
+  });
+
+  it("keeps heartbeat-child exec events internal for protected telegram primary DMs", async () => {
+    const tmpDir = await createCaseDir("hb-exec-protected-telegram-child");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "last", isolatedSession: true },
+        },
+      },
+      channels: {
+        telegram: {
+          allowFrom: ["8582659364"],
+          accounts: { default: { botToken: "token", allowFrom: ["8582659364"] } },
+        },
+      },
+      session: { store: storePath },
+    };
+    const baseSessionKey = "agent:main:telegram:direct:thomas";
+    const heartbeatSessionKey = `${baseSessionKey}:heartbeat`;
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [baseSessionKey]: {
+          sessionId: "sid-base",
+          updatedAt: Date.now(),
+          channel: "telegram",
+          chatType: "direct",
+          lastChannel: "telegram",
+          lastTo: "8582659364",
+          lastAccountId: "default",
+          routeMetadata: {
+            scope: "peer-scoped-direct",
+            provenance: { provider: "telegram", chatType: "direct" },
+          },
+        },
+        [heartbeatSessionKey]: {
+          sessionId: "sid-heartbeat",
+          updatedAt: Date.now() + 1,
+          channel: "telegram",
+          chatType: "direct",
+          heartbeatIsolatedBaseSessionKey: baseSessionKey,
+          routeMetadata: {
+            scope: "heartbeat-isolated",
+            heartbeatIsolatedBaseSessionKey: baseSessionKey,
+            provenance: { provider: "telegram", chatType: "direct" },
+          },
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: scan completed", {
+      sessionKey: heartbeatSessionKey,
+      contextKey: "exec:scan",
+      trusted: false,
+      deliveryContext: { channel: "hook", to: "8582659364", accountId: "default" },
+    });
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "Handled internally" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg1", chatId: "8582659364" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      sessionKey: heartbeatSessionKey,
+      reason: "exec-event",
+      deps: {
+        ...createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+        telegram: sendTelegram,
+      },
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+    const calledCtx = replySpy.mock.calls[0]?.[0] as {
+      Provider?: string;
+      Body?: string;
+      OriginatingChannel?: string | null;
+      OriginatingTo?: string | null;
+      ForceSenderIsOwnerFalse?: boolean;
+    };
+    expect(calledCtx.Provider).toBe("exec-event");
+    expect(calledCtx.ForceSenderIsOwnerFalse).toBe(true);
+    expect(calledCtx.OriginatingChannel).toBeUndefined();
+    expect(calledCtx.OriginatingTo).toBeUndefined();
+    expect(calledCtx.Body).toContain("Handle the result internally");
+    expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+    expect(getLastHeartbeatEvent()).toMatchObject({
+      status: "skipped",
+      reason: "protected-primary-dm",
+    });
+  });
+
+  it("blocks async exec relays that try to borrow a protected telegram primary DM", async () => {
+    const tmpDir = await createCaseDir("hb-exec-protected-telegram-main");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: { every: "5m", target: "last" },
+        },
+      },
+      channels: {
+        telegram: {
+          allowFrom: ["8582659364"],
+          accounts: { default: { botToken: "token", allowFrom: ["8582659364"] } },
+        },
+      },
+      session: { store: storePath },
+    };
+    const sessionKey = resolveMainSessionKey(cfg);
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        [sessionKey]: {
+          sessionId: "sid-main",
+          updatedAt: Date.now(),
+          routeMetadata: {
+            scope: "agent-main",
+            provenance: { provider: "cli", chatType: "direct" },
+          },
+        },
+      }),
+    );
+    enqueueSystemEvent("exec finished: backup completed", {
+      sessionKey,
+      contextKey: "exec:backup",
+      trusted: false,
+      deliveryContext: { channel: "telegram", to: "8582659364", accountId: "default" },
+    });
+
+    const replySpy = vi.fn().mockResolvedValue({ text: "Handled internally" });
+    const sendWhatsApp = vi
+      .fn<
+        (to: string, text: string, opts?: unknown) => Promise<{ messageId: string; toJid: string }>
+      >()
+      .mockResolvedValue({ messageId: "m1", toJid: "jid" });
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg1", chatId: "8582659364" });
+
+    const res = await runHeartbeatOnce({
+      cfg,
+      sessionKey,
+      reason: "exec-event",
+      deps: {
+        ...createHeartbeatDeps(sendWhatsApp, { getReplyFromConfig: replySpy }),
+        telegram: sendTelegram,
+      },
+    });
+
+    expect(res.status).toBe("ran");
+    expect(sendTelegram).toHaveBeenCalledTimes(0);
+    const calledCtx = replySpy.mock.calls[0]?.[0] as {
+      Provider?: string;
+      Body?: string;
+      OriginatingChannel?: string | null;
+      OriginatingTo?: string | null;
+    };
+    expect(calledCtx.Provider).toBe("exec-event");
+    expect(calledCtx.OriginatingChannel).toBeUndefined();
+    expect(calledCtx.OriginatingTo).toBeUndefined();
+    expect(calledCtx.Body).toContain("Handle the result internally");
+    expect(calledCtx.Body).not.toContain("Please relay the command output to the user");
+    expect(getLastHeartbeatEvent()).toMatchObject({
+      status: "skipped",
+      reason: "protected-primary-dm",
+    });
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -29,9 +29,7 @@ import type { ReplyPayload } from "../auto-reply/types.js";
 import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelHeartbeatDeps } from "../channels/plugins/types.public.js";
 import { loadConfig } from "../config/config.js";
-import {
-  resolveAgentMainSessionKey,
-} from "../config/sessions/main-session.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
 import { loadSessionStore } from "../config/sessions/store-load.js";
 import {
@@ -45,18 +43,22 @@ import { resolveCronSession } from "../cron/isolated-agent/session.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { getQueueSize } from "../process/command-queue.js";
 import { CommandLane } from "../process/lanes.js";
+import { resolveSessionRoute } from "../routing/resolve-route.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
   resolveAgentIdFromSessionKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { resolveSessionRoute } from "../routing/resolve-route.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import {
+  normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { escapeRegExp } from "../utils.js";
+import { deliveryContextFromSession } from "../utils/delivery-context.shared.js";
+import type { DeliveryContext } from "../utils/delivery-context.types.js";
+import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import { loadOrCreateDeviceIdentity } from "./device-identity.js";
 import { formatErrorMessage, hasErrnoCode } from "./errors.js";
 import { isWithinActiveHours } from "./heartbeat-active-hours.js";
@@ -94,6 +96,7 @@ import { buildOutboundSessionContext } from "./outbound/session-context.js";
 import {
   resolveHeartbeatDeliveryTarget,
   resolveHeartbeatSenderContext,
+  type OutboundTarget,
 } from "./outbound/targets.js";
 import {
   consumeSystemEventEntries,
@@ -593,6 +596,157 @@ type HeartbeatPromptResolution = {
   hasCronEvents: boolean;
 };
 
+type AsyncHeartbeatRelayPolicy = {
+  blockReason:
+    | "protected-primary-dm"
+    | "internal-background-session"
+    | "ambiguous-async-provenance"
+    | null;
+  useStoredSessionRoute: boolean;
+};
+
+function resolveHeartbeatBaseSessionKey(sessionKey: string, entry?: SessionEntry): string {
+  const storedBaseSessionKey = normalizeLowercaseStringOrEmpty(
+    entry?.heartbeatIsolatedBaseSessionKey,
+  );
+  if (storedBaseSessionKey) {
+    return storedBaseSessionKey;
+  }
+  const normalizedSessionKey = normalizeLowercaseStringOrEmpty(sessionKey);
+  return normalizedSessionKey.endsWith(":heartbeat")
+    ? normalizedSessionKey.replace(/:heartbeat$/u, "")
+    : normalizedSessionKey;
+}
+
+function normalizeTelegramPrimaryDirectTarget(target: unknown): string {
+  const trimmed = normalizeOptionalString(target);
+  if (!trimmed) {
+    return "";
+  }
+  const normalized = trimmed.replace(/^telegram:/iu, "");
+  return /^\d+$/u.test(normalized) ? normalized : "";
+}
+
+function resolveHeartbeatSessionThreadId(entry?: SessionEntry): string | number | undefined {
+  return (
+    entry?.deliveryContext?.threadId ??
+    entry?.lastThreadId ??
+    entry?.origin?.threadId ??
+    entry?.routeMetadata?.provenance?.threadId ??
+    undefined
+  );
+}
+
+function isProtectedTelegramPrimaryDeliveryContext(deliveryContext?: DeliveryContext): boolean {
+  return (
+    normalizeLowercaseStringOrEmpty(deliveryContext?.channel) === "telegram" &&
+    deliveryContext?.threadId == null &&
+    Boolean(normalizeTelegramPrimaryDirectTarget(deliveryContext?.to))
+  );
+}
+
+function isProtectedTelegramPrimaryHeartbeatSession(params: {
+  sessionKey: string;
+  entry?: SessionEntry;
+}): boolean {
+  const baseSessionKey = resolveHeartbeatBaseSessionKey(params.sessionKey, params.entry);
+  if (!/^agent:[^:]+:telegram:direct:[^:]+$/u.test(baseSessionKey)) {
+    return false;
+  }
+  const routeScope = normalizeLowercaseStringOrEmpty(params.entry?.routeMetadata?.scope);
+  return (
+    (!routeScope || routeScope === "peer-scoped-direct" || routeScope === "heartbeat-isolated") &&
+    resolveHeartbeatSessionThreadId(params.entry) == null
+  );
+}
+
+function isProtectedTelegramPrimaryBaseSession(params: {
+  sessionKey: string;
+  entry?: SessionEntry;
+}): boolean {
+  if (!params.entry) {
+    return false;
+  }
+  if (
+    !/^agent:[^:]+:telegram:direct:[^:]+$/u.test(normalizeLowercaseStringOrEmpty(params.sessionKey))
+  ) {
+    return false;
+  }
+  const routeScope = normalizeLowercaseStringOrEmpty(params.entry?.routeMetadata?.scope);
+  return (
+    (!routeScope || routeScope === "peer-scoped-direct") &&
+    resolveHeartbeatSessionThreadId(params.entry) == null
+  );
+}
+
+function blockHeartbeatUserDeliveryTarget(
+  delivery: OutboundTarget,
+  reason: NonNullable<AsyncHeartbeatRelayPolicy["blockReason"]> = "protected-primary-dm",
+): OutboundTarget {
+  return {
+    channel: "none",
+    reason,
+    accountId: delivery.accountId,
+    lastChannel: delivery.lastChannel,
+    lastAccountId: delivery.lastAccountId,
+  };
+}
+
+function hasDeliverableHeartbeatSessionRoute(entry?: SessionEntry): boolean {
+  const route = deliveryContextFromSession(entry);
+  return Boolean(route?.channel && isDeliverableMessageChannel(route.channel) && route.to);
+}
+
+function resolveAsyncHeartbeatRelayPolicy(params: {
+  sessionKey: string;
+  entry?: SessionEntry;
+  baseEntry?: SessionEntry;
+  turnSource?: DeliveryContext;
+  pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
+  shouldInspectPendingEvents: boolean;
+}): AsyncHeartbeatRelayPolicy | false {
+  if (!params.shouldInspectPendingEvents || params.pendingEventEntries.length === 0) {
+    return false;
+  }
+
+  const baseSessionKey = resolveHeartbeatBaseSessionKey(params.sessionKey, params.entry);
+  if (
+    isProtectedTelegramPrimaryBaseSession({
+      sessionKey: baseSessionKey,
+      entry: params.baseEntry,
+    })
+  ) {
+    return { blockReason: "protected-primary-dm", useStoredSessionRoute: false };
+  }
+  if (
+    isProtectedTelegramPrimaryHeartbeatSession({
+      sessionKey: params.sessionKey,
+      entry: params.entry,
+    })
+  ) {
+    return { blockReason: "protected-primary-dm", useStoredSessionRoute: false };
+  }
+  if (isProtectedTelegramPrimaryDeliveryContext(params.turnSource)) {
+    return { blockReason: "protected-primary-dm", useStoredSessionRoute: false };
+  }
+  if (params.turnSource?.channel && params.turnSource?.to) {
+    return { blockReason: null, useStoredSessionRoute: false };
+  }
+
+  const baseRouteScope = normalizeLowercaseStringOrEmpty(params.baseEntry?.routeMetadata?.scope);
+  if (!hasDeliverableHeartbeatSessionRoute(params.baseEntry)) {
+    return {
+      blockReason:
+        baseRouteScope === "explicit" || baseRouteScope === "agent-main"
+          ? "internal-background-session"
+          : "ambiguous-async-provenance",
+      useStoredSessionRoute: false,
+    };
+  }
+
+  return { blockReason: null, useStoredSessionRoute: true };
+}
+
 function appendHeartbeatWorkspacePathHint(prompt: string, workspaceDir: string): string {
   if (!/heartbeat\.md/i.test(prompt)) {
     return prompt;
@@ -610,6 +764,7 @@ function resolveHeartbeatRunPrompt(params: {
   heartbeat?: HeartbeatConfig;
   preflight: HeartbeatPreflight;
   canRelayToUser: boolean;
+  suppressExecUserRelay?: boolean;
   workspaceDir: string;
   startedAt: number;
   heartbeatFileContent?: string;
@@ -664,7 +819,9 @@ After completing all due tasks, reply HEARTBEAT_OK.`;
 
   // Fallback to original behavior
   const basePrompt = hasExecCompletion
-    ? buildExecEventPrompt({ deliverToUser: params.canRelayToUser })
+    ? buildExecEventPrompt({
+        deliverToUser: params.canRelayToUser && !params.suppressExecUserRelay,
+      })
     : hasCronEvents
       ? buildCronEventPrompt(cronEvents, { deliverToUser: params.canRelayToUser })
       : resolveHeartbeatPrompt(params.cfg, params.heartbeat);
@@ -749,15 +906,38 @@ export async function runHeartbeatOnce(opts: {
   // sending the full conversation history (~100K tokens) to the LLM.
   // Delivery routing still uses the main session entry (lastChannel, lastTo).
   const useIsolatedSession = heartbeat?.isolatedSession === true;
+  const baseSessionKey = resolveHeartbeatBaseSessionKey(sessionKey, entry);
+  const baseEntry =
+    preflight.session.store[baseSessionKey] ?? (baseSessionKey === sessionKey ? entry : undefined);
+  const asyncRelayPolicy = resolveAsyncHeartbeatRelayPolicy({
+    sessionKey,
+    entry,
+    baseEntry,
+    turnSource: preflight.turnSourceDeliveryContext,
+    pendingEventEntries: preflight.pendingEventEntries,
+    shouldInspectPendingEvents: preflight.shouldInspectPendingEvents,
+  });
+  const blockAsyncRelay = Boolean(asyncRelayPolicy?.blockReason);
+  const shouldUseStoredSessionRoute =
+    asyncRelayPolicy?.useStoredSessionRoute && heartbeat?.target !== "none";
+  const heartbeatDeliveryConfig = shouldUseStoredSessionRoute
+    ? {
+        ...heartbeat,
+        target: "last" as const,
+        to: undefined,
+        accountId: undefined,
+      }
+    : heartbeat;
   const delivery = resolveHeartbeatDeliveryTarget({
     cfg,
     entry,
-    heartbeat,
+    heartbeat: heartbeatDeliveryConfig,
     // Isolated heartbeat runs drain system events from their dedicated
     // `:heartbeat` session, not from the base session we peek during preflight.
     // Reusing base-session turnSource routing here can pin later isolated runs
     // to stale channels/threads because that base-session event context remains queued.
-    turnSource: useIsolatedSession ? undefined : preflight.turnSourceDeliveryContext,
+    turnSource:
+      useIsolatedSession || blockAsyncRelay ? undefined : preflight.turnSourceDeliveryContext,
   });
   const heartbeatAccountId = heartbeat?.accountId?.trim();
   if (delivery.reason === "unknown-account") {
@@ -780,21 +960,21 @@ export async function runHeartbeatOnce(opts: {
           accountId: delivery.accountId,
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
-  const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
   const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId, {
     channel: delivery.channel !== "none" ? delivery.channel : undefined,
     accountId: delivery.accountId,
   }).responsePrefix;
 
-  const canRelayToUser = Boolean(
-    delivery.channel !== "none" && delivery.to && visibility.showAlerts,
-  );
+  const canRelayToUser =
+    !blockAsyncRelay &&
+    Boolean(delivery.channel !== "none" && delivery.to && visibility.showAlerts);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   const { prompt, hasExecCompletion, hasCronEvents } = resolveHeartbeatRunPrompt({
     cfg,
     heartbeat,
     preflight,
     canRelayToUser,
+    suppressExecUserRelay: blockAsyncRelay,
     workspaceDir,
     startedAt,
     heartbeatFileContent: preflight.heartbeatFileContent,
@@ -811,6 +991,22 @@ export async function runHeartbeatOnce(opts: {
     }
     return { status: "skipped", reason: "no-tasks-due" };
   }
+
+  const effectiveDelivery = blockAsyncRelay
+    ? blockHeartbeatUserDeliveryTarget(
+        delivery,
+        asyncRelayPolicy?.blockReason ?? "protected-primary-dm",
+      )
+    : delivery;
+  const effectiveVisibility =
+    effectiveDelivery.channel !== "none"
+      ? resolveHeartbeatVisibility({
+          cfg,
+          channel: effectiveDelivery.channel,
+          accountId: effectiveDelivery.accountId,
+        })
+      : { showOk: false, showAlerts: false, useIndicator: true };
+  const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery: effectiveDelivery });
 
   let runSessionKey = sessionKey;
   if (useIsolatedSession) {
@@ -923,21 +1119,27 @@ export async function runHeartbeatOnce(opts: {
     From: sender,
     To: sender,
     OriginatingChannel:
-      !suppressOriginatingContext && delivery.channel !== "none" ? delivery.channel : undefined,
-    OriginatingTo: !suppressOriginatingContext ? delivery.to : undefined,
-    AccountId: delivery.accountId,
-    MessageThreadId: delivery.threadId,
+      !suppressOriginatingContext && effectiveDelivery.channel !== "none"
+        ? effectiveDelivery.channel
+        : undefined,
+    OriginatingTo: !suppressOriginatingContext ? effectiveDelivery.to : undefined,
+    AccountId: effectiveDelivery.accountId,
+    MessageThreadId: effectiveDelivery.threadId,
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: runSessionKey,
     ForceSenderIsOwnerFalse: hasExecCompletion || hasUntrustedPendingEvents,
   };
-  if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
+  if (
+    !effectiveVisibility.showAlerts &&
+    !effectiveVisibility.showOk &&
+    !effectiveVisibility.useIndicator
+  ) {
     emitHeartbeatEvent({
       status: "skipped",
       reason: "alerts-disabled",
       durationMs: Date.now() - startedAt,
-      channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      accountId: delivery.accountId,
+      channel: effectiveDelivery.channel !== "none" ? effectiveDelivery.channel : undefined,
+      accountId: effectiveDelivery.accountId,
     });
     return { status: "skipped", reason: "alerts-disabled" };
   }
@@ -949,17 +1151,17 @@ export async function runHeartbeatOnce(opts: {
     sessionKey,
   });
   const canAttemptHeartbeatOk = Boolean(
-    visibility.showOk && delivery.channel !== "none" && delivery.to,
+    effectiveVisibility.showOk && effectiveDelivery.channel !== "none" && effectiveDelivery.to,
   );
   const maybeSendHeartbeatOk = async () => {
-    if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
+    if (!canAttemptHeartbeatOk || effectiveDelivery.channel === "none" || !effectiveDelivery.to) {
       return false;
     }
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
+    const heartbeatPlugin = getChannelPlugin(effectiveDelivery.channel);
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
         cfg,
-        accountId: delivery.accountId,
+        accountId: effectiveDelivery.accountId,
         deps: opts.deps,
       });
       if (!readiness.ok) {
@@ -968,10 +1170,10 @@ export async function runHeartbeatOnce(opts: {
     }
     await deliverOutboundPayloads({
       cfg,
-      channel: delivery.channel,
-      to: delivery.to,
-      accountId: delivery.accountId,
-      threadId: delivery.threadId,
+      channel: effectiveDelivery.channel,
+      to: effectiveDelivery.to,
+      accountId: effectiveDelivery.accountId,
+      threadId: effectiveDelivery.threadId,
       payloads: [{ text: heartbeatOkText }],
       session: outboundSession,
       deps: opts.deps,
@@ -1015,10 +1217,12 @@ export async function runHeartbeatOnce(opts: {
         status: "ok-empty",
         reason: opts.reason,
         durationMs: Date.now() - startedAt,
-        channel: delivery.channel !== "none" ? delivery.channel : undefined,
-        accountId: delivery.accountId,
+        channel: effectiveDelivery.channel !== "none" ? effectiveDelivery.channel : undefined,
+        accountId: effectiveDelivery.accountId,
         silent: !okSent,
-        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-empty") : undefined,
+        indicatorType: effectiveVisibility.useIndicator
+          ? resolveIndicatorType("ok-empty")
+          : undefined,
       });
       await updateTaskTimestamps();
       consumeInspectedSystemEvents();
@@ -1052,10 +1256,12 @@ export async function runHeartbeatOnce(opts: {
         status: "ok-token",
         reason: opts.reason,
         durationMs: Date.now() - startedAt,
-        channel: delivery.channel !== "none" ? delivery.channel : undefined,
-        accountId: delivery.accountId,
+        channel: effectiveDelivery.channel !== "none" ? effectiveDelivery.channel : undefined,
+        accountId: effectiveDelivery.accountId,
         silent: !okSent,
-        indicatorType: visibility.useIndicator ? resolveIndicatorType("ok-token") : undefined,
+        indicatorType: effectiveVisibility.useIndicator
+          ? resolveIndicatorType("ok-token")
+          : undefined,
       });
       await updateTaskTimestamps();
       consumeInspectedSystemEvents();
@@ -1091,8 +1297,8 @@ export async function runHeartbeatOnce(opts: {
         preview: normalized.text.slice(0, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: false,
-        channel: delivery.channel !== "none" ? delivery.channel : undefined,
-        accountId: delivery.accountId,
+        channel: effectiveDelivery.channel !== "none" ? effectiveDelivery.channel : undefined,
+        accountId: effectiveDelivery.accountId,
       });
       await updateTaskTimestamps();
       consumeInspectedSystemEvents();
@@ -1107,21 +1313,21 @@ export async function runHeartbeatOnce(opts: {
           .join("\n")
       : normalized.text;
 
-    if (delivery.channel === "none" || !delivery.to) {
+    if (effectiveDelivery.channel === "none" || !effectiveDelivery.to) {
       emitHeartbeatEvent({
         status: "skipped",
-        reason: delivery.reason ?? "no-target",
+        reason: effectiveDelivery.reason ?? "no-target",
         preview: previewText?.slice(0, 200),
         durationMs: Date.now() - startedAt,
         hasMedia: mediaUrls.length > 0,
-        accountId: delivery.accountId,
+        accountId: effectiveDelivery.accountId,
       });
       await updateTaskTimestamps();
       consumeInspectedSystemEvents();
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    if (!visibility.showAlerts) {
+    if (!effectiveVisibility.showAlerts) {
       await updateTaskTimestamps();
       await restoreHeartbeatUpdatedAt({
         storePath,
@@ -1133,17 +1339,17 @@ export async function runHeartbeatOnce(opts: {
         reason: "alerts-disabled",
         preview: previewText?.slice(0, 200),
         durationMs: Date.now() - startedAt,
-        channel: delivery.channel,
+        channel: effectiveDelivery.channel,
         hasMedia: mediaUrls.length > 0,
-        accountId: delivery.accountId,
-        indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
+        accountId: effectiveDelivery.accountId,
+        indicatorType: effectiveVisibility.useIndicator ? resolveIndicatorType("sent") : undefined,
       });
       consumeInspectedSystemEvents();
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    const deliveryAccountId = delivery.accountId;
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
+    const deliveryAccountId = effectiveDelivery.accountId;
+    const heartbeatPlugin = getChannelPlugin(effectiveDelivery.channel);
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
         cfg,
@@ -1157,11 +1363,11 @@ export async function runHeartbeatOnce(opts: {
           preview: previewText?.slice(0, 200),
           durationMs: Date.now() - startedAt,
           hasMedia: mediaUrls.length > 0,
-          channel: delivery.channel,
-          accountId: delivery.accountId,
+          channel: effectiveDelivery.channel,
+          accountId: effectiveDelivery.accountId,
         });
         log.info("heartbeat: channel not ready", {
-          channel: delivery.channel,
+          channel: effectiveDelivery.channel,
           reason: readiness.reason,
         });
         return { status: "skipped", reason: readiness.reason };
@@ -1170,11 +1376,11 @@ export async function runHeartbeatOnce(opts: {
 
     await deliverOutboundPayloads({
       cfg,
-      channel: delivery.channel,
-      to: delivery.to,
+      channel: effectiveDelivery.channel,
+      to: effectiveDelivery.to,
       accountId: deliveryAccountId,
       session: outboundSession,
-      threadId: delivery.threadId,
+      threadId: effectiveDelivery.threadId,
       payloads: [
         ...reasoningPayloads,
         ...(shouldSkipMain
@@ -1205,13 +1411,13 @@ export async function runHeartbeatOnce(opts: {
 
     emitHeartbeatEvent({
       status: "sent",
-      to: delivery.to,
+      to: effectiveDelivery.to,
       preview: previewText?.slice(0, 200),
       durationMs: Date.now() - startedAt,
       hasMedia: mediaUrls.length > 0,
-      channel: delivery.channel,
-      accountId: delivery.accountId,
-      indicatorType: visibility.useIndicator ? resolveIndicatorType("sent") : undefined,
+      channel: effectiveDelivery.channel,
+      accountId: effectiveDelivery.accountId,
+      indicatorType: effectiveVisibility.useIndicator ? resolveIndicatorType("sent") : undefined,
     });
     await updateTaskTimestamps();
     consumeInspectedSystemEvents();
@@ -1222,9 +1428,9 @@ export async function runHeartbeatOnce(opts: {
       status: "failed",
       reason,
       durationMs: Date.now() - startedAt,
-      channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      accountId: delivery.accountId,
-      indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
+      channel: effectiveDelivery.channel !== "none" ? effectiveDelivery.channel : undefined,
+      accountId: effectiveDelivery.accountId,
+      indicatorType: effectiveVisibility.useIndicator ? resolveIndicatorType("failed") : undefined,
     });
     log.error(`heartbeat failed: ${reason}`, { error: reason });
     return { status: "failed", reason };

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -30,7 +30,6 @@ import { getChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelHeartbeatDeps } from "../channels/plugins/types.public.js";
 import { loadConfig } from "../config/config.js";
 import {
-  canonicalizeMainSessionAlias,
   resolveAgentMainSessionKey,
 } from "../config/sessions/main-session.js";
 import { resolveStorePath } from "../config/sessions/paths.js";
@@ -49,13 +48,12 @@ import { CommandLane } from "../process/lanes.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
-  parseAgentSessionKey,
   resolveAgentIdFromSessionKey,
-  toAgentStoreSessionKey,
+  parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { resolveSessionRoute } from "../routing/resolve-route.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import {
-  normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
 import { escapeRegExp } from "../utils.js";
@@ -222,8 +220,14 @@ function resolveHeartbeatSession(
   const sessionCfg = cfg.session;
   const scope = sessionCfg?.scope ?? "per-sender";
   const resolvedAgentId = normalizeAgentId(agentId ?? resolveDefaultAgentId(cfg));
-  const mainSessionKey =
-    scope === "global" ? "global" : resolveAgentMainSessionKey({ cfg, agentId: resolvedAgentId });
+  const mainSessionKey = resolveSessionRoute({
+    cfg,
+    agentId: resolvedAgentId,
+    surface: "heartbeat",
+    sessionScope: scope === "global" ? "global" : "agent",
+    mainKey: cfg.session?.mainKey,
+    appendHeartbeatSuffix: false,
+  }).sessionKey;
   const storeAgentId = scope === "global" ? resolveDefaultAgentId(cfg) : resolvedAgentId;
   const storePath = resolveStorePath(sessionCfg?.store, {
     agentId: storeAgentId,
@@ -241,6 +245,25 @@ function resolveHeartbeatSession(
     };
   }
 
+  const resolveBaseSessionKey = (rawSessionInput?: string) => {
+    const resolved = resolveSessionRoute({
+      cfg,
+      agentId: resolvedAgentId,
+      surface: "heartbeat",
+      rawSessionInput,
+      sessionScope: "agent",
+      mainKey: cfg.session?.mainKey,
+      appendHeartbeatSuffix: false,
+    });
+    if (resolved.sessionKey === "global") {
+      return null;
+    }
+    if (resolveAgentIdFromSessionKey(resolved.sessionKey) !== normalizeAgentId(resolvedAgentId)) {
+      return null;
+    }
+    return resolved.sessionKey;
+  };
+
   // Guard: never route heartbeats to subagent sessions, regardless of entry path.
   const forced = forcedSessionKey?.trim();
   if (forced && isSubagentSessionKey(forced)) {
@@ -254,29 +277,15 @@ function resolveHeartbeatSession(
   }
 
   if (forced && !isSubagentSessionKey(forced)) {
-    const forcedCandidate = toAgentStoreSessionKey({
-      agentId: resolvedAgentId,
-      requestKey: forced,
-      mainKey: cfg.session?.mainKey,
-    });
-    if (!isSubagentSessionKey(forcedCandidate)) {
-      const forcedCanonical = canonicalizeMainSessionAlias({
-        cfg,
-        agentId: resolvedAgentId,
-        sessionKey: forcedCandidate,
-      });
-      if (forcedCanonical !== "global" && !isSubagentSessionKey(forcedCanonical)) {
-        const sessionAgentId = resolveAgentIdFromSessionKey(forcedCanonical);
-        if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {
-          return {
-            sessionKey: forcedCanonical,
-            storePath,
-            store,
-            entry: store[forcedCanonical],
-            suppressOriginatingContext: false,
-          };
-        }
-      }
+    const forcedCanonical = resolveBaseSessionKey(forced);
+    if (forcedCanonical) {
+      return {
+        sessionKey: forcedCanonical,
+        storePath,
+        store,
+        entry: store[forcedCanonical],
+        suppressOriginatingContext: false,
+      };
     }
   }
 
@@ -291,47 +300,15 @@ function resolveHeartbeatSession(
     };
   }
 
-  const normalized = normalizeLowercaseStringOrEmpty(trimmed);
-  if (normalized === "main" || normalized === "global") {
+  const canonical = resolveBaseSessionKey(trimmed);
+  if (canonical) {
     return {
-      sessionKey: mainSessionKey,
+      sessionKey: canonical,
       storePath,
       store,
-      entry: mainEntry,
+      entry: store[canonical],
       suppressOriginatingContext: false,
     };
-  }
-
-  const candidate = toAgentStoreSessionKey({
-    agentId: resolvedAgentId,
-    requestKey: trimmed,
-    mainKey: cfg.session?.mainKey,
-  });
-  if (isSubagentSessionKey(candidate)) {
-    return {
-      sessionKey: mainSessionKey,
-      storePath,
-      store,
-      entry: mainEntry,
-      suppressOriginatingContext: false,
-    };
-  }
-  const canonical = canonicalizeMainSessionAlias({
-    cfg,
-    agentId: resolvedAgentId,
-    sessionKey: candidate,
-  });
-  if (canonical !== "global" && !isSubagentSessionKey(canonical)) {
-    const sessionAgentId = resolveAgentIdFromSessionKey(canonical);
-    if (sessionAgentId === normalizeAgentId(resolvedAgentId)) {
-      return {
-        sessionKey: canonical,
-        storePath,
-        store,
-        entry: store[canonical],
-        suppressOriginatingContext: false,
-      };
-    }
   }
 
   return {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -704,9 +704,9 @@ function resolveAsyncHeartbeatRelayPolicy(params: {
   turnSource?: DeliveryContext;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   shouldInspectPendingEvents: boolean;
-}): AsyncHeartbeatRelayPolicy | false {
+}): AsyncHeartbeatRelayPolicy | undefined {
   if (!params.shouldInspectPendingEvents || params.pendingEventEntries.length === 0) {
-    return false;
+    return undefined;
   }
 
   const baseSessionKey = resolveHeartbeatBaseSessionKey(params.sessionKey, params.entry);

--- a/src/infra/outbound/session-binding.types.ts
+++ b/src/infra/outbound/session-binding.types.ts
@@ -4,7 +4,8 @@ export type SessionBindingPlacement = "current" | "child";
 export type SessionBindingErrorCode =
   | "BINDING_ADAPTER_UNAVAILABLE"
   | "BINDING_CAPABILITY_UNSUPPORTED"
-  | "BINDING_CREATE_FAILED";
+  | "BINDING_CREATE_FAILED"
+  | "BINDING_PROTECTED_CONVERSATION";
 
 export type ConversationRef = {
   channel: string;

--- a/src/plugin-sdk/gateway-runtime.ts
+++ b/src/plugin-sdk/gateway-runtime.ts
@@ -6,5 +6,7 @@ export {
   createOperatorApprovalsGatewayClient,
   withOperatorApprovalsGatewayClient,
 } from "../gateway/operator-approvals-client.js";
+export { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
+export { getActiveTaskCount, getTotalQueueSize } from "../process/command-queue.js";
 export type { EventFrame } from "../gateway/protocol/index.js";
 export type { GatewayRequestHandlerOptions } from "../gateway/server-methods/types.js";

--- a/src/plugin-sdk/routing.ts
+++ b/src/plugin-sdk/routing.ts
@@ -3,7 +3,9 @@ export {
   deriveLastRoutePolicy,
   resolveAgentRoute,
   resolveInboundLastRouteSessionKey,
+  resolveSessionRoute,
   type ResolvedAgentRoute,
+  type ResolvedSessionRoute,
   type RoutePeer,
   type RoutePeerKind,
 } from "../routing/resolve-route.js";

--- a/src/plugin-sdk/status-helpers.ts
+++ b/src/plugin-sdk/status-helpers.ts
@@ -321,6 +321,14 @@ export function buildTokenChannelStatusSummary(
     tokenSource?: string | null;
     running?: boolean | null;
     mode?: string | null;
+    connected?: boolean | null;
+    lastInboundAt?: number | null;
+    lastOutboundAt?: number | null;
+    healthState?: string | null;
+    deliveryTruth?: string | null;
+    transportTruth?: string | null;
+    routeIntegrity?: string | null;
+    sessionStoreIntegrity?: string | null;
     lastStartAt?: number | null;
     lastStopAt?: number | null;
     lastError?: string | null;
@@ -334,6 +342,14 @@ export function buildTokenChannelStatusSummary(
     tokenSource: snapshot.tokenSource ?? "none",
     probe: snapshot.probe,
     lastProbeAt: snapshot.lastProbeAt ?? null,
+    ...(typeof snapshot.connected === "boolean" ? { connected: snapshot.connected } : {}),
+    lastInboundAt: snapshot.lastInboundAt ?? null,
+    lastOutboundAt: snapshot.lastOutboundAt ?? null,
+    healthState: snapshot.healthState ?? null,
+    deliveryTruth: snapshot.deliveryTruth ?? null,
+    transportTruth: snapshot.transportTruth ?? null,
+    routeIntegrity: snapshot.routeIntegrity ?? null,
+    sessionStoreIntegrity: snapshot.sessionStoreIntegrity ?? null,
   };
   if (opts?.includeMode === false) {
     return base;

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -5,6 +5,7 @@ import {
   deriveLastRoutePolicy,
   resolveAgentRoute,
   resolveInboundLastRouteSessionKey,
+  resolveSessionRoute,
 } from "./resolve-route.js";
 
 type ResolvedRouteExpectation = {
@@ -47,6 +48,66 @@ function expectResolvedRoute(
 function createCompatPeer(kind: CompatRoutePeerKind, id: string) {
   return { kind, id } as unknown as NonNullable<Parameters<typeof resolveAgentRoute>[0]["peer"]>;
 }
+
+describe("resolveSessionRoute", () => {
+  test("routes direct Telegram actors through the canonical peer session key", () => {
+    const resolved = resolveSessionRoute({
+      cfg: {
+        session: {
+          dmScope: "per-channel-peer",
+          identityLinks: {
+            thomas: ["telegram:thomas"],
+          },
+        },
+      },
+      agentId: "main",
+      mainKey: "main",
+      surface: "telegram",
+      actor: {
+        provider: "telegram",
+        accountId: "default",
+        from: "thomas",
+        identityLinkKey: "thomas",
+        chatType: "direct",
+        label: "thomas",
+      },
+    });
+
+    expect(resolved.sessionKey).toBe("agent:main:telegram:direct:thomas");
+    expect(resolved.scope).toBe("peer-scoped-direct");
+    expect(resolved.reason).toBe("telegram-peer-direct");
+    expect(resolved.explicit).toBe(false);
+    expect(resolved.surface).toBe("telegram");
+    expect(resolved.resolverVersion).toBe("2026-04-15-route-v1");
+  });
+
+  test("isolates heartbeat sessions from an explicit base session key", () => {
+    const resolved = resolveSessionRoute({
+      agentId: "main",
+      mainKey: "main",
+      surface: "heartbeat",
+      heartbeatBaseSessionKey: "agent:main:telegram:direct:thomas",
+    });
+
+    expect(resolved.sessionKey).toBe("agent:main:telegram:direct:thomas:heartbeat");
+    expect(resolved.scope).toBe("heartbeat-isolated");
+    expect(resolved.reason).toBe("heartbeat-isolated-base-session");
+    expect(resolved.explicit).toBe(true);
+  });
+
+  test("uses the canonical main bucket for blank tui sessions", () => {
+    const resolved = resolveSessionRoute({
+      agentId: "main",
+      mainKey: "main",
+      surface: "tui",
+    });
+
+    expect(resolved.sessionKey).toBe("agent:main:main");
+    expect(resolved.mainSessionKey).toBe("agent:main:main");
+    expect(resolved.scope).toBe("agent-main");
+    expect(resolved.reason).toBe("tui-agent-main");
+  });
+});
 
 describe("resolveAgentRoute", () => {
   const expectDirectRouteSessionKey = (params: {

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -10,6 +10,7 @@ import {
   buildAgentMainSessionKey,
   buildAgentPeerSessionKey,
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   normalizeAccountId,
   normalizeAgentId,
@@ -18,10 +19,65 @@ import {
 
 /** @deprecated Use ChatType from channels/chat-type.js */
 export type RoutePeerKind = ChatType;
+export type RouteSurface = "telegram" | "tui" | "webchat" | "heartbeat" | "cron" | "hook" | "api";
+export type RouteScope =
+  | "agent-main"
+  | "peer-scoped-direct"
+  | "explicit"
+  | "heartbeat-isolated"
+  | "global";
 
 export type RoutePeer = {
   kind: ChatType;
   id: string;
+};
+
+export type RouteActor = {
+  provider?: string | null;
+  accountId?: string | null;
+  from?: string | null;
+  to?: string | null;
+  identityLinkKey?: string | null;
+  chatType?: ChatType | null;
+  label?: string | null;
+};
+
+export type ResolveSessionRouteInput = {
+  cfg?: OpenClawConfig | null;
+  agentId?: string | null;
+  surface?: string | null;
+  rawSessionInput?: string | null;
+  sessionScope?: "agent" | "global";
+  mainKey?: string | null;
+  actor?: RouteActor | null;
+  heartbeatBaseSessionKey?: string | null;
+  appendHeartbeatSuffix?: boolean;
+};
+
+export type SessionRouteProvenance = {
+  provider: string | null;
+  accountId: string | null;
+  from: string | null;
+  to: string | null;
+  identityLinkKey: string | null;
+  chatType: ChatType | null;
+  label: string | null;
+  heartbeatBaseSessionKey: string | null;
+  sessionScope: "agent" | "global";
+  dmScope: OpenClawConfig["session"] extends { dmScope?: infer T } ? T | null : string | null;
+};
+
+export type ResolvedSessionRoute = {
+  agentId: string;
+  sessionKey: string;
+  mainSessionKey: string;
+  scope: RouteScope;
+  reason: string;
+  explicit: boolean;
+  surface: RouteSurface;
+  actorFingerprint: string | null;
+  provenance: SessionRouteProvenance;
+  resolverVersion: typeof ROUTE_RESOLVER_VERSION;
 };
 
 export type ResolveAgentRouteInput = {
@@ -45,6 +101,13 @@ export type ResolvedAgentRoute = {
   sessionKey: string;
   /** Convenience alias for direct-chat collapse. */
   mainSessionKey: string;
+  scope: RouteScope;
+  reason: string;
+  explicit: boolean;
+  surface: RouteSurface;
+  actorFingerprint: string | null;
+  provenance: SessionRouteProvenance;
+  resolverVersion: typeof ROUTE_RESOLVER_VERSION;
   /** Which session should receive inbound last-route updates. */
   lastRoutePolicy: "main" | "session";
   /** Match description for debugging/logging. */
@@ -61,6 +124,8 @@ export type ResolvedAgentRoute = {
 };
 
 export { DEFAULT_ACCOUNT_ID, DEFAULT_AGENT_ID } from "./session-key.js";
+
+const ROUTE_RESOLVER_VERSION = "2026-04-15-route-v1" as const;
 
 export function deriveLastRoutePolicy(params: {
   sessionKey: string;
@@ -113,6 +178,328 @@ export function buildAgentSessionKey(params: {
   });
 }
 
+function normalizeRouteSurface(value: string | undefined | null): RouteSurface {
+  const normalized = normalizeToken(value);
+  if (
+    normalized === "telegram" ||
+    normalized === "tui" ||
+    normalized === "webchat" ||
+    normalized === "heartbeat" ||
+    normalized === "cron" ||
+    normalized === "hook" ||
+    normalized === "api"
+  ) {
+    return normalized;
+  }
+  return "api";
+}
+
+function normalizeRouteScopeFromSessionKey(sessionKey: string | undefined | null): RouteScope {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!normalized) {
+    return "agent-main";
+  }
+  if (normalized === "global") {
+    return "global";
+  }
+  if (normalized.endsWith(":heartbeat")) {
+    return "heartbeat-isolated";
+  }
+  if (/:direct:/.test(normalized)) {
+    return "peer-scoped-direct";
+  }
+  if (/^agent:[^:]+:main$/.test(normalized)) {
+    return "agent-main";
+  }
+  if (/^agent:[^:]+:explicit:/.test(normalized)) {
+    return "explicit";
+  }
+  return "explicit";
+}
+
+function buildRouteActorFingerprint(actor: RouteActor | null): string | null {
+  if (!actor) {
+    return null;
+  }
+  const parts = [
+    actor.provider ?? "",
+    actor.accountId ?? "",
+    actor.chatType ?? "",
+    actor.from ?? "",
+    actor.to ?? "",
+    actor.identityLinkKey ?? "",
+  ];
+  return parts.every((value) => value === "") ? null : parts.join("|");
+}
+
+function normalizeRouteActor(
+  actor: RouteActor | undefined | null,
+  fallbackSurface: RouteSurface,
+): {
+  provider: string | null;
+  accountId: string;
+  from: string | null;
+  to: string | null;
+  identityLinkKey: string | null;
+  chatType: ChatType | null;
+  label: string | null;
+} | null {
+  if (!actor || typeof actor !== "object") {
+    return null;
+  }
+  const provider = normalizeToken(actor.provider ?? fallbackSurface);
+  const accountId = normalizeAccountId(actor.accountId);
+  const from = normalizeToken(actor.from);
+  const to = normalizeToken(actor.to);
+  const identityLinkKey = normalizeToken(actor.identityLinkKey);
+  const normalizedChatType = normalizeChatType(actor.chatType ?? undefined);
+  const chatType =
+    normalizedChatType ??
+    (normalizeToken(actor.chatType) === "direct"
+      ? "direct"
+      : normalizeToken(actor.chatType) === "group"
+        ? "group"
+        : normalizeToken(actor.chatType) === "channel"
+          ? "channel"
+          : null);
+  const label = normalizeId(actor.label);
+  if (!(provider || accountId || from || to || identityLinkKey || chatType || label)) {
+    return null;
+  }
+  return {
+    provider: provider || null,
+    accountId,
+    from: from || null,
+    to: to || null,
+    identityLinkKey: identityLinkKey || null,
+    chatType,
+    label: label || null,
+  };
+}
+
+function resolveRoutePeerId(
+  actor:
+    | {
+        identityLinkKey: string | null;
+        from: string | null;
+        to: string | null;
+        label: string | null;
+      }
+    | null,
+): string | null {
+  if (!actor) {
+    return null;
+  }
+  if (actor.identityLinkKey) {
+    return actor.identityLinkKey;
+  }
+  if (actor.from) {
+    return actor.from;
+  }
+  if (actor.to) {
+    return actor.to;
+  }
+  if (actor.label) {
+    return actor.label;
+  }
+  return null;
+}
+
+function normalizeExplicitRouteSessionKey(
+  rawSessionInput: string | undefined | null,
+  agentId: string,
+  mainKey: string,
+): string {
+  const trimmed = normalizeId(rawSessionInput);
+  const lowered = normalizeToken(trimmed);
+  const canonicalMainSessionKey = buildAgentMainSessionKey({ agentId, mainKey });
+  const canonicalMainAliasKey = buildAgentMainSessionKey({
+    agentId,
+    mainKey: DEFAULT_MAIN_KEY,
+  });
+  const legacyMainSessionKey = buildAgentMainSessionKey({
+    agentId: DEFAULT_AGENT_ID,
+    mainKey,
+  });
+  const legacyMainAliasKey = buildAgentMainSessionKey({
+    agentId: DEFAULT_AGENT_ID,
+    mainKey: DEFAULT_MAIN_KEY,
+  });
+  if (!trimmed) {
+    return canonicalMainSessionKey;
+  }
+  if (lowered === "global" || lowered === "unknown") {
+    return lowered;
+  }
+  if (
+    lowered === "main" ||
+    lowered === normalizeToken(mainKey) ||
+    lowered === canonicalMainSessionKey ||
+    lowered === canonicalMainAliasKey ||
+    lowered === legacyMainSessionKey ||
+    lowered === legacyMainAliasKey
+  ) {
+    return canonicalMainSessionKey;
+  }
+  if (lowered.startsWith("agent:")) {
+    return normalizeLowercaseStringOrEmpty(trimmed);
+  }
+  return `agent:${normalizeAgentId(agentId)}:${normalizeLowercaseStringOrEmpty(trimmed)}`;
+}
+
+function normalizeHeartbeatSessionKey(sessionKey: string): string {
+  const normalized = normalizeLowercaseStringOrEmpty(sessionKey);
+  if (!normalized || normalized === "global") {
+    return normalized || "global";
+  }
+  return normalized.endsWith(":heartbeat")
+    ? normalized.replace(/(:heartbeat)+$/u, ":heartbeat")
+    : `${normalized}:heartbeat`;
+}
+
+function resolveHeartbeatBaseSessionKey(params: {
+  agentId: string;
+  mainKey: string;
+  sessionScope: "agent" | "global";
+  rawSessionInput?: string | null;
+  heartbeatBaseSessionKey?: string | null;
+}): string {
+  if (params.sessionScope === "global") {
+    return "global";
+  }
+  if (params.heartbeatBaseSessionKey?.trim()) {
+    return normalizeExplicitRouteSessionKey(
+      params.heartbeatBaseSessionKey,
+      params.agentId,
+      params.mainKey,
+    );
+  }
+  if (params.rawSessionInput?.trim()) {
+    return normalizeExplicitRouteSessionKey(params.rawSessionInput, params.agentId, params.mainKey);
+  }
+  return buildAgentMainSessionKey({
+    agentId: params.agentId,
+    mainKey: params.mainKey,
+  });
+}
+
+function resolveActorSessionKey(params: {
+  cfg?: OpenClawConfig | null;
+  agentId: string;
+  mainKey: string;
+  actor: NonNullable<ReturnType<typeof normalizeRouteActor>>;
+}): string {
+  if (!params.actor.chatType || !params.actor.provider) {
+    return buildAgentMainSessionKey({
+      agentId: params.agentId,
+      mainKey: params.mainKey,
+    });
+  }
+  const peerId = resolveRoutePeerId(params.actor);
+  return buildAgentPeerSessionKey({
+    agentId: params.agentId,
+    mainKey: params.mainKey,
+    channel: params.actor.provider,
+    accountId: params.actor.accountId ?? DEFAULT_ACCOUNT_ID,
+    peerKind: params.actor.chatType,
+    peerId,
+    dmScope: params.cfg?.session?.dmScope,
+    identityLinks: params.cfg?.session?.identityLinks,
+  });
+}
+
+export function resolveSessionRoute(input: ResolveSessionRouteInput): ResolvedSessionRoute {
+  const cfg = input?.cfg && typeof input.cfg === "object" ? input.cfg : undefined;
+  const surface = normalizeRouteSurface(input?.surface);
+  const sessionScope = input?.sessionScope === "global" ? "global" : "agent";
+  const mainKey = normalizeToken(input?.mainKey) || DEFAULT_MAIN_KEY;
+  const agentId = pickFirstExistingAgentId(cfg, input?.agentId);
+  const actor = normalizeRouteActor(input?.actor, surface);
+  const mainSessionKey =
+    sessionScope === "global"
+      ? "global"
+      : normalizeLowercaseStringOrEmpty(
+          buildAgentMainSessionKey({
+            agentId,
+            mainKey,
+          }),
+        );
+  const explicitInput = normalizeId(input?.rawSessionInput);
+
+  let sessionKey = mainSessionKey;
+  let reason = `${surface}-agent-main`;
+  let explicit = false;
+
+  if (sessionScope === "global") {
+    sessionKey = "global";
+    reason = `${surface}-global`;
+  } else if (surface === "heartbeat") {
+    const baseSessionKey = resolveHeartbeatBaseSessionKey({
+      agentId,
+      mainKey,
+      sessionScope,
+      rawSessionInput: explicitInput,
+      heartbeatBaseSessionKey: input?.heartbeatBaseSessionKey,
+    });
+    if (input?.appendHeartbeatSuffix === false) {
+      sessionKey = baseSessionKey;
+      explicit = Boolean(explicitInput || input?.heartbeatBaseSessionKey);
+      reason = input?.heartbeatBaseSessionKey?.trim()
+        ? "heartbeat-base-session"
+        : explicitInput
+          ? "heartbeat-explicit-base"
+          : "heartbeat-agent-main-base";
+    } else {
+      sessionKey = normalizeHeartbeatSessionKey(baseSessionKey);
+      explicit = Boolean(explicitInput || input?.heartbeatBaseSessionKey);
+      reason = input?.heartbeatBaseSessionKey?.trim()
+        ? "heartbeat-isolated-base-session"
+        : explicitInput
+          ? "heartbeat-isolated-explicit"
+          : "heartbeat-isolated-agent-main";
+    }
+  } else if (explicitInput) {
+    sessionKey = normalizeExplicitRouteSessionKey(explicitInput, agentId, mainKey);
+    explicit = true;
+    reason = `${surface}-explicit-session`;
+  } else if (actor?.provider && actor.chatType) {
+    sessionKey = normalizeLowercaseStringOrEmpty(
+      resolveActorSessionKey({
+        cfg,
+        agentId,
+        mainKey,
+        actor,
+      }),
+    );
+    reason = actor.chatType === "direct" ? `${surface}-peer-direct` : `${surface}-peer`;
+  }
+
+  const scope = normalizeRouteScopeFromSessionKey(sessionKey);
+  return {
+    agentId,
+    sessionKey,
+    mainSessionKey,
+    scope,
+    reason,
+    explicit,
+    surface,
+    actorFingerprint: buildRouteActorFingerprint(actor),
+    provenance: {
+      provider: actor?.provider ?? null,
+      accountId: actor?.accountId ?? null,
+      from: actor?.from ?? null,
+      to: actor?.to ?? null,
+      identityLinkKey: actor?.identityLinkKey ?? null,
+      chatType: actor?.chatType ?? null,
+      label: actor?.label ?? null,
+      heartbeatBaseSessionKey: input?.heartbeatBaseSessionKey?.trim() || null,
+      sessionScope,
+      dmScope: cfg?.session?.dmScope ?? null,
+    },
+    resolverVersion: ROUTE_RESOLVER_VERSION,
+  };
+}
+
 function listAgents(cfg: OpenClawConfig) {
   const agents = cfg.agents?.list;
   return Array.isArray(agents) ? agents : [];
@@ -150,7 +537,14 @@ function resolveAgentLookupCache(cfg: OpenClawConfig): AgentLookupCache {
   return next;
 }
 
-export function pickFirstExistingAgentId(cfg: OpenClawConfig, agentId: string): string {
+export function pickFirstExistingAgentId(
+  cfg: OpenClawConfig | null | undefined,
+  agentId: string | undefined | null,
+): string {
+  if (!cfg || typeof cfg !== "object") {
+    const trimmed = (agentId ?? "").trim();
+    return trimmed ? sanitizeAgentId(trimmed) : "main";
+  }
   const lookup = resolveAgentLookupCache(cfg);
   const trimmed = (agentId ?? "").trim();
   if (!trimmed) {
@@ -678,28 +1072,39 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
-    const sessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentSessionKey({
-        agentId: resolvedAgentId,
-        channel,
-        accountId,
-        peer,
-        dmScope,
-        identityLinks,
-      }),
-    );
-    const mainSessionKey = normalizeLowercaseStringOrEmpty(
-      buildAgentMainSessionKey({
-        agentId: resolvedAgentId,
-        mainKey: DEFAULT_MAIN_KEY,
-      }),
-    );
+    const resolved = resolveSessionRoute({
+      cfg: input.cfg,
+      agentId: resolvedAgentId,
+      surface: channel || "api",
+      sessionScope: "agent",
+      actor: peer
+        ? {
+            provider: channel,
+            accountId,
+            from: normalizeId(peer.id),
+            to: normalizeId(peer.id),
+            chatType: peer.kind,
+          }
+        : {
+            provider: channel,
+            accountId,
+          },
+    });
+    const sessionKey = resolved.sessionKey;
+    const mainSessionKey = resolved.mainSessionKey;
     const route = {
       agentId: resolvedAgentId,
       channel,
       accountId,
       sessionKey,
       mainSessionKey,
+      scope: resolved.scope,
+      reason: resolved.reason,
+      explicit: resolved.explicit,
+      surface: resolved.surface,
+      actorFingerprint: resolved.actorFingerprint,
+      provenance: resolved.provenance,
+      resolverVersion: resolved.resolverVersion,
       lastRoutePolicy: deriveLastRoutePolicy({ sessionKey, mainSessionKey }),
       matchedBy,
     };

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -19,9 +19,14 @@ import {
   __testing as sessionBindingTesting,
   getSessionBindingService,
 } from "../infra/outbound/session-binding-service.js";
-import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
+import {
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "../infra/system-events.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
+import { completeTaskRunByRunId, createRunningTaskRun } from "./task-executor.js";
 import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
 import { configureTaskFlowRegistryRuntime } from "./task-flow-registry.store.js";
 import {
@@ -600,7 +605,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("reroutes protected Telegram ACP completions to the bound child thread instead of the primary DM", async () => {
+  it("queues protected Telegram ACP completions on the bound child lane instead of the primary DM", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -622,13 +627,6 @@ describe("task-registry", () => {
           parentConversationId: "-1007777777777",
         },
       });
-      hoisted.sendMessageMock.mockResolvedValue({
-        channel: "telegram",
-        to: "-1007777777777",
-        threadId: "77",
-        via: "direct",
-      });
-
       createTaskRecord({
         runtime: "acp",
         ownerKey: "agent:main:telegram:direct:thomas",
@@ -647,19 +645,94 @@ describe("task-registry", () => {
       });
 
       await waitForAssertion(() =>
-        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
-          expect.objectContaining({
+        expect(findTaskByRunId("run-protected-thread-bound")).toMatchObject({
+          status: "succeeded",
+          deliveryStatus: "session_queued",
+        }),
+      );
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      expect(peekSystemEvents("agent:main:telegram:direct:thomas")).toEqual([]);
+      expect(peekSystemEventEntries("agent:codex:acp:protected-child")).toEqual([
+        expect.objectContaining({
+          text: expect.stringContaining("Completed safely in the child lane."),
+          deliveryContext: {
             channel: "telegram",
             to: "-1007777777777",
+            accountId: "default",
             threadId: "77",
-            mirror: expect.objectContaining({
-              sessionKey: "agent:codex:acp:protected-child",
-            }),
-          }),
-        ),
+          },
+        }),
+      ]);
+    });
+  });
+
+  it("keeps protected Telegram managed ACP completions on the child session lane with bound delivery context", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      sessionBindingTesting.resetSessionBindingAdaptersForTests();
+      await telegramThreadBindingsTesting.resetTelegramThreadBindingsForTests();
+      createTelegramThreadBindingManager({
+        accountId: "default",
+        persist: false,
+        enableSweeper: false,
+      });
+      const childSessionKey = "agent:codex:acp:protected-managed-child";
+      await getSessionBindingService().bind({
+        targetSessionKey: childSessionKey,
+        targetKind: "session",
+        placement: "current",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-1007777777777:topic:88",
+          parentConversationId: "-1007777777777",
+        },
+      });
+
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:main:telegram:direct:thomas",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:8582659364",
+          accountId: "default",
+        },
+        childSessionKey,
+        runId: "run-protected-managed",
+        task: "Investigate issue",
+        startedAt: 10,
+      });
+
+      completeTaskRunByRunId({
+        runId: "run-protected-managed",
+        runtime: "acp",
+        sessionKey: childSessionKey,
+        terminalSummary: "Completed safely in the child lane.",
+        endedAt: 40,
+        lastEventAt: 40,
+      });
+
+      await waitForAssertion(() =>
+        expect(findTaskByRunId("run-protected-managed")).toMatchObject({
+          status: "succeeded",
+          deliveryStatus: "session_queued",
+        }),
       );
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
       expect(peekSystemEvents("agent:main:telegram:direct:thomas")).toEqual([]);
-      expect(peekSystemEvents("agent:codex:acp:protected-child")).toEqual([]);
+      expect(peekSystemEventEntries(childSessionKey)).toEqual([
+        expect.objectContaining({
+          text: expect.stringContaining("Completed safely in the child lane."),
+          deliveryContext: {
+            channel: "telegram",
+            to: "-1007777777777",
+            accountId: "default",
+            threadId: "88",
+          },
+        }),
+      ]);
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as telegramThreadBindingsTesting,
+  createTelegramThreadBindingManager,
+} from "../../extensions/telegram/src/thread-bindings.js";
 import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
 import { startAcpSpawnParentStreamRelay } from "../agents/acp-spawn-parent-stream.js";
 import { resetCronActiveJobsForTests } from "../cron/active-jobs.js";
@@ -11,6 +15,10 @@ import {
   hasPendingHeartbeatWake,
   resetHeartbeatWakeStateForTests,
 } from "../infra/heartbeat-wake.js";
+import {
+  __testing as sessionBindingTesting,
+  getSessionBindingService,
+} from "../infra/outbound/session-binding-service.js";
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
@@ -215,7 +223,7 @@ describe("task-registry", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
     if (ORIGINAL_STATE_DIR === undefined) {
       delete process.env.OPENCLAW_STATE_DIR;
@@ -231,6 +239,8 @@ describe("task-registry", () => {
     resetTaskRegistryMaintenanceRuntimeForTests();
     resetTaskRegistryForTests({ persist: false });
     resetTaskFlowRegistryForTests({ persist: false });
+    sessionBindingTesting.resetSessionBindingAdaptersForTests();
+    await telegramThreadBindingsTesting.resetTelegramThreadBindingsForTests();
     hoisted.sendMessageMock.mockReset();
     hoisted.cancelSessionMock.mockReset();
     hoisted.killSubagentRunAdminMock.mockReset();
@@ -587,6 +597,149 @@ describe("task-registry", () => {
         ),
       );
       expect(peekSystemEvents("agent:main:main")).toEqual([]);
+    });
+  });
+
+  it("reroutes protected Telegram ACP completions to the bound child thread instead of the primary DM", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      sessionBindingTesting.resetSessionBindingAdaptersForTests();
+      await telegramThreadBindingsTesting.resetTelegramThreadBindingsForTests();
+      createTelegramThreadBindingManager({
+        accountId: "default",
+        persist: false,
+        enableSweeper: false,
+      });
+      await getSessionBindingService().bind({
+        targetSessionKey: "agent:codex:acp:protected-child",
+        targetKind: "session",
+        placement: "current",
+        conversation: {
+          channel: "telegram",
+          accountId: "default",
+          conversationId: "-1007777777777:topic:77",
+          parentConversationId: "-1007777777777",
+        },
+      });
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "telegram",
+        to: "-1007777777777",
+        threadId: "77",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:telegram:direct:thomas",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:8582659364",
+          accountId: "default",
+        },
+        childSessionKey: "agent:codex:acp:protected-child",
+        runId: "run-protected-thread-bound",
+        task: "Investigate issue",
+        status: "succeeded",
+        deliveryStatus: "pending",
+        terminalSummary: "Completed safely in the child lane.",
+      });
+
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "telegram",
+            to: "-1007777777777",
+            threadId: "77",
+            mirror: expect.objectContaining({
+              sessionKey: "agent:codex:acp:protected-child",
+            }),
+          }),
+        ),
+      );
+      expect(peekSystemEvents("agent:main:telegram:direct:thomas")).toEqual([]);
+      expect(peekSystemEvents("agent:codex:acp:protected-child")).toEqual([]);
+    });
+  });
+
+  it("fails closed to the ACP child session when the protected Telegram DM has no safe bound destination", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      hoisted.sendMessageMock.mockClear();
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:telegram:direct:thomas",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:8582659364",
+          accountId: "default",
+        },
+        childSessionKey: "agent:codex:acp:protected-fail-closed",
+        runId: "run-protected-fail-closed",
+        task: "Investigate issue",
+        status: "succeeded",
+        deliveryStatus: "pending",
+        terminalSummary: "Held safely in the child lane.",
+      });
+
+      await waitForAssertion(() =>
+        expect(findTaskByRunId("run-protected-fail-closed")).toMatchObject({
+          status: "succeeded",
+          deliveryStatus: "session_queued",
+        }),
+      );
+      expect(hoisted.sendMessageMock).not.toHaveBeenCalled();
+      expect(peekSystemEvents("agent:main:telegram:direct:thomas")).toEqual([]);
+      expect(peekSystemEvents("agent:codex:acp:protected-fail-closed")).toEqual([
+        "Background task done: ACP background task (run run-prot). Held safely in the child lane.",
+      ]);
+    });
+  });
+
+  it("keeps non-protected Telegram ACP completions on their direct requester lane", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "telegram",
+        to: "telegram:8582659364",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:telegram:atlas:direct:thomas",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:8582659364",
+          accountId: "atlas",
+        },
+        childSessionKey: "agent:codex:acp:atlas-direct",
+        runId: "run-atlas-direct",
+        task: "Investigate issue",
+        status: "succeeded",
+        deliveryStatus: "pending",
+        terminalSummary: "Delivered directly to the named account lane.",
+      });
+
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "telegram",
+            to: "telegram:8582659364",
+            accountId: "atlas",
+            mirror: expect.objectContaining({
+              sessionKey: "agent:main:telegram:atlas:direct:thomas",
+            }),
+          }),
+        ),
+      );
+      expect(peekSystemEvents("agent:main:telegram:atlas:direct:thomas")).toEqual([]);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1031,6 +1031,21 @@ function canDeliverTaskToRequesterOrigin(task: TaskRecord): boolean {
   return Boolean(channel && to && isDeliverableMessageChannel(channel));
 }
 
+function shouldQueueProtectedPrimaryTelegramTerminalUpdate(
+  task: TaskRecord,
+  owner: TaskDeliveryOwner,
+): boolean {
+  const childSessionKey = normalizeOptionalString(task.childSessionKey);
+  const ownerSessionKey = normalizeOptionalString(owner.sessionKey);
+  return Boolean(
+    task.runtime === "acp" &&
+      task.scopeKind === "session" &&
+      isProtectedPrimaryTelegramOwnerSessionKey(task.ownerKey) &&
+      childSessionKey &&
+      ownerSessionKey === childSessionKey,
+  );
+}
+
 function resolveMissingOwnerDeliveryStatus(task: TaskRecord): TaskDeliveryStatus {
   return task.scopeKind === "system" ? "not_applicable" : "parent_missing";
 }
@@ -1110,7 +1125,10 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
       });
     }
     const eventText = formatTaskTerminalMessage(latest);
-    if (!canDeliverTaskToRequesterOrigin(latest)) {
+    if (
+      shouldQueueProtectedPrimaryTelegramTerminalUpdate(latest, owner) ||
+      !canDeliverTaskToRequesterOrigin(latest)
+    ) {
       try {
         queueTaskSystemEvent(latest, eventText);
         if (latest.terminalOutcome === "blocked") {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -4,10 +4,12 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
+import { createBoundDeliveryRouter } from "../infra/outbound/bound-delivery-router.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { resolveConversationDeliveryTarget } from "../utils/delivery-context.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
 import { isDeliverableMessageChannel } from "../utils/message-channel.js";
 import {
@@ -89,6 +91,64 @@ type TaskDeliveryOwner = {
   requesterOrigin?: TaskDeliveryState["requesterOrigin"];
   flowId?: string;
 };
+
+function isProtectedPrimaryTelegramOwnerSessionKey(sessionKey?: string): boolean {
+  const normalized = normalizeOptionalString(sessionKey);
+  return Boolean(normalized && /^agent:[^:]+:telegram:direct:[^:]+$/u.test(normalized));
+}
+
+function resolveProtectedPrimaryTelegramAcpDeliveryOwner(
+  task: TaskRecord,
+  owner: TaskDeliveryOwner,
+): TaskDeliveryOwner {
+  const childSessionKey = normalizeOptionalString(task.childSessionKey);
+  if (
+    task.runtime !== "acp" ||
+    task.scopeKind !== "session" ||
+    !childSessionKey ||
+    !isProtectedPrimaryTelegramOwnerSessionKey(owner.sessionKey)
+  ) {
+    return owner;
+  }
+
+  const route = createBoundDeliveryRouter().resolveDestination({
+    eventKind: "task_completion",
+    targetSessionKey: childSessionKey,
+    failClosed: true,
+  });
+  if (route.mode === "bound" && route.binding) {
+    const telegramTopicMatch =
+      route.binding.conversation.channel === "telegram"
+        ? /^(-?\d+):topic:(\d+)$/u.exec(route.binding.conversation.conversationId)
+        : null;
+    const boundTarget = telegramTopicMatch
+      ? {
+          to: telegramTopicMatch[1],
+          threadId: telegramTopicMatch[2],
+        }
+      : resolveConversationDeliveryTarget({
+          channel: route.binding.conversation.channel,
+          conversationId: route.binding.conversation.conversationId,
+          parentConversationId: route.binding.conversation.parentConversationId,
+        });
+    return {
+      sessionKey: childSessionKey,
+      requesterOrigin: normalizeDeliveryContext({
+        channel: route.binding.conversation.channel,
+        accountId: route.binding.conversation.accountId,
+        to: boundTarget.to,
+        threadId: boundTarget.threadId,
+      }),
+      flowId: owner.flowId,
+    };
+  }
+
+  return {
+    sessionKey: childSessionKey,
+    requesterOrigin: undefined,
+    flowId: owner.flowId,
+  };
+}
 
 export type ParentFlowLinkErrorCode =
   | "scope_kind_not_session"
@@ -784,21 +844,21 @@ function getLinkedFlowForDelivery(task: TaskRecord) {
 function resolveTaskDeliveryOwner(task: TaskRecord): TaskDeliveryOwner {
   const flow = getLinkedFlowForDelivery(task);
   if (flow) {
-    return {
+    return resolveProtectedPrimaryTelegramAcpDeliveryOwner(task, {
       sessionKey: flow.ownerKey.trim(),
       requesterOrigin: normalizeDeliveryContext(
         flow.requesterOrigin ?? taskDeliveryStates.get(task.taskId)?.requesterOrigin,
       ),
       flowId: flow.flowId,
-    };
+    });
   }
   if (task.scopeKind !== "session") {
     return {};
   }
-  return {
+  return resolveProtectedPrimaryTelegramAcpDeliveryOwner(task, {
     sessionKey: task.ownerKey.trim(),
     requesterOrigin: normalizeDeliveryContext(taskDeliveryStates.get(task.taskId)?.requesterOrigin),
-  };
+  });
 }
 
 function syncManagedFlowCancellationFromTask(task: TaskRecord): void {

--- a/src/terminal/health-style.ts
+++ b/src/terminal/health-style.ts
@@ -24,6 +24,9 @@ export function styleHealthChannelLine(line: string, rich: boolean): string {
   if (normalized.startsWith("ok")) {
     return applyPrefix("ok", theme.success);
   }
+  if (normalized.startsWith("degraded")) {
+    return applyPrefix("degraded", theme.warn);
+  }
   if (normalized.startsWith("linked")) {
     return applyPrefix("linked", theme.success);
   }

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -51,7 +51,7 @@ function createMockBtwPresenter(): MockBtwPresenter & HandlerBtwPresenter {
 describe("tui-event-handlers: handleAgentEvent", () => {
   const makeState = (overrides?: Partial<TuiStateAccess>): TuiStateAccess => ({
     agentDefaultId: "main",
-    sessionMainKey: "agent:main:main",
+    sessionMainKey: "main",
     sessionScope: "global",
     agents: [],
     currentAgentId: "main",

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -30,7 +30,7 @@ describe("tui session actions", () => {
 
     const state: TuiStateAccess = {
       agentDefaultId: "main",
-      sessionMainKey: "agent:main:main",
+      sessionMainKey: "main",
       sessionScope: "global",
       agents: [],
       currentAgentId: "main",
@@ -136,7 +136,7 @@ describe("tui session actions", () => {
 
     const state: TuiStateAccess = {
       agentDefaultId: "main",
-      sessionMainKey: "agent:main:main",
+      sessionMainKey: "main",
       sessionScope: "global",
       agents: [],
       currentAgentId: "main",
@@ -222,7 +222,7 @@ describe("tui session actions", () => {
 
     const state: TuiStateAccess = {
       agentDefaultId: "main",
-      sessionMainKey: "agent:main:main",
+      sessionMainKey: "main",
       sessionScope: "global",
       agents: [],
       currentAgentId: "main",
@@ -300,7 +300,7 @@ describe("tui session actions", () => {
 
     const state: TuiStateAccess = {
       agentDefaultId: "main",
-      sessionMainKey: "agent:main:main",
+      sessionMainKey: "main",
       sessionScope: "global",
       agents: [],
       currentAgentId: "main",

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -89,7 +89,8 @@ export function createSessionActions(context: SessionActionContext) {
         state.currentAgentId =
           state.agents[0]?.id ?? normalizeAgentId(result.defaultId ?? state.currentAgentId);
       }
-      const nextSessionKey = resolveSessionKey(initialSessionInput);
+      const nextSessionInput = initialSessionInput || "";
+      const nextSessionKey = resolveSessionKey(nextSessionInput);
       if (nextSessionKey !== state.currentSessionKey) {
         state.currentSessionKey = nextSessionKey;
       }

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -58,13 +58,13 @@ describe("tui slash commands", () => {
 });
 
 describe("resolveTuiSessionKey", () => {
-  it("uses global only as the default when scope is global", () => {
+  it("keeps the session global when scope is global", () => {
     expect(
       resolveTuiSessionKey({
         raw: "",
         sessionScope: "global",
         currentAgentId: "main",
-        sessionMainKey: "agent:main:main",
+        sessionMainKey: "main",
       }),
     ).toBe("global");
     expect(
@@ -72,18 +72,18 @@ describe("resolveTuiSessionKey", () => {
         raw: "test123",
         sessionScope: "global",
         currentAgentId: "main",
-        sessionMainKey: "agent:main:main",
+        sessionMainKey: "main",
       }),
-    ).toBe("agent:main:test123");
+    ).toBe("global");
   });
 
   it("keeps explicit agent-prefixed keys unchanged", () => {
     expect(
       resolveTuiSessionKey({
         raw: "agent:ops:incident",
-        sessionScope: "global",
+        sessionScope: "per-sender",
         currentAgentId: "main",
-        sessionMainKey: "agent:main:main",
+        sessionMainKey: "main",
       }),
     ).toBe("agent:ops:incident");
   });
@@ -93,18 +93,18 @@ describe("resolveTuiSessionKey", () => {
     expect(
       resolveTuiSessionKey({
         raw: "agent:main:Test1",
-        sessionScope: "global",
+        sessionScope: "per-sender",
         currentAgentId: "main",
-        sessionMainKey: "agent:main:main",
+        sessionMainKey: "main",
       }),
     ).toBe("agent:main:test1");
     // Uppercase in bare form (prefixed by currentAgentId)
     expect(
       resolveTuiSessionKey({
         raw: "Test1",
-        sessionScope: "global",
+        sessionScope: "per-sender",
         currentAgentId: "main",
-        sessionMainKey: "agent:main:main",
+        sessionMainKey: "main",
       }),
     ).toBe("agent:main:test1");
   });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -11,12 +11,11 @@ import {
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { loadConfig, type OpenClawConfig } from "../config/config.js";
 import {
-  buildAgentMainSessionKey,
   normalizeAgentId,
   normalizeMainKey,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
-import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { resolveSessionRoute } from "../routing/resolve-route.js";
 import { getSlashCommands } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
@@ -51,28 +50,24 @@ export {
 } from "./tui-submit.js";
 
 export function resolveTuiSessionKey(params: {
+  cfg?: OpenClawConfig;
   raw?: string;
   sessionScope: SessionScope;
   currentAgentId: string;
   sessionMainKey: string;
 }) {
-  const trimmed = (params.raw ?? "").trim();
-  if (!trimmed) {
-    if (params.sessionScope === "global") {
-      return "global";
-    }
-    return buildAgentMainSessionKey({
-      agentId: params.currentAgentId,
-      mainKey: params.sessionMainKey,
-    });
-  }
-  if (trimmed === "global" || trimmed === "unknown") {
-    return trimmed;
-  }
-  if (trimmed.startsWith("agent:")) {
-    return normalizeLowercaseStringOrEmpty(trimmed);
-  }
-  return `agent:${params.currentAgentId}:${normalizeLowercaseStringOrEmpty(trimmed)}`;
+  return resolveSessionRoute({
+    cfg: params.cfg,
+    agentId: params.currentAgentId,
+    surface: "tui",
+    rawSessionInput: (params.raw ?? "").trim() || undefined,
+    sessionScope: params.sessionScope === "global" ? "global" : "agent",
+    mainKey: params.sessionMainKey,
+  }).sessionKey;
+}
+
+function resolveConfiguredTuiDefaultSessionInput(_cfg: OpenClawConfig, _agentId: string) {
+  return null;
 }
 
 export function resolveInitialTuiAgentId(params: {
@@ -472,6 +467,7 @@ export async function runTui(opts: TuiOptions) {
 
   const resolveSessionKey = (raw?: string) => {
     return resolveTuiSessionKey({
+      cfg: config,
       raw,
       sessionScope,
       currentAgentId,
@@ -479,7 +475,9 @@ export async function runTui(opts: TuiOptions) {
     });
   };
 
-  currentSessionKey = resolveSessionKey(initialSessionInput);
+  const configuredDefaultSessionInput =
+    initialSessionInput || resolveConfiguredTuiDefaultSessionInput(config, currentAgentId) || "";
+  currentSessionKey = resolveSessionKey(configuredDefaultSessionInput);
 
   const updateHeader = () => {
     const sessionLabel = formatSessionKey(currentSessionKey);


### PR DESCRIPTION
**Summary**
Ports the proven installed-dist stability remediation into OpenClaw source for `v2026.4.14` so the fixes survive rebuilds and future updates.

**What Changed**
- Added canonical session-route resolution across Telegram, TUI, heartbeat, cron, API, and webchat.
- Added load-time session-store self-heal for legacy heartbeat provenance contradictions and moved session artifacts/Telegram sidecars out of live session storage.
- Upgraded session write locks to structured lease-style payloads with ownership metadata.
- Made Telegram poller stall handling lane-aware so busy processing is distinguished from dead transport.
- Improved overflow recovery when provider token counts are missing by synthesizing recovery token estimates and preserving token-count provenance.
- Surfaced route/store/delivery/transport truth through status and health, and degraded health instead of masking contradictions as healthy.
- Added and updated regression tests for routing, self-heal, lock hygiene, Telegram polling, overflow recovery, TUI behavior, and health/status output.

**Validation**
- `pnpm test src/routing/resolve-route.test.ts src/config/sessions/store.session-key-normalization.test.ts src/tui/tui.test.ts src/tui/tui-session-actions.test.ts src/cron/isolated-agent/run.session-key.test.ts src/gateway/http-utils.request-context.test.ts src/agents/session-write-lock.test.ts extensions/telegram/src/polling-session.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/commands/health.test.ts src/commands/health.command.coverage.test.ts`
- `pnpm build`
- `OPENCLAW_DIST_ROOT=dist node ~/.openclaw/workspace/scripts/openclaw-route-matrix.mjs --json`
- Rebuilt-dist smoke passed for heartbeat self-heal, structured lock payloads, Telegram poller markers, and overflow recovery markers.

**Remaining Risk**
This is a broad cross-cutting change touching routing, persistence, heartbeat, Telegram runtime, health/status, and plugin-sdk seams. The code-level and rebuilt-dist validations are strong, but real operational durability still depends on live traffic and fault-injection coverage that was not run here.
