### PR TITLE
fix: handle MiniMax prompt_cache_hit_tokens to prevent token double-counting

### DIFF
--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -28,6 +28,8 @@ export type UsageLike = {
   total_tokens?: number;
   cache_read?: number;
   cache_write?: number;
+  // MiniMax uses prompt_cache_hit_tokens for cache read count.
+  prompt_cache_hit_tokens?: number;
 };
 
 export type NormalizedUsage = {
@@ -88,6 +90,7 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
     raw.cacheRead ??
       raw.cache_read ??
       raw.cache_read_input_tokens ??
+      raw.prompt_cache_hit_tokens ??
       raw.cached_tokens ??
       raw.input_tokens_details?.cached_tokens ??
       raw.prompt_tokens_details?.cached_tokens,
@@ -99,7 +102,8 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   const usesOpenAIStylePromptTotals =
     raw.cached_tokens !== undefined ||
     raw.input_tokens_details?.cached_tokens !== undefined ||
-    raw.prompt_tokens_details?.cached_tokens !== undefined;
+    raw.prompt_tokens_details?.cached_tokens !== undefined ||
+    raw.prompt_cache_hit_tokens !== undefined;
 
   // Some providers (pi-ai OpenAI-format) pre-subtract cached_tokens from
   // prompt/input totals upstream, while OpenAI-style prompt/input aliases


### PR DESCRIPTION
## Problem

Closes #68470

MiniMax models (M2.5, M2.7) report cache hits via `prompt_cache_hit_tokens` in the usage response, but this field was not recognized by the token accounting pipeline. Since MiniMax includes cached tokens in `prompt_tokens` (same as OpenAI), the cache read was counted twice:

1. Once in `prompt_tokens` (passed through as `input`)
2. Again as an unrecognized cache field that fell through to `derivePromptTokens()` which sums `input + cacheRead + cacheWrite`

This causes `tokenUsedRatio` to reach the 65% compaction threshold at only ~20% actual context usage, triggering unnecessary compaction that repeatedly destroys conversation context.

## Fix

Three changes in `src/agents/usage.ts`:

1. **Add `prompt_cache_hit_tokens` to `UsageLike` type** — so the field is recognized from MiniMax responses
2. **Add it to the `cacheRead` extraction chain** — so cache hits are properly extracted as `cacheRead`
3. **Add it to `usesOpenAIStylePromptTotals` detection** — so the existing `rawInput - cacheRead` normalization kicks in, preventing double-counting

This follows the exact same pattern already used for Moonshot `cached_tokens`, OpenAI `input_tokens_details.cached_tokens`, and Kimi `prompt_tokens_details.cached_tokens`.

## Impact

- Before: 16 unnecessary compactions per session, context lost at ~20% usage
- After: compaction correctly triggers at ~65% actual usage