### PR TITLE
fix(feishu): silence sdk logs during setup probe

### DIFF
--- a/extensions/feishu/src/client.test.ts
+++ b/extensions/feishu/src/client.test.ts
@@ -347,6 +347,38 @@ describe("createFeishuClient HTTP timeout", () => {
       expect.objectContaining({ timeout: 45_000 }),
     );
   });
+
+  it("passes custom loggers through and bypasses the shared client cache", () => {
+    const logger = {
+      error: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+    };
+
+    const first = createFeishuClient(
+      {
+        appId: "app_logger",
+        appSecret: "secret_logger", // pragma: allowlist secret
+        accountId: "logger-test",
+      },
+      { logger },
+    );
+    const second = createFeishuClient(
+      {
+        appId: "app_logger",
+        appSecret: "secret_logger", // pragma: allowlist secret
+        accountId: "logger-test",
+      },
+      { logger },
+    );
+
+    expect(clientCtorMock).toHaveBeenCalledTimes(2);
+    expect(readCallOptions(clientCtorMock, 0).logger).toBe(logger);
+    expect(readCallOptions(clientCtorMock, 1).logger).toBe(logger);
+    expect(first).not.toBe(second);
+  });
 });
 
 describe("createFeishuWSClient proxy handling", () => {

--- a/extensions/feishu/src/client.ts
+++ b/extensions/feishu/src/client.ts
@@ -159,6 +159,20 @@ export type FeishuClientCredentials = {
   config?: Pick<FeishuConfig, "httpTimeoutMs">;
 };
 
+export type FeishuClientLogger = {
+  error: (...msg: unknown[]) => void;
+  warn: (...msg: unknown[]) => void;
+  info: (...msg: unknown[]) => void;
+  debug: (...msg: unknown[]) => void;
+  trace: (...msg: unknown[]) => void;
+};
+
+export type FeishuClientOptions = {
+  // Custom loggers are treated as one-off clients so setup/status probes can
+  // suppress SDK info noise without altering the shared runtime client cache.
+  logger?: FeishuClientLogger;
+};
+
 function resolveConfiguredHttpTimeoutMs(creds: FeishuClientCredentials): number {
   const clampTimeout = (value: number): number => {
     const rounded = Math.floor(value);
@@ -194,12 +208,29 @@ function resolveConfiguredHttpTimeoutMs(creds: FeishuClientCredentials): number 
  * Create or get a cached Feishu client for an account.
  * Accepts any object with appId, appSecret, and optional domain/accountId.
  */
-export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client {
+export function createFeishuClient(
+  creds: FeishuClientCredentials,
+  options: FeishuClientOptions = {},
+): Lark.Client {
   const { accountId = "default", appId, appSecret, domain } = creds;
   const defaultHttpTimeoutMs = resolveConfiguredHttpTimeoutMs(creds);
 
   if (!appId || !appSecret) {
     throw new Error(`Feishu credentials not configured for account "${accountId}"`);
+  }
+
+  const createClient = () =>
+    new feishuClientSdk.Client({
+      appId,
+      appSecret,
+      appType: feishuClientSdk.AppType.SelfBuild,
+      domain: resolveDomain(domain),
+      httpInstance: createTimeoutHttpInstance(defaultHttpTimeoutMs),
+      ...(options.logger ? { logger: options.logger } : {}),
+    });
+
+  if (options.logger) {
+    return createClient();
   }
 
   // Check cache
@@ -215,13 +246,7 @@ export function createFeishuClient(creds: FeishuClientCredentials): Lark.Client 
   }
 
   // Create new client with timeout-aware HTTP instance
-  const client = new feishuClientSdk.Client({
-    appId,
-    appSecret,
-    appType: feishuClientSdk.AppType.SelfBuild,
-    domain: resolveDomain(domain),
-    httpInstance: createTimeoutHttpInstance(defaultHttpTimeoutMs),
-  });
+  const client = createClient();
 
   // Cache it
   clientCache.set(accountId, {

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -126,6 +126,18 @@ describe("probeFeishu", () => {
 
     await expectDefaultSuccessResult();
     expect(requestFn).toHaveBeenCalledTimes(1);
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      DEFAULT_CREDS,
+      expect.objectContaining({
+        logger: expect.objectContaining({
+          error: expect.any(Function),
+          warn: expect.any(Function),
+          info: expect.any(Function),
+          debug: expect.any(Function),
+          trace: expect.any(Function),
+        }),
+      }),
+    );
   });
 
   it("passes the probe timeout to the Feishu request", async () => {

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -1,6 +1,10 @@
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { raceWithTimeoutAndAbort } from "./async.js";
-import { createFeishuClient, type FeishuClientCredentials } from "./client.js";
+import {
+  createFeishuClient,
+  type FeishuClientCredentials,
+  type FeishuClientLogger,
+} from "./client.js";
 import type { FeishuProbeResult } from "./types.js";
 
 /** Cache probe results to reduce repeated health-check calls.
@@ -16,6 +20,14 @@ export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
 export type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;
+};
+
+const silentProbeLogger: FeishuClientLogger = {
+  error() {},
+  warn() {},
+  info() {},
+  debug() {},
+  trace() {},
 };
 
 type FeishuPingResponse = {
@@ -79,7 +91,9 @@ export async function probeFeishu(
   }
 
   try {
-    const client = createFeishuClient(creds) as FeishuRequestClient;
+    const client = createFeishuClient(creds, {
+      logger: silentProbeLogger,
+    }) as FeishuRequestClient;
     // Feishu-provided endpoint for OpenClaw, supported on both Feishu (CN)
     // and Lark (international). No OAuth scopes required. Validates
     // credentials and registers the app as an AI agent (智能体).


### PR DESCRIPTION
## Summary
- silence Feishu SDK logger output during setup/status probing
- avoid reusing the shared runtime client when a custom probe logger is supplied
- add regression coverage for probe/client logger behavior

## Testing
- node scripts/run-vitest.mjs run extensions/feishu/src/client.test.ts extensions/feishu/src/probe.test.ts extensions/feishu/src/setup-surface.test.ts
- manual regression: first-time Feishu setup and reconfiguration no longer print `[info]` probe logs in the wizard

Closes #67497