### PR TITLE
fix(agents): mark redacted session history output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2622,6 +2622,7 @@ Docs: https://docs.openclaw.ai
 - Slack: fix outbound replies failing with "unresolved SecretRef" for accounts configured via `file` or `exec` secret sources; the send path now tolerates the runtime snapshot retaining an unresolved channel SecretRef when a boot-resolved token override is already available. (#68954) Thanks @openperf.
 - Control UI/device pairing: explain scope and role approval upgrades during reconnects, and show requested versus approved access in the Control UI and `openclaw devices` so broader reconnects no longer look like lost pairings. (#69221) Thanks @obviyus.
 - Gateway/Control UI: surface pending scope, role, and device-metadata pairing approvals in auth errors and Control UI hints so broader reconnects no longer look like random auth breakage. (#69226) Thanks @obviyus.
+- Redaction/agent-visible: surface a machine-readable `[OPENCLAW-REDACTED]` marker alongside the existing `contentRedacted: true` structured flag on the `sessions_history` tool response when OpenClaw masks secret-looking values, and add a shared `redactSensitiveTextForAgent` helper so any future agent-visible tool output can append the same marker. The notice explicitly tells agents not to write redacted placeholders back to config files, which mitigates accidental secret clobbering when agents read-modify-write `openclaw.json` or `.env`. (#68425)
 
 ## 2026.4.19-beta.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 - Codex app-server: keep native web search observations out of mirrored chat transcripts while preserving tool progress telemetry. Fixes #85109. Thanks @ugitmebaby.
 - OpenCode Go: strip unsupported Kimi reasoning replay fields before provider requests so repeated `kimi-k2.6` turns do not fail schema validation. Fixes #83812. Thanks @Sleeck.
 - Browser/CDP: add a WSL2 portproxy self-loop hint when Chrome DevTools endpoints accept connections but return an empty HTTP reply. Fixes #59209. Thanks @Owlock.
+- Agents/tools: add a machine-readable `sessions_history.notice` marker when returned history content is redacted so agents do not write redacted placeholders back to config or secret files. (#68425, #68483) Thanks @lyfuci.
 - Agents/OpenAI: preserve structured provider error code, type, and redacted body metadata on boundary-aware transport failures.
 - Doctor/Codex: point native Codex asset warnings at the canonical `openclaw migrate plan codex` preview command. Fixes #84948. Thanks @markoa.
 - CLI/models: make `capability model auth logout --agent` remove auth profiles from the selected non-default agent store. Fixes #85092. Thanks @islandpreneur007.

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -683,14 +683,52 @@ describe("sessions tools", () => {
       truncated?: boolean;
       contentTruncated?: boolean;
       contentRedacted?: boolean;
+      notice?: string;
     };
     expect(details.contentRedacted).toBe(true);
     expect(details.contentTruncated).toBe(false);
     expect(details.truncated).toBe(false);
+    // When content is redacted, surface a machine-readable notice so agents can
+    // detect redaction from the response text itself, not only the structured flag.
+    expect(typeof details.notice).toBe("string");
+    expect(details.notice).toContain("[OPENCLAW-REDACTED]");
+    expect(details.notice).toContain("do NOT write this output back");
     const msg = details.messages?.[0] as { content?: Array<{ type?: string; text?: string }> };
     const textBlock = msg?.content?.find((b) => b.type === "text");
     expect(typeof textBlock?.text).toBe("string");
     expect(textBlock?.text).not.toContain("sk-1234567890abcdef1234");
+  });
+
+  it("sessions_history omits the redaction notice when nothing was redacted", async () => {
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "just regular content with no secrets" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-no-redact-1", { sessionKey: "main" });
+    const details = result.details as {
+      contentRedacted?: boolean;
+      notice?: string;
+    };
+    expect(details.contentRedacted).toBe(false);
+    expect(details.notice).toBeUndefined();
   });
 
   it("sessions_history sets both contentRedacted and contentTruncated independently", async () => {

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -731,6 +731,62 @@ describe("sessions tools", () => {
     expect(details.notice).toBeUndefined();
   });
 
+  it("sessions_history omits the redaction notice when redacted messages are dropped by the byte cap", async () => {
+    // Regression for Codex P2 on #68483: contentRedacted + notice must be derived from the
+    // payload that is actually returned, not from the full pre-cap history. Otherwise an
+    // older redacted message that the byte cap dropped still flips the flag and the notice
+    // fires with "in this output" even though nothing in the final output is redacted.
+    callGatewayMock.mockReset();
+    const padding = "y".repeat(8_000);
+    // First message contains a secret and will be redacted; later messages push it out past
+    // the sessions_history byte cap so the returned payload only contains non-redacted ones.
+    const oldMessages = Array.from({ length: 30 }, (_, idx) => ({
+      role: "assistant" as const,
+      content: [
+        {
+          type: "text",
+          text:
+            idx === 0
+              ? `leaking sk-1234567890abcdef1234 ${padding}`
+              : `safe message ${idx} ${padding}`,
+        },
+      ],
+    }));
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return { messages: oldMessages };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-cap-drops-redacted", {
+      sessionKey: "main",
+      includeTools: true,
+    });
+    const details = result.details as {
+      messages?: Array<Record<string, unknown>>;
+      truncated?: boolean;
+      contentRedacted?: boolean;
+      notice?: string;
+    };
+
+    expect(details.truncated).toBe(true);
+    // The redacted message was dropped; the returned payload has no redaction marker.
+    expect(details.contentRedacted).toBe(false);
+    expect(details.notice).toBeUndefined();
+    // Sanity check: the kept messages don't contain the redacted placeholder from the dropped message.
+    const allKeptText = JSON.stringify(details.messages ?? []);
+    expect(allKeptText).not.toContain("sk-12");
+    expect(allKeptText).not.toContain("leaking");
+  });
+
   it("sessions_history sets both contentRedacted and contentTruncated independently", async () => {
     callGatewayMock.mockReset();
     const longPrefix = "safe text ".repeat(420);

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -32,6 +32,7 @@ vi.mock("../config/config.js", () => ({
 }));
 
 import "./test-helpers/fast-openclaw-tools-sessions.js";
+import { OPENCLAW_REDACTED_MARKER, OPENCLAW_REDACTED_NOTICE } from "../logging/redact.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { testing as agentStepTesting } from "./tools/agent-step.js";
 import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
@@ -775,14 +776,94 @@ describe("sessions tools", () => {
       truncated?: boolean;
       contentTruncated?: boolean;
       contentRedacted?: boolean;
+      notice?: string;
     };
     expect(details.contentRedacted).toBe(true);
     expect(details.contentTruncated).toBe(false);
     expect(details.truncated).toBe(false);
+    expect(details.notice).toBe(`${OPENCLAW_REDACTED_MARKER} ${OPENCLAW_REDACTED_NOTICE}`);
     const msg = details.messages?.[0] as { content?: Array<{ type?: string; text?: string }> };
     const textBlock = msg?.content?.find((b) => b.type === "text");
     expect(typeof textBlock?.text).toBe("string");
     expect(textBlock?.text).not.toContain("sk-1234567890abcdef1234");
+  });
+
+  it("sessions_history omits redaction notice when no returned content is redacted", async () => {
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return {
+          messages: [
+            {
+              role: "assistant",
+              content: [{ type: "text", text: "regular content" }],
+            },
+          ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-no-redact-1", { sessionKey: "main" });
+    const details = result.details as {
+      contentRedacted?: boolean;
+      notice?: string;
+    };
+    expect(details.contentRedacted).toBe(false);
+    expect(details.notice).toBeUndefined();
+  });
+
+  it("sessions_history derives redaction notice from the returned capped payload", async () => {
+    callGatewayMock.mockReset();
+    const padding = "y".repeat(8_000);
+    const oldMessages = Array.from({ length: 30 }, (_, idx) => ({
+      role: "assistant" as const,
+      content: [
+        {
+          type: "text",
+          text:
+            idx === 0
+              ? `leaking sk-1234567890abcdef1234 ${padding}`
+              : `safe message ${idx} ${padding}`,
+        },
+      ],
+    }));
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "chat.history") {
+        return { messages: oldMessages };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools().find((candidate) => candidate.name === "sessions_history");
+    if (!tool) {
+      throw new Error("missing sessions_history tool");
+    }
+
+    const result = await tool.execute("call-cap-drops-redacted", {
+      sessionKey: "main",
+      includeTools: true,
+    });
+    const details = result.details as {
+      messages?: Array<Record<string, unknown>>;
+      truncated?: boolean;
+      contentRedacted?: boolean;
+      notice?: string;
+    };
+
+    expect(details.truncated).toBe(true);
+    expect(details.contentRedacted).toBe(false);
+    expect(details.notice).toBeUndefined();
+    const keptText = JSON.stringify(details.messages ?? []);
+    expect(keptText).not.toContain("sk-1234567890abcdef1234");
+    expect(keptText).not.toContain("leaking");
   });
 
   it("sessions_history sets both contentRedacted and contentTruncated independently", async () => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -260,7 +260,6 @@ export function createSessionsHistoryTool(opts?: {
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
-      const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);
       const cappedMessages = capArrayByJsonBytes(
         sanitizedMessages.map((entry) => entry.message),
         SESSIONS_HISTORY_MAX_BYTES,
@@ -271,6 +270,14 @@ export function createSessionsHistoryTool(opts?: {
         bytes: cappedMessages.bytes,
         maxBytes: SESSIONS_HISTORY_MAX_BYTES,
       });
+      // Derive contentRedacted from the payload we are *returning* (post-cap + hard-cap),
+      // not from the full sanitized set. Otherwise the notice fires for redactions that
+      // happened in messages that were dropped by byte-cap or replaced by the hard-cap
+      // placeholder — a false positive for agents consuming the final payload.
+      const hardenedItemSet = new Set(hardened.items);
+      const contentRedacted = sanitizedMessages.some(
+        (entry) => hardenedItemSet.has(entry.message) && entry.redacted,
+      );
       return jsonResult({
         sessionKey: displayKey,
         messages: hardened.items,

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -4,7 +4,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
-import { redactToolPayloadText } from "../../logging/redact.js";
+import {
+  OPENCLAW_REDACTED_MARKER,
+  OPENCLAW_REDACTED_NOTICE,
+  redactToolPayloadText,
+} from "../../logging/redact.js";
 import { readStringValue } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
@@ -274,6 +278,12 @@ export function createSessionsHistoryTool(opts?: {
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,
         contentRedacted,
+        // Surface the structured redaction flag as a machine-readable marker plus the
+        // shared guidance body so agents that scan text (not just structured fields)
+        // can still detect redaction and avoid writing placeholders back to config.
+        ...(contentRedacted
+          ? { notice: `${OPENCLAW_REDACTED_MARKER} ${OPENCLAW_REDACTED_NOTICE}` }
+          : {}),
         bytes: hardened.bytes,
       });
     },

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -4,7 +4,11 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { capArrayByJsonBytes } from "../../gateway/session-utils.fs.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
-import { redactToolPayloadText } from "../../logging/redact.js";
+import {
+  OPENCLAW_REDACTED_MARKER,
+  OPENCLAW_REDACTED_NOTICE,
+  redactToolPayloadText,
+} from "../../logging/redact.js";
 import { readStringValue } from "../../shared/string-coerce.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import {
@@ -260,7 +264,6 @@ export function createSessionsHistoryTool(opts?: {
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);
       const sanitizedMessages = selectedMessages.map((message) => sanitizeHistoryMessage(message));
       const contentTruncated = sanitizedMessages.some((entry) => entry.truncated);
-      const contentRedacted = sanitizedMessages.some((entry) => entry.redacted);
       const cappedMessages = capArrayByJsonBytes(
         sanitizedMessages.map((entry) => entry.message),
         SESSIONS_HISTORY_MAX_BYTES,
@@ -271,6 +274,10 @@ export function createSessionsHistoryTool(opts?: {
         bytes: cappedMessages.bytes,
         maxBytes: SESSIONS_HISTORY_MAX_BYTES,
       });
+      const hardenedItemSet = new Set(hardened.items);
+      const contentRedacted = sanitizedMessages.some(
+        (entry) => hardenedItemSet.has(entry.message) && entry.redacted,
+      );
       return jsonResult({
         sessionKey: displayKey,
         messages: hardened.items,
@@ -278,6 +285,9 @@ export function createSessionsHistoryTool(opts?: {
         droppedMessages: droppedMessages || hardened.hardCapped,
         contentTruncated,
         contentRedacted,
+        ...(contentRedacted
+          ? { notice: `${OPENCLAW_REDACTED_MARKER} ${OPENCLAW_REDACTED_NOTICE}` }
+          : {}),
         bytes: hardened.bytes,
       });
     },

--- a/src/logging/redact.test.ts
+++ b/src/logging/redact.test.ts
@@ -4,9 +4,12 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   getDefaultRedactPatterns,
+  OPENCLAW_REDACTED_MARKER,
+  OPENCLAW_REDACTED_NOTICE,
   redactSensitiveFieldValue,
   redactSensitiveLines,
   redactSensitiveText,
+  redactSensitiveTextForAgent,
   resolveRedactOptions,
 } from "./redact.js";
 
@@ -418,5 +421,47 @@ describe("redactSensitiveLines", () => {
     expect(joined).toContain("-----END PRIVATE KEY-----");
     expect(joined).toContain("…redacted…");
     expect(joined).not.toContain("ABCDEF1234567890");
+  });
+});
+
+describe("redactSensitiveTextForAgent", () => {
+  it("appends the machine-readable marker when redaction actually fires", () => {
+    const input = '{"apiKey":"abcdef1234567890ghij","model":"foo"}';
+    const output = redactSensitiveTextForAgent(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toContain('"apiKey":"abcdef…ghij"');
+    expect(output).toContain(OPENCLAW_REDACTED_MARKER);
+    expect(output).toContain(OPENCLAW_REDACTED_NOTICE);
+    // The marker should come after the redacted payload, separated by a blank line.
+    expect(output.indexOf(OPENCLAW_REDACTED_MARKER)).toBeGreaterThan(
+      output.indexOf('"model":"foo"'),
+    );
+    expect(output).toMatch(/\n\n\[OPENCLAW-REDACTED\] /);
+  });
+
+  it("returns the input unchanged when no redaction fires", () => {
+    const input = "just a regular tool output with no secrets";
+    const output = redactSensitiveTextForAgent(input, {
+      mode: "tools",
+      patterns: defaults,
+    });
+    expect(output).toBe(input);
+    expect(output).not.toContain(OPENCLAW_REDACTED_MARKER);
+  });
+
+  it("returns the input unchanged when mode is off, even if secrets are present", () => {
+    const input = '{"apiKey":"abcdef1234567890ghij"}';
+    const output = redactSensitiveTextForAgent(input, {
+      mode: "off",
+      patterns: defaults,
+    });
+    expect(output).toBe(input);
+    expect(output).not.toContain(OPENCLAW_REDACTED_MARKER);
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(redactSensitiveTextForAgent("", { mode: "tools", patterns: defaults })).toBe("");
   });
 });

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -205,6 +205,46 @@ export function redactSensitiveFieldValue(key: string, value: string): string {
   return value;
 }
 
+/**
+ * Machine-readable marker appended to agent-visible text when OpenClaw redacts
+ * secret-looking values. The marker is deliberately stable so downstream
+ * tooling, agents, and operators can detect redaction from the text alone.
+ * Keep this string stable; external docs, agents, and contracts reference it.
+ */
+export const OPENCLAW_REDACTED_MARKER = "[OPENCLAW-REDACTED]";
+
+/**
+ * Standard warning body used with {@link OPENCLAW_REDACTED_MARKER}. Stays
+ * stable so agents and external detection can match on the marker plus a
+ * short, documented guidance tail.
+ */
+export const OPENCLAW_REDACTED_NOTICE =
+  'OpenClaw redacted one or more secret-looking values (apiKey, token, secret, password, bearer) in this output. Treat redacted placeholders (for example "***" or "abc123…xyz") as opaque markers: do NOT write this output back to config files, .env files, or any on-disk secret, and do not echo the placeholder as a real value in subsequent tool calls. Re-fetch the real value from environment variables or the authoritative config source when you need it.';
+
+/**
+ * Redact text for agent-visible tool outputs. When redaction fires, append a
+ * machine-readable marker ({@link OPENCLAW_REDACTED_MARKER}) plus a short
+ * guidance note so the agent can detect redaction even when the placeholder
+ * itself (e.g. `"***"`) is not unambiguous on its own.
+ *
+ * Logs, UI labels, and other non-agent consumers should keep using
+ * {@link redactSensitiveText} to avoid marker pollution in those surfaces.
+ */
+export function redactSensitiveTextForAgent(text: string, options?: RedactOptions): string {
+  if (!text) {
+    return text;
+  }
+  const resolved = resolveRedactOptions(options);
+  if (resolved.mode === "off" || !resolved.patterns.length) {
+    return text;
+  }
+  const redacted = redactText(text, resolved.patterns);
+  if (redacted === text) {
+    return text;
+  }
+  return `${redacted}\n\n${OPENCLAW_REDACTED_MARKER} ${OPENCLAW_REDACTED_NOTICE}`;
+}
+
 export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_PATTERNS];
 }

--- a/src/logging/redact.ts
+++ b/src/logging/redact.ts
@@ -358,6 +358,11 @@ export function redactSecrets<T>(value: T): T {
   return redactStructuredSecretValue("", value, new WeakSet<object>(), options) as T;
 }
 
+export const OPENCLAW_REDACTED_MARKER = "[OPENCLAW-REDACTED]";
+
+export const OPENCLAW_REDACTED_NOTICE =
+  'OpenClaw redacted one or more secret-looking values in this output. Treat redacted placeholders such as "***" or "abc123…xyz" as opaque markers: do not write them back to config files, .env files, or on-disk secrets. Re-fetch the real value from the authoritative source when you need it.';
+
 export function getDefaultRedactPatterns(): string[] {
   return [...DEFAULT_REDACT_PATTERNS];
 }


### PR DESCRIPTION
## Summary
- rewrites the redaction-marker PR into a smaller API-focused `sessions_history` patch
- returns a machine-readable `notice` only when the capped payload returned to the agent still contains redacted content
- avoids broad changes to transcript text contracts or unrelated redaction surfaces
- adds focused tests and an unreleased changelog entry crediting @lyfuci

## Verification
- `git diff --check origin/main...HEAD`
- `AUTOREVIEW_AUTO_TESTS=0 AUTOREVIEW_OPENCLAW_MAINTAINER_VALIDATION=1 .agents/skills/autoreview/scripts/autoreview --mode branch --base origin/main`
- remote proof attempted but blocked before test execution: `node scripts/crabbox-wrapper.mjs run --provider blacksmith-testbox --shell -- "pnpm test:serial src/agents/openclaw-tools.sessions.test.ts"` failed because Blacksmith is not authenticated
- direct AWS Crabbox fallback attempted but blocked before test execution: `../crabbox/bin/crabbox run --provider aws --shell -- "pnpm test:serial src/agents/openclaw-tools.sessions.test.ts"` failed because AWS credentials/IMDS role are unavailable

Behavior addressed: agents can mistake redacted placeholders in returned session history for real values and write them back into config or secrets.
Real environment tested: not completed; both permitted remote runners are blocked before command execution in this environment.
Exact steps or command run after this patch: `git diff --check origin/main...HEAD`; autoreview command listed above; remote Crabbox/Testbox commands listed above.
Evidence after fix: focused regression coverage is included in `src/agents/openclaw-tools.sessions.test.ts`; autoreview is clean.
Observed result after fix: static diff check and autoreview pass; remote runtime proof is blocked by runner auth/credentials.
What was not tested: the focused Vitest file and `pnpm check:changed` were not run because local testing is disallowed for this task and remote runners are unavailable.
