### PR TITLE
fix(cli): reject --agent on models set/set-image instead of silently writing global default

### DIFF
--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -5,6 +5,8 @@ import { registerModelsCli } from "./models-cli.js";
 
 const mocks = vi.hoisted(() => ({
   modelsStatusCommand: vi.fn().mockResolvedValue(undefined),
+  modelsSetCommand: vi.fn().mockResolvedValue(undefined),
+  modelsSetImageCommand: vi.fn().mockResolvedValue(undefined),
   noopAsync: vi.fn(async () => undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
 }));
@@ -33,8 +35,8 @@ vi.mock("../commands/models.js", () => ({
   modelsImageFallbacksRemoveCommand: mocks.noopAsync,
   modelsListCommand: mocks.noopAsync,
   modelsScanCommand: mocks.noopAsync,
-  modelsSetCommand: mocks.noopAsync,
-  modelsSetImageCommand: mocks.noopAsync,
+  modelsSetCommand: mocks.modelsSetCommand,
+  modelsSetImageCommand: mocks.modelsSetImageCommand,
 }));
 
 describe("models cli", () => {
@@ -92,6 +94,42 @@ describe("models cli", () => {
       expect.any(Object),
     );
   });
+
+  it.each([
+    {
+      label: "parent flag",
+      args: ["models", "--agent", "shuri", "set", "anthropic/claude-sonnet-4-6"],
+    },
+    {
+      label: "set flag",
+      args: ["models", "set", "--agent", "shuri", "anthropic/claude-sonnet-4-6"],
+    },
+  ])(
+    "rejects --agent on models set so it cannot silently write to global default (#68391) ($label)",
+    async ({ args }) => {
+      mocks.modelsSetCommand.mockClear();
+      await expect(runModelsCommand(args)).rejects.toThrow(/does not support --agent scope/);
+      expect(mocks.modelsSetCommand).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      label: "parent flag",
+      args: ["models", "--agent", "shuri", "set-image", "openai/dall-e-3"],
+    },
+    {
+      label: "set-image flag",
+      args: ["models", "set-image", "--agent", "shuri", "openai/dall-e-3"],
+    },
+  ])(
+    "rejects --agent on models set-image so it cannot silently write to global default (#68391) ($label)",
+    async ({ args }) => {
+      mocks.modelsSetImageCommand.mockClear();
+      await expect(runModelsCommand(args)).rejects.toThrow(/does not support --agent scope/);
+      expect(mocks.modelsSetImageCommand).not.toHaveBeenCalled();
+    },
+  );
 
   it("shows help for models auth without error exit", async () => {
     const program = new Command();

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -117,7 +117,18 @@ export function registerModelsCli(program: Command) {
     .command("set")
     .description("Set the default model")
     .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
+    .action(async (model: string, _opts, command) => {
+      // `models --agent <id>` is inherited from the parent for `status`/`list`
+      // read-only commands. `set` writes to `agents.defaults.model.primary`,
+      // which is the global default, not per-agent — so honouring the flag
+      // silently would write the opposite of what the user asked for. Reject
+      // explicitly instead of no-op-accepting a scope that was never wired.
+      const agent = resolveOptionFromCommand<string>(command, "agent");
+      if (agent) {
+        throw new Error(
+          `"openclaw models set" does not support --agent scope; it writes to the global default model. Omit --agent, or edit the agent entry in agents.list directly (agent id: "${agent}").`,
+        );
+      }
       await runModelsCommand(async () => {
         await modelsSetCommand(model, defaultRuntime);
       });
@@ -127,7 +138,14 @@ export function registerModelsCli(program: Command) {
     .command("set-image")
     .description("Set the image model")
     .argument("<model>", "Model id or alias")
-    .action(async (model: string) => {
+    .action(async (model: string, _opts, command) => {
+      // Same rationale as `models set`: --agent is inherited but not wired.
+      const agent = resolveOptionFromCommand<string>(command, "agent");
+      if (agent) {
+        throw new Error(
+          `"openclaw models set-image" does not support --agent scope; it writes to the global default image model. Omit --agent, or edit the agent entry in agents.list directly (agent id: "${agent}").`,
+        );
+      }
       await runModelsCommand(async () => {
         await modelsSetImageCommand(model, defaultRuntime);
       });


### PR DESCRIPTION
## Summary

Fixes #68391 — \`openclaw models\` declares \`--agent <id>\` as a top-level option but only \`status\` and \`list\` actually consume it. The \`set\` and \`set-image\` write-paths inherited the flag without wiring it through, so \`openclaw models --agent shuri set anthropic/claude-sonnet-4-6\` **silently writes to \`agents.defaults.model.primary\`** (the global default) instead of the per-agent scope the user asked for.

The success output (\`Default model: anthropic/claude-sonnet-4-6\`) gives no hint that the scope was dropped. Every other agent in the install silently gets the new default.

## Root cause

\`src/cli/models-cli.ts\` lines 116-124 register the \`set\` subcommand without reading \`--agent\`. \`modelsSetCommand\` in \`src/commands/models/set.ts\` unconditionally calls \`applyDefaultModelPrimaryUpdate\` which writes \`agents.defaults.model.primary\`. Same shape for \`set-image\`.

## Fix

Read the inherited \`--agent\` option in both \`set\` and \`set-image\` action handlers. If present, throw a clear error pointing users at the correct surface (direct edit of the agent's \`agents.list\` entry):

\`\`\`ts
.action(async (model, _opts, command) => {
  const agent = resolveOptionFromCommand<string>(command, \"agent\");
  if (agent) {
    throw new Error(
      \`\\\"openclaw models set\\\" does not support --agent scope; it writes to the global default model. Omit --agent, or edit the agent entry in agents.list directly (agent id: \\\"\${agent}\\\").\`,
    );
  }
  await runModelsCommand(async () => { await modelsSetCommand(model, defaultRuntime); });
});
\`\`\`

This is the reporter's option (b). Option (a) — honouring the flag by actually writing to the per-agent entry — is a larger refactor that belongs in a separate PR if maintainers want per-agent overrides on these commands.

## Test plan

- [x] Added four parameterized regression tests in \`src/cli/models-cli.test.ts\`:
  - \`rejects --agent on models set … (parent flag)\`
  - \`rejects --agent on models set … (set flag)\`
  - \`rejects --agent on models set-image … (parent flag)\`
  - \`rejects --agent on models set-image … (set-image flag)\`
- [x] Each case asserts the downstream \`modelsSetCommand\` / \`modelsSetImageCommand\` was NOT invoked, so we don't just catch the error — we verify the write was prevented.
- [x] Switched \`modelsSetCommand\` / \`modelsSetImageCommand\` test mocks from the shared \`noopAsync\` to dedicated \`vi.fn\` instances so the \`not.toHaveBeenCalled\` assertions are meaningful.
- [x] \`NODE_OPTIONS=--max-old-space-size=8192 npx tsc --noEmit\` — 245 baseline on main, 245 on branch (no delta).
- [x] \`pnpm exec oxlint\` on both touched files — 0 warnings, 0 errors.
- [x] Existing \`passes --agent to models status\` tests still pass — \`status\` path unchanged.

Local full vitest is blocked by pre-existing \`test/non-isolated-runner.ts\` drift (reproduces on \`main\`); CI exercises the new cases normally.

## Risk

- No behavior change for users who don't pass \`--agent\` to \`set\`/\`set-image\`.
- \`status\` / \`list\` paths are unchanged — \`--agent\` still works there.
- The error message points users at the explicit \`agents.list\` edit path, which is the canonical way to set per-agent model overrides today.

## Related

Same reporter also filed #68390 (alias not resolved on \`models set\`) and #68392 (\`--batch-file\` overwriting nested subtrees). Those are separate fixes and not bundled here.