### PR TITLE
fix(ollama): strip ollama/ prefix from modelId in chat requests

### DIFF
--- a/extensions/ollama/src/stream.test.ts
+++ b/extensions/ollama/src/stream.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildAssistantMessage, createOllamaStreamFn } from "./stream.js";
+import {
+  buildAssistantMessage,
+  buildOllamaChatRequest,
+  createOllamaStreamFn,
+  stripOllamaProviderPrefix,
+} from "./stream.js";
 
 function makeOllamaResponse(params: {
   content?: string;
@@ -224,5 +229,48 @@ describe("createOllamaStreamFn thinking events", () => {
     // Text content index should be 0 (no thinking block)
     const textStart = events.find((e) => e.type === "text_start") as { contentIndex?: number };
     expect(textStart?.contentIndex).toBe(0);
+  });
+});
+
+describe("stripOllamaProviderPrefix (#67435)", () => {
+  it("strips the `ollama/` prefix when present", () => {
+    expect(stripOllamaProviderPrefix("ollama/qwen3:14b-q8_0")).toBe("qwen3:14b-q8_0");
+  });
+
+  it("strips case-insensitively", () => {
+    expect(stripOllamaProviderPrefix("Ollama/qwen3")).toBe("qwen3");
+    expect(stripOllamaProviderPrefix("OLLAMA/qwen3")).toBe("qwen3");
+  });
+
+  it("leaves bare model ids unchanged", () => {
+    expect(stripOllamaProviderPrefix("qwen3:14b-q8_0")).toBe("qwen3:14b-q8_0");
+  });
+
+  it("does not strip prefixes that merely start with ollama", () => {
+    // Defensive: e.g. a model literally named "ollamaX/..." should NOT get
+    // stripped because the separator is part of the prefix match.
+    expect(stripOllamaProviderPrefix("ollamaX/weird")).toBe("ollamaX/weird");
+  });
+
+  it("trims whitespace before prefix check", () => {
+    expect(stripOllamaProviderPrefix("  ollama/qwen3  ")).toBe("qwen3");
+  });
+});
+
+describe("buildOllamaChatRequest model-id normalization (#67435)", () => {
+  it("sends the bare model id to Ollama when a prefixed id is passed in", () => {
+    const body = buildOllamaChatRequest({
+      modelId: "ollama/qwen3:14b-q8_0",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(body.model).toBe("qwen3:14b-q8_0");
+  });
+
+  it("passes through bare model ids unchanged", () => {
+    const body = buildOllamaChatRequest({
+      modelId: "qwen3:14b-q8_0",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(body.model).toBe("qwen3:14b-q8_0");
   });
 });

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -220,6 +220,18 @@ export function createConfiguredOllamaCompatStreamWrapper(
 // Ollama compat wrapper now owns more than num_ctx injection.
 export const createConfiguredOllamaCompatNumCtxWrapper = createConfiguredOllamaCompatStreamWrapper;
 
+/**
+ * Strip the `ollama/` provider prefix from a model id so the wire value
+ * matches what Ollama's own API expects. Mirrors the equivalent strip in
+ * `embedding-provider.ts#normalizeEmbeddingModel`, which already had this
+ * fix — the chat request path was missing it, hitting Ollama with
+ * `ollama/<model>` and getting a 404 `model '...' not found`. See #67435.
+ */
+export function stripOllamaProviderPrefix(modelId: string): string {
+  const trimmed = modelId.trim();
+  return trimmed.toLowerCase().startsWith("ollama/") ? trimmed.slice("ollama/".length) : trimmed;
+}
+
 export function buildOllamaChatRequest(params: {
   modelId: string;
   messages: OllamaChatMessage[];
@@ -228,7 +240,7 @@ export function buildOllamaChatRequest(params: {
   stream?: boolean;
 }): OllamaChatRequest {
   return {
-    model: params.modelId,
+    model: stripOllamaProviderPrefix(params.modelId),
     messages: params.messages,
     stream: params.stream ?? true,
     ...(params.tools && params.tools.length > 0 ? { tools: params.tools } : {}),


### PR DESCRIPTION
## What

`extensions/ollama/src/stream.ts` — extract `stripOllamaProviderPrefix()` (exported) and call it inside `buildOllamaChatRequest` before writing the wire `model` field.

## Why

Fixes #67435.

Ollama's `/api/chat` expects the bare model id (e.g. `qwen3:14b-q8_0`). OpenClaw's internal model ref carries the provider prefix (`ollama/qwen3:14b-q8_0`), so every chat call hit a 404:

```
404 {"error":"model 'ollama/qwen3:14b-q8_0' not found"}
```

The embedding provider path already had this fix (`embedding-provider.ts:95-101 normalizeEmbeddingModel`); the chat path was missing the symmetric strip. That's the asymmetry this PR closes.

## Relationship to #67449

#67449 was a prior attempt at the same fix that got auto-closed by `openclaw-barnacle` for a queue-over-limit reason (author had >10 active PRs). Greptile reviewed #67449 positively before the close. This PR ships the fix from a contributor whose queue is under the limit, with one incremental improvement:

- Export `stripOllamaProviderPrefix()` from `stream.ts` so future call sites share the same rule instead of duplicating the strip (the embedding path currently duplicates the substring logic; a follow-up can DRY it).

## Behavior

| Input model id | Before | After |
|---------------|--------|-------|
| `"ollama/qwen3:14b-q8_0"` | wire: `ollama/qwen3:14b-q8_0` → 404 | wire: `qwen3:14b-q8_0` → 200 |
| `"qwen3:14b-q8_0"` | wire: `qwen3:14b-q8_0` (ok) | unchanged |
| `"Ollama/qwen3"` (mixed case) | wire: `Ollama/qwen3` → 404 | wire: `qwen3` → 200 |
| `"ollamaX/weird"` | wire: `ollamaX/weird` | unchanged (guard: prefix is `ollama/`, not `ollama`-prefix) |

## Test

7 new cases in `stream.test.ts`:

- 5 for the helper: prefix strip / case-insensitive / bare / guard / whitespace
- 2 for `buildOllamaChatRequest`: prefixed input → bare wire, bare input → unchanged

`pnpm test -- extensions/ollama/src/stream.test.ts` runs via `runtime-config` project which has a pre-existing non-isolated-runner infra bug unrelated to this change. Logic independently verified against 6 input shapes via an isolated `node -e` script (6/6 pass).

`tsc --noEmit` reports one pre-existing error on `stream.ts:648` (TS2554 on `options?.onPayload?.(body, model)`) that also reproduces on `main` with no edits — unrelated to this change.

## Risk

Low. Single pure-function helper plus one call-site replacement. Existing callers that already pass bare model ids see byte-for-byte unchanged wire output.