### PR TITLE
[codex] fix(telegram): allow ACP bindings for direct chats

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -222,7 +222,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
 - In multi-account setups (2+ account ids), set an explicit default (`channels.telegram.defaultAccount` or `channels.telegram.accounts.default`) to avoid fallback routing; `openclaw doctor` warns when this is missing or invalid.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
-- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for forum topics (use canonical `chatId:topic:topicId` in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
+- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for direct chats and forum topics. Use a plain chat id for direct chats or canonical `chatId:topic:topicId` for forum topics in `match.peer.id`. Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
 - Retry policy: see [Retry policy](/concepts/retry).
 

--- a/extensions/telegram/src/channel.bindings.test.ts
+++ b/extensions/telegram/src/channel.bindings.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { telegramBindingsAdapter } from "./channel.js";
+
+describe("telegramBindingsAdapter", () => {
+  it("normalizes configured direct-chat ACP bindings", () => {
+    const compiled = telegramBindingsAdapter.compileConfiguredBinding({
+      conversationId: "123456789",
+    });
+
+    expect(compiled).toEqual({
+      conversationId: "123456789",
+      parentConversationId: "123456789",
+    });
+    expect(
+      telegramBindingsAdapter.matchInboundConversation({
+        compiledBinding: compiled!,
+        conversationId: "123456789",
+        parentConversationId: "123456789",
+      }),
+    ).toEqual({
+      conversationId: "123456789",
+      parentConversationId: "123456789",
+      matchPriority: 2,
+    });
+  });
+
+  it("continues normalizing configured topic ACP bindings", () => {
+    const compiled = telegramBindingsAdapter.compileConfiguredBinding({
+      conversationId: "-1001234567890:topic:42",
+    });
+
+    expect(compiled).toEqual({
+      conversationId: "-1001234567890:topic:42",
+      parentConversationId: "-1001234567890",
+    });
+    expect(
+      telegramBindingsAdapter.matchInboundConversation({
+        compiledBinding: compiled!,
+        conversationId: "-1001234567890:topic:42",
+        parentConversationId: "-1001234567890",
+      }),
+    ).toEqual({
+      conversationId: "-1001234567890:topic:42",
+      parentConversationId: "-1001234567890",
+      matchPriority: 2,
+    });
+  });
+
+  it("rejects bare negative chat ids so whole group chats still do not bind implicitly", () => {
+    expect(
+      telegramBindingsAdapter.compileConfiguredBinding({
+        conversationId: "-1001234567890",
+      }),
+    ).toBeNull();
+  });
+});

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -225,12 +225,19 @@ const telegramMessageActions: ChannelMessageActionAdapter = {
 
 function normalizeTelegramAcpConversationId(conversationId: string) {
   const parsed = parseTelegramTopicConversation({ conversationId });
-  if (!parsed || !parsed.chatId.startsWith("-")) {
+  if (parsed) {
+    return {
+      conversationId: parsed.canonicalConversationId,
+      parentConversationId: parsed.chatId,
+    };
+  }
+  const normalizedConversationId = normalizeOptionalString(conversationId);
+  if (!normalizedConversationId || normalizedConversationId.startsWith("-")) {
     return null;
   }
   return {
-    conversationId: parsed.canonicalConversationId,
-    parentConversationId: parsed.chatId,
+    conversationId: normalizedConversationId,
+    parentConversationId: normalizedConversationId,
   };
 }
 
@@ -243,11 +250,29 @@ function matchTelegramAcpConversation(params: {
   if (!binding) {
     return null;
   }
+  const normalizedConversationId = normalizeOptionalString(params.conversationId);
+  const normalizedParentConversationId =
+    normalizeOptionalString(params.parentConversationId) ?? normalizedConversationId;
+  if (!binding.conversationId.includes(":topic:")) {
+    if (
+      !normalizedConversationId ||
+      normalizedConversationId.startsWith("-") ||
+      binding.conversationId !== normalizedConversationId ||
+      normalizedParentConversationId !== normalizedConversationId
+    ) {
+      return null;
+    }
+    return {
+      conversationId: normalizedConversationId,
+      parentConversationId: normalizedParentConversationId,
+      matchPriority: 2,
+    };
+  }
   const incoming = parseTelegramTopicConversation({
     conversationId: params.conversationId,
     parentConversationId: params.parentConversationId,
   });
-  if (!incoming || !incoming.chatId.startsWith("-")) {
+  if (!incoming) {
     return null;
   }
   if (binding.conversationId !== incoming.canonicalConversationId) {
@@ -259,6 +284,25 @@ function matchTelegramAcpConversation(params: {
     matchPriority: 2,
   };
 }
+
+export const telegramBindingsAdapter = {
+  selfParentConversationByDefault: true,
+  compileConfiguredBinding: ({ conversationId }) =>
+    normalizeTelegramAcpConversationId(conversationId),
+  matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) =>
+    matchTelegramAcpConversation({
+      bindingConversationId: compiledBinding.conversationId,
+      conversationId,
+      parentConversationId,
+    }),
+  resolveCommandConversation: ({ threadId, originatingTo, commandTo, fallbackTo }) =>
+    resolveTelegramCommandConversation({
+      threadId,
+      originatingTo,
+      commandTo,
+      fallbackTo,
+    }),
+} as const;
 
 function shouldTreatTelegramDeliveredTextAsVisible(params: {
   kind: "tool" | "block" | "final";
@@ -611,24 +655,7 @@ export const telegramPlugin = createChatChannelPlugin({
       resolveGroupPolicy: (account) => account.config.groupPolicy,
       resolveGroupOverrides: resolveTelegramAllowlistGroupOverrides,
     }),
-    bindings: {
-      selfParentConversationByDefault: true,
-      compileConfiguredBinding: ({ conversationId }) =>
-        normalizeTelegramAcpConversationId(conversationId),
-      matchInboundConversation: ({ compiledBinding, conversationId, parentConversationId }) =>
-        matchTelegramAcpConversation({
-          bindingConversationId: compiledBinding.conversationId,
-          conversationId,
-          parentConversationId,
-        }),
-      resolveCommandConversation: ({ threadId, originatingTo, commandTo, fallbackTo }) =>
-        resolveTelegramCommandConversation({
-          threadId,
-          originatingTo,
-          commandTo,
-          fallbackTo,
-        }),
-    },
+    bindings: telegramBindingsAdapter,
     conversationBindings: {
       supportsCurrentConversationBinding: true,
       defaultTopLevelPlacement: "current",


### PR DESCRIPTION
## Summary

This change allows top-level Telegram `bindings[]` entries with `type: "acp"` to target direct chats in addition to forum topics.

## Root Cause

Telegram ACP binding normalization and matching only accepted topic-shaped conversation ids. Plain direct-chat ids were rejected during configured-binding compilation, so direct-message ACP bindings never became eligible for route resolution and fell back to the default route/session path.

## Changes

- accept plain positive Telegram chat ids when compiling configured ACP bindings
- match direct-chat inbound conversations before topic parsing so DM bindings do not get misclassified as topic ids
- keep bare negative chat ids rejected so whole-group bindings are still not implicitly enabled
- extract the Telegram bindings adapter for focused unit coverage
- document that Telegram ACP bindings support direct chats as well as forum topics

## Validation

- `node --no-maglev /tmp/openclaw-upstream.hKdV5W/node_modules/vitest/vitest.mjs run extensions/telegram/src/channel.bindings.test.ts extensions/telegram/src/bot-message-context.acp-bindings.test.ts`
