### PR TITLE
mattermost: fix /oc_* slash command 503 from duplicate slash-state instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+- Gateway/startup: skip plugin-backed auth-profile overlays during startup secrets preflight, reducing gateway readiness latency while keeping reload and OAuth recovery paths overlay-capable. (#68327) Thanks @JIRBOY.
+- Plugins/onboarding: carry ClawHub install metadata through channel setup catalogs so missing channel plugins can install from ClawHub before npm/local fallback. Thanks @vincentkoc.
+
+### Fixes
+
+- Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.
+- Gateway/channels: cap startup fanout at four channel/account handoffs and recover from Bonjour ciao self-probe races, reducing Windows startup stalls with many Telegram accounts. Fixes #75687.
+- Gateway/sessions: keep `sessions.list` polling responsive on large session stores by reusing list-safe session cache/indexes and returning a lightweight compaction checkpoint preview instead of heavyweight summaries. Thanks @rolandrscheel.
+- CLI/update: treat inherited Gateway service markers as origin hints and only block package replacement when the managed Gateway is still live, so self-updates can stop the service and continue safely. (#75729) Thanks @hxy91819.
+- Agents/failover: exempt run-level timeouts that fire during tool execution from model fallback, timeout-triggered compaction, and generic timeout payload synthesis. Long `process(poll)`, browser, or `exec` tool calls that exceed `agents.defaults.timeoutSeconds` previously rotated auth profiles, switched to a fallback model, and surfaced a misleading "LLM request timed out" error even though the primary model had already responded. Mirrors the existing `timedOutDuringCompaction` precedent (#46889). Fixes #52147. (#75873) Thanks @simonusa.
+- Docker: copy Bun 1.3.13 from a digest-pinned image and keep CI on the same version. Fixes #74356. Thanks @fede-kamel and @sallyom.
+- Mattermost/slash commands: preserve slash-command activation state across bundled-entry loader and native ESM paths so `/oc_*` callbacks stop getting stuck on `503 "not yet initialized"`. (#68089) Thanks @allenliang2022.
 ## 2026.5.2
 
 ### Highlights
@@ -2557,7 +2572,6 @@ Docs: https://docs.openclaw.ai
 - Memory-core: preserve stored vector dimensions during read-only recovery so memory indexes do not lose vector metadata while repairing read-only state.
 - Reply/block streaming: preserve post-stream incomplete-turn error payloads after block streaming already emitted content, so users get the warning instead of silence. (#67991) Thanks @obviyus.
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
-- Mattermost/slash commands: preserve slash-command activation state across bundled-entry loader and native ESM paths so `/oc_*` callbacks stop getting stuck on `503 "not yet initialized"`. (#68089) Thanks @allenliang2022.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - Slack/streaming: resolve native streaming recipient teams from the inbound user when available, with a monitor-team fallback, so DM and shared-workspace streams target the right recipient more reliably.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2557,6 +2557,7 @@ Docs: https://docs.openclaw.ai
 - Memory-core: preserve stored vector dimensions during read-only recovery so memory indexes do not lose vector metadata while repairing read-only state.
 - Reply/block streaming: preserve post-stream incomplete-turn error payloads after block streaming already emitted content, so users get the warning instead of silence. (#67991) Thanks @obviyus.
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
+- Mattermost/slash commands: preserve slash-command activation state across bundled-entry loader and native ESM paths so `/oc_*` callbacks stop getting stuck on `503 "not yet initialized"`. (#68089) Thanks @allenliang2022.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
 - Slack/streaming: resolve native streaming recipient teams from the inbound user when available, with a monitor-team fallback, so DM and shared-workspace streams target the right recipient more reliably.
 - macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.

--- a/extensions/mattermost/index.ts
+++ b/extensions/mattermost/index.ts
@@ -1,14 +1,16 @@
-import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
-// Import the slash route registration statically so `./src/mattermost/slash-state.ts`
-// loads through the same native-ESM module instance as `monitor-slash.ts` (which
-// calls `activateSlashCommands`) and `monitor.ts` (which calls
-// `deactivateSlashCommands` / `getSlashCommandState`). Going through the sync
-// jiti loader (`loadBundledEntryExportSync`) would create a second instance of
-// `slash-state.ts` whose `accountStates` map is never populated, so the HTTP
-// route would keep returning 503 "Slash commands are not yet initialized" even
-// after activation succeeds. See SDK guidance: do not mix static and dynamic
-// imports for the same runtime surface.
-import { registerSlashCommandRoute } from "./slash-route-api.js";
+import {
+  defineBundledChannelEntry,
+  loadBundledEntryExportSync,
+} from "openclaw/plugin-sdk/channel-entry-contract";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
+
+function registerSlashCommandRoute(api: OpenClawPluginApi): void {
+  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
+    specifier: "./slash-route-api.js",
+    exportName: "registerSlashCommandRoute",
+  });
+  register(api);
+}
 
 export default defineBundledChannelEntry({
   id: "mattermost",

--- a/extensions/mattermost/index.ts
+++ b/extensions/mattermost/index.ts
@@ -1,16 +1,14 @@
-import {
-  defineBundledChannelEntry,
-  loadBundledEntryExportSync,
-} from "openclaw/plugin-sdk/channel-entry-contract";
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk/channel-entry-contract";
-
-function registerSlashCommandRoute(api: OpenClawPluginApi): void {
-  const register = loadBundledEntryExportSync<(api: OpenClawPluginApi) => void>(import.meta.url, {
-    specifier: "./slash-route-api.js",
-    exportName: "registerSlashCommandRoute",
-  });
-  register(api);
-}
+import { defineBundledChannelEntry } from "openclaw/plugin-sdk/channel-entry-contract";
+// Import the slash route registration statically so `./src/mattermost/slash-state.ts`
+// loads through the same native-ESM module instance as `monitor-slash.ts` (which
+// calls `activateSlashCommands`) and `monitor.ts` (which calls
+// `deactivateSlashCommands` / `getSlashCommandState`). Going through the sync
+// jiti loader (`loadBundledEntryExportSync`) would create a second instance of
+// `slash-state.ts` whose `accountStates` map is never populated, so the HTTP
+// route would keep returning 503 "Slash commands are not yet initialized" even
+// after activation succeeds. See SDK guidance: do not mix static and dynamic
+// imports for the same runtime surface.
+import { registerSlashCommandRoute } from "./slash-route-api.js";
 
 export default defineBundledChannelEntry({
   id: "mattermost",

--- a/extensions/mattermost/slash-route-api.ts
+++ b/extensions/mattermost/slash-route-api.ts
@@ -1,1 +1,1 @@
-export { registerSlashCommandRoute } from "./src/mattermost/slash-state.js";
+export { registerSlashCommandRoute } from "./src/mattermost/slash-route.js";

--- a/extensions/mattermost/src/mattermost/slash-route.ts
+++ b/extensions/mattermost/src/mattermost/slash-route.ts
@@ -1,0 +1,203 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Readable } from "node:stream";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/core";
+import {
+  isRequestBodyLimitError,
+  readRequestBodyWithLimit,
+} from "openclaw/plugin-sdk/webhook-ingress";
+import type { MattermostConfig } from "../types.js";
+import {
+  parseSlashCommandPayload,
+  resolveSlashCommandConfig,
+  type MattermostSlashCommandConfig,
+} from "./slash-commands.js";
+import {
+  getSlashCommandAccountStates,
+  resolveSlashHandlerForCommand,
+  resolveSlashHandlerForToken,
+  type SlashHandlerMatch,
+} from "./slash-shared-state.js";
+
+const MULTI_ACCOUNT_BODY_MAX_BYTES = 64 * 1024;
+const MULTI_ACCOUNT_BODY_TIMEOUT_MS = 5_000;
+
+/**
+ * Register the HTTP route for slash command callbacks.
+ * Called during plugin registration.
+ *
+ * The single HTTP route dispatches to the correct per-account handler by
+ * matching the inbound token against each account's known tokens, falling back
+ * to registered team/trigger ownership so upstream validation can accept a
+ * rotated Mattermost token.
+ */
+export function registerSlashCommandRoute(api: OpenClawPluginApi) {
+  const mmConfig = api.config.channels?.mattermost as MattermostConfig | undefined;
+  const accountStates = getSlashCommandAccountStates();
+
+  // Collect callback paths from both top-level and per-account config.
+  // Command registration uses account.config.commands, so the HTTP route
+  // registration must include any account-specific callbackPath overrides.
+  // Also extract the pathname from an explicit callbackUrl when it differs
+  // from callbackPath, so that Mattermost callbacks hit a registered route.
+  const callbackPaths = new Set<string>();
+
+  const addCallbackPaths = (raw: Partial<MattermostSlashCommandConfig> | undefined) => {
+    const resolved = resolveSlashCommandConfig(raw);
+    callbackPaths.add(resolved.callbackPath);
+    if (resolved.callbackUrl) {
+      try {
+        const urlPath = new URL(resolved.callbackUrl).pathname;
+        if (urlPath && urlPath !== resolved.callbackPath) {
+          callbackPaths.add(urlPath);
+        }
+      } catch {
+        // Invalid URL — ignore, will be caught during registration
+      }
+    }
+  };
+
+  addCallbackPaths(mmConfig?.commands as Partial<MattermostSlashCommandConfig> | undefined);
+
+  const accountsRaw = mmConfig?.accounts ?? {};
+  for (const accountId of Object.keys(accountsRaw)) {
+    addCallbackPaths(accountsRaw[accountId]?.commands);
+  }
+
+  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
+    if (accountStates.size === 0) {
+      res.statusCode = 503;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(
+        JSON.stringify({
+          response_type: "ephemeral",
+          text: "Slash commands are not yet initialized. Please try again in a moment.",
+        }),
+      );
+      return;
+    }
+
+    // We need to peek at the body to route to the right account handler. Each
+    // account handler still performs upstream token validation before running a
+    // command.
+
+    // If there's only one active account (common case), route directly.
+    if (accountStates.size === 1) {
+      const [, state] = [...accountStates.entries()][0];
+      if (!state.handler) {
+        res.statusCode = 503;
+        res.setHeader("Content-Type", "application/json; charset=utf-8");
+        res.end(
+          JSON.stringify({
+            response_type: "ephemeral",
+            text: "Slash commands are not yet initialized. Please try again in a moment.",
+          }),
+        );
+        return;
+      }
+      await state.handler(req, res);
+      return;
+    }
+
+    // Multi-account: buffer the body, find the matching account by token or
+    // registered team/trigger, then replay the request to the correct handler.
+    // Use the bounded helper so a slow/never-finishing client cannot tie up the
+    // routing handler indefinitely (Slowloris).
+    let bodyStr: string;
+    try {
+      bodyStr = await readRequestBodyWithLimit(req, {
+        maxBytes: MULTI_ACCOUNT_BODY_MAX_BYTES,
+        timeoutMs: MULTI_ACCOUNT_BODY_TIMEOUT_MS,
+      });
+    } catch (error) {
+      if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
+        res.statusCode = 408;
+        res.end("Request body timeout");
+        return;
+      }
+      res.statusCode = 413;
+      res.end("Payload Too Large");
+      return;
+    }
+
+    // Parse the token for the fast path; if it misses, parse the full slash
+    // payload so rotated tokens can still route by registered team/trigger.
+    let token: string | null = null;
+    const ct = req.headers["content-type"] ?? "";
+    try {
+      if (ct.includes("application/json")) {
+        token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
+      } else {
+        token = new URLSearchParams(bodyStr).get("token");
+      }
+    } catch {
+      // parse failed — will be caught by handler
+    }
+
+    let match: SlashHandlerMatch = token ? resolveSlashHandlerForToken(token) : { kind: "none" };
+    if (match.kind === "none") {
+      const payload = parseSlashCommandPayload(bodyStr, ct);
+      if (payload) {
+        match = resolveSlashHandlerForCommand({
+          teamId: payload.team_id,
+          command: payload.command,
+        });
+      }
+    }
+
+    if (match.kind === "none") {
+      // No matching account — reject
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(
+        JSON.stringify({
+          response_type: "ephemeral",
+          text: "Unauthorized: invalid command token.",
+        }),
+      );
+      return;
+    }
+
+    if (match.kind === "ambiguous") {
+      api.logger.warn?.(
+        `mattermost: slash callback matched multiple accounts via ${match.source} (${match.accountIds.join(", ")})`,
+      );
+      const conflictText =
+        match.source === "token"
+          ? "Conflict: command token is not unique across accounts."
+          : "Conflict: slash command is not unique across accounts.";
+      res.statusCode = 409;
+      res.setHeader("Content-Type", "application/json; charset=utf-8");
+      res.end(
+        JSON.stringify({
+          response_type: "ephemeral",
+          text: conflictText,
+        }),
+      );
+      return;
+    }
+
+    const matchedHandler = match.handler;
+
+    // Replay: create a synthetic readable that re-emits the buffered body
+    const syntheticReq = new Readable({
+      read() {
+        this.push(Buffer.from(bodyStr, "utf8"));
+        this.push(null);
+      },
+    }) as IncomingMessage;
+
+    syntheticReq.method = req.method;
+    syntheticReq.url = req.url;
+    syntheticReq.headers = req.headers;
+
+    await matchedHandler(syntheticReq, res);
+  };
+
+  for (const callbackPath of callbackPaths) {
+    api.registerHttpRoute({
+      path: callbackPath,
+      auth: "plugin",
+      handler: routeHandler,
+    });
+  }
+}

--- a/extensions/mattermost/src/mattermost/slash-shared-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-shared-state.ts
@@ -1,0 +1,139 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ResolvedMattermostAccount } from "./accounts.js";
+import {
+  normalizeSlashCommandTrigger,
+  type MattermostRegisteredCommand,
+} from "./slash-commands.js";
+
+type SlashHandlerMatchSource = "token" | "command";
+
+export type SlashHandlerMatch =
+  | { kind: "none" }
+  | {
+      kind: "single";
+      source: SlashHandlerMatchSource;
+      handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+      accountIds: string[];
+    }
+  | {
+      kind: "ambiguous";
+      source: SlashHandlerMatchSource;
+      accountIds: string[];
+    };
+
+export type SlashCommandAccountState = {
+  /** Tokens from registered/current commands, used for fast-path routing. */
+  commandTokens: Set<string>;
+  /** Registered command IDs for cleanup on shutdown. */
+  registeredCommands: MattermostRegisteredCommand[];
+  /** Current HTTP handler for this account. */
+  handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
+  /** The account that activated slash commands. */
+  account: ResolvedMattermostAccount;
+  /** Map from trigger to original command name (for skill commands that start with oc_). */
+  triggerMap: Map<string, string>;
+};
+
+const MATTERMOST_SLASH_STATE_KEY = Symbol.for("openclaw.mattermost.slashCommandState");
+
+type MattermostSlashCommandSharedState = {
+  accountStates: Map<string, SlashCommandAccountState>;
+};
+
+// The slash route can load through the bundled-entry jiti path while the
+// monitor imports this state through native ESM. Keep the live state on a
+// process-global symbol so both loaders share one Map.
+function getMattermostSlashCommandSharedState(): MattermostSlashCommandSharedState {
+  const globalState = globalThis as typeof globalThis & {
+    [MATTERMOST_SLASH_STATE_KEY]?: MattermostSlashCommandSharedState;
+  };
+  if (!globalState[MATTERMOST_SLASH_STATE_KEY]) {
+    globalState[MATTERMOST_SLASH_STATE_KEY] = {
+      accountStates: new Map<string, SlashCommandAccountState>(),
+    };
+  }
+  return globalState[MATTERMOST_SLASH_STATE_KEY];
+}
+
+export function getSlashCommandAccountStates(): Map<string, SlashCommandAccountState> {
+  return getMattermostSlashCommandSharedState().accountStates;
+}
+
+export function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {
+  const matches: Array<{
+    accountId: string;
+    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+  }> = [];
+
+  for (const [accountId, state] of getSlashCommandAccountStates()) {
+    if (state.commandTokens.has(token) && state.handler) {
+      matches.push({ accountId, handler: state.handler });
+    }
+  }
+
+  if (matches.length === 0) {
+    return { kind: "none" };
+  }
+  if (matches.length === 1) {
+    return {
+      kind: "single",
+      source: "token",
+      handler: matches[0].handler,
+      accountIds: [matches[0].accountId],
+    };
+  }
+
+  return {
+    kind: "ambiguous",
+    source: "token",
+    accountIds: matches.map((entry) => entry.accountId),
+  };
+}
+
+export function resolveSlashHandlerForCommand(params: {
+  teamId: string;
+  command: string;
+}): SlashHandlerMatch {
+  const trigger = normalizeSlashCommandTrigger(params.command);
+  if (!trigger) {
+    return { kind: "none" };
+  }
+
+  const matches: Array<{
+    accountId: string;
+    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+  }> = [];
+
+  for (const [accountId, state] of getSlashCommandAccountStates()) {
+    if (
+      state.handler &&
+      state.registeredCommands.some(
+        (cmd) => cmd.teamId === params.teamId && cmd.trigger === trigger,
+      )
+    ) {
+      matches.push({ accountId, handler: state.handler });
+    }
+  }
+
+  if (matches.length === 0) {
+    return { kind: "none" };
+  }
+  if (matches.length === 1) {
+    return {
+      kind: "single",
+      source: "command",
+      handler: matches[0].handler,
+      accountIds: [matches[0].accountId],
+    };
+  }
+
+  return {
+    kind: "ambiguous",
+    source: "command",
+    accountIds: matches.map((entry) => entry.accountId),
+  };
+}
+
+export function getSlashCommandState(accountId: string): SlashCommandAccountState | null {
+  return getSlashCommandAccountStates().get(accountId) ?? null;
+}

--- a/extensions/mattermost/src/mattermost/slash-state.dual-load.test.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.dual-load.test.ts
@@ -1,0 +1,75 @@
+import { loadBundledEntryExportSync } from "openclaw/plugin-sdk/channel-entry-contract";
+import { afterEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig, RuntimeEnv } from "../runtime-api.js";
+import type { ResolvedMattermostAccount } from "./accounts.js";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
+import { activateSlashCommands, deactivateSlashCommands } from "./slash-state.js";
+
+function createResolvedMattermostAccount(accountId: string): ResolvedMattermostAccount {
+  return {
+    accountId,
+    enabled: true,
+    botTokenSource: "config",
+    baseUrlSource: "config",
+    config: {},
+  };
+}
+
+function createRegisteredCommand(params?: {
+  token?: string;
+  teamId?: string;
+  trigger?: string;
+}): MattermostRegisteredCommand {
+  return {
+    id: "cmd-1",
+    teamId: params?.teamId ?? "team-1",
+    trigger: params?.trigger ?? "oc_status",
+    token: params?.token ?? "valid-token",
+    url: "https://gateway.example.com/slash",
+    managed: false,
+  };
+}
+
+const slashApi = {
+  cfg: {},
+  runtime: {
+    log: () => {},
+    error: () => {},
+    exit: () => {},
+  },
+} satisfies {
+  cfg: OpenClawConfig;
+  runtime: RuntimeEnv;
+};
+
+afterEach(() => {
+  deactivateSlashCommands();
+});
+
+describe("slash-state dual loader", () => {
+  it("shares activated slash state between the bundled-entry loader path and native ESM imports", () => {
+    const resolveFromBundledLoader = loadBundledEntryExportSync<
+      (token: string) => {
+        kind: "none" | "single" | "ambiguous";
+        accountIds?: string[];
+        source?: "token" | "command";
+      }
+    >(new URL("../../index.ts", import.meta.url).href, {
+      specifier: "./src/mattermost/slash-shared-state.js",
+      exportName: "resolveSlashHandlerForToken",
+    });
+
+    activateSlashCommands({
+      account: createResolvedMattermostAccount("default"),
+      commandTokens: ["valid-token"],
+      registeredCommands: [createRegisteredCommand()],
+      api: slashApi,
+    });
+
+    expect(resolveFromBundledLoader("valid-token")).toMatchObject({
+      kind: "single",
+      source: "token",
+      accountIds: ["default"],
+    });
+  });
+});

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -10,7 +10,6 @@
  * overwrite each other's tokens, registered commands, or handlers.
  */
 
-import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ResolvedMattermostAccount } from "./accounts.js";
 import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import {

--- a/extensions/mattermost/src/mattermost/slash-state.ts
+++ b/extensions/mattermost/src/mattermost/slash-state.ts
@@ -11,141 +11,29 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { Readable } from "node:stream";
-import type { MattermostConfig } from "../types.js";
 import type { ResolvedMattermostAccount } from "./accounts.js";
-import {
-  isRequestBodyLimitError,
-  readRequestBodyWithLimit,
-  type OpenClawPluginApi,
-} from "./runtime-api.js";
-import {
-  normalizeSlashCommandTrigger,
-  parseSlashCommandPayload,
-  resolveSlashCommandConfig,
-  type MattermostRegisteredCommand,
-} from "./slash-commands.js";
+import type { MattermostRegisteredCommand } from "./slash-commands.js";
 import {
   clearMattermostSlashCommandValidationCacheForAccount,
   createSlashCommandHttpHandler,
 } from "./slash-http.js";
+import {
+  getSlashCommandAccountStates,
+  getSlashCommandState,
+  resolveSlashHandlerForCommand,
+  resolveSlashHandlerForToken,
+  type SlashCommandAccountState,
+} from "./slash-shared-state.js";
 
-const MULTI_ACCOUNT_BODY_MAX_BYTES = 64 * 1024;
-const MULTI_ACCOUNT_BODY_TIMEOUT_MS = 5_000;
-type SlashHandlerMatchSource = "token" | "command";
-type SlashHandlerMatch =
-  | { kind: "none" }
-  | {
-      kind: "single";
-      source: SlashHandlerMatchSource;
-      handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
-      accountIds: string[];
-    }
-  | {
-      kind: "ambiguous";
-      source: SlashHandlerMatchSource;
-      accountIds: string[];
-    };
-
-// ─── Per-account state ───────────────────────────────────────────────────────
-
-type SlashCommandAccountState = {
-  /** Tokens from registered/current commands, used for fast-path routing. */
-  commandTokens: Set<string>;
-  /** Registered command IDs for cleanup on shutdown. */
-  registeredCommands: MattermostRegisteredCommand[];
-  /** Current HTTP handler for this account. */
-  handler: ((req: IncomingMessage, res: ServerResponse) => Promise<void>) | null;
-  /** The account that activated slash commands. */
-  account: ResolvedMattermostAccount;
-  /** Map from trigger to original command name (for skill commands that start with oc_). */
-  triggerMap: Map<string, string>;
-};
+export {
+  getSlashCommandState,
+  resolveSlashHandlerForCommand,
+  resolveSlashHandlerForToken,
+  type SlashCommandAccountState,
+} from "./slash-shared-state.js";
 
 /** Map from accountId → per-account slash command state. */
-const accountStates = new Map<string, SlashCommandAccountState>();
-
-export function resolveSlashHandlerForToken(token: string): SlashHandlerMatch {
-  const matches: Array<{
-    accountId: string;
-    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
-  }> = [];
-
-  for (const [accountId, state] of accountStates) {
-    if (state.commandTokens.has(token) && state.handler) {
-      matches.push({ accountId, handler: state.handler });
-    }
-  }
-
-  if (matches.length === 0) {
-    return { kind: "none" };
-  }
-  if (matches.length === 1) {
-    return {
-      kind: "single",
-      source: "token",
-      handler: matches[0].handler,
-      accountIds: [matches[0].accountId],
-    };
-  }
-
-  return {
-    kind: "ambiguous",
-    source: "token",
-    accountIds: matches.map((entry) => entry.accountId),
-  };
-}
-
-export function resolveSlashHandlerForCommand(params: {
-  teamId: string;
-  command: string;
-}): SlashHandlerMatch {
-  const trigger = normalizeSlashCommandTrigger(params.command);
-  if (!trigger) {
-    return { kind: "none" };
-  }
-
-  const matches: Array<{
-    accountId: string;
-    handler: (req: IncomingMessage, res: ServerResponse) => Promise<void>;
-  }> = [];
-
-  for (const [accountId, state] of accountStates) {
-    if (
-      state.handler &&
-      state.registeredCommands.some(
-        (cmd) => cmd.teamId === params.teamId && cmd.trigger === trigger,
-      )
-    ) {
-      matches.push({ accountId, handler: state.handler });
-    }
-  }
-
-  if (matches.length === 0) {
-    return { kind: "none" };
-  }
-  if (matches.length === 1) {
-    return {
-      kind: "single",
-      source: "command",
-      handler: matches[0].handler,
-      accountIds: [matches[0].accountId],
-    };
-  }
-
-  return {
-    kind: "ambiguous",
-    source: "command",
-    accountIds: matches.map((entry) => entry.accountId),
-  };
-}
-
-/**
- * Get the slash command state for a specific account, or null if not activated.
- */
-export function getSlashCommandState(accountId: string): SlashCommandAccountState | null {
-  return accountStates.get(accountId) ?? null;
-}
+const accountStates = getSlashCommandAccountStates();
 
 /**
  * Activate slash commands for a specific account.
@@ -211,192 +99,5 @@ export function deactivateSlashCommands(accountId?: string) {
       clearMattermostSlashCommandValidationCacheForAccount(stateAccountId);
     }
     accountStates.clear();
-  }
-}
-
-/**
- * Register the HTTP route for slash command callbacks.
- * Called during plugin registration.
- *
- * The single HTTP route dispatches to the correct per-account handler by
- * matching the inbound token against each account's known tokens, falling back
- * to registered team/trigger ownership so upstream validation can accept a
- * rotated Mattermost token.
- */
-export function registerSlashCommandRoute(api: OpenClawPluginApi) {
-  const mmConfig = api.config.channels?.mattermost as MattermostConfig | undefined;
-
-  // Collect callback paths from both top-level and per-account config.
-  // Command registration uses account.config.commands, so the HTTP route
-  // registration must include any account-specific callbackPath overrides.
-  // Also extract the pathname from an explicit callbackUrl when it differs
-  // from callbackPath, so that Mattermost callbacks hit a registered route.
-  const callbackPaths = new Set<string>();
-
-  const addCallbackPaths = (
-    raw: Partial<import("./slash-commands.js").MattermostSlashCommandConfig> | undefined,
-  ) => {
-    const resolved = resolveSlashCommandConfig(raw);
-    callbackPaths.add(resolved.callbackPath);
-    if (resolved.callbackUrl) {
-      try {
-        const urlPath = new URL(resolved.callbackUrl).pathname;
-        if (urlPath && urlPath !== resolved.callbackPath) {
-          callbackPaths.add(urlPath);
-        }
-      } catch {
-        // Invalid URL — ignore, will be caught during registration
-      }
-    }
-  };
-
-  const commandsRaw = mmConfig?.commands as
-    | Partial<import("./slash-commands.js").MattermostSlashCommandConfig>
-    | undefined;
-  addCallbackPaths(commandsRaw);
-
-  const accountsRaw = mmConfig?.accounts ?? {};
-  for (const accountId of Object.keys(accountsRaw)) {
-    const accountCommandsRaw = accountsRaw[accountId]?.commands;
-    addCallbackPaths(accountCommandsRaw);
-  }
-
-  const routeHandler = async (req: IncomingMessage, res: ServerResponse) => {
-    if (accountStates.size === 0) {
-      res.statusCode = 503;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(
-        JSON.stringify({
-          response_type: "ephemeral",
-          text: "Slash commands are not yet initialized. Please try again in a moment.",
-        }),
-      );
-      return;
-    }
-
-    // We need to peek at the body to route to the right account handler. Each
-    // account handler still performs upstream token validation before running a
-    // command.
-
-    // If there's only one active account (common case), route directly.
-    if (accountStates.size === 1) {
-      const [, state] = [...accountStates.entries()][0];
-      if (!state.handler) {
-        res.statusCode = 503;
-        res.setHeader("Content-Type", "application/json; charset=utf-8");
-        res.end(
-          JSON.stringify({
-            response_type: "ephemeral",
-            text: "Slash commands are not yet initialized. Please try again in a moment.",
-          }),
-        );
-        return;
-      }
-      await state.handler(req, res);
-      return;
-    }
-
-    // Multi-account: buffer the body, find the matching account by token or
-    // registered team/trigger, then replay the request to the correct handler.
-    // Use the bounded helper so a slow/never-finishing client cannot tie up the
-    // routing handler indefinitely (Slowloris).
-    let bodyStr: string;
-    try {
-      bodyStr = await readRequestBodyWithLimit(req, {
-        maxBytes: MULTI_ACCOUNT_BODY_MAX_BYTES,
-        timeoutMs: MULTI_ACCOUNT_BODY_TIMEOUT_MS,
-      });
-    } catch (error) {
-      if (isRequestBodyLimitError(error, "REQUEST_BODY_TIMEOUT")) {
-        res.statusCode = 408;
-        res.end("Request body timeout");
-        return;
-      }
-      res.statusCode = 413;
-      res.end("Payload Too Large");
-      return;
-    }
-
-    // Parse the token for the fast path; if it misses, parse the full slash
-    // payload so rotated tokens can still route by registered team/trigger.
-    let token: string | null = null;
-    const ct = req.headers["content-type"] ?? "";
-    try {
-      if (ct.includes("application/json")) {
-        token = (JSON.parse(bodyStr) as { token?: string }).token ?? null;
-      } else {
-        token = new URLSearchParams(bodyStr).get("token");
-      }
-    } catch {
-      // parse failed — will be caught by handler
-    }
-
-    let match: SlashHandlerMatch = token ? resolveSlashHandlerForToken(token) : { kind: "none" };
-    if (match.kind === "none") {
-      const payload = parseSlashCommandPayload(bodyStr, ct);
-      if (payload) {
-        match = resolveSlashHandlerForCommand({
-          teamId: payload.team_id,
-          command: payload.command,
-        });
-      }
-    }
-
-    if (match.kind === "none") {
-      // No matching account — reject
-      res.statusCode = 401;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(
-        JSON.stringify({
-          response_type: "ephemeral",
-          text: "Unauthorized: invalid command token.",
-        }),
-      );
-      return;
-    }
-
-    if (match.kind === "ambiguous") {
-      api.logger.warn?.(
-        `mattermost: slash callback matched multiple accounts via ${match.source} (${match.accountIds.join(", ")})`,
-      );
-      const conflictText =
-        match.source === "token"
-          ? "Conflict: command token is not unique across accounts."
-          : "Conflict: slash command is not unique across accounts.";
-      res.statusCode = 409;
-      res.setHeader("Content-Type", "application/json; charset=utf-8");
-      res.end(
-        JSON.stringify({
-          response_type: "ephemeral",
-          text: conflictText,
-        }),
-      );
-      return;
-    }
-
-    const matchedHandler = match.handler;
-
-    // Replay: create a synthetic readable that re-emits the buffered body
-    const syntheticReq = new Readable({
-      read() {
-        this.push(Buffer.from(bodyStr, "utf8"));
-        this.push(null);
-      },
-    }) as IncomingMessage;
-
-    // Copy necessary IncomingMessage properties
-    syntheticReq.method = req.method;
-    syntheticReq.url = req.url;
-    syntheticReq.headers = req.headers;
-
-    await matchedHandler(syntheticReq, res);
-  };
-
-  for (const callbackPath of callbackPaths) {
-    api.registerHttpRoute({
-      path: callbackPath,
-      auth: "plugin",
-      handler: routeHandler,
-    });
   }
 }


### PR DESCRIPTION
## Summary

- **Problem**: Mattermost slash commands (`/oc_model`, `/oc_status`, `/oc_help`, …) always return `503 Service Unavailable` with `{"response_type":"ephemeral","text":"Slash commands are not yet initialized. Please try again in a moment."}`, even after the log confirms `mattermost: slash commands activated for account default (8 commands)`.
- **Why it matters**: On macOS/Linux installs, every \`/oc_*\` slash command in Mattermost is broken, with no path to recovery short of patching the installed npm package. Slack, Discord, etc. are unaffected.
- **What changed**: `extensions/mattermost/index.ts` now imports `registerSlashCommandRoute` statically from `./slash-route-api.js` instead of resolving it through the sync jiti loader `loadBundledEntryExportSync`. That makes the plugin-registration path and the monitor path share a single ESM instance of `slash-state.ts`, so the HTTP route closure and `activateSlashCommands` see the same `accountStates` map.
- **What did NOT change (scope boundary)**: No changes to `slash-state.ts`, `monitor-slash.ts`, `monitor.ts`, the HTTP handler, slash command registration flow, or any other extension. Just the single import in `extensions/mattermost/index.ts`. Slack's `extensions/slack/index.ts` has a similar-looking dual-path import, but its route handler does not close over module state (the handler uses `await import("./handler.runtime.js")` inside), so Slack is not affected by the same bug and is explicitly out of scope here.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

`extensions/mattermost/index.ts::registerFull` used `loadBundledEntryExportSync(import.meta.url, { specifier: "./slash-route-api.js", exportName: "registerSlashCommandRoute" })` to load the route registrar. On macOS/Linux that helper resolves through **jiti** (see `src/plugin-sdk/channel-entry-contract.ts`: `nodeRequire` is only tried inside the Win32 branch, everywhere else falls through to `getJiti(modulePath)(modulePath)`).

`slash-route-api.ts` re-exports `registerSlashCommandRoute` from `./src/mattermost/slash-state.js`. Loading it via jiti causes jiti to re-evaluate `slash-state.ts` inside its own module registry, producing a second live instance of the module. Meanwhile `src/mattermost/monitor-slash.ts` and `src/mattermost/monitor.ts` (and therefore the channel runtime loaded via `await import("./channel.runtime-*.js")`) import `./slash-state.js` through native ESM, giving them instance A.

The result: two separate `accountStates` maps.

- `activateSlashCommands` / `deactivateSlashCommands` mutate the **ESM** copy → the log line "slash commands activated for account default (N commands)" fires on the ESM instance.
- `registerSlashCommandRoute`'s `routeHandler` closure closes over the **jiti** copy's `accountStates` → `accountStates.size` stays `0` for the lifetime of the process → every callback returns `503 "Slash commands are not yet initialized. Please try again in a moment."`.

This matches the guidance in `src/plugin-sdk/CLAUDE.md`:

> Do not mix static and dynamic imports for the same runtime surface when shaping SDK seams.

The fix is the straightforward application of that rule: `index.ts` should import `./slash-route-api.js` statically so `slash-state.ts` loads through native ESM exactly once, shared with the monitor / channel-runtime path.

### Missing detection / guardrail

There is a good unit test for the token-routing logic in `extensions/mattermost/src/mattermost/slash-state.test.ts`, but it only exercises one import of `slash-state`, so it cannot detect the dual-instance bug. I am happy to add a regression test that specifically simulates loading `slash-route-api.js` through jiti alongside the native ESM import and asserts that activation flows through to the route handler — happy to do it in this PR if maintainers prefer. I did not include it in the initial patch because simulating the jiti boundary in Vitest is a bit more involved than the fix itself, and I wanted the minimal-risk diff to land first.

### Contributing context

The same `loadBundledEntryExportSync` pattern is used in `extensions/feishu/index.ts`, `extensions/nostr/index.ts`, `extensions/qqbot/index.ts`, `extensions/slack/index.ts`, `extensions/zalouser/index.ts`. Slack is safe because its handler does `await import("./handler.runtime.js")` inside the request closure instead of closing over module state. I did not audit the others in depth; if similar closures-over-module-state exist there, they would have the same failure mode and warrant a follow-up. Flagging for visibility, not proposing to change them in this PR.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Seam / integration test
- **Target test or file**: `extensions/mattermost/src/mattermost/slash-state.dual-load.test.ts` (new) — would load `slash-route-api.ts` through a jiti instance and `slash-state.ts` through native ESM in the same test, activate commands on the ESM side, then drive an HTTP request against the jiti-registered route and assert that it does **not** return 503.
- **Scenario to lock in**: "route handler registered via `loadBundledEntryExportSync` observes activations performed via the monitor's static import of `slash-state.js`."
- **Why this is the smallest reliable guardrail**: The bug is entirely a module-identity bug; pure-unit tests that import `slash-state.ts` once do not reproduce it. A boundary test that crosses the same jiti / ESM seam is the minimum.
- **Existing test that already covers this**: None — `slash-state.test.ts` is single-import only.
- **If no new test is added, why not**: I did not want to block the fix on writing the jiti-boundary harness; happy to add it as a follow-up or in this PR if a reviewer prefers.

## User-visible / Behavior Changes

- Mattermost `/oc_status`, `/oc_model`, `/oc_models`, `/oc_new`, `/oc_help`, `/oc_think`, `/oc_reasoning`, `/oc_verbose` (and any user-defined slash commands registered through the same path) start working again instead of responding `503 Service Unavailable / "Slash commands are not yet initialized."`.
- No config changes. No new permissions. The HTTP route path, callback URL behavior, 401/409/413 responses, and multi-account dispatch logic are all unchanged.

## Diagram

```text
Before (broken):

  registerFull(api)
    └─ loadBundledEntryExportSync(...) ──(jiti)──► slash-state.ts   (instance B)
                                                     └─ accountStates_B  ◄── routeHandler closure
                                                                                 (size always 0 → 503)

  channel.runtime.ts ──(native ESM import)──► slash-state.ts   (instance A)
                                                 └─ accountStates_A  ◄── activateSlashCommands writes here


After (fixed):

  registerFull(api)
    └─ import { registerSlashCommandRoute } from "./slash-route-api.js"
                                    │
                                    ▼
                              slash-state.ts   (single ESM instance)
                                    └─ accountStates  ◄── routeHandler AND activateSlashCommands
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — slash-command dispatch semantics, token validation, and multi-account routing are unchanged. The fix only restores the previously-intended flow.
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.3.x (Darwin 25.3.0, arm64)
- Runtime/container: Node 22.22.0, openclaw installed via `npm i -g openclaw@2026.4.15`, gateway started as the launchd `ai.openclaw.gateway` LaunchAgent.
- Integration/channel: Mattermost 11.5.1 (team edition) behind Caddy, multiple `channels.mattermost.accounts.*` entries (default / forge / kline / probe / quill / scout) but only the `default` account has team-admin permission to register commands, so `accountStates.size === 1` — the most common production shape.

### Steps

1. Gateway boots; logs show:
   ```
   [plugins] mattermost: registered slash command callback at /api/channels/mattermost/command
   [mattermost] slash commands activated for account default (8 commands)
   [mattermost] slash commands registered (8 commands across 1 teams, callback=http://<lan>:18789/api/channels/mattermost/command)
   ```
2. Trigger `/oc_model` from the Mattermost UI. Server also reproducible via:
   ```
   curl -sS -o /dev/null -w "HTTP %{http_code}\n" -X POST \
     http://127.0.0.1:18789/api/channels/mattermost/command \
     -d 'token=<real-token>&command=/oc_model'
   ```

### Expected

- For a single-account setup, the `size === 1` branch should dispatch straight to `state.handler`, which validates the token internally and returns the normal slash-command response (200 with the ephemeral reply, or a 401 only for a genuinely wrong token).

### Actual (before the fix)

- `HTTP 503` with body `{"response_type":"ephemeral","text":"Slash commands are not yet initialized. Please try again in a moment."}`, even though the activation log fired seconds earlier. The Mattermost UI surfaces this as `触发器 "oc_model" 返回了响应状态 503 Service Unavailable.` / "Trigger \"oc_model\" returned response status 503 Service Unavailable."

## Evidence

Failing-before / passing-after against a locally patched installed dist (equivalent rewrite of this TS change onto the bundled output, `/opt/homebrew/lib/node_modules/openclaw/dist/extensions/mattermost/index.js`):

Before (immediately after `launchctl kickstart -k gui/$UID/ai.openclaw.gateway`, well past activation):

```
$ curl -sS -o /dev/null -w "HTTP %{http_code}\n" -X POST \
    http://127.0.0.1:18789/api/channels/mattermost/command \
    -d 'token=foo&command=/oc_model'
HTTP 503
$ curl -sS -X POST http://127.0.0.1:18789/api/channels/mattermost/command \
    -d 'token=foo&command=/oc_model'
{"response_type":"ephemeral","text":"Slash commands are not yet initialized. Please try again in a moment."}
```

After applying the equivalent patch and restarting the gateway:

```
$ curl -sS -o /dev/null -w "HTTP %{http_code}\n" -X POST \
    http://127.0.0.1:18789/api/channels/mattermost/command \
    -d 'token=foo&command=/oc_model'
HTTP 400
$ curl -sS -X POST http://127.0.0.1:18789/api/channels/mattermost/command \
    -d 'token=foo&command=/oc_model'
{"response_type":"ephemeral","text":"Invalid slash command payload."}
$ curl -sS -o /dev/null -w "HTTP %{http_code}\n" -X POST \
    http://127.0.0.1:18789/api/channels/mattermost/command \
    --data-urlencode 'token=not-a-real-token' \
    --data-urlencode 'command=/oc_model' \
    --data-urlencode 'team_id=498ogwtouigf8xfbuks451e8aa' \
    --data-urlencode 'channel_id=c' --data-urlencode 'user_id=u' \
    --data-urlencode 'user_name=n' --data-urlencode 'text=' \
    --data-urlencode 'trigger_id=t'
HTTP 401
```

Interpretation: the `503 "not yet initialized"` path is now unreachable — incoming requests flow into the real handler, which correctly rejects malformed payloads (400) and bad tokens (401). A real Mattermost-signed request with the registered token returns the normal slash-command response.

Relevant gateway log lines from the fixed run (unchanged shape, included for completeness):

```
[plugins] mattermost: registered slash command callback at /api/channels/mattermost/command
[mattermost] [default] starting channel
[mattermost] connected as @nova
[mattermost] command /oc_model already registered (id=fffuot5kpjgafkmx7rc5fk9xjc)
[mattermost] slash commands activated for account default (8 commands)
[mattermost] slash commands registered (8 commands across 1 teams, callback=http://<lan>:18789/api/channels/mattermost/command)
```

## Human Verification

- **Verified scenarios**:
  - Single-account (`accountStates.size === 1`) dispatch path, which was the production failure.
  - End-to-end via the running `ai.openclaw.gateway` LaunchAgent and real Mattermost (`/oc_model` from the Mattermost UI).
  - 400 / 401 paths reached correctly with synthetic curl payloads.
- **Edge cases checked**:
  - Restart via `launchctl kickstart -k` between before/after so the Node process and jiti registry are both replaced.
  - Confirmed that the fix does not regress the registered-HTTP-route path set for known `callbackPath` / `callbackUrl` overrides (route registration log is unchanged).
- **What I did NOT verify**:
  - Multi-account (`accountStates.size > 1`) token-routing path — code path is untouched, but I did not have a second team-admin account to activate commands on. The unit tests in `slash-state.test.ts` cover that branch.
  - `pnpm check` / `pnpm build` / `pnpm test` — I did not run these locally before opening the PR (this is my first contribution to the repo and I wanted to avoid a large-deps install cycle before you tell me which gates you want covered). Please run CI; happy to iterate on any failures or add the jiti-boundary regression test if that is what you would like to see.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- **Risk**: `slash-route-api.ts` and transitively `./src/mattermost/slash-state.ts` now load eagerly as part of the plugin entry, instead of only when `registerFull` fires through jiti. `slash-state.ts` is a small module (≈300 LOC, top-level state is just one `Map`), but this does add it to the mattermost plugin's cold-start import cost.
  - **Mitigation**: the module has no expensive side effects at import time (just a `new Map()` and function definitions), matches how `monitor.ts` already imports it on the hot monitor path, and aligns with the SDK guidance that says the eager/light contract belongs next to the plugin entry and only the heavy runtime should live behind a lazy `*.runtime.ts` boundary. I am happy to instead introduce a dedicated `slash-route.runtime.ts` and keep `registerSlashCommandRoute` lazy-but-single-instance if maintainers prefer that shape.
- **Risk**: Other bundled channels use the same `loadBundledEntryExportSync` pattern and may have similar dual-instance bugs depending on whether their route registrars close over module state.
  - **Mitigation**: Out of scope for this PR — Slack is demonstrably fine. Happy to open a follow-up audit if useful.