### PR TITLE
fix(exec): surface signal-killed subprocesses as structured errors instead of silent undefined

### DIFF
--- a/src/node-host/invoke-sigkill.test.ts
+++ b/src/node-host/invoke-sigkill.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for signal-killed process handling in exec invocations.
+ *
+ * When a subprocess is terminated by a signal (SIGKILL, SIGTERM, etc.)
+ * rather than exiting normally, Node.js delivers `exit(null, "SIGKILL")`
+ * instead of `exit(0)` or `exit(N)`. Previously this was silently treated
+ * as `exitCode = undefined` with no error, making it impossible to
+ * distinguish OOM kills from clean runs. This test suite verifies that
+ * signal-killed processes are now surfaced with a structured error message.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import EventEmitter from "node:events";
+
+// We test the exit handler logic directly by simulating the child process
+// events without actually spawning a subprocess.
+
+function makeChildStub() {
+  const ee = new EventEmitter() as ChildProcess;
+  (ee as any).stdout = new EventEmitter();
+  (ee as any).stderr = new EventEmitter();
+  (ee as any).kill = vi.fn();
+  (ee as any).pid = 99999;
+  return ee;
+}
+
+describe("exec signal-kill classification", () => {
+  it("surfaces SIGKILL as a structured error instead of silent undefined exit", async () => {
+    // Simulate what Node delivers when the OS kills a process:
+    //   exit(null, "SIGKILL")
+    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+
+    // Inline the relevant finalize logic from invoke.ts
+    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
+      let errorMsg: string | null = null;
+      let exitCode: number | undefined;
+
+      if (code === null && signal) {
+        errorMsg = `process killed by signal ${signal}`;
+      } else {
+        exitCode = code === null ? undefined : code;
+      }
+
+      results.push({ exitCode, error: errorMsg });
+    }
+
+    runExitHandler(null, "SIGKILL");
+
+    expect(results).toHaveLength(1);
+    expect(results[0].exitCode).toBeUndefined();
+    expect(results[0].error).toBe("process killed by signal SIGKILL");
+  });
+
+  it("leaves normal zero-exit unaffected", () => {
+    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+
+    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
+      let errorMsg: string | null = null;
+      let exitCode: number | undefined;
+      if (code === null && signal) {
+        errorMsg = `process killed by signal ${signal}`;
+      } else {
+        exitCode = code === null ? undefined : code;
+      }
+      results.push({ exitCode, error: errorMsg });
+    }
+
+    runExitHandler(0, null);
+
+    expect(results[0].exitCode).toBe(0);
+    expect(results[0].error).toBeNull();
+  });
+
+  it("leaves non-zero exit unaffected", () => {
+    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+
+    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
+      let errorMsg: string | null = null;
+      let exitCode: number | undefined;
+      if (code === null && signal) {
+        errorMsg = `process killed by signal ${signal}`;
+      } else {
+        exitCode = code === null ? undefined : code;
+      }
+      results.push({ exitCode, error: errorMsg });
+    }
+
+    runExitHandler(1, null);
+    runExitHandler(127, null);
+
+    expect(results[0].exitCode).toBe(1);
+    expect(results[1].exitCode).toBe(127);
+  });
+
+  it("classifies SIGTERM the same way as SIGKILL", () => {
+    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+
+    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
+      let errorMsg: string | null = null;
+      let exitCode: number | undefined;
+      if (code === null && signal) {
+        errorMsg = `process killed by signal ${signal}`;
+      } else {
+        exitCode = code === null ? undefined : code;
+      }
+      results.push({ exitCode, error: errorMsg });
+    }
+
+    runExitHandler(null, "SIGTERM");
+
+    expect(results[0].error).toBe("process killed by signal SIGTERM");
+    expect(results[0].exitCode).toBeUndefined();
+  });
+});

--- a/src/node-host/invoke-sigkill.test.ts
+++ b/src/node-host/invoke-sigkill.test.ts
@@ -6,110 +6,54 @@
  * instead of `exit(0)` or `exit(N)`. Previously this was silently treated
  * as `exitCode = undefined` with no error, making it impossible to
  * distinguish OOM kills from clean runs. This test suite verifies that
- * signal-killed processes are now surfaced with a structured error message.
+ * signal-killed processes are now surfaced with a structured error message
+ * via the `resolveExitResult` helper.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ChildProcess } from "node:child_process";
-import EventEmitter from "node:events";
+import { describe, it, expect } from "vitest";
+import { resolveExitResult } from "./invoke.js";
 
-// We test the exit handler logic directly by simulating the child process
-// events without actually spawning a subprocess.
+describe("resolveExitResult", () => {
+  it("surfaces SIGKILL as a structured error", () => {
+    const result = resolveExitResult(null, "SIGKILL", false);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.error).toBe("process killed by signal SIGKILL");
+  });
 
-function makeChildStub() {
-  const ee = new EventEmitter() as ChildProcess;
-  (ee as any).stdout = new EventEmitter();
-  (ee as any).stderr = new EventEmitter();
-  (ee as any).kill = vi.fn();
-  (ee as any).pid = 99999;
-  return ee;
-}
-
-describe("exec signal-kill classification", () => {
-  it("surfaces SIGKILL as a structured error instead of silent undefined exit", async () => {
-    // Simulate what Node delivers when the OS kills a process:
-    //   exit(null, "SIGKILL")
-    const results: Array<{ exitCode?: number; error?: string | null }> = [];
-
-    // Inline the relevant finalize logic from invoke.ts
-    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
-      let errorMsg: string | null = null;
-      let exitCode: number | undefined;
-
-      if (code === null && signal) {
-        errorMsg = `process killed by signal ${signal}`;
-      } else {
-        exitCode = code === null ? undefined : code;
-      }
-
-      results.push({ exitCode, error: errorMsg });
-    }
-
-    runExitHandler(null, "SIGKILL");
-
-    expect(results).toHaveLength(1);
-    expect(results[0].exitCode).toBeUndefined();
-    expect(results[0].error).toBe("process killed by signal SIGKILL");
+  it("surfaces SIGTERM as a structured error", () => {
+    const result = resolveExitResult(null, "SIGTERM", false);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.error).toBe("process killed by signal SIGTERM");
   });
 
   it("leaves normal zero-exit unaffected", () => {
-    const results: Array<{ exitCode?: number; error?: string | null }> = [];
-
-    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
-      let errorMsg: string | null = null;
-      let exitCode: number | undefined;
-      if (code === null && signal) {
-        errorMsg = `process killed by signal ${signal}`;
-      } else {
-        exitCode = code === null ? undefined : code;
-      }
-      results.push({ exitCode, error: errorMsg });
-    }
-
-    runExitHandler(0, null);
-
-    expect(results[0].exitCode).toBe(0);
-    expect(results[0].error).toBeNull();
+    const result = resolveExitResult(0, null, false);
+    expect(result.exitCode).toBe(0);
+    expect(result.error).toBeNull();
   });
 
   it("leaves non-zero exit unaffected", () => {
-    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+    const r1 = resolveExitResult(1, null, false);
+    expect(r1.exitCode).toBe(1);
+    expect(r1.error).toBeNull();
 
-    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
-      let errorMsg: string | null = null;
-      let exitCode: number | undefined;
-      if (code === null && signal) {
-        errorMsg = `process killed by signal ${signal}`;
-      } else {
-        exitCode = code === null ? undefined : code;
-      }
-      results.push({ exitCode, error: errorMsg });
-    }
-
-    runExitHandler(1, null);
-    runExitHandler(127, null);
-
-    expect(results[0].exitCode).toBe(1);
-    expect(results[1].exitCode).toBe(127);
+    const r127 = resolveExitResult(127, null, false);
+    expect(r127.exitCode).toBe(127);
+    expect(r127.error).toBeNull();
   });
 
-  it("classifies SIGTERM the same way as SIGKILL", () => {
-    const results: Array<{ exitCode?: number; error?: string | null }> = [];
+  it("preserves timeout-kill semantics (timedOut=true suppresses signal error)", () => {
+    // When the internal timeout fires child.kill("SIGKILL"), the exit event
+    // delivers (null, "SIGKILL"). This should NOT set error — callers rely on
+    // timedOut=true with error=null for intentional timeouts.
+    const result = resolveExitResult(null, "SIGKILL", true);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.error).toBeNull();
+  });
 
-    function runExitHandler(code: number | null, signal: NodeJS.Signals | null) {
-      let errorMsg: string | null = null;
-      let exitCode: number | undefined;
-      if (code === null && signal) {
-        errorMsg = `process killed by signal ${signal}`;
-      } else {
-        exitCode = code === null ? undefined : code;
-      }
-      results.push({ exitCode, error: errorMsg });
-    }
-
-    runExitHandler(null, "SIGTERM");
-
-    expect(results[0].error).toBe("process killed by signal SIGTERM");
-    expect(results[0].exitCode).toBeUndefined();
+  it("handles null code with no signal", () => {
+    const result = resolveExitResult(null, null, false);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.error).toBeNull();
   });
 });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -276,7 +276,16 @@ async function runCommand(
     child.on("error", (err) => {
       finalize(undefined, err.message);
     });
-    child.on("exit", (code) => {
+    child.on("exit", (code, signal) => {
+      // When a process is killed by a signal (e.g. SIGKILL from OOM pressure
+      // or debug.swd_panic watchpoints on macOS), `code` is null and `signal`
+      // carries the signal name.  Surface this as a structured error so callers
+      // can distinguish "process was killed" from "process exited with non-zero
+      // code" and apply appropriate retry / reporting logic.
+      if (code === null && signal) {
+        finalize(undefined, `process killed by signal ${signal}`);
+        return;
+      }
       finalize(code === null ? undefined : code, null);
     });
   });

--- a/src/node-host/invoke.ts
+++ b/src/node-host/invoke.ts
@@ -191,6 +191,27 @@ function requireExecApprovalsBaseHash(
   }
 }
 
+/**
+ * Resolve the exit-code and error for a child process exit event.
+ *
+ * When a process is terminated by a signal (SIGKILL from OOM, SIGTERM, etc.)
+ * and the kill was NOT caused by an intentional timeout, surface the signal as
+ * a structured error string. Timeout-kills preserve the legacy contract:
+ * `timedOut: true, error: null`.
+ *
+ * @internal Exported for testing; not part of the public API.
+ */
+export function resolveExitResult(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  timedOut: boolean,
+): { exitCode: number | undefined; error: string | null } {
+  if (code === null && signal && !timedOut) {
+    return { exitCode: undefined, error: `process killed by signal ${signal}` };
+  }
+  return { exitCode: code === null ? undefined : code, error: null };
+}
+
 async function runCommand(
   argv: string[],
   cwd: string | undefined,
@@ -277,16 +298,8 @@ async function runCommand(
       finalize(undefined, err.message);
     });
     child.on("exit", (code, signal) => {
-      // When a process is killed by a signal (e.g. SIGKILL from OOM pressure
-      // or debug.swd_panic watchpoints on macOS), `code` is null and `signal`
-      // carries the signal name.  Surface this as a structured error so callers
-      // can distinguish "process was killed" from "process exited with non-zero
-      // code" and apply appropriate retry / reporting logic.
-      if (code === null && signal) {
-        finalize(undefined, `process killed by signal ${signal}`);
-        return;
-      }
-      finalize(code === null ? undefined : code, null);
+      const result = resolveExitResult(code, signal, timedOut);
+      finalize(result.exitCode, result.error);
     });
   });
 }


### PR DESCRIPTION
## Problem

When a subprocess is killed by an OS signal (SIGKILL from OOM pressure, macOS `debug.swd_panic=1` watchpoints, etc.) Node.js delivers `exit(null, "SIGKILL")` to the exit handler. The previous code treated `code === null` as `exitCode = undefined` with `error = null`:

```ts
child.on('exit', (code) => {
  finalize(code === null ? undefined : code, null);  // ← signal kills are silent
});
```

This means:
- Agent receives a response with `success: false`, `exitCode: undefined`, `error: null`
- Impossible to distinguish OOM kill from "process returned no exit code"
- No actionable signal in logs — kills are invisible

**Real-world trigger:** macOS with `debug.swd_panic=1` (read-only sysctl) sends SIGKILL when software watchpoints trip on memory access violations. Python/subprocess spawns under memory pressure are silently killed, producing confusing empty tool results.

## Fix

Add the `signal` parameter to the exit handler and surface it as a structured error:

```ts
child.on('exit', (code, signal) => {
  if (code === null && signal) {
    finalize(undefined, `process killed by signal ${signal}`);
    return;
  }
  finalize(code === null ? undefined : code, null);
});
```

## Effect

| Scenario | Before | After |
|----------|--------|-------|
| SIGKILL (OOM) | `success: false, error: null` | `success: false, error: "process killed by signal SIGKILL"` |
| SIGTERM | `success: false, error: null` | `success: false, error: "process killed by signal SIGTERM"` |
| `exit(0)` | `success: true` | `success: true` (unchanged) |
| `exit(1)` | `exitCode: 1` | `exitCode: 1` (unchanged) |

## Tests

4 unit tests covering SIGKILL, SIGTERM, clean exit, and non-zero exit.

---

*Submitted by Bartok 🎻 — diagnosed from a macOS M1 Max with `debug.swd_panic=1` killing Python subprocesses during audio generation under memory pressure.*