### PR TITLE
Parse multiline MEDIA directives

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -105,6 +105,18 @@ describe("splitMediaFromOutput", () => {
     ]);
   });
 
+  it("consumes only one continuation line after an empty media directive", () => {
+    const result = splitMediaFromOutput("Before\nMEDIA:\n/tmp/screenshot.png\nREADME.md\nAfter");
+
+    expect(result.text).toBe("Before\nREADME.md\nAfter");
+    expect(result.mediaUrls).toEqual(["/tmp/screenshot.png"]);
+    expect(result.segments).toEqual([
+      { type: "text", text: "Before" },
+      { type: "media", url: "/tmp/screenshot.png" },
+      { type: "text", text: "README.md\nAfter" },
+    ]);
+  });
+
   it("returns ordered text and media segments while ignoring fenced MEDIA lines", () => {
     const result = splitMediaFromOutput(
       "Before\nMEDIA:https://example.com/a.png\n```text\nMEDIA:https://example.com/ignored.png\n```\nAfter",

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -92,6 +92,19 @@ describe("splitMediaFromOutput", () => {
     }
   });
 
+  it("accepts a media directive with the path on the next line", () => {
+    const result = splitMediaFromOutput("Before\nMEDIA:\n/tmp/screenshot.png\nAfter");
+
+    expect(result.text).toBe("Before\nAfter");
+    expect(result.mediaUrls).toEqual(["/tmp/screenshot.png"]);
+    expect(result.mediaUrl).toBe("/tmp/screenshot.png");
+    expect(result.segments).toEqual([
+      { type: "text", text: "Before" },
+      { type: "media", url: "/tmp/screenshot.png" },
+      { type: "text", text: "After" },
+    ]);
+  });
+
   it("returns ordered text and media segments while ignoring fenced MEDIA lines", () => {
     const result = splitMediaFromOutput(
       "Before\nMEDIA:https://example.com/a.png\n```text\nMEDIA:https://example.com/ignored.png\n```\nAfter",

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -108,10 +108,7 @@ function isValidMedia(
 function isValidContinuationMedia(candidate: string, wasQuoted: boolean): boolean {
   const hasSpaces = /\s/.test(candidate);
   const allowSpaces =
-    wasQuoted ||
-    /^https?:\/\//i.test(candidate) ||
-    candidate.startsWith("file://") ||
-    looksLikeLocalFilePath(candidate);
+    wasQuoted || /^https?:\/\//i.test(candidate) || looksLikeLocalFilePath(candidate);
 
   if (hasSpaces && !allowSpaces) {
     return false;
@@ -214,38 +211,24 @@ export function splitMediaFromOutput(raw: string): {
     const isEmptyMediaDirective = matches.every((match) => (match[1] ?? "").trim() === "");
     if (isEmptyMediaDirective) {
       let nextLineOffset = lineOffset + line.length + 1;
-      const continuationSegments: ParsedMediaOutputSegment[] = [];
-      let consumedContinuationLines = 0;
-
-      for (let nextLineIndex = lineIndex + 1; nextLineIndex < lines.length; nextLineIndex += 1) {
-        const nextLine = lines[nextLineIndex];
-        if (hasFenceMarkers && isInsideFence(fenceSpans, nextLineOffset)) {
-          break;
-        }
-
+      const nextLine = lines[lineIndex + 1];
+      if (
+        nextLine !== undefined &&
+        !(hasFenceMarkers && isInsideFence(fenceSpans, nextLineOffset))
+      ) {
         const candidateText = nextLine.trim();
-        if (!candidateText) {
-          break;
+        if (candidateText) {
+          const unwrapped = unwrapQuoted(candidateText);
+          const candidate = normalizeMediaSource(cleanCandidate(unwrapped ?? candidateText));
+          if (isValidContinuationMedia(candidate, unwrapped !== undefined)) {
+            media.push(candidate);
+            foundMediaToken = true;
+            segments.push({ type: "media", url: candidate });
+            lineIndex += 1;
+            lineOffset = nextLineOffset + nextLine.length + 1;
+            continue;
+          }
         }
-
-        const unwrapped = unwrapQuoted(candidateText);
-        const candidate = normalizeMediaSource(cleanCandidate(unwrapped ?? candidateText));
-        if (!isValidContinuationMedia(candidate, unwrapped !== undefined)) {
-          break;
-        }
-
-        media.push(candidate);
-        foundMediaToken = true;
-        continuationSegments.push({ type: "media", url: candidate });
-        consumedContinuationLines += 1;
-        nextLineOffset += nextLine.length + 1;
-      }
-
-      if (continuationSegments.length > 0) {
-        segments.push(...continuationSegments);
-        lineIndex += consumedContinuationLines;
-        lineOffset = nextLineOffset;
-        continue;
       }
 
       keptLines.push(line);

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -105,6 +105,24 @@ function isValidMedia(
   return false;
 }
 
+function isValidContinuationMedia(candidate: string, wasQuoted: boolean): boolean {
+  const hasSpaces = /\s/.test(candidate);
+  const allowSpaces =
+    wasQuoted ||
+    /^https?:\/\//i.test(candidate) ||
+    candidate.startsWith("file://") ||
+    looksLikeLocalFilePath(candidate);
+
+  if (hasSpaces && !allowSpaces) {
+    return false;
+  }
+
+  return isValidMedia(candidate, {
+    allowSpaces,
+    allowBareFilename: wasQuoted || !hasSpaces,
+  });
+}
+
 function unwrapQuoted(value: string): string | undefined {
   const trimmed = value.trim();
   if (trimmed.length < 2) {
@@ -174,7 +192,8 @@ export function splitMediaFromOutput(raw: string): {
   const keptLines: string[] = [];
 
   let lineOffset = 0; // Track character offset for fence checking
-  for (const line of lines) {
+  for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+    const line = lines[lineIndex];
     // Skip MEDIA extraction if this line is inside a fenced code block
     if (hasFenceMarkers && isInsideFence(fenceSpans, lineOffset)) {
       keptLines.push(line);
@@ -192,7 +211,43 @@ export function splitMediaFromOutput(raw: string): {
     }
 
     const matches = Array.from(line.matchAll(MEDIA_TOKEN_RE));
-    if (matches.length === 0) {
+    const isEmptyMediaDirective = matches.every((match) => (match[1] ?? "").trim() === "");
+    if (isEmptyMediaDirective) {
+      let nextLineOffset = lineOffset + line.length + 1;
+      const continuationSegments: ParsedMediaOutputSegment[] = [];
+      let consumedContinuationLines = 0;
+
+      for (let nextLineIndex = lineIndex + 1; nextLineIndex < lines.length; nextLineIndex += 1) {
+        const nextLine = lines[nextLineIndex];
+        if (hasFenceMarkers && isInsideFence(fenceSpans, nextLineOffset)) {
+          break;
+        }
+
+        const candidateText = nextLine.trim();
+        if (!candidateText) {
+          break;
+        }
+
+        const unwrapped = unwrapQuoted(candidateText);
+        const candidate = normalizeMediaSource(cleanCandidate(unwrapped ?? candidateText));
+        if (!isValidContinuationMedia(candidate, unwrapped !== undefined)) {
+          break;
+        }
+
+        media.push(candidate);
+        foundMediaToken = true;
+        continuationSegments.push({ type: "media", url: candidate });
+        consumedContinuationLines += 1;
+        nextLineOffset += nextLine.length + 1;
+      }
+
+      if (continuationSegments.length > 0) {
+        segments.push(...continuationSegments);
+        lineIndex += consumedContinuationLines;
+        lineOffset = nextLineOffset;
+        continue;
+      }
+
       keptLines.push(line);
       pushTextSegment(line);
       lineOffset += line.length + 1; // +1 for newline


### PR DESCRIPTION
## Summary
- Parse empty `MEDIA:` directives whose media path appears on the following line.
- Preserve ordered text/media segments when consuming the continuation path.
- Keep the change scoped to media output parsing only; no delivery, routeReply, prompt, config, or secret changes.

## Tests
- `PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm exec vitest run --config vitest.config.ts src/media/parse.test.ts --reporter=dot --silent=passed-only`
- `PATH=/opt/node-v22.22.0/bin:$PATH node scripts/run-tsgo.mjs`
- `PATH=/opt/node-v22.22.0/bin:$PATH node scripts/run-oxlint.mjs`
- `PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm format:check src/media/parse.ts src/media/parse.test.ts`
- `git diff --check`
- `PATH=/opt/node-v22.22.0/bin:$PATH corepack pnpm check:no-conflict-markers`