### PR TITLE
fix(whatsapp): add QR login result codes and preflight hook

### DIFF
--- a/extensions/whatsapp/login-qr-runtime.ts
+++ b/extensions/whatsapp/login-qr-runtime.ts
@@ -1,3 +1,4 @@
+type PreflightWebLoginWithQrStart = typeof import("./src/login-qr.js").preflightWebLoginWithQrStart;
 type StartWebLoginWithQr = typeof import("./src/login-qr.js").startWebLoginWithQr;
 type WaitForWebLogin = typeof import("./src/login-qr.js").waitForWebLogin;
 
@@ -6,6 +7,13 @@ let loginQrModulePromise: Promise<typeof import("./src/login-qr.js")> | null = n
 function loadLoginQrModule() {
   loginQrModulePromise ??= import("./src/login-qr.js");
   return loginQrModulePromise;
+}
+
+export async function preflightWebLoginWithQrStart(
+  ...args: Parameters<PreflightWebLoginWithQrStart>
+): ReturnType<PreflightWebLoginWithQrStart> {
+  const { preflightWebLoginWithQrStart } = await loadLoginQrModule();
+  return await preflightWebLoginWithQrStart(...args);
 }
 
 export async function startWebLoginWithQr(

--- a/extensions/whatsapp/src/agent-tools-login.test.ts
+++ b/extensions/whatsapp/src/agent-tools-login.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createWhatsAppLoginTool } from "./agent-tools-login.js";
+
+const hoisted = vi.hoisted(() => ({
+  startWebLoginWithQr: vi.fn(),
+  waitForWebLogin: vi.fn(),
+}));
+
+vi.mock("../login-qr-api.js", () => ({
+  startWebLoginWithQr: hoisted.startWebLoginWithQr,
+  waitForWebLogin: hoisted.waitForWebLogin,
+}));
+
+describe("createWhatsAppLoginTool", () => {
+  beforeEach(() => {
+    hoisted.startWebLoginWithQr.mockReset();
+    hoisted.waitForWebLogin.mockReset();
+  });
+
+  it("preserves unstable-auth code on non-QR start results", async () => {
+    hoisted.startWebLoginWithQr.mockResolvedValueOnce({
+      code: "whatsapp-auth-unstable",
+      message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+    });
+
+    const tool = createWhatsAppLoginTool();
+    const result = await tool.execute("tool-call", {
+      action: "start",
+      timeoutMs: 5_000,
+    });
+
+    expect(hoisted.startWebLoginWithQr).toHaveBeenCalledWith({
+      timeoutMs: 5_000,
+      force: false,
+    });
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+        },
+      ],
+      details: { qr: false, code: "whatsapp-auth-unstable" },
+    });
+  });
+
+  it("returns QR details without adding an unstable code", async () => {
+    hoisted.startWebLoginWithQr.mockResolvedValueOnce({
+      qrDataUrl: "data:image/png;base64,abc123",
+      message: "QR already active. Scan it in WhatsApp -> Linked Devices.",
+    });
+
+    const tool = createWhatsAppLoginTool();
+    const result = await tool.execute("tool-call", {
+      action: "start",
+      force: true,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: [
+            "QR already active. Scan it in WhatsApp -> Linked Devices.",
+            "",
+            "Open WhatsApp → Linked Devices and scan:",
+            "",
+            "![whatsapp-qr](data:image/png;base64,abc123)",
+          ].join("\n"),
+        },
+      ],
+      details: { qr: true },
+    });
+  });
+});

--- a/extensions/whatsapp/src/agent-tools-login.ts
+++ b/extensions/whatsapp/src/agent-tools-login.ts
@@ -52,7 +52,7 @@ export function createWhatsAppLoginTool(): ChannelAgentTool {
               text: result.message,
             },
           ],
-          details: { qr: false },
+          details: { qr: false, ...(result.code ? { code: result.code } : {}) },
         };
       }
 

--- a/extensions/whatsapp/src/channel.runtime.ts
+++ b/extensions/whatsapp/src/channel.runtime.ts
@@ -1,4 +1,5 @@
 import {
+  preflightWebLoginWithQrStart as preflightWebLoginWithQrStartImpl,
   startWebLoginWithQr as startWebLoginWithQrImpl,
   waitForWebLogin as waitForWebLoginImpl,
 } from "../login-qr-runtime.js";
@@ -31,6 +32,8 @@ type ReadWebAuthSnapshotBestEffort = typeof import("./auth-store.js").readWebAut
 type ReadWebSelfId = typeof import("./auth-store.js").readWebSelfId;
 type WebAuthExists = typeof import("./auth-store.js").webAuthExists;
 type LoginWeb = typeof import("./login.js").loginWeb;
+type PreflightWebLoginWithQrStart =
+  typeof import("../login-qr-runtime.js").preflightWebLoginWithQrStart;
 type StartWebLoginWithQr = typeof import("../login-qr-runtime.js").startWebLoginWithQr;
 type WaitForWebLogin = typeof import("../login-qr-runtime.js").waitForWebLogin;
 type WhatsAppSetupWizard = typeof import("./setup-surface.js").whatsappSetupWizard;
@@ -94,6 +97,12 @@ export function webAuthExists(...args: Parameters<WebAuthExists>): ReturnType<We
 
 export function loginWeb(...args: Parameters<LoginWeb>): ReturnType<LoginWeb> {
   return loginWebImpl(...args);
+}
+
+export async function preflightWebLoginWithQrStart(
+  ...args: Parameters<PreflightWebLoginWithQrStart>
+): ReturnType<PreflightWebLoginWithQrStart> {
+  return await preflightWebLoginWithQrStartImpl(...args);
 }
 
 export async function startWebLoginWithQr(

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -303,6 +303,15 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> =
             timeoutMs,
             verbose,
           }),
+        loginWithQrStartPreflight: async ({ accountId, force, timeoutMs, verbose }) =>
+          await (
+            await loadWhatsAppChannelRuntime()
+          ).preflightWebLoginWithQrStart({
+            accountId,
+            force,
+            timeoutMs,
+            verbose,
+          }),
         loginWithQrWait: async ({ accountId, timeoutMs }) =>
           await (await loadWhatsAppChannelRuntime()).waitForWebLogin({ accountId, timeoutMs }),
         logoutAccount: async ({ account, runtime }) => {

--- a/extensions/whatsapp/src/login-qr.ts
+++ b/extensions/whatsapp/src/login-qr.ts
@@ -51,6 +51,14 @@ function waitForNextTask(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+type WebLoginStartParams = {
+  verbose?: boolean;
+  timeoutMs?: number;
+  force?: boolean;
+  accountId?: string;
+  runtime?: RuntimeEnv;
+};
+
 const ACTIVE_LOGIN_TTL_MS = 3 * 60_000;
 const activeLogins = new Map<string, ActiveLogin>();
 
@@ -160,32 +168,15 @@ async function waitForQrOrRecoveredLogin(params: {
 }
 
 export async function startWebLoginWithQr(
-  opts: {
-    verbose?: boolean;
-    timeoutMs?: number;
-    force?: boolean;
-    accountId?: string;
-    runtime?: RuntimeEnv;
-  } = {},
+  opts: WebLoginStartParams = {},
 ): Promise<StartWebLoginWithQrResult> {
+  const preflight = await preflightWebLoginWithQrStart(opts);
+  if (preflight) {
+    return preflight;
+  }
   const runtime = opts.runtime ?? defaultRuntime;
   const cfg = loadConfig();
   const account = resolveWhatsAppAccount({ cfg, accountId: opts.accountId });
-  const authState = await readWebAuthExistsForDecision(account.authDir);
-  if (authState.outcome === "unstable") {
-    return {
-      code: WHATSAPP_AUTH_UNSTABLE_CODE,
-      message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
-    };
-  }
-  if (authState.exists && !opts.force) {
-    const selfId = readWebSelfId(account.authDir);
-    const who = selfId.e164 ?? selfId.jid ?? "unknown";
-    return {
-      message: `WhatsApp is already linked (${who}). Say “relink” if you want a fresh QR.`,
-    };
-  }
-
   const existing = activeLogins.get(account.accountId);
   if (existing && isLoginFresh(existing) && existing.qrDataUrl) {
     return {
@@ -284,6 +275,28 @@ export async function startWebLoginWithQr(
     qrDataUrl: login.qrDataUrl,
     message: "Scan this QR in WhatsApp → Linked Devices.",
   };
+}
+
+export async function preflightWebLoginWithQrStart(
+  opts: WebLoginStartParams = {},
+): Promise<StartWebLoginWithQrResult | null> {
+  const cfg = loadConfig();
+  const account = resolveWhatsAppAccount({ cfg, accountId: opts.accountId });
+  const authState = await readWebAuthExistsForDecision(account.authDir);
+  if (authState.outcome === "unstable") {
+    return {
+      code: WHATSAPP_AUTH_UNSTABLE_CODE,
+      message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+    };
+  }
+  if (authState.exists && !opts.force) {
+    const selfId = readWebSelfId(account.authDir);
+    const who = selfId.e164 ?? selfId.jid ?? "unknown";
+    return {
+      message: `WhatsApp is already linked (${who}). Say “relink” if you want a fresh QR.`,
+    };
+  }
+  return null;
 }
 
 export async function waitForWebLogin(

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -318,6 +318,7 @@ export type ChannelLoginWithQrStartResult = {
   qrDataUrl?: string;
   message: string;
   connected?: boolean;
+  code?: string;
 };
 
 export type ChannelLoginWithQrWaitResult = {
@@ -338,6 +339,12 @@ export type ChannelGatewayAdapter<ResolvedAccount = unknown> = {
   stopAccount?: (ctx: ChannelGatewayContext<ResolvedAccount>) => Promise<void>;
   /** Keep gateway auth bypass resolution mirrored through a lightweight top-level `gateway-auth-api.ts` artifact. */
   resolveGatewayAuthBypassPaths?: (params: { cfg: OpenClawConfig }) => string[];
+  loginWithQrStartPreflight?: (params: {
+    accountId?: string;
+    force?: boolean;
+    timeoutMs?: number;
+    verbose?: boolean;
+  }) => Promise<ChannelLoginWithQrStartResult | null>;
   loginWithQrStart?: (params: {
     accountId?: string;
     force?: boolean;

--- a/src/gateway/server-methods/web.test.ts
+++ b/src/gateway/server-methods/web.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
+import type { GatewayRequestHandlerOptions } from "./shared-types.js";
+
+const hoisted = vi.hoisted(() => ({
+  listChannelPlugins: vi.fn<() => ChannelPlugin[]>(() => []),
+}));
+
+vi.mock("../../channels/plugins/index.js", () => ({
+  listChannelPlugins: hoisted.listChannelPlugins,
+}));
+
+import { webHandlers } from "./web.js";
+
+function createWebLoginPlugin(
+  gateway: NonNullable<ChannelPlugin["gateway"]>,
+): ChannelPlugin<Record<string, never>> {
+  return {
+    id: "whatsapp",
+    meta: {
+      id: "whatsapp",
+      label: "WhatsApp",
+      selectionLabel: "WhatsApp",
+      docsPath: "/whatsapp",
+      blurb: "WhatsApp",
+    },
+    capabilities: {
+      chatTypes: ["direct"],
+    },
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({}),
+    },
+    gatewayMethods: ["web.login.start", "web.login.wait"],
+    gateway,
+  };
+}
+
+function createHandlerOptions(params: {
+  respond: GatewayRequestHandlerOptions["respond"];
+  stopChannel: (channelId: string, accountId?: string) => Promise<void>;
+}): GatewayRequestHandlerOptions {
+  return {
+    req: {
+      id: "req_1",
+      method: "web.login.start",
+    } as never,
+    params: {},
+    client: null,
+    isWebchatConnect: () => false,
+    respond: params.respond,
+    context: {
+      stopChannel: params.stopChannel,
+    } as never,
+  };
+}
+
+describe("webHandlers", () => {
+  beforeEach(() => {
+    hoisted.listChannelPlugins.mockReset().mockReturnValue([]);
+  });
+
+  it("does not stop the channel when QR login preflight returns unstable auth", async () => {
+    const stopChannel = vi.fn(async () => undefined);
+    const respond = vi.fn();
+    const loginWithQrStart = vi.fn(async () => ({
+      qrDataUrl: "data:image/png;base64,qr",
+      message: "Scan this QR in WhatsApp -> Linked Devices.",
+    }));
+    const loginWithQrStartPreflight = vi.fn(async () => ({
+      code: "whatsapp-auth-unstable",
+      message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+    }));
+    hoisted.listChannelPlugins.mockReturnValue([
+      createWebLoginPlugin({
+        loginWithQrStart,
+        loginWithQrStartPreflight,
+      }),
+    ]);
+
+    await webHandlers["web.login.start"](
+      createHandlerOptions({
+        respond,
+        stopChannel,
+      }),
+    );
+
+    expect(loginWithQrStartPreflight).toHaveBeenCalledOnce();
+    expect(stopChannel).not.toHaveBeenCalled();
+    expect(loginWithQrStart).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        code: "whatsapp-auth-unstable",
+        message: "WhatsApp auth state is still stabilizing. Retry login in a moment.",
+      },
+      undefined,
+    );
+  });
+
+  it("stops the channel before starting QR login when preflight allows it", async () => {
+    const stopChannel = vi.fn(async () => undefined);
+    const respond = vi.fn();
+    const loginWithQrStart = vi.fn(async () => ({
+      qrDataUrl: "data:image/png;base64,qr",
+      message: "Scan this QR in WhatsApp -> Linked Devices.",
+    }));
+    const loginWithQrStartPreflight = vi.fn(async () => null);
+    hoisted.listChannelPlugins.mockReturnValue([
+      createWebLoginPlugin({
+        loginWithQrStart,
+        loginWithQrStartPreflight,
+      }),
+    ]);
+
+    await webHandlers["web.login.start"](
+      createHandlerOptions({
+        respond,
+        stopChannel,
+      }),
+    );
+
+    expect(loginWithQrStartPreflight).toHaveBeenCalledOnce();
+    expect(stopChannel).toHaveBeenCalledWith("whatsapp", undefined);
+    expect(loginWithQrStart).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      {
+        qrDataUrl: "data:image/png;base64,qr",
+        message: "Scan this QR in WhatsApp -> Linked Devices.",
+      },
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/web.test.ts
+++ b/src/gateway/server-methods/web.test.ts
@@ -39,6 +39,7 @@ function createWebLoginPlugin(
 function createHandlerOptions(params: {
   respond: GatewayRequestHandlerOptions["respond"];
   stopChannel: (channelId: string, accountId?: string) => Promise<void>;
+  startChannel?: (channelId: string, accountId?: string) => Promise<void>;
 }): GatewayRequestHandlerOptions {
   return {
     req: {
@@ -50,6 +51,11 @@ function createHandlerOptions(params: {
     isWebchatConnect: () => false,
     respond: params.respond,
     context: {
+      getRuntimeSnapshot: () => ({
+        channels: {},
+        channelAccounts: {},
+      }),
+      startChannel: params.startChannel ?? (async () => undefined),
       stopChannel: params.stopChannel,
     } as never,
   };

--- a/src/gateway/server-methods/web.ts
+++ b/src/gateway/server-methods/web.ts
@@ -82,13 +82,7 @@ export const webHandlers: GatewayRequestHandlers = {
         respondProviderUnsupported(respond, provider.id);
         return;
       }
-      const wasRunning = wasChannelRunning({
-        context,
-        channelId: provider.id,
-        accountId,
-      });
-      await context.stopChannel(provider.id, accountId);
-      const result = await provider.gateway.loginWithQrStart({
+      const loginParams = {
         force: Boolean((params as { force?: boolean }).force),
         timeoutMs:
           typeof (params as { timeoutMs?: unknown }).timeoutMs === "number"
@@ -96,7 +90,19 @@ export const webHandlers: GatewayRequestHandlers = {
             : undefined,
         verbose: Boolean((params as { verbose?: boolean }).verbose),
         accountId,
+      };
+      const preflightResult = await provider.gateway.loginWithQrStartPreflight?.(loginParams);
+      if (preflightResult) {
+        respond(true, preflightResult, undefined);
+        return;
+      }
+      const wasRunning = wasChannelRunning({
+        context,
+        channelId: provider.id,
+        accountId,
       });
+      await context.stopChannel(provider.id, accountId);
+      const result = await provider.gateway.loginWithQrStart(loginParams);
       if (result.connected) {
         await context.startChannel(provider.id, accountId);
       } else if (wasRunning && !result.qrDataUrl) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: after #67815, WhatsApp still lacked a clean shared QR-login contract for machine-readable non-QR outcomes and a gateway preflight seam to return them before stop/start.
- Why it matters: callers still had to infer QR login outcomes from prose, and `web.login.start` could still stop the channel before a safe plugin-level non-QR result was returned.
- What changed: this PR adds QR login result codes to the shared adapter surface, propagates them through the WhatsApp tool/runtime wrappers, and adds the gateway preflight hook that WhatsApp uses before stop/start.
- What did NOT change (scope boundary): this does not yet add existing-QR reuse ahead of preflight; that stays in the next PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #67815
- Related #67816
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: WhatsApp QR login outcomes were still primarily prose, and there was no generic gateway preflight seam for plugin-owned “do not stop/start” QR checks.
- Missing detection / guardrail: no machine-readable result code in `ChannelLoginWithQrStartResult`, and no optional `loginWithQrStartPreflight` hook in the gateway adapter.
- Contributing context (if known): #67815 merged the auth/runtime base first; this PR now carries only the QR result-code + preflight contract layer.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/whatsapp/src/agent-tools-login.test.ts`
  - `extensions/whatsapp/src/login-qr.test.ts`
  - `src/gateway/server-methods/web.test.ts`
- Scenario the test should lock in: structured non-QR QR-login outcomes survive through the shared/tool surface, and gateway preflight prevents stop-before-start when WhatsApp can already return a safe non-QR result.
- Why this is the smallest reliable guardrail: the remaining behavior lives at the WhatsApp QR seam and the generic web login gateway handler.
- Existing test that already covers this (if any): #67815 covers the broader WhatsApp auth/runtime reconciliation base.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- WhatsApp QR-login outcomes now carry machine-readable codes through the shared adapter surface.
- `web.login.start` can return safe WhatsApp preflight results before stopping the channel.

## Diagram (if applicable)

```text
Before:
[web.login.start] -> [stop channel] -> [WhatsApp says unstable/already-linked] -> [no QR]

After:
[web.login.start] -> [WhatsApp preflight] -> [safe non-QR result] OR [stop channel] -> [start QR]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): WhatsApp QR login / gateway web login
- Relevant config (redacted): default WhatsApp account config

### Steps

1. Trigger WhatsApp QR login when the plugin would return unstable-auth or already-linked before QR creation.
2. Exercise `web.login.start` and the WhatsApp login tool.
3. Verify a machine-readable non-QR result is returned without forcing stop-before-start.

### Expected

- Gateway preflight returns safe non-QR results before stop/start.
- WhatsApp QR-login result codes survive the shared adapter/tool path.

### Actual

- Verified with focused WhatsApp QR/tool/gateway coverage after the change.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/whatsapp/src/agent-tools-login.test.ts extensions/whatsapp/src/login-qr.test.ts src/gateway/server-methods/web.test.ts`
  - `pnpm tsgo`
- Edge cases checked:
  - unstable-auth QR result
  - already-linked QR result
  - gateway preflight avoiding stop-before-start
- What you did **not** verify:
  - live QR scan with a real WhatsApp device

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: the shared QR-login adapter surface grows slightly.
  - Mitigation: the new result code field and preflight hook are optional and covered by focused gateway/plugin tests.
