### PR TITLE
fix(exec): avoid waiting for final session result in approval followups

### DIFF
--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -53,7 +53,33 @@ describe("exec approval followup", () => {
         channel: undefined,
         to: undefined,
       }),
-      { expectFinal: true },
+      { expectFinal: false },
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("only waits for accepted when resuming a session followup", async () => {
+    vi.mocked(callGatewayTool).mockResolvedValueOnce({
+      status: "accepted",
+      runId: "run-followup-accepted",
+    });
+
+    await expect(
+      sendExecApprovalFollowup({
+        approvalId: "req-accepted-only",
+        sessionKey: "agent:main:main",
+        resultText: "Exec finished (gateway id=req-accepted-only, code 0)\nok",
+      }),
+    ).resolves.toBe(true);
+
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "agent",
+      expect.any(Object),
+      expect.objectContaining({
+        sessionKey: "agent:main:main",
+        idempotencyKey: "exec-approval-followup:req-accepted-only",
+      }),
+      { expectFinal: false },
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });
@@ -104,7 +130,7 @@ describe("exec approval followup", () => {
         threadId: target.threadId,
         idempotencyKey: `exec-approval-followup:req-${target.channel}`,
       }),
-      { expectFinal: true },
+      { expectFinal: false },
     );
     expect(sendMessage).not.toHaveBeenCalled();
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -228,7 +228,11 @@ export async function sendExecApprovalFollowup(
           turnSourceAccountId: params.turnSourceAccountId,
           turnSourceThreadId: params.turnSourceThreadId,
         }),
-        { expectFinal: true },
+        // Only wait for the followup turn to be accepted. Waiting for the
+        // final agent result here turns a background completion notification
+        // into a full session-turn wait, which can deadlock behind an already
+        // busy session lane and surface as a bogus followup timeout.
+        { expectFinal: false },
       );
       return true;
     } catch (err) {


### PR DESCRIPTION
## Summary

Fix async exec approval followups so they only wait for the session resume request to be accepted, not for the full resumed agent turn to finish.

Previously this path used `expectFinal: true`, which could block behind a busy session lane and hit a 60s timeout, making async exec completion look like OpenClaw had frozen.

## Change

- switch exec approval followup session resume to `expectFinal: false`
- add a regression test for accepted-only followup behavior
- update existing assertions accordingly

## Verification

- `src/agents/bash-tools.exec-approval-followup.test.ts` ✅ 15/15
- `src/agents/bash-tools.exec-host-gateway.test.ts` ✅ 6/6
- `src/agents/bash-tools.exec-host-shared.test.ts` ✅ 11/11
- `src/agents/bash-tools.exec.approval-id.test.ts` ✅ 29/29
- `src/agents/subagent-announce.timeout.test.ts` ✅ 14/14
- `pnpm build` ✅
- live smoke after gateway restart ✅ (`async-followup-live-ok`)

## Scope

Only includes:
- `src/agents/bash-tools.exec-approval-followup.ts`
- `src/agents/bash-tools.exec-approval-followup.test.ts`
