### PR TITLE
fix(ui): add aria-label to pinned message Unpin button

### DIFF
--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -995,6 +995,7 @@ function renderPinnedSection(
                         requestUpdate();
                       }}
                       title="Unpin"
+                      aria-label="Unpin"
                     >
                       ${icons.x}
                     </button>


### PR DESCRIPTION
## Summary

The icon-only Unpin button in the pinned messages section had a `title="Unpin"` tooltip but no `aria-label`, so screen readers announced it as plain "button" with no context.

**Fix:** Add `aria-label="Unpin"` to match the existing `title`.

## Files changed

- `ui/src/ui/views/chat.ts` — 1 line added

## Test plan

- [ ] Pin a message in the Control UI
- [ ] Tab to the Unpin button with a screen reader — confirm it announces "Unpin"
- [ ] Confirm no visual change