### PR TITLE
Slack mention-skip should still emit message hooks

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare.silent-ingest.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.silent-ingest.test.ts
@@ -1,0 +1,135 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import { describe, expect, it, vi } from "vitest";
+import type { ResolvedSlackAccount } from "../../accounts.js";
+import type { SlackMessageEvent } from "../../types.js";
+import { createInboundSlackTestContext } from "./prepare.test-helpers.js";
+
+const internalHookMocks = vi.hoisted(() => ({
+  createInternalHookEvent: vi.fn(
+    (type: string, action: string, sessionKey: string, context: Record<string, unknown>) => ({
+      type,
+      action,
+      sessionKey,
+      context,
+      timestamp: new Date(),
+      messages: [],
+    }),
+  ),
+  triggerInternalHook: vi.fn(async () => undefined),
+}));
+
+vi.mock("openclaw/plugin-sdk/hook-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/hook-runtime")>(
+    "openclaw/plugin-sdk/hook-runtime",
+  );
+  return {
+    ...actual,
+    createInternalHookEvent: internalHookMocks.createInternalHookEvent,
+    triggerInternalHook: internalHookMocks.triggerInternalHook,
+  };
+});
+
+import { prepareSlackMessage } from "./prepare.js";
+
+describe("slack mention-skip silent ingest", () => {
+  const account: ResolvedSlackAccount = {
+    accountId: "default",
+    enabled: true,
+    botTokenSource: "config",
+    appTokenSource: "config",
+    userTokenSource: "none",
+    config: {},
+  };
+
+  function createMessage(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
+    return {
+      channel: "C123",
+      channel_type: "channel",
+      user: "U1",
+      text: "hello without mention",
+      ts: "1713260000.1000",
+      ...overrides,
+    } as SlackMessageEvent;
+  }
+
+  it("emits internal message:received when ingest is enabled", async () => {
+    internalHookMocks.createInternalHookEvent.mockClear();
+    internalHookMocks.triggerInternalHook.mockClear();
+
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            groups: {
+              "*": {
+                requireMention: true,
+                ingest: true,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as never;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: createMessage(),
+      opts: { source: "message" },
+    });
+
+    expect(result).toBeNull();
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "received",
+      expect.stringContaining("slack"),
+      expect.objectContaining({
+        channelId: "slack",
+        content: "hello without mention",
+        messageId: "1713260000.1000",
+      }),
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit when channel ingest is false and wildcard ingest is true", async () => {
+    internalHookMocks.createInternalHookEvent.mockClear();
+    internalHookMocks.triggerInternalHook.mockClear();
+
+    const ctx = createInboundSlackTestContext({
+      cfg: {
+        channels: {
+          slack: {
+            enabled: true,
+            groups: {
+              C123: {
+                requireMention: true,
+                ingest: false,
+              },
+              "*": {
+                requireMention: true,
+                ingest: true,
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    ctx.resolveUserName = async () => ({ name: "Alice" }) as never;
+
+    const result = await prepareSlackMessage({
+      ctx,
+      account,
+      message: createMessage(),
+      opts: { source: "message" },
+    });
+
+    expect(result).toBeNull();
+    expect(internalHookMocks.createInternalHookEvent).not.toHaveBeenCalled();
+    expect(internalHookMocks.triggerInternalHook).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -15,6 +15,13 @@ import {
 import { resolveControlCommandGate } from "openclaw/plugin-sdk/command-auth";
 import { hasControlCommand } from "openclaw/plugin-sdk/command-auth";
 import { shouldHandleTextCommands } from "openclaw/plugin-sdk/command-auth";
+import { resolveChannelGroupPolicy } from "openclaw/plugin-sdk/config-runtime";
+import {
+  createInternalHookEvent,
+  fireAndForgetHook,
+  toInternalMessageReceivedContext,
+  triggerInternalHook,
+} from "openclaw/plugin-sdk/hook-runtime";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
 import {
   buildPendingHistoryContextFromMap,
@@ -525,19 +532,57 @@ export async function prepareSlackMessage(params: {
         ? "[Slack file]"
         : "";
     const pendingBody = pendingText || fallbackFile;
+    const senderName = pendingBody ? await resolveSenderName() : undefined;
     recordPendingHistoryEntryIfEnabled({
       historyMap: ctx.channelHistories,
       historyKey,
       limit: ctx.historyLimit,
       entry: pendingBody
         ? {
-            sender: await resolveSenderName(),
+            sender: senderName,
             body: pendingBody,
             timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
             messageId: message.ts,
           }
         : null,
     });
+    const slackGroupPolicy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "slack",
+      groupId: message.channel,
+      accountId: account.accountId,
+    });
+    const ingestEnabled =
+      slackGroupPolicy.groupConfig?.ingest ?? slackGroupPolicy.defaultConfig?.ingest;
+    if (ingestEnabled === true && sessionKey && pendingBody) {
+      const slackFrom = isRoom ? `slack:channel:${message.channel}` : `slack:group:${message.channel}`;
+      const slackTo = `channel:${message.channel}`;
+      fireAndForgetHook(
+        triggerInternalHook(
+          createInternalHookEvent(
+            "message",
+            "received",
+            sessionKey,
+            toInternalMessageReceivedContext({
+              from: slackFrom,
+              to: slackTo,
+              content: pendingBody,
+              timestamp: message.ts ? Math.round(Number(message.ts) * 1000) : undefined,
+              channelId: "slack",
+              accountId: account.accountId,
+              conversationId: slackTo,
+              messageId: message.ts,
+              senderId: senderId || undefined,
+              senderName,
+              provider: "slack",
+              surface: "slack",
+              threadId: threadContext.messageThreadId,
+            }),
+          ),
+        ),
+        "slack: mention-skip message hook failed",
+      );
+    }
     return null;
   }
 


### PR DESCRIPTION
## Summary
- emit an internal `message:received` hook from Slack's `no-mention` skip path when group ingest is enabled
- preserve existing pending-history behavior while allowing silent-ingest style transcript archiving
- add regression coverage for Slack mention-skip silent ingest behavior

## Testing
- `corepack pnpm vitest run extensions/slack/src/monitor/message-handler/prepare.silent-ingest.test.ts extensions/slack/src/monitor/message-handler/prepare.test.ts`
