### PR TITLE
fix(memory-core): rewrite qmd index on managed collection repair

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1226,10 +1226,13 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual([]);
     expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
     expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("suspected null-byte collection metadata"),
+    );
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("qmd managed collections rebuilt for update repair"),
     );
 
     await manager.close();
@@ -1283,10 +1286,13 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual([]);
     expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
     expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("suspected null-byte collection metadata"),
+    );
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("qmd managed collections rebuilt for update repair"),
     );
 
     await manager.close();
@@ -1340,10 +1346,13 @@ describe("QmdMemoryManager", () => {
       .map((args) => args[args.indexOf("--name") + 1]);
 
     expect(updateCalls).toBe(2);
-    expect(removeCalls).toEqual(["memory-root-main", "memory-dir-main"]);
+    expect(removeCalls).toEqual([]);
     expect(addCalls).toEqual(["memory-root-main", "memory-dir-main"]);
     expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("duplicate document constraint"),
+    );
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("qmd managed collections rebuilt for update repair"),
     );
 
     await manager.close();

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -454,6 +454,16 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async ensureCollections(): Promise<void> {
+    const configDir = path.join(this.xdgConfigHome, "qmd");
+    await fs.mkdir(configDir, { recursive: true });
+    const lines = ["collections:"];
+    for (const collection of this.qmd.collections) {
+      lines.push(`  ${collection.name}:`);
+      lines.push(`    path: ${collection.path}`);
+      lines.push(`    pattern: ${JSON.stringify(collection.pattern)}`);
+    }
+    await fs.writeFile(path.join(configDir, "index.yml"), lines.join("\n") + "\n", "utf8");
+
     // QMD collections are persisted inside the index database and must be created
     // via the CLI. Prefer listing existing collections when supported, otherwise
     // fall back to best-effort idempotent `qmd collection add`.
@@ -927,24 +937,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private async rebuildManagedCollectionsForRepair(reason: string): Promise<void> {
-    for (const collection of this.qmd.collections) {
-      try {
-        await this.removeCollection(collection.name);
-      } catch (removeErr) {
-        const removeMessage = formatErrorMessage(removeErr);
-        if (!this.isCollectionMissingError(removeMessage)) {
-          log.warn(`qmd collection remove failed for ${collection.name}: ${removeMessage}`);
-        }
-      }
-      try {
-        await this.addCollection(collection.path, collection.name, collection.pattern);
-      } catch (addErr) {
-        const addMessage = formatErrorMessage(addErr);
-        if (!this.isCollectionAlreadyExistsError(addMessage)) {
-          log.warn(`qmd collection add failed for ${collection.name}: ${addMessage}`);
-        }
-      }
-    }
+    await this.ensureCollections();
     log.warn(`qmd managed collections rebuilt for update repair (${reason})`);
   }
 


### PR DESCRIPTION
## Summary
- rewrite `index.yml` before ensuring managed QMD collections
- reuse `ensureCollections()` during managed collection repair instead of hand-rolling remove/add loops
- keep repair behavior aligned with the normal collection bootstrap path

## Why
The local deployment carried this as a qmd-manager resilience patch so managed collection repair always rewrites the QMD index file before re-ensuring collections. This reduces drift between the steady-state bootstrap path and the repair path.

## Validation
- focused qmd-manager test suite passed locally (88/88)
