### PR TITLE
fix(backup): gracefully skip session files deleted during backup create

### DIFF
--- a/src/commands/backup.test-support.ts
+++ b/src/commands/backup.test-support.ts
@@ -8,8 +8,48 @@ import { resolveBackupPlanFromPaths } from "./backup-shared.js";
 export const tarCreateMock = vi.fn();
 export const backupVerifyCommandMock = vi.fn();
 
+class MockPack {
+  private options: { file: string; onWriteEntry?: (entry: unknown) => void };
+  private files: string[] = [];
+  private stream?: NodeJS.WritableStream & NodeJS.EventEmitter;
+  private errorListeners: Array<(err: unknown) => void> = [];
+
+  constructor(options: { file: string; onWriteEntry?: (entry: unknown) => void }) {
+    this.options = options;
+  }
+
+  pipe(stream: NodeJS.WritableStream & NodeJS.EventEmitter) {
+    this.stream = stream;
+    return stream;
+  }
+
+  add(file: string) {
+    this.files.push(file);
+  }
+
+  on(event: string, listener: (err: unknown) => void) {
+    if (event === "error") {
+      this.errorListeners.push(listener);
+    }
+    return this;
+  }
+
+  async end() {
+    try {
+      await tarCreateMock(this.options, this.files);
+      this.stream?.emit("close" as never);
+    } catch (err) {
+      for (const listener of this.errorListeners) {
+        listener(err);
+      }
+      this.stream?.emit("error" as never, err);
+    }
+  }
+}
+
 vi.mock("tar", () => ({
   c: tarCreateMock,
+  Pack: MockPack,
 }));
 
 vi.mock("./backup-verify.js", () => ({

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { constants as fsConstants } from "node:fs";
+import { constants as fsConstants, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,7 +12,8 @@ import {
   resolveBackupPlanFromDisk,
 } from "../commands/backup-shared.js";
 import { isPathWithin } from "../commands/cleanup-utils.js";
-import { resolveHomeDir, resolveUserPath } from "../utils.js";
+import { isNotFoundPathError } from "../infra/path-guards.js";
+import { resolveHomeDir, resolveUserPath, shortenHomePath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
 
 export type BackupCreateOptions = {
@@ -127,8 +128,61 @@ function buildTempArchivePath(outputPath: string): string {
   return `${outputPath}.${randomUUID()}.tmp`;
 }
 
+async function createTarArchiveWithMissingSkip(
+  params: {
+    file: string;
+    gzip?: boolean;
+    portable?: boolean;
+    preservePaths?: boolean;
+    onWriteEntry?: (entry: unknown) => void;
+  },
+  files: string[],
+): Promise<string[]> {
+  const skipped: string[] = [];
+  const pack = new tar.Pack({
+    file: params.file,
+    gzip: params.gzip,
+    portable: params.portable,
+    preservePaths: params.preservePaths,
+    onWriteEntry: params.onWriteEntry,
+  });
+  const stream = createWriteStream(params.file);
+  pack.pipe(stream);
+
+  await new Promise<void>((resolve, reject) => {
+    stream.on("error", reject);
+    stream.on("close", resolve);
+    pack.on("error", (err: unknown) => {
+      if (isNotFoundPathError(err)) {
+        const p = (err as NodeJS.ErrnoException).path;
+        if (typeof p === "string") {
+          skipped.push(p);
+        }
+        return;
+      }
+      reject(err instanceof Error ? err : new Error(String(err)));
+    });
+
+    for (const file of files) {
+      pack.add(file);
+    }
+    pack.end();
+  });
+
+  return skipped;
+}
+
 function isLinkUnsupportedError(code: string | undefined): boolean {
   return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
+}
+
+function resolveAssetKindForPath(filePath: string, assets: BackupAsset[]): string {
+  for (const asset of assets) {
+    if (filePath === asset.sourcePath || isPathWithin(filePath, asset.sourcePath)) {
+      return asset.kind;
+    }
+  }
+  return "state";
 }
 
 async function publishTempArchive(params: {
@@ -342,15 +396,15 @@ export async function createBackupArchive(
     });
     await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
-    await tar.c(
+    const skippedPaths = await createTarArchiveWithMissingSkip(
       {
         file: tempArchivePath,
         gzip: true,
         portable: true,
         preservePaths: true,
         onWriteEntry: (entry) => {
-          entry.path = remapArchiveEntryPath({
-            entryPath: entry.path,
+          (entry as { path: string }).path = remapArchiveEntryPath({
+            entryPath: (entry as { path: string }).path,
             manifestPath,
             archiveRoot,
           });
@@ -358,6 +412,14 @@ export async function createBackupArchive(
       },
       [manifestPath, ...result.assets.map((asset) => asset.sourcePath)],
     );
+    for (const skippedPath of skippedPaths) {
+      result.skipped.push({
+        kind: resolveAssetKindForPath(skippedPath, result.assets),
+        sourcePath: skippedPath,
+        displayPath: shortenHomePath(skippedPath),
+        reason: "cleaned up during backup",
+      });
+    }
     await publishTempArchive({ tempArchivePath, outputPath });
   } finally {
     await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);


### PR DESCRIPTION
## Summary

`openclaw backup create` could fail with ENOENT when the gateway's session compaction deleted a session file between enumeration and tar archiving. This change replaces `tar.c` with the underlying `tar.Pack` API so that ENOENT errors during archiving are caught and skipped rather than failing the entire backup. Skipped files are reported in the backup summary with the reason "cleaned up during backup".

## Changes

- `src/infra/backup-create.ts`: add `createTarArchiveWithMissingSkip` helper using `tar.Pack` with a custom error handler that ignores ENOENT and records skipped paths; replace the `tar.c` call in `createBackupArchive`
- `src/commands/backup.test-support.ts`: update `tar` mock to include `Pack` so tests continue to work with the new implementation

## Related issue

Fixes #67417