### PR TITLE
fix(minimax): disable tool call ID sanitization for Anthropic-compatible API

### DIFF
--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -136,7 +136,7 @@ describe("minimax provider hooks", () => {
       } as never),
     ).toMatchObject({
       sanitizeMode: "full",
-      sanitizeToolCallIds: true,
+      sanitizeToolCallIds: false,
       preserveSignatures: true,
       validateAnthropicTurns: true,
     });

--- a/extensions/minimax/provider-registration.ts
+++ b/extensions/minimax/provider-registration.ts
@@ -42,8 +42,25 @@ const HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS = buildProviderReplayFamilyHooks({
   family: "hybrid-anthropic-openai",
   anthropicModelDropThinkingBlocks: true,
 });
-const MINIMAX_PROVIDER_HOOKS = {
+// MiniMax's Anthropic-compatible API generates its own tool call IDs and
+// rejects tool results if the echoed ID doesn't match exactly (error 2013).
+// Disable tool call ID sanitization so IDs roundtrip verbatim for that API;
+// OpenAI-compatible paths keep default sanitization.
+const MINIMAX_REPLAY_HOOKS: typeof HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS = {
   ...HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS,
+  buildReplayPolicy: (ctx) => {
+    const base = HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS.buildReplayPolicy?.(ctx);
+    if (!base) {
+      return base;
+    }
+    if (ctx.modelApi === "anthropic-messages") {
+      return { ...base, sanitizeToolCallIds: false };
+    }
+    return base;
+  },
+};
+const MINIMAX_PROVIDER_HOOKS = {
+  ...MINIMAX_REPLAY_HOOKS,
   ...MINIMAX_FAST_MODE_STREAM_HOOKS,
   resolveReasoningOutputMode: () => "native" as const,
 };


### PR DESCRIPTION
## Summary

Re-opens #65371 against the current replay-hook API (the original PR was written before the `buildProviderReplayFamilyHooks` factory landed and no longer applies).

- **Problem:** MiniMax's Anthropic-compatible API generates its own tool call IDs and rejects tool results if the echoed ID doesn't match exactly (error 2013: *"tool result's tool id not found"*).
- **Why it matters:** The default `hybrid-anthropic-openai` replay policy sets `sanitizeToolCallIds: true` + `toolCallIdMode: "strict"`, which rewrites IDs and breaks the MiniMax roundtrip. All tool use fails.
- **What changed:** Introduces a thin `MINIMAX_REPLAY_HOOKS` wrapper around `HYBRID_ANTHROPIC_OPENAI_REPLAY_HOOKS` that overrides `buildReplayPolicy` to set `sanitizeToolCallIds: false` when `modelApi === "anthropic-messages"`. `MINIMAX_PROVIDER_HOOKS` consumes the wrapper, so both the `minimax` and `minimax-portal` providers inherit it through a single spread.
- **What did NOT change:** OpenAI-compatible paths (`openai-completions`) keep strict sanitization. The factory API itself isn't touched (could be a follow-up to add a `sanitizeToolCallIds` knob to `buildProviderReplayFamilyHooks` so consumers don't need the wrapper pattern).

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations (MiniMax provider plugin)

## Linked Issue/PR

- Closes #65380
- Closes #41257 — MiniMax models' tool calls are stripped instead of executed
- Supersedes #65371 (API drift)
- Related to #41839 — MiniMax M2.5 tool calls have no effect
- Same pattern as #34176 (ollama skip) and #52644 (Anthropic skip), scoped to MiniMax
- Prior attempt #24599 tried to fix error 2013 by adding more sanitization — the correct fix is to disable it

## Root Cause

- Root cause: the hybrid-anthropic-openai replay policy strictly sanitizes tool call IDs, but MiniMax's Anthropic-compatible API requires byte-exact ID echo.
- Missing detection / guardrail: no per-provider opt-out for tool-ID sanitization in the shared replay-family factory.
- Contributing context: fix follows the same pattern used for ollama and Anthropic, but scoped via a wrapper because the factory options don't yet expose a sanitizeToolCallIds knob.

## Regression Test Plan

- `extensions/minimax/index.test.ts` asserts `sanitizeToolCallIds: false` for the minimax provider on `anthropic-messages`, and `true` for the minimax-portal provider on `openai-completions`. Both cases covered.

## Verified locally

- `pnpm test extensions/minimax/index.test.ts` — 8/8 pass
- `pnpm build` clean
- End-to-end: a production MiniMax-M2.7 deployment running via this change executes tool calls (browser, web_search, exec) without error 2013.