### PR TITLE
fix(whatsapp): finish timeout-aware setup and status handling

### DIFF
--- a/extensions/whatsapp/src/auth-store.test.ts
+++ b/extensions/whatsapp/src/auth-store.test.ts
@@ -176,18 +176,18 @@ describe("auth-store", () => {
     readdirSpy.mockRestore();
   });
 
-  it("does not delete unrelated non-empty directories on logout", async () => {
-    const authDir = createTempAuthDir("openclaw-wa-auth-unrelated");
-    fsSync.writeFileSync(path.join(authDir, "notes.txt"), "keep me", "utf-8");
+  it("clears auth state even when the auth barrier times out", async () => {
+    hoisted.waitForCredsSaveQueueWithTimeout.mockResolvedValueOnce("timed_out");
+    const authDir = createTempAuthDir("openclaw-wa-auth-timeout");
+    fsSync.mkdirSync(path.join(authDir, "nested"));
     const runtime = {
       log: vi.fn(),
       error: vi.fn(),
       exit: vi.fn(),
     };
 
-    await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(false);
-    expect(fsSync.existsSync(authDir)).toBe(true);
-    expect(fsSync.existsSync(path.join(authDir, "notes.txt"))).toBe(true);
+    await expect(logoutWeb({ authDir, runtime: runtime as never })).resolves.toBe(true);
+    expect(fsSync.existsSync(authDir)).toBe(false);
   });
 
   it("throws a typed unstable-auth error when channel selection times out", async () => {

--- a/extensions/whatsapp/src/auth-store.ts
+++ b/extensions/whatsapp/src/auth-store.ts
@@ -294,12 +294,16 @@ export async function logoutWeb(params: {
   const runtime = params.runtime ?? defaultRuntime;
   const resolvedAuthDir = resolveUserPath(params.authDir ?? resolveDefaultWebAuthDir());
   const barrierResult = await waitForWebAuthBarrier(resolvedAuthDir, "logoutWeb");
+  const forceClear = barrierResult === "timed_out";
   if (barrierResult === "timed_out") {
     runtime.log(
       info("WhatsApp auth state is still stabilizing; clearing cached credentials anyway."),
     );
   }
-  if (!(await shouldClearOnLogout(resolvedAuthDir, Boolean(params.isLegacyAuthDir)))) {
+  if (
+    !forceClear &&
+    !(await shouldClearOnLogout(resolvedAuthDir, Boolean(params.isLegacyAuthDir)))
+  ) {
     runtime.log(info("No WhatsApp Web session found; nothing to delete."));
     return false;
   }

--- a/extensions/whatsapp/src/channel.setup.test.ts
+++ b/extensions/whatsapp/src/channel.setup.test.ts
@@ -5,6 +5,7 @@ import { createQueuedWizardPrompter } from "../../../test/helpers/plugins/setup-
 import { whatsappApprovalAuth } from "./approval-auth.js";
 import { WHATSAPP_AUTH_UNSTABLE_CODE } from "./auth-store.js";
 import { whatsappPlugin } from "./channel.js";
+import { whatsappSetupPlugin } from "./channel.setup.js";
 import { checkWhatsAppHeartbeatReady } from "./heartbeat.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { finalizeWhatsAppSetup } from "./setup-finalize.js";
@@ -27,7 +28,7 @@ import {
 const hoisted = vi.hoisted(() => ({
   loginWeb: vi.fn(async () => {}),
   pathExists: vi.fn(async () => false),
-  readWebAuthState: vi.fn(async (): Promise<"linked" | "not-linked" | "unstable"> => "not-linked"),
+  readWebAuthExistsBestEffort: vi.fn(async () => ({ exists: false, timedOut: false })),
   readWebAuthExistsForDecision: vi.fn(
     async (): Promise<{ outcome: "stable"; exists: boolean } | { outcome: "unstable" }> => ({
       outcome: "stable",
@@ -94,7 +95,7 @@ vi.mock("./auth-store.js", async () => {
   const actual = await vi.importActual<typeof import("./auth-store.js")>("./auth-store.js");
   return {
     ...actual,
-    readWebAuthState: hoisted.readWebAuthState,
+    readWebAuthExistsBestEffort: hoisted.readWebAuthExistsBestEffort,
     readWebAuthExistsForDecision: hoisted.readWebAuthExistsForDecision,
   };
 });
@@ -133,7 +134,10 @@ function createSeparatePhoneHarness(params: { selectValues: string[]; textValues
 }
 
 async function runSeparatePhoneFlow(params: { selectValues: string[]; textValues?: string[] }) {
-  hoisted.pathExists.mockResolvedValue(true);
+  hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+    outcome: "stable",
+    exists: true,
+  });
   const harness = createSeparatePhoneHarness({
     selectValues: params.selectValues,
     textValues: params.textValues,
@@ -149,8 +153,11 @@ describe("whatsapp setup wizard", () => {
     hoisted.loginWeb.mockReset();
     hoisted.pathExists.mockReset();
     hoisted.pathExists.mockResolvedValue(false);
-    hoisted.readWebAuthState.mockReset();
-    hoisted.readWebAuthState.mockResolvedValue("not-linked");
+    hoisted.readWebAuthExistsBestEffort.mockReset();
+    hoisted.readWebAuthExistsBestEffort.mockResolvedValue({
+      exists: false,
+      timedOut: false,
+    });
     hoisted.readWebAuthExistsForDecision.mockReset();
     hoisted.readWebAuthExistsForDecision.mockResolvedValue({
       outcome: "stable",
@@ -208,7 +215,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("enables allowlist self-chat mode for personal-phone setup", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createWhatsAppPersonalPhoneHarness(createQueuedWizardPrompter);
 
     const result = await runConfigureWithHarness({
@@ -231,7 +241,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("forces wildcard allowFrom for open policy without allowFrom follow-up prompts", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "open"],
     });
@@ -367,7 +380,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("runs WhatsApp login when not linked and user confirms linking", async () => {
-    hoisted.pathExists.mockResolvedValue(false);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: false,
+    });
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
     const runtime = createRuntime();
 
@@ -380,7 +396,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("skips relink note when already linked and relink is declined", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "disabled"],
     });
@@ -394,7 +413,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("shows follow-up login command note when not linked and linking is skipped", async () => {
-    hoisted.pathExists.mockResolvedValue(false);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: false,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "disabled"],
     });
@@ -404,6 +426,34 @@ describe("whatsapp setup wizard", () => {
     });
 
     expectWhatsAppLoginFollowup(harness);
+  });
+
+  it("skips the QR decision when auth state is still stabilizing", async () => {
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "unstable",
+    });
+    const harness = createSeparatePhoneHarness({
+      selectValues: ["separate", "disabled"],
+    });
+
+    await runConfigureWithHarness({
+      harness,
+    });
+
+    expect(hoisted.loginWeb).not.toHaveBeenCalled();
+    expect(harness.note).toHaveBeenCalledWith(
+      expect.stringContaining("WhatsApp auth state is still stabilizing."),
+      "WhatsApp linking",
+    );
+    expect(harness.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("openclaw channels login"),
+      "WhatsApp",
+    );
+    expect(harness.select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "WhatsApp phone setup",
+      }),
+    );
   });
 
   it("heartbeat readiness uses configured defaultAccount for active listener checks", async () => {
@@ -454,8 +504,33 @@ describe("whatsapp setup wizard", () => {
     expect(result).toEqual({ ok: false, reason: WHATSAPP_AUTH_UNSTABLE_CODE });
   });
 
-  it("does not treat unstable auth as configured in generic plugin config checks", async () => {
-    hoisted.readWebAuthState.mockResolvedValueOnce("unstable");
+  it("heartbeat readiness still supports the legacy webAuthExists dep seam", async () => {
+    const result = await checkWhatsAppHeartbeatReady({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                authDir: "/tmp/default",
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      deps: {
+        webAuthExists: async () => true,
+        hasActiveWebListener: () => true,
+      },
+    });
+
+    expect(result).toEqual({ ok: true, reason: "ok" });
+  });
+
+  it("keeps generic plugin config checks configured when auth reads time out", async () => {
+    hoisted.readWebAuthExistsBestEffort.mockResolvedValue({
+      exists: false,
+      timedOut: true,
+    });
 
     await expect(
       whatsappPlugin.config.isConfigured?.(
@@ -464,6 +539,15 @@ describe("whatsapp setup wizard", () => {
         } as never,
         {} as never,
       ),
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
+
+    await expect(
+      whatsappSetupPlugin.config.isConfigured?.(
+        {
+          authDir: "/tmp/work",
+        } as never,
+        {} as never,
+      ),
+    ).resolves.toBe(true);
   });
 });

--- a/extensions/whatsapp/src/channel.setup.ts
+++ b/extensions/whatsapp/src/channel.setup.ts
@@ -1,6 +1,6 @@
 import type { ChannelPlugin } from "openclaw/plugin-sdk/core";
 import { type ResolvedWhatsAppAccount } from "./accounts.js";
-import { readWebAuthState } from "./auth-store.js";
+import { readWebAuthExistsBestEffort } from "./auth-store.js";
 import { resolveWhatsAppGroupIntroHint } from "./group-intro.js";
 import {
   resolveWhatsAppGroupRequireMention,
@@ -19,7 +19,10 @@ export const whatsappSetupPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
     },
     setupWizard: whatsappSetupWizardProxy,
     setup: whatsappSetupAdapter,
-    isConfigured: async (account) => (await readWebAuthState(account.authDir)) === "linked",
+    isConfigured: async (account) => {
+      const auth = await readWebAuthExistsBestEffort(account.authDir);
+      return auth.exists || auth.timedOut;
+    },
   }),
   lifecycle: {
     detectLegacyStateMigrations: ({ oauthDir }) =>

--- a/extensions/whatsapp/src/channel.status.test.ts
+++ b/extensions/whatsapp/src/channel.status.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedWhatsAppAccount } from "./accounts.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+
+const hoisted = vi.hoisted(() => ({
+  readWebAuthExistsBestEffort: vi.fn(async () => ({ exists: false, timedOut: false })),
+  readWebAuthSnapshotBestEffort: vi.fn(async () => ({
+    linked: false,
+    timedOut: false,
+    authAgeMs: null,
+    selfId: { e164: null, jid: null, lid: null },
+  })),
+  loadWhatsAppChannelRuntime: vi.fn(),
+}));
+
+vi.mock("./shared.js", async () => {
+  const actual = await vi.importActual<typeof import("./shared.js")>("./shared.js");
+  return {
+    ...actual,
+    loadWhatsAppChannelRuntime: hoisted.loadWhatsAppChannelRuntime,
+  };
+});
+
+import { whatsappPlugin } from "./channel.js";
+
+function createAccount(): ResolvedWhatsAppAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    sendReadReceipts: true,
+    authDir: "/tmp/openclaw-whatsapp-status",
+    isLegacyAuthDir: false,
+  };
+}
+
+describe("whatsapp channel status", () => {
+  beforeEach(() => {
+    hoisted.readWebAuthExistsBestEffort.mockReset().mockResolvedValue({
+      exists: false,
+      timedOut: false,
+    });
+    hoisted.readWebAuthSnapshotBestEffort.mockReset().mockResolvedValue({
+      linked: false,
+      timedOut: false,
+      authAgeMs: null,
+      selfId: { e164: null, jid: null, lid: null },
+    });
+    hoisted.loadWhatsAppChannelRuntime.mockReset().mockImplementation(async () => ({
+      readWebAuthExistsBestEffort: hoisted.readWebAuthExistsBestEffort,
+      readWebAuthSnapshotBestEffort: hoisted.readWebAuthSnapshotBestEffort,
+      logWebSelfId: vi.fn(),
+      preflightWebLoginWithQrStart: vi.fn(),
+      startWebLoginWithQr: vi.fn(),
+      waitForWebLogin: vi.fn(),
+      getActiveWebListener: vi.fn(),
+      monitorWebChannel: vi.fn(),
+    }));
+  });
+
+  it("keeps configured true and leaves linked unset when account snapshot auth times out", async () => {
+    hoisted.readWebAuthExistsBestEffort.mockResolvedValueOnce({
+      exists: false,
+      timedOut: true,
+    });
+
+    const snapshot = await whatsappPlugin.status?.buildAccountSnapshot?.({
+      account: createAccount(),
+      cfg: {} as OpenClawConfig,
+      runtime: undefined,
+      probe: undefined,
+      audit: undefined,
+    });
+
+    expect(snapshot).toEqual(
+      expect.objectContaining({
+        accountId: "default",
+        configured: true,
+      }),
+    );
+    expect(snapshot?.linked).toBeUndefined();
+  });
+
+  it("keeps configured true and leaves linked unset in the channel summary when auth times out", async () => {
+    hoisted.readWebAuthSnapshotBestEffort.mockResolvedValueOnce({
+      linked: false,
+      timedOut: true,
+      authAgeMs: null,
+      selfId: { e164: null, jid: null, lid: null },
+    });
+
+    const summary = await whatsappPlugin.status?.buildChannelSummary?.({
+      account: createAccount(),
+      cfg: {} as OpenClawConfig,
+      defaultAccountId: "default",
+      snapshot: {
+        accountId: "default",
+      },
+    } as never);
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        configured: true,
+      }),
+    );
+    expect(summary?.linked).toBeUndefined();
+  });
+});

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -49,6 +49,12 @@ const loadWhatsAppChannelReactAction = createLazyRuntimeModule(
   () => import("./channel-react-action.js"),
 );
 
+function resolveConfiguredStateOnAuthTimeout(params: { snapshotConfigured?: boolean }): boolean {
+  // For observational status timeouts, preserve the last known configured bit when present.
+  // Otherwise fall back to the account-derived channel-configured state for WhatsApp.
+  return params.snapshotConfigured ?? true;
+}
+
 function parseWhatsAppExplicitTarget(raw: string) {
   const normalized = normalizeWhatsAppTarget(raw);
   if (!normalized) {
@@ -76,8 +82,10 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         setupWizard: whatsappSetupWizardProxy,
         setup: whatsappSetupAdapter,
         isConfigured: async (account) => {
-          const channelRuntime = await loadWhatsAppChannelRuntime();
-          return (await channelRuntime.readWebAuthState(account.authDir)) === "linked";
+          const auth = await (
+            await loadWhatsAppChannelRuntime()
+          ).readWebAuthExistsBestEffort(account.authDir);
+          return auth.exists || auth.timedOut;
         },
       }),
       agentTools: () => [createWhatsAppLoginTool()],
@@ -187,35 +195,27 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
           const channelRuntime = await loadWhatsAppChannelRuntime();
           const authDir = account.authDir;
           const auth = authDir
-            ? await channelRuntime.readWebAuthSnapshot(authDir)
+            ? await channelRuntime.readWebAuthSnapshotBestEffort(authDir)
             : {
-                state: "not-linked" as const,
+                linked: false,
+                timedOut: false,
                 authAgeMs: null,
                 selfId: { e164: null, jid: null, lid: null },
               };
           const linked =
             typeof snapshot.linked === "boolean"
               ? snapshot.linked
-              : auth.state === "unstable"
+              : auth.timedOut
                 ? undefined
-                : auth.state === "linked";
-          const summaryAuthState =
-            auth.state === "unstable"
-              ? auth.state
-              : linked === true
-                ? "linked"
-                : linked === false
-                  ? "not-linked"
-                  : undefined;
-          const statusState = summaryAuthState === undefined ? undefined : summaryAuthState;
-          const configured =
-            auth.state === "unstable"
-              ? typeof snapshot.configured === "boolean"
-                ? snapshot.configured
-                : true
-              : typeof linked === "boolean"
-                ? linked
-                : auth.state === "linked";
+                : auth.linked;
+          const configured = auth.timedOut
+            ? resolveConfiguredStateOnAuthTimeout({
+                snapshotConfigured:
+                  typeof snapshot.configured === "boolean" ? snapshot.configured : undefined,
+              })
+            : typeof linked === "boolean"
+              ? linked
+              : auth.linked;
           const authAgeMs = typeof linked === "boolean" && linked ? auth.authAgeMs : null;
           const self =
             typeof linked === "boolean" && linked
@@ -223,7 +223,6 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
               : { e164: null, jid: null, lid: null };
           return {
             configured,
-            ...(statusState ? { statusState } : {}),
             ...(typeof linked === "boolean" ? { linked } : {}),
             authAgeMs,
             self,
@@ -241,19 +240,14 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
         },
         resolveAccountSnapshot: async ({ account, runtime }) => {
           const channelRuntime = await loadWhatsAppChannelRuntime();
-          const authState = await channelRuntime.readWebAuthState(account.authDir);
+          const auth = await channelRuntime.readWebAuthExistsBestEffort(account.authDir);
           return {
             accountId: account.accountId,
             name: account.name,
             enabled: account.enabled,
-            configured: true,
+            configured: auth.timedOut ? resolveConfiguredStateOnAuthTimeout({}) : auth.exists,
             extra: {
-              statusState: authState,
-              ...(authState === "linked"
-                ? { linked: true }
-                : authState === "not-linked"
-                  ? { linked: false }
-                  : {}),
+              ...(auth.timedOut ? {} : { linked: auth.exists }),
               connected: runtime?.connected ?? false,
               reconnectAttempts: runtime?.reconnectAttempts,
               lastConnectedAt: runtime?.lastConnectedAt ?? null,

--- a/extensions/whatsapp/src/heartbeat.ts
+++ b/extensions/whatsapp/src/heartbeat.ts
@@ -1,23 +1,35 @@
+import type { ChannelHeartbeatDeps } from "openclaw/plugin-sdk/core";
 import { resolveWhatsAppAccount } from "./accounts.js";
 import { readWebAuthExistsForDecision, WHATSAPP_AUTH_UNSTABLE_CODE } from "./auth-store.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { loadWhatsAppChannelRuntime } from "./shared.js";
 
+async function readHeartbeatAuthState(params: { authDir: string; deps?: ChannelHeartbeatDeps }) {
+  if (params.deps?.readWebAuthExistsForDecision) {
+    return await params.deps.readWebAuthExistsForDecision();
+  }
+  if (params.deps?.webAuthExists) {
+    return {
+      outcome: "stable" as const,
+      exists: await params.deps.webAuthExists(),
+    };
+  }
+  return await readWebAuthExistsForDecision(params.authDir);
+}
+
 export async function checkWhatsAppHeartbeatReady(params: {
   cfg: OpenClawConfig;
   accountId?: string;
-  deps?: {
-    readWebAuthExistsForDecision?: typeof readWebAuthExistsForDecision;
-    hasActiveWebListener?: (accountId?: string) => boolean;
-  };
+  deps?: ChannelHeartbeatDeps;
 }) {
   if (params.cfg.web?.enabled === false) {
     return { ok: false as const, reason: "whatsapp-disabled" as const };
   }
   const account = resolveWhatsAppAccount({ cfg: params.cfg, accountId: params.accountId });
-  const authState = await (
-    params.deps?.readWebAuthExistsForDecision ?? readWebAuthExistsForDecision
-  )(account.authDir);
+  const authState = await readHeartbeatAuthState({
+    authDir: account.authDir,
+    deps: params.deps,
+  });
   if (authState.outcome === "unstable") {
     return { ok: false as const, reason: WHATSAPP_AUTH_UNSTABLE_CODE };
   }

--- a/extensions/whatsapp/src/setup-finalize.ts
+++ b/extensions/whatsapp/src/setup-finalize.ts
@@ -15,6 +15,7 @@ import {
   resolveWhatsAppAccount,
   resolveWhatsAppAuthDir,
 } from "./accounts.js";
+import { readWebAuthExistsForDecision } from "./auth-store.js";
 import { loginWeb } from "./login.js";
 import { whatsappSetupAdapter } from "./setup-core.js";
 
@@ -401,42 +402,55 @@ export async function finalizeWhatsAppSetup(params: {
           input: {},
         });
 
-  const linked = await detectWhatsAppLinked(next, accountId);
   const { authDir } = resolveWhatsAppAuthDir({
     cfg: next,
     accountId,
   });
+  const authDecision = await readWebAuthExistsForDecision(authDir);
 
-  if (!linked) {
+  if (authDecision.outcome === "unstable") {
     await params.prompter.note(
       [
-        "Scan the QR with WhatsApp on your phone.",
+        "WhatsApp auth state is still stabilizing.",
+        "Skip QR linking for now and retry linking in a moment if needed.",
         `Credentials are stored under ${authDir}/ for future runs.`,
         `Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`,
       ].join("\n"),
       "WhatsApp linking",
     );
-  }
-
-  const wantsLink = await params.prompter.confirm({
-    message: linked ? "WhatsApp already linked. Re-link now?" : "Link WhatsApp now (QR)?",
-    initialValue: !linked,
-  });
-  if (wantsLink) {
-    try {
-      await loginWeb(false, undefined, params.runtime, accountId);
-    } catch (error) {
-      params.runtime.error(`WhatsApp login failed: ${String(error)}`);
+  } else {
+    const linked = authDecision.exists;
+    if (!linked) {
       await params.prompter.note(
-        `Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`,
-        "WhatsApp help",
+        [
+          "Scan the QR with WhatsApp on your phone.",
+          `Credentials are stored under ${authDir}/ for future runs.`,
+          `Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`,
+        ].join("\n"),
+        "WhatsApp linking",
       );
     }
-  } else if (!linked) {
-    await params.prompter.note(
-      `Run \`${formatCliCommand("openclaw channels login")}\` later to link WhatsApp.`,
-      "WhatsApp",
-    );
+
+    const wantsLink = await params.prompter.confirm({
+      message: linked ? "WhatsApp already linked. Re-link now?" : "Link WhatsApp now (QR)?",
+      initialValue: !linked,
+    });
+    if (wantsLink) {
+      try {
+        await loginWeb(false, undefined, params.runtime, accountId);
+      } catch (error) {
+        params.runtime.error(`WhatsApp login failed: ${String(error)}`);
+        await params.prompter.note(
+          `Docs: ${formatDocsLink("/whatsapp", "whatsapp")}`,
+          "WhatsApp help",
+        );
+      }
+    } else if (!linked) {
+      await params.prompter.note(
+        `Run \`${formatCliCommand("openclaw channels login")}\` later to link WhatsApp.`,
+        "WhatsApp",
+      );
+    }
   }
 
   next = await promptWhatsAppDmAccess({

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -31,8 +31,14 @@ const hoisted = vi.hoisted(() => ({
   ),
   loginWeb: vi.fn(async () => {}),
   pathExists: vi.fn(async () => false),
-  readWebAuthState: vi.fn<(authDir: string) => Promise<"linked" | "not-linked" | "unstable">>(
-    async () => "not-linked",
+  readWebAuthExistsBestEffort: vi.fn<
+    (authDir: string) => Promise<{ exists: boolean; timedOut: boolean }>
+  >(async () => ({ exists: false, timedOut: false })),
+  readWebAuthExistsForDecision: vi.fn(
+    async (): Promise<{ outcome: "stable"; exists: boolean } | { outcome: "unstable" }> => ({
+      outcome: "stable",
+      exists: false,
+    }),
   ),
   resolveWhatsAppAuthDir: vi.fn<
     (params: { cfg: OpenClawConfig; accountId: string }) => { authDir: string }
@@ -75,7 +81,8 @@ vi.mock("./auth-store.js", async () => {
   const actual = await vi.importActual<typeof import("./auth-store.js")>("./auth-store.js");
   return {
     ...actual,
-    readWebAuthState: hoisted.readWebAuthState,
+    readWebAuthExistsBestEffort: hoisted.readWebAuthExistsBestEffort,
+    readWebAuthExistsForDecision: hoisted.readWebAuthExistsForDecision,
   };
 });
 
@@ -129,7 +136,10 @@ function expectFinalizeResult(result: Awaited<ReturnType<typeof runFinalizeWithH
 }
 
 async function runSeparatePhoneFlow(params: { selectValues: string[]; textValues?: string[] }) {
-  hoisted.pathExists.mockResolvedValue(true);
+  hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+    outcome: "stable",
+    exists: true,
+  });
   const harness = createSeparatePhoneHarness({
     selectValues: params.selectValues,
     textValues: params.textValues,
@@ -149,8 +159,16 @@ describe("whatsapp setup wizard", () => {
     hoisted.loginWeb.mockReset();
     hoisted.pathExists.mockReset();
     hoisted.pathExists.mockResolvedValue(false);
-    hoisted.readWebAuthState.mockReset();
-    hoisted.readWebAuthState.mockResolvedValue("not-linked");
+    hoisted.readWebAuthExistsBestEffort.mockReset();
+    hoisted.readWebAuthExistsBestEffort.mockResolvedValue({
+      exists: false,
+      timedOut: false,
+    });
+    hoisted.readWebAuthExistsForDecision.mockReset();
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: false,
+    });
     hoisted.resolveWhatsAppAuthDir.mockReset();
     hoisted.resolveWhatsAppAuthDir.mockReturnValue({ authDir: "/tmp/openclaw-whatsapp-test" });
   });
@@ -178,7 +196,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("writes named-account DM policy and allowFrom instead of the channel root", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "open"],
     });
@@ -221,9 +242,10 @@ describe("whatsapp setup wizard", () => {
     hoisted.resolveWhatsAppAuthDir.mockImplementation(({ accountId }: { accountId: string }) => ({
       authDir: accountId === "work" ? "/tmp/work" : "/tmp/default",
     }));
-    hoisted.readWebAuthState.mockImplementation(async (authDir: string) =>
-      authDir === "/tmp/work" ? "linked" : "not-linked",
-    );
+    hoisted.readWebAuthExistsBestEffort.mockImplementation(async (authDir: string) => ({
+      exists: authDir === "/tmp/work",
+      timedOut: false,
+    }));
 
     const status = await whatsappGetStatus({
       cfg: {
@@ -246,13 +268,16 @@ describe("whatsapp setup wizard", () => {
 
     expect(status.configured).toBe(true);
     expect(status.statusLines).toEqual(["WhatsApp (work): linked"]);
-    expect(hoisted.readWebAuthState).toHaveBeenCalledWith("/tmp/default");
-    expect(hoisted.readWebAuthState).toHaveBeenCalledWith("/tmp/work");
+    expect(hoisted.readWebAuthExistsBestEffort).toHaveBeenCalledWith("/tmp/default");
+    expect(hoisted.readWebAuthExistsBestEffort).toHaveBeenCalledWith("/tmp/work");
   });
 
-  it("shows auth stabilizing when auth reads time out", async () => {
+  it("keeps setup status linked when auth reads time out", async () => {
     hoisted.resolveWhatsAppAuthDir.mockReturnValue({ authDir: "/tmp/work" });
-    hoisted.readWebAuthState.mockResolvedValue("unstable");
+    hoisted.readWebAuthExistsBestEffort.mockResolvedValueOnce({
+      exists: false,
+      timedOut: true,
+    });
 
     const status = await whatsappGetStatus({
       cfg: {
@@ -271,8 +296,8 @@ describe("whatsapp setup wizard", () => {
       },
     });
 
-    expect(status.configured).toBe(false);
-    expect(status.statusLines).toEqual(["WhatsApp (work): auth stabilizing"]);
+    expect(status.configured).toBe(true);
+    expect(status.statusLines).toEqual(["WhatsApp (work): linked"]);
   });
 
   it("uses configured defaultAccount for omitted-account finalize writes", async () => {
@@ -300,7 +325,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("enables allowlist self-chat mode for personal-phone setup", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createWhatsAppPersonalPhoneHarness(createQueuedWizardPrompter);
 
     const result = expectFinalizeResult(
@@ -313,7 +341,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("forces wildcard allowFrom for open policy without allowFrom follow-up prompts", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "open"],
     });
@@ -329,7 +360,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("runs WhatsApp login when not linked and user confirms linking", async () => {
-    hoisted.pathExists.mockResolvedValue(false);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: false,
+    });
     const harness = createWhatsAppLinkingHarness(createQueuedWizardPrompter);
     const runtime = createRuntime();
 
@@ -342,7 +376,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("skips relink note when already linked and relink is declined", async () => {
-    hoisted.pathExists.mockResolvedValue(true);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: true,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "disabled"],
     });
@@ -356,7 +393,10 @@ describe("whatsapp setup wizard", () => {
   });
 
   it("shows follow-up login command note when not linked and linking is skipped", async () => {
-    hoisted.pathExists.mockResolvedValue(false);
+    hoisted.readWebAuthExistsForDecision.mockResolvedValue({
+      outcome: "stable",
+      exists: false,
+    });
     const harness = createSeparatePhoneHarness({
       selectValues: ["separate", "disabled"],
     });

--- a/extensions/whatsapp/src/setup-surface.test.ts
+++ b/extensions/whatsapp/src/setup-surface.test.ts
@@ -31,6 +31,9 @@ const hoisted = vi.hoisted(() => ({
   ),
   loginWeb: vi.fn(async () => {}),
   pathExists: vi.fn(async () => false),
+  readWebAuthState: vi.fn<(authDir: string) => Promise<"linked" | "not-linked" | "unstable">>(
+    async () => "not-linked",
+  ),
   readWebAuthExistsBestEffort: vi.fn<
     (authDir: string) => Promise<{ exists: boolean; timedOut: boolean }>
   >(async () => ({ exists: false, timedOut: false })),
@@ -81,6 +84,7 @@ vi.mock("./auth-store.js", async () => {
   const actual = await vi.importActual<typeof import("./auth-store.js")>("./auth-store.js");
   return {
     ...actual,
+    readWebAuthState: hoisted.readWebAuthState,
     readWebAuthExistsBestEffort: hoisted.readWebAuthExistsBestEffort,
     readWebAuthExistsForDecision: hoisted.readWebAuthExistsForDecision,
   };
@@ -159,6 +163,8 @@ describe("whatsapp setup wizard", () => {
     hoisted.loginWeb.mockReset();
     hoisted.pathExists.mockReset();
     hoisted.pathExists.mockResolvedValue(false);
+    hoisted.readWebAuthState.mockReset();
+    hoisted.readWebAuthState.mockResolvedValue("not-linked");
     hoisted.readWebAuthExistsBestEffort.mockReset();
     hoisted.readWebAuthExistsBestEffort.mockResolvedValue({
       exists: false,
@@ -242,10 +248,9 @@ describe("whatsapp setup wizard", () => {
     hoisted.resolveWhatsAppAuthDir.mockImplementation(({ accountId }: { accountId: string }) => ({
       authDir: accountId === "work" ? "/tmp/work" : "/tmp/default",
     }));
-    hoisted.readWebAuthExistsBestEffort.mockImplementation(async (authDir: string) => ({
-      exists: authDir === "/tmp/work",
-      timedOut: false,
-    }));
+    hoisted.readWebAuthState.mockImplementation(async (authDir: string) =>
+      authDir === "/tmp/work" ? "linked" : "not-linked",
+    );
 
     const status = await whatsappGetStatus({
       cfg: {
@@ -268,16 +273,13 @@ describe("whatsapp setup wizard", () => {
 
     expect(status.configured).toBe(true);
     expect(status.statusLines).toEqual(["WhatsApp (work): linked"]);
-    expect(hoisted.readWebAuthExistsBestEffort).toHaveBeenCalledWith("/tmp/default");
-    expect(hoisted.readWebAuthExistsBestEffort).toHaveBeenCalledWith("/tmp/work");
+    expect(hoisted.readWebAuthState).toHaveBeenCalledWith("/tmp/default");
+    expect(hoisted.readWebAuthState).toHaveBeenCalledWith("/tmp/work");
   });
 
-  it("keeps setup status linked when auth reads time out", async () => {
+  it("shows auth stabilizing when auth reads time out", async () => {
     hoisted.resolveWhatsAppAuthDir.mockReturnValue({ authDir: "/tmp/work" });
-    hoisted.readWebAuthExistsBestEffort.mockResolvedValueOnce({
-      exists: false,
-      timedOut: true,
-    });
+    hoisted.readWebAuthState.mockResolvedValue("unstable");
 
     const status = await whatsappGetStatus({
       cfg: {
@@ -296,8 +298,8 @@ describe("whatsapp setup wizard", () => {
       },
     });
 
-    expect(status.configured).toBe(true);
-    expect(status.statusLines).toEqual(["WhatsApp (work): linked"]);
+    expect(status.configured).toBe(false);
+    expect(status.statusLines).toEqual(["WhatsApp (work): auth stabilizing"]);
   });
 
   it("uses configured defaultAccount for omitted-account finalize writes", async () => {

--- a/extensions/whatsapp/src/status-issues.test.ts
+++ b/extensions/whatsapp/src/status-issues.test.ts
@@ -20,25 +20,6 @@ describe("collectWhatsAppStatusIssues", () => {
     ]);
   });
 
-  it("reports auth reads that are still stabilizing", () => {
-    const issues = collectWhatsAppStatusIssues([
-      {
-        accountId: "default",
-        enabled: true,
-        statusState: "unstable",
-      },
-    ]);
-
-    expect(issues).toEqual([
-      expect.objectContaining({
-        channel: "whatsapp",
-        accountId: "default",
-        kind: "auth",
-        message: "Auth state is still stabilizing.",
-      }),
-    ]);
-  });
-
   it("reports linked but disconnected runtime state", () => {
     const issues = collectWhatsAppStatusIssues([
       {
@@ -83,5 +64,16 @@ describe("collectWhatsAppStatusIssues", () => {
         message: expect.stringContaining("Linked but stale"),
       }),
     ]);
+  });
+
+  it("does not report a not-linked auth issue when linked state is unknown", () => {
+    const issues = collectWhatsAppStatusIssues([
+      {
+        accountId: "default",
+        enabled: true,
+      },
+    ]);
+
+    expect(issues).toEqual([]);
   });
 });

--- a/extensions/whatsapp/src/status-issues.ts
+++ b/extensions/whatsapp/src/status-issues.ts
@@ -48,7 +48,7 @@ export function collectWhatsAppStatusIssues(
     readAccount: readWhatsAppAccountStatus,
     collectIssues: ({ account, accountId, issues }) => {
       const linked = account.linked === true;
-      const statusState = asString(account.statusState);
+      const linkedKnown = typeof account.linked === "boolean";
       const running = account.running === true;
       const connected = account.connected === true;
       const reconnectAttempts =
@@ -58,18 +58,7 @@ export function collectWhatsAppStatusIssues(
       const lastError = asString(account.lastError);
       const healthState = asString(account.healthState);
 
-      if (statusState === "unstable") {
-        issues.push({
-          channel: "whatsapp",
-          accountId,
-          kind: "auth",
-          message: "Auth state is still stabilizing.",
-          fix: "Wait a moment for queued credential writes to finish, then retry the command or rerun health.",
-        });
-        return;
-      }
-
-      if (!linked) {
+      if (linkedKnown && !linked) {
         issues.push({
           channel: "whatsapp",
           accountId,
@@ -77,6 +66,10 @@ export function collectWhatsAppStatusIssues(
           message: "Not linked (no WhatsApp Web session).",
           fix: `Run: ${formatCliCommand("openclaw channels login")} (scan QR on the gateway host).`,
         });
+        return;
+      }
+
+      if (!linked) {
         return;
       }
 

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -137,8 +137,18 @@ export type ChannelAccountState =
   | "enabled"
   | "disabled";
 
+export type ChannelAuthExistsDecision =
+  | {
+      outcome: "stable";
+      exists: boolean;
+    }
+  | {
+      outcome: "unstable";
+    };
+
 export type ChannelHeartbeatDeps = {
   webAuthExists?: () => Promise<boolean>;
+  readWebAuthExistsForDecision?: () => Promise<ChannelAuthExistsDecision>;
   hasActiveWebListener?: (accountId?: string) => boolean;
 };
 

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -105,8 +105,10 @@ export type { ReplyPayload } from "../auto-reply/reply-payload.js";
 export type { AllowlistMatch } from "../channels/allowlist-match.js";
 export type {
   BaseProbeResult,
+  ChannelAuthExistsDecision,
   ChannelAccountSnapshot,
   ChannelGroupContext,
+  ChannelHeartbeatDeps,
   ChannelMessageActionName,
   ChannelMeta,
   ChannelSetupInput,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: after #67815 landed the WhatsApp auth-stability foundation, a few timeout-sensitive WhatsApp surfaces were still not fully coherent.
- Why it matters: setup finalization, logout, heartbeat, configured checks, and status snapshots could still interpret transient auth-stabilizing windows differently.
- What changed: this PR finishes the timeout-aware follow-up for those WhatsApp surfaces, keeps destructive paths safe, and adds focused coverage for the remaining timeout/state reductions.
- What did NOT change (scope boundary): this does not add QR preflight/result-code behavior or active-QR reuse; those remain in the later PRs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #67815
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the auth barrier work introduced unstable/timeout outcomes, but a few WhatsApp follow-up decision paths still had inconsistent timeout reductions after #67815.
- Missing detection / guardrail: there was not yet one consistent timeout policy across setup finalize, explicit logout, heartbeat auth deps, configured checks, and status/account snapshots.
- Contributing context (if known): #67815 merged a broader base than originally planned, so this PR is now the narrower “finish timeout/state handling” follow-up.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/whatsapp/src/auth-store.test.ts`
  - `extensions/whatsapp/src/channel.setup.test.ts`
  - `extensions/whatsapp/src/channel.status.test.ts`
  - `extensions/whatsapp/src/setup-surface.test.ts`
  - `extensions/whatsapp/src/status-issues.test.ts`
- Scenario the test should lock in: timeout-backed auth reads do not turn logout into a no-op, setup finalize avoids false QR/relink decisions, heartbeat supports the richer auth-decision seam, and observational status/configured checks stay best-effort.
- Why this is the smallest reliable guardrail: the remaining regressions live inside the WhatsApp plugin’s timeout interpretation and state reduction logic.
- Existing test that already covers this (if any): #67815 covers the broader auth barrier and runtime reconciliation base.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- WhatsApp setup finalization handles auth-stabilizing windows more safely.
- Explicit logout still clears auth state when the barrier times out.
- Heartbeat/configured/status paths stay internally consistent during timeout-backed reads.

## Diagram (if applicable)

```text
Before:
[timeout-backed auth read] -> [surface-specific reduction] -> [mixed WhatsApp behavior]

After:
[timeout-backed auth read] -> [surface-specific timeout policy] -> [safe/logout-safe or best-effort configured/status behavior]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp
- Relevant config (redacted): default WhatsApp account config

### Steps

1. Trigger timeout-backed auth reads through WhatsApp setup/status/logout/heartbeat paths.
2. Exercise setup finalize, explicit logout, configured checks, and status snapshots.
3. Verify they use the intended timeout behavior instead of collapsing to a wrong linked/not-linked decision.

### Expected

- Timeout-backed setup/logout/heartbeat/status behavior is consistent and safe.

### Actual

- Verified with focused WhatsApp plugin coverage after the change.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/whatsapp/src/auth-store.test.ts extensions/whatsapp/src/channel.setup.test.ts extensions/whatsapp/src/channel.status.test.ts extensions/whatsapp/src/setup-surface.test.ts extensions/whatsapp/src/status-issues.test.ts`
  - `pnpm tsgo`
- Edge cases checked:
  - logout on timeout
  - unstable setup finalize path
  - heartbeat legacy dep seam compatibility
  - configured/status behavior during timeout
- What you did **not** verify:
  - live WhatsApp device behavior outside automated coverage

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: timeout-backed configured/status behavior is still subtle.
  - Mitigation: the remaining cases are covered directly in plugin-scoped tests and stay narrowly limited to WhatsApp.
