### PR TITLE
fix: strip invalid webchat delivery recipients

### DIFF
--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -12,7 +12,9 @@ export function normalizeDeliveryContext(context?: DeliveryContext): DeliveryCon
     typeof context.channel === "string"
       ? (normalizeMessageChannel(context.channel) ?? context.channel.trim())
       : undefined;
-  const to = normalizeOptionalString(context.to);
+  const rawTo = normalizeOptionalString(context.to);
+  const hasStructuredTargetPrefix = Boolean(rawTo && /^[a-z][a-z0-9_-]*:/i.test(rawTo));
+  const to = channel === "webchat" && !hasStructuredTargetPrefix ? undefined : rawTo;
   const accountId = normalizeAccountId(context.accountId);
   const threadId =
     typeof context.threadId === "number" && Number.isFinite(context.threadId)

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -56,6 +56,25 @@ describe("delivery context helpers", () => {
       accountId: "acct-1",
     });
 
+    expect(
+      normalizeDeliveryContext({
+        channel: " webchat ",
+        to: " webchat:user-123 ",
+        accountId: " acct-1 ",
+      }),
+    ).toEqual({
+      channel: "webchat",
+      to: "webchat:user-123",
+      accountId: "acct-1",
+    });
+
+    expect(
+      normalizeDeliveryContext({ channel: " webchat ", to: " +15555550123 ", accountId: "acct-1" }),
+    ).toEqual({
+      channel: "webchat",
+      accountId: "acct-1",
+    });
+
     expect(normalizeDeliveryContext({ channel: "  " })).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Strip `to` when normalizing `webchat` delivery contexts.

This prevents stale or cross-channel recipient targets from being preserved inside a `webchat`-origin delivery context, where later fallback paths can accidentally treat them as real outbound recipients.

## What changed

- update `normalizeDeliveryContext` so `channel === "webchat"` always normalizes with no `to`
- add regression coverage showing a `webchat` context drops a phone-number-shaped `to`

## Why

`webchat` should not behave like a real outbound direct-message target. If a stale `to` leaks into a `webchat` delivery context, downstream routing/fallback can misinterpret it and produce wrong-recipient delivery behavior.

This keeps the fix narrowly scoped and leaves other channels unchanged.

## Notes

Related to the general family of webchat / cross-channel delivery contamination issues, including wrong-recipient fallback behavior.
