### PR TITLE
fix(feishu): reduce startup latency by parallelizing probe and capping timeouts

### DIFF
--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -1,22 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createNonExitingRuntimeEnv } from "../../../test/helpers/plugins/runtime-env.js";
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 
-const probeFeishuMock = vi.hoisted(() => vi.fn());
+const fetchBotIdentityForMonitorMock = vi.hoisted(() => vi.fn());
+const monitorSingleAccountMock = vi.hoisted(() => vi.fn(() => new Promise<void>(() => {})));
 
-vi.mock("./probe.js", () => ({
-  probeFeishu: probeFeishuMock,
+vi.mock("./monitor.startup.js", () => ({
+  fetchBotIdentityForMonitor: fetchBotIdentityForMonitorMock,
 }));
 
-vi.mock("./client.js", async () => {
-  const { createFeishuClientMockModule } = await import("./monitor.test-mocks.js");
-  return createFeishuClientMockModule();
-});
-vi.mock("./runtime.js", async () => {
-  const { createFeishuRuntimeMockModule } = await import("./monitor.test-mocks.js");
-  return createFeishuRuntimeMockModule();
-});
+vi.mock("./monitor.account.js", () => ({
+  monitorSingleAccount: monitorSingleAccountMock,
+  resolveReactionSyntheticEvent: vi.fn(),
+}));
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
   return {
@@ -39,153 +35,84 @@ function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig 
   } as ClawdbotConfig;
 }
 
-async function waitForStartedAccount(started: string[], accountId: string) {
-  for (let i = 0; i < 10 && !started.includes(accountId); i += 1) {
-    await Promise.resolve();
-  }
-}
-
 afterEach(() => {
   stopFeishuMonitor();
+  vi.clearAllMocks();
 });
 
 describe("Feishu monitor startup preflight", () => {
-  it("starts account probes sequentially to avoid startup bursts", async () => {
-    let inFlight = 0;
-    let maxInFlight = 0;
+  it("probes multiple accounts concurrently instead of serially", async () => {
     const started: string[] = [];
     let releaseProbes!: () => void;
     const probesReleased = new Promise<void>((resolve) => {
-      releaseProbes = () => resolve();
-    });
-    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
-      started.push(account.accountId);
-      inFlight += 1;
-      maxInFlight = Math.max(maxInFlight, inFlight);
-      await probesReleased;
-      inFlight -= 1;
-      return { ok: true, botOpenId: `bot_${account.accountId}` };
+      releaseProbes = resolve;
     });
 
-    const abortController = new AbortController();
+    fetchBotIdentityForMonitorMock.mockImplementation(async (account: { accountId: string }) => {
+      started.push(account.accountId);
+      await probesReleased;
+      return { botOpenId: `bot_${account.accountId}` };
+    });
+
     const monitorPromise = monitorFeishuProvider({
       config: buildMultiAccountWebsocketConfig(["alpha", "beta", "gamma"]),
-      abortSignal: abortController.signal,
     });
 
-    try {
-      await Promise.resolve();
-      await Promise.resolve();
+    await Promise.resolve();
+    expect(started.sort()).toEqual(["alpha", "beta", "gamma"]);
 
-      expect(started).toEqual(["alpha"]);
-      expect(maxInFlight).toBe(1);
-    } finally {
-      releaseProbes();
-      abortController.abort();
-      await monitorPromise;
-    }
+    releaseProbes();
+    await monitorPromise;
   });
 
-  it("does not refetch bot info after a failed sequential preflight", async () => {
-    const started: string[] = [];
-    let releaseBetaProbe!: () => void;
-    const betaProbeReleased = new Promise<void>((resolve) => {
-      releaseBetaProbe = () => resolve();
+  it("forces startup probe timeoutMs to 3000ms", async () => {
+    fetchBotIdentityForMonitorMock.mockResolvedValue({ botOpenId: "bot_alpha" });
+
+    await monitorFeishuProvider({
+      config: buildMultiAccountWebsocketConfig(["alpha"]),
     });
 
-    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
-      started.push(account.accountId);
-      if (account.accountId === "alpha") {
-        return { ok: false };
-      }
-      await betaProbeReleased;
-      return { ok: true, botOpenId: `bot_${account.accountId}` };
-    });
-
-    const abortController = new AbortController();
-    const monitorPromise = monitorFeishuProvider({
-      config: buildMultiAccountWebsocketConfig(["alpha", "beta"]),
-      abortSignal: abortController.signal,
-    });
-
-    try {
-      await waitForStartedAccount(started, "beta");
-      expect(started).toEqual(["alpha", "beta"]);
-      expect(started.filter((accountId) => accountId === "alpha")).toHaveLength(1);
-    } finally {
-      releaseBetaProbe();
-      abortController.abort();
-      await monitorPromise;
-    }
-  });
-
-  it("continues startup when probe layer reports timeout", async () => {
-    const started: string[] = [];
-    let releaseBetaProbe!: () => void;
-    const betaProbeReleased = new Promise<void>((resolve) => {
-      releaseBetaProbe = () => resolve();
-    });
-
-    probeFeishuMock.mockImplementation((account: { accountId: string }) => {
-      started.push(account.accountId);
-      if (account.accountId === "alpha") {
-        return Promise.resolve({ ok: false, error: "probe timed out after 10000ms" });
-      }
-      return betaProbeReleased.then(() => ({ ok: true, botOpenId: `bot_${account.accountId}` }));
-    });
-
-    const abortController = new AbortController();
-    const runtime = createNonExitingRuntimeEnv();
-    const monitorPromise = monitorFeishuProvider({
-      config: buildMultiAccountWebsocketConfig(["alpha", "beta"]),
-      runtime,
-      abortSignal: abortController.signal,
-    });
-
-    try {
-      await waitForStartedAccount(started, "beta");
-      expect(started).toEqual(["alpha", "beta"]);
-      expect(runtime.error).toHaveBeenCalledWith(
-        expect.stringContaining("bot info probe timed out"),
-      );
-    } finally {
-      releaseBetaProbe();
-      abortController.abort();
-      await monitorPromise;
-    }
-  });
-
-  it("stops sequential preflight when aborted during probe", async () => {
-    const started: string[] = [];
-    probeFeishuMock.mockImplementation(
-      (account: { accountId: string }, options: { abortSignal?: AbortSignal }) => {
-        started.push(account.accountId);
-        return new Promise((resolve) => {
-          options.abortSignal?.addEventListener(
-            "abort",
-            () => resolve({ ok: false, error: "probe aborted" }),
-            { once: true },
-          );
-        });
-      },
+    expect(fetchBotIdentityForMonitorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: "alpha" }),
+      expect.objectContaining({ timeoutMs: 3000 }),
     );
+  });
 
-    const abortController = new AbortController();
-    const monitorPromise = monitorFeishuProvider({
-      config: buildMultiAccountWebsocketConfig(["alpha", "beta"]),
-      abortSignal: abortController.signal,
-    });
+  it("starts runtime monitors in background and returns after probes complete", async () => {
+    fetchBotIdentityForMonitorMock.mockResolvedValue({ botOpenId: "bot_alpha" });
 
-    try {
-      await Promise.resolve();
-      expect(started).toEqual(["alpha"]);
+    await expect(
+      monitorFeishuProvider({
+        config: buildMultiAccountWebsocketConfig(["alpha"]),
+      }),
+    ).resolves.toBeUndefined();
 
-      abortController.abort();
-      await monitorPromise;
+    expect(monitorSingleAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        botOpenIdSource: expect.objectContaining({
+          kind: "prefetched",
+          botOpenId: "bot_alpha",
+        }),
+      }),
+    );
+  });
 
-      expect(started).toEqual(["alpha"]);
-    } finally {
-      abortController.abort();
-    }
+  it("degrades failed probes instead of blocking startup", async () => {
+    fetchBotIdentityForMonitorMock
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce({ botOpenId: "bot_beta" });
+
+    await expect(
+      monitorFeishuProvider({
+        config: buildMultiAccountWebsocketConfig(["alpha", "beta"]),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(monitorSingleAccountMock).toHaveBeenCalledTimes(1);
+    expect(monitorSingleAccountMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ accountId: "beta" }),
+      }),
+    );
   });
 });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -20,6 +20,8 @@ export type MonitorFeishuOpts = {
   accountId?: string;
 };
 
+const FEISHU_STARTUP_HARD_TIMEOUT_MS = 3_000;
+
 export {
   clearFeishuWebhookRateLimitStateForTest,
   getFeishuWebhookRateLimitStateSizeForTest,
@@ -27,6 +29,44 @@ export {
   resolveReactionSyntheticEvent,
 };
 export type { FeishuReactionCreatedEvent };
+
+function logFeishuStartupProbeWarning(
+  accountId: string,
+  runtime: RuntimeEnv | undefined,
+  detail: string,
+): void {
+  const log = runtime?.error ?? runtime?.log ?? console.warn;
+  log(`feishu[${accountId}]: ${detail}`);
+}
+
+function startFeishuAccountMonitorInBackground(params: {
+  cfg: ClawdbotConfig;
+  account: ReturnType<typeof resolveFeishuRuntimeAccount>;
+  runtime?: RuntimeEnv;
+  abortSignal?: AbortSignal;
+  botOpenIdSource?:
+    | {
+        kind: "prefetched";
+        botOpenId?: string;
+        botName?: string;
+      }
+    | undefined;
+}): void {
+  void monitorSingleAccount({
+    cfg: params.cfg,
+    account: params.account,
+    runtime: params.runtime,
+    abortSignal: params.abortSignal,
+    botOpenIdSource: params.botOpenIdSource,
+  }).catch((error) => {
+    const detail = error instanceof Error ? error.message : String(error);
+    logFeishuStartupProbeWarning(
+      params.account.accountId,
+      params.runtime,
+      `background runtime monitor failed: ${detail}`,
+    );
+  });
+}
 
 export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promise<void> {
   const cfg = opts.config;
@@ -44,12 +84,13 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     if (!account.enabled || !account.configured) {
       throw new Error(`Feishu account "${opts.accountId}" not configured or disabled`);
     }
-    return monitorSingleAccount({
+    startFeishuAccountMonitorInBackground({
       cfg,
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
     });
+    return;
   }
 
   const accounts = listEnabledFeishuAccounts(cfg);
@@ -61,36 +102,51 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     `feishu: starting ${accounts.length} account(s): ${accounts.map((a) => a.accountId).join(", ")}`,
   );
 
-  const monitorPromises: Promise<void>[] = [];
-  for (const account of accounts) {
-    if (opts.abortSignal?.aborted) {
-      log("feishu: abort signal received during startup preflight; stopping startup");
-      break;
-    }
-
-    // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
-      runtime: opts.runtime,
-      abortSignal: opts.abortSignal,
-    });
-
-    if (opts.abortSignal?.aborted) {
-      log("feishu: abort signal received during startup preflight; stopping startup");
-      break;
-    }
-
-    monitorPromises.push(
-      monitorSingleAccount({
-        cfg,
-        account,
+  const startupProbeResults = await Promise.allSettled(
+    accounts.map(async (account) => {
+      const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
-      }),
-    );
-  }
+        timeoutMs: FEISHU_STARTUP_HARD_TIMEOUT_MS,
+      });
+      return { account, botOpenId, botName };
+    }),
+  );
 
-  await Promise.all(monitorPromises);
+  for (const result of startupProbeResults) {
+    if (opts.abortSignal?.aborted) {
+      log("feishu: abort signal received during startup preflight; stopping startup");
+      break;
+    }
+
+    if (result.status === "rejected") {
+      logFeishuStartupProbeWarning(
+        "unknown",
+        opts.runtime,
+        `startup probe failed: ${
+          result.reason instanceof Error ? result.reason.message : String(result.reason)
+        }`,
+      );
+      continue;
+    }
+
+    const { account, botOpenId, botName } = result.value;
+    if (!botOpenId) {
+      logFeishuStartupProbeWarning(
+        account.accountId,
+        opts.runtime,
+        "startup probe degraded; continuing without prefetched bot identity",
+      );
+    }
+
+    startFeishuAccountMonitorInBackground({
+      cfg,
+      account,
+      runtime: opts.runtime,
+      abortSignal: opts.abortSignal,
+      botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+    });
+  }
 }
 
 export function stopFeishuMonitor(accountId?: string): void {

--- a/extensions/feishu/src/setup-surface.test.ts
+++ b/extensions/feishu/src/setup-surface.test.ts
@@ -7,8 +7,10 @@ import {
   runSetupWizardConfigure,
 } from "../../../test/helpers/plugins/setup-wizard.js";
 
+const probeFeishuMock = vi.hoisted(() => vi.fn(async () => ({ ok: false, error: "mocked" })));
+
 vi.mock("./probe.js", () => ({
-  probeFeishu: vi.fn(async () => ({ ok: false, error: "mocked" })),
+  probeFeishu: probeFeishuMock,
 }));
 
 vi.mock("./app-registration.js", () => ({
@@ -102,6 +104,25 @@ describe("feishu setup wizard", () => {
 });
 
 describe("feishu setup wizard status", () => {
+  it("caps startup status probe timeout at 3000ms", async () => {
+    await feishuGetStatus({
+      cfg: {
+        channels: {
+          feishu: {
+            appId: "cli_a123456",
+            appSecret: "sample-app-credential", // pragma: allowlist secret
+          },
+        },
+      } as never,
+      accountOverrides: {},
+    });
+
+    expect(probeFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({ appId: "cli_a123456" }),
+      expect.objectContaining({ timeoutMs: 3000 }),
+    );
+  });
+
   it("treats SecretRef appSecret as configured when appId is present", async () => {
     const status = await feishuGetStatus({
       cfg: {

--- a/extensions/feishu/src/setup-surface.ts
+++ b/extensions/feishu/src/setup-surface.ts
@@ -25,6 +25,7 @@ import { probeFeishu } from "./probe.js";
 import type { FeishuConfig, FeishuDomain } from "./types.js";
 
 const channel = "feishu" as const;
+const FEISHU_STATUS_PROBE_TIMEOUT_MS = 3_000;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -528,7 +529,9 @@ export const feishuSetupWizard: ChannelSetupWizard = {
       let probeResult = null;
       if (configured && resolvedCredentials) {
         try {
-          probeResult = await probeFeishu(resolvedCredentials);
+          probeResult = await probeFeishu(resolvedCredentials, {
+            timeoutMs: FEISHU_STATUS_PROBE_TIMEOUT_MS,
+          });
         } catch {}
       }
       if (!configured) {


### PR DESCRIPTION
When Feishu is enabled, gateway startup is blocked for ~100s before `chat.history` becomes available. With Feishu disabled the same call resolves in ~8s.

## Root cause: two blocking paths in the startup chain

**1. `monitorFeishuProvider()` in `monitor.ts`**

Current behavior:
- `fetchBotIdentityForMonitor()` is awaited serially per account with a 30s timeout
- `monitorSingleAccount()` (which internally awaits a long-lived WebSocket/webhook connection) is pushed into `Promise.all()` and awaited before the function returns
- this means gateway startup waits for every Feishu account to fully connect before proceeding

Proposed fix:
- run probes concurrently via `Promise.allSettled`
- cap startup probe timeout at 3000ms
- start `monitorSingleAccount()` as a background task, not a startup-blocking awaited promise

**2. `resolveStatusLines()` in `setup-surface.ts`**

Current behavior:
- the setup/status surface calls `await probeFeishu(...)` synchronously
- this probe is also allowed to inherit the long default timeout
- so status resolution itself can block startup

Proposed fix:
- cap the status probe at 3000ms
- fall back to a degraded / deferred status instead of blocking

## Measured impact

Before patch:

| mode | `chat.history` ready |
|---|---|
| `feishu=false` | 8.22s |
| `feishu=true` | 100.49s |

This strongly suggests a Feishu-specific startup bottleneck, shaped like one or more fixed 30s serial waits.