### PR TITLE
test(anthropic): pin Opus 4.7 variant resolution + thinking-default regression coverage

### DIFF
--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -252,6 +252,67 @@ describe("anthropic provider replay hooks", () => {
     ).toBe(false);
   });
 
+  describe("Opus 4.7 variant regression coverage", () => {
+    const opus46Template: ProviderRuntimeModel = {
+      id: "claude-opus-4-6",
+      name: "Claude Opus 4.6",
+      provider: "anthropic",
+      api: "anthropic-messages",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 200_000,
+      maxTokens: 32_000,
+    } as ProviderRuntimeModel;
+
+    it.each(["claude-opus-4.7", "claude-opus-4-7-20260901"])(
+      "resolves %s from the 4.6 template family",
+      async (modelId) => {
+        const provider = await registerSingleProviderPlugin(anthropicPlugin);
+        const resolved = provider.resolveDynamicModel?.({
+          provider: "anthropic",
+          modelId,
+          modelRegistry: createModelRegistry([opus46Template]),
+        } as ProviderResolveDynamicModelContext);
+
+        expect(resolved).toMatchObject({
+          provider: "anthropic",
+          id: modelId,
+          api: "anthropic-messages",
+          reasoning: true,
+        });
+      },
+    );
+
+    it("marks claude-opus-4-7 as a modern model", async () => {
+      const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+      expect(
+        provider.isModernModelRef?.({
+          provider: "anthropic",
+          modelId: "claude-opus-4-7",
+        } as never),
+      ).toBe(true);
+    });
+
+    it.each(["claude-opus-4.7", "claude-opus-4-7-20260901"])(
+      "keeps %s default thinking level separate from adaptive",
+      async (modelId) => {
+        const provider = await registerSingleProviderPlugin(anthropicPlugin);
+
+        expect(
+          provider.resolveThinkingProfile?.({
+            provider: "anthropic",
+            modelId,
+          } as never),
+        ).toMatchObject({
+          levels: expect.arrayContaining([{ id: "xhigh" }, { id: "adaptive" }, { id: "max" }]),
+          defaultLevel: "off",
+        });
+      },
+    );
+  });
+
   it("resolves claude-cli synthetic oauth auth", async () => {
     readClaudeCliCredentialsForRuntimeMock.mockReset();
     readClaudeCliCredentialsForRuntimeMock.mockReturnValue({


### PR DESCRIPTION
AI-assisted: yes (Claude). Testing level: focused tests.

## Summary

Pins the Opus 4.7 behavior that fixed #67710 so future refactors don't silently regress it. Test-only; no production code change.

Closes #67710.

### Why the issue is still open

The original "configured+missing" Opus 4.7 symptom was resolved by Peter's `628b454eff feat: default Anthropic to Opus 4.7` (~26 minutes after the issue was filed). The follow-up `a2753e2d9f fix: keep Opus 4.7 effort separate from adaptive thinking` pinned the thinking-level decision. Neither PR linked a `Closes #67710`, so the issue stayed open despite the behavior being live on `main`.

### Changes

`extensions/anthropic/index.test.ts` — new `describe("Opus 4.7 variant regression coverage")` block:

- `claude-opus-4.7` and `claude-opus-4-7-20260901` resolve from the 4.6 template family (exercises the dot and date-suffix branches of `resolveAnthropicForwardCompatModel`).
- `claude-opus-4-7` is marked as a modern model (regression coverage for `ANTHROPIC_MODERN_MODEL_PREFIXES`).
- `claude-opus-4.7` and `claude-opus-4-7-20260901` keep default thinking level `off` with `xhigh`/`adaptive`/`max` levels available — pins `a2753e2d9f`.

### Notes

- Earlier scope of this PR (adding Sonnet 4.7 forward-compat + Opus 4.7 adaptive-default) was dropped: Anthropic has not shipped Sonnet 4.7, and the Opus 4.7 adaptive-default change directly conflicted with `a2753e2d9f`.
- PDF tool test update from the earlier scope was also dropped — already on main via `892baf2e81`.

## Verification

- `pnpm test extensions/anthropic/index.test.ts` — 17/17 green, including 5 new cases.