### PR TITLE
fix(exec): fail closed on Windows shell wrappers in allowlist mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Node host/exec: require approval for Windows PowerShell and pwsh shell-wrapper runs in allowlist mode, matching the existing cmd.exe wrapper behavior. (#67655) Thanks @plgonzalezrx8.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -374,7 +374,7 @@ Notes:
 - `system.run` supports `--cwd`, `--env KEY=VAL`, `--command-timeout`, and `--needs-screen-recording`.
 - For shell wrappers (`bash|sh|zsh ... -c/-lc`), request-scoped `--env` values are reduced to an explicit allowlist (`TERM`, `LANG`, `LC_*`, `COLORTERM`, `NO_COLOR`, `FORCE_COLOR`).
 - For allow-always decisions in allowlist mode, known dispatch wrappers (`env`, `nice`, `nohup`, `stdbuf`, `timeout`) persist inner executable paths instead of wrapper paths. If unwrapping is not safe, no allowlist entry is persisted automatically.
-- On Windows node hosts in allowlist mode, shell-wrapper runs via `cmd.exe /c` require approval (allowlist entry alone does not auto-allow the wrapper form).
+- On Windows node hosts in allowlist mode, shell-wrapper runs via `cmd.exe /c` or `powershell`/`pwsh -Command` require approval (allowlist entry alone does not auto-allow the wrapper form).
 - `system.notify` supports `--priority <passive|active|timeSensitive>` and `--delivery <system|overlay|auto>`.
 - Node hosts ignore `PATH` overrides and strip dangerous startup/shell keys (`DYLD_*`, `LD_*`, `NODE_OPTIONS`, `PYTHON*`, `PERL*`, `RUBYOPT`, `SHELLOPTS`, `PS4`). If you need extra PATH entries, configure the node host service environment (or install tools in standard locations) instead of passing `PATH` via `--env`.
 - On macOS node mode, `system.run` is gated by exec approvals in the macOS app (Settings → Exec approvals).

--- a/docs/nodes/troubleshooting.md
+++ b/docs/nodes/troubleshooting.md
@@ -93,8 +93,8 @@ run as an approval mismatch instead of trusting the edited payload.
 - `LOCATION_BACKGROUND_UNAVAILABLE` → app is backgrounded but only While Using permission exists.
 - `SYSTEM_RUN_DENIED: approval required` → exec request needs explicit approval.
 - `SYSTEM_RUN_DENIED: allowlist miss` → command blocked by allowlist mode.
-  On Windows node hosts, shell-wrapper forms like `cmd.exe /c ...` are treated as allowlist misses in
-  allowlist mode unless approved via ask flow.
+  On Windows node hosts, shell-wrapper forms like `cmd.exe /c ...` or `powershell`/`pwsh -Command ...`
+  are treated as allowlist misses in allowlist mode unless approved via ask flow.
 
 ## Fast recovery loop
 

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -147,6 +147,17 @@ describe("evaluateSystemRunPolicy", () => {
     expect(denied.errorMessage).toContain("Windows shell wrappers like cmd.exe /c");
   });
 
+  it("blocks Windows PowerShell wrappers in allowlist mode", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(
+        buildPolicyParams({ isWindows: true, cmdInvocation: false, shellWrapperInvocation: true }),
+      ),
+    );
+    expect(denied.shellWrapperBlocked).toBe(true);
+    expect(denied.windowsShellWrapperBlocked).toBe(true);
+    expect(denied.errorMessage).toContain("powershell -Command");
+  });
+
   it("does not block Windows cmd.exe invocations without inline shell-wrapper transport", () => {
     const allowed = expectAllowedDecision(
       evaluateSystemRunPolicy(

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -64,13 +64,13 @@ describe("formatSystemRunAllowlistMissMessage", () => {
     ).toContain("shell wrappers like sh/bash/zsh -c require approval");
   });
 
-  it("adds Windows shell-wrapper guidance when blocked by cmd.exe policy", () => {
+  it("adds Windows shell-wrapper guidance when blocked by Windows wrapper policy", () => {
     expect(
       formatSystemRunAllowlistMissMessage({
         shellWrapperBlocked: true,
         windowsShellWrapperBlocked: true,
       }),
-    ).toContain("Windows shell wrappers like cmd.exe /c require approval");
+    ).toContain("Windows shell wrappers like cmd.exe /c or powershell/pwsh -Command");
   });
 });
 
@@ -155,7 +155,7 @@ describe("evaluateSystemRunPolicy", () => {
     );
     expect(denied.shellWrapperBlocked).toBe(true);
     expect(denied.windowsShellWrapperBlocked).toBe(true);
-    expect(denied.errorMessage).toContain("powershell -Command");
+    expect(denied.errorMessage).toContain("powershell/pwsh -Command");
   });
 
   it("does not block Windows cmd.exe invocations without inline shell-wrapper transport", () => {

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -35,7 +35,7 @@ export function formatSystemRunAllowlistMissMessage(params?: {
   if (params?.windowsShellWrapperBlocked) {
     return (
       "SYSTEM_RUN_DENIED: allowlist miss " +
-      "(Windows shell wrappers like cmd.exe /c require approval; " +
+      "(Windows shell wrappers like cmd.exe /c or powershell -Command require approval; " +
       "approve once/always or run with --ask on-miss|always)"
     );
   }
@@ -63,13 +63,10 @@ export function evaluateSystemRunPolicy(params: {
 }): SystemRunPolicyDecision {
   // POSIX node execution intentionally uses `/bin/sh -lc` as a transport wrapper.
   // Keep allowlist decisions based on the analyzed inner shell payload there.
-  // Windows `cmd.exe /c` wrappers still require explicit approval because they
+  // Windows shell wrappers still require explicit approval because they can
   // change execution semantics for builtins and quoting/parsing behavior.
   const windowsShellWrapperBlocked =
-    params.security === "allowlist" &&
-    params.shellWrapperInvocation &&
-    params.isWindows &&
-    params.cmdInvocation;
+    params.security === "allowlist" && params.shellWrapperInvocation && params.isWindows;
   const shellWrapperBlocked = windowsShellWrapperBlocked;
   const analysisOk = shellWrapperBlocked ? false : params.analysisOk;
   const allowlistSatisfied = shellWrapperBlocked ? false : params.allowlistSatisfied;

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -35,7 +35,7 @@ export function formatSystemRunAllowlistMissMessage(params?: {
   if (params?.windowsShellWrapperBlocked) {
     return (
       "SYSTEM_RUN_DENIED: allowlist miss " +
-      "(Windows shell wrappers like cmd.exe /c or powershell -Command require approval; " +
+      "(Windows shell wrappers like cmd.exe /c or powershell/pwsh -Command require approval; " +
       "approve once/always or run with --ask on-miss|always)"
     );
   }


### PR DESCRIPTION
## Issue
In Windows allowlist mode, the wrapper guard only failed closed for `cmd.exe`-style invocations. That left a gap where other shell-wrapper transports such as `powershell -Command` could still be analyzed like a normal allowlisted command, which is the wrong security posture for inline shell payloads and command chaining.

## Fix
- block any Windows shell-wrapper transport in allowlist mode when `shellWrapperInvocation` is true, instead of limiting the guard to `cmdInvocation`
- update the denial guidance so it explicitly calls out `powershell -Command` alongside `cmd.exe /c`
- add regression coverage for the Windows PowerShell-wrapper path in `src/node-host/exec-policy.test.ts`

## How to test
- run: `pnpm test src/node-host/exec-policy.test.ts src/node-host/invoke-system-run.test.ts -t "PowerShell|shell wrapper|cmd.exe wrappers|allowlist"`
- verify the new PowerShell-wrapper regression covers `isWindows: true`, `shellWrapperInvocation: true`, and `cmdInvocation: false`
- confirm the decision is denied, `windowsShellWrapperBlocked` is set, and the error guidance mentions `powershell -Command`