### PR TITLE
Feat/acp tui lazy init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - Dependencies: refresh workspace dependency pins, including TypeBox 1.1.37, AWS SDK 3.1041.0, Microsoft Teams 2.0.9, and Marked 18.0.3. Thanks @mariozechner, @aws, and @microsoft.
 - Discord/channels: add reusable message-channel access groups plus Discord channel-audience DM authorization, so allowlists can reference `accessGroup:<name>` across channel auth paths. (#75813)
 - Crabbox/scripts: print the selected Crabbox binary, version, and supported providers before `pnpm crabbox:*` commands, and reject stale binaries that lack `blacksmith-testbox` provider support.
+- Feat/acp tui lazy init (#67692). Thanks @wangshu94
 
 ### Fixes
 

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -1,3 +1,4 @@
+import type { AcpSessionResolution } from "../acp/control-plane/manager.types.js";
 import {
   formatThinkingLevels,
   isThinkingLevelSupported,
@@ -17,8 +18,7 @@ import {
 import { formatErrorMessage } from "../infra/errors.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizeAgentId } from "../routing/session-key.js";
-import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { defaultRuntime, type RuntimeEnv } from "../runtime.js";
 import { applyVerboseOverride } from "../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../sessions/model-overrides.js";
@@ -32,6 +32,7 @@ import { resolveAgentRuntimeConfig } from "./agent-runtime-config.js";
 import {
   listAgentIds,
   resolveAgentDir,
+  resolveAgentConfig,
   resolveEffectiveModelFallbacks,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
@@ -306,7 +307,34 @@ async function prepareAgentCommandExecution(
       );
     }
   }
-  const agentCfg = cfg.agents?.defaults;
+  // Resolve sessionAgentId and sessionResolution early for agent config selection
+  const sessionResolution = resolveSession({
+    cfg,
+    to: opts.to,
+    sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
+    agentId: agentIdOverride,
+  });
+
+  const {
+    sessionId,
+    sessionKey,
+    sessionEntry: sessionEntryRaw,
+    sessionStore,
+    storePath,
+    isNewSession,
+    persistedThinking,
+    persistedVerbose,
+  } = sessionResolution;
+  const sessionAgentId =
+    agentIdOverride ??
+    resolveSessionAgentId({
+      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
+      config: cfg,
+    });
+
+  const resolvedAgentCfg = resolveAgentConfig(cfg, sessionAgentId);
+  const agentCfg = resolvedAgentCfg ?? cfg.agents?.defaults;
   const configuredModel = resolveConfiguredModelRef({
     cfg,
     defaultProvider: DEFAULT_PROVIDER,
@@ -350,30 +378,6 @@ async function prepareAgentCommandExecution(
     overrideSeconds: timeoutSecondsRaw,
   });
 
-  const sessionResolution = resolveSession({
-    cfg,
-    to: opts.to,
-    sessionId: opts.sessionId,
-    sessionKey: opts.sessionKey,
-    agentId: agentIdOverride,
-  });
-
-  const {
-    sessionId,
-    sessionKey,
-    sessionEntry: sessionEntryRaw,
-    sessionStore,
-    storePath,
-    isNewSession,
-    persistedThinking,
-    persistedVerbose,
-  } = sessionResolution;
-  const sessionAgentId =
-    agentIdOverride ??
-    resolveSessionAgentId({
-      sessionKey: sessionKey ?? opts.sessionKey?.trim(),
-      config: cfg,
-    });
   const outboundSession = buildOutboundSessionContext({
     cfg,
     agentId: sessionAgentId,
@@ -392,11 +396,11 @@ async function prepareAgentCommandExecution(
   const runId = opts.runId?.trim() || sessionId;
   const { getAcpSessionManager } = await loadAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
-  const acpResolution = sessionKey
-    ? acpManager.resolveSession({
-        cfg,
-        sessionKey,
-      })
+  // Resolve existing ACP session metadata only; lazy initialization is deferred
+  // to agentCommandInternal so it runs after send-policy checks, ensuring that
+  // a policy denial never triggers ACP metadata writes or external runtime startup.
+  const acpResolution: AcpSessionResolution | null = sessionKey
+    ? acpManager.resolveSession({ cfg, sessionKey })
     : null;
   const body =
     !isRawModelRun && acpResolution?.kind === "ready"
@@ -431,6 +435,7 @@ async function prepareAgentCommandExecution(
     runId,
     acpManager,
     acpResolution,
+    resolvedAgentCfg,
   };
 }
 
@@ -466,8 +471,9 @@ async function agentCommandInternal(
     agentDir,
     runId,
     acpManager,
-    acpResolution,
+    resolvedAgentCfg,
   } = prepared;
+  let acpResolution = prepared.acpResolution;
   let sessionEntry = prepared.sessionEntry;
 
   try {
@@ -481,6 +487,42 @@ async function agentCommandInternal(
       });
       if (sendPolicy === "deny") {
         throw new Error("send blocked by session policy");
+      }
+    }
+
+    // Lazily initialize ACP session after send-policy passes, so a policy
+    // denial never triggers ACP metadata writes or external runtime startup.
+    if (acpResolution?.kind === "none" && resolvedAgentCfg?.runtime?.type === "acp" && sessionKey) {
+      const acpConfig = resolvedAgentCfg.runtime.acp;
+      const acpAgent = normalizeAgentId(
+        normalizeOptionalString(acpConfig?.agent) ?? sessionAgentId,
+      );
+      // Check dispatch and agent policy before writing any ACP metadata or starting a runtime.
+      const { resolveAcpDispatchPolicyError, resolveAcpAgentPolicyError } =
+        await loadAcpPolicyRuntime();
+      const dispatchPolicyError = resolveAcpDispatchPolicyError(cfg);
+      const agentPolicyError = !dispatchPolicyError
+        ? resolveAcpAgentPolicyError(cfg, acpAgent)
+        : null;
+      if (!dispatchPolicyError && !agentPolicyError) {
+        try {
+          await acpManager.initializeSession({
+            cfg,
+            sessionKey,
+            agent: acpAgent,
+            // Default to "persistent" so TUI sessions carry context across turns.
+            mode: acpConfig?.mode ?? "persistent",
+            cwd: normalizeOptionalString(acpConfig?.cwd),
+            backendId:
+              normalizeOptionalString(acpConfig?.backend) ??
+              normalizeOptionalString(cfg.acp?.backend),
+          });
+          // Re-resolve after initialization so the ready meta is available for runTurn.
+          acpResolution = acpManager.resolveSession({ cfg, sessionKey });
+        } catch (error) {
+          // Fall back to embedded if ACP initialization fails.
+          log.warn(`ACP initialization failed for ${sessionKey}: ${String(error)}`);
+        }
       }
     }
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -4,6 +4,7 @@ import type {
   AgentContextLimitsConfig,
   AgentDefaultsConfig,
 } from "../config/types.agent-defaults.js";
+import type { AgentRuntimeConfig } from "../config/types.agents.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { DEFAULT_AGENT_ID, normalizeAgentId } from "../routing/session-key.js";
 import { readStringValue } from "../shared/string-coerce.js";
@@ -34,6 +35,11 @@ export type ResolvedAgentConfig = {
   embeddedPi?: AgentEntry["embeddedPi"];
   sandbox?: AgentEntry["sandbox"];
   tools?: AgentEntry["tools"];
+  runtime?: AgentRuntimeConfig;
+  skipBootstrap?: AgentDefaultsConfig["skipBootstrap"];
+  skipOptionalBootstrapFiles?: AgentDefaultsConfig["skipOptionalBootstrapFiles"];
+  models?: AgentDefaultsConfig["models"];
+  contextTokens?: AgentDefaultsConfig["contextTokens"];
 };
 
 let defaultAgentWarned = false;
@@ -137,6 +143,11 @@ export function resolveAgentConfig(
       typeof entry.embeddedPi === "object" && entry.embeddedPi ? entry.embeddedPi : undefined,
     sandbox: entry.sandbox,
     tools: entry.tools,
+    runtime: entry.runtime,
+    skipBootstrap: agentDefaults?.skipBootstrap,
+    skipOptionalBootstrapFiles: agentDefaults?.skipOptionalBootstrapFiles,
+    models: agentDefaults?.models,
+    contextTokens: agentDefaults?.contextTokens,
   };
 }
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -565,6 +565,84 @@ describe("resolveAgentConfig", () => {
     expect(result?.tools?.allow).toEqual(["read"]);
   });
 
+  it("returns runtime, skipBootstrap, models, contextTokens from agent defaults", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          skipBootstrap: true,
+          models: {
+            "anthropic/claude-sonnet-4-6": {
+              alias: "sonnet",
+            },
+          },
+          contextTokens: 150000,
+        },
+        list: [{ id: "main" }],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "main");
+
+    expect(result?.skipBootstrap).toBe(true);
+    expect(result?.models).toEqual({
+      "anthropic/claude-sonnet-4-6": {
+        alias: "sonnet",
+      },
+    });
+    expect(result?.contextTokens).toBe(150000);
+  });
+
+  it("includes runtime config with ACP type", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "tui-agent",
+            runtime: {
+              type: "acp",
+              acp: {
+                agent: "custom-acp-agent",
+                mode: "persistent",
+                backend: "custom",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "tui-agent");
+
+    expect(result?.runtime).toEqual({
+      type: "acp",
+      acp: {
+        agent: "custom-acp-agent",
+        mode: "persistent",
+        backend: "custom",
+      },
+    });
+  });
+
+  it("per-agent runtime config is included in resolved config", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [
+          {
+            id: "acp-agent",
+            runtime: {
+              type: "acp",
+              acp: {
+                mode: "oneshot",
+              },
+            },
+          },
+        ],
+      },
+    };
+    const result = resolveAgentConfig(cfg, "acp-agent");
+
+    expect(result?.runtime?.type).toBe("acp");
+    expect(result?.runtime?.type === "acp" && result.runtime.acp?.mode).toBe("oneshot");
+  });
+
   it("should normalize agent id", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -20,6 +20,7 @@ import { createAcpSessionMeta, createAcpTestConfig } from "./test-fixtures/acp-r
 const managerMocks = vi.hoisted(() => ({
   resolveSession: vi.fn(),
   runTurn: vi.fn(),
+  initializeSession: vi.fn(),
   getObservabilitySnapshot: vi.fn(() => ({
     turns: { queueDepth: 0 },
     runtimeCache: { activeSessions: 0 },
@@ -91,6 +92,10 @@ const transcriptMocks = vi.hoisted(() => ({
 const bindingServiceMocks = vi.hoisted(() => ({
   listBySession: vi.fn<(sessionKey: string) => SessionBindingRecord[]>(() => []),
   unbind: vi.fn<(input: unknown) => Promise<SessionBindingRecord[]>>(async () => []),
+}));
+
+const agentConfigMocks = vi.hoisted(() => ({
+  resolveAgentConfig: vi.fn<(cfg: OpenClawConfig, agentId: string) => unknown>(() => undefined),
 }));
 
 vi.mock("./dispatch-acp-manager.runtime.js", () => ({
@@ -179,6 +184,11 @@ vi.mock("../../logging/diagnostic.js", () => ({
 vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
   persistAcpDispatchTranscript: (params: unknown) =>
     transcriptMocks.persistAcpDispatchTranscript(params),
+}));
+
+vi.mock("../../agents/agent-scope-config.js", () => ({
+  resolveAgentConfig: (cfg: OpenClawConfig, agentId: string) =>
+    agentConfigMocks.resolveAgentConfig(cfg, agentId),
 }));
 
 const sessionKey = "agent:codex-acp:session-1";
@@ -358,6 +368,7 @@ describe("tryDispatchAcpReply", () => {
   beforeEach(() => {
     managerMocks.resolveSession.mockReset();
     managerMocks.runTurn.mockReset();
+    managerMocks.initializeSession.mockReset();
     managerMocks.runTurn.mockImplementation(
       async ({ onEvent }: { onEvent?: (event: unknown) => Promise<void> }) => {
         await onEvent?.({ type: "done" });
@@ -390,6 +401,8 @@ describe("tryDispatchAcpReply", () => {
     bindingServiceMocks.listBySession.mockReturnValue([]);
     bindingServiceMocks.unbind.mockReset();
     bindingServiceMocks.unbind.mockResolvedValue([]);
+    agentConfigMocks.resolveAgentConfig.mockReset();
+    agentConfigMocks.resolveAgentConfig.mockReturnValue(undefined);
     globalThis.fetch = originalFetch;
   });
 
@@ -1512,5 +1525,164 @@ describe("tryDispatchAcpReply", () => {
     expect(result?.counts.final).toBe(0);
     expect(routeMocks.routeReply).not.toHaveBeenCalled();
     expect(ttsMocks.maybeApplyTtsToPayload).not.toHaveBeenCalled();
+  });
+
+  describe("lazy ACP session initialization", () => {
+    it("initializes ACP session when kind is 'none' and agent has runtime.type: 'acp'", async () => {
+      // Setup: acpResolution.kind === "none"
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: {
+            mode: "persistent",
+          },
+        },
+      });
+
+      // Setup: policies allow
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValue(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValue(null);
+
+      // Setup: init succeeds, re-resolve returns ready
+      managerMocks.initializeSession.mockResolvedValueOnce(undefined);
+      managerMocks.resolveSession.mockReturnValueOnce({
+        kind: "ready",
+        sessionKey,
+        meta: createAcpSessionMeta(),
+      });
+
+      // Mock turn execution with visible text
+      mockVisibleTextTurn("initialized");
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      // Verify init was called
+      expect(managerMocks.initializeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionKey: expect.stringContaining("session"),
+        }),
+      );
+
+      // Verify turn was executed (not skipped)
+      expect(managerMocks.runTurn).toHaveBeenCalled();
+      expect(result).not.toBeNull();
+    });
+
+    it("skips ACP when kind is 'none' and agent doesn't have runtime.type: 'acp'", async () => {
+      // When resolveSession returns "none" but agent is not ACP-configured,
+      // the function should return null (fallback to embedded)
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      // Should not attempt init or turn
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(managerMocks.runTurn).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("respects dispatch policy during lazy ACP init", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // Dispatch policy denies
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(
+        new AcpRuntimeError("ACP_DISPATCH_DISABLED", "Dispatch policy blocks ACP"),
+      );
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("respects agent policy during lazy ACP init", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // First policy check passes
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      // Second policy check fails
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(
+        new AcpRuntimeError("ACP_SESSION_INIT_FAILED", "Agent policy blocks access"),
+      );
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(managerMocks.initializeSession).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it("falls back to non-ACP path when lazy ACP init fails", async () => {
+      managerMocks.resolveSession.mockReturnValueOnce({ kind: "none" });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      // Policies allow
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(null);
+
+      // Init fails
+      managerMocks.initializeSession.mockRejectedValueOnce(new Error("ACP backend unavailable"));
+
+      const result = await runDispatch({ bodyForAgent: "test" });
+
+      expect(result).toBeNull();
+      expect(managerMocks.runTurn).not.toHaveBeenCalled();
+    });
+
+    it("re-resolves ACP session after successful lazy init", async () => {
+      // First call: kind === "none"
+      managerMocks.resolveSession
+        .mockReturnValueOnce({ kind: "none" })
+        // Second call (after init): kind === "ready"
+        .mockReturnValueOnce({
+          kind: "ready",
+          sessionKey,
+          meta: createAcpSessionMeta(),
+        });
+
+      // Setup: agent config has runtime.type: "acp"
+      agentConfigMocks.resolveAgentConfig.mockReturnValueOnce({
+        runtime: {
+          type: "acp",
+          acp: { mode: "persistent" },
+        },
+      });
+
+      policyMocks.resolveAcpDispatchPolicyError.mockReturnValueOnce(null);
+      policyMocks.resolveAcpAgentPolicyError.mockReturnValueOnce(null);
+
+      managerMocks.initializeSession.mockResolvedValueOnce(undefined);
+      mockVisibleTextTurn();
+
+      await runDispatch({ bodyForAgent: "test" });
+
+      // Verify resolveSession called twice: once for check, once for re-resolve
+      expect(managerMocks.resolveSession).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/src/auto-reply/reply/dispatch-acp.test.ts
+++ b/src/auto-reply/reply/dispatch-acp.test.ts
@@ -186,7 +186,8 @@ vi.mock("./dispatch-acp-transcript.runtime.js", () => ({
     transcriptMocks.persistAcpDispatchTranscript(params),
 }));
 
-vi.mock("../../agents/agent-scope-config.js", () => ({
+vi.mock("../../agents/agent-scope-config.js", async () => ({
+  ...(await vi.importActual("../../agents/agent-scope-config.js")),
   resolveAgentConfig: (cfg: OpenClawConfig, agentId: string) =>
     agentConfigMocks.resolveAgentConfig(cfg, agentId),
 }));

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -7,6 +7,12 @@ import {
   resolveSessionIdentityFromMeta,
 } from "../../acp/runtime/session-identity.js";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveAgentIdFromSessionKey,
+  resolveMainSessionKey,
+} from "../../config/sessions/main-session.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { TtsAutoMode } from "../../config/types.tts.js";
 import { logVerbose } from "../../globals.js";
@@ -16,7 +22,6 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import { generateSecureUuid } from "../../infra/secure-random.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
 import { markDiagnosticSessionProgress } from "../../logging/diagnostic.js";
-import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -76,6 +81,44 @@ type DispatchProcessedRecorder = (
     error?: string;
   },
 ) => void;
+
+function resolveConfigAwareAgentIdFromSessionKey(cfg: OpenClawConfig, sessionKey: string): string {
+  const configuredDefaultMainSessionKey = resolveMainSessionKey(cfg);
+  const configuredDefaultAgentId = resolveAgentIdFromSessionKey(configuredDefaultMainSessionKey);
+
+  const canonicalKey = canonicalizeMainSessionAlias({
+    cfg,
+    agentId: configuredDefaultAgentId,
+    sessionKey,
+  });
+
+  return resolveAgentIdFromSessionKey(canonicalKey);
+}
+
+function resolveAgentAcpInitInput(
+  cfg: OpenClawConfig,
+  sessionKey: string,
+): {
+  agentId: string;
+  acpAgentId?: string;
+  mode: "persistent" | "oneshot";
+  cwd?: string;
+  backendId?: string;
+} | null {
+  const agentId = resolveConfigAwareAgentIdFromSessionKey(cfg, sessionKey);
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  if (!agentConfig || agentConfig.runtime?.type !== "acp") {
+    return null;
+  }
+  const acpConfig = agentConfig.runtime.acp;
+  return {
+    agentId,
+    acpAgentId: normalizeOptionalString(acpConfig?.agent) ?? undefined,
+    mode: acpConfig?.mode ?? "persistent",
+    cwd: normalizeOptionalString(acpConfig?.cwd) ?? undefined,
+    backendId: normalizeOptionalString(acpConfig?.backend) ?? undefined,
+  };
+}
 
 function resolveFirstContextText(
   ctx: FinalizedMsgContext,
@@ -333,12 +376,56 @@ export async function tryDispatchAcpReply(params: {
 
   const { getAcpSessionManager } = await loadDispatchAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
-  const acpResolution = acpManager.resolveSession({
+  let acpResolution = acpManager.resolveSession({
     cfg: params.cfg,
     sessionKey,
   });
   if (acpResolution.kind === "none") {
-    return null;
+    // For agents with `runtime.type: "acp"` (e.g. TUI sessions), ACP metadata has not yet
+    // been written. Lazily initialize the ACP session now so the turn flows through the ACP
+    // execution path rather than falling back to the embedded reply path.
+    //
+    // Guard: skip init entirely for turns that would be short-circuited as empty below.
+    // Without this, first-time sessions are initialized (metadata written, runtime started)
+    // for mention-only / empty inbound events that produce no ACP work.
+    if (!resolveAcpPromptText(params.ctx) && !hasInboundMedia(params.ctx)) {
+      return null;
+    }
+    const acpInit = resolveAgentAcpInitInput(params.cfg, sessionKey);
+    if (!acpInit) {
+      return null;
+    }
+    // Check dispatch and agent policy before writing any ACP metadata or starting a runtime.
+    if (resolveAcpDispatchPolicyError(params.cfg)) {
+      return null;
+    }
+    const candidateAgent = acpInit.acpAgentId ?? acpInit.agentId;
+    if (resolveAcpAgentPolicyError(params.cfg, candidateAgent)) {
+      return null;
+    }
+    try {
+      await acpManager.initializeSession({
+        cfg: params.cfg,
+        sessionKey,
+        agent: candidateAgent,
+        mode: acpInit.mode,
+        cwd: acpInit.cwd,
+        backendId: acpInit.backendId,
+      });
+    } catch (initErr) {
+      logVerbose(
+        `dispatch-acp: lazy ACP init failed for ${sessionKey}: ${formatErrorMessage(initErr)}`,
+      );
+      return null;
+    }
+    // Re-resolve after initialization.
+    acpResolution = acpManager.resolveSession({
+      cfg: params.cfg,
+      sessionKey,
+    });
+    if (acpResolution.kind === "none") {
+      return null;
+    }
   }
   const canonicalSessionKey = acpResolution.sessionKey;
   const acpAgentId = resolveAgentIdFromSessionKey(canonicalSessionKey);


### PR DESCRIPTION
## Summary

- **Problem:** Agents configured with `runtime: { type: "acp" }` in `openclaw.json` silently
  fall back to the embedded reply path when invoked from the TUI. No ACP session is ever
  started, so the external ACP runtime (e.g. Claude CLI via the `codex`/`claude` backend) is
  never reached, and turns are executed locally instead.

- **Why it matters:** Users who want a specific agent to always use an external ACP runtime
  (for isolation, a different model harness, persistent session continuity, etc.) have no
  supported way to achieve that from the TUI today. The `bindings` config path — the only
  existing ACP activation mechanism — requires a channel plugin with
  `compileConfiguredBinding` + `matchInboundConversation`, which the TUI surface does not
  have and cannot have.

- **What changed:** `tryDispatchAcpReply` in `src/auto-reply/reply/dispatch-acp.ts` now
  performs a **lazy ACP session initialization** when `acpManager.resolveSession()` returns
  `kind: "none"`. Before returning `null` (which causes fallback to embedded), the code reads
  the session's agent config and, if `runtime.type === "acp"` is set, calls
  `acpManager.initializeSession()` to bootstrap the ACP metadata on the first turn. All
  subsequent turns on the same session key find the metadata already written and proceed
  through the normal ACP dispatch path.

- **What did NOT change (scope boundary):** Sessions that do not have `runtime.type: "acp"`
  configured behave exactly as before — `resolveAgentAcpInitInput` returns `null` immediately
  and the existing `return null` (embedded fallback) is taken. The existing bindings-based
  activation path is untouched. No new config keys are introduced.

## Change Type (select all)

- [x] Bug fix
- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** `tryDispatchAcpReply` gates all ACP execution on
  `acpManager.resolveSession()` returning `kind: "ready"`. That only happens when `.acp`
  metadata already exists in the session store. For channel-based flows, metadata is written
  during binding activation (triggered by inbound channel messages). For TUI flows there is no
  channel, no binding, and no code path that calls `initializeSession()` — so the session
  store never has `.acp` metadata, `resolveSession()` always returns `kind: "none"`, and ACP
  is never entered.

- **Missing detection / guardrail:** Nothing in the dispatch path checked whether the agent
  entry itself declared `runtime.type: "acp"`. The assumption was that ACP is always activated
  externally (via bindings), not by agent config intent.

- **Contributing context:** The `bindings` schema requires `match.channel` (a non-optional
  `z.string()`), so it is impossible to define a channel-agnostic binding that would fire for
  TUI sessions. Additionally, `AgentEntrySchema` uses `.strict()`, so placing `bindings` inside
  an agent entry object causes a validation error (`Unrecognized key: "bindings"`), leading
  users to believe the feature is broken even if they try to work around it.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/dispatch-acp.test.ts`
- Scenario the test should lock in: When `acpManager.resolveSession()` returns `kind: "none"`
  and the session's agent entry has `runtime.type: "acp"`, `tryDispatchAcpReply` must call
  `acpManager.initializeSession()` and then re-resolve before proceeding. When the agent entry
  does NOT have `runtime.type: "acp"`, behavior must be unchanged (`null` returned immediately).
- Why this is the smallest reliable guardrail: The helper `resolveAgentAcpInitInput` and the
  init+re-resolve block are pure control-flow changes within a single function that is already
  unit-tested in `dispatch-acp.test.ts`.
- If no new test is added, why not: Tests covering this seam should be added as follow-up; the
  existing mock infrastructure in `dispatch-acp.test.ts` can be extended to stub
  `resolveAgentConfig` and `acpManager.initializeSession`.

## User-visible / Behavior Changes

Users can now configure an agent with `runtime.type: "acp"` and use it from the TUI; it will
automatically start an ACP session on the first turn.

**Example `openclaw.json`:**

```json
{
  "agents": {
    "list": [
      {
        "id": "main",
        "name": "Main Agent"
      },
      {
        "id": "work-agent",
        "name": "Work Agent (ACP via Claude CLI)",
        "runtime": {
          "type": "acp",
          "acp": {
            "agent": "claude",
            "mode": "persistent",
            "cwd": "/home/user/projects/myrepo"
          }
        }
      }
    ]
  }
}
```

With this config, switching to `work-agent` in the TUI and sending a message will:

1. Detect `runtime.type: "acp"` on the first turn.
2. Call `acpManager.initializeSession()` to register the ACP session and write `.acp` metadata.
3. Route the turn (and all future turns) through `acpManager.runTurn()` — the same path used
   by channel-based (WhatsApp, Telegram, etc.) ACP sessions.

**Supported `runtime.acp` fields:**

| Field     | Type                        | Default            | Description                                     |
| --------- | --------------------------- | ------------------ | ----------------------------------------------- |
| `agent`   | `string`                    | agent id           | ACP harness adapter id (e.g. `claude`, `codex`) |
| `mode`    | `"persistent" \| "oneshot"` | `"persistent"`     | Session continuity mode                         |
| `cwd`     | `string`                    | —                  | Working directory passed to the ACP runtime     |
| `backend` | `string`                    | from `acp.backend` | Override the ACP backend registration id        |

**What was NOT working before (and now works):**

Previously, if a user placed `bindings` inside an agent entry:

```json
{
  "agents": {
    "list": [
      {
        "id": "work-agent",
        "bindings": []
      }
    ]
  }
}
```

This fails config validation because `AgentEntrySchema` uses `.strict()` and `bindings` is a
root-level config key, not an agent-entry key. The correct placement for `bindings` is at the
top level of `openclaw.json`. However, even with correct placement, channel-based bindings
cannot match TUI sessions because TUI has no channel plugin. The `runtime.type: "acp"` approach
in this PR is the proper solution for TUI.

## Diagram

```text
Before (TUI + runtime.type: "acp"):

[TUI message]
  → dispatchInboundMessage
  → hookRunner.runReplyDispatch
  → tryDispatchAcpReplyHook          (via acpx plugin)
  → tryDispatchAcpReply
  → acpManager.resolveSession()      → kind: "none"  (no .acp metadata written)
  → return null                      ← ACP never entered
  → [falls back to embedded reply]

After (TUI + runtime.type: "acp"):

[TUI message]
  → dispatchInboundMessage
  → hookRunner.runReplyDispatch
  → tryDispatchAcpReplyHook
  → tryDispatchAcpReply
  → acpManager.resolveSession()      → kind: "none"
  → resolveAgentAcpInitInput()       → { agentId, mode: "persistent", ... }
  → acpManager.initializeSession()   ← writes .acp metadata to session store
  → acpManager.resolveSession()      → kind: "ready"
  → acpManager.runTurn(...)          ← ACP runtime executes the turn
  → delivery.deliver(...)            → reply sent back to TUI
```

## Security Impact (required)

- New permissions/capabilities? **Yes** — agents configured with `runtime.type: "acp"` now
  execute via the external ACP runtime (e.g. Claude CLI subprocess) when invoked from the TUI.
  This is the intended and declared behavior of `runtime.type: "acp"`; it is opt-in via
  explicit agent config.
- Secrets/tokens handling changed? **No** — ACP backend auth is unchanged.
- New/changed network calls? **No** — the ACP backend already manages connections.
- Command/tool execution surface changed? **No** — `initializeSession` is the same call made
  by the bindings path; no new execution surface is introduced.
- Data access scope changed? **No**
- Risk: An agent inadvertently configured with `runtime.type: "acp"` would attempt ACP init on
  the first TUI turn. If no ACP backend is registered, `initializeSession` throws, is caught
  gracefully, logged at verbose level, and the function returns `null` — falling through to the
  embedded path. No crash, no user-visible error; the session continues embedded.
  - Mitigation: Graceful catch + verbose log in `tryDispatchAcpReply`; no behavior change for
    agents without `runtime.type: "acp"`.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / bun
- Model/provider: Any (ACP backend: Claude CLI / `codex`)
- Integration/channel: TUI (terminal UI)
- Relevant config (redacted): see `openclaw.json` snippet above

### Steps

1. Add an agent entry with `runtime: { type: "acp", acp: { agent: "claude" } }` to
   `openclaw.json`.
2. Start the gateway: `openclaw gateway run`.
3. Open the TUI and select the ACP-configured agent.
4. Send a message.

### Expected

- On first message: `acpManager.initializeSession()` is called; verbose log shows
  `acp-dispatch: session=<key> outcome=ok latencyMs=...`.
- Response is generated by the ACP runtime (Claude CLI process), not the embedded model.
- Subsequent messages in the same TUI session reuse the existing ACP session (no re-init).

### Actual (before fix)

- No ACP init; no verbose log for the session.
- Response comes from the embedded inference path.
- `runtime.type: "acp"` config has no effect from the TUI.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets (see Diagram section and Steps above)
- [ ] Screenshot/recording

## Human Verification (required)

- Verified scenarios: ACP agent invoked from TUI initializes session and routes turns through
  ACP runtime; non-ACP agents are completely unaffected; init failure (no backend registered)
  falls through gracefully to embedded path without crashing.
- Edge cases checked: `acpInit.acpAgentId` may be undefined (falls back to `agentId` from
  session key); `mode` defaults to `"persistent"` when not specified; `cwd` and `backendId`
  are optional and forwarded as-is.
- What you did **not** verify: multi-turn session resumption across gateway restarts; oneshot
  mode behavior; TUI behavior when ACP backend is busy or rate-limited.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? **Yes** — agents without `runtime.type: "acp"` are completely unaffected.
- Config/env changes? **No** — `runtime.type: "acp"` was already a valid config field; no new
  keys introduced.
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** First-turn latency increase for ACP-configured agents in TUI (one extra
  `initializeSession` call on the cold path).
  - **Mitigation:** Init is lazy (only on first turn); subsequent turns see `kind: "ready"`
    immediately. For long-lived TUI sessions this is negligible.

- **Risk:** If `initializeSession` is slow or the ACP backend is flaky, the first turn could
  time out or appear hung.
  - **Mitigation:** `initializeSession` is the same path used by all channel-based ACP sessions
    today; no new timeout surface is introduced. The existing ACP abort signal and error
    handling apply.

---

## Code Diff (for reference)

**File:** `src/auto-reply/reply/dispatch-acp.ts`

```diff
+import { resolveAgentConfig } from "../../agents/agent-scope-config.js";

+/**
+ * Resolve ACP init params for an agent that has `runtime.type: "acp"` configured.
+ * Returns null if the agent does not have ACP runtime configured.
+ */
+function resolveAgentAcpInitInput(
+  cfg: OpenClawConfig,
+  sessionKey: string,
+): {
+  agentId: string;
+  acpAgentId?: string;
+  mode: "persistent" | "oneshot";
+  cwd?: string;
+  backendId?: string;
+} | null {
+  const agentId = resolveAgentIdFromSessionKey(sessionKey);
+  const agentConfig = resolveAgentConfig(cfg, agentId);
+  if (!agentConfig || agentConfig.runtime?.type !== "acp") {
+    return null;
+  }
+  const acpConfig = agentConfig.runtime.acp;
+  return {
+    agentId,
+    acpAgentId: normalizeOptionalString(acpConfig?.agent) ?? undefined,
+    // Default to "persistent" so TUI sessions carry context across turns.
+    mode: acpConfig?.mode ?? "persistent",
+    cwd: normalizeOptionalString(acpConfig?.cwd) ?? undefined,
+    backendId: normalizeOptionalString(acpConfig?.backend) ?? undefined,
+  };
+}

   const { getAcpSessionManager } = await loadDispatchAcpManagerRuntime();
   const acpManager = getAcpSessionManager();
-  const acpResolution = acpManager.resolveSession({
+  let acpResolution = acpManager.resolveSession({
     cfg: params.cfg,
     sessionKey,
   });
   if (acpResolution.kind === "none") {
-    return null;
+    // For agents with `runtime.type: "acp"` (e.g. TUI sessions), ACP metadata has not yet
+    // been written. Lazily initialize the ACP session now so the turn flows through the ACP
+    // execution path rather than falling back to the embedded reply path.
+    const acpInit = resolveAgentAcpInitInput(params.cfg, sessionKey);
+    if (!acpInit) {
+      return null;
+    }
+    try {
+      await acpManager.initializeSession({
+        cfg: params.cfg,
+        sessionKey,
+        agent: acpInit.acpAgentId ?? acpInit.agentId,
+        mode: acpInit.mode,
+        cwd: acpInit.cwd,
+        backendId: acpInit.backendId,
+      });
+    } catch (initErr) {
+      logVerbose(
+        `dispatch-acp: lazy ACP init failed for ${sessionKey}: ${formatErrorMessage(initErr)}`,
+      );
+      return null;
+    }
+    // Re-resolve after initialization.
+    acpResolution = acpManager.resolveSession({
+      cfg: params.cfg,
+      sessionKey,
+    });
+    if (acpResolution.kind === "none") {
+      return null;
+    }
   }
```
