### PR TITLE
feat(line): add optional requireMentionForNonText group gate

### DIFF
--- a/extensions/line/src/bot-handlers.test.ts
+++ b/extensions/line/src/bot-handlers.test.ts
@@ -286,6 +286,7 @@ function createLineWebhookTestContext(params: {
   groupPolicy?: LineAccountConfig["groupPolicy"];
   dmPolicy?: LineAccountConfig["dmPolicy"];
   requireMention?: boolean;
+  requireMentionForNonText?: boolean;
   groupHistories?: Map<string, HistoryEntry[]>;
   replayCache?: ReturnType<typeof createLineWebhookReplayCache>;
 }): Parameters<typeof handleLineWebhookEvents>[1] {
@@ -293,6 +294,19 @@ function createLineWebhookTestContext(params: {
     ...(params.groupPolicy ? { groupPolicy: params.groupPolicy } : {}),
     ...(params.dmPolicy ? { dmPolicy: params.dmPolicy } : {}),
   };
+  const groupEntry =
+    params.requireMention === undefined && params.requireMentionForNonText === undefined
+      ? undefined
+      : {
+          "*": {
+            ...(params.requireMention === undefined
+              ? {}
+              : { requireMention: params.requireMention }),
+            ...(params.requireMentionForNonText === undefined
+              ? {}
+              : { requireMentionForNonText: params.requireMentionForNonText }),
+          },
+        };
   return {
     cfg: { channels: { line: lineConfig } },
     account: {
@@ -303,9 +317,7 @@ function createLineWebhookTestContext(params: {
       tokenSource: "config",
       config: {
         ...lineConfig,
-        ...(params.requireMention === undefined
-          ? {}
-          : { groups: { "*": { requireMention: params.requireMention } } }),
+        ...(groupEntry === undefined ? {} : { groups: groupEntry }),
       },
     },
     runtime: createRuntime(),
@@ -1012,6 +1024,68 @@ describe("handleLineWebhookEvents", () => {
     });
 
     await expectRequireMentionGroupMessageProcessed(event);
+  });
+
+  it("skips non-text group messages when requireMentionForNonText is set", async () => {
+    // LINE does not deliver mention metadata on non-text messages, so the
+    // bot can never be @-mentioned on an image in a group. Opting in to
+    // `requireMentionForNonText` causes those messages to be skipped under
+    // `requireMention`, matching how bots behave in other group chats.
+    const processMessage = vi.fn();
+    const event = createTestMessageEvent({
+      message: {
+        id: "m-strict-img",
+        type: "image",
+        contentProvider: { type: "line" },
+        quoteToken: "q-strict-img",
+      },
+      source: { type: "group", groupId: "group-1", userId: "user-strict-img" },
+      webhookEventId: "evt-strict-img",
+    });
+
+    await handleLineWebhookEvents(
+      [event],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: true,
+        requireMentionForNonText: true,
+      }),
+    );
+
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("still processes text group messages with bot mention when requireMentionForNonText is set", async () => {
+    // Opting in to `requireMentionForNonText` must not regress the regular
+    // text @-mention path.
+    const processMessage = vi.fn();
+    const event = createTestMessageEvent({
+      message: {
+        id: "m-strict-text-mention",
+        type: "text",
+        text: "@Bot hi there",
+        mention: {
+          mentionees: [{ index: 0, length: 4, type: "user", isSelf: true }],
+        },
+      } as unknown as MessageEvent["message"],
+      source: { type: "group", groupId: "group-1", userId: "user-strict-text-mention" },
+      webhookEventId: "evt-strict-text-mention",
+    });
+
+    await handleLineWebhookEvents(
+      [event],
+      createLineWebhookTestContext({
+        processMessage,
+        groupPolicy: "open",
+        requireMention: true,
+        requireMentionForNonText: true,
+      }),
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
   it("does not bypass mention gating when non-bot mention is present with control command", async () => {

--- a/extensions/line/src/bot-handlers.ts
+++ b/extensions/line/src/bot-handlers.ts
@@ -432,6 +432,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
   if (isGroup) {
     const groupConfig = resolveLineGroupConfig({ config: account.config, groupId, roomId });
     const requireMention = groupConfig?.requireMention !== false;
+    const requireMentionForNonText = groupConfig?.requireMentionForNonText === true;
     const rawText = message.type === "text" ? message.text : "";
     const sourceInfo = getLineSourceInfo(event.source);
     const peerId = groupId ?? roomId ?? sourceInfo.userId ?? "unknown";
@@ -446,9 +447,18 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     const wasMentionedByPattern =
       message.type === "text" ? matchesMentionPatterns(rawText, mentionRegexes) : false;
     const wasMentioned = wasMentionedByNative || wasMentionedByPattern;
+    // Non-text LINE messages (image, sticker, video, audio, file, location)
+    // do not carry `mention.mentionees` in the LINE Messaging API, so the bot
+    // can never be @-mentioned on them. When `requireMentionForNonText` is
+    // opted in we still run the mention gate for those messages, which
+    // results in them being skipped under `requireMention`. This matches how
+    // bots behave in WhatsApp/Telegram/Discord/Slack groups where
+    // unaddressed media does not trigger a reply. The default (`false`)
+    // preserves the historical fail-open behavior.
+    const canDetectMention = message.type === "text" || requireMentionForNonText;
     const mentionDecision = resolveInboundMentionDecision({
       facts: {
-        canDetectMention: message.type === "text",
+        canDetectMention,
         wasMentioned,
         hasAnyMention: hasAnyLineMention(message),
         implicitMentionKinds: [],

--- a/extensions/line/src/config-schema.ts
+++ b/extensions/line/src/config-schema.ts
@@ -35,6 +35,7 @@ const LineGroupConfigSchema = z
     enabled: z.boolean().optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     requireMention: z.boolean().optional(),
+    requireMentionForNonText: z.boolean().optional(),
     systemPrompt: z.string().optional(),
     skills: z.array(z.string()).optional(),
   })

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -40,6 +40,17 @@ export interface LineGroupConfig {
   enabled?: boolean;
   allowFrom?: Array<string | number>;
   requireMention?: boolean;
+  /**
+   * When `true`, non-text messages (images, stickers, videos, audio, files,
+   * locations) in groups with `requireMention: true` are also gated by the
+   * mention check. The LINE Messaging API does not deliver
+   * `mention.mentionees` on non-text messages, so enabling this option
+   * causes unmentionable media in a group to be skipped, matching how bots
+   * behave in WhatsApp/Telegram/Discord/Slack groups. Defaults to `false`
+   * to preserve the historical fail-open behavior where non-text group
+   * messages bypass `requireMention`.
+   */
+  requireMentionForNonText?: boolean;
   systemPrompt?: string;
   skills?: string[];
 }


### PR DESCRIPTION
## Summary

When `requireMention: true` is set on a LINE group, text messages are correctly gated by `resolveInboundMentionDecision`, but non-text messages (image, sticker, video, audio, file, location) always bypass the gate via `canDetectMention: message.type === "text"`. The LINE Messaging API never delivers `mention.mentionees` on non-text messages, so a bot cannot be @-mentioned on an image in a group, yet the handler still calls `processMessage` for every piece of unaddressed media. In busy groups this leads to the agent processing large volumes of images/stickers/videos that were never directed at it.

This PR adds an opt-in `requireMentionForNonText?: boolean` to `LineGroupConfig` (default `false`). When enabled, non-text messages participate in the same mention gate as text, and because LINE does not expose a native bot mention on those messages they are skipped under `requireMention` — matching how WhatsApp/Telegram/Discord/Slack groups behave: unaddressed media does not trigger a reply.

Because the default is `false`, the historical fail-open behavior is fully preserved. The existing test ``allows non-text group messages through when requireMention is set (cannot detect mention)`` continues to pass unchanged.

## Why an opt-in and not a default change

Flipping the default would be a behavior change for every deployment that currently relies on non-text group media reaching the bot (e.g. groups that send images for the agent to analyze without explicit @-mention). Keeping it opt-in preserves that flow while giving operators a one-line knob to bring LINE in line with other channels.

## Example config

\`\`\`jsonc
{
  "channels": {
    "line": {
      "accounts": {
        "default": {
          "groups": {
            "G0123456789abcdef": {
              "requireMention": true,
              "requireMentionForNonText": true
            }
          }
        }
      }
    }
  }
}
\`\`\`

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Test plan

- [x] `pnpm test:extension line` — **235/235 passing**, including two new tests:
  - `skips non-text group messages when requireMentionForNonText is set`
  - `still processes text group messages with bot mention when requireMentionForNonText is set`
- [x] Existing `allows non-text group messages through when requireMention is set (cannot detect mention)` left untouched and still passes (default unchanged).
- [x] No shared plugin-sdk / contract surfaces touched — only files under `extensions/line/src/`.

## AI-assistance disclosure

- [x] AI-assisted (Cursor + Claude). Marked per CONTRIBUTING.md.
- [x] Fully tested locally via `pnpm test:extension line` before opening this PR.
- [x] I understand what the code does: the change threads a new optional group-config field into the existing mention-gate call in `bot-handlers.ts` and wires it through the zod schema + TS type; the shared mention-decision helper is unchanged.

Made with [Cursor](https://cursor.com)