### PR TITLE
fix: prevent infinite retry loops on tool parameter validation errors

### DIFF
--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -55,10 +55,15 @@ function isLegacyToolExecuteArgs(args: ToolExecuteArgsAny): args is ToolExecuteA
 function describeToolExecutionError(err: unknown): {
   message: string;
   stack?: string;
+  retryable?: boolean;
 } {
   if (err instanceof Error) {
     const message = err.message?.trim() ? err.message : String(err);
-    return { message, stack: err.stack };
+    const retryable =
+      err && typeof err === "object" && "retryable" in err
+        ? Boolean((err as { retryable?: unknown }).retryable)
+        : undefined;
+    return { message, stack: err.stack, retryable };
   }
   return { message: String(err) };
 }
@@ -137,11 +142,13 @@ function normalizeToolExecutionResult(params: {
 function buildToolExecutionErrorResult(params: {
   toolName: string;
   message: string;
+  retryable?: boolean;
 }): AgentToolResult<unknown> {
   return jsonResult({
     status: "error",
     tool: params.toolName,
     error: params.message,
+    retryable: params.retryable,
   });
 }
 
@@ -268,6 +275,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
           return buildToolExecutionErrorResult({
             toolName: normalizedName,
             message: described.message,
+            retryable: described.retryable,
           });
         }
       },

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -10,7 +10,9 @@ export type RequiredParamGroup = {
 const RETRY_GUIDANCE_SUFFIX = " Supply correct parameters before retrying.";
 
 function parameterValidationError(message: string): Error {
-  return new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
+  const err = new Error(`${message}.${RETRY_GUIDANCE_SUFFIX}`);
+  (err as Error & { retryable: boolean }).retryable = false;
+  return err;
 }
 
 function describeReceivedParamValue(value: unknown, allowEmpty = false): string | undefined {


### PR DESCRIPTION
Closes #68026

Marks parameter validation errors as non-retryable so the agent does not enter an infinite loop when tool arguments are missing or malformed.