### PR TITLE
CLI: bake git commit at build time so --version reports built commit not live HEAD [AI-assisted]

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -383,4 +383,70 @@ describe("git commit resolution", () => {
 
     expect(resolveCommitHash({ cwd: repoRoot, env: {} })).toBe("ccccccc");
   });
+
+  it("prefers injected build-time commit over live git and build-info", async () => {
+    const temp = await makeTempDir("git-commit-injected-priority");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "0123456789abcdef0123456789abcdef01234567\n",
+    });
+
+    expect(
+      resolveCommitHash({
+        cwd: repoRoot,
+        env: {},
+        readers: {
+          readInjectedCommit: () => "abc1234",
+          readBuildInfoCommit: () => "deadbee",
+        },
+      }),
+    ).toBe("abc1234");
+  });
+
+  it("env GIT_COMMIT still overrides an injected build-time commit", async () => {
+    const temp = await makeTempDir("git-commit-injected-env-override");
+    expect(
+      resolveCommitHash({
+        cwd: temp,
+        env: { GIT_COMMIT: "feedfac" },
+        readers: {
+          readInjectedCommit: () => "abc1234",
+        },
+      }),
+    ).toBe("feedfac");
+  });
+
+  it("falls through to live git when no build-time commit was injected", async () => {
+    const temp = await makeTempDir("git-commit-injected-absent");
+    const repoRoot = path.join(temp, "repo");
+    await makeFakeGitRepo(repoRoot, {
+      head: "0123456789abcdef0123456789abcdef01234567\n",
+    });
+
+    expect(
+      resolveCommitHash({
+        cwd: repoRoot,
+        env: {},
+        readers: {
+          readInjectedCommit: () => null,
+          readBuildInfoCommit: () => "deadbee",
+        },
+      }),
+    ).toBe("0123456");
+  });
+
+  it("caches injected build-time commit results per resolved search directory", async () => {
+    const temp = await makeTempDir("git-commit-injected-cache");
+    const readInjectedCommit = vi.fn(() => "abc1234");
+
+    expect(resolveCommitHash({ cwd: temp, env: {}, readers: { readInjectedCommit } })).toBe(
+      "abc1234",
+    );
+    const firstCallReads = readInjectedCommit.mock.calls.length;
+    expect(firstCallReads).toBeGreaterThan(0);
+    expect(resolveCommitHash({ cwd: temp, env: {}, readers: { readInjectedCommit } })).toBe(
+      "abc1234",
+    );
+    expect(readInjectedCommit.mock.calls.length).toBe(firstCallReads);
+  });
 });

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -6,6 +6,8 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { resolveGitHeadPath } from "./git-root.js";
 import { resolveOpenClawPackageRootSync } from "./openclaw-root.js";
 
+declare const __OPENCLAW_GIT_COMMIT__: string | undefined;
+
 const formatCommit = (value?: string | null) => {
   if (!value) {
     return null;
@@ -27,6 +29,7 @@ export type CommitMetadataReaders = {
   readGitCommit?: (searchDir: string, packageRoot: string | null) => string | null | undefined;
   readBuildInfoCommit?: () => string | null;
   readPackageJsonCommit?: () => string | null;
+  readInjectedCommit?: () => string | null;
 };
 
 function isMissingPathError(error: unknown): boolean {
@@ -187,6 +190,12 @@ const readCommitFromPackageJson = () => {
   }
 };
 
+const readCommitFromInjectedDefine = (): string | null => {
+  // Replaced by tsdown at build time with a string literal. Dev runs from source
+  // leave it undefined; the `typeof` guard lets us fall through to live git.
+  return typeof __OPENCLAW_GIT_COMMIT__ === "string" ? formatCommit(__OPENCLAW_GIT_COMMIT__) : null;
+};
+
 const readCommitFromBuildInfo = () => {
   try {
     const require = createRequire(import.meta.url);
@@ -229,6 +238,11 @@ export const resolveCommitHash = (
   const searchDir = resolveCommitSearchDir(options);
   if (cachedGitCommitBySearchDir.has(searchDir)) {
     return cachedGitCommitBySearchDir.get(searchDir) ?? null;
+  }
+  // Baked-in commit is authoritative for built binaries — it cannot drift as HEAD moves.
+  const injectedCommit = readers.readInjectedCommit?.() ?? readCommitFromInjectedDefine();
+  if (injectedCommit) {
+    return cacheGitCommit(searchDir, injectedCommit);
   }
   const packageRoot = resolveOpenClawPackageRootSync({
     cwd: options.cwd,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { defineConfig, type UserConfig } from "tsdown";
@@ -27,6 +28,27 @@ type OnLogFunction = InputOptionsArg extends { onLog?: infer OnLog } ? NonNullab
 
 const env = {
   NODE_ENV: "production",
+};
+
+function resolveBuildTimeCommit(): string | undefined {
+  const envCommit = process.env.GIT_COMMIT?.trim() || process.env.GIT_SHA?.trim();
+  let raw = envCommit ?? "";
+  if (!raw) {
+    try {
+      raw = execSync("git rev-parse HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+        .toString()
+        .trim();
+    } catch {
+      raw = "";
+    }
+  }
+  const match = raw.match(/[0-9a-fA-F]{7,40}/);
+  return match ? match[0].slice(0, 7).toLowerCase() : undefined;
+}
+
+const BUILD_TIME_COMMIT = resolveBuildTimeCommit();
+const BUILD_TIME_DEFINES: Record<string, string> = {
+  __OPENCLAW_GIT_COMMIT__: BUILD_TIME_COMMIT ? JSON.stringify(BUILD_TIME_COMMIT) : "undefined",
 };
 
 const SUPPRESSED_EVAL_WARNING_PATHS = [
@@ -85,6 +107,7 @@ function nodeBuildConfig(config: UserConfig): UserConfig {
   return {
     ...config,
     env,
+    define: { ...BUILD_TIME_DEFINES, ...config.define },
     fixedExtension: false,
     platform: "node",
     inputOptions: buildInputOptions,


### PR DESCRIPTION
Fixes #68148.

## Summary

Before: `node dist/index.js --version` reports the current value of `.git/HEAD`, which can drift past the commit the binary was actually built from.

After: the short SHA is baked into `dist/` at build time as a tsdown compile-time define, so `--version` reports what's executing — even if HEAD moves after the build.

## Priority order

New: `GIT_COMMIT`/`GIT_SHA` env → **injected define** → live git → `build-info.json` → `package.json.gitHead`.

Env override still wins (CI use case). Live git becomes the **fallback for dev runs from source** (no define injected), which is where the existing `"prefers live git metadata over stale build info in a real checkout"` test case (unchanged, still passing) captures correct behavior.

## Changes

- `tsdown.config.ts`: resolve short SHA at bundle time (env `GIT_COMMIT`/`GIT_SHA` → `git rev-parse HEAD` → `undefined`), pass as `define.__OPENCLAW_GIT_COMMIT__` to every `nodeBuildConfig` output (covers both the unified core build and every `buildBundledPluginConfigs` entry).
- `src/infra/git-commit.ts`: add `declare const __OPENCLAW_GIT_COMMIT__`, a `readCommitFromInjectedDefine` helper, and a `readInjectedCommit` slot on `CommitMetadataReaders`. `resolveCommitHash` consults it after the env override and cache check, before live git.
- `src/infra/git-commit.test.ts`: 4 new cases covering injected-beats-live-git, env-still-overrides-injected, null-injected-falls-through, and cache-stability.

No change to `scripts/write-build-info.ts` — `dist/build-info.json` remains for external tooling.

## Repro (on `upstream/main` before the fix)

```bash
git worktree add -b repro /tmp/repro upstream/main
cd /tmp/repro
pnpm install --frozen-lockfile && pnpm build
git log -1 --format=%h                    # be7a415
node dist/index.js --version              # OpenClaw 2026.4.16 (be7a415)
git commit --allow-empty -m "shift HEAD"
node dist/index.js --version              # OpenClaw 2026.4.16 (d2d0ede)  ← lie
```

Same sequence after the fix: second `--version` still reports `be7a415`.

## Testing

- [x] `pnpm test src/infra/git-commit` (via `vitest.infra.config.ts`) — 18/18 pass (14 existing + 4 new)
- [x] `pnpm build` — green
- [x] `pnpm check` — green
- [x] `pnpm test` — one flaky 120s-timeout in `extensions/memory-core/src/memory/index.test.ts > "indexes multimodal image and audio files from extra paths with Gemini structured inputs"`; zero import-path coupling to this PR's changes; **passed cleanly on isolated re-run**. All other 60 shards green.
- [x] End-to-end: built binary + empty commit + HEAD shift → `--version` stays stable at the built commit; `env GIT_COMMIT=deadbee ... --version` correctly reports `deadbee` (override preserved).

## AI-assisted disclosure

- **Degree of testing**: fully tested — focused unit lane + full `pnpm build && pnpm check && pnpm test` + end-to-end HEAD-shift repro both before and after the fix.
- **Tool**: Claude Code (Opus 4.7). Sparkeros (PR author) reviewed and confirmed understanding of every change.
- **Prompt / session**: the session explored the issue collaboratively — identified root cause in `resolveCommitHash` priority order, confirmed no existing upstream PR addresses it (PR #56372 is cache-only), chose the bundler-define approach over alternatives (file-based marker, live-git-with-disclaimer), deliberately kept scope narrow by not also wiring the vestigial `__OPENCLAW_VERSION__` define.
- I understand what this code does and why each line is there.
