### PR TITLE
Gateway: prune orphaned agentRunStarts entries

### DIFF
--- a/src/gateway/server-methods/agent-job.ts
+++ b/src/gateway/server-methods/agent-job.ts
@@ -34,6 +34,13 @@ function pruneAgentRunCache(now = Date.now()) {
       agentRunCache.delete(runId);
     }
   }
+  // Prune orphaned agentRunStarts entries whose terminal lifecycle event
+  // was lost (crash, race). Each entry is a start timestamp.
+  for (const [runId, startedAt] of agentRunStarts) {
+    if (now - startedAt > AGENT_RUN_CACHE_TTL_MS) {
+      agentRunStarts.delete(runId);
+    }
+  }
 }
 
 function recordAgentRunSnapshot(entry: AgentRunSnapshot) {


### PR DESCRIPTION
## Summary

- Problem: `pruneAgentRunCache()` clears `agentRunCache` entries on TTL but never touches the sibling `agentRunStarts` map, so timestamps for runs that lose their terminal lifecycle event (crash, race, forced disconnect) accumulate forever.
- Why it matters: On long-lived gateways this is a slow leak. Each orphaned entry is small, but they never drain, and the map is walked on every agent lifecycle emit — adding O(N) pressure to the hot path.
- What changed: Added a matching TTL sweep for `agentRunStarts` inside `pruneAgentRunCache()` in `src/gateway/server-methods/agent-job.ts:37-43`, keyed off the same `AGENT_RUN_CACHE_TTL_MS` already in use.
- What did NOT change (scope boundary): Pruning policy for `agentRunCache` itself, the TTL constant, and the call sites of `pruneAgentRunCache()`. No wire-protocol changes.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Terminal lifecycle events for agent runs can be lost (process crash, transport reset, forced client disconnect). When that happens, the `agentRunStarts` timestamp never gets removed, because removal is tied to the terminal event rather than a TTL.
- Missing detection / guardrail: No sweep or TTL on the `agentRunStarts` map — only `agentRunCache` had one.
- Contributing context (if known): Surfaced during a 2026-04-13 gateway audit that also flagged (separately, already landed on main) a session write-lock exit listener leak and a Discord heartbeat timer leak.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/server-methods/agent-job.test.ts` (does not exist yet — happy to add in a follow-up if desired; the one-line addition here mirrors the existing `agentRunCache` sweep pattern four lines above).
- Scenario the test should lock in: starting an agent run, simulating a lost terminal event, advancing time past `AGENT_RUN_CACHE_TTL_MS`, triggering `pruneAgentRunCache()`, and asserting `agentRunStarts` no longer contains the run id.
- Why this is the smallest reliable guardrail: the bug is entirely inside the pruning function; a fake-timer unit test around `pruneAgentRunCache()` catches it without spinning up a gateway.
- Existing test that already covers this (if any): None found — the existing `agentRunCache` TTL behavior has no direct unit test either.
- If no new test is added, why not: Keeping this PR minimal per the repo's narrow-scope preference; can add the unit test in a follow-up if the maintainers prefer it land alongside.

## User-visible / Behavior Changes

None. Internal map bookkeeping only.

## Diagram

N/A — map sweep, no flow change.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 15.x (Darwin 25.3.0)
- Runtime/container: Node 22 via pnpm
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: default

### Steps

1. Check out this branch.
2. `pnpm install && pnpm check && pnpm test src/gateway/server-methods`.
3. Inspect `pruneAgentRunCache()` in `src/gateway/server-methods/agent-job.ts` — the new block matches the existing `agentRunCache` sweep pattern.

### Expected

- `pnpm check` green. Gateway tests green. No new warnings.

### Actual

- `pnpm check` green. `pnpm test src/gateway/server-methods` green. Full `pnpm test` green.

## Evidence

- [x] Passing tests locally (`pnpm check` + scoped + full `pnpm test`)

## Human Verification

- Verified scenarios: ran `pnpm check` and `pnpm test src/gateway/server-methods` after the cherry-pick onto current `origin/main`; both green. Ran the full `pnpm test` suite; green.
- Edge cases checked: confirmed the new sweep uses the same `now - startedAt > AGENT_RUN_CACHE_TTL_MS` comparison as the existing cache sweep so the two maps drain on the same cadence.
- What I did not verify: long-running gateway observation — I did not run a live gateway for hours to watch the map drain in practice. The fix is mechanically obvious (mirrors the adjacent sweep) and the hot-path impact is bounded by the existing TTL.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — entries just start draining on the next `pruneAgentRunCache()` tick.

## Risks and Mitigations

- Risk: map is iterated during mutation.
  - Mitigation: the existing `agentRunCache` sweep uses the same `for ... of ...` + `delete(key)` pattern four lines above, and JS `Map` iteration tolerates in-loop deletion of the current/upcoming key.
