### PR TITLE
fix(daemon): resolve modern fnm aliases/default path on Linux service PATH

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -24,6 +24,14 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/home/testuser/.npm-global/bin");
     expect(result).toContain("/home/testuser/bin");
     expect(result).toContain("/home/testuser/.nvm/current/bin");
+    // fnm: both the modern `aliases/default/bin` path (produced by
+    // `fnm alias <ver> default`) and the legacy `current/bin` session-local
+    // symlink — modern installs that were never `fnm use`d only have the
+    // aliases path, so resolving only `current/bin` leaves Node unreachable
+    // from systemd-managed gateway lifecycles.
+    expect(result).toContain("/home/testuser/.local/share/fnm/aliases/default/bin");
+    expect(result).toContain("/home/testuser/.local/share/fnm/current/bin");
+    expect(result).toContain("/home/testuser/.fnm/aliases/default/bin");
     expect(result).toContain("/home/testuser/.fnm/current/bin");
     expect(result).toContain("/home/testuser/.volta/bin");
     expect(result).toContain("/home/testuser/.asdf/shims");
@@ -96,7 +104,31 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/opt/volta/bin");
     expect(result).toContain("/opt/asdf/shims");
     expect(result).toContain("/opt/nvm/current/bin");
+    // Both the modern aliases/default path and the legacy current path
+    // must be reachable when FNM_DIR is explicitly configured.
+    expect(result).toContain("/opt/fnm/aliases/default/bin");
     expect(result).toContain("/opt/fnm/current/bin");
+  });
+
+  it("resolves modern fnm aliases/default path on Linux even when current/bin is absent (#68169)", () => {
+    // Repro for #68169: fnm install + `fnm alias <ver> default` creates
+    // $FNM_DIR/aliases/default/bin but NOT $FNM_DIR/current/bin. A systemd
+    // user service lifecycle never enters an interactive `fnm use` shell,
+    // so `doctor` would previously warn that the resolved PATH was missing
+    // required dirs. The resolver must include the aliases path so that
+    // modern non-interactive installs are still discoverable.
+    const result = getMinimalServicePathPartsFromEnv({
+      platform: "linux",
+      env: {
+        HOME: "/home/systemduser",
+        FNM_DIR: "/home/systemduser/.local/share/fnm",
+      },
+    });
+
+    expect(result).toContain("/home/systemduser/.local/share/fnm/aliases/default/bin");
+    // Legacy session-local path is kept for backwards compatibility with
+    // older installs that rely on `current/bin` being present.
+    expect(result).toContain("/home/systemduser/.local/share/fnm/current/bin");
   });
 
   it("includes version manager directories on macOS when HOME is set", () => {

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -177,6 +177,13 @@ export function resolveLinuxUserBinDirs(
   // Env-configured bin roots (override defaults when present).
   addCommonEnvConfiguredBinDirs(dirs, env);
   addNonEmptyDir(dirs, appendSubdir(env?.NVM_DIR, "current/bin"));
+  // fnm: modern installs use `aliases/default/bin` as the persistent default
+  // written by `fnm alias <ver> default`. `current/bin` is a session-local
+  // symlink that only exists after `fnm use` runs in an interactive shell,
+  // so it is absent on systemd-managed installs that never enter that shell.
+  // Check the modern path first, keep the legacy one for older installs —
+  // matches the macOS resolver pattern at `resolveDarwinUserBinDirs`.
+  addNonEmptyDir(dirs, appendSubdir(env?.FNM_DIR, "aliases/default/bin"));
   addNonEmptyDir(dirs, appendSubdir(env?.FNM_DIR, "current/bin"));
 
   // Common user bin directories
@@ -184,7 +191,10 @@ export function resolveLinuxUserBinDirs(
 
   // Node version managers
   dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink
-  dirs.push(`${home}/.fnm/current/bin`); // fnm
+  dirs.push(`${home}/.local/share/fnm/aliases/default/bin`); // fnm modern default
+  dirs.push(`${home}/.local/share/fnm/current/bin`); // fnm legacy session-local
+  dirs.push(`${home}/.fnm/aliases/default/bin`); // fnm customized to ~/.fnm (modern)
+  dirs.push(`${home}/.fnm/current/bin`); // fnm customized to ~/.fnm (legacy)
   dirs.push(`${home}/.local/share/pnpm`); // pnpm global bin
 
   return dirs;


### PR DESCRIPTION
## Summary

Fixes #68169 — \`openclaw doctor\` on Linux reported the gateway service PATH was missing required dirs for any fnm install that uses the modern persistent-default pattern (\`fnm alias <ver> default\`). \`resolveLinuxUserBinDirs\` in \`src/daemon/service-env.ts\` only probed \`\$FNM_DIR/current/bin\` and \`~/.fnm/current/bin\`, both of which are session-local symlinks that fnm **only** creates when \`fnm use <ver>\` runs in an interactive shell. Systemd-managed gateway lifecycles never enter that shell, so the Node binary was effectively invisible.

## Root cause

\`resolveDarwinUserBinDirs\` (same file, ~line 127) already walks both the modern \`aliases/default/bin\` and the legacy \`current/bin\` paths. \`resolveLinuxUserBinDirs\` was a straight mirror of the Darwin resolver except it only included \`current/bin\` for fnm — that asymmetry pre-dates the fnm upstream change where \`alias <ver> default\` became the recommended install pattern.

## Fix

Mirror the Darwin pattern. Probe \`\$FNM_DIR/aliases/default/bin\` first (the persistent modern path) and keep \`\$FNM_DIR/current/bin\` afterwards for older installs that still rely on it. Do the same for the home-relative defaults:
- \`~/.local/share/fnm/aliases/default/bin\` + \`~/.local/share/fnm/current/bin\`
- \`~/.fnm/aliases/default/bin\` + \`~/.fnm/current/bin\`

Both paths coexist so older \`fnm use\`-only installs continue to work, and modern \`fnm alias default\` installs now resolve without needing an interactive shell.

## Test plan

- [x] Added a dedicated regression test \`resolves modern fnm aliases/default path on Linux even when current/bin is absent (#68169)\` exercising the exact systemd scenario from the issue body.
- [x] Extended the default-path test (\`includes user bin directories when HOME is set on Linux\`) and the env-configured test (\`includes env-configured bin roots when HOME is set on Linux\`) to assert the new aliases paths.
- [x] \`NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit\` — 247 baseline on main, 247 on branch.
- [x] \`pnpm exec oxlint\` on both touched files — 0 warnings, 0 errors.

Local full vitest is blocked by pre-existing \`test/non-isolated-runner.ts\` drift (reproduces on \`main\`); CI exercises the new cases normally.

## Risk

- No existing path is removed — \`current/bin\` is preserved, so older installs that relied on it still resolve.
- No cross-platform effect: \`resolveDarwinUserBinDirs\` and the Windows PATH path are untouched.
- The test asserts the modern-install scenario passes without requiring \`current/bin\` on disk, pinning the regression so a future "cleanup" can't accidentally drop the aliases path.