### PR TITLE
fix(telegram): reset sessions after unrecoverable context overflow

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -13,6 +13,8 @@ const state = vi.hoisted(() => ({
   runEmbeddedPiAgentMock: vi.fn(),
   runWithModelFallbackMock: vi.fn(),
   isInternalMessageChannelMock: vi.fn((_: unknown) => false),
+  isLikelyContextOverflowErrorMock: vi.fn((_?: string) => false),
+  isContextOverflowErrorMock: vi.fn((_?: string) => false),
 }));
 
 vi.mock("../../agents/pi-embedded.js", () => ({
@@ -44,9 +46,9 @@ vi.mock("../../agents/bootstrap-budget.js", () => ({
 vi.mock("../../agents/pi-embedded-helpers.js", () => ({
   BILLING_ERROR_USER_MESSAGE: "billing",
   isCompactionFailureError: () => false,
-  isContextOverflowError: () => false,
+  isContextOverflowError: (msg?: string) => state.isContextOverflowErrorMock(msg),
   isBillingErrorMessage: () => false,
-  isLikelyContextOverflowError: () => false,
+  isLikelyContextOverflowError: (msg?: string) => state.isLikelyContextOverflowErrorMock(msg),
   isRateLimitErrorMessage: () => false,
   isTransientHttpError: () => false,
   sanitizeUserFacingText: (text?: string) => text ?? "",
@@ -231,6 +233,10 @@ describe("runAgentTurnWithFallback", () => {
     state.runWithModelFallbackMock.mockReset();
     state.isInternalMessageChannelMock.mockReset();
     state.isInternalMessageChannelMock.mockReturnValue(false);
+    state.isLikelyContextOverflowErrorMock.mockReset();
+    state.isLikelyContextOverflowErrorMock.mockReturnValue(false);
+    state.isContextOverflowErrorMock.mockReset();
+    state.isContextOverflowErrorMock.mockReturnValue(false);
     state.runWithModelFallbackMock.mockImplementation(async (params: FallbackRunnerParams) => ({
       result: await params.run("anthropic", "claude"),
       provider: "anthropic",
@@ -1901,5 +1907,95 @@ describe("runAgentTurnWithFallback", () => {
       authProfileOverride: "anthropic:openclaw",
       authProfileOverrideSource: "user",
     });
+  });
+
+  it("auto-resets session when context overflow is thrown", async () => {
+    state.isLikelyContextOverflowErrorMock.mockReturnValue(true);
+
+    state.runWithModelFallbackMock.mockImplementation(async (_params: FallbackRunnerParams) => {
+      throw new Error("Context window exceeded: prompt is too long");
+    });
+
+    const resetMock = vi.fn(async () => true);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { replyOperation } = createMockReplyOperation();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {} satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: resetMock,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "agent:main:main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+      replyOperation,
+    });
+
+    expect(resetMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("final");
+    expect((result as { payload: { text: string } }).payload.text).toContain(
+      "reset our conversation",
+    );
+  });
+
+  it("auto-resets session on final embedded context overflow with no payload", async () => {
+    state.isContextOverflowErrorMock.mockReturnValue(true);
+
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => ({
+      payloads: [],
+      meta: {
+        error: {
+          message: "Context window exceeded",
+          kind: "context_overflow",
+        },
+      },
+    }));
+
+    const resetMock = vi.fn(async () => true);
+    const runAgentTurnWithFallback = await getRunAgentTurnWithFallback();
+    const { replyOperation } = createMockReplyOperation();
+    const result = await runAgentTurnWithFallback({
+      commandBody: "hello",
+      followupRun: createFollowupRun(),
+      sessionCtx: {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext,
+      opts: {} satisfies GetReplyOptions,
+      typingSignals: createMockTypingSignaler(),
+      blockReplyPipeline: null,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      applyReplyToMode: (payload) => payload,
+      shouldEmitToolResult: () => true,
+      shouldEmitToolOutput: () => false,
+      pendingToolTasks: new Set(),
+      resetSessionAfterCompactionFailure: resetMock,
+      resetSessionAfterRoleOrderingConflict: async () => false,
+      isHeartbeat: false,
+      sessionKey: "agent:main:main",
+      getActiveSessionEntry: () => undefined,
+      resolvedVerboseLevel: "off",
+      replyOperation,
+    });
+
+    expect(resetMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("final");
+    expect((result as { payload: { text: string } }).payload.text).toContain(
+      "reset our conversation",
+    );
   });
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1458,6 +1458,25 @@ export async function runAgentTurnWithFallback(params: {
         };
       }
 
+      // Auto-recover from context overflow by resetting the session.
+      // Without this, the bloated session persists and every subsequent
+      // message fails with the same overflow error, causing channels like
+      // Telegram to stall permanently.  See #68494.
+      if (
+        isContextOverflow &&
+        !didResetAfterCompactionFailure &&
+        (await params.resetSessionAfterCompactionFailure(message))
+      ) {
+        didResetAfterCompactionFailure = true;
+        params.replyOperation?.fail("run_failed", err);
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Context overflow — I've reset our conversation to start fresh. Please try again.",
+          },
+        };
+      }
+
       if (isTransientHttp && !didRetryTransientHttpError) {
         didRetryTransientHttpError = true;
         // Retry the full runWithModelFallback() cycle — transient errors
@@ -1517,6 +1536,21 @@ export async function runAgentTurnWithFallback(params: {
   if (finalEmbeddedError && !hasPayloadText) {
     const errorMsg = finalEmbeddedError.message ?? "";
     if (isContextOverflowError(errorMsg)) {
+      // Attempt auto-reset so the next inbound message starts fresh instead
+      // of hitting the same overflow.  See #68494.
+      if (
+        !didResetAfterCompactionFailure &&
+        (await params.resetSessionAfterCompactionFailure(errorMsg))
+      ) {
+        didResetAfterCompactionFailure = true;
+        params.replyOperation?.fail("run_failed", finalEmbeddedError);
+        return {
+          kind: "final",
+          payload: {
+            text: "⚠️ Context overflow — I've reset our conversation to start fresh. Please try again.",
+          },
+        };
+      }
       params.replyOperation?.fail("run_failed", finalEmbeddedError);
       return {
         kind: "final",


### PR DESCRIPTION
## What does this PR do?

Auto-resets the active session when a Telegram-linked conversation hits an unrecoverable context overflow, instead of leaving the bloated session alive and causing subsequent messages to fail repeatedly.

Fixes #68494

## Root Cause

Two context-overflow paths in `src/auto-reply/reply/agent-runner-execution.ts` surfaced a user-facing warning but did not reset the poisoned session:

- `src/auto-reply/reply/agent-runner-execution.ts:1461` — thrown exception path after overflow classification
- `src/auto-reply/reply/agent-runner-execution.ts:1536` — final embedded error fallback path when no payload text is produced

That meant the same oversized session stayed bound to later inbound Telegram messages, so each new turn kept failing against the same overflowed history.

## Applied Approach

Reused the existing session recovery mechanism instead of adding a new reset path:

- kept using `resetSessionAfterCompactionFailure(...)`
- kept using `didResetAfterCompactionFailure` as the single-reset guard
- added the same recovery behavior to both unrecoverable overflow surfaces

This keeps the fix small, consistent with existing recovery logic, and avoids introducing new session-reset abstractions.

## Solution Details

- Added auto-reset for thrown context overflow before the generic fallback message is returned in `src/auto-reply/reply/agent-runner-execution.ts`
- Added auto-reset for final embedded overflow errors with no payload in `src/auto-reply/reply/agent-runner-execution.ts`
- Added regression tests for both paths in `src/auto-reply/reply/agent-runner-execution.test.ts`

## What Bottleneck Does This Solve?

It removes failure loop where Telegram bot can become effectively silent after a long-running session overflows context and never rotates to a fresh session.

## Corrected Result

After this change:

- unrecoverable context overflow resets the active session
- user gets a clear “conversation was reset” reply
- next inbound Telegram message starts from a fresh session instead of reusing poisoned history
- Telegram channel no longer stays stuck on same overflowed session

## Workflow

**Targeted regression test:**
```bash
$ pnpm vitest run src/auto-reply/reply/agent-runner-execution.test.ts --reporter=dot

 RUN  v4.1.4 C:/Users/xyzsa/Desktop/skills/mygithub/openclaw

·································

 Test Files  1 passed (1)
      Tests  33 passed (33)
   Duration  2.48s
```

**Additional validation:**
```bash
$ git diff --check -- src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-execution.test.ts
# no output
```

**Repo-wide check status:**
```bash
$ pnpm check
# fails in unrelated optional-extension/module resolution paths
# e.g. missing '@line/bot-sdk', '@twurple/*', 'dompurify', '@aws-sdk/*'
```

## Why This Is Safe

- only touches existing overflow recovery behavior
- reuses existing reset callback and single-reset guard
- scope limited to two overflow branches plus regression tests
- no routing, transport, or session store contract changes
- covered by unit tests for both affected paths

## Related

- Fixes #68494