### PR TITLE
fix(mattermost): support filePath and path as mediaUrl fallbacks in handleAction

### DIFF
--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -215,7 +215,13 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =
-      typeof params.media === "string" ? params.media.trim() || undefined : undefined;
+      typeof params.media === "string"
+        ? params.media.trim() || undefined
+        : typeof params.filePath === "string"
+          ? params.filePath.trim() || undefined
+          : typeof params.path === "string"
+            ? params.path.trim() || undefined
+            : undefined;
 
     const result = await (
       await loadMattermostChannelRuntime()


### PR DESCRIPTION
## Summary

The Mattermost `handleAction` only checked `params.media` for media URL, ignoring `filePath` and `path` which are commonly used by agents. This is inconsistent with other channel handlers like Discord and Google Chat.

## Problem

When an agent uses the message tool with `filePath` or `path` instead of `media`:
- Discord handler: supports `media` → `path` → `filePath` fallback
- Google Chat handler: supports `media` → `filePath` → `path` fallback  
- Mattermost handler: only checks `media` → file upload fails silently

## Fix

Add fallback chain for media URL resolution:
1. `params.media`
2. `params.filePath`
3. `params.path`

## Related

This is a partial fix for #67784. The other parts (threadId and mediaLocalRoots) are already addressed by:
- PR #52120 (thread context inheritance)
- PR #58439 (mediaLocalRoots forwarding)

## Test Plan
- [x] Existing unit tests pass
- [x] Lint passes

Closes openclaw#67784 (filePath/path fallback only)