### PR TITLE
fix(approvals): back off native handler bootstrap retries

### DIFF
--- a/src/infra/approval-handler-bootstrap.test.ts
+++ b/src/infra/approval-handler-bootstrap.test.ts
@@ -28,6 +28,17 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     await Promise.resolve();
   };
 
+  const createTestLogger = () => ({
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+    isEnabled: vi.fn().mockReturnValue(true),
+    isVerboseEnabled: vi.fn().mockReturnValue(false),
+    verbose: vi.fn(),
+  });
+
   const createApprovalPlugin = () =>
     ({
       id: "slack",
@@ -194,16 +205,7 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     const channelRuntime = createRuntimeChannel();
     const start = vi.fn().mockRejectedValueOnce(new Error("boom")).mockResolvedValueOnce(undefined);
     const stop = vi.fn().mockResolvedValue(undefined);
-    const logger = {
-      error: vi.fn(),
-      warn: vi.fn(),
-      info: vi.fn(),
-      debug: vi.fn(),
-      child: vi.fn(),
-      isEnabled: vi.fn().mockReturnValue(true),
-      isVerboseEnabled: vi.fn().mockReturnValue(false),
-      verbose: vi.fn(),
-    };
+    const logger = createTestLogger();
     createChannelApprovalHandlerFromCapability
       .mockResolvedValueOnce({ start, stop })
       .mockResolvedValueOnce({ start, stop });
@@ -223,6 +225,85 @@ describe("startChannelApprovalHandlerBootstrap", () => {
     expect(logger.error).toHaveBeenCalledWith(
       "failed to start native approval handler: Error: boom",
     );
+
+    await cleanup();
+  });
+
+  it("backs off repeated registered-context startup failures", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const start = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom 1"))
+      .mockRejectedValueOnce(new Error("boom 2"))
+      .mockResolvedValueOnce(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const logger = createTestLogger();
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start, stop })
+      .mockResolvedValueOnce({ start, stop })
+      .mockResolvedValueOnce({ start, stop });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, logger });
+
+    registerApprovalContext(channelRuntime);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1_999);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledWith("retrying native approval handler startup in 1s");
+    expect(logger.warn).toHaveBeenCalledWith("retrying native approval handler startup in 2s");
+
+    await cleanup();
+  });
+
+  it("backs off pairing-required startup failures and reports the approval pairing action", async () => {
+    vi.useFakeTimers();
+    const channelRuntime = createRuntimeChannel();
+    const pairingError = Object.assign(new Error("pairing required"), {
+      name: "GatewayClientRequestError",
+      details: {
+        code: "PAIRING_REQUIRED",
+        reason: "scope-upgrade",
+        requestId: "req-approval-123",
+      },
+    });
+    const start = vi.fn().mockRejectedValueOnce(pairingError).mockResolvedValueOnce(undefined);
+    const stop = vi.fn().mockResolvedValue(undefined);
+    const logger = createTestLogger();
+    createChannelApprovalHandlerFromCapability
+      .mockResolvedValueOnce({ start, stop })
+      .mockResolvedValueOnce({ start, stop });
+
+    const cleanup = await startTestBootstrap({ channelRuntime, logger });
+
+    registerApprovalContext(channelRuntime);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "native approval handler startup requires gateway device pairing for operator.approvals; retrying in 300s. Approve pending request req-approval-123 with `openclaw devices approve req-approval-123`.",
+    );
+
+    await vi.advanceTimersByTimeAsync(299_000);
+    await flushTransitions();
+
+    expect(start).toHaveBeenCalledTimes(2);
 
     await cleanup();
   });

--- a/src/infra/approval-handler-bootstrap.ts
+++ b/src/infra/approval-handler-bootstrap.ts
@@ -2,6 +2,10 @@ import { resolveChannelApprovalCapability } from "../channels/plugins/approvals.
 import type { ChannelRuntimeSurface } from "../channels/plugins/channel-runtime-surface.types.js";
 import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  ConnectErrorDetailCodes,
+  readConnectErrorDetailCode,
+} from "../gateway/protocol/connect-error-details.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   CHANNEL_APPROVAL_NATIVE_RUNTIME_CONTEXT_CAPABILITY,
@@ -14,7 +18,65 @@ import {
 } from "./channel-runtime-context.js";
 
 type ApprovalBootstrapHandler = ChannelApprovalHandler;
-const APPROVAL_HANDLER_BOOTSTRAP_RETRY_MS = 1_000;
+const APPROVAL_HANDLER_BOOTSTRAP_INITIAL_RETRY_MS = 1_000;
+const APPROVAL_HANDLER_BOOTSTRAP_MAX_RETRY_MS = 60_000;
+const APPROVAL_HANDLER_BOOTSTRAP_PAIRING_REQUIRED_RETRY_MS = 300_000;
+
+type ApprovalBootstrapRetryDecision = {
+  delayMs: number;
+  reason: "pairing-required" | "transient";
+};
+
+function readErrorDetails(error: unknown): unknown {
+  if (!error || typeof error !== "object" || Array.isArray(error)) {
+    return undefined;
+  }
+  return (error as { details?: unknown }).details;
+}
+
+function readPairingRequestId(details: unknown): string | undefined {
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return undefined;
+  }
+  const requestId = (details as { requestId?: unknown }).requestId;
+  return typeof requestId === "string" && requestId.trim().length > 0
+    ? requestId.trim()
+    : undefined;
+}
+
+function isPairingRequiredStartupError(error: unknown): boolean {
+  const details = readErrorDetails(error);
+  if (readConnectErrorDetailCode(details) === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
+    return true;
+  }
+  return /pairing required/i.test(String(error));
+}
+
+function resolveApprovalHandlerRetryDecision(
+  error: unknown,
+  retryAttempt: number,
+): ApprovalBootstrapRetryDecision {
+  if (isPairingRequiredStartupError(error)) {
+    return {
+      delayMs: APPROVAL_HANDLER_BOOTSTRAP_PAIRING_REQUIRED_RETRY_MS,
+      reason: "pairing-required",
+    };
+  }
+
+  const exponentialDelay =
+    APPROVAL_HANDLER_BOOTSTRAP_INITIAL_RETRY_MS * 2 ** Math.max(0, retryAttempt);
+  return {
+    delayMs: Math.min(exponentialDelay, APPROVAL_HANDLER_BOOTSTRAP_MAX_RETRY_MS),
+    reason: "transient",
+  };
+}
+
+function formatRetryDelay(delayMs: number): string {
+  if (delayMs % 1_000 === 0) {
+    return `${delayMs / 1_000}s`;
+  }
+  return `${delayMs}ms`;
+}
 
 export async function startChannelApprovalHandlerBootstrap(params: {
   plugin: Pick<ChannelPlugin, "id" | "meta" | "approvalCapability">;
@@ -33,8 +95,12 @@ export async function startChannelApprovalHandlerBootstrap(params: {
   let activeGeneration = 0;
   let activeHandler: ApprovalBootstrapHandler | null = null;
   let retryTimer: NodeJS.Timeout | null = null;
+  let retryAttempt = 0;
   const invalidateActiveHandler = () => {
     activeGeneration += 1;
+  };
+  const resetRetryState = () => {
+    retryAttempt = 0;
   };
   const clearRetryTimer = () => {
     if (!retryTimer) {
@@ -81,6 +147,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     activeHandler = handler as ApprovalBootstrapHandler;
     try {
       await handler.start();
+      resetRetryState();
     } catch (error) {
       if (activeHandler === handler) {
         activeHandler = null;
@@ -95,11 +162,29 @@ export async function startChannelApprovalHandlerBootstrap(params: {
       logger.error(`${label}: ${String(error)}`);
     });
   };
-  const scheduleRetryForContext = (context: unknown, generation: number) => {
+  const logRetryDecision = (error: unknown, decision: ApprovalBootstrapRetryDecision) => {
+    const retryLabel = formatRetryDelay(decision.delayMs);
+    if (decision.reason === "pairing-required") {
+      const requestId = readPairingRequestId(readErrorDetails(error));
+      const requestHint = requestId
+        ? `Approve pending request ${requestId} with \`openclaw devices approve ${requestId}\`.`
+        : "Run `openclaw devices list` and approve the pending request.";
+      logger.warn(
+        `native approval handler startup requires gateway device pairing for operator.approvals; retrying in ${retryLabel}. ${requestHint}`,
+      );
+      return;
+    }
+
+    logger.warn(`retrying native approval handler startup in ${retryLabel}`);
+  };
+  const scheduleRetryForContext = (context: unknown, generation: number, error: unknown) => {
     if (generation !== activeGeneration) {
       return;
     }
+    const decision = resolveApprovalHandlerRetryDecision(error, retryAttempt);
+    retryAttempt += 1;
     clearRetryTimer();
+    logRetryDecision(error, decision);
     retryTimer = setTimeout(() => {
       retryTimer = null;
       if (generation !== activeGeneration) {
@@ -109,7 +194,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
         "failed to retry native approval handler",
         startHandlerForRegisteredContext(context, generation),
       );
-    }, APPROVAL_HANDLER_BOOTSTRAP_RETRY_MS);
+    }, decision.delayMs);
     retryTimer.unref?.();
   };
   const startHandlerForRegisteredContext = async (context: unknown, generation: number) => {
@@ -118,7 +203,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
     } catch (error) {
       if (generation === activeGeneration) {
         logger.error(`failed to start native approval handler: ${String(error)}`);
-        scheduleRetryForContext(context, generation);
+        scheduleRetryForContext(context, generation, error);
       }
     }
   };
@@ -132,6 +217,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
       onEvent: (event) => {
         if (event.type === "registered") {
           clearRetryTimer();
+          resetRetryState();
           invalidateActiveHandler();
           const generation = activeGeneration;
           spawn(
@@ -141,6 +227,7 @@ export async function startChannelApprovalHandlerBootstrap(params: {
           return;
         }
         clearRetryTimer();
+        resetRetryState();
         invalidateActiveHandler();
         spawn("failed to stop native approval handler", stopHandler());
       },
@@ -154,13 +241,15 @@ export async function startChannelApprovalHandlerBootstrap(params: {
   });
   if (existingContext !== undefined) {
     clearRetryTimer();
+    resetRetryState();
     invalidateActiveHandler();
-    await startHandlerForContext(existingContext, activeGeneration);
+    await startHandlerForRegisteredContext(existingContext, activeGeneration);
   }
 
   return async () => {
     unsubscribe();
     clearRetryTimer();
+    resetRetryState();
     invalidateActiveHandler();
     await stopHandler();
   };


### PR DESCRIPTION
## Summary

Fixes a native approval handler bootstrap retry storm observed in production when the handler could not connect to the gateway because the local device lacked `operator.approvals`.

The previous behavior retried every 1000ms for all startup failures. When Matrix native approvals failed with `PAIRING_REQUIRED`, that became an infinite 1-second loop that repeatedly attempted gateway connections and could degrade the host.

This patch keeps successful startup behavior unchanged, but changes failed startup retry behavior:

- transient startup failures use bounded exponential backoff: 1s, 2s, 4s, capped at 60s
- `PAIRING_REQUIRED` startup failures back off immediately to 300s
- pairing-required diagnostics now explicitly mention `operator.approvals`
- if a pairing request id is present, logs include the exact `openclaw devices approve <requestId>` command
- retry state resets on successful startup, context replacement/removal, and cleanup
- already-registered runtime contexts now use the guarded retry path instead of throwing out of bootstrap

## Production evidence

On `openclaw-1`, Matrix native approvals for the `codex` account requested `operator.approvals` while the gateway device only had `operator.read`. Gateway logs showed repeated `scope-upgrade` / `pairing required` failures once per second, which combined with hanging CLI probes and produced a process/load spiral.

The local machine was temporarily protected with a systemd preload shim that stretches this exact retry to 300s. This source fix is intended to make that shim removable after an OpenClaw build containing this patch is deployed.

## Validation

Targeted tests:

```bash
npx --yes pnpm@10.32.1 exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/approval-handler-bootstrap.test.ts
```

Result: 1 file passed, 8 tests passed.

Formatting:

```bash
npx --yes pnpm@10.32.1 exec oxfmt --check src/infra/approval-handler-bootstrap.ts src/infra/approval-handler-bootstrap.test.ts
```

Result: clean.

Lint:

```bash
npx --yes pnpm@10.32.1 exec oxlint src/infra/approval-handler-bootstrap.ts src/infra/approval-handler-bootstrap.test.ts
```

Result: 0 warnings, 0 errors.

Patch check:

```bash
git diff --check
```

Result: clean.
