### PR TITLE
fix(config): refuse to restore from a polluted backup containing redacted secrets (#68423)

### DIFF
--- a/src/config/backup-pollution.test.ts
+++ b/src/config/backup-pollution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { findRedactedSecretSites } from "./backup-pollution.js";
+
+describe("findRedactedSecretSites", () => {
+  it("returns empty array for clean configs", () => {
+    expect(
+      findRedactedSecretSites({
+        gateway: { mode: "local", auth: { token: "real-secret-token-value" } },
+        plugins: { entries: { brave: { config: { webSearch: { apiKey: "BSAreal-key-1234" } } } } },
+      }),
+    ).toEqual([]);
+  });
+
+  it("flags asterisk-redacted apiKey at any depth", () => {
+    expect(
+      findRedactedSecretSites({
+        plugins: {
+          entries: {
+            brave: { config: { webSearch: { apiKey: "***" } } },
+          },
+        },
+      }),
+    ).toEqual(["plugins.entries.brave.config.webSearch.apiKey"]);
+  });
+
+  it("flags ASCII ellipsis-style maskApiKey output", () => {
+    expect(
+      findRedactedSecretSites({
+        models: { providers: { bailian: { apiKey: "sk-12345...5678abcd" } } },
+      }),
+    ).toEqual(["models.providers.bailian.apiKey"]);
+  });
+
+  it("flags unicode ellipsis variants", () => {
+    expect(
+      findRedactedSecretSites({
+        gateway: { auth: { token: "tok-abc\u2026xyz-99" } },
+      }),
+    ).toEqual(["gateway.auth.token"]);
+  });
+
+  it("collects every polluted site under one config", () => {
+    expect(
+      findRedactedSecretSites({
+        gateway: { auth: { token: "***" } },
+        models: { providers: { openai: { apiKey: "sk-12...ab" } } },
+      }).toSorted(),
+    ).toEqual(["gateway.auth.token", "models.providers.openai.apiKey"]);
+  });
+
+  it("ignores asterisks in non-secret keys", () => {
+    expect(
+      findRedactedSecretSites({
+        ui: { greeting: "***", placeholder: "***" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("ignores long high-entropy real secrets that contain dots", () => {
+    expect(
+      findRedactedSecretSites({
+        plugins: {
+          entries: {
+            x: { config: { apiKey: "sk-proj-9c2.4f8.7a1.b3e.0d2.6c5.9a8.1f4.afterFully" } },
+          },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("walks arrays without crashing", () => {
+    expect(
+      findRedactedSecretSites({
+        list: [{ token: "***" }, { token: "real-token" }],
+      }),
+    ).toEqual(["list.0.token"]);
+  });
+});

--- a/src/config/backup-pollution.ts
+++ b/src/config/backup-pollution.ts
@@ -73,3 +73,14 @@ export function findRedactedSecretSites(parsed: unknown): string[] {
   walk(parsed, [], hits);
   return hits;
 }
+
+export function formatBackupRestoreRefusalWarning(
+  backupPath: string,
+  pollutedSites: string[],
+): string {
+  return (
+    `Refusing to restore config from backup ${backupPath}: backup contains ` +
+    `redacted-placeholder secret values at ${pollutedSites.join(", ")}. ` +
+    "Inspect the backup chain manually before recovery."
+  );
+}

--- a/src/config/backup-pollution.ts
+++ b/src/config/backup-pollution.ts
@@ -1,0 +1,75 @@
+/**
+ * Detects redacted-placeholder pollution in a parsed config object so the
+ * recovery path can refuse to restore from a backup that was clobbered by an
+ * agent writing tool-output redactions back to disk (#68423).
+ *
+ * Scope: secret-shaped string values such as apiKey/token/password/secret/key.
+ * Patterns matched:
+ *  - "***" (and longer asterisk runs) — common generic redaction
+ *  - "<short prefix>...<short suffix>" — OpenClaw maskApiKey output shape
+ *  - "<short prefix>…<short suffix>" — unicode-ellipsis variants
+ */
+
+const SECRET_FIELD_SUFFIXES = [
+  "apikey",
+  "api_key",
+  "secret",
+  "token",
+  "password",
+  "passcode",
+  "credential",
+];
+
+const ASTERISK_REDACTION = /^\*{3,}$/;
+const SHORT_TOKEN_BOUND = 12;
+const ELLIPSIS_REDACTION = /^[\w+/=:.\-@]{1,12}(?:\.{3}|\u2026)[\w+/=:.\-@]{1,12}$/;
+
+function isSecretFieldName(key: string): boolean {
+  const lower = key.toLowerCase();
+  return SECRET_FIELD_SUFFIXES.some((suffix) => lower === suffix || lower.endsWith(suffix));
+}
+
+function isRedactedValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (ASTERISK_REDACTION.test(trimmed)) {
+    return true;
+  }
+  // Constrain ellipsis-shaped redactions to short tokens so high-entropy
+  // real secrets that happen to contain dots are not flagged.
+  if (trimmed.length <= SHORT_TOKEN_BOUND * 2 + 3 && ELLIPSIS_REDACTION.test(trimmed)) {
+    return true;
+  }
+  return false;
+}
+
+function walk(value: unknown, path: string[], hits: string[]): void {
+  if (value === null || value === undefined) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      walk(value[i], [...path, String(i)], hits);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    const nextPath = [...path, key];
+    if (typeof child === "string" && isSecretFieldName(key) && isRedactedValue(child)) {
+      hits.push(nextPath.join("."));
+      continue;
+    }
+    walk(child, nextPath, hits);
+  }
+}
+
+export function findRedactedSecretSites(parsed: unknown): string[] {
+  const hits: string[] = [];
+  walk(parsed, [], hits);
+  return hits;
+}

--- a/src/config/io.observe-recovery.test.ts
+++ b/src/config/io.observe-recovery.test.ts
@@ -158,4 +158,45 @@ describe("config observe recovery", () => {
       expect(observe?.lastKnownGoodIno ?? null).toBeNull();
     });
   });
+
+  it("refuses to restore from a backup that contains redacted-placeholder secret values (#68423)", async () => {
+    await withSuiteHome(async (home) => {
+      const { deps, configPath, warn } = makeDeps(home);
+      const goodConfig = {
+        update: { channel: "beta" },
+        gateway: { mode: "local", auth: { mode: "token", token: "real-secret-token-value" } },
+        channels: { telegram: { enabled: true, dmPolicy: "pairing", groupPolicy: "allowlist" } },
+      };
+      await seedConfig(configPath, goodConfig);
+      const pollutedBackup = {
+        ...goodConfig,
+        gateway: { mode: "local", auth: { mode: "token", token: "***" } },
+      };
+      await fsp.writeFile(
+        `${configPath}.bak`,
+        `${JSON.stringify(pollutedBackup, null, 2)}\n`,
+        "utf-8",
+      );
+
+      const clobberedRaw = `${JSON.stringify({ update: { channel: "beta" } }, null, 2)}\n`;
+      await fsp.writeFile(configPath, clobberedRaw, "utf-8");
+
+      const recovered = await maybeRecoverSuspiciousConfigRead({
+        deps,
+        configPath,
+        raw: clobberedRaw,
+        parsed: { update: { channel: "beta" } },
+      });
+
+      // Recovery is refused — the original (clobbered) raw is returned unchanged
+      // so the gateway surfaces the real failure rather than silently fixating
+      // a polluted backup.
+      expect(recovered.raw).toBe(clobberedRaw);
+      await expect(fsp.readFile(configPath, "utf-8")).resolves.toBe(clobberedRaw);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("Refusing to restore config from backup"),
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("gateway.auth.token"));
+    });
+  });
 });

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import { isRecord } from "../utils.js";
+import { findRedactedSecretSites } from "./backup-pollution.js";
 import {
   appendConfigAuditRecord,
   appendConfigAuditRecordSync,
@@ -550,6 +551,15 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
     return { raw: params.raw, parsed: params.parsed };
   }
 
+  const pollutedSites = findRedactedSecretSites(backupParsed);
+  if (pollutedSites.length > 0) {
+    params.deps.logger.warn(
+      `Refusing to restore config from backup ${backupPath}: backup contains redacted-placeholder secret values at ${pollutedSites.join(", ")}. ` +
+        "Inspect the backup chain manually before recovery.",
+    );
+    return { raw: params.raw, parsed: params.parsed };
+  }
+
   const clobberedPath = await persistClobberedConfigSnapshot({
     deps: params.deps,
     configPath: params.configPath,
@@ -641,6 +651,15 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
   }
   const backup = backupBaseline ?? readConfigFingerprintForPathSync(params.deps, backupPath);
   if (!backup?.gatewayMode) {
+    return { raw: params.raw, parsed: params.parsed };
+  }
+
+  const pollutedSites = findRedactedSecretSites(backupParsed);
+  if (pollutedSites.length > 0) {
+    params.deps.logger.warn(
+      `Refusing to restore config from backup ${backupPath}: backup contains redacted-placeholder secret values at ${pollutedSites.join(", ")}. ` +
+        "Inspect the backup chain manually before recovery.",
+    );
     return { raw: params.raw, parsed: params.parsed };
   }
 

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import { isRecord } from "../utils.js";
-import { findRedactedSecretSites } from "./backup-pollution.js";
+import { findRedactedSecretSites, formatBackupRestoreRefusalWarning } from "./backup-pollution.js";
 import {
   appendConfigAuditRecord,
   appendConfigAuditRecordSync,
@@ -553,10 +553,7 @@ export async function maybeRecoverSuspiciousConfigRead(params: {
 
   const pollutedSites = findRedactedSecretSites(backupParsed);
   if (pollutedSites.length > 0) {
-    params.deps.logger.warn(
-      `Refusing to restore config from backup ${backupPath}: backup contains redacted-placeholder secret values at ${pollutedSites.join(", ")}. ` +
-        "Inspect the backup chain manually before recovery.",
-    );
+    params.deps.logger.warn(formatBackupRestoreRefusalWarning(backupPath, pollutedSites));
     return { raw: params.raw, parsed: params.parsed };
   }
 
@@ -656,10 +653,7 @@ export function maybeRecoverSuspiciousConfigReadSync(params: {
 
   const pollutedSites = findRedactedSecretSites(backupParsed);
   if (pollutedSites.length > 0) {
-    params.deps.logger.warn(
-      `Refusing to restore config from backup ${backupPath}: backup contains redacted-placeholder secret values at ${pollutedSites.join(", ")}. ` +
-        "Inspect the backup chain manually before recovery.",
-    );
+    params.deps.logger.warn(formatBackupRestoreRefusalWarning(backupPath, pollutedSites));
     return { raw: params.raw, parsed: params.parsed };
   }
 


### PR DESCRIPTION
## Summary

Closes #68423.

`maybeRecoverSuspiciousConfigRead` would silently restore from `~/.openclaw/openclaw.json.bak` whenever the live config looked clobbered (update-channel-only root). It did not verify the backup itself was clean. If an agent had previously written tool-output redactions (`"***"` / `"<short>...<short>"`) back into the live config, the rotation pipeline copied that pollution to `.bak`, and the next observe pass _restored_ from the polluted backup — fixating the pollution. The reporter hit a 14-hour 401 outage from this on 2026-04-18.

## Change

- `src/config/backup-pollution.ts` (new): `findRedactedSecretSites(parsed)` walks an arbitrary parsed config and returns dot-paths of secret-shaped fields (apiKey, token, secret, password, key, credential) whose value matches one of:
  - `***` or longer asterisk runs (Hermes-style redaction)
  - `<short prefix>...<short suffix>` — OpenClaw maskApiKey output shape, bounded so high-entropy real secrets containing dots don't false-positive
  - `<short prefix>…<short suffix>` — unicode-ellipsis variant
- `src/config/io.observe-recovery.ts`: both async + sync recovery paths now call `findRedactedSecretSites` on the parsed backup before copying it over the live config. If any sites match, the recovery is refused, a warn line lists the offending paths, and the original (clobbered) raw is returned so the gateway surfaces the real failure rather than fixating pollution.

## Why this scope only

This PR addresses the most acute item from the issue (refuse restore from polluted backup). The reporter also suggested:

1. Validating before _creating_ backups (prevent pollution spread)
2. Multi-level rotation (`.bak.daily`, `.bak.weekly`)
3. `openclaw config validate` CLI

Those are valuable but each touches a different code path (`maintainConfigBackups`, rotation policy, CLI surface). Easier to land separately once the maintainer signals direction. Happy to follow up on any of them.

## Tests

- `src/config/backup-pollution.test.ts` — 8 unit tests covering clean configs, asterisk + ASCII ellipsis + unicode ellipsis, multi-site detection, non-secret keys ignored, long real secrets ignored, array walking.
- `src/config/io.observe-recovery.test.ts` — new integration test seeds a polluted `.bak` (`gateway.auth.token: "***"`) plus a clobbered live config and asserts the recovery is refused and the warn line names `gateway.auth.token`.

\`pnpm vitest run src/config/backup-pollution.test.ts src/config/io.observe-recovery.test.ts\` — 12/12 passing locally.

## Test plan

- [x] Unit tests for `findRedactedSecretSites` cover the three redaction shapes
- [x] Integration test covers the refusal path on the async recovery
- [x] Adjacent config tests still pass (`io.write-config.test.ts`, `config.backup-rotation.test.ts`)