### PR TITLE
fix(mattermost): auto-reconnect WebSocket after consecutive health check failures

### DIFF
--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -234,9 +234,6 @@ export function createMattermostConnectOnce(
                 ? "mattermost: failed to get initial update_at"
                 : "mattermost: health check error";
             opts.runtime.error?.(`${label}: ${String(err)}`);
-            // If the health check has failed N times in a row, the WebSocket
-            // is likely in a zombie state (TCP connected but no events).
-            // Terminate it so the reconnect loop can establish a fresh one.
             if (
               healthCheckFailureThreshold > 0 &&
               consecutiveHealthCheckFailures >= healthCheckFailureThreshold

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -139,11 +139,28 @@ export function parsePostedEvent(
   return parsePostedPayload(payload);
 }
 
+export type CreateMattermostConnectOnceExtendedOpts = {
+  /**
+   * Number of consecutive health check failures before forcibly terminating
+   * the WebSocket to trigger a reconnect.
+   *
+   * When the health check REST API call fails repeatedly, the WebSocket may
+   * be in a zombie state — connected at the TCP level but no longer receiving
+   * events. Terminating the connection after N failures ensures the reconnect
+   * loop can establish a fresh WebSocket.
+   *
+   * Default: 3 (≈ 90s with default 30s interval).
+   * Set to 0 to disable this behaviour (legacy behaviour).
+   */
+  healthCheckFailureThreshold?: number;
+};
+
 export function createMattermostConnectOnce(
-  opts: CreateMattermostConnectOnceOpts,
+  opts: CreateMattermostConnectOnceOpts & CreateMattermostConnectOnceExtendedOpts = {} as CreateMattermostConnectOnceOpts,
 ): () => Promise<void> {
   const webSocketFactory = opts.webSocketFactory ?? defaultMattermostWebSocketFactory;
   const healthCheckIntervalMs = opts.healthCheckIntervalMs ?? 30_000;
+  const healthCheckFailureThreshold = opts.healthCheckFailureThreshold ?? 3;
   return async () => {
     const flowId = randomUUID();
     const ws = webSocketFactory(opts.wsUrl);
@@ -159,6 +176,7 @@ export function createMattermostConnectOnce(
         let healthCheckInFlight = false;
         let healthCheckTimer: ReturnType<typeof setTimeout> | undefined;
         let initialUpdateAt: number | undefined;
+        let consecutiveHealthCheckFailures = 0;
 
         const clearTimers = () => {
           if (healthCheckTimer !== undefined) {
@@ -203,15 +221,32 @@ export function createMattermostConnectOnce(
               stopHealthChecks();
               ws.terminate();
             }
+            // Health check succeeded — reset the consecutive failure counter.
+            consecutiveHealthCheckFailures = 0;
           } catch (err) {
             if (!healthCheckEnabled || settled) {
               return;
             }
+            consecutiveHealthCheckFailures++;
             const label =
               initialUpdateAt === undefined
                 ? "mattermost: failed to get initial update_at"
                 : "mattermost: health check error";
             opts.runtime.error?.(`${label}: ${String(err)}`);
+            // If the health check has failed N times in a row, the WebSocket
+            // is likely in a zombie state (TCP connected but no events).
+            // Terminate it so the reconnect loop can establish a fresh one.
+            if (
+              healthCheckFailureThreshold > 0 &&
+              consecutiveHealthCheckFailures >= healthCheckFailureThreshold
+            ) {
+              opts.runtime.error?.(
+                `mattermost: ${consecutiveHealthCheckFailures} consecutive health check failures — terminating WebSocket to force reconnect`,
+              );
+              stopHealthChecks();
+              ws.terminate();
+              return;
+            }
           } finally {
             healthCheckInFlight = false;
             scheduleHealthCheck();

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -212,6 +212,7 @@ export function createMattermostConnectOnce(
             }
             if (initialUpdateAt === undefined) {
               initialUpdateAt = current;
+              consecutiveHealthCheckFailures = 0;
               return;
             }
             if (current !== initialUpdateAt) {


### PR DESCRIPTION
## Problem

When the Mattermost WebSocket connection enters a **zombie state** (TCP connected but no longer receiving events), the bot stays alive and can still send messages via REST API, but **stops receiving all incoming messages**. The health check REST API call fails repeatedly, but the WebSocket is never terminated, so the reconnect loop never triggers.

This can last for **hours** until someone manually restarts the gateway — which is what happened with the `@dandan\ bot today.

## Root Cause

The health check in `createMattermostConnectOnce()` logs failures but never terminates the WebSocket, even after dozens of consecutive REST API failures:

```typescript
catch (err) {
  // Just logs the error, never closes the WebSocket
  opts.runtime.error?.(`mattermost: health check error`);
  // healthCheckInFlight is reset, scheduleHealthCheck continues...
}
```

## Fix

Added a new option `healthCheckFailureThreshold` (default: `3`) that counts consecutive health check failures. When the threshold is reached, the WebSocket is forcibly terminated, allowing the reconnect loop (`runWithReconnect`) to establish a fresh connection.

### Changes

1. **New type**: `CreateMattermostConnectOnceExtendedOpts` with documented option
2. **Failure counter**: `consecutiveHealthCheckFailures` tracked in health check loop
3. **Auto-terminate**: After N consecutive failures, logs and terminates the WebSocket
4. **Reset on success**: Counter resets to 0 when health check succeeds
5. **Opt-out**: Set `healthCheckFailureThreshold: 0` to restore legacy behavior

### Expected Behavior

With default settings (`healthCheckFailureThreshold: 3`, 30s interval):
- **~90 seconds** after REST API becomes unreachable → WebSocket terminated → reconnect loop kicks in → fresh WebSocket established
- Previously: stuck indefinitely until manual restart

### Logs (when fix triggers)

```
mattermost: health check error: TypeError: fetch failed
mattermost: health check error: TypeError: fetch failed
mattermost: health check error: TypeError: fetch failed
mattermost: 3 consecutive health check failures — terminating WebSocket to force reconnect
```