### PR TITLE
fix(auto-reply): preserve friendly basename for reply-media staging

### DIFF
--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -57,6 +57,27 @@ describe("createReplyMediaPathNormalizer", () => {
         mediaAccess: expect.objectContaining({
           workspaceDir: "/tmp/agent-workspace",
         }),
+        originalFilename: "photo.png",
+      }),
+    );
+  });
+
+  it("forwards friendly basenames to outbound attachment staging for #68536", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    await normalize({
+      mediaUrls: ["./out/Plan - Detailed.docx"],
+    });
+
+    expect(resolveOutboundAttachmentFromUrl).toHaveBeenCalledWith(
+      path.join("/tmp/agent-workspace", "out", "Plan - Detailed.docx"),
+      5 * 1024 * 1024,
+      expect.objectContaining({
+        originalFilename: "Plan - Detailed.docx",
       }),
     );
   });

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -150,8 +150,18 @@ export function createReplyMediaPathNormalizer(params: {
     if (cached) {
       return await cached;
     }
+    // Preserve the friendly basename so downstream transports (WhatsApp,
+    // Matrix, Discord) can present `Plan - Detailed.docx` to the recipient
+    // instead of the staged `<uuid>.docx` filename — see #68536. The staging
+    // path under `~/.openclaw/media/outbound/<uuid>.<ext>` remains unchanged;
+    // only the metadata that transports consult for the user-visible name
+    // is threaded through.
+    const originalFilename = isLikelyLocalMediaSource(media)
+      ? path.basename(media)
+      : undefined;
     const persistPromise = resolveOutboundAttachmentFromUrl(media, maxBytes, {
       mediaAccess: resolveMediaAccessForSource(media),
+      originalFilename,
     })
       .then((saved) => saved.path)
       .catch((err) => {

--- a/src/media/outbound-attachment.ts
+++ b/src/media/outbound-attachment.ts
@@ -9,6 +9,13 @@ export async function resolveOutboundAttachmentFromUrl(
     mediaAccess?: OutboundMediaAccess;
     localRoots?: readonly string[];
     readFile?: (filePath: string) => Promise<Buffer>;
+    /**
+     * Friendly basename from the original source (e.g. `Plan - Detailed.docx`).
+     * Forwarded to `saveMediaBuffer` so downstream transports (WhatsApp, Matrix,
+     * Discord) can present the human-readable filename to the recipient instead
+     * of the staged `<uuid>.<ext>` staging name — see #68536.
+     */
+    originalFilename?: string;
   },
 ): Promise<{ path: string; contentType?: string }> {
   const media = await loadWebMedia(
@@ -25,6 +32,7 @@ export async function resolveOutboundAttachmentFromUrl(
     media.contentType ?? undefined,
     "outbound",
     maxBytes,
+    options?.originalFilename,
   );
   return { path: saved.path, contentType: saved.contentType };
 }


### PR DESCRIPTION
## Problem

Reply-media normalization persisted local attachments via `resolveOutboundAttachmentFromUrl` without forwarding the original basename. The path ended up under `~/.openclaw/media/outbound/<uuid>.<ext>`, and downstream transports (WhatsApp, Matrix, Discord) could only see the staged UUID filename — never the friendly source name.

Reporter in #68536 showed a live WhatsApp conversation where users repeatedly complained about receiving `ca9d1d0c-be06-4794-8ec7-fd2de183243c.docx` instead of `Plan - Detailed.docx`. The explicit-message-tool path already supports `originalFilename` (via `saveMediaBuffer`); only the reply-media seam was dropping it.

## Fix

- `src/media/outbound-attachment.ts` — accept `originalFilename` in the options bag and forward it to `saveMediaBuffer`.
- `src/auto-reply/reply/reply-media-paths.ts` — in `persistLocalReplyMedia`, extract `path.basename(media)` for sources that are `isLikelyLocalMediaSource`, and pass through. Staging path under `~/.openclaw/media/outbound/<uuid>.<ext>` is unchanged — only transport-facing metadata benefits.

## Scope

Intentionally tight: only the reply-media seam cited in #68536. No change to explicit-message-tool filename handling (already correct) or to the response-prefix config.

## Testing

- `tsc` clean on touched files (same pre-existing main errors unrelated to this change).
- `oxlint` clean on touched files.
- Added regression test in `reply-media-paths.test.ts` asserting `resolveOutboundAttachmentFromUrl` is called with `expect.objectContaining({ originalFilename: "Plan - Detailed.docx" })` for a workspace-relative local path; extended the existing workspace-relative assertion with the same check.

Fixes #68536