### PR TITLE
Harden subagent completion delivery

### DIFF
--- a/extensions/imessage/src/monitor/deliver.test.ts
+++ b/extensions/imessage/src/monitor/deliver.test.ts
@@ -7,8 +7,6 @@ const sendMessageIMessageMock = vi.hoisted(() =>
     sentText: message,
   })),
 );
-const chunkTextWithModeMock = vi.hoisted(() => vi.fn((text: string) => [text]));
-const resolveChunkModeMock = vi.hoisted(() => vi.fn(() => "length"));
 const convertMarkdownTablesMock = vi.hoisted(() => vi.fn((text: string) => text));
 const resolveMarkdownTableModeMock = vi.hoisted(() => vi.fn(() => "code"));
 
@@ -20,8 +18,6 @@ vi.mock("../send.js", () => ({
 vi.mock("./deliver.runtime.js", () => ({
   loadConfig: vi.fn(() => ({})),
   resolveMarkdownTableMode: vi.fn(() => resolveMarkdownTableModeMock()),
-  chunkTextWithMode: (text: string) => chunkTextWithModeMock(text),
-  resolveChunkMode: vi.fn(() => resolveChunkModeMock()),
   convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
 }));
 
@@ -37,20 +33,17 @@ describe("deliverReplies", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    chunkTextWithModeMock.mockImplementation((text: string) => [text]);
   });
 
   it("propagates payload replyToId through all text chunks", async () => {
-    chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
-
     await deliverReplies({
-      replies: [{ text: "first|second", replyToId: "reply-1" }],
+      replies: [{ text: "first second", replyToId: "reply-1" }],
       target: "chat_id:10",
       client,
       accountId: "default",
       runtime,
       maxBytes: 4096,
-      textLimit: 4000,
+      textLimit: 6,
     });
 
     expect(sendMessageIMessageMock).toHaveBeenCalledTimes(2);
@@ -127,19 +120,18 @@ describe("deliverReplies", () => {
     // never with the full un-chunked text before sending begins.
     // Pre-send population widened the false-positive window in self-chat.
     const remember = vi.fn();
-    chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
     sendMessageIMessageMock
       .mockResolvedValueOnce({ messageId: "imsg-1", sentText: "first" })
       .mockResolvedValueOnce({ messageId: "imsg-2", sentText: "second" });
 
     await deliverReplies({
-      replies: [{ text: "first|second" }],
+      replies: [{ text: "first second" }],
       target: "chat_id:30",
       client,
       accountId: "acct-3",
       runtime,
       maxBytes: 2048,
-      textLimit: 4000,
+      textLimit: 6,
       sentMessageCache: { remember },
     });
 
@@ -177,5 +169,23 @@ describe("deliverReplies", () => {
       text: "<media:image>",
       messageId: "imsg-media-1",
     });
+  });
+
+  it("closes dangling code fences before sending text", async () => {
+    await deliverReplies({
+      replies: [{ text: "```js\nconst x = 1;" }],
+      target: "chat_id:50",
+      client,
+      accountId: "acct-5",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+    });
+
+    expect(sendMessageIMessageMock).toHaveBeenCalledWith(
+      "chat_id:50",
+      "```js\nconst x = 1;\n```",
+      expect.anything(),
+    );
   });
 });

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -4,17 +4,100 @@ import {
 } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { findCodeRegions, isInsideCode } from "openclaw/plugin-sdk/text-runtime";
 import type { createIMessageRpcClient } from "../client.js";
 import { sendMessageIMessage } from "../send.js";
 import {
-  chunkTextWithMode,
   convertMarkdownTables,
   loadConfig,
-  resolveChunkMode,
   resolveMarkdownTableMode,
 } from "./deliver.runtime.js";
 import type { SentMessageCache } from "./echo-cache.js";
-import { sanitizeOutboundText } from "./sanitize-outbound.js";
+import { normalizeIMessageDeliveryText } from "./sanitize-outbound.js";
+
+function findSafeChunkBoundary(text: string, limit: number): number {
+  if (limit <= 0 || text.length <= limit) {
+    return text.length;
+  }
+  const codeRegions = findCodeRegions(text);
+  const preferredNeedles = ["\n\n", "\n", ". ", "! ", "? ", ", ", " "];
+  for (const needle of preferredNeedles) {
+    let searchFrom = Math.min(limit, text.length);
+    for (;;) {
+      const start = text.lastIndexOf(needle, searchFrom);
+      if (start < 0) {
+        break;
+      }
+      const boundary = start + needle.length;
+      if (boundary > 0 && !isInsideCode(Math.max(0, boundary - 1), codeRegions)) {
+        return boundary;
+      }
+      searchFrom = start - 1;
+    }
+  }
+  return limit;
+}
+
+function splitIMessageTextSafely(text: string, limit: number): string[] {
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit && limit > 0) {
+    const boundary = findSafeChunkBoundary(remaining, limit);
+    const next = remaining.slice(0, boundary).trim();
+    if (next) {
+      chunks.push(next);
+    }
+    remaining = remaining.slice(Math.max(1, boundary)).trimStart();
+  }
+  if (remaining) {
+    chunks.push(remaining.trim());
+  }
+  return chunks.filter(Boolean);
+}
+
+function chunkIMessageText(text: string, limit: number): string[] {
+  const normalized = normalizeIMessageDeliveryText(text ?? "");
+  if (!normalized) {
+    return [];
+  }
+  if (limit <= 0 || normalized.length <= limit) {
+    return [normalized];
+  }
+  const paragraphs = normalized
+    .split(/\n{2,}/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (paragraphs.length <= 1) {
+    return splitIMessageTextSafely(normalized, limit);
+  }
+  const chunks: string[] = [];
+  let current = "";
+  for (const paragraph of paragraphs) {
+    const candidate = current ? `${current}\n\n${paragraph}` : paragraph;
+    if (candidate.length <= limit) {
+      current = candidate;
+      continue;
+    }
+    if (current) {
+      chunks.push(current);
+    }
+    if (paragraph.length <= limit) {
+      current = paragraph;
+      continue;
+    }
+    const safeChunks = splitIMessageTextSafely(paragraph, limit);
+    if (safeChunks.length === 0) {
+      current = "";
+      continue;
+    }
+    chunks.push(...safeChunks.slice(0, -1));
+    current = safeChunks.at(-1) ?? "";
+  }
+  if (current) {
+    chunks.push(current);
+  }
+  return chunks;
+}
 
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
@@ -35,16 +118,14 @@ export async function deliverReplies(params: {
     channel: "imessage",
     accountId,
   });
-  const chunkMode = resolveChunkMode(cfg, "imessage", accountId);
   for (const payload of replies) {
-    const rawText = sanitizeOutboundText(payload.text ?? "");
     const reply = resolveSendableOutboundReplyParts(payload, {
-      text: convertMarkdownTables(rawText, tableMode),
+      text: convertMarkdownTables(normalizeIMessageDeliveryText(payload.text ?? ""), tableMode),
     });
     const delivered = await deliverTextOrMediaReply({
       payload,
       text: reply.text,
-      chunkText: (value) => chunkTextWithMode(value, textLimit, chunkMode),
+      chunkText: (value) => chunkIMessageText(value, textLimit),
       sendText: async (chunk) => {
         const sent = await sendMessageIMessage(target, chunk, {
           maxBytes,

--- a/extensions/imessage/src/monitor/deliver.ts
+++ b/extensions/imessage/src/monitor/deliver.ts
@@ -56,19 +56,18 @@ function splitIMessageTextSafely(text: string, limit: number): string[] {
 }
 
 function chunkIMessageText(text: string, limit: number): string[] {
-  const normalized = normalizeIMessageDeliveryText(text ?? "");
-  if (!normalized) {
+  if (!text) {
     return [];
   }
-  if (limit <= 0 || normalized.length <= limit) {
-    return [normalized];
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
   }
-  const paragraphs = normalized
+  const paragraphs = text
     .split(/\n{2,}/)
     .map((part) => part.trim())
     .filter(Boolean);
   if (paragraphs.length <= 1) {
-    return splitIMessageTextSafely(normalized, limit);
+    return splitIMessageTextSafely(text, limit);
   }
   const chunks: string[] = [];
   let current = "";

--- a/extensions/imessage/src/monitor/sanitize-outbound.test.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { sanitizeOutboundText } from "./sanitize-outbound.js";
+import { normalizeIMessageDeliveryText, sanitizeOutboundText } from "./sanitize-outbound.js";
 
 describe("sanitizeOutboundText", () => {
   it("returns empty string unchanged", () => {
@@ -60,5 +60,23 @@ describe("sanitizeOutboundText", () => {
     expect(result).not.toContain("+#+#");
     expect(result).not.toMatch(/assistant to=final/i);
     expect(result).toContain("Actual reply");
+  });
+
+  it("strips leaked OpenClaw internal context envelopes", () => {
+    const text = [
+      "Visible intro",
+      "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "OpenClaw runtime context (internal):",
+      "secret",
+      "<<<END_OPENCLAW_INTERNAL_CONTEXT>>>",
+      "Visible outro",
+    ].join("\n");
+    expect(sanitizeOutboundText(text)).toBe("Visible intro\nVisible outro");
+  });
+
+  it("closes dangling code fences for iMessage delivery", () => {
+    expect(normalizeIMessageDeliveryText("```js\nconst x = 1;")).toBe(
+      "```js\nconst x = 1;\n```",
+    );
   });
 });

--- a/extensions/imessage/src/monitor/sanitize-outbound.ts
+++ b/extensions/imessage/src/monitor/sanitize-outbound.ts
@@ -7,6 +7,17 @@ import { stripAssistantInternalScaffolding } from "openclaw/plugin-sdk/text-runt
 const INTERNAL_SEPARATOR_RE = /(?:#\+){2,}#?/g;
 const ASSISTANT_ROLE_MARKER_RE = /\bassistant\s+to\s*=\s*\w+/gi;
 const ROLE_TURN_MARKER_RE = /\b(?:user|system|assistant)\s*:\s*$/gm;
+const OPENCLAW_INTERNAL_BLOCK_RE =
+  /(?:^|\n)\s*(?:Human:\s*)?(?:\[[^\n]*\]\s*)?<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>[\s\S]*?<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\s*/g;
+const OPENCLAW_INTERNAL_LINE_RE =
+  /(?:^|\n)\s*(?:\[Inter-session message][^\n]*|OpenClaw runtime context \(internal\):|This context is runtime-generated, not user-authored\. Keep internal details private\.|sourceSession=[^\n]*|sourceChannel=[^\n]*|sourceTool=[^\n]*)(?=\n|$)/gim;
+
+function stripSuspiciousIMessageTextArtifacts(text: string): string {
+  return text
+    .replace(/\n{3,}/g, "\n\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
 
 /**
  * Strip all assistant-internal scaffolding from outbound text before delivery.
@@ -20,12 +31,27 @@ export function sanitizeOutboundText(text: string): string {
 
   let cleaned = stripAssistantInternalScaffolding(text);
 
+  cleaned = cleaned.replace(OPENCLAW_INTERNAL_BLOCK_RE, "\n");
+  cleaned = cleaned.replace(OPENCLAW_INTERNAL_LINE_RE, "\n");
   cleaned = cleaned.replace(INTERNAL_SEPARATOR_RE, "");
   cleaned = cleaned.replace(ASSISTANT_ROLE_MARKER_RE, "");
   cleaned = cleaned.replace(ROLE_TURN_MARKER_RE, "");
+  cleaned = stripSuspiciousIMessageTextArtifacts(cleaned);
 
   // Collapse excessive blank lines left after stripping.
   cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();
 
   return cleaned;
+}
+
+function closeDanglingCodeFence(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const fenceCount = (text.match(/(^|\n)```/g) ?? []).length;
+  return fenceCount % 2 === 0 ? text : `${text}\n\`\`\``;
+}
+
+export function normalizeIMessageDeliveryText(text: string): string {
+  return closeDanglingCodeFence(sanitizeOutboundText(text ?? ""));
 }

--- a/extensions/imessage/src/send.ts
+++ b/extensions/imessage/src/send.ts
@@ -4,6 +4,7 @@ import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import { resolveOutboundAttachmentFromUrl } from "openclaw/plugin-sdk/media-runtime";
 import { convertMarkdownTables } from "openclaw/plugin-sdk/text-runtime";
 import { stripInlineDirectiveTagsForDelivery } from "openclaw/plugin-sdk/text-runtime";
+import { normalizeIMessageDeliveryText } from "./monitor/sanitize-outbound.js";
 import { resolveIMessageAccount, type ResolvedIMessageAccount } from "./accounts.js";
 import { createIMessageRpcClient, type IMessageRpcClient } from "./client.js";
 import { formatIMessageChatTarget, type IMessageService, parseIMessageTarget } from "./targets.js";
@@ -142,7 +143,7 @@ export async function sendMessageIMessage(
       channel: "imessage",
       accountId: account.accountId,
     });
-    message = convertMarkdownTables(message, tableMode);
+    message = convertMarkdownTables(normalizeIMessageDeliveryText(message), tableMode);
   }
   message = stripInlineDirectiveTagsForDelivery(message).text;
   if (!message.trim() && !filePath) {

--- a/src/agents/internal-events.ts
+++ b/src/agents/internal-events.ts
@@ -19,6 +19,11 @@ export type AgentTaskCompletionInternalEvent = {
   status: AgentInternalEventStatus;
   statusLabel: string;
   result: string;
+  userDeliveryPayload?: {
+    text: string;
+    source: "empty" | "child-blocks" | "named-section" | "sanitized-fallback";
+    capturedAt: number;
+  };
   mediaUrls?: string[];
   statsLine?: string;
   replyInstruction: string;

--- a/src/agents/subagent-announce-delivery.ts
+++ b/src/agents/subagent-announce-delivery.ts
@@ -341,6 +341,7 @@ async function maybeQueueSubagentAnnounce(params: {
   sourceChannel?: string;
   sourceTool?: string;
   internalEvents?: AgentInternalEvent[];
+  forceQueueWhenActive?: boolean;
   signal?: AbortSignal;
 }): Promise<"steered" | "queued" | "none" | "dropped"> {
   if (params.signal?.aborted) {
@@ -373,7 +374,18 @@ async function maybeQueueSubagentAnnounce(params: {
     queueSettings.mode === "collect" ||
     queueSettings.mode === "steer-backlog" ||
     queueSettings.mode === "interrupt";
-  if (isActive && (shouldFollowup || queueSettings.mode === "steer")) {
+  const mustQueueWhileActive = isActive && params.forceQueueWhenActive === true;
+  const effectiveQueueSettings = mustQueueWhileActive
+    ? {
+        ...queueSettings,
+        mode:
+          shouldFollowup || queueSettings.mode === "steer" ? queueSettings.mode : ("interrupt" as const),
+        debounceMs: 0,
+        cap: Math.max(queueSettings.cap ?? 20, 200),
+        dropPolicy: "old" as const,
+      }
+    : queueSettings;
+  if (isActive && (shouldFollowup || queueSettings.mode === "steer" || mustQueueWhileActive)) {
     const origin = resolveAnnounceOrigin(entry, params.requesterOrigin);
     const didQueue = enqueueAnnounce({
       key: buildAnnounceQueueKey(canonicalKey, origin),
@@ -389,7 +401,7 @@ async function maybeQueueSubagentAnnounce(params: {
         sourceChannel: params.sourceChannel,
         sourceTool: params.sourceTool,
       },
-      settings: queueSettings,
+      settings: effectiveQueueSettings,
       send: sendAnnounce,
     });
     return didQueue ? "queued" : "dropped";
@@ -541,6 +553,7 @@ export async function deliverSubagentAnnouncement(params: {
   signal?: AbortSignal;
 }): Promise<SubagentAnnounceDeliveryResult> {
   return await runSubagentAnnounceDispatch({
+    announceId: params.announceId,
     expectsCompletionMessage: params.expectsCompletionMessage,
     signal: params.signal,
     queue: async () =>
@@ -555,6 +568,7 @@ export async function deliverSubagentAnnouncement(params: {
         sourceChannel: params.sourceChannel,
         sourceTool: params.sourceTool,
         internalEvents: params.internalEvents,
+        forceQueueWhenActive: params.expectsCompletionMessage && !params.requesterIsSubagent,
         signal: params.signal,
       }),
     direct: async () =>

--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildAnnounceIdFromChildRun } from "./announce-idempotency.js";
 import {
+  __testing as dispatchTesting,
   mapQueueOutcomeToDeliveryResult,
   runSubagentAnnounceDispatch,
 } from "./subagent-announce-dispatch.js";
@@ -28,6 +30,10 @@ describe("mapQueueOutcomeToDeliveryResult", () => {
 });
 
 describe("runSubagentAnnounceDispatch", () => {
+  afterEach(() => {
+    dispatchTesting.setDepsForTest();
+  });
+
   async function runNonCompletionDispatch(params: {
     queueOutcome: "none" | "queued" | "steered";
     directDelivered?: boolean;
@@ -69,7 +75,7 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
-  it("uses direct-first ordering for completion mode", async () => {
+  it("uses queue-first ordering for completion mode", async () => {
     const queue = vi.fn(async () => "queued" as const);
     const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
@@ -79,20 +85,19 @@ describe("runSubagentAnnounceDispatch", () => {
       direct,
     });
 
-    expect(direct).toHaveBeenCalledTimes(1);
-    expect(queue).not.toHaveBeenCalled();
-    expect(result.path).toBe("direct");
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect(direct).not.toHaveBeenCalled();
+    expect(result.path).toBe("queued");
     expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
+      { phase: "queue-primary", delivered: true, path: "queued", error: undefined },
     ]);
   });
 
-  it("falls back to queue when completion direct send fails", async () => {
-    const queue = vi.fn(async () => "steered" as const);
+  it("falls back to direct when completion queue cannot deliver", async () => {
+    const queue = vi.fn(async () => "none" as const);
     const direct = vi.fn(async () => ({
-      delivered: false,
+      delivered: true,
       path: "direct" as const,
-      error: "network",
     }));
 
     const result = await runSubagentAnnounceDispatch({
@@ -101,16 +106,16 @@ describe("runSubagentAnnounceDispatch", () => {
       direct,
     });
 
-    expect(direct).toHaveBeenCalledTimes(1);
     expect(queue).toHaveBeenCalledTimes(1);
-    expect(result.path).toBe("steered");
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(result.path).toBe("direct");
     expect(result.phases).toEqual([
-      { phase: "direct-primary", delivered: false, path: "direct", error: "network" },
-      { phase: "queue-fallback", delivered: true, path: "steered", error: undefined },
+      { phase: "queue-primary", delivered: false, path: "none", error: undefined },
+      { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
     ]);
   });
 
-  it("returns direct failure when completion fallback queue cannot deliver", async () => {
+  it("returns direct failure when completion direct fallback cannot deliver", async () => {
     const queue = vi.fn(async () => "none" as const);
     const direct = vi.fn(async () => ({
       delivered: false,
@@ -130,8 +135,8 @@ describe("runSubagentAnnounceDispatch", () => {
       error: "failed",
     });
     expect(result.phases).toEqual([
+      { phase: "queue-primary", delivered: false, path: "none", error: undefined },
       { phase: "direct-primary", delivered: false, path: "direct", error: "failed" },
-      { phase: "queue-fallback", delivered: false, path: "none", error: undefined },
     ]);
   });
 
@@ -154,17 +159,13 @@ describe("runSubagentAnnounceDispatch", () => {
     });
   });
 
-  it("preserves direct failure when completion dispatch aborts before fallback queue", async () => {
+  it("preserves queue result when completion dispatch aborts before direct fallback", async () => {
     const controller = new AbortController();
-    const queue = vi.fn(async () => "queued" as const);
-    const direct = vi.fn(async () => {
+    const queue = vi.fn(async () => {
       controller.abort();
-      return {
-        delivered: false,
-        path: "direct" as const,
-        error: "direct failed before abort",
-      };
+      return "none" as const;
     });
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
     const result = await runSubagentAnnounceDispatch({
       expectsCompletionMessage: true,
@@ -173,19 +174,18 @@ describe("runSubagentAnnounceDispatch", () => {
       direct,
     });
 
-    expect(direct).toHaveBeenCalledTimes(1);
-    expect(queue).not.toHaveBeenCalled();
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect(direct).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       delivered: false,
-      path: "direct",
-      error: "direct failed before abort",
+      path: "none",
     });
     expect(result.phases).toEqual([
       {
-        phase: "direct-primary",
+        phase: "queue-primary",
         delivered: false,
-        path: "direct",
-        error: "direct failed before abort",
+        path: "none",
+        error: undefined,
       },
     ]);
   });
@@ -208,6 +208,109 @@ describe("runSubagentAnnounceDispatch", () => {
     expect(result).toEqual({
       delivered: false,
       path: "none",
+      phases: [],
+    });
+  });
+
+  it("short-circuits when the announce was already delivered", async () => {
+    const announceId = buildAnnounceIdFromChildRun({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-1",
+    });
+    dispatchTesting.setDepsForTest({
+      getRuns: () =>
+        new Map([
+          [
+            "run-1",
+            {
+              runId: "run-1",
+              childSessionKey: "agent:main:subagent:worker",
+              requesterSessionKey: "agent:main:main",
+              requesterDisplayKey: "main",
+              task: "task",
+              cleanup: "keep",
+              createdAt: 1,
+              completionAnnouncedAt: 10,
+              deliveryClaim: {
+                announceId,
+                state: "delivered",
+                token: "token-1",
+                path: "queued",
+                claimedAt: 5,
+                updatedAt: 10,
+              },
+            },
+          ],
+        ]),
+      persist: vi.fn(),
+    });
+    const queue = vi.fn(async () => "queued" as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
+
+    const result = await runSubagentAnnounceDispatch({
+      announceId,
+      expectsCompletionMessage: true,
+      queue,
+      direct,
+    });
+
+    expect(queue).not.toHaveBeenCalled();
+    expect(direct).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      delivered: true,
+      path: "queued",
+      phases: [],
+    });
+  });
+
+  it("rejects a concurrent in-flight announce claim", async () => {
+    const announceId = buildAnnounceIdFromChildRun({
+      childSessionKey: "agent:main:subagent:worker",
+      childRunId: "run-2",
+    });
+    dispatchTesting.setDepsForTest({
+      getRuns: () =>
+        new Map([
+          [
+            "run-2",
+            {
+              runId: "run-2",
+              childSessionKey: "agent:main:subagent:worker",
+              requesterSessionKey: "agent:main:main",
+              requesterDisplayKey: "main",
+              task: "task",
+              cleanup: "keep",
+              createdAt: 1,
+              deliveryClaim: {
+                announceId,
+                state: "claimed",
+                token: "token-2",
+                path: "none",
+                claimedAt: 5,
+                updatedAt: 5,
+              },
+            },
+          ],
+        ]),
+      now: () => 10,
+      persist: vi.fn(),
+    });
+    const queue = vi.fn(async () => "queued" as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
+
+    const result = await runSubagentAnnounceDispatch({
+      announceId,
+      expectsCompletionMessage: true,
+      queue,
+      direct,
+    });
+
+    expect(queue).not.toHaveBeenCalled();
+    expect(direct).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      delivered: false,
+      path: "none",
+      error: "delivery-already-in-flight",
       phases: [],
     });
   });

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -236,7 +236,8 @@ export async function runSubagentAnnounceDispatch(params: {
     finalResult = fallbackDirect;
     return withPhases(finalResult);
   } finally {
-    finalizePersistedAnnounceDeliveryClaim(params.announceId, claim.token, finalResult);
+    const token = claim.status === "started" ? claim.token : undefined;
+    finalizePersistedAnnounceDeliveryClaim(params.announceId, token, finalResult);
   }
 }
 

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -1,3 +1,8 @@
+import { buildAnnounceIdFromChildRun } from "./announce-idempotency.js";
+import { subagentRuns } from "./subagent-registry-memory.js";
+import { persistSubagentRunsToDisk } from "./subagent-registry-state.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
 export type SubagentDeliveryPath = "queued" | "steered" | "direct" | "none";
 
 export type SubagentAnnounceQueueOutcome = "steered" | "queued" | "none" | "dropped";
@@ -17,6 +22,120 @@ export type SubagentAnnounceDispatchPhaseResult = {
   path: SubagentDeliveryPath;
   error?: string;
 };
+
+const ANNOUNCE_DELIVERY_LEASE_TTL_MS = 5 * 60_000;
+
+type SubagentAnnounceDispatchDeps = {
+  getRuns: () => Map<string, SubagentRunRecord>;
+  now: () => number;
+  persist: () => void;
+  randomUUID: () => string;
+};
+
+const defaultSubagentAnnounceDispatchDeps: SubagentAnnounceDispatchDeps = {
+  getRuns: () => subagentRuns,
+  now: () => Date.now(),
+  persist: () => persistSubagentRunsToDisk(subagentRuns),
+  randomUUID: () => crypto.randomUUID(),
+};
+
+let subagentAnnounceDispatchDeps: SubagentAnnounceDispatchDeps =
+  defaultSubagentAnnounceDispatchDeps;
+
+type DeliveryClaimResult =
+  | { status: "skipped" | "started"; token?: string }
+  | { status: "already-delivered" | "in-flight"; path?: SubagentDeliveryPath };
+
+function findSubagentRunEntryByAnnounceId(announceId?: string): SubagentRunRecord | null {
+  const normalized = announceId?.trim();
+  if (!normalized) {
+    return null;
+  }
+  for (const entry of subagentAnnounceDispatchDeps.getRuns().values()) {
+    if (
+      buildAnnounceIdFromChildRun({
+        childSessionKey: entry.childSessionKey,
+        childRunId: entry.runId,
+      }) === normalized
+    ) {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function beginPersistedAnnounceDeliveryClaim(announceId?: string): DeliveryClaimResult {
+  const normalized = announceId?.trim();
+  if (!normalized) {
+    return { status: "skipped" };
+  }
+  const entry = findSubagentRunEntryByAnnounceId(normalized);
+  if (!entry) {
+    return { status: "skipped" };
+  }
+  const now = subagentAnnounceDispatchDeps.now();
+  const existing = entry.deliveryClaim;
+  if (typeof entry.completionAnnouncedAt === "number" || existing?.state === "delivered") {
+    return {
+      status: "already-delivered",
+      path: existing?.path ?? "none",
+    };
+  }
+  if (
+    existing?.state === "claimed" &&
+    now - (existing.updatedAt ?? existing.claimedAt ?? 0) < ANNOUNCE_DELIVERY_LEASE_TTL_MS
+  ) {
+    return {
+      status: "in-flight",
+      path: existing.path ?? "none",
+    };
+  }
+  entry.deliveryClaim = {
+    announceId: normalized,
+    state: "claimed",
+    token: subagentAnnounceDispatchDeps.randomUUID(),
+    path: "none",
+    claimedAt: now,
+    updatedAt: now,
+  };
+  subagentAnnounceDispatchDeps.persist();
+  return {
+    status: "started",
+    token: entry.deliveryClaim.token,
+  };
+}
+
+function finalizePersistedAnnounceDeliveryClaim(
+  announceId: string | undefined,
+  token: string | undefined,
+  result: SubagentAnnounceDeliveryResult,
+) {
+  const normalized = announceId?.trim();
+  if (!normalized || !token) {
+    return;
+  }
+  const entry = findSubagentRunEntryByAnnounceId(normalized);
+  if (!entry?.deliveryClaim || entry.deliveryClaim.token !== token) {
+    return;
+  }
+  if (result.delivered) {
+    const now = subagentAnnounceDispatchDeps.now();
+    entry.deliveryClaim = {
+      ...entry.deliveryClaim,
+      announceId: normalized,
+      state: "delivered",
+      path: result.path ?? "none",
+      updatedAt: now,
+    };
+    if (typeof entry.completionAnnouncedAt !== "number") {
+      entry.completionAnnouncedAt = now;
+    }
+    subagentAnnounceDispatchDeps.persist();
+    return;
+  }
+  delete entry.deliveryClaim;
+  subagentAnnounceDispatchDeps.persist();
+}
 
 export function mapQueueOutcomeToDeliveryResult(
   outcome: SubagentAnnounceQueueOutcome,
@@ -40,6 +159,7 @@ export function mapQueueOutcomeToDeliveryResult(
 }
 
 export async function runSubagentAnnounceDispatch(params: {
+  announceId?: string;
   expectsCompletionMessage: boolean;
   signal?: AbortSignal;
   queue: () => Promise<SubagentAnnounceQueueOutcome>;
@@ -62,6 +182,21 @@ export async function runSubagentAnnounceDispatch(params: {
     phases,
   });
 
+  const claim = beginPersistedAnnounceDeliveryClaim(params.announceId);
+  if (claim.status === "already-delivered") {
+    return withPhases({
+      delivered: true,
+      path: claim.path ?? "none",
+    });
+  }
+  if (claim.status === "in-flight") {
+    return withPhases({
+      delivered: false,
+      path: "none",
+      error: "delivery-already-in-flight",
+    });
+  }
+
   if (params.signal?.aborted) {
     return withPhases({
       delivered: false,
@@ -69,38 +204,49 @@ export async function runSubagentAnnounceDispatch(params: {
     });
   }
 
-  if (!params.expectsCompletionMessage) {
+  let finalResult: SubagentAnnounceDeliveryResult = {
+    delivered: false,
+    path: "none",
+  };
+
+  try {
     const primaryQueueOutcome = await params.queue();
     const primaryQueue = mapQueueOutcomeToDeliveryResult(primaryQueueOutcome);
     appendPhase("queue-primary", primaryQueue);
-    if (primaryQueue.delivered) {
-      return withPhases(primaryQueue);
+
+    if (primaryQueue.delivered || primaryQueueOutcome === "dropped") {
+      finalResult = primaryQueue;
+      return withPhases(finalResult);
     }
-    if (primaryQueueOutcome === "dropped") {
-      return withPhases(primaryQueue);
+
+    if (!params.expectsCompletionMessage) {
+      const primaryDirect = await params.direct();
+      appendPhase("direct-primary", primaryDirect);
+      finalResult = primaryDirect;
+      return withPhases(finalResult);
     }
 
-    const primaryDirect = await params.direct();
-    appendPhase("direct-primary", primaryDirect);
-    return withPhases(primaryDirect);
-  }
+    if (params.signal?.aborted) {
+      finalResult = primaryQueue;
+      return withPhases(finalResult);
+    }
 
-  const primaryDirect = await params.direct();
-  appendPhase("direct-primary", primaryDirect);
-  if (primaryDirect.delivered) {
-    return withPhases(primaryDirect);
+    const fallbackDirect = await params.direct();
+    appendPhase("direct-primary", fallbackDirect);
+    finalResult = fallbackDirect;
+    return withPhases(finalResult);
+  } finally {
+    finalizePersistedAnnounceDeliveryClaim(params.announceId, claim.token, finalResult);
   }
-
-  if (params.signal?.aborted) {
-    return withPhases(primaryDirect);
-  }
-
-  const fallbackQueueOutcome = await params.queue();
-  const fallbackQueue = mapQueueOutcomeToDeliveryResult(fallbackQueueOutcome);
-  appendPhase("queue-fallback", fallbackQueue);
-  if (fallbackQueue.delivered) {
-    return withPhases(fallbackQueue);
-  }
-
-  return withPhases(primaryDirect);
 }
+
+export const __testing = {
+  setDepsForTest(overrides?: Partial<SubagentAnnounceDispatchDeps>) {
+    subagentAnnounceDispatchDeps = overrides
+      ? {
+          ...defaultSubagentAnnounceDispatchDeps,
+          ...overrides,
+        }
+      : defaultSubagentAnnounceDispatchDeps;
+  },
+};

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -2402,6 +2402,59 @@ describe("subagent announce formatting", () => {
     expect(msg).not.toContain("placeholder waiting text that should be ignored");
   });
 
+  it("prefers descendant findings over persisted round-one user payloads", async () => {
+    subagentRegistryMock.countPendingDescendantRuns.mockReturnValue(0);
+    subagentRegistryMock.listSubagentRunsForRequester.mockImplementation(
+      (sessionKey: string, scope?: { requesterRunId?: string }) => {
+        if (sessionKey !== "agent:main:subagent:parent") {
+          return [];
+        }
+        if (scope?.requesterRunId !== "run-parent-persisted-payload") {
+          return [];
+        }
+        return [
+          {
+            runId: "run-child-a",
+            childSessionKey: "agent:main:subagent:parent:subagent:a",
+            requesterSessionKey: "agent:main:subagent:parent",
+            requesterDisplayKey: "parent",
+            task: "child task a",
+            label: "child-a",
+            cleanup: "keep",
+            createdAt: 10,
+            endedAt: 20,
+            cleanupCompletedAt: 21,
+            frozenResultText: "result from child a",
+            outcome: { status: "ok" },
+          },
+        ];
+      },
+    );
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:parent",
+      childRunId: "run-parent-persisted-payload",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "placeholder waiting text that should be ignored",
+      roundOneUserDeliveryPayload: {
+        text: "stale persisted payload",
+        source: "sanitized-fallback",
+        capturedAt: 1,
+      },
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(agentSpy).toHaveBeenCalledTimes(1);
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: { message?: string } };
+    const msg = call?.params?.message ?? "";
+    expect(msg).toContain("result from child a");
+    expect(msg).not.toContain("stale persisted payload");
+    expect(msg).not.toContain("placeholder waiting text that should be ignored");
+  });
+
   it("dedupes stale direct-child rows before building child completion findings", async () => {
     subagentRegistryMock.countPendingDescendantRuns.mockReturnValue(0);
     subagentRegistryMock.listSubagentRunsForRequester.mockImplementation(

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -1702,7 +1702,7 @@ describe("subagent announce formatting", () => {
     expect(new Set(idempotencyKeys).size).toBe(2);
   });
 
-  it("prefers direct delivery first for completion-mode and then queues on direct failure", async () => {
+  it("prefers queue delivery first for active completion-mode parents", async () => {
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
     embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
     sessionStore = {
@@ -1714,10 +1714,6 @@ describe("subagent announce formatting", () => {
         queueDebounceMs: 0,
       },
     };
-    agentSpy
-      .mockRejectedValueOnce(new Error("direct delivery unavailable"))
-      .mockResolvedValueOnce({ runId: "run-main", status: "ok" });
-
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:worker",
       childRunId: "run-completion-direct-fallback",
@@ -1729,14 +1725,12 @@ describe("subagent announce formatting", () => {
 
     expect(didAnnounce).toBe(true);
     expect(sendSpy).not.toHaveBeenCalled();
-    expect(agentSpy).toHaveBeenCalledTimes(2);
+    await vi.waitFor(() => {
+      expect(agentSpy).toHaveBeenCalledTimes(1);
+    });
     expect(agentSpy.mock.calls[0]?.[0]).toMatchObject({
       method: "agent",
       params: { sessionKey: "agent:main:main", channel: "whatsapp", to: "+1555", deliver: true },
-    });
-    expect(agentSpy.mock.calls[1]?.[0]).toMatchObject({
-      method: "agent",
-      params: { sessionKey: "agent:main:main" },
     });
   });
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -142,7 +142,7 @@ function tryExtractNamedUserDeliverySection(text: string): string {
   return (endMatch ? afterMarker.slice(0, endMatch.index) : afterMarker).trim();
 }
 
-function extractUserFacingCompletionPayload(text: string): {
+export function extractUserFacingCompletionPayload(text: string): {
   text: string;
   source: StoredUserDeliveryPayload["source"];
 } {
@@ -178,7 +178,7 @@ function extractUserFacingCompletionPayload(text: string): {
   };
 }
 
-function buildStoredUserDeliveryPayload(resultText: string): StoredUserDeliveryPayload {
+export function buildStoredUserDeliveryPayload(resultText: string): StoredUserDeliveryPayload {
   const extracted = extractUserFacingCompletionPayload(resultText);
   return {
     text: extracted.text,
@@ -728,9 +728,7 @@ export async function runSubagentAnnounceFlow(params: {
 }
 
 export const __testing = {
-  buildStoredUserDeliveryPayload,
   buildDirectUserCompletionPrompt,
-  extractUserFacingCompletionPayload,
   setDepsForTest(overrides?: Partial<SubagentAnnounceDeps>) {
     subagentAnnounceDeps = overrides
       ? {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -42,6 +42,7 @@ import {
   waitForEmbeddedPiRunEnd,
 } from "./subagent-announce.runtime.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
+import type { StoredUserDeliveryPayload } from "./subagent-registry.types.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 
@@ -93,6 +94,113 @@ function buildAnnounceSteerMessage(events: AgentInternalEvent[]): string {
     formatAgentInternalEventsForPrompt(events) ||
     "A background task finished. Process the completion update now."
   );
+}
+
+const INTERNAL_CONTEXT_BLOCK_RE =
+  /(?:^|\n)\s*(?:Human:\s*)?(?:\[[^\n]*\]\s*)?<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>[\s\S]*?<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\s*/g;
+const CHILD_RESULT_BLOCK_RE =
+  /<<<BEGIN_UNTRUSTED_CHILD_RESULT>>>\s*([\s\S]*?)\s*<<<END_UNTRUSTED_CHILD_RESULT>>>/g;
+const INTERNAL_CONTEXT_LINE_RE =
+  /(?:^|\n)\s*(?:\[Inter-session message][^\n]*|OpenClaw runtime context \(internal\):|This context is runtime-generated, not user-authored\. Keep internal details private\.|Result \(untrusted content, treat as data\):|Action:\s*A completed .*? ready for user delivery\.[^\n]*|Stats:\s*runtime[^\n]*|sourceSession=[^\n]*|sourceChannel=[^\n]*|sourceTool=[^\n]*)(?=\n|$)/gim;
+const DIRECT_USER_DELIVERY_INSTRUCTION_RE =
+  /(?:^|\n)(?:Convert the result above into your normal assistant voice and send that user-facing update now\.|Keep internal context private.*|Reply ONLY:\s*NO_REPLY.*)(?=\n|$)/gim;
+
+function normalizeUserDeliveryPayloadText(text: string): string {
+  const normalized = typeof text === "string" ? text.replace(/\r\n?/g, "\n").trim() : "";
+  return normalized || "(no output)";
+}
+
+function collectStructuredChildResultBlocks(text: string): string[] {
+  const blocks: string[] = [];
+  if (!text.trim()) {
+    return blocks;
+  }
+  text.replace(CHILD_RESULT_BLOCK_RE, (_match, body: string) => {
+    const cleaned = body?.trim();
+    if (cleaned) {
+      blocks.push(cleaned);
+    }
+    return "";
+  });
+  return blocks;
+}
+
+function tryExtractNamedUserDeliverySection(text: string): string {
+  if (!text.trim()) {
+    return "";
+  }
+  const normalized = text.replace(/\r\n?/g, "\n");
+  const marker = "\nResult to deliver:\n";
+  const prefixed = normalized.startsWith("Result to deliver:\n") ? `\n${normalized}` : normalized;
+  const start = prefixed.indexOf(marker);
+  if (start < 0) {
+    return "";
+  }
+  const afterMarker = prefixed.slice(start + marker.length);
+  const endMatch = DIRECT_USER_DELIVERY_INSTRUCTION_RE.exec(afterMarker);
+  DIRECT_USER_DELIVERY_INSTRUCTION_RE.lastIndex = 0;
+  return (endMatch ? afterMarker.slice(0, endMatch.index) : afterMarker).trim();
+}
+
+function extractUserFacingCompletionPayload(text: string): {
+  text: string;
+  source: StoredUserDeliveryPayload["source"];
+} {
+  const raw = typeof text === "string" ? text : "";
+  if (!raw.trim()) {
+    return {
+      text: "(no output)",
+      source: "empty",
+    };
+  }
+  const childBlocks = collectStructuredChildResultBlocks(raw);
+  if (childBlocks.length > 0) {
+    return {
+      text: normalizeUserDeliveryPayloadText(childBlocks.join("\n\n")),
+      source: "child-blocks",
+    };
+  }
+  const namedSection = tryExtractNamedUserDeliverySection(raw);
+  if (namedSection) {
+    return {
+      text: normalizeUserDeliveryPayloadText(namedSection),
+      source: "named-section",
+    };
+  }
+  let cleaned = raw;
+  cleaned = cleaned.replace(INTERNAL_CONTEXT_BLOCK_RE, "\n");
+  cleaned = cleaned.replace(CHILD_RESULT_BLOCK_RE, "$1");
+  cleaned = cleaned.replace(INTERNAL_CONTEXT_LINE_RE, "\n");
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n").trim();
+  return {
+    text: normalizeUserDeliveryPayloadText(cleaned),
+    source: "sanitized-fallback",
+  };
+}
+
+function buildStoredUserDeliveryPayload(resultText: string): StoredUserDeliveryPayload {
+  const extracted = extractUserFacingCompletionPayload(resultText);
+  return {
+    text: extracted.text,
+    source: extracted.source,
+    capturedAt: Date.now(),
+  };
+}
+
+function buildDirectUserCompletionPrompt(params: {
+  announceType: SubagentAnnounceType;
+  resultText: string;
+}): string {
+  const payload = extractUserFacingCompletionPayload(params.resultText);
+  return [
+    `A completed ${params.announceType} is ready for user delivery.`,
+    "",
+    "Result to deliver:",
+    payload.text,
+    "",
+    "Convert the result above into your normal assistant voice and send that user-facing update now.",
+    "Keep internal context private and do not mention system/log/stats/session details.",
+  ].join("\n");
 }
 
 function hasUsableSessionEntry(entry: unknown): boolean {
@@ -228,11 +336,13 @@ export async function runSubagentAnnounceFlow(params: {
   timeoutMs: number;
   cleanup: "delete" | "keep";
   roundOneReply?: string;
+  roundOneUserDeliveryPayload?: StoredUserDeliveryPayload | null;
   /**
    * Fallback text preserved from the pre-wake run when a wake continuation
    * completes with NO_REPLY despite an earlier final summary already existing.
    */
   fallbackReply?: string;
+  fallbackUserDeliveryPayload?: StoredUserDeliveryPayload | null;
   waitForCompletion?: boolean;
   startedAt?: number;
   endedAt?: number;
@@ -366,6 +476,8 @@ export async function runSubagentAnnounceFlow(params: {
       }
     }
 
+    let persistedUserDeliveryPayload = params.roundOneUserDeliveryPayload ?? undefined;
+
     if (!childCompletionFindings) {
       const fallbackReply = normalizeOptionalString(params.fallbackReply);
       const fallbackIsSilent =
@@ -417,6 +529,9 @@ export async function runSubagentAnnounceFlow(params: {
             return true;
           }
           reply = cleaned;
+          persistedUserDeliveryPayload =
+            params.fallbackUserDeliveryPayload ??
+            (reply ? buildStoredUserDeliveryPayload(reply) : undefined);
         } else {
           return true;
         }
@@ -429,11 +544,17 @@ export async function runSubagentAnnounceFlow(params: {
               return true;
             }
             reply = cleanedFallback;
+            persistedUserDeliveryPayload =
+              params.fallbackUserDeliveryPayload ??
+              (reply ? buildStoredUserDeliveryPayload(reply) : undefined);
           } else {
             return true;
           }
         } else {
           reply = cleaned;
+          if (!persistedUserDeliveryPayload && reply) {
+            persistedUserDeliveryPayload = buildStoredUserDeliveryPayload(reply);
+          }
         }
       }
     }
@@ -485,6 +606,10 @@ export async function runSubagentAnnounceFlow(params: {
       }
     }
 
+    const userDeliveryPayload = !requesterIsSubagent
+      ? persistedUserDeliveryPayload ?? buildStoredUserDeliveryPayload(findings)
+      : undefined;
+    const usePlainUserDeliveryPrompt = expectsCompletionMessage && !requesterIsSubagent;
     const replyInstruction = buildAnnounceReplyInstruction({
       requesterIsSubagent,
       announceType,
@@ -506,11 +631,17 @@ export async function runSubagentAnnounceFlow(params: {
         status: outcome.status,
         statusLabel,
         result: findings,
+        userDeliveryPayload,
         statsLine,
         replyInstruction,
       },
     ];
-    const triggerMessage = buildAnnounceSteerMessage(internalEvents);
+    const triggerMessage = usePlainUserDeliveryPrompt
+      ? buildDirectUserCompletionPrompt({
+          announceType,
+          resultText: userDeliveryPayload?.text ?? findings,
+        })
+      : buildAnnounceSteerMessage(internalEvents);
 
     // Send to the requester session. For nested subagents this is an internal
     // follow-up injection (deliver=false) so the orchestrator receives it.
@@ -597,6 +728,9 @@ export async function runSubagentAnnounceFlow(params: {
 }
 
 export const __testing = {
+  buildStoredUserDeliveryPayload,
+  buildDirectUserCompletionPrompt,
+  extractUserFacingCompletionPayload,
   setDepsForTest(overrides?: Partial<SubagentAnnounceDeps>) {
     subagentAnnounceDeps = overrides
       ? {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -607,7 +607,9 @@ export async function runSubagentAnnounceFlow(params: {
     }
 
     const userDeliveryPayload = !requesterIsSubagent
-      ? persistedUserDeliveryPayload ?? buildStoredUserDeliveryPayload(findings)
+      ? childCompletionFindings?.trim()
+        ? buildStoredUserDeliveryPayload(findings)
+        : persistedUserDeliveryPayload ?? buildStoredUserDeliveryPayload(findings)
       : undefined;
     const usePlainUserDeliveryPrompt = expectsCompletionMessage && !requesterIsSubagent;
     const replyInstruction = buildAnnounceReplyInstruction({

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -10,10 +10,10 @@ import {
 } from "../tasks/task-executor.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
 import {
+  buildStoredUserDeliveryPayload,
   captureSubagentCompletionReply,
   runSubagentAnnounceFlow,
   type SubagentRunOutcome,
-  __testing as subagentAnnounceTesting,
 } from "./subagent-announce.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -185,7 +185,7 @@ export function createSubagentRegistryLifecycleController(params: {
       });
       entry.frozenResultText = captured?.trim() ? capFrozenResultText(captured) : null;
       entry.userDeliveryPayload = entry.frozenResultText
-        ? subagentAnnounceTesting.buildStoredUserDeliveryPayload(entry.frozenResultText)
+        ? buildStoredUserDeliveryPayload(entry.frozenResultText)
         : null;
     } catch {
       entry.frozenResultText = null;
@@ -245,7 +245,7 @@ export function createSubagentRegistryLifecycleController(params: {
       }
       entry.frozenResultText = nextFrozen;
       entry.frozenResultCapturedAt = capturedAt;
-      entry.userDeliveryPayload = subagentAnnounceTesting.buildStoredUserDeliveryPayload(nextFrozen);
+      entry.userDeliveryPayload = buildStoredUserDeliveryPayload(nextFrozen);
       changed = true;
     }
     if (changed) {

--- a/src/agents/subagent-registry-lifecycle.ts
+++ b/src/agents/subagent-registry-lifecycle.ts
@@ -13,6 +13,7 @@ import {
   captureSubagentCompletionReply,
   runSubagentAnnounceFlow,
   type SubagentRunOutcome,
+  __testing as subagentAnnounceTesting,
 } from "./subagent-announce.js";
 import {
   SUBAGENT_ENDED_REASON_COMPLETE,
@@ -183,8 +184,12 @@ export function createSubagentRegistryLifecycleController(params: {
         waitForReply: entry.expectsCompletionMessage === true,
       });
       entry.frozenResultText = captured?.trim() ? capFrozenResultText(captured) : null;
+      entry.userDeliveryPayload = entry.frozenResultText
+        ? subagentAnnounceTesting.buildStoredUserDeliveryPayload(entry.frozenResultText)
+        : null;
     } catch {
       entry.frozenResultText = null;
+      entry.userDeliveryPayload = null;
     }
     entry.frozenResultCapturedAt = Date.now();
     return true;
@@ -240,6 +245,7 @@ export function createSubagentRegistryLifecycleController(params: {
       }
       entry.frozenResultText = nextFrozen;
       entry.frozenResultCapturedAt = capturedAt;
+      entry.userDeliveryPayload = subagentAnnounceTesting.buildStoredUserDeliveryPayload(nextFrozen);
       changed = true;
     }
     if (changed) {
@@ -406,6 +412,7 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.wakeOnDescendantSettle = undefined;
       entry.fallbackFrozenResultText = undefined;
       entry.fallbackFrozenResultCapturedAt = undefined;
+      entry.fallbackUserDeliveryPayload = undefined;
       const completionReason = resolveCleanupCompletionReason(entry);
       await emitCompletionEndedHookIfNeeded(entry, completionReason);
       const shouldDeleteAttachments = cleanup === "delete" || !entry.retainAttachmentsOnKeep;
@@ -415,6 +422,7 @@ export function createSubagentRegistryLifecycleController(params: {
       if (cleanup === "delete") {
         entry.frozenResultText = undefined;
         entry.frozenResultCapturedAt = undefined;
+        entry.userDeliveryPayload = undefined;
       }
       completeCleanupBookkeeping({
         runId,
@@ -461,6 +469,7 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.wakeOnDescendantSettle = undefined;
       entry.fallbackFrozenResultText = undefined;
       entry.fallbackFrozenResultCapturedAt = undefined;
+      entry.fallbackUserDeliveryPayload = undefined;
       const shouldDeleteAttachments = cleanup === "delete" || !entry.retainAttachmentsOnKeep;
       if (shouldDeleteAttachments) {
         await safeRemoveAttachmentsDir(entry);
@@ -533,7 +542,9 @@ export function createSubagentRegistryLifecycleController(params: {
         timeoutMs: params.subagentAnnounceTimeoutMs,
         cleanup: entry.cleanup,
         roundOneReply: entry.frozenResultText ?? undefined,
+        roundOneUserDeliveryPayload: entry.userDeliveryPayload ?? undefined,
         fallbackReply: entry.fallbackFrozenResultText ?? undefined,
+        fallbackUserDeliveryPayload: entry.fallbackUserDeliveryPayload ?? undefined,
         waitForCompletion: false,
         startedAt: entry.startedAt,
         endedAt: entry.endedAt,
@@ -580,6 +591,7 @@ export function createSubagentRegistryLifecycleController(params: {
       entry.cleanupHandled = false;
       entry.cleanupCompletedAt = undefined;
       entry.completionAnnouncedAt = undefined;
+      entry.deliveryClaim = undefined;
       mutated = true;
     }
 

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -237,13 +237,18 @@ export function createSubagentRunManager(params: {
       outcome: undefined,
       frozenResultText: undefined,
       frozenResultCapturedAt: undefined,
+      userDeliveryPayload: undefined,
       fallbackFrozenResultText: preserveFrozenResultFallback ? source.frozenResultText : undefined,
       fallbackFrozenResultCapturedAt: preserveFrozenResultFallback
         ? source.frozenResultCapturedAt
         : undefined,
+      fallbackUserDeliveryPayload: preserveFrozenResultFallback
+        ? source.userDeliveryPayload
+        : undefined,
       cleanupCompletedAt: undefined,
       cleanupHandled: false,
       completionAnnouncedAt: undefined,
+      deliveryClaim: undefined,
       suppressAnnounceReason: undefined,
       announceRetryCount: undefined,
       lastAnnounceRetryAt: undefined,
@@ -322,6 +327,9 @@ export function createSubagentRunManager(params: {
       archiveAtMs,
       cleanupHandled: false,
       completionAnnouncedAt: undefined,
+      deliveryClaim: undefined,
+      userDeliveryPayload: undefined,
+      fallbackUserDeliveryPayload: undefined,
       wakeOnDescendantSettle: undefined,
       attachmentsDir: registerParams.attachmentsDir,
       attachmentsRootDir: registerParams.attachmentsRootDir,

--- a/src/agents/subagent-registry.types.ts
+++ b/src/agents/subagent-registry.types.ts
@@ -3,6 +3,27 @@ import type { SubagentRunOutcome } from "./subagent-announce-output.js";
 import type { SubagentLifecycleEndedReason } from "./subagent-lifecycle-events.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
 
+export type StoredUserDeliveryPayloadSource =
+  | "empty"
+  | "child-blocks"
+  | "named-section"
+  | "sanitized-fallback";
+
+export type StoredUserDeliveryPayload = {
+  text: string;
+  source: StoredUserDeliveryPayloadSource;
+  capturedAt: number;
+};
+
+export type SubagentDeliveryClaim = {
+  announceId: string;
+  state: "claimed" | "delivered";
+  token: string;
+  path: "queued" | "steered" | "direct" | "none";
+  claimedAt: number;
+  updatedAt: number;
+};
+
 export type SubagentRunRecord = {
   runId: string;
   childSessionKey: string;
@@ -38,6 +59,9 @@ export type SubagentRunRecord = {
   fallbackFrozenResultCapturedAt?: number;
   endedHookEmittedAt?: number;
   completionAnnouncedAt?: number;
+  deliveryClaim?: SubagentDeliveryClaim;
+  userDeliveryPayload?: StoredUserDeliveryPayload | null;
+  fallbackUserDeliveryPayload?: StoredUserDeliveryPayload | null;
   attachmentsDir?: string;
   attachmentsRootDir?: string;
   retainAttachmentsOnKeep?: boolean;


### PR DESCRIPTION
## Summary
- persist a per-run delivery claim and user-safe delivery payload for subagent completions
- route active-parent completion announces queue-first with fail-closed semantics instead of direct-first fallback behavior
- harden iMessage delivery normalization and chunking to avoid leaking internal context and to preserve multiline/code payloads safely

## Why
A production bug leaked internal subagent/control-plane envelopes into iMessage, and a second bug allowed duplicate user-visible completion delivery when a parent session was active while a child completion also delivered directly.

This change moves the fix to source-level architecture instead of relying on downstream `dist` patching:
- separates persisted user-delivery payloads from internal orchestration text
- makes announce delivery idempotent across queue/direct transitions with a persisted run claim
- prevents direct external delivery while an active parent session can still accept the completion through its announce queue

## Implementation Notes
- add `deliveryClaim`, `userDeliveryPayload`, and `fallbackUserDeliveryPayload` to subagent run records
- extract user-facing completion payloads from structured child-result blocks first, then named delivery sections, then sanitized fallback cleanup
- persist payload/claim state through completion freeze, cleanup retries, and steer restarts
- normalize iMessage text before send, close dangling code fences, and chunk around non-code boundaries when possible

## Verification
- `corepack pnpm exec vitest run src/agents/subagent-announce-dispatch.test.ts src/agents/subagent-announce.format.e2e.test.ts`
- `corepack pnpm exec vitest run src/agents/subagent-registry-lifecycle.test.ts src/agents/subagent-announce-delivery.test.ts`
- `corepack pnpm exec vitest run extensions/imessage/src/monitor/sanitize-outbound.test.ts extensions/imessage/src/monitor/deliver.test.ts`
