### PR TITLE
fix(kilocode): send auth header in model discovery to include BYOK models

### DIFF
--- a/extensions/kilocode/provider-models.test.ts
+++ b/extensions/kilocode/provider-models.test.ts
@@ -114,7 +114,7 @@ describe("discoverKilocodeModels (fetch path)", () => {
       expect(mockFetch).toHaveBeenCalledWith(
         KILOCODE_MODELS_URL,
         expect.objectContaining({
-          headers: { Accept: "application/json" },
+          headers: expect.objectContaining({ Accept: "application/json" }),
         }),
       );
 
@@ -131,6 +131,58 @@ describe("discoverKilocodeModels (fetch path)", () => {
       expect(sonnet?.contextWindow).toBe(200000);
       expect(sonnet?.maxTokens).toBe(8192);
     });
+  });
+
+  it("sends Authorization header when KILOCODE_API_KEY is set", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeAutoModel()] }),
+    });
+    const origApiKey = process.env.KILOCODE_API_KEY;
+    process.env.KILOCODE_API_KEY = "test-api-key-123";
+    try {
+      await withFetchPathTest(mockFetch, async () => {
+        await discoverKilocodeModels();
+        expect(mockFetch).toHaveBeenCalledWith(
+          KILOCODE_MODELS_URL,
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              Accept: "application/json",
+              Authorization: "Bearer test-api-key-123",
+            }),
+          }),
+        );
+      });
+    } finally {
+      if (origApiKey === undefined) {
+        delete process.env.KILOCODE_API_KEY;
+      } else {
+        process.env.KILOCODE_API_KEY = origApiKey;
+      }
+    }
+  });
+
+  it("omits Authorization header when KILOCODE_API_KEY is not set", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [makeAutoModel()] }),
+    });
+    const origApiKey = process.env.KILOCODE_API_KEY;
+    delete process.env.KILOCODE_API_KEY;
+    try {
+      await withFetchPathTest(mockFetch, async () => {
+        await discoverKilocodeModels();
+        const callArgs = mockFetch.mock.calls[0][1] as { headers: Record<string, string> };
+        expect(callArgs.headers).toEqual({ Accept: "application/json" });
+        expect(callArgs.headers).not.toHaveProperty("Authorization");
+      });
+    } finally {
+      if (origApiKey === undefined) {
+        delete process.env.KILOCODE_API_KEY;
+      } else {
+        process.env.KILOCODE_API_KEY = origApiKey;
+      }
+    }
   });
 
   it("falls back to static catalog on network error", async () => {

--- a/extensions/kilocode/provider-models.test.ts
+++ b/extensions/kilocode/provider-models.test.ts
@@ -173,7 +173,7 @@ describe("discoverKilocodeModels (fetch path)", () => {
       await withFetchPathTest(mockFetch, async () => {
         await discoverKilocodeModels();
         const callArgs = mockFetch.mock.calls[0][1] as { headers: Record<string, string> };
-        expect(callArgs.headers).toEqual({ Accept: "application/json" });
+        expect(callArgs.headers).toMatchObject({ Accept: "application/json" });
         expect(callArgs.headers).not.toHaveProperty("Authorization");
       });
     } finally {

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -127,8 +127,14 @@ export async function discoverKilocodeModels(): Promise<ModelDefinitionConfig[]>
   }
 
   try {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    const apiKey = process.env.KILOCODE_API_KEY;
+    if (apiKey) {
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
     const response = await fetch(KILOCODE_MODELS_URL, {
-      headers: { Accept: "application/json" },
+      headers,
       signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
     });
 

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -132,6 +132,10 @@ export async function discoverKilocodeModels(): Promise<ModelDefinitionConfig[]>
     if (apiKey) {
       headers["Authorization"] = `Bearer ${apiKey}`;
     }
+    const orgId = process.env.KILOCODE_ORGANIZATION_ID;
+    if (orgId) {
+      headers["X-KiloCode-OrganizationId"] = orgId;
+    }
 
     const response = await fetch(KILOCODE_MODELS_URL, {
       headers,

--- a/extensions/kilocode/provider-models.ts
+++ b/extensions/kilocode/provider-models.ts
@@ -128,11 +128,11 @@ export async function discoverKilocodeModels(): Promise<ModelDefinitionConfig[]>
 
   try {
     const headers: Record<string, string> = { Accept: "application/json" };
-    const apiKey = process.env.KILOCODE_API_KEY;
+    const apiKey = process.env.KILOCODE_API_KEY?.trim();
     if (apiKey) {
       headers["Authorization"] = `Bearer ${apiKey}`;
     }
-    const orgId = process.env.KILOCODE_ORGANIZATION_ID;
+    const orgId = process.env.KILOCODE_ORGANIZATION_ID?.trim();
     if (orgId) {
       headers["X-KiloCode-OrganizationId"] = orgId;
     }

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -33,7 +33,7 @@ const allowedRawFetchCallsites = new Set([
   bundledPluginCallsite("github-copilot", "login.ts", 80),
   bundledPluginCallsite("googlechat", "src/auth.ts", 83),
   bundledPluginCallsite("huggingface", "models.ts", 142),
-  bundledPluginCallsite("kilocode", "provider-models.ts", 130),
+  bundledPluginCallsite("kilocode", "provider-models.ts", 140),
   bundledPluginCallsite("matrix", "src/matrix/sdk/transport.ts", 112),
   bundledPluginCallsite("microsoft-foundry", "onboard.ts", 479),
   bundledPluginCallsite("microsoft", "speech-provider.ts", 140),


### PR DESCRIPTION
## Summary
- Send `KILOCODE_API_KEY` as a Bearer token in the **extension** kilocode model discovery fetch so the gateway can resolve the user and include their BYOK models in the response.

## Problem
When OpenClaw discovers models via `fetch(KILOCODE_MODELS_URL)` in `extensions/kilocode/provider-models.ts`, it sends no auth header. The gateway (`api.kilo.ai/api/gateway/models`) only appends BYOK models when it can identify the user. Without auth, BYOK models are silently dropped, making BYOK providers like `zai-coding` non-functional in Kiloclaw.

## Scope note
PR #32352 introduced dynamic model discovery in **two** code paths:
- **`src/agents/kilocode-models.ts`** — core path (used by standard OpenClaw)
- **`extensions/kilocode/provider-models.ts`** — extension path (used by Kiloclaw)

This PR only fixes the **extension path**. The core path still has the same unauthenticated fetch, so #65578 (the regression affecting standard OpenClaw users like SergioNR) will require a separate fix to `src/agents/kilocode-models.ts`.

## Why this works
- `KILOCODE_API_KEY` is already in the environment (Kiloclaw passes it as an env var)
- It's a JWT with `kiloUserId` and `version: 3` — the exact format the gateway already validates
- The gateway's `getUserFromAuth()` already reads `Authorization: Bearer` headers and resolves users
- **Zero changes needed in Kilo-Org/cloud**

## Backward compatibility
- No `KILOCODE_API_KEY` → no `Authorization` header → same behavior as today
- Test environment returns static catalog before fetch is called (existing tests unaffected)
- Non-Kiloclaw OpenClaw instances are unaffected
- Trims env vars before use to handle stray whitespace/newlines (review feedback from #66175)

Recreated from a clean branch after #66175 was closed for picking up unrelated commits during a rebase.

Related openclaw/openclaw#65578 (extension path only; core path still unfixed)
Related Kilo-Org/cloud#2384

🤖 AI-assisted (Kilo with GLM-5.1). Fully reviewed and understood by the author. Lightly tested — verified via curl that the gateway endpoint returns BYOK models when authenticated and omits them when not.