### PR TITLE
fix(commands): emit WARN when bootstrap files are truncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Commands/bootstrap: forward the bootstrap truncation `warn` callback from `resolveCommandsSystemPromptBundle` so command-built system prompts emit the same WARN diagnostics as the CLI prepare path instead of silently dropping the warning. (#68307) Thanks @1aifanatic.
 - Agents/bootstrap: resolve bootstrap from workspace truth instead of stale session transcript markers, keep embedded bootstrap instructions on a hidden user-context prelude, suppress normal `/new` and `/reset` greetings while `BOOTSTRAP.md` is still pending, and make the embedded runner read the bootstrap ritual before replying normally.
 - Onboarding/non-interactive: preserve existing gateway auth tokens during re-onboard so active local gateway clients are not disconnected by an implicit token rotation. (#67821) Thanks @BKF-Gitty.
 - Gateway/hello-ok: always report negotiated auth metadata for successful shared-auth handshakes, including control-ui bypass coverage when no device token is issued. (#67810) Thanks @BunsDev.

--- a/src/auto-reply/reply/commands-system-prompt.test.ts
+++ b/src/auto-reply/reply/commands-system-prompt.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../agents/bootstrap-files.js", () => ({
     bootstrapFiles: [],
     contextFiles: [],
   })),
+  makeBootstrapWarn: vi.fn(() => vi.fn()),
 }));
 
 vi.mock("../../agents/sandbox.js", () => ({

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,6 +1,6 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
-import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
+import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
@@ -13,8 +13,11 @@ import { buildSystemPromptParams } from "../../agents/system-prompt-params.js";
 import { buildAgentSystemPrompt } from "../../agents/system-prompt.js";
 import type { WorkspaceBootstrapFile } from "../../agents/workspace.js";
 import { getRemoteSkillEligibility } from "../../infra/skills-remote.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import type { HandleCommandsParams } from "./commands-types.js";
+
+const log = createSubsystemLogger("commands-system-prompt");
 
 export type CommandsSystemPromptBundle = {
   systemPrompt: string;
@@ -40,6 +43,11 @@ export async function resolveCommandsSystemPromptBundle(
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: targetSessionEntry?.sessionId,
+    warn: makeBootstrapWarn({
+      sessionLabel: params.sessionKey ?? targetSessionEntry?.sessionId ?? "",
+      workspaceDir,
+      warn: (message) => log.warn(message),
+    }),
   });
   const sandboxRuntime = resolveSandboxRuntimeStatus({
     cfg: params.cfg,


### PR DESCRIPTION
## Summary

- `resolveCommandsSystemPromptBundle` was calling `resolveBootstrapContextForRun` without a `warn` callback
- Bootstrap file truncation warnings were silently discarded in the commands / system-prompt path
- Wires up `makeBootstrapWarn` backed by a `createSubsystemLogger` so truncation warnings now surface at WARN level, consistent with the compact and attempt runner paths

## Test plan

- [ ] `resolveCommandsSystemPromptBundle` is called with a large bootstrap file exceeding `bootstrapMaxChars`
- [ ] A WARN log entry `workspace bootstrap file ... is N chars (limit M); truncating in injected context (sessionKey=...)` appears
- [ ] No regression: existing tests for `resolveCommandsSystemPromptBundle` still pass (the mock uses `objectContaining`, so the new `warn` field is ignored)