### PR TITLE
feat(hooks): allow prompt hooks to dynamically narrow tool + skill surface

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -311,6 +311,11 @@ export async function runEmbeddedPiAgent(
       modelId = hookSelection.modelId;
       const legacyBeforeAgentStartResult = hookSelection.legacyBeforeAgentStartResult;
 
+      // If a plugin set toolsAllow via before_prompt_build or before_agent_start,
+      // merge it with any cron-provided toolsAllow. Cron (params) takes precedence;
+      // hook-derived toolsAllow only applies when params.toolsAllow is not set.
+      const effectiveToolsAllow = params.toolsAllow ?? hookSelection.hookToolsAllow;
+
       const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
         provider,
         modelId,
@@ -763,7 +768,7 @@ export async function runEmbeddedPiAgent(
             silentExpected: params.silentExpected,
             bootstrapContextMode: params.bootstrapContextMode,
             bootstrapContextRunKind: params.bootstrapContextRunKind,
-            toolsAllow: params.toolsAllow,
+            toolsAllow: effectiveToolsAllow,
             disableMessageTool: params.disableMessageTool,
             requireExplicitMessageTarget: params.requireExplicitMessageTarget,
             internalEvents: params.internalEvents,

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -24,7 +24,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 export type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[] },
+    event: { prompt: string; messages: unknown[]; availableTools?: string[] },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -36,6 +36,7 @@ export type PromptBuildHookRunner = {
 export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
+  availableTools?: string[];
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -46,6 +47,7 @@ export async function resolvePromptBuildHookResult(params: {
           {
             prompt: params.prompt,
             messages: params.messages,
+            availableTools: params.availableTools,
           },
           params.hookCtx,
         )
@@ -86,6 +88,8 @@ export async function resolvePromptBuildHookResult(params: {
       promptBuildResult?.appendSystemContext,
       legacyResult?.appendSystemContext,
     ]),
+    // First defined toolsAllow wins (before_prompt_build takes precedence over legacy hook).
+    toolsAllow: promptBuildResult?.toolsAllow ?? legacyResult?.toolsAllow,
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.prompt-helpers.ts
@@ -24,7 +24,7 @@ import type { EmbeddedRunAttemptParams } from "./types.js";
 export type PromptBuildHookRunner = {
   hasHooks: (hookName: "before_prompt_build" | "before_agent_start") => boolean;
   runBeforePromptBuild: (
-    event: { prompt: string; messages: unknown[]; availableTools?: string[] },
+    event: { prompt: string; messages: unknown[]; availableTools?: string[]; availableSkills?: string[] },
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforePromptBuildResult | undefined>;
   runBeforeAgentStart: (
@@ -37,6 +37,7 @@ export async function resolvePromptBuildHookResult(params: {
   prompt: string;
   messages: unknown[];
   availableTools?: string[];
+  availableSkills?: string[];
   hookCtx: PluginHookAgentContext;
   hookRunner?: PromptBuildHookRunner | null;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
@@ -48,6 +49,7 @@ export async function resolvePromptBuildHookResult(params: {
             prompt: params.prompt,
             messages: params.messages,
             availableTools: params.availableTools,
+            availableSkills: params.availableSkills,
           },
           params.hookCtx,
         )
@@ -90,6 +92,8 @@ export async function resolvePromptBuildHookResult(params: {
     ]),
     // First defined toolsAllow wins (before_prompt_build takes precedence over legacy hook).
     toolsAllow: promptBuildResult?.toolsAllow ?? legacyResult?.toolsAllow,
+    // First defined skillsAllow wins (before_prompt_build takes precedence over legacy hook).
+    skillsAllow: promptBuildResult?.skillsAllow ?? legacyResult?.skillsAllow,
   };
 }
 

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -89,6 +89,7 @@ describe("resolvePromptBuildHookResult", () => {
       systemPrompt: "legacy-system",
       prependSystemContext: undefined,
       appendSystemContext: undefined,
+      toolsAllow: undefined,
     });
   });
 
@@ -132,6 +133,28 @@ describe("resolvePromptBuildHookResult", () => {
     expect(result.prependContext).toBe("prompt context\n\nlegacy context");
     expect(result.prependSystemContext).toBe("prompt prepend\n\nlegacy prepend");
     expect(result.appendSystemContext).toBe("prompt append\n\nlegacy append");
+    expect(result.toolsAllow).toBeUndefined();
+  });
+
+  it("prefers prompt-build toolsAllow over legacy hook toolsAllow", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn(() => true),
+      runBeforePromptBuild: vi.fn(async () => ({
+        toolsAllow: ["read", "exec"],
+      })),
+      runBeforeAgentStart: vi.fn(async () => ({
+        toolsAllow: ["write"],
+      })),
+    };
+
+    const result = await resolvePromptBuildHookResult({
+      prompt: "hello",
+      messages: [],
+      hookCtx: {},
+      hookRunner,
+    });
+
+    expect(result.toolsAllow).toEqual(["read", "exec"]);
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -688,7 +688,7 @@ export async function runEmbeddedAttempt(
       senderIsOwner: params.senderIsOwner,
       warn: (message) => log.warn(message),
     });
-    const effectiveTools = [...tools, ...filteredBundledTools];
+    let effectiveTools = [...tools, ...filteredBundledTools];
     const allowedToolNames = collectAllowedToolNames({
       tools: effectiveTools,
       clientTools,
@@ -1833,6 +1833,7 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
+          availableTools: toolsRaw.map((tool) => tool.name),
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
@@ -1866,6 +1867,18 @@ export async function runEmbeddedAttempt(
             systemPromptText = prependedOrAppendedSystemPrompt;
             log.debug(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
+            );
+          }
+
+          // Apply toolsAllow from the full before_prompt_build hook to narrow the tool surface.
+          // This is the load-bearing call for dynamic tool resolution — plugins have access to
+          // availableTools here and can make informed classification decisions.
+          if (hookResult?.toolsAllow && hookResult.toolsAllow.length > 0) {
+            const originalLength = effectiveTools.length;
+            const allowSet = new Set(hookResult.toolsAllow);
+            effectiveTools = effectiveTools.filter((t) => allowSet.has(t.name));
+            log.debug(
+              `hooks: toolsAllow narrowed tools ${originalLength} → ${effectiveTools.length}`,
             );
           }
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1833,7 +1833,9 @@ export async function runEmbeddedAttempt(
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,
           messages: activeSession.messages,
-          availableTools: toolsRaw.map((tool) => tool.name),
+          // Use effectiveTools (includes bundled MCP/LSP tools) so plugins
+          // see the complete tool surface when making classification decisions.
+          availableTools: effectiveTools.map((tool) => tool.name),
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
@@ -1877,8 +1879,12 @@ export async function runEmbeddedAttempt(
             const originalLength = effectiveTools.length;
             const allowSet = new Set(hookResult.toolsAllow);
             effectiveTools = effectiveTools.filter((t) => allowSet.has(t.name));
+            // Update the session's active tools so the model actually sees the
+            // narrowed set. Without this, the session retains the full tool list
+            // captured at createAgentSession time and the filtering is a no-op.
+            activeSession.setActiveToolsByName(hookResult.toolsAllow);
             log.debug(
-              `hooks: toolsAllow narrowed tools ${originalLength} → ${effectiveTools.length}`,
+              `hooks: toolsAllow narrowed tools ${originalLength} → ${effectiveTools.length} (session tools updated)`,
             );
           }
         }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -145,6 +145,7 @@ import { buildEmbeddedSandboxInfo } from "../sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "../session-manager-cache.js";
 import { prepareSessionManagerForRun } from "../session-manager-init.js";
 import { resolveEmbeddedRunSkillEntries } from "../skills-runtime.js";
+import { loadWorkspaceSkillEntries } from "../../skills.js";
 import {
   describeEmbeddedAgentStreamStrategy,
   resetEmbeddedAgentBaseStreamFnCacheForTest,
@@ -845,15 +846,14 @@ export async function runEmbeddedAttempt(
       },
     });
 
-    const builtAppendPrompt =
-      resolveSystemPromptOverride({
+    const agentSystemPromptOverride = resolveSystemPromptOverride({
         config: params.config,
         agentId: sessionAgentId,
-      }) ??
-      buildEmbeddedSystemPrompt({
+      });
+    const appendPromptParams = {
         workspaceDir: effectiveWorkspace,
         defaultThinkLevel: params.thinkLevel,
-        reasoningLevel: params.reasoningLevel ?? "off",
+        reasoningLevel: params.reasoningLevel ?? ("off" as const),
         extraSystemPrompt: params.extraSystemPrompt,
         ownerNumbers: params.ownerNumbers,
         ownerDisplay: ownerDisplay.ownerDisplay,
@@ -879,7 +879,8 @@ export async function runEmbeddedAttempt(
         includeMemorySection: !params.contextEngine || params.contextEngine.info.id === "legacy",
         memoryCitationsMode: params.config?.memory?.citations,
         promptContribution,
-      });
+      };
+    const builtAppendPrompt = agentSystemPromptOverride ?? buildEmbeddedSystemPrompt(appendPromptParams);
     const appendPrompt = transformProviderSystemPrompt({
       provider: params.provider,
       config: params.config,
@@ -1836,6 +1837,11 @@ export async function runEmbeddedAttempt(
           // Use effectiveTools (includes bundled MCP/LSP tools) so plugins
           // see the complete tool surface when making classification decisions.
           availableTools: effectiveTools.map((tool) => tool.name),
+          // Pass loaded skill names so plugins can classify skill relevance.
+          // Use skillEntries if live-loaded, otherwise fall back to snapshot skill names.
+          availableSkills: skillEntries && skillEntries.length > 0
+            ? skillEntries.map((s) => s.skill.name)
+            : params.skillsSnapshot?.skills?.map((s) => s.name) ?? [],
           hookCtx,
           hookRunner,
           legacyBeforeAgentStartResult: params.legacyBeforeAgentStartResult,
@@ -1885,6 +1891,67 @@ export async function runEmbeddedAttempt(
             activeSession.setActiveToolsByName(hookResult.toolsAllow);
             log.debug(
               `hooks: toolsAllow narrowed tools ${originalLength} → ${effectiveTools.length} (session tools updated)`,
+            );
+          }
+
+          // Apply skillsAllow from the hook to narrow the skill catalog in the system prompt.
+          // When set, only listed skills have their descriptions injected — reducing prompt
+          // tokens from irrelevant skill guidance.
+          // Skip when the system prompt is fully overridden (no skills prompt to filter).
+          if (
+            hookResult?.skillsAllow &&
+            !agentSystemPromptOverride
+          ) {
+            const skillAllowSet = new Set(hookResult.skillsAllow);
+
+            // Determine original skill count and build filtered prompt.
+            // When skills come from a snapshot, skillEntries is empty — use
+            // the snapshot's resolvedSkills or its skill name list instead.
+            let originalSkillCount: number;
+            let narrowedSkillsPrompt: string;
+
+            if (skillEntries && skillEntries.length > 0) {
+              // Live-loaded path: filter entries and rebuild prompt.
+              originalSkillCount = skillEntries.length;
+              const filteredSkillEntries = skillEntries.filter((s) => skillAllowSet.has(s.skill.name));
+              narrowedSkillsPrompt = resolveSkillsPromptForRun({
+                // Omit snapshot so we don't short-circuit to the pre-built prompt.
+                entries: filteredSkillEntries,
+                config: params.config,
+                workspaceDir: effectiveWorkspace,
+                agentId: sessionAgentId,
+              });
+            } else if (params.skillsSnapshot) {
+              // Snapshot path: load entries on demand and filter.
+              originalSkillCount = params.skillsSnapshot.skills?.length ?? 0;
+              const freshEntries = loadWorkspaceSkillEntries(effectiveWorkspace, {
+                config: params.config,
+                agentId: sessionAgentId,
+              });
+              const filteredEntries = freshEntries.filter((s) => skillAllowSet.has(s.skill.name));
+              narrowedSkillsPrompt = resolveSkillsPromptForRun({
+                // Omit snapshot so we rebuild from filtered entries.
+                entries: filteredEntries,
+                config: params.config,
+                workspaceDir: effectiveWorkspace,
+                agentId: sessionAgentId,
+              });
+            } else {
+              // No skills at all — nothing to filter.
+              originalSkillCount = 0;
+              narrowedSkillsPrompt = "";
+            }
+
+            // Re-apply the system prompt with the narrowed skills catalog.
+            const narrowedAppendPrompt = buildEmbeddedSystemPrompt({
+              ...appendPromptParams,
+              skillsPrompt: narrowedSkillsPrompt,
+            });
+            const narrowedSystemPromptOverride = createSystemPromptOverride(narrowedAppendPrompt);
+            systemPromptText = narrowedSystemPromptOverride();
+            applySystemPromptOverrideToSession(activeSession, systemPromptText);
+            log.debug(
+              `hooks: skillsAllow narrowed skills ${originalSkillCount} → ${hookResult.skillsAllow.length} (system prompt rebuilt)`,
             );
           }
         }

--- a/src/agents/pi-embedded-runner/run/setup.test.ts
+++ b/src/agents/pi-embedded-runner/run/setup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveHookModelSelection } from "./setup.js";
+
+describe("resolveHookModelSelection", () => {
+  it("does not call before_prompt_build for early toolsAllow (moved to attempt phase)", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_model_resolve", "before_prompt_build", "before_agent_start"].includes(hookName),
+      ),
+      runBeforeModelResolve: vi.fn(async () => undefined),
+      runBeforePromptBuild: vi.fn(async () => ({ toolsAllow: ["read", "exec"] })),
+      runBeforeAgentStart: vi.fn(async () => ({ toolsAllow: ["write"] })),
+    };
+
+    const result = await resolveHookModelSelection({
+      prompt: "hello",
+      provider: "openai",
+      modelId: "gpt-5",
+      hookRunner: hookRunner as never,
+      hookContext: { sessionId: "test-session", workspaceDir: "/tmp/test" },
+    });
+
+    // before_prompt_build is no longer called in setup — toolsAllow extraction
+    // happens in attempt.ts where availableTools is populated
+    expect(hookRunner.runBeforePromptBuild).not.toHaveBeenCalled();
+    // Legacy before_agent_start toolsAllow still flows through
+    expect(result.hookToolsAllow).toEqual(["write"]);
+    expect(result.legacyBeforeAgentStartResult?.toolsAllow).toEqual(["write"]);
+  });
+
+  it("falls back to legacy before_agent_start toolsAllow", async () => {
+    const hookRunner = {
+      hasHooks: vi.fn((hookName: string) =>
+        ["before_prompt_build", "before_agent_start"].includes(hookName),
+      ),
+      runBeforePromptBuild: vi.fn(async () => ({ prependContext: "ctx" })),
+      runBeforeAgentStart: vi.fn(async () => ({ toolsAllow: ["read"] })),
+    };
+
+    const result = await resolveHookModelSelection({
+      prompt: "hello",
+      provider: "openai",
+      modelId: "gpt-5",
+      hookRunner: hookRunner as never,
+      hookContext: { sessionId: "test-session", workspaceDir: "/tmp/test" },
+    });
+
+    expect(result.hookToolsAllow).toEqual(["read"]);
+  });
+});

--- a/src/agents/pi-embedded-runner/run/setup.ts
+++ b/src/agents/pi-embedded-runner/run/setup.ts
@@ -35,6 +35,10 @@ type HookRunnerLike = {
     input: { prompt: string },
     context: HookContext,
   ): Promise<PluginHookBeforeAgentStartResult | undefined>;
+  runBeforePromptBuild(
+    input: { prompt: string; messages: unknown[]; availableTools?: string[] },
+    context: HookContext,
+  ): Promise<{ toolsAllow?: string[] } | undefined>;
 };
 
 export async function resolveHookModelSelection(params: {
@@ -96,6 +100,10 @@ export async function resolveHookModelSelection(params: {
     provider,
     modelId,
     legacyBeforeAgentStartResult,
+    // toolsAllow is now consumed from the full before_prompt_build call in attempt.ts,
+    // where availableTools is populated and plugins can make informed decisions.
+    // Legacy before_agent_start toolsAllow is still supported here for backwards compat.
+    hookToolsAllow: legacyBeforeAgentStartResult?.toolsAllow,
   };
 }
 

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -16,6 +16,18 @@ export type PluginHookBeforePromptBuildEvent = {
   prompt: string;
   /** Session messages prepared for this run. */
   messages: unknown[];
+  /**
+   * Names of tools available for this turn (after policy pipeline filtering).
+   * Populated on the full prompt-build call in the attempt phase.
+   * Plugins should use this to dynamically select which tools to include via
+   * `toolsAllow` — no hardcoded tool lists needed.
+   *
+   * When `availableTools` is undefined or empty, the plugin is being called in a
+   * context where tool information is not yet available. Return `undefined` for
+   * `toolsAllow` in this case; the full call with populated `availableTools` will
+   * follow.
+   */
+  availableTools?: string[];
 };
 
 export type PluginHookBeforePromptBuildResult = {
@@ -31,6 +43,23 @@ export type PluginHookBeforePromptBuildResult = {
    * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
    */
   appendSystemContext?: string;
+  /**
+   * Optional tool allow-list for this turn. When set, only the listed tools are
+   * sent to the model — the same filtering that `toolsAllow` on cron payloads
+   * already applies (intersection with the owner's static policy, never additive).
+   *
+   * Plugins can use this to dynamically narrow the tool surface per-turn based
+   * on task classification, reducing token overhead and model confusion.
+   *
+   * Applied from the full `before_prompt_build` call in attempt.ts, where
+   * `availableTools` is populated. Plugins that need to inspect available tools
+   * before deciding which to allow should check `event.availableTools`.
+   *
+   * Safety guarantee: this list is intersected with the tools that survive the
+   * existing policy pipeline — it can only *remove* tools, never grant access
+   * to tools the owner denied.
+   */
+  toolsAllow?: string[];
 };
 
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
@@ -38,6 +67,7 @@ export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
   "prependContext",
   "prependSystemContext",
   "appendSystemContext",
+  "toolsAllow",
 ] as const satisfies readonly (keyof PluginHookBeforePromptBuildResult)[];
 
 type MissingPluginPromptMutationResultFields = Exclude<

--- a/src/plugins/hook-before-agent-start.types.ts
+++ b/src/plugins/hook-before-agent-start.types.ts
@@ -28,6 +28,14 @@ export type PluginHookBeforePromptBuildEvent = {
    * follow.
    */
   availableTools?: string[];
+  /**
+   * Names of skills loaded for this session. Plugins can use this to dynamically
+   * select which skills to include in the system prompt via `skillsAllow`.
+   *
+   * When `availableSkills` is undefined or empty, the plugin is being called in a
+   * context where skill information is not yet available.
+   */
+  availableSkills?: string[];
 };
 
 export type PluginHookBeforePromptBuildResult = {
@@ -60,6 +68,20 @@ export type PluginHookBeforePromptBuildResult = {
    * to tools the owner denied.
    */
   toolsAllow?: string[];
+  /**
+   * Optional skill allow-list for this turn. When set, only the listed skills
+   * have their full descriptions injected into the system prompt. All other
+   * skills are omitted from the skills catalog.
+   *
+   * Plugins can use this to dynamically narrow the skill surface per-turn based
+   * on task classification, reducing token overhead from irrelevant skill
+   * descriptions.
+   *
+   * Safety guarantee: this list is intersected with the skills that are already
+   * loaded — it can only *remove* skills from the prompt, never inject skills
+   * that weren't loaded.
+   */
+  skillsAllow?: string[];
 };
 
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
@@ -68,6 +90,7 @@ export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
   "prependSystemContext",
   "appendSystemContext",
   "toolsAllow",
+  "skillsAllow",
 ] as const satisfies readonly (keyof PluginHookBeforePromptBuildResult)[];
 
 type MissingPluginPromptMutationResultFields = Exclude<

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -246,6 +246,8 @@ export function createHookRunner(
       left: acc?.appendSystemContext,
       right: next.appendSystemContext,
     }),
+    // First plugin to set toolsAllow wins (higher priority).
+    toolsAllow: firstDefined(acc?.toolsAllow, next.toolsAllow),
   });
 
   const mergeSubagentSpawningResult = (

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -248,6 +248,8 @@ export function createHookRunner(
     }),
     // First plugin to set toolsAllow wins (higher priority).
     toolsAllow: firstDefined(acc?.toolsAllow, next.toolsAllow),
+    // First plugin to set skillsAllow wins (higher priority).
+    skillsAllow: firstDefined(acc?.skillsAllow, next.skillsAllow),
   });
 
   const mergeSubagentSpawningResult = (


### PR DESCRIPTION
## Summary

- **Problem:** `before_prompt_build` hook fires in `setup.ts` where `availableTools` is always empty, so plugins can never classify tools or return meaningful `toolsAllow`. Symmetrically, plugins had no way to narrow the skill catalog injected into the system prompt, even though skills are often a larger token cost than tool definitions.
- **Why it matters:** Plugins that want to reduce token usage by narrowing the prompt surface (e.g., LLM classifiers on 40+ tool + 20+ skill deployments) cannot function on the tool side at all, and have no lever on the skill side.
- **What changed (tools):** Moved `toolsAllow` consumption to `attempt.ts` where the full tool list exists; exposed `availableTools` on the hook event; added `runBeforePromptBuild` to `HookRunnerLike`.
- **What changed (skills — new in this revision):** Added `skillsAllow: string[]` to `HookBeforePromptBuildResult`. When returned, the skill catalog injected into the system prompt is filtered to only the listed skills and the system prompt is rebuilt before the model call. Merge semantics match `toolsAllow` (first plugin to set wins).
- **What did NOT change (scope boundary):** Static tool and skill policy pipelines untouched. `toolsAllow` / `skillsAllow` can only narrow, never expand access or inject new skills.
- **Follow-up fix:** `toolsAllow` from hook was filtering a local variable but not updating the session's active tools. Added `activeSession.setActiveToolsByName()` so the model actually receives the narrowed set. Also fixed `availableTools` to source from `effectiveTools` (includes bundled MCP/LSP tools).

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A — new capability.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `setup.test.ts`, `attempt.test.ts`
- Scenario the test should lock in:
  - `toolsAllow` from hook result filters `effectiveTools` in attempt
  - `skillsAllow` from hook result filters the skills catalog and rebuilds the system prompt
  - `setup` declares `runBeforePromptBuild` interface
- Why this is the smallest reliable guardrail: Unit tests verify the filtering logic without needing a running gateway
- If no new test is added, why not: Tests are added for the tools path; skills path currently verified end-to-end on a live gateway (see Evidence). Unit coverage for skills wiring can be added as a follow-up.

## User-visible / Behavior Changes

Plugins can now return `toolsAllow` AND/OR `skillsAllow` from `before_prompt_build` to narrow the prompt surface per-turn. No change for users without such plugins — both fields are optional and default to passthrough.

## Diagram (if applicable)

```text
Before:
[before_prompt_build in attempt.ts] -> plugin returns toolsAllow
  -> effectiveTools filtered (local var only)
  -> session.agent.state.tools unchanged -> model sees ALL tools
  -> skills catalog static -> model sees ALL skill descriptions

After:
[before_prompt_build in attempt.ts] -> plugin returns { toolsAllow, skillsAllow }
  -> effectiveTools filtered
  -> activeSession.setActiveToolsByName() -> model sees ONLY allowed tools
  -> skills catalog filtered via skillsAllow
  -> system prompt rebuilt -> model sees ONLY allowed skill descriptions
```

## Security Impact (required)

- New permissions/capabilities? No — can only narrow existing surface
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes — plugins can reduce it, never expand
- Skill injection surface changed? Yes — plugins can reduce it, never inject new skills
- Data access scope changed? No
- If any Yes, explain risk + mitigation: `toolsAllow` and `skillsAllow` are intersected with items that already survived the respective policy pipelines. A plugin cannot grant access to tools or skills denied by owner config. Skill content is filtered at the catalog level; the underlying workspace skills are unaffected.

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node v25.8.0
- Model/provider: Any
- Integration/channel: Any with 40+ tools and/or 15+ skills
- Relevant config: Plugin implementing `before_prompt_build` hook returning `toolsAllow` and/or `skillsAllow`

### Steps

1. Register a plugin that implements `before_prompt_build`
2. Plugin receives `availableTools` and `availableSkills` arrays and returns `toolsAllow` and/or `skillsAllow` subsets
3. Observe `effectiveTools` is filtered to only allowed tools
4. Observe system prompt is rebuilt with only allowed skill descriptions

### Expected

- Plugin receives full tool + skill lists, returns subsets, model sees only subsets

### Actual

- Confirmed via diff inspection, unit tests (tools path), and live gateway validation (both paths)

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers

**Tools path (committed earlier in this PR):** Measured via LiteLLM `prompt_tokens` (provider ground truth). Before fix: 75,877 avg tokens/turn. After fix: 71,829 avg tokens/turn. **−4,048 tokens/turn (5.3%)** on a 42-tool heavy session.

**Skills path (new in this revision):** Validated on a live prod gateway running this branch against an LLM classifier plugin. Gateway log confirms both paths fire on every turn:

```
18:04:53 [agent/embedded] hooks: toolsAllow narrowed tools 40 → 19 (session tools updated)
18:04:53 [agent/embedded] hooks: skillsAllow narrowed skills 15 → 0 (system prompt rebuilt)
18:05:01 [agent/embedded] hooks: toolsAllow narrowed tools 42 → 27 (session tools updated)
18:05:01 [agent/embedded] hooks: skillsAllow narrowed skills 21 → 0 (system prompt rebuilt)
```

Plugin-side telemetry shows the skill classifier making contextually correct selections across turns, e.g. `skillsAllow: ["github","research-qa"]` on PR-review prompts, `skillsAllow: ["himalaya"]` on email cron prompts, `skillsAllow: ["skill-creator"]` on skill-authoring prompts.

## Human Verification (required)

- Verified scenarios: Diff inspection of all files, unit test coverage for tools filtering, end-to-end validation of both tools + skills narrowing on a live gateway
- Edge cases checked: Empty `toolsAllow`/`skillsAllow`, cron `toolsAllow` precedence, `AgentTool.name` vs `.function.name`, `agentSystemPromptOverride` skip path for skills, snapshot vs live-loaded skill entry paths
- What you did not verify: Full CI (tsgo OOMs on test machine)

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — `skillsAllow` is an optional new field; plugins that don't set it see no change
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- **Risk:** Plugin returns empty `toolsAllow` → model sees zero tools
  - **Mitigation:** Empty array is treated as "no filtering" (passthrough)
- **Risk:** Plugin returns `skillsAllow: []` → system prompt loses all skills descriptions
  - **Mitigation:** Empty array is applied as-stated (rebuild with zero skills). This is intentional — the plugin is signaling "no skills needed this turn." Passthrough-on-undefined is still the default when the plugin doesn't set the field at all.
- **Risk:** Skill filter dropped a skill the model actually needed
  - **Mitigation:** `skillsAllow` only filters catalog injection into the system prompt; it does not prevent the agent from reading a skill file at runtime if explicitly referenced. Classifier plugins should be conservative (include-on-doubt semantics).
