### PR TITLE
fix(google): correct gemini preview model versions

### DIFF
--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -6,7 +6,7 @@ import {
 
 const GEMINI_MODEL_ALIASES: Record<string, string> = {
   pro: "gemini-3.1-pro-preview",
-  flash: "gemini-3.1-flash-preview",
+  flash: "gemini-3-flash-preview",
   "flash-lite": "gemini-3.1-flash-lite-preview",
 };
 const GEMINI_CLI_DEFAULT_MODEL_REF = "google-gemini-cli/gemini-3-flash-preview";


### PR DESCRIPTION
Minor fix for incorrect model from existing, I didn't think the template was necessary given the model referenced doesn't exist, so this wouldn't work, and the default is actually specified correctly as -3-flash