### PR TITLE
fix(ui): constrain web chat width to 920px for better readability

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -63,6 +63,13 @@
   background: transparent;
 }
 
+/* Chat thread inner - constrain width for readability */
+.chat-thread-inner {
+  max-width: 920px;
+  margin: 0 auto;
+  width: 100%;
+}
+
 .chat-thread-inner > :first-child {
   margin-top: 0 !important;
 }
@@ -477,12 +484,14 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  margin: 0 18px 14px;
+  margin: 0 auto 14px;
   padding: 0;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   flex-shrink: 0;
+  max-width: 920px;
+  width: calc(100% - 36px);
   transition:
     border-color var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease;


### PR DESCRIPTION
## Summary

Fixes #68369

The "new chat" welcome state and message thread in the web dashboard were stretching to the full width of the content area instead of being constrained to a readable column width. This is a regression fix.

## Root Cause

 had no  or  constraint — it inherited  from , which fills the entire content column. The same applied to .

## Fix

Added max-width constraint of 920px to both elements:

- : Added , , and  for centering
- : Changed from fixed side margins to , added  and 

## Test Plan

- [ ] Open web dashboard at http://127.0.0.1:18789/chat
- [ ] Click "New chat"
- [ ] Verify chat content is constrained to ~920px max-width and centered
- [ ] Verify input bar is also constrained and centered

## Screenshots

N/A - CSS-only change with clear before/after behavior

Closes openclaw#68369