### PR TITLE
fix(status): share model resolution and lock group activation defaults

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -288,4 +288,21 @@ describe("resolveContextTokensForModel", () => {
 
     expect(result).toBe(160_000);
   });
+
+  it("uses canonical openai-codex gpt-5.4 context tokens when read-only callers cannot warm discovery", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        },
+      } as never,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(272_000);
+  });
 });

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -381,6 +381,26 @@ function isAnthropic1MModel(provider: string, model: string): boolean {
   return ANTHROPIC_1M_MODEL_PREFIXES.some((prefix) => modelId.startsWith(prefix));
 }
 
+function resolveKnownProviderModelContextTokens(params: {
+  provider?: string;
+  model?: string;
+}): number | undefined {
+  const provider = normalizeProviderId(params.provider ?? "");
+  const normalized = normalizeLowercaseStringOrEmpty(params.model ?? "");
+  const model = normalized.includes("/")
+    ? (normalized.split("/").at(-1) ?? normalized)
+    : normalized;
+
+  // Match the runtime forward-compat metadata used by the embedded runner so
+  // read-only status/session callers do not fall all the way back to the
+  // generic 200k default for the modern Codex GPT-5.4 lane.
+  if (provider === "openai-codex" && (model === "gpt-5.4" || model === "gpt-5.4-codex")) {
+    return 272_000;
+  }
+
+  return undefined;
+}
+
 export function resolveContextTokensForModel(params: {
   cfg?: OpenClawConfig;
   provider?: string;
@@ -389,8 +409,12 @@ export function resolveContextTokensForModel(params: {
   fallbackContextTokens?: number;
   allowAsyncLoad?: boolean;
 }): number | undefined {
-  if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
-    return params.contextTokensOverride;
+  const contextTokensOverride =
+    typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0
+      ? Math.floor(params.contextTokensOverride)
+      : undefined;
+  if (contextTokensOverride !== undefined) {
+    return contextTokensOverride;
   }
 
   const ref = resolveProviderModelRef({
@@ -464,6 +488,14 @@ export function resolveContextTokensForModel(params: {
     if (qualifiedResult !== undefined) {
       return qualifiedResult;
     }
+  }
+
+  const knownContextTokens = resolveKnownProviderModelContextTokens({
+    provider: ref?.provider ?? params.provider,
+    model: ref?.model ?? params.model,
+  });
+  if (knownContextTokens !== undefined) {
+    return knownContextTokens;
   }
 
   return params.fallbackContextTokens;

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -186,6 +186,8 @@ function createCommandsStatusRuntimeModuleMock() {
       includeTranscriptUsage?: boolean;
       taskLineOverride?: string;
       resolveDefaultThinkingLevel?: () => unknown;
+      isGroup?: boolean;
+      defaultGroupActivation?: () => "always" | "mention";
     }) => {
       resolveQueueSettingsMock({
         channel: params.statusChannel,
@@ -222,6 +224,10 @@ function createCommandsStatusRuntimeModuleMock() {
             configuredAgent?.thinkingDefault ?? (await params.resolveDefaultThinkingLevel?.()),
         },
         sessionEntry: params.sessionEntry,
+        groupActivation:
+          params.isGroup && typeof params.defaultGroupActivation === "function"
+            ? params.defaultGroupActivation()
+            : undefined,
         modelAuth,
         includeTranscriptUsage: params.includeTranscriptUsage,
       });
@@ -912,6 +918,46 @@ describe("session_status tool", () => {
         }),
       }),
     );
+  });
+
+  it("derives default group activation from channel config when no session override exists", async () => {
+    const savedConfig = mockConfig;
+    try {
+      resetSessionStore({
+        main: {
+          sessionId: "status-group-default",
+          updatedAt: 10,
+          channel: "discord",
+          chatType: "channel",
+          groupId: "channel:123",
+        },
+      });
+
+      mockConfig = {
+        ...createMockConfig(),
+        channels: {
+          discord: {
+            groups: {
+              "*": { requireMention: false },
+            },
+          },
+        },
+        tools: {
+          agentToAgent: { enabled: false },
+        },
+      };
+
+      const tool = getSessionStatusTool();
+
+      await tool.execute("call-group-default-activation", {});
+
+      const firstCall = buildStatusMessageMock.mock.calls[0]?.[0] as {
+        groupActivation?: string;
+      };
+      expect(firstCall?.groupActivation).toBe("always");
+    } finally {
+      mockConfig = savedConfig;
+    }
   });
 
   it("resolves sessionId inputs", async () => {

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -6,6 +6,7 @@ import type {
   VerboseLevel,
 } from "../../auto-reply/thinking.js";
 import { loadConfig } from "../../config/config.js";
+import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import {
   loadSessionStore,
   resolveStorePath,
@@ -515,6 +516,25 @@ export function createSessionStatusTool(opts?: {
         relatedSessionKey: resolved.key,
         callerOwnerKey: visibilityRequesterKey,
       });
+      const statusChannel =
+        statusSessionEntry.channel ??
+        statusSessionEntry.lastChannel ??
+        statusSessionEntry.origin?.provider ??
+        "unknown";
+      const defaultGroupActivation = () => {
+        if (!isGroup) {
+          return "mention" as const;
+        }
+        return resolveChannelGroupRequireMention({
+          cfg,
+          channel: statusChannel as never,
+          groupId: statusSessionEntry.groupId,
+          accountId:
+            statusSessionEntry.lastAccountId ?? statusSessionEntry.deliveryContext?.accountId,
+        })
+          ? "mention"
+          : "always";
+      };
       const { buildStatusText } = await loadCommandsStatusRuntime();
       const statusText = await buildStatusText({
         cfg,
@@ -523,11 +543,7 @@ export function createSessionStatusTool(opts?: {
         parentSessionKey: statusSessionEntry.parentSessionKey,
         sessionScope: cfg.session?.scope,
         storePath,
-        statusChannel:
-          statusSessionEntry.channel ??
-          statusSessionEntry.lastChannel ??
-          statusSessionEntry.origin?.provider ??
-          "unknown",
+        statusChannel,
         provider: providerForCard,
         model: defaultModelForCard,
         resolvedThinkLevel: statusSessionEntry.thinkingLevel as ThinkLevel | undefined,
@@ -537,7 +553,7 @@ export function createSessionStatusTool(opts?: {
         resolvedElevatedLevel: statusSessionEntry.elevatedLevel as ElevatedLevel | undefined,
         resolveDefaultThinkingLevel: async () => cfg.agents?.defaults?.thinkingDefault,
         isGroup,
-        defaultGroupActivation: () => "mention",
+        defaultGroupActivation,
         taskLineOverride: taskLine,
         skipDefaultTaskLookup: true,
         primaryModelLabelOverride: primaryModelLabel,

--- a/src/commands/status.summary.runtime.test.ts
+++ b/src/commands/status.summary.runtime.test.ts
@@ -39,6 +39,23 @@ describe("statusSummaryRuntime.resolveContextTokensForModel", () => {
 
     expect(contextTokens).toBe(272_000);
   });
+
+  it("uses canonical openai-codex gpt-5.4 context tokens instead of the generic 200k fallback", () => {
+    const contextTokens = statusSummaryRuntime.resolveContextTokensForModel({
+      cfg: {
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+        },
+      } as never,
+      provider: "openai-codex",
+      model: "gpt-5.4",
+      allowAsyncLoad: false,
+    });
+
+    expect(contextTokens).toBe(272_000);
+  });
 });
 
 describe("statusSummaryRuntime.resolveSessionModelRef", () => {

--- a/src/commands/status.summary.runtime.ts
+++ b/src/commands/status.summary.runtime.ts
@@ -1,7 +1,7 @@
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveContextTokensForModel as resolveSharedContextTokensForModel } from "../agents/context.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { parseModelRef, resolvePersistedSelectedModelRef } from "../agents/model-selection.js";
-import { normalizeProviderId } from "../agents/provider-id.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -88,40 +88,6 @@ function resolveConfiguredStatusModelRef(params: {
   return { provider: params.defaultProvider, model: params.defaultModel };
 }
 
-function resolveConfiguredProviderContextTokens(
-  cfg: OpenClawConfig | undefined,
-  provider: string,
-  model: string,
-): number | undefined {
-  const providers = cfg?.models?.providers;
-  if (!providers || typeof providers !== "object") {
-    return undefined;
-  }
-  const providerKey = normalizeProviderId(provider);
-  for (const [id, providerConfig] of Object.entries(providers)) {
-    if (normalizeProviderId(id) !== providerKey || !Array.isArray(providerConfig?.models)) {
-      continue;
-    }
-    for (const entry of providerConfig.models) {
-      const contextTokens =
-        typeof entry?.contextTokens === "number"
-          ? entry.contextTokens
-          : typeof entry?.contextWindow === "number"
-            ? entry.contextWindow
-            : undefined;
-      if (
-        typeof entry?.id === "string" &&
-        entry.id === model &&
-        typeof contextTokens === "number" &&
-        contextTokens > 0
-      ) {
-        return contextTokens;
-      }
-    }
-  }
-  return undefined;
-}
-
 function classifySessionKey(key: string, entry?: SessionEntry) {
   if (key === "global") {
     return "global";
@@ -170,21 +136,7 @@ function resolveContextTokensForModel(params: {
   fallbackContextTokens?: number;
   allowAsyncLoad?: boolean;
 }): number | undefined {
-  void params.allowAsyncLoad;
-  if (typeof params.contextTokensOverride === "number" && params.contextTokensOverride > 0) {
-    return params.contextTokensOverride;
-  }
-  if (params.provider && params.model) {
-    const configuredContextTokens = resolveConfiguredProviderContextTokens(
-      params.cfg,
-      params.provider,
-      params.model,
-    );
-    if (configuredContextTokens !== undefined) {
-      return configuredContextTokens;
-    }
-  }
-  return params.fallbackContextTokens ?? DEFAULT_CONTEXT_TOKENS;
+  return resolveSharedContextTokensForModel(params);
 }
 
 export const statusSummaryRuntime = {

--- a/src/gateway/http-utils.model-override.test.ts
+++ b/src/gateway/http-utils.model-override.test.ts
@@ -13,7 +13,7 @@ vi.mock("./server-model-catalog.js", () => ({
   loadGatewayModelCatalog: () => loadGatewayModelCatalogMock(),
 }));
 
-import { resolveOpenAiCompatModelOverride } from "./http-utils.js";
+import { resolveAgentIdFromModel, resolveOpenAiCompatModelOverride } from "./http-utils.js";
 
 function createReq(headers: Record<string, string> = {}): IncomingMessage {
   return { headers } as IncomingMessage;
@@ -29,6 +29,7 @@ describe("resolveOpenAiCompatModelOverride", () => {
             "openai/gpt-5.4": {},
           },
         },
+        list: [{ id: "main" }, { id: "hephaestus" }],
       },
     } satisfies OpenClawConfig);
     loadGatewayModelCatalogMock
@@ -45,6 +46,35 @@ describe("resolveOpenAiCompatModelOverride", () => {
       }),
     ).resolves.toEqual({
       errorMessage: "Model 'claude-cli/opus' is not allowed for agent 'main'.",
+    });
+  });
+
+  it("treats openclaw provider-model forms as model overrides, not agent ids", async () => {
+    await expect(
+      resolveOpenAiCompatModelOverride({
+        req: createReq(),
+        agentId: "main",
+        model: "openclaw/openai/gpt-5.4",
+      }),
+    ).resolves.toEqual({
+      modelOverride: "openai/gpt-5.4",
+    });
+  });
+
+  it("still treats openclaw single-segment forms as agent ids when configured", () => {
+    expect(resolveAgentIdFromModel("openclaw/hephaestus")).toBe("hephaestus");
+  });
+
+  it("rejects invalid openclaw body model forms that are neither agent ids nor provider models", async () => {
+    await expect(
+      resolveOpenAiCompatModelOverride({
+        req: createReq(),
+        agentId: "main",
+        model: "openclaw/not-a-real-target",
+      }),
+    ).resolves.toEqual({
+      errorMessage:
+        "Invalid `model`. Use `openclaw`, `openclaw/<agentId>`, or `openclaw/<provider>/<model>`.",
     });
   });
 });

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -215,10 +215,24 @@ export function resolveAgentIdFromModel(
     return resolveDefaultAgentId(cfg);
   }
 
-  const m =
-    raw.match(/^openclaw[:/](?<agentId>[a-z0-9][a-z0-9_-]{0,63})$/i) ??
-    raw.match(/^agent:(?<agentId>[a-z0-9][a-z0-9_-]{0,63})$/i);
-  const agentId = m?.groups?.agentId;
+  const openclawTarget = raw.match(/^openclaw[:/](?<target>[^\s].+)$/i)?.groups?.target?.trim();
+  if (openclawTarget) {
+    if (openclawTarget.includes("/")) {
+      return undefined;
+    }
+    const normalized = normalizeAgentId(openclawTarget);
+    const configuredAgents = new Set(
+      (Array.isArray(cfg?.agents?.list) ? cfg.agents.list : [])
+        .map((entry) => normalizeAgentId(entry?.id))
+        .filter(Boolean),
+    );
+    if (!configuredAgents.has(normalized)) {
+      return undefined;
+    }
+    return normalized;
+  }
+
+  const agentId = raw.match(/^agent:(?<agentId>[a-z0-9][a-z0-9_-]{0,63})$/i)?.groups?.agentId;
   if (!agentId) {
     return undefined;
   }
@@ -230,19 +244,24 @@ export async function resolveOpenAiCompatModelOverride(params: {
   agentId: string;
   model: string | undefined;
 }): Promise<{ modelOverride?: string; errorMessage?: string }> {
+  const cfg = loadConfig();
   const requestModel = params.model?.trim();
-  if (requestModel && !resolveAgentIdFromModel(requestModel)) {
-    return {
-      errorMessage: "Invalid `model`. Use `openclaw` or `openclaw/<agentId>`.",
-    };
+  let bodyModelOverrideRaw: string | undefined;
+  if (requestModel && !resolveAgentIdFromModel(requestModel, cfg)) {
+    const target = requestModel.match(/^openclaw[:/](?<target>[^\s].+)$/i)?.groups?.target?.trim();
+    if (!target || !target.includes("/")) {
+      return {
+        errorMessage:
+          "Invalid `model`. Use `openclaw`, `openclaw/<agentId>`, or `openclaw/<provider>/<model>`.",
+      };
+    }
+    bodyModelOverrideRaw = target;
   }
 
-  const raw = getHeader(params.req, "x-openclaw-model")?.trim();
+  const raw = getHeader(params.req, "x-openclaw-model")?.trim() ?? bodyModelOverrideRaw;
   if (!raw) {
     return {};
   }
-
-  const cfg = loadConfig();
   const defaultModelRef = resolveDefaultModelForAgent({ cfg, agentId: params.agentId });
   const defaultProvider = defaultModelRef.provider;
   const parsed = parseModelRef(raw, defaultProvider);

--- a/src/gateway/session-utils.search.test.ts
+++ b/src/gateway/session-utils.search.test.ts
@@ -652,4 +652,40 @@ describe("listSessionsFromStore search", () => {
       },
     });
   });
+
+  test("derives canonical openai-codex gpt-5.4 context tokens when the session entry is missing them", () => {
+    const now = Date.now();
+    const result = listSingleSession({
+      cfg: {
+        session: { mainKey: "main" },
+        agents: {
+          defaults: {
+            model: { primary: "openai-codex/gpt-5.4" },
+          },
+          list: [{ id: "main", default: true }],
+        },
+      } as unknown as OpenClawConfig,
+      storePath: path.join(os.tmpdir(), "openclaw-session-utils-codex-default-context"),
+      key: "agent:main:main",
+      entry: {
+        sessionId: "sess-codex-default-context",
+        updatedAt: now,
+        modelProvider: "openai-codex",
+        model: "gpt-5.4",
+        totalTokens: 3_000,
+        totalTokensFresh: true,
+        inputTokens: 2_000,
+        outputTokens: 1_000,
+      } as SessionEntry,
+    });
+
+    expect(result.sessions[0]).toMatchObject({
+      key: "agent:main:main",
+      modelProvider: "openai-codex",
+      model: "gpt-5.4",
+      totalTokens: 3_000,
+      totalTokensFresh: true,
+      contextTokens: 272_000,
+    });
+  });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -6,8 +6,8 @@ import {
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { lookupContextTokens, resolveContextTokensForModel } from "../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
+import { resolveContextTokensForModel } from "../agents/context.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import type { ModelCatalogEntry } from "../agents/model-catalog.js";
 import {
   inferUniqueProviderFromConfiguredModels,
@@ -945,10 +945,12 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     defaultProvider: DEFAULT_PROVIDER,
     defaultModel: DEFAULT_MODEL,
   });
-  const contextTokens =
-    cfg.agents?.defaults?.contextTokens ??
-    lookupContextTokens(resolved.model, { allowAsyncLoad: false }) ??
-    DEFAULT_CONTEXT_TOKENS;
+  const contextTokens = resolveContextTokensForModel({
+    cfg,
+    provider: resolved.provider,
+    model: resolved.model,
+    allowAsyncLoad: false,
+  });
   return {
     modelProvider: resolved.provider ?? null,
     model: resolved.model ?? null,


### PR DESCRIPTION
## Summary

- Problem: status-related surfaces had drifted in how they resolved model/session state, and `session_status` was missing regression coverage for configured group activation defaults.
- Why it matters: operator-facing status output is only useful if it reflects real config/runtime behavior, and fallback-path regressions are easy to miss without focused coverage.
- What changed: this branch shares model resolution across status and compat paths, keeps the config-aware group activation fallback in `session_status`, and adds a regression test for `groups["*"].requireMention = false` when no session override exists.
- What did NOT change (scope boundary): this PR does not change queue execution, reply orchestration, or fix the separate scratchpad non-reply issue.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: status/compat code paths had drifted in their model/session resolution behavior, and the config-driven group activation fallback in `session_status` was not locked in by a regression test.
- Missing detection / guardrail: no targeted unit test asserted the `requireMention: false` fallback for a group/channel session with no saved `groupActivation` override.
- Contributing context (if known): this surfaced while debugging a separate non-reply issue, where the displayed activation mode looked like the cause.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openclaw-tools.session-status.test.ts`
- Scenario the test should lock in: when channel config sets `groups["*"].requireMention = false` and the session has no `groupActivation` override, `session_status` should resolve the fallback activation to `always`.
- Why this is the smallest reliable guardrail: it exercises the exact fallback path without needing a live channel run.
- Existing test that already covers this (if any): none found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Status and compat surfaces resolve model/session state more consistently.
- `session_status` is now regression-covered for configured always-on group activation defaults.

## Diagram (if applicable)

```text
Before:
status path A -> one resolution path
compat path B -> different resolution path
group activation fallback -> unguarded

After:
status path A -> shared resolution
compat path B -> shared resolution
group activation fallback -> regression-covered
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: local OpenClaw source checkout
- Model/provider: N/A
- Integration/channel (if any): status/session surfaces
- Relevant config (redacted): `channels.discord.groups["*"].requireMention = false`

### Steps

1. Configure a group/channel default with `requireMention: false`.
2. Open a group/channel session with no saved `groupActivation` override.
3. Run `session_status`.

### Expected

- The fallback activation resolves to `always`.

### Actual

- This path was not locked down by regression coverage, and status/compat resolution had drifted.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reviewed the shared resolution changes, confirmed the config-aware group activation path in `session_status`, and added targeted regression coverage for the `requireMention: false` default case.
- Edge cases checked: no session override, group/channel fallback path, status-only behavior.
- What you did **not** verify: a full repo-wide local `pnpm check`, because this checkout is already red on unrelated TypeScript failures outside the touched files.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: some status logic may still be duplicated in paths not touched here.
  - Mitigation: this PR reduces duplication and adds focused coverage on the config-driven fallback.
- Risk: readers may assume this fixes unrelated live reply/queue behavior.
  - Mitigation: the scope boundary is explicit.
