### PR TITLE
fix(whatsapp): stop DM allowFrom fallback into group policy sender bypass

### DIFF
--- a/extensions/whatsapp/src/inbound-policy.test.ts
+++ b/extensions/whatsapp/src/inbound-policy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { resolveWhatsAppInboundPolicy } from "./inbound-policy.js";
+import type { OpenClawConfig } from "./runtime-api.js";
+
+describe("resolveWhatsAppInboundPolicy", () => {
+  it("does not let DM allowFrom entries bypass the group allowlist gate", () => {
+    // Regression for the senderFilterBypass path: when DM allowFrom is set,
+    // groupAllowFrom is absent, groupPolicy is allowlist, and no groups are
+    // configured, a random group sender must still be denied. Previously,
+    // resolveGroupAllowFromSources silently fell back from an empty
+    // groupAllowFrom to allowFrom, which promoted the DM entries into
+    // effectiveGroupAllowFrom and flipped senderFilterBypass on for every
+    // group.
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          allowFrom: ["+15551234567"],
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveWhatsAppInboundPolicy({ cfg, selfE164: "+19995551212" });
+
+    // DM allowFrom must not leak into the resolved groupAllowFrom.
+    expect(policy.groupAllowFrom).toEqual([]);
+
+    // A random group that is NOT in the (empty) groupAllowFrom and has no
+    // explicit groups entry must not be allowed through via senderFilterBypass.
+    const groupPolicy = policy.resolveConversationGroupPolicy("120363000000000000@g.us");
+    expect(groupPolicy.allowlistEnabled).toBe(true);
+    expect(groupPolicy.allowed).toBe(false);
+  });
+
+  it("keeps explicit groupAllowFrom working independently of DM allowFrom", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          allowFrom: ["+15551234567"],
+          groupAllowFrom: ["+19998887777"],
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveWhatsAppInboundPolicy({ cfg, selfE164: "+19995551212" });
+
+    expect(policy.groupAllowFrom).toEqual(["+19998887777"]);
+
+    // With an explicit groupAllowFrom and no explicit group entries, senderFilterBypass
+    // legitimately allows the group through; sender-level filtering handles the rest.
+    const groupPolicy = policy.resolveConversationGroupPolicy("120363000000000000@g.us");
+    expect(groupPolicy.allowed).toBe(true);
+  });
+});

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -91,10 +91,14 @@ export function resolveWhatsAppInboundPolicy(params: {
     configuredAllowFrom.length > 0 ? configuredAllowFrom : params.selfE164 ? [params.selfE164] : [];
   // Only use explicit groupAllowFrom. DM allowFrom entries (from pairing)
   // should not grant group access or bypass the group allowlist gate.
+  // groupAllowFromFallbackToAllowFrom: false is required because an empty
+  // groupAllowFrom otherwise silently falls back to allowFrom inside
+  // resolveGroupAllowFromSources, which would re-introduce the bypass.
   const groupAllowFrom = account.groupAllowFrom ?? [];
   const { effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
     allowFrom: configuredAllowFrom,
     groupAllowFrom,
+    groupAllowFromFallbackToAllowFrom: false,
   });
   const defaultGroupPolicy = resolveDefaultGroupPolicy(params.cfg);
   const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -89,10 +89,9 @@ export function resolveWhatsAppInboundPolicy(params: {
   const dmPolicy = account.dmPolicy ?? "pairing";
   const dmAllowFrom =
     configuredAllowFrom.length > 0 ? configuredAllowFrom : params.selfE164 ? [params.selfE164] : [];
-  const groupAllowFrom =
-    account.groupAllowFrom ??
-    (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined) ??
-    [];
+  // Only use explicit groupAllowFrom. DM allowFrom entries (from pairing)
+  // should not grant group access or bypass the group allowlist gate.
+  const groupAllowFrom = account.groupAllowFrom ?? [];
   const { effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
     allowFrom: configuredAllowFrom,
     groupAllowFrom,


### PR DESCRIPTION
## Summary

Stops DM `allowFrom` entries (from pairing) from leaking into group policy sender bypass. When `account.groupAllowFrom` is undefined, the code fell back to `configuredAllowFrom` (DM entries), making `hasGroupAllowFrom` true and triggering the sender filter bypass for all groups.

## Root Cause

In `inbound-policy.ts` line 92-95:
```ts
const groupAllowFrom =
    account.groupAllowFrom ??
    (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined) ??
    [];
```

When no `groupAllowFrom` is configured, DM `allowFrom` entries flow in as fallback. This makes `effectiveGroupAllowFrom` non-empty, setting `hasGroupAllowFrom: true` in `resolveConversationGroupPolicy`, which triggers the sender bypass for groups.

## Fix

One-line change. Only use explicit `groupAllowFrom`:
```ts
const groupAllowFrom = account.groupAllowFrom ?? [];
```

## Test Plan

- [x] All 58 WhatsApp test files pass
- [x] Verified `resolveEffectiveAllowFromLists` receives empty `groupAllowFrom` when only DM entries exist

Note: this supersedes #56978 which targeted the same bug but against an older code path that was since refactored.

Closes #56957