### PR TITLE
fix(agents): honor explicit long Anthropic cache TTL on custom hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
 - Telegram/media: parse lowercase media directives in block replies and preserve outbound attachment filenames, so generated files send once with their original names. (#69641) Thanks @obviyus.
+- Agents/Anthropic: honor explicit `cacheRetention: "long"` for custom `anthropic-messages` endpoints by applying the 1-hour ephemeral cache TTL independently of the Anthropic/Vertex hostname allowlist. Implicit and env-driven long retention still require an allowlisted host. (#67800) Thanks @MonkeyLeeT.
 
 ## 2026.4.19-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+### Fixes
+
+- Agents/Anthropic: honor explicit `cacheRetention: "long"` for custom `anthropic-messages` endpoints by applying the 1-hour ephemeral cache TTL independently of the Anthropic/Vertex hostname allowlist. Implicit and env-driven long retention still require an allowlisted host. (#67800) Thanks @MonkeyLeeT.
+- fix(agents): honor explicit long Anthropic cache TTL on custom hosts (#67800). Thanks @MonkeyLeeT
+
 ## 2026.4.20
 
 ### Changes
@@ -106,8 +115,6 @@ Docs: https://docs.openclaw.ai
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
 - Telegram/media: parse lowercase media directives in block replies and preserve outbound attachment filenames, so generated files send once with their original names. (#69641) Thanks @obviyus.
-- Agents/Anthropic: honor explicit `cacheRetention: "long"` for custom `anthropic-messages` endpoints by applying the 1-hour ephemeral cache TTL independently of the Anthropic/Vertex hostname allowlist. Implicit and env-driven long retention still require an allowlisted host. (#67800) Thanks @MonkeyLeeT.
-- fix(agents): honor explicit long Anthropic cache TTL on custom hosts (#67800). Thanks @MonkeyLeeT
 
 ## 2026.4.19-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
 - Telegram/media: parse lowercase media directives in block replies and preserve outbound attachment filenames, so generated files send once with their original names. (#69641) Thanks @obviyus.
 - Agents/Anthropic: honor explicit `cacheRetention: "long"` for custom `anthropic-messages` endpoints by applying the 1-hour ephemeral cache TTL independently of the Anthropic/Vertex hostname allowlist. Implicit and env-driven long retention still require an allowlisted host. (#67800) Thanks @MonkeyLeeT.
+- fix(agents): honor explicit long Anthropic cache TTL on custom hosts (#67800). Thanks @MonkeyLeeT
 
 ## 2026.4.19-beta.2
 

--- a/src/agents/anthropic-payload-policy.test.ts
+++ b/src/agents/anthropic-payload-policy.test.ts
@@ -86,7 +86,7 @@ describe("anthropic payload policy", () => {
     });
   });
 
-  it("denies proxied Anthropic service tier and omits long-TTL upgrades for custom hosts", () => {
+  it("denies proxied Anthropic service tier but honors explicit long TTL for custom hosts", () => {
     const policy = resolveAnthropicPayloadPolicy({
       provider: "anthropic",
       api: "anthropic-messages",
@@ -103,6 +103,59 @@ describe("anthropic payload policy", () => {
     applyAnthropicPayloadPolicyToParams(payload, policy);
 
     expect(payload).not.toHaveProperty("service_tier");
+    expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral", ttl: "1h" })]);
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral", ttl: "1h" } }],
+    });
+  });
+
+  it("keeps implicit env-driven long retention conservative for custom hosts", () => {
+    const previous = process.env.PI_CACHE_RETENTION;
+    process.env.PI_CACHE_RETENTION = "long";
+    try {
+      const policy = resolveAnthropicPayloadPolicy({
+        provider: "anthropic",
+        api: "anthropic-messages",
+        baseUrl: "https://proxy.example.com/anthropic",
+        enableCacheControl: true,
+      });
+      const payload: TestPayload = {
+        system: [{ type: "text", text: "Follow policy." }],
+        messages: [{ role: "user", content: "Hello" }],
+      };
+
+      applyAnthropicPayloadPolicyToParams(payload, policy);
+
+      expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral" })]);
+      expect(payload.messages[0]).toEqual({
+        role: "user",
+        content: [{ type: "text", text: "Hello", cache_control: { type: "ephemeral" } }],
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env.PI_CACHE_RETENTION;
+      } else {
+        process.env.PI_CACHE_RETENTION = previous;
+      }
+    }
+  });
+
+  it("keeps explicit short retention unchanged for custom hosts", () => {
+    const policy = resolveAnthropicPayloadPolicy({
+      provider: "anthropic",
+      api: "anthropic-messages",
+      baseUrl: "https://proxy.example.com/anthropic",
+      cacheRetention: "short",
+      enableCacheControl: true,
+    });
+    const payload: TestPayload = {
+      system: [{ type: "text", text: "Follow policy." }],
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    applyAnthropicPayloadPolicyToParams(payload, policy);
+
     expect(payload.system).toEqual([textBlock("Follow policy.", { type: "ephemeral" })]);
     expect(payload.messages[0]).toEqual({
       role: "user",

--- a/src/agents/anthropic-payload-policy.ts
+++ b/src/agents/anthropic-payload-policy.ts
@@ -58,7 +58,12 @@ function resolveAnthropicEphemeralCacheControl(
   if (retention === "none") {
     return undefined;
   }
-  const ttl = retention === "long" && isLongTtlEligibleEndpoint(baseUrl) ? "1h" : undefined;
+  // Trust explicit long-retention opt-ins for Anthropic-compatible custom providers.
+  // Keep hostname gating for implicit/env-driven long retention so defaults stay conservative.
+  const ttl =
+    retention === "long" && (cacheRetention === "long" || isLongTtlEligibleEndpoint(baseUrl))
+      ? "1h"
+      : undefined;
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 


### PR DESCRIPTION
## Summary

- honor explicit `cacheRetention: "long"` for custom `anthropic-messages` providers when building Anthropic cache-control payloads
- keep the existing hostname allowlist behavior for implicit or env-driven long retention so defaults remain conservative
- add regression coverage for explicit long, explicit short, and env-driven long retention on custom hosts

## Why

Custom Anthropic-compatible proxies can support 1-hour prompt-cache TTLs even when they do not use Anthropic or Vertex hostnames. OpenClaw was silently downgrading explicit `cacheRetention: "long"` to the default 5-minute ephemeral cache for those providers.

Closes #67164.

## Root Cause

`src/agents/anthropic-payload-policy.ts` only emitted `ttl: "1h"` when `cacheRetention` was `long` **and** the `baseUrl` hostname matched a hardcoded Anthropic/Vertex allowlist. That made explicit long-retention opt-ins ineffective for custom `anthropic-messages` endpoints.

## Behavior Change

- explicit `cacheRetention: "long"` now emits `cache_control: { type: "ephemeral", ttl: "1h" }` even for custom hosts
- implicit/env-driven long retention still requires an allowlisted host
- explicit `short` and `none` behavior are unchanged

## Validation

- `pnpm test src/agents/anthropic-payload-policy.test.ts`
