### PR TITLE
fix(lobster): surface workflow path errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/Lobster: surface missing bare or path-like workflow file errors while preserving inline pipelines that pass `.json`, `.yaml`, `.yml`, or `.lobster` arguments. Fixes #68101. (#68106) Thanks @vvitovec, @nnish16, @1aifanatic, and @kirkluokun.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -173,6 +173,33 @@ describe("createEmbeddedLobsterRunner", () => {
     }
   });
 
+  it("surfaces missing relative workflow file errors instead of falling back to pipeline parsing", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
+
+    try {
+      const runtime = {
+        runToolRequest: vi.fn(),
+        resumeToolRequest: vi.fn(),
+      };
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+
+      await expect(
+        runner.run({
+          action: "run",
+          pipeline: "lobster/missing-workflow.lobster",
+          cwd: tempDir,
+          timeoutMs: 2000,
+          maxStdoutBytes: 4096,
+        }),
+      ).rejects.toThrow(/ENOENT|no such file/i);
+      expect(runtime.runToolRequest).not.toHaveBeenCalled();
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("throws when the embedded runtime returns an error envelope", async () => {
     const runtime = {
       runToolRequest: vi.fn().mockResolvedValue({

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -143,6 +143,49 @@ describe("createEmbeddedLobsterRunner", () => {
     }
   });
 
+  it("detects existing workflow file paths that contain spaces", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
+    const workflowDir = path.join(tempDir, "My Workflows");
+    const workflowPath = path.join(workflowDir, "daily workflow.lobster");
+    await fs.mkdir(workflowDir, { recursive: true });
+    await fs.writeFile(workflowPath, "steps: []\n", "utf8");
+
+    try {
+      const runtime = {
+        runToolRequest: vi.fn().mockResolvedValue({
+          ok: true,
+          protocolVersion: 1,
+          status: "ok",
+          output: [],
+          requiresApproval: null,
+        }),
+        resumeToolRequest: vi.fn(),
+      };
+      const runner = createEmbeddedLobsterRunner({
+        loadRuntime: vi.fn().mockResolvedValue(runtime),
+      });
+
+      await runner.run({
+        action: "run",
+        pipeline: "My Workflows/daily workflow.lobster",
+        cwd: tempDir,
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      });
+
+      expect(runtime.runToolRequest).toHaveBeenCalledWith({
+        filePath: workflowPath,
+        args: undefined,
+        ctx: expect.objectContaining({
+          cwd: tempDir,
+          mode: "tool",
+        }),
+      });
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns a parse error when workflow args are invalid JSON", async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lobster-runner-"));
     const workflowPath = path.join(tempDir, "workflow.lobster");

--- a/extensions/lobster/src/lobster-runner.test.ts
+++ b/extensions/lobster/src/lobster-runner.test.ts
@@ -185,18 +185,65 @@ describe("createEmbeddedLobsterRunner", () => {
         loadRuntime: vi.fn().mockResolvedValue(runtime),
       });
 
-      await expect(
-        runner.run({
-          action: "run",
-          pipeline: "lobster/missing-workflow.lobster",
-          cwd: tempDir,
-          timeoutMs: 2000,
-          maxStdoutBytes: 4096,
-        }),
-      ).rejects.toThrow(/ENOENT|no such file/i);
+      for (const pipeline of ["missing-workflow.lobster", "lobster/missing-workflow.lobster"]) {
+        await expect(
+          runner.run({
+            action: "run",
+            pipeline,
+            cwd: tempDir,
+            timeoutMs: 2000,
+            maxStdoutBytes: 4096,
+          }),
+        ).rejects.toThrow(/ENOENT|no such file/i);
+      }
       expect(runtime.runToolRequest).not.toHaveBeenCalled();
     } finally {
       await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps inline pipelines with workflow-like arguments on the pipeline path", async () => {
+    const runtime = {
+      runToolRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        status: "ok",
+        output: [],
+        requiresApproval: null,
+      }),
+      resumeToolRequest: vi.fn(),
+    };
+    const runner = createEmbeddedLobsterRunner({
+      loadRuntime: vi.fn().mockResolvedValue(runtime),
+    });
+    const pipelines = [
+      "exec --json=true cat fixture.json",
+      "exec --json=true cat fixture.yaml",
+      "exec --json=true cat fixture.yml",
+      "exec --json=true cat fixture.lobster",
+      "exec --json=true cat fixture.json | jq .",
+    ];
+
+    for (const pipeline of pipelines) {
+      await runner.run({
+        action: "run",
+        pipeline,
+        cwd: process.cwd(),
+        timeoutMs: 2000,
+        maxStdoutBytes: 4096,
+      });
+    }
+
+    expect(runtime.runToolRequest).toHaveBeenCalledTimes(pipelines.length);
+    for (const pipeline of pipelines) {
+      expect(runtime.runToolRequest).toHaveBeenCalledWith({
+        pipeline,
+        ctx: expect.objectContaining({
+          cwd: process.cwd(),
+          mode: "tool",
+          signal: expect.any(AbortSignal),
+        }),
+      });
     }
   });
 

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -235,16 +235,17 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
   return resolved;
 }
 
+function looksLikeWorkflowFileCandidate(candidate: string) {
+  const ext = path.extname(candidate).toLowerCase();
+  return [".lobster", ".yaml", ".yml", ".json"].includes(ext);
+}
+
 async function detectWorkflowFile(candidate: string, cwd: string) {
   const trimmed = candidate.trim();
-  if (!trimmed || trimmed.includes("|")) {
+  if (!trimmed || trimmed.includes("|") || !looksLikeWorkflowFileCandidate(trimmed)) {
     return null;
   }
-  try {
-    return await resolveWorkflowFile(trimmed, cwd);
-  } catch {
-    return null;
-  }
+  return await resolveWorkflowFile(trimmed, cwd);
 }
 
 function parseWorkflowArgs(argsJson: string) {

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -236,6 +236,9 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
 }
 
 function looksLikeWorkflowFileCandidate(candidate: string) {
+  if (/\s/.test(candidate)) {
+    return false;
+  }
   const ext = path.extname(candidate).toLowerCase();
   return [".lobster", ".yaml", ".yml", ".json"].includes(ext);
 }

--- a/extensions/lobster/src/lobster-runner.ts
+++ b/extensions/lobster/src/lobster-runner.ts
@@ -236,9 +236,6 @@ async function resolveWorkflowFile(candidate: string, cwd: string) {
 }
 
 function looksLikeWorkflowFileCandidate(candidate: string) {
-  if (/\s/.test(candidate)) {
-    return false;
-  }
   const ext = path.extname(candidate).toLowerCase();
   return [".lobster", ".yaml", ".yml", ".json"].includes(ext);
 }
@@ -247,6 +244,16 @@ async function detectWorkflowFile(candidate: string, cwd: string) {
   const trimmed = candidate.trim();
   if (!trimmed || trimmed.includes("|") || !looksLikeWorkflowFileCandidate(trimmed)) {
     return null;
+  }
+  if (/\s/.test(trimmed)) {
+    try {
+      return await resolveWorkflowFile(trimmed, cwd);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+      return null;
+    }
   }
   return await resolveWorkflowFile(trimmed, cwd);
 }


### PR DESCRIPTION
## Summary
- stop treating workflow-looking filenames as inline pipelines when resolution fails
- surface the original workflow path error for `.lobster`, `.yaml`, `.yml`, and `.json` inputs
- add a regression test for missing relative workflow files

## Why this matters
Fixes #68101.

Today a missing relative workflow path like `lobster/missing-workflow.lobster` gets reinterpreted as a pipeline command and fails with a misleading `Unknown command` message. This keeps the existing inline pipeline path untouched, but fails closed for inputs that already look like workflow files so users get a real path/file error instead.

## Validation
- `corepack pnpm install --filter @openclaw/lobster... --ignore-scripts --frozen-lockfile`
- `corepack pnpm exec vitest run --project extensions extensions/lobster/src/lobster-runner.test.ts`
