### PR TITLE
fix(telegram): preserve customCommands priority in menu budget trimming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ Docs: https://docs.openclaw.ai
 - Agents/openai-completions: always send `stream_options.include_usage` on streaming requests, so local and custom OpenAI-compatible backends report real context usage instead of showing 0%. (#68746) Thanks @kagura-agent.
 - Agents/nested lanes: scope nested agent work per target session so a long-running nested run on one session no longer head-of-line blocks unrelated sessions across the gateway. (#67785) Thanks @stainlu.
 - Agents/status: preserve carried-forward session token totals for providers that omit usage metadata, so `/status` and `openclaw sessions` keep showing the last known context usage instead of dropping back to unknown/0%. (#67695) Thanks @stainlu.
+- Telegram/commands: preserve user-defined `customCommands` priority when the combined native + custom menu exceeds Telegram's 100-command or 5700-char payload cap, so operator commands are no longer silently dropped from `setMyCommands` on startup. Fixes #68333.
 - Install/update: keep legacy update verification compatible with the QA Lab runtime shim, so updating older global installs to beta no longer fails after npm installs the package successfully.
 
 ## 2026.4.19-beta.1
@@ -208,7 +209,6 @@ Docs: https://docs.openclaw.ai
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 - Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
-- Telegram/commands: preserve user-defined `customCommands` priority when the combined native + custom menu exceeds Telegram's 100-command or 5700-char payload cap, so operator commands are no longer silently dropped from `setMyCommands` on startup. Fixes #68333.
 
 ## 2026.4.15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,7 @@ Docs: https://docs.openclaw.ai
 - Active Memory: raise the blocking recall timeout ceiling to 120 seconds and reject larger config values during plugin schema validation. Fixes #68410. (#68480) Thanks @Bartok9.
 - Control UI/chat: keep history-backed user image uploads visible after chat reload while filtering blocked or non-image transcript media paths. (#68415) Thanks @mraleko.
 - Matrix/plugins: keep remaining Matrix event helpers on the canonical `matrix-js-sdk` subpath so build and plugin-load entrypoint checks stay consistent. (#68498) Thanks @masatohoshino.
+- Telegram/commands: preserve user-defined `customCommands` priority when the combined native + custom menu exceeds Telegram's 100-command or 5700-char payload cap, so operator commands are no longer silently dropped from `setMyCommands` on startup. Fixes #68333.
 
 ## 2026.4.15
 

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -553,7 +553,11 @@ export const registerTelegramNativeCommands = ({
       return telegramCfg;
     }
   };
+  // User-defined customCommands come first so that Telegram's 100-command and
+  // 5700-char payload caps drop native/plugin entries (from the tail) before
+  // the operator's explicit intent. See openclaw/openclaw#68333.
   const allCommandsFull: Array<{ command: string; description: string }> = [
+    ...customCommands,
     ...nativeCommands
       .map((command) => {
         const normalized = normalizeTelegramCommandName(command.name);
@@ -572,7 +576,6 @@ export const registerTelegramNativeCommands = ({
       })
       .filter((cmd): cmd is { command: string; description: string } => cmd !== null),
     ...(nativeEnabled ? pluginCatalog.commands : []),
-    ...customCommands,
   ];
   const {
     commandsToRegister,

--- a/extensions/telegram/src/bot.command-menu.test.ts
+++ b/extensions/telegram/src/bot.command-menu.test.ts
@@ -116,7 +116,51 @@ describe("createTelegramBot command menu", () => {
       command: normalizeTelegramCommandName(command.name),
       description: command.description,
     }));
-    expect(registered.slice(0, native.length)).toEqual(native);
+    // Custom commands are registered before native ones so budget trimming drops
+    // native/plugin entries from the tail first. See openclaw/openclaw#68333.
+    expect(registered.slice(0, 2)).toEqual([
+      { command: "custom_backup", description: "Git backup" },
+      { command: "custom_generate", description: "Create an image" },
+    ]);
+    expect(registered.slice(2, 2 + native.length)).toEqual(native);
+  });
+
+  it("preserves customCommands when combined list exceeds the text budget", async () => {
+    const longDescription = "A".repeat(250);
+    const customCommandCount = 40;
+    const customCommands = Array.from({ length: customCommandCount }, (_, index) => ({
+      command: `custom_cmd_${index.toString().padStart(2, "0")}`,
+      description: longDescription,
+    }));
+    const config = {
+      commands: { native: true },
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          customCommands,
+        },
+      },
+    } satisfies OpenClawConfig;
+    loadConfig.mockReturnValue(config);
+    const commandsSynced = waitForNextSetMyCommands();
+
+    createTelegramBot({ token: "tok" });
+
+    await commandsSynced;
+
+    const registered = setMyCommandsSpy.mock.calls.at(-1)?.[0] as Array<{
+      command: string;
+      description: string;
+    }>;
+    for (const custom of customCommands) {
+      expect(registered.some((entry) => entry.command === custom.command)).toBe(true);
+    }
   });
 
   it("ignores custom commands that collide with native commands", async () => {


### PR DESCRIPTION
## What & Why

Telegram `customCommands` defined by operators were silently dropped on startup whenever the combined native + plugin + custom command list exceeded Telegram's 100-command or 5700-char `setMyCommands` payload cap. `allCommandsFull` was assembled as `[native, plugin, custom]`, so the existing tail-drop trimmer in `fitTelegramCommandsWithinTextBudget` trimmed operator-defined entries first.

Fix: reorder `allCommandsFull` to `[custom, native, plugin]` in `extensions/telegram/src/bot-native-commands.ts` so the trimmer drops native/plugin entries from the tail before touching operator intent.

Closes #68333.

## AI-assisted PR checklist

- [x] Mark as AI-assisted in the PR title or description — **AI-assisted**
- [x] Note the degree of testing — **fully tested**
- [x] Include prompts or session logs if possible — session was a rigid 9-phase fix workflow (reproduce → root-cause → scoped fix → regression test → full local CI simulation → rebase → ship); no public transcript link available
- [x] Confirm you understand what the code does — yes, verified the tail-drop trimmer behavior in `fitTelegramCommandsWithinTextBudget` and traced the command assembly order in `createTelegramBot`
- [x] If you have access to Codex, run `codex review --base origin/main` locally — Codex not available in this environment; ran the equivalent full local gate (`pnpm check`, `pnpm build`, `pnpm test:extension telegram`) instead
- [x] Resolve or reply to bot review conversations after you address them — will do on review

## Testing

- `pnpm check` (tsgo:all, oxlint across 11727 files, import-cycle guards, format:check) — green
- `pnpm build` — green, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings
- `pnpm test:extension telegram` (91 files, 1298 tests) — all pass
- `pnpm test extensions/telegram/src/bot.command-menu.test.ts --run` — 4/4 pass, including new regression test `preserves customCommands when combined list exceeds the text budget` (40 customs × 250-char descriptions)