### PR TITLE
feat(memory): per-agent dreaming control

### DIFF
--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -507,7 +507,7 @@ By default, dreaming runs for all agents. You can disable dreaming for specific 
       { id: "main", dreaming: { enabled: false } },
       { id: "oracle", dreaming: { enabled: false } },
       { id: "librarian" },
-    ]
+    ],
   },
   plugins: {
     entries: {

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -496,6 +496,35 @@ For conceptual behavior and slash commands, see [Dreaming](/concepts/dreaming).
 | `enabled`   | `boolean` | `false`     | Enable or disable dreaming entirely               |
 | `frequency` | `string`  | `0 3 * * *` | Optional cron cadence for the full dreaming sweep |
 
+### Per-agent dreaming control
+
+By default, dreaming runs for all agents. You can disable dreaming for specific agents by setting `dreaming.enabled = false` in the agent configuration:
+
+```json5
+{
+  agents: {
+    list: [
+      { id: "main", dreaming: { enabled: false } },
+      { id: "oracle", dreaming: { enabled: false } },
+      { id: "librarian" },
+    ]
+  },
+  plugins: {
+    entries: {
+      "memory-core": {
+        config: {
+          dreaming: {
+            enabled: true,
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+In this example, `main` and `oracle` will not run dreaming, but `librarian` will (inheriting the global `enabled: true`).
+
 ### Example
 
 ```json5

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -7303,6 +7303,15 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   description:
                     "Optional runtime descriptor for this agent. Use embedded for default OpenClaw execution or acp for external ACP harness defaults.",
                 },
+                dreaming: {
+                  type: "object",
+                  properties: {
+                    enabled: {
+                      type: "boolean",
+                    },
+                  },
+                  additionalProperties: false,
+                },
               },
               required: ["id"],
               additionalProperties: false,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -119,6 +119,11 @@ export type AgentConfig = {
   tools?: AgentToolsConfig;
   /** Optional runtime descriptor for this agent. */
   runtime?: AgentRuntimeConfig;
+  /** Optional per-agent dreaming overrides. */
+  dreaming?: {
+    /** Set to false to disable dreaming for this agent. */
+    enabled?: boolean;
+  };
 };
 
 export type AgentsConfig = {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -860,6 +860,12 @@ export const AgentEntrySchema = z
     params: z.record(z.string(), z.unknown()).optional(),
     tools: AgentToolsSchema,
     runtime: AgentRuntimeSchema,
+    dreaming: z
+      .object({
+        enabled: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/memory-host-sdk/dreaming.test.ts
+++ b/src/memory-host-sdk/dreaming.test.ts
@@ -160,6 +160,38 @@ describe("memory dreaming host helpers", () => {
     ]);
   });
 
+  it("filters out agents with dreaming.enabled = false", () => {
+    resolveAgentWorkspaceDir.mockImplementation((_cfg: OpenClawConfig, agentId: string) => {
+      return `/workspace/${agentId}`;
+    });
+
+    const cfg = {
+      agents: {
+        list: [
+          { id: "alpha" },
+          { id: "beta", dreaming: { enabled: false } },
+          { id: "gamma", dreaming: { enabled: true } },
+          { id: "delta" },
+        ],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveMemoryDreamingWorkspaces(cfg)).toEqual([
+      {
+        workspaceDir: "/workspace/alpha",
+        agentIds: ["alpha"],
+      },
+      {
+        workspaceDir: "/workspace/gamma",
+        agentIds: ["gamma"],
+      },
+      {
+        workspaceDir: "/workspace/delta",
+        agentIds: ["delta"],
+      },
+    ]);
+  });
+
   it("uses default agent fallback and timezone-aware day helpers", () => {
     resolveDefaultAgentId.mockReturnValue("fallback");
     const cfg = {} as OpenClawConfig;

--- a/src/memory-host-sdk/dreaming.ts
+++ b/src/memory-host-sdk/dreaming.ts
@@ -600,6 +600,9 @@ export function resolveMemoryDreamingWorkspaces(cfg: OpenClawConfig): MemoryDrea
     if (!entry || typeof entry !== "object" || typeof entry.id !== "string") {
       continue;
     }
+    if (entry.dreaming?.enabled === false) {
+      continue;
+    }
     const id = normalizeOptionalLowercaseString(entry.id);
     if (!id || seenAgents.has(id)) {
       continue;


### PR DESCRIPTION
## Summary

Add ability to selectively enable/disable dreaming for specific agents, addressing OOM issues when all agents run dreaming simultaneously.

## Problem

Gateway was killed by OOM Killer (exceeding 6GB MemoryMax) because all 13 agents ran dreaming simultaneously at 3AM cron.

## Solution

- Add `dreaming.enabled` option to `AgentConfig` type
- Modify `resolveMemoryDreamingWorkspaces()` to skip agents with `dreaming.enabled = false`

## Usage

```json
{
  "agents": {
    "list": [
      { "id": "main", "dreaming": { "enabled": false } },
      { "id": "oracle", "dreaming": { "enabled": false } }
    ]
  }
}
```

Fixes #67413