### PR TITLE
fix(ui): ensure markdown-it-task-lists is bundled by Vite [AI-assisted]

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -132,6 +132,7 @@ function depsInstalled(kind) {
     const require = createRequire(path.join(uiDir, "package.json"));
     require.resolve("vite");
     require.resolve("dompurify");
+    require.resolve("markdown-it-task-lists");
     if (kind === "test") {
       require.resolve("vitest");
       require.resolve("@vitest/browser-playwright");

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(() => {
     base,
     publicDir: path.resolve(here, "public"),
     optimizeDeps: {
-      include: ["lit/directives/repeat.js"],
+      include: ["lit/directives/repeat.js", "markdown-it-task-lists"],
     },
     build: {
       outDir: path.resolve(here, "../dist/control-ui"),


### PR DESCRIPTION
## Summary

Fixes #67680 — Control UI renders a blank page because the Vite production bundle contains an unresolved bare module specifier for `markdown-it-task-lists`.

## Root Cause

The `markdown-it-task-lists` package is declared in `ui/package.json` but the build pre-flight check in `scripts/ui.js` only validates `vite` and `dompurify`. If `markdown-it-task-lists` is not installed (e.g., incomplete `pnpm install` in CI), Vite cannot resolve the import and emits a bare specifier in the output bundle. Browsers cannot load bare specifiers, causing the entire UI to crash.

## Fix

1. **`scripts/ui.js`**: Add `markdown-it-task-lists` to the `depsInstalled()` pre-flight check. If the package is missing, `pnpm install` runs automatically before `vite build`.
2. **`ui/vite.config.ts`**: Add `markdown-it-task-lists` to `optimizeDeps.include` for consistent pre-bundling.

## Changed Files
- `scripts/ui.js` — 1 line added (`require.resolve('markdown-it-task-lists')`)
- `ui/vite.config.ts` — `optimizeDeps.include` extended

## Testing

- Verified `require.resolve('markdown-it-task-lists')` resolves correctly from `ui/package.json`
- Existing `ui/src/ui/markdown.test.ts` covers task list rendering

Closes #67680

> [!NOTE]
> This PR also contains the wizard guard fix from #67663 (shared base branch). GitHub will auto-deduplicate when either is merged first.

---
> [!NOTE]
> This contribution was made with the assistance of AI tools (Antigravity).