### PR TITLE
fix(hooks): include stack trace and event context in internal hook error logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/diagnostics: include the full stack trace and event context (`type`, `action`, `sessionKey`) in internal hook error logs, with the stack also surfaced on the default console surface so operator logs no longer hide hook handler failures behind a one-line message. (#68300) Thanks @1aifanatic.
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -300,7 +300,11 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
       await handler(event);
     } catch (err) {
       const message = formatErrorMessage(err);
-      log.error(`Hook error [${event.type}:${event.action}]: ${message}`);
+      const stack = err instanceof Error ? err.stack : undefined;
+      log.error(`Hook error [${event.type}:${event.action}]: ${message}`, {
+        stack,
+        event: { type: event.type, action: event.action, sessionKey: event.sessionKey },
+      });
     }
   }
 }

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -301,9 +301,11 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
     } catch (err) {
       const message = formatErrorMessage(err);
       const stack = err instanceof Error ? err.stack : undefined;
-      log.error(`Hook error [${event.type}:${event.action}]: ${message}`, {
+      const headline = `Hook error [${event.type}:${event.action}]: ${message}`;
+      log.error(headline, {
         stack,
         event: { type: event.type, action: event.action, sessionKey: event.sessionKey },
+        consoleMessage: stack ? `${headline}\n${stack}` : headline,
       });
     }
   }


### PR DESCRIPTION
## Summary

- Hook handler errors were logged with only the error message, no stack trace
- Errors like `f.toLowerCase is not a function` in `agent:bootstrap` hooks could not be traced to their source without source maps
- Now logs the full stack trace and event context (`type`, `action`, `sessionKey`) alongside the error message

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #68124

## Root Cause

`triggerInternalHook` caught handler errors and logged only `err.message`. Without the stack trace, operators running 20+ agents with per-agent workspaces had no way to identify which hook or handler was throwing on every bootstrap.

## Fix

Extract `err.stack` from Error instances and pass it as a structured field in the log call alongside the event `type`, `action`, and `sessionKey`. Non-Error throws fall back to `undefined` for the stack field.