### PR TITLE
fix(feishu): preserve URL boundaries in post markdown messages

### DIFF
--- a/extensions/feishu/src/markdown-urls.test.ts
+++ b/extensions/feishu/src/markdown-urls.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { wrapBareUrlsForFeishuMarkdown } from "./markdown-urls.js";
+
+describe("wrapBareUrlsForFeishuMarkdown", () => {
+  it("returns input untouched when no http(s) URL is present", () => {
+    expect(wrapBareUrlsForFeishuMarkdown("hello world")).toBe("hello world");
+    expect(wrapBareUrlsForFeishuMarkdown("")).toBe("");
+  });
+
+  it("wraps a bare URL containing underscores and ampersands", () => {
+    const input = "请打开 https://example.com/v1/verify?flow_id=A_B_C&user_code=DEMO-1234 完成授权";
+    const expected =
+      "请打开 [https://example.com/v1/verify?flow_id=A_B_C&user_code=DEMO-1234](https://example.com/v1/verify?flow_id=A_B_C&user_code=DEMO-1234) 完成授权";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("stops at adjacent Chinese characters without absorbing them", () => {
+    const input = "see https://example.com/a_b你好";
+    const expected = "see [https://example.com/a_b](https://example.com/a_b)你好";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("leaves existing markdown links alone", () => {
+    const input = "[docs](https://example.com/a_b_c) and bare https://example.com/x_y";
+    const expected =
+      "[docs](https://example.com/a_b_c) and bare [https://example.com/x_y](https://example.com/x_y)";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("leaves image syntax alone", () => {
+    const input = "![logo](https://cdn.example.com/a_b.png) plus https://example.com/z_1";
+    const expected =
+      "![logo](https://cdn.example.com/a_b.png) plus [https://example.com/z_1](https://example.com/z_1)";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("leaves angle-bracket autolinks alone", () => {
+    const input = "<https://example.com/a_b> vs https://example.com/c_d";
+    const expected =
+      "<https://example.com/a_b> vs [https://example.com/c_d](https://example.com/c_d)";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("does not touch URLs inside inline code", () => {
+    const input = "run `curl https://example.com/a_b` then open https://example.com/c_d";
+    const expected =
+      "run `curl https://example.com/a_b` then open [https://example.com/c_d](https://example.com/c_d)";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("does not touch URLs inside fenced code blocks", () => {
+    const input = [
+      "prefix https://example.com/a_b",
+      "```",
+      "GET https://example.com/in_code",
+      "```",
+      "suffix https://example.com/c_d",
+    ].join("\n");
+    const expected = [
+      "prefix [https://example.com/a_b](https://example.com/a_b)",
+      "```",
+      "GET https://example.com/in_code",
+      "```",
+      "suffix [https://example.com/c_d](https://example.com/c_d)",
+    ].join("\n");
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("trims a trailing sentence period out of the URL", () => {
+    const input = "see https://example.com/a_b.";
+    const expected = "see [https://example.com/a_b](https://example.com/a_b).";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("trims a trailing comma out of the URL", () => {
+    const input = "visit https://example.com/a_b, then continue";
+    const expected = "visit [https://example.com/a_b](https://example.com/a_b), then continue";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("does not absorb a closing paren that wraps the URL in prose", () => {
+    const input = "(see https://example.com/a_b)";
+    const expected = "(see [https://example.com/a_b](https://example.com/a_b))";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("keeps inner parens in display text and percent-encodes them in the destination", () => {
+    const input = "wiki https://example.com/Foo_(bar)_baz end";
+    const expected =
+      "wiki [https://example.com/Foo_(bar)_baz](https://example.com/Foo_%28bar%29_baz) end";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("percent-encodes an unmatched mid-URL `)` so the destination is not truncated", () => {
+    const input = "bug https://example.com/a)b_c here";
+    const expected = "bug [https://example.com/a)b_c](https://example.com/a%29b_c) here";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("percent-encodes an unmatched mid-URL `(` in the destination", () => {
+    const input = "case https://example.com/a(b_c end";
+    const expected = "case [https://example.com/a(b_c](https://example.com/a%28b_c) end";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("wraps multiple URLs in the same line", () => {
+    const input = "a https://example.com/a_1 b https://example.com/b_2 c";
+    const expected =
+      "a [https://example.com/a_1](https://example.com/a_1) b [https://example.com/b_2](https://example.com/b_2) c";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("wraps http URLs as well as https", () => {
+    const input = "open http://example.com/a_b now";
+    const expected = "open [http://example.com/a_b](http://example.com/a_b) now";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("is idempotent on already-wrapped output", () => {
+    const input = "open https://example.com/a_b please";
+    const once = wrapBareUrlsForFeishuMarkdown(input);
+    const twice = wrapBareUrlsForFeishuMarkdown(once);
+    expect(twice).toBe(once);
+  });
+
+  it("wraps URL at the start of the string", () => {
+    const input = "https://example.com/a_b is ready";
+    const expected = "[https://example.com/a_b](https://example.com/a_b) is ready";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("wraps URL at the end of the string with no trailing char", () => {
+    const input = "open https://example.com/a_b";
+    const expected = "open [https://example.com/a_b](https://example.com/a_b)";
+    expect(wrapBareUrlsForFeishuMarkdown(input)).toBe(expected);
+  });
+
+  it("strips mask sentinels from input to block forged placeholders", () => {
+    const forged = "prefix \u0001MDURL0\u0002 and https://example.com/a_b after";
+    const expected = "prefix MDURL0 and [https://example.com/a_b](https://example.com/a_b) after";
+    expect(wrapBareUrlsForFeishuMarkdown(forged)).toBe(expected);
+  });
+});

--- a/extensions/feishu/src/markdown-urls.ts
+++ b/extensions/feishu/src/markdown-urls.ts
@@ -1,0 +1,113 @@
+const SENTINEL_OPEN = "\u0001";
+const SENTINEL_CLOSE = "\u0002";
+const MASK_PREFIX = `${SENTINEL_OPEN}MDURL`;
+const MASK_RESTORE_RE = new RegExp(`${MASK_PREFIX}(\\d+)${SENTINEL_CLOSE}`, "g");
+
+const FENCED_CODE_RE = /```[\s\S]*?```/g;
+const INLINE_CODE_RE = /`+[^`\n]+?`+/g;
+const MARKDOWN_LINK_RE = /!?\[[^\]\n]*\]\([^)\n]*\)/g;
+const ANGLE_AUTOLINK_RE = /<https?:\/\/[^\s>]+>/g;
+
+// RFC 3986 URL chars plus `%`. Whitespace, `<`, `>`, quotes, backticks, and
+// non-ASCII (e.g. Chinese) terminate the match naturally.
+const BARE_URL_RE = /\bhttps?:\/\/[A-Za-z0-9\-._~:/?#[\]@!$&'()*+,;=%]+/g;
+
+const TRAILING_SENTENCE_PUNCT_RE = /[.,;:!?'"]+$/;
+
+function encodeDestinationParens(url: string): string {
+  return url.replace(/\(/g, "%28").replace(/\)/g, "%29");
+}
+
+function countUnbalancedTrailingParens(url: string): number {
+  let opens = 0;
+  let closes = 0;
+  for (let i = 0; i < url.length; i++) {
+    const ch = url[i];
+    if (ch === "(") {
+      opens++;
+    } else if (ch === ")") {
+      closes++;
+    }
+  }
+  const unbalanced = closes - opens;
+  if (unbalanced <= 0) {
+    return 0;
+  }
+  let trailing = 0;
+  for (let i = url.length - 1; i >= 0 && url[i] === ")" && trailing < unbalanced; i--) {
+    trailing++;
+  }
+  return trailing;
+}
+
+function maskRegions(input: string, stash: string[]): string {
+  const replacer = (match: string): string => {
+    const index = stash.length;
+    stash.push(match);
+    return `${MASK_PREFIX}${index}${SENTINEL_CLOSE}`;
+  };
+  // Order matters: fenced code first so its body is frozen before inline
+  // code or link regexes can peek inside it.
+  return input
+    .replace(FENCED_CODE_RE, replacer)
+    .replace(INLINE_CODE_RE, replacer)
+    .replace(MARKDOWN_LINK_RE, replacer)
+    .replace(ANGLE_AUTOLINK_RE, replacer);
+}
+
+function restoreRegions(input: string, stash: string[]): string {
+  return input.replace(MASK_RESTORE_RE, (_, id: string) => stash[Number(id)] ?? "");
+}
+
+function stripSentinels(text: string): string {
+  return text.split(SENTINEL_OPEN).join("").split(SENTINEL_CLOSE).join("");
+}
+
+function wrapOneBareUrl(match: string): string {
+  const puncMatch = match.match(TRAILING_SENTENCE_PUNCT_RE);
+  const puncTail = puncMatch ? puncMatch[0] : "";
+  const withoutPunc = puncTail ? match.slice(0, -puncTail.length) : match;
+
+  const parenCount = countUnbalancedTrailingParens(withoutPunc);
+  const url = parenCount > 0 ? withoutPunc.slice(0, -parenCount) : withoutPunc;
+  const trailing = `${")".repeat(parenCount)}${puncTail}`;
+
+  if (!url) {
+    return match;
+  }
+  // Percent-encode `(` and `)` on the destination side so a markdown parser
+  // never closes the destination at a mid-URL `)`. The display side keeps
+  // the literal URL so recipients still see the exact address.
+  return `[${url}](${encodeDestinationParens(url)})${trailing}`;
+}
+
+/**
+ * Wrap bare http(s) URLs as `[url](url)` so Feishu's post `md` tag does not
+ * have to infer link boundaries. Feishu's markdown parser treats `_` as an
+ * italic marker, which breaks autolinks on URLs such as
+ * `https://host/path?flow_id=...&user_code=...`.
+ *
+ * Regions that already carry link semantics — markdown links, image syntax,
+ * angle-bracket autolinks, inline code, and fenced code blocks — are masked
+ * out before matching, so they are never double-wrapped or mutated.
+ *
+ * Trailing sentence punctuation (`.,;:!?'"`) and unbalanced `)` are pushed
+ * back outside the wrapped link so prose punctuation stays intact.
+ *
+ * Sentinel control characters used internally for masking are stripped from
+ * the input to prevent forged tokens from substituting stashed content.
+ */
+export function wrapBareUrlsForFeishuMarkdown(text: string): string {
+  if (!text) {
+    return text;
+  }
+  const safe =
+    text.includes(SENTINEL_OPEN) || text.includes(SENTINEL_CLOSE) ? stripSentinels(text) : text;
+  if (!safe.includes("http")) {
+    return safe;
+  }
+  const stash: string[] = [];
+  const masked = maskRegions(safe, stash);
+  const wrapped = masked.replace(BARE_URL_RE, wrapOneBareUrl);
+  return restoreRegions(wrapped, stash);
+}

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -131,6 +131,36 @@ describe("getMessageFeishu", () => {
     expect(result).toEqual({ messageId: "om_send", chatId: "oc_send" });
   });
 
+  it("wraps bare URLs in the post payload so Feishu md renders them as links", async () => {
+    const create = vi.fn().mockResolvedValue({ code: 0, data: { message_id: "om_url" } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        message: {
+          create,
+          reply: vi.fn(),
+          get: mockClientGet,
+          list: mockClientList,
+          patch: mockClientPatch,
+        },
+      },
+    });
+
+    const url = "https://example.com/v1/verify?flow_id=A_B_C&user_code=DEMO-1234";
+    await sendMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      to: "oc_url",
+      text: `open ${url}`,
+    });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    const sent = create.mock.calls[0][0] as { data: { content: string; msg_type: string } };
+    expect(sent.data.msg_type).toBe("post");
+    const body = JSON.parse(sent.data.content) as {
+      zh_cn: { content: [[{ tag: string; text: string }]] };
+    };
+    expect(body.zh_cn.content[0][0].text).toBe(`open [${url}](${url})`);
+  });
+
   it("extracts text content from interactive card elements", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -7,6 +7,7 @@ import {
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { wrapBareUrlsForFeishuMarkdown } from "./markdown-urls.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent, buildMentionedMessage } from "./mention.js";
 import { parsePostContent } from "./post.js";
@@ -434,6 +435,9 @@ export function buildFeishuPostMessagePayload(params: { messageText: string }): 
   msgType: string;
 } {
   const { messageText } = params;
+  // Feishu's post "md" tag breaks autolink at underscores inside URLs, so we
+  // pre-wrap bare http(s) URLs into explicit `[url](url)` form.
+  const safeText = wrapBareUrlsForFeishuMarkdown(messageText);
   return {
     content: JSON.stringify({
       zh_cn: {
@@ -441,7 +445,7 @@ export function buildFeishuPostMessagePayload(params: { messageText: string }): 
           [
             {
               tag: "md",
-              text: messageText,
+              text: safeText,
             },
           ],
         ],


### PR DESCRIPTION
Feishu's `md` tag treats `_` as an italic marker, so its autolink parser terminates at the first underscore. URLs with underscore-separated parameters lost their tail to unclickable static text.

Pre-wrap bare http(s) URLs as `[url](url)` before building the payload. Existing markdown links, image syntax, angle-bracket autolinks, inline code, and fenced code blocks are masked out first to keep already-linked content untouched.

## Summary

- **Problem**: Feishu post `md` renderer cuts bare URLs at the first `_`, so URLs with underscore-separated params become half-static text.
- **Fix**: Pre-wrap bare http(s) URLs as `[url](url)` inside `buildFeishuPostMessagePayload`; existing link / code regions are masked out first.
- **Scope**: plugin-local to `extensions/feishu`; no change to cards, other channels, or public SDK.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- [x] This PR fixes a bug or regression

## Root Cause

Feishu's `md` tag uses `_` as an italic delimiter, so the autolink parser stops at the first underscore and renders the remainder as inert text. No existing test asserted that bare URLs survived the post payload as clickable links.

## Regression Test Plan

- Coverage level: [x] Unit test · [x] Seam / integration test
- Target: `extensions/feishu/src/markdown-urls.test.ts` (19 cases) + one integration case in `extensions/feishu/src/send.test.ts` asserting the exact `body.zh_cn.content[0][0].text` after `sendMessageFeishu`.
- Scenario locked in: `open https://host/path?foo_bar=1&baz_qux=2` → `open [https://host/path?foo_bar=1&baz_qux=2](https://host/path?foo_bar=1&baz_qux=2)`.

## User-visible / Behavior Changes

URLs containing underscores render as fully clickable links in Feishu post messages. No other behavior change.

## Diagram

N/A

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Send a Feishu message whose body contains `https://host/path?foo_bar=1&baz_qux=2`.
2. Open the message in the Feishu client.

### Expected

Full URL is clickable.

### Actual (before)

Only the prefix before the first `_` is clickable; the tail is static text.

## Evidence

`pnpm test -- extensions/feishu/src/markdown-urls.test.ts extensions/feishu/src/send.test.ts extensions/feishu/src/post.test.ts` → 36/36 pass. Lint / format clean on all four touched files.

## Human Verification

Covered by unit + integration tests: underscore/ampersand URLs, adjacency to Chinese characters, URLs inside/outside existing link and code constructs, trailing punctuation, balanced inner parens, multiple URLs per line, http + https, idempotence. Not verified: live delivery to a production Feishu tenant.

## Review Conversations

- [x] New PR; no prior review conversations.

## Compatibility / Migration

Backward compatible. No config / env changes. No migration.

## Risks and Mitigations

- Risk: double-wrapping an already-linked URL → Mitigation: mask-then-replace skips `[text](url)`, `![alt](url)`, `<url>`, inline code, fenced code; idempotence test covers it.
- Risk: absorbing adjacent punctuation → Mitigation: trailing `.,;:!?'"` and unbalanced `)` are pushed back outside the wrap; locked by unit tests.