### PR TITLE
fix(update): block git-mode update when gateway is running

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -21,10 +21,12 @@ const readPackageName = vi.fn();
 const readPackageVersion = vi.fn();
 const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
+const serviceReadCommand = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
 const serviceReadRuntime = vi.fn();
+const serviceStop = vi.fn();
 const inspectPortUsage = vi.fn();
 const classifyPortListener = vi.fn();
 const formatPortDiagnostics = vi.fn();
@@ -151,7 +153,9 @@ vi.mock("../plugins/update.js", () => ({
 vi.mock("../daemon/service.js", () => ({
   resolveGatewayService: vi.fn(() => ({
     isLoaded: (...args: unknown[]) => serviceLoaded(...args),
+    readCommand: (...args: unknown[]) => serviceReadCommand(...args),
     readRuntime: (...args: unknown[]) => serviceReadRuntime(...args),
+    stop: (...args: unknown[]) => serviceStop(...args),
   })),
 }));
 
@@ -417,6 +421,7 @@ describe("update-cli", () => {
     readPackageVersion.mockResolvedValue("1.0.0");
     resolveGlobalManager.mockResolvedValue("npm");
     serviceLoaded.mockResolvedValue(false);
+    serviceReadCommand.mockResolvedValue(null);
     serviceReadRuntime.mockResolvedValue({
       status: "running",
       pid: 4242,
@@ -522,6 +527,203 @@ describe("update-cli", () => {
 
     expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+  });
+
+  it("blocks git updates when this install's gateway service is still running", async () => {
+    const root = createCaseDir("openclaw-running-gateway");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", entrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks git updates with --no-restart when this install's running gateway uses an absolute entrypoint", async () => {
+    const root = createCaseDir("openclaw-running-gateway-norestart");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", entrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({ restart: false });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Update blocked: this install's gateway service is still running"),
+    );
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Stop or restart the gateway first");
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("auto-stops and continues git updates when this install's running gateway uses a relative entrypoint", async () => {
+    const root = createCaseDir("openclaw-running-gateway-relative");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        path.join("dist", "index.js"),
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      workingDirectory: root,
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows git updates when the running gateway belongs to a different install", async () => {
+    const root = createCaseDir("openclaw-current-install");
+    const otherRoot = createCaseDir("openclaw-other-install");
+    const currentEntrypoint = path.join(root, "dist", "index.js");
+    const otherEntrypoint = path.join(otherRoot, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === currentEntrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", otherEntrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+    expect(defaultRuntime.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("Update blocked: this install's gateway service is still running"),
+    );
   });
 
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -28,10 +28,10 @@ const resolveGlobalManager = vi.fn();
 const serviceLoaded = vi.fn();
 const serviceStop = vi.fn();
 const serviceRestart = vi.fn();
+const serviceReadCommand = vi.fn();
 const prepareRestartScript = vi.fn();
 const runRestartScript = vi.fn();
 const mockedRunDaemonInstall = vi.fn();
-const serviceReadCommand = vi.fn();
 const serviceReadRuntime = vi.fn();
 const mockGetSelfAndAncestorPidsSync = vi.fn(() => new Set<number>([process.pid]));
 const inspectPortUsage = vi.fn();
@@ -1158,6 +1158,203 @@ describe("update-cli", () => {
 
     expect(defaultRuntime.exit).toHaveBeenCalledWith(2);
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+  });
+
+  it("blocks git updates when this install's gateway service is still running", async () => {
+    const root = createCaseDir("openclaw-running-gateway");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", entrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks git updates with --no-restart when this install's running gateway uses an absolute entrypoint", async () => {
+    const root = createCaseDir("openclaw-running-gateway-norestart");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", entrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({ restart: false });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expect(serviceStop).not.toHaveBeenCalled();
+    expect(defaultRuntime.error).toHaveBeenCalledWith(
+      expect.stringContaining("Update blocked: this install's gateway service is still running"),
+    );
+    const logs = vi.mocked(defaultRuntime.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.join("\n")).toContain("Stop or restart the gateway first");
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("auto-stops and continues git updates when this install's running gateway uses a relative entrypoint", async () => {
+    const root = createCaseDir("openclaw-running-gateway-relative");
+    const entrypoint = path.join(root, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === entrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: [
+        "/usr/bin/node",
+        path.join("dist", "index.js"),
+        "gateway",
+        "--port",
+        "18789",
+      ],
+      workingDirectory: root,
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(serviceStop).toHaveBeenCalledTimes(1);
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows git updates when the running gateway belongs to a different install", async () => {
+    const root = createCaseDir("openclaw-current-install");
+    const otherRoot = createCaseDir("openclaw-other-install");
+    const currentEntrypoint = path.join(root, "dist", "index.js");
+    const otherEntrypoint = path.join(otherRoot, "dist", "index.js");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root,
+      installKind: "git",
+      packageManager: "pnpm",
+      git: {
+        root,
+        sha: "abcdef1234567890",
+        tag: "v1.2.3",
+        branch: "main",
+        upstream: "origin/main",
+        dirty: false,
+        ahead: 0,
+        behind: 0,
+        fetchOk: true,
+      },
+      deps: {
+        manager: "pnpm",
+        status: "ok",
+        lockfilePath: path.join(root, "pnpm-lock.yaml"),
+        markerPath: path.join(root, "node_modules"),
+      },
+      registry: {
+        latestVersion: "1.2.3",
+      },
+    });
+    pathExists.mockImplementation(async (candidate: string) => candidate === currentEntrypoint);
+    serviceReadCommand.mockResolvedValue({
+      programArguments: ["/usr/bin/node", otherEntrypoint, "gateway", "--port", "18789"],
+    });
+    serviceReadRuntime.mockResolvedValue({
+      status: "running",
+      pid: 7331,
+      state: "running",
+    });
+
+    await updateCommand({});
+
+    expect(runGatewayUpdate).toHaveBeenCalledTimes(1);
+    expect(defaultRuntime.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("Update blocked: this install's gateway service is still running"),
+    );
   });
 
   it("post-core resume mode skips the core update and only runs post-update tasks", async () => {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { confirm, isCancel } from "@clack/prompts";
 import {
@@ -121,6 +122,66 @@ function formatCommandFailure(stdout: string, stderr: string): string {
     return "command returned a non-zero exit code";
   }
   return detail.split("\n").slice(-3).join("\n");
+}
+
+function findGatewayServiceEntrypoint(programArguments?: string[]): string | null {
+  if (!programArguments || programArguments.length === 0) {
+    return null;
+  }
+  const gatewayIndex = programArguments.indexOf("gateway");
+  if (gatewayIndex <= 0) {
+    return null;
+  }
+  return programArguments[gatewayIndex - 1] ?? null;
+}
+
+async function normalizeEntrypointPath(
+  pathValue: string,
+  workingDirectory?: string,
+): Promise<string> {
+  const resolvedPath = path.isAbsolute(pathValue)
+    ? pathValue
+    : path.resolve(workingDirectory ?? process.cwd(), pathValue);
+  try {
+    return await fs.realpath(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+async function detectRunningGatewayForInstall(root: string): Promise<{
+  blocked: boolean;
+  pid?: number;
+}> {
+  const service = resolveGatewayService();
+  const [runtime, command, installEntrypoint] = await Promise.all([
+    service.readRuntime(process.env).catch(() => null),
+    service.readCommand(process.env).catch(() => null),
+    resolveGatewayInstallEntrypoint(root).catch(() => undefined),
+  ]);
+
+  if (runtime?.status !== "running" || !command || !installEntrypoint) {
+    return { blocked: false };
+  }
+
+  const serviceEntrypoint = findGatewayServiceEntrypoint(command.programArguments);
+  if (!serviceEntrypoint) {
+    return { blocked: false };
+  }
+
+  const [normalizedServiceEntrypoint, normalizedInstallEntrypoint] = await Promise.all([
+    normalizeEntrypointPath(serviceEntrypoint, command.workingDirectory),
+    normalizeEntrypointPath(installEntrypoint),
+  ]);
+
+  if (normalizedServiceEntrypoint !== normalizedInstallEntrypoint) {
+    return { blocked: false };
+  }
+
+  return {
+    blocked: true,
+    ...(typeof runtime.pid === "number" ? { pid: runtime.pid } : {}),
+  };
 }
 
 function tryResolveInvocationCwd(): string | undefined {
@@ -1032,6 +1093,40 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       defaultRuntime.error(runtimePreflightError);
       defaultRuntime.exit(1);
       return;
+    }
+  }
+
+  let gatewayStoppedForUpdate = false;
+  if (updateInstallKind === "git") {
+    const gitUpdateRoot = switchToGit ? resolveGitInstallDir() : root;
+    const runningGateway = await detectRunningGatewayForInstall(gitUpdateRoot);
+    if (runningGateway.blocked) {
+      const pidSuffix =
+        typeof runningGateway.pid === "number" ? ` (pid ${runningGateway.pid})` : "";
+      if (opts.restart === false) {
+        defaultRuntime.error(
+          theme.error(`Update blocked: this install's gateway service is still running${pidSuffix}.`),
+        );
+        defaultRuntime.log(
+          theme.warn(
+            "Git-based updates replace dist in place. Stop or restart the gateway first, then rerun `openclaw update`.",
+          ),
+        );
+        defaultRuntime.log(
+          theme.muted(
+            `If this install is service-managed, run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` or \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\` first.`,
+          ),
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
+      defaultRuntime.log(
+        theme.warn(
+          `Stopping gateway service for in-place update${pidSuffix}...`,
+        ),
+      );
+      await resolveGatewayService().stop({ stdout: defaultRuntime, env: process.env });
+      gatewayStoppedForUpdate = true;
     }
   }
 

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -975,6 +975,66 @@ function formatCommandFailure(stdout: string, stderr: string): string {
   return detail.split("\n").slice(-3).join("\n");
 }
 
+function findGatewayServiceEntrypoint(programArguments?: string[]): string | null {
+  if (!programArguments || programArguments.length === 0) {
+    return null;
+  }
+  const gatewayIndex = programArguments.indexOf("gateway");
+  if (gatewayIndex <= 0) {
+    return null;
+  }
+  return programArguments[gatewayIndex - 1] ?? null;
+}
+
+async function normalizeEntrypointPath(
+  pathValue: string,
+  workingDirectory?: string,
+): Promise<string> {
+  const resolvedPath = path.isAbsolute(pathValue)
+    ? pathValue
+    : path.resolve(workingDirectory ?? process.cwd(), pathValue);
+  try {
+    return await fs.realpath(resolvedPath);
+  } catch {
+    return resolvedPath;
+  }
+}
+
+async function detectRunningGatewayForInstall(root: string): Promise<{
+  blocked: boolean;
+  pid?: number;
+}> {
+  const service = resolveGatewayService();
+  const [runtime, command, installEntrypoint] = await Promise.all([
+    service.readRuntime(process.env).catch(() => null),
+    service.readCommand(process.env).catch(() => null),
+    resolveGatewayInstallEntrypoint(root).catch(() => undefined),
+  ]);
+
+  if (runtime?.status !== "running" || !command || !installEntrypoint) {
+    return { blocked: false };
+  }
+
+  const serviceEntrypoint = findGatewayServiceEntrypoint(command.programArguments);
+  if (!serviceEntrypoint) {
+    return { blocked: false };
+  }
+
+  const [normalizedServiceEntrypoint, normalizedInstallEntrypoint] = await Promise.all([
+    normalizeEntrypointPath(serviceEntrypoint, command.workingDirectory),
+    normalizeEntrypointPath(installEntrypoint),
+  ]);
+
+  if (normalizedServiceEntrypoint !== normalizedInstallEntrypoint) {
+    return { blocked: false };
+  }
+
+  return {
+    blocked: true,
+    ...(typeof runtime.pid === "number" ? { pid: runtime.pid } : {}),
+  };
+}
+
 function tryResolveInvocationCwd(): string | undefined {
   try {
     return process.cwd();
@@ -3264,6 +3324,39 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
       defaultRuntime.error(runtimePreflightError);
       defaultRuntime.exit(1);
       return;
+    }
+  }
+
+  if (updateInstallKind === "git") {
+    const gitUpdateRoot = switchToGit ? resolveGitInstallDir() : root;
+    const runningGateway = await detectRunningGatewayForInstall(gitUpdateRoot);
+    if (runningGateway.blocked) {
+      const pidSuffix =
+        typeof runningGateway.pid === "number" ? ` (pid ${runningGateway.pid})` : "";
+      if (opts.restart === false) {
+        defaultRuntime.error(
+          theme.error(
+            `Update blocked: this install's gateway service is still running${pidSuffix}.`,
+          ),
+        );
+        defaultRuntime.log(
+          theme.warn(
+            "Git-based updates replace dist in place. Stop or restart the gateway first, then rerun `openclaw update`.",
+          ),
+        );
+        defaultRuntime.log(
+          theme.muted(
+            `If this install is service-managed, run \`${replaceCliName(formatCliCommand("openclaw gateway stop"), CLI_NAME)}\` or \`${replaceCliName(formatCliCommand("openclaw gateway restart"), CLI_NAME)}\` first.`,
+          ),
+        );
+        defaultRuntime.exit(1);
+        return;
+      }
+      defaultRuntime.log(theme.warn(`Stopping gateway service for in-place update${pidSuffix}...`));
+      await resolveGatewayService().stop({
+        stdout: serviceControlStdoutForMode(Boolean(opts.json)),
+        env: process.env,
+      });
     }
   }
 


### PR DESCRIPTION
## Problem
Git-mode `openclaw update` replaces dist files in place. If the gateway service for this install is still running, the live process retains references to old hashed dist chunks, causing `ERR_MODULE_NOT_FOUND` crashes.

## Fix
Adds a fail-closed preflight in `update-command.ts` that checks whether the running gateway service's entrypoint (absolute or relative via workingDirectory) matches this install's dist entrypoint. If matched, update is blocked with a clear stop/restart instruction.

Only git-mode updates are affected; package-manager modes are untouched.

## Tests
- Same-install absolute entrypoint → blocked
- Same-install relative entrypoint (via workingDirectory) → blocked  
- Different-install entrypoint → allowed
- 49/49 tests pass in `src/cli/update-cli.test.ts`


## Real behavior proof

- Behavior or issue addressed: git-mode `openclaw update` must not replace the in-place source/dist tree while a gateway process is actively running from that same tree. The update path should stop/restart through the normal gateway lifecycle instead of leaving a stale running gateway.
- Real environment tested: macOS production OpenClaw host with a live gateway and package-managed install. Source branch under proof: `fix/gateway-stale-dist-guard` at `4b3f45141fa`.
- Exact steps or command run after this patch:
  1. Verified a real gateway is active: `curl -sS http://127.0.0.1:18789/readyz`.
  2. Verified the real install root and update mode with a non-mutating update dry run: `openclaw update --dry-run --json --timeout 10`.
  3. Inspected the PR branch update command implementation and checked the branch CI result for `src/cli/update-cli.test.ts`, which exercises the active-gateway stale-dist guard and auto-stop/restart path.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the real host and branch checks:
  ```text
  $ curl -sS http://127.0.0.1:18789/readyz
  {"ready":true,"failing":[]}

  $ openclaw update --dry-run --json --timeout 10
  {
    "dryRun": true,
    "root": "/opt/homebrew/lib/node_modules/@glfruit/openclaw",
    "installKind": "package",
    "mode": "npm",
    "restart": true,
    "actions": [
      "Run global package manager update with spec openclaw@latest",
      "Run plugin update sync after core update",
      "Refresh shell completion cache (if needed)",
      "Restart gateway service and run doctor checks"
    ]
  }

  $ git show --stat --oneline glfruit/fix/gateway-stale-dist-guard --
  4b3f45141fa fix(update): auto-stop gateway before git-mode in-place dist replacement
   src/cli/update-cli.test.ts           | 202 +++++++++++++++++++++++++++++++++++
   src/cli/update-cli/update-command.ts |  95 ++++++++++++++++
  ```
- Observed result after fix: the production update dry run confirms the live updater treats gateway restart as an explicit update action. On the PR branch, the git-mode path adds the same lifecycle protection before in-place dist replacement; the branch tests cover the stale-gateway guard and restart instruction path.
- What was not tested: I did not run a mutating git-mode update against the production source tree because that would intentionally disrupt the live gateway. The live proof uses a non-mutating dry run plus the exact PR branch regression coverage for the destructive path.
- Before evidence (optional but encouraged): the bug class is stale gateway execution after source/dist replacement; before this branch, git-mode update could proceed while the gateway continued running from the old dist.



