### PR TITLE
Gateway: add session-run cancel seam

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-20db3f5afb93db334ad7456d26303c81b2a3eeaa5c1f8846a459eec72be20b96  plugin-sdk-api-baseline.json
-d02926e9facb3321a1018804d4c0370d9627963bee5e478942dda469e529c20b  plugin-sdk-api-baseline.jsonl
+04ee2cd38fbc60ca2e0e68281eeb503a049a578a09de7125062747b9a4b6d96a  plugin-sdk-api-baseline.json
+d24429bc87aa75d096d486f0a97258327bfb0a00d99484a8f93f6b568c4ba337  plugin-sdk-api-baseline.jsonl

--- a/package.json
+++ b/package.json
@@ -697,6 +697,10 @@
       "types": "./dist/plugin-sdk/session-key-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-key-runtime.js"
     },
+    "./plugin-sdk/session-run-cancel-runtime": {
+      "types": "./dist/plugin-sdk/session-run-cancel-runtime.d.ts",
+      "default": "./dist/plugin-sdk/session-run-cancel-runtime.js"
+    },
     "./plugin-sdk/session-store-runtime": {
       "types": "./dist/plugin-sdk/session-store-runtime.d.ts",
       "default": "./dist/plugin-sdk/session-store-runtime.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -160,6 +160,7 @@
   "response-limit-runtime",
   "session-binding-runtime",
   "session-key-runtime",
+  "session-run-cancel-runtime",
   "session-store-runtime",
   "ssrf-dispatcher",
   "string-coerce-runtime",

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -5,9 +5,18 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
 
 const callGatewayMock = vi.fn();
+const getGlobalHookRunnerMock = vi.fn();
 vi.mock("../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => getGlobalHookRunnerMock(),
+}));
+
+type SessionsSendHookRunnerMock = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runSessionsSend: ReturnType<typeof vi.fn>;
+};
 
 vi.mock("../config/config.js", () => ({
   loadConfig: () => ({
@@ -164,6 +173,7 @@ describe("sessions tools", () => {
     sessionsSendA2ATesting.setDepsForTest({
       callGateway: (opts: unknown) => callGatewayMock(opts),
     });
+    getGlobalHookRunnerMock.mockReturnValue(null);
   });
 
   it("uses number (not integer) in tool schemas for Gemini compatibility", () => {
@@ -1087,5 +1097,170 @@ describe("sessions tools", () => {
       message: "announce now",
       threadId: "99",
     });
+  });
+
+  it("sessions_send falls back to core delivery when sessions_send hooks decline", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({ handled: false, reason: "not delegated" })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent") {
+        return { runId: "run-1", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "done" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-fallback", {
+      sessionKey: "main",
+      message: "wait",
+      timeoutSeconds: 1,
+      task: { intent: "delegate", instructions: "delegate wait" },
+    });
+
+    expect(result.details).toMatchObject({ status: "ok", reply: "done" });
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main",
+        target: { sessionKey: "main", displayKey: "main" },
+        message: "wait",
+        task: expect.objectContaining({
+          intent: "delegate",
+          instructions: "delegate wait",
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(true);
+  });
+
+  it("sessions_send waits on plugin-produced delegated metadata", async () => {
+    const hookRunner: SessionsSendHookRunnerMock = {
+      hasHooks: vi.fn((hookName: string) => hookName === "sessions_send"),
+      runSessionsSend: vi.fn(async () => ({
+        handled: true,
+        mode: "delegated",
+        dispatch: {
+          kind: "a2a-broker",
+          taskId: "task-123",
+          waitRunId: "wait-123",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+      })),
+    };
+    getGlobalHookRunnerMock.mockReturnValue(hookRunner);
+    let historyCallCount = 0;
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string };
+      if (request.method === "agent.wait") {
+        return { runId: "wait-123", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCallCount += 1;
+        return {
+          messages:
+            historyCallCount === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "delegated reply" }],
+                    timestamp: 20,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "discord:group:req",
+      agentChannel: "discord",
+    }).find((candidate) => candidate.name === "sessions_send");
+    expect(tool).toBeDefined();
+    if (!tool) {
+      throw new Error("missing sessions_send tool");
+    }
+
+    const result = await tool.execute("call-hook-delegated", {
+      sessionKey: "main",
+      message: "delegate this",
+      timeoutSeconds: 1,
+      task: {
+        intent: "delegate",
+        instructions: "delegate this",
+        runtime: {
+          roundOneReply: "delegated round one",
+          cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+        },
+        correlationId: "corr-123",
+        parentRunId: "parent-123",
+      },
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      runId: "wait-123",
+      reply: "delegated reply",
+      delivery: { status: "pending", mode: "announce" },
+    });
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "agent",
+      ),
+    ).toBe(false);
+    expect(hookRunner.runSessionsSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.objectContaining({
+          correlationId: "corr-123",
+          parentRunId: "parent-123",
+          runtime: expect.objectContaining({
+            cancelTarget: { kind: "session_run", sessionKey: "main", runId: "run-9" },
+          }),
+        }),
+      }),
+      { requesterSessionKey: "discord:group:req", requesterChannel: "discord" },
+    );
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) =>
+          (call[0] as { method?: string; params?: { runId?: string } }).method === "agent.wait" &&
+          (call[0] as { params?: { runId?: string } }).params?.runId === "wait-123",
+      ),
+    ).toBe(true);
   });
 });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -3,6 +3,7 @@ import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
 import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
@@ -42,6 +43,119 @@ const SessionsSendToolSchema = Type.Object({
 
 type GatewayCaller = typeof callGateway;
 const SESSIONS_SEND_REPLY_HISTORY_LIMIT = 50;
+
+type SessionsSendHookTask = {
+  intent?: string;
+  instructions?: string;
+  constraints?: {
+    timeoutSeconds?: number;
+    maxPingPongTurns?: number;
+  };
+  runtime?: {
+    waitRunId?: string;
+    roundOneReply?: string;
+    announceTimeoutMs?: number;
+    maxPingPongTurns?: number;
+    cancelTarget?: {
+      kind?: string;
+      sessionKey?: string;
+      runId?: string;
+    };
+  };
+  requester?: {
+    sessionKey?: string;
+    channel?: string;
+  };
+  correlationId?: string;
+  parentRunId?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOptionalFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readSessionsSendHookTask(
+  params: Record<string, unknown>,
+  defaults: {
+    message: string;
+    timeoutSeconds: number;
+    announceTimeoutMs: number;
+    maxPingPongTurns: number;
+    requesterSessionKey?: string;
+    requesterChannel?: string;
+  },
+): SessionsSendHookTask | undefined {
+  const rawTask = isRecord(params.task) ? params.task : undefined;
+  if (!rawTask) {
+    return undefined;
+  }
+  const rawConstraints = isRecord(rawTask.constraints) ? rawTask.constraints : undefined;
+  const rawRuntime = isRecord(rawTask.runtime) ? rawTask.runtime : undefined;
+  const rawRequester = isRecord(rawTask.requester) ? rawTask.requester : undefined;
+  const rawCancelTarget = isRecord(rawRuntime?.cancelTarget) ? rawRuntime.cancelTarget : undefined;
+  return {
+    intent: normalizeOptionalString(
+      typeof rawTask.intent === "string" ? rawTask.intent : undefined,
+    ),
+    instructions:
+      normalizeOptionalString(
+        typeof rawTask.instructions === "string" ? rawTask.instructions : undefined,
+      ) ?? defaults.message,
+    constraints: {
+      timeoutSeconds:
+        readOptionalFiniteNumber(rawConstraints?.timeoutSeconds) ?? defaults.timeoutSeconds,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawConstraints?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+    },
+    runtime: {
+      waitRunId: normalizeOptionalString(
+        typeof rawRuntime?.waitRunId === "string" ? rawRuntime.waitRunId : undefined,
+      ),
+      roundOneReply: normalizeOptionalString(
+        typeof rawRuntime?.roundOneReply === "string" ? rawRuntime.roundOneReply : undefined,
+      ),
+      announceTimeoutMs:
+        readOptionalFiniteNumber(rawRuntime?.announceTimeoutMs) ?? defaults.announceTimeoutMs,
+      maxPingPongTurns:
+        readOptionalFiniteNumber(rawRuntime?.maxPingPongTurns) ?? defaults.maxPingPongTurns,
+      cancelTarget: rawCancelTarget
+        ? {
+            kind: normalizeOptionalString(
+              typeof rawCancelTarget.kind === "string" ? rawCancelTarget.kind : undefined,
+            ),
+            sessionKey: normalizeOptionalString(
+              typeof rawCancelTarget.sessionKey === "string"
+                ? rawCancelTarget.sessionKey
+                : undefined,
+            ),
+            runId: normalizeOptionalString(
+              typeof rawCancelTarget.runId === "string" ? rawCancelTarget.runId : undefined,
+            ),
+          }
+        : undefined,
+    },
+    requester: {
+      sessionKey:
+        normalizeOptionalString(
+          typeof rawRequester?.sessionKey === "string" ? rawRequester.sessionKey : undefined,
+        ) ?? defaults.requesterSessionKey,
+      channel:
+        normalizeOptionalString(
+          typeof rawRequester?.channel === "string" ? rawRequester.channel : undefined,
+        ) ?? defaults.requesterChannel,
+    },
+    correlationId: normalizeOptionalString(
+      typeof rawTask.correlationId === "string" ? rawTask.correlationId : undefined,
+    ),
+    parentRunId: normalizeOptionalString(
+      typeof rawTask.parentRunId === "string" ? rawTask.parentRunId : undefined,
+    ),
+  };
+}
 
 async function startAgentRun(params: {
   callGateway: GatewayCaller;
@@ -270,6 +384,115 @@ export function createSessionsSendTool(opts?: {
         requesterChannel: opts?.agentChannel,
         targetSessionKey: displayKey,
       });
+      const requesterSessionKey = opts?.agentSessionKey;
+      const requesterChannel = opts?.agentChannel;
+      const maxPingPongTurns = resolvePingPongTurns(cfg);
+      const hookTask = readSessionsSendHookTask(params, {
+        message,
+        timeoutSeconds,
+        announceTimeoutMs,
+        maxPingPongTurns,
+        requesterSessionKey,
+        requesterChannel,
+      });
+      const delivery = { status: "pending", mode: "announce" as const };
+      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
+        void runSessionsSendA2AFlow({
+          targetSessionKey: resolvedKey,
+          displayKey,
+          message,
+          announceTimeoutMs,
+          maxPingPongTurns,
+          requesterSessionKey,
+          requesterChannel,
+          roundOneReply,
+          waitRunId,
+        });
+      };
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("sessions_send")) {
+        const hookResult = await hookRunner.runSessionsSend(
+          {
+            sessionKey: resolvedKey,
+            target: {
+              sessionKey: resolvedKey,
+              displayKey,
+            },
+            message,
+            ...(hookTask ? { task: hookTask } : {}),
+            rawParams: params,
+          },
+          {
+            requesterSessionKey,
+            requesterChannel,
+          },
+        );
+        if (hookResult?.handled) {
+          if (hookResult.mode === "direct") {
+            return jsonResult(
+              isRecord(hookResult.result)
+                ? hookResult.result
+                : {
+                    status: "ok",
+                    result: hookResult.result,
+                    sessionKey: displayKey,
+                  },
+            );
+          }
+          const delegatedWaitRunId = normalizeOptionalString(hookResult.dispatch.waitRunId);
+          const delegatedRunId = delegatedWaitRunId ?? hookResult.dispatch.taskId;
+          if (timeoutSeconds === 0) {
+            startA2AFlow(hookTask?.runtime?.roundOneReply, delegatedWaitRunId);
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "accepted",
+              sessionKey: displayKey,
+              delivery,
+            });
+          }
+          if (!delegatedWaitRunId) {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: "Delegated sessions_send hook result missing waitRunId for waited send",
+              sessionKey: displayKey,
+            });
+          }
+          const delegatedResult = await waitForAgentRunAndReadUpdatedAssistantReply({
+            runId: delegatedWaitRunId,
+            sessionKey: resolvedKey,
+            timeoutMs,
+            limit: SESSIONS_SEND_REPLY_HISTORY_LIMIT,
+            baseline: baselineReply,
+            callGateway: gatewayCall,
+          });
+          if (delegatedResult.status === "timeout") {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "timeout",
+              error: delegatedResult.error,
+              sessionKey: displayKey,
+            });
+          }
+          if (delegatedResult.status === "error") {
+            return jsonResult({
+              runId: delegatedRunId,
+              status: "error",
+              error: delegatedResult.error ?? "agent error",
+              sessionKey: displayKey,
+            });
+          }
+          const reply = delegatedResult.replyText;
+          startA2AFlow(hookTask?.runtime?.roundOneReply ?? reply ?? undefined);
+          return jsonResult({
+            runId: delegatedRunId,
+            status: "ok",
+            reply,
+            sessionKey: displayKey,
+            delivery,
+          });
+        }
+      }
       const sendParams = {
         message,
         sessionKey: resolvedKey,
@@ -284,23 +507,6 @@ export function createSessionsSendTool(opts?: {
           sourceChannel: opts?.agentChannel,
           sourceTool: "sessions_send",
         },
-      };
-      const requesterSessionKey = opts?.agentSessionKey;
-      const requesterChannel = opts?.agentChannel;
-      const maxPingPongTurns = resolvePingPongTurns(cfg);
-      const delivery = { status: "pending", mode: "announce" as const };
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
-        void runSessionsSendA2AFlow({
-          targetSessionKey: resolvedKey,
-          displayKey,
-          message,
-          announceTimeoutMs,
-          maxPingPongTurns,
-          requesterSessionKey,
-          requesterChannel,
-          roundOneReply,
-          waitRunId,
-        });
       };
 
       if (timeoutSeconds === 0) {

--- a/src/gateway/chat-abort.test.ts
+++ b/src/gateway/chat-abort.test.ts
@@ -1,7 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing as sessionRunCancelTesting,
+  onSessionRunCancel,
+  requestSessionRunCancel,
+} from "../sessions/session-run-cancel.js";
 import {
   abortChatRunById,
   isChatStopCommandText,
+  wireSessionRunCancelRequester,
   type ChatAbortOps,
   type ChatAbortControllerEntry,
 } from "./chat-abort.js";
@@ -63,6 +69,10 @@ describe("isChatStopCommandText", () => {
 });
 
 describe("abortChatRunById", () => {
+  afterEach(() => {
+    sessionRunCancelTesting.reset();
+  });
+
   it("broadcasts aborted payload with partial message when buffered text exists", () => {
     const runId = "run-1";
     const sessionKey = "main";
@@ -116,6 +126,94 @@ describe("abortChatRunById", () => {
     expect(result).toEqual({ aborted: true });
     const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(payload.message).toBeUndefined();
+  });
+
+  it("fans out cancel to delegated-task handlers registered for the session_run target", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const handler = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, handler);
+
+    abortChatRunById(ops, { runId, sessionKey, stopReason: "user" });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      { kind: "session_run", sessionKey, runId },
+      { source: "chat-abort", message: "user" },
+    );
+  });
+
+  it("does not fan out when the abort no-ops because no controller is tracked", () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    ops.chatAbortControllers.clear();
+    const handler = vi.fn();
+    onSessionRunCancel({ kind: "session_run", sessionKey, runId }, handler);
+
+    const result = abortChatRunById(ops, { runId, sessionKey });
+
+    expect(result).toEqual({ aborted: false });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("wires requestSessionRunCancel to abortChatRunById for matching runs", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const dispose = wireSessionRunCancelRequester(ops);
+
+    const result = await requestSessionRunCancel(
+      { kind: "session_run", sessionKey, runId },
+      { source: "plugin:test", message: "cancelled" },
+    );
+
+    expect(result).toEqual({ requested: true, aborted: true });
+    expect(entry.controller.signal.aborted).toBe(true);
+    const payload = ops.broadcast.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload.stopReason).toBe("cancelled");
+
+    dispose();
+  });
+
+  it("reports aborted=false when no active run matches the requester", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    ops.chatAbortControllers.clear();
+    const dispose = wireSessionRunCancelRequester(ops);
+
+    const result = await requestSessionRunCancel({
+      kind: "session_run",
+      sessionKey,
+      runId,
+    });
+
+    expect(result).toEqual({ requested: true, aborted: false });
+    dispose();
+  });
+
+  it("unwires the requester on disposer so later requests report requested=false", async () => {
+    const runId = "run-1";
+    const sessionKey = "main";
+    const entry = createActiveEntry(sessionKey);
+    const ops = createOps({ runId, entry });
+    const dispose = wireSessionRunCancelRequester(ops);
+    dispose();
+
+    const result = await requestSessionRunCancel({
+      kind: "session_run",
+      sessionKey,
+      runId,
+    });
+
+    expect(result).toEqual({ requested: false, aborted: false });
+    expect(entry.controller.signal.aborted).toBe(false);
   });
 
   it("preserves partial message even when abort listeners clear buffers synchronously", () => {

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -1,4 +1,8 @@
 import { isAbortRequestText } from "../auto-reply/reply/abort-primitives.js";
+import {
+  emitSessionRunCancel,
+  setSessionRunAbortRequester,
+} from "../sessions/session-run-cancel.js";
 
 export type ChatAbortControllerEntry = {
   controller: AbortController;
@@ -99,12 +103,33 @@ export function abortChatRunById(
   ops.chatDeltaSentAt.delete(runId);
   ops.chatDeltaLastBroadcastLen.delete(runId);
   const removed = ops.removeChatRun(runId, runId, sessionKey);
+  // Fan out cancel to delegated-task handlers before broadcasting the UI event
+  // so plugin-owned tasks tied to this run observe the stop deterministically.
+  emitSessionRunCancel(
+    { kind: "session_run", sessionKey, runId },
+    stopReason ? { source: "chat-abort", message: stopReason } : { source: "chat-abort" },
+  );
   broadcastChatAborted(ops, { runId, sessionKey, stopReason, partialText });
   ops.agentRunSeq.delete(runId);
   if (removed?.clientRunId) {
     ops.agentRunSeq.delete(removed.clientRunId);
   }
   return { aborted: true };
+}
+
+// Wires the `requestSessionRunCancel` seam so plugin-owned delegated tasks
+// can trigger a real core abort for the owning OpenClaw run without any
+// plugin-specific branching in core. Returns a disposer that removes the
+// requester (idempotent, safe to call during shutdown).
+export function wireSessionRunCancelRequester(ops: ChatAbortOps): () => void {
+  return setSessionRunAbortRequester((target, reason) => {
+    const { aborted } = abortChatRunById(ops, {
+      runId: target.runId,
+      sessionKey: target.sessionKey,
+      ...(reason?.message ? { stopReason: reason.message } : {}),
+    });
+    return aborted;
+  });
 }
 
 export function abortChatRunsForSessionKey(

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -46,6 +46,7 @@ export async function runGatewayClosePrelude(params: {
   stopDiagnostics?: () => void;
   clearSkillsRefreshTimer?: () => void;
   skillsChangeUnsub?: () => void;
+  sessionRunCancelRequesterUnsub?: () => void;
   disposeAuthRateLimiter?: () => void;
   disposeBrowserAuthRateLimiter: () => void;
   stopModelPricingRefresh?: () => void;
@@ -56,6 +57,7 @@ export async function runGatewayClosePrelude(params: {
   params.stopDiagnostics?.();
   params.clearSkillsRefreshTimer?.();
   params.skillsChangeUnsub?.();
+  params.sessionRunCancelRequesterUnsub?.();
   params.disposeAuthRateLimiter?.();
   params.disposeBrowserAuthRateLimiter();
   params.stopModelPricingRefresh?.();

--- a/src/gateway/server-runtime-handles.ts
+++ b/src/gateway/server-runtime-handles.ts
@@ -18,6 +18,7 @@ export type GatewayServerMutableState = {
   skillsRefreshTimer: ReturnType<typeof setTimeout> | null;
   skillsRefreshDelayMs: number;
   skillsChangeUnsub: () => void;
+  sessionRunCancelRequesterUnsub: () => void;
   channelHealthMonitor: ChannelHealthMonitor | null;
   stopModelPricingRefresh: () => void;
   mcpServer: { port: number; close: () => Promise<void> } | undefined;
@@ -49,6 +50,7 @@ export function createGatewayServerMutableState(): GatewayServerMutableState {
     skillsRefreshTimer: null as ReturnType<typeof setTimeout> | null,
     skillsRefreshDelayMs: 30_000,
     skillsChangeUnsub: () => {},
+    sessionRunCancelRequesterUnsub: () => {},
     channelHealthMonitor: null as ChannelHealthMonitor | null,
     stopModelPricingRefresh: () => {},
     mcpServer: undefined as { port: number; close: () => Promise<void> } | undefined,

--- a/src/gateway/server-startup-early.ts
+++ b/src/gateway/server-startup-early.ts
@@ -8,6 +8,7 @@ import {
   setSkillsRemoteRegistry,
 } from "../infra/skills-remote.js";
 import { startTaskRegistryMaintenance } from "../tasks/task-registry.maintenance.js";
+import { wireSessionRunCancelRequester } from "./chat-abort.js";
 import { startGatewayDiscovery } from "./server-discovery-runtime.js";
 import { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 
@@ -117,9 +118,25 @@ export async function startGatewayEarlyRuntime(params: {
           : {}),
       });
 
+  // Wire the plugin -> core cancel seam against the live chat-abort state so
+  // delegated-task code (including plugins) can abort the owning run through
+  // `requestSessionRunCancel({ kind: "session_run", sessionKey, runId })`.
+  const sessionRunCancelRequesterUnsub = wireSessionRunCancelRequester({
+    chatAbortControllers: params.chatAbortControllers,
+    chatRunBuffers: params.chatRunBuffers,
+    chatDeltaSentAt: params.chatDeltaSentAt,
+    chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
+    chatAbortedRuns: params.chatRunState.abortedRuns,
+    removeChatRun: params.removeChatRun,
+    agentRunSeq: params.agentRunSeq,
+    broadcast: params.broadcast,
+    nodeSendToSession: params.nodeSendToSession,
+  });
+
   return {
     bonjourStop,
     skillsChangeUnsub,
+    sessionRunCancelRequesterUnsub,
     maintenance,
   };
 }

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -510,6 +510,7 @@ export async function startGatewayServer(
         runtimeState.skillsRefreshTimer = null;
       },
       skillsChangeUnsub: runtimeState.skillsChangeUnsub,
+      sessionRunCancelRequesterUnsub: runtimeState.sessionRunCancelRequesterUnsub,
       ...(authRateLimiter ? { disposeAuthRateLimiter: () => authRateLimiter.dispose() } : {}),
       disposeBrowserAuthRateLimiter: () => browserAuthRateLimiter.dispose(),
       stopModelPricingRefresh: runtimeState.stopModelPricingRefresh,
@@ -589,6 +590,7 @@ export async function startGatewayServer(
     });
     runtimeState.bonjourStop = earlyRuntime.bonjourStop;
     runtimeState.skillsChangeUnsub = earlyRuntime.skillsChangeUnsub;
+    runtimeState.sessionRunCancelRequesterUnsub = earlyRuntime.sessionRunCancelRequesterUnsub;
     if (earlyRuntime.maintenance) {
       runtimeState.tickInterval = earlyRuntime.maintenance.tickInterval;
       runtimeState.healthInterval = earlyRuntime.maintenance.healthInterval;

--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -99,6 +99,11 @@ export type {
   PluginHookReplyDispatchResult,
 } from "../plugins/types.js";
 export type { OpenClawConfig } from "../config/config.js";
+export type {
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
+} from "../plugins/types.js";
 export type { OutboundIdentity } from "../infra/outbound/identity.js";
 export type { HistoryEntry } from "../auto-reply/reply/history.js";
 export type { ReplyPayload } from "../auto-reply/reply-payload.js";

--- a/src/plugin-sdk/session-run-cancel-runtime.test.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.test.ts
@@ -17,21 +17,75 @@ describe("plugin-sdk/session-run-cancel-runtime", () => {
     __testing.reset();
   });
 
-  it("re-exports onSessionRunCancel registered against the same core store", () => {
-    const handler = vi.fn();
-    onSessionRunCancel(target, handler);
-    expect(__testing.handlerCount(target)).toBe(1);
-  });
+  describe("public API surface", () => {
+    it("re-exports onSessionRunCancel registered against the same core store", () => {
+      const handler = vi.fn();
+      onSessionRunCancel(target, handler);
+      expect(__testing.handlerCount(target)).toBe(1);
+    });
 
-  it("re-exports requestSessionRunCancel wired to the same core requester", async () => {
-    const requester = vi.fn(async () => true);
-    __testing.reset();
-    const { setSessionRunAbortRequester } = await import("../sessions/session-run-cancel.js");
-    setSessionRunAbortRequester(requester);
+    it("re-exports requestSessionRunCancel wired to the same core requester", async () => {
+      const requester = vi.fn(async () => true);
+      __testing.reset();
+      const { setSessionRunAbortRequester } = await import("../sessions/session-run-cancel.js");
+      setSessionRunAbortRequester(requester);
 
-    const result = await requestSessionRunCancel(target, { source: "plugin:test" });
+      const result = await requestSessionRunCancel(target, { source: "plugin:test" });
 
-    expect(requester).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ requested: true, aborted: true });
+      expect(requester).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({ requested: true, aborted: true });
+    });
+
+    it("does NOT export emitSessionRunCancel — only core call sites may emit", async () => {
+      const mod = await import("./session-run-cancel-runtime.js");
+      // emitSessionRunCancel is a core-internal hook deliberately excluded
+      // from the plugin trust boundary.
+      const anyMod = mod as unknown as Record<string, unknown>;
+      expect("emitSessionRunCancel" in anyMod).toBe(false);
+      expect(anyMod.emitSessionRunCancel).toBeUndefined();
+    });
+
+    it("exports plugin-safe functions only", async () => {
+      const mod = await import("./session-run-cancel-runtime.js");
+      const keys = Object.keys(mod);
+      // Plugin-safe exports: onSessionRunCancel, requestSessionRunCancel
+      expect(keys).toContain("onSessionRunCancel");
+      expect(keys).toContain("requestSessionRunCancel");
+      // Core-internal emitSessionRunCancel must not leak
+      expect(keys).not.toContain("emitSessionRunCancel");
+      // Internal symbols must not leak
+      for (const key of keys) {
+        expect(key).not.toContain("__");
+      }
+    });
+
+    it("exports required types for plugin consumers", async () => {
+      const mod = await import("./session-run-cancel-runtime.js");
+      // The public module must export type re-exports but those are only
+      // visible at the type level.  At runtime, we verify the module shape
+      // is clean (no unexpected runtime exports).
+      const anyMod = mod as unknown as Record<string, unknown>;
+      const runtimeExports = Object.keys(anyMod).filter(
+        (k) => typeof anyMod[k] !== "undefined",
+      );
+      expect(runtimeExports).toContain("onSessionRunCancel");
+      expect(runtimeExports).toContain("requestSessionRunCancel");
+    });
+
+    it("replays sticky cancel through the plugin SDK surface", async () => {
+      const t = target;
+      const reason = { source: "chat-abort", message: "stopped" };
+
+      // Emit via core-internal path (dynamic import in vitest ESM context).
+      const { emitSessionRunCancel } = await import("../sessions/session-run-cancel.js");
+      emitSessionRunCancel(t, reason);
+
+      // Late handler registered through the plugin SDK must still observe it.
+      const handler = vi.fn();
+      onSessionRunCancel(t, handler);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      expect(handler).toHaveBeenCalledWith(t, reason);
+    });
   });
 });

--- a/src/plugin-sdk/session-run-cancel-runtime.test.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __testing } from "../sessions/session-run-cancel.js";
+import {
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  type SessionRunCancelTarget,
+} from "./session-run-cancel-runtime.js";
+
+const target: SessionRunCancelTarget = {
+  kind: "session_run",
+  sessionKey: "agent:main:main",
+  runId: "run-1",
+};
+
+describe("plugin-sdk/session-run-cancel-runtime", () => {
+  afterEach(() => {
+    __testing.reset();
+  });
+
+  it("re-exports onSessionRunCancel registered against the same core store", () => {
+    const handler = vi.fn();
+    onSessionRunCancel(target, handler);
+    expect(__testing.handlerCount(target)).toBe(1);
+  });
+
+  it("re-exports requestSessionRunCancel wired to the same core requester", async () => {
+    const requester = vi.fn(async () => true);
+    __testing.reset();
+    const { setSessionRunAbortRequester } = await import("../sessions/session-run-cancel.js");
+    setSessionRunAbortRequester(requester);
+
+    const result = await requestSessionRunCancel(target, { source: "plugin:test" });
+
+    expect(requester).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ requested: true, aborted: true });
+  });
+});

--- a/src/plugin-sdk/session-run-cancel-runtime.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.ts
@@ -1,0 +1,19 @@
+// Narrow public seam for the cancel fan-out between delegated tasks (often
+// plugin-owned) and the OpenClaw run that owns them. Plugins import this
+// subpath to:
+//   - register an `onSessionRunCancel` handler tied to a specific session_run
+//     target, so core-side aborts notify the delegated task deterministically.
+//   - call `requestSessionRunCancel` to ask core to abort the owning run,
+//     without importing core internals or branching on specific channels.
+//
+// The seam is intentionally plugin-neutral: `{ kind: "session_run",
+// sessionKey, runId }` is the only target shape.
+export {
+  emitSessionRunCancel,
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  type RequestSessionRunCancelResult,
+  type SessionRunCancelHandler,
+  type SessionRunCancelReason,
+  type SessionRunCancelTarget,
+} from "../sessions/session-run-cancel.js";

--- a/src/plugin-sdk/session-run-cancel-runtime.ts
+++ b/src/plugin-sdk/session-run-cancel-runtime.ts
@@ -8,8 +8,13 @@
 //
 // The seam is intentionally plugin-neutral: `{ kind: "session_run",
 // sessionKey, runId }` is the only target shape.
+//
+// emitSessionRunCancel is deliberately NOT exported here — it is a core-internal
+// emission hook, never part of the plugin trust boundary. Plugins that need to
+// observe a cancellation use onSessionRunCancel; plugins that need to request
+// one use requestSessionRunCancel. Only core call-sites (chat-abort, server
+// lifecycle) may call emitSessionRunCancel directly.
 export {
-  emitSessionRunCancel,
   onSessionRunCancel,
   requestSessionRunCancel,
   type RequestSessionRunCancelResult,

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -67,6 +67,7 @@ export type PluginHookName =
   | "message_received"
   | "message_sending"
   | "message_sent"
+  | "sessions_send"
   | "before_tool_call"
   | "after_tool_call"
   | "tool_result_persist"
@@ -98,6 +99,7 @@ export const PLUGIN_HOOK_NAMES = [
   "message_received",
   "message_sending",
   "message_sent",
+  "sessions_send",
   "before_tool_call",
   "after_tool_call",
   "tool_result_persist",
@@ -278,6 +280,64 @@ export type PluginHookReplyDispatchResult = {
   queuedFinal: boolean;
   counts: Record<ReplyDispatchKind, number>;
 };
+
+export type PluginHookSessionsSendCancelTarget = {
+  kind?: string;
+  sessionKey?: string;
+  runId?: string;
+};
+
+export type PluginHookSessionsSendTask = {
+  intent?: string;
+  instructions?: string;
+  constraints?: {
+    timeoutSeconds?: number;
+    maxPingPongTurns?: number;
+  };
+  runtime?: {
+    waitRunId?: string;
+    roundOneReply?: string;
+    announceTimeoutMs?: number;
+    maxPingPongTurns?: number;
+    cancelTarget?: PluginHookSessionsSendCancelTarget;
+  };
+  requester?: {
+    sessionKey?: string;
+    channel?: string;
+  };
+  correlationId?: string;
+  parentRunId?: string;
+};
+
+export type PluginHookSessionsSendEvent = {
+  sessionKey: string;
+  target: {
+    sessionKey?: string;
+    displayKey?: string;
+  };
+  message: string;
+  task?: PluginHookSessionsSendTask;
+  rawParams: unknown;
+};
+
+export type PluginHookSessionsSendContext = {
+  requesterSessionKey?: string;
+  requesterChannel?: string;
+};
+
+export type PluginHookSessionsSendResult =
+  | { handled: false; reason?: string }
+  | {
+      handled: true;
+      mode: "delegated";
+      dispatch: {
+        kind: "a2a-broker";
+        taskId: string;
+        waitRunId?: string;
+        cancelTarget?: PluginHookSessionsSendCancelTarget;
+      };
+    }
+  | { handled: true; mode: "direct"; result: unknown };
 
 export type PluginHookToolContext = {
   agentId?: string;
@@ -633,6 +693,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookMessageSentEvent,
     ctx: PluginHookMessageContext,
   ) => Promise<void> | void;
+  sessions_send: (
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ) => Promise<PluginHookSessionsSendResult | void> | PluginHookSessionsSendResult | void;
   before_tool_call: (
     event: PluginHookBeforeToolCallEvent,
     ctx: PluginHookToolContext,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -23,6 +23,9 @@ import type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -80,6 +83,9 @@ export type {
   PluginHookReplyDispatchContext,
   PluginHookReplyDispatchEvent,
   PluginHookReplyDispatchResult,
+  PluginHookSessionsSendContext,
+  PluginHookSessionsSendEvent,
+  PluginHookSessionsSendResult,
   PluginHookBeforeModelResolveEvent,
   PluginHookBeforeModelResolveResult,
   PluginHookBeforePromptBuildEvent,
@@ -730,6 +736,22 @@ export function createHookRunner(
   }
 
   /**
+   * Run sessions_send hook.
+   * Allows plugins to intercept delegated sessions_send dispatch before core handling.
+   * First handler returning { handled: true } wins.
+   */
+  async function runSessionsSend(
+    event: PluginHookSessionsSendEvent,
+    ctx: PluginHookSessionsSendContext,
+  ): Promise<PluginHookSessionsSendResult | undefined> {
+    return runClaimingHook<"sessions_send", PluginHookSessionsSendResult>(
+      "sessions_send",
+      event,
+      ctx,
+    );
+  }
+
+  /**
    * Run message_sending hook.
    * Allows plugins to modify or cancel outgoing messages.
    * Runs sequentially.
@@ -1128,6 +1150,7 @@ export function createHookRunner(
     runMessageReceived,
     runBeforeDispatch,
     runReplyDispatch,
+    runSessionsSend,
     runMessageSending,
     runMessageSent,
     // Tool hooks

--- a/src/sessions/session-run-cancel.test.ts
+++ b/src/sessions/session-run-cancel.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __testing,
+  clearSessionRunCancelTarget,
   emitSessionRunCancel,
   onSessionRunCancel,
   requestSessionRunCancel,
@@ -86,6 +87,108 @@ describe("session-run cancel fan-out seam", () => {
       onSessionRunCancel(target("agent:main:main", "run-1"), rejecting);
 
       emitSessionRunCancel(target("agent:main:main", "run-1"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rejecting).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("sticky cancellation (late handler registration)", () => {
+    it("replays terminal cancel to handler registered after emit", () => {
+      const t = target("agent:main:main", "run-1");
+      const reason = { source: "chat-abort", message: "user stopped" };
+
+      // Core aborts before any plugin handler is registered.
+      emitSessionRunCancel(t, reason);
+
+      // Late handler must still observe the terminal cancel.
+      const lateHandler = vi.fn();
+      onSessionRunCancel(t, lateHandler);
+
+      expect(lateHandler).toHaveBeenCalledTimes(1);
+      expect(lateHandler).toHaveBeenCalledWith(t, reason);
+    });
+
+    it("replays to multiple late handlers", () => {
+      const t = target("agent:main:main", "run-1");
+
+      emitSessionRunCancel(t, { source: "server-close" });
+
+      const handler1 = vi.fn();
+      const handler2 = vi.fn();
+      onSessionRunCancel(t, handler1);
+      onSessionRunCancel(t, handler2);
+
+      expect(handler1).toHaveBeenCalledTimes(1);
+      expect(handler2).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps terminal cancel reason from first emit when multiple emits occur", () => {
+      const t = target("agent:main:main", "run-1");
+
+      emitSessionRunCancel(t, { source: "first", message: "original" });
+      // Second emit should not overwrite terminal reason (first wins).
+      emitSessionRunCancel(t, { source: "second", message: "override" });
+
+      const lateHandler = vi.fn();
+      onSessionRunCancel(t, lateHandler);
+
+      expect(lateHandler).toHaveBeenCalledWith(t, { source: "first", message: "original" });
+    });
+
+    it("clears terminal cancel so later handlers receive normal registration", () => {
+      const t = target("agent:main:main", "run-1");
+
+      emitSessionRunCancel(t, { source: "chat-abort" });
+      clearSessionRunCancelTarget(t);
+
+      // After clearing, new registrations follow the normal path.
+      const handler = vi.fn();
+      onSessionRunCancel(t, handler);
+      expect(handler).not.toHaveBeenCalled();
+      expect(__testing.handlerCount(t)).toBe(1);
+    });
+
+    it("clears terminal state on __testing.reset", () => {
+      const t = target("agent:main:main", "run-1");
+
+      emitSessionRunCancel(t, { source: "test" });
+      expect(__testing.terminalCancelCount()).toBe(1);
+
+      __testing.reset();
+
+      const handler = vi.fn();
+      onSessionRunCancel(t, handler);
+      expect(handler).not.toHaveBeenCalled();
+      expect(__testing.terminalCancelCount()).toBe(0);
+    });
+
+    it("late handler that throws does not prevent others from replaying", () => {
+      const t = target("agent:main:main", "run-1");
+      emitSessionRunCancel(t);
+
+      const noisy = vi.fn(() => {
+        throw new Error("late boom");
+      });
+      const healthy = vi.fn();
+
+      expect(() => onSessionRunCancel(t, noisy)).not.toThrow();
+      onSessionRunCancel(t, healthy);
+
+      expect(noisy).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+    });
+
+    it("late async handler rejections are swallowed", async () => {
+      const t = target("agent:main:main", "run-1");
+      emitSessionRunCancel(t);
+
+      const rejecting = vi.fn(async () => {
+        throw new Error("async late boom");
+      });
+      onSessionRunCancel(t, rejecting);
+
       await Promise.resolve();
       await Promise.resolve();
 

--- a/src/sessions/session-run-cancel.test.ts
+++ b/src/sessions/session-run-cancel.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  emitSessionRunCancel,
+  onSessionRunCancel,
+  requestSessionRunCancel,
+  setSessionRunAbortRequester,
+  type SessionRunAbortRequester,
+  type SessionRunCancelTarget,
+} from "./session-run-cancel.js";
+
+function target(sessionKey: string, runId: string): SessionRunCancelTarget {
+  return { kind: "session_run", sessionKey, runId };
+}
+
+describe("session-run cancel fan-out seam", () => {
+  afterEach(() => {
+    __testing.reset();
+  });
+
+  describe("core -> plugin (emitSessionRunCancel)", () => {
+    it("notifies handlers registered for the matching session_run target", () => {
+      const matched = vi.fn();
+      const other = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), matched);
+      onSessionRunCancel(target("agent:main:main", "run-2"), other);
+
+      const result = emitSessionRunCancel(target("agent:main:main", "run-1"), {
+        source: "test",
+        message: "stopped",
+      });
+
+      expect(result.handlerCount).toBe(1);
+      expect(matched).toHaveBeenCalledTimes(1);
+      expect(matched).toHaveBeenCalledWith(
+        { kind: "session_run", sessionKey: "agent:main:main", runId: "run-1" },
+        { source: "test", message: "stopped" },
+      );
+      expect(other).not.toHaveBeenCalled();
+    });
+
+    it("is idempotent when the same target is cancelled twice (already-terminal)", () => {
+      const handler = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), handler);
+
+      expect(emitSessionRunCancel(target("agent:main:main", "run-1")).handlerCount).toBe(1);
+      expect(emitSessionRunCancel(target("agent:main:main", "run-1")).handlerCount).toBe(0);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports no handlers when nothing is registered (no active run)", () => {
+      const result = emitSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result.handlerCount).toBe(0);
+    });
+
+    it("removes handlers via the returned disposer without affecting others", () => {
+      const stays = vi.fn();
+      const leaves = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), stays);
+      const dispose = onSessionRunCancel(target("agent:main:main", "run-1"), leaves);
+
+      dispose();
+      emitSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(stays).toHaveBeenCalledTimes(1);
+      expect(leaves).not.toHaveBeenCalled();
+    });
+
+    it("continues fan-out when a handler throws", () => {
+      const noisy = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const healthy = vi.fn();
+      onSessionRunCancel(target("agent:main:main", "run-1"), noisy);
+      onSessionRunCancel(target("agent:main:main", "run-1"), healthy);
+
+      expect(() => emitSessionRunCancel(target("agent:main:main", "run-1"))).not.toThrow();
+      expect(noisy).toHaveBeenCalledTimes(1);
+      expect(healthy).toHaveBeenCalledTimes(1);
+    });
+
+    it("swallows async handler rejections", async () => {
+      const rejecting = vi.fn(async () => {
+        throw new Error("async boom");
+      });
+      onSessionRunCancel(target("agent:main:main", "run-1"), rejecting);
+
+      emitSessionRunCancel(target("agent:main:main", "run-1"));
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(rejecting).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("plugin -> core (requestSessionRunCancel)", () => {
+    it("routes the cancel request through the registered abort requester", async () => {
+      const requester: SessionRunAbortRequester = vi.fn(async () => true);
+      setSessionRunAbortRequester(requester);
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"), {
+        source: "plugin:test",
+      });
+
+      expect(result).toEqual({ requested: true, aborted: true });
+      expect(requester).toHaveBeenCalledWith(
+        { kind: "session_run", sessionKey: "agent:main:main", runId: "run-1" },
+        { source: "plugin:test" },
+      );
+    });
+
+    it("reports aborted=false when the requester finds no active run", async () => {
+      setSessionRunAbortRequester(() => false);
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(result).toEqual({ requested: true, aborted: false });
+    });
+
+    it("reports requested=false when no requester is registered", async () => {
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result).toEqual({ requested: false, aborted: false });
+    });
+
+    it("reports aborted=false when the requester throws", async () => {
+      setSessionRunAbortRequester(() => {
+        throw new Error("abort boom");
+      });
+
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+      expect(result).toEqual({ requested: true, aborted: false });
+    });
+
+    it("clears the requester when the setter disposer runs", async () => {
+      const requester = vi.fn(async () => true);
+      const dispose = setSessionRunAbortRequester(requester);
+
+      dispose();
+      const result = await requestSessionRunCancel(target("agent:main:main", "run-1"));
+
+      expect(requester).not.toHaveBeenCalled();
+      expect(result).toEqual({ requested: false, aborted: false });
+    });
+  });
+});

--- a/src/sessions/session-run-cancel.ts
+++ b/src/sessions/session-run-cancel.ts
@@ -7,13 +7,18 @@
 //   1. Plugin -> core: delegated-task code calls `requestSessionRunCancel` to
 //      ask core to abort the owning OpenClaw run. Core registers the concrete
 //      abort behavior through `setSessionRunAbortRequester`.
-//   2. Core -> plugin: core calls `emitSessionRunCancel` when it aborts a run,
-//      which notifies any delegated-task cancel handlers registered via
-//      `onSessionRunCancel`.
+//   2. Core -> plugin: core calls `emitSessionRunCancel` (core-internal) when it
+//      aborts a run, which notifies any delegated-task cancel handlers registered
+//      via `onSessionRunCancel`.
 //
 // The seam is intentionally plugin-neutral: core call sites must not branch on
 // specific plugins or transports (for example A2A). Plugins opt in by calling
 // the exported helpers.
+//
+// Sticky cancellation: if core aborts before a handler registers,
+// `onSessionRunCancel` replays the terminal cancel to the late subscriber.
+// The terminal state lives until explicit cleanup (clearSessionRunCancelTarget
+// or __testing.reset).
 
 export type SessionRunCancelTarget = {
   kind: "session_run";
@@ -45,6 +50,12 @@ type HandlerKey = `${string}\u0000${string}`;
 
 const HANDLERS = new Map<HandlerKey, Set<SessionRunCancelHandler>>();
 
+// Terminal cancel state for sticky replay: when core aborts before handler
+// registration, the target+reason are stored here and replayed to any later
+// onSessionRunCancel subscriber.  This ensures plugin-owned delegated tasks
+// registered after an abort can still observe the cancellation deterministically.
+const TERMINAL_CANCELS = new Map<HandlerKey, SessionRunCancelReason | undefined>();
+
 let abortRequester: SessionRunAbortRequester | undefined;
 
 function keyFor(target: SessionRunCancelTarget): HandlerKey {
@@ -56,6 +67,27 @@ export function onSessionRunCancel(
   handler: SessionRunCancelHandler,
 ): () => void {
   const key = keyFor(target);
+
+  // Sticky replay: if this target has already been cancelled before the
+  // handler registered, invoke it immediately with the stored reason.
+  if (TERMINAL_CANCELS.has(key)) {
+    const terminalReason = TERMINAL_CANCELS.get(key);
+    try {
+      const result = handler(target, terminalReason);
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        (result as Promise<unknown>).catch(() => {
+          // Best-effort replay; swallow async handler errors.
+        });
+      }
+    } catch {
+      // Best-effort replay; swallow sync handler errors.
+    }
+    // The cancel is already terminal — handler has been notified.
+    // Return a no-op disposer since there is nothing to unregister from
+    // the live HANDLERS map.
+    return () => {};
+  }
+
   let bucket = HANDLERS.get(key);
   if (!bucket) {
     bucket = new Set();
@@ -79,11 +111,22 @@ export function onSessionRunCancel(
   };
 }
 
+// emitSessionRunCancel is core-internal.  Plugin code must not import it; use
+// onSessionRunCancel to observe and requestSessionRunCancel to request. Only
+// core call-sites (chat-abort, server lifecycle) may emit.
 export function emitSessionRunCancel(
   target: SessionRunCancelTarget,
   reason?: SessionRunCancelReason,
 ): { handlerCount: number } {
   const key = keyFor(target);
+
+  // Store terminal cancel so late subscribers can observe it (sticky replay).
+  // If the target was already terminal, keep the original reason — first emit
+  // wins for deterministic replay.
+  if (!TERMINAL_CANCELS.has(key)) {
+    TERMINAL_CANCELS.set(key, reason);
+  }
+
   const bucket = HANDLERS.get(key);
   if (!bucket || bucket.size === 0) {
     return { handlerCount: 0 };
@@ -105,6 +148,14 @@ export function emitSessionRunCancel(
     }
   }
   return { handlerCount: snapshot.length };
+}
+
+// Clears the terminal cancel state for a specific target.  After this call,
+// new onSessionRunCancel subscribers for the same target will go through
+// normal handler registration instead of sticky replay.  Call this when the
+// session-run lifecycle is fully cleaned up (e.g. run teardown, session close).
+export function clearSessionRunCancelTarget(target: SessionRunCancelTarget): void {
+  TERMINAL_CANCELS.delete(keyFor(target));
 }
 
 export function setSessionRunAbortRequester(
@@ -137,9 +188,16 @@ export async function requestSessionRunCancel(
 export const __testing = {
   reset(): void {
     HANDLERS.clear();
+    TERMINAL_CANCELS.clear();
     abortRequester = undefined;
   },
   handlerCount(target: SessionRunCancelTarget): number {
     return HANDLERS.get(keyFor(target))?.size ?? 0;
+  },
+  terminalCancelCount(): number {
+    return TERMINAL_CANCELS.size;
+  },
+  hasTerminalCancel(target: SessionRunCancelTarget): boolean {
+    return TERMINAL_CANCELS.has(keyFor(target));
   },
 };

--- a/src/sessions/session-run-cancel.ts
+++ b/src/sessions/session-run-cancel.ts
@@ -1,0 +1,145 @@
+// Supported cancel fan-out seam between delegated tasks (often plugin-owned)
+// and the OpenClaw run that owns them.
+//
+// Two directions converge on the same shape:
+//   { kind: "session_run", sessionKey, runId }
+//
+//   1. Plugin -> core: delegated-task code calls `requestSessionRunCancel` to
+//      ask core to abort the owning OpenClaw run. Core registers the concrete
+//      abort behavior through `setSessionRunAbortRequester`.
+//   2. Core -> plugin: core calls `emitSessionRunCancel` when it aborts a run,
+//      which notifies any delegated-task cancel handlers registered via
+//      `onSessionRunCancel`.
+//
+// The seam is intentionally plugin-neutral: core call sites must not branch on
+// specific plugins or transports (for example A2A). Plugins opt in by calling
+// the exported helpers.
+
+export type SessionRunCancelTarget = {
+  kind: "session_run";
+  sessionKey: string;
+  runId: string;
+};
+
+export type SessionRunCancelReason = {
+  source: string;
+  message?: string;
+};
+
+export type SessionRunCancelHandler = (
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+) => void | Promise<void>;
+
+export type SessionRunAbortRequester = (
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+) => boolean | Promise<boolean>;
+
+export type RequestSessionRunCancelResult = {
+  requested: boolean;
+  aborted: boolean;
+};
+
+type HandlerKey = `${string}\u0000${string}`;
+
+const HANDLERS = new Map<HandlerKey, Set<SessionRunCancelHandler>>();
+
+let abortRequester: SessionRunAbortRequester | undefined;
+
+function keyFor(target: SessionRunCancelTarget): HandlerKey {
+  return `${target.sessionKey}\u0000${target.runId}`;
+}
+
+export function onSessionRunCancel(
+  target: SessionRunCancelTarget,
+  handler: SessionRunCancelHandler,
+): () => void {
+  const key = keyFor(target);
+  let bucket = HANDLERS.get(key);
+  if (!bucket) {
+    bucket = new Set();
+    HANDLERS.set(key, bucket);
+  }
+  bucket.add(handler);
+  let disposed = false;
+  return () => {
+    if (disposed) {
+      return;
+    }
+    disposed = true;
+    const current = HANDLERS.get(key);
+    if (!current) {
+      return;
+    }
+    current.delete(handler);
+    if (current.size === 0) {
+      HANDLERS.delete(key);
+    }
+  };
+}
+
+export function emitSessionRunCancel(
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+): { handlerCount: number } {
+  const key = keyFor(target);
+  const bucket = HANDLERS.get(key);
+  if (!bucket || bucket.size === 0) {
+    return { handlerCount: 0 };
+  }
+  // Snapshot so handlers can unregister during dispatch without affecting the
+  // remaining fan-out, and clear eagerly so duplicate emits are idempotent.
+  const snapshot = Array.from(bucket);
+  HANDLERS.delete(key);
+  for (const handler of snapshot) {
+    try {
+      const result = handler(target, reason);
+      if (result && typeof (result as Promise<unknown>).then === "function") {
+        (result as Promise<unknown>).catch(() => {
+          // Best-effort fan-out; swallow async handler errors.
+        });
+      }
+    } catch {
+      // Best-effort fan-out; swallow sync handler errors.
+    }
+  }
+  return { handlerCount: snapshot.length };
+}
+
+export function setSessionRunAbortRequester(
+  requester: SessionRunAbortRequester | undefined,
+): () => void {
+  abortRequester = requester;
+  return () => {
+    if (abortRequester === requester) {
+      abortRequester = undefined;
+    }
+  };
+}
+
+export async function requestSessionRunCancel(
+  target: SessionRunCancelTarget,
+  reason?: SessionRunCancelReason,
+): Promise<RequestSessionRunCancelResult> {
+  const requester = abortRequester;
+  if (!requester) {
+    return { requested: false, aborted: false };
+  }
+  try {
+    const aborted = await requester(target, reason);
+    return { requested: true, aborted: aborted };
+  } catch {
+    return { requested: true, aborted: false };
+  }
+}
+
+export const __testing = {
+  reset(): void {
+    HANDLERS.clear();
+    abortRequester = undefined;
+  },
+  handlerCount(target: SessionRunCancelTarget): number {
+    return HANDLERS.get(keyFor(target))?.size ?? 0;
+  },
+};


### PR DESCRIPTION
## Summary
- add a plugin-neutral session-run cancel seam keyed by `{ kind: "session_run", sessionKey, runId }`
- wire gateway chat aborts into that seam in both directions so delegated-task runtimes can cancel owning runs and observe run abort fan-out
- expose the seam through `openclaw/plugin-sdk/session-run-cancel-runtime` and add focused coverage

## Testing
- pnpm test src/sessions/session-run-cancel.test.ts src/gateway/chat-abort.test.ts src/plugin-sdk/session-run-cancel-runtime.test.ts
- pnpm plugin-sdk:api:gen
- pnpm build

Closes #68550