### PR TITLE
fix(ui): add aria-label to icon-only buttons missing accessible names

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -778,6 +778,7 @@ export function renderChat(props: ChatProps) {
       class="chat-thread"
       role="log"
       aria-live="polite"
+      aria-busy=${isBusy ? "true" : "false"}
       @scroll=${props.onChatScroll}
       @click=${handleCodeBlockCopy}
     >


### PR DESCRIPTION
## Summary

Fixes WCAG 2.1 SC 4.1.2 (Name, Role, Value) violations on icon-only buttons that had a \`title\` tooltip but no \`aria-label\`, causing screen readers to announce them as plain "button" with no context.

## Files changed

**\`ui/src/ui/views/markdown-sidebar.ts\`**
- Close sidebar button: add \`aria-label="Close sidebar"\`

**\`ui/src/ui/app-render.helpers.ts\`**
- Refresh button: add \`aria-label\` mirroring \`title\`
- Thinking toggle: add \`aria-label\` mirroring \`title\`
- Tool calls toggle: add \`aria-label\` mirroring \`title\`
- Focus mode toggle: add \`aria-label\` mirroring \`title\`
- Cron filter toggle: add \`aria-label\` mirroring \`title\`

**\`ui/src/ui/chat/grouped-render.ts\`**
- Tool message collapse button: add \`aria-label\` reflecting current expanded/collapsed state ("Expand tool calls" / "Collapse tool calls")

**\`ui/src/ui/views/chat.ts\`**
- Add \`aria-busy="true"\` to the \`role="log"\` live region while a response is streaming, and \`"false"\` once streaming ends. This suppresses noisy token-by-token announcements in NVDA/JAWS during generation; the completed response is then announced cleanly. Trade-off: users cannot follow along mid-stream with a screen reader.

## Test plan

- [ ] Open Control UI with a screen reader (VoiceOver / NVDA)
- [ ] Tab to each affected button and confirm it announces its purpose
- [ ] Start a streaming response — confirm no token-by-token announcements during streaming; confirm the completed message is announced once streaming finishes
- [ ] Confirm no visual change