### PR TITLE
fix(gateway): preserve non-text MCP content blocks in HTTP gateway tool-call results

### DIFF
--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -10,18 +10,24 @@ import {
 } from "./mcp-http.protocol.js";
 import type { McpLoopbackTool, McpToolSchemaEntry } from "./mcp-http.schema.js";
 
-type McpTextContent = {
-  type: "text";
-  text: string;
-};
+// MCP content-block types per the spec: text/image/audio/resource/resource_link.
+// Typed blocks (those with a recognized `type` string) pass through untouched so
+// image data/mimeType, resource uris, audio payloads, etc. survive the gateway.
+// Anything that isn't a typed object is wrapped into a text block as before.
+type McpContentBlock = { type: string; [key: string]: unknown };
 
-function normalizeToolCallContent(result: unknown): McpTextContent[] {
+export function normalizeToolCallContent(result: unknown): McpContentBlock[] {
   const content = (result as { content?: unknown })?.content;
   if (Array.isArray(content)) {
-    return content.map((block: { type?: string; text?: string }) => ({
-      type: (block.type ?? "text") as "text",
-      text: block.text ?? (typeof block === "string" ? block : JSON.stringify(block)),
-    }));
+    return content.map((block) => {
+      if (block && typeof block === "object" && typeof (block as { type?: unknown }).type === "string") {
+        return block as McpContentBlock;
+      }
+      return {
+        type: "text",
+        text: typeof block === "string" ? block : JSON.stringify(block),
+      };
+    });
   }
   return [
     {

--- a/src/gateway/mcp-http.test.ts
+++ b/src/gateway/mcp-http.test.ts
@@ -302,3 +302,62 @@ describe("createMcpLoopbackServerConfig", () => {
     );
   });
 });
+
+describe("normalizeToolCallContent", () => {
+  it("passes image blocks through with data and mimeType intact", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    const result = {
+      content: [
+        { type: "image", data: "QkFEU0NSRUVOU0hPVA==", mimeType: "image/png" },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "image", data: "QkFEU0NSRUVOU0hPVA==", mimeType: "image/png" },
+    ]);
+  });
+
+  it("passes resource_link blocks through with uri and name intact", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    const result = {
+      content: [{ type: "resource_link", uri: "file:///tmp/out.png", name: "out.png" }],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "resource_link", uri: "file:///tmp/out.png", name: "out.png" },
+    ]);
+  });
+
+  it("passes audio blocks through with data and mimeType intact", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    const result = {
+      content: [{ type: "audio", data: "UklGRg==", mimeType: "audio/wav" }],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "audio", data: "UklGRg==", mimeType: "audio/wav" },
+    ]);
+  });
+
+  it("preserves existing text blocks untouched", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    const result = { content: [{ type: "text", text: "hello" }] };
+    expect(normalizeToolCallContent(result)).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  it("wraps untyped content entries into text blocks", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    const result = { content: ["plain string", { foo: "bar" }] };
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "text", text: "plain string" },
+      { type: "text", text: JSON.stringify({ foo: "bar" }) },
+    ]);
+  });
+
+  it("falls back to a single text block when result has no content array", async () => {
+    const { normalizeToolCallContent } = await import("./mcp-http.handlers.js");
+    expect(normalizeToolCallContent("raw string result")).toEqual([
+      { type: "text", text: "raw string result" },
+    ]);
+    expect(normalizeToolCallContent({ other: "shape" })).toEqual([
+      { type: "text", text: JSON.stringify({ other: "shape" }) },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #68037 — the HTTP MCP gateway was dropping every non-text field from `tools/call` results, breaking `browser.screenshot` and every other tool that returns an image/audio/resource block.

## Root cause

`normalizeToolCallContent` in `src/gateway/mcp-http.handlers.ts` mapped every returned content block to `{type: block.type ?? "text", text: block.text ?? …}`:

\`\`\`ts
return content.map((block: { type?: string; text?: string }) => ({
  type: (block.type ?? "text") as "text",
  text: block.text ?? (typeof block === "string" ? block : JSON.stringify(block)),
}));
\`\`\`

Image/audio/resource blocks have no `text` field, so they came out as `{type: "image", text: undefined}` and lost `data`, `mimeType`, `uri`, `name`, `resource`, `annotations`, etc. Downstream Zod validation against the MCP content-block schema then failed with `"expected string, received undefined"` on `data`/`mimeType`.

## Fix

Pass typed blocks through unmodified; only synthesize a text block when the entry is a primitive string or an object without a recognized `type` field. Widen the return type from `McpTextContent[]` to an open `McpContentBlock` union so the pass-through survives TypeScript's inference.

\`\`\`ts
return content.map((block) => {
  if (block && typeof block === "object" && typeof (block as { type?: unknown }).type === "string") {
    return block as McpContentBlock;
  }
  return {
    type: "text",
    text: typeof block === "string" ? block : JSON.stringify(block),
  };
});
\`\`\`

This is the fix the reporter proposed (pass-through for valid typed blocks, fallback for everything else). If stricter validation is preferred later, the union can be narrowed to an explicit discriminated schema.

## Test plan

- [x] Added six unit tests in \`src/gateway/mcp-http.test.ts\` covering:
  - image block pass-through with \`data\` + \`mimeType\` preserved
  - \`resource_link\` pass-through with \`uri\` + \`name\` preserved
  - audio block pass-through with \`data\` + \`mimeType\` preserved
  - existing text blocks untouched
  - untyped entries (primitive string, plain object) wrapped into text
  - fallback when \`result.content\` is absent entirely
- [x] \`npx tsc --noEmit\` — 247 baseline on \`main\`, 247 on branch (no new errors).
- [x] \`pnpm exec oxlint\` on touched files — 0 warnings, 0 errors.
- [x] Existing \`mcp-http.test.ts\` integration cases untouched.

Local full vitest is blocked by pre-existing \`test/non-isolated-runner.ts\` drift (reproduces on \`main\`) — CI will exercise the new tests normally.

## Security / behavior notes

- The fix trusts any block with a string \`type\` field. That matches what the MCP protocol-level schema validates client-side anyway: bad payloads fail Zod at the client with a cleaner error than today's silent field-drop.
- No existing text-block behavior changes — strings and untyped plain objects still get wrapped, and a non-array \`result\` still collapses to a single text block.