### PR TITLE
agents/compaction: hint at toolResultMaxChars when overflow persists after compaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -530,6 +530,7 @@ Docs: https://docs.openclaw.ai
 - Anthropic/models: add Claude Opus 4.7 `xhigh` reasoning effort support and keep it separate from adaptive thinking.
 - Control UI/settings: overhaul the settings and slash-command experience with faster presets, quick-create flows, and refreshed command discovery. (#67819) Thanks @BunsDev.
 - macOS/gateway: add `screen.snapshot` support for macOS app nodes, including runtime plumbing, default macOS allowlisting, and docs for monitor preview flows. (#67954) Thanks @BunsDev.
+- Agents/compaction: when a context overflow persists after auto-compaction already ran in the same cycle, log a `[context-overflow-hint]` warn line pointing at `agents.defaults.contextLimits.toolResultMaxChars`; compaction troubleshooting docs updated with the matching symptom. Thanks @MotherSphere.
 
 ### Fixes
 

--- a/docs/concepts/compaction.md
+++ b/docs/concepts/compaction.md
@@ -167,6 +167,16 @@ trims tool output without summarizing.
 outputs may be large. Try enabling
 [session pruning](/concepts/session-pruning).
 
+**Compact succeeds but the next turn still overflows?** If you see
+`auto-compaction succeeded` immediately followed by another
+`context overflow detected`, the bottleneck is the current turn's payload,
+not the summarized history. A common cause is one or more large `toolResult`
+entries in the same turn. Cap per-tool-result excerpts with
+`agents.defaults.contextLimits.toolResultMaxChars` (see
+[Token Use and Costs](/reference/token-use)). The runtime surfaces this
+case explicitly with a `[context-overflow-hint]` warn log pointing at the
+same knob.
+
 **Context feels stale after compaction?** Use `/compact Focus on <topic>` to
 guide the summary, or enable the [memory flush](/concepts/memory) so notes
 survive.

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -397,6 +397,60 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("logs context-overflow-hint pointing at toolResultMaxChars after a prior compaction", async () => {
+    const overflowError = makeOverflowError();
+
+    // First overflow compacts, retry overflows again, second compact succeeds.
+    // The hint should fire on the second overflow (compactionAttempts > 0),
+    // not on the first.
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect
+      .mockResolvedValueOnce(
+        makeCompactionSuccess({
+          summary: "Compacted 1",
+          firstKeptEntryId: "entry-3",
+          tokensBefore: 180000,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompactionSuccess({
+          summary: "Compacted 2",
+          firstKeptEntryId: "entry-5",
+          tokensBefore: 160000,
+        }),
+      );
+
+    await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("[context-overflow-hint]"));
+    expect(mockedLog.warn).toHaveBeenCalledWith(expect.stringContaining("toolResultMaxChars"));
+  });
+
+  it("does not log context-overflow-hint on the first overflow before any compaction", async () => {
+    const overflowError = makeOverflowError();
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: overflowError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted 1",
+        firstKeptEntryId: "entry-3",
+        tokensBefore: 180000,
+      }),
+    );
+
+    await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedLog.warn).not.toHaveBeenCalledWith(
+      expect.stringContaining("[context-overflow-hint]"),
+    );
+  });
+
   it("does not attempt compaction for compaction_failure errors", async () => {
     const compactionFailureError = new Error(
       "request_too_large: summarization failed - Request size exceeds model context window",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1164,6 +1164,19 @@ export async function runEmbeddedPiAgent(
                 `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
                 `error=${errorText.slice(0, 200)}`,
             );
+            // If this overflow came back after we already compacted earlier in the
+            // same overflow cycle, the bottleneck is the current turn's payload
+            // (typically large toolResult entries), not the summarized history.
+            // Surface an actionable hint pointing at the config knob.
+            if (overflowCompactionAttempts > 0) {
+              log.warn(
+                `[context-overflow-hint] overflow persisted after compaction for ${provider}/${modelId}; ` +
+                  `this typically indicates the current turn's payload (often large toolResult entries) ` +
+                  `exceeds the window even after history is summarized. Consider capping per-tool-result ` +
+                  `excerpts via agents.defaults.contextLimits.toolResultMaxChars. ` +
+                  `See /concepts/compaction#troubleshooting.`,
+              );
+            }
             const isCompactionFailure = isCompactionFailureError(errorText);
             const hadAttemptLevelCompaction = attemptCompactionCount > 0;
             // If this attempt already compacted (SDK auto-compaction), avoid immediately


### PR DESCRIPTION
## Summary

- **Problem:** When a context overflow triggers auto-compaction and the retry still overflows within the same cycle, the existing `[context-overflow-diag]` log only reports state; it does not tell operators that the bottleneck is the current turn's payload (usually large `toolResult` entries) rather than summarized history. Users end up watching compact → retry → overflow loops with no concrete next action.
- **Why it matters:** `agents.defaults.contextLimits.toolResultMaxChars` already exists for this exact scenario but users have to stumble onto it via deep reference docs.
- **What changed:** When `overflowCompactionAttempts > 0` at the start of overflow handling (this overflow persists after a prior compaction in the same cycle), emit a new `[context-overflow-hint]` warn log pointing explicitly at `agents.defaults.contextLimits.toolResultMaxChars` and the troubleshooting anchor. Added a matching bullet under `docs/concepts/compaction.md` Troubleshooting and two regression tests.
- **What did NOT change (scope boundary):** No behavior change in the compaction loop itself — same branches, same retry count, same error paths. No new imports, no schema/config changes. Existing `[context-overflow-diag]` output untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the `[context-overflow-diag]` warn line already carries `compactionAttempts=N` but does not translate "N > 0 means your current turn is too big even after history was summarized" into an actionable pointer. Operators tailing logs have no obvious path to the relevant config knob.
- Missing detection / guardrail: no runtime message specifically covers the compact-then-retry-then-overflow pattern; the existing \`post-compaction tool-result truncation did not help\` log only fires on the narrower \`compact_then_truncate\` preflight route.
- Contributing context: reproduced in practice on a 177-message GPT-5.4 session that overflowed mid tool-loop with ~45 KB of toolResult payload in a single turn. Auto-compaction succeeded, the retry still overflowed immediately, and \`openclaw.json\` had no \`agents.defaults.contextLimits\` configured — the default path every install starts from.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: \`src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts\`
- Scenario the test should lock in: hint log fires on the second overflow in a compact-then-retry-then-overflow cycle, and does NOT fire on the first overflow of a fresh session.
- Why this is the smallest reliable guardrail: the hint is a pure additive log line driven by a single branch on \`overflowCompactionAttempts > 0\`; a unit test around the embedded run harness asserts both paths without needing a real provider or context engine.
- Existing test that already covers this: none; added two new cases in the same file.
- If no new test is added, why not: N/A.

## Local validation

- \`pnpm test src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts\` → 17/17 pass (15 existing + 2 new).
- \`pnpm check\` (tsgo + oxlint + format + import-cycles + madge) → 0 warnings, 0 errors across 11722 files.