### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -255,7 +255,7 @@ detect_os_or_die() {
     OS="unknown"
     if [[ "$OSTYPE" == "darwin"* ]]; then
         OS="macos"
-    elif [[ "$OSTYPE" == "linux-gnu"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
+    elif [[ "$OSTYPE" == "linux"* ]] || [[ -n "${WSL_DISTRO_NAME:-}" ]]; then
         OS="linux"
     fi
 


### PR DESCRIPTION
Is there any reason to use the starting string _linux-gnu_ in the **_detect_os_or_die_** method?
I'm using openSUSE, and OSTYPE variable returns the string _linux_

<img width="727" height="108" alt="Screenshot From 2026-04-15 21-46-38" src="https://github.com/user-attachments/assets/9e19e4b8-41f1-4d7e-8974-f8b74f92adfb" />

I can change the variable by running the `OSTYPE=linux-gnu` command, but maybe it could be fixed this way.

___

Before installing OpenClaw, you should install the required libraries:

`sudo zypper install curl, nodejs, git`

In this particular case, openSUSE comes with _curl_ preinstalled, but some Linux distros don't. So, the people using those distros will have to use their package managers anyway before starting the installation of OpenClaw.
After that, if you try to run the next command with the current state of the _install.sh_ file

`curl -fsSL https://openclaw.ai/install.sh | bash`

you'll get the following error (which doesn't give any clue about how to solve it)

<img width="791" height="213" alt="Screenshot From 2026-05-15 23-56-08" src="https://github.com/user-attachments/assets/6e090050-a452-4923-b805-bbe6ed4d2ff3" />

But if you apply the change I'm proposing, and run the previous command, the installation will end successfully in a few minutes, and finally the setup process will start.

<img width="1417" height="864" alt="Screenshot From 2026-05-15 23-59-56" src="https://github.com/user-attachments/assets/b06594ce-5156-434f-873a-73b6a8df261e" />
