### PR TITLE
fix(heartbeat): route outbound mirror to isolated session key

### DIFF
--- a/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
+++ b/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
@@ -60,7 +60,7 @@ describe("runHeartbeatOnce – isolated session outbound mirror routing", () => 
 
       const deliverSpy = vi
         .spyOn(deliverModule, "deliverOutboundPayloads")
-        .mockResolvedValue(undefined);
+        .mockResolvedValue([]);
       const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
       replySpy.mockResolvedValue({ text: "Heartbeat reply" });
 
@@ -98,7 +98,7 @@ describe("runHeartbeatOnce – isolated session outbound mirror routing", () => 
 
       const deliverSpy = vi
         .spyOn(deliverModule, "deliverOutboundPayloads")
-        .mockResolvedValue(undefined);
+        .mockResolvedValue([]);
       const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
       replySpy.mockResolvedValue({ text: "Heartbeat reply" });
 

--- a/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
+++ b/src/infra/heartbeat-runner.isolated-session-mirror.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as replyModule from "../auto-reply/reply.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+import * as deliverModule from "./outbound/deliver.js";
+import { resetSystemEventsForTest } from "./system-events.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  resetSystemEventsForTest();
+});
+
+/**
+ * Regression: when `heartbeat.isolatedSession: true`, the outbound delivery's
+ * `session.key` must be the isolated `:heartbeat` session key, NOT the base
+ * session key.
+ *
+ * Why this matters: outbound delivery uses `session.key` to resolve the mirror
+ * sessionKey passed to `appendAssistantMessageToSessionTranscript`. When the
+ * base key is used, the heartbeat assistant text is appended to the base
+ * session's `sessionFile` instead of the isolated heartbeat session's file.
+ * That leaves the isolated session entry registered in `sessions.json` with a
+ * `sessionFile` path that is never created on disk, breaking heartbeat
+ * transcript history and causing downstream consumers (e.g. file-watchers) to
+ * miscategorize heartbeat output as DM messages.
+ *
+ * Fixes: #56941, #57577
+ */
+describe("runHeartbeatOnce – isolated session outbound mirror routing", () => {
+  function makeIsolatedHeartbeatConfig(tmpDir: string, storePath: string): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: tmpDir,
+          heartbeat: {
+            every: "5m",
+            target: "whatsapp",
+            isolatedSession: true,
+          },
+        },
+      },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      session: { store: storePath },
+    };
+  }
+
+  it("uses the isolated :heartbeat session key for outbound mirror, not the base key", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const expectedIsolatedKey = `${baseSessionKey}:heartbeat`;
+
+      await seedSessionStore(storePath, baseSessionKey, {
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+1555",
+      });
+
+      const deliverSpy = vi
+        .spyOn(deliverModule, "deliverOutboundPayloads")
+        .mockResolvedValue(undefined);
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "Heartbeat reply" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: baseSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(deliverSpy).toHaveBeenCalled();
+      const deliverCall = deliverSpy.mock.calls[0]?.[0];
+      expect(deliverCall?.session?.key).toBe(expectedIsolatedKey);
+      // Must NOT be the base key — that would cause the mirror append to write
+      // to the base session's sessionFile.
+      expect(deliverCall?.session?.key).not.toBe(baseSessionKey);
+    });
+  });
+
+  it("uses the isolated key on wake re-entry from an already-suffixed session", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedKey = `${baseSessionKey}:heartbeat`;
+
+      await seedSessionStore(storePath, isolatedKey, {
+        sessionId: "sid",
+        updatedAt: 1,
+        lastChannel: "whatsapp",
+        lastProvider: "whatsapp",
+        lastTo: "+1555",
+      });
+
+      const deliverSpy = vi
+        .spyOn(deliverModule, "deliverOutboundPayloads")
+        .mockResolvedValue(undefined);
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "Heartbeat reply" });
+
+      // Simulate wake handler passing an already-suffixed key.
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+        },
+      });
+
+      expect(deliverSpy).toHaveBeenCalled();
+      const deliverCall = deliverSpy.mock.calls[0]?.[0];
+      // Key should remain stable at the single :heartbeat suffix and be used
+      // as the outbound session key (not double-suffixed, not the base key).
+      expect(deliverCall?.session?.key).toBe(isolatedKey);
+    });
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -966,10 +966,17 @@ export async function runHeartbeatOnce(opts: {
   }
 
   const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
+  // Use runSessionKey so that when isolatedSession is enabled, outbound delivery
+  // mirrors the assistant transcript to the isolated `:heartbeat` session's
+  // sessionFile rather than the base session's. Without this, the heartbeat
+  // run's assistant message is appended to the base session transcript file —
+  // the isolated session entry is created in sessions.json but its sessionFile
+  // is never written to disk, breaking transcript history for the heartbeat.
+  // Fixes: #56941, #57577
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId,
-    sessionKey,
+    sessionKey: runSessionKey,
   });
   const canAttemptHeartbeatOk = Boolean(
     visibility.showOk && delivery.channel !== "none" && delivery.to,


### PR DESCRIPTION
## Summary

When `heartbeat.isolatedSession: true`, the heartbeat runner correctly creates a fresh isolated session at `<base>:heartbeat` and runs the agent against it. However, **outbound delivery (and the transcript mirror it triggers) was keyed off the BASE session**, not the isolated one.

Result: the isolated heartbeat session is registered in `sessions.json` with a `sessionFile` path that is never written to disk, while the heartbeat assistant text gets appended to the *base* session's transcript file.

Fixes #56941
Fixes #57577

## Root cause

`src/infra/heartbeat-runner.ts:838-893` correctly sets `runSessionKey = isolatedSessionKey` for isolated heartbeats. But a few lines later (line 969-973), `outboundSession` is built from the original `sessionKey`:

```ts
const outboundSession = buildOutboundSessionContext({
  cfg,
  agentId,
  sessionKey,  // ← base key, not runSessionKey
});
```

`deliverOutboundPayloads` (in `outbound/deliver.ts`) then resolves the mirror sessionKey via `params.mirror?.sessionKey ?? params.session?.key` and calls `appendAssistantMessageToSessionTranscript({ sessionKey: <base>, ... })`. The append walks `sessions.json[<base>]` and writes to that entry's `sessionFile` — leaving the isolated heartbeat session entry's `sessionFile` orphaned (registered, never created on disk).

## Why claude-cli backends mask the bug

Claude CLI manages its own session files at `~/.claude/projects/`, so OpenClaw never writes a transcript for those backends regardless. The bug only manifests visibly for backends where OpenClaw owns transcript writing (`openai-codex`, `anthropic`, etc.). For those backends, downstream consumers (file-watchers, external dashboards reading `sessions.json`) miscategorize heartbeat output as DM messages because the JSONL file's owning session key in the registry is the base session, not the heartbeat session.

## Fix

Pass `runSessionKey` to `buildOutboundSessionContext`. One-line change.

```diff
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId,
-    sessionKey,
+    sessionKey: runSessionKey,
   });
```

For non-isolated heartbeats, `runSessionKey === sessionKey`, so this is a no-op. For isolated heartbeats, it routes the outbound delivery and transcript mirror to the correct isolated session.

## Test

Added `src/infra/heartbeat-runner.isolated-session-mirror.test.ts` with two cases:

1. **Fresh base key**: runner invoked with the base session key, isolated session is created, delivery's `session.key` must equal `<base>:heartbeat`.
2. **Wake re-entry**: runner invoked with an already-suffixed `<base>:heartbeat` key (simulating wake handler re-entry), delivery's `session.key` must remain stable at the single suffix.

Verified the test fails on `main` (`Received: "agent:main:main"`) and passes after the fix.

## Test plan

- [x] New test passes locally with the fix
- [x] Existing `heartbeat-runner.isolated-key-stability.test.ts` (11 tests) still passes
- [ ] CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)