### PR TITLE
Fix doctor SecretRef false positive and normalize task timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -534,6 +534,7 @@ Docs: https://docs.openclaw.ai
 - fix(infra): block workspace state-directory env override [AI]. (#75940) Thanks @pgondhi987.
 - MCP/OpenAI: normalize parameter-free tool schemas whose top-level object `properties` is missing, null, or invalid before sending tools to OpenAI, so MCP tools without params stay usable. Fixes #75362. Thanks @tolkonepiu and @SymbolStar.
 - Control UI/WebChat: add server-side chat-draft microphone dictation via the existing audio transcription pipeline, avoiding browser Web Speech while keeping provider credentials on the Gateway. Fixes #47311. Thanks @jmomford.
+- Doctor/Gateway: suppress false `gateway.auth.token` SecretRef unavailable warnings in `openclaw doctor` when the configured SecretRef resolves successfully. Fixes #65201. Thanks @isopenclaw.
 - TTS: honor explicit short `[[tts:text]]...[[/tts:text]]` blocks while keeping untagged short auto-TTS suppressed, so tagged voice replies are synthesized instead of being dropped as empty voice-only payloads. Fixes #73758. Thanks @yfge.
 - Hooks/doctor: warn when `hooks.transformsDir` points outside the canonical hooks transform directory, so invalid workspace skill paths get a direct recovery hint before the Gateway crash-loops. Fixes #75853. Thanks @midobk.
 - Proxy/audio: convert standard `FormData` bodies before proxy-backed undici fetches, so audio transcription and multipart uploads no longer send `[object FormData]` when `HTTP_PROXY` or `HTTPS_PROXY` is configured. Fixes #48554. Thanks @dco5.

--- a/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
+++ b/src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts
@@ -6,6 +6,7 @@ import {
   createDoctorRuntime,
   ensureAuthProfileStore,
   mockDoctorConfigSnapshot,
+  resolveGatewayAuthTokenForService,
 } from "./doctor.e2e-harness.js";
 import { loadDoctorCommandForTest, terminalNoteMock } from "./doctor.note-test-helpers.js";
 import "./doctor.fast-path-mocks.js";
@@ -370,5 +371,87 @@ describe("doctor command", () => {
     expect(String(gatewayAuthNote?.[0])).toContain(
       "Doctor will not overwrite gateway.auth.token with a plaintext value.",
     );
+  });
+
+  it("does not warn when a SecretRef-managed gateway token resolves successfully", async () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+        auth: {
+          mode: "token",
+          token: {
+            source: "env",
+            provider: "default",
+            id: "CUSTOM_GATEWAY_TOKEN",
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+    };
+    mockDoctorConfigSnapshot({
+      config: cfg,
+      parsed: cfg,
+    });
+
+    const previousCustomToken = process.env.CUSTOM_GATEWAY_TOKEN;
+    process.env.CUSTOM_GATEWAY_TOKEN = "resolved-token";
+    resolveGatewayAuthTokenForService.mockResolvedValueOnce({ token: "resolved-token" });
+    try {
+      await doctorCommand(createDoctorRuntime(), {
+        nonInteractive: true,
+        workspaceSuggestions: false,
+      });
+    } finally {
+      if (previousCustomToken === undefined) {
+        delete process.env.CUSTOM_GATEWAY_TOKEN;
+      } else {
+        process.env.CUSTOM_GATEWAY_TOKEN = previousCustomToken;
+      }
+    }
+
+    const gatewayAuthNote = terminalNoteMock.mock.calls.find((call) => call[1] === "Gateway auth");
+    const gatewayAuthMessage =
+      typeof gatewayAuthNote?.[0] === "string"
+        ? gatewayAuthNote[0]
+        : (JSON.stringify(gatewayAuthNote?.[0]) ?? "");
+    expect(gatewayAuthMessage).not.toContain(
+      "Gateway token is managed via SecretRef and is currently unavailable.",
+    );
+  });
+
+  it("does not resolve SecretRef gateway tokens for non-token auth modes", async () => {
+    const cfg = {
+      gateway: {
+        mode: "local",
+        auth: {
+          mode: "trusted-proxy",
+          token: {
+            source: "env",
+            provider: "default",
+            id: "CUSTOM_GATEWAY_TOKEN",
+          },
+        },
+      },
+      secrets: {
+        providers: {
+          default: { source: "env" },
+        },
+      },
+    };
+    mockDoctorConfigSnapshot({
+      config: cfg,
+      parsed: cfg,
+    });
+
+    await doctorCommand(createDoctorRuntime(), {
+      nonInteractive: true,
+      workspaceSuggestions: false,
+    });
+
+    expect(resolveGatewayAuthTokenForService).not.toHaveBeenCalled();
   });
 });

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -151,7 +151,7 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     value: ctx.cfg.gateway?.auth?.token,
     defaults: ctx.cfg.secrets?.defaults,
   }).ref;
-  const auth = resolveGatewayAuth({
+  let auth = resolveGatewayAuth({
     authConfig: ctx.cfg.gateway?.auth,
     tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
   });
@@ -168,9 +168,23 @@ async function runGatewayAuthHealth(ctx: DoctorHealthFlowContext): Promise<void>
     return;
   }
   if (gatewayTokenRef) {
+    const { resolveGatewayAuthTokenForService } =
+      await import("../commands/doctor-gateway-auth-token.js");
+    const gatewayTokenResolution = await resolveGatewayAuthTokenForService(ctx.cfg, process.env);
+    if (gatewayTokenResolution.token) {
+      auth = resolveGatewayAuth({
+        authConfig: ctx.cfg.gateway?.auth,
+        authOverride: { token: gatewayTokenResolution.token },
+        tailscaleMode: ctx.cfg.gateway?.tailscale?.mode ?? "off",
+      });
+      if (auth.mode === "token" && auth.token) {
+        return;
+      }
+    }
     note(
       [
-        "Gateway token is managed via SecretRef and is currently unavailable.",
+        gatewayTokenResolution.unavailableReason ??
+          "Gateway token is managed via SecretRef and is currently unavailable.",
         "Doctor will not overwrite gateway.auth.token with a plaintext value.",
         "Resolve/rotate the external secret source, then rerun doctor.",
       ].join("\n"),


### PR DESCRIPTION
## Summary
- resolve SecretRef-managed `gateway.auth.token` before doctor decides whether token auth is missing
- avoid false-positive doctor guidance when the SecretRef resolves successfully
- normalize task `createdAt` to the earliest lifecycle timestamp so historical skew does not keep surfacing in `tasks audit`

## Why
Two cleanup items had already been fixed locally in a packaged install, but they would regress on the next upstream update unless they were moved onto the real release chain:
1. doctor could still warn about a missing gateway token even when a SecretRef-backed token resolved correctly at runtime
2. task timestamp skew was being tolerated in audit output instead of normalized at write/update time

## Tests
- `node scripts/test-projects.mjs src/tasks/task-registry.test.ts src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts src/commands/doctor-gateway-auth-token.test.ts`

## Notes
- the local SQLite backfill used to clear historical task warnings is intentionally **not** part of this PR; this PR only contains the code-level fix so future builds do not regress