### PR TITLE
feat(gateway): accept audio/file content blocks in /v1/chat/completions

### DIFF
--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -21582,15 +21582,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                             minimum: 0,
                             maximum: 9007199254740991,
                           },
-                          allowUrl: {
-                            type: "boolean",
-                          },
-                          urlAllowlist: {
-                            type: "array",
-                            items: {
-                              type: "string",
-                            },
-                          },
                           allowedMimes: {
                             type: "array",
                             items: {
@@ -21598,16 +21589,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                             },
                           },
                           maxBytes: {
-                            type: "integer",
-                            exclusiveMinimum: 0,
-                            maximum: 9007199254740991,
-                          },
-                          maxRedirects: {
-                            type: "integer",
-                            minimum: 0,
-                            maximum: 9007199254740991,
-                          },
-                          timeoutMs: {
                             type: "integer",
                             exclusiveMinimum: 0,
                             maximum: 9007199254740991,

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -21541,6 +21541,111 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         description:
                           "Image fetch/validation controls for OpenAI-compatible `image_url` parts.",
                       },
+                      audio: {
+                        type: "object",
+                        properties: {
+                          enabled: {
+                            type: "boolean",
+                          },
+                          maxParts: {
+                            type: "integer",
+                            minimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxBytes: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxTotalBytes: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          allowedMimes: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                            },
+                          },
+                        },
+                        additionalProperties: false,
+                      },
+                      files: {
+                        type: "object",
+                        properties: {
+                          enabled: {
+                            type: "boolean",
+                          },
+                          maxParts: {
+                            type: "integer",
+                            minimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          allowUrl: {
+                            type: "boolean",
+                          },
+                          urlAllowlist: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                            },
+                          },
+                          allowedMimes: {
+                            type: "array",
+                            items: {
+                              type: "string",
+                            },
+                          },
+                          maxBytes: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxRedirects: {
+                            type: "integer",
+                            minimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          timeoutMs: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxTotalBytes: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          maxChars: {
+                            type: "integer",
+                            exclusiveMinimum: 0,
+                            maximum: 9007199254740991,
+                          },
+                          pdf: {
+                            type: "object",
+                            properties: {
+                              maxPages: {
+                                type: "integer",
+                                exclusiveMinimum: 0,
+                                maximum: 9007199254740991,
+                              },
+                              maxPixels: {
+                                type: "integer",
+                                exclusiveMinimum: 0,
+                                maximum: 9007199254740991,
+                              },
+                              minTextChars: {
+                                type: "integer",
+                                minimum: 0,
+                                maximum: 9007199254740991,
+                              },
+                            },
+                            additionalProperties: false,
+                          },
+                        },
+                        additionalProperties: false,
+                      },
                     },
                     additionalProperties: false,
                   },

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -287,25 +287,14 @@ export type GatewayHttpChatCompletionsFilesConfig = {
   enabled?: boolean;
   /** Max number of `file` parts per request. Default: 5. */
   maxParts?: number;
-  /** Allow URL fetches for file sources. Default: false. */
-  allowUrl?: boolean;
-  /**
-   * Optional hostname allowlist for URL fetches.
-   * Supports exact hosts and `*.example.com` wildcards.
-   */
-  urlAllowlist?: string[];
   /** Allowed MIME types (case-insensitive). */
   allowedMimes?: string[];
-  /** Max bytes per file. Default: 20MB. */
+  /** Max bytes per file (base64-decoded). Default: 20MB. */
   maxBytes?: number;
   /** Max cumulative decoded file bytes in one request. Default: 50MB. */
   maxTotalBytes?: number;
   /** Max decoded characters per file after extraction. Default: 200k. */
   maxChars?: number;
-  /** Max redirects when fetching a URL. Default: 3. */
-  maxRedirects?: number;
-  /** Fetch timeout in ms. Default: 10s. */
-  timeoutMs?: number;
   /** PDF handling (application/pdf). */
   pdf?: GatewayHttpResponsesPdfConfig;
 };

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -237,6 +237,10 @@ export type GatewayHttpChatCompletionsConfig = {
   maxTotalImageBytes?: number;
   /** Image input controls for `image_url` parts. */
   images?: GatewayHttpChatCompletionsImagesConfig;
+  /** Audio input controls for `input_audio` parts (transcribed via STT). */
+  audio?: GatewayHttpChatCompletionsAudioConfig;
+  /** File input controls for `file` parts (text extraction). */
+  files?: GatewayHttpChatCompletionsFilesConfig;
 };
 
 export type GatewayHttpChatCompletionsImagesConfig = {
@@ -255,6 +259,55 @@ export type GatewayHttpChatCompletionsImagesConfig = {
   maxRedirects?: number;
   /** Fetch timeout in ms. Default: 10s. */
   timeoutMs?: number;
+};
+
+export type GatewayHttpChatCompletionsAudioConfig = {
+  /**
+   * If false, `input_audio` parts are rejected with 400. Default: true when
+   * chatCompletions is enabled. Audio is transcribed via the same STT pipeline
+   * used by Telegram voice preflight (`cfg.tools.media.audio`), so at least one
+   * audio provider must be configured for this to work.
+   */
+  enabled?: boolean;
+  /** Max number of `input_audio` parts per request. Default: 4. */
+  maxParts?: number;
+  /** Max bytes per audio attachment (base64-decoded). Default: 25MB. */
+  maxBytes?: number;
+  /** Max cumulative decoded audio bytes in one request. Default: 50MB. */
+  maxTotalBytes?: number;
+  /** Allowed MIME types (case-insensitive). Default: common audio formats. */
+  allowedMimes?: string[];
+};
+
+export type GatewayHttpChatCompletionsFilesConfig = {
+  /**
+   * If false, `file` parts are rejected with 400. Default: true when
+   * chatCompletions is enabled.
+   */
+  enabled?: boolean;
+  /** Max number of `file` parts per request. Default: 5. */
+  maxParts?: number;
+  /** Allow URL fetches for file sources. Default: false. */
+  allowUrl?: boolean;
+  /**
+   * Optional hostname allowlist for URL fetches.
+   * Supports exact hosts and `*.example.com` wildcards.
+   */
+  urlAllowlist?: string[];
+  /** Allowed MIME types (case-insensitive). */
+  allowedMimes?: string[];
+  /** Max bytes per file. Default: 20MB. */
+  maxBytes?: number;
+  /** Max cumulative decoded file bytes in one request. Default: 50MB. */
+  maxTotalBytes?: number;
+  /** Max decoded characters per file after extraction. Default: 200k. */
+  maxChars?: number;
+  /** Max redirects when fetching a URL. Default: 3. */
+  maxRedirects?: number;
+  /** Fetch timeout in ms. Default: 10s. */
+  timeoutMs?: number;
+  /** PDF handling (application/pdf). */
+  pdf?: GatewayHttpResponsesPdfConfig;
 };
 
 export type GatewayHttpResponsesConfig = {

--- a/src/config/zod-schema.gateway-chat-completions-multimodal.test.ts
+++ b/src/config/zod-schema.gateway-chat-completions-multimodal.test.ts
@@ -24,14 +24,10 @@ describe("OpenClawSchema gateway.http.endpoints.chatCompletions multimodal valid
                 files: {
                   enabled: true,
                   maxParts: 5,
-                  allowUrl: false,
-                  urlAllowlist: ["*.example.com"],
                   allowedMimes: ["text/plain", "application/pdf"],
                   maxBytes: 20_971_520,
                   maxTotalBytes: 52_428_800,
                   maxChars: 200_000,
-                  maxRedirects: 3,
-                  timeoutMs: 10_000,
                   pdf: { maxPages: 4, maxPixels: 4_000_000, minTextChars: 200 },
                 },
               },
@@ -90,6 +86,33 @@ describe("OpenClawSchema gateway.http.endpoints.chatCompletions multimodal valid
         },
       }),
     ).toThrow();
+  });
+
+  it("rejects URL-fetch keys on chatCompletions.files (runtime does not fetch URLs here)", () => {
+    // chatCompletions `file` parts are always base64-encoded; the URL-fetch
+    // fields that exist on /v1/responses input_file config are intentionally
+    // absent here to avoid surfacing operator knobs that have no effect.
+    const deadValues: Record<string, unknown> = {
+      allowUrl: true,
+      urlAllowlist: ["*.example.com"],
+      maxRedirects: 3,
+      timeoutMs: 10_000,
+    };
+    for (const [deadField, value] of Object.entries(deadValues)) {
+      expect(() =>
+        OpenClawSchema.parse({
+          gateway: {
+            http: {
+              endpoints: {
+                chatCompletions: {
+                  files: { [deadField]: value },
+                },
+              },
+            },
+          },
+        }),
+      ).toThrow();
+    }
   });
 
   it("rejects non-positive numeric limits on audio/files", () => {

--- a/src/config/zod-schema.gateway-chat-completions-multimodal.test.ts
+++ b/src/config/zod-schema.gateway-chat-completions-multimodal.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import { OpenClawSchema } from "./zod-schema.js";
+
+describe("OpenClawSchema gateway.http.endpoints.chatCompletions multimodal validation", () => {
+  it("accepts audio and files blocks alongside existing image limits", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                enabled: true,
+                maxBodyBytes: 20_971_520,
+                maxImageParts: 8,
+                maxTotalImageBytes: 20_971_520,
+                images: { allowUrl: false, maxBytes: 10_485_760 },
+                audio: {
+                  enabled: true,
+                  maxParts: 4,
+                  maxBytes: 26_214_400,
+                  maxTotalBytes: 52_428_800,
+                  allowedMimes: ["audio/mpeg", "audio/wav"],
+                },
+                files: {
+                  enabled: true,
+                  maxParts: 5,
+                  allowUrl: false,
+                  urlAllowlist: ["*.example.com"],
+                  allowedMimes: ["text/plain", "application/pdf"],
+                  maxBytes: 20_971_520,
+                  maxTotalBytes: 52_428_800,
+                  maxChars: 200_000,
+                  maxRedirects: 3,
+                  timeoutMs: 10_000,
+                  pdf: { maxPages: 4, maxPixels: 4_000_000, minTextChars: 200 },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts the minimal audio.enabled / files.enabled toggle shape", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                enabled: true,
+                audio: { enabled: false },
+                files: { enabled: false },
+              },
+            },
+          },
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects unknown keys inside chatCompletions.audio", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                audio: { unknownField: true },
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects unknown keys inside chatCompletions.files", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                files: { unknownField: true },
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-positive numeric limits on audio/files", () => {
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                audio: { maxBytes: 0 },
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow();
+
+    expect(() =>
+      OpenClawSchema.parse({
+        gateway: {
+          http: {
+            endpoints: {
+              chatCompletions: {
+                files: { maxParts: -1 },
+              },
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -815,7 +815,8 @@ export const OpenClawSchema = z
                       .object({
                         enabled: z.boolean().optional(),
                         maxParts: z.number().int().nonnegative().optional(),
-                        ...ResponsesEndpointUrlFetchShape,
+                        allowedMimes: z.array(z.string()).optional(),
+                        maxBytes: z.number().int().positive().optional(),
                         maxTotalBytes: z.number().int().positive().optional(),
                         maxChars: z.number().int().positive().optional(),
                         pdf: z

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -801,6 +801,34 @@ export const OpenClawSchema = z
                       })
                       .strict()
                       .optional(),
+                    audio: z
+                      .object({
+                        enabled: z.boolean().optional(),
+                        maxParts: z.number().int().nonnegative().optional(),
+                        maxBytes: z.number().int().positive().optional(),
+                        maxTotalBytes: z.number().int().positive().optional(),
+                        allowedMimes: z.array(z.string()).optional(),
+                      })
+                      .strict()
+                      .optional(),
+                    files: z
+                      .object({
+                        enabled: z.boolean().optional(),
+                        maxParts: z.number().int().nonnegative().optional(),
+                        ...ResponsesEndpointUrlFetchShape,
+                        maxTotalBytes: z.number().int().positive().optional(),
+                        maxChars: z.number().int().positive().optional(),
+                        pdf: z
+                          .object({
+                            maxPages: z.number().int().positive().optional(),
+                            maxPixels: z.number().int().positive().optional(),
+                            minTextChars: z.number().int().nonnegative().optional(),
+                          })
+                          .strict()
+                          .optional(),
+                      })
+                      .strict()
+                      .optional(),
                   })
                   .strict()
                   .optional(),

--- a/src/gateway/openai-http.multimodal.test.ts
+++ b/src/gateway/openai-http.multimodal.test.ts
@@ -235,4 +235,27 @@ describe("openai-http limits resolution for multimodal config", () => {
     });
     expect(limits.files.enabled).toBe(false);
   });
+
+  it("propagates operator-supplied audio/file byte + mime limits to the resolver", () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits({
+      audio: {
+        maxBytes: 1234,
+        maxTotalBytes: 5678,
+        allowedMimes: ["audio/flac"],
+      },
+      files: {
+        maxBytes: 2468,
+        maxTotalBytes: 8642,
+        maxChars: 9999,
+        allowedMimes: ["text/plain"],
+      },
+    });
+    expect(limits.audio.maxBytes).toBe(1234);
+    expect(limits.audio.maxTotalBytes).toBe(5678);
+    expect(limits.audio.allowedMimes.has("audio/flac")).toBe(true);
+    expect(limits.files.maxBytes).toBe(2468);
+    expect(limits.files.maxTotalBytes).toBe(8642);
+    expect(limits.files.maxChars).toBe(9999);
+    expect(limits.files.allowedMimes.has("text/plain")).toBe(true);
+  });
 });

--- a/src/gateway/openai-http.multimodal.test.ts
+++ b/src/gateway/openai-http.multimodal.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const extractFileContentFromSourceMock = vi.fn();
+const transcribeFirstAudioMock = vi.fn();
+const loadConfigMock = vi.fn();
+
+vi.mock("../media/input-files.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../media/input-files.js")>("../media/input-files.js");
+  return {
+    ...actual,
+    extractFileContentFromSource: (...args: unknown[]) => extractFileContentFromSourceMock(...args),
+  };
+});
+
+vi.mock("../media-understanding/audio-preflight.js", () => ({
+  transcribeFirstAudio: (...args: unknown[]) => transcribeFirstAudioMock(...args),
+}));
+
+vi.mock("../config/io.js", async () => {
+  const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
+  return {
+    ...actual,
+    loadConfig: () => loadConfigMock(),
+  };
+});
+
+import { __testOnlyOpenAiHttp } from "./openai-http.js";
+
+describe("openai-http multimodal content-block parsers", () => {
+  it("extracts input_audio parts and normalizes mime", () => {
+    const parts = __testOnlyOpenAiHttp.extractAudioParts([
+      { type: "text", text: "listen" },
+      { type: "input_audio", input_audio: { data: "AAAA", format: "wav" } },
+      { type: "input_audio", input_audio: { data: "BBBB", format: "audio/mpeg" } },
+    ]);
+    expect(parts).toEqual([
+      { data: "AAAA", mime: "audio/wav" },
+      { data: "BBBB", mime: "audio/mpeg" },
+    ]);
+  });
+
+  it("falls back to audio/wav when format is missing", () => {
+    const parts = __testOnlyOpenAiHttp.extractAudioParts([
+      { type: "input_audio", input_audio: { data: "ZZZZ" } },
+    ]);
+    expect(parts).toEqual([{ data: "ZZZZ", mime: "audio/wav" }]);
+  });
+
+  it("ignores audio parts with no data", () => {
+    expect(
+      __testOnlyOpenAiHttp.extractAudioParts([
+        { type: "input_audio", input_audio: { format: "wav" } },
+        { type: "input_audio" },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("extracts file parts with mime_type and filename", () => {
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: { file_data: "SGVsbG8=", mime_type: "text/plain", filename: "hi.txt" },
+      },
+    ]);
+    expect(parts).toEqual([{ data: "SGVsbG8=", mediaType: "text/plain", filename: "hi.txt" }]);
+  });
+
+  it("parses data URI file_data and extracts mime from metadata", () => {
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: { file_data: "data:text/markdown;base64,SGVsbG8=", filename: "doc.md" },
+      },
+    ]);
+    expect(parts).toEqual([{ data: "SGVsbG8=", mediaType: "text/markdown", filename: "doc.md" }]);
+  });
+
+  it("rejects non-base64 file data URIs", () => {
+    expect(() =>
+      __testOnlyOpenAiHttp.extractFileParts([
+        {
+          type: "file",
+          file: { file_data: "data:text/plain,SGVsbG8=", filename: "a.txt" },
+        },
+      ]),
+    ).toThrow(/must be base64 encoded/);
+  });
+
+  it("detects video_url content parts", () => {
+    expect(
+      __testOnlyOpenAiHttp.hasVideoUrlPart([
+        { type: "text", text: "describe" },
+        { type: "video_url", video_url: { url: "data:video/mp4;base64,AAAA" } },
+      ]),
+    ).toBe(true);
+    expect(__testOnlyOpenAiHttp.hasVideoUrlPart([{ type: "text", text: "hi" }])).toBe(false);
+  });
+});
+
+describe("openai-http audio resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfigMock.mockReturnValue({ tools: { media: { audio: { enabled: true } } } });
+  });
+
+  it("transcribes audio parts and returns transcripts", async () => {
+    transcribeFirstAudioMock.mockResolvedValueOnce("Hello from user");
+
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    const transcripts = await __testOnlyOpenAiHttp.resolveAudiosForRequest(
+      {
+        audioParts: [{ data: Buffer.from("ignored").toString("base64"), mime: "audio/wav" }],
+      },
+      limits,
+    );
+    expect(transcripts).toEqual(["Hello from user"]);
+    expect(transcribeFirstAudioMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects audio parts with unsupported MIME", async () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    await expect(
+      __testOnlyOpenAiHttp.resolveAudiosForRequest(
+        {
+          audioParts: [{ data: Buffer.from("x").toString("base64"), mime: "audio/weird" }],
+        },
+        limits,
+      ),
+    ).rejects.toThrow(/Unsupported audio MIME type/);
+  });
+
+  it("enforces maxParts", async () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits({
+      audio: { maxParts: 1 },
+    });
+    await expect(
+      __testOnlyOpenAiHttp.resolveAudiosForRequest(
+        {
+          audioParts: [
+            { data: "AAAA", mime: "audio/wav" },
+            { data: "BBBB", mime: "audio/wav" },
+          ],
+        },
+        limits,
+      ),
+    ).rejects.toThrow(/Too many input_audio parts/);
+  });
+});
+
+describe("openai-http file resolver", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts text file and wraps it as a file context block", async () => {
+    extractFileContentFromSourceMock.mockResolvedValueOnce({
+      filename: "note.txt",
+      text: "secret=BANANA",
+    });
+
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    const result = await __testOnlyOpenAiHttp.resolveFilesForRequest(
+      {
+        fileParts: [
+          { data: "c2VjcmV0PUJBTkFOQQ==", mediaType: "text/plain", filename: "note.txt" },
+        ],
+      },
+      limits,
+    );
+
+    expect(result.images).toEqual([]);
+    expect(result.contexts).toHaveLength(1);
+    expect(result.contexts[0]).toMatch(/<file name="note.txt">/);
+    expect(result.contexts[0]).toContain("secret=BANANA");
+  });
+
+  it("merges PDF-extracted images into the images result", async () => {
+    extractFileContentFromSourceMock.mockResolvedValueOnce({
+      filename: "report.pdf",
+      text: "",
+      images: [{ type: "image", data: "QUJD", mimeType: "image/png" }],
+    });
+
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    const result = await __testOnlyOpenAiHttp.resolveFilesForRequest(
+      {
+        fileParts: [{ data: "AAAA", mediaType: "application/pdf", filename: "report.pdf" }],
+      },
+      limits,
+    );
+
+    expect(result.images).toEqual([{ type: "image", data: "QUJD", mimeType: "image/png" }]);
+    expect(result.contexts).toHaveLength(1);
+    expect(result.contexts[0]).toContain("[PDF content rendered to images]");
+  });
+
+  it("enforces maxParts for file content", async () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits({
+      files: { maxParts: 1 },
+    });
+    await expect(
+      __testOnlyOpenAiHttp.resolveFilesForRequest(
+        {
+          fileParts: [
+            { data: "AAAA", mediaType: "text/plain", filename: "a.txt" },
+            { data: "BBBB", mediaType: "text/plain", filename: "b.txt" },
+          ],
+        },
+        limits,
+      ),
+    ).rejects.toThrow(/Too many file parts/);
+  });
+});
+
+describe("openai-http limits resolution for multimodal config", () => {
+  it("applies default audio and file limits when config is absent", () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    expect(limits.audio.enabled).toBe(true);
+    expect(limits.audio.maxParts).toBeGreaterThan(0);
+    expect(limits.files.enabled).toBe(true);
+    expect(limits.files.maxParts).toBeGreaterThan(0);
+  });
+
+  it("honours audio.enabled=false to disable audio content blocks", () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits({
+      audio: { enabled: false },
+    });
+    expect(limits.audio.enabled).toBe(false);
+  });
+
+  it("honours files.enabled=false to disable file content blocks", () => {
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits({
+      files: { enabled: false },
+    });
+    expect(limits.files.enabled).toBe(false);
+  });
+});

--- a/src/gateway/openai-http.multimodal.test.ts
+++ b/src/gateway/openai-http.multimodal.test.ts
@@ -146,6 +146,23 @@ describe("openai-http audio resolver", () => {
       ),
     ).rejects.toThrow(/Too many input_audio parts/);
   });
+
+  it("rejects audio parts with malformed base64 before staging the tmp file", async () => {
+    // Regression: Node's Buffer.from(..., "base64") silently drops invalid
+    // characters, so without a canonicalizeBase64 gate a malformed payload
+    // produced an empty tmp file and surfaced as a silent 200 with no
+    // transcript. The handler wraps this throw in its try/catch → 400.
+    const limits = __testOnlyOpenAiHttp.resolveOpenAiChatCompletionsLimits(undefined);
+    await expect(
+      __testOnlyOpenAiHttp.resolveAudiosForRequest(
+        {
+          audioParts: [{ data: "not base64 @#$%^&", mime: "audio/wav" }],
+        },
+        limits,
+      ),
+    ).rejects.toThrow(/invalid 'data' field|base64/i);
+    expect(transcribeFirstAudioMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("openai-http file resolver", () => {
@@ -257,5 +274,149 @@ describe("openai-http limits resolution for multimodal config", () => {
     expect(limits.files.maxTotalBytes).toBe(8642);
     expect(limits.files.maxChars).toBe(9999);
     expect(limits.files.allowedMimes.has("text/plain")).toBe(true);
+  });
+});
+
+describe("openai-http active-turn parsing error handling", () => {
+  it("propagates malformed file_data errors so the handler can map them to 400", () => {
+    // Regression: resolveActiveTurnContext used to let these exceptions bubble
+    // past the handler's try/catch and surface as 500s.
+    expect(() =>
+      __testOnlyOpenAiHttp.resolveActiveTurnContext([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              file: { file_data: "data:text/plain,SGVsbG8=", filename: "a.txt" },
+            },
+          ],
+        },
+      ]),
+    ).toThrow(/must be base64 encoded/);
+  });
+
+  it("does not throw on structurally valid but media-only user turns", () => {
+    expect(() =>
+      __testOnlyOpenAiHttp.resolveActiveTurnContext([
+        {
+          role: "user",
+          content: [
+            {
+              type: "file",
+              file: {
+                file_data: "data:text/plain;base64,SGVsbG8=",
+                filename: "note.txt",
+              },
+            },
+          ],
+        },
+      ]),
+    ).not.toThrow();
+  });
+});
+
+describe("openai-http buildAgentPrompt: media-only active user turns", () => {
+  it("first-turn file-only: synthesises a filename-aware placeholder (avoids Missing user message 400)", () => {
+    const messages = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            file: { file_data: "data:text/plain;base64,SGVsbG8=", filename: "report.pdf" },
+          },
+        ],
+      },
+    ];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    expect(message).not.toBe("");
+    expect(message).toContain("report.pdf");
+    expect(message).toMatch(/file|attached/i);
+  });
+
+  it("subsequent file-only: placeholder becomes current message (no stale prior text leak)", () => {
+    const messages = [
+      { role: "user", content: "what did we decide?" },
+      { role: "assistant", content: "we agreed to ship on Friday." },
+      {
+        role: "user",
+        content: [
+          {
+            type: "file",
+            file: { file_data: "data:text/plain;base64,SGVsbG8=", filename: "minutes.md" },
+          },
+        ],
+      },
+    ];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    // The current-message portion must reference the file, NOT reuse the prior
+    // user's "what did we decide?" as the current question.
+    expect(message).toContain("minutes.md");
+    // History block may still contain prior text, but it must not be the
+    // tail / current message. The current-message block is the synthesised
+    // placeholder referencing the filename.
+    const tail = message.split(/User:\s*/).pop() ?? "";
+    expect(tail).toContain("minutes.md");
+    expect(tail).not.toMatch(/^what did we decide\?$/);
+  });
+
+  it("subsequent audio-only: placeholder replaces stale prior text as current message", () => {
+    const audioData = Buffer.from("audio").toString("base64");
+    const messages = [
+      { role: "user", content: "status?" },
+      { role: "assistant", content: "all green." },
+      {
+        role: "user",
+        content: [{ type: "input_audio", input_audio: { data: audioData, format: "wav" } }],
+      },
+    ];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    expect(message).toMatch(/audio/i);
+    const tail = message.split(/User:\s*/).pop() ?? "";
+    expect(tail).not.toBe("status?");
+  });
+
+  it("subsequent image-only: placeholder scopes mention to the active turn only", () => {
+    const messages = [
+      { role: "user", content: "last question" },
+      { role: "assistant", content: "answered." },
+      {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } }],
+      },
+    ];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    expect(message).toMatch(/image/i);
+    const tail = message.split(/User:\s*/).pop() ?? "";
+    expect(tail).not.toBe("last question");
+  });
+
+  it("does not synthesise a placeholder for non-active historical media turns", () => {
+    // Only the last user message is treated as active; historical media-only
+    // turns should not get mentioned (their bytes are not replayed).
+    const messages = [
+      {
+        role: "user",
+        content: [{ type: "image_url", image_url: { url: "data:image/png;base64,AAAA" } }],
+      },
+      { role: "assistant", content: "ok." },
+      { role: "user", content: "and this?" },
+    ];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    expect(message).toContain("and this?");
+    expect(message).not.toMatch(/image/i);
+  });
+
+  it("turns with no text and no media still produce empty prompt (caller surfaces 400)", () => {
+    const messages = [{ role: "user", content: "" }];
+    const ctx = __testOnlyOpenAiHttp.resolveActiveTurnContext(messages);
+    const { message } = __testOnlyOpenAiHttp.buildAgentPrompt(messages, ctx);
+    expect(message).toBe("");
   });
 });

--- a/src/gateway/openai-http.multimodal.test.ts
+++ b/src/gateway/openai-http.multimodal.test.ts
@@ -87,6 +87,71 @@ describe("openai-http multimodal content-block parsers", () => {
     ).toThrow(/must be base64 encoded/);
   });
 
+  it("infers mediaType from filename extension when mime_type is omitted (.pdf)", () => {
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: { file_data: "SGVsbG8=", filename: "report.pdf" },
+      },
+    ]);
+    expect(parts).toEqual([
+      { data: "SGVsbG8=", mediaType: "application/pdf", filename: "report.pdf" },
+    ]);
+  });
+
+  it("infers mediaType from filename extension when mime_type is omitted (.txt)", () => {
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: { file_data: "SGVsbG8=", filename: "notes.txt" },
+      },
+    ]);
+    expect(parts).toEqual([{ data: "SGVsbG8=", mediaType: "text/plain", filename: "notes.txt" }]);
+  });
+
+  it("leaves mediaType undefined when neither mime_type nor a useful filename extension is given", () => {
+    // Downstream extractFileContentFromSource will turn undefined into a
+    // "missing media type" 400 — caller surfaces it via the file resolver
+    // try/catch. We deliberately don't fabricate a mediaType here.
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      { type: "file", file: { file_data: "SGVsbG8=" } },
+    ]);
+    expect(parts).toEqual([{ data: "SGVsbG8=", mediaType: undefined, filename: "file" }]);
+  });
+
+  it("infers a mediaType even for extensions outside the default allowlist (.docx)", () => {
+    // Inference is unconditional so the downstream allowedMimes gate can emit
+    // a specific "Unsupported file MIME type: <mime>" instead of the generic
+    // "missing media type" error — this gives operators actionable diagnostics.
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: { file_data: "SGVsbG8=", filename: "proposal.docx" },
+      },
+    ]);
+    expect(parts).toEqual([
+      {
+        data: "SGVsbG8=",
+        mediaType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        filename: "proposal.docx",
+      },
+    ]);
+  });
+
+  it("prefers explicit mime_type over filename inference", () => {
+    const parts = __testOnlyOpenAiHttp.extractFileParts([
+      {
+        type: "file",
+        file: {
+          file_data: "SGVsbG8=",
+          filename: "note.pdf",
+          mime_type: "text/plain",
+        },
+      },
+    ]);
+    expect(parts[0].mediaType).toBe("text/plain");
+  });
+
   it("detects video_url content parts", () => {
     expect(
       __testOnlyOpenAiHttp.hasVideoUrlPart([

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -1,20 +1,29 @@
 import { randomUUID } from "node:crypto";
+import { unlink, writeFile } from "node:fs/promises";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join as pathJoin } from "node:path";
 import type { ImageContent } from "../agents/command/types.js";
 import { normalizeUsage, toOpenAiChatCompletionsUsage } from "../agents/usage.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
+import { loadConfig } from "../config/io.js";
 import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
+import { transcribeFirstAudio } from "../media-understanding/audio-preflight.js";
 import { estimateBase64DecodedBytes } from "../media/base64.js";
+import { renderFileContextBlock } from "../media/file-context.js";
 import {
   DEFAULT_INPUT_IMAGE_MAX_BYTES,
   DEFAULT_INPUT_IMAGE_MIMES,
   DEFAULT_INPUT_MAX_REDIRECTS,
   DEFAULT_INPUT_TIMEOUT_MS,
+  extractFileContentFromSource,
   extractImageContentFromSource,
   normalizeMimeList,
+  resolveInputFileLimits,
+  type InputFileLimits,
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
@@ -39,6 +48,7 @@ import {
   resolveOpenAiCompatibleHttpSenderIsOwner,
 } from "./http-utils.js";
 import { normalizeInputHostnameAllowlist } from "./input-allowlist.js";
+import { wrapUntrustedFileContent } from "./openresponses-file-content.js";
 
 type OpenAiHttpOptions = {
   auth: ResolvedGatewayAuth;
@@ -68,6 +78,24 @@ const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
 const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 const DEFAULT_OPENAI_MAX_IMAGE_PARTS = 8;
 const DEFAULT_OPENAI_MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024;
+const DEFAULT_OPENAI_MAX_AUDIO_PARTS = 4;
+const DEFAULT_OPENAI_MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+const DEFAULT_OPENAI_MAX_TOTAL_AUDIO_BYTES = 50 * 1024 * 1024;
+const DEFAULT_OPENAI_AUDIO_MIMES = [
+  "audio/wav",
+  "audio/x-wav",
+  "audio/mpeg",
+  "audio/mp3",
+  "audio/ogg",
+  "audio/oga",
+  "audio/webm",
+  "audio/m4a",
+  "audio/mp4",
+  "audio/flac",
+];
+const DEFAULT_OPENAI_MAX_FILE_PARTS = 5;
+const DEFAULT_OPENAI_MAX_FILE_BYTES = 20 * 1024 * 1024;
+const DEFAULT_OPENAI_MAX_TOTAL_FILE_BYTES = 50 * 1024 * 1024;
 const DEFAULT_OPENAI_IMAGE_LIMITS: InputImageLimits = {
   allowUrl: false,
   allowedMimes: new Set(DEFAULT_INPUT_IMAGE_MIMES),
@@ -76,17 +104,39 @@ const DEFAULT_OPENAI_IMAGE_LIMITS: InputImageLimits = {
   timeoutMs: DEFAULT_INPUT_TIMEOUT_MS,
 };
 
+type ResolvedAudioLimits = {
+  enabled: boolean;
+  maxParts: number;
+  maxBytes: number;
+  maxTotalBytes: number;
+  allowedMimes: Set<string>;
+};
+
+type ResolvedFileLimits = InputFileLimits & {
+  enabled: boolean;
+  maxParts: number;
+  maxTotalBytes: number;
+};
+
 type ResolvedOpenAiChatCompletionsLimits = {
   maxBodyBytes: number;
   maxImageParts: number;
   maxTotalImageBytes: number;
   images: InputImageLimits;
+  audio: ResolvedAudioLimits;
+  files: ResolvedFileLimits;
 };
 
 function resolveOpenAiChatCompletionsLimits(
   config: GatewayHttpChatCompletionsConfig | undefined,
 ): ResolvedOpenAiChatCompletionsLimits {
   const imageConfig = config?.images;
+  const audioConfig = config?.audio;
+  const fileConfig = config?.files;
+  const fileLimits = resolveInputFileLimits({
+    ...fileConfig,
+    maxBytes: fileConfig?.maxBytes ?? DEFAULT_OPENAI_MAX_FILE_BYTES,
+  });
   return {
     maxBodyBytes: config?.maxBodyBytes ?? DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES,
     maxImageParts:
@@ -104,6 +154,25 @@ function resolveOpenAiChatCompletionsLimits(
       maxBytes: imageConfig?.maxBytes ?? DEFAULT_INPUT_IMAGE_MAX_BYTES,
       maxRedirects: imageConfig?.maxRedirects ?? DEFAULT_INPUT_MAX_REDIRECTS,
       timeoutMs: imageConfig?.timeoutMs ?? DEFAULT_INPUT_TIMEOUT_MS,
+    },
+    audio: {
+      enabled: audioConfig?.enabled !== false,
+      maxParts:
+        typeof audioConfig?.maxParts === "number"
+          ? Math.max(0, Math.floor(audioConfig.maxParts))
+          : DEFAULT_OPENAI_MAX_AUDIO_PARTS,
+      maxBytes: audioConfig?.maxBytes ?? DEFAULT_OPENAI_MAX_AUDIO_BYTES,
+      maxTotalBytes: audioConfig?.maxTotalBytes ?? DEFAULT_OPENAI_MAX_TOTAL_AUDIO_BYTES,
+      allowedMimes: normalizeMimeList(audioConfig?.allowedMimes, DEFAULT_OPENAI_AUDIO_MIMES),
+    },
+    files: {
+      enabled: fileConfig?.enabled !== false,
+      ...fileLimits,
+      maxParts:
+        typeof fileConfig?.maxParts === "number"
+          ? Math.max(0, Math.floor(fileConfig.maxParts))
+          : DEFAULT_OPENAI_MAX_FILE_PARTS,
+      maxTotalBytes: fileConfig?.maxTotalBytes ?? DEFAULT_OPENAI_MAX_TOTAL_FILE_BYTES,
     },
   };
 }
@@ -274,10 +343,130 @@ function extractImageUrls(content: unknown): string[] {
   return urls;
 }
 
+type ParsedAudioPart = { data: string; mime: string };
+type ParsedFilePart = { data: string; mediaType?: string; filename: string };
+
+function resolveInputAudioPart(part: unknown): ParsedAudioPart | undefined {
+  if (!part || typeof part !== "object") {
+    return undefined;
+  }
+  const inputAudio = (part as { input_audio?: unknown }).input_audio;
+  if (!inputAudio || typeof inputAudio !== "object") {
+    return undefined;
+  }
+  const rawData = (inputAudio as { data?: unknown }).data;
+  const data = typeof rawData === "string" ? rawData.trim() : "";
+  if (!data) {
+    return undefined;
+  }
+  const rawFormat = (inputAudio as { format?: unknown }).format;
+  const format = typeof rawFormat === "string" ? rawFormat.trim().toLowerCase() : "";
+  const mime = format ? (format.includes("/") ? format : `audio/${format}`) : "audio/wav";
+  return { data, mime };
+}
+
+function extractAudioParts(content: unknown): ParsedAudioPart[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const out: ParsedAudioPart[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    if ((part as { type?: unknown }).type !== "input_audio") {
+      continue;
+    }
+    const resolved = resolveInputAudioPart(part);
+    if (resolved) {
+      out.push(resolved);
+    }
+  }
+  return out;
+}
+
+function resolveFilePart(part: unknown): ParsedFilePart | undefined {
+  if (!part || typeof part !== "object") {
+    return undefined;
+  }
+  const file = (part as { file?: unknown }).file;
+  if (!file || typeof file !== "object") {
+    return undefined;
+  }
+  const rawData = (file as { file_data?: unknown }).file_data;
+  const rawDataStr = typeof rawData === "string" ? rawData.trim() : "";
+  if (!rawDataStr) {
+    return undefined;
+  }
+  const filenameRaw = (file as { filename?: unknown }).filename;
+  const filename = typeof filenameRaw === "string" && filenameRaw.length > 0 ? filenameRaw : "file";
+  const mimeRaw = (file as { mime_type?: unknown }).mime_type;
+  let mediaType = typeof mimeRaw === "string" ? mimeRaw : undefined;
+  let base64Data = rawDataStr;
+  const dataUriMatch = /^data:([^,]*?),(.*)$/is.exec(rawDataStr);
+  if (dataUriMatch) {
+    const metadata = normalizeOptionalString(dataUriMatch[1]) ?? "";
+    base64Data = dataUriMatch[2] ?? "";
+    const metadataParts = metadata
+      .split(";")
+      .map((p) => normalizeOptionalString(p) ?? "")
+      .filter(Boolean);
+    const isBase64 = metadataParts.some((p) => normalizeLowercaseStringOrEmpty(p) === "base64");
+    if (!isBase64) {
+      throw new Error("file file_data data URI must be base64 encoded");
+    }
+    if (!mediaType) {
+      mediaType = metadataParts.find((p) => p.includes("/"));
+    }
+  }
+  if (!base64Data) {
+    throw new Error("file file_data missing payload");
+  }
+  return { data: base64Data, mediaType, filename };
+}
+
+function extractFileParts(content: unknown): ParsedFilePart[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const out: ParsedFilePart[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    if ((part as { type?: unknown }).type !== "file") {
+      continue;
+    }
+    const resolved = resolveFilePart(part);
+    if (resolved) {
+      out.push(resolved);
+    }
+  }
+  return out;
+}
+
+function hasVideoUrlPart(content: unknown): boolean {
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    if ((part as { type?: unknown }).type === "video_url") {
+      return true;
+    }
+  }
+  return false;
+}
+
 type ActiveTurnContext = {
   activeTurnIndex: number;
   activeUserMessageIndex: number;
   urls: string[];
+  audioParts: ParsedAudioPart[];
+  fileParts: ParsedFilePart[];
+  hasVideoUrl: boolean;
 };
 
 function parseImageUrlToSource(url: string): InputImageSource {
@@ -320,13 +509,24 @@ function resolveActiveTurnContext(messagesUnknown: unknown): ActiveTurnContext {
     if (normalizedRole !== "user" && normalizedRole !== "tool") {
       continue;
     }
+    const isUser = normalizedRole === "user";
     return {
       activeTurnIndex: i,
-      activeUserMessageIndex: normalizedRole === "user" ? i : -1,
-      urls: normalizedRole === "user" ? extractImageUrls(msg.content) : [],
+      activeUserMessageIndex: isUser ? i : -1,
+      urls: isUser ? extractImageUrls(msg.content) : [],
+      audioParts: isUser ? extractAudioParts(msg.content) : [],
+      fileParts: isUser ? extractFileParts(msg.content) : [],
+      hasVideoUrl: isUser ? hasVideoUrlPart(msg.content) : false,
     };
   }
-  return { activeTurnIndex: -1, activeUserMessageIndex: -1, urls: [] };
+  return {
+    activeTurnIndex: -1,
+    activeUserMessageIndex: -1,
+    urls: [],
+    audioParts: [],
+    fileParts: [],
+    hasVideoUrl: false,
+  };
 }
 
 async function resolveImagesForRequest(
@@ -366,9 +566,143 @@ async function resolveImagesForRequest(
   return images;
 }
 
+async function resolveAudiosForRequest(
+  activeTurnContext: Pick<ActiveTurnContext, "audioParts">,
+  limits: ResolvedOpenAiChatCompletionsLimits,
+): Promise<string[]> {
+  const parts = activeTurnContext.audioParts;
+  if (parts.length === 0) {
+    return [];
+  }
+  if (parts.length > limits.audio.maxParts) {
+    throw new Error(`Too many input_audio parts (${parts.length}; limit ${limits.audio.maxParts})`);
+  }
+
+  // Loading cfg is a sync snapshot lookup after first process load, so it's
+  // cheap per-request and lets us reuse the Telegram/LINE STT pipeline via
+  // transcribeFirstAudio (which dispatches to configured media providers).
+  const cfg = loadConfig();
+  const transcripts: string[] = [];
+  let totalBytes = 0;
+
+  for (const part of parts) {
+    if (!limits.audio.allowedMimes.has(part.mime)) {
+      throw new Error(`Unsupported audio MIME type: ${part.mime}`);
+    }
+    const sourceBytes = estimateBase64DecodedBytes(part.data);
+    if (sourceBytes > limits.audio.maxBytes) {
+      throw new Error(`Audio too large: ${sourceBytes} bytes (limit ${limits.audio.maxBytes})`);
+    }
+    totalBytes += sourceBytes;
+    if (totalBytes > limits.audio.maxTotalBytes) {
+      throw new Error(
+        `Total audio payload too large (${totalBytes}; limit ${limits.audio.maxTotalBytes})`,
+      );
+    }
+
+    // transcribeFirstAudio consumes attachments via MsgContext with file paths,
+    // mirroring the Telegram/LINE voice preflight flow. We stage the decoded
+    // audio to a tmp file so the STT runner can open it.
+    const extGuess = part.mime.split("/")[1] ?? "wav";
+    const safeExt = extGuess.replace(/[^a-z0-9]/gi, "") || "wav";
+    const tmpPath = pathJoin(tmpdir(), `openclaw-audio-${randomUUID()}.${safeExt}`);
+    await writeFile(tmpPath, Buffer.from(part.data, "base64"));
+    try {
+      const transcript = await transcribeFirstAudio({
+        ctx: {
+          MediaPaths: [tmpPath],
+          MediaTypes: [part.mime],
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any,
+        cfg,
+        agentDir: undefined,
+      });
+      if (transcript) {
+        transcripts.push(transcript);
+      }
+    } finally {
+      try {
+        await unlink(tmpPath);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
+  }
+
+  return transcripts;
+}
+
+type FileResolutionResult = {
+  contexts: string[];
+  images: ImageContent[];
+};
+
+async function resolveFilesForRequest(
+  activeTurnContext: Pick<ActiveTurnContext, "fileParts">,
+  limits: ResolvedOpenAiChatCompletionsLimits,
+): Promise<FileResolutionResult> {
+  const parts = activeTurnContext.fileParts;
+  if (parts.length === 0) {
+    return { contexts: [], images: [] };
+  }
+  if (parts.length > limits.files.maxParts) {
+    throw new Error(`Too many file parts (${parts.length}; limit ${limits.files.maxParts})`);
+  }
+  const contexts: string[] = [];
+  const images: ImageContent[] = [];
+  let totalBytes = 0;
+  for (const part of parts) {
+    const sourceBytes = estimateBase64DecodedBytes(part.data);
+    if (sourceBytes > limits.files.maxBytes) {
+      throw new Error(`File too large: ${sourceBytes} bytes (limit ${limits.files.maxBytes})`);
+    }
+    totalBytes += sourceBytes;
+    if (totalBytes > limits.files.maxTotalBytes) {
+      throw new Error(
+        `Total file payload too large (${totalBytes}; limit ${limits.files.maxTotalBytes})`,
+      );
+    }
+    const extracted = await extractFileContentFromSource({
+      source: {
+        type: "base64",
+        data: part.data,
+        mediaType: part.mediaType,
+        filename: part.filename,
+      },
+      limits: limits.files,
+    });
+    const rawText = extracted.text;
+    if (rawText?.trim()) {
+      contexts.push(
+        renderFileContextBlock({
+          filename: extracted.filename,
+          content: wrapUntrustedFileContent(rawText),
+        }),
+      );
+    } else if (extracted.images && extracted.images.length > 0) {
+      contexts.push(
+        renderFileContextBlock({
+          filename: extracted.filename,
+          content: "[PDF content rendered to images]",
+          surroundContentWithNewlines: false,
+        }),
+      );
+    }
+    if (extracted.images && extracted.images.length > 0) {
+      images.push(...extracted.images);
+    }
+  }
+  return { contexts, images };
+}
+
 export const __testOnlyOpenAiHttp = {
   resolveImagesForRequest,
+  resolveAudiosForRequest,
+  resolveFilesForRequest,
   resolveOpenAiChatCompletionsLimits,
+  extractAudioParts,
+  extractFileParts,
+  hasVideoUrlPart,
 };
 
 function buildAgentPrompt(
@@ -565,7 +899,94 @@ export async function handleOpenAiHttpRequest(
     return true;
   }
 
-  if (!prompt.message && images.length === 0) {
+  // Reject video_url content blocks explicitly. Providing text -> agent handoff
+  // for video would require a keyframe extraction pipeline not yet wired into
+  // the gateway. Being explicit prevents silent content drops.
+  if (activeTurnContext.hasVideoUrl) {
+    sendJson(res, 400, {
+      error: {
+        message:
+          "video_url content blocks are not supported. Extract keyframes to image_url or transcribe externally.",
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
+
+  let audioTranscripts: string[] = [];
+  if (limits.audio.enabled && activeTurnContext.audioParts.length > 0) {
+    try {
+      audioTranscripts = await resolveAudiosForRequest(activeTurnContext, limits);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      logWarn(`openai-compat: invalid input_audio content: ${detail}`);
+      sendJson(res, 400, {
+        error: {
+          message: `Invalid input_audio content in \`messages\`: ${detail}`,
+          type: "invalid_request_error",
+        },
+      });
+      return true;
+    }
+  } else if (!limits.audio.enabled && activeTurnContext.audioParts.length > 0) {
+    sendJson(res, 400, {
+      error: {
+        message: "input_audio content blocks are disabled on this gateway.",
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
+
+  let fileResolution: FileResolutionResult = { contexts: [], images: [] };
+  if (limits.files.enabled && activeTurnContext.fileParts.length > 0) {
+    try {
+      fileResolution = await resolveFilesForRequest(activeTurnContext, limits);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      logWarn(`openai-compat: invalid file content: ${detail}`);
+      sendJson(res, 400, {
+        error: {
+          message: `Invalid file content in \`messages\`: ${detail}`,
+          type: "invalid_request_error",
+        },
+      });
+      return true;
+    }
+  } else if (!limits.files.enabled && activeTurnContext.fileParts.length > 0) {
+    sendJson(res, 400, {
+      error: {
+        message: "file content blocks are disabled on this gateway.",
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
+
+  // Audio transcripts are user-authored content (voice note → speech), so they
+  // prepend to prompt.message. File contexts mirror /v1/responses behaviour by
+  // attaching to extraSystemPrompt, which keeps untrusted file content clearly
+  // scoped outside the user-authored turn.
+  let finalMessage = prompt.message;
+  if (audioTranscripts.length > 0) {
+    const transcriptBlock = audioTranscripts
+      .map((t, idx) =>
+        audioTranscripts.length > 1
+          ? `[Audio ${idx + 1} transcript]\n${t}`
+          : `[Audio transcript]\n${t}`,
+      )
+      .join("\n\n");
+    finalMessage = finalMessage ? `${transcriptBlock}\n\n${finalMessage}` : transcriptBlock;
+  }
+
+  const fileContext =
+    fileResolution.contexts.length > 0 ? fileResolution.contexts.join("\n\n") : undefined;
+  const extraSystemPrompt =
+    [prompt.extraSystemPrompt, fileContext].filter(Boolean).join("\n\n") || undefined;
+  const allImages =
+    fileResolution.images.length > 0 ? images.concat(fileResolution.images) : images;
+
+  if (!finalMessage && allImages.length === 0) {
     sendJson(res, 400, {
       error: {
         message: "Missing user message in `messages`.",
@@ -580,9 +1001,9 @@ export async function handleOpenAiHttpRequest(
   const abortController = new AbortController();
   const commandInput = buildAgentCommandInput({
     prompt: {
-      message: prompt.message,
-      extraSystemPrompt: prompt.extraSystemPrompt,
-      images: images.length > 0 ? images : undefined,
+      message: finalMessage,
+      extraSystemPrompt,
+      images: allImages.length > 0 ? allImages : undefined,
     },
     modelOverride,
     sessionKey,

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -12,7 +12,7 @@ import type { GatewayHttpChatCompletionsConfig } from "../config/types.gateway.j
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { transcribeFirstAudio } from "../media-understanding/audio-preflight.js";
-import { estimateBase64DecodedBytes } from "../media/base64.js";
+import { canonicalizeBase64, estimateBase64DecodedBytes } from "../media/base64.js";
 import { renderFileContextBlock } from "../media/file-context.js";
 import {
   DEFAULT_INPUT_IMAGE_MAX_BYTES,
@@ -75,7 +75,6 @@ type OpenAiChatCompletionRequest = {
 };
 
 const DEFAULT_OPENAI_CHAT_COMPLETIONS_BODY_BYTES = 20 * 1024 * 1024;
-const IMAGE_ONLY_USER_MESSAGE = "User sent image(s) with no text.";
 const DEFAULT_OPENAI_MAX_IMAGE_PARTS = 8;
 const DEFAULT_OPENAI_MAX_TOTAL_IMAGE_BYTES = 20 * 1024 * 1024;
 const DEFAULT_OPENAI_MAX_AUDIO_PARTS = 4;
@@ -600,13 +599,24 @@ async function resolveAudiosForRequest(
       );
     }
 
+    // Node's base64 decoder is lenient and silently drops invalid characters,
+    // so a malformed payload would stage an empty/truncated file and surface
+    // as a confusing "no transcript" 200 response. Mirror the image/file paths
+    // (media/input-files.ts:{280,335}) which gate Buffer.from("base64") behind
+    // canonicalizeBase64; here we map the failure to an Error so the handler's
+    // try/catch returns 400 invalid_request_error instead.
+    const canonicalAudioData = canonicalizeBase64(part.data);
+    if (!canonicalAudioData) {
+      throw new Error("input_audio base64 source has invalid 'data' field");
+    }
+
     // transcribeFirstAudio consumes attachments via MsgContext with file paths,
     // mirroring the Telegram/LINE voice preflight flow. We stage the decoded
     // audio to a tmp file so the STT runner can open it.
     const extGuess = part.mime.split("/")[1] ?? "wav";
     const safeExt = extGuess.replace(/[^a-z0-9]/gi, "") || "wav";
     const tmpPath = pathJoin(tmpdir(), `openclaw-audio-${randomUUID()}.${safeExt}`);
-    await writeFile(tmpPath, Buffer.from(part.data, "base64"));
+    await writeFile(tmpPath, Buffer.from(canonicalAudioData, "base64"));
     try {
       // transcribeFirstAudio expects a full MsgContext (channel id, sender,
       // timestamps, etc.), but its audio-preflight code path only reads
@@ -708,11 +718,58 @@ export const __testOnlyOpenAiHttp = {
   extractAudioParts,
   extractFileParts,
   hasVideoUrlPart,
+  resolveActiveTurnContext,
+  buildAgentPrompt,
 };
+
+/**
+ * Synthesise a user-message placeholder for an active user turn that carries
+ * only media (image/audio/file) with no accompanying text. Without this, a
+ * text-less turn gets skipped entirely and the previous turn's text would
+ * leak into the agent prompt as "current message" (stale-text bug); first
+ * turns with no prior text would trip the "Missing user message" 400 gate.
+ */
+function buildActiveUserTurnPlaceholder(activeTurnContext: ActiveTurnContext): string {
+  const parts: string[] = [];
+  if (activeTurnContext.urls.length > 0) {
+    parts.push(
+      activeTurnContext.urls.length === 1 ? "1 image" : `${activeTurnContext.urls.length} images`,
+    );
+  }
+  if (activeTurnContext.audioParts.length > 0) {
+    parts.push(
+      activeTurnContext.audioParts.length === 1
+        ? "1 audio clip"
+        : `${activeTurnContext.audioParts.length} audio clips`,
+    );
+  }
+  if (activeTurnContext.fileParts.length > 0) {
+    const names = activeTurnContext.fileParts
+      .map((p) => p.filename.trim())
+      .filter((name) => name.length > 0);
+    if (names.length > 0) {
+      parts.push(
+        names.length === 1
+          ? `file "${names[0]}"`
+          : `files: ${names.map((n) => `"${n}"`).join(", ")}`,
+      );
+    } else {
+      parts.push(
+        activeTurnContext.fileParts.length === 1
+          ? "1 file"
+          : `${activeTurnContext.fileParts.length} files`,
+      );
+    }
+  }
+  if (parts.length === 0) {
+    return "";
+  }
+  return `User attached ${parts.join(" + ")} with no accompanying text.`;
+}
 
 function buildAgentPrompt(
   messagesUnknown: unknown,
-  activeUserMessageIndex: number,
+  activeTurnContext: ActiveTurnContext,
 ): {
   message: string;
   extraSystemPrompt?: string;
@@ -728,7 +785,6 @@ function buildAgentPrompt(
     }
     const role = normalizeOptionalString(msg.role) ?? "";
     const content = extractTextContent(msg.content).trim();
-    const hasImage = extractImageUrls(msg.content).length > 0;
     if (!role) {
       continue;
     }
@@ -744,12 +800,14 @@ function buildAgentPrompt(
       continue;
     }
 
-    // Keep the image-only placeholder scoped to the active user turn so we don't
-    // mention historical image-only turns whose bytes are intentionally not replayed.
+    // For the active user turn, synthesise a placeholder when text is empty so
+    // media-only turns (image/audio/file) still contribute a "current message"
+    // entry. Historical media-only turns are intentionally skipped — their
+    // bytes are not replayed, and mentioning them here would confuse the agent.
+    const isActiveUserTurn =
+      normalizedRole === "user" && i === activeTurnContext.activeUserMessageIndex;
     const messageContent =
-      normalizedRole === "user" && !content && hasImage && i === activeUserMessageIndex
-        ? IMAGE_ONLY_USER_MESSAGE
-        : content;
+      !content && isActiveUserTurn ? buildActiveUserTurnPlaceholder(activeTurnContext) : content;
     if (!messageContent) {
       continue;
     }
@@ -888,8 +946,25 @@ export async function handleOpenAiHttpRequest(
     });
     return true;
   }
-  const activeTurnContext = resolveActiveTurnContext(payload.messages);
-  const prompt = buildAgentPrompt(payload.messages, activeTurnContext.activeUserMessageIndex);
+  // Parsing content blocks (file_data data URIs in particular) can throw on
+  // malformed input. Catching here turns those errors into 400
+  // invalid_request_error instead of bubbling up to the Node http server as
+  // an unhandled exception that becomes a 500.
+  let activeTurnContext: ActiveTurnContext;
+  try {
+    activeTurnContext = resolveActiveTurnContext(payload.messages);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    logWarn(`openai-compat: invalid content block: ${detail}`);
+    sendJson(res, 400, {
+      error: {
+        message: `Invalid content in \`messages\`: ${detail}`,
+        type: "invalid_request_error",
+      },
+    });
+    return true;
+  }
+  const prompt = buildAgentPrompt(payload.messages, activeTurnContext);
   let images: ImageContent[] = [];
   try {
     images = await resolveImagesForRequest(activeTurnContext, limits);

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -608,6 +608,11 @@ async function resolveAudiosForRequest(
     const tmpPath = pathJoin(tmpdir(), `openclaw-audio-${randomUUID()}.${safeExt}`);
     await writeFile(tmpPath, Buffer.from(part.data, "base64"));
     try {
+      // transcribeFirstAudio expects a full MsgContext (channel id, sender,
+      // timestamps, etc.), but its audio-preflight code path only reads
+      // ctx.MediaPaths + ctx.MediaTypes. We synthesise the minimal shape here
+      // rather than inventing fake channel metadata; the `as any` is scoped
+      // to this single object literal.
       const transcript = await transcribeFirstAudio({
         ctx: {
           MediaPaths: [tmpPath],

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -27,6 +27,7 @@ import {
   type InputImageLimits,
   type InputImageSource,
 } from "../media/input-files.js";
+import { mimeTypeFromFilePath } from "../media/mime.js";
 import { defaultRuntime } from "../runtime.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -420,6 +421,17 @@ function resolveFilePart(part: unknown): ParsedFilePart | undefined {
   }
   if (!base64Data) {
     throw new Error("file file_data missing payload");
+  }
+  // OpenAI-compat clients commonly send `file_data` + `filename` with no
+  // explicit `mime_type` (and no `data:<mime>;base64,` envelope). Rather than
+  // hard-failing downstream with "input_file missing media type", infer from
+  // the filename extension when we can. Downstream allowedMimes enforcement
+  // (input-files.ts:371) still rejects unsupported types with a clear 400.
+  if (!mediaType) {
+    const inferred = mimeTypeFromFilePath(filename);
+    if (inferred) {
+      mediaType = inferred;
+    }
   }
   return { data: base64Data, mediaType, filename };
 }


### PR DESCRIPTION
## Summary

The OpenAI-compatible `/v1/chat/completions` endpoint currently recognises only `text` / `input_text` / `image_url` content parts and silently drops `input_audio`, `file`, and `video_url`. This brings it closer to parity with the Telegram/LINE channel ingress and the existing `/v1/responses` handler — those already reuse the internal media pipeline (STT preflight, file content extraction, PDF image merging, provider dispatch) but that plumbing never got wired into chat.completions.

No agent-runtime or schema change is needed: we flatten extracted media into the message / extraSystemPrompt / images[] shape the agent already accepts.

## What changes

**`input_audio`** — base64 audio is staged to a tmp file and transcribed via `transcribeFirstAudio` (same STT preflight the Telegram voice-note flow uses). The transcript is prepended to the user message so the agent sees speech content. Requires an audio provider configured under `cfg.tools.media.audio`.

**`file`** — mirrors the `/v1/responses` pattern: `extractFileContentFromSource` is called, extracted text is wrapped with `renderFileContextBlock` + `wrapUntrustedFileContent` and appended to `extraSystemPrompt`; any PDF-page images merge into `images[]`.

**`video_url`** — explicitly rejected with HTTP 400 and a clear error message, rather than silently dropped. A keyframe/transcription pipeline isn't wired up for that shape yet, so it's better to tell callers to extract keyframes to `image_url` or transcribe externally.

## Config additions (under `gateway.http.endpoints.chatCompletions`)

```jsonc
{
  "audio": {
    "enabled": true,
    "maxParts": 4,
    "maxBytes": 26214400,
    "maxTotalBytes": 52428800,
    "allowedMimes": ["audio/wav", "audio/mpeg", "audio/ogg", "audio/m4a", "audio/flac", "audio/webm"]
  },
  "files": {
    "enabled": true,
    "maxParts": 5,
    "maxBytes": 20971520,
    "maxTotalBytes": 52428800,
    "allowUrl": false,
    "allowedMimes": ["text/plain", "text/markdown", "text/html", "text/csv", "application/json", "application/pdf"],
    "pdf": { "maxPages": 4 }
  }
}
```

Both types have `enabled` toggles. Defaults are conservative (audio 25MB/part & 50MB total, files 20MB/part & 50MB total, base64 only). **`maxBodyBytes` default is unchanged at 20MB** — operators expecting larger payloads should raise it explicitly.

## Test plan

- [x] Unit tests: `src/gateway/openai-http.multimodal.test.ts` covers parsers (audio/file/video_url), audio resolver (transcribe round-trip mocked, MIME allowlist, maxParts), file resolver (text → `<file>` block wrap, PDF images merge, maxParts), limits defaults + enabled toggles — **16 new tests, all passing**.
- [x] Existing tests: `openai-http.test.ts` (11 cases) + `openai-http.image-budget.test.ts` (2) — **13/13 still pass, no regression**.
- [x] Full `pnpm check`: tsgo 0 errors, oxlint 0 warnings, import-cycles 0, madge 0.
- [x] Live E2E against a patched gateway (same logic, applied to the bundled v2026.4.14 dist):
  - text + image_url (regression) ✅
  - file text/plain → model correctly extracts `FORK-BANANA-99` token from attachment ✅
  - file text/markdown → model parses bullets as JSON array ✅
  - file application/octet-stream → 400 Unsupported MIME ✅
  - video_url → 400 not-supported-yet ✅
  - input_audio WAV → HTTP 200, pipeline completes through transcribe round-trip ✅
  - LINE webhook on same gateway → still 200 (no regression) ✅

## Motivation

Mobile/desktop chat apps that speak OpenAI's chat.completions API (e.g. ClawTalk, a voice-driven Android client for OpenClaw being built against this gateway) need file and audio inputs to have feature parity with what users can already do via Telegram/LINE. The extractors and STT runner already exist and are provider-agnostic — this PR is mostly glue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
