### PR TITLE
fix(plugins): enable native jiti for doctor-contract loader to cut status cold-start ~13s

### DIFF
--- a/src/plugins/doctor-contract-registry.test.ts
+++ b/src/plugins/doctor-contract-registry.test.ts
@@ -61,6 +61,37 @@ describe("doctor-contract-registry getJiti", () => {
     );
   });
 
+  it("enables native jiti loading on Linux for contract-api modules (#68282)", () => {
+    // Reporter measured ~15.7s first-call cost for `openclaw status` dominated
+    // by doctor contract loading on the default (non-native) jiti path, vs
+    // ~2.1s with `tryNative: true`. Assert the Linux path requests native
+    // loading explicitly so the default `dist/extensions/*` gate in
+    // `resolvePluginLoaderJitiTryNative` does not downgrade us.
+    const pluginRoot = makeTempDir();
+    fs.writeFileSync(path.join(pluginRoot, "contract-api.js"), "export default {};\n", "utf-8");
+    mocks.loadPluginManifestRegistry.mockReturnValue({
+      plugins: [{ id: "test-plugin", rootDir: pluginRoot }],
+      diagnostics: [],
+    });
+    const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+
+    try {
+      listPluginDoctorLegacyConfigRules({
+        workspaceDir: pluginRoot,
+        env: {},
+      });
+    } finally {
+      platformSpy.mockRestore();
+    }
+
+    expect(mocks.createJiti).toHaveBeenCalledTimes(1);
+    expect(mocks.createJiti.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        tryNative: true,
+      }),
+    );
+  });
+
   it("prefers doctor-contract-api over the broader contract-api surface", () => {
     const pluginRoot = makeTempDir();
     fs.writeFileSync(

--- a/src/plugins/doctor-contract-registry.ts
+++ b/src/plugins/doctor-contract-registry.ts
@@ -48,6 +48,18 @@ function getJiti(modulePath: string) {
     cache: jitiLoaders,
     modulePath,
     importerUrl: import.meta.url,
+    // Doctor-contract artifacts live under `dist/extensions/<plugin>/contract-api.js`
+    // in shipped builds — a pure built JS bundle. The default resolver gates
+    // `dist/extensions/*` to `tryNative: false` (see
+    // `resolvePluginLoaderJitiTryNative` in `sdk-alias.ts`), which adds ~14s
+    // of cold-start cost on first `openclaw status` / `openclaw doctor`
+    // invocation (measured: ~15.7s default vs ~2.1s with tryNative). Flip the
+    // gate to native where the platform supports it — jiti falls back to its
+    // transpile path on native-import failure, so aliased `openclaw/plugin-sdk/*`
+    // imports inside contract modules still resolve. Windows disables native
+    // jiti entirely (see `supportsNativeJitiRuntime`), so keep that platform
+    // on the slower-but-known path.
+    tryNative: process.platform !== "win32",
   });
 }
 


### PR DESCRIPTION
## Summary

Fixes #68282 — \`openclaw status\` (and \`--json\`, \`--deep\`, \`--usage\`) pays a ~15s first-call penalty on every fresh process, dominated by doctor-contract loading through the default jiti path. The reporter measured the contract-api artifact in isolation at **15.7s default vs 2.1s with \`tryNative: true\`**, and \`listPluginDoctorLegacyConfigRules\` ate 21.8s of the total 17s config-validation wall time.

## Root cause

\`src/plugins/doctor-contract-registry.ts:46-52\` built the loader via:

\`\`\`ts
function getJiti(modulePath: string) {
  return getCachedPluginJitiLoader({
    cache: jitiLoaders,
    modulePath,
    importerUrl: import.meta.url,
  });
}
\`\`\`

Without \`tryNative\` explicit, \`getCachedPluginJitiLoader\` defers to \`resolvePluginLoaderJitiTryNative\` in \`src/plugins/sdk-alias.ts\`. That function has an unconditional guard that returns \`false\` whenever \`modulePath\` matches \`/dist/extensions/\` — which is exactly where contract artifacts live in shipped builds (\`dist/extensions/telegram/contract-api.js\` etc.). So every doctor contract load took the slow transpile-and-cache path on cold start.

## Fix

Pass \`tryNative: process.platform !== \"win32\"\` explicitly from the doctor registry:

\`\`\`ts
function getJiti(modulePath: string) {
  return getCachedPluginJitiLoader({
    cache: jitiLoaders,
    modulePath,
    importerUrl: import.meta.url,
    tryNative: process.platform !== \"win32\",
  });
}
\`\`\`

Jiti keeps its transpile path as a fallback on native-import failure, so aliased \`openclaw/plugin-sdk/*\` imports inside contract modules still resolve via the existing alias-map flow. Windows is left on the pre-existing slower path because \`supportsNativeJitiRuntime\` in \`sdk-alias.ts\` disables native jiti for that platform anyway.

## Test plan

- [x] Added a regression test \`enables native jiti loading on Linux for contract-api modules (#68282)\` in \`src/plugins/doctor-contract-registry.test.ts\`, mirroring the existing \`disables native jiti loading on Windows for contract-api modules\` case. Asserts \`createJiti\` is invoked with \`tryNative: true\` when \`process.platform\` returns \`linux\`.
- [x] Existing Windows test (\`disables native jiti loading on Windows\`) still passes because the new pass-through evaluates to \`false\` on Windows.
- [x] \`NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit\` — 245 baseline on main, 245 on branch (no delta).
- [x] \`pnpm exec oxlint\` on both touched files — 0 warnings, 0 errors.

Local full vitest is blocked by pre-existing \`test/non-isolated-runner.ts\` drift (reproduces on \`main\`); CI exercises the new case normally.

## Risk

- Contract artifacts in \`dist/extensions/<plugin>/\` are built JS bundles — native import is the fast and correct path for them. The transpile fallback remains active if a native-load edge case (e.g. a contract module that imports a TS source path directly) fails.
- Windows path is unchanged because \`supportsNativeJitiRuntime\` already disables native jiti there.
- No API surface changes; doctor-rule loading emits the same \`PluginDoctorContractEntry\` values, just faster on first call.

## Measurement (from issue body)

| Path | First-call |
|------|------------|
| default jiti | ~15.7s |
| \`tryNative: true\` | ~2.1s |
| native \`import()\` | ~3.0s |

This PR puts the doctor registry on the 2.1s path.