### PR TITLE
fix(ui): use i18n t() for Node option in exec approvals target select

### DIFF
--- a/ui/src/ui/views/nodes-exec-approvals.ts
+++ b/ui/src/ui/views/nodes-exec-approvals.ts
@@ -256,7 +256,7 @@ function renderExecApprovalsTarget(state: ExecApprovalsState) {
               }}
             >
               <option value="gateway" ?selected=${state.target === "gateway"}>Gateway</option>
-              <option value="node" ?selected=${state.target === "node"}>Node</option>
+              <option value="node" ?selected=${state.target === "node"}>${t("nodes.binding.node")}</option>
             </select>
           </label>
           ${state.target === "node"


### PR DESCRIPTION
## What

Fix hardcoded `Node` string in `ui/src/ui/views/nodes-exec-approvals.ts` that bypasses the i18n system.

The translation key `nodes.binding.node` already exists in all locale files with proper translations (e.g. `节点` for zh-CN, `節點` for zh-TW).

## How

Replace the hardcoded string in the exec approvals target `<select>` with `t("nodes.binding.node")`.

## Testing

1. Open Control UI with zh-CN locale
2. Navigate to Nodes → Exec Approvals
3. Confirm the "Node" Host option is no longer hardcoded English

## Related

Fixes #24803