### PR TITLE
fix: prevent toLowerCase error when model.id or model.name is undefined

### DIFF
--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -102,6 +102,7 @@ function canonicalizeLegacyResolvedModel(params: {
 }): Model<Api> {
   if (
     normalizeProviderId(params.provider) !== "openai-codex" ||
+    typeof params.model.id !== "string" ||
     params.model.id.trim().toLowerCase() !== "gpt-5.4-codex"
   ) {
     return params.model;
@@ -110,7 +111,10 @@ function canonicalizeLegacyResolvedModel(params: {
     ...params.model,
     id: "gpt-5.4",
     name:
-      params.model.name.trim().toLowerCase() === "gpt-5.4-codex" ? "gpt-5.4" : params.model.name,
+      typeof params.model.name === "string" &&
+      params.model.name.trim().toLowerCase() === "gpt-5.4-codex"
+        ? "gpt-5.4"
+        : params.model.name,
   };
 }
 


### PR DESCRIPTION
## Summary
Fixes the "f.toLowerCase is not a function" error that occurs in the agent:bootstrap hook when model.id or model.name is undefined.

## Root Cause
In `canonicalizeLegacyResolvedModel()` (src/agents/pi-embedded-runner/model.ts), the code called `.trim().toLowerCase()` on `params.model.id` and `params.model.name` without first checking if they are strings. When these properties are undefined (which can happen with certain model configurations), it causes a TypeError.

## Fix
Added `typeof` checks before calling string methods:
- Check `typeof params.model.id === "string"` before calling trim/toLowerCase
- Check `typeof params.model.name === "string"` before calling trim/toLowerCase

## Test Plan
- [x] Existing unit tests pass (src/agents/pi-embedded-runner/model.inline-provider.test.ts)
- [x] Lint checks pass

Closes openclaw#68124