### PR TITLE
fix(memory-core): silence expected operator.admin scope miss in dreaming cleanup

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -678,6 +678,31 @@ describe("generateAndAppendDreamNarrative", () => {
     );
   });
 
+  it("does not warn when cleanup fails with missing operator.admin scope (background cron fallback path)", async () => {
+    // The plugin subagent running from a background cron falls through to a
+    // synthetic operator client without admin scope (see
+    // `rejects fallback session deletion without minting admin scope` in
+    // src/gateway/server-plugins.test.ts). `sessions.delete` requires
+    // operator.admin, so this error fires on every dreaming cycle and is
+    // expected — it should not surface as a user-visible warning.
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.deleteSession.mockRejectedValue(new Error("missing scope: operator.admin"));
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "rem", snippets: ["some memory"] },
+      logger,
+    });
+
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    expect(logger.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("narrative session cleanup failed"),
+    );
+  });
+
   it("handles subagent error gracefully", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -932,9 +932,21 @@ export async function generateAndAppendDreamNarrative(params: {
     try {
       await params.subagent.deleteSession({ sessionKey });
     } catch (cleanupErr) {
-      params.logger.warn(
-        `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(cleanupErr)}`,
-      );
+      const errMessage = formatErrorMessage(cleanupErr);
+      // `sessions.delete` requires operator.admin. When dreaming runs from a
+      // background cron (no inherited operator scope) the plugin subagent
+      // falls through to a synthetic operator client that intentionally
+      // defaults to [operator.write] and does not mint admin — see
+      // `rejects fallback session deletion without minting admin scope` in
+      // src/gateway/server-plugins.test.ts. That path is guaranteed to reject
+      // delete with "missing scope: operator.admin" on every cycle, so treat
+      // it as an expected no-op rather than emitting noise. Genuine failures
+      // (any other error) are still surfaced as warn.
+      if (!errMessage.includes("missing scope: operator.admin")) {
+        params.logger.warn(
+          `memory-core: narrative session cleanup failed for ${params.data.phase} phase: ${errMessage}`,
+        );
+      }
     }
 
     await scrubDreamingNarrativeArtifacts(params.logger).catch((scrubErr: unknown) => {


### PR DESCRIPTION
## Summary

Dreaming cron's narrative cleanup logs `memory-core: narrative session cleanup failed for <phase> phase: missing scope: operator.admin` on **every** dreaming cycle, making healthy instances look broken.

Root cause: `subagent.deleteSession` dispatches `sessions.delete` which requires `ADMIN_SCOPE`. In background-cron context there is no inherited operator scope, so the plugin subagent falls through to a synthetic operator client that intentionally defaults to `[WRITE_SCOPE]` and does not mint admin — this is codified by the existing `rejects fallback session deletion without minting admin scope` test in `src/gateway/server-plugins.test.ts`.

The cleanup was already best-effort (wrapped in try/catch), so functionally nothing was broken — but the `warn` surfaced on every cycle.

## Fix

Suppress the `warn` **only** for the specific `"missing scope: operator.admin"` error (the expected background-cron path). Every other cleanup error — network, timeout, stale run, etc. — still surfaces as warn unchanged.

This preserves the existing security invariant (background plugin calls don't auto-mint admin) rather than weakening scope enforcement just to quiet the log.

## Why not grant admin to the synthetic client?

The existing test `rejects fallback session deletion without minting admin scope` locks in that behaviour as a deliberate security choice. Auto-minting admin in the fallback path would broaden privilege escalation surface for any plugin running in background context, which reviewers would correctly reject. Handling the known-expected error at the memory-core call site is the minimally invasive fix.

## Known caveat

Orphan narrative subagent sessions still accumulate because the delete is a no-op from the cron path. This PR **does not** address that — tracked separately. A follow-up could expose a privileged self-cleanup path (e.g. `sessions.delete.owned`) scoped to sessions the caller created, but that's a larger design change.

## Test plan

- [x] New test: `does not warn when cleanup fails with missing operator.admin scope (background cron fallback path)` — asserts `logger.warn` is not called with the cleanup message when `deleteSession` rejects with `missing scope: operator.admin`
- [x] Existing test: `waits once more before cleanup after timeout and logs cleanup failures` — unchanged, still passes (mock rejects with `"still active"`, which is not the operator.admin case, so warn still fires)
- [x] All 43 `dreaming-narrative.test.ts` tests pass
- [x] All 35 `server-plugins.test.ts` tests pass (including the scope-enforcement test)
- [x] Typecheck clean
- [x] Lint / import-cycle / madge checks all green

## Before / After

Before (every dreaming cycle, log level warn):
```
2026-04-17T03:02:32.816+10:00 [plugins] memory-core: narrative session cleanup failed for light phase: missing scope: operator.admin
2026-04-17T03:03:01.502+10:00 [plugins] memory-core: narrative session cleanup failed for rem phase: missing scope: operator.admin
```

After: silent on the scope-mismatch case, still warns on genuine failures.