### PR TITLE
feat(feishu): add list action to read chat history by container_id

### DIFF
--- a/extensions/feishu/src/channel.runtime.ts
+++ b/extensions/feishu/src/channel.runtime.ts
@@ -22,6 +22,7 @@ import {
 import {
   editMessageFeishu as editMessageFeishuImpl,
   getMessageFeishu as getMessageFeishuImpl,
+  listFeishuChatMessages as listFeishuChatMessagesImpl,
   sendCardFeishu as sendCardFeishuImpl,
   sendMessageFeishu as sendMessageFeishuImpl,
 } from "./send.js";
@@ -42,6 +43,7 @@ export const feishuChannelRuntime = {
   getFeishuMemberInfo: getFeishuMemberInfoImpl,
   editMessageFeishu: editMessageFeishuImpl,
   getMessageFeishu: getMessageFeishuImpl,
+  listFeishuChatMessages: listFeishuChatMessagesImpl,
   sendCardFeishu: sendCardFeishuImpl,
   sendMessageFeishu: sendMessageFeishuImpl,
 };

--- a/extensions/feishu/src/channel.test.ts
+++ b/extensions/feishu/src/channel.test.ts
@@ -233,6 +233,7 @@ describe("feishuPlugin actions", () => {
     expect(getDescribedActions(cfg)).toEqual([
       "send",
       "read",
+      "list",
       "edit",
       "thread-reply",
       "pin",
@@ -263,6 +264,7 @@ describe("feishuPlugin actions", () => {
     expect(getDescribedActions(disabledCfg)).toEqual([
       "send",
       "read",
+      "list",
       "edit",
       "thread-reply",
       "pin",
@@ -301,6 +303,7 @@ describe("feishuPlugin actions", () => {
     expect(getDescribedActions(cfg, "default")).toEqual([
       "send",
       "read",
+      "list",
       "edit",
       "thread-reply",
       "pin",
@@ -313,6 +316,7 @@ describe("feishuPlugin actions", () => {
     expect(getDescribedActions(cfg, "work")).toEqual([
       "send",
       "read",
+      "list",
       "edit",
       "thread-reply",
       "pin",

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -169,6 +169,7 @@ function describeFeishuMessageTool({
   const actions = new Set<ChannelMessageActionName>([
     "send",
     "read",
+    "list",
     "edit",
     "thread-reply",
     "pin",
@@ -751,6 +752,35 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
               };
             }
             return jsonActionResult({ ok: true, channel: "feishu", action: "read", message });
+          }
+
+          if (ctx.action === "list") {
+            const chatId =
+              readFirstString(ctx.params, ["channelId", "chatId", "target"]) ??
+              (typeof ctx.params.threadId === "string" ? ctx.params.threadId : undefined);
+            if (!chatId) {
+              throw new Error("Feishu list requires channelId or target (chat_id).");
+            }
+            const limit = typeof ctx.params.limit === "number" ? ctx.params.limit : 50;
+            const pageToken =
+              typeof ctx.params.pageToken === "string" ? ctx.params.pageToken : undefined;
+            const sortType =
+              ctx.params.sortType === "ByCreateTimeDesc" ? "ByCreateTimeDesc" : "ByCreateTimeAsc";
+            const { listFeishuChatMessages } = await loadFeishuChannelRuntime();
+            const result = await listFeishuChatMessages({
+              cfg: ctx.cfg,
+              chatId,
+              limit,
+              pageToken,
+              sortType,
+              accountId: ctx.accountId ?? undefined,
+            });
+            return jsonActionResult({
+              ok: true,
+              channel: "feishu",
+              action: "list",
+              ...result,
+            });
           }
 
           if (ctx.action === "edit") {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -429,6 +429,72 @@ export type SendFeishuMessageParams = {
   accountId?: string;
 };
 
+/**
+ * List messages in a Feishu chat/group by container_id (chat_id).
+ * Uses container_id_type=chat to query chat history.
+ */
+export async function listFeishuChatMessages(params: {
+  cfg: ClawdbotConfig;
+  chatId: string;
+  limit?: number;
+  pageToken?: string;
+  sortType?: "ByCreateTimeAsc" | "ByCreateTimeDesc";
+  accountId?: string;
+}): Promise<{ messages: FeishuThreadMessageInfo[]; pageToken?: string; hasMore: boolean }> {
+  const { cfg, chatId, limit = 50, pageToken, sortType = "ByCreateTimeAsc", accountId } = params;
+  const account = resolveFeishuRuntimeAccount({ cfg, accountId });
+  if (!account.configured) {
+    throw new Error(`Feishu account "${account.accountId}" not configured`);
+  }
+
+  const client = createFeishuClient(account);
+
+  const response = (await client.im.message.list({
+    params: {
+      container_id_type: "chat",
+      container_id: chatId,
+      sort_type: sortType,
+      page_size: Math.min(limit, 50),
+      ...(pageToken ? { page_token: pageToken } : {}),
+    },
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      has_more?: boolean;
+      page_token?: string;
+      items?: Array<FeishuMessageGetItem>;
+    };
+  };
+
+  if (response.code !== 0) {
+    throw new Error(
+      `Feishu chat list failed: code=${response.code} msg=${response.msg ?? "unknown"}`,
+    );
+  }
+
+  const items = response.data?.items ?? [];
+  const messages: FeishuThreadMessageInfo[] = items
+    .slice(0, limit)
+    .map((item) => {
+      const parsed = parseFeishuMessageItem(item);
+      return {
+        messageId: parsed.messageId,
+        senderId: parsed.senderId,
+        senderType: parsed.senderType,
+        content: parsed.content,
+        contentType: parsed.contentType,
+        createTime: parsed.createTime,
+      };
+    });
+
+  return {
+    messages,
+    hasMore: response.data?.has_more ?? false,
+    pageToken: response.data?.page_token,
+  };
+}
+
 export function buildFeishuPostMessagePayload(params: { messageText: string }): {
   content: string;
   msgType: string;

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -6,6 +6,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "react",
   "reactions",
   "read",
+  "list",
   "edit",
   "unsend",
   "reply",

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -17,6 +17,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     react: "to",
     reactions: "to",
     read: "to",
+    list: "channelId",
     edit: "to",
     unsend: "to",
     reply: "to",


### PR DESCRIPTION
## Summary
Adds a new `list` action to the Feishu channel plugin that enables reading chat history for a given chat/group by `container_id`.

## Motivation
Currently the Feishu plugin only supports fetching a single message by `messageId`. There is no way to retrieve chat history for a group/channel, which is needed for use cases like summarizing group chat history, building reminder/analysis bots, and project management workflows.

## Changes
- Added `list` action to Feishu plugin `api.ts`
- Accepts `channelId`/`target` as the `container_id` (chat_id)
- Supports `limit`, `pageToken`, `sortType` params
- Returns array of messages with `messageId`, `senderId`, `createTime`, `text`, `msgType`
- Required scope: `im:message.group_msg` or `im:message.group_msg:readonly`

## Testing
Manually tested against a live Feishu group — successfully returns message history.