### PR TITLE
fix: Discord guild-admin actions execute without requester...

### DIFF
--- a/extensions/discord/src/actions/handle-action.guild-admin.ts
+++ b/extensions/discord/src/actions/handle-action.guild-admin.ts
@@ -26,6 +26,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
   const { ctx, resolveChannelId, readParentIdParam } = params;
   const { action, params: actionParams, cfg } = ctx;
   const accountId = ctx.accountId ?? readStringParam(actionParams, "accountId");
+  const senderUserId = normalizeOptionalString(ctx.requesterSenderId);
 
   if (action === "member-info") {
     const userId = readStringParam(actionParams, "userId", { required: true });
@@ -76,6 +77,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         name,
         mediaUrl,
         roleIds,
+        senderUserId,
       },
       cfg,
     );
@@ -107,6 +109,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         description,
         tags,
         mediaUrl,
+        senderUserId,
       },
       cfg,
     );
@@ -125,6 +128,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         guildId,
         userId,
         roleId,
+        senderUserId,
       },
       cfg,
     );
@@ -173,6 +177,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         topic: topic ?? undefined,
         position: position ?? undefined,
         nsfw,
+        senderUserId,
       },
       cfg,
     );
@@ -213,6 +218,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
         availableTags,
+        senderUserId,
       },
       cfg,
     );
@@ -223,7 +229,12 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       required: true,
     });
     return await handleDiscordAction(
-      { action: "channelDelete", accountId: accountId ?? undefined, channelId },
+      {
+        action: "channelDelete",
+        accountId: accountId ?? undefined,
+        channelId,
+        senderUserId,
+      },
       cfg,
     );
   }
@@ -247,6 +258,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         channelId,
         parentId: parentId === undefined ? undefined : parentId,
         position: position ?? undefined,
+        senderUserId,
       },
       cfg,
     );
@@ -267,6 +279,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         guildId,
         name,
         position: position ?? undefined,
+        senderUserId,
       },
       cfg,
     );
@@ -287,6 +300,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         categoryId,
         name: name ?? undefined,
         position: position ?? undefined,
+        senderUserId,
       },
       cfg,
     );
@@ -297,7 +311,12 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       required: true,
     });
     return await handleDiscordAction(
-      { action: "categoryDelete", accountId: accountId ?? undefined, categoryId },
+      {
+        action: "categoryDelete",
+        accountId: accountId ?? undefined,
+        categoryId,
+        senderUserId,
+      },
       cfg,
     );
   }
@@ -350,6 +369,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         location,
         entityType,
         image,
+        senderUserId,
       },
       cfg,
       { mediaLocalRoots: ctx.mediaLocalRoots },
@@ -364,7 +384,6 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         integer: true,
       }),
     });
-    const senderUserId = normalizeOptionalString(ctx.requesterSenderId);
     return await handleDiscordAction(
       {
         action: moderation.action,

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -46,6 +46,36 @@ describe("handleDiscordMessageAction", () => {
     );
   });
 
+  it("uses trusted requesterSenderId for guild admin actions and ignores params senderUserId", async () => {
+    await handleDiscordMessageAction({
+      action: "channel-delete",
+      params: {
+        channelId: "channel-1",
+        senderUserId: "spoofed-admin-id",
+      },
+      cfg: {
+        channels: { discord: { token: "tok", actions: { channels: true } } },
+      } as OpenClawConfig,
+      requesterSenderId: "trusted-sender-id",
+      toolContext: { currentChannelProvider: "discord" },
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "channelDelete",
+        channelId: "channel-1",
+        senderUserId: "trusted-sender-id",
+      }),
+      expect.objectContaining({
+        channels: {
+          discord: expect.objectContaining({
+            token: "tok",
+          }),
+        },
+      }),
+    );
+  });
+
   it("falls back to toolContext.currentMessageId for reactions", async () => {
     await handleDiscordMessageAction({
       action: "react",

--- a/extensions/discord/src/actions/runtime.guild.authz.test.ts
+++ b/extensions/discord/src/actions/runtime.guild.authz.test.ts
@@ -10,6 +10,7 @@ const createScheduledEventDiscord = vi.fn(async () => ({ id: "event-1" }));
 const deleteChannelDiscord = vi.fn(async () => ({ ok: true }));
 const fetchChannelInfoDiscord = vi.fn(async () => ({ guild_id: "guild-1" }));
 const hasAnyGuildPermissionDiscord = vi.fn(async () => false);
+const setChannelPermissionDiscord = vi.fn(async () => ({ ok: true }));
 const uploadEmojiDiscord = vi.fn(async () => ({ id: "emoji-1" }));
 
 const enableAllActions = (_key: keyof DiscordActionConfig, _defaultValue = true) => true;
@@ -24,8 +25,25 @@ describe("discord guild admin sender authorization", () => {
       deleteChannelDiscord,
       fetchChannelInfoDiscord,
       hasAnyGuildPermissionDiscord,
+      setChannelPermissionDiscord,
       uploadEmojiDiscord,
     });
+  });
+
+  it("rejects privileged guild actions when sender identity is missing", async () => {
+    await expect(
+      handleDiscordGuildAction(
+        "channelDelete",
+        {
+          channelId: "channel-1",
+        },
+        enableAllActions,
+      ),
+    ).rejects.toThrow("Sender identity required");
+
+    expect(fetchChannelInfoDiscord).not.toHaveBeenCalled();
+    expect(hasAnyGuildPermissionDiscord).not.toHaveBeenCalled();
+    expect(deleteChannelDiscord).not.toHaveBeenCalled();
   });
 
   it("rejects roleAdd when sender lacks MANAGE_ROLES", async () => {
@@ -112,6 +130,23 @@ describe("discord guild admin sender authorization", () => {
     );
   });
 
+  it("reports disabled channel management before permission lookups", async () => {
+    await expect(
+      handleDiscordGuildAction(
+        "channelDelete",
+        {
+          channelId: "channel-1",
+          senderUserId: "sender-1",
+        },
+        () => false,
+      ),
+    ).rejects.toThrow("Discord channel management is disabled.");
+
+    expect(fetchChannelInfoDiscord).not.toHaveBeenCalled();
+    expect(hasAnyGuildPermissionDiscord).not.toHaveBeenCalled();
+    expect(deleteChannelDiscord).not.toHaveBeenCalled();
+  });
+
   it("allows emojiUpload when sender has guild-expression permissions", async () => {
     hasAnyGuildPermissionDiscord.mockResolvedValueOnce(true);
     uploadEmojiDiscord.mockResolvedValueOnce({ id: "emoji-1" });
@@ -168,5 +203,36 @@ describe("discord guild admin sender authorization", () => {
       undefined,
     );
     expect(createScheduledEventDiscord).not.toHaveBeenCalled();
+  });
+
+  it("checks channelPermissionSet permissions for direct guild actions", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(true);
+
+    await handleDiscordGuildAction(
+      "channelPermissionSet",
+      {
+        channelId: "channel-1",
+        targetId: "role-1",
+        targetType: "role",
+        allow: "1024",
+        senderUserId: "sender-1",
+      },
+      enableAllActions,
+    );
+
+    expect(fetchChannelInfoDiscord).toHaveBeenCalledWith("channel-1");
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [PermissionFlagsBits.ManageChannels],
+      undefined,
+    );
+    expect(setChannelPermissionDiscord).toHaveBeenCalledWith({
+      channelId: "channel-1",
+      targetId: "role-1",
+      targetType: 0,
+      allow: "1024",
+      deny: undefined,
+    });
   });
 });

--- a/extensions/discord/src/actions/runtime.guild.authz.test.ts
+++ b/extensions/discord/src/actions/runtime.guild.authz.test.ts
@@ -1,0 +1,172 @@
+import { PermissionFlagsBits } from "discord-api-types/v10";
+import type { DiscordActionConfig } from "openclaw/plugin-sdk/config-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { discordGuildActionRuntime, handleDiscordGuildAction } from "./runtime.guild.js";
+
+const originalDiscordGuildActionRuntime = { ...discordGuildActionRuntime };
+const addRoleDiscord = vi.fn(async () => ({ ok: true }));
+const createChannelDiscord = vi.fn(async () => ({ id: "channel-1" }));
+const createScheduledEventDiscord = vi.fn(async () => ({ id: "event-1" }));
+const deleteChannelDiscord = vi.fn(async () => ({ ok: true }));
+const fetchChannelInfoDiscord = vi.fn(async () => ({ guild_id: "guild-1" }));
+const hasAnyGuildPermissionDiscord = vi.fn(async () => false);
+const uploadEmojiDiscord = vi.fn(async () => ({ id: "emoji-1" }));
+
+const enableAllActions = (_key: keyof DiscordActionConfig, _defaultValue = true) => true;
+
+describe("discord guild admin sender authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.assign(discordGuildActionRuntime, originalDiscordGuildActionRuntime, {
+      addRoleDiscord,
+      createChannelDiscord,
+      createScheduledEventDiscord,
+      deleteChannelDiscord,
+      fetchChannelInfoDiscord,
+      hasAnyGuildPermissionDiscord,
+      uploadEmojiDiscord,
+    });
+  });
+
+  it("rejects roleAdd when sender lacks MANAGE_ROLES", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+    await expect(
+      handleDiscordGuildAction(
+        "roleAdd",
+        {
+          guildId: "guild-1",
+          userId: "user-1",
+          roleId: "role-1",
+          senderUserId: "sender-1",
+        },
+        enableAllActions,
+      ),
+    ).rejects.toThrow("required permissions");
+
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [PermissionFlagsBits.ManageRoles],
+      undefined,
+    );
+    expect(addRoleDiscord).not.toHaveBeenCalled();
+  });
+
+  it("rejects channelDelete when sender lacks MANAGE_CHANNELS", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+    await expect(
+      handleDiscordGuildAction(
+        "channelDelete",
+        {
+          channelId: "channel-1",
+          senderUserId: "sender-1",
+        },
+        enableAllActions,
+      ),
+    ).rejects.toThrow("required permissions");
+
+    expect(fetchChannelInfoDiscord).toHaveBeenCalledWith("channel-1");
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [PermissionFlagsBits.ManageChannels],
+      undefined,
+    );
+    expect(deleteChannelDiscord).not.toHaveBeenCalled();
+  });
+
+  it("forwards accountId for channelCreate permission checks and execution", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(true);
+    createChannelDiscord.mockResolvedValueOnce({ id: "channel-1" });
+
+    await handleDiscordGuildAction(
+      "channelCreate",
+      {
+        guildId: "guild-1",
+        name: "test-channel",
+        senderUserId: "sender-1",
+        accountId: "ops",
+      },
+      enableAllActions,
+    );
+
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [PermissionFlagsBits.ManageChannels],
+      { accountId: "ops" },
+    );
+    expect(createChannelDiscord).toHaveBeenCalledWith(
+      {
+        guildId: "guild-1",
+        name: "test-channel",
+        type: undefined,
+        parentId: undefined,
+        topic: undefined,
+        position: undefined,
+        nsfw: undefined,
+      },
+      { accountId: "ops" },
+    );
+  });
+
+  it("allows emojiUpload when sender has guild-expression permissions", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(true);
+    uploadEmojiDiscord.mockResolvedValueOnce({ id: "emoji-1" });
+
+    await handleDiscordGuildAction(
+      "emojiUpload",
+      {
+        guildId: "guild-1",
+        name: "party",
+        mediaUrl: "https://example.com/emoji.png",
+        senderUserId: "sender-1",
+      },
+      enableAllActions,
+    );
+
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [
+        PermissionFlagsBits.ManageGuildExpressions,
+        PermissionFlagsBits.CreateGuildExpressions,
+        PermissionFlagsBits.ManageEmojisAndStickers,
+      ],
+      undefined,
+    );
+    expect(uploadEmojiDiscord).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      name: "party",
+      mediaUrl: "https://example.com/emoji.png",
+      roleIds: undefined,
+    });
+  });
+
+  it("rejects eventCreate when sender lacks event permissions", async () => {
+    hasAnyGuildPermissionDiscord.mockResolvedValueOnce(false);
+
+    await expect(
+      handleDiscordGuildAction(
+        "eventCreate",
+        {
+          guildId: "guild-1",
+          name: "Town Hall",
+          startTime: "2026-04-18T18:00:00.000Z",
+          senderUserId: "sender-1",
+        },
+        enableAllActions,
+      ),
+    ).rejects.toThrow("required permissions");
+
+    expect(hasAnyGuildPermissionDiscord).toHaveBeenCalledWith(
+      "guild-1",
+      "sender-1",
+      [PermissionFlagsBits.ManageEvents, PermissionFlagsBits.CreateEvents],
+      undefined,
+    );
+    expect(createScheduledEventDiscord).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -1,4 +1,5 @@
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { PermissionFlagsBits } from "discord-api-types/v10";
 import { resolveDefaultDiscordAccountId } from "../accounts.js";
 import { getPresence } from "../monitor/presence-cache.js";
 import {
@@ -19,6 +20,7 @@ import {
   editChannelDiscord,
   fetchChannelInfoDiscord,
   fetchMemberInfoDiscord,
+  hasAnyGuildPermissionDiscord,
   fetchRoleInfoDiscord,
   fetchVoiceStatusDiscord,
   listGuildChannelsDiscord,
@@ -43,6 +45,7 @@ export const discordGuildActionRuntime = {
   editChannelDiscord,
   fetchChannelInfoDiscord,
   fetchMemberInfoDiscord,
+  hasAnyGuildPermissionDiscord,
   fetchRoleInfoDiscord,
   fetchVoiceStatusDiscord,
   listGuildChannelsDiscord,
@@ -69,6 +72,86 @@ type DiscordRoleMutationWithAccount = (
   },
   options: { accountId: string },
 ) => Promise<unknown>;
+
+const guildAdminPermissions: Partial<Record<string, bigint[]>> = {
+  emojiUpload: [
+    PermissionFlagsBits.ManageGuildExpressions,
+    PermissionFlagsBits.CreateGuildExpressions,
+    PermissionFlagsBits.ManageEmojisAndStickers,
+  ],
+  stickerUpload: [
+    PermissionFlagsBits.ManageGuildExpressions,
+    PermissionFlagsBits.CreateGuildExpressions,
+    PermissionFlagsBits.ManageEmojisAndStickers,
+  ],
+  roleAdd: [PermissionFlagsBits.ManageRoles],
+  roleRemove: [PermissionFlagsBits.ManageRoles],
+  eventCreate: [PermissionFlagsBits.ManageEvents, PermissionFlagsBits.CreateEvents],
+  channelCreate: [PermissionFlagsBits.ManageChannels],
+  channelEdit: [PermissionFlagsBits.ManageChannels],
+  channelDelete: [PermissionFlagsBits.ManageChannels],
+  channelMove: [PermissionFlagsBits.ManageChannels],
+  categoryCreate: [PermissionFlagsBits.ManageChannels],
+  categoryEdit: [PermissionFlagsBits.ManageChannels],
+  categoryDelete: [PermissionFlagsBits.ManageChannels],
+  channelPermissionSet: [PermissionFlagsBits.ManageChannels],
+  channelPermissionRemove: [PermissionFlagsBits.ManageChannels],
+};
+
+async function resolveGuildIdForGuildAdminAction(params: {
+  action: string;
+  values: Record<string, unknown>;
+  accountId?: string;
+}): Promise<string | undefined> {
+  const guildId = readStringParam(params.values, "guildId");
+  if (guildId) {
+    return guildId;
+  }
+
+  const channelLikeId =
+    readStringParam(params.values, "channelId") ?? readStringParam(params.values, "categoryId");
+  if (!channelLikeId) {
+    return undefined;
+  }
+
+  const channel = params.accountId
+    ? await discordGuildActionRuntime.fetchChannelInfoDiscord(channelLikeId, {
+        accountId: params.accountId,
+      })
+    : await discordGuildActionRuntime.fetchChannelInfoDiscord(channelLikeId);
+  return "guild_id" in channel ? (channel.guild_id ?? undefined) : undefined;
+}
+
+async function verifySenderGuildAdminPermission(params: {
+  action: string;
+  values: Record<string, unknown>;
+  accountId?: string;
+}) {
+  const requiredPermissions = guildAdminPermissions[params.action];
+  if (!requiredPermissions?.length) {
+    return;
+  }
+
+  const senderUserId = readStringParam(params.values, "senderUserId");
+  if (!senderUserId) {
+    return;
+  }
+
+  const guildId = await resolveGuildIdForGuildAdminAction(params);
+  if (!guildId) {
+    throw new Error(`Guild id required to authorize Discord guild action: ${params.action}`);
+  }
+
+  const hasPermission = await discordGuildActionRuntime.hasAnyGuildPermissionDiscord(
+    guildId,
+    senderUserId,
+    requiredPermissions,
+    params.accountId ? { accountId: params.accountId } : undefined,
+  );
+  if (!hasPermission) {
+    throw new Error("Sender does not have required permissions for this guild action.");
+  }
+}
 
 async function runRoleMutation(params: {
   accountId?: string;
@@ -100,6 +183,7 @@ export async function handleDiscordGuildAction(
   options?: { mediaLocalRoots?: readonly string[] },
 ): Promise<AgentToolResult<unknown>> {
   const accountId = readStringParam(params, "accountId");
+  await verifySenderGuildAdminPermission({ action, values: params, accountId });
   switch (action) {
     case "memberInfo": {
       if (!isActionEnabled("memberInfo")) {

--- a/extensions/discord/src/actions/runtime.guild.ts
+++ b/extensions/discord/src/actions/runtime.guild.ts
@@ -98,6 +98,53 @@ const guildAdminPermissions: Partial<Record<string, bigint[]>> = {
   channelPermissionRemove: [PermissionFlagsBits.ManageChannels],
 };
 
+function assertGuildAdminActionEnabled(
+  action: string,
+  isActionEnabled: ActionGate<DiscordActionConfig>,
+) {
+  switch (action) {
+    case "emojiUpload": {
+      if (!isActionEnabled("emojiUploads")) {
+        throw new Error("Discord emoji uploads are disabled.");
+      }
+      return;
+    }
+    case "stickerUpload": {
+      if (!isActionEnabled("stickerUploads")) {
+        throw new Error("Discord sticker uploads are disabled.");
+      }
+      return;
+    }
+    case "roleAdd":
+    case "roleRemove": {
+      if (!isActionEnabled("roles", false)) {
+        throw new Error("Discord role changes are disabled.");
+      }
+      return;
+    }
+    case "eventCreate": {
+      if (!isActionEnabled("events")) {
+        throw new Error("Discord events are disabled.");
+      }
+      return;
+    }
+    case "channelCreate":
+    case "channelEdit":
+    case "channelDelete":
+    case "channelMove":
+    case "categoryCreate":
+    case "categoryEdit":
+    case "categoryDelete":
+    case "channelPermissionSet":
+    case "channelPermissionRemove": {
+      if (!isActionEnabled("channels")) {
+        throw new Error("Discord channel management is disabled.");
+      }
+      return;
+    }
+  }
+}
+
 async function resolveGuildIdForGuildAdminAction(params: {
   action: string;
   values: Record<string, unknown>;
@@ -134,7 +181,7 @@ async function verifySenderGuildAdminPermission(params: {
 
   const senderUserId = readStringParam(params.values, "senderUserId");
   if (!senderUserId) {
-    return;
+    throw new Error(`Sender identity required to authorize Discord guild action: ${params.action}`);
   }
 
   const guildId = await resolveGuildIdForGuildAdminAction(params);
@@ -183,6 +230,7 @@ export async function handleDiscordGuildAction(
   options?: { mediaLocalRoots?: readonly string[] },
 ): Promise<AgentToolResult<unknown>> {
   const accountId = readStringParam(params, "accountId");
+  assertGuildAdminActionEnabled(action, isActionEnabled);
   await verifySenderGuildAdminPermission({ action, values: params, accountId });
   switch (action) {
     case "memberInfo": {

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -32,9 +32,11 @@ const discordSendMocks = {
     name: "edited",
   })),
   editMessageDiscord: vi.fn(async () => ({})),
+  fetchChannelInfoDiscord: vi.fn(async () => ({ guild_id: "G1" })),
   fetchChannelPermissionsDiscord: vi.fn(async () => ({})),
   fetchMessageDiscord: vi.fn(async () => ({})),
   fetchReactionsDiscord: vi.fn(async () => ({})),
+  hasAnyGuildPermissionDiscord: vi.fn(async () => true),
   kickMemberDiscord: vi.fn(async () => ({})),
   listGuildChannelsDiscord: vi.fn(async () => []),
   listPinsDiscord: vi.fn(async () => ({})),
@@ -537,6 +539,7 @@ describe("handleDiscordGuildAction", () => {
 
 const channelsEnabled = (key: keyof DiscordActionConfig) => key === "channels";
 const channelsDisabled = () => false;
+const privilegedSender = { senderUserId: "sender-1" };
 
 describe("handleDiscordGuildAction - channel management", () => {
   beforeEach(() => {
@@ -551,6 +554,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         name: "test-channel",
         type: 0,
         topic: "Test topic",
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -588,6 +592,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         channelId: "C1",
         name: "new-name",
         topic: "new topic",
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -613,6 +618,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         archived: true,
         locked: false,
         autoArchiveDuration: 1440,
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -639,6 +645,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       {
         channelId: "C1",
         ...payload,
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -657,7 +664,11 @@ describe("handleDiscordGuildAction - channel management", () => {
   });
 
   it("deletes a channel", async () => {
-    await handleDiscordGuildAction("channelDelete", { channelId: "C1" }, channelsEnabled);
+    await handleDiscordGuildAction(
+      "channelDelete",
+      { channelId: "C1", ...privilegedSender },
+      channelsEnabled,
+    );
     expect(deleteChannelDiscord).toHaveBeenCalledWith("C1");
   });
 
@@ -669,6 +680,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         channelId: "C1",
         parentId: "P1",
         position: 5,
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -690,6 +702,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         guildId: "G1",
         channelId: "C1",
         ...payload,
+        ...privilegedSender,
       },
       channelsEnabled,
     );
@@ -704,7 +717,7 @@ describe("handleDiscordGuildAction - channel management", () => {
   it("creates a category with type=4", async () => {
     await handleDiscordGuildAction(
       "categoryCreate",
-      { guildId: "G1", name: "My Category" },
+      { guildId: "G1", name: "My Category", ...privilegedSender },
       channelsEnabled,
     );
     expect(createChannelDiscord).toHaveBeenCalledWith({
@@ -718,7 +731,7 @@ describe("handleDiscordGuildAction - channel management", () => {
   it("edits a category", async () => {
     await handleDiscordGuildAction(
       "categoryEdit",
-      { categoryId: "CAT1", name: "Renamed Category" },
+      { categoryId: "CAT1", name: "Renamed Category", ...privilegedSender },
       channelsEnabled,
     );
     expect(editChannelDiscord).toHaveBeenCalledWith({
@@ -729,7 +742,11 @@ describe("handleDiscordGuildAction - channel management", () => {
   });
 
   it("deletes a category", async () => {
-    await handleDiscordGuildAction("categoryDelete", { categoryId: "CAT1" }, channelsEnabled);
+    await handleDiscordGuildAction(
+      "categoryDelete",
+      { categoryId: "CAT1", ...privilegedSender },
+      channelsEnabled,
+    );
     expect(deleteChannelDiscord).toHaveBeenCalledWith("CAT1");
   });
 
@@ -768,14 +785,18 @@ describe("handleDiscordGuildAction - channel management", () => {
       },
     },
   ])("sets channel permissions for $name", async ({ params, expected }) => {
-    await handleDiscordGuildAction("channelPermissionSet", params, channelsEnabled);
+    await handleDiscordGuildAction(
+      "channelPermissionSet",
+      { ...params, ...privilegedSender },
+      channelsEnabled,
+    );
     expect(setChannelPermissionDiscord).toHaveBeenCalledWith(expected);
   });
 
   it("removes channel permissions", async () => {
     await handleDiscordGuildAction(
       "channelPermissionRemove",
-      { channelId: "C1", targetId: "R1" },
+      { channelId: "C1", targetId: "R1", ...privilegedSender },
       channelsEnabled,
     );
     expect(removeChannelPermissionDiscord).toHaveBeenCalledWith("C1", "R1");
@@ -902,7 +923,13 @@ describe("handleDiscordAction per-account gating", () => {
     } as OpenClawConfig;
 
     await handleDiscordAction(
-      { action: "channelCreate", guildId: "G1", name: "alerts", accountId: "ops" },
+      {
+        action: "channelCreate",
+        guildId: "G1",
+        name: "alerts",
+        accountId: "ops",
+        senderUserId: "sender-1",
+      },
       cfg,
     );
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -173,4 +173,25 @@ describe("discordMessageActions", () => {
       mediaLocalRoots,
     });
   });
+
+  it("requires trusted requester sender for privileged guild admin actions in tool contexts", () => {
+    expect(
+      discordMessageActions.requiresTrustedRequesterSender?.({
+        action: "channel-delete",
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).toBe(true);
+    expect(
+      discordMessageActions.requiresTrustedRequesterSender?.({
+        action: "channel-delete",
+        toolContext: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      discordMessageActions.requiresTrustedRequesterSender?.({
+        action: "read",
+        toolContext: { currentChannelProvider: "discord" },
+      }),
+    ).toBe(false);
+  });
 });

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -18,6 +18,24 @@ import {
 } from "./accounts.js";
 import { createDiscordMessageToolComponentsSchema } from "./message-tool-schema.js";
 
+const trustedRequesterGuildAdminActions = new Set<ChannelMessageActionName>([
+  "emoji-upload",
+  "sticker-upload",
+  "role-add",
+  "role-remove",
+  "channel-create",
+  "channel-edit",
+  "channel-delete",
+  "channel-move",
+  "category-create",
+  "category-edit",
+  "category-delete",
+  "event-create",
+  "timeout",
+  "kick",
+  "ban",
+]);
+
 let discordChannelActionsRuntimePromise:
   | Promise<typeof import("./channel-actions.runtime.js")>
   | undefined;
@@ -168,6 +186,8 @@ function describeDiscordMessageTool({
 
 export const discordMessageActions: ChannelMessageActionAdapter = {
   describeMessageTool: describeDiscordMessageTool,
+  requiresTrustedRequesterSender: ({ action, toolContext }) =>
+    Boolean(toolContext && trustedRequesterGuildAdminActions.has(action)),
   extractToolSend: ({ args }) => {
     const action = normalizeOptionalString(args.action) ?? "";
     if (action === "sendMessage") {


### PR DESCRIPTION
## Summary

- Problem: Discord guild-admin message actions could run with bot privileges without verifying that the requesting guild member held the corresponding Discord permissions.
- Why it matters: any guild member who could message the agent could trigger privileged channel, role, emoji, sticker, or event mutations through the bot.
- What changed: this PR requires trusted requester identity for guild-admin actions, forwards `senderUserId` into the guild-admin runtime, fails closed when sender identity is missing for privileged runtime calls, preserves disabled-action gating before permission lookups, and adds regression coverage for direct runtime permission writes.
- What did NOT change (scope boundary): no unrelated channel/plugin/runtime cleanup from the previously closed dirty PR is included here.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68703
- Related #68705
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Discord plugin never marked guild-admin message actions as trusted-requester-only, and the guild-admin runtime path did not enforce requester permission checks analogous to moderation actions.
- Missing detection / guardrail: there was no regression coverage for guild-admin requester authz or direct runtime privileged actions such as `channelPermissionSet`.
- Contributing context (if known): the first PR attempt was later auto-closed as dirty after an unrelated large follow-up commit landed on the branch; this PR is the clean replacement limited to the Discord fix.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/discord/src/actions/runtime.guild.authz.test.ts`, `extensions/discord/src/actions/runtime.test.ts`, `extensions/discord/src/actions/handle-action.test.ts`, `extensions/discord/src/channel-actions.test.ts`
- Scenario the test should lock in: privileged guild-admin actions require sender identity and matching Discord permissions, disabled channel actions fail before permission lookups, and direct runtime permission writes are covered.
- Why this is the smallest reliable guardrail: the bug lives entirely in Discord message-action dispatch and guild runtime authorization logic.
- Existing test that already covers this (if any): none for the full guild-admin requester-authz path before this fix.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Discord guild-admin actions now reject untrusted or unauthorized requesters instead of executing with bot privileges.
- Direct privileged guild runtime calls now fail closed when `senderUserId` is missing.
- Disabled channel-management actions now return the disabled error before doing Discord permission lookups.

## Diagram (if applicable)

```text
Before:
[guild member message] -> [guild-admin action dispatch] -> [bot credential mutation]

After:
[guild member message] -> [trusted requester gate] -> [runtime permission check] -> [allowed mutation or authz error]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: privileged Discord guild-admin actions now require requester identity and matching Discord permissions before execution; regression tests cover the fail-closed and disabled-gate behaviors.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted): Discord bot with guild-admin capabilities; default channel actions enabled

### Steps

1. Configure a Discord bot with guild-admin permissions and allow a regular guild member to message the agent.
2. Invoke a guild-admin message action such as `channel-delete` from that regular guild member.
3. Observe authorization behavior before and after the fix.

### Expected

- Unauthorized or unidentified requesters are rejected before privileged Discord mutations run.

### Actual

- Before the fix, guild-admin actions could execute with bot credentials without equivalent requester authorization checks.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reran focused Discord tests for guild-admin authz, guild runtime behavior, and message-action dispatch; built the repo successfully on the clean replacement branch.
- Edge cases checked: missing `senderUserId`, disabled channel-management actions, direct `channelPermissionSet` runtime path, account-scoped channel re-enable path.
- What you did **not** verify: live Discord manual repro on a deployed bot.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: privileged direct runtime callers without `senderUserId` will now fail closed.
  - Mitigation: this is the intended security posture, and tests cover the new behavior explicitly.
