### PR TITLE
Plugins: add sessions_send delegation hook

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-20db3f5afb93db334ad7456d26303c81b2a3eeaa5c1f8846a459eec72be20b96  plugin-sdk-api-baseline.json
-d02926e9facb3321a1018804d4c0370d9627963bee5e478942dda469e529c20b  plugin-sdk-api-baseline.jsonl
+04ee2cd38fbc60ca2e0e68281eeb503a049a578a09de7125062747b9a4b6d96a  plugin-sdk-api-baseline.json
+d24429bc87aa75d096d486f0a97258327bfb0a00d99484a8f93f6b568c4ba337  plugin-sdk-api-baseline.jsonl

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -5,9 +5,18 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
+const getGlobalHookRunnerMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => getGlobalHookRunnerMock(),
+}));
+
+type SessionsSendHookRunnerMock = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runSessionsSend: ReturnType<typeof vi.fn>;
+};
 
 vi.mock("../config/config.js", () => ({
   loadConfig: () => ({
@@ -164,6 +173,7 @@ describe("sessions tools", () => {
     sessionsSendA2ATesting.setDepsForTest({
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
+    getGlobalHookRunnerMock.mockReturnValue(null);
   });
 
   it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
@@ -1087,5 +1097,170 @@ describe("sessions tools", () => {
       message: "announce now",
       threadId: "99",
     });
+  });
+
+  it("sessions_send falls back to core delivery when sessions_send hooks decline", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({ handled: false, reason: "not delegated" })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-1", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "done" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-fallback", {
+      sessionKey: "main",
+      message: "wait",
+      timeoutSeconds: 1,
+      task: { intent: "delegate", instructions: "delegate wait" },
+    });
+
+    expect(result.details).toMatchObject({ status: "ok", reply: "done" });
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        target: { sessionKey: "main", displayKey: "main" },
+        message: "wait",
+        task: expect.objectContaining({
+          intent: "delegate",
+          instructions: "delegate wait",
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(true);
+  });
+
+  it("sessions_send waits on plugin-produced delegated metadata", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({
+        handled: true,
+        mode: "delegated",
+        dispatch: {
+          kind: "a2a-broker",
+          taskId: "task-123",
+          waitRunId: "wait-123",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+      })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { runId: "wait-123", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "delegated reply" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-delegated", {
+      sessionKey: "main",
+      message: "delegate this",
+      timeoutSeconds: 1,
+      task: {
+        intent: "delegate",
+        instructions: "delegate this",
+        runtime: {
+          roundOneReply: "delegated round one",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+        correlationId: "corr-123",
+        parentRunId: "parent-123",
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      runId: "wait-123",
+      reply: "delegated reply",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(false);
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          correlationId: "corr-123",
+          parentRunId: "parent-123",
+          runtime: expect.objectContaining({
+            cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+          }),
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) =>
+          (call[0] as { method?: string; params?: { runId?: string } }).method === "agent.wait" &&
+          (call[0] as { params?: { runId?: string } }).params?.runId === "wait-123",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -42,6 +43,119 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+
+type SessionsSendHookTask = {
+  intent?: string;
+  instructions?: string;
+  constraints?: {
+    timeoutSeconds?: number;
+    maxPingPongTurns?: number;
+  };
+  runtime?: {
+    waitRunId?: string;
+    roundOneReply?: string;
+    announceTimeoutMs?: number;
+    maxPingPongTurns?: number;
+    cancelTarget?: {
+      kind?: string;
+      sessionKey?: string;
+      runId?: string;
+    };
+  };
+  requester?: {
+    sessionKey?: string;
+    channel?: string;
+  };
+  correlationId?: string;
+  parentRunId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOptionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readSessionsSendHookTask(
+  params: Record<string, unknown>,
+  defaults: {
+    message: string;
+    timeoutSeconds: number;
+    announceTimeoutMs: number;
+    maxPingPongTurns: number;
+    requesterSessionKey?: string;
+    requesterChannel?: string;
+  },
+): SessionsSendHookTask | undefined {
+  const rawTask = isRecord(params.task) ? params.task : undefined;
+  if (!rawTask) {
+    return undefined;
+  }
+  const rawConstraints = isRecord(rawTask.constraints) ? rawTask.constraints : undefined;
+  const rawRuntime = isRecord(rawTask.runtime) ? rawTask.runtime : undefined;
+  const rawRequester = isRecord(rawTask.requester) ? rawTask.requester : undefined;
+  const rawCancelTarget = isRecord(rawRuntime?.cancelTarget) ? rawRuntime.cancelTarget : undefined;
+  return {
+    intent: normalizeOptionalString(
+      typeof rawTask.intent === "string" ? rawTask.intent : undefined,
+    ),
+    instructions:
+      normalizeOptionalString(
+        typeof rawTask.instructions === "string" ? rawTask.instructions : undefined,
+      ) ?? defaults.message,
+    constraints: {
+      timeoutSeconds:
+        readOptionalFiniteNumber(rawConstraints?.timeoutSeconds) ?? defaults.timeoutSeconds,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawConstraints?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+    },
+    runtime: {
+      waitRunId: normalizeOptionalString(
+        typeof rawRuntime?.waitRunId === "string" ? rawRuntime.waitRunId : undefined,
+      ),
+      roundOneReply: normalizeOptionalString(
+        typeof rawRuntime?.roundOneReply === "string" ? rawRuntime.roundOneReply : undefined,
+      ),
+      announceTimeoutMs:
+        readOptionalFiniteNumber(rawRuntime?.announceTimeoutMs) ?? defaults.announceTimeoutMs,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawRuntime?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+      cancelTarget: rawCancelTarget
+        ? {
+            kind: normalizeOptionalString(
+              typeof rawCancelTarget.kind === "string" ? rawCancelTarget.kind : undefined,
+            ),
+            sessionKey: normalizeOptionalString(
+              typeof rawCancelTarget.sessionKey === "string"
+                ? rawCancelTarget.sessionKey
+                : undefined,
+            ),
+            runId: normalizeOptionalString(
+              typeof rawCancelTarget.runId === "string" ? rawCancelTarget.runId : undefined,
+            ),
+          }
+        : undefined,
+    },
+    requester: {
+      sessionKey:
+        normalizeOptionalString(
+          typeof rawRequester?.sessionKey === "string" ? rawRequester.sessionKey : undefined,
+        ) ?? defaults.requesterSessionKey,
+      channel:
+        normalizeOptionalString(
+          typeof rawRequester?.channel === "string" ? rawRequester.channel : undefined,
+        ) ?? defaults.requesterChannel,
+    },
+    correlationId: normalizeOptionalString(
+      typeof rawTask.correlationId === "string" ? rawTask.correlationId : undefined,
+    ),
+    parentRunId: normalizeOptionalString(
+      typeof rawTask.parentRunId === "string" ? rawTask.parentRunId : undefined,
+    ),
+  };
+}
 
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
@@ -270,6 +384,115 @@ export function createSessionsSendTool(opts?: {
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
       });
+      const requesterSessionKey = opts?.agentSessionKey;
+      const requesterChannel = opts?.agentChannel;
+      const maxPingPongTurns = resolvePingPongTurns(cfg);
+      const hookTask = readSessionsSendHookTask(params, {
+        message,
+        timeoutSeconds,
+        announceTimeoutMs,
+        maxPingPongTurns,
+        requesterSessionKey,
+        requesterChannel,
+      });
+      const delivery = { status: "pending", mode: "announce" as const };
+      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+        void runSessionsSendA2AFlow({
+          targetSessionKey: resolvedKey,
+          displayKey,
+          message,
+          announceTimeoutMs,
+          maxPingPongTurns,
+          requesterSessionKey,
+          requesterChannel,
+          roundOneReply,
+          waitRunId,
+        });
+      };
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("sessions_send")) {
+        const hookResult = await hookRunner.runSessionsSend(
+          {
+            sessionKey: resolvedKey,
+            target: {
+              sessionKey: resolvedKey,
+              displayKey,
+            },
+            message,
+            ...(hookTask ? { task: hookTask } : {}),
+            rawParams: params,
+          },
+          {
+            requesterSessionKey,
+            requesterChannel,
+          },
+        );
+        if (hookResult?.handled) {
+          if (hookResult.mode === "direct") {
+            return jsonResult(
+              isRecord(hookResult.result)
+                ? hookResult.result
+                : {
+                    status: "ok",
+                    result: hookResult.result,
+                    sessionKey: displayKey,
+                  },
+            );
+          }
+          const delegatedWaitRunId = normalizeOptionalString(hookResult.dispatch.waitRunId);
+          const delegatedRunId = delegatedWaitRunId ?? hookResult.dispatch.taskId;
+          if (timeoutSeconds === 0) {
+            startA2AFlow(hookTask?.runtime?.roundOneReply, delegatedWaitRunId);
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "accepted",
+              sessionKey: displayKey,
+              delivery,
+            });
+          }
+          if (!delegatedWaitRunId) {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: "Delegated sessions_send hook result missing waitRunId for waited send",
+              sessionKey: displayKey,
+            });
+          }
+          const delegatedResult = await waitForAgentRunAndReadUpdatedAssistantReply({
+            runId: delegatedWaitRunId,
+            sessionKey: resolvedKey,
+            timeoutMs,
+            limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+            baseline: baselineReply,
+            callGateway: gatewayCall,
+          });
+          if (delegatedResult.status === "timeout") {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "timeout",
+              error: delegatedResult.error,
+              sessionKey: displayKey,
+            });
+          }
+          if (delegatedResult.status === "error") {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: delegatedResult.error ?? "agent error",
+              sessionKey: displayKey,
+            });
+          }
+          const reply = delegatedResult.replyText;
+          startA2AFlow(hookTask?.runtime?.roundOneReply ?? reply ?? undefined);
+          return jsonResult({
+            runId: delegatedRunId,
+            status: "ok",
+            reply,
+            sessionKey: displayKey,
+            delivery,
+          });
+        }
+      }
       const sendParams = {
         message,
         sessionKey: resolvedKey,
@@ -284,23 +507,6 @@ export function createSessionsSendTool(opts?: {
           sourceChannel: opts?.agentChannel,
           sourceTool: "sessions_send",
         },
-      };
-      const requesterSessionKey = opts?.agentSessionKey;
-      const requesterChannel = opts?.agentChannel;
-      const maxPingPongTurns = resolvePingPongTurns(cfg);
-      const delivery = { status: "pending", mode: "announce" as const };
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
-        void runSessionsSendA2AFlow({
-          targetSessionKey: resolvedKey,
-          displayKey,
-          message,
-          announceTimeoutMs,
-          maxPingPongTurns,
-          requesterSessionKey,
-          requesterChannel,
-          roundOneReply,
-          waitRunId,
-        });
       };
 
       if (timeoutSeconds === 0) {

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -99,6 +99,11 @@ export type {
   PluginHookReplyDispatchResult,
 } from "../plugins/types.js";
 export type { OpenClawConfig } from "../config/config.js";
+export type {
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
+} from "../plugins/types.js";
 export type { OutboundIdentity } from "../infra/outbound/identity.js";
 export type { HistoryEntry } from "../auto-reply/reply/history.js";
 export type { ReplyPayload } from "../auto-reply/reply-payload.js";

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -67,6 +67,7 @@ export type PluginHookName =
   | "message_received"
   | "message_sending"
   | "message_sent"
+  | "sessions_send"
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
@@ -98,6 +99,7 @@ export const PLUGIN_HOOK_NAMES = [
   "message_received",
   "message_sending",
   "message_sent",
+  "sessions_send",
   "before_tool_call",
   "after_tool_call",
   "tool_result_persist",
@@ -278,6 +280,64 @@ export type PluginHookReplyDispatchResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
 };
+
+export type PluginHookSessionsSendCancelTarget = {
+  kind?: string;
+  sessionKey?: string;
+  runId?: string;
+};
+
+export type PluginHookSessionsSendTask = {
+  intent?: string;
+  instructions?: string;
+  constraints?: {
+    timeoutSeconds?: number;
+    maxPingPongTurns?: number;
+  };
+  runtime?: {
+    waitRunId?: string;
+    roundOneReply?: string;
+    announceTimeoutMs?: number;
+    maxPingPongTurns?: number;
+    cancelTarget?: PluginHookSessionsSendCancelTarget;
+  };
+  requester?: {
+    sessionKey?: string;
+    channel?: string;
+  };
+  correlationId?: string;
+  parentRunId?: string;
+};
+
+export type PluginHookSessionsSendEvent = {
+  sessionKey: string;
+  target: {
+    sessionKey?: string;
+    displayKey?: string;
+  };
+  message: string;
+  task?: PluginHookSessionsSendTask;
+  rawParams: unknown;
+};
+
+export type PluginHookSessionsSendContext = {
+  requesterSessionKey?: string;
+  requesterChannel?: string;
+};
+
+export type PluginHookSessionsSendResult =
+  | { handled: false; reason?: string }
+  | {
+      handled: true;
+      mode: "delegated";
+      dispatch: {
+        kind: "a2a-broker";
+        taskId: string;
+        waitRunId?: string;
+        cancelTarget?: PluginHookSessionsSendCancelTarget;
+      };
+    }
+  | { handled: true; mode: "direct"; result: unknown };
 
 export type PluginHookToolContext = {
   agentId?: string;
@@ -633,6 +693,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookMessageSentEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
+  sessions_send: (
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ) => Promise<PluginHookSessionsSendResult | void> | PluginHookSessionsSendResult | void;
   before_tool_call: (
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -23,6 +23,9 @@ import type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -80,6 +83,9 @@ export type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -730,6 +736,22 @@ export function createHookRunner(
   }
 
   /**
+   * Run sessions_send hook.
+   * Allows plugins to intercept delegated sessions_send dispatch before core handling.
+   * First handler returning { handled: true } wins.
+   */
+  async function runSessionsSend(
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ): Promise<PluginHookSessionsSendResult | undefined> {
+    return runClaimingHook<"sessions_send", PluginHookSessionsSendResult>(
+      "sessions_send",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -1128,6 +1150,7 @@ export function createHookRunner(
     runMessageReceived,
     runBeforeDispatch,
     runReplyDispatch,
+    runSessionsSend,
     runMessageSending,
     runMessageSent,
     // Tool hooks


### PR DESCRIPTION
## Summary
- add a typed plugin `sessions_send` hook to the core hook runner and Plugin SDK exports
- let `sessions_send` consult the hook before default handling, with delegated metadata support and direct fallback
- cover declined-hook fallback and delegated wait metadata paths in the sessions tool tests

## Testing
- pnpm test src/agents/openclaw-tools.sessions.test.ts
- pnpm plugin-sdk:api:gen
- pnpm build

Closes #68548