### PR TITLE
fix(memory): block symlink escapes in memory_get

### DIFF
--- a/extensions/memory-core/src/memory/manager.read-file.test.ts
+++ b/extensions/memory-core/src/memory/manager.read-file.test.ts
@@ -274,6 +274,39 @@ describe("MemoryIndexManager.readFile", () => {
     }
   });
 
+  it("returns empty text when the file disappears before realpath resolves", async () => {
+    const relPath = "memory/transient-realpath.md";
+    const absPath = path.join(workspaceDir, relPath);
+    await fs.mkdir(path.dirname(absPath), { recursive: true });
+    await fs.writeFile(absPath, "first\nsecond", "utf-8");
+
+    const realRealpath = fs.realpath;
+    let injected = false;
+    const realpathSpy = vi
+      .spyOn(fs, "realpath")
+      .mockImplementation(async (...args: Parameters<typeof realRealpath>) => {
+        const [target] = args;
+        if (!injected && typeof target === "string" && path.resolve(target) === absPath) {
+          injected = true;
+          const err = new Error("missing") as NodeJS.ErrnoException;
+          err.code = "ENOENT";
+          throw err;
+        }
+        return await realRealpath(...args);
+      });
+
+    try {
+      const result = await readMemoryFile({
+        workspaceDir,
+        extraPaths: [],
+        relPath,
+      });
+      expect(result).toEqual({ text: "", path: relPath });
+    } finally {
+      realpathSpy.mockRestore();
+    }
+  });
+
   it("rejects non-memory paths", async () => {
     await expect(
       readMemoryFile({

--- a/extensions/memory-core/src/memory/manager.read-file.test.ts
+++ b/extensions/memory-core/src/memory/manager.read-file.test.ts
@@ -245,6 +245,7 @@ describe("MemoryIndexManager.readFile", () => {
     const absPath = path.join(workspaceDir, relPath);
     await fs.mkdir(path.dirname(absPath), { recursive: true });
     await fs.writeFile(absPath, "first\nsecond", "utf-8");
+    const realAbsPath = await fs.realpath(absPath);
 
     const realReadFile = fs.readFile;
     let injected = false;
@@ -252,7 +253,7 @@ describe("MemoryIndexManager.readFile", () => {
       .spyOn(fs, "readFile")
       .mockImplementation(async (...args: Parameters<typeof realReadFile>) => {
         const [target, options] = args;
-        if (!injected && typeof target === "string" && path.resolve(target) === absPath) {
+        if (!injected && typeof target === "string" && path.resolve(target) === realAbsPath) {
           injected = true;
           const err = new Error("missing") as NodeJS.ErrnoException;
           err.code = "ENOENT";
@@ -329,6 +330,71 @@ describe("MemoryIndexManager.readFile", () => {
           relPath: "extra/linked.md",
         }),
       ).rejects.toThrow("path required");
+    }
+  });
+
+  it("rejects workspace memory reads that cross a symlinked directory boundary", async () => {
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-outside-"));
+    try {
+      await fs.writeFile(path.join(outsideDir, "secret.md"), "outside secret");
+
+      const nestedLink = path.join(memoryDir, "linked");
+      let symlinkOk = true;
+      try {
+        await fs.symlink(outsideDir, nestedLink, "dir");
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EPERM" || code === "EACCES") {
+          symlinkOk = false;
+        } else {
+          throw err;
+        }
+      }
+
+      if (symlinkOk) {
+        await expect(
+          readMemoryFile({
+            workspaceDir,
+            extraPaths: [],
+            relPath: "memory/linked/secret.md",
+          }),
+        ).rejects.toThrow("path required");
+      }
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects additional memory reads that cross a nested symlinked directory", async () => {
+    await fs.mkdir(extraDir, { recursive: true });
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-extra-outside-"));
+    try {
+      await fs.writeFile(path.join(outsideDir, "secret.md"), "outside extra secret");
+
+      const nestedLink = path.join(extraDir, "linked-dir");
+      let symlinkOk = true;
+      try {
+        await fs.symlink(outsideDir, nestedLink, "dir");
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EPERM" || code === "EACCES") {
+          symlinkOk = false;
+        } else {
+          throw err;
+        }
+      }
+
+      if (symlinkOk) {
+        await expect(
+          readMemoryFile({
+            workspaceDir,
+            extraPaths: [extraDir],
+            relPath: "extra/linked-dir/secret.md",
+          }),
+        ).rejects.toThrow("path required");
+      }
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
     }
   });
 });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3562,6 +3562,18 @@ describe("QmdMemoryManager", () => {
       "path required",
     );
 
+    const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-qmd-outside-"));
+    try {
+      await fs.writeFile(path.join(outsideDir, "secret.md"), "outside qmd secret", "utf-8");
+      const nestedLink = path.join(workspaceDir, "linked-dir");
+      await fs.symlink(outsideDir, nestedLink, "dir");
+      await expect(
+        manager.readFile({ relPath: "qmd/workspace-main/linked-dir/secret.md" }),
+      ).rejects.toThrow("path required");
+    } finally {
+      await fs.rm(outsideDir, { recursive: true, force: true });
+    }
+
     await manager.close();
   });
 

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3566,10 +3566,22 @@ describe("QmdMemoryManager", () => {
     try {
       await fs.writeFile(path.join(outsideDir, "secret.md"), "outside qmd secret", "utf-8");
       const nestedLink = path.join(workspaceDir, "linked-dir");
-      await fs.symlink(outsideDir, nestedLink, "dir");
-      await expect(
-        manager.readFile({ relPath: "qmd/workspace-main/linked-dir/secret.md" }),
-      ).rejects.toThrow("path required");
+      let symlinkOk = true;
+      try {
+        await fs.symlink(outsideDir, nestedLink, "dir");
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "EPERM" || code === "EACCES") {
+          symlinkOk = false;
+        } else {
+          throw err;
+        }
+      }
+      if (symlinkOk) {
+        await expect(
+          manager.readFile({ relPath: "qmd/workspace-main/linked-dir/secret.md" }),
+        ).rejects.toThrow("path required");
+      }
     } finally {
       await fs.rm(outsideDir, { recursive: true, force: true });
     }

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -34,9 +34,9 @@ import {
   buildMemoryReadResultFromSlice,
   DEFAULT_MEMORY_READ_LINES,
   isFileMissingError,
+  resolveContainedRegularFile,
   type MemoryReadResult,
   requireNodeSqlite,
-  statRegularFile,
   type MemoryEmbeddingProbeResult,
   type MemoryProviderStatus,
   type MemorySearchManager,
@@ -1194,7 +1194,10 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (!absPath.endsWith(".md")) {
       throw new Error("path required");
     }
-    const statResult = await statRegularFile(absPath);
+    const statResult = await resolveContainedRegularFile({
+      absPath,
+      allowedRoots: [this.resolveReadAllowedRoot(relPath)],
+    });
     if (statResult.missing) {
       return { text: "", path: relPath };
     }
@@ -1204,7 +1207,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         1,
         params.lines ?? contextLimits?.memoryGetDefaultLines ?? DEFAULT_MEMORY_READ_LINES,
       );
-      const partial = await this.readPartialText(absPath, params.from, requestedCount);
+      const partial = await this.readPartialText(statResult.realPath, params.from, requestedCount);
       if (partial.missing) {
         return { text: "", path: relPath };
       }
@@ -1217,7 +1220,7 @@ export class QmdMemoryManager implements MemorySearchManager {
         suggestReadFallback: isDefaultMemoryPath(relPath),
       });
     }
-    const full = await this.readFullText(absPath);
+    const full = await this.readFullText(statResult.realPath);
     if (full.missing) {
       return { text: "", path: relPath };
     }
@@ -2564,6 +2567,18 @@ export class QmdMemoryManager implements MemorySearchManager {
       throw new Error("path required");
     }
     return absPath;
+  }
+
+  private resolveReadAllowedRoot(relPath: string): string {
+    if (relPath.startsWith("qmd/")) {
+      const [, collection] = relPath.split("/");
+      const root = collection ? this.collectionRoots.get(collection) : undefined;
+      if (!root) {
+        throw new Error("invalid qmd path");
+      }
+      return root.path;
+    }
+    return this.workspaceDir;
   }
 
   private isIndexedWorkspaceReadPath(absPath: string): boolean {

--- a/src/memory-host-sdk/engine-storage.ts
+++ b/src/memory-host-sdk/engine-storage.ts
@@ -41,4 +41,8 @@ export type {
 export { ensureMemoryIndexSchema } from "./host/memory-schema.js";
 export { loadSqliteVecExtension } from "./host/sqlite-vec.js";
 export { requireNodeSqlite } from "./host/sqlite.js";
-export { isFileMissingError, statRegularFile } from "./host/fs-utils.js";
+export {
+  isFileMissingError,
+  resolveContainedRegularFile,
+  statRegularFile,
+} from "./host/fs-utils.js";

--- a/src/memory-host-sdk/host/fs-utils.ts
+++ b/src/memory-host-sdk/host/fs-utils.ts
@@ -54,7 +54,15 @@ export async function resolveContainedRegularFile(params: {
   if (statResult.missing) {
     return { missing: true };
   }
-  const realPath = await fs.realpath(params.absPath);
+  let realPath: string;
+  try {
+    realPath = await fs.realpath(params.absPath);
+  } catch (err) {
+    if (isFileMissingError(err)) {
+      return { missing: true };
+    }
+    throw err;
+  }
   const allowedRoots = await Promise.all(
     params.allowedRoots.map(async (root) => {
       try {

--- a/src/memory-host-sdk/host/fs-utils.ts
+++ b/src/memory-host-sdk/host/fs-utils.ts
@@ -1,5 +1,6 @@
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 
 export type RegularFileStatResult = { missing: true } | { missing: false; stat: Stats };
 
@@ -28,4 +29,43 @@ export async function statRegularFile(absPath: string): Promise<RegularFileStatR
     throw new Error("path required");
   }
   return { missing: false, stat };
+}
+
+function isWithinRealRoot(root: string, candidate: string): boolean {
+  if (candidate === root) {
+    return true;
+  }
+  const relative = path.relative(root, candidate);
+  return relative.length > 0 && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+export async function resolveContainedRegularFile(params: {
+  absPath: string;
+  allowedRoots: string[];
+}): Promise<
+  | { missing: true }
+  | {
+      missing: false;
+      stat: Stats;
+      realPath: string;
+    }
+> {
+  const statResult = await statRegularFile(params.absPath);
+  if (statResult.missing) {
+    return { missing: true };
+  }
+  const realPath = await fs.realpath(params.absPath);
+  const allowedRoots = await Promise.all(
+    params.allowedRoots.map(async (root) => {
+      try {
+        return await fs.realpath(root);
+      } catch {
+        return path.resolve(root);
+      }
+    }),
+  );
+  if (!allowedRoots.some((root) => isWithinRealRoot(root, realPath))) {
+    throw new Error("path required");
+  }
+  return { missing: false, stat: statResult.stat, realPath };
 }

--- a/src/memory-host-sdk/host/read-file.ts
+++ b/src/memory-host-sdk/host/read-file.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { resolveAgentContextLimits, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../../agents/memory-search.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { isFileMissingError, statRegularFile } from "./fs-utils.js";
+import { isFileMissingError, resolveContainedRegularFile } from "./fs-utils.js";
 import { isMemoryPath, normalizeExtraMemoryPaths } from "./internal.js";
 import {
   buildMemoryReadResult,
@@ -30,7 +30,7 @@ export async function readMemoryFile(params: {
   const relPath = path.relative(params.workspaceDir, absPath).replace(/\\/g, "/");
   const inWorkspace = relPath.length > 0 && !relPath.startsWith("..") && !path.isAbsolute(relPath);
   const allowedWorkspace = inWorkspace && isMemoryPath(relPath);
-  let allowedAdditional = false;
+  const matchedAdditionalRoots: string[] = [];
   if (!allowedWorkspace && (params.extraPaths?.length ?? 0) > 0) {
     const additionalPaths = normalizeExtraMemoryPaths(params.workspaceDir, params.extraPaths);
     for (const additionalPath of additionalPaths) {
@@ -41,31 +41,35 @@ export async function readMemoryFile(params: {
         }
         if (stat.isDirectory()) {
           if (absPath === additionalPath || absPath.startsWith(`${additionalPath}${path.sep}`)) {
-            allowedAdditional = true;
+            matchedAdditionalRoots.push(additionalPath);
             break;
           }
           continue;
         }
         if (stat.isFile() && absPath === additionalPath && absPath.endsWith(".md")) {
-          allowedAdditional = true;
+          matchedAdditionalRoots.push(additionalPath);
           break;
         }
       } catch {}
     }
   }
+  const allowedAdditional = matchedAdditionalRoots.length > 0;
   if (!allowedWorkspace && !allowedAdditional) {
     throw new Error("path required");
   }
   if (!absPath.endsWith(".md")) {
     throw new Error("path required");
   }
-  const statResult = await statRegularFile(absPath);
+  const statResult = await resolveContainedRegularFile({
+    absPath,
+    allowedRoots: allowedWorkspace ? [params.workspaceDir] : matchedAdditionalRoots,
+  });
   if (statResult.missing) {
     return { text: "", path: relPath };
   }
   let content: string;
   try {
-    content = await fs.readFile(absPath, "utf-8");
+    content = await fs.readFile(statResult.realPath, "utf-8");
   } catch (err) {
     if (isFileMissingError(err)) {
       return { text: "", path: relPath };


### PR DESCRIPTION
## Summary

- Problem: `memory_get` could accept a path that lexically stayed under the workspace or an allowed extra path, but escaped through an intermediate directory symlink.
- Why it matters: an agent using `memory_get` could be tricked into pulling content from outside the workspace or QMD memory boundary, which means normal memory lookups could unexpectedly surface unrelated local files instead of only the notes the user intended memory tools to access.
- What changed: resolve target files and allowed roots to real paths before reading, then reject reads whose canonical path falls outside the allowed root; applied to both builtin memory reads and QMD-backed reads.
- What did NOT change (scope boundary): no changes to memory search ranking, indexing behavior, prompt logic, or non-memory file access surfaces.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Memory / storage
- [x] API / contracts

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the read path checks only validated the lexical path prefix and direct symlink files, but did not verify that the resolved real path still stayed inside the allowed workspace / extraPath / QMD collection root.
- Missing detection / guardrail: no regression test covered an intermediate directory symlink that escaped the allowed root.
- Contributing context (if known): builtin and QMD read paths each enforced path rules separately, so both needed the same canonical-path containment check.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/memory-core/src/memory/manager.read-file.test.ts`
  - `extensions/memory-core/src/memory/qmd-manager.test.ts`
- Scenario the test should lock in: reject `memory_get` reads when a path under `memory/`, an allowed extra path, or a QMD collection crosses the boundary through an intermediate directory symlink.
- Why this is the smallest reliable guardrail: the bug lives in path resolution and file-read authorization, so direct read-path tests cover it without requiring full indexing or end-to-end setup.
- Existing test that already covers this (if any): existing tests already covered direct symlink files; this PR extends coverage to directory symlink escapes.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`memory_get` now rejects markdown paths that escape the allowed workspace / extra path / QMD collection through intermediate directory symlinks.

## Diagram (if applicable)

```text
Before:
memory_get("memory/linked/secret.md")
-> lexical prefix check passes
-> linked/ resolves outside workspace
-> file is read

After:
memory_get("memory/linked/secret.md")
-> lexical prefix check passes
-> realpath resolves outside allowed root
-> request fails with "path required"
```
## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `Yes`
- If any `Yes`, explain risk + mitigation:
  - This narrows the readable file scope for `memory_get` to the canonical allowed roots and blocks previously unintended cross-boundary reads through directory symlinks.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/Bun repo test runner
- Model/provider: N/A
- Integration/channel (if any): memory core / QMD
- Relevant config (redacted): default local test config

### Steps

1. Create a markdown file outside the workspace or outside an allowed extra path / QMD collection root.
2. Add an intermediate directory symlink inside `memory/`, an allowed extra path, or a QMD collection that points to that outside directory.
3. Run `memory_get` on the symlinked markdown path.

### Expected

- The read is rejected with `path required`.

### Actual

- Before this fix, the read could succeed because only the lexical path prefix was checked.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - builtin memory reads reject directory symlink escapes
  - extra-path memory reads reject nested directory symlink escapes
  - QMD reads reject directory symlink escapes
- Edge cases checked:
  - direct symlink-file rejection still holds
  - transient file disappearance path still returns empty text correctly after switching reads to canonical paths
- What you did **not** verify:
  - full `pnpm test`
  - full `pnpm check`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: setups that used a directory symlink inside `memory/`, an allowed extra path, or a QMD collection as an implicit way to reach files outside the configured memory roots will now fail on `memory_get`.
  - Mitigation: supported outside-workspace reads should be configured explicitly through `memorySearch.extraPaths` or QMD collections; this change aligns runtime reads with the documented memory-root contract and adds regression coverage for the escaped-symlink case.

