### PR TITLE
Prewarm mirrored outbound sessions before first callback

### DIFF
--- a/extensions/deepinfra/speech-provider.test.ts
+++ b/extensions/deepinfra/speech-provider.test.ts
@@ -7,18 +7,18 @@ const {
   readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfigMock,
 } = vi.hoisted(() => ({
-    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-    postJsonRequestMock: vi.fn(),
-    readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-      return new Uint8Array(await response.arrayBuffer());
-    }),
-    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
-      allowPrivateNetwork: false,
-      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-      dispatcherPolicy: undefined,
-    })),
-  }));
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  postJsonRequestMock: vi.fn(),
+  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
+    return new Uint8Array(await response.arrayBuffer());
+  }),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://api.deepinfra.com/v1/openai",
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+    dispatcherPolicy: undefined,
+  })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -202,9 +202,7 @@ function hasGeminiThoughtSignatureTruncationFootprint(value: string): boolean {
   );
 }
 
-function sanitizeGeminiThoughtSignature(
-  thoughtSignature: string | undefined,
-): string | undefined {
+function sanitizeGeminiThoughtSignature(thoughtSignature: string | undefined): string | undefined {
   if (typeof thoughtSignature !== "string") {
     return undefined;
   }
@@ -552,9 +550,7 @@ function convertGoogleMessages(model: GoogleTransportModel, context: Context) {
             : undefined;
           parts.push({
             text: sanitizeTransportPayloadText(block.text),
-            ...(sanitizedTextSignature
-              ? { thoughtSignature: sanitizedTextSignature }
-              : {}),
+            ...(sanitizedTextSignature ? { thoughtSignature: sanitizedTextSignature } : {}),
           });
           continue;
         }

--- a/extensions/kimi-coding/stream.test.ts
+++ b/extensions/kimi-coding/stream.test.ts
@@ -318,7 +318,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -359,7 +359,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -391,7 +391,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },
@@ -418,7 +418,7 @@ describe("kimi tool-call markup wrapper", () => {
             {
               id: "call_1",
               type: "function",
-              function: { name: "exec", arguments: "{\"command\":\"pwd\"}" },
+              function: { name: "exec", arguments: '{"command":"pwd"}' },
             },
           ],
         },

--- a/extensions/oc-path/src/oc-path/edit.ts
+++ b/extensions/oc-path/src/oc-path/edit.ts
@@ -26,11 +26,17 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
   guardSentinel(newValue, formatOcPath(path));
   if (path.section === "[frontmatter]") {
     const key = path.item ?? path.field;
-    if (key === undefined) {return { ok: false, reason: "unresolved" };}
+    if (key === undefined) {
+      return { ok: false, reason: "unresolved" };
+    }
     const idx = ast.frontmatter.findIndex((e) => e.key === key);
-    if (idx === -1) {return { ok: false, reason: "unresolved" };}
+    if (idx === -1) {
+      return { ok: false, reason: "unresolved" };
+    }
     const existing = ast.frontmatter[idx];
-    if (existing === undefined) {return { ok: false, reason: "unresolved" };}
+    if (existing === undefined) {
+      return { ok: false, reason: "unresolved" };
+    }
     const newEntry: FrontmatterEntry = { ...existing, value: newValue };
     const newFm = ast.frontmatter.slice();
     newFm[idx] = newEntry;
@@ -43,16 +49,26 @@ export function setMdOcPath(ast: MdAst, path: OcPath, newValue: string): MdEditR
 
   const sectionSlug = path.section.toLowerCase();
   const blockIdx = ast.blocks.findIndex((b) => b.slug === sectionSlug);
-  if (blockIdx === -1) {return { ok: false, reason: "unresolved" };}
+  if (blockIdx === -1) {
+    return { ok: false, reason: "unresolved" };
+  }
   const block = ast.blocks[blockIdx];
-  if (block === undefined) {return { ok: false, reason: "unresolved" };}
+  if (block === undefined) {
+    return { ok: false, reason: "unresolved" };
+  }
 
   const itemSlug = path.item.toLowerCase();
   const itemIdx = block.items.findIndex((i) => i.slug === itemSlug);
-  if (itemIdx === -1) {return { ok: false, reason: "unresolved" };}
+  if (itemIdx === -1) {
+    return { ok: false, reason: "unresolved" };
+  }
   const item = block.items[itemIdx];
-  if (item === undefined) {return { ok: false, reason: "unresolved" };}
-  if (item.kv === undefined) {return { ok: false, reason: "no-item-kv" };}
+  if (item === undefined) {
+    return { ok: false, reason: "unresolved" };
+  }
+  if (item.kv === undefined) {
+    return { ok: false, reason: "no-item-kv" };
+  }
   if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {
     return { ok: false, reason: "unresolved" };
   }
@@ -78,9 +94,15 @@ function rebuildBlockBody(block: AstBlock, newItems: readonly AstItem[]): string
   for (let i = 0; i < newItems.length; i++) {
     const newItem = newItems[i];
     const oldItem = block.items[i];
-    if (newItem === undefined || oldItem === undefined) {continue;}
-    if (newItem.kv === undefined || oldItem.kv === undefined) {continue;}
-    if (newItem.kv.value === oldItem.kv.value) {continue;}
+    if (newItem === undefined || oldItem === undefined) {
+      continue;
+    }
+    if (newItem.kv === undefined || oldItem.kv === undefined) {
+      continue;
+    }
+    if (newItem.kv.value === oldItem.kv.value) {
+      continue;
+    }
     const re = new RegExp(`^(\\s*-\\s*${escapeRegex(oldItem.kv.key)}\\s*:\\s*).*$`, "m");
     body = body.replace(re, `$1${newItem.kv.value}`);
   }
@@ -101,19 +123,29 @@ function finalize(ast: MdAst): MdEditResult {
     parts.push("---");
   }
   if (ast.preamble.length > 0) {
-    if (parts.length > 0) {parts.push("");}
+    if (parts.length > 0) {
+      parts.push("");
+    }
     parts.push(ast.preamble);
   }
   for (const block of ast.blocks) {
-    if (parts.length > 0) {parts.push("");}
+    if (parts.length > 0) {
+      parts.push("");
+    }
     parts.push(`## ${block.heading}`);
-    if (block.bodyText.length > 0) {parts.push(block.bodyText);}
+    if (block.bodyText.length > 0) {
+      parts.push(block.bodyText);
+    }
   }
   return { ok: true, ast: { ...ast, raw: parts.join("\n") } };
 }
 
 function formatFrontmatterValue(value: string): string {
-  if (value.length === 0) {return '""';}
-  if (/[:#&*?|<>=!%@`,[\]{}\r\n]/.test(value)) {return JSON.stringify(value);}
+  if (value.length === 0) {
+    return '""';
+  }
+  if (/[:#&*?|<>=!%@`,[\]{}\r\n]/.test(value)) {
+    return JSON.stringify(value);
+  }
   return value;
 }

--- a/extensions/oc-path/src/oc-path/jsonc/emit.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/emit.ts
@@ -33,7 +33,9 @@ export function emitJsonc(ast: JsoncAst, opts: JsoncEmitOptions = {}): string {
   }
 
   // Render mode loses comments; walks leaves for caller-injected sentinel.
-  if (ast.root === null) {return "";}
+  if (ast.root === null) {
+    return "";
+  }
   return renderValue(ast.root, guardPath, []);
 }
 

--- a/extensions/oc-path/src/oc-path/jsonc/resolve.ts
+++ b/extensions/oc-path/src/oc-path/jsonc/resolve.ts
@@ -26,11 +26,15 @@ export type JsoncOcPathMatch =
     };
 
 export function resolveJsoncOcPath(ast: JsoncAst, path: OcPath): JsoncOcPathMatch | null {
-  if (ast.root === null) {return null;}
+  if (ast.root === null) {
+    return null;
+  }
 
   const segments: string[] = [];
   const collect = (slot: string | undefined): void => {
-    if (slot === undefined) {return;}
+    if (slot === undefined) {
+      return;
+    }
     for (const s of splitRespectingBrackets(slot, ".")) {
       segments.push(isQuotedSeg(s) ? unquoteSeg(s) : s);
     }
@@ -39,32 +43,44 @@ export function resolveJsoncOcPath(ast: JsoncAst, path: OcPath): JsoncOcPathMatc
   collect(path.item);
   collect(path.field);
 
-  if (segments.length === 0) {return { kind: "root", node: ast };}
+  if (segments.length === 0) {
+    return { kind: "root", node: ast };
+  }
 
   let current: JsoncValue = ast.root;
   let lastEntry: JsoncEntry | null = null;
   const walked: string[] = [];
 
   for (let seg of segments) {
-    if (seg.length === 0) {return null;}
+    if (seg.length === 0) {
+      return null;
+    }
     if (isPositionalSeg(seg)) {
       const concrete = positionalForJsonc(current, seg);
-      if (concrete !== null) {seg = concrete;}
+      if (concrete !== null) {
+        seg = concrete;
+      }
     }
     walked.push(seg);
     if (current.kind === "object") {
       const entry = current.entries.find((e) => e.key === seg);
-      if (entry === undefined) {return null;}
+      if (entry === undefined) {
+        return null;
+      }
       lastEntry = entry;
       current = entry.value;
       continue;
     }
     if (current.kind === "array") {
       const idx = Number(seg);
-      if (!Number.isInteger(idx) || idx < 0 || idx >= current.items.length) {return null;}
+      if (!Number.isInteger(idx) || idx < 0 || idx >= current.items.length) {
+        return null;
+      }
       lastEntry = null;
       const item = current.items[idx];
-      if (item === undefined) {return null;}
+      if (item === undefined) {
+        return null;
+      }
       current = item;
       continue;
     }

--- a/extensions/oc-path/src/oc-path/parse.ts
+++ b/extensions/oc-path/src/oc-path/parse.ts
@@ -12,14 +12,7 @@
  */
 
 import MarkdownIt from "markdown-it";
-
-import type {
-  AstBlock,
-  AstItem,
-  Diagnostic,
-  FrontmatterEntry,
-  ParseResult,
-} from "./ast.js";
+import type { AstBlock, AstItem, Diagnostic, FrontmatterEntry, ParseResult } from "./ast.js";
 import { slugify } from "./slug.js";
 
 type Token = ReturnType<MarkdownIt["parse"]>[number];
@@ -153,7 +146,9 @@ function extractItems(tokens: readonly Token[], bodyFileLine: number): AstItem[]
   const items: AstItem[] = [];
   for (let i = 0; i < tokens.length; i++) {
     const t = tokens[i];
-    if (t.type !== "list_item_open" || t.map === null) {continue;}
+    if (t.type !== "list_item_open" || t.map === null) {
+      continue;
+    }
     // First inline at the item's own depth is the item text.
     let nestedDepth = 0;
     let text = "";
@@ -175,9 +170,7 @@ function extractItems(tokens: readonly Token[], bodyFileLine: number): AstItem[]
       text,
       slug: kvMatch ? slugify(kvMatch[1]) : slugify(text),
       line: bodyFileLine + t.map[0],
-      ...(kvMatch !== null
-        ? { kv: { key: kvMatch[1].trim(), value: kvMatch[2].trim() } }
-        : {}),
+      ...(kvMatch !== null ? { kv: { key: kvMatch[1].trim(), value: kvMatch[2].trim() } } : {}),
     });
   }
   return items;

--- a/extensions/oc-path/src/oc-path/resolve.ts
+++ b/extensions/oc-path/src/oc-path/resolve.ts
@@ -35,39 +35,61 @@ export type OcPathMatch =
 export function resolveMdOcPath(ast: MdAst, path: OcPath): OcPathMatch | null {
   if (path.section === "[frontmatter]") {
     const key = path.item ?? path.field;
-    if (key === undefined) {return null;}
+    if (key === undefined) {
+      return null;
+    }
     const entry = ast.frontmatter.find((e) => e.key === key);
-    if (entry === undefined) {return null;}
+    if (entry === undefined) {
+      return null;
+    }
     return { kind: "frontmatter", node: entry };
   }
 
-  if (path.section === undefined) {return { kind: "root", node: ast };}
+  if (path.section === undefined) {
+    return { kind: "root", node: ast };
+  }
 
   const block = ast.blocks.find((b) => b.slug === path.section!.toLowerCase());
-  if (block === undefined) {return null;}
-  if (path.item === undefined) {return { kind: "block", node: block };}
+  if (block === undefined) {
+    return null;
+  }
+  if (path.item === undefined) {
+    return { kind: "block", node: block };
+  }
 
   // Item dispatch: ordinal (#N) > positional ($last) > slug.
   // Ordinal uses document order so duplicate-slug items stay distinct.
   let item: AstItem | undefined;
   if (isOrdinalSeg(path.item)) {
     const n = parseOrdinalSeg(path.item);
-    if (n === null || n < 0 || n >= block.items.length) {return null;}
+    if (n === null || n < 0 || n >= block.items.length) {
+      return null;
+    }
     item = block.items[n];
   } else if (isPositionalSeg(path.item)) {
     const concrete = resolvePositionalSeg(path.item, {
       indexable: true,
       size: block.items.length,
     });
-    if (concrete === null) {return null;}
+    if (concrete === null) {
+      return null;
+    }
     item = block.items[Number(concrete)];
   } else {
     item = block.items.find((i) => i.slug === path.item!.toLowerCase());
   }
-  if (item === undefined) {return null;}
-  if (path.field === undefined) {return { kind: "item", node: item, block };}
+  if (item === undefined) {
+    return null;
+  }
+  if (path.field === undefined) {
+    return { kind: "item", node: item, block };
+  }
 
-  if (item.kv === undefined) {return null;}
-  if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {return null;}
+  if (item.kv === undefined) {
+    return null;
+  }
+  if (item.kv.key.toLowerCase() !== path.field.toLowerCase()) {
+    return null;
+  }
   return { kind: "item-field", node: item, block, value: item.kv.value };
 }

--- a/extensions/oc-path/src/oc-path/tests/oc-path.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/oc-path.test.ts
@@ -52,10 +52,7 @@ describe("parseOcPath", () => {
   });
 
   it("rejects control chars in ignored query values", () => {
-    expectOcPathError(
-      () => parseOcPath("oc://SOUL.md?ignored=\x00"),
-      "OC_PATH_CONTROL_CHAR",
-    );
+    expectOcPathError(() => parseOcPath("oc://SOUL.md?ignored=\x00"), "OC_PATH_CONTROL_CHAR");
   });
 
   it("rejects missing scheme", () => {

--- a/extensions/oc-path/src/oc-path/tests/scenarios/roundtrip-property.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/roundtrip-property.test.ts
@@ -82,7 +82,6 @@ describe("roundtrip-property", () => {
   });
 });
 
-
 function generateCorpus(count: number): string[] {
   const corpus: string[] = [];
   // Deterministic seed so flaky failures don't surface differently each run.

--- a/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
+++ b/extensions/oc-path/src/oc-path/tests/scenarios/security-and-limits.test.ts
@@ -12,7 +12,6 @@ import {
 import { parseJsonc } from "../../jsonc/parse.js";
 import { parseJsonl } from "../../jsonl/parse.js";
 
-
 describe("encoding edges", () => {
   it("strips leading UTF-8 BOM from path string", () => {
     expect(parseOcPath("﻿oc://X/Y").file).toBe("X");
@@ -36,7 +35,6 @@ describe("encoding edges", () => {
     expect(() => parseOcPath("oc://X.md/items/[k=a\x00b]")).toThrow(OcPathError);
   });
 });
-
 
 describe("file-slot containment", () => {
   it("rejects absolute POSIX file slot", () => {
@@ -72,7 +70,6 @@ describe("file-slot containment", () => {
     expect(() => formatOcPath({ file: "foo/../bar" })).toThrow(/Parent-directory/);
   });
 });
-
 
 describe("path-string and traversal caps", () => {
   it("parseOcPath rejects strings longer than MAX_PATH_LENGTH", () => {
@@ -123,7 +120,6 @@ describe("path-string and traversal caps", () => {
   });
 });
 
-
 describe("sentinel literal at format boundary", () => {
   it("formatOcPath rejects a struct carrying the redaction sentinel", () => {
     expect(() => formatOcPath({ file: "AGENTS.md", section: "__OPENCLAW_REDACTED__" })).toThrow(
@@ -131,7 +127,6 @@ describe("sentinel literal at format boundary", () => {
     );
   });
 });
-
 
 describe("numeric segments dispatch by node kind", () => {
   it("negative numeric key on object resolves as literal key (openclaw#59934)", () => {
@@ -153,7 +148,6 @@ describe("numeric segments dispatch by node kind", () => {
   });
 });
 
-
 describe("setOcPath value coercion is locale-independent and exact-match", () => {
   it("number coercion accepts `1.5`, refuses `1,5`", () => {
     const ast = parseJsonc('{"x":1.0}').ast;
@@ -173,7 +167,6 @@ describe("setOcPath value coercion is locale-independent and exact-match", () =>
     expect(setOcPath(ast, parseOcPath("oc://X/x"), "yes").ok).toBe(false);
   });
 });
-
 
 describe("predicate-value injection is contained", () => {
   it("regex metacharacters in predicate value match literally, not as regex", () => {
@@ -212,7 +205,6 @@ describe("predicate-value injection is contained", () => {
     expect(matches).toHaveLength(1);
   });
 });
-
 
 describe("structural rejection", () => {
   it("rejects mismatched brackets and braces", () => {

--- a/extensions/openrouter/speech-provider.test.ts
+++ b/extensions/openrouter/speech-provider.test.ts
@@ -7,18 +7,18 @@ const {
   readProviderBinaryResponseMock,
   resolveProviderHttpRequestConfigMock,
 } = vi.hoisted(() => ({
-    assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
-    postJsonRequestMock: vi.fn(),
-    readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
-      return new Uint8Array(await response.arrayBuffer());
-    }),
-    resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
-      baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
-      allowPrivateNetwork: false,
-      headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
-      dispatcherPolicy: undefined,
-    })),
-  }));
+  assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
+  postJsonRequestMock: vi.fn(),
+  readProviderBinaryResponseMock: vi.fn(async (response: Response) => {
+    return new Uint8Array(await response.arrayBuffer());
+  }),
+  resolveProviderHttpRequestConfigMock: vi.fn((params: Record<string, unknown>) => ({
+    baseUrl: params.baseUrl ?? params.defaultBaseUrl ?? "https://openrouter.ai/api/v1",
+    allowPrivateNetwork: false,
+    headers: new Headers(params.defaultHeaders as HeadersInit | undefined),
+    dispatcherPolicy: undefined,
+  })),
+}));
 
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -35,7 +35,8 @@ class FakeTransport implements OpenClawTransport {
     this.calls.push({ method, params, options });
     const response = this.responses[method];
     if (typeof response === "function") {
-      return (await response(params, options, this)) as T;
+      const value = await response(params, options, this);
+      return value as T;
     }
     return response as T;
   }

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -178,7 +178,8 @@ export function collectBundledPluginBuildEntries(params = {}) {
   for (const candidate of collectBundledPluginCandidates(cwd, extensionsRoot)) {
     const { dirName, pluginDir, relativeFiles, topLevelPublicSurfaceEntries } = candidate;
     const manifestPath = path.join(pluginDir, "openclaw.plugin.json");
-    const hasManifest = relativeFiles?.includes("openclaw.plugin.json") ?? fs.existsSync(manifestPath);
+    const hasManifest =
+      relativeFiles?.includes("openclaw.plugin.json") ?? fs.existsSync(manifestPath);
     const packageJsonPath = path.join(pluginDir, "package.json");
     const packageJson = readBundledPluginPackageJson(packageJsonPath, {
       hasPackageJson: relativeFiles?.includes("package.json"),

--- a/scripts/lib/changed-extensions.mjs
+++ b/scripts/lib/changed-extensions.mjs
@@ -71,7 +71,11 @@ function listChangedPaths(base, head = "HEAD") {
 }
 
 function listAvailableExtensionIdsFromGit() {
-  const packageFiles = runGit(["ls-files", "--", `:(glob)${BUNDLED_PLUGIN_PATH_PREFIX}*/package.json`])
+  const packageFiles = runGit([
+    "ls-files",
+    "--",
+    `:(glob)${BUNDLED_PLUGIN_PATH_PREFIX}*/package.json`,
+  ])
     .split("\n")
     .map((line) => normalizeRelative(line.trim()))
     .filter((line) => line.length > 0);

--- a/scripts/lib/extension-test-plan.mjs
+++ b/scripts/lib/extension-test-plan.mjs
@@ -70,7 +70,9 @@ function isPathInsideRepo(relativePath) {
 }
 
 function isSkippedTrackedTestFile(relativePath) {
-  return relativePath.split("/").some((segment) => segment === "dist" || segment === "node_modules");
+  return relativePath
+    .split("/")
+    .some((segment) => segment === "dist" || segment === "node_modules");
 }
 
 function listTrackedTestFiles(rootPath) {

--- a/scripts/test-built-status-message-runtime.mjs
+++ b/scripts/test-built-status-message-runtime.mjs
@@ -8,15 +8,14 @@ import { parsePackageRootArg } from "./lib/package-root-args.mjs";
 const STATUS_MESSAGE_RUNTIME_RE = /^status-message\.runtime(?:-[A-Za-z0-9_-]+)?\.js$/u;
 
 export function findBuiltStatusMessageRuntimePath(distDir) {
-  const candidates = listBuiltStatusMessageRuntimeFiles(distDir)
-    .toSorted((left, right) => {
-      const leftHasHash = left !== "status-message.runtime.js";
-      const rightHasHash = right !== "status-message.runtime.js";
-      if (leftHasHash !== rightHasHash) {
-        return leftHasHash ? -1 : 1;
-      }
-      return left.localeCompare(right);
-    });
+  const candidates = listBuiltStatusMessageRuntimeFiles(distDir).toSorted((left, right) => {
+    const leftHasHash = left !== "status-message.runtime.js";
+    const rightHasHash = right !== "status-message.runtime.js";
+    if (leftHasHash !== rightHasHash) {
+      return leftHasHash ? -1 : 1;
+    }
+    return left.localeCompare(right);
+  });
 
   assert.ok(candidates.length > 0, `missing built status-message runtime bundle under ${distDir}`);
 

--- a/src/auto-reply/reply/session-updates.runtime.ts
+++ b/src/auto-reply/reply/session-updates.runtime.ts
@@ -1,1 +1,1 @@
-export { ensureSkillSnapshot } from "./session-updates.js";
+export { ensureSkillSnapshot, prewarmMirroredSession } from "./session-updates.js";

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -50,6 +50,9 @@ vi.mock("../../agents/skills.js", () => ({
 
 vi.mock("../../agents/skills/refresh.js", () => ({
   ensureSkillsWatcher: ensureSkillsWatcherMock,
+}));
+
+vi.mock("../../agents/skills/refresh-state.js", () => ({
   getSkillsSnapshotVersion: getSkillsSnapshotVersionMock,
   shouldRefreshSnapshotForVersion: shouldRefreshSnapshotForVersionMock,
 }));
@@ -181,5 +184,49 @@ describe("ensureSkillSnapshot", () => {
         skillFilter: ["telegram-callbacks"],
       }),
     );
+  });
+
+  it("refreshes stale mirrored session snapshots during prewarm", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = {
+      sessionId: "sess-1",
+      updatedAt: 1,
+      skillsSnapshot: {
+        prompt: "old-skills",
+        skills: [],
+        resolvedSkills: [],
+        version: 1,
+      },
+    };
+    const store = {
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    };
+    loadSessionStoreMock.mockReturnValue(store);
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    getSkillsSnapshotVersionMock.mockReturnValue(2);
+    shouldRefreshSnapshotForVersionMock.mockReturnValue(true);
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "fresh-skills",
+      skills: [],
+      resolvedSkills: [],
+      version: 2,
+    });
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(shouldRefreshSnapshotForVersionMock).toHaveBeenCalledWith(1, 2);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalled();
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).toMatchObject({
+      sessionId: "sess-1",
+      skillsSnapshot: expect.objectContaining({
+        prompt: "fresh-skills",
+        version: 2,
+      }),
+    });
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).not.toHaveProperty("systemSent");
   });
 });

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -15,7 +15,12 @@ const {
   resolveSessionStoreEntryMock,
   updateSessionStoreMock,
 } = vi.hoisted(() => ({
-  buildWorkspaceSkillSnapshotMock: vi.fn(() => ({ prompt: "", skills: [], resolvedSkills: [] })),
+  buildWorkspaceSkillSnapshotMock: vi.fn(() => ({
+    prompt: "",
+    skills: [],
+    resolvedSkills: [],
+    version: 0,
+  })),
   ensureSkillsWatcherMock: vi.fn(),
   getSkillsSnapshotVersionMock: vi.fn(() => 0),
   shouldRefreshSnapshotForVersionMock: vi.fn(() => false),
@@ -25,7 +30,7 @@ const {
     hasAnyBin: () => false,
   })),
   resolveAgentConfigMock: vi.fn(() => undefined),
-  resolveAgentSkillsFilterMock: vi.fn(() => undefined as string[] | undefined),
+  resolveAgentSkillsFilterMock: vi.fn<() => string[] | undefined>(() => undefined),
   resolveAgentWorkspaceDirMock: vi.fn(() => "/tmp/workspace"),
   resolveSessionAgentIdMock: vi.fn(() => "writer"),
   resolveAgentIdFromSessionKeyMock: vi.fn(() => "main"),
@@ -83,7 +88,12 @@ const { ensureSkillSnapshot, prewarmMirroredSession } = await import("./session-
 describe("ensureSkillSnapshot", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    buildWorkspaceSkillSnapshotMock.mockReturnValue({ prompt: "", skills: [], resolvedSkills: [] });
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "",
+      skills: [],
+      resolvedSkills: [],
+      version: 0,
+    });
     getSkillsSnapshotVersionMock.mockReturnValue(0);
     shouldRefreshSnapshotForVersionMock.mockReturnValue(false);
     getRemoteSkillEligibilityMock.mockReturnValue({
@@ -146,6 +156,7 @@ describe("ensureSkillSnapshot", () => {
       prompt: "skills",
       skills: [],
       resolvedSkills: [],
+      version: 0,
     });
 
     await prewarmMirroredSession({

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -7,8 +7,13 @@ const {
   shouldRefreshSnapshotForVersionMock,
   getRemoteSkillEligibilityMock,
   resolveAgentConfigMock,
+  resolveAgentSkillsFilterMock,
+  resolveAgentWorkspaceDirMock,
   resolveSessionAgentIdMock,
   resolveAgentIdFromSessionKeyMock,
+  loadSessionStoreMock,
+  resolveSessionStoreEntryMock,
+  updateSessionStoreMock,
 } = vi.hoisted(() => ({
   buildWorkspaceSkillSnapshotMock: vi.fn(() => ({ prompt: "", skills: [], resolvedSkills: [] })),
   ensureSkillsWatcherMock: vi.fn(),
@@ -20,12 +25,22 @@ const {
     hasAnyBin: () => false,
   })),
   resolveAgentConfigMock: vi.fn(() => undefined),
+  resolveAgentSkillsFilterMock: vi.fn(() => undefined as string[] | undefined),
+  resolveAgentWorkspaceDirMock: vi.fn(() => "/tmp/workspace"),
   resolveSessionAgentIdMock: vi.fn(() => "writer"),
   resolveAgentIdFromSessionKeyMock: vi.fn(() => "main"),
+  loadSessionStoreMock: vi.fn(),
+  resolveSessionStoreEntryMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(
+    async (_storePath: string, update: (store: Record<string, unknown>) => unknown) =>
+      update(loadSessionStoreMock()),
+  ),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: resolveAgentConfigMock,
+  resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,
+  resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock,
   resolveSessionAgentId: resolveSessionAgentIdMock,
 }));
 
@@ -40,9 +55,14 @@ vi.mock("../../agents/skills/refresh.js", () => ({
 }));
 
 vi.mock("../../config/sessions.js", () => ({
-  updateSessionStore: vi.fn(),
+  updateSessionStore: updateSessionStoreMock,
   resolveSessionFilePath: vi.fn(),
   resolveSessionFilePathOptions: vi.fn(),
+}));
+
+vi.mock("../../config/sessions/store.js", () => ({
+  loadSessionStore: loadSessionStoreMock,
+  resolveSessionStoreEntry: resolveSessionStoreEntryMock,
 }));
 
 vi.mock("../../infra/skills-remote.js", () => ({
@@ -55,7 +75,7 @@ vi.mock("../../routing/session-key.js", () => ({
   resolveAgentIdFromSessionKey: resolveAgentIdFromSessionKeyMock,
 }));
 
-const { ensureSkillSnapshot } = await import("./session-updates.js");
+const { ensureSkillSnapshot, prewarmMirroredSession } = await import("./session-updates.js");
 
 describe("ensureSkillSnapshot", () => {
   beforeEach(() => {
@@ -69,8 +89,13 @@ describe("ensureSkillSnapshot", () => {
       hasAnyBin: () => false,
     });
     resolveAgentConfigMock.mockReturnValue(undefined);
+    resolveAgentSkillsFilterMock.mockReturnValue(undefined);
+    resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     resolveSessionAgentIdMock.mockReturnValue("writer");
     resolveAgentIdFromSessionKeyMock.mockReturnValue("main");
+    updateSessionStoreMock.mockImplementation(async (_storePath, update) =>
+      update(loadSessionStoreMock()),
+    );
   });
 
   afterEach(() => {
@@ -104,5 +129,57 @@ describe("ensureSkillSnapshot", () => {
       expect.objectContaining({ agentId: "writer" }),
     );
     expect(resolveAgentIdFromSessionKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("prewarms mirrored sessions without consuming first-turn system state", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = { sessionId: "sess-1", updatedAt: 1 };
+    const store = {
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    };
+    loadSessionStoreMock.mockReturnValue(store);
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "skills",
+      skills: [],
+      resolvedSkills: [],
+    });
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(updateSessionStoreMock).toHaveBeenCalled();
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).toMatchObject({
+      sessionId: "sess-1",
+      skillsSnapshot: expect.objectContaining({ prompt: "skills" }),
+    });
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).not.toHaveProperty("systemSent");
+  });
+
+  it("prewarms mirrored sessions with the agent skill filter", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = { sessionId: "sess-1", updatedAt: 1 };
+    loadSessionStoreMock.mockReturnValue({
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    });
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    resolveAgentSkillsFilterMock.mockReturnValue(["telegram-callbacks"]);
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledWith(
+      "/tmp/workspace",
+      expect.objectContaining({
+        agentId: "writer",
+        skillFilter: ["telegram-callbacks"],
+      }),
+    );
   });
 });

--- a/src/auto-reply/reply/session-updates.test.ts
+++ b/src/auto-reply/reply/session-updates.test.ts
@@ -27,13 +27,19 @@ const {
   shouldRefreshSnapshotForVersionMock,
   getRemoteSkillEligibilityMock,
   resolveAgentConfigMock,
+  resolveAgentSkillsFilterMock,
+  resolveAgentWorkspaceDirMock,
   resolveSessionAgentIdMock,
   resolveAgentIdFromSessionKeyMock,
+  loadSessionStoreMock,
+  resolveSessionStoreEntryMock,
+  updateSessionStoreMock,
 } = vi.hoisted(() => ({
   buildWorkspaceSkillSnapshotMock: vi.fn((..._args: unknown[]) => ({
     prompt: "",
     skills: [] as unknown[],
     resolvedSkills: [] as unknown[],
+    version: 0,
   })),
   ensureSkillsWatcherMock: vi.fn(),
   getSkillsSnapshotVersionMock: vi.fn(() => 0),
@@ -44,12 +50,22 @@ const {
     hasAnyBin: () => false,
   })),
   resolveAgentConfigMock: vi.fn(() => undefined),
+  resolveAgentSkillsFilterMock: vi.fn<() => string[] | undefined>(() => undefined),
+  resolveAgentWorkspaceDirMock: vi.fn(() => "/tmp/workspace"),
   resolveSessionAgentIdMock: vi.fn(() => "writer"),
   resolveAgentIdFromSessionKeyMock: vi.fn(() => "main"),
+  loadSessionStoreMock: vi.fn(),
+  resolveSessionStoreEntryMock: vi.fn(),
+  updateSessionStoreMock: vi.fn(
+    async (_storePath: string, update: (store: Record<string, unknown>) => unknown) =>
+      update(loadSessionStoreMock()),
+  ),
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: resolveAgentConfigMock,
+  resolveAgentSkillsFilter: resolveAgentSkillsFilterMock,
+  resolveAgentWorkspaceDir: resolveAgentWorkspaceDirMock,
   resolveSessionAgentId: resolveSessionAgentIdMock,
 }));
 
@@ -67,9 +83,14 @@ vi.mock("../../agents/skills/refresh-state.js", () => ({
 }));
 
 vi.mock("../../config/sessions.js", () => ({
-  updateSessionStore: vi.fn(),
+  updateSessionStore: updateSessionStoreMock,
   resolveSessionFilePath: vi.fn(),
   resolveSessionFilePathOptions: vi.fn(),
+}));
+
+vi.mock("../../config/sessions/store.js", () => ({
+  loadSessionStore: loadSessionStoreMock,
+  resolveSessionStoreEntry: resolveSessionStoreEntryMock,
 }));
 
 vi.mock("../../infra/skills-remote.js", () => ({
@@ -82,14 +103,19 @@ vi.mock("../../routing/session-key.js", () => ({
   resolveAgentIdFromSessionKey: resolveAgentIdFromSessionKeyMock,
 }));
 
-const { ensureSkillSnapshot, resetResolvedSkillsCacheForTests } =
+const { ensureSkillSnapshot, prewarmMirroredSession, resetResolvedSkillsCacheForTests } =
   await import("./session-updates.js");
 
 describe("ensureSkillSnapshot", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetResolvedSkillsCacheForTests();
-    buildWorkspaceSkillSnapshotMock.mockReturnValue({ prompt: "", skills: [], resolvedSkills: [] });
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "",
+      skills: [],
+      resolvedSkills: [],
+      version: 0,
+    });
     getSkillsSnapshotVersionMock.mockReturnValue(0);
     shouldRefreshSnapshotForVersionMock.mockReturnValue(false);
     getRemoteSkillEligibilityMock.mockReturnValue({
@@ -98,8 +124,13 @@ describe("ensureSkillSnapshot", () => {
       hasAnyBin: () => false,
     });
     resolveAgentConfigMock.mockReturnValue(undefined);
+    resolveAgentSkillsFilterMock.mockReturnValue(undefined);
+    resolveAgentWorkspaceDirMock.mockReturnValue("/tmp/workspace");
     resolveSessionAgentIdMock.mockReturnValue("writer");
     resolveAgentIdFromSessionKeyMock.mockReturnValue("main");
+    updateSessionStoreMock.mockImplementation(async (_storePath, update) =>
+      update(loadSessionStoreMock()),
+    );
   });
 
   afterEach(() => {
@@ -134,6 +165,103 @@ describe("ensureSkillSnapshot", () => {
     expect(workspaceDir).toBe(TEST_WORKSPACE_DIR);
     expect(snapshotParams.agentId).toBe("writer");
     expect(resolveAgentIdFromSessionKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("prewarms mirrored sessions without consuming first-turn system state", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = { sessionId: "sess-1", updatedAt: 1 };
+    const store = {
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    };
+    loadSessionStoreMock.mockReturnValue(store);
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "skills",
+      skills: [],
+      resolvedSkills: [],
+      version: 0,
+    });
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(updateSessionStoreMock).toHaveBeenCalled();
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).toMatchObject({
+      sessionId: "sess-1",
+      skillsSnapshot: expect.objectContaining({ prompt: "skills" }),
+    });
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).not.toHaveProperty("systemSent");
+  });
+
+  it("prewarms mirrored sessions with the agent skill filter", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = { sessionId: "sess-1", updatedAt: 1 };
+    loadSessionStoreMock.mockReturnValue({
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    });
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    resolveAgentSkillsFilterMock.mockReturnValue(["telegram-callbacks"]);
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalledWith(
+      "/tmp/workspace",
+      expect.objectContaining({
+        agentId: "writer",
+        skillFilter: ["telegram-callbacks"],
+      }),
+    );
+  });
+
+  it("refreshes stale mirrored session snapshots during prewarm", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    const entry = {
+      sessionId: "sess-1",
+      updatedAt: 1,
+      skillsSnapshot: {
+        prompt: "old-skills",
+        skills: [],
+        resolvedSkills: [],
+        version: 1,
+      },
+    };
+    const store = {
+      "agent:writer:telegram:group:-100123:topic:42": entry,
+    };
+    loadSessionStoreMock.mockReturnValue(store);
+    resolveSessionStoreEntryMock.mockReturnValue({ existing: entry, legacyKeys: [] });
+    getSkillsSnapshotVersionMock.mockReturnValue(2);
+    shouldRefreshSnapshotForVersionMock.mockReturnValue(true);
+    buildWorkspaceSkillSnapshotMock.mockReturnValue({
+      prompt: "fresh-skills",
+      skills: [],
+      resolvedSkills: [],
+      version: 2,
+    });
+
+    await prewarmMirroredSession({
+      cfg: {},
+      storePath: "/tmp/sessions.json",
+      sessionKey: "agent:writer:telegram:group:-100123:topic:42",
+    });
+
+    expect(shouldRefreshSnapshotForVersionMock).toHaveBeenCalledWith(1, 2);
+    expect(buildWorkspaceSkillSnapshotMock).toHaveBeenCalled();
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).toMatchObject({
+      sessionId: "sess-1",
+      skillsSnapshot: expect.objectContaining({
+        prompt: "fresh-skills",
+        version: 2,
+      }),
+    });
+    expect(store["agent:writer:telegram:group:-100123:topic:42"]).not.toHaveProperty("systemSent");
   });
 
   it("reuses cached resolvedSkills across calls with same workspaceDir/version/filter", async () => {
@@ -234,6 +362,7 @@ describe("ensureSkillSnapshot", () => {
         prompt: "",
         skills: [],
         resolvedSkills: config?.channels?.discord?.token ? [{ name: "discord" }] : [],
+        version: 0,
       };
     });
 
@@ -271,6 +400,7 @@ describe("ensureSkillSnapshot", () => {
       prompt: "",
       skills: [],
       resolvedSkills: [{ name: "discord" }],
+      version: 0,
     });
 
     const snapshot = strippedSnapshot("discord");

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -252,13 +252,15 @@ export async function prewarmMirroredSession(params: {
     config: params.cfg,
   });
   const skillFilter = resolveAgentSkillsFilter(params.cfg, agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   if (
     sessionEntry.skillsSnapshot &&
+    !shouldRefreshSnapshotForVersion(sessionEntry.skillsSnapshot.version, snapshotVersion) &&
     matchesSkillFilter(sessionEntry.skillsSnapshot.skillFilter, skillFilter)
   ) {
     return;
   }
-  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
   await ensureSkillSnapshot({
     sessionEntry,
     sessionStore,

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,7 +1,11 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentId,
+} from "../../agents/agent-scope.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
 import { buildWorkspaceSkillSnapshot } from "../../agents/skills.js";
 import { matchesSkillFilter } from "../../agents/skills/filter.js";
@@ -17,6 +21,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { loadSessionStore, resolveSessionStoreEntry } from "../../config/sessions/store.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveStableSessionEndTranscript } from "../../gateway/session-transcript-files.fs.js";
 import { logVerbose } from "../../globals.js";
@@ -220,6 +225,51 @@ export async function ensureSkillSnapshot(params: {
   }
 
   return { sessionEntry: nextEntry, skillsSnapshot, systemSent };
+}
+
+export async function prewarmMirroredSession(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  sessionKey: string;
+}): Promise<void> {
+  if (process.env.OPENCLAW_TEST_FAST === "1") {
+    return;
+  }
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return;
+  }
+  const sessionStore = loadSessionStore(params.storePath, { skipCache: true });
+  const sessionEntry = resolveSessionStoreEntry({
+    store: sessionStore,
+    sessionKey,
+  }).existing;
+  if (!sessionEntry?.sessionId) {
+    return;
+  }
+  const agentId = resolveSessionAgentId({
+    sessionKey,
+    config: params.cfg,
+  });
+  const skillFilter = resolveAgentSkillsFilter(params.cfg, agentId);
+  if (
+    sessionEntry.skillsSnapshot &&
+    matchesSkillFilter(sessionEntry.skillsSnapshot.skillFilter, skillFilter)
+  ) {
+    return;
+  }
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+  await ensureSkillSnapshot({
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    storePath: params.storePath,
+    sessionId: sessionEntry.sessionId,
+    isFirstTurnInSession: false,
+    workspaceDir,
+    cfg: params.cfg,
+    skillFilter,
+  });
 }
 
 export async function incrementCompactionCount(params: {

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -1,6 +1,10 @@
 import crypto from "node:crypto";
 import path from "node:path";
-import { resolveSessionAgentId } from "../../agents/agent-scope.js";
+import {
+  resolveAgentSkillsFilter,
+  resolveAgentWorkspaceDir,
+  resolveSessionAgentId,
+} from "../../agents/agent-scope.js";
 import { canExecRequestNode } from "../../agents/exec-defaults.js";
 import { buildWorkspaceSkillSnapshot, type SkillSnapshot } from "../../agents/skills.js";
 import { matchesSkillFilter } from "../../agents/skills/filter.js";
@@ -19,6 +23,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { loadSessionStore, resolveSessionStoreEntry } from "../../config/sessions/store.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   forgetActiveSessionForShutdown,
@@ -345,6 +350,53 @@ export async function ensureSkillSnapshot(params: {
   }
 
   return { sessionEntry: nextEntry, skillsSnapshot, systemSent };
+}
+
+export async function prewarmMirroredSession(params: {
+  cfg: OpenClawConfig;
+  storePath: string;
+  sessionKey: string;
+}): Promise<void> {
+  if (process.env.OPENCLAW_TEST_FAST === "1") {
+    return;
+  }
+  const sessionKey = normalizeOptionalString(params.sessionKey);
+  if (!sessionKey) {
+    return;
+  }
+  const sessionStore = loadSessionStore(params.storePath, { skipCache: true });
+  const sessionEntry = resolveSessionStoreEntry({
+    store: sessionStore,
+    sessionKey,
+  }).existing;
+  if (!sessionEntry?.sessionId) {
+    return;
+  }
+  const agentId = resolveSessionAgentId({
+    sessionKey,
+    config: params.cfg,
+  });
+  const skillFilter = resolveAgentSkillsFilter(params.cfg, agentId);
+  const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+  const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
+  if (
+    sessionEntry.skillsSnapshot &&
+    !shouldRefreshSnapshotForVersion(sessionEntry.skillsSnapshot.version, snapshotVersion) &&
+    matchesSkillFilter(sessionEntry.skillsSnapshot.skillFilter, skillFilter)
+  ) {
+    return;
+  }
+  await ensureSkillSnapshot({
+    sessionEntry,
+    sessionStore,
+    sessionKey,
+    storePath: params.storePath,
+    sessionId: sessionEntry.sessionId,
+    isFirstTurnInSession: false,
+    workspaceDir,
+    cfg: params.cfg,
+    skillFilter,
+  });
 }
 
 export async function incrementCompactionCount(params: {

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1425,7 +1425,11 @@ function collectDryRunRefs(params: {
     if (!ref) {
       continue;
     }
-    if (includeAllDiscoveredRefs || targetPaths.has(target.path) || providerAliases.has(ref.provider)) {
+    if (
+      includeAllDiscoveredRefs ||
+      targetPaths.has(target.path) ||
+      providerAliases.has(ref.provider)
+    ) {
       refsByKey.set(secretRefKey(ref), ref);
     }
   }

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -316,16 +316,7 @@ describe("cron cli", () => {
         enqueued: true,
         runId: "manual:job-1:123:0",
         runStatus: status,
-        args: [
-          "cron",
-          "run",
-          "job-1",
-          "--wait",
-          "--wait-timeout",
-          "1s",
-          "--poll-interval",
-          "1ms",
-        ],
+        args: ["cron", "run", "job-1", "--wait", "--wait-timeout", "1s", "--poll-interval", "1ms"],
       });
 
       expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -134,7 +134,10 @@ describe("registerPreActionHooks", () => {
       .command("create")
       .option("--json")
       .action(() => {});
-    program.command("doctor").option("--lint").action(() => {});
+    program
+      .command("doctor")
+      .option("--lint")
+      .action(() => {});
     program.command("completion").action(() => {});
     program.command("secrets").action(() => {});
     program

--- a/src/commands/doctor/shared/allowfrom-fallback-migration.ts
+++ b/src/commands/doctor/shared/allowfrom-fallback-migration.ts
@@ -53,7 +53,9 @@ function readOwnDmAllowFrom(params: { channelName: string; account: ChannelRecor
   );
 }
 
-function findGeneratedChannelConfigSchema(channelName: string): Record<string, unknown> | undefined {
+function findGeneratedChannelConfigSchema(
+  channelName: string,
+): Record<string, unknown> | undefined {
   const normalizedChannelId = normalizeAnyChannelId(channelName);
   return GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA.find(
     (entry) => entry.channelId === channelName || entry.channelId === normalizedChannelId,

--- a/src/cron/isolated-agent/run.runtime-plugins.test.ts
+++ b/src/cron/isolated-agent/run.runtime-plugins.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { makeIsolatedAgentTurnParams, setupRunCronIsolatedAgentTurnSuite } from "./run.suite-helpers.js";
+import {
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
 import {
   loadRunCronIsolatedAgentTurn,
   ensureRuntimePluginsLoadedMock,

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -1,5 +1,5 @@
-import { listHealthChecks } from "./health-check-registry.js";
 import { scrubDoctorErrorMessage } from "./doctor-error-message.js";
+import { listHealthChecks } from "./health-check-registry.js";
 import {
   HEALTH_FINDING_SEVERITY_RANK,
   healthFindingMeetsSeverity,

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -4,15 +4,22 @@ import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbo
 import { setMinimalOutboundSessionPluginRegistryForTests } from "./outbound-session.test-helpers.js";
 
 const mocks = vi.hoisted(() => ({
-  recordSessionMetaFromInbound: vi.fn(async () => ({ ok: true })),
+  recordSessionMetaFromInbound: vi.fn(
+    async () => null as { sessionId: string; updatedAt: number } | null,
+  ),
   resolveStorePath: vi.fn(
     (_store: unknown, params?: { agentId?: string }) => `/stores/${params?.agentId ?? "main"}.json`,
   ),
+  prewarmMirroredSession: vi.fn(async () => undefined),
 }));
 
 vi.mock("../../config/sessions/inbound.runtime.js", () => ({
   recordSessionMetaFromInbound: mocks.recordSessionMetaFromInbound,
   resolveStorePath: mocks.resolveStorePath,
+}));
+
+vi.mock("../../auto-reply/reply/session-updates.runtime.js", () => ({
+  prewarmMirroredSession: mocks.prewarmMirroredSession,
 }));
 
 describe("resolveOutboundSessionRoute", () => {
@@ -413,6 +420,7 @@ describe("ensureOutboundSessionEntry", () => {
   beforeEach(() => {
     mocks.recordSessionMetaFromInbound.mockClear();
     mocks.resolveStorePath.mockClear();
+    mocks.prewarmMirroredSession.mockClear();
   });
 
   it("persists metadata in the owning session store for the route session key", async () => {
@@ -442,5 +450,37 @@ describe("ensureOutboundSessionEntry", () => {
         sessionKey: "agent:main:workspace:channel:c1",
       }),
     );
+  });
+
+  it("prewarms mirrored outbound sessions before the first callback turn", async () => {
+    const cfg = {
+      session: {
+        store: "/stores/{agentId}.json",
+      },
+    } as OpenClawConfig;
+    mocks.recordSessionMetaFromInbound.mockResolvedValueOnce({
+      sessionId: "sess-1",
+      updatedAt: 1,
+    });
+
+    await ensureOutboundSessionEntry({
+      cfg,
+      channel: "telegram",
+      route: {
+        sessionKey: "agent:main:telegram:group:-100123:topic:42",
+        baseSessionKey: "agent:main:telegram:group:-100123",
+        peer: { kind: "group", id: "-100123:topic:42" },
+        chatType: "group",
+        from: "telegram:group:-100123:topic:42",
+        to: "telegram:-100123",
+        threadId: 42,
+      },
+    });
+
+    expect(mocks.prewarmMirroredSession).toHaveBeenCalledWith({
+      cfg,
+      storePath: "/stores/main.json",
+      sessionKey: "agent:main:telegram:group:-100123:topic:42",
+    });
   });
 });

--- a/src/infra/outbound/outbound-session.test.ts
+++ b/src/infra/outbound/outbound-session.test.ts
@@ -9,10 +9,14 @@ type InboundMetadataParams = {
 };
 
 const mocks = vi.hoisted(() => ({
-  recordSessionMetaFromInbound: vi.fn(async (_params: InboundMetadataParams) => ({ ok: true })),
+  recordSessionMetaFromInbound: vi.fn(
+    async (_params: InboundMetadataParams) =>
+      null as { sessionId: string; updatedAt: number } | null,
+  ),
   resolveStorePath: vi.fn(
     (_store: unknown, params?: { agentId?: string }) => `/stores/${params?.agentId ?? "main"}.json`,
   ),
+  prewarmMirroredSession: vi.fn(async () => undefined),
 }));
 
 function firstMockArg(
@@ -33,6 +37,10 @@ function firstMockArg(
 vi.mock("../../config/sessions/inbound.runtime.js", () => ({
   recordSessionMetaFromInbound: mocks.recordSessionMetaFromInbound,
   resolveStorePath: mocks.resolveStorePath,
+}));
+
+vi.mock("../../auto-reply/reply/session-updates.runtime.js", () => ({
+  prewarmMirroredSession: mocks.prewarmMirroredSession,
 }));
 
 describe("resolveOutboundSessionRoute", () => {
@@ -483,6 +491,7 @@ describe("ensureOutboundSessionEntry", () => {
   beforeEach(() => {
     mocks.recordSessionMetaFromInbound.mockClear();
     mocks.resolveStorePath.mockClear();
+    mocks.prewarmMirroredSession.mockClear();
   });
 
   it("persists metadata in the owning session store for the route session key", async () => {
@@ -513,5 +522,37 @@ describe("ensureOutboundSessionEntry", () => {
     );
     expect(metadata.storePath).toBe("/stores/main.json");
     expect(metadata.sessionKey).toBe("agent:main:workspace:channel:c1");
+  });
+
+  it("prewarms mirrored outbound sessions before the first callback turn", async () => {
+    const cfg = {
+      session: {
+        store: "/stores/{agentId}.json",
+      },
+    } as OpenClawConfig;
+    mocks.recordSessionMetaFromInbound.mockResolvedValueOnce({
+      sessionId: "sess-1",
+      updatedAt: 1,
+    });
+
+    await ensureOutboundSessionEntry({
+      cfg,
+      channel: "telegram",
+      route: {
+        sessionKey: "agent:main:telegram:group:-100123:topic:42",
+        baseSessionKey: "agent:main:telegram:group:-100123",
+        peer: { kind: "group", id: "-100123:topic:42" },
+        chatType: "group",
+        from: "telegram:group:-100123:topic:42",
+        to: "telegram:-100123",
+        threadId: 42,
+      },
+    });
+
+    expect(mocks.prewarmMirroredSession).toHaveBeenCalledWith({
+      cfg,
+      storePath: "/stores/main.json",
+      sessionKey: "agent:main:telegram:group:-100123:topic:42",
+    });
   });
 });

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -13,6 +13,15 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { buildOutboundBaseSessionKey } from "./base-session-key.js";
 import type { ResolvedMessagingTarget } from "./target-resolver.js";
 
+let sessionUpdatesRuntimePromise:
+  | Promise<typeof import("../../auto-reply/reply/session-updates.runtime.js")>
+  | undefined;
+
+async function loadSessionUpdatesRuntime() {
+  sessionUpdatesRuntimePromise ??= import("../../auto-reply/reply/session-updates.runtime.js");
+  return await sessionUpdatesRuntimePromise;
+}
+
 export type OutboundSessionRoute = {
   sessionKey: string;
   baseSessionKey: string;
@@ -154,10 +163,19 @@ export async function ensureOutboundSessionEntry(params: {
     OriginatingTo: params.route.to,
   };
   try {
-    await recordSessionMetaFromInbound({
+    const sessionEntry = await recordSessionMetaFromInbound({
       storePath,
       sessionKey: params.route.sessionKey,
       ctx,
+    });
+    if (!sessionEntry?.sessionId) {
+      return;
+    }
+    const { prewarmMirroredSession } = await loadSessionUpdatesRuntime();
+    await prewarmMirroredSession({
+      cfg: params.cfg,
+      storePath,
+      sessionKey: params.route.sessionKey,
     });
   } catch {
     // Do not block outbound sends on session meta writes.

--- a/src/infra/outbound/outbound-session.ts
+++ b/src/infra/outbound/outbound-session.ts
@@ -13,6 +13,15 @@ import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { buildOutboundBaseSessionKey } from "./base-session-key.js";
 import type { ResolvedMessagingTarget } from "./target-resolver.js";
 
+let sessionUpdatesRuntimePromise:
+  | Promise<typeof import("../../auto-reply/reply/session-updates.runtime.js")>
+  | undefined;
+
+async function loadSessionUpdatesRuntime() {
+  sessionUpdatesRuntimePromise ??= import("../../auto-reply/reply/session-updates.runtime.js");
+  return await sessionUpdatesRuntimePromise;
+}
+
 export type OutboundSessionRoute = {
   sessionKey: string;
   baseSessionKey: string;
@@ -203,10 +212,19 @@ export async function ensureOutboundSessionEntry(params: {
     OriginatingTo: params.route.to,
   };
   try {
-    await recordSessionMetaFromInbound({
+    const sessionEntry = await recordSessionMetaFromInbound({
       storePath,
       sessionKey: params.route.sessionKey,
       ctx,
+    });
+    if (!sessionEntry?.sessionId) {
+      return;
+    }
+    const { prewarmMirroredSession } = await loadSessionUpdatesRuntime();
+    await prewarmMirroredSession({
+      cfg: params.cfg,
+      storePath,
+      sessionKey: params.route.sessionKey,
     });
   } catch {
     // Do not block outbound sends on session meta writes.

--- a/src/plugins/compat/registry.ts
+++ b/src/plugins/compat/registry.ts
@@ -33,11 +33,11 @@ export const PLUGIN_COMPAT_RECORDS = [
     removeAfter: "2026-08-16",
     replacement: "`gateway_stop` hook",
     docsPath: "/plugins/hooks#upcoming-deprecations",
-    surfaces: ["api.on(\"deactivate\", ...)", "plugin typed hook registration"],
+    surfaces: ['api.on("deactivate", ...)', "plugin typed hook registration"],
     diagnostics: ["plugin runtime compatibility warning"],
     tests: ["src/plugins/loader.test.ts"],
     releaseNote:
-      "`api.on(\"deactivate\", ...)` remains wired as a deprecated compatibility alias while plugins migrate to `gateway_stop`.",
+      '`api.on("deactivate", ...)` remains wired as a deprecated compatibility alias while plugins migrate to `gateway_stop`.',
   },
   {
     code: "hook-only-plugin-shape",

--- a/src/tts/directives.test.ts
+++ b/src/tts/directives.test.ts
@@ -116,12 +116,17 @@ describe("parseTtsDirectives provider-aware routing", () => {
   });
 
   it("routes to preferred provider aliases when no provider token is declared", () => {
-    const azure = makeProvider("azure-speech", 20, ({ key, value }) => {
-      if (key === "speed") {
-        return { handled: true, overrides: { speed: Number(value) } };
-      }
-      return undefined;
-    }, { aliases: ["azure"] });
+    const azure = makeProvider(
+      "azure-speech",
+      20,
+      ({ key, value }) => {
+        if (key === "speed") {
+          return { handled: true, overrides: { speed: Number(value) } };
+        }
+        return undefined;
+      },
+      { aliases: ["azure"] },
+    );
 
     const result = parseTtsDirectives("[[tts:speed=1.5]]", fullPolicy, {
       providers: [elevenlabs, azure],

--- a/test/scripts/test-live-codex-harness-docker.test.ts
+++ b/test/scripts/test-live-codex-harness-docker.test.ts
@@ -41,23 +41,17 @@ describe("scripts/test-live-codex-harness-docker.sh", () => {
   it("forwards API-key auth through both OpenAI and Codex env names", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
-    expect(script).toContain('printf \'OPENAI_API_KEY=%s\\n\' "${OPENAI_API_KEY}"');
-    expect(script).toContain('printf \'CODEX_API_KEY=%s\\n\' "${CODEX_API_KEY:-$OPENAI_API_KEY}"');
-    expect(script.indexOf("OPENAI_API_KEY=%s")).toBeLessThan(
-      script.indexOf("CODEX_API_KEY=%s"),
-    );
+    expect(script).toContain("printf 'OPENAI_API_KEY=%s\\n' \"${OPENAI_API_KEY}\"");
+    expect(script).toContain("printf 'CODEX_API_KEY=%s\\n' \"${CODEX_API_KEY:-$OPENAI_API_KEY}\"");
+    expect(script.indexOf("OPENAI_API_KEY=%s")).toBeLessThan(script.indexOf("CODEX_API_KEY=%s"));
   });
 
   it("keeps API-key runs on the ephemeral Docker home", () => {
     const script = fs.readFileSync(SCRIPT_PATH, "utf8");
 
     expect(script).toContain('DOCKER_USER="$(id -u):$(id -g)"');
-    expect(script).toContain(
-      'if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then',
-    );
-    expect(script).toContain(
-      'if [[ -z "${DOCKER_HOME_DIR:-}" ]]; then',
-    );
+    expect(script).toContain('if [[ "$CODEX_HARNESS_AUTH_MODE" == "api-key" ]]; then');
+    expect(script).toContain('if [[ -z "${DOCKER_HOME_DIR:-}" ]]; then');
     expect(script).not.toContain('DOCKER_USER="0:0"');
     expect(script).toContain(
       'DOCKER_HOME_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/openclaw-docker-home.XXXXXX")"',
@@ -74,9 +68,7 @@ describe("scripts/test-live-codex-harness-docker.sh", () => {
     expect(script).toContain(
       'chmod 0777 "$DOCKER_HOME_DIR" "$CONFIG_DIR" "$WORKSPACE_DIR" || true',
     );
-    expect(script).toContain(
-      'if [[ "$CODEX_HARNESS_AUTH_MODE" != "api-key" ]]; then',
-    );
+    expect(script).toContain('if [[ "$CODEX_HARNESS_AUTH_MODE" != "api-key" ]]; then');
     expect(script.indexOf('PROFILE_STATUS="api-key-env"')).toBeLessThan(
       script.indexOf("openclaw_live_append_array DOCKER_RUN_ARGS PROFILE_MOUNT"),
     );


### PR DESCRIPTION
## Summary
- prewarm mirrored outbound sessions after `message send` records session metadata
- reuse the existing session skills snapshot logic so the first callback turn is not a cold-start session
- add regression coverage for proactive outbound send followed by the first callback turn, stale snapshot refresh, and current resolved-skills cache behavior from `main`

## Testing
- `node scripts/test-projects.mjs src/auto-reply/reply/session-updates.test.ts src/infra/outbound/outbound-session.test.ts src/gateway/server-methods/send.test.ts`
- `node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `git diff --check`

## Real behavior proof
Behavior addressed: proactive Telegram message sends with inline buttons now prewarm the mirrored outbound session before the first callback turn, so the first button tap is handled in the existing session instead of cold-starting or dropping context.

Real environment tested: Project Alpha Raspberry Pi 5 running OpenClaw with the Telegram plugin in the real Project Alpha Telegram group, using the paper-trading scan flow.

Exact steps or command run after this patch: deployed the OpenClaw build containing this PR to the Pi runtime, sent a Project Alpha scan message with a Telegram inline `Next set` button, then tapped `Next set` from Telegram.

Evidence after fix: Copied live output from the redacted real Telegram group after tapping the inline button:

```text
[openclaw-pi5] Scan 05/15 11:45 AM ET — ideas 4-6 of 6

D. F LONG
Why: above VWAP; RSI aligned; EMA stack aligned; context market internals acceptable.
Timing: cautionary

E. NVDA LONG
Why: above VWAP; RSI aligned; EMA stack aligned; context market internals acceptable.
Timing: cautionary
```

Observed result after fix: the first inline-button callback delivered the next scan page without requiring `/new`, without a missing-transcript/session-store error, and without losing the scan context. The user also confirmed in the live project thread: "the telegram buttons worked great" after the deployed build.

What was not tested: I did not run a broad live Telegram media/card matrix for this PR; local verification covered the mirrored-session prewarm unit/regression path, gateway send path, and core test typecheck.

## Related
- Fixes #68429
