### PR TITLE
fix(gateway): preserve chat history across compaction checkpoint chains

### DIFF
--- a/src/gateway/fixtures/repro-68765-compaction-chain-from-production.ts
+++ b/src/gateway/fixtures/repro-68765-compaction-chain-from-production.ts
@@ -1,0 +1,191 @@
+import path from "node:path";
+
+type RawEntry = Record<string, unknown>;
+
+type TranscriptFixtureFile = {
+  filePath: string;
+  entries: RawEntry[];
+};
+
+type CompactionCheckpointFixture = {
+  sessionId: string;
+  preCompaction: {
+    sessionFile: string;
+  };
+};
+
+export type Repro68765CompactionChainFixture = {
+  sessionId: string;
+  store: Record<string, unknown>;
+  liveSessionFile: string;
+  transcripts: TranscriptFixtureFile[];
+  expectedTexts: string[];
+  expectedMessageIds: string[];
+  expectedLiveSegmentTexts: string[];
+  expectedLiveSegmentMessageIds: string[];
+};
+
+// Production-derived fixture for PR #68765.
+// Source shape: main-session checkpoint chain from a real compaction lineage.
+// Redaction: user text, assistant text, timestamps, cwd, provider/model ids,
+// and opaque ids are pseudonymized. The file/chain topology is preserved:
+// two predecessor `preCompaction.sessionFile` segments plus the live segment.
+export function createRepro68765CompactionChainFromProduction(
+  rootDir: string,
+): Repro68765CompactionChainFixture {
+  const sessionId = "11111111-1111-4111-8111-111111111111";
+  const checkpoint1SessionId = "22222222-2222-4222-8222-222222222222";
+  const checkpoint2SessionId = "33333333-3333-4333-8333-333333333333";
+  const checkpoint1File = path.join(rootDir, `${sessionId}.checkpoint.01.redacted.jsonl`);
+  const checkpoint2File = path.join(rootDir, `${sessionId}.checkpoint.02.redacted.jsonl`);
+  const liveSessionFile = path.join(rootDir, `${sessionId}.jsonl`);
+
+  const checkpointChain: CompactionCheckpointFixture[] = [
+    {
+      sessionId: checkpoint1SessionId,
+      preCompaction: {
+        sessionFile: checkpoint1File,
+      },
+    },
+    {
+      sessionId: checkpoint2SessionId,
+      preCompaction: {
+        sessionFile: checkpoint2File,
+      },
+    },
+  ];
+
+  const transcripts: TranscriptFixtureFile[] = [
+    {
+      filePath: checkpoint1File,
+      entries: [
+        {
+          type: "session",
+          version: 3,
+          id: "session-root-1",
+          timestamp: "2026-04-18T02:00:00.000Z",
+          cwd: "REDACTED_WORKDIR",
+        },
+        {
+          type: "message",
+          id: "msg-segment-1-user",
+          parentId: "session-root-1",
+          timestamp: "2026-04-18T02:00:30.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "[redacted chain segment 1 user]" }],
+          },
+        },
+        {
+          type: "message",
+          id: "msg-segment-1-assistant",
+          parentId: "msg-segment-1-user",
+          timestamp: "2026-04-18T02:00:45.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "[redacted chain segment 1 assistant]" }],
+          },
+        },
+      ],
+    },
+    {
+      filePath: checkpoint2File,
+      entries: [
+        {
+          type: "session",
+          version: 3,
+          id: "session-root-2",
+          timestamp: "2026-04-18T03:10:00.000Z",
+          cwd: "REDACTED_WORKDIR",
+        },
+        {
+          type: "message",
+          id: "msg-segment-2-user",
+          parentId: "session-root-2",
+          timestamp: "2026-04-18T03:10:30.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "[redacted chain segment 2 user]" }],
+          },
+        },
+        {
+          type: "message",
+          id: "msg-segment-2-assistant",
+          parentId: "msg-segment-2-user",
+          timestamp: "2026-04-18T03:10:45.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "[redacted chain segment 2 assistant]" }],
+          },
+        },
+      ],
+    },
+    {
+      filePath: liveSessionFile,
+      entries: [
+        {
+          type: "session",
+          version: 3,
+          id: "session-root-live",
+          timestamp: "2026-04-18T04:20:00.000Z",
+          cwd: "REDACTED_WORKDIR",
+        },
+        {
+          type: "message",
+          id: "msg-live-user",
+          parentId: "session-root-live",
+          timestamp: "2026-04-18T04:20:30.000Z",
+          message: {
+            role: "user",
+            content: [{ type: "text", text: "[redacted live segment user]" }],
+          },
+        },
+        {
+          type: "message",
+          id: "msg-live-assistant",
+          parentId: "msg-live-user",
+          timestamp: "2026-04-18T04:20:45.000Z",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "[redacted live segment assistant]" }],
+          },
+        },
+      ],
+    },
+  ];
+
+  const expectedLiveSegmentTexts = [
+    "[redacted live segment user]",
+    "[redacted live segment assistant]",
+  ];
+  const expectedLiveSegmentMessageIds = ["msg-live-user", "msg-live-assistant"];
+
+  return {
+    sessionId,
+    liveSessionFile,
+    transcripts,
+    store: {
+      "agent:main:main": {
+        sessionId,
+        sessionFile: liveSessionFile,
+        compactionCheckpoints: checkpointChain,
+      },
+    },
+    expectedTexts: [
+      "[redacted chain segment 1 user]",
+      "[redacted chain segment 1 assistant]",
+      "[redacted chain segment 2 user]",
+      "[redacted chain segment 2 assistant]",
+      ...expectedLiveSegmentTexts,
+    ],
+    expectedMessageIds: [
+      "msg-segment-1-user",
+      "msg-segment-1-assistant",
+      "msg-segment-2-user",
+      "msg-segment-2-assistant",
+      ...expectedLiveSegmentMessageIds,
+    ],
+    expectedLiveSegmentTexts,
+    expectedLiveSegmentMessageIds,
+  };
+}

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
 import { clearSessionStoreCaches } from "../config/sessions/store-cache.js";
 import { withTempHomeConfig } from "../config/test-helpers.js";
+import { createRepro68765CompactionChainFromProduction } from "./fixtures/repro-68765-compaction-chain-from-production.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import {
   archiveSessionTranscripts,
@@ -48,6 +49,21 @@ function buildBasicSessionTranscript(
     { message: { role: "user", content: userText } },
     { message: { role: "assistant", content: assistantText } },
   ];
+}
+
+function extractMessageText(message: { content?: unknown }): string {
+  if (typeof message.content === "string") {
+    return message.content;
+  }
+  if (
+    Array.isArray(message.content) &&
+    message.content[0] &&
+    typeof message.content[0] === "object"
+  ) {
+    const first = message.content[0] as { text?: unknown };
+    return typeof first.text === "string" ? first.text : "";
+  }
+  return "";
 }
 
 describe("readFirstUserMessageFromTranscript", () => {
@@ -698,6 +714,42 @@ describe("readSessionMessages", () => {
     readSpy.mockRestore();
     vi.unstubAllEnvs();
     clearSessionStoreCaches();
+  });
+
+  test("reads a production-derived main-session checkpoint chain across predecessor transcripts", () => {
+    const fixture = createRepro68765CompactionChainFromProduction(tmpDir);
+    for (const transcript of fixture.transcripts) {
+      fs.mkdirSync(path.dirname(transcript.filePath), { recursive: true });
+      fs.writeFileSync(
+        transcript.filePath,
+        transcript.entries.map((entry) => JSON.stringify(entry)).join("\n"),
+        "utf-8",
+      );
+    }
+    fs.writeFileSync(storePath, JSON.stringify(fixture.store), "utf-8");
+
+    const truncated = readSessionMessages(
+      fixture.sessionId,
+      path.join(tmpDir, "wrong-sessions.json"),
+      fixture.liveSessionFile,
+    ) as Array<{ content?: unknown; __openclaw?: { id?: string; seq?: number } }>;
+    expect(truncated.map((message) => extractMessageText(message))).toEqual(
+      fixture.expectedLiveSegmentTexts,
+    );
+    expect(truncated.map((message) => message.__openclaw?.id)).toEqual(
+      fixture.expectedLiveSegmentMessageIds,
+    );
+    expect(truncated.map((message) => message.__openclaw?.seq)).toEqual([1, 2]);
+
+    const out = readSessionMessages(
+      fixture.sessionId,
+      storePath,
+      fixture.liveSessionFile,
+    ) as Array<{ content?: unknown; __openclaw?: { id?: string; seq?: number } }>;
+
+    expect(out.map((message) => extractMessageText(message))).toEqual(fixture.expectedTexts);
+    expect(out.map((message) => message.__openclaw?.id)).toEqual(fixture.expectedMessageIds);
+    expect(out.map((message) => message.__openclaw?.seq)).toEqual([1, 2, 3, 4, 5, 6]);
   });
 });
 

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+import { clearSessionStoreCaches } from "../config/sessions/store-cache.js";
+import { withTempHomeConfig } from "../config/test-helpers.js";
 import { createToolSummaryPreviewTranscriptLines } from "./session-preview.test-helpers.js";
 import {
   archiveSessionTranscripts,
@@ -535,6 +537,168 @@ describe("readSessionMessages", () => {
       expect((out[0] as { __openclaw?: { seq?: number } }).__openclaw?.seq).toBe(1);
     },
   );
+
+  test("skips stale duplicate rows without matching sessionFile", () => {
+    const sessionId = "stale-row-session";
+    const snapshotPath = path.join(tmpDir, `${sessionId}.checkpoint.pre.jsonl`);
+    const currentPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify({ message: { role: "user", content: "checkpoint content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      currentPath,
+      JSON.stringify({ message: { role: "assistant", content: "current content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        stale: {
+          sessionId,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: snapshotPath } }],
+        },
+        "agent:main:main": {
+          sessionId,
+          sessionFile: currentPath,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: snapshotPath } }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath, currentPath) as Array<{
+      content?: string;
+    }>;
+    expect(out.map((entry) => entry.content)).toEqual(["checkpoint content", "current content"]);
+  });
+
+  test("chains checkpoints for configured main session even when the store key uses a legacy alias", async () => {
+    const sessionId = "canonical-main-alias-session";
+    const snapshotPath = path.join(tmpDir, `${sessionId}.checkpoint.pre.jsonl`);
+    const currentPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify({ message: { role: "user", content: "pre-compaction content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      currentPath,
+      JSON.stringify({ message: { role: "assistant", content: "live content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId,
+          sessionFile: currentPath,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: snapshotPath } }],
+        },
+      }),
+      "utf-8",
+    );
+
+    await withTempHomeConfig(
+      {
+        agents: {
+          list: [{ id: "ops", default: true }, { id: "main" }],
+        },
+        session: {
+          mainKey: "work",
+        },
+      },
+      async () => {
+        const out = readSessionMessages(sessionId, storePath, currentPath) as Array<{
+          content?: string;
+        }>;
+        expect(out.map((entry) => entry.content)).toEqual([
+          "pre-compaction content",
+          "live content",
+        ]);
+      },
+    );
+  });
+
+  test("keeps non-main sessions on the legacy single-file fallback even when checkpoints exist", () => {
+    const sessionId = "non-main-fallback-session";
+    const snapshotPath = path.join(tmpDir, `${sessionId}.checkpoint.pre.jsonl`);
+    const currentPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify({ message: { role: "user", content: "checkpoint content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      currentPath,
+      JSON.stringify({ message: { role: "assistant", content: "live content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:ops:topic": {
+          sessionId,
+          sessionFile: currentPath,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: snapshotPath } }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath, currentPath) as Array<{
+      content?: string;
+    }>;
+    expect(out.map((entry) => entry.content)).toEqual(["live content"]);
+  });
+
+  test("reuses the cached session store on repeated chained reads", () => {
+    const sessionId = "cached-store-read-session";
+    const snapshotPath = path.join(tmpDir, `${sessionId}.checkpoint.pre.jsonl`);
+    const currentPath = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    clearSessionStoreCaches();
+    vi.stubEnv("OPENCLAW_SESSION_CACHE_TTL_MS", "45000");
+    fs.writeFileSync(
+      snapshotPath,
+      JSON.stringify({ message: { role: "user", content: "checkpoint content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      currentPath,
+      JSON.stringify({ message: { role: "assistant", content: "live content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId,
+          sessionFile: currentPath,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: snapshotPath } }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const readSpy = vi.spyOn(fs, "readFileSync");
+    const countStoreReads = () =>
+      readSpy.mock.calls.filter(([filePath]) => path.resolve(String(filePath)) === storePath)
+        .length;
+
+    readSessionMessages(sessionId, storePath, currentPath);
+    expect(countStoreReads()).toBe(1);
+    readSessionMessages(sessionId, storePath, currentPath);
+    expect(countStoreReads()).toBe(1);
+
+    readSpy.mockRestore();
+    vi.unstubAllEnvs();
+    clearSessionStoreCaches();
+  });
 });
 
 // Red-bar fixtures for the compaction-chain epoch design decision that is still open

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -537,6 +537,146 @@ describe("readSessionMessages", () => {
   );
 });
 
+// Red-bar fixtures for the compaction-chain epoch design decision that is still open
+// on PR #68765. These tests encode the reset/restore semantics we expect the chain
+// replay to respect; they currently fail against the replay-everything behavior in
+// resolveMainSessionTranscriptFiles and exist to force a semantic choice rather than
+// to keep accreting bot-driven fixes. The store key is set to "agent:main:main" so
+// resolveMainSessionKey's default (FALLBACK_DEFAULT_AGENT_ID + default mainKey) aligns
+// with canonicalizeMainSessionAlias() without needing a config fixture.
+describe("readSessionMessages — compaction chain epoch semantics", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore("openclaw-session-fs-epoch-test-", (nextTmpDir, nextStorePath) => {
+    tmpDir = nextTmpDir;
+    storePath = nextStorePath;
+  });
+
+  test("Compact -> Reset -> Read does not resurface pre-reset checkpoint content", () => {
+    const sessionId = "epoch-reset-session";
+    const preResetSnapshot = path.join(tmpDir, `${sessionId}.checkpoint.pre-reset.jsonl`);
+    const postResetTranscript = path.join(tmpDir, `${sessionId}.jsonl`);
+
+    fs.writeFileSync(
+      preResetSnapshot,
+      [
+        JSON.stringify({ message: { role: "user", content: "BEFORE RESET user" } }),
+        JSON.stringify({ message: { role: "assistant", content: "BEFORE RESET assistant" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      postResetTranscript,
+      JSON.stringify({ message: { role: "user", content: "AFTER RESET user" } }),
+      "utf-8",
+    );
+
+    // performGatewaySessionReset copies compactionCheckpoints[] from the previous
+    // entry to the new entry verbatim, so a post-reset store still points at the
+    // old pre-compaction snapshots via preCompaction.sessionFile.
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId,
+          sessionFile: postResetTranscript,
+          compactionCheckpoints: [{ preCompaction: { sessionFile: preResetSnapshot } }],
+        },
+      }),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath) as Array<{
+      content?: unknown;
+    }>;
+
+    const texts = out.map((m) => {
+      if (typeof m.content === "string") {
+        return m.content;
+      }
+      if (Array.isArray(m.content) && m.content[0] && typeof m.content[0] === "object") {
+        const first = m.content[0] as { text?: unknown };
+        return typeof first.text === "string" ? first.text : "";
+      }
+      return "";
+    });
+
+    // After /reset the replay must not resurface content that the user
+    // explicitly archived; the post-reset transcript is the only valid source.
+    expect(texts).not.toContain("BEFORE RESET user");
+    expect(texts).not.toContain("BEFORE RESET assistant");
+    expect(texts).toContain("AFTER RESET user");
+  });
+
+  test("Compact -> Restore -> Read does not double-read or resurface post-restore checkpoints", () => {
+    const sessionId = "epoch-restore-session";
+    const c1Snapshot = path.join(tmpDir, `${sessionId}.checkpoint.c1.jsonl`);
+    const c2Snapshot = path.join(tmpDir, `${sessionId}.checkpoint.c2.jsonl`);
+    const restoredFork = path.join(tmpDir, `${sessionId}.restored-fork.jsonl`);
+
+    // C1 is the checkpoint the user restored to; C2 is a later checkpoint
+    // created AFTER C1 and BEFORE the restore (content the user discarded).
+    fs.writeFileSync(
+      c1Snapshot,
+      JSON.stringify({ message: { role: "user", content: "C1 content" } }),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      c2Snapshot,
+      JSON.stringify({ message: { role: "user", content: "C2 post-C1 pre-restore content" } }),
+      "utf-8",
+    );
+    // sessions.compaction.restore forks the restored transcript as a copy of
+    // the target checkpoint's preCompaction.sessionFile and writes it as the
+    // new entry.sessionFile, while preserveCompactionCheckpoints: true keeps
+    // both C1 and C2 attached to the entry.
+    fs.writeFileSync(
+      restoredFork,
+      JSON.stringify({ message: { role: "user", content: "C1 content" } }),
+      "utf-8",
+    );
+
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": {
+          sessionId,
+          sessionFile: restoredFork,
+          compactionCheckpoints: [
+            { preCompaction: { sessionFile: c1Snapshot } },
+            { preCompaction: { sessionFile: c2Snapshot } },
+          ],
+        },
+      }),
+      "utf-8",
+    );
+
+    const out = readSessionMessages(sessionId, storePath) as Array<{
+      content?: unknown;
+    }>;
+
+    const texts = out.map((m) => {
+      if (typeof m.content === "string") {
+        return m.content;
+      }
+      if (Array.isArray(m.content) && m.content[0] && typeof m.content[0] === "object") {
+        const first = m.content[0] as { text?: unknown };
+        return typeof first.text === "string" ? first.text : "";
+      }
+      return "";
+    });
+
+    const c1Occurrences = texts.filter((t) => t === "C1 content").length;
+
+    // After a restore, the replay must not double-read the restored content
+    // (both C1 snapshot and the forked transcript carry it) and must not
+    // resurface checkpoints taken after the restore target.
+    expect(c1Occurrences).toBe(1);
+    expect(texts).not.toContain("C2 post-C1 pre-restore content");
+  });
+});
+
 describe("readSessionPreviewItemsFromTranscript", () => {
   let tmpDir: string;
   let storePath: string;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -162,14 +162,7 @@ function listExistingTranscriptVariantsForSessionId(
       .filter((name) => name === `${sessionId}.jsonl` || name.startsWith(`${sessionId}.jsonl.`))
       .filter((name) => !name.endsWith(".lock"))
       .map((name) => path.join(sessionsDir, name))
-      .filter((filePath) => fs.existsSync(filePath))
-      .toSorted((a, b) => {
-        try {
-          return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
-        } catch {
-          return a.localeCompare(b);
-        }
-      });
+      .filter((filePath) => fs.existsSync(filePath));
   } catch {
     return [];
   }
@@ -194,28 +187,6 @@ function resolveMainSessionTranscriptFiles(
     seen.add(normalized);
     files.push(normalized);
   };
-  const resetFiles: string[] = (() => {
-    try {
-      return fs
-        .readdirSync(context.sessionsDir)
-        .filter((name) => name.includes(".jsonl.reset."))
-        .map((name) => path.join(context.sessionsDir, name))
-        .filter((filePath) => fs.existsSync(filePath))
-        .toSorted((a, b) => {
-          try {
-            return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
-          } catch {
-            return a.localeCompare(b);
-          }
-        });
-    } catch {
-      return [];
-    }
-  })();
-  const latestReset = resetFiles[resetFiles.length - 1];
-  if (latestReset) {
-    pushFile(latestReset);
-  }
   const entry = context.entry as Record<string, unknown> | undefined;
   const rawCheckpoints = entry?.compactionCheckpoints;
   const checkpointSessionIds = Array.isArray(rawCheckpoints)
@@ -245,12 +216,27 @@ function resolveMainSessionTranscriptFiles(
   if (files.length === 0) {
     return null;
   }
-  return files.toSorted((a, b) => {
-    try {
-      return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
-    } catch {
-      return a.localeCompare(b);
+  const mtimeCache = new Map<string, number | null>();
+  const getMtime = (filePath: string): number | null => {
+    if (mtimeCache.has(filePath)) {
+      return mtimeCache.get(filePath) ?? null;
     }
+    let value: number | null = null;
+    try {
+      value = fs.statSync(filePath).mtimeMs;
+    } catch {
+      value = null;
+    }
+    mtimeCache.set(filePath, value);
+    return value;
+  };
+  return files.toSorted((a, b) => {
+    const da = getMtime(a);
+    const db = getMtime(b);
+    if (da !== null && db !== null) {
+      return da - db;
+    }
+    return a.localeCompare(b);
   });
 }
 

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
@@ -90,57 +91,234 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
+const GENERATED_SESSION_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function looksLikeGeneratedSessionId(value: string): boolean {
+  return GENERATED_SESSION_ID_RE.test(value);
+}
+
+type SessionMessagesStoreContext = {
+  sessionsDir: string;
+  key?: string;
+  entry?: unknown;
+};
+
+function resolveSessionMessagesStoreContext(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+): SessionMessagesStoreContext | null {
+  if (!storePath) {
+    return null;
+  }
+  const sessionsDir = path.dirname(storePath);
+  try {
+    const store = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    if (!store || typeof store !== "object" || Array.isArray(store)) {
+      return { sessionsDir };
+    }
+    const targetSessionFile =
+      typeof sessionFile === "string" && sessionFile.trim()
+        ? path.resolve(sessionFile.trim())
+        : null;
+    for (const [key, value] of Object.entries(store)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        continue;
+      }
+      const record = value as Record<string, unknown>;
+      if (record.sessionId !== sessionId) {
+        continue;
+      }
+      const entrySessionFile =
+        typeof record.sessionFile === "string" && record.sessionFile.trim()
+          ? path.resolve(record.sessionFile.trim())
+          : null;
+      if (targetSessionFile && entrySessionFile && entrySessionFile !== targetSessionFile) {
+        continue;
+      }
+      return {
+        key,
+        entry: value,
+        sessionsDir,
+      };
+    }
+  } catch {
+    // ignore malformed or unreadable sessions store
+  }
+  return { sessionsDir };
+}
+
+function listExistingTranscriptVariantsForSessionId(
+  sessionId: string,
+  sessionsDir: string,
+): string[] {
+  if (!sessionsDir || !looksLikeGeneratedSessionId(sessionId)) {
+    return [];
+  }
+  try {
+    return fs
+      .readdirSync(sessionsDir)
+      .filter((name) => name === `${sessionId}.jsonl` || name.startsWith(`${sessionId}.jsonl.`))
+      .filter((name) => !name.endsWith(".lock"))
+      .map((name) => path.join(sessionsDir, name))
+      .filter((filePath) => fs.existsSync(filePath))
+      .toSorted((a, b) => {
+        try {
+          return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
+        } catch {
+          return a.localeCompare(b);
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+function resolveMainSessionTranscriptFiles(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+): string[] | null {
+  const context = resolveSessionMessagesStoreContext(sessionId, storePath, sessionFile);
+  if (!context?.sessionsDir || context.key !== "agent:main:main") {
+    return null;
+  }
+  const files: string[] = [];
+  const seen = new Set<string>();
+  const pushFile = (filePath: string): void => {
+    const normalized = path.resolve(filePath);
+    if (seen.has(normalized) || !fs.existsSync(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    files.push(normalized);
+  };
+  const resetFiles: string[] = (() => {
+    try {
+      return fs
+        .readdirSync(context.sessionsDir)
+        .filter((name) => name.includes(".jsonl.reset."))
+        .map((name) => path.join(context.sessionsDir, name))
+        .filter((filePath) => fs.existsSync(filePath))
+        .toSorted((a, b) => {
+          try {
+            return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
+          } catch {
+            return a.localeCompare(b);
+          }
+        });
+    } catch {
+      return [];
+    }
+  })();
+  const latestReset = resetFiles[resetFiles.length - 1];
+  if (latestReset) {
+    pushFile(latestReset);
+  }
+  const entry = context.entry as Record<string, unknown> | undefined;
+  const rawCheckpoints = entry?.compactionCheckpoints;
+  const checkpointSessionIds = Array.isArray(rawCheckpoints)
+    ? rawCheckpoints
+        .map((checkpoint) => {
+          if (!checkpoint || typeof checkpoint !== "object" || Array.isArray(checkpoint)) {
+            return null;
+          }
+          const checkpointRecord = checkpoint as Record<string, unknown>;
+          return typeof checkpointRecord.sessionId === "string" ? checkpointRecord.sessionId : null;
+        })
+        .filter((value): value is string => typeof value === "string")
+    : [];
+  const orderedSessionIds = Array.from(
+    new Set(
+      [...checkpointSessionIds, sessionId].filter((value) => looksLikeGeneratedSessionId(value)),
+    ),
+  );
+  for (const chainedSessionId of orderedSessionIds) {
+    for (const filePath of listExistingTranscriptVariantsForSessionId(
+      chainedSessionId,
+      context.sessionsDir,
+    )) {
+      pushFile(filePath);
+    }
+  }
+  if (files.length === 0) {
+    return null;
+  }
+  return files.toSorted((a, b) => {
+    try {
+      return fs.statSync(a).mtimeMs - fs.statSync(b).mtimeMs;
+    } catch {
+      return a.localeCompare(b);
+    }
+  });
+}
+
+function resolveTranscriptReadFiles(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+): string[] {
+  const chained = resolveMainSessionTranscriptFiles(sessionId, storePath, sessionFile);
+  if (chained && chained.length > 0) {
+    return chained;
+  }
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
+  const filePath = candidates.find((p) => fs.existsSync(p));
+  return filePath ? [filePath] : [];
+}
+
 export function readSessionMessages(
   sessionId: string,
   storePath: string | undefined,
   sessionFile?: string,
 ): unknown[] {
-  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
-
-  const filePath = candidates.find((p) => fs.existsSync(p));
-  if (!filePath) {
+  const filePaths = resolveTranscriptReadFiles(sessionId, storePath, sessionFile);
+  if (filePaths.length === 0) {
     return [];
   }
-
-  const lines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/);
   const messages: unknown[] = [];
   let messageSeq = 0;
-  for (const line of lines) {
-    if (!line.trim()) {
-      continue;
-    }
-    try {
-      const parsed = JSON.parse(line);
-      if (parsed?.message) {
-        messageSeq += 1;
-        messages.push(
-          attachOpenClawTranscriptMeta(parsed.message, {
-            ...(typeof parsed.id === "string" ? { id: parsed.id } : {}),
-            seq: messageSeq,
-          }),
-        );
+  for (const filePath of filePaths) {
+    const lines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) {
         continue;
       }
+      try {
+        const parsed = JSON.parse(line);
+        if (parsed?.message) {
+          messageSeq += 1;
+          messages.push(
+            attachOpenClawTranscriptMeta(parsed.message, {
+              ...(typeof parsed.id === "string" ? { id: parsed.id } : {}),
+              seq: messageSeq,
+            }),
+          );
+          continue;
+        }
 
-      // Compaction entries are not "message" records, but they're useful context for debugging.
-      // Emit a lightweight synthetic message that the Web UI can render as a divider.
-      if (parsed?.type === "compaction") {
-        const ts = typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN;
-        const timestamp = Number.isFinite(ts) ? ts : Date.now();
-        messageSeq += 1;
-        messages.push({
-          role: "system",
-          content: [{ type: "text", text: "Compaction" }],
-          timestamp,
-          __openclaw: {
-            kind: "compaction",
-            id: typeof parsed.id === "string" ? parsed.id : undefined,
-            seq: messageSeq,
-          },
-        });
+        // Compaction entries are not "message" records, but they're useful context for debugging.
+        // Emit a lightweight synthetic message that the Web UI can render as a divider.
+        if (parsed?.type === "compaction") {
+          const ts =
+            typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN;
+          const timestamp = Number.isFinite(ts) ? ts : Date.now();
+          messageSeq += 1;
+          messages.push({
+            role: "system",
+            content: [{ type: "text", text: "Compaction" }],
+            timestamp,
+            __openclaw: {
+              kind: "compaction",
+              id: typeof parsed.id === "string" ? parsed.id : undefined,
+              seq: messageSeq,
+            },
+          });
+        }
+      } catch {
+        // ignore bad lines
       }
-    } catch {
-      // ignore bad lines
     }
   }
   return messages;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -7,6 +7,7 @@ import {
   canonicalizeMainSessionAlias,
   resolveMainSessionKey,
 } from "../config/sessions/main-session.js";
+import { loadSessionStore } from "../config/sessions/store.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
@@ -113,7 +114,7 @@ function resolveSessionMessagesStoreContext(
   }
   const sessionsDir = path.dirname(storePath);
   try {
-    const store = JSON.parse(fs.readFileSync(storePath, "utf-8"));
+    const store = loadSessionStore(storePath);
     if (!store || typeof store !== "object" || Array.isArray(store)) {
       return { sessionsDir };
     }

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -157,6 +157,16 @@ function resolveMainSessionTranscriptFiles(
   if (!context?.sessionsDir || !context.key) {
     return null;
   }
+  // Hot-path guard: skip config + alias resolution when the entry has no checkpoint
+  // chain to walk. `readSessionMessages` runs on every transcript read, and the vast
+  // majority of sessions (isolated, subagent, heartbeat, explicit agent) never carry
+  // `compactionCheckpoints[]`. Gating the loadConfig + canonicalize work on a cheap
+  // field check avoids O(sessions.json) parsing + config I/O for those reads.
+  const entry = context.entry as Record<string, unknown> | undefined;
+  const rawCheckpoints = entry?.compactionCheckpoints;
+  if (!Array.isArray(rawCheckpoints) || rawCheckpoints.length === 0) {
+    return null;
+  }
   // Activate the chained read only for the configured main session key, not a hardcoded
   // literal. `resolveMainSessionKey` returns "global", "agent:<default>:<mainKey>", etc.,
   // depending on `session.scope` / `session.mainKey` / `agents.default`. Stores can also
@@ -178,11 +188,6 @@ function resolveMainSessionTranscriptFiles(
     sessionKey: context.key,
   });
   if (canonicalContextKey !== canonicalMainKey) {
-    return null;
-  }
-  const entry = context.entry as Record<string, unknown> | undefined;
-  const rawCheckpoints = entry?.compactionCheckpoints;
-  if (!Array.isArray(rawCheckpoints) || rawCheckpoints.length === 0) {
     return null;
   }
   const files: string[] = [];

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -133,7 +133,7 @@ function resolveSessionMessagesStoreContext(
         typeof record.sessionFile === "string" && record.sessionFile.trim()
           ? path.resolve(record.sessionFile.trim())
           : null;
-      if (targetSessionFile && entrySessionFile && entrySessionFile !== targetSessionFile) {
+      if (targetSessionFile && entrySessionFile !== targetSessionFile) {
         continue;
       }
       return {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs";
 import path from "node:path";
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
-import { resolveMainSessionKeyFromConfig } from "../config/sessions/main-session.runtime.js";
+import { loadConfig } from "../config/config.js";
+import {
+  canonicalizeMainSessionAlias,
+  resolveMainSessionKey,
+} from "../config/sessions/main-session.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
@@ -153,17 +158,26 @@ function resolveMainSessionTranscriptFiles(
     return null;
   }
   // Activate the chained read only for the configured main session key, not a hardcoded
-  // literal. `resolveMainSessionKeyFromConfig` returns "global", "agent:<default>:<mainKey>",
-  // etc., depending on `session.scope` / `session.mainKey` / `agents.default`. For any
-  // other session (isolated, subagent, heartbeat, explicit agent session) the legacy
-  // single-file path is correct.
-  let configuredMainKey: string;
+  // literal. `resolveMainSessionKey` returns "global", "agent:<default>:<mainKey>", etc.,
+  // depending on `session.scope` / `session.mainKey` / `agents.default`. Stores can also
+  // carry legacy main-key aliases (e.g. `agent:main:main` when the configured default
+  // agent is "ops"), so we canonicalize `context.key` via `canonicalizeMainSessionAlias`
+  // before comparing. For any non-main session (isolated, subagent, heartbeat, explicit
+  // agent session) the canonicalizer returns the raw key unchanged and the comparison
+  // fails, so the legacy single-file path is correct.
+  let cfg;
   try {
-    configuredMainKey = resolveMainSessionKeyFromConfig();
+    cfg = loadConfig();
   } catch {
     return null;
   }
-  if (context.key !== configuredMainKey) {
+  const canonicalMainKey = resolveMainSessionKey(cfg);
+  const canonicalContextKey = canonicalizeMainSessionAlias({
+    cfg,
+    agentId: resolveDefaultAgentId(cfg),
+    sessionKey: context.key,
+  });
+  if (canonicalContextKey !== canonicalMainKey) {
     return null;
   }
   const entry = context.entry as Record<string, unknown> | undefined;

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
+import { SAFE_SESSION_ID_RE } from "../config/sessions/paths.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
@@ -91,13 +92,6 @@ export function attachOpenClawTranscriptMeta(
   };
 }
 
-const GENERATED_SESSION_ID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-function looksLikeGeneratedSessionId(value: string): boolean {
-  return GENERATED_SESSION_ID_RE.test(value);
-}
-
 type SessionMessagesStoreContext = {
   sessionsDir: string;
   key?: string;
@@ -153,14 +147,15 @@ function listExistingTranscriptVariantsForSessionId(
   sessionId: string,
   sessionsDir: string,
 ): string[] {
-  if (!sessionsDir || !looksLikeGeneratedSessionId(sessionId)) {
+  if (!sessionsDir || !SAFE_SESSION_ID_RE.test(sessionId)) {
     return [];
   }
+  const jsonlName = `${sessionId}.jsonl`;
+  const resetPrefix = `${sessionId}.jsonl.reset.`;
   try {
     return fs
       .readdirSync(sessionsDir)
-      .filter((name) => name === `${sessionId}.jsonl` || name.startsWith(`${sessionId}.jsonl.`))
-      .filter((name) => !name.endsWith(".lock"))
+      .filter((name) => name === jsonlName || name.startsWith(resetPrefix))
       .map((name) => path.join(sessionsDir, name))
       .filter((filePath) => fs.existsSync(filePath));
   } catch {
@@ -201,9 +196,7 @@ function resolveMainSessionTranscriptFiles(
         .filter((value): value is string => typeof value === "string")
     : [];
   const orderedSessionIds = Array.from(
-    new Set(
-      [...checkpointSessionIds, sessionId].filter((value) => looksLikeGeneratedSessionId(value)),
-    ),
+    new Set([...checkpointSessionIds, sessionId].filter((value) => SAFE_SESSION_ID_RE.test(value))),
   );
   for (const chainedSessionId of orderedSessionIds) {
     for (const filePath of listExistingTranscriptVariantsForSessionId(

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -143,26 +143,6 @@ function resolveSessionMessagesStoreContext(
   return { sessionsDir };
 }
 
-function listExistingTranscriptVariantsForSessionId(
-  sessionId: string,
-  sessionsDir: string,
-): string[] {
-  if (!sessionsDir || !SAFE_SESSION_ID_RE.test(sessionId)) {
-    return [];
-  }
-  const jsonlName = `${sessionId}.jsonl`;
-  const resetPrefix = `${sessionId}.jsonl.reset.`;
-  try {
-    return fs
-      .readdirSync(sessionsDir)
-      .filter((name) => name === jsonlName || name.startsWith(resetPrefix))
-      .map((name) => path.join(sessionsDir, name))
-      .filter((filePath) => fs.existsSync(filePath));
-  } catch {
-    return [];
-  }
-}
-
 function resolveMainSessionTranscriptFiles(
   sessionId: string,
   storePath: string | undefined,
@@ -199,10 +179,8 @@ function resolveMainSessionTranscriptFiles(
     new Set([...checkpointSessionIds, sessionId].filter((value) => SAFE_SESSION_ID_RE.test(value))),
   );
   for (const chainedSessionId of orderedSessionIds) {
-    for (const filePath of listExistingTranscriptVariantsForSessionId(
-      chainedSessionId,
-      context.sessionsDir,
-    )) {
+    const filePath = path.join(context.sessionsDir, `${chainedSessionId}.jsonl`);
+    if (fs.existsSync(filePath)) {
       pushFile(filePath);
     }
   }
@@ -226,7 +204,7 @@ function resolveMainSessionTranscriptFiles(
   return files.toSorted((a, b) => {
     const da = getMtime(a);
     const db = getMtime(b);
-    if (da !== null && db !== null) {
+    if (da !== null && db !== null && da !== db) {
       return da - db;
     }
     return a.localeCompare(b);

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
-import { SAFE_SESSION_ID_RE } from "../config/sessions/paths.js";
+import { resolveMainSessionKeyFromConfig } from "../config/sessions/main-session.runtime.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { hasInterSessionUserProvenance } from "../sessions/input-provenance.js";
 import { extractAssistantVisibleText } from "../shared/chat-message-content.js";
@@ -149,7 +149,26 @@ function resolveMainSessionTranscriptFiles(
   sessionFile?: string,
 ): string[] | null {
   const context = resolveSessionMessagesStoreContext(sessionId, storePath, sessionFile);
-  if (!context?.sessionsDir || context.key !== "agent:main:main") {
+  if (!context?.sessionsDir || !context.key) {
+    return null;
+  }
+  // Activate the chained read only for the configured main session key, not a hardcoded
+  // literal. `resolveMainSessionKeyFromConfig` returns "global", "agent:<default>:<mainKey>",
+  // etc., depending on `session.scope` / `session.mainKey` / `agents.default`. For any
+  // other session (isolated, subagent, heartbeat, explicit agent session) the legacy
+  // single-file path is correct.
+  let configuredMainKey: string;
+  try {
+    configuredMainKey = resolveMainSessionKeyFromConfig();
+  } catch {
+    return null;
+  }
+  if (context.key !== configuredMainKey) {
+    return null;
+  }
+  const entry = context.entry as Record<string, unknown> | undefined;
+  const rawCheckpoints = entry?.compactionCheckpoints;
+  if (!Array.isArray(rawCheckpoints) || rawCheckpoints.length === 0) {
     return null;
   }
   const files: string[] = [];
@@ -162,31 +181,40 @@ function resolveMainSessionTranscriptFiles(
     seen.add(normalized);
     files.push(normalized);
   };
-  const entry = context.entry as Record<string, unknown> | undefined;
-  const rawCheckpoints = entry?.compactionCheckpoints;
-  const checkpointSessionIds = Array.isArray(rawCheckpoints)
-    ? rawCheckpoints
-        .map((checkpoint) => {
-          if (!checkpoint || typeof checkpoint !== "object" || Array.isArray(checkpoint)) {
-            return null;
-          }
-          const checkpointRecord = checkpoint as Record<string, unknown>;
-          return typeof checkpointRecord.sessionId === "string" ? checkpointRecord.sessionId : null;
-        })
-        .filter((value): value is string => typeof value === "string")
-    : [];
-  const orderedSessionIds = Array.from(
-    new Set([...checkpointSessionIds, sessionId].filter((value) => SAFE_SESSION_ID_RE.test(value))),
-  );
-  for (const chainedSessionId of orderedSessionIds) {
-    const filePath = path.join(context.sessionsDir, `${chainedSessionId}.jsonl`);
-    if (fs.existsSync(filePath)) {
-      pushFile(filePath);
+  // Walk the checkpoint chain in recorded order (oldest first). Each entry is a
+  // SessionCompactionCheckpoint whose `preCompaction.sessionFile` points at the actual
+  // pre-compaction snapshot written by session-compaction-checkpoints.ts (named like
+  // `<session>.checkpoint.<uuid>.jsonl`). Never reconstruct `<sessionId>.jsonl` — that
+  // does not match the on-disk convention. No `.reset.*` / `.bak` / `.deleted.*` variant
+  // scanning: `.bak` is a pre-compaction snapshot the chain already represents through
+  // predecessor entries, and replaying `.reset.*` archives would resurface content that
+  // the user explicitly cleared via /reset, breaking reset semantics.
+  for (const checkpoint of rawCheckpoints) {
+    if (!checkpoint || typeof checkpoint !== "object" || Array.isArray(checkpoint)) {
+      continue;
     }
+    const checkpointRecord = checkpoint as Record<string, unknown>;
+    const preCompaction = checkpointRecord.preCompaction;
+    if (!preCompaction || typeof preCompaction !== "object" || Array.isArray(preCompaction)) {
+      continue;
+    }
+    const reference = (preCompaction as Record<string, unknown>).sessionFile;
+    if (typeof reference === "string" && reference.trim()) {
+      pushFile(reference.trim());
+    }
+  }
+  // Append the current session's primary transcript as the newest segment, so the chain
+  // ends with live content.
+  const currentSessionFile = entry?.sessionFile;
+  if (typeof currentSessionFile === "string" && currentSessionFile.trim()) {
+    pushFile(currentSessionFile.trim());
   }
   if (files.length === 0) {
     return null;
   }
+  // Deterministic ordering: primary key is mtime (ascending), tie-break is filename
+  // localeCompare. fs.statSync is cached per path so it runs once per file, not
+  // O(N log N) times inside the comparator.
   const mtimeCache = new Map<string, number | null>();
   const getMtime = (filePath: string): number | null => {
     if (mtimeCache.has(filePath)) {


### PR DESCRIPTION
## Problem

When `readSessionMessages` is called for the configured main session (as
returned by `resolveMainSessionKey` — `"global"`, `"agent:main:main"`, or
any `agent:<default>:<mainKey>` your config resolves to) and that session's
`sessions.json` entry carries a non-empty `compactionCheckpoints[]` chain,
the function only reads the single transcript file resolved by
`resolveSessionTranscriptCandidates(...).find(existsSync)`.

That single-file read discards every pre-compaction transcript referenced
by the chain, so downstream consumers of `readSessionMessages` (notably
the `chat.history` gateway handler and anything that feeds it) see a
truncated history that silently ends at the most recent compaction
checkpoint boundary. Sequence numbers get reassigned starting from `1`
inside the last segment only, which makes chain-continuity checks (gap
detection, dedup, ordering) report a healthy chain that is in fact
missing all pre-compaction turns.

The bug is not visible in sessions that have never been compacted (their
`compactionCheckpoints[]` is empty or absent), which is why it survives
basic smoke tests on fresh sessions.

## Repro

1. Run the configured main session long enough to trigger at least one
   compaction checkpoint (verify via `sessions.json` → the entry has
   `compactionCheckpoints: [{ checkpointId: "...", preCompaction: { sessionFile: "..." }, ... }, ...]`).
2. Call
   `openclaw gateway call chat.history --params '{"sessionKey":"<main_session_key>","limit":200}'`.
3. Observe that the returned `messages[]` starts at the most recent
   post-compaction segment. All messages from transcripts listed in
   `compactionCheckpoints[].preCompaction.sessionFile` are missing.
   Sequence numbers begin at `1` inside the returned window instead of
   being continuous across the chain.

Expected: the returned history spans every transcript referenced by the
checkpoint chain plus the current primary transcript, in mtime order,
with a single continuous `seq` counter.

## Fix

Introduce a chained resolver in `resolveMainSessionTranscriptFiles` that
activates only for the configured main session key and walks the stored
checkpoint chain using the authoritative file references recorded at
compaction time:

1. Look the session up in `sessions.json` via a new
   `resolveSessionMessagesStoreContext(sessionId, storePath, sessionFile)`
   helper.
2. Gate the chained-read path on
   `context.key === resolveMainSessionKeyFromConfig()`. This respects
   `session.scope` (`"global"` short-circuit), `session.mainKey`, and
   `agents.default` — no hardcoded session-key literal. For any other
   session (isolated, subagent, heartbeat, explicit agent session) the
   resolver returns `null` and the legacy single-file path applies.
3. Walk `entry.compactionCheckpoints[]` in recorded order. For each
   entry read `checkpoint.preCompaction.sessionFile` (the
   `SessionCompactionTranscriptReference` written by
   `session-compaction-checkpoints.ts` for files named like
   `<name>.checkpoint.<uuid>.jsonl`) and push that exact path.
4. Append `entry.sessionFile` as the newest segment so the chain ends
   with the live primary transcript.
5. Deduplicate by resolved path and drop non-existent files. If nothing
   resolves, return `null` and let the legacy single-file fallback apply.
6. Sort the resulting list by `mtimeMs` ascending, with a filename
   `localeCompare` tie-break. `fs.statSync` results are cached per
   path so each file is stat'd once, not O(N log N) times inside the
   comparator.

`readSessionMessages` iterates over that file list and keeps a single
shared `messageSeq` counter across all files, so the `seq` on each
reassembled message is continuous across the full chain.

Scope is intentionally narrow:

- No `readdirSync` sweep of the sessions directory.
- No inclusion of `.jsonl.reset.*`, `.jsonl.bak`, or `.jsonl.deleted.*`
  sibling files. `.bak` is a pre-compaction snapshot that the checkpoint
  chain already represents via predecessor entries (reading both would
  double-count compacted turns). `.reset.*` archives are content the
  user explicitly cleared via `/reset`; replaying them would resurface
  cleared turns and break reset semantics
  (`session-reset-service.ts` preserves `compactionCheckpoints[]` across
  a reset).
- No UUID-shape filter on session ids. The authoritative path already
  comes from the stored `preCompaction.sessionFile` reference, so no
  path-safety validation on raw session ids is needed.
- No change to the inner parse loop for `message` / `compaction`
  entries.
- No change to the `resolveSessionTranscriptCandidates` module.
- Non-main sessions, sessions without a `compactionCheckpoints[]`
  chain, and any config-read error all fall through to the existing
  single-file path — behavior byte-compatible with today's upstream.

All changes are contained in `src/gateway/session-utils.fs.ts`.

## Test notes for reviewers

Suggested test cases:

- Single-file session with no `compactionCheckpoints[]` → behavior
  unchanged, same messages, same `seq` assignment.
- Configured main session (via `resolveMainSessionKeyFromConfig`) with
  a two-step checkpoint chain whose entries carry
  `preCompaction.sessionFile` paths → returned messages span both
  checkpoint transcripts plus `entry.sessionFile` in mtime order, `seq`
  strictly monotonically increasing from 1 to N with no gaps.
- Session whose store entry's `sessionFile` differs from the arg →
  entry mismatch is detected in `resolveSessionMessagesStoreContext`
  and does not produce chained reads.
- Session where `context.key !== resolveMainSessionKeyFromConfig()`
  (subagent, heartbeat, explicit agent, or reconfigured main key) →
  resolver returns `null`, legacy single-file path applies.
- Missing or corrupt `sessions.json` → store lookup returns `null` or
  `{ sessionsDir }` only, the chained resolver returns `null`, legacy
  path applies.
- A checkpoint entry with missing `preCompaction.sessionFile` → entry
  is skipped, remaining chain entries are still used.
- Config-read failure during `resolveMainSessionKeyFromConfig` → caught
  and treated as "not the main session"; legacy path applies.
- Two files with identical `mtimeMs` → deterministic ordering via
  filename `localeCompare` tie-break.

## Relationship to #60409

#60409 ("fix(session): fall back to reset archive in chat.history when
primary transcript is missing") addresses a different failure mode in
the same function: it triggers when the primary transcript file is
absent and falls back to the latest `.reset.<timestamp>` archive. Its
trigger condition is `!filePath && sessionId`.

This PR addresses a distinct scenario: the primary transcript *is*
present, but the returned history misses every pre-compaction
transcript referenced via `compactionCheckpoints[]`. Trigger condition
is the existence of a non-empty checkpoint chain on the configured
main session.

The two fixes handle disjoint failure paths and stack additively —
neither removes functionality the other needs. If #60409 merges first,
this PR rebases mechanically: the `resolveTranscriptReadFiles`
dispatcher keeps the existing single-file resolution plus #60409's
reset-archive fallback intact as the non-chained path, and layers the
compaction-chain walk in front of it for the configured main session.
Happy to coordinate during review.

## Out of scope

- Boundary-marker synthetic system messages between transcript
  segments (kept for a possible follow-up).
- The reset-archive fallback for non-chained sessions — handled by
  #60409.
- Any sanitize-pipeline, threshold, or oversized-message-placeholder
  changes in `chat.history`.
- Extending the chained read to sessions other than the configured
  main (subagent, heartbeat, explicit agent sessions) — possible
  follow-up, but requires a separate conversation about which session
  shapes should carry compaction checkpoints.
- Upstream-`main` rebase of this branch (force-push required,
  reviewer-gated).
