### PR TITLE
Harden localized docs link scheme checks

### DIFF
--- a/scripts/docs-i18n/localized_links.go
+++ b/scripts/docs-i18n/localized_links.go
@@ -321,17 +321,23 @@ func (ri *routeIndex) localizeURL(raw string) string {
 }
 
 func hasURLScheme(raw string) bool {
-	lowerRaw := strings.ToLower(raw)
 	switch {
-	case strings.HasPrefix(lowerRaw, "http://"), strings.HasPrefix(lowerRaw, "https://"):
+	case hasSchemePrefix(raw, "http://"), hasSchemePrefix(raw, "https://"):
 		return true
-	case strings.HasPrefix(lowerRaw, "mailto:"), strings.HasPrefix(lowerRaw, "tel:"):
+	case hasSchemePrefix(raw, "mailto:"), hasSchemePrefix(raw, "tel:"):
 		return true
-	case strings.HasPrefix(lowerRaw, "data:"), strings.HasPrefix(lowerRaw, "javascript:"), strings.HasPrefix(lowerRaw, "vbscript:"):
+	case hasSchemePrefix(raw, "data:"), hasSchemePrefix(raw, "javascript:"), hasSchemePrefix(raw, "vbscript:"):
 		return true
 	default:
 		return false
 	}
+}
+
+func hasSchemePrefix(raw, prefix string) bool {
+	if len(raw) < len(prefix) {
+		return false
+	}
+	return strings.EqualFold(raw[:len(prefix)], prefix)
 }
 
 func splitURLSuffix(raw string) (string, string) {

--- a/scripts/docs-i18n/localized_links.go
+++ b/scripts/docs-i18n/localized_links.go
@@ -321,12 +321,13 @@ func (ri *routeIndex) localizeURL(raw string) string {
 }
 
 func hasURLScheme(raw string) bool {
+	lowerRaw := strings.ToLower(raw)
 	switch {
-	case strings.HasPrefix(raw, "http://"), strings.HasPrefix(raw, "https://"):
+	case strings.HasPrefix(lowerRaw, "http://"), strings.HasPrefix(lowerRaw, "https://"):
 		return true
-	case strings.HasPrefix(raw, "mailto:"), strings.HasPrefix(raw, "tel:"):
+	case strings.HasPrefix(lowerRaw, "mailto:"), strings.HasPrefix(lowerRaw, "tel:"):
 		return true
-	case strings.HasPrefix(raw, "data:"), strings.HasPrefix(raw, "javascript:"):
+	case strings.HasPrefix(lowerRaw, "data:"), strings.HasPrefix(lowerRaw, "javascript:"), strings.HasPrefix(lowerRaw, "vbscript:"):
 		return true
 	default:
 		return false

--- a/scripts/docs-i18n/localized_links_test.go
+++ b/scripts/docs-i18n/localized_links_test.go
@@ -55,6 +55,11 @@ func TestLocalizeBodyLinks(t *testing.T) {
 			want:  `<a href="vbscript:msgbox(1)">bad</a>`,
 		},
 		{
+			name:  "mixed-case javascript scheme stays unchanged",
+			input: `<a href="Javascript:alert(1)">bad</a>`,
+			want:  `<a href="Javascript:alert(1)">bad</a>`,
+		},
+		{
 			name:  "missing localized page stays unchanged",
 			input: `See [FAQ](/help/faq).`,
 			want:  `See [FAQ](/help/faq).`,

--- a/scripts/docs-i18n/localized_links_test.go
+++ b/scripts/docs-i18n/localized_links_test.go
@@ -50,6 +50,11 @@ func TestLocalizeBodyLinks(t *testing.T) {
 			want:  `See [Config](/zh-CN/gateway/configuration).`,
 		},
 		{
+			name:  "vbscript scheme stays unchanged",
+			input: `<a href="vbscript:msgbox(1)">bad</a>`,
+			want:  `<a href="vbscript:msgbox(1)">bad</a>`,
+		},
+		{
 			name:  "missing localized page stays unchanged",
 			input: `See [FAQ](/help/faq).`,
 			want:  `See [FAQ](/help/faq).`,


### PR DESCRIPTION
## Summary
- normalize localized link scheme checks to lowercase before matching
- treat `vbscript:` the same as other absolute non-route schemes
- add regression coverage for a `vbscript:` href so localized docs rewriting leaves it untouched

## Testing
- not run locally (`go` toolchain unavailable in this environment)
