### PR TITLE
feat: add circuit breaker for command lane saturation

### DIFF
--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -22,6 +22,7 @@ type CommandQueueModule = typeof import("./command-queue.js");
 
 let clearCommandLane: CommandQueueModule["clearCommandLane"];
 let CommandLaneClearedError: CommandQueueModule["CommandLaneClearedError"];
+let CommandLaneTimeoutError: CommandQueueModule["CommandLaneTimeoutError"];
 let enqueueCommand: CommandQueueModule["enqueueCommand"];
 let enqueueCommandInLane: CommandQueueModule["enqueueCommandInLane"];
 let GatewayDrainingError: CommandQueueModule["GatewayDrainingError"];
@@ -60,6 +61,7 @@ describe("command queue", () => {
     ({
       clearCommandLane,
       CommandLaneClearedError,
+      CommandLaneTimeoutError,
       enqueueCommand,
       enqueueCommandInLane,
       GatewayDrainingError,
@@ -356,6 +358,90 @@ describe("command queue", () => {
     deferred.resolve();
     await expect(first).resolves.toBe("first");
     await expect(second).resolves.toBe("second");
+  });
+
+  // AGE-728: per-task maxExecutionMs timeout
+  it("rejects a task that exceeds maxExecutionMs with CommandLaneTimeoutError", async () => {
+    const lane = `timeout-basic-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    vi.useFakeTimers();
+    try {
+      // Task that never resolves on its own — will be killed by the timeout.
+      // Attach .catch() immediately to suppress unhandled-rejection noise during
+      // timer advancement (the Promise rejects before the await expect() line runs).
+      const taskPromise = enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+        maxExecutionMs: 100,
+      });
+      const caught = taskPromise.catch((err) => err);
+
+      await vi.advanceTimersByTimeAsync(110);
+
+      await expect(caught).resolves.toBeInstanceOf(CommandLaneTimeoutError);
+      expect(diagnosticMocks.diag.error).toHaveBeenCalledWith(
+        expect.stringContaining("lane task timeout: lane="),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("frees the lane slot after maxExecutionMs so queued tasks can run (AGE-724 regression)", async () => {
+    const lane = `timeout-unblocks-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    vi.useFakeTimers();
+    try {
+      // First task hangs — will be killed by the 100 ms timeout.
+      // Attach .catch() immediately to suppress unhandled-rejection during timer advancement.
+      const firstCaught = enqueueCommandInLane(lane, () => new Promise<never>(() => {}), {
+        maxExecutionMs: 100,
+      }).catch((err) => err);
+
+      // Second task is queued behind it; should run once the first times out.
+      let secondRan = false;
+      const second = enqueueCommandInLane(lane, async () => {
+        secondRan = true;
+        return "ok";
+      });
+
+      expect(secondRan).toBe(false);
+
+      // Advance past the timeout — first task is killed, lane slot freed.
+      await vi.advanceTimersByTimeAsync(110);
+
+      await expect(firstCaught).resolves.toBeInstanceOf(CommandLaneTimeoutError);
+      await expect(second).resolves.toBe("ok");
+      expect(secondRan).toBe(true);
+      expect(getActiveTaskCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not time out tasks below the maxExecutionMs threshold", async () => {
+    const lane = `timeout-no-early-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    vi.useFakeTimers();
+    try {
+      let resolveTask!: (v: string) => void;
+      const taskPromise = enqueueCommandInLane(
+        lane,
+        () =>
+          new Promise<string>((r) => {
+            resolveTask = r;
+          }),
+        { maxExecutionMs: 500 },
+      );
+
+      // Advance to just under the limit — no timeout yet.
+      await vi.advanceTimersByTimeAsync(400);
+      resolveTask("done");
+      await expect(taskPromise).resolves.toBe("done");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("rejects new enqueues with GatewayDrainingError after markGatewayDraining", async () => {

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -25,6 +25,7 @@ let CommandLaneClearedError: CommandQueueModule["CommandLaneClearedError"];
 let CommandLaneTimeoutError: CommandQueueModule["CommandLaneTimeoutError"];
 let enqueueCommand: CommandQueueModule["enqueueCommand"];
 let enqueueCommandInLane: CommandQueueModule["enqueueCommandInLane"];
+let CommandLaneCircuitBreakerError: CommandQueueModule["CommandLaneCircuitBreakerError"];
 let GatewayDrainingError: CommandQueueModule["GatewayDrainingError"];
 let getActiveTaskCount: CommandQueueModule["getActiveTaskCount"];
 let getQueueSize: CommandQueueModule["getQueueSize"];
@@ -64,6 +65,7 @@ describe("command queue", () => {
       CommandLaneTimeoutError,
       enqueueCommand,
       enqueueCommandInLane,
+      CommandLaneCircuitBreakerError,
       GatewayDrainingError,
       getActiveTaskCount,
       getQueueSize,
@@ -534,5 +536,77 @@ describe("command queue", () => {
       release();
       commandQueueA.resetAllLanes();
     }
+  });
+  it("rejects new enqueues with CommandLaneCircuitBreakerError when depth threshold is met (AGE-2494)", async () => {
+    const lane = `cb-depth-${Date.now()}`;
+    // Fill lane to depth 2 (1 active + 1 queued)
+    let release1!: () => void;
+    const blocker1 = new Promise<void>((res) => {
+      release1 = res;
+    });
+    void enqueueCommandInLane(lane, () => blocker1, { circuitBreakerDepth: 2 });
+    void enqueueCommandInLane(lane, () => Promise.resolve(), { circuitBreakerDepth: 2 });
+    // Third enqueue should trip the breaker (depth >= 2)
+    await expect(
+      enqueueCommandInLane(lane, () => Promise.resolve(), { circuitBreakerDepth: 2 }),
+    ).rejects.toBeInstanceOf(CommandLaneCircuitBreakerError);
+    expect(diagnosticMocks.diag.warn).toHaveBeenCalledWith(
+      expect.stringContaining("[circuit-breaker]"),
+    );
+    release1();
+  });
+
+  it("does not trip circuit breaker below depth threshold (AGE-2494)", async () => {
+    const lane = `cb-nodepth-${Date.now()}`;
+    let release1!: () => void;
+    const blocker1 = new Promise<void>((res) => {
+      release1 = res;
+    });
+    const task1 = enqueueCommandInLane(lane, () => blocker1, { circuitBreakerDepth: 5 });
+    // Second enqueue is at depth 2 — well below threshold of 5
+    const task2 = enqueueCommandInLane(lane, () => Promise.resolve("ok"), {
+      circuitBreakerDepth: 5,
+    });
+    release1();
+    await task1;
+    await expect(task2).resolves.toBe("ok");
+  });
+
+  it("CommandLaneCircuitBreakerError includes retryAfterMs (AGE-2494)", async () => {
+    const lane = `cb-retry-${Date.now()}`;
+    let release1!: () => void;
+    const blocker1 = new Promise<void>((res) => {
+      release1 = res;
+    });
+    void enqueueCommandInLane(lane, () => blocker1, { circuitBreakerDepth: 1 });
+    let err: unknown;
+    try {
+      await enqueueCommandInLane(lane, () => Promise.resolve(), { circuitBreakerDepth: 1 });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CommandLaneCircuitBreakerError);
+    expect(
+      (err as InstanceType<typeof CommandLaneCircuitBreakerError>).retryAfterMs,
+    ).toBeGreaterThan(0);
+    release1();
+  });
+
+  it("enqueueCommand (main lane) has circuit breaker enabled by default (AGE-2494)", async () => {
+    // Fill main lane to depth >= 9 then verify the next enqueue trips the breaker
+    const releasers: Array<() => void> = [];
+    for (let i = 0; i < 9; i++) {
+      const blocker = new Promise<void>((res) => {
+        releasers.push(res);
+      });
+      void enqueueCommand(() => blocker);
+    }
+    await expect(enqueueCommand(() => Promise.resolve())).rejects.toBeInstanceOf(
+      CommandLaneCircuitBreakerError,
+    );
+    for (const release of releasers) {
+      release();
+    }
+    resetCommandQueueStateForTest();
   });
 });

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -28,6 +28,23 @@ export class GatewayDrainingError extends Error {
   }
 }
 
+/**
+ * Dedicated error type thrown when a queued command exceeds its per-task
+ * execution budget (`maxExecutionMs`). The lane slot is freed immediately so
+ * queued work behind it is not blocked.
+ *
+ * Used by nested lane to cap a single stalled LLM call at 5 minutes instead
+ * of the previous unbounded wait (root cause of AGE-724 / 60-min stall).
+ */
+export class CommandLaneTimeoutError extends Error {
+  constructor(lane: string, maxExecutionMs: number) {
+    super(
+      `Command lane "${lane}" task timed out after ${maxExecutionMs}ms and was aborted to free the lane slot`,
+    );
+    this.name = "CommandLaneTimeoutError";
+  }
+}
+
 // Minimal in-process queue to serialize command executions.
 // Default lane ("main") preserves the existing behavior. Additional lanes allow
 // low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
@@ -39,6 +56,7 @@ type QueueEntry = {
   reject: (reason?: unknown) => void;
   enqueuedAt: number;
   warnAfterMs: number;
+  maxExecutionMs?: number;
   onWait?: (waitMs: number, queuedAhead: number) => void;
 };
 
@@ -185,8 +203,24 @@ function drainLane(lane: string) {
         state.activeTaskIds.add(taskId);
         void (async () => {
           const startTime = Date.now();
+          // Per-task execution timeout (AGE-728): when maxExecutionMs is set, race
+          // the task against a deadline. On timeout the lane slot is freed immediately
+          // so queued tasks behind it are not blocked.
+          let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+          const taskWithTimeout: Promise<unknown> =
+            entry.maxExecutionMs != null
+              ? new Promise<unknown>((res, rej) => {
+                  timeoutHandle = setTimeout(() => {
+                    rej(new CommandLaneTimeoutError(lane, entry.maxExecutionMs!));
+                  }, entry.maxExecutionMs);
+                  void entry.task().then(res, rej);
+                })
+              : entry.task();
           try {
-            const result = await entry.task();
+            const result = await taskWithTimeout;
+            if (timeoutHandle != null) {
+              clearTimeout(timeoutHandle);
+            }
             const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
             if (completedCurrentGeneration) {
               notifyActiveTaskWaiters();
@@ -197,9 +231,16 @@ function drainLane(lane: string) {
             }
             entry.resolve(result);
           } catch (err) {
+            if (timeoutHandle != null) {
+              clearTimeout(timeoutHandle);
+            }
             const completedCurrentGeneration = completeTask(state, taskId, taskGeneration);
             const isProbeLane = lane.startsWith("auth-probe:") || lane.startsWith("session:probe-");
-            if (!isProbeLane && !isExpectedNonErrorLaneFailure(err)) {
+            if (err instanceof CommandLaneTimeoutError) {
+              diag.error(
+                `lane task timeout: lane=${lane} maxExecutionMs=${entry.maxExecutionMs} durationMs=${Date.now() - startTime} active=${state.activeTaskIds.size} queued=${state.queue.length}`,
+              );
+            } else if (!isProbeLane && !isExpectedNonErrorLaneFailure(err)) {
               diag.error(
                 `lane task error: lane=${lane} durationMs=${Date.now() - startTime} error="${String(err)}"`,
               );
@@ -244,6 +285,17 @@ export function enqueueCommandInLane<T>(
   task: () => Promise<T>,
   opts?: {
     warnAfterMs?: number;
+    /**
+     * Maximum wall-clock milliseconds a task may execute before it is
+     * rejected with `CommandLaneTimeoutError` and the lane slot is freed.
+     *
+     * Set to `300_000` (5 minutes) for the nested lane to prevent a single
+     * stalled LLM call from blocking all nested agent operations indefinitely
+     * (root cause of AGE-724 / 60-min stall recurrence).
+     *
+     * Omit (default) for lanes where no cap is desired.
+     */
+    maxExecutionMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
   },
 ): Promise<T> {
@@ -261,6 +313,7 @@ export function enqueueCommandInLane<T>(
       reject,
       enqueuedAt: Date.now(),
       warnAfterMs,
+      maxExecutionMs: opts?.maxExecutionMs,
       onWait: opts?.onWait,
     });
     logLaneEnqueue(cleaned, getLaneDepth(state));

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -29,6 +29,27 @@ export class GatewayDrainingError extends Error {
 }
 
 /**
+ * Dedicated error type thrown when a new command is rejected because the lane
+ * circuit breaker is open — the lane is saturated (depth threshold or oldest
+ * entry wait threshold exceeded). Callers should back off and retry after
+ * `retryAfterMs` milliseconds.
+ *
+ * Introduced in AGE-2494 to fail fast when queueAhead > 8 or the oldest
+ * queued entry has waited > 600 seconds, preventing cascading queue buildup
+ * during LLM provider degradation events.
+ */
+export class CommandLaneCircuitBreakerError extends Error {
+  readonly retryAfterMs: number;
+  constructor(lane: string, retryAfterMs: number) {
+    super(
+      `Command lane "${lane}" circuit breaker open: lane is saturated. Retry after ${retryAfterMs}ms.`,
+    );
+    this.name = "CommandLaneCircuitBreakerError";
+    this.retryAfterMs = retryAfterMs;
+  }
+}
+
+/**
  * Dedicated error type thrown when a queued command exceeds its per-task
  * execution budget (`maxExecutionMs`). The lane slot is freed immediately so
  * queued work behind it is not blocked.
@@ -297,6 +318,19 @@ export function enqueueCommandInLane<T>(
      */
     maxExecutionMs?: number;
     onWait?: (waitMs: number, queuedAhead: number) => void;
+    /** Optional priority for queue ordering. Higher values run first. Default: 0. */
+    priority?: number;
+    /**
+     * Maximum number of tasks (queued + active) allowed in the lane before the
+     * circuit breaker trips and new enqueues are rejected with
+     * `CommandLaneCircuitBreakerError`. Omit to disable depth-based tripping.
+     */
+    circuitBreakerDepth?: number;
+    /**
+     * Maximum milliseconds the oldest queued entry may have waited before the
+     * circuit breaker trips. Omit to disable wait-time-based tripping.
+     */
+    circuitBreakerWaitMs?: number;
   },
 ): Promise<T> {
   const queueState = getQueueState();
@@ -306,6 +340,27 @@ export function enqueueCommandInLane<T>(
   const cleaned = normalizeLane(lane);
   const warnAfterMs = opts?.warnAfterMs ?? 2_000;
   const state = getLaneState(cleaned);
+  // Circuit breaker: fail fast when the lane is saturated to prevent
+  // cascading queue buildup during LLM provider degradation. (AGE-2494)
+  const cbDepth = opts?.circuitBreakerDepth;
+  const cbWaitMs = opts?.circuitBreakerWaitMs;
+  if (cbDepth != null || cbWaitMs != null) {
+    const depth = getLaneDepth(state);
+    const depthTripped = cbDepth != null && depth >= cbDepth;
+    let waitTripped = false;
+    if (cbWaitMs != null && state.queue.length > 0) {
+      const oldestWait = Date.now() - Math.min(...state.queue.map((e) => e.enqueuedAt));
+      waitTripped = oldestWait >= cbWaitMs;
+    }
+    if (depthTripped || waitTripped) {
+      // Estimate retry-after: 30s per task ahead, capped at 5 minutes.
+      const retryAfterMs = Math.min(depth * 30_000, 300_000);
+      diag.warn(
+        `[circuit-breaker] lane ${cleaned} open: depth=${depth} depthTripped=${depthTripped} waitTripped=${waitTripped} retryAfterMs=${retryAfterMs}`,
+      );
+      return Promise.reject(new CommandLaneCircuitBreakerError(cleaned, retryAfterMs));
+    }
+  }
   return new Promise<T>((resolve, reject) => {
     state.queue.push({
       task: () => task(),
@@ -328,7 +383,14 @@ export function enqueueCommand<T>(
     onWait?: (waitMs: number, queuedAhead: number) => void;
   },
 ): Promise<T> {
-  return enqueueCommandInLane(CommandLane.Main, task, opts);
+  // Enable circuit breaker for the main run lane (AGE-2494): fail fast when
+  // queueAhead > 8 or the oldest queued run has waited > 10 minutes, to
+  // prevent cascading queue buildup during LLM provider degradation events.
+  return enqueueCommandInLane(CommandLane.Main, task, {
+    ...opts,
+    circuitBreakerDepth: 9,
+    circuitBreakerWaitMs: 600_000,
+  });
 }
 
 export function getQueueSize(lane: string = CommandLane.Main) {


### PR DESCRIPTION
## Summary

Add `CommandLaneCircuitBreakerError` and opt-in circuit breaker options (`circuitBreakerDepth`, `circuitBreakerWaitMs`) to `enqueueCommandInLane`.

Enable by default for the main run lane: depth >= 9 or oldest queued entry wait >= 600s triggers the breaker, returning an immediate error with `retryAfterMs` hint instead of queuing behind stuck retries.

**Root cause:** 2026-04-10 rate-limit cascade where 10 tasks queued with 800+ second waits turned a 5-min degradation into 30+ min outage.

## Dependencies

This PR builds on PR #68381 (maxExecutionMs per-task timeout / patch 0016) which adds `CommandLaneTimeoutError` and the `maxExecutionMs` option. The circuit breaker complements the timeout: timeouts kill running tasks; the circuit breaker rejects new enqueues when the lane is saturated.

## Files changed

- `src/process/command-queue.ts`: Add `CommandLaneCircuitBreakerError`, circuit breaker logic in `enqueueCommandInLane`, and default breaker config for main lane
- `src/process/command-queue.test.ts`: Add 4 test cases for depth tripping, no-trip-below-threshold, retryAfterMs, and default main lane breaker

## Verification

```bash
npx vitest run src/process/command-queue.test.ts
```

26/26 tests pass (22 baseline + 4 new circuit breaker tests).

Upstream candidate: patch 0045
Refs AGE-4963