### PR TITLE
fix(telegram): reject zero and negative replyToMessageId values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/assistant media: require `operator.read` scope for assistant-media file and metadata requests on identity-bearing HTTP auth paths so callers without a read scope can no longer access assistant media. (#68175) Thanks @eleqtrizit.
 - Exec approvals/display: escape raw control characters (including newline and carriage return) in the shared and macOS approval-prompt command sanitizers, so trailing command payloads no longer render on hidden extra lines in the approval UI. (#68198)
 - OpenAI Codex/OAuth + Pi: keep imported Codex CLI OAuth bootstrap, Pi auth export, and runtime overlay handling aligned so Codex sessions survive refresh and health checks without leaking transient CLI state into saved auth files. Thanks @vincentkoc.
+- Telegram/reply-id: reject zero and negative `replyToMessageId` values in the shared outbound normalizer so invalid reply targets are dropped instead of being forwarded to the Telegram API. (#68306) Thanks @1aifanatic.
 
 ## 2026.4.15
 

--- a/extensions/telegram/src/outbound-params.test.ts
+++ b/extensions/telegram/src/outbound-params.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+import {
+  normalizeTelegramReplyToMessageId,
+  parseTelegramReplyToMessageId,
+  parseTelegramThreadId,
+} from "./outbound-params.js";
 
 describe("parseTelegramThreadId", () => {
   it("parses numeric and scoped thread ids", () => {
@@ -18,12 +22,62 @@ describe("parseTelegramThreadId", () => {
   });
 });
 
+describe("normalizeTelegramReplyToMessageId", () => {
+  it("accepts positive finite numbers", () => {
+    expect(normalizeTelegramReplyToMessageId(42)).toBe(42);
+    expect(normalizeTelegramReplyToMessageId(1)).toBe(1);
+    expect(normalizeTelegramReplyToMessageId(1.9)).toBe(1);
+  });
+
+  it("rejects zero and negative numbers", () => {
+    expect(normalizeTelegramReplyToMessageId(0)).toBeUndefined();
+    expect(normalizeTelegramReplyToMessageId(-1)).toBeUndefined();
+  });
+
+  it("rejects non-finite numbers", () => {
+    expect(normalizeTelegramReplyToMessageId(Infinity)).toBeUndefined();
+    expect(normalizeTelegramReplyToMessageId(NaN)).toBeUndefined();
+  });
+
+  it("rejects non-numeric types", () => {
+    expect(normalizeTelegramReplyToMessageId(undefined)).toBeUndefined();
+    expect(normalizeTelegramReplyToMessageId(null)).toBeUndefined();
+    expect(normalizeTelegramReplyToMessageId({})).toBeUndefined();
+  });
+
+  it("accepts numeric strings with positive value", () => {
+    expect(normalizeTelegramReplyToMessageId("99")).toBe(99);
+  });
+
+  it("rejects zero and negative strings", () => {
+    expect(normalizeTelegramReplyToMessageId("0")).toBeUndefined();
+    expect(normalizeTelegramReplyToMessageId("-5")).toBeUndefined();
+  });
+
+  it("rejects UUID and non-numeric strings", () => {
+    expect(
+      normalizeTelegramReplyToMessageId("550e8400-e29b-41d4-a716-446655440000"),
+    ).toBeUndefined();
+  });
+});
+
 describe("parseTelegramReplyToMessageId", () => {
-  it("parses reply-to message ids", () => {
+  it("parses valid positive reply-to message ids", () => {
     expect(parseTelegramReplyToMessageId("123")).toBe(123);
+    expect(parseTelegramReplyToMessageId("1")).toBe(1);
   });
 
   it("returns undefined for missing reply-to ids", () => {
     expect(parseTelegramReplyToMessageId(null)).toBeUndefined();
+  });
+
+  it("returns undefined for non-positive reply-to ids", () => {
+    expect(parseTelegramReplyToMessageId("0")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("-1")).toBeUndefined();
+  });
+
+  it("returns undefined for non-numeric strings like UUIDs", () => {
+    expect(parseTelegramReplyToMessageId("550e8400-e29b-41d4-a716-446655440000")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("abc")).toBeUndefined();
   });
 });

--- a/extensions/telegram/src/outbound-params.ts
+++ b/extensions/telegram/src/outbound-params.ts
@@ -8,13 +8,18 @@ function parseIntegerId(value: string): number | undefined {
 
 export function normalizeTelegramReplyToMessageId(value: unknown): number | undefined {
   if (typeof value === "number") {
-    return Number.isFinite(value) ? Math.trunc(value) : undefined;
+    const truncated = Number.isFinite(value) ? Math.trunc(value) : undefined;
+    return truncated != null && truncated > 0 ? truncated : undefined;
   }
   if (typeof value !== "string") {
     return undefined;
   }
   const trimmed = value.trim();
-  return trimmed ? parseIntegerId(trimmed) : undefined;
+  if (!trimmed) {
+    return undefined;
+  }
+  const parsed = parseIntegerId(trimmed);
+  return parsed != null && parsed > 0 ? parsed : undefined;
 }
 
 export function parseTelegramReplyToMessageId(replyToId?: string | null): number | undefined {


### PR DESCRIPTION
## Summary

- `normalizeTelegramReplyToMessageId` now rejects `0` and negative values in addition to non-numeric inputs
- Telegram message IDs are always positive integers; passing `0` or a negative value would result in a `400 Bad Request` from the Telegram API
- Both the numeric branch (`typeof value === "number"`) and the string branch now enforce `> 0`

## Test plan

- [ ] `normalizeTelegramReplyToMessageId(0)` returns `undefined`
- [ ] `normalizeTelegramReplyToMessageId(-1)` returns `undefined`
- [ ] `normalizeTelegramReplyToMessageId("0")` returns `undefined`
- [ ] `normalizeTelegramReplyToMessageId("-5")` returns `undefined`
- [ ] `normalizeTelegramReplyToMessageId(42)` returns `42`
- [ ] `normalizeTelegramReplyToMessageId("99")` returns `99`
- [ ] UUID strings return `undefined`
- [ ] Existing `parseTelegramThreadId` behaviour is unchanged