### PR TITLE
perf: reduce lazy CLI startup plugin loading

### DIFF
--- a/src/plugins/cli-registry-loader.test.ts
+++ b/src/plugins/cli-registry-loader.test.ts
@@ -1,0 +1,75 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+const mocks = vi.hoisted(() => ({
+  loadOpenClawPluginCliRegistry: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
+  resolveManifestActivationPluginIds: vi.fn(),
+}));
+
+vi.mock("./loader.js", () => ({
+  loadOpenClawPluginCliRegistry: (...args: unknown[]) =>
+    mocks.loadOpenClawPluginCliRegistry(...args),
+  loadOpenClawPlugins: (...args: unknown[]) => mocks.loadOpenClawPlugins(...args),
+}));
+
+vi.mock("./activation-planner.js", () => ({
+  resolveManifestActivationPluginIds: (...args: unknown[]) =>
+    mocks.resolveManifestActivationPluginIds(...args),
+}));
+
+let resolvePrimaryCommandPluginIdsForCli: typeof import("./cli-registry-loader.js").resolvePrimaryCommandPluginIdsForCli;
+let loadPluginCliMetadataEntries: typeof import("./cli-registry-loader.js").loadPluginCliMetadataEntries;
+
+describe("plugins/cli-registry-loader", () => {
+  beforeAll(async () => {
+    ({ resolvePrimaryCommandPluginIdsForCli, loadPluginCliMetadataEntries } =
+      await import("./cli-registry-loader.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveManifestActivationPluginIds.mockReturnValue([]);
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue({
+      cliRegistrars: [
+        {
+          pluginId: "demo",
+          commands: ["demo"],
+          descriptors: [{ name: "demo", description: "Demo command", hasSubcommands: true }],
+          register: vi.fn(),
+        },
+      ],
+    });
+  });
+
+  it("resolves plugin ids for a primary command through manifest activation", () => {
+    mocks.resolveManifestActivationPluginIds.mockReturnValue(["demo-plugin"]);
+
+    const result = resolvePrimaryCommandPluginIdsForCli({
+      cfg: {} as OpenClawConfig,
+      primaryCommand: "demo",
+    });
+
+    expect(result).toEqual(["demo-plugin"]);
+    expect(mocks.resolveManifestActivationPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: { kind: "command", command: "demo" },
+      }),
+    );
+  });
+
+  it("loads metadata entries without forcing the full runtime loader", async () => {
+    const entries = await loadPluginCliMetadataEntries({
+      cfg: {} as OpenClawConfig,
+      primaryCommand: "gateway",
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      pluginId: "demo",
+      names: ["demo"],
+    });
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+  });
+});

--- a/src/plugins/cli-registry-loader.ts
+++ b/src/plugins/cli-registry-loader.ts
@@ -78,6 +78,21 @@ function resolvePrimaryCommandPluginIds(
   });
 }
 
+export function resolvePrimaryCommandPluginIdsForCli(params: {
+  cfg?: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  logger?: PluginLogger;
+  primaryCommand?: string;
+}): string[] {
+  const logger = resolvePluginCliLogger(params.logger);
+  const context = resolvePluginCliLoadContext({
+    cfg: params.cfg,
+    env: params.env,
+    logger,
+  });
+  return resolvePrimaryCommandPluginIds(context, params.primaryCommand);
+}
+
 export function resolvePluginCliLoadContext(params: {
   cfg?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -182,6 +197,28 @@ export async function loadPluginCliRegistrationEntries(params: {
     primaryCommand: params.primaryCommand,
     loaderOptions: params.loaderOptions,
   });
+  return buildPluginCliCommandGroupEntries({
+    registry,
+    config,
+    workspaceDir,
+    logger,
+  });
+}
+
+export async function loadPluginCliMetadataEntries(
+  params: PluginCliPublicLoadParams,
+): Promise<PluginCliCommandGroupEntry[]> {
+  const logger = resolvePluginCliLogger(params.logger);
+  const context = resolvePluginCliLoadContext({
+    cfg: params.cfg,
+    env: params.env,
+    logger,
+  });
+  const { config, workspaceDir, registry } = await loadPluginCliMetadataRegistryWithContext(
+    context,
+    { primaryCommand: params.primaryCommand },
+    params.loaderOptions,
+  );
   return buildPluginCliCommandGroupEntries({
     registry,
     config,

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -265,7 +265,7 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
-  it("keeps runtime CLI command registration on the full plugin loader for legacy channel plugins", async () => {
+  it("uses metadata CLI loading for lazy registration when no plugin primary is selected", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({
       config: autoEnabledConfig,
@@ -291,7 +291,7 @@ describe("registerPluginCliCommands", () => {
       mode: "lazy",
     });
 
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
       expect.objectContaining({
         config: autoEnabledConfig,
         activationSourceConfig: rawConfig,
@@ -300,7 +300,7 @@ describe("registerPluginCliCommands", () => {
         },
       }),
     );
-    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {
@@ -322,7 +322,7 @@ describe("registerPluginCliCommands", () => {
   });
 
   it("falls back to eager registration when descriptors do not cover every command root", async () => {
-    mocks.loadOpenClawPlugins.mockReturnValue(
+    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(
       createCliRegistry({
         memoryCommands: ["memory", "memory-admin"],
         memoryDescriptors: [
@@ -344,6 +344,7 @@ describe("registerPluginCliCommands", () => {
     });
 
     expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("registers a selected plugin primary eagerly during lazy startup", async () => {
@@ -369,7 +370,7 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps full CLI loading when primary command planning finds no plugin match", async () => {
+  it("keeps metadata-only CLI loading when primary command planning finds no plugin match", async () => {
     const program = createProgram();
     program.exitOverride();
 
@@ -378,11 +379,12 @@ describe("registerPluginCliCommands", () => {
       primary: "memory",
     });
 
-    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
       expect.not.objectContaining({
         onlyPluginIds: expect.anything(),
       }),
     );
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("returns null for validated plugin CLI config when the snapshot is invalid", async () => {
@@ -401,10 +403,26 @@ describe("registerPluginCliCommands", () => {
       valid: true,
       config: loadedConfig,
     });
-    mocks.loadConfig.mockReturnValueOnce(loadedConfig);
 
     await expect(loadValidatedConfigForPluginRegistration()).resolves.toBe(loadedConfig);
-    expect(mocks.loadConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it("uses metadata-only plugin CLI loading for lazy builtin commands", async () => {
+    const program = createProgram();
+
+    await registerPluginCliCommands(program, {} as OpenClawConfig, undefined, undefined, {
+      mode: "lazy",
+      primary: "gateway",
+    });
+
+    expect(mocks.resolveManifestActivationPluginIds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trigger: { kind: "command", command: "gateway" },
+      }),
+    );
+    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledTimes(1);
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 
   it("skips plugin CLI registration from validated config when the snapshot is invalid", async () => {

--- a/src/plugins/cli.test.ts
+++ b/src/plugins/cli.test.ts
@@ -265,7 +265,7 @@ describe("registerPluginCliCommands", () => {
     );
   });
 
-  it("uses metadata CLI loading for lazy registration when no plugin primary is selected", async () => {
+  it("keeps full CLI loading for lazy registration when no plugin primary is selected", async () => {
     const { rawConfig, autoEnabledConfig } = createAutoEnabledCliFixture();
     mocks.applyPluginAutoEnable.mockReturnValue({
       config: autoEnabledConfig,
@@ -291,7 +291,7 @@ describe("registerPluginCliCommands", () => {
       mode: "lazy",
     });
 
-    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.objectContaining({
         config: autoEnabledConfig,
         activationSourceConfig: rawConfig,
@@ -300,7 +300,7 @@ describe("registerPluginCliCommands", () => {
         },
       }),
     );
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
   });
 
   it("lazy-registers descriptor-backed plugin commands on first invocation", async () => {
@@ -322,7 +322,7 @@ describe("registerPluginCliCommands", () => {
   });
 
   it("falls back to eager registration when descriptors do not cover every command root", async () => {
-    mocks.loadOpenClawPluginCliRegistry.mockResolvedValue(
+    mocks.loadOpenClawPlugins.mockReturnValue(
       createCliRegistry({
         memoryCommands: ["memory", "memory-admin"],
         memoryDescriptors: [
@@ -344,7 +344,7 @@ describe("registerPluginCliCommands", () => {
     });
 
     expect(mocks.memoryRegister).toHaveBeenCalledTimes(1);
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
   });
 
   it("registers a selected plugin primary eagerly during lazy startup", async () => {
@@ -370,7 +370,7 @@ describe("registerPluginCliCommands", () => {
     expect(mocks.memoryListAction).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps metadata-only CLI loading when primary command planning finds no plugin match", async () => {
+  it("keeps full CLI loading when primary command planning finds no plugin match", async () => {
     const program = createProgram();
     program.exitOverride();
 
@@ -379,12 +379,21 @@ describe("registerPluginCliCommands", () => {
       primary: "memory",
     });
 
-    expect(mocks.loadOpenClawPluginCliRegistry).toHaveBeenCalledWith(
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledWith(
       expect.not.objectContaining({
         onlyPluginIds: expect.anything(),
       }),
     );
-    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
+    expect(mocks.loadOpenClawPluginCliRegistry).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate primary plugin resolution during eager registration", async () => {
+    await registerPluginCliCommands(createProgram(), {} as OpenClawConfig, undefined, undefined, {
+      mode: "eager",
+      primary: "gateway",
+    });
+
+    expect(mocks.resolveManifestActivationPluginIds).toHaveBeenCalledTimes(1);
   });
 
   it("returns null for validated plugin CLI config when the snapshot is invalid", async () => {

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,4 +1,6 @@
 import type { Command } from "commander";
+import { cliCommandCatalog } from "../cli/command-catalog.js";
+import { matchesCommandPath } from "../cli/command-path-matches.js";
 import { readConfigFileSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
@@ -20,6 +22,12 @@ type RegisterPluginCliOptions = {
 };
 
 const logger = createPluginCliLogger();
+
+function isKnownCoreCommandPath(commandPath: string[]): boolean {
+  return cliCommandCatalog.some((entry) =>
+    matchesCommandPath(entry.commandPath.slice(), commandPath),
+  );
+}
 
 export const loadValidatedConfigForPluginRegistration =
   async (): Promise<OpenClawConfig | null> => {
@@ -47,28 +55,35 @@ export async function registerPluginCliCommands(
 ) {
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? undefined;
-  const primaryPluginIds = resolvePrimaryCommandPluginIdsForCli({
-    cfg,
-    env,
-    logger,
-    primaryCommand: primary,
-  });
-  const entries =
-    mode === "lazy" && primaryPluginIds.length === 0
-      ? await loadPluginCliMetadataEntries({
+  const primaryPluginIds =
+    mode === "lazy" && primary
+      ? resolvePrimaryCommandPluginIdsForCli({
           cfg,
           env,
-          loaderOptions,
-          primaryCommand: primary,
           logger,
+          primaryCommand: primary,
         })
-      : await loadPluginCliRegistrationEntriesWithDefaults({
-          cfg,
-          env,
-          loaderOptions,
-          primaryCommand: primary,
-          logger,
-        });
+      : [];
+  const shouldUseMetadataOnlyEntries =
+    mode === "lazy" &&
+    !!primary &&
+    primaryPluginIds.length === 0 &&
+    isKnownCoreCommandPath([primary]);
+  const entries = shouldUseMetadataOnlyEntries
+    ? await loadPluginCliMetadataEntries({
+        cfg,
+        env,
+        loaderOptions,
+        primaryCommand: primary,
+        logger,
+      })
+    : await loadPluginCliRegistrationEntriesWithDefaults({
+        cfg,
+        env,
+        loaderOptions,
+        primaryCommand: primary,
+        logger,
+      });
 
   await registerPluginCliCommandGroups(program, entries, {
     mode,

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,10 +1,12 @@
 import type { Command } from "commander";
-import { loadConfig, readConfigFileSnapshot } from "../config/config.js";
+import { readConfigFileSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createPluginCliLogger,
   loadPluginCliDescriptors,
+  loadPluginCliMetadataEntries,
   loadPluginCliRegistrationEntriesWithDefaults,
+  resolvePrimaryCommandPluginIdsForCli,
   type PluginCliLoaderOptions,
 } from "./cli-registry-loader.js";
 import { registerPluginCliCommandGroups } from "./register-plugin-cli-command-groups.js";
@@ -25,7 +27,7 @@ export const loadValidatedConfigForPluginRegistration =
     if (!snapshot.valid) {
       return null;
     }
-    return loadConfig();
+    return snapshot.config;
   };
 
 export async function getPluginCliCommandDescriptors(
@@ -45,22 +47,35 @@ export async function registerPluginCliCommands(
 ) {
   const mode = options?.mode ?? "eager";
   const primary = options?.primary ?? undefined;
+  const primaryPluginIds = resolvePrimaryCommandPluginIdsForCli({
+    cfg,
+    env,
+    logger,
+    primaryCommand: primary,
+  });
+  const entries =
+    mode === "lazy" && primaryPluginIds.length === 0
+      ? await loadPluginCliMetadataEntries({
+          cfg,
+          env,
+          loaderOptions,
+          primaryCommand: primary,
+          logger,
+        })
+      : await loadPluginCliRegistrationEntriesWithDefaults({
+          cfg,
+          env,
+          loaderOptions,
+          primaryCommand: primary,
+          logger,
+        });
 
-  await registerPluginCliCommandGroups(
-    program,
-    await loadPluginCliRegistrationEntriesWithDefaults({
-      cfg,
-      env,
-      loaderOptions,
-      primaryCommand: primary,
-    }),
-    {
-      mode,
-      primary,
-      existingCommands: new Set(program.commands.map((cmd) => cmd.name())),
-      logger,
-    },
-  );
+  await registerPluginCliCommandGroups(program, entries, {
+    mode,
+    primary,
+    existingCommands: new Set(program.commands.map((cmd) => cmd.name())),
+    logger,
+  });
 }
 
 export async function registerPluginCliCommandsFromValidatedConfig(


### PR DESCRIPTION
## Prompt to recreate this PR

> Sync the startup-hang fix work into the real OpenClaw/OpenClaw repo at /home/contact/openclaw, not the temporary partial folder.  
> Then:
> 1. apply the code changes to this real repo,  
> 2. create a branch,  
> 3. commit the changes,  
> 4. open a PR to OpenClaw/OpenClaw,  
> 5. install dependencies,  
> 6. run tests/build in that repo,  
> 7. report the PR URL and any test failures.

## Summary

- avoid an unnecessary second config load during plugin CLI registration by reusing the validated config snapshot
- add a metadata-entry loading path for plugin CLI registration helpers
- keep lazy CLI startup on the metadata-only path when no plugin-specific primary command needs eager runtime registration
- add focused regression coverage for the new helper path and lazy CLI startup behavior

## Testing

- `pnpm install`
- `pnpm test src/plugins/cli-registry-loader.test.ts src/plugins/cli.test.ts src/plugins/loader.cli-metadata.test.ts src/cli/plugin-registry-loader.test.ts src/cli/daemon-cli/probe.test.ts`
- `pnpm test src/cli/run-main.exit.test.ts src/cli/completion-cli.test.ts`
- `pnpm build`
- `pnpm openclaw --help`

## Notes

- `pnpm openclaw gateway status --json` did not complete cleanly in this local dirty-tree/dev verification path; it exited under the timeout wrapper after triggering the repo rebuild-on-run path, so I am calling that out explicitly rather than treating it as a green smoke test.
