### PR TITLE
fix(telegram): suppress NO_REPLY sentinel before sendMessageTelegram API call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/silent reply: suppress the `NO_REPLY` sentinel inside `sendMessageTelegram` before any API call, mirroring the existing Slack guard, while preserving sends that carry an inline keyboard or media payload so structured replies still post. (#68304) Thanks @1aifanatic.
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1764,6 +1764,33 @@ describe("sendMessageTelegram", () => {
     expect(sendMessage.mock.calls.map((call) => String(call[1] ?? "")).join("")).toBe(plainText);
     expect(res.messageId).toBe("96");
   });
+
+  it("suppresses NO_REPLY sentinel before any API call when no payload is attached", async () => {
+    const sendMessage = vi.fn();
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram("123", "NO_REPLY", { token: "tok", api });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(res).toEqual({ messageId: "suppressed", chatId: "" });
+  });
+
+  it("still sends NO_REPLY when inline buttons are attached so the keyboard payload is preserved", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 7, chat: { id: "123" } });
+    const api = { sendMessage } as unknown as { sendMessage: typeof sendMessage };
+
+    const res = await sendMessageTelegram("123", "NO_REPLY", {
+      token: "tok",
+      api,
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0][2]?.reply_markup).toEqual({
+      inline_keyboard: [[{ text: "OK", callback_data: "ok" }]],
+    });
+    expect(res.messageId).toBe("7");
+  });
 });
 
 describe("reactMessageTelegram", () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -7,6 +7,7 @@ import { recordChannelActivity } from "openclaw/plugin-sdk/infra-runtime";
 import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
+import { isSilentReplyText } from "openclaw/plugin-sdk/reply-chunking";
 import { normalizeOptionalString, redactSensitiveText } from "openclaw/plugin-sdk/text-runtime";
 import { type ResolvedTelegramAccount, resolveTelegramAccount } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
@@ -618,6 +619,11 @@ export async function sendMessageTelegram(
   text: string,
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
+  const trimmedText = normalizeOptionalString(text) ?? "";
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: "" };
+  }
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
   const chatId = await resolveAndPersistChatId({

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -620,7 +620,8 @@ export async function sendMessageTelegram(
   opts: TelegramSendOpts = {},
 ): Promise<TelegramSendResult> {
   const trimmedText = normalizeOptionalString(text) ?? "";
-  if (isSilentReplyText(trimmedText) && !opts.mediaUrl) {
+  const hasButtons = Array.isArray(opts.buttons) && opts.buttons.length > 0;
+  if (isSilentReplyText(trimmedText) && !opts.mediaUrl && !hasButtons) {
     logVerbose("telegram send: suppressed NO_REPLY token before API call");
     return { messageId: "suppressed", chatId: "" };
   }


### PR DESCRIPTION
## Summary

- `sendMessageSlack` guards against `NO_REPLY` sentinel tokens before calling the Slack API
- `sendMessageTelegram` was missing the same guard — a `NO_REPLY` token could reach the Telegram API
- This caused a visible flash of text (truncated to "NO") that Telegram briefly showed and then deleted once the stream handler suppressed the sentinel

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #38603

## Root Cause

When an agent outputs visible narration text before the `NO_REPLY` sentinel in the same response, the text streams to Telegram as a live preview. OpenClaw's stream handler correctly suppresses `NO_REPLY` at the end, but the preview was already delivered. `sendMessageSlack` has a defensive guard that intercepts `NO_REPLY` tokens before any API call; `sendMessageTelegram` lacked this guard.

## Fix

Added `isSilentReplyText` check at the entry of `sendMessageTelegram`, matching the existing Slack pattern. Returns a suppressed no-op result without making a network call when the text is a `NO_REPLY` sentinel and no media is attached.