### PR TITLE
fix(cron): close task ledger on timeout + add runTimeoutSeconds wall-clock kill

### DIFF
--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -40,6 +40,7 @@ function hasAgentTurnPayloadHint(payload: UnknownRecord) {
     normalizeTrimmedStringArray(payload.toolsAllow, { allowNull: true }) !== undefined ||
     hasTrimmedStringValue(payload.thinking) ||
     typeof payload.timeoutSeconds === "number" ||
+    typeof payload.runTimeoutSeconds === "number" ||
     typeof payload.lightContext === "boolean" ||
     typeof payload.allowUnsafeExternalContent === "boolean"
   );
@@ -202,6 +203,14 @@ function coercePayload(payload: UnknownRecord) {
       delete next.timeoutSeconds;
     }
   }
+  if ("runTimeoutSeconds" in next) {
+    const runTimeoutSeconds = parseOptionalField(TimeoutSecondsFieldSchema, next.runTimeoutSeconds);
+    if (runTimeoutSeconds !== undefined) {
+      next.runTimeoutSeconds = runTimeoutSeconds;
+    } else {
+      delete next.runTimeoutSeconds;
+    }
+  }
   if ("fallbacks" in next) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);
     if (fallbacks !== undefined) {
@@ -230,6 +239,7 @@ function coercePayload(payload: UnknownRecord) {
     delete next.fallbacks;
     delete next.thinking;
     delete next.timeoutSeconds;
+    delete next.runTimeoutSeconds;
     delete next.lightContext;
     delete next.allowUnsafeExternalContent;
     delete next.toolsAllow;
@@ -359,6 +369,9 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
 
   if (typeof payload.timeoutSeconds !== "number" && typeof next.timeoutSeconds === "number") {
     payload.timeoutSeconds = next.timeoutSeconds;
+  }
+  if (typeof payload.runTimeoutSeconds !== "number" && typeof next.runTimeoutSeconds === "number") {
+    payload.runTimeoutSeconds = next.runTimeoutSeconds;
   }
   if (!Array.isArray(payload.fallbacks) && Array.isArray(next.fallbacks)) {
     const fallbacks = normalizeTrimmedStringArray(next.fallbacks);

--- a/src/cron/service/timer.run-timeout.test.ts
+++ b/src/cron/service/timer.run-timeout.test.ts
@@ -1,0 +1,218 @@
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createAbortAwareIsolatedRunner,
+  createDeferred,
+  createIsolatedRegressionJob,
+  noopLogger,
+  setupCronRegressionFixtures,
+  writeCronJobs,
+} from "../../../test/helpers/cron/service-regression-fixtures.js";
+import { findTaskByRunId, resetTaskRegistryForTests } from "../../tasks/task-registry.js";
+import { createCronServiceState } from "./state.js";
+import type { CronServiceDeps } from "./state.js";
+import { onTimer } from "./timer.js";
+
+const FAST_TIMEOUT_SECONDS = 1;
+const timerFixtures = setupCronRegressionFixtures({
+  prefix: "cron-service-timer-run-timeout-",
+});
+
+function withStateDirForStorePath(storePath: string) {
+  const stateRoot = path.dirname(path.dirname(storePath));
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  process.env.OPENCLAW_STATE_DIR = stateRoot;
+  resetTaskRegistryForTests();
+  return () => {
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+    resetTaskRegistryForTests();
+  };
+}
+
+/**
+ * Runner that deliberately ignores the abort signal so the `timeoutSeconds`
+ * inner budget cannot stop it. Only the `runTimeoutSeconds` wall-clock kill
+ * can unblock the race, which is precisely the behaviour we are asserting.
+ * The runner exposes a `release()` hook so tests can let it resolve after
+ * validating that the wall-clock kill fired first.
+ */
+function createUnresponsiveIsolatedRunner() {
+  let observedAbortSignal: AbortSignal | undefined;
+  const started = createDeferred<void>();
+  let release!: () => void;
+  const finished = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const runIsolatedAgentJob = vi.fn(async ({ abortSignal }) => {
+    observedAbortSignal = abortSignal;
+    started.resolve();
+    // Ignore abort on purpose: this simulates a wedged agentTurn that swallows
+    // the inner abort, which is exactly the failure mode `runTimeoutSeconds`
+    // exists to bound.
+    await finished;
+    return { status: "ok" as const, summary: "wedged-but-released" };
+  }) as CronServiceDeps["runIsolatedAgentJob"];
+
+  return {
+    runIsolatedAgentJob,
+    getObservedAbortSignal: () => observedAbortSignal,
+    waitForStart: () => started.promise,
+    release,
+  };
+}
+
+describe("cron service timer run-timeout registry-close behaviour", () => {
+  let restoreStateDir: (() => void) | undefined;
+
+  beforeEach(() => {
+    restoreStateDir = undefined;
+  });
+
+  afterEach(() => {
+    restoreStateDir?.();
+    restoreStateDir = undefined;
+  });
+
+  it("closes the task-ledger row as timed_out when payload.timeoutSeconds fires", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerFixtures.makeStorePath();
+      restoreStateDir = withStateDirForStorePath(store.storePath);
+
+      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+      const cronJob = createIsolatedRegressionJob({
+        id: "run-timeout-ledger-close",
+        name: "run timeout ledger close",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: {
+          kind: "agentTurn",
+          message: "work",
+          timeoutSeconds: FAST_TIMEOUT_SECONDS,
+        },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      let now = scheduledAt;
+      const abortAwareRunner = createAbortAwareIsolatedRunner();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async (params) => {
+          const result = await abortAwareRunner.runIsolatedAgentJob(params);
+          now += 5;
+          return result;
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await abortAwareRunner.waitForStart();
+      await vi.advanceTimersByTimeAsync(Math.ceil(FAST_TIMEOUT_SECONDS * 1_000) + 10);
+      await timerPromise;
+
+      // Scheduler-side bookkeeping should have flipped to error with a timeout
+      // error message (pre-existing behaviour).
+      const job = state.store?.jobs.find((entry) => entry.id === "run-timeout-ledger-close");
+      expect(job?.state.lastStatus).toBe("error");
+      expect(job?.state.lastError).toContain("timed out");
+
+      // Task ledger row must be closed in a terminal state (new behaviour).
+      // Prior to this fix the `onTimer` error path returned without writing
+      // the ledger, leaving the row in a stale `running` state for the audit
+      // sweeper to later flag as `stale_running` / `lost`.
+      const ledgerRow = findTaskByRunId(`cron:run-timeout-ledger-close:${scheduledAt}`);
+      expect(ledgerRow).toBeDefined();
+      expect(ledgerRow?.runtime).toBe("cron");
+      expect(ledgerRow?.sourceId).toBe("run-timeout-ledger-close");
+      // The registry-close path in executeJobCoreWithTimeout maps the
+      // "timed out" error → `timed_out` terminal status so dashboards can
+      // distinguish wall-clock kills from generic errors.
+      expect(ledgerRow?.status).toBe("timed_out");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fires the runTimeoutSeconds wall-clock kill when the inner abort is ignored", async () => {
+    vi.useFakeTimers();
+    try {
+      const store = timerFixtures.makeStorePath();
+      restoreStateDir = withStateDirForStorePath(store.storePath);
+
+      const scheduledAt = Date.parse("2026-02-15T13:00:00.000Z");
+      // timeoutSeconds (inner budget) > runTimeoutSeconds (wall-clock) so the
+      // only way to unblock the race is the hard kill. If the hard kill
+      // doesn't fire the test will hang on `await timerPromise` — this is
+      // intentional: we want a test failure if the wall-clock code path
+      // regresses.
+      const cronJob = createIsolatedRegressionJob({
+        id: "run-timeout-wall-clock",
+        name: "run timeout wall clock",
+        scheduledAt,
+        schedule: { kind: "at", at: new Date(scheduledAt).toISOString() },
+        payload: {
+          kind: "agentTurn",
+          message: "wedged work",
+          timeoutSeconds: 30,
+          runTimeoutSeconds: 1,
+        },
+        state: { nextRunAtMs: scheduledAt },
+      });
+      await writeCronJobs(store.storePath, [cronJob]);
+
+      let now = scheduledAt;
+      const unresponsiveRunner = createUnresponsiveIsolatedRunner();
+      const state = createCronServiceState({
+        cronEnabled: true,
+        storePath: store.storePath,
+        log: noopLogger,
+        nowMs: () => now,
+        enqueueSystemEvent: vi.fn(),
+        requestHeartbeatNow: vi.fn(),
+        runIsolatedAgentJob: vi.fn(async (params) => {
+          const result = await unresponsiveRunner.runIsolatedAgentJob(params);
+          now += 5;
+          return result;
+        }),
+      });
+
+      const timerPromise = onTimer(state);
+      await unresponsiveRunner.waitForStart();
+
+      // Drive fake time past runTimeoutSeconds (1s) but well under
+      // timeoutSeconds (30s). The wall-clock timer should abort.
+      await vi.advanceTimersByTimeAsync(1_100);
+      // Let the abort handler unblock any queued microtasks, then drain the
+      // runner so the enclosing Promise.race can observe the reject.
+      await Promise.resolve();
+      unresponsiveRunner.release();
+
+      await timerPromise;
+
+      // The abort signal was delivered even though the runner ignored it: this
+      // demonstrates the wall-clock path invoked `runAbortController.abort()`.
+      expect(unresponsiveRunner.getObservedAbortSignal()?.aborted).toBe(true);
+
+      const job = state.store?.jobs.find((entry) => entry.id === "run-timeout-wall-clock");
+      expect(job?.state.lastStatus).toBe("error");
+      expect(job?.state.lastError).toContain("timed out");
+
+      // The ledger row should still be closed terminally (same registry-close
+      // path exercised for both inner timeout + wall-clock kill).
+      const ledgerRow = findTaskByRunId(`cron:run-timeout-wall-clock:${scheduledAt}`);
+      expect(ledgerRow).toBeDefined();
+      expect(ledgerRow?.status).toBe("timed_out");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -74,30 +74,105 @@ type StartupCatchupPlan = {
   deferredJobIds: string[];
 };
 
+/**
+ * Default hard wall-clock kill for cron-spawned agentTurn sessions when no
+ * explicit `runTimeoutSeconds` is supplied: 30 minutes. Chosen so the ceiling
+ * is comfortably above any reasonable agentTurn budget but bounded enough to
+ * guarantee a wedged session cannot outlive its parent schedule on hourly or
+ * more frequent cadences.
+ *
+ * This default is only applied to agentTurn payloads; systemEvent payloads and
+ * payloads that don't resolve a job timeout continue to run unbounded.
+ */
+export const DEFAULT_CRON_RUN_TIMEOUT_MS = 30 * 60_000;
+
+function resolveRunTimeoutMs(job: CronJob, jobTimeoutMs: number | undefined): number | undefined {
+  if (job.payload.kind !== "agentTurn") {
+    return undefined;
+  }
+  const raw = job.payload.runTimeoutSeconds;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
+    return Math.floor(raw) * 1000;
+  }
+  const minimum = typeof jobTimeoutMs === "number" ? jobTimeoutMs * 2 : 0;
+  return Math.max(minimum, DEFAULT_CRON_RUN_TIMEOUT_MS);
+}
+
 export async function executeJobCoreWithTimeout(
   state: CronServiceState,
   job: CronJob,
 ): Promise<Awaited<ReturnType<typeof executeJobCore>>> {
   const jobTimeoutMs = resolveCronJobTimeoutMs(job);
-  if (typeof jobTimeoutMs !== "number") {
+  const runTimeoutMs = resolveRunTimeoutMs(job, jobTimeoutMs);
+  if (typeof jobTimeoutMs !== "number" && typeof runTimeoutMs !== "number") {
     return await executeJobCore(state, job);
   }
 
   const runAbortController = new AbortController();
   let timeoutId: NodeJS.Timeout | undefined;
+  let hardKillId: NodeJS.Timeout | undefined;
+  let hardKilled = false;
   try {
     return await Promise.race([
       executeJobCore(state, job, runAbortController.signal),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          runAbortController.abort(timeoutErrorMessage());
-          reject(new Error(timeoutErrorMessage()));
-        }, jobTimeoutMs);
+        if (typeof jobTimeoutMs === "number") {
+          timeoutId = setTimeout(() => {
+            try {
+              runAbortController.abort(timeoutErrorMessage());
+            } catch {
+              // ignore: aborting a non-abortable controller is benign
+            }
+            reject(new Error(timeoutErrorMessage()));
+          }, jobTimeoutMs);
+        }
+        if (typeof runTimeoutMs === "number") {
+          hardKillId = setTimeout(() => {
+            hardKilled = true;
+            try {
+              runAbortController.abort("cron: run wall-clock timeout (runTimeoutSeconds) exceeded");
+            } catch {
+              // ignore
+            }
+            try {
+              state.deps.log.warn(
+                { jobId: job.id, runTimeoutMs },
+                "cron: runTimeoutSeconds wall-clock kill fired",
+              );
+            } catch {
+              // ignore
+            }
+            reject(new Error(timeoutErrorMessage()));
+          }, runTimeoutMs);
+        }
       }),
     ]);
+  } catch (err) {
+    // Forensic breadcrumb so timeouts can be correlated with task ledger state.
+    try {
+      state.deps.log.warn(
+        {
+          jobId: job.id,
+          jobName: job.name,
+          jobTimeoutMs: jobTimeoutMs ?? null,
+          runTimeoutMs: runTimeoutMs ?? null,
+          hardKilled,
+          err: String((err as Error | undefined)?.message ?? err),
+        },
+        hardKilled
+          ? "cron: wall-clock timeout aborted run"
+          : "cron: payload.timeoutSeconds aborted run",
+      );
+    } catch {
+      // ignore log failures
+    }
+    throw err;
   } finally {
     if (timeoutId) {
       clearTimeout(timeoutId);
+    }
+    if (hardKillId) {
+      clearTimeout(hardKillId);
     }
   }
 }
@@ -759,13 +834,40 @@ export async function onTimer(state: CronServiceState) {
           { jobId: id, jobName: job.name, timeoutMs: jobTimeoutMs ?? null },
           `cron: job failed: ${errorText}`,
         );
+        const endedAt = state.deps.nowMs();
+        // Belt-and-suspenders: proactively close the task ledger row now. The
+        // locked() apply-outcome pass below normally handles this, but if the
+        // lock contends or the worker pool tears down unexpectedly (e.g. a
+        // runTimeoutSeconds wall-clock kill interrupts a wedged job) we can
+        // leave a ledger row open, resulting in stale `running` task rows and
+        // session registry entries. Closing here is idempotent because
+        // tryFinishCronTaskRun looks up by runId and the subsequent
+        // applyOutcomeToStoredJob call will be a no-op when the row is
+        // already terminal. See #68634 / OPENCLAW_CRON_TIMEOUT_REGISTRY_PATCH_V1.
+        try {
+          tryFinishCronTaskRun(state, {
+            taskRunId,
+            status: "error",
+            error: errorText,
+            endedAt,
+          });
+        } catch (closeErr) {
+          try {
+            state.deps.log.warn(
+              { jobId: id, err: String(closeErr) },
+              "cron: proactive ledger close failed",
+            );
+          } catch {
+            // ignore log failures
+          }
+        }
         return {
           jobId: id,
           taskRunId,
           status: "error",
           error: errorText,
           startedAt,
-          endedAt: state.deps.nowMs(),
+          endedAt,
         };
       }
     };

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -93,6 +93,15 @@ type CronAgentTurnPayloadFields = {
   fallbacks?: string[];
   thinking?: string;
   timeoutSeconds?: number;
+  /**
+   * Hard wall-clock kill for the entire run, independent of
+   * {@link timeoutSeconds} (which governs the LLM turn budget).
+   *
+   * Defaults to `max(timeoutSeconds * 2, 1800s)` for cron-spawned sessions so a
+   * wedged child can't outlive its parent schedule even if the inner abort is
+   * ignored. See {@link executeJobCoreWithTimeout}.
+   */
+  runTimeoutSeconds?: number;
   allowUnsafeExternalContent?: boolean;
   /** Immutable external hook provenance for async dispatch. */
   externalContentSource?: HookExternalContentSource;


### PR DESCRIPTION
## Summary

Two related fixes so cron `agentTurn` jobs can't leave stale task- or session-registry rows behind when they time out:

1. **Close the task ledger row from the onTimer error path** (belt-and-suspenders). Previously the ledger row was only closed inside the `locked()` apply-outcome pass; when that pass contended on the lock or the worker pool tore down unexpectedly (e.g. a `runTimeoutSeconds` wall-clock kill interrupts a wedged isolated run) the row stayed open and the audit sweeper later flagged it `stale_running` → `lost`. The close is idempotent: `tryFinishCronTaskRun` looks up by `runId` and the subsequent `applyOutcomeToStoredJob` is a no-op once the row is terminal.

2. **Add `CronAgentTurnPayloadFields.runTimeoutSeconds`** — a hard wall-clock kill for the whole run, independent of `timeoutSeconds` (which only governs the LLM turn budget). Defaults to `max(timeoutSeconds * 2, 1800s)` for cron-spawned `agentTurn` sessions so a wedged child that swallows its inner abort still cannot outlive its parent schedule on hourly or more frequent cadences.

## Production repro

APC's production gateway accumulated **29 stale_running tasks + 25 lost tasks over six days**. Root cause: cron payload timeouts killed the agent loop but left both the session registry and task registry in an inconsistent state — the ledger row was still `running` long after the process was gone.

Post-patch (re-applied in place on the running gateway as a hot patch, see below):
- Audit sweeper: **63 → 53** errors
- `stale_running` task count: **29 → 0**

## Deployer note (pre-merge)

Operators running OpenClaw from source who want to pick this up before it merges can re-apply via the same script we used for the APC gateway:

```
~/.openclaw/scripts/apply-cron-timeout-patch.sh
```

(OpenClaw-host-side tooling; not included in this PR.)

## Tests

New file: `src/cron/service/timer.run-timeout.test.ts` exercises both paths end-to-end through `onTimer` + fake timers:

- **`timeoutSeconds` exceeded → ledger row closes as `timed_out`** — regression against the bug where the error path returned without closing the ledger.
- **`runTimeoutSeconds < timeoutSeconds` + runner that ignores `abortSignal` → wall-clock kill aborts the run** — regression against the scenario that caused the production `lost` tasks. If the wall-clock path regresses the test will hang on `timerPromise`, surfacing as a timeout; this is intentional.

Full cron suite: `node scripts/run-vitest.mjs run --config test/vitest/vitest.cron.config.ts` → **78 files / 625 tests passing** (including the 2 new ones).

## Files

- `src/cron/types.ts` (+9) — `runTimeoutSeconds` field w/ JSDoc
- `src/cron/normalize.ts` (+19) — coerce + top-level passthrough for the new field, mirroring the existing `timeoutSeconds` handling
- `src/cron/service/timer.ts` (+116) — `DEFAULT_CRON_RUN_TIMEOUT_MS` + `resolveRunTimeoutMs` + dual-timer `Promise.race` in `executeJobCoreWithTimeout` + proactive `tryFinishCronTaskRun` call in `onTimer`'s error path + forensic warn log on timeout
- `src/cron/service/timer.run-timeout.test.ts` (+204, new) — regression coverage

## Reviewer notes

- Opened as **draft** since this is a cross-cutting fix for a small but high-blast-radius code path. Happy to mark ready after first review pass.
- `DEFAULT_CRON_RUN_TIMEOUT_MS = 30 * 60_000` (30 min) is deliberately generous — intended as a safety net rather than a tight bound. If you'd prefer opt-in-only (no default wall-clock for agentTurn payloads that omit `runTimeoutSeconds`) it's a one-line change in `resolveRunTimeoutMs`.
- No change to the `locked()` apply-outcome pass; the new `onTimer` close is purely additive and idempotent.
