### PR TITLE
fix(gateway): stop restarting gateway on OAuth token refresh (auth.profiles.*) [AI-assisted]

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -98,6 +98,13 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
   { prefix: "talk", kind: "none" },
   { prefix: "skills", kind: "none" },
   { prefix: "secrets", kind: "none" },
+  // Top-level `auth.profiles.*` is touched whenever an OAuth provider refreshes
+  // its token (email/openai-codex/etc.).  Credentials are read per-request via
+  // the auth token resolution path, so a gateway restart is not required —
+  // and restarting mid-dispatch drops in-flight WebSocket work.  The separate
+  // `gateway.auth.*` path (auth token/mode for the gateway itself) still
+  // restarts via the `gateway` rule below.
+  { prefix: "auth", kind: "none" },
   { prefix: "plugins", kind: "restart" },
   { prefix: "ui", kind: "none" },
   { prefix: "gateway", kind: "restart" },

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -252,6 +252,42 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartGateway).toBe(true);
   });
 
+  it("treats top-level auth.profiles changes as no-op (OAuth token refresh)", () => {
+    // Regression: an OAuth provider refreshing its token writes to
+    // `auth.profiles.<provider>:<email>` and previously matched no rule,
+    // falling through to the default "restart gateway" branch and dropping
+    // in-flight WebSocket work.  `auth.profiles.*` credentials are read per
+    // request by the auth token resolution path, so a restart is not needed.
+    const plan = buildGatewayReloadPlan([
+      "auth.profiles.openai-codex:user@example.com",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toContain("auth.profiles.openai-codex:user@example.com");
+  });
+
+  it("treats auth.* changes as no-op even for nested paths", () => {
+    const plan = buildGatewayReloadPlan([
+      "auth.profiles.anthropic:user@example.com.lastRefreshedAt",
+      "auth.someFutureField",
+    ]);
+    expect(plan.restartGateway).toBe(false);
+    expect(plan.noopPaths).toEqual(
+      expect.arrayContaining([
+        "auth.profiles.anthropic:user@example.com.lastRefreshedAt",
+        "auth.someFutureField",
+      ]),
+    );
+  });
+
+  it("still restarts for gateway.auth.* changes (distinct from top-level auth.*)", () => {
+    // Defence in depth: the new `auth` no-op rule must NOT shadow the
+    // pre-existing `gateway.auth.token` / `gateway.auth.mode` restart behaviour.
+    const plan = buildGatewayReloadPlan(["gateway.auth.token", "auth.profiles.foo"]);
+    expect(plan.restartGateway).toBe(true);
+    expect(plan.restartReasons).toContain("gateway.auth.token");
+    expect(plan.noopPaths).toContain("auth.profiles.foo");
+  });
+
   it.each([
     {
       path: "browser.enabled",


### PR DESCRIPTION
## Bug

`buildGatewayReloadPlan()` in [`src/gateway/config-reload-plan.ts`](src/gateway/config-reload-plan.ts) treats any unmatched config path as a gateway restart trigger (existing test at L250: *"defaults unknown paths to restart"*). The reload rules list has no entry for the top-level `auth` prefix, so every OAuth token refresh — which writes to `auth.profiles.<provider>:<email>` — falls through to that default and SIGTERMs the gateway.

Because a single config-file write usually emits several changed paths at once (via `diffConfigPaths`), the restart fires even when most paths in the batch are benign (`meta.lastTouchedAt`, `wizard.lastRunAt`). A passive mtime bump from any writer (auth provider token refresh, wizard state update, UI touch) is enough.

## Observed in the wild

```
[reload] config change detected; evaluating reload
  (meta.lastTouchedAt, wizard.lastRunAt,
   auth.profiles.openai-codex:user@example.com,
   agents.defaults.model.primary,
   agents.defaults.models.claude-cli/claude-sonnet-4-6, ...,
   tools.web.search.apiKey)
...~90s later...
[gateway] signal SIGTERM received
[gateway] received SIGTERM; shutting down
```

Upstream client saw: `Gateway timeout: Remote end closed connection without response` — an in-flight WebSocket dispatch was dropped by the restart.

## Fix

Add `{ prefix: "auth", kind: "none" }` to `BASE_RELOAD_RULES_TAIL`.

`auth.profiles.*` credentials are read per-request via the auth token resolution path (see [`src/config/plugin-auto-enable.shared.ts`](src/config/plugin-auto-enable.shared.ts) — `cfg.auth?.profiles` is dereferenced lazily), so a gateway restart is not required on refresh. The distinct **`gateway.auth.token`** / **`gateway.auth.mode`** paths continue to restart via the pre-existing `{ prefix: "gateway", kind: "restart" }` rule, and a new defence-in-depth test asserts that restart path is unchanged.

### Why not also change the default?

I considered flipping the unmatched-path default from `restart` → `hot` (so that new, un-ruled config fields never silently SIGTERM a running gateway). That would break the existing *"defaults unknown paths to restart"* test, which is documented conservative behaviour. Kept this PR surgical; happy to follow up with a separate PR if maintainers want to broaden the policy.

## Tests

3 new cases in [`src/gateway/config-reload.test.ts`](src/gateway/config-reload.test.ts):

1. Top-level `auth.profiles.<provider>:<email>` → `restartGateway: false`, path in `noopPaths`
2. Nested `auth.*` paths (including future unknown sub-keys) → `restartGateway: false`
3. Defence in depth: `gateway.auth.token` + `auth.profiles.foo` in the same batch → still `restartGateway: true` (the `auth` rule must not shadow the `gateway` rule)

Targeted run:
```
$ pnpm exec vitest run src/gateway/config-reload.test.ts
 ✓ |gateway-core| src/gateway/config-reload.test.ts (51 tests) 87ms
 Test Files  1 passed (1)
      Tests  51 passed (51)
```

## Disclosure

AI-assisted. Investigation + patch authored by Claude (Anthropic) under human direction; bug was discovered while running live E2E harness against a real gateway instance and tracing the SIGTERM back to its source in the reload planner.