### PR TITLE
fix(feishu): stop auto-forwarding mentions when disabled

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -71,6 +71,12 @@ Default: `allowlist`
 - `false` — respond without @mention
 - Per-group override: `channels.feishu.groups.<chat_id>.requireMention`
 
+**Mention forwarding** (`channels.feishu.mentionForwardMode`):
+
+- `"auto"` — when a message mentions the bot and other entities, replies automatically @mention those other entities
+- `"none"` — do not forward other mentions into the bot's reply
+- Per-group override: `channels.feishu.groups.<chat_id>.mentionForwardMode`
+
 ---
 
 ## Group configuration examples
@@ -109,6 +115,18 @@ Default: `allowlist`
       groupPolicy: "allowlist",
       // Group IDs look like: oc_xxx
       groupAllowFrom: ["oc_xxx", "oc_yyy"],
+    },
+  },
+}
+```
+
+### Keep multi-bot group replies independent
+
+```json5
+{
+  channels: {
+    feishu: {
+      mentionForwardMode: "none",
     },
   },
 }
@@ -370,33 +388,35 @@ See [Get group/user IDs](#get-groupuser-ids) for lookup tips.
 
 Full configuration: [Gateway configuration](/gateway/configuration)
 
-| Setting                                           | Description                                | Default          |
-| ------------------------------------------------- | ------------------------------------------ | ---------------- |
-| `channels.feishu.enabled`                         | Enable/disable the channel                 | `true`           |
-| `channels.feishu.domain`                          | API domain (`feishu` or `lark`)            | `feishu`         |
-| `channels.feishu.connectionMode`                  | Event transport (`websocket` or `webhook`) | `websocket`      |
-| `channels.feishu.defaultAccount`                  | Default account for outbound routing       | `default`        |
-| `channels.feishu.verificationToken`               | Required for webhook mode                  | —                |
-| `channels.feishu.encryptKey`                      | Required for webhook mode                  | —                |
-| `channels.feishu.webhookPath`                     | Webhook route path                         | `/feishu/events` |
-| `channels.feishu.webhookHost`                     | Webhook bind host                          | `127.0.0.1`      |
-| `channels.feishu.webhookPort`                     | Webhook bind port                          | `3000`           |
-| `channels.feishu.accounts.<id>.appId`             | App ID                                     | —                |
-| `channels.feishu.accounts.<id>.appSecret`         | App Secret                                 | —                |
-| `channels.feishu.accounts.<id>.domain`            | Per-account domain override                | `feishu`         |
-| `channels.feishu.dmPolicy`                        | DM policy                                  | `allowlist`      |
-| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)                | [BotOwnerId]     |
-| `channels.feishu.groupPolicy`                     | Group policy                               | `allowlist`      |
-| `channels.feishu.groupAllowFrom`                  | Group allowlist                            | —                |
-| `channels.feishu.requireMention`                  | Require @mention in groups                 | `true`           |
-| `channels.feishu.groups.<chat_id>.requireMention` | Per-group @mention override                | inherited        |
-| `channels.feishu.groups.<chat_id>.enabled`        | Enable/disable a specific group            | `true`           |
-| `channels.feishu.textChunkLimit`                  | Message chunk size                         | `2000`           |
-| `channels.feishu.mediaMaxMb`                      | Media size limit                           | `30`             |
-| `channels.feishu.streaming`                       | Streaming card output                      | `true`           |
-| `channels.feishu.blockStreaming`                  | Block-level streaming                      | `true`           |
-| `channels.feishu.typingIndicator`                 | Send typing reactions                      | `true`           |
-| `channels.feishu.resolveSenderNames`              | Resolve sender display names               | `true`           |
+| Setting                                               | Description                                | Default          |
+| ----------------------------------------------------- | ------------------------------------------ | ---------------- |
+| `channels.feishu.enabled`                             | Enable/disable the channel                 | `true`           |
+| `channels.feishu.domain`                              | API domain (`feishu` or `lark`)            | `feishu`         |
+| `channels.feishu.connectionMode`                      | Event transport (`websocket` or `webhook`) | `websocket`      |
+| `channels.feishu.defaultAccount`                      | Default account for outbound routing       | `default`        |
+| `channels.feishu.verificationToken`                   | Required for webhook mode                  | —                |
+| `channels.feishu.encryptKey`                          | Required for webhook mode                  | —                |
+| `channels.feishu.webhookPath`                         | Webhook route path                         | `/feishu/events` |
+| `channels.feishu.webhookHost`                         | Webhook bind host                          | `127.0.0.1`      |
+| `channels.feishu.webhookPort`                         | Webhook bind port                          | `3000`           |
+| `channels.feishu.accounts.<id>.appId`                 | App ID                                     | —                |
+| `channels.feishu.accounts.<id>.appSecret`             | App Secret                                 | —                |
+| `channels.feishu.accounts.<id>.domain`                | Per-account domain override                | `feishu`         |
+| `channels.feishu.dmPolicy`                            | DM policy                                  | `allowlist`      |
+| `channels.feishu.allowFrom`                           | DM allowlist (open_id list)                | [BotOwnerId]     |
+| `channels.feishu.groupPolicy`                         | Group policy                               | `allowlist`      |
+| `channels.feishu.groupAllowFrom`                      | Group allowlist                            | —                |
+| `channels.feishu.requireMention`                      | Require @mention in groups                 | `true`           |
+| `channels.feishu.mentionForwardMode`                  | Forward non-bot mentions into replies      | `auto`           |
+| `channels.feishu.groups.<chat_id>.requireMention`     | Per-group @mention override                | inherited        |
+| `channels.feishu.groups.<chat_id>.mentionForwardMode` | Per-group mention forwarding override      | inherited        |
+| `channels.feishu.groups.<chat_id>.enabled`            | Enable/disable a specific group            | `true`           |
+| `channels.feishu.textChunkLimit`                      | Message chunk size                         | `2000`           |
+| `channels.feishu.mediaMaxMb`                          | Media size limit                           | `30`             |
+| `channels.feishu.streaming`                           | Streaming card output                      | `true`           |
+| `channels.feishu.blockStreaming`                      | Block-level streaming                      | `true`           |
+| `channels.feishu.typingIndicator`                     | Send typing reactions                      | `true`           |
+| `channels.feishu.resolveSenderNames`                  | Resolve sender display names               | `true`           |
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -306,11 +306,16 @@ vi.mock("openclaw/plugin-sdk/conversation-runtime", async () => {
   };
 });
 
-async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessageEvent }) {
+async function dispatchMessage(params: {
+  cfg: ClawdbotConfig;
+  event: FeishuMessageEvent;
+  botOpenId?: string;
+}) {
   const runtime = createRuntimeEnv();
   await handleFeishuMessage({
     cfg: params.cfg,
     event: params.event,
+    botOpenId: params.botOpenId,
     runtime,
   });
   return runtime;
@@ -1380,6 +1385,105 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("keeps auto mention forwarding enabled by default for group mention-forward requests", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group-chat": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: { open_id: "ou-sender" },
+      },
+      message: {
+        message_id: "msg-group-mention-forward-auto",
+        chat_id: "oc-group-chat",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_bot @_designer hello" }),
+        mentions: [
+          { key: "@_bot", id: { open_id: "ou_bot" }, name: "bot", tenant_key: "" },
+          {
+            key: "@_designer",
+            id: { open_id: "ou_designer" },
+            name: "designer",
+            tenant_key: "",
+          },
+        ],
+      },
+    };
+
+    await dispatchMessage({ cfg, event, botOpenId: "ou_bot" });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentionTargets: [{ key: "@_designer", name: "designer", openId: "ou_designer" }],
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("Your reply will automatically @mention: designer"),
+      }),
+    );
+  });
+
+  it("disables auto mention forwarding when mentionForwardMode is none", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          mentionForwardMode: "none",
+          groups: {
+            "oc-group-chat": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: { open_id: "ou-sender" },
+      },
+      message: {
+        message_id: "msg-group-mention-forward-none",
+        chat_id: "oc-group-chat",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_bot @_designer hello" }),
+        mentions: [
+          { key: "@_bot", id: { open_id: "ou_bot" }, name: "bot", tenant_key: "" },
+          {
+            key: "@_designer",
+            id: { open_id: "ou_designer" },
+            name: "designer",
+            tenant_key: "",
+          },
+        ],
+      },
+    };
+
+    await dispatchMessage({ cfg, event, botOpenId: "ou_bot" });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentionTargets: undefined,
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.not.stringContaining("Your reply will automatically @mention"),
+      }),
+    );
   });
 
   it("drops message when groupConfig.enabled is false", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -415,6 +415,7 @@ export async function handleFeishuMessage(params: {
     : Date.now();
 
   let requireMention = false; // DMs never require mention; groups may override below
+  let forwardMentionTargets = true;
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       log(`feishu[${account.accountId}]: group ${ctx.chatId} is disabled`);
@@ -465,7 +466,7 @@ export async function handleFeishuMessage(params: {
       }
     }
 
-    ({ requireMention } = resolveFeishuReplyPolicy({
+    ({ requireMention, forwardMentionTargets } = resolveFeishuReplyPolicy({
       isDirectMessage: false,
       cfg,
       accountId: account.accountId,
@@ -495,6 +496,15 @@ export async function handleFeishuMessage(params: {
       return;
     }
   } else {
+    ({ forwardMentionTargets } = resolveFeishuReplyPolicy({
+      isDirectMessage: true,
+      cfg,
+      accountId: account.accountId,
+    }));
+  }
+  const effectiveMentionTargets = forwardMentionTargets ? ctx.mentionTargets : undefined;
+  if (ctx.mentionTargets?.length && !forwardMentionTargets) {
+    log(`feishu[${account.accountId}]: mention forward request suppressed by mentionForwardMode`);
   }
 
   try {
@@ -773,7 +783,10 @@ export async function handleFeishuMessage(params: {
 
     const envelopeOptions = core.channel.reply.resolveEnvelopeFormatOptions(cfg);
     const messageBody = buildFeishuAgentBody({
-      ctx,
+      ctx: {
+        ...ctx,
+        mentionTargets: effectiveMentionTargets,
+      },
       quotedContent,
       permissionErrorForAgent,
       botOpenId,
@@ -1105,7 +1118,7 @@ export async function handleFeishuMessage(params: {
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
-            mentionTargets: ctx.mentionTargets,
+            mentionTargets: effectiveMentionTargets,
             accountId: account.accountId,
             identity,
             messageCreateTimeMs,
@@ -1214,7 +1227,7 @@ export async function handleFeishuMessage(params: {
         replyInThread,
         rootId: ctx.rootId,
         threadReply,
-        mentionTargets: ctx.mentionTargets,
+        mentionTargets: effectiveMentionTargets,
         accountId: account.accountId,
         identity,
         messageCreateTimeMs,

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -220,6 +220,32 @@ describe("FeishuConfigSchema optimization flags", () => {
   });
 });
 
+describe("FeishuConfigSchema mentionForwardMode", () => {
+  it("defaults mentionForwardMode to undefined when not set", () => {
+    const result = FeishuConfigSchema.parse({});
+    expect(result.mentionForwardMode).toBeUndefined();
+  });
+
+  it("accepts mentionForwardMode at top level", () => {
+    const result = FeishuConfigSchema.parse({ mentionForwardMode: "none" });
+    expect(result.mentionForwardMode).toBe("none");
+  });
+
+  it("accepts mentionForwardMode in group config", () => {
+    const result = FeishuGroupSchema.parse({ mentionForwardMode: "none" });
+    expect(result.mentionForwardMode).toBe("none");
+  });
+
+  it("accepts mentionForwardMode in account config", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: { mentionForwardMode: "none" },
+      },
+    });
+    expect(result.accounts?.main?.mentionForwardMode).toBe("none");
+  });
+});
+
 describe("FeishuConfigSchema actions", () => {
   it("accepts top-level reactions action gate", () => {
     const result = FeishuConfigSchema.parse({

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -137,10 +137,12 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  * causing the reply to appear as a topic (话题) under the original message.
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
+const MentionForwardModeSchema = z.enum(["auto", "none"]).optional();
 
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    mentionForwardMode: MentionForwardModeSchema,
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -164,6 +166,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  mentionForwardMode: MentionForwardModeSchema,
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),

--- a/extensions/feishu/src/policy.test.ts
+++ b/extensions/feishu/src/policy.test.ts
@@ -30,7 +30,7 @@ describe("resolveFeishuReplyPolicy", () => {
         groupPolicy: "open",
         groupId: "oc_1",
       }),
-    ).toEqual({ requireMention: false });
+    ).toEqual({ requireMention: false, forwardMentionTargets: true });
   });
 
   it("keeps explicit top-level mention gating in open groups", () => {
@@ -41,7 +41,7 @@ describe("resolveFeishuReplyPolicy", () => {
         groupPolicy: "open",
         groupId: "oc_1",
       }),
-    ).toEqual({ requireMention: true });
+    ).toEqual({ requireMention: true, forwardMentionTargets: true });
   });
 
   it("keeps explicit account mention gating in open groups", () => {
@@ -62,7 +62,7 @@ describe("resolveFeishuReplyPolicy", () => {
         groupPolicy: "open",
         groupId: "oc_1",
       }),
-    ).toEqual({ requireMention: true });
+    ).toEqual({ requireMention: true, forwardMentionTargets: true });
   });
 
   it("keeps explicit per-group mention gating in open groups", () => {
@@ -76,7 +76,7 @@ describe("resolveFeishuReplyPolicy", () => {
         groupPolicy: "open",
         groupId: "oc_1",
       }),
-    ).toEqual({ requireMention: true });
+    ).toEqual({ requireMention: true, forwardMentionTargets: true });
   });
 
   it("defaults allowlist groups to require mentions", () => {
@@ -87,7 +87,53 @@ describe("resolveFeishuReplyPolicy", () => {
         groupPolicy: "allowlist",
         groupId: "oc_1",
       }),
-    ).toEqual({ requireMention: true });
+    ).toEqual({ requireMention: true, forwardMentionTargets: true });
+  });
+
+  it("disables mention forwarding when top-level mentionForwardMode is none", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({ mentionForwardMode: "none" }),
+        groupPolicy: "allowlist",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: true, forwardMentionTargets: false });
+  });
+
+  it("disables mention forwarding for direct messages when account mentionForwardMode is none", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: true,
+        cfg: createCfg({
+          mentionForwardMode: "auto",
+          accounts: {
+            work: {
+              mentionForwardMode: "none",
+            },
+          },
+        }),
+        accountId: "work",
+      }),
+    ).toEqual({ requireMention: false, forwardMentionTargets: false });
+  });
+
+  it("prefers per-group mentionForwardMode over inherited config", () => {
+    expect(
+      resolveFeishuReplyPolicy({
+        isDirectMessage: false,
+        cfg: createCfg({
+          mentionForwardMode: "auto",
+          groups: {
+            oc_1: {
+              mentionForwardMode: "none",
+            },
+          },
+        }),
+        groupPolicy: "allowlist",
+        groupId: "oc_1",
+      }),
+    ).toEqual({ requireMention: true, forwardMentionTargets: false });
   });
 });
 

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -188,11 +188,7 @@ export function resolveFeishuReplyPolicy(params: {
    * @-mentions are still delivered to the agent.
    */
   groupPolicy?: "open" | "allowlist" | "disabled" | "allowall";
-}): { requireMention: boolean } {
-  if (params.isDirectMessage) {
-    return { requireMention: false };
-  }
-
+}): { requireMention: boolean; forwardMentionTargets: boolean } {
   const feishuCfg = params.cfg.channels?.feishu;
   const resolvedCfg = resolveMergedAccountConfig<FeishuConfig>({
     channelConfig: feishuCfg,
@@ -201,10 +197,23 @@ export function resolveFeishuReplyPolicy(params: {
     normalizeAccountId,
     omitKeys: ["defaultAccount"],
   });
-  const groupRequireMention = resolveFeishuGroupConfig({
-    cfg: resolvedCfg,
-    groupId: params.groupId,
-  })?.requireMention;
+  const groupConfig = params.isDirectMessage
+    ? undefined
+    : resolveFeishuGroupConfig({
+        cfg: resolvedCfg,
+        groupId: params.groupId,
+      });
+  const forwardMentionTargets =
+    (groupConfig?.mentionForwardMode ?? resolvedCfg.mentionForwardMode ?? "auto") !== "none";
+
+  if (params.isDirectMessage) {
+    return {
+      requireMention: false,
+      forwardMentionTargets,
+    };
+  }
+
+  const groupRequireMention = groupConfig?.requireMention;
 
   return {
     requireMention:
@@ -213,5 +222,6 @@ export function resolveFeishuReplyPolicy(params: {
         : typeof resolvedCfg.requireMention === "boolean"
           ? resolvedCfg.requireMention
           : params.groupPolicy !== "open",
+    forwardMentionTargets,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: Feishu group replies automatically @mention other inbound mention targets when a message mentions the bot plus additional entities.
- Why it matters: In multi-bot group chats, this turns one user message into repeated cross-pings that generate unnecessary notifications and group noise, making independent bot replies unreliable in practice.
- What changed: Added a Feishu `mentionForwardMode` (`"auto" | "none"`) config seam, applied that single policy to both agent prompt injection and outbound reply mention delivery, and documented the minimal opt-out config.
- What did NOT change (scope boundary): This PR does not change mention parsing, bot detection heuristics, or the default behavior for existing Feishu users.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68357
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu mention-forward handling treated every non-self mention target as an outbound reply mention target, and that behavior was hardwired into both the agent prompt and the reply dispatcher.
- Missing detection / guardrail: There was no config seam to disable forwarded mentions and no regression test covering the “multi-mention inbound, but do not forward mentions in the reply” case.
- Contributing context (if known): The original implementation assumed mention-forwarding was always desirable and did not account for multi-bot group workflows.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/feishu/src/config-schema.test.ts`
  - `extensions/feishu/src/policy.test.ts`
  - `extensions/feishu/src/bot.test.ts`
- Scenario the test should lock in: `mentionForwardMode: "none"` suppresses both the injected agent prompt hint and the outbound Feishu mention targets, while default `"auto"` preserves existing behavior.
- Why this is the smallest reliable guardrail: The bug lives in Feishu config resolution plus the inbound-to-outbound dispatch seam, so schema + policy + bot dispatch tests cover the behavior change without requiring live Feishu E2E.
- Existing test that already covers this (if any): Existing mention-forward coverage only covered the default auto-forward behavior.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Feishu now supports `mentionForwardMode: "auto" | "none"` at top-level and per-group config scope.
- Default behavior remains `"auto"` for backward compatibility.
- Setting `mentionForwardMode: "none"` stops replies from automatically @mentioning other inbound mention targets.
- `docs/channels/feishu.md` now includes the minimal config needed to disable this behavior.

## Diagram (if applicable)

```text
Before:
[user mentions @bot + @other] -> [Feishu mention-forward path] -> [agent prompt says auto-mention] -> [reply auto-mentions @other]

After:
[user mentions @bot + @other] -> [mentionForwardMode resolved]
  -> auto -> [existing behavior preserved]
  -> none -> [no prompt auto-mention hint] -> [no outbound forwarded mentions]
```
## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo test runner
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): `channels.feishu.mentionForwardMode: "none"` in targeted test config

### Steps

1. Configure Feishu with `mentionForwardMode: "none"`.
2. Send a group message that mentions the bot and at least one additional target.
3. Observe the built agent body and dispatcher params.

### Expected

- The agent prompt does not say the reply will automatically @mention the other target.
- The outbound reply dispatcher does not pass forwarded `mentionTargets`.

### Actual

- Before this change, both the prompt hint and outbound reply mention targets were still present.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified, and how:

- Verified scenarios:
  - Default behavior still forwards mentions when `mentionForwardMode` is unset.
  - `mentionForwardMode: "none"` suppresses forwarded mentions in policy resolution.
  - `mentionForwardMode: "none"` suppresses both prompt injection and dispatcher mention targets in Feishu bot flow.
  - The minimal Feishu channel docs now describe how to disable the behavior.
- Edge cases checked:
  - Direct-message policy resolution with account override.
  - Per-group override precedence over inherited config.
- What you did **not** verify:
  - Live Feishu end-to-end behavior against a real group chat.
  - Repo-wide `pnpm tsgo` green status, because the current tree still has unrelated pre-existing `extensions/qa-lab` failures.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Users who depend on the old behavior could see unexpected changes if the default changed.
  - Mitigation: The default remains `"auto"`; behavior only changes when users explicitly opt out.

- Risk: Prompt and dispatcher behavior could drift apart again in future refactors.
  - Mitigation: Added regression coverage at schema, policy, and bot dispatch levels.

- Risk: The new config would be hard to discover without docs.
  - Mitigation: Added the minimal Feishu docs entry and config example in the same PR.
