### PR TITLE
fix(tts): strip stray closing [[/tts:text]] variants to stop caption leak

### DIFF
--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -6,7 +6,7 @@ const OPEN_POLICY: SpeechModelOverridePolicy = {
   enabled: true,
   allowProvider: true,
   allowVoice: true,
-  allowModel: true,
+  allowModelId: true,
   allowText: true,
   allowVoiceSettings: true,
 };
@@ -33,6 +33,9 @@ describe("parseTtsDirectives", () => {
       { providers: [] },
     );
     expect(result.cleanedText).toBe("spoken content");
+    // blockRegex never fires on the malformed input, so ttsText stays unset —
+    // downstream TTS falls back to cleanedText instead of overrides.ttsText.
+    expect(result.ttsText).toBeUndefined();
     expect(result.hasDirective).toBe(true);
   });
 
@@ -46,7 +49,7 @@ describe("parseTtsDirectives", () => {
     expect(result.hasDirective).toBe(true);
   });
 
-  it("strips a stray '/tts:text]]' closer with no leading brackets", () => {
+  it("strips a stray '[/tts:text]]' closer with a single leading bracket", () => {
     const result = parseTtsDirectives(
       "hello [/tts:text]] world",
       OPEN_POLICY,

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { parseTtsDirectives } from "./directives.js";
+import type { SpeechModelOverridePolicy } from "./provider-types.js";
+
+const OPEN_POLICY: SpeechModelOverridePolicy = {
+  enabled: true,
+  allowProvider: true,
+  allowVoice: true,
+  allowModel: true,
+  allowText: true,
+  allowVoiceSettings: true,
+};
+
+describe("parseTtsDirectives", () => {
+  it("strips a well-paired [[tts:text]]...[[/tts:text]] block and captures the text", () => {
+    const result = parseTtsDirectives(
+      "[[tts:voiceId=XXX model=eleven_v3]][[tts:text]]spoken content[[/tts:text]]",
+      OPEN_POLICY,
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("");
+    expect(result.ttsText).toBe("spoken content");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("strips a stray '[/tts:text]]' closing tag that does not pair with an opener (#67343)", () => {
+    // Reporter's exact symptom: the caption leaked `spoken content[/tts:text]]`
+    // because the model emitted a single '[' before the closer, so the paired
+    // blockRegex did not match and the closer survived.
+    const result = parseTtsDirectives(
+      "[[tts:voiceId=XXX model=eleven_v3]][[tts:text]]spoken content[/tts:text]]",
+      OPEN_POLICY,
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("spoken content");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("strips a stray '[[/tts:text]' closer that is missing a trailing ']'", () => {
+    const result = parseTtsDirectives(
+      "[[tts:text]]content[[/tts:text]",
+      OPEN_POLICY,
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("content");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("strips a stray '/tts:text]]' closer with no leading brackets", () => {
+    const result = parseTtsDirectives(
+      "hello [/tts:text]] world",
+      OPEN_POLICY,
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("hello  world");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("tolerates whitespace inside a stray closer", () => {
+    const result = parseTtsDirectives(
+      "[[tts:text]]content[[ / tts : text ]]",
+      OPEN_POLICY,
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("content");
+    expect(result.hasDirective).toBe(true);
+  });
+
+  it("leaves unrelated text that merely mentions 'tts:text' untouched", () => {
+    const result = parseTtsDirectives("this mentions tts:text in prose", OPEN_POLICY, {
+      providers: [],
+    });
+    expect(result.cleanedText).toBe("this mentions tts:text in prose");
+    // No opener and no closer-shaped tokens → no directive.
+    expect(result.hasDirective).toBe(false);
+  });
+
+  it("returns the raw text verbatim when the policy is disabled", () => {
+    const result = parseTtsDirectives(
+      "[[tts:text]]content[/tts:text]]",
+      { ...OPEN_POLICY, enabled: false },
+      { providers: [] },
+    );
+    expect(result.cleanedText).toBe("[[tts:text]]content[/tts:text]]");
+    expect(result.hasDirective).toBe(false);
+  });
+});

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -9,6 +9,8 @@ const OPEN_POLICY: SpeechModelOverridePolicy = {
   allowModelId: true,
   allowText: true,
   allowVoiceSettings: true,
+  allowNormalization: true,
+  allowSeed: true,
 };
 
 describe("parseTtsDirectives", () => {

--- a/src/tts/directives.ts
+++ b/src/tts/directives.ts
@@ -62,6 +62,18 @@ export function parseTtsDirectives(
     return "";
   });
 
+  // Defensive cleanup for stray closing tags that do not pair with an opener.
+  // The model sometimes emits a malformed closer (single `[`, extra `]`, stray
+  // slash, etc.) which left visible text like "[/tts:text]]" in the Telegram
+  // voice-note caption even though the audio itself rendered correctly. See
+  // #67343. Matches the canonical closer plus the common one-bracket-off
+  // variants; the opener side is already covered below by directiveRegex.
+  const strayClosingRegex = /\[{1,2}\s*\/\s*tts\s*:\s*text\s*\]{1,2}/gi;
+  cleanedText = cleanedText.replace(strayClosingRegex, () => {
+    hasDirective = true;
+    return "";
+  });
+
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;


### PR DESCRIPTION
## What

`src/tts/directives.ts` — run a tolerant "stray closer" regex between the paired `blockRegex` and the single-directive `directiveRegex`:

```ts
const strayClosingRegex = /\[{1,2}\s*\/\s*tts\s*:\s*text\s*\]{1,2}/gi;
cleanedText = cleanedText.replace(strayClosingRegex, () => {
  hasDirective = true;
  return "";
});
```

The paired regex still does the primary work (captures the inner text into `overrides.ttsText`); the new one is a defensive cleanup for malformed closers that escape the paired match.

## Why

Fixes #67343.

The canonical block regex requires both `[[tts:text]]` and `[[/tts:text]]`. When the agent emits a slightly malformed closer — single `[` before the slash, a missing `]`, whitespace padding, or a stray `/tts:text]]` without the leading brackets — the paired regex does not match and the `[[tts:text]]` opener gets swept up later by `directiveRegex`, leaving the closer in the output text.

Reporter (@KurtVogel) observed the caption rendering `spoken content[/tts:text]]` on Telegram voice notes: audio was right (ElevenLabs still synthesised the inner span), but the Telegram caption showed the stray closer.

Reproduced directly against the old code:

| input | before | after |
|-------|--------|-------|
| `[[tts:text]]spoken[[/tts:text]]` | `""` | `""` (unchanged) |
| `[[tts:text]]spoken[/tts:text]]` | **`"spoken[/tts:text]]"`** | **`"spoken"`** |
| `[[tts:text]]spoken[[/tts:text]` | `"spoken[[/tts:text]" " | `"spoken"` |
| `[[tts:text]]spoken[[ / tts : text ]]` | `"spoken[[ / tts : text ]]"` | `"spoken"` |
| prose mentioning `tts:text` | unchanged | unchanged |

## Test

New file `src/tts/directives.test.ts` with 7 cases (all paired, all stray closers covered above, prose-preservation, and policy-disabled passthrough).

```
pnpm test -- src/tts/directives.test.ts
# Test Files  1 passed
# Tests       7 passed
```

This test suite runs in the `unit-fast` project (not the `runtime-config` one that has a pre-existing non-isolated-runner infra bug), so CI exercises the new coverage.

## Risk

Low. The stray regex only matches shapes that look like a TTS `[/tts:text]` closer — it requires the literal `tts:text` string with a forward slash. Adjacent prose ("this mentions tts:text in prose") is left alone by the `/\s*\/\s*tts\s*:\s*text\s*/` slash-before-tts anchor. The `hasDirective` flag is set when the stray closer fires, matching the existing contract so downstream delivery paths know something was stripped.