### PR TITLE
Prevent setup prompts from crashing on blank option labels

### DIFF
--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -1,5 +1,155 @@
-import { describe, expect, it } from "vitest";
-import { tokenizedOptionFilter } from "./clack-prompter.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const selectMock = vi.hoisted(() => vi.fn());
+const multiselectMock = vi.hoisted(() => vi.fn());
+const autocompleteMultiselectMock = vi.hoisted(() => vi.fn());
+const confirmMock = vi.hoisted(() => vi.fn());
+const introMock = vi.hoisted(() => vi.fn());
+const outroMock = vi.hoisted(() => vi.fn());
+const textMock = vi.hoisted(() => vi.fn());
+const cancelMock = vi.hoisted(() => vi.fn());
+const spinnerStartMock = vi.hoisted(() => vi.fn());
+const spinnerMessageMock = vi.hoisted(() => vi.fn());
+const spinnerStopMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@clack/prompts", () => ({
+  autocompleteMultiselect: autocompleteMultiselectMock,
+  cancel: cancelMock,
+  confirm: confirmMock,
+  intro: introMock,
+  isCancel: () => false,
+  multiselect: multiselectMock,
+  outro: outroMock,
+  select: selectMock,
+  spinner: () => ({
+    start: spinnerStartMock,
+    message: spinnerMessageMock,
+    stop: spinnerStopMock,
+  }),
+  text: textMock,
+}));
+
+import { createClackPrompter, tokenizedOptionFilter } from "./clack-prompter.js";
+
+describe("createClackPrompter", () => {
+  afterEach(() => {
+    selectMock.mockReset();
+    multiselectMock.mockReset();
+    autocompleteMultiselectMock.mockReset();
+    confirmMock.mockReset();
+    introMock.mockReset();
+    outroMock.mockReset();
+    textMock.mockReset();
+    cancelMock.mockReset();
+    spinnerStartMock.mockReset();
+    spinnerMessageMock.mockReset();
+    spinnerStopMock.mockReset();
+  });
+
+  it("falls back to the option value when select labels are blank", async () => {
+    selectMock.mockResolvedValue("telegram");
+    const prompter = createClackPrompter();
+
+    await prompter.select({
+      message: "Select channel",
+      options: [
+        {
+          value: "telegram",
+          label: "   ",
+        },
+      ],
+    });
+
+    expect(selectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            value: "telegram",
+            label: "telegram",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("falls back to the option value when multiselect labels are blank", async () => {
+    multiselectMock.mockResolvedValue(["signal"]);
+    const prompter = createClackPrompter();
+
+    await prompter.multiselect({
+      message: "Select channels",
+      options: [
+        {
+          value: "signal",
+          label: "",
+        },
+      ],
+    });
+
+    expect(multiselectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            value: "signal",
+            label: "signal",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("preserves non-empty labels", async () => {
+    selectMock.mockResolvedValue("telegram");
+    const prompter = createClackPrompter();
+
+    await prompter.select({
+      message: "Select channel",
+      options: [
+        {
+          value: "telegram",
+          label: "Telegram",
+        },
+      ],
+    });
+
+    expect(selectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            value: "telegram",
+            label: "Telegram",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("preserves padded non-empty labels unchanged", async () => {
+    selectMock.mockResolvedValue("telegram");
+    const prompter = createClackPrompter();
+
+    await prompter.select({
+      message: "Select channel",
+      options: [
+        {
+          value: "telegram",
+          label: "  Telegram  ",
+        },
+      ],
+    });
+
+    expect(selectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          expect.objectContaining({
+            value: "telegram",
+            label: "  Telegram  ",
+          }),
+        ],
+      }),
+    );
+  });
+});
 
 describe("tokenizedOptionFilter", () => {
   it("matches tokens regardless of order", () => {

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -42,6 +42,16 @@ function buildOptionSearchText<T>(option: Option<T>): string {
   return normalizeLowercaseStringOrEmpty(`${label} ${hint} ${value}`);
 }
 
+function normalizePromptOptionLabel<T>(option: { label?: string; value?: T }): string {
+  const rawLabel = typeof option.label === "string" ? option.label : undefined;
+  const label = rawLabel?.trim() ?? "";
+  if (rawLabel !== undefined && label.length > 0) {
+    return rawLabel;
+  }
+  const fallback = option.value == null ? "" : String(option.value).trim();
+  return fallback.length > 0 ? fallback : "Unnamed option";
+}
+
 export function tokenizedOptionFilter<T>(search: string, option: Option<T>): boolean {
   const tokens = normalizeSearchTokens(search);
   if (tokens.length === 0) {
@@ -67,7 +77,7 @@ export function createClackPrompter(): WizardPrompter {
         await select({
           message: stylePromptMessage(params.message),
           options: params.options.map((opt) => {
-            const base = { value: opt.value, label: opt.label };
+            const base = { value: opt.value, label: normalizePromptOptionLabel(opt) };
             return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
           }) as Option<(typeof params.options)[number]["value"]>[],
           initialValue: params.initialValue,
@@ -75,7 +85,7 @@ export function createClackPrompter(): WizardPrompter {
       ),
     multiselect: async (params) => {
       const options = params.options.map((opt) => {
-        const base = { value: opt.value, label: opt.label };
+        const base = { value: opt.value, label: normalizePromptOptionLabel(opt) };
         return opt.hint === undefined ? base : { ...base, hint: stylePromptHint(opt.hint) };
       }) as Option<(typeof params.options)[number]["value"]>[];
 


### PR DESCRIPTION
AI-assisted: Codex
Testing degree: targeted local validation (format, lint, wizard unit test, typecheck)## Summary

- Problem: setup prompts forwarded option labels to Clack unchanged, so a blank or whitespace-only label could crash onboarding when Clack tried to trim it.
- Why it matters: malformed runtime metadata should not take down `openclaw onboard` or any other wizard flow before the user can recover.
- What changed: `src/wizard/clack-prompter.ts` now normalizes select/multiselect labels to a safe fallback derived from the option value, and `src/wizard/clack-prompter.test.ts` locks that behavior in with unit coverage.
- What did NOT change (scope boundary): this PR does not change channel metadata generation, onboarding flow logic, or any plugin manifests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the prompt adapter assumed every option label was already a non-empty string and passed it through directly.
- Missing detection / guardrail: prompt-level tests covered tokenized search behavior but did not verify that malformed labels are normalized before reaching Clack.
- Contributing context (if known): some runtime/discovered setup options can be assembled from plugin or channel metadata, so one bad label can leak into onboarding.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/wizard/clack-prompter.test.ts`
- Scenario the test should lock in: blank select and multiselect labels are rewritten to a safe fallback value instead of being forwarded unchanged.
- Why this is the smallest reliable guardrail: the failure happens inside the prompt adapter before higher-level onboarding logic can recover, so adapter-level coverage is the narrowest place to catch it.
- Existing test that already covers this (if any): existing `tokenizedOptionFilter` tests in the same file.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Setup prompts no longer crash when an option label is blank; they fall back to the option value.

## Diagram (if applicable)

```text
Before:
[select option with blank label] -> [prompt adapter forwards blank label] -> [Clack trims undefined/blank path] -> [wizard crashes]

After:
[select option with blank label] -> [prompt adapter normalizes label from option value] -> [Clack renders prompt] -> [wizard continues]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu Linux
- Runtime/container: local Node 25.4.0 checkout
- Model/provider: N/A
- Integration/channel (if any): setup wizard / onboarding prompts
- Relevant config (redacted): N/A

### Steps

1. Call `createClackPrompter().select(...)` or `.multiselect(...)` with a blank label.
2. Render the prompt through Clack.
3. Observe whether the prompt crashes or renders.

### Expected

- Blank labels are normalized before reaching Clack, and the prompt still renders.

### Actual

- Before this patch the label was passed through unchanged, allowing downstream prompt rendering to fail on malformed labels.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec oxfmt --check src/wizard/clack-prompter.ts src/wizard/clack-prompter.test.ts`
  - `pnpm exec oxlint src/wizard/clack-prompter.ts src/wizard/clack-prompter.test.ts`
  - `node scripts/run-vitest.mjs run --config test/vitest/vitest.wizard.config.ts src/wizard/clack-prompter.test.ts`
  - `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.json --noEmit --pretty false`
- Edge cases checked:
  - blank whitespace-only label for `select`
  - blank empty-string label for `multiselect`
  - non-empty labels remain unchanged
- What you did **not** verify:
  - a live end-to-end `openclaw onboard` session from this source checkout

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: fallback labels derived from option values could be less polished than curated labels.
  - Mitigation: the fallback only applies when the provided label is blank, and curated non-empty labels are preserved unchanged.
