### PR TITLE
fix(cron): enable failure alerts by default for recurring jobs

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -195,6 +195,8 @@ for narrative text and keep technical terms in English."
 
 Failure notifications follow a separate destination path:
 
+- Failure alerts are enabled by default after repeated execution failures. Set global `cron.failureAlert.enabled: false` or per-job `failureAlert: false` to opt out.
+- By default, alerts fire after `2` consecutive failures and then wait `3600000` ms before repeating for the same job.
 - `cron.failureDestination` sets a global default for failure notifications.
 - `job.delivery.failureDestination` overrides that per job.
 - If neither is set and the job already delivers via `announce`, failure notifications now fall back to that primary announce target.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1280,8 +1280,8 @@ One-shot jobs stay enabled until retry attempts are exhausted, then disable whil
 {
   cron: {
     failureAlert: {
-      enabled: false,
-      after: 3,
+      enabled: true,
+      after: 2,
       cooldownMs: 3600000,
       includeSkipped: false,
       mode: "announce",
@@ -1291,9 +1291,9 @@ One-shot jobs stay enabled until retry attempts are exhausted, then disable whil
 }
 ```
 
-- `enabled`: enable failure alerts for cron jobs (default: `false`).
-- `after`: consecutive failures before an alert fires (positive integer, min: `1`).
-- `cooldownMs`: minimum milliseconds between repeated alerts for the same job (non-negative integer).
+- `enabled`: controls failure alerts for cron jobs. Omit or set to `true` to alert after repeated failures; set to `false` to disable global default alerts.
+- `after`: consecutive failures before an alert fires (default: `2`; positive integer, min: `1`).
+- `cooldownMs`: minimum milliseconds between repeated alerts for the same job (default: `3600000`; non-negative integer).
 - `includeSkipped`: count consecutive skipped runs toward the alert threshold (default: `false`). Skipped runs are tracked separately and do not affect execution-error backoff.
 - `mode`: delivery mode - `"announce"` sends via a channel message; `"webhook"` posts to the configured webhook.
 - `accountId`: optional account or channel id to scope alert delivery.

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -117,6 +117,49 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it("alerts by default when failureAlert is unset", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "wrong model id",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "default alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        job: expect.objectContaining({ id: job.id }),
+        channel: "telegram",
+        to: "19098680",
+        text: expect.stringContaining('Cron job "default alert job" failed 2 times'),
+      }),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("supports per-job failure alert override when global alerts are disabled", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -147,6 +147,49 @@ describe("CronService failure alerts", () => {
     await store.cleanup();
   });
 
+  it("alerts by default when failureAlert is unset", async () => {
+    const store = await makeStorePath();
+    const sendCronFailureAlert = vi.fn(async () => undefined);
+    const runIsolatedAgentJob = vi.fn(async () => ({
+      status: "error" as const,
+      error: "wrong model id",
+    }));
+
+    const cron = createFailureAlertCron({
+      storePath: store.storePath,
+      runIsolatedAgentJob,
+      sendCronFailureAlert,
+    });
+
+    await cron.start();
+    const job = await cron.add({
+      name: "default alert job",
+      enabled: true,
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "agentTurn", message: "run report" },
+      delivery: { mode: "announce", channel: "telegram", to: "19098680" },
+    });
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).not.toHaveBeenCalled();
+
+    await cron.run(job.id, "force");
+    expect(sendCronFailureAlert).toHaveBeenCalledTimes(1);
+    expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        job: expect.objectContaining({ id: job.id }),
+        channel: "telegram",
+        to: "19098680",
+        text: expect.stringContaining('Cron job "default alert job" failed 2 times'),
+      }),
+    );
+
+    cron.stop();
+    await store.cleanup();
+  });
+
   it("supports per-job failure alert override when global alerts are disabled", async () => {
     const store = await makeStorePath();
     const sendCronFailureAlert = vi.fn(async () => undefined);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -312,7 +312,7 @@ function resolveFailureAlert(
   if (job.failureAlert === false) {
     return null;
   }
-  if (!jobConfig && globalConfig?.enabled !== true) {
+  if (globalConfig?.enabled === false) {
     return null;
   }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -312,7 +312,7 @@ function resolveFailureAlert(
   if (job.failureAlert === false) {
     return null;
   }
-  if (globalConfig?.enabled === false) {
+  if (!jobConfig && globalConfig?.enabled === false) {
     return null;
   }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -770,7 +770,7 @@ function resolveFailureAlert(state: CronServiceState, job: CronJob): ResolvedFai
   if (job.failureAlert === false) {
     return null;
   }
-  if (globalConfig?.enabled === false) {
+  if (!jobConfig && globalConfig?.enabled === false) {
     return null;
   }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -770,7 +770,7 @@ function resolveFailureAlert(state: CronServiceState, job: CronJob): ResolvedFai
   if (job.failureAlert === false) {
     return null;
   }
-  if (!jobConfig && globalConfig?.enabled !== true) {
+  if (globalConfig?.enabled === false) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Problem: Recurring cron jobs could accumulate consecutive failures indefinitely without notifying the user unless `cron.failureAlert.enabled` was explicitly set to `true`.
- Why it matters: A recurring cron could fail many times in a row, for example 95 consecutive failures, while only applying backoff/logging and leaving the user unaware.
- What changed: Failure alerts are now enabled by default and can be disabled explicitly with `cron.failureAlert.enabled: false`; existing defaults still apply (`after: 2`, `cooldownMs: 1 hour`).
- What did NOT change (scope boundary): This does not change retry scheduling, backoff behavior, failure destination resolution, job execution, delivery semantics, or per-job `failureAlert: false` opt-out behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveFailureAlert` treated global failure alerts as opt-in by returning `null` unless `cron.failureAlert.enabled === true` or a per-job failure alert override existed.
- Missing detection / guardrail: There was no guardrail ensuring recurring cron execution failures alert by default after repeated consecutive failures.
- Contributing context (if known): The failure counter and alerting path existed, but the default gate prevented alerts from firing for users who had not explicitly enabled the config.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cron/service.failure-alert.test.ts`
- Scenario the test should lock in: A recurring cron job with no explicit `cron.failureAlert.enabled` config should send a failure alert once `consecutiveErrors` reaches the default threshold.
- Why this is the smallest reliable guardrail: The bug is isolated to `resolveFailureAlert` gating and can be validated through the cron service failure-alert seam without running a full scheduler integration.
- Existing test that already covers this (if any): Existing failure-alert tests cover configured global/per-job alert behavior, cooldown, and opt-out behavior, but did not catch the default-off gap.
- If no new test is added, why not: No new test was added in this PR because the requested patch is a focused one-line behavior change; follow-up coverage should be added in `src/cron/service.failure-alert.test.ts`.

## User-visible / Behavior Changes

Recurring cron jobs now send failure alerts by default after repeated failures unless the user explicitly opts out with `cron.failureAlert.enabled: false` or per-job `failureAlert: false`.

## Diagram (if applicable)

```text
Before:
[recurring cron fails] -> [consecutiveErrors increments] -> [alert skipped unless enabled=true]

After:
[recurring cron fails] -> [consecutiveErrors increments] -> [default alert threshold reached] -> [failure alert sent]
