### PR TITLE
fix(run): preserve model-scoped cooldown writes on incomplete turns

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -860,16 +860,14 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
 
     expect(result.payloads?.[0]?.isError).toBe(true);
     expect(mockedMarkAuthProfileFailure).toHaveBeenCalledTimes(2);
-    expect(
-      mockedMarkAuthProfileFailure.mock.calls.map(
-        (call) => (call[0] as { modelId?: string }).modelId,
-      ),
-    ).toEqual(["gpt-5.4", "gpt-5.4"]);
-    expect(
-      mockedMarkAuthProfileFailure.mock.calls.map(
-        (call) => (call[0] as { profileId?: string }).profileId,
-      ),
-    ).toEqual(["openai:p1", "openai:p1"]);
+    expect(mockedMarkAuthProfileFailure.mock.calls.map((call) => call[0]?.modelId)).toEqual([
+      "gpt-5.4",
+      "gpt-5.4",
+    ]);
+    expect(mockedMarkAuthProfileFailure.mock.calls.map((call) => call[0]?.profileId)).toEqual([
+      "openai:p1",
+      "openai:p1",
+    ]);
   });
 
   it("detects structured bullet-only plans with intent cues as planning-only GPT turns", () => {

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -5,6 +5,7 @@ import {
   loadRunOverflowCompactionHarness,
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
+  mockedHandleAssistantFailover,
   mockedLog,
   mockedMarkAuthProfileFailure,
   mockedResolveAuthProfileOrder,
@@ -832,8 +833,12 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     );
   });
 
-  it("persists incomplete-turn cooldowns with the active model id on every write", async () => {
+  it("persists generic incomplete-turn cooldowns with the active model id", async () => {
     mockedClassifyFailoverReason.mockReturnValue("rate_limit");
+    mockedHandleAssistantFailover.mockResolvedValue({
+      action: "continue_normal",
+      overloadProfileRotations: 0,
+    });
     mockedResolveAuthProfileOrder.mockReturnValue(["openai:p1"]);
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
@@ -859,15 +864,14 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     });
 
     expect(result.payloads?.[0]?.isError).toBe(true);
-    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledTimes(2);
-    expect(mockedMarkAuthProfileFailure.mock.calls.map((call) => call[0]?.modelId)).toEqual([
-      "gpt-5.4",
-      "gpt-5.4",
-    ]);
-    expect(mockedMarkAuthProfileFailure.mock.calls.map((call) => call[0]?.profileId)).toEqual([
-      "openai:p1",
-      "openai:p1",
-    ]);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledTimes(1);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai:p1",
+        reason: "rate_limit",
+        modelId: "gpt-5.4",
+      }),
+    );
   });
 
   it("detects structured bullet-only plans with intent cues as planning-only GPT turns", () => {

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -6,6 +6,8 @@ import {
   mockedClassifyFailoverReason,
   mockedGlobalHookRunner,
   mockedLog,
+  mockedMarkAuthProfileFailure,
+  mockedResolveAuthProfileOrder,
   mockedRunEmbeddedAttempt,
   mockedResolveModelAsync,
   overflowBaseRunParams,
@@ -780,6 +782,94 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(mockedLog.warn).toHaveBeenCalledWith(
       expect.stringContaining("reasoning-only retries exhausted"),
     );
+  });
+
+  it("persists reasoning-only exhausted cooldowns with the active model id", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("rate_limit");
+    mockedResolveAuthProfileOrder.mockReturnValue(["openai:p1"]);
+    mockedRunEmbeddedAttempt.mockResolvedValue(
+      makeAttemptResult({
+        externalAbort: true,
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "end_turn",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [
+            {
+              type: "thinking",
+              thinking: "internal reasoning",
+              thinkingSignature: JSON.stringify({
+                id: "rs_reasoning_exhausted_rate_limit",
+                type: "reasoning",
+              }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "openai:p1",
+      authProfileIdSource: "auto",
+      reasoningLevel: "on",
+      runId: "run-reasoning-only-exhausted-model-scoped-cooldown",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(3);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledTimes(1);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        profileId: "openai:p1",
+        reason: "rate_limit",
+        modelId: "gpt-5.4",
+      }),
+    );
+  });
+
+  it("persists incomplete-turn cooldowns with the active model id on every write", async () => {
+    mockedClassifyFailoverReason.mockReturnValue("rate_limit");
+    mockedResolveAuthProfileOrder.mockReturnValue(["openai:p1"]);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "error",
+          provider: "openai",
+          model: "gpt-5.4",
+          errorMessage: "rate limit exceeded",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.4",
+      authProfileId: "openai:p1",
+      authProfileIdSource: "auto",
+      runId: "run-incomplete-turn-model-scoped-cooldown",
+    });
+
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(mockedMarkAuthProfileFailure).toHaveBeenCalledTimes(2);
+    expect(
+      mockedMarkAuthProfileFailure.mock.calls.map(
+        (call) => (call[0] as { modelId?: string }).modelId,
+      ),
+    ).toEqual(["gpt-5.4", "gpt-5.4"]);
+    expect(
+      mockedMarkAuthProfileFailure.mock.calls.map(
+        (call) => (call[0] as { profileId?: string }).profileId,
+      ),
+    ).toEqual(["openai:p1", "openai:p1"]);
   });
 
   it("detects structured bullet-only plans with intent cues as planning-only GPT turns", () => {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -216,7 +216,9 @@ export const mockedGetApiKeyForModel = vi.fn(
     mode: "api-key" as const,
   }),
 );
-export const mockedMarkAuthProfileFailure = vi.fn(async () => {});
+export const mockedMarkAuthProfileFailure = vi.fn(
+  async (_params: { profileId?: string; reason?: string; modelId?: string } = {}) => {},
+);
 export const mockedResolveAuthProfileOrder = vi.fn(() => [] as string[]);
 export const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -216,6 +216,7 @@ export const mockedGetApiKeyForModel = vi.fn(
     mode: "api-key" as const,
   }),
 );
+export const mockedMarkAuthProfileFailure = vi.fn(async () => {});
 export const mockedResolveAuthProfileOrder = vi.fn(() => [] as string[]);
 export const mockedShouldPreferExplicitConfigApiKeyAuth = vi.fn(() => false);
 
@@ -382,6 +383,8 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
       mode: "api-key",
     }),
   );
+  mockedMarkAuthProfileFailure.mockReset();
+  mockedMarkAuthProfileFailure.mockResolvedValue(undefined);
   mockedResolveAuthProfileOrder.mockReset();
   mockedResolveAuthProfileOrder.mockReturnValue([]);
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReset();
@@ -425,7 +428,7 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
 
   vi.doMock("../auth-profiles.js", () => ({
     isProfileInCooldown: vi.fn(() => false),
-    markAuthProfileFailure: vi.fn(async () => {}),
+    markAuthProfileFailure: mockedMarkAuthProfileFailure,
     markAuthProfileGood: vi.fn(async () => {}),
     markAuthProfileUsed: vi.fn(async () => {}),
     resolveProfilesUnavailableReason: vi.fn(() => undefined),

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.harness.ts
@@ -146,6 +146,8 @@ export const mockedDescribeFailoverError = vi.fn<MockDescribeFailoverError>(
   }),
 );
 export const mockedResolveFailoverStatus = vi.fn<MockResolveFailoverStatus>();
+let realHandleAssistantFailover: ((params: unknown) => Promise<unknown>) | undefined;
+export const mockedHandleAssistantFailover = vi.fn<(params: unknown) => Promise<unknown>>();
 
 export const mockedLog: {
   debug: Mock<(...args: unknown[]) => void>;
@@ -387,6 +389,10 @@ export function resetRunOverflowCompactionHarnessMocks(): void {
   );
   mockedMarkAuthProfileFailure.mockReset();
   mockedMarkAuthProfileFailure.mockResolvedValue(undefined);
+  mockedHandleAssistantFailover.mockReset();
+  if (realHandleAssistantFailover) {
+    mockedHandleAssistantFailover.mockImplementation(realHandleAssistantFailover);
+  }
   mockedResolveAuthProfileOrder.mockReset();
   mockedResolveAuthProfileOrder.mockReturnValue([]);
   mockedShouldPreferExplicitConfigApiKeyAuth.mockReset();
@@ -544,6 +550,20 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     describeFailoverError: mockedDescribeFailoverError,
     resolveFailoverStatus: mockedResolveFailoverStatus,
   }));
+
+  vi.doMock("./run/assistant-failover.js", async () => {
+    const actual = await vi.importActual<typeof import("./run/assistant-failover.js")>(
+      "./run/assistant-failover.js",
+    );
+    realHandleAssistantFailover = actual.handleAssistantFailover as unknown as (
+      params: unknown,
+    ) => Promise<unknown>;
+    mockedHandleAssistantFailover.mockImplementation(realHandleAssistantFailover);
+    return {
+      ...actual,
+      handleAssistantFailover: mockedHandleAssistantFailover,
+    };
+  });
 
   vi.doMock("./lanes.js", () => ({
     resolveSessionLane: vi.fn(() => "session-lane"),

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2177,6 +2177,7 @@ export async function runEmbeddedPiAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: resolveRunAuthProfileFailureReason(assistantFailoverReason),
+                modelId,
               });
             }
             return {
@@ -2285,6 +2286,7 @@ export async function runEmbeddedPiAgent(
               await maybeMarkAuthProfileFailure({
                 profileId: lastProfileId,
                 reason: resolveRunAuthProfileFailureReason(assistantFailoverReason),
+                modelId,
               });
             }
 


### PR DESCRIPTION
Closes #67661

## Problem

Fallback did not always work as expected because OpenClaw could keep retrying a model/provider that was already exhausted and still within its active cooldown window.

In the incomplete-turn paths, the auth-profile failure write could omit the active `modelId`. That weakened model-scoped cooldown enforcement and allowed the same exhausted model to be retried again within the same run/session instead of continuing cleanly to the next fallback.

## Change

- pass the active `modelId` when persisting incomplete-turn auth-profile failures
- cover both reasoning-only exhausted responses and incomplete-turn failure writes with unit tests
- keep the fix scoped to the incomplete-turn cooldown write path only

## Tests

- `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`

## Limitation

This improves fallback within the same run/session only.

It does **not** add a persistent cross-session or cross-agent exhausted-model registry. Fresh new sessions can still retry a model later unless that provider already participates in the existing persisted auth-profile cooldown system.
