### PR TITLE
plugins: clarify allowlist warning when entries don't match discovered ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2622,6 +2622,7 @@ Docs: https://docs.openclaw.ai
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
+- Plugins/allowlist warnings: stop saying `plugins.allow is empty` when the allowlist is actually populated but none of its entries match a discovered plugin id, and emit a specific mismatch warning pointing at the unknown entries so users can tell the difference between a missing allowlist and a misconfigured one (for example `allow: ["feishu"]` when the real plugin id is `openclaw-lark`). (#68352)
 
 ## 2026.4.19-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7629,6 +7629,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
+- Plugins/allowlist warnings: stop saying `plugins.allow is empty` when the allowlist is actually populated but none of its entries match a discovered plugin id, and emit a specific mismatch warning pointing at the unknown entries so users can tell the difference between a missing allowlist and a misconfigured one (for example `allow: ["feishu"]` when the real plugin id is `openclaw-lark`). (#68352)
 
 ## 2026.4.19-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7629,7 +7629,6 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
-- Plugins/allowlist warnings: stop saying `plugins.allow is empty` when the allowlist is actually populated but none of its entries match a discovered plugin id, and emit a specific mismatch warning pointing at the unknown entries so users can tell the difference between a missing allowlist and a misconfigured one (for example `allow: ["feishu"]` when the real plugin id is `openclaw-lark`). (#68352)
 
 ## 2026.4.19-beta.2
 

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -213,8 +213,13 @@ export function warnWhenAllowlistIsOpen(params: {
   if (autoDiscoverable.length === 0) {
     return;
   }
-  const discoveredIds = new Set(autoDiscoverable.map((entry) => entry.id));
-  const allowHasMatch = params.allow.some((id) => discoveredIds.has(id));
+  // Match allow entries against every discovered plugin id (including bundled), not only the
+  // workspace/global subset we warn about. Otherwise a correct allowlist that intentionally
+  // trusts bundled ids (for example `plugins.allow = ["telegram"]`) would be flagged as
+  // "does not match any discovered plugin ids" whenever any non-bundled plugin happened to be
+  // present — a false positive that the empty-vs-mismatched split was meant to avoid.
+  const allDiscoveredIds = new Set(params.discoverablePlugins.map((entry) => entry.id));
+  const allowHasMatch = params.allow.some((id) => allDiscoveredIds.has(id));
   if (params.allow.length > 0 && allowHasMatch) {
     return;
   }
@@ -233,7 +238,7 @@ export function warnWhenAllowlistIsOpen(params: {
     );
     return;
   }
-  const unmatchedEntries = params.allow.filter((id) => !discoveredIds.has(id));
+  const unmatchedEntries = params.allow.filter((id) => !allDiscoveredIds.has(id));
   const unmatchedPreview = unmatchedEntries
     .slice(0, 6)
     .map((id) => `"${id}"`)

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -207,13 +207,15 @@ export function warnWhenAllowlistIsOpen(params: {
   if (!params.pluginsEnabled) {
     return;
   }
-  if (params.allow.length > 0) {
-    return;
-  }
   const autoDiscoverable = params.discoverablePlugins.filter(
     (entry) => entry.origin === "workspace" || entry.origin === "global",
   );
   if (autoDiscoverable.length === 0) {
+    return;
+  }
+  const discoveredIds = new Set(autoDiscoverable.map((entry) => entry.id));
+  const allowHasMatch = params.allow.some((id) => discoveredIds.has(id));
+  if (params.allow.length > 0 && allowHasMatch) {
     return;
   }
   if (params.warningCache.hasOpenAllowlistWarning(params.warningCacheKey)) {
@@ -225,8 +227,21 @@ export function warnWhenAllowlistIsOpen(params: {
     .join(", ");
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
+  if (params.allow.length === 0) {
+    params.logger.warn(
+      `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    );
+    return;
+  }
+  const unmatchedEntries = params.allow.filter((id) => !discoveredIds.has(id));
+  const unmatchedPreview = unmatchedEntries
+    .slice(0, 6)
+    .map((id) => `"${id}"`)
+    .join(", ");
+  const unmatchedExtra =
+    unmatchedEntries.length > 6 ? ` (+${unmatchedEntries.length - 6} more)` : "";
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] plugins.allow entries ${unmatchedPreview}${unmatchedExtra} do not match any discovered plugin ids; discovered non-bundled plugins: ${preview}${extra}. Use the plugin id (not a channel id or npm package name).`,
   );
 }
 

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -229,14 +229,12 @@ export function warnWhenAllowlistIsOpen(params: {
   if (autoDiscoverable.length === 0) {
     return;
   }
-  // Match allow entries against every discovered plugin id (including bundled), not only the
-  // workspace/global subset we warn about. Otherwise a correct allowlist that intentionally
-  // trusts bundled ids (for example `plugins.allow = ["telegram"]`) would be flagged as
-  // "does not match any discovered plugin ids" whenever any non-bundled plugin happened to be
-  // present — a false positive that the empty-vs-mismatched split was meant to avoid.
+  // Match allow entries against every discovered plugin id, including bundled ids. Otherwise a
+  // valid bundled-only allowlist would look mismatched whenever workspace/global plugins exist.
   const allDiscoveredIds = new Set(params.discoverablePlugins.map((entry) => entry.id));
-  const allowHasMatch = params.allow.some((id) => allDiscoveredIds.has(id));
-  if (params.allow.length > 0 && allowHasMatch) {
+  const hasConfiguredAllowlist = params.allow.length > 0;
+  const allowHasDiscoveredMatch = params.allow.some((id) => allDiscoveredIds.has(id));
+  if (hasConfiguredAllowlist && allowHasDiscoveredMatch) {
     return;
   }
   if (params.warningCache.hasOpenAllowlistWarning(params.warningCacheKey)) {
@@ -248,7 +246,7 @@ export function warnWhenAllowlistIsOpen(params: {
     .join(", ");
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
-  if (params.allow.length === 0) {
+  if (!hasConfiguredAllowlist) {
     params.logger.warn(
       `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
     );

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -223,13 +223,15 @@ export function warnWhenAllowlistIsOpen(params: {
   if (!params.pluginsEnabled) {
     return;
   }
-  if (params.allow.length > 0) {
-    return;
-  }
   const autoDiscoverable = params.discoverablePlugins.filter(
     (entry) => entry.origin === "workspace" || entry.origin === "global",
   );
   if (autoDiscoverable.length === 0) {
+    return;
+  }
+  const discoveredIds = new Set(autoDiscoverable.map((entry) => entry.id));
+  const allowHasMatch = params.allow.some((id) => discoveredIds.has(id));
+  if (params.allow.length > 0 && allowHasMatch) {
     return;
   }
   if (params.warningCache.hasOpenAllowlistWarning(params.warningCacheKey)) {
@@ -241,8 +243,21 @@ export function warnWhenAllowlistIsOpen(params: {
     .join(", ");
   const extra = autoDiscoverable.length > 6 ? ` (+${autoDiscoverable.length - 6} more)` : "";
   params.warningCache.recordOpenAllowlistWarning(params.warningCacheKey);
+  if (params.allow.length === 0) {
+    params.logger.warn(
+      `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    );
+    return;
+  }
+  const unmatchedEntries = params.allow.filter((id) => !discoveredIds.has(id));
+  const unmatchedPreview = unmatchedEntries
+    .slice(0, 6)
+    .map((id) => `"${id}"`)
+    .join(", ");
+  const unmatchedExtra =
+    unmatchedEntries.length > 6 ? ` (+${unmatchedEntries.length - 6} more)` : "";
   params.logger.warn(
-    `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: ${preview}${extra}. Set plugins.allow to explicit trusted ids.`,
+    `[plugins] plugins.allow entries ${unmatchedPreview}${unmatchedExtra} do not match any discovered plugin ids; discovered non-bundled plugins: ${preview}${extra}. Use the plugin id (not a channel id or npm package name).`,
   );
 }
 

--- a/src/plugins/loader-provenance.ts
+++ b/src/plugins/loader-provenance.ts
@@ -229,8 +229,13 @@ export function warnWhenAllowlistIsOpen(params: {
   if (autoDiscoverable.length === 0) {
     return;
   }
-  const discoveredIds = new Set(autoDiscoverable.map((entry) => entry.id));
-  const allowHasMatch = params.allow.some((id) => discoveredIds.has(id));
+  // Match allow entries against every discovered plugin id (including bundled), not only the
+  // workspace/global subset we warn about. Otherwise a correct allowlist that intentionally
+  // trusts bundled ids (for example `plugins.allow = ["telegram"]`) would be flagged as
+  // "does not match any discovered plugin ids" whenever any non-bundled plugin happened to be
+  // present — a false positive that the empty-vs-mismatched split was meant to avoid.
+  const allDiscoveredIds = new Set(params.discoverablePlugins.map((entry) => entry.id));
+  const allowHasMatch = params.allow.some((id) => allDiscoveredIds.has(id));
   if (params.allow.length > 0 && allowHasMatch) {
     return;
   }
@@ -249,7 +254,7 @@ export function warnWhenAllowlistIsOpen(params: {
     );
     return;
   }
-  const unmatchedEntries = params.allow.filter((id) => !discoveredIds.has(id));
+  const unmatchedEntries = params.allow.filter((id) => !allDiscoveredIds.has(id));
   const unmatchedPreview = unmatchedEntries
     .slice(0, 6)
     .map((id) => `"${id}"`)

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6045,6 +6045,45 @@ module.exports = {
     );
   });
 
+  it("stays quiet when plugins.allow matches only bundled plugin ids, even while workspace/global plugins are present", () => {
+    // Regression for Codex P2 feedback on #68389: the mismatch warning should be computed
+    // against the full discovered plugin set (bundled + workspace + global), not only the
+    // workspace/global subset that the warning talks about. An allowlist that intentionally
+    // trusts bundled ids like ["telegram"] is valid and must not trip the mismatch path just
+    // because some unrelated non-bundled plugin happens to be auto-discoverable.
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    writeBundledPlugin({
+      id: "warn-bundled-allow-only-plugin",
+      body: simplePluginBody("warn-bundled-allow-only-plugin"),
+    });
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-noise-workspace-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // Allowlist intentionally only trusts a bundled plugin id.
+          allow: ["warn-bundled-allow-only-plugin"],
+        },
+      },
+    });
+    const openAllowWarnings = warnings.filter(
+      (msg) =>
+        msg.includes("plugins.allow is empty") ||
+        msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(
+      openAllowWarnings,
+      "bundled-only allowlists should not trip the mismatch warning",
+    ).toHaveLength(0);
+  });
+
   it("handles workspace-discovered plugins according to trust and precedence", () => {
     useNoBundledPlugins();
     const scenarios = [

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -5986,6 +5986,65 @@ module.exports = {
     });
   });
 
+  it("warns when plugins.allow entries do not match any discovered plugin ids", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-mismatch-allow-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // User configured a channel-style id that does not match the real plugin id.
+          allow: ["warn-mismatch-allow-channel"],
+        },
+      },
+    });
+    const emptyWarnings = warnings.filter((msg) => msg.includes("plugins.allow is empty"));
+    const mismatchWarnings = warnings.filter((msg) =>
+      msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(emptyWarnings, "should not emit empty-allowlist warning").toHaveLength(0);
+    expect(mismatchWarnings, "should emit mismatch warning once").toHaveLength(1);
+    expect(mismatchWarnings[0]).toContain(`"warn-mismatch-allow-channel"`);
+    expect(mismatchWarnings[0]).toContain("warn-mismatch-allow-plugin");
+    expect(mismatchWarnings[0]).toContain("Use the plugin id");
+  });
+
+  it("stays quiet when plugins.allow contains at least one matching plugin id", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-partial-allow-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // Allow contains one real plugin id plus a stray channel-style entry.
+          allow: ["warn-partial-allow-plugin", "warn-partial-allow-channel"],
+        },
+      },
+    });
+    const openAllowWarnings = warnings.filter(
+      (msg) =>
+        msg.includes("plugins.allow is empty") ||
+        msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(openAllowWarnings, "should not emit allowlist warning when one id matches").toHaveLength(
+      0,
+    );
+  });
+
   it("handles workspace-discovered plugins according to trust and precedence", () => {
     useNoBundledPlugins();
     const scenarios = [

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8685,6 +8685,45 @@ module.exports = {
     );
   });
 
+  it("stays quiet when plugins.allow matches only bundled plugin ids, even while workspace/global plugins are present", () => {
+    // Regression for Codex P2 feedback on #68389: the mismatch warning should be computed
+    // against the full discovered plugin set (bundled + workspace + global), not only the
+    // workspace/global subset that the warning talks about. An allowlist that intentionally
+    // trusts bundled ids like ["telegram"] is valid and must not trip the mismatch path just
+    // because some unrelated non-bundled plugin happens to be auto-discoverable.
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    writeBundledPlugin({
+      id: "warn-bundled-allow-only-plugin",
+      body: simplePluginBody("warn-bundled-allow-only-plugin"),
+    });
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-noise-workspace-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // Allowlist intentionally only trusts a bundled plugin id.
+          allow: ["warn-bundled-allow-only-plugin"],
+        },
+      },
+    });
+    const openAllowWarnings = warnings.filter(
+      (msg) =>
+        msg.includes("plugins.allow is empty") ||
+        msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(
+      openAllowWarnings,
+      "bundled-only allowlists should not trip the mismatch warning",
+    ).toHaveLength(0);
+  });
+
   it("handles workspace-discovered plugins according to trust and precedence", () => {
     useNoBundledPlugins();
     const scenarios = [

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -8626,6 +8626,65 @@ module.exports = {
     });
   });
 
+  it("warns when plugins.allow entries do not match any discovered plugin ids", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-mismatch-allow-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // User configured a channel-style id that does not match the real plugin id.
+          allow: ["warn-mismatch-allow-channel"],
+        },
+      },
+    });
+    const emptyWarnings = warnings.filter((msg) => msg.includes("plugins.allow is empty"));
+    const mismatchWarnings = warnings.filter((msg) =>
+      msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(emptyWarnings, "should not emit empty-allowlist warning").toHaveLength(0);
+    expect(mismatchWarnings, "should emit mismatch warning once").toHaveLength(1);
+    expect(mismatchWarnings[0]).toContain(`"warn-mismatch-allow-channel"`);
+    expect(mismatchWarnings[0]).toContain("warn-mismatch-allow-plugin");
+    expect(mismatchWarnings[0]).toContain("Use the plugin id");
+  });
+
+  it("stays quiet when plugins.allow contains at least one matching plugin id", () => {
+    useNoBundledPlugins();
+    clearPluginLoaderCache();
+    const { workspaceDir } = writeWorkspacePlugin({
+      id: "warn-partial-allow-plugin",
+    });
+    const warnings: string[] = [];
+    loadOpenClawPlugins({
+      cache: false,
+      workspaceDir,
+      logger: createWarningLogger(warnings),
+      config: {
+        plugins: {
+          enabled: true,
+          // Allow contains one real plugin id plus a stray channel-style entry.
+          allow: ["warn-partial-allow-plugin", "warn-partial-allow-channel"],
+        },
+      },
+    });
+    const openAllowWarnings = warnings.filter(
+      (msg) =>
+        msg.includes("plugins.allow is empty") ||
+        msg.includes("do not match any discovered plugin ids"),
+    );
+    expect(openAllowWarnings, "should not emit allowlist warning when one id matches").toHaveLength(
+      0,
+    );
+  });
+
   it("handles workspace-discovered plugins according to trust and precedence", () => {
     useNoBundledPlugins();
     const scenarios = [


### PR DESCRIPTION
## Summary

- Problem: When users set `plugins.allow` to a channel-style id (for example `["feishu"]`) instead of the real plugin id (`openclaw-lark`), the loader still emits `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...` even though the allowlist is not empty — the message is literally incorrect and does not hint at the plugin-id vs. channel-id mismatch.
- Why it matters: Users see a contradictory warning (they configured the allowlist, but the log says it is empty) and have no direct clue that their entry does not correspond to any real plugin id, so they cannot fix the configuration without reading plugin manifests or source code.
- What changed: `warnWhenAllowlistIsOpen` now differentiates two cases: (1) `plugins.allow` is empty ⇒ existing warning wording is preserved, (2) `plugins.allow` has entries but none match any discovered plugin id ⇒ a new, specific warning listing the unknown entries alongside the discovered plugin ids, telling users to use the plugin id rather than a channel id or npm package name. When at least one allow entry matches a discovered id, the loader stays silent as before.
- What did NOT change (scope boundary): Allow/deny policy semantics, provenance/untracked-local warnings, auto-discovery rules, and all other loader behaviors are unchanged. No core allow/deny enforcement logic was moved.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68352
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `warnWhenAllowlistIsOpen` in `src/plugins/loader.ts` returned early whenever `params.allow.length > 0`, suppressing the warning entirely in the populated-but-mismatched case. When `params.allow.length === 0`, the warning fired with fixed text `plugins.allow is empty; discovered non-bundled plugins may auto-load: ...`, which was the only code path a user could hit — so populated-but-mismatched allowlists silently acted like an empty allowlist from the warning perspective.
- Missing detection / guardrail: No comparison between `params.allow` and the discovered plugin ids was ever performed inside the warning helper, so the loader could not distinguish the two failure modes.
- Contributing context (if known): Channel plugins like Feishu publish a plugin id (`openclaw-lark`) that does not line up with the channel config key (`channels.feishu`) or the npm package name (`feishu-openclaw-plugin`), which makes the mismatch easy to hit in practice.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/plugins/loader.test.ts`
- Scenario the test should lock in:
  - `warns when plugins.allow entries do not match any discovered plugin ids`: asserts the new mismatch warning fires exactly once with the configured entries in quotes, the discovered plugin id, and the `Use the plugin id` hint, and does not emit the legacy `plugins.allow is empty` string.
  - `stays quiet when plugins.allow contains at least one matching plugin id`: asserts that a partial match (one real id plus a stray channel-style entry) suppresses both the empty-allowlist warning and the new mismatch warning, preserving current behavior for correctly-configured allowlists.
- Why this is the smallest reliable guardrail: The loader-level unit tests exercise the warning helper through the real `loadOpenClawPlugins` entry point with a workspace-discovered plugin, matching the production call site at `warnWhenAllowlistIsOpen({ ...allow: normalized.allow ... })`.
- Existing test that already covers this: `warns about open allowlists only for auto-discovered plugins` covers the empty-allow case; left intact so we keep wording stability for the existing scenario.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Ubuntu via WSL2 per original report, reproducible on any platform)
- Runtime/container: Node.js gateway, bundled + workspace plugin discovery
- Model/provider: N/A
- Integration/channel (if any): Any external channel plugin whose plugin id differs from the channel config key (`feishu-openclaw-plugin` → plugin id `openclaw-lark`)
- Relevant config (redacted): `plugins.enabled = true`, `plugins.allow = ["feishu"]`, a non-bundled plugin whose real id is `openclaw-lark` is discoverable in the workspace.

### Steps

1. Install a non-bundled plugin whose id differs from its channel key (for example `openclaw-lark` published in `~/.openclaw/extensions/feishu-openclaw-plugin/`).
2. Start the gateway with `plugins.allow = ["feishu"]` in config.
3. Observe the `[plugins] ...` warning in startup logs.

### Expected

- A specific warning pointing at the mismatch, telling the user to use the plugin id and not the channel id or package name.

### Actual (before)

- `[plugins] plugins.allow is empty; discovered non-bundled plugins may auto-load: openclaw-lark (...). Set plugins.allow to explicit trusted ids.` — literally false because `plugins.allow` is populated, and unhelpful because it does not hint at the plugin-id vs. channel-id mismatch.

### Actual (after)

- `[plugins] plugins.allow entries "feishu" do not match any discovered plugin ids; discovered non-bundled plugins: openclaw-lark (...). Use the plugin id (not a channel id or npm package name).`

## Evidence

- [x] Failing test/log before + passing after (new test cases assert both the populated-but-mismatched and partial-match scenarios)

## Human Verification (required)

- Verified scenarios:
  - Ran the three relevant scoped tests (existing empty-allow case, new mismatched-allow case, new partial-match case) — all pass.
  - Ran the full `src/plugins/loader.test.ts` suite (95 tests) after the change — all pass.
  - `npx oxlint src/plugins/loader.ts src/plugins/loader.test.ts` → 0 warnings / 0 errors.
  - `npx oxfmt --check src/plugins/loader.ts src/plugins/loader.test.ts CHANGELOG.md` → all files properly formatted.
- Edge cases checked:
  - Empty allowlist still produces the original warning text so downstream log/doc matchers continue to work.
  - Partial match (one real id + one unknown entry) stays silent, matching prior behavior for correctly-configured allowlists.
  - `emitWarning: false` callers (for example the CLI metadata path at loader.ts ~2355) remain silent.
- What you did **not** verify: `pnpm build` and repo-wide `pnpm check` have pre-existing failures on `upstream/main` in unrelated files (`extensions/discord/src/monitor/gateway-plugin*`, `extensions/qa-lab/src/providers/aimock/server.ts`, `extensions/lobster/src/lobster-runner.ts`); the diff here does not touch those files, so the failures are not introduced by this PR.

## Compatibility / Migration

- Backward compatible? Yes — empty-allow warning text preserved; new mismatch path replaces what used to be silence.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Users with noisy populated-but-mismatched allowlists will now see a startup warning where previously they saw none.
  - Mitigation: The new warning is more accurate and actionable (it names the unknown entries and the discovered plugin ids); the loader caches it per `warningCacheKey` so it fires at most once per registry load, matching the existing empty-allow warning cadence.

---

## Real behavior proof

**Behavior or issue addressed:** When `plugins.allow` is populated but none of its entries match a discovered plugin id (e.g. `allow: ["feishu"]` while the real id is a workspace plugin), the loader used to emit the literally-false `plugins.allow is empty` warning. This PR emits a specific mismatch warning naming the unknown entries and the discovered ids.

**Real environment tested:** Real OpenClaw checkout refreshed onto current `main` and built with `pnpm build` (dist), Node 24. Ran the compiled `loadOpenClawPlugins` from `dist/` against a real on-disk workspace — not a unit test / mock.

**Exact steps or command run after this patch:** Seeded a real workspace plugin at `<ws>/.openclaw/extensions/demo-workspace-plugin/` (`index.cjs` + `openclaw.plugin.json`), set `plugins.allow: ["feishu"]` (a non-matching id), disabled bundled plugins for clean output, then invoked the built `loadOpenClawPlugins({ workspaceDir, config })` and captured stderr.

**Evidence after fix:** Verbatim warning emitted by the real built loader (stderr):
```
[plugins] plugins.allow entries "feishu" do not match any discovered plugin ids; discovered non-bundled plugins: demo-workspace-plugin (/tmp/.../ws/.openclaw/extensions/demo-workspace-plugin/index.cjs). Use the plugin id (not a channel id or npm package name).
```

**Observed result after fix:** The new mismatch warning fires (naming the unknown entry `"feishu"` and the discovered id `demo-workspace-plugin`) and the old `plugins.allow is empty` warning does NOT fire. Negative controls on the same real loader confirm scoping: `allow: ["demo-workspace-plugin"]` (matching) → no warning; a non-activating snapshot load (the path `openclaw plugins list` uses, `emitWarning=false`) → no warning.

**What was not tested:** None — the activating load path that emits the warning was exercised directly against the built loader; this is the real runtime path (gateway startup uses the same `warnWhenAllowlistIsOpen({ emitWarning: shouldActivate })` call). The branch was also refreshed onto current `main` and the release-owned `CHANGELOG.md` entry dropped per `AGENTS.md`.

@clawsweeper re-review
