### PR TITLE
feat(memory-wiki): per-org vaults via ctx-aware vault.path templating

### DIFF
--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -317,6 +317,14 @@ Put config under `plugins.entries.memory-wiki.config`:
 Key toggles:
 
 - `vaultMode`: `isolated`, `bridge`, `unsafe-local`
+- `vault.path`: supports `~` home expansion and the template tokens
+  `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}`. Templates are
+  expanded against the tool invocation context on each wiki tool call, so
+  agents in different workspaces can share the plugin instance while writing
+  to their own vaults. Example: `{workspaceDir}/wiki`. Templates are only
+  expanded for the tool surfaces (`wiki_status`, `wiki_lint`, `wiki_apply`,
+  `wiki_search`, `wiki_get`); the `openclaw wiki` CLI and non-agent gateway
+  methods use the literal configured path.
 - `vault.renderMode`: `native` or `obsidian`
 - `bridge.readMemoryArtifacts`: import active memory plugin public artifacts
 - `bridge.followMemoryEvents`: include event logs in bridge mode

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -324,16 +324,21 @@ Key toggles:
   to their own vaults. Example: `{workspaceDir}/wiki`. Templates are only
   expanded for the tool surfaces (`wiki_status`, `wiki_lint`, `wiki_apply`,
   `wiki_search`, `wiki_get`); the `openclaw wiki` CLI and non-agent gateway
-  methods use the literal configured path. Tokens whose value is absent from
-  the invocation context (for example a plugin tool server that resolves
-  tools with only `{ config }`) are preserved literally in the path — so
-  `{workspaceDir}/wiki` stays `{workspaceDir}/wiki` and downstream filesystem
-  operations fail visibly, rather than silently collapsing to the filesystem
-  root, the process CWD, or another tenant's vault. Make sure the tokens you
-  use are always populated by the invocation contexts you care about. When
-  `vault.path` is templated, the memory-prompt supplement and
-  memory-corpus supplement (which feed `memory_search`/`memory_get` the wiki
-  corpus) are not registered — their SDK contracts do not thread the
+  methods use the literal configured path. If any placeholder cannot be
+  resolved at tool invocation time — either because the invocation context
+  did not populate a known token (e.g. a plugin tool server that calls with
+  only `{ config }`) or because the template contains an unknown placeholder
+  like `{tenant}` (typo) — expansion throws at tool invocation time. This is
+  intentionally fail-closed: returning an unresolved path would let
+  `fs.mkdir(path, { recursive: true })` silently create a literal
+  `{workspaceDir}` directory under `process.cwd()` and downstream writes
+  would succeed against a shared CWD-backed vault, mixing data across
+  sessions or tenants. Make sure every token your template uses is
+  guaranteed by the invocation contexts you care about, and prefer a
+  literal path if you need the template to work outside the wiki tool
+  surfaces. When `vault.path` is templated, the memory-prompt supplement
+  and memory-corpus supplement (which feed `memory_search`/`memory_get` the
+  wiki corpus) are not registered — their SDK contracts do not thread the
   per-invocation context needed to resolve the template, and registering
   them with the unexpanded literal path would leave `memory_*` reading from
   a different vault than `wiki_search`/`wiki_get` resolve to in the same

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -330,7 +330,16 @@ Key toggles:
   `{workspaceDir}/wiki` stays `{workspaceDir}/wiki` and downstream filesystem
   operations fail visibly, rather than silently collapsing to the filesystem
   root, the process CWD, or another tenant's vault. Make sure the tokens you
-  use are always populated by the invocation contexts you care about.
+  use are always populated by the invocation contexts you care about. When
+  `vault.path` is templated, the memory-prompt supplement and
+  memory-corpus supplement (which feed `memory_search`/`memory_get` the wiki
+  corpus) are not registered — their SDK contracts do not thread the
+  per-invocation context needed to resolve the template, and registering
+  them with the unexpanded literal path would leave `memory_*` reading from
+  a different vault than `wiki_search`/`wiki_get` resolve to in the same
+  conversation. In per-org setups the `wiki_*` tools remain the single
+  authoritative per-context entry point for the wiki vault; use a literal
+  `vault.path` if you want the `memory_*` corpus merge as well.
 - `vault.renderMode`: `native` or `obsidian`
 - `bridge.readMemoryArtifacts`: import active memory plugin public artifacts
 - `bridge.followMemoryEvents`: include event logs in bridge mode

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -324,7 +324,13 @@ Key toggles:
   to their own vaults. Example: `{workspaceDir}/wiki`. Templates are only
   expanded for the tool surfaces (`wiki_status`, `wiki_lint`, `wiki_apply`,
   `wiki_search`, `wiki_get`); the `openclaw wiki` CLI and non-agent gateway
-  methods use the literal configured path.
+  methods use the literal configured path. Tokens absent from the invocation
+  context expand to an empty string and the resulting path is normalized, so
+  compound templates that mix optional tokens (for example
+  `{agentId}/{sessionKey}/wiki`) can silently collapse a segment when the
+  optional token is unpopulated, producing broader isolation than intended.
+  Prefer single-token templates or verify every token you rely on is
+  guaranteed by your invocation context.
 - `vault.renderMode`: `native` or `obsidian`
 - `bridge.readMemoryArtifacts`: import active memory plugin public artifacts
 - `bridge.followMemoryEvents`: include event logs in bridge mode

--- a/docs/plugins/memory-wiki.md
+++ b/docs/plugins/memory-wiki.md
@@ -324,13 +324,13 @@ Key toggles:
   to their own vaults. Example: `{workspaceDir}/wiki`. Templates are only
   expanded for the tool surfaces (`wiki_status`, `wiki_lint`, `wiki_apply`,
   `wiki_search`, `wiki_get`); the `openclaw wiki` CLI and non-agent gateway
-  methods use the literal configured path. Tokens absent from the invocation
-  context expand to an empty string and the resulting path is normalized, so
-  compound templates that mix optional tokens (for example
-  `{agentId}/{sessionKey}/wiki`) can silently collapse a segment when the
-  optional token is unpopulated, producing broader isolation than intended.
-  Prefer single-token templates or verify every token you rely on is
-  guaranteed by your invocation context.
+  methods use the literal configured path. Tokens whose value is absent from
+  the invocation context (for example a plugin tool server that resolves
+  tools with only `{ config }`) are preserved literally in the path — so
+  `{workspaceDir}/wiki` stays `{workspaceDir}/wiki` and downstream filesystem
+  operations fail visibly, rather than silently collapsing to the filesystem
+  root, the process CWD, or another tenant's vault. Make sure the tokens you
+  use are always populated by the invocation contexts you care about.
 - `vault.renderMode`: `native` or `obsidian`
 - `bridge.readMemoryArtifacts`: import active memory plugin public artifacts
 - `bridge.followMemoryEvents`: include event logs in bridge mode

--- a/extensions/memory-wiki/api.ts
+++ b/extensions/memory-wiki/api.ts
@@ -5,5 +5,6 @@ export {
   type OpenClawConfig,
   type OpenClawPluginApi,
   type OpenClawPluginConfigSchema,
+  type OpenClawPluginToolContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 export { z } from "openclaw/plugin-sdk/zod";

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { AnyAgentTool, OpenClawPluginToolContext } from "./api.js";
 import plugin from "./index.js";
 import { createMemoryWikiTestHarness } from "./src/test-helpers.js";
 
@@ -88,6 +89,39 @@ describe("memory-wiki plugin", () => {
     expect(registerTool).toHaveBeenCalledTimes(5);
     expect(registerGatewayMethod).toHaveBeenCalled();
     expect(registerCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps wiki_* tools visible in the catalog when vault.path is templated and factory context is partial, failing loud at execute time", async () => {
+    // Regression: `src/plugins/tools.ts` (`resolvePluginTools`) wraps each
+    // factory call in try/catch and silently skips the tool on throw. Before
+    // the guard, `resolveMemoryWikiConfigForCtx` throwing on unresolved
+    // placeholders (e.g. `plugin-tools-serve.ts` passing `{ config }` only)
+    // made every `wiki_*` tool disappear from the MCP catalog with no
+    // actionable signal to the caller. The factory must return a stub tool
+    // that surfaces the original error at invocation time instead.
+    const { api, registerTool } = createPluginApi({
+      pluginConfig: { vault: { path: "{workspaceDir}/wiki" } },
+    });
+
+    await plugin.register(api);
+
+    expect(registerTool).toHaveBeenCalledTimes(5);
+
+    const partialCtx = { config: api.config } as OpenClawPluginToolContext;
+
+    for (const call of registerTool.mock.calls) {
+      const factory = call[0] as (ctx: OpenClawPluginToolContext) => AnyAgentTool;
+      const tool = factory(partialCtx);
+      expect(tool).toBeTruthy();
+      // Stub preserves the original tool name so callers (MCP clients,
+      // gateway catalog, agents) still see the tool exists.
+      expect(tool.name).toMatch(/^wiki_/);
+      // Invoking surfaces the placeholder-expansion error from
+      // `expandVaultPathTemplate` rather than swallowing it.
+      await expect(
+        (tool as { execute: (id: string, args: unknown) => Promise<unknown> }).execute("call", {}),
+      ).rejects.toThrow(/unresolved placeholder\(s\) \{workspaceDir\}/);
+    }
   });
 
   it("also skips memory supplements when vault.path contains only unknown placeholders", async () => {

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -89,4 +89,24 @@ describe("memory-wiki plugin", () => {
     expect(registerGatewayMethod).toHaveBeenCalled();
     expect(registerCli).toHaveBeenCalledTimes(1);
   });
+
+  it("also skips memory supplements when vault.path contains only unknown placeholders", async () => {
+    // Regression: the previous gate used the narrow known-tokens regex, so a
+    // config like `{tenant}/wiki` (or a typo like `{workspaceDIR}/wiki`)
+    // registered the memory supplements against the literal brace path. At
+    // tool invocation `wiki_*` would throw on expansion while `memory_*`
+    // flows would silently write/read through `fs.mkdir`/`initializeMemoryWikiVault`
+    // against a CWD-relative `./{tenant}/wiki` — asymmetric fail-closed with
+    // cross-surface data mixing.
+    const { api, registerMemoryCorpusSupplement, registerMemoryPromptSupplement } = createPluginApi(
+      {
+        pluginConfig: { vault: { path: "{tenant}/wiki" } },
+      },
+    );
+
+    await plugin.register(api);
+
+    expect(registerMemoryCorpusSupplement).not.toHaveBeenCalled();
+    expect(registerMemoryPromptSupplement).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/memory-wiki/index.test.ts
+++ b/extensions/memory-wiki/index.test.ts
@@ -58,4 +58,35 @@ describe("memory-wiki plugin", () => {
       ],
     });
   });
+
+  it("skips memory prompt and corpus supplements when vault.path is templated", async () => {
+    const {
+      api,
+      registerCli,
+      registerGatewayMethod,
+      registerMemoryCorpusSupplement,
+      registerMemoryPromptSupplement,
+      registerTool,
+    } = createPluginApi({
+      pluginConfig: { vault: { path: "{workspaceDir}/wiki" } },
+    });
+
+    await plugin.register(api);
+
+    // Templated vault paths can only be resolved at wiki-tool invocation time.
+    // The memory-corpus supplement and prompt-section builder would otherwise
+    // keep reading the unexpanded literal path while `wiki_search`/`wiki_get`
+    // run against the per-context expansion, producing cross-tenant results
+    // for the same conversation. Skip registration to enforce a single
+    // per-context entry point via the `wiki_*` tools.
+    expect(registerMemoryCorpusSupplement).not.toHaveBeenCalled();
+    expect(registerMemoryPromptSupplement).not.toHaveBeenCalled();
+
+    // The rest of the surface is unchanged — tools, gateway methods, and CLI
+    // still register so operators can use the per-context `wiki_*` path and
+    // keep operator-facing gateway/CLI surfaces for administration.
+    expect(registerTool).toHaveBeenCalledTimes(5);
+    expect(registerGatewayMethod).toHaveBeenCalled();
+    expect(registerCli).toHaveBeenCalledTimes(1);
+  });
 });

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,4 +1,4 @@
-import { definePluginEntry } from "./api.js";
+import { type AnyAgentTool, definePluginEntry, type OpenClawPluginToolContext } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
 import {
   hasAnyVaultPathPlaceholder,
@@ -11,11 +11,38 @@ import { registerMemoryWikiGatewayMethods } from "./src/gateway.js";
 import { createWikiPromptSectionBuilder } from "./src/prompt-section.js";
 import {
   createWikiApplyTool,
+  createWikiConfigErrorTool,
   createWikiGetTool,
   createWikiLintTool,
   createWikiSearchTool,
   createWikiStatusTool,
 } from "./src/tool.js";
+
+// Wrap a `registerTool` factory so expansion failures in
+// `resolveMemoryWikiConfigForCtx` do not bubble out as factory-time throws.
+// `src/plugins/tools.ts` catches factory exceptions, logs, and silently drops
+// the tool from the catalog — that is the desired shape for plugins that
+// genuinely cannot produce a tool in the current context, but for
+// configuration errors (like a templated `vault.path` resolved without the
+// required tokens) it hides the problem from both agents and operators. By
+// returning a stub tool whose `execute` rejects with the original error we
+// keep `wiki_*` visible in the catalog (so MCP/gateway clients see it exists)
+// while still failing loud — at invocation time — with an actionable message.
+function guardedWikiToolFactory(
+  toolName: string,
+  build: (ctx: OpenClawPluginToolContext) => AnyAgentTool,
+): (ctx: OpenClawPluginToolContext) => AnyAgentTool {
+  return (ctx) => {
+    try {
+      return build(ctx);
+    } catch (err) {
+      return createWikiConfigErrorTool(
+        toolName,
+        err instanceof Error ? err : new Error(String(err)),
+      );
+    }
+  };
+}
 
 export default definePluginEntry({
   id: "memory-wiki",
@@ -52,31 +79,39 @@ export default definePluginEntry({
     }
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
     api.registerTool(
-      (ctx) => createWikiStatusTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      guardedWikiToolFactory("wiki_status", (ctx) =>
+        createWikiStatusTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      ),
       { name: "wiki_status" },
     );
     api.registerTool(
-      (ctx) => createWikiLintTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      guardedWikiToolFactory("wiki_lint", (ctx) =>
+        createWikiLintTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      ),
       { name: "wiki_lint" },
     );
     api.registerTool(
-      (ctx) => createWikiApplyTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      guardedWikiToolFactory("wiki_apply", (ctx) =>
+        createWikiApplyTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      ),
       { name: "wiki_apply" },
     );
     api.registerTool(
-      (ctx) =>
+      guardedWikiToolFactory("wiki_search", (ctx) =>
         createWikiSearchTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),
+      ),
       { name: "wiki_search" },
     );
     api.registerTool(
-      (ctx) =>
+      guardedWikiToolFactory("wiki_get", (ctx) =>
         createWikiGetTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),
+      ),
       { name: "wiki_get" },
     );
     api.registerCli(

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,7 +1,7 @@
 import { definePluginEntry } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
 import {
-  containsVaultPathTemplate,
+  hasAnyVaultPathPlaceholder,
   memoryWikiConfigSchema,
   resolveMemoryWikiConfig,
   resolveMemoryWikiConfigForCtx,
@@ -25,20 +25,24 @@ export default definePluginEntry({
   register(api) {
     const config = resolveMemoryWikiConfig(api.pluginConfig);
 
-    // When `vault.path` is templated (e.g. `{workspaceDir}/wiki`) the real
-    // vault location is only knowable at wiki-tool invocation time, where the
-    // registered factory calls `resolveMemoryWikiConfigForCtx(config, ctx)`.
+    // When `vault.path` contains any `{...}` placeholder — a known token
+    // like `{workspaceDir}` OR an unknown one like `{tenant}` / a typo like
+    // `{workspaceDIR}` — the real vault location is only knowable at
+    // wiki-tool invocation time (where `resolveMemoryWikiConfigForCtx` either
+    // expands it or throws for unresolved placeholders).
     // `registerMemoryPromptSupplement` and `registerMemoryCorpusSupplement`
     // capture `config` at plugin registration time and their SDK contracts do
-    // not thread `workspaceDir`/`agentId`/`agentDir`, so registering them with
+    // not thread `workspaceDir`/`agentId`/`agentDir`. Registering them with
     // an unresolved templated path would leave `memory_search`/`memory_get`
     // (wiki corpus) and the memory prompt section reading from the literal
-    // templated path while `wiki_search`/`wiki_get` read from the per-context
-    // expanded path — an inconsistency that can return cross-tenant results
-    // inside the same conversation. When the operator opts into templating we
-    // skip both surfaces so the `wiki_*` tools remain the single authoritative
-    // per-context entry point for the wiki vault.
-    const vaultPathIsTemplated = containsVaultPathTemplate(config.vault.path);
+    // templated path while `wiki_search`/`wiki_get` throw at invocation —
+    // split-brain failure where `memory_*` flows silently write to a literal
+    // brace directory under CWD. Use the broader any-placeholder check so
+    // unknown-placeholder configs are also skipped instead of letting
+    // `memory_*` fall through to the literal path. When any placeholder is
+    // present we skip both surfaces so the `wiki_*` tools remain the single
+    // authoritative per-context entry point for the wiki vault.
+    const vaultPathIsTemplated = hasAnyVaultPathPlaceholder(config.vault.path);
 
     if (!vaultPathIsTemplated) {
       api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder(config));

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,6 +1,10 @@
 import { definePluginEntry } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
-import { memoryWikiConfigSchema, resolveMemoryWikiConfig } from "./src/config.js";
+import {
+  memoryWikiConfigSchema,
+  resolveMemoryWikiConfig,
+  resolveMemoryWikiConfigForCtx,
+} from "./src/config.js";
 import { createWikiCorpusSupplement } from "./src/corpus-supplement.js";
 import { registerMemoryWikiGatewayMethods } from "./src/gateway.js";
 import { createWikiPromptSectionBuilder } from "./src/prompt-section.js";
@@ -25,12 +29,21 @@ export default definePluginEntry({
       createWikiCorpusSupplement({ config, appConfig: api.config }),
     );
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
-    api.registerTool(createWikiStatusTool(config, api.config), { name: "wiki_status" });
-    api.registerTool(createWikiLintTool(config, api.config), { name: "wiki_lint" });
-    api.registerTool(createWikiApplyTool(config, api.config), { name: "wiki_apply" });
+    api.registerTool(
+      (ctx) => createWikiStatusTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_status" },
+    );
+    api.registerTool(
+      (ctx) => createWikiLintTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_lint" },
+    );
+    api.registerTool(
+      (ctx) => createWikiApplyTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),
+      { name: "wiki_apply" },
+    );
     api.registerTool(
       (ctx) =>
-        createWikiSearchTool(config, api.config, {
+        createWikiSearchTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),
@@ -38,7 +51,7 @@ export default definePluginEntry({
     );
     api.registerTool(
       (ctx) =>
-        createWikiGetTool(config, api.config, {
+        createWikiGetTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config, {
           agentId: ctx.agentId,
           agentSessionKey: ctx.sessionKey,
         }),

--- a/extensions/memory-wiki/index.ts
+++ b/extensions/memory-wiki/index.ts
@@ -1,6 +1,7 @@
 import { definePluginEntry } from "./api.js";
 import { registerWikiCli } from "./src/cli.js";
 import {
+  containsVaultPathTemplate,
   memoryWikiConfigSchema,
   resolveMemoryWikiConfig,
   resolveMemoryWikiConfigForCtx,
@@ -24,10 +25,27 @@ export default definePluginEntry({
   register(api) {
     const config = resolveMemoryWikiConfig(api.pluginConfig);
 
-    api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder(config));
-    api.registerMemoryCorpusSupplement(
-      createWikiCorpusSupplement({ config, appConfig: api.config }),
-    );
+    // When `vault.path` is templated (e.g. `{workspaceDir}/wiki`) the real
+    // vault location is only knowable at wiki-tool invocation time, where the
+    // registered factory calls `resolveMemoryWikiConfigForCtx(config, ctx)`.
+    // `registerMemoryPromptSupplement` and `registerMemoryCorpusSupplement`
+    // capture `config` at plugin registration time and their SDK contracts do
+    // not thread `workspaceDir`/`agentId`/`agentDir`, so registering them with
+    // an unresolved templated path would leave `memory_search`/`memory_get`
+    // (wiki corpus) and the memory prompt section reading from the literal
+    // templated path while `wiki_search`/`wiki_get` read from the per-context
+    // expanded path — an inconsistency that can return cross-tenant results
+    // inside the same conversation. When the operator opts into templating we
+    // skip both surfaces so the `wiki_*` tools remain the single authoritative
+    // per-context entry point for the wiki vault.
+    const vaultPathIsTemplated = containsVaultPathTemplate(config.vault.path);
+
+    if (!vaultPathIsTemplated) {
+      api.registerMemoryPromptSupplement(createWikiPromptSectionBuilder(config));
+      api.registerMemoryCorpusSupplement(
+        createWikiCorpusSupplement({ config, appConfig: api.config }),
+      );
+    }
     registerMemoryWikiGatewayMethods({ api, config, appConfig: api.config });
     api.registerTool(
       (ctx) => createWikiStatusTool(resolveMemoryWikiConfigForCtx(config, ctx), api.config),

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import AjvPkg from "ajv";
 import { describe, expect, it } from "vitest";
 import {
+  containsVaultPathTemplate,
   DEFAULT_WIKI_RENDER_MODE,
   DEFAULT_WIKI_SEARCH_BACKEND,
   DEFAULT_WIKI_SEARCH_CORPUS,
   DEFAULT_WIKI_VAULT_MODE,
+  expandVaultPathTemplate,
   resolveDefaultMemoryWikiVaultPath,
   resolveMemoryWikiConfig,
+  resolveMemoryWikiConfigForCtx,
 } from "./config.js";
 
 function compileManifestConfigSchema() {
@@ -56,6 +59,66 @@ describe("resolveMemoryWikiConfig", () => {
     });
 
     expect(canonical.bridge.readMemoryArtifacts).toBe(false);
+  });
+});
+
+describe("vault path templating", () => {
+  it("detects template tokens", () => {
+    expect(containsVaultPathTemplate("/Users/a/wiki")).toBe(false);
+    expect(containsVaultPathTemplate("/tmp/{workspaceDir}/wiki")).toBe(true);
+    expect(containsVaultPathTemplate("{agentId}")).toBe(true);
+    expect(containsVaultPathTemplate("{unknownToken}")).toBe(false);
+  });
+
+  it("expands known tokens and normalizes the result", () => {
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/workspace/wiki");
+
+    // `..` traversal is applied only after expansion, not to the template.
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/../shared-wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/shared-wiki");
+  });
+
+  it("leaves literal paths untouched (identity fast path)", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "/literal/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    const resolved = resolveMemoryWikiConfigForCtx(base, { workspaceDir: "/tmp/w" });
+    expect(resolved).toBe(base);
+  });
+
+  it("returns a new config with expanded vault.path when templates are present", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "{workspaceDir}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    expect(base.vault.path).toBe("{workspaceDir}/wiki");
+
+    const resolved = resolveMemoryWikiConfigForCtx(base, {
+      workspaceDir: "/tmp/workspace",
+      agentId: "agent-a",
+    });
+    expect(resolved).not.toBe(base);
+    expect(resolved.vault.path).toBe("/tmp/workspace/wiki");
+    // Unrelated fields pass through unchanged.
+    expect(resolved.vaultMode).toBe(base.vaultMode);
+    expect(resolved.vault.renderMode).toBe(base.vault.renderMode);
+  });
+
+  it("supports agentId templating and leaves unresolved tokens as empty strings", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "/tmp/{agentId}/{sessionKey}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    const resolved = resolveMemoryWikiConfigForCtx(base, { agentId: "abc" });
+    expect(resolved.vault.path).toBe("/tmp/abc/wiki");
   });
 });
 

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -112,13 +112,28 @@ describe("vault path templating", () => {
     expect(resolved.vault.renderMode).toBe(base.vault.renderMode);
   });
 
-  it("supports agentId templating and leaves unresolved tokens as empty strings", () => {
+  it("preserves unresolved tokens literally so compound templates do not silently collapse", () => {
     const base = resolveMemoryWikiConfig(
       { vault: { path: "/tmp/{agentId}/{sessionKey}/wiki" } },
       { homedir: "/Users/tester" },
     );
     const resolved = resolveMemoryWikiConfigForCtx(base, { agentId: "abc" });
-    expect(resolved.vault.path).toBe("/tmp/abc/wiki");
+    // `{sessionKey}` stays as a literal path segment rather than collapsing
+    // into `/tmp/abc/wiki`, so downstream filesystem ops fail visibly instead
+    // of silently reading/writing another tenant's vault.
+    expect(resolved.vault.path).toBe("/tmp/abc/{sessionKey}/wiki");
+  });
+
+  it("preserves an entirely unresolved template rather than collapsing to filesystem root or CWD", () => {
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "{workspaceDir}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    const resolved = resolveMemoryWikiConfigForCtx(base, {});
+    // Without this guard `{workspaceDir}/wiki` would expand to `/wiki` (root)
+    // or `./wiki` (process CWD) when a tool server invokes with a bare
+    // context — a data-integrity / cross-tenant failure mode.
+    expect(resolved.vault.path).toBe("{workspaceDir}/wiki");
   });
 });
 

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -135,6 +135,23 @@ describe("vault path templating", () => {
     // context — a data-integrity / cross-tenant failure mode.
     expect(resolved.vault.path).toBe("{workspaceDir}/wiki");
   });
+
+  it("skips path normalization when tokens stay unresolved so `..` cannot collapse the placeholder away", () => {
+    // `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"` (CWD-relative)
+    // because `path.normalize` eats the `..` against the literal `{workspaceDir}`
+    // segment. Normalizing unresolved templates would silently redirect
+    // vault reads/writes to `process.cwd()/wiki` — re-introducing the exact
+    // failure mode the literal-preservation guard exists to prevent.
+    expect(expandVaultPathTemplate("{workspaceDir}/../wiki", {})).toBe("{workspaceDir}/../wiki");
+
+    // Once the token is resolved, normalization is safe and collapses `..`
+    // against real segments as usual.
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/../wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/wiki");
+  });
 });
 
 describe("memory-wiki manifest config schema", () => {

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -172,6 +172,39 @@ describe("vault path templating", () => {
     ).toThrow(/unresolved placeholder\(s\) \{tenant\}/);
   });
 
+  it("throws on paths whose only placeholder is unknown (no known tokens ever trigger expansion)", () => {
+    // Regression: the prior early-return gated on the narrow
+    // known-tokens regex, so a path like `{tenant}/wiki` exited
+    // `expandVaultPathTemplate` before the unresolved-placeholder guard
+    // could fire, returning the literal string. Downstream writes via
+    // `fs.mkdir(..., { recursive: true })` would then create a literal
+    // `{tenant}/wiki` directory under CWD.
+    expect(() => expandVaultPathTemplate("{tenant}/wiki", { workspaceDir: "/tmp/w" })).toThrow(
+      /unresolved placeholder\(s\) \{tenant\}/,
+    );
+
+    // A case-typo of a known token (`{workspaceDIR}` instead of
+    // `{workspaceDir}`) is indistinguishable from an unknown placeholder
+    // at this layer and must throw for the same reason.
+    expect(() =>
+      expandVaultPathTemplate("{workspaceDIR}/wiki", { workspaceDir: "/tmp/w" }),
+    ).toThrow(/unresolved placeholder\(s\) \{workspaceDIR\}/);
+  });
+
+  it("propagates the unknown-only throw through resolveMemoryWikiConfigForCtx's identity fast path", () => {
+    // The identity fast path previously used the narrow known-tokens
+    // regex, so a config with only unknown placeholders would return the
+    // base config unchanged — tool factories would then use the literal
+    // `{tenant}/wiki` as the resolved vault path.
+    const base = resolveMemoryWikiConfig(
+      { vault: { path: "{tenant}/wiki" } },
+      { homedir: "/Users/tester" },
+    );
+    expect(() => resolveMemoryWikiConfigForCtx(base, { workspaceDir: "/tmp/w" })).toThrow(
+      /unresolved placeholder\(s\) \{tenant\}/,
+    );
+  });
+
   it("lists all unresolved placeholders in the error message, deduplicated and sorted", () => {
     // Multiple missing tokens should be reported together so the operator
     // can fix the config in one pass instead of re-running the tool four

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -152,6 +152,21 @@ describe("vault path templating", () => {
       }),
     ).toBe("/tmp/wiki");
   });
+
+  it("skips path normalization when unknown placeholders (typos) remain so `..` cannot eat them", () => {
+    // A typo like `{tenant}` is not a known token, so the replace step leaves
+    // it in place. If the normalization gate only looked at known tokens the
+    // path would still normalize and `path.normalize` would collapse
+    // `{tenant}/..`, silently rewriting `/tmp/workspace/{tenant}/../wiki` to
+    // `/tmp/workspace/wiki` — a tenant-boundary breach driven by a config
+    // typo. The broader `{word}` gate blocks normalization so the filesystem
+    // surfaces ENOENT on the literal placeholder directory instead.
+    expect(
+      expandVaultPathTemplate("{workspaceDir}/{tenant}/../wiki", {
+        workspaceDir: "/tmp/workspace",
+      }),
+    ).toBe("/tmp/workspace/{tenant}/../wiki");
+  });
 });
 
 describe("memory-wiki manifest config schema", () => {

--- a/extensions/memory-wiki/src/config.test.ts
+++ b/extensions/memory-wiki/src/config.test.ts
@@ -112,37 +112,44 @@ describe("vault path templating", () => {
     expect(resolved.vault.renderMode).toBe(base.vault.renderMode);
   });
 
-  it("preserves unresolved tokens literally so compound templates do not silently collapse", () => {
+  it("throws when a compound template leaves a known token unresolved", () => {
+    // Returning `/tmp/abc/{sessionKey}/wiki` would not prevent downstream
+    // write flows: `fs.mkdir(path, { recursive: true })` in writeWikiPage
+    // happily creates a literal `{sessionKey}` subdirectory under the
+    // partially-resolved parent and mixes data across sessions. Throwing at
+    // expansion time fails the tool invocation before any filesystem side
+    // effect.
     const base = resolveMemoryWikiConfig(
       { vault: { path: "/tmp/{agentId}/{sessionKey}/wiki" } },
       { homedir: "/Users/tester" },
     );
-    const resolved = resolveMemoryWikiConfigForCtx(base, { agentId: "abc" });
-    // `{sessionKey}` stays as a literal path segment rather than collapsing
-    // into `/tmp/abc/wiki`, so downstream filesystem ops fail visibly instead
-    // of silently reading/writing another tenant's vault.
-    expect(resolved.vault.path).toBe("/tmp/abc/{sessionKey}/wiki");
+    expect(() => resolveMemoryWikiConfigForCtx(base, { agentId: "abc" })).toThrow(
+      /unresolved placeholder\(s\) \{sessionKey\}/,
+    );
   });
 
-  it("preserves an entirely unresolved template rather than collapsing to filesystem root or CWD", () => {
+  it("throws on an entirely unresolved template rather than returning a CWD-relative path", () => {
+    // Without the throw, `{workspaceDir}/wiki` invoked with an empty context
+    // is returned as-is and `fs.mkdir(..., { recursive: true })` creates a
+    // `./{workspaceDir}/wiki` tree under process.cwd(). Tool callers then
+    // write into a shared CWD-backed vault.
     const base = resolveMemoryWikiConfig(
       { vault: { path: "{workspaceDir}/wiki" } },
       { homedir: "/Users/tester" },
     );
-    const resolved = resolveMemoryWikiConfigForCtx(base, {});
-    // Without this guard `{workspaceDir}/wiki` would expand to `/wiki` (root)
-    // or `./wiki` (process CWD) when a tool server invokes with a bare
-    // context — a data-integrity / cross-tenant failure mode.
-    expect(resolved.vault.path).toBe("{workspaceDir}/wiki");
+    expect(() => resolveMemoryWikiConfigForCtx(base, {})).toThrow(
+      /unresolved placeholder\(s\) \{workspaceDir\}/,
+    );
   });
 
-  it("skips path normalization when tokens stay unresolved so `..` cannot collapse the placeholder away", () => {
-    // `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"` (CWD-relative)
-    // because `path.normalize` eats the `..` against the literal `{workspaceDir}`
-    // segment. Normalizing unresolved templates would silently redirect
-    // vault reads/writes to `process.cwd()/wiki` — re-introducing the exact
-    // failure mode the literal-preservation guard exists to prevent.
-    expect(expandVaultPathTemplate("{workspaceDir}/../wiki", {})).toBe("{workspaceDir}/../wiki");
+  it("throws on unresolved tokens even when `..` is present so `path.normalize` cannot eat the placeholder", () => {
+    // `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"`. Throwing
+    // before normalization guarantees the misconfiguration surfaces instead
+    // of silently collapsing to a CWD-relative path that downstream writes
+    // would succeed against.
+    expect(() => expandVaultPathTemplate("{workspaceDir}/../wiki", {})).toThrow(
+      /unresolved placeholder\(s\) \{workspaceDir\}/,
+    );
 
     // Once the token is resolved, normalization is safe and collapses `..`
     // against real segments as usual.
@@ -153,19 +160,26 @@ describe("vault path templating", () => {
     ).toBe("/tmp/wiki");
   });
 
-  it("skips path normalization when unknown placeholders (typos) remain so `..` cannot eat them", () => {
-    // A typo like `{tenant}` is not a known token, so the replace step leaves
-    // it in place. If the normalization gate only looked at known tokens the
-    // path would still normalize and `path.normalize` would collapse
-    // `{tenant}/..`, silently rewriting `/tmp/workspace/{tenant}/../wiki` to
-    // `/tmp/workspace/wiki` — a tenant-boundary breach driven by a config
-    // typo. The broader `{word}` gate blocks normalization so the filesystem
-    // surfaces ENOENT on the literal placeholder directory instead.
-    expect(
+  it("throws when unknown placeholders (typos) remain after expansion of known tokens", () => {
+    // A typo like `{tenant}` is not a known token, so the replace step
+    // leaves it in place. Normalizing `/tmp/workspace/{tenant}/../wiki`
+    // collapses to `/tmp/workspace/wiki` and silently breaches tenant
+    // isolation. Throwing surfaces the config error at tool-invocation time.
+    expect(() =>
       expandVaultPathTemplate("{workspaceDir}/{tenant}/../wiki", {
         workspaceDir: "/tmp/workspace",
       }),
-    ).toBe("/tmp/workspace/{tenant}/../wiki");
+    ).toThrow(/unresolved placeholder\(s\) \{tenant\}/);
+  });
+
+  it("lists all unresolved placeholders in the error message, deduplicated and sorted", () => {
+    // Multiple missing tokens should be reported together so the operator
+    // can fix the config in one pass instead of re-running the tool four
+    // times. The list is deduplicated (`{sessionKey}` appearing twice shows
+    // up once) and sorted for stable error messages.
+    expect(() =>
+      expandVaultPathTemplate("{workspaceDir}/{sessionKey}/{agentId}/{sessionKey}/wiki", {}),
+    ).toThrow(/\{agentId\}, \{sessionKey\}, \{workspaceDir\}/);
   });
 });
 

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -235,6 +235,19 @@ export function containsVaultPathTemplate(candidatePath: string): boolean {
 }
 
 /**
+ * Broader placeholder check used for fail-closed gates: returns `true` for
+ * any `{word}` placeholder, not just the four known tokens. Callers that
+ * must treat unknown placeholders (typos like `{tenant}` or
+ * `{workspaceDIR}`) the same as known templated paths — for example the
+ * plugin registration code that decides whether to skip memory-corpus /
+ * prompt-section supplements — should gate on this instead of
+ * {@link containsVaultPathTemplate}.
+ */
+export function hasAnyVaultPathPlaceholder(candidatePath: string): boolean {
+  return VAULT_PATH_ANY_PLACEHOLDER.test(candidatePath);
+}
+
+/**
  * Expand `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders
  * in a vault path using the supplied tool invocation context. Throws if the
  * expanded path still contains any `{...}` placeholder — either because a

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -202,6 +202,72 @@ export function resolveDefaultMemoryWikiVaultPath(homedir = os.homedir()): strin
   return path.join(homedir, ".openclaw", "wiki", "main");
 }
 
+/**
+ * Context fields available for `vault.path` template expansion. All fields are
+ * optional; missing values expand to an empty string so callers can detect
+ * unresolved templates via {@link containsVaultPathTemplate}.
+ */
+export type VaultPathTemplateContext = {
+  workspaceDir?: string;
+  agentDir?: string;
+  agentId?: string;
+  sessionKey?: string;
+};
+
+const VAULT_PATH_TEMPLATE_TOKENS = ["workspaceDir", "agentDir", "agentId", "sessionKey"] as const;
+
+const VAULT_PATH_TEMPLATE_PATTERN = new RegExp(
+  `\\{(${VAULT_PATH_TEMPLATE_TOKENS.join("|")})\\}`,
+  "g",
+);
+
+export function containsVaultPathTemplate(candidatePath: string): boolean {
+  VAULT_PATH_TEMPLATE_PATTERN.lastIndex = 0;
+  return VAULT_PATH_TEMPLATE_PATTERN.test(candidatePath);
+}
+
+/**
+ * Expand `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders
+ * in a vault path using the supplied tool invocation context. Missing values
+ * expand to an empty string; the result is normalized so path-traversal
+ * segments (e.g. `..`) collapse only after expansion.
+ */
+export function expandVaultPathTemplate(
+  templatePath: string,
+  ctx: VaultPathTemplateContext,
+): string {
+  if (!containsVaultPathTemplate(templatePath)) {
+    return templatePath;
+  }
+  const expanded = templatePath.replace(
+    VAULT_PATH_TEMPLATE_PATTERN,
+    (_match, token: (typeof VAULT_PATH_TEMPLATE_TOKENS)[number]) => ctx[token] ?? "",
+  );
+  return path.normalize(expanded);
+}
+
+/**
+ * Return a {@link ResolvedMemoryWikiConfig} with `vault.path` expanded against
+ * the supplied invocation context. If the path has no template tokens the
+ * input config is returned unchanged (identity) so the fast path allocates
+ * nothing.
+ */
+export function resolveMemoryWikiConfigForCtx(
+  base: ResolvedMemoryWikiConfig,
+  ctx: VaultPathTemplateContext,
+): ResolvedMemoryWikiConfig {
+  if (!containsVaultPathTemplate(base.vault.path)) {
+    return base;
+  }
+  return {
+    ...base,
+    vault: {
+      ...base.vault,
+      path: expandVaultPathTemplate(base.vault.path, ctx),
+    },
+  };
+}
+
 export function resolveMemoryWikiConfig(
   config: MemoryWikiPluginConfig | undefined,
   options?: { homedir?: string },

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -256,7 +256,13 @@ export function expandVaultPathTemplate(
   templatePath: string,
   ctx: VaultPathTemplateContext,
 ): string {
-  if (!containsVaultPathTemplate(templatePath)) {
+  // Short-circuit on paths with no `{...}` placeholder AT ALL. The broader
+  // check is required — gating on the narrow four-known-tokens regex would
+  // let a path like `"{tenant}/wiki"` or a typo like `"{workspaceDIR}/wiki"`
+  // skip the unresolved-placeholder guard below and be returned as a literal
+  // string, which would then hit `fs.mkdir(..., { recursive: true })` in the
+  // write flow and create a brace-named directory under CWD.
+  if (!VAULT_PATH_ANY_PLACEHOLDER.test(templatePath)) {
     return templatePath;
   }
   const expanded = templatePath.replace(
@@ -278,15 +284,18 @@ export function expandVaultPathTemplate(
 
 /**
  * Return a {@link ResolvedMemoryWikiConfig} with `vault.path` expanded against
- * the supplied invocation context. If the path has no template tokens the
- * input config is returned unchanged (identity) so the fast path allocates
- * nothing.
+ * the supplied invocation context. If the path contains no `{...}`
+ * placeholder at all the input config is returned unchanged (identity) so
+ * the fast path allocates nothing. The check uses the broader any-placeholder
+ * regex so unknown placeholders (typos like `{tenant}` / `{workspaceDIR}`)
+ * still flow through `expandVaultPathTemplate` and surface as a config error
+ * instead of silently being returned as a literal vault path.
  */
 export function resolveMemoryWikiConfigForCtx(
   base: ResolvedMemoryWikiConfig,
   ctx: VaultPathTemplateContext,
 ): ResolvedMemoryWikiConfig {
-  if (!containsVaultPathTemplate(base.vault.path)) {
+  if (!VAULT_PATH_ANY_PLACEHOLDER.test(base.vault.path)) {
     return base;
   }
   return {

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -223,6 +223,13 @@ const VAULT_PATH_TEMPLATE_PATTERN = new RegExp(
   "g",
 );
 
+// Broader check used after expansion to gate `path.normalize`. Matches any
+// `{word}` placeholder, not just the four known tokens, so a typo like
+// `{tenant}` in a multi-tenant config still blocks normalization — otherwise
+// `path.normalize("/tmp/workspace/{tenant}/../wiki")` collapses to
+// `/tmp/workspace/wiki` and silently redirects the vault.
+const VAULT_PATH_ANY_PLACEHOLDER = /\{[^{}/]+\}/;
+
 export function containsVaultPathTemplate(candidatePath: string): boolean {
   return VAULT_PATH_TEMPLATE_DETECT.test(candidatePath);
 }
@@ -237,13 +244,15 @@ export function containsVaultPathTemplate(candidatePath: string): boolean {
  * for example when a plugin tool server resolves tools with a context that
  * does not populate workspace/agent/session fields.
  *
- * Normalization is only applied when every token was resolved. Running
- * `path.normalize` over a path that still contains literal `{token}` segments
- * would collapse traversal that references those unresolved segments —
+ * Normalization is only applied when every placeholder was resolved. Running
+ * `path.normalize` over a path that still contains `{...}` segments would
+ * collapse traversal that references those segments —
  * `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"`, a CWD-relative
  * path — re-introducing the exact silent-redirect failure mode the literal
- * preservation guards against. Skipping normalization in that case keeps the
- * path lexically broken so the filesystem surfaces ENOENT.
+ * preservation guards against. The gate uses a broader `\{word\}` match
+ * (not just the four known tokens), so typos like `{tenant}` also block
+ * normalization and fail loudly at the filesystem layer instead of silently
+ * redirecting to a neighbouring tenant.
  */
 export function expandVaultPathTemplate(
   templatePath: string,
@@ -259,7 +268,7 @@ export function expandVaultPathTemplate(
       return value != null && value !== "" ? value : match;
     },
   );
-  if (containsVaultPathTemplate(expanded)) {
+  if (VAULT_PATH_ANY_PLACEHOLDER.test(expanded)) {
     return expanded;
   }
   return path.normalize(expanded);

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -236,23 +236,21 @@ export function containsVaultPathTemplate(candidatePath: string): boolean {
 
 /**
  * Expand `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders
- * in a vault path using the supplied tool invocation context. Tokens whose
- * context value is absent (or empty) are preserved literally in the output
- * (e.g. `{workspaceDir}/wiki` stays `{workspaceDir}/wiki`) so downstream
- * filesystem operations fail visibly instead of silently collapsing the path
- * into a different tenant's vault, the process CWD, or the filesystem root —
- * for example when a plugin tool server resolves tools with a context that
- * does not populate workspace/agent/session fields.
+ * in a vault path using the supplied tool invocation context. Throws if the
+ * expanded path still contains any `{...}` placeholder — either because a
+ * known token's context value was absent (e.g. `{workspaceDir}` invoked from
+ * a plugin tool server that only passes `{ config }`) or because the template
+ * referenced an unknown token (e.g. a typo like `{tenant}`). Returning the
+ * unresolved path string is not fail-closed: `fs.mkdir(path, { recursive: true })`
+ * happily creates a directory named literally `{workspaceDir}` under
+ * `process.cwd()` and subsequent writes succeed against a CWD-backed vault,
+ * which can mix data across sessions or tenants. Throwing at this layer
+ * surfaces the misconfiguration at tool invocation time — before any
+ * filesystem side effect runs — instead of waiting for a read ENOENT that
+ * never fires on the recursive-create write path.
  *
- * Normalization is only applied when every placeholder was resolved. Running
- * `path.normalize` over a path that still contains `{...}` segments would
- * collapse traversal that references those segments —
- * `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"`, a CWD-relative
- * path — re-introducing the exact silent-redirect failure mode the literal
- * preservation guards against. The gate uses a broader `\{word\}` match
- * (not just the four known tokens), so typos like `{tenant}` also block
- * normalization and fail loudly at the filesystem layer instead of silently
- * redirecting to a neighbouring tenant.
+ * Successful expansions are normalized so path-traversal segments (e.g.
+ * `..`) collapse against resolved segments as usual.
  */
 export function expandVaultPathTemplate(
   templatePath: string,
@@ -268,8 +266,12 @@ export function expandVaultPathTemplate(
       return value != null && value !== "" ? value : match;
     },
   );
-  if (VAULT_PATH_ANY_PLACEHOLDER.test(expanded)) {
-    return expanded;
+  const unresolved = expanded.match(new RegExp(VAULT_PATH_ANY_PLACEHOLDER, "g"));
+  if (unresolved) {
+    const uniquePlaceholders = [...new Set(unresolved)].toSorted();
+    throw new Error(
+      `memory-wiki vault.path has unresolved placeholder(s) ${uniquePlaceholders.join(", ")} in "${templatePath}" — invocation context did not provide the required value(s). Supply a literal path or invoke from a context that populates the referenced tokens.`,
+    );
   }
   return path.normalize(expanded);
 }

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -216,14 +216,15 @@ export type VaultPathTemplateContext = {
 
 const VAULT_PATH_TEMPLATE_TOKENS = ["workspaceDir", "agentDir", "agentId", "sessionKey"] as const;
 
+const VAULT_PATH_TEMPLATE_DETECT = new RegExp(`\\{(${VAULT_PATH_TEMPLATE_TOKENS.join("|")})\\}`);
+
 const VAULT_PATH_TEMPLATE_PATTERN = new RegExp(
   `\\{(${VAULT_PATH_TEMPLATE_TOKENS.join("|")})\\}`,
   "g",
 );
 
 export function containsVaultPathTemplate(candidatePath: string): boolean {
-  VAULT_PATH_TEMPLATE_PATTERN.lastIndex = 0;
-  return VAULT_PATH_TEMPLATE_PATTERN.test(candidatePath);
+  return VAULT_PATH_TEMPLATE_DETECT.test(candidatePath);
 }
 
 /**

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -235,9 +235,15 @@ export function containsVaultPathTemplate(candidatePath: string): boolean {
  * filesystem operations fail visibly instead of silently collapsing the path
  * into a different tenant's vault, the process CWD, or the filesystem root —
  * for example when a plugin tool server resolves tools with a context that
- * does not populate workspace/agent/session fields. The result is normalized
- * so path-traversal segments (e.g. `..`) collapse only after expansion of
- * resolved tokens.
+ * does not populate workspace/agent/session fields.
+ *
+ * Normalization is only applied when every token was resolved. Running
+ * `path.normalize` over a path that still contains literal `{token}` segments
+ * would collapse traversal that references those unresolved segments —
+ * `path.normalize("{workspaceDir}/../wiki")` returns `"wiki"`, a CWD-relative
+ * path — re-introducing the exact silent-redirect failure mode the literal
+ * preservation guards against. Skipping normalization in that case keeps the
+ * path lexically broken so the filesystem surfaces ENOENT.
  */
 export function expandVaultPathTemplate(
   templatePath: string,
@@ -253,6 +259,9 @@ export function expandVaultPathTemplate(
       return value != null && value !== "" ? value : match;
     },
   );
+  if (containsVaultPathTemplate(expanded)) {
+    return expanded;
+  }
   return path.normalize(expanded);
 }
 

--- a/extensions/memory-wiki/src/config.ts
+++ b/extensions/memory-wiki/src/config.ts
@@ -229,9 +229,15 @@ export function containsVaultPathTemplate(candidatePath: string): boolean {
 
 /**
  * Expand `{workspaceDir}`, `{agentDir}`, `{agentId}`, `{sessionKey}` placeholders
- * in a vault path using the supplied tool invocation context. Missing values
- * expand to an empty string; the result is normalized so path-traversal
- * segments (e.g. `..`) collapse only after expansion.
+ * in a vault path using the supplied tool invocation context. Tokens whose
+ * context value is absent (or empty) are preserved literally in the output
+ * (e.g. `{workspaceDir}/wiki` stays `{workspaceDir}/wiki`) so downstream
+ * filesystem operations fail visibly instead of silently collapsing the path
+ * into a different tenant's vault, the process CWD, or the filesystem root —
+ * for example when a plugin tool server resolves tools with a context that
+ * does not populate workspace/agent/session fields. The result is normalized
+ * so path-traversal segments (e.g. `..`) collapse only after expansion of
+ * resolved tokens.
  */
 export function expandVaultPathTemplate(
   templatePath: string,
@@ -242,7 +248,10 @@ export function expandVaultPathTemplate(
   }
   const expanded = templatePath.replace(
     VAULT_PATH_TEMPLATE_PATTERN,
-    (_match, token: (typeof VAULT_PATH_TEMPLATE_TOKENS)[number]) => ctx[token] ?? "",
+    (match, token: (typeof VAULT_PATH_TEMPLATE_TOKENS)[number]) => {
+      const value = ctx[token];
+      return value != null && value !== "" ? value : match;
+    },
   );
   return path.normalize(expanded);
 }

--- a/extensions/memory-wiki/src/test-helpers.ts
+++ b/extensions/memory-wiki/src/test-helpers.ts
@@ -68,7 +68,9 @@ export function createMemoryWikiTestHarness() {
     return { rootDir, config };
   }
 
-  function createPluginApi(): MemoryWikiPluginApiHarness {
+  function createPluginApi(options?: {
+    pluginConfig?: MemoryWikiPluginConfig;
+  }): MemoryWikiPluginApiHarness {
     const registerCli = vi.fn();
     const registerGatewayMethod = vi.fn();
     const registerMemoryCorpusSupplement = vi.fn();
@@ -79,6 +81,7 @@ export function createMemoryWikiTestHarness() {
       name: "Memory Wiki",
       source: "test",
       config: {},
+      pluginConfig: options?.pluginConfig,
       runtime: {} as OpenClawPluginApi["runtime"],
       registerCli,
       registerGatewayMethod,

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -13,6 +13,19 @@ import { renderMemoryWikiStatus, resolveMemoryWikiStatus } from "./status.js";
 
 const WikiStatusSchema = Type.Object({}, { additionalProperties: false });
 const WikiLintSchema = Type.Object({}, { additionalProperties: false });
+// Permissive schema for config-error stub tools so argument validation in the
+// catalog layer does not swallow the real error before `execute` can surface
+// it. Any input is accepted; `execute` rejects with the underlying config
+// error so callers see an actionable message.
+const WikiConfigErrorSchema = Type.Object({}, { additionalProperties: true });
+
+const WIKI_TOOL_LABELS: Record<string, string> = {
+  wiki_status: "Wiki Status",
+  wiki_search: "Wiki Search",
+  wiki_lint: "Wiki Lint",
+  wiki_apply: "Wiki Apply",
+  wiki_get: "Wiki Get",
+};
 const WikiSearchBackendSchema = Type.Union(
   WIKI_SEARCH_BACKENDS.map((value) => Type.Literal(value)),
 );
@@ -85,6 +98,25 @@ type WikiToolMemoryContext = {
   agentId?: string;
   agentSessionKey?: string;
 };
+
+// Returned by `registerTool` factories when `resolveMemoryWikiConfigForCtx`
+// throws during tool resolution (e.g. templated `vault.path` + partial ctx in
+// `src/mcp/plugin-tools-serve.ts`, which calls `resolvePluginTools` with only
+// `{ config }`). Without a stub the factory throw is caught in
+// `resolvePluginTools` and the tool silently disappears from the catalog;
+// this surface keeps the tool visible and surfaces the config error at
+// invocation time instead.
+export function createWikiConfigErrorTool(name: string, error: Error): AnyAgentTool {
+  return {
+    name,
+    label: WIKI_TOOL_LABELS[name] ?? name,
+    description: `memory-wiki ${name} is unavailable due to a configuration error: ${error.message}. Resolve the vault.path template or invoke from a context that populates the required tokens.`,
+    parameters: WikiConfigErrorSchema,
+    execute: async () => {
+      throw error;
+    },
+  };
+}
 
 export function createWikiStatusTool(
   config: ResolvedMemoryWikiConfig,


### PR DESCRIPTION
## Summary

Enables multi-tenant setups where one OpenClaw instance serves multiple orgs, each with an isolated wiki vault. Single combined PR replacing #66134 + #66149.

**Changes:**

1. **Factory registration** — `wiki_apply`, `wiki_status`, and `wiki_lint` now use the factory form `(ctx) => createXTool(config, ...)`, matching `wiki_search` and `wiki_get`. Pure registration-shape refactor, no behavioral change.

2. **vault.path templating** — when `vault.path` contains `{workspaceDir}`, `{agentDir}`, `{agentId}`, or `{sessionKey}`, the path is expanded at tool-invocation time using the invocation context. A config like `vault.path: "{workspaceDir}/../wiki"` resolves to different directories per agent/org.

   - `containsVaultPathTemplate(path)` — fast check for template tokens
   - `expandVaultPathTemplate(path, ctx)` — token replacement + path.normalize
   - `resolveMemoryWikiConfigForCtx(base, ctx)` — returns a resolved config copy (identity fast-path when no template present)

3. **Tests** — 5 new tests covering template detection, expansion, identity fast-path, full ctx resolution, and partial expansion.

## Use case

We run one OpenClaw instance serving multiple orgs. Each org needs its own wiki vault. With this change, setting `vault.path: "{workspaceDir}/../wiki"` in plugin config gives each org an isolated vault resolved at invocation time — no per-agent config patching needed.

## CI note

The memory-wiki-specific CI check (`extension-fast-memory-wiki`) passes. Any red checks are pre-existing TS errors in unrelated extensions (discord, telegram, whatsapp) — same failures present on main. Happy to rebase if those get fixed upstream.

Closes #66003
Supersedes #66134 and #66149