### PR TITLE
fix: remove truncated preview from inbound system events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/Teams inbound: keep queued message system events to routing labels only, avoiding truncated duplicate message previews while preserving the full body in the channel payload. (#67761) Thanks @jgallowa07.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Harden macOS shell wrapper allowlist parsing [AI]. (#78518) Thanks @pgondhi987.

--- a/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.thread-parent.test.ts
@@ -72,6 +72,27 @@ describe("msteams thread parent context injection", () => {
     channels: { msteams: { groupPolicy: "open" } },
   } as OpenClawConfig;
 
+  it("queues inbound message system events without the message preview", async () => {
+    const { deps, enqueueSystemEvent } = createMessageHandlerDeps(cfg);
+    const handler = createMSTeamsMessageHandler(deps);
+
+    await handler({
+      activity: buildChannelActivity({
+        id: "msg-preview-1",
+        text: "please investigate the deployment preview leak",
+      }),
+      sendActivity: vi.fn(async () => undefined),
+    } as unknown as Parameters<typeof handler>[0]);
+
+    expect(enqueueSystemEvent).toHaveBeenCalledWith(
+      "Teams message in channel from Test User",
+      expect.objectContaining({
+        contextKey: `msteams:message:${channelConversationId}:msg-preview-1`,
+      }),
+    );
+    expect(enqueueSystemEvent.mock.calls[0]?.[0]).not.toContain("deployment preview leak");
+  });
+
   it("enqueues a Replying to @sender system event on the first thread reply", async () => {
     fetchChannelMessageMock.mockResolvedValueOnce({
       id: "thread-root-123",

--- a/extensions/msteams/src/monitor-handler/message-handler.ts
+++ b/extensions/msteams/src/monitor-handler/message-handler.ts
@@ -498,7 +498,7 @@ export function createMSTeamsMessageHandler(deps: MSTeamsMessageHandlerDeps) {
       ? `Teams DM from ${senderName}`
       : `Teams message in ${conversationType} from ${senderName}`;
 
-    core.system.enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+    core.system.enqueueSystemEvent(inboundLabel, {
       sessionKey: route.sessionKey,
       contextKey: `msteams:message:${conversationId}:${activity.id ?? "unknown"}`,
     });

--- a/extensions/slack/src/monitor/message-handler/prepare.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.test.ts
@@ -161,7 +161,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
 
     assertPrepared(prepared);
     expect(enqueueSystemEventMock).toHaveBeenCalledWith(
-      expect.stringContaining("Slack DM from Alice: hi"),
+      "Slack DM from Alice",
       expect.objectContaining({
         sessionKey: expect.any(String),
         contextKey: "slack:message:D123:1.000",

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -653,7 +653,7 @@ export async function prepareSlackMessage(params: {
       ? `slack:channel:${message.channel}`
       : `slack:group:${message.channel}`;
 
-  enqueueSystemEvent(`${inboundLabel}: ${preview}`, {
+  enqueueSystemEvent(inboundLabel, {
     sessionKey,
     contextKey: `slack:message:${message.channel}:${message.ts ?? "unknown"}`,
     trusted: false,


### PR DESCRIPTION
## Summary

Removes the truncated 160-char message preview from system event headers for Slack, MS Teams, and Mattermost channels.

## Problem

System events were including a truncated preview of the message body:

```
System: [2026-04-15 21:56:40 MDT] Slack DM from Jared: What I'm saying is that you are can handle this task (you just showed me you can), but starting tomorrow (and including tomorrow), When we're planning the day o
```

This caused the model to sometimes reference the truncated header instead of the full message body, leading to responses like "your message got cut off at 'day o'" when the full message was delivered correctly.

## Solution

System events now only contain the notification label without message content:

```
System: [2026-04-15 21:56:40 MDT] Slack DM from Jared
```

The system event's purpose is notification ("a message arrived"), not content delivery. The full message body is delivered separately in the user turn.

## Changes

- `extensions/slack/src/monitor/message-handler/prepare.ts` — remove preview from system event (keep for debug logging/type compat)
- `extensions/msteams/src/monitor-handler/message-handler.ts` — remove preview from system event (keep for debug logging)
- `extensions/mattermost/src/mattermost/monitor.ts` — remove preview from system event

## Testing

- `pnpm test:extension slack` — ✅ 641 tests passed
- `pnpm test:extension msteams` — ✅ 862 tests passed
- `pnpm test:extension mattermost` — ✅ 316 passed (1 timeout failure unrelated to changes)
- `pnpm build` — ✅
- Pre-commit hooks — ✅

Fixes #67503