### PR TITLE
fix(memory-core): strip dreaming managed blocks from daily memory reads

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3604,6 +3604,59 @@ describe("QmdMemoryManager", () => {
     readFileSpy.mockRestore();
   });
 
+  it("strips dreaming managed blocks from partial reads of daily memory files", async () => {
+    const relPath = path.join("memory", "2026-04-18.md");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    const lines = [
+      "# 2026-04-18 Daily Log",
+      "",
+      "## Morning notes",
+      "line-4",
+      "line-5",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "dreaming-candidate-1",
+      "dreaming-candidate-2",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "## Afternoon notes",
+      "line-13",
+      "line-14",
+    ];
+    await fs.writeFile(path.join(workspaceDir, relPath), lines.join("\n"), "utf-8");
+
+    const { manager } = await createManager();
+
+    // Partial read that would span the dreaming block in the raw file
+    const result = await manager.readFile({ relPath, from: 1, lines: 10 });
+    expect(result.text).not.toContain("dreaming-candidate");
+    expect(result.text).not.toContain("openclaw:dreaming");
+    expect(result.text).toContain("Morning notes");
+    expect(result.text).toContain("Afternoon notes");
+
+    await manager.close();
+  });
+
+  it("uses efficient streaming partial read for non-daily memory files", async () => {
+    const readFileSpy = vi.spyOn(fs, "readFile");
+    const relPath = path.join("memory", "window.md");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceDir, relPath),
+      Array.from({ length: 20 }, (_, i) => `line-${i + 1}`).join("\n"),
+      "utf-8",
+    );
+
+    const { manager } = await createManager();
+    const result = await manager.readFile({ relPath, from: 5, lines: 3 });
+    expect(result.text).toContain("line-5");
+    // Non-daily files should use streaming partial read, not readFile
+    expect(readFileSpy).not.toHaveBeenCalled();
+
+    await manager.close();
+    readFileSpy.mockRestore();
+  });
+
   it("returns a bounded default excerpt for qmd memory reads without explicit lines", async () => {
     const relPath = path.join("memory", "default-window.md");
     await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1216,6 +1216,11 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (partial.missing) {
         return { text: "", path: relPath };
       }
+      // TODO(#68367): partial reads of daily memory files still expose dreaming
+      // blocks.  Stripping here would shift line numbers relative to the raw
+      // file, which breaks callers that paginate with from/lines offsets.
+      // A future fix could read-then-strip the full file and re-slice, or
+      // introduce virtual line mapping.
       return buildMemoryReadResultFromSlice({
         selectedLines: partial.selectedLines,
         relPath,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1208,6 +1208,28 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
     const contextLimits = resolveAgentContextLimits(this.cfg, this.agentId);
     if (params.from !== undefined || params.lines !== undefined) {
+      // For daily memory files, read the full file and strip dreaming blocks
+      // before slicing so that line numbers are consistent with a full read
+      // and cross-session staging data is never exposed.  Daily files are
+      // small (a few KB) so the overhead of a full read is negligible.
+      // See openclaw/openclaw#68367.
+      if (isDailyMemoryPath(relPath)) {
+        const full = await this.readFullText(absPath);
+        if (full.missing) {
+          return { text: "", path: relPath };
+        }
+        const stripped = stripDreamingManagedBlocks(full.text);
+        return buildMemoryReadResult({
+          content: stripped,
+          relPath,
+          from: params.from,
+          lines: params.lines,
+          defaultLines: contextLimits?.memoryGetDefaultLines ?? DEFAULT_MEMORY_READ_LINES,
+          maxChars: contextLimits?.memoryGetMaxChars,
+          suggestReadFallback: isDefaultMemoryPath(relPath),
+        });
+      }
+      // Non-daily files: use efficient streaming partial read.
       const requestedCount = Math.max(
         1,
         params.lines ?? contextLimits?.memoryGetDefaultLines ?? DEFAULT_MEMORY_READ_LINES,
@@ -1216,11 +1238,6 @@ export class QmdMemoryManager implements MemorySearchManager {
       if (partial.missing) {
         return { text: "", path: relPath };
       }
-      // TODO(#68367): partial reads of daily memory files still expose dreaming
-      // blocks.  Stripping here would shift line numbers relative to the raw
-      // file, which breaks callers that paginate with from/lines offsets.
-      // A future fix could read-then-strip the full file and re-slice, or
-      // introduce virtual line mapping.
       return buildMemoryReadResultFromSlice({
         selectedLines: partial.selectedLines,
         relPath,

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -48,6 +48,7 @@ import {
   type ResolvedQmdConfig,
   type ResolvedQmdMcporterConfig,
 } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { stripDreamingManagedBlocks } from "openclaw/plugin-sdk/memory-host-markdown";
 import {
   localeLowercasePreservingWhitespace,
   normalizeLowercaseStringOrEmpty,
@@ -85,6 +86,13 @@ const IGNORED_MEMORY_WATCH_DIR_NAMES = new Set([
   ".tox",
   "__pycache__",
 ]);
+
+/** Match `memory/YYYY-MM-DD.md` (the daily journal file pattern). */
+const DAILY_MEMORY_PATH_RE = /(?:^|[/\\])memory[/\\]\d{4}-\d{2}-\d{2}\.md$/;
+
+function isDailyMemoryPath(relPath: string): boolean {
+  return DAILY_MEMORY_PATH_RE.test(relPath);
+}
 
 function isDefaultMemoryPath(relPath: string): boolean {
   const normalized = relPath.trim().replace(/^\.\//, "").replace(/\\/g, "/");
@@ -1221,8 +1229,12 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (full.missing) {
       return { text: "", path: relPath };
     }
+    // Strip managed dreaming blocks from daily memory files so that
+    // light-sleep / REM staging data from other sessions is not leaked
+    // into memory_get results.  See openclaw/openclaw#68367.
+    const fullText = isDailyMemoryPath(relPath) ? stripDreamingManagedBlocks(full.text) : full.text;
     return buildMemoryReadResult({
-      content: full.text,
+      content: fullText,
       relPath,
       from: params.from,
       lines: params.lines,

--- a/src/plugin-sdk/memory-host-markdown.test.ts
+++ b/src/plugin-sdk/memory-host-markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { replaceManagedMarkdownBlock, withTrailingNewline } from "./memory-host-markdown.js";
+import {
+  replaceManagedMarkdownBlock,
+  stripDreamingManagedBlocks,
+  withTrailingNewline,
+} from "./memory-host-markdown.js";
 
 describe("withTrailingNewline", () => {
   it("preserves trailing newlines", () => {
@@ -46,5 +50,121 @@ describe("replaceManagedMarkdownBlock", () => {
         body: "beta",
       }),
     ).toBe("alpha\n\n<!-- start -->\nbeta\n<!-- end -->\n");
+  });
+});
+
+describe("stripDreamingManagedBlocks", () => {
+  it("returns content unchanged when no dreaming blocks present", () => {
+    const input = "# Daily Log\n\n- did something\n- learned something\n";
+    expect(stripDreamingManagedBlocks(input)).toBe(input);
+  });
+
+  it("strips a light sleep block with heading", () => {
+    const input = [
+      "# Daily Log",
+      "",
+      "- did something",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- candidate 1",
+      "- candidate 2",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "## Notes",
+      "kept",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Daily Log");
+    expect(result).toContain("- did something");
+    expect(result).toContain("## Notes");
+    expect(result).toContain("kept");
+    expect(result).not.toContain("Light Sleep");
+    expect(result).not.toContain("candidate 1");
+    expect(result).not.toContain("openclaw:dreaming");
+  });
+
+  it("strips a REM sleep block with heading", () => {
+    const input = [
+      "# Log",
+      "",
+      "## REM Sleep",
+      "<!-- openclaw:dreaming:rem:start -->",
+      "dream narrative here",
+      "<!-- openclaw:dreaming:rem:end -->",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Log");
+    expect(result).not.toContain("REM Sleep");
+    expect(result).not.toContain("dream narrative");
+  });
+
+  it("strips both light and REM blocks from the same document", () => {
+    const input = [
+      "# Daily Log",
+      "",
+      "- user content",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- light candidate",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "## REM Sleep",
+      "<!-- openclaw:dreaming:rem:start -->",
+      "- rem narrative",
+      "<!-- openclaw:dreaming:rem:end -->",
+      "",
+      "## My Notes",
+      "important stuff",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("- user content");
+    expect(result).toContain("## My Notes");
+    expect(result).toContain("important stuff");
+    expect(result).not.toContain("Light Sleep");
+    expect(result).not.toContain("REM Sleep");
+    expect(result).not.toContain("candidate");
+    expect(result).not.toContain("narrative");
+  });
+
+  it("strips a block without its heading (marker-only)", () => {
+    const input = [
+      "# Log",
+      "",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- orphan candidate",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "real content",
+      "",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    expect(result).toContain("# Log");
+    expect(result).toContain("real content");
+    expect(result).not.toContain("orphan candidate");
+  });
+
+  it("collapses excessive blank lines after stripping", () => {
+    const input = [
+      "before",
+      "",
+      "",
+      "## Light Sleep",
+      "<!-- openclaw:dreaming:light:start -->",
+      "- stuff",
+      "<!-- openclaw:dreaming:light:end -->",
+      "",
+      "",
+      "after",
+    ].join("\n");
+    const result = stripDreamingManagedBlocks(input);
+    // No run of 3+ consecutive newlines should remain
+    expect(result).not.toMatch(/\n{3,}/);
+    expect(result).toContain("before");
+    expect(result).toContain("after");
   });
 });

--- a/src/plugin-sdk/memory-host-markdown.ts
+++ b/src/plugin-sdk/memory-host-markdown.ts
@@ -32,3 +32,46 @@ export function replaceManagedMarkdownBlock(params: ManagedMarkdownBlockParams):
   }
   return `${trimmed}\n\n${managedBlock}\n`;
 }
+
+/**
+ * Managed dreaming block definitions used for stripping.
+ * Must stay in sync with the markers emitted by `writeDailyDreamingPhaseBlock`.
+ */
+const DREAMING_MANAGED_BLOCKS: ReadonlyArray<{
+  heading: string;
+  startMarker: string;
+  endMarker: string;
+}> = [
+  {
+    heading: "## Light Sleep",
+    startMarker: "<!-- openclaw:dreaming:light:start -->",
+    endMarker: "<!-- openclaw:dreaming:light:end -->",
+  },
+  {
+    heading: "## REM Sleep",
+    startMarker: "<!-- openclaw:dreaming:rem:start -->",
+    endMarker: "<!-- openclaw:dreaming:rem:end -->",
+  },
+];
+
+/**
+ * Strip all managed dreaming blocks (Light Sleep / REM Sleep) from a markdown
+ * document.  Removes the optional heading line (e.g. `## Light Sleep`), the
+ * start/end markers, and everything between them.
+ *
+ * This is safe to call on any content — when no dreaming blocks are present
+ * the input is returned unchanged.
+ */
+export function stripDreamingManagedBlocks(content: string): string {
+  let result = content;
+  for (const block of DREAMING_MANAGED_BLOCKS) {
+    const pattern = new RegExp(
+      `(?:${escapeRegex(block.heading)}\\n)?${escapeRegex(block.startMarker)}[\\s\\S]*?${escapeRegex(block.endMarker)}\\n?`,
+      "gm",
+    );
+    result = result.replace(pattern, "");
+  }
+  // Collapse runs of 3+ blank lines into 2.
+  result = result.replace(/\n{3,}/g, "\n\n");
+  return result;
+}


### PR DESCRIPTION
## Problem

Light sleep and REM dreaming phases write managed blocks into daily memory files (`memory/YYYY-MM-DD.md`) when using inline storage mode. These blocks contain session-agnostic candidate memories that leak cross-session context when other sessions read the same daily file via `memory_get`.

While the default storage mode was changed to `"separate"` (writing to `memory/dreaming/light/` instead), users who:
- Explicitly use `"inline"` or `"both"` storage mode
- Switched from `"inline"` to `"separate"` but have old blocks in daily files
- Use any configuration where dreaming blocks end up in daily files

...still experience cross-session contamination when reading daily memory files.

## Solution

### 1. New utility: `stripDreamingManagedBlocks()` (`memory-host-markdown.ts`)

Strips all managed dreaming blocks (`<!-- openclaw:dreaming:{light,rem}:{start,end} -->`) and their optional headings (`## Light Sleep`, `## REM Sleep`) from markdown content. Collapses excessive blank lines after stripping.

This function is in the plugin-sdk so it can be reused by other extensions if needed.

### 2. Apply stripping in `QmdMemoryManager.readFile()`

When reading daily memory files (matching `memory/YYYY-MM-DD.md` pattern), the dreaming blocks are stripped before returning content to the caller. This ensures `memory_get` results are clean of staging data from other sessions.

**Important**: The dreaming blocks are preserved on disk — only the read path is filtered. The dreaming subsystem continues to read the raw file content through its own code path.

### 3. Comprehensive tests

6 test cases covering:
- No-op on content without dreaming blocks
- Light sleep block with heading
- REM sleep block with heading
- Both blocks in same document
- Block without heading (marker-only)
- Blank line collapsing after stripping

## Files changed

- `src/plugin-sdk/memory-host-markdown.ts` — Added `stripDreamingManagedBlocks()`
- `src/plugin-sdk/memory-host-markdown.test.ts` — Added 6 tests for the new function
- `extensions/memory-core/src/memory/qmd-manager.ts` — Applied stripping in `readFile()` for daily memory paths

Fixes #68367