### PR TITLE
fix: improve cli help and gateway guidance

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -10,6 +10,10 @@ title: "CLI Reference"
 
 This page describes the current CLI behavior. If commands change, update this doc.
 
+Tip: root help should expand command groups that have subcommands. For example,
+`openclaw models --help` should list `auth`, `list`, `set`, `status`, and other
+models subcommands directly instead of only showing the top-level command stub.
+
 ## Command pages
 
 - [`setup`](/cli/setup)

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -115,7 +115,12 @@ Examples:
 
 ```bash
 openclaw models auth login --provider openai-codex --set-default
+openclaw gateway restart
+openclaw models status --probe --probe-provider openai-codex
 ```
+
+If you just reauthenticated a provider used by a supervised gateway, restart the
+gateway so long-lived sessions reload the refreshed credentials.
 
 Notes:
 

--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -166,6 +166,10 @@ const tryOutputBareRootHelp = async () => {
   return false;
 };
 
+if (process.argv.length > 4 && process.argv.slice(2).includes("--help")) {
+  process.env.OPENCLAW_DISABLE_LAZY_SUBCOMMANDS ??= "1";
+}
+
 if (await tryOutputBareRootHelp()) {
   // OK
 } else {

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -56,7 +56,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--no-probe", "Skip RPC probe")
     .option("--require-rpc", "Exit non-zero when the RPC probe fails", false)
-    .option("--deep", "Scan system-level services", false)
+    .option("--deep", "Scan system-level services and include config/auth diagnostics", false)
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts, command) => {
       const { runDaemonStatus } = await loadDaemonStatusModule();

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -140,6 +140,11 @@ export function registerGatewayCli(program: Command) {
       .command("gateway")
       .description("Run, inspect, and query the WebSocket Gateway")
       .addHelpText(
+        "beforeAll",
+        () =>
+          `${theme.muted("Note:")} ${theme.command("openclaw gateway")} runs the foreground gateway runtime. For supervised service control use ${theme.command("openclaw gateway status")}, ${theme.command("openclaw gateway restart")}, or ${theme.command("openclaw gateway stop")}.\n\n`,
+      )
+      .addHelpText(
         "after",
         () =>
           `\n${theme.heading("Examples:")}\n${formatHelpExamples([

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -71,6 +71,21 @@ type GatewayRunOpts = {
 
 const gatewayLog = createSubsystemLogger("gateway");
 
+function buildGatewayLockUserHint(err: unknown, port: number): string[] {
+  const message =
+    typeof err === "object" && err && "message" in err ? String(err.message) : String(err);
+  const hints = [
+    `Check gateway state with: ${formatCliCommand("openclaw gateway status")}`,
+    `If the gateway is supervised, restart it with: ${formatCliCommand("openclaw gateway restart")}`,
+  ];
+  if (/EADDRINUSE|address already in use|port .* in use/i.test(message)) {
+    hints.push(
+      `If another process owns port ${port}, run: ${formatCliCommand(`openclaw gateway run --port ${port} --force`)}`,
+    );
+  }
+  return hints;
+}
+
 const GATEWAY_RUN_VALUE_KEYS = [
   "port",
   "bind",
@@ -576,6 +591,9 @@ async function runGatewayCommand(opts: GatewayRunOpts) {
       defaultRuntime.error(
         `Gateway failed to start: ${errMessage}\nIf the gateway is supervised, stop it with: ${formatCliCommand("openclaw gateway stop")}`,
       );
+      for (const hint of buildGatewayLockUserHint(err, port)) {
+        defaultRuntime.error(hint);
+      }
       try {
         const diagnostics = await inspectPortUsage(port);
         if (diagnostics.status === "busy") {

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -28,6 +28,7 @@ import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
+import { formatHelpExamples } from "./help-format.js";
 
 function runModelsCommand(action: () => Promise<void>) {
   return runCommandWithRuntime(defaultRuntime, action);
@@ -289,6 +290,25 @@ export function registerModelsCli(program: Command) {
 
   const auth = models.command("auth").description("Manage model auth profiles");
   auth.option("--agent <id>", "Agent id for auth order get/set/clear");
+  auth.addHelpText(
+    "after",
+    () =>
+      `\n${theme.heading("Common auth flows:")}\n${formatHelpExamples([
+        ["openclaw models auth add", "Interactive helper that chooses auth or token setup."],
+        [
+          "openclaw models auth login --provider openai-codex --set-default",
+          "Reauthenticate Codex and refresh the default model recommendation.",
+        ],
+        [
+          "openclaw models auth setup-token --provider anthropic",
+          "Run a provider token setup flow when a plugin exposes one.",
+        ],
+        [
+          "openclaw models status --probe",
+          "Verify configured providers with live auth probes after login.",
+        ],
+      ])}`,
+  );
   auth.action(() => {
     auth.help();
   });

--- a/src/cli/program/help.ts
+++ b/src/cli/program/help.ts
@@ -22,17 +22,18 @@ const ROOT_COMMANDS_HINT =
 
 const EXAMPLES = [
   ["openclaw models --help", "Show detailed help for the models command."],
-  [
-    "openclaw channels login --verbose",
-    "Link personal WhatsApp Web and show QR + connection logs.",
-  ],
+  ["openclaw channels login --channel whatsapp", "Link a WhatsApp account and show the QR flow."],
   [
     'openclaw message send --target +15555550123 --message "Hi" --json',
     "Send via your web session and print JSON result.",
   ],
-  ["openclaw gateway --port 18789", "Run the WebSocket Gateway locally."],
-  ["openclaw --dev gateway", "Run a dev Gateway (isolated state/config) on ws://127.0.0.1:19001."],
-  ["openclaw gateway --force", "Kill anything bound to the default gateway port, then start it."],
+  ["openclaw gateway status", "Check gateway service status and probe reachability."],
+  ["openclaw gateway restart", "Restart the supervised gateway service."],
+  ["openclaw gateway run --port 18789", "Run the WebSocket Gateway locally in the foreground."],
+  [
+    "openclaw --dev gateway run",
+    "Run a dev Gateway (isolated state/config) on ws://127.0.0.1:19001.",
+  ],
   ["openclaw gateway ...", "Gateway control via WebSocket."],
   [
     'openclaw agent --to +15555550123 --message "Run summary" --deliver',

--- a/src/commands/gateway-status/output.ts
+++ b/src/commands/gateway-status/output.ts
@@ -3,6 +3,7 @@ import { writeRuntimeJson } from "../../runtime.js";
 import { colorize, theme } from "../../terminal/theme.js";
 import { serializeGatewayDiscoveryBeacon } from "./discovery.js";
 import {
+  type GatewayConfigSummary,
   isProbeReachable,
   isScopeLimitedProbeFailure,
   renderProbeSummaryLine,
@@ -15,6 +16,25 @@ export type GatewayStatusWarning = {
   message: string;
   targetIds?: string[];
 };
+
+function formatGatewayAuthConfigLine(configSummary: GatewayConfigSummary): string {
+  const authConfig = configSummary.gateway;
+  const local = authConfig.authTokenConfigured
+    ? "token"
+    : authConfig.authPasswordConfigured
+      ? "password"
+      : "none-detected";
+  const remote = authConfig.remoteUrl
+    ? authConfig.remoteTokenConfigured
+      ? "token"
+      : authConfig.remotePasswordConfigured
+        ? "password"
+        : "none-detected"
+    : null;
+  return remote
+    ? `mode=${authConfig.authMode ?? "unknown"} · local=${local} · remote=${remote}`
+    : `mode=${authConfig.authMode ?? "unknown"} · local=${local}`;
+}
 
 export function pickPrimaryProbedTarget(probed: GatewayStatusProbedTarget[]) {
   const reachable = probed.filter((entry) => isProbeReachable(entry.probe));
@@ -205,6 +225,12 @@ export function writeGatewayStatusText(params: {
       );
     }
     if (result.configSummary) {
+      params.runtime.log(
+        `  ${colorize(params.rich, theme.info, "Gateway config")}: mode=${result.configSummary.gateway.mode ?? "unknown"} · bind=${result.configSummary.gateway.bind ?? "unknown"}`,
+      );
+      params.runtime.log(
+        `  ${colorize(params.rich, theme.info, "Gateway auth")}: ${formatGatewayAuthConfigLine(result.configSummary)}`,
+      );
       const wideArea =
         result.configSummary.discovery.wideAreaEnabled === true
           ? "enabled"
@@ -213,6 +239,11 @@ export function writeGatewayStatusText(params: {
             : "unknown";
       params.runtime.log(
         `  ${colorize(params.rich, theme.info, "Wide-area discovery")}: ${wideArea}`,
+      );
+    }
+    if (result.authDiagnostics.length > 0) {
+      params.runtime.log(
+        `  ${colorize(params.rich, theme.warn, "Auth hint")}: ${result.authDiagnostics[0]}`,
       );
     }
     params.runtime.log("");


### PR DESCRIPTION
## Summary
- expand nested help more reliably for deeper `--help` invocations
- clarify gateway foreground runtime vs supervised service commands
- improve gateway status/auth/help output and models auth guidance

## Testing
- corepack pnpm install --frozen-lockfile
- corepack pnpm exec node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.unit.config.ts src/cli/command-registration-policy.test.ts src/cli/program/register.subclis.test.ts src/cli/daemon-cli/register-service-commands.test.ts src/cli/gateway-cli/register.option-collisions.test.ts
- PATH="/tmp:$PATH" pnpm check