### PR TITLE
fix(telegram): skip delete before non-empty command sync

### DIFF
--- a/extensions/telegram/src/bot-native-command-menu.test.ts
+++ b/extensions/telegram/src/bot-native-command-menu.test.ts
@@ -150,7 +150,7 @@ describe("bot-native-command-menu", () => {
     );
   });
 
-  it("deletes stale commands before setting new menu", async () => {
+  it("skips deleteMyCommands before setting a non-empty menu", async () => {
     const callOrder: string[] = [];
     const deleteMyCommands = vi.fn(async (options?: { scope?: { type?: string } }) => {
       callOrder.push(options?.scope?.type ? `delete:${options.scope.type}` : "delete:default");
@@ -170,15 +170,11 @@ describe("bot-native-command-menu", () => {
     });
 
     await vi.waitFor(() => {
-      expect(setMyCommands).toHaveBeenCalled();
+      expect(setMyCommands).toHaveBeenCalledTimes(2);
     });
 
-    expect(callOrder).toEqual([
-      "delete:default",
-      "delete:all_group_chats",
-      "set:default",
-      "set:all_group_chats",
-    ]);
+    expect(deleteMyCommands).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["set:default", "set:all_group_chats"]);
   });
 
   it("registers the menu in default and group chat scopes", async () => {
@@ -202,6 +198,29 @@ describe("bot-native-command-menu", () => {
     expect(setMyCommands).toHaveBeenCalledWith(commands, {
       scope: { type: "all_group_chats" },
     });
+  });
+
+  it("deletes commands when syncing an empty menu", async () => {
+    const callOrder: string[] = [];
+    const deleteMyCommands = vi.fn(async (options?: { scope?: { type?: string } }) => {
+      callOrder.push(options?.scope?.type ? `delete:${options.scope.type}` : "delete:default");
+    });
+    const setMyCommands = vi.fn(async () => undefined);
+
+    syncMenuCommandsWithMocks({
+      deleteMyCommands,
+      setMyCommands,
+      commandsToRegister: [],
+      accountId: `test-empty-delete-${Date.now()}`,
+      botIdentity: "bot-a",
+    });
+
+    await vi.waitFor(() => {
+      expect(deleteMyCommands).toHaveBeenCalledTimes(2);
+    });
+
+    expect(setMyCommands).not.toHaveBeenCalled();
+    expect(callOrder).toEqual(["delete:default", "delete:all_group_chats"]);
   });
 
   it("produces a stable hash regardless of command order (#32017)", () => {
@@ -241,6 +260,7 @@ describe("bot-native-command-menu", () => {
     await vi.waitFor(() => {
       expect(setMyCommands).toHaveBeenCalledTimes(2);
     });
+    await Promise.resolve();
 
     // Second sync with the same commands — hash is cached, should skip.
     syncMenuCommandsWithMocks({

--- a/extensions/telegram/src/bot-native-command-menu.ts
+++ b/extensions/telegram/src/bot-native-command-menu.ts
@@ -312,10 +312,8 @@ export function syncTelegramMenuCommands(params: {
       return;
     }
 
-    // Keep delete -> set ordering to avoid stale deletions racing after fresh registrations.
-    const deleteSucceeded = await deleteTelegramMenuCommandsForScopes({ bot, runtime });
-
     if (commandsToRegister.length === 0) {
+      const deleteSucceeded = await deleteTelegramMenuCommandsForScopes({ bot, runtime });
       if (!deleteSucceeded) {
         runtime.log?.("telegram: deleteMyCommands failed; skipping empty-menu hash cache write");
         return;


### PR DESCRIPTION
## Summary
- skip `deleteMyCommands()` before syncing a non-empty Telegram command menu
- preserve explicit deletes when syncing an empty menu
- add targeted tests for both paths and stabilize the unchanged-hash test

## Why
PR #32059 already avoids unnecessary syncs when the menu hash is unchanged. When the command set changes, startup still clears Telegram commands before setting the new non-empty menu. This follow-up keeps the explicit clear behavior for empty menus while using a single `setMyCommands()` call for the normal non-empty path.

## Testing
- `pnpm -C /Users/pingu/.openclaw/tmp/openclaw-pr-shallow exec vitest run extensions/telegram/src/bot-native-command-menu.test.ts`