### PR TITLE
discord: timebox native-command defer before dispatch

### DIFF
--- a/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
+++ b/extensions/discord/src/monitor/native-command.plugin-dispatch.test.ts
@@ -2,7 +2,7 @@ import { ChannelType } from "discord-api-types/v10";
 import type { NativeCommandSpec } from "openclaw/plugin-sdk/command-auth";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
 import { clearPluginCommands, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createTestRegistry,
   setActivePluginRegistry,
@@ -343,6 +343,10 @@ describe("Discord native plugin command dispatch", () => {
       await import("./native-command.js"));
   });
 
+  afterEach(() => {
+    discordNativeCommandTesting.setDeferTimeoutMs(1500);
+  });
+
   beforeEach(async () => {
     vi.clearAllMocks();
     clearPluginCommands();
@@ -383,6 +387,30 @@ describe("Discord native plugin command dispatch", () => {
         accountId: params.accountId,
       }),
     );
+  });
+
+  it("abandons dispatch when interaction defer times out", async () => {
+    const cfg = createConfig();
+    const interaction = createInteraction();
+    const command = await createStatusCommand(cfg);
+    const dispatchSpy = createDispatchSpy();
+
+    discordNativeCommandTesting.setDeferTimeoutMs(5);
+    interaction.defer.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, 50);
+        }),
+    );
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(
+      interaction as unknown,
+    );
+
+    expect(interaction.defer).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalled();
   });
 
   it("executes plugin commands from the real registry through the native Discord command path", async () => {

--- a/extensions/discord/src/monitor/native-command.ts
+++ b/extensions/discord/src/monitor/native-command.ts
@@ -45,6 +45,7 @@ import {
   resolveSendableOutboundReplyParts,
   resolveTextChunksWithFallback,
 } from "openclaw/plugin-sdk/reply-payload";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { createSubsystemLogger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import {
@@ -90,6 +91,8 @@ const log = createSubsystemLogger("discord/native-command");
 // Discord application command and option descriptions are limited to 1-100 chars.
 // https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-structure
 const DISCORD_COMMAND_DESCRIPTION_MAX = 100;
+const DISCORD_NATIVE_COMMAND_SLOW_MS = 3000;
+let discordNativeCommandDeferTimeoutMs = 1500;
 let matchPluginCommandImpl = pluginRuntime.matchPluginCommand;
 let executePluginCommandImpl = pluginRuntime.executePluginCommand;
 let dispatchReplyWithDispatcherImpl = dispatchReplyWithDispatcher;
@@ -122,6 +125,11 @@ export const __testing = {
   ): typeof resolveDiscordNativeInteractionRouteState {
     const previous = resolveDiscordNativeInteractionRouteStateImpl;
     resolveDiscordNativeInteractionRouteStateImpl = next;
+    return previous;
+  },
+  setDeferTimeoutMs(next: number): number {
+    const previous = discordNativeCommandDeferTimeoutMs;
+    discordNativeCommandDeferTimeoutMs = next;
     return previous;
   },
 };
@@ -605,15 +613,40 @@ function hasRenderableReplyPayload(payload: ReplyPayload): boolean {
   return false;
 }
 
+function isDiscordInteractionTimeout(error: unknown): error is Error {
+  return error instanceof Error && error.message === "timeout";
+}
+
+async function withDiscordInteractionTimeout<T>(fn: () => Promise<T>, timeoutMs: number): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      fn(),
+      new Promise<T>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
 async function safeDiscordInteractionCall<T>(
   label: string,
   fn: () => Promise<T>,
+  options?: { swallowTimeout?: boolean },
 ): Promise<T | null> {
   try {
     return await fn();
   } catch (error) {
     if (isDiscordUnknownInteraction(error)) {
       logVerbose(`discord: ${label} skipped (interaction expired)`);
+      return null;
+    }
+    if (options?.swallowTimeout && isDiscordInteractionTimeout(error)) {
+      log.warn(`discord: ${label} timed out`);
       return null;
     }
     throw error;
@@ -693,10 +726,18 @@ export function createDiscordNativeCommand(params: {
     options = options;
 
     async run(interaction: CommandInteraction) {
-      const deferred = await safeDiscordInteractionCall("interaction defer", () =>
-        interaction.defer(),
+      const commandLogLabel = resolveDiscordCommandLogLabel(commandDefinition);
+      const interactionId = interaction.rawData.id;
+      const nativeCommandLabel = `/${commandLogLabel} interaction=${interactionId}`;
+      const startedAt = Date.now();
+      logVerbose(`discord: native command start ${nativeCommandLabel}`);
+      const deferred = await safeDiscordInteractionCall(
+        `interaction defer ${nativeCommandLabel}`,
+        () => withDiscordInteractionTimeout(() => interaction.defer(), discordNativeCommandDeferTimeoutMs),
+        { swallowTimeout: true },
       );
       if (deferred === null) {
+        logVerbose(`discord: native command aborted before dispatch ${nativeCommandLabel}`);
         return;
       }
       const commandArgs = argDefinitions?.length
@@ -711,20 +752,33 @@ export function createDiscordNativeCommand(params: {
           } satisfies CommandArgs)
         : undefined;
       const prompt = buildCommandTextFromArgs(commandDefinition, commandArgsWithRaw);
-      await dispatchDiscordCommandInteraction({
-        interaction,
-        prompt,
-        command: commandDefinition,
-        commandArgs: commandArgsWithRaw,
-        cfg,
-        discordConfig,
-        accountId,
-        sessionPrefix,
-        // Slash commands are deferred up front, so all later responses must use
-        // follow-up/edit semantics instead of the initial reply endpoint.
-        preferFollowUp: true,
-        threadBindings,
-      });
+      try {
+        await dispatchDiscordCommandInteraction({
+          interaction,
+          prompt,
+          command: commandDefinition,
+          commandArgs: commandArgsWithRaw,
+          cfg,
+          discordConfig,
+          accountId,
+          sessionPrefix,
+          // Slash commands are deferred up front, so all later responses must use
+          // follow-up/edit semantics instead of the initial reply endpoint.
+          preferFollowUp: true,
+          threadBindings,
+        });
+      } catch (error) {
+        log.warn(
+          `discord: native command failed ${nativeCommandLabel} after ${Date.now() - startedAt}ms (${formatErrorMessage(error)})`,
+        );
+        throw error;
+      }
+      const durationMs = Date.now() - startedAt;
+      if (durationMs >= DISCORD_NATIVE_COMMAND_SLOW_MS) {
+        log.warn(`discord: native command slow ${nativeCommandLabel} (${durationMs}ms)`);
+      } else {
+        logVerbose(`discord: native command ok ${nativeCommandLabel} (${durationMs}ms)`);
+      }
     }
   })();
 }
@@ -1343,7 +1397,9 @@ async function deliverDiscordInteractionReply(params: {
       if (!chunk.trim()) {
         continue;
       }
-      await interaction.followUp({ content: chunk });
+      await safeDiscordInteractionCall("interaction follow-up chunk", () =>
+        interaction.followUp({ content: chunk }),
+      );
     }
     return;
   }


### PR DESCRIPTION
## Summary

Fix Discord native command handling so a stalled interaction defer does not block the command acknowledgment path long enough for the interaction to fail.

This change:
- adds a short timeout around `interaction.defer()`
- treats defer timeout as a recoverable abort for the native command path
- adds minimal lifecycle logging for native commands (`start`, `abort`, `slow`, `fail`, `ok`)
- adds a regression test for the slow/stalled defer case
- wraps chunked follow-up sends with the same interaction guard used elsewhere in the native command reply path

## Root cause

`createDiscordNativeCommand().run()` deferred the interaction immediately, but the guard only handled expired interactions. If the defer call itself became stuck, the acknowledgment path could stall before dispatch started.

## Validation

Ran:

```bash
node scripts/test-extension.mjs discord
```

Result:
- 112 test files passed
- 935 tests passed

## Scope

This is intentionally a minimal fix focused on the ACK-critical defer path and reply-path consistency inside `native-command.ts`.
