### PR TITLE
fix: pass through image/audio/resource content blocks in MCP HTTP gateway

### DIFF
--- a/src/gateway/mcp-http.handlers.test.ts
+++ b/src/gateway/mcp-http.handlers.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { normalizeToolCallContent } from "./mcp-http.handlers.js";
+
+describe("normalizeToolCallContent", () => {
+  it("passes through text blocks unchanged", () => {
+    const result = { content: [{ type: "text", text: "Hello world" }] };
+    expect(normalizeToolCallContent(result)).toEqual([{ type: "text", text: "Hello world" }]);
+  });
+
+  it("passes through image blocks with data and mimeType", () => {
+    const result = {
+      content: [
+        {
+          type: "image",
+          data: "base64encodeddata",
+          mimeType: "image/png",
+        },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      {
+        type: "image",
+        data: "base64encodeddata",
+        mimeType: "image/png",
+      },
+    ]);
+  });
+
+  it("passes through audio blocks with data and mimeType", () => {
+    const result = {
+      content: [
+        {
+          type: "audio",
+          data: "base64encodedaudio",
+          mimeType: "audio/mpeg",
+        },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      {
+        type: "audio",
+        data: "base64encodedaudio",
+        mimeType: "audio/mpeg",
+      },
+    ]);
+  });
+
+  it("passes through resource blocks with resource field", () => {
+    const result = {
+      content: [
+        {
+          type: "resource",
+          resource: {
+            uri: "file:///path/to/file.txt",
+            mimeType: "text/plain",
+            text: "file contents",
+          },
+        },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      {
+        type: "resource",
+        resource: {
+          uri: "file:///path/to/file.txt",
+          mimeType: "text/plain",
+          text: "file contents",
+        },
+      },
+    ]);
+  });
+
+  it("passes through resource_link blocks with uri", () => {
+    const result = {
+      content: [
+        {
+          type: "resource_link",
+          uri: "https://example.com/file.pdf",
+          name: "Document",
+          mimeType: "application/pdf",
+        },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      {
+        type: "resource_link",
+        uri: "https://example.com/file.pdf",
+        name: "Document",
+        mimeType: "application/pdf",
+      },
+    ]);
+  });
+
+  it("handles mixed content blocks", () => {
+    const result = {
+      content: [
+        { type: "text", text: "Here is an image:" },
+        { type: "image", data: "imagedata", mimeType: "image/jpeg" },
+        { type: "text", text: "And a resource:" },
+        {
+          type: "resource",
+          resource: { uri: "file:///doc.txt", text: "content" },
+        },
+      ],
+    };
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "text", text: "Here is an image:" },
+      { type: "image", data: "imagedata", mimeType: "image/jpeg" },
+      { type: "text", text: "And a resource:" },
+      { type: "resource", resource: { uri: "file:///doc.txt", text: "content" } },
+    ]);
+  });
+
+  it("falls back to text for string content", () => {
+    const result = { content: ["just a string"] };
+    expect(normalizeToolCallContent(result)).toEqual([{ type: "text", text: "just a string" }]);
+  });
+
+  it("falls back to text for non-array content", () => {
+    const result = "plain string result";
+    expect(normalizeToolCallContent(result)).toEqual([
+      { type: "text", text: "plain string result" },
+    ]);
+  });
+
+  it("falls back to JSON for malformed blocks", () => {
+    const result = { content: [{ foo: "bar" }] };
+    expect(normalizeToolCallContent(result)).toEqual([{ type: "text", text: '{"foo":"bar"}' }]);
+  });
+});

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -10,18 +10,31 @@ import {
 } from "./mcp-http.protocol.js";
 import type { McpLoopbackTool, McpToolSchemaEntry } from "./mcp-http.schema.js";
 
-type McpTextContent = {
-  type: "text";
-  text: string;
-};
+type McpContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string }
+  | { type: "audio"; data: string; mimeType: string }
+  | { type: "resource"; resource: { uri: string; mimeType?: string; text?: string; blob?: string } }
+  | { type: "resource_link"; uri: string; name?: string; mimeType?: string };
 
-function normalizeToolCallContent(result: unknown): McpTextContent[] {
+export function normalizeToolCallContent(result: unknown): McpContentBlock[] {
   const content = (result as { content?: unknown })?.content;
   if (Array.isArray(content)) {
-    return content.map((block: { type?: string; text?: string }) => ({
-      type: (block.type ?? "text") as "text",
-      text: block.text ?? (typeof block === "string" ? block : JSON.stringify(block)),
-    }));
+    return content.map((block: unknown) => {
+      // Pass through valid content blocks directly to preserve image/audio/resource fields
+      if (
+        block &&
+        typeof block === "object" &&
+        typeof (block as { type?: string }).type === "string"
+      ) {
+        return block as McpContentBlock;
+      }
+      // Fallback for string or malformed blocks
+      return {
+        type: "text",
+        text: typeof block === "string" ? block : JSON.stringify(block),
+      };
+    });
   }
   return [
     {


### PR DESCRIPTION
## Summary

Fixes the HTTP MCP gateway stripping image, audio, and resource fields from tool results.

## Root Cause

The `normalizeToolCallContent` function was mapping all content blocks to only `{type, text}`, discarding other fields like `data`, `mimeType`, `resource`, `uri`, etc. This caused downstream Zod validation to fail for any tool returning non-text content.

## Fix

- Pass through valid content blocks directly to preserve all fields
- Only apply fallback transformation for strings or malformed blocks
- Updated type definition to include all MCP content block types

## Test Plan

- Added comprehensive test coverage for all content block types (text, image, audio, resource, resource_link)
- All 9 new tests pass
- Manually verified that image blocks now retain `data` and `mimeType` fields

Closes openclaw#68037