### PR TITLE
Route durable agent work through TaskFlow

### DIFF
--- a/skills/taskflow/SKILL.md
+++ b/skills/taskflow/SKILL.md
@@ -10,11 +10,14 @@ Use TaskFlow when a job needs to outlive one prompt or one detached run, but you
 
 ## When to use it
 
+- Any non-trivial agent work that needs multiple steps, code changes, background execution, waiting, handoff, or recovery after interruption
 - Multi-step background work with one owner
 - Work that waits on detached ACP or subagent tasks
 - Jobs that may need to emit one clear update back to the owner
 - Jobs that need small persisted state between steps
 - Plugin or tool work that must survive restarts and revision conflicts cleanly
+
+Simple one-turn answers do not need TaskFlow. Everything else should either use a TaskFlow-aware execution path (`sessions_spawn` / subagents for detached work, plugin runtime `api.runtime.tasks.flow` for orchestrated plugins) or explicitly identify the existing TaskFlow record before continuing.
 
 ## What TaskFlow owns
 

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -153,6 +153,25 @@ describe("buildAgentSystemPrompt", () => {
     );
   });
 
+  it("includes TaskFlow runtime guidance in full and minimal prompts", () => {
+    const fullPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+    const minimalPrompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "minimal",
+    });
+
+    for (const prompt of [fullPrompt, minimalPrompt]) {
+      expect(prompt).toContain("## TaskFlow Runtime");
+      expect(prompt).toContain("Simple one-turn answers may complete inline.");
+      expect(prompt).toContain("use OpenClaw Tasks / TaskFlow as the durable execution surface");
+      expect(prompt).toContain("`sessions_spawn` / subagents for detached work");
+      expect(prompt).toContain("api.runtime.tasks.flow");
+      expect(prompt).toContain("Do not create legacy `memory/task-capsules` state.");
+    }
+  });
+
   it("omits skills in minimal prompt mode when skillsPrompt is absent", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -137,6 +137,17 @@ function buildHeartbeatSection(params: { isMinimal: boolean; heartbeatPrompt?: s
   ];
 }
 
+function buildTaskFlowSection() {
+  return [
+    "## TaskFlow Runtime",
+    "Simple one-turn answers may complete inline.",
+    "For non-trivial work that needs multiple steps, code changes, background execution, waiting, handoff, or recovery after interruption, use OpenClaw Tasks / TaskFlow as the durable execution surface.",
+    "Prefer existing TaskFlow-aware paths: `sessions_spawn` / subagents for detached work, plugin runtime `api.runtime.tasks.flow` for orchestrated plugins, and `openclaw tasks` for inspection and recovery.",
+    "Memory files are evidence and recovery notes, not the source of truth for active task runtime. Do not create legacy `memory/task-capsules` state.",
+    "",
+  ];
+}
+
 function buildExecApprovalPromptGuidance(params: {
   runtimeChannel?: string;
   inlineButtonsEnabled?: boolean;
@@ -700,6 +711,7 @@ export function buildAgentSystemPrompt(params: {
       : []),
     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",
     "",
+    ...buildTaskFlowSection(),
     ...buildOverridablePromptSection({
       override: providerSectionOverrides.interaction_style,
       fallback: [],


### PR DESCRIPTION
## Summary
- Add a core TaskFlow Runtime section to the agent system prompt for both full and minimal prompt modes.
- Clarify that simple one-turn answers may stay inline, while non-trivial work should use OpenClaw Tasks / TaskFlow paths.
- Update the bundled `taskflow` skill to match the runtime policy and discourage legacy `memory/task-capsules` state.

## Verification
- `NODE_OPTIONS=--preserve-symlinks ./node_modules/.bin/oxfmt --check src/agents/system-prompt.ts src/agents/system-prompt.test.ts skills/taskflow/SKILL.md`
- `NODE_OPTIONS=--preserve-symlinks ./node_modules/.bin/vitest run --config test/vitest/vitest.unit-fast.config.ts src/agents/system-prompt.test.ts` (58 tests passed)
- `NODE_OPTIONS=--preserve-symlinks ./node_modules/.bin/tsgo -p tsconfig.core.test.json --incremental false --pretty false`
- Direct frontmatter smoke for `skills/taskflow/SKILL.md` and `skills/taskflow-inbox-triage/SKILL.md`

Note: the local pre-commit hook's repo-wide `pnpm check` was skipped with `FAST_COMMIT=1` because `pnpm` is not installed in this runtime; the targeted checks above were run using the existing repository `node_modules`.