### PR TITLE
status: reduce diagnosis noise in status --all

### DIFF
--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { summarizeLogTail } from "./gateway.js";
+
+describe("summarizeLogTail", () => {
+  it("filters routine ws chatter and timestamped plain text", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [ws] ⇄ res ✓ 200 ok",
+      "2026-04-15T12:00:01.000Z this is plain assistant text",
+      "2026-04-15T12:00:02.000Z [diagnostic] queue depth high",
+    ]);
+
+    expect(lines).toEqual(["2026-04-15T12:00:02.000Z [diagnostic] queue depth high"]);
+  });
+
+  it("filters tool/web_fetch wrapper residue together", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [tools] web_fetch failed: 404",
+      "  - Begin external-content",
+      "  - Source: Web Fetch",
+      "  - 404: Not Found",
+      "2026-04-15T12:00:02.000Z [tasks/executor] retrying background task",
+    ]);
+
+    expect(lines).toEqual(["2026-04-15T12:00:02.000Z [tasks/executor] retrying background task"]);
+  });
+
+  it("filters routine feishu and exec chatter but keeps structured operational logs", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [feishu] received message chat_id=abc",
+      "2026-04-15T12:00:01.000Z [exec] elevated command: openclaw status --all",
+      "2026-04-15T12:00:02.000Z [agent/embedded] token refresh 401 invalid_grant · re-auth required",
+    ]);
+
+    expect(lines).toEqual([
+      "2026-04-15T12:00:02.000Z [agent/embedded] token refresh 401 invalid_grant · re-auth required",
+    ]);
+  });
+
+  it("groups repeated lane wait diagnostics by lane", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [diagnostic] lane wait exceeded: lane=session:agent:avery waitedMs=113000 queueAhead=0",
+      "2026-04-15T12:00:01.000Z [diagnostic] lane wait exceeded: lane=session:agent:avery waitedMs=113200 queueAhead=0",
+    ]);
+
+    expect(lines).toEqual([
+      "[diagnostic] lane wait exceeded: session:agent:avery · last 113s · queueAhead 0 ×2",
+    ]);
+  });
+
+  it("groups repeated best-effort subagent-end and detached-flow failures", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      "2026-04-15T12:00:01.000Z [agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      "2026-04-15T12:00:02.000Z [tasks/executor] Failed to create one-task flow for detached run",
+      "2026-04-15T12:00:03.000Z [tasks/executor] Failed to create one-task flow for detached run",
+    ]);
+
+    expect(lines).toEqual([
+      "[agents/subagent-registry] context-engine onSubagentEnded failed (best-effort) ×2",
+      "[tasks/executor] Failed to create one-task flow for detached run ×2",
+    ]);
+  });
+
+  it("groups repeated context-overflow diagnostics by session and provider even when field order varies", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agent/embedded] [context-overflow-diag] sessionKey=agent:avery:feishu:direct provider=openai-codex/gpt-5.4 source=provider messages=193 diagId=one",
+      "2026-04-15T12:00:01.000Z [agent/embedded] [context-overflow-diag] provider=openai-codex/gpt-5.4 diagId=two messages=193 sessionKey=agent:avery:feishu:direct source=provider",
+    ]);
+
+    expect(lines).toEqual([
+      "[agent/embedded] context overflow: agent:avery:feishu:direct · provider openai-codex/gpt-5.4 · last messages 193 ×2",
+    ]);
+  });
+
+  it("groups repeated auto-compaction attempts by provider", () => {
+    const lines = summarizeLogTail([
+      "2026-04-15T12:00:00.000Z [agent/embedded] context overflow detected (attempt 1/3); attempting auto-compaction for openai-codex/gpt-5.4",
+      "2026-04-15T12:00:01.000Z [agent/embedded] context overflow detected (attempt 2/3); attempting auto-compaction for openai-codex/gpt-5.4",
+    ]);
+
+    expect(lines).toEqual([
+      "[agent/embedded] context overflow auto-compaction attempted (openai-codex/gpt-5.4) ×2",
+    ]);
+  });
+});

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -21,6 +21,14 @@ function countMatches(haystack: string, needle: string): number {
   return haystack.split(needle).length - 1;
 }
 
+function formatDurationSeconds(msText: string | null | undefined): string {
+  const ms = Number(msText);
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "unknown";
+  }
+  return `${Math.max(1, Math.round(ms / 1000))}s`;
+}
+
 function shorten(message: string, maxLen: number): string {
   const cleaned = message.replace(/\s+/g, " ").trim();
   if (cleaned.length <= maxLen) {
@@ -36,6 +44,52 @@ function normalizeGwsLine(line: string): string {
     .replace(/\s+id=[^\s]+/g, "")
     .replace(/\s+error=Error:.*$/g, "")
     .trim();
+}
+
+function splitTimestampPrefix(line: string): { hasTimestampPrefix: boolean; content: string } {
+  const match = line.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z?\s+(.*)$/);
+  if (!match) {
+    return { hasTimestampPrefix: false, content: line.trimStart() };
+  }
+  return { hasTimestampPrefix: true, content: (match[1] ?? "").trimStart() };
+}
+
+function shouldSkipLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return true;
+  }
+
+  const { hasTimestampPrefix, content } = splitTimestampPrefix(trimmed);
+  const normalized = normalizeLowercaseStringOrEmpty(content || trimmed);
+
+  if (
+    normalized.includes("begin external-content") ||
+    normalized.includes("end external-content") ||
+    normalized === "source: web fetch" ||
+    normalized === "404: not found"
+  ) {
+    return true;
+  }
+
+  if (hasTimestampPrefix && !content.startsWith("[")) {
+    return true;
+  }
+
+  if (
+    (normalized.startsWith("[ws]") && normalized.includes("⇄ res ✓")) ||
+    normalized.startsWith("[feishu] received message") ||
+    normalized.startsWith("[feishu] dispatch message") ||
+    normalized.startsWith("[feishu] stream start") ||
+    normalized.startsWith("[feishu] stream close") ||
+    normalized.startsWith("[exec] elevated command") ||
+    normalized.startsWith("[tools] read failed") ||
+    normalized.startsWith("[tools] web_fetch failed")
+  ) {
+    return true;
+  }
+
+  return false;
 }
 
 function consumeJsonBlock(
@@ -85,9 +139,25 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
   };
 
   const lines = rawLines.map((line) => line.trimEnd()).filter(Boolean);
+  let skipIndentedResidue = false;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const trimmedStart = line.trimStart();
+    const { content } = splitTimestampPrefix(trimmedStart);
+    const matchText = content || trimmedStart;
+
+    if (skipIndentedResidue) {
+      if (/^\s*[-*•]\s+/.test(line) || /^\s{2,}\S/.test(line)) {
+        continue;
+      }
+      skipIndentedResidue = false;
+    }
+
+    if (shouldSkipLine(line)) {
+      skipIndentedResidue = /\[tools\]\s+(read failed|web_fetch failed)/i.test(trimmedStart);
+      continue;
+    }
+
     if (
       (trimmedStart.startsWith('"') ||
         trimmedStart === "}" ||
@@ -101,8 +171,65 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       continue;
     }
 
+    const laneWait = matchText.match(
+      /(?:^\[[^\]]+\]\s+)?lane wait exceeded:\s+lane=([^\s]+)\s+waitedMs=(\d+)\s+queueAhead=(\d+)/,
+    );
+    if (laneWait) {
+      const lane = laneWait[1] ?? "unknown";
+      const waited = formatDurationSeconds(laneWait[2]);
+      const queueAhead = laneWait[3] ?? "unknown";
+      addGroup(
+        `lane:${lane}:${queueAhead}`,
+        `[diagnostic] lane wait exceeded: ${lane} · last ${waited} · queueAhead ${queueAhead}`,
+      );
+      continue;
+    }
+
+    if (matchText.includes("context-engine onSubagentEnded failed (best-effort)")) {
+      addGroup(
+        "subagent-ended-best-effort",
+        "[agents/subagent-registry] context-engine onSubagentEnded failed (best-effort)",
+      );
+      continue;
+    }
+
+    if (matchText.includes("Failed to create one-task flow for detached run")) {
+      addGroup(
+        "detached-flow-create-failed",
+        "[tasks/executor] Failed to create one-task flow for detached run",
+      );
+      continue;
+    }
+
+    if (matchText.includes("[context-overflow-diag]")) {
+      const sessionKey = matchText.match(/\bsessionKey=([^\s]+)/)?.[1] ?? null;
+      const provider = matchText.match(/\bprovider=([^\s]+)/)?.[1] ?? null;
+      const messages = matchText.match(/\bmessages=([^\s]+)/)?.[1] ?? "unknown";
+      if (sessionKey && provider) {
+        addGroup(
+          `overflow:${sessionKey}:${provider}`,
+          `[agent/embedded] context overflow: ${sessionKey} · provider ${provider} · last messages ${messages}`,
+        );
+        continue;
+      }
+    }
+
+    const autoCompaction = matchText.match(
+      /context overflow detected \(attempt \d+\/\d+\); attempting auto-compaction for ([^\s]+)/,
+    );
+    if (autoCompaction) {
+      const provider = autoCompaction[1] ?? "unknown";
+      addGroup(
+        `overflow-compaction:${provider}`,
+        `[agent/embedded] context overflow auto-compaction attempted (${provider})`,
+      );
+      continue;
+    }
+
     // "[openai-codex] Token refresh failed: 401 { ...json... }"
-    const tokenRefresh = line.match(/^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/);
+    const tokenRefresh = matchText.match(
+      /^\[([^\]]+)\]\s+Token refresh failed:\s*(\d+)\s*(\{)?\s*$/,
+    );
     if (tokenRefresh) {
       const tag = tokenRefresh[1] ?? "unknown";
       const status = tokenRefresh[2] ?? "unknown";
@@ -132,7 +259,7 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
     }
 
     // "Embedded agent failed before reply: OAuth token refresh failed for openai-codex: ..."
-    const embedded = line.match(
+    const embedded = matchText.match(
       /^Embedded agent failed before reply:\s+OAuth token refresh failed for ([^:]+):/,
     );
     if (embedded) {
@@ -143,11 +270,11 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
 
     // "[gws] ⇄ res ✗ agent ... errorCode=UNAVAILABLE errorMessage=Error: OAuth token refresh failed ... runId=..."
     if (
-      line.startsWith("[gws]") &&
-      line.includes("errorCode=UNAVAILABLE") &&
-      line.includes("OAuth token refresh failed")
+      matchText.startsWith("[gws]") &&
+      matchText.includes("errorCode=UNAVAILABLE") &&
+      matchText.includes("OAuth token refresh failed")
     ) {
-      const normalized = normalizeGwsLine(line);
+      const normalized = normalizeGwsLine(matchText);
       addGroup(`gws:${normalized}`, normalized);
       continue;
     }

--- a/src/daemon/diagnostics.test.ts
+++ b/src/daemon/diagnostics.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const readFile = vi.hoisted(() => vi.fn<(path: string, encoding: string) => Promise<string>>());
+const resolveGatewayLogPaths = vi.hoisted(() =>
+  vi.fn(() => ({
+    stdoutPath: "/tmp/gateway.stdout.log",
+    stderrPath: "/tmp/gateway.stderr.log",
+  })),
+);
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile,
+  },
+}));
+
+vi.mock("./launchd.js", () => ({
+  resolveGatewayLogPaths,
+}));
+
+import { readLastGatewayErrorLine } from "./diagnostics.js";
+
+describe("readLastGatewayErrorLine", () => {
+  afterEach(() => {
+    readFile.mockReset();
+    resolveGatewayLogPaths.mockClear();
+  });
+
+  it("returns the latest curated gateway error match", async () => {
+    readFile.mockImplementation(async (path: string) => {
+      if (path.includes("stderr")) {
+        return "info\nrefusing to bind gateway on 0.0.0.0:18789\n";
+      }
+      return "";
+    });
+
+    await expect(readLastGatewayErrorLine(process.env)).resolves.toBe(
+      "refusing to bind gateway on 0.0.0.0:18789",
+    );
+  });
+
+  it("returns null when logs contain only unrelated noise", async () => {
+    readFile.mockImplementation(async (path: string) => {
+      if (path.includes("stderr")) {
+        return "[tools] web_fetch failed: 404\n";
+      }
+      return "2026-04-15T12:00:00.000Z hello from local debugging\n";
+    });
+
+    await expect(readLastGatewayErrorLine(process.env)).resolves.toBeNull();
+  });
+});

--- a/src/daemon/diagnostics.ts
+++ b/src/daemon/diagnostics.ts
@@ -9,21 +9,6 @@ const GATEWAY_LOG_ERROR_PATTERNS = [
   /tailscale .* requires/i,
 ];
 
-async function readLastLogLine(filePath: string): Promise<string | null> {
-  try {
-    const raw = await fs.readFile(filePath, "utf8");
-    const lines = raw.split(/\r?\n/).map((line) => line.trim());
-    for (let i = lines.length - 1; i >= 0; i -= 1) {
-      if (lines[i]) {
-        return lines[i];
-      }
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
 export async function readLastGatewayErrorLine(env: NodeJS.ProcessEnv): Promise<string | null> {
   const { stdoutPath, stderrPath } = resolveGatewayLogPaths(env);
   const stderrRaw = await fs.readFile(stderrPath, "utf8").catch(() => "");
@@ -40,5 +25,5 @@ export async function readLastGatewayErrorLine(env: NodeJS.ProcessEnv): Promise<
       return line;
     }
   }
-  return (await readLastLogLine(stderrPath)) ?? (await readLastLogLine(stdoutPath));
+  return null;
 }


### PR DESCRIPTION
$## Summary\n- filter routine gateway tail noise and wrapper residue from `status --all` diagnosis output\n- group repeated lane-wait, subagent-end, detached-flow, and context-overflow diagnostics into concise summaries\n- stop surfacing unrelated fallback `Gateway last log line` noise when no curated gateway error is present\n\n## Testing\n- pnpm exec vitest run src/commands/status-all/gateway.test.ts src/daemon/diagnostics.test.ts\n- pnpm check