### PR TITLE
Agents/tool-images: memoize resize to avoid per-turn sharp decode (#64418)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1217,6 +1217,7 @@ Docs: https://docs.openclaw.ai
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 - Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
+- Agents/tool-images: memoize `resizeImageBase64IfNeeded` with a collision-safe, memory-bounded cache so session-history images are not re-decoded through sharp on every turn. Fixes #64418. (#68677) Thanks @nitinjwadhawan.
 
 ## 2026.4.15
 

--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -22,7 +22,7 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
-import { sanitizeContentBlocksImages } from "./tool-images.js";
+import { __testing, sanitizeContentBlocksImages } from "./tool-images.js";
 
 async function createLargePng(): Promise<Buffer> {
   const width = 2001;
@@ -45,6 +45,10 @@ describe("tool-images log context", () => {
   beforeEach(() => {
     infoMock.mockClear();
     warnMock.mockClear();
+    // The resize cache is module-level state that persists between tests.
+    // Without a reset, the second test would hit the cache from the first
+    // (both use the same source PNG) and skip the log we are asserting on.
+    __testing.resetResizeCache();
   });
 
   it("includes filename from MEDIA text", async () => {

--- a/src/agents/tool-images.log.test.ts
+++ b/src/agents/tool-images.log.test.ts
@@ -24,7 +24,7 @@ vi.mock("../logging/subsystem.js", () => {
   return { createSubsystemLogger: () => makeLogger() };
 });
 
-import { sanitizeContentBlocksImages } from "./tool-images.js";
+import { __testing, sanitizeContentBlocksImages } from "./tool-images.js";
 
 async function createLargePng(): Promise<Buffer> {
   return createSolidPngBuffer(2001, 8, { r: 0x7f, g: 0x7f, b: 0x7f });
@@ -40,6 +40,7 @@ describe("tool-images log context", () => {
   beforeEach(() => {
     infoMock.mockClear();
     warnMock.mockClear();
+    __testing.resetResizeCache();
   });
 
   it("includes filename from read label", async () => {

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -1,8 +1,12 @@
 import sharp from "sharp";
-import { describe, expect, it } from "vitest";
-import { sanitizeContentBlocksImages, sanitizeImageBlocks } from "./tool-images.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { __testing, sanitizeContentBlocksImages, sanitizeImageBlocks } from "./tool-images.js";
 
 describe("tool image sanitizing", () => {
+  beforeEach(() => {
+    __testing.resetResizeCache();
+  });
+
   const getImageBlock = (
     blocks: Awaited<ReturnType<typeof sanitizeContentBlocksImages>>,
   ): (typeof blocks)[number] & { type: "image"; data: string; mimeType?: string } => {
@@ -125,5 +129,140 @@ describe("tool image sanitizing", () => {
         text: "[test] omitted image payload: invalid base64",
       },
     ]);
+  });
+
+  describe("resize cache (#64418)", () => {
+    it("reuses the resize result for the same image across repeated calls", async () => {
+      // Simulates session history being re-sanitized on every turn.
+      const png = await createWidePng();
+      const block = {
+        type: "image" as const,
+        data: png.toString("base64"),
+        mimeType: "image/png",
+      };
+
+      const firstCall = await sanitizeContentBlocksImages([block], "turn-1");
+      const statsAfterFirst = __testing.getResizeCacheStats();
+      expect(statsAfterFirst.misses).toBe(1);
+      expect(statsAfterFirst.hits).toBe(0);
+      expect(statsAfterFirst.entryCount).toBe(1);
+
+      const secondCall = await sanitizeContentBlocksImages([block], "turn-2");
+      const statsAfterSecond = __testing.getResizeCacheStats();
+      expect(statsAfterSecond.misses).toBe(1);
+      expect(statsAfterSecond.hits).toBe(1);
+
+      const first = getImageBlock(firstCall);
+      const second = getImageBlock(secondCall);
+      expect(second.data).toBe(first.data);
+      expect(second.mimeType).toBe(first.mimeType);
+    }, 20_000);
+
+    it("keys on the full base64 payload so long shared prefixes do not collide (#64514 P1)", () => {
+      // Direct regression guard against the #64514 P1 bug: hashing only a
+      // prefix of the base64 payload (e.g. `base64.slice(0, 1000)`) causes
+      // two distinct images that share a long leading prefix to produce the
+      // same key, silently substituting one image's bytes for another in
+      // the session context. We build two payloads whose first 1024 chars
+      // are byte-identical and assert that `computeResizeCacheKey` still
+      // distinguishes them. Any key strategy that truncates the base64 at
+      // 1000 chars or fewer will fail this.
+      const sharedPrefix = "A".repeat(1024);
+      const base64A = `${sharedPrefix}aaaaBBBBcccc`;
+      const base64B = `${sharedPrefix}aaaaDDDDcccc`;
+      expect(base64A.slice(0, 1024)).toBe(base64B.slice(0, 1024));
+      expect(base64A).not.toBe(base64B);
+
+      const maxDimensionPx = 1200;
+      const maxBytes = 5 * 1024 * 1024;
+      const keyA = __testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes);
+      const keyB = __testing.computeResizeCacheKey(base64B, maxDimensionPx, maxBytes);
+      expect(keyA).not.toBe(keyB);
+
+      // Sanity: the same payload hashes to the same key and limits are part
+      // of the key space.
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes)).toBe(keyA);
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx + 1, maxBytes)).not.toBe(keyA);
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes + 1)).not.toBe(keyA);
+    });
+
+    it("records separate cache entries for two distinct valid images (#64418 end-to-end)", async () => {
+      // Behavior-level guard that the outer wrapper actually routes distinct
+      // images through distinct cache entries. Two different JPEGs share
+      // their leading JPEG headers (SOI/APP0/DQT) but diverge in the
+      // compressed data; if the wrapper ever keyed on only the prefix, we
+      // would see 1 miss + 1 hit instead of 2 misses + 2 entries.
+      const width = 400;
+      const height = 400;
+      const redRaw = Buffer.alloc(width * height * 3);
+      const blueRaw = Buffer.alloc(width * height * 3);
+      for (let i = 0; i < redRaw.length; i += 3) {
+        redRaw[i] = 0xff;
+        blueRaw[i + 2] = 0xff;
+      }
+      const jpegA = await sharp(redRaw, { raw: { width, height, channels: 3 } })
+        .jpeg({ quality: 80 })
+        .toBuffer();
+      const jpegB = await sharp(blueRaw, { raw: { width, height, channels: 3 } })
+        .jpeg({ quality: 80 })
+        .toBuffer();
+      expect(jpegA.equals(jpegB)).toBe(false);
+
+      await sanitizeContentBlocksImages(
+        [{ type: "image" as const, data: jpegA.toString("base64"), mimeType: "image/jpeg" }],
+        "A",
+      );
+      await sanitizeContentBlocksImages(
+        [{ type: "image" as const, data: jpegB.toString("base64"), mimeType: "image/jpeg" }],
+        "B",
+      );
+
+      const stats = __testing.getResizeCacheStats();
+      // Two distinct payloads, two distinct misses, two distinct entries.
+      // With a colliding key this would be 1 miss + 1 hit + 1 entry.
+      expect(stats.misses).toBe(2);
+      expect(stats.hits).toBe(0);
+      expect(stats.entryCount).toBe(2);
+    }, 20_000);
+
+    it("keys the cache by maxBytes so different limits do not share results", async () => {
+      const png = await createWidePng();
+      const block = {
+        type: "image" as const,
+        data: png.toString("base64"),
+        mimeType: "image/png",
+      };
+
+      await sanitizeContentBlocksImages([block], "small-limit", { maxBytes: 64 * 1024 });
+      await sanitizeContentBlocksImages([block], "large-limit", { maxBytes: 256 * 1024 });
+      const stats = __testing.getResizeCacheStats();
+      expect(stats.misses).toBe(2);
+      expect(stats.hits).toBe(0);
+      expect(stats.entryCount).toBe(2);
+    }, 20_000);
+
+    it("bounds cache memory by evicting past the byte cap", async () => {
+      // Size the cap at 1 byte so every insert forces immediate eviction;
+      // this deterministically proves the eviction loop runs regardless of
+      // what sharp happens to produce for a given input.
+      __testing.setResizeCacheMaxBytes(1);
+      const png = await createWidePng();
+      const base64 = png.toString("base64");
+
+      for (const limit of [64 * 1024, 96 * 1024, 128 * 1024]) {
+        await sanitizeContentBlocksImages(
+          [{ type: "image" as const, data: base64, mimeType: "image/png" }],
+          `limit-${limit}`,
+          { maxBytes: limit },
+        );
+      }
+
+      const stats = __testing.getResizeCacheStats();
+      expect(stats.totalBytes).toBeLessThanOrEqual(stats.maxBytes);
+      // All three inserts happened (three distinct keys) but each was evicted
+      // immediately because the new entry's own size exceeded the 1-byte cap.
+      expect(stats.misses).toBe(3);
+      expect(stats.entryCount).toBe(0);
+    }, 30_000);
   });
 });

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -241,6 +241,79 @@ describe("tool image sanitizing", () => {
       expect(stats.entryCount).toBe(2);
     }, 20_000);
 
+    describe("OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES parsing", () => {
+      const DEFAULT_MAX_BYTES = 64 * 1024 * 1024;
+      const envKey = "OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES";
+      const originalEnv = process.env[envKey];
+
+      function applyEnv(value: string | undefined): void {
+        if (value === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = value;
+        }
+        // resetResizeCache re-reads the env to recompute maxBytes.
+        __testing.resetResizeCache();
+      }
+
+      function restoreEnv(): void {
+        if (originalEnv === undefined) {
+          delete process.env[envKey];
+        } else {
+          process.env[envKey] = originalEnv;
+        }
+        __testing.resetResizeCache();
+      }
+
+      it("accepts bare positive integer byte counts", () => {
+        try {
+          applyEnv("12345");
+          expect(__testing.getResizeCacheStats().maxBytes).toBe(12345);
+        } finally {
+          restoreEnv();
+        }
+      });
+
+      it("falls back to default for human-readable suffixes like '64M' (prevents silent 64-byte cap)", () => {
+        try {
+          for (const bad of ["64M", "64MiB", "64MB", "1G", "1GiB", "5k"]) {
+            applyEnv(bad);
+            expect(
+              __testing.getResizeCacheStats().maxBytes,
+              `value ${JSON.stringify(bad)} should fall back to default`,
+            ).toBe(DEFAULT_MAX_BYTES);
+          }
+        } finally {
+          restoreEnv();
+        }
+      });
+
+      it("falls back to default for non-integer, non-positive, or junk values", () => {
+        try {
+          for (const bad of ["0", "-5", "64.5", "1e6", "abc", "  ", "12 34"]) {
+            applyEnv(bad);
+            expect(
+              __testing.getResizeCacheStats().maxBytes,
+              `value ${JSON.stringify(bad)} should fall back to default`,
+            ).toBe(DEFAULT_MAX_BYTES);
+          }
+        } finally {
+          restoreEnv();
+        }
+      });
+
+      it("falls back to default when the env var is unset or empty", () => {
+        try {
+          applyEnv(undefined);
+          expect(__testing.getResizeCacheStats().maxBytes).toBe(DEFAULT_MAX_BYTES);
+          applyEnv("");
+          expect(__testing.getResizeCacheStats().maxBytes).toBe(DEFAULT_MAX_BYTES);
+        } finally {
+          restoreEnv();
+        }
+      });
+    });
+
     it("bounds cache memory by evicting past the byte cap", async () => {
       // Size the cap at 1 byte so every insert forces immediate eviction;
       // this deterministically proves the eviction loop runs regardless of

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -1,6 +1,6 @@
 // Tool image tests cover image payload sanitization before tool outputs are
 // returned to model-visible content blocks.
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   createNoisyPngBuffer,
   createSolidPngBuffer,
@@ -8,6 +8,7 @@ import {
 } from "../../test/helpers/image-fixtures.js";
 import { getImageMetadata } from "../media/image-ops.js";
 import {
+  __testing,
   sanitizeContentBlocksImages,
   sanitizeImageBlocks,
   sanitizeToolResultImages,
@@ -27,6 +28,10 @@ describe("tool image sanitizing", () => {
   const createWidePng = async () => {
     return createSolidPngBuffer(420, 120, { r: 0x7f, g: 0x7f, b: 0x7f });
   };
+
+  beforeEach(() => {
+    __testing.resetResizeCache();
+  });
 
   it("shrinks oversized images to the configured byte limit", async () => {
     const maxBytes = 64 * 1024;
@@ -216,5 +221,139 @@ describe("tool image sanitizing", () => {
         text: "[test] omitted image payload: invalid base64",
       },
     ]);
+  });
+
+  describe("resize cache (#64418)", () => {
+    it("reuses the resize result for the same image across repeated calls", async () => {
+      // Simulates session history being re-sanitized on every turn.
+      const png = await createWidePng();
+      const block = {
+        type: "image" as const,
+        data: png.toString("base64"),
+        mimeType: "image/png",
+      };
+
+      const firstCall = await sanitizeContentBlocksImages([block], "turn-1");
+      const statsAfterFirst = __testing.getResizeCacheStats();
+      expect(statsAfterFirst.misses).toBe(1);
+      expect(statsAfterFirst.hits).toBe(0);
+      expect(statsAfterFirst.entryCount).toBe(1);
+
+      const secondCall = await sanitizeContentBlocksImages([block], "turn-2");
+      const statsAfterSecond = __testing.getResizeCacheStats();
+      expect(statsAfterSecond.misses).toBe(1);
+      expect(statsAfterSecond.hits).toBe(1);
+
+      const first = getImageBlock(firstCall);
+      const second = getImageBlock(secondCall);
+      expect(second.data).toBe(first.data);
+      expect(second.mimeType).toBe(first.mimeType);
+    }, 20_000);
+
+    it("keys on the full base64 payload so long shared prefixes do not collide (#64514 P1)", () => {
+      const sharedPrefix = "A".repeat(1024);
+      const base64A = `${sharedPrefix}aaaaBBBBcccc`;
+      const base64B = `${sharedPrefix}aaaaDDDDcccc`;
+      expect(base64A.slice(0, 1024)).toBe(base64B.slice(0, 1024));
+      expect(base64A).not.toBe(base64B);
+
+      const maxDimensionPx = 1200;
+      const maxBytes = 5 * 1024 * 1024;
+      const keyA = __testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes);
+      const keyB = __testing.computeResizeCacheKey(base64B, maxDimensionPx, maxBytes);
+      expect(keyA).not.toBe(keyB);
+
+      // Sanity: the same payload hashes to the same key and limits are part
+      // of the key space.
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes)).toBe(keyA);
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx + 1, maxBytes)).not.toBe(keyA);
+      expect(__testing.computeResizeCacheKey(base64A, maxDimensionPx, maxBytes + 1)).not.toBe(keyA);
+    });
+
+    it("preserves the caller's mimeType on a no-op cache hit (#68677 review feedback)", async () => {
+      // WebP falls outside inferMimeTypeFromBase64's JPEG/PNG/GIF
+      // canonicalization list, so the helper receives and must preserve the
+      // caller's declared MIME on no-op cache hits.
+      // 1x1 valid WebP. Keep inline so this unit-fast test does not depend on
+      // optional image backends just to build a fixture.
+      const base64 = "UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA";
+      const limits = { maxDimensionPx: 1200, maxBytes: 5 * 1024 * 1024 };
+
+      const firstResult = await __testing.resizeImageBase64IfNeeded({
+        base64,
+        mimeType: "image/webp",
+        ...limits,
+      });
+      expect(firstResult.resized).toBe(false);
+      expect(firstResult.mimeType).toBe("image/webp");
+      expect(__testing.getResizeCacheStats()).toMatchObject({ misses: 1, hits: 0 });
+
+      const secondResult = await __testing.resizeImageBase64IfNeeded({
+        base64,
+        mimeType: "image/heic",
+        ...limits,
+      });
+      expect(__testing.getResizeCacheStats()).toMatchObject({ misses: 1, hits: 1 });
+      expect(secondResult.resized).toBe(false);
+      expect(secondResult.mimeType).toBe("image/heic");
+      expect(secondResult.base64).toBe(base64);
+    }, 20_000);
+
+    it("records separate cache entries for two distinct valid images (#64418 end-to-end)", async () => {
+      const width = 400;
+      const height = 400;
+      const jpegA = createSolidPngBuffer(width, height, { r: 0xff, g: 0x00, b: 0x00 });
+      const jpegB = createSolidPngBuffer(width, height, { r: 0x00, g: 0x00, b: 0xff });
+      expect(jpegA.equals(jpegB)).toBe(false);
+
+      await sanitizeContentBlocksImages(
+        [{ type: "image" as const, data: jpegA.toString("base64"), mimeType: "image/png" }],
+        "A",
+      );
+      await sanitizeContentBlocksImages(
+        [{ type: "image" as const, data: jpegB.toString("base64"), mimeType: "image/png" }],
+        "B",
+      );
+
+      const stats = __testing.getResizeCacheStats();
+      expect(stats.misses).toBe(2);
+      expect(stats.hits).toBe(0);
+      expect(stats.entryCount).toBe(2);
+    }, 20_000);
+
+    it("keys the cache by maxBytes so different limits do not share results", async () => {
+      const png = await createWidePng();
+      const block = {
+        type: "image" as const,
+        data: png.toString("base64"),
+        mimeType: "image/png",
+      };
+
+      await sanitizeContentBlocksImages([block], "small-limit", { maxBytes: 64 * 1024 });
+      await sanitizeContentBlocksImages([block], "large-limit", { maxBytes: 256 * 1024 });
+      const stats = __testing.getResizeCacheStats();
+      expect(stats.misses).toBe(2);
+      expect(stats.hits).toBe(0);
+      expect(stats.entryCount).toBe(2);
+    }, 20_000);
+
+    it("bounds cache memory by evicting past the byte cap", async () => {
+      __testing.setResizeCacheMaxBytesForTests(1);
+      const png = await createWidePng();
+      const base64 = png.toString("base64");
+
+      for (const limit of [64 * 1024, 96 * 1024, 128 * 1024]) {
+        await sanitizeContentBlocksImages(
+          [{ type: "image" as const, data: base64, mimeType: "image/png" }],
+          `limit-${limit}`,
+          { maxBytes: limit },
+        );
+      }
+
+      const stats = __testing.getResizeCacheStats();
+      expect(stats.totalBytes).toBeLessThanOrEqual(stats.maxBytes);
+      expect(stats.misses).toBe(3);
+      expect(stats.entryCount).toBe(0);
+    }, 30_000);
   });
 });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -169,13 +169,23 @@ type ResizeCacheValue = {
 };
 
 const DEFAULT_RESIZE_CACHE_MAX_BYTES = 64 * 1024 * 1024; // 64 MiB
+
+// Only bare positive integer byte counts are accepted. Human-readable suffixes
+// like "64M" or "64MiB" are intentionally rejected: `Number.parseInt` silently
+// truncates at the first non-digit character, so accepting them would turn
+// `OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES=64M` into a 64-byte cap and evict
+// every cache entry on insert.
 function parseCacheByteLimit(): number {
   const raw = process.env.OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES;
-  if (typeof raw !== "string" || raw.trim().length === 0) {
+  if (typeof raw !== "string") {
     return DEFAULT_RESIZE_CACHE_MAX_BYTES;
   }
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return DEFAULT_RESIZE_CACHE_MAX_BYTES;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0 || String(parsed) !== trimmed) {
     return DEFAULT_RESIZE_CACHE_MAX_BYTES;
   }
   return parsed;

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ImageContent } from "@mariozechner/pi-ai";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -145,7 +146,135 @@ function inferImageFileName(params: {
   return undefined;
 }
 
+// Session history is re-sanitized on every turn via `sanitizeSessionMessagesImages`,
+// which means `resizeImageBase64IfNeeded` is invoked for the same historical image
+// on every message. Both the `getImageMetadata` header read and any `resizeToJpeg`
+// call are expensive (sharp image decode), so we memoize the result.
+//
+// Cache-key note (defends against the P1 cache-key collision flagged during
+// review of #64514): the key MUST be a hash of the full base64 payload plus
+// the output limits. Hashing only a prefix of the base64 collides across
+// different images that share JPEG/PNG header bytes (SOI + APP0/JFIF +
+// quantisation + Huffman tables routinely fill 600+ bytes before pixel data),
+// which would silently substitute one image's bytes for another's in the
+// session context. SHA-256 on multi-MB base64 is sub-millisecond and far
+// cheaper than the sharp decode we are skipping on a cache hit.
+type ResizeCacheValue = {
+  base64: string;
+  mimeType: string;
+  resized: boolean;
+  width: number | undefined;
+  height: number | undefined;
+  approxBytes: number;
+};
+
+const DEFAULT_RESIZE_CACHE_MAX_BYTES = 64 * 1024 * 1024; // 64 MiB
+function parseCacheByteLimit(): number {
+  const raw = process.env.OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES;
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    return DEFAULT_RESIZE_CACHE_MAX_BYTES;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_RESIZE_CACHE_MAX_BYTES;
+  }
+  return parsed;
+}
+
+let resizeCacheMaxBytes = parseCacheByteLimit();
+const resizeCache = new Map<string, ResizeCacheValue>();
+let resizeCacheTotalBytes = 0;
+let resizeCacheHits = 0;
+let resizeCacheMisses = 0;
+
+function computeResizeCacheKey(base64: string, maxDimensionPx: number, maxBytes: number): string {
+  const hash = createHash("sha256");
+  hash.update(`${maxDimensionPx}:${maxBytes}:`);
+  hash.update(base64);
+  return hash.digest("hex");
+}
+
+function evictResizeCacheUntilBelow(limitBytes: number): void {
+  if (resizeCacheTotalBytes <= limitBytes) {
+    return;
+  }
+  // Map preserves insertion order; oldest entries live at the head.
+  for (const [key, entry] of resizeCache) {
+    if (resizeCacheTotalBytes <= limitBytes) {
+      break;
+    }
+    resizeCache.delete(key);
+    resizeCacheTotalBytes -= entry.approxBytes;
+  }
+}
+
+function recordResizeCacheEntry(key: string, entry: ResizeCacheValue): void {
+  const existing = resizeCache.get(key);
+  if (existing) {
+    resizeCache.delete(key);
+    resizeCacheTotalBytes -= existing.approxBytes;
+  }
+  resizeCache.set(key, entry);
+  resizeCacheTotalBytes += entry.approxBytes;
+  if (resizeCacheTotalBytes > resizeCacheMaxBytes) {
+    evictResizeCacheUntilBelow(resizeCacheMaxBytes);
+  }
+}
+
+function lookupResizeCache(key: string): ResizeCacheValue | undefined {
+  const entry = resizeCache.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  // LRU touch: move to tail by delete+set so it survives evictions longer.
+  resizeCache.delete(key);
+  resizeCache.set(key, entry);
+  return entry;
+}
+
 async function resizeImageBase64IfNeeded(params: {
+  base64: string;
+  mimeType: string;
+  maxDimensionPx: number;
+  maxBytes: number;
+  label?: string;
+  fileName?: string;
+}): Promise<{
+  base64: string;
+  mimeType: string;
+  resized: boolean;
+  width?: number;
+  height?: number;
+}> {
+  const cacheKey = computeResizeCacheKey(params.base64, params.maxDimensionPx, params.maxBytes);
+  const cached = lookupResizeCache(cacheKey);
+  if (cached) {
+    resizeCacheHits += 1;
+    return {
+      base64: cached.base64,
+      mimeType: cached.mimeType,
+      resized: cached.resized,
+      width: cached.width,
+      height: cached.height,
+    };
+  }
+  resizeCacheMisses += 1;
+
+  const result = await computeResizeImageBase64(params);
+  recordResizeCacheEntry(cacheKey, {
+    base64: result.base64,
+    mimeType: result.mimeType,
+    resized: result.resized,
+    width: result.width,
+    height: result.height,
+    // Upper bound for eviction accounting. Cheap to compute and matches the
+    // dominant memory contribution of an entry (the base64 string itself).
+    approxBytes: result.base64.length,
+  });
+  return result;
+}
+
+async function computeResizeImageBase64(params: {
   base64: string;
   mimeType: string;
   maxDimensionPx: number;
@@ -360,3 +489,39 @@ export async function sanitizeToolResultImages(
   const next = await sanitizeContentBlocksImages(content, label, opts);
   return { ...result, content: next };
 }
+
+export const __testing = {
+  resetResizeCache(): void {
+    resizeCache.clear();
+    resizeCacheTotalBytes = 0;
+    resizeCacheHits = 0;
+    resizeCacheMisses = 0;
+    resizeCacheMaxBytes = parseCacheByteLimit();
+  },
+  setResizeCacheMaxBytes(value: number): void {
+    resizeCacheMaxBytes = Math.max(1, Math.floor(value));
+    evictResizeCacheUntilBelow(resizeCacheMaxBytes);
+  },
+  getResizeCacheStats(): {
+    entryCount: number;
+    totalBytes: number;
+    maxBytes: number;
+    hits: number;
+    misses: number;
+  } {
+    return {
+      entryCount: resizeCache.size,
+      totalBytes: resizeCacheTotalBytes,
+      maxBytes: resizeCacheMaxBytes,
+      hits: resizeCacheHits,
+      misses: resizeCacheMisses,
+    };
+  },
+  // Exposed so tests can directly assert the key-collision safety property
+  // called out on PR #64514: two inputs that share a long leading prefix
+  // must still produce distinct keys. Going through `sanitizeContentBlocksImages`
+  // alone cannot prove this because the cache is only populated on the
+  // success path, and two different payloads can silently converge on the
+  // same stats with a colliding key.
+  computeResizeCacheKey,
+};

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -3,6 +3,7 @@
  *
  * Downscales and recompresses oversized base64 image blocks before provider replay.
  */
+import { createHash } from "node:crypto";
 import { canonicalizeBase64 } from "@openclaw/media-core/base64";
 import { formatByteSize, resolveIntegerOption } from "@openclaw/normalization-core";
 import { toErrorObject } from "../infra/errors.js";
@@ -163,7 +164,123 @@ function inferImageFileName(params: {
   return undefined;
 }
 
+// Session history is re-sanitized on every turn via `sanitizeSessionMessagesImages`,
+// which means `resizeImageBase64IfNeeded` is invoked for the same historical image
+// on every message. Both the header/metadata reads and any `resizeToJpeg` call are
+// expensive image work, so memoize the result behind a small byte-bounded LRU.
+//
+// Cache-key note: the key must hash the full base64 payload plus output limits.
+// Prefix hashing can collide across different images that share format/header
+// bytes, silently substituting one image's bytes for another in session context.
+type ResizeCacheValue = {
+  base64: string;
+  mimeType: string;
+  resized: boolean;
+  width: number | undefined;
+  height: number | undefined;
+  approxBytes: number;
+};
+
+const RESIZE_CACHE_MAX_BYTES = 64 * 1024 * 1024; // 64 MiB
+const resizeCache = new Map<string, ResizeCacheValue>();
+let resizeCacheMaxBytes = RESIZE_CACHE_MAX_BYTES;
+let resizeCacheTotalBytes = 0;
+let resizeCacheHits = 0;
+let resizeCacheMisses = 0;
+
+function computeResizeCacheKey(base64: string, maxDimensionPx: number, maxBytes: number): string {
+  const hash = createHash("sha256");
+  hash.update(`${maxDimensionPx}:${maxBytes}:`);
+  hash.update(base64);
+  return hash.digest("hex");
+}
+
+function evictResizeCacheUntilBelow(limitBytes: number): void {
+  if (resizeCacheTotalBytes <= limitBytes) {
+    return;
+  }
+  // Map preserves insertion order; oldest entries live at the head.
+  for (const [key, entry] of resizeCache) {
+    if (resizeCacheTotalBytes <= limitBytes) {
+      break;
+    }
+    resizeCache.delete(key);
+    resizeCacheTotalBytes -= entry.approxBytes;
+  }
+}
+
+function recordResizeCacheEntry(key: string, entry: ResizeCacheValue): void {
+  const existing = resizeCache.get(key);
+  if (existing) {
+    resizeCache.delete(key);
+    resizeCacheTotalBytes -= existing.approxBytes;
+  }
+  resizeCache.set(key, entry);
+  resizeCacheTotalBytes += entry.approxBytes;
+  if (resizeCacheTotalBytes > resizeCacheMaxBytes) {
+    evictResizeCacheUntilBelow(resizeCacheMaxBytes);
+  }
+}
+
+function lookupResizeCache(key: string): ResizeCacheValue | undefined {
+  const entry = resizeCache.get(key);
+  if (!entry) {
+    return undefined;
+  }
+  // LRU touch: move to tail by delete+set so it survives evictions longer.
+  resizeCache.delete(key);
+  resizeCache.set(key, entry);
+  return entry;
+}
+
 async function resizeImageBase64IfNeeded(params: {
+  base64: string;
+  mimeType: string;
+  maxDimensionPx: number;
+  maxBytes: number;
+  label?: string;
+  fileName?: string;
+}): Promise<{
+  base64: string;
+  mimeType: string;
+  resized: boolean;
+  width?: number;
+  height?: number;
+}> {
+  const cacheKey = computeResizeCacheKey(params.base64, params.maxDimensionPx, params.maxBytes);
+  const cached = lookupResizeCache(cacheKey);
+  if (cached) {
+    resizeCacheHits += 1;
+    return {
+      base64: cached.base64,
+      // For a no-op cache hit (no resize happened), preserve the caller's
+      // declared mimeType. The same bytes can legitimately arrive with
+      // different declared MIME types when the header is not canonicalized by
+      // `inferMimeTypeFromBase64` (e.g. WebP/HEIC). Resized hits are always
+      // transformation-derived JPEGs, so the cached MIME is correct there.
+      mimeType: cached.resized ? cached.mimeType : params.mimeType,
+      resized: cached.resized,
+      width: cached.width,
+      height: cached.height,
+    };
+  }
+  resizeCacheMisses += 1;
+
+  const result = await computeResizeImageBase64(params);
+  recordResizeCacheEntry(cacheKey, {
+    base64: result.base64,
+    mimeType: result.mimeType,
+    resized: result.resized,
+    width: result.width,
+    height: result.height,
+    // Upper bound for eviction accounting. Cheap to compute and matches the
+    // dominant memory contribution of an entry (the base64 string itself).
+    approxBytes: result.base64.length,
+  });
+  return result;
+}
+
+async function computeResizeImageBase64(params: {
   base64: string;
   mimeType: string;
   maxDimensionPx: number;
@@ -400,3 +517,36 @@ export async function sanitizeToolResultImages(
   const next = await sanitizeContentBlocksImages(content, label, opts);
   return { ...result, content: next };
 }
+export const testing = {
+  resetResizeCache(): void {
+    resizeCache.clear();
+    resizeCacheMaxBytes = RESIZE_CACHE_MAX_BYTES;
+    resizeCacheTotalBytes = 0;
+    resizeCacheHits = 0;
+    resizeCacheMisses = 0;
+  },
+  setResizeCacheMaxBytesForTests(value: number): void {
+    // Test-only seam: the production cap is intentionally fixed so this PR does
+    // not add a new operator/environment configuration surface.
+    resizeCacheMaxBytes = Math.max(1, Math.floor(value));
+    evictResizeCacheUntilBelow(resizeCacheMaxBytes);
+  },
+  getResizeCacheStats(): {
+    entryCount: number;
+    totalBytes: number;
+    maxBytes: number;
+    hits: number;
+    misses: number;
+  } {
+    return {
+      entryCount: resizeCache.size,
+      totalBytes: resizeCacheTotalBytes,
+      maxBytes: resizeCacheMaxBytes,
+      hits: resizeCacheHits,
+      misses: resizeCacheMisses,
+    };
+  },
+  computeResizeCacheKey,
+  resizeImageBase64IfNeeded,
+};
+export { testing as __testing };


### PR DESCRIPTION
## Summary

Session history is re-sanitized on every turn via `sanitizeSessionMessagesImages`, which means `resizeImageBase64IfNeeded` is invoked for the same historical image on every message. Both the `getImageMetadata` header read and any `resizeToJpeg` call are expensive sharp decodes, so we memoize the result with a collision-safe, byte-bounded LRU cache.

Fixes #64418.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #64418
- Related #64514 (prior attempt, auto-closed under `too-many-prs`; this PR addresses both review concerns raised there — see below)
- [x] This PR fixes a bug or regression

## What's in scope

- Add SHA-256-keyed resize-result cache in `src/agents/tool-images.ts`.
- Eviction by total cached bytes with a fixed internal 64 MiB cap.
- Focused cache regression tests in `tool-images.test.ts` plus a cache reset in `tool-images.log.test.ts`.

## Addressing #64514 review feedback

#64514 was a prior attempt that was auto-closed under the `too-many-prs` rule, not rejected on merits. Two substantive review concerns were raised there (by `@greptile-apps` and `@chatgpt-codex-connector`); both are addressed upfront here:

- **P1 (cache-key collision).** #64514 hashed only `base64.slice(0, 1000)`, which collides across JPEGs that share SOI + APP0/JFIF + DQT + DHT headers — silently substituting one image's bytes for another's in the model context. This PR hashes the full base64 payload. SHA-256 over several MB is sub-millisecond and still far cheaper than the sharp decode we skip on a cache hit.
- **P2 (unbounded memory).** #64514 used a 200-entry count-based cap, worst-case ≈ 1.3 GB RSS. This PR uses a byte-bounded LRU (64 MiB default), so total cache footprint is fixed regardless of entry size.

Credit to `@EronFan` for the original repro and the call-site integration.

## Tests

- **`keys on the full base64 payload so long shared prefixes do not collide (#64514 P1)`** — direct unit test on `computeResizeCacheKey`. Constructs two strings with a 1024-char identical leading prefix and asserts the keys differ. Mutation-verified: I temporarily patched the keyer to `hash.update(base64.slice(0, 1000))` and confirmed this test fails with `expected '213f2963...' not to be '213f2963...'`, then reverted.
- **`records separate cache entries for two distinct valid images (#64418 end-to-end)`** — wires through `sanitizeContentBlocksImages` with two different valid JPEGs to prove the key is routed through the actual cache wrapper (not just the internal helper).
- **`reuses the resize result for the same image across repeated calls`** — simulates the session-history replay, asserts `misses=1, hits=1` after two calls with the same block.
- **`keys the cache by maxBytes so different limits do not share results`**.
- **`bounds cache memory by evicting past the byte cap`** — deterministic test: sets cap to 1 byte and verifies `entryCount=0, totalBytes <= maxBytes` after three inserts.
- **`tool-images.log.test.ts`** — cache reset added to `beforeEach` so the shared PNG used across tests doesn't let a cache hit silently skip the log lines the tests are asserting on.

## Benchmark

10 turns, same 47 KB PNG (via `tsx`):

| Config | Total | Per turn | Speedup |
|---|---|---|---|
| Cold (cache reset each turn) | 51.9 ms | 5.19 ms | 1× |
| Hot  (cache retained)        | 10.3 ms | 1.03 ms | **5.1×** |

`Image resized to fit limits` log fires **1× instead of 10×** — matches the duplicate-log symptom described in #64418.

## Real Behavior Proof

> **Added 2026-05-18** in response to [ClawSweeper review](https://github.com/openclaw/openclaw/pull/68677#issuecomment-4354745918) asking for after-fix evidence beyond the synthetic benchmark above. This section uses the actual `sanitizeContentBlocksImages` function this PR memoizes, with cache stats read back from the same `__testing.getResizeCacheStats()` hook the unit tests use.

**Behavior or issue addressed:** Per #64418, OpenClaw re-decodes the same historical image with sharp on every agent turn because `sanitizeSessionMessagesImages` re-sanitizes the whole session history each turn. Symptom: `Image resized to fit limits` log line fires once per turn instead of once per distinct image. This PR memoizes the resize result keyed by SHA-256 over the full base64 payload (collision-safe) and effective sanitizer limits, with byte-bounded LRU eviction under a fixed internal 64 MiB cap.

**Real environment tested:** Local node v22.14.0 + sharp built from `pnpm install`. Generated a real 4096x4096 PNG via sharp (228 KB) to make the resize work non-trivial. Imported the actual exports from this PR's `src/agents/tool-images.ts` (`sanitizeContentBlocksImages` + `__testing.{resetResizeCache, getResizeCacheStats}`) — no mocks, no synthetic shortcut.

**Exact steps or command run after this patch:**
1. Rebuilt the cache on top of current `origin/main` sanitizer behavior (current HEAD `7e48708154`): preserves `readImageMetadataFromHeader` header-only no-op pass-through, `MAX_IMAGE_INPUT_PIXELS`, backend-unavailable handling, `resolveIntegerOption` normalization, and current media-core imports.
2. Removed the proposed `OPENCLAW_IMAGE_RESIZE_CACHE_MAX_BYTES` operator env knob and release-owned `CHANGELOG.md` edit; production cache retention is a fixed internal 64 MiB byte cap.
3. `pnpm test src/agents/tool-images.test.ts src/agents/tool-images.log.test.ts` → **18 passed**.
3. Wrote a focused Node driver `src/agents/.proof-image-cache.mts` that: generates a real 4096x4096 PNG with sharp, calls `sanitizeContentBlocksImages([imgBlock], "proof")` 10 times in two scenarios — (a) **cold**: `__testing.resetResizeCache()` between every call (simulates current main where the cache doesn't exist); (b) **hot**: cache retained across calls (this PR's behavior). Times each call with `perf_hooks.performance.now()` and reads back `__testing.getResizeCacheStats()` at the end.
4. `node --import tsx src/agents/.proof-image-cache.mts`.

**Evidence after fix:**

Captured terminal output (redacted of nothing — all values are deterministic synthetic content):

```text
[setup] generating realistic 4096x4096 PNG (cause sharp to do real decode work)…
[setup] generated 233666 bytes (~228 KiB)

[cold] simulating MAIN: reset cache between every turn (same image, decoded N times)
[agents/tool-images] Image resized to fit limits: 4096x4096px 228.2KB -> 4.4KB (-98.1%)
[cold turn 1] 195.65 ms
[agents/tool-images] Image resized to fit limits: 4096x4096px 228.2KB -> 4.4KB (-98.1%)
[cold turn 2] 89.37 ms
... [8 more identical "Image resized to fit limits" log lines + cold turn timings 70-90 ms each] ...
[cold turn 10] 70.94 ms
[cold] final stats: hits=0 misses=1 entryCount=1

[hot] simulating PR: cache retained across turns (same image, decoded once, cached after)
[agents/tool-images] Image resized to fit limits: 4096x4096px 228.2KB -> 4.4KB (-98.1%)
[hot turn 1] 70.82 ms
[hot turn 2] 5.92 ms
[hot turn 3] 6.45 ms
[hot turn 4] 6.47 ms
[hot turn 5] 6.15 ms
[hot turn 6] 6.94 ms
[hot turn 7] 6.23 ms
[hot turn 8] 6.67 ms
[hot turn 9] 6.10 ms
[hot turn 10] 6.30 ms
[hot] final stats: hits=9 misses=1 entryCount=1

============================================================
[summary] 10 turns, single 4096x4096 PNG
[summary] cold total: 876.31 ms (avg 87.63 ms/turn)
[summary] hot  total: 128.03 ms (avg 12.80 ms/turn)
[summary] speedup:    6.84×
[summary] hot cache:  hits=9 misses=1 (expected 9/1)

[PROOF] ✓ resize cache eliminates 9/10 sharp decodes for repeated session-history images
[PROOF] ✓ realized 6.8× speedup on session-history replay of the same image
```

**Observed result after fix:** Three independent signals from real terminal output all confirm the fix:
1. **Cache stats** (read back from `__testing.getResizeCacheStats()`, the same hook the unit tests use): hot scenario shows `hits=9 misses=1` — exactly one decode for 10 invocations of the same image.
2. **Per-turn latency**: cold turns are ~75–90 ms each (real sharp decode), hot turns 2–10 are ~6 ms each (cache hit). Speedup: **6.84×** across 10 turns.
3. **`Image resized to fit limits` log line count**: fires 10× in the cold scenario (the bug symptom), 1× in the hot scenario (the fix). This is the user-visible log-fire-count described in #64418.

**What was not tested:**
- A full openclaw chat session against a live model provider — the driver invokes the same `sanitizeContentBlocksImages` function the agent calls on every turn, but in isolation rather than through the full agent loop. The agent's call path is covered by the existing `sanitizeImageBlocks`/`sanitizeContentBlocksImages` unit tests, plus the cache hit/miss assertions added in this PR's regression suite.
- Behavior under memory pressure beyond the 1-byte eviction unit test — the byte-bounded eviction is unit-tested but not stress-tested with a real-world high-volume image stream.

## Verification

- `pnpm test src/agents/tool-images.test.ts src/agents/tool-images.log.test.ts` — 18 passed.
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 pnpm check:changed` — green (typecheck, lint, import cycles, runtime-sidecar, webhook, and pairing guards).
- Linter diagnostics on touched files — 0 errors.
- Rebuilt onto current `origin/main`; no changelog entry or new runtime env/config surface remains.

## Security Impact

No new permissions, secrets/token handling, network calls, command/tool execution surface, or data-access scope changes. The cache holds already-in-memory sanitized image bytes keyed by a SHA-256 hash of those bytes plus the configured size limits; no additional data leaves the process.

## AI-assisted disclosure (per `CONTRIBUTING.md`)

- [x] Built with AI assistance (Cursor + Claude).
- [x] Testing degree: lightly tested (scoped unit + integration tests + mutation test on the collision guard; no repro on a real long session beyond the synthetic benchmark).
- [x] I understand what the code does.
- [x] Will address bot review conversations as an author.
- [ ] `codex review --base origin/main` run locally — not run, Codex CLI not available in this session.


