### PR TITLE
fix(gateway): extend image-support name fallback to direct anthropic provider

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -1004,4 +1004,31 @@ describe("resolveGatewayModelSupportsImages", () => {
       }),
     ).resolves.toBe(true);
   });
+
+  test("treats direct anthropic Claude models as image-capable when catalog entry is stale", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "claude-opus-4-7",
+        provider: "anthropic",
+        loadGatewayModelCatalog: async () => [
+          {
+            id: "claude-opus-4-7",
+            name: "Claude Opus 4.7",
+            provider: "anthropic",
+            input: ["text"],
+          },
+        ],
+      }),
+    ).resolves.toBe(true);
+  });
+
+  test("treats direct anthropic Claude models as image-capable when catalog entry is missing", async () => {
+    await expect(
+      resolveGatewayModelSupportsImages({
+        model: "claude-opus-4-7",
+        provider: "anthropic",
+        loadGatewayModelCatalog: async () => [],
+      }),
+    ).resolves.toBe(true);
+  });
 });

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1009,6 +1009,17 @@ export async function resolveGatewayModelSupportsImages(params: {
       normalizeLowercaseStringOrEmpty(params.model),
       normalizeLowercaseStringOrEmpty(modelEntry?.name),
     ].filter(Boolean);
+    // Name-based fallback for Anthropic/Claude models whose catalog entries
+    // may lag behind newly released model IDs (e.g. claude-opus-4-7).
+    const isAnthropicClaudeByName =
+      (normalizedProvider === "anthropic" || normalizedProvider === "claude-cli") &&
+      normalizedCandidates.some(
+        (candidate) =>
+          candidate === "opus" ||
+          candidate === "sonnet" ||
+          candidate === "haiku" ||
+          candidate.startsWith("claude-"),
+      );
     if (modelEntry) {
       if (modelEntry.input?.includes("image")) {
         return true;
@@ -1028,30 +1039,12 @@ export async function resolveGatewayModelSupportsImages(params: {
       ) {
         return true;
       }
-      if (
-        normalizedProvider === "claude-cli" &&
-        normalizedCandidates.some(
-          (candidate) =>
-            candidate === "opus" ||
-            candidate === "sonnet" ||
-            candidate === "haiku" ||
-            candidate.startsWith("claude-"),
-        )
-      ) {
+      if (isAnthropicClaudeByName) {
         return true;
       }
       return false;
     }
-    if (
-      normalizedProvider === "claude-cli" &&
-      normalizedCandidates.some(
-        (candidate) =>
-          candidate === "opus" ||
-          candidate === "sonnet" ||
-          candidate === "haiku" ||
-          candidate.startsWith("claude-"),
-      )
-    ) {
+    if (isAnthropicClaudeByName) {
       return true;
     }
     return false;


### PR DESCRIPTION
## Problem

When using the direct `anthropic` provider with a newly released Claude model (e.g. `claude-opus-4-7`), pasted images are silently dropped. The gateway logs confirm:

```
parseMessageWithAttachments: 1 attachment(s) dropped — model does not support images
```

The root cause is in `resolveGatewayModelSupportsImages`: when the model catalog either has no entry or has a stale entry without `input: ["image"]`, the function's name-based fallback only recognises `claude-cli` as an Anthropic-class provider — not the `anthropic` provider itself. New models hit `return false` and the caller drops all attachments.

## Fix

Add `anthropic` alongside `claude-cli` in the name-based image-support check so that any Claude model name (`claude-*`, `opus`, `sonnet`, `haiku`) is treated as image-capable regardless of catalog freshness.

The duplicated predicate in the catalog-hit and catalog-miss branches is extracted into a single `isAnthropicClaudeByName` const to keep the logic DRY.

## Changes

- **`src/gateway/session-utils.ts`** — extend name-based fallback to `anthropic` provider; extract shared predicate
- **`src/gateway/session-utils.test.ts`** — add two tests: catalog-stale and catalog-miss paths for `anthropic` provider

## Testing

All 56 existing + 2 new tests pass:
```
✓ treats direct anthropic Claude models as image-capable when catalog entry is stale
✓ treats direct anthropic Claude models as image-capable when catalog entry is missing
```

Closes #68044