### PR TITLE
fix(secrets): reject noisy plain exec stdout

### DIFF
--- a/src/secrets/resolve.test.ts
+++ b/src/secrets/resolve.test.ts
@@ -237,6 +237,24 @@ describe("secret ref resolver", () => {
     expect(value).toBe("plain-secret");
   });
 
+  itPosix("rejects polluted single-value exec output when jsonOnly is false", async () => {
+    const root = await createCaseDir("exec-plain-polluted");
+    const scriptPath = path.join(root, "resolver-plain-polluted.sh");
+    await writeSecureFile(
+      scriptPath,
+      [
+        "#!/bin/sh",
+        "printf '%s\\n' '[plugins][lcm]Pluginloaded(enabled=true)'",
+        "printf '%s\\n' 'full'",
+      ].join("\n"),
+      0o700,
+    );
+
+    await expect(resolveExecSecret(scriptPath, { jsonOnly: false })).rejects.toThrow(
+      "returned noisy stdout",
+    );
+  });
+
   itPosix(
     "tolerates stdin write errors when exec provider exits before consuming a large request",
     async () => {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -572,7 +572,18 @@ function parseExecValues(params: {
     try {
       parsed = JSON.parse(trimmed) as unknown;
     } catch {
-      return { [params.ids[0]]: trimmed };
+      const nonEmptyLines = params.stdout
+        .split(/\r?\n/u)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+      if (nonEmptyLines.length !== 1) {
+        throw providerResolutionError({
+          source: "exec",
+          provider: params.providerName,
+          message: `Exec provider "${params.providerName}" returned noisy stdout; emit a single plain-text line or JSON.`,
+        });
+      }
+      return { [params.ids[0]]: nonEmptyLines[0] };
     }
   } else {
     try {


### PR DESCRIPTION
## Summary

- Problem: the exec secret resolver accepted any non-JSON single-value stdout verbatim when `jsonOnly: false`, including plugin/log noise followed by the intended scalar.
- Why it matters: if an exec-backed resolver emits machine output plus incidental logs, OpenClaw can treat the entire polluted stdout as the configured value.
- What changed: the plain-text fallback now only accepts exactly one non-empty line; noisy multi-line stdout must be emitted as JSON or it is rejected.
- What did NOT change (scope boundary): this PR does not alter JSON exec-provider handling, config writeback behavior, or gateway hot-reload semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #64821
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `parseExecValues()` in `src/secrets/resolve.ts` trimmed full stdout and, for `jsonOnly: false` single-id exec providers, returned the entire non-JSON payload as the resolved value.
- Missing detection / guardrail: there was no regression test covering noisy stdout before the intended scalar output.
- Contributing context (if known): a local debug reproduction confirmed that plugin-style log noise can reach this fallback path and be accepted verbatim.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/secrets/resolve.test.ts`
- Scenario the test should lock in: a non-JSON single-value exec provider that prints plugin/log noise plus the intended value on separate lines is rejected instead of folded into the resolved scalar.
- Why this is the smallest reliable guardrail: the bug is isolated to the plain-text fallback parser, so a focused unit test exercises the exact trust boundary without unrelated gateway setup.
- Existing test that already covers this (if any): `supports non-JSON single-value exec output when jsonOnly is false` continues to cover the valid single-line case.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Exec providers using `jsonOnly: false` must emit either JSON or exactly one non-empty plain-text line.
- Multi-line noisy stdout is now rejected with an explicit error instead of being silently accepted as the resolved value.

## Diagram (if applicable)

```text
Before:
[exec provider stdout: log line + plain value] -> [non-JSON single-id fallback] -> [entire polluted stdout accepted]

After:
[exec provider stdout: log line + plain value] -> [non-JSON single-id fallback] -> [explicit noisy-stdout error]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - The change tightens secret-resolution parsing by rejecting ambiguous plain-text output; valid single-line plain output and JSON output continue to work.

## Repro + Verification

### Environment

- OS: macOS local dev
- Runtime/container: pnpm workspace tests
- Model/provider: N/A
- Integration/channel (if any): exec-backed secret provider
- Relevant config (redacted): `jsonOnly: false` single-id exec provider

### Steps

1. Run an exec provider that prints plugin/log noise on one line and the intended plain value on the next.
2. Resolve the provider with `jsonOnly: false`.

### Expected

- OpenClaw rejects noisy stdout and asks for JSON or one clean line.

### Actual

- Verified by focused regression tests and local gates.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Ran targeted secret-resolver tests, `pnpm check`, and `pnpm build`.
- Edge cases checked: valid one-line plain output still works; noisy multi-line plain output now throws.
- What you did **not** verify: external third-party plugins or out-of-repo bridge workflows beyond the focused parser seam.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Mostly`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: an existing exec provider that relied on multi-line non-JSON stdout will now fail instead of being tolerated.
  - Mitigation: JSON output remains fully supported, and valid plain-text output still works when the provider emits one clean line.
