### PR TITLE
Normalize hook conversation ids across channels

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -6,6 +6,7 @@ import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/c
 import {
   buildCanonicalSentMessageHookContext,
   deriveInboundMessageHookContext,
+  normalizeMessagingConversationId,
   toPluginInboundClaimEvent,
   toPluginInboundClaimContext,
   toInternalMessagePreprocessedContext,
@@ -137,7 +138,7 @@ describe("message hook mappers", () => {
     expect(toPluginMessageContext(canonical)).toEqual({
       channelId: "demo-chat",
       accountId: "acc-1",
-      conversationId: "demo-chat:chat:456",
+      conversationId: "chat:456",
     });
     expect(toPluginMessageReceivedEvent(canonical)).toEqual({
       from: "demo-chat:user:123",
@@ -244,7 +245,7 @@ describe("message hook mappers", () => {
     expect(toPluginMessageContext(canonical)).toEqual({
       channelId: "demo-chat",
       accountId: "acc-1",
-      conversationId: "demo-chat:chat:456",
+      conversationId: "chat:456",
     });
     expect(toPluginMessageSentEvent(canonical)).toEqual({
       to: "demo-chat:chat:456",
@@ -264,5 +265,16 @@ describe("message hook mappers", () => {
       isGroup: true,
       groupId: "demo-chat:chat:456",
     });
+  });
+
+  it("normalizes outbound conversation ids with common prefixes", () => {
+    expect(normalizeMessagingConversationId("telegram", "telegram:8514222276")).toBe("8514222276");
+    expect(normalizeMessagingConversationId("slack", "channel:C02GQA1RLB0")).toBe("C02GQA1RLB0");
+    expect(normalizeMessagingConversationId("discord", "user:1177378744822943744")).toBe(
+      "1177378744822943744",
+    );
+    expect(normalizeMessagingConversationId("msteams", "19:conv@thread.v2")).toBe(
+      "19:conv@thread.v2",
+    );
   });
 });

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -162,13 +162,20 @@ export function buildCanonicalSentMessageHookContext(params: {
   };
 }
 
+export function normalizeMessagingConversationId(
+  channelId: string,
+  conversationId: string | undefined,
+): string | undefined {
+  return stripChannelPrefix(conversationId, channelId);
+}
+
 export function toPluginMessageContext(
   canonical: CanonicalInboundMessageHookContext | CanonicalSentMessageHookContext,
 ): PluginHookMessageContext {
   return {
     channelId: canonical.channelId,
     accountId: canonical.accountId,
-    conversationId: canonical.conversationId,
+    conversationId: normalizeMessagingConversationId(canonical.channelId, canonical.conversationId),
   };
 }
 


### PR DESCRIPTION
## Summary
- normalize plugin hook conversation ids through the shared message hook mapper path
- strip common messaging prefixes for outbound hook contexts so pending lookups match inbound claim contexts
- add regression coverage for prefixed Telegram, Slack, and Discord style conversation ids

## Testing
- corepack pnpm vitest run src/hooks/message-hook-mappers.test.ts