### PR TITLE
feat(feishu): allow custom accountId during Feishu channel onboarding

### DIFF
--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -23,7 +23,7 @@ const { listAccountIds: listFeishuAccountIds, resolveDefaultAccountId } = create
   },
 );
 
-export { listFeishuAccountIds };
+export { listFeishuAccountIds, resolveDefaultAccountId };
 
 type FeishuCredentialResolutionMode = "inspect" | "strict";
 type FeishuResolvedSecretRef = NonNullable<ReturnType<typeof coerceSecretRef>>;

--- a/extensions/feishu/src/setup-core.ts
+++ b/extensions/feishu/src/setup-core.ts
@@ -1,9 +1,9 @@
 import {
   DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
   type ChannelSetupAdapter,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/setup";
-import { resolveDefaultFeishuAccountId } from "./accounts.js";
 import type { FeishuConfig } from "./types.js";
 
 export function setFeishuNamedAccountEnabled(
@@ -31,7 +31,9 @@ export function setFeishuNamedAccountEnabled(
 }
 
 export const feishuSetupAdapter: ChannelSetupAdapter = {
-  resolveAccountId: ({ cfg, accountId }) => accountId?.trim() || resolveDefaultFeishuAccountId(cfg),
+  resolveAccountId: ({ accountId }) => {
+    return normalizeAccountId(accountId);
+  },
   applyAccountConfig: ({ cfg, accountId }) => {
     const isDefault = !accountId || accountId === DEFAULT_ACCOUNT_ID;
     if (isDefault) {

--- a/extensions/feishu/src/setup-surface.ts
+++ b/extensions/feishu/src/setup-surface.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
   formatDocsLink,
   hasConfiguredSecretInput,
   mergeAllowFromEntries,
@@ -12,7 +13,7 @@ import {
   type OpenClawConfig,
   type SecretInput,
 } from "openclaw/plugin-sdk/setup";
-import { inspectFeishuCredentials, resolveDefaultFeishuAccountId } from "./accounts.js";
+import { inspectFeishuCredentials, resolveDefaultFeishuAccountId, listFeishuAccountIds } from "./accounts.js";
 import {
   beginAppRegistration,
   getAppOwnerOpenId,
@@ -500,6 +501,80 @@ export async function runFeishuLogin(params: {
 }
 
 // ---------------------------------------------------------------------------
+// Account ID resolution helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Prompt user for a new account ID when adding additional Feishu accounts.
+ * Validates format and checks for duplicates.
+ */
+async function promptNewAccountId(
+  prompter: WizardPrompter,
+  existingAccounts: string[],
+): Promise<string> {
+  const suggestedId = `feishu-${existingAccounts.length + 1}`;
+
+  const newId = await prompter.text({
+    message: "Enter new account ID (lowercase letters, numbers, underscores, hyphens)",
+    initialValue: suggestedId,
+    validate: (value) => {
+      const trimmed = value?.trim();
+      if (!trimmed) {
+        return "Account ID cannot be empty";
+      }
+      if (!/^[a-z0-9][a-z0-9_-]{0,63}$/.test(trimmed)) {
+        return "Account ID can only contain lowercase letters, numbers, underscores, and hyphens, and must start with a letter or number";
+      }
+      const normalized = trimmed.toLowerCase();
+      if (existingAccounts.includes(normalized)) {
+        return `Account ID "${normalized}" already exists`;
+      }
+      return undefined;
+    },
+  });
+
+  return normalizeAccountId(newId);
+}
+
+/**
+ * Resolve account ID for configuration, prompting user when adding
+ * subsequent accounts.
+ */
+async function resolveAccountIdForConfigureWithPrompt(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+  accountOverride: string | undefined;
+  defaultAccountId: string;
+}): Promise<string> {
+  const { cfg, prompter, accountOverride, defaultAccountId } = params;
+
+  // If accountOverride is provided, use it directly
+  if (typeof accountOverride === "string" && accountOverride.trim()) {
+    return normalizeAccountId(accountOverride);
+  }
+
+  const existingAccounts = listFeishuAccountIds(cfg);
+
+  // If no existing accounts, use default
+  if (existingAccounts.length === 0) {
+    return defaultAccountId;
+  }
+
+  // Ask user if they want to create a new account
+  const useNew = await prompter.confirm({
+    message: `You have ${existingAccounts.length} Feishu account(s) (${existingAccounts.join(", ")}). Create a new account?`,
+    initialValue: false,
+  });
+
+  if (useNew) {
+    return promptNewAccountId(prompter, existingAccounts);
+  }
+
+  // Use the default/first existing account
+  return resolveDefaultFeishuAccountId(cfg) ?? defaultAccountId;
+}
+
+// ---------------------------------------------------------------------------
 // Exported wizard
 // ---------------------------------------------------------------------------
 
@@ -507,13 +582,15 @@ export { feishuSetupAdapter } from "./setup-core.js";
 
 export const feishuSetupWizard: ChannelSetupWizard = {
   channel,
-  resolveAccountIdForConfigure: ({ accountOverride, defaultAccountId, cfg }) =>
-    (typeof accountOverride === "string" && accountOverride.trim()
-      ? accountOverride.trim()
-      : undefined) ??
-    resolveDefaultFeishuAccountId(cfg) ??
-    defaultAccountId,
-  resolveShouldPromptAccountIds: () => false,
+  resolveAccountIdForConfigure: async (params) => {
+    return resolveAccountIdForConfigureWithPrompt({
+      cfg: params.cfg,
+      prompter: params.prompter,
+      accountOverride: params.accountOverride,
+      defaultAccountId: params.defaultAccountId,
+    });
+  },
+  resolveShouldPromptAccountIds: () => true,
   status: {
     configuredLabel: "configured",
     unconfiguredLabel: "needs app credentials",


### PR DESCRIPTION
## Problem

When adding a second Feishu IM channel in the same OpenClaw instance, 
the accountId is always forced to DEFAULT_ACCOUNT_ID ("default"), 
making it impossible to register multiple independent Feishu bots.

## Changes

- `extensions/feishu/src/setup-surface.ts`: Changed 
  `resolveAccountIdForConfigure` to prompt the user for a custom 
  accountId when a Feishu account already exists. Changed 
  `resolveShouldPromptAccountIds` to return `true`.
- `extensions/feishu/src/setup-core.ts`: Updated `resolveAccountId` 
  to use the provided accountId instead of always returning 
  DEFAULT_ACCOUNT_ID.
- `extensions/feishu/src/accounts.ts`: Exported helper for listing 
  existing Feishu accountIds.

## Backward Compatibility

- First Feishu account still defaults to `default` automatically.
- Existing configurations are not affected.
