### PR TITLE
fix(codex): attach stdin error listener to prevent gateway EPIPE crash

### DIFF
--- a/extensions/codex/src/app-server/client.test.ts
+++ b/extensions/codex/src/app-server/client.test.ts
@@ -68,6 +68,14 @@ describe("CodexAppServerClient", () => {
     expect(outbound.method).toBe("model/list");
   });
 
+  it("swallows EPIPE errors emitted on stdin after subprocess exit", () => {
+    const harness = createClientHarness();
+    clients.push(harness.client);
+
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    expect(() => harness.process.stdin.emit("error", epipe)).not.toThrow();
+  });
+
   it("preserves JSON-RPC error codes", async () => {
     const harness = createClientHarness();
     clients.push(harness.client);

--- a/extensions/codex/src/app-server/client.ts
+++ b/extensions/codex/src/app-server/client.ts
@@ -64,6 +64,9 @@ export class CodexAppServerClient {
         embeddedAgentLog.debug(`codex app-server stderr: ${text}`);
       }
     });
+    child.stdin.on?.("error", (error) => {
+      embeddedAgentLog.debug("codex app-server stdin error", { error });
+    });
     child.once("error", (error) =>
       this.closeWithError(error instanceof Error ? error : new Error(String(error))),
     );

--- a/extensions/codex/src/app-server/transport.ts
+++ b/extensions/codex/src/app-server/transport.ts
@@ -4,6 +4,7 @@ export type CodexAppServerTransport = {
     end?: () => unknown;
     destroy?: () => unknown;
     unref?: () => unknown;
+    on?: (event: "error", listener: (error: Error) => void) => unknown;
   };
   stdout: NodeJS.ReadableStream & {
     destroy?: () => unknown;


### PR DESCRIPTION
## Summary

Fixes #67886 — attaches a stdin error listener to `CodexAppServerClient` so the codex app-server subprocess can fail cleanly without taking down the whole OpenClaw gateway daemon.

## Root cause

`CodexAppServerTransport.stdin` is a Node `Writable` stream. When the subprocess exits after emitting unparseable stdout (for example an interactive prompt on init, or a deprecated-config error), OpenClaw still tries to write the JSON-RPC initialize payload to the now-closed pipe. Node emits an asynchronous `error` event on that stream; with no listener attached, the default handler rethrows, crashing the entire gateway daemon.

The existing constructor already wires `stdout` / `stderr` / `error` / `exit` handlers on the child, but never wires anything on `stdin`. This PR adds a debug-level listener so the pipe teardown noise is absorbed while the existing `exit` handler continues to run `closeWithError`.

## Changes

- `extensions/codex/src/app-server/client.ts` — attach `child.stdin.on('error', …)` in the constructor, logging at debug level.
- `extensions/codex/src/app-server/transport.ts` — widen the typed `stdin` shape to expose an optional `on('error', …)` method so tests and alternate transports participate without casting.
- `extensions/codex/src/app-server/client.test.ts` — assert that emitting `EPIPE` on the harness stdin does not throw.

## Test plan

- [x] `NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit` — no new TS errors on touched files (baseline 243 on main, 243 on branch).
- [x] `pnpm exec oxlint <touched files>` — 0 warnings, 0 errors.
- [x] Added unit test `swallows EPIPE errors emitted on stdin after subprocess exit`.

Local full vitest run is blocked by pre-existing infra drift on my machine (`test/non-isolated-runner.ts` fails to resolve base `TestRunner` import) — reproduces identically on `main`, so it is not caused by this change. CI should exercise the new test normally.