### PR TITLE
fix(outbound): pack newline-mode paragraphs up to limit

### DIFF
--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -494,10 +494,10 @@ describe("chunkTextWithMode", () => {
       expected: ["Line one\nLine two"],
     },
     {
-      name: "newline mode (blank-line split)",
+      name: "newline mode packs short blank-line-separated paragraphs",
       text: "Para one\n\nPara two",
       mode: "newline" as const,
-      expected: ["Para one", "Para two"],
+      expected: ["Para one\n\nPara two"],
     },
   ] as const)(
     "applies mode-specific chunking behavior: $name",
@@ -529,10 +529,10 @@ describe("chunkMarkdownTextWithMode", () => {
       expected: ["Line one\nLine two"],
     },
     {
-      name: "newline mode splits by blank line",
+      name: "newline mode packs short blank-line-separated paragraphs",
       text: "Para one\n\nPara two",
       mode: "newline" as const,
-      expected: ["Para one", "Para two"],
+      expected: ["Para one\n\nPara two"],
     },
   ] as const)("applies markdown/newline mode behavior: $name", ({ text, mode, expected, name }) => {
     expectChunkModeCase({
@@ -551,6 +551,13 @@ describe("chunkMarkdownTextWithMode", () => {
       expect(chunkMarkdownTextWithMode(text, limit, "newline"), name).toEqual(expected);
     },
   );
+
+  it("packs multiple paragraphs up to the limit in newline mode", () => {
+    expect(chunkMarkdownTextWithMode("Alpha\n\nBeta\n\nGamma", 14, "newline")).toEqual([
+      "Alpha\n\nBeta",
+      "Gamma",
+    ]);
+  });
 });
 
 describe("resolveChunkMode", () => {

--- a/src/auto-reply/chunk.test.ts
+++ b/src/auto-reply/chunk.test.ts
@@ -153,9 +153,15 @@ const newlineModeFenceCases = (() => {
       expected: [fence],
     },
     {
-      name: "splits between fence and following paragraph",
+      name: "keeps short fenced block and following paragraph together",
       text: `${fence}\n\nAfter`,
       limit: 1000,
+      expected: [`${fence}\n\nAfter`],
+    },
+    {
+      name: "splits oversized fenced block away from following paragraph",
+      text: `${fence}\n\nAfter`,
+      limit: fence.length + 1,
       expected: [fence, "After"],
     },
     {
@@ -523,10 +529,10 @@ describe("chunkTextWithMode", () => {
       expected: ["Line one\nLine two"],
     },
     {
-      name: "newline mode (blank-line split)",
+      name: "newline mode packs short blank-line-separated paragraphs",
       text: "Para one\n\nPara two",
       mode: "newline" as const,
-      expected: ["Para one", "Para two"],
+      expected: ["Para one\n\nPara two"],
     },
   ] as const)(
     "applies mode-specific chunking behavior: $name",
@@ -558,10 +564,10 @@ describe("chunkMarkdownTextWithMode", () => {
       expected: ["Line one\nLine two"],
     },
     {
-      name: "newline mode splits by blank line",
+      name: "newline mode packs short blank-line-separated paragraphs",
       text: "Para one\n\nPara two",
       mode: "newline" as const,
-      expected: ["Para one", "Para two"],
+      expected: ["Para one\n\nPara two"],
     },
   ] as const)("applies markdown/newline mode behavior: $name", ({ text, mode, expected, name }) => {
     expectChunkModeCase({
@@ -580,6 +586,13 @@ describe("chunkMarkdownTextWithMode", () => {
       expect(chunkMarkdownTextWithMode(text, limit, "newline"), name).toEqual(expected);
     },
   );
+
+  it("packs multiple paragraphs up to the limit in newline mode", () => {
+    expect(chunkMarkdownTextWithMode("Alpha\n\nBeta\n\nGamma", 14, "newline")).toEqual([
+      "Alpha\n\nBeta",
+      "Gamma",
+    ]);
+  });
 });
 
 describe("resolveChunkMode", () => {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -214,6 +214,7 @@ export function chunkByParagraph(
   const spans = parseFenceSpans(normalized);
 
   const parts: string[] = [];
+  const separators: string[] = [];
   const re = /\n[\t ]*\n+/g; // paragraph break: blank line(s), allowing whitespace
   let lastIndex = 0;
   for (const match of normalized.matchAll(re)) {
@@ -225,23 +226,49 @@ export function chunkByParagraph(
     }
 
     parts.push(normalized.slice(lastIndex, idx));
+    separators.push(match[0]);
     lastIndex = idx + match[0].length;
   }
   parts.push(normalized.slice(lastIndex));
 
   const chunks: string[] = [];
-  for (const part of parts) {
+  let currentChunk = "";
+
+  const pushParagraph = (paragraph: string, separatorBefore?: string) => {
+    if (!currentChunk) {
+      if (paragraph.length <= limit) {
+        currentChunk = paragraph;
+        return;
+      }
+      if (!splitLongParagraphs) {
+        chunks.push(paragraph);
+        return;
+      }
+      chunks.push(...chunkText(paragraph, limit));
+      return;
+    }
+
+    const candidate = `${currentChunk}${separatorBefore ?? "\n\n"}${paragraph}`;
+    if (candidate.length <= limit) {
+      currentChunk = candidate;
+      return;
+    }
+
+    chunks.push(currentChunk);
+    currentChunk = "";
+    pushParagraph(paragraph);
+  };
+
+  for (const [index, part] of parts.entries()) {
     const paragraph = part.replace(/\s+$/g, "");
     if (!paragraph.trim()) {
       continue;
     }
-    if (paragraph.length <= limit) {
-      chunks.push(paragraph);
-    } else if (!splitLongParagraphs) {
-      chunks.push(paragraph);
-    } else {
-      chunks.push(...chunkText(paragraph, limit));
-    }
+    pushParagraph(paragraph, separators[index - 1]);
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
   }
 
   return chunks;
@@ -263,7 +290,7 @@ export function chunkMarkdownTextWithMode(text: string, limit: number, mode: Chu
     // If a paragraph must be split by length, defer to the markdown-aware chunker.
     const paragraphChunks = chunkByParagraph(text, limit, { splitLongParagraphs: false });
     const out: string[] = [];
-    for (const chunk of paragraphChunks) {
+    for (const chunk of paragraphChunks.flatMap(splitPackedFenceParagraphChunk)) {
       const nested = chunkMarkdownText(chunk, limit);
       if (!nested.length && chunk) {
         out.push(chunk);
@@ -290,6 +317,21 @@ function splitByNewline(
   }
   lines.push(text.slice(start));
   return lines;
+}
+
+function splitPackedFenceParagraphChunk(chunk: string): string[] {
+  for (const span of parseFenceSpans(chunk)) {
+    const separator = chunk.slice(span.end).match(/^\n[\t ]*\n+/)?.[0];
+    if (!separator) {
+      continue;
+    }
+    const tail = chunk.slice(span.end + separator.length);
+    if (!tail.trim()) {
+      continue;
+    }
+    return [chunk.slice(0, span.end), ...splitPackedFenceParagraphChunk(tail)];
+  }
+  return [chunk];
 }
 
 function resolveChunkEarlyReturn(text: string, limit: number): string[] | undefined {

--- a/src/auto-reply/chunk.ts
+++ b/src/auto-reply/chunk.ts
@@ -217,6 +217,7 @@ export function chunkByParagraph(
   const spans = parseFenceSpans(normalized);
 
   const parts: string[] = [];
+  const separators: string[] = [];
   const re = /\n[\t ]*\n+/g; // paragraph break: blank line(s), allowing whitespace
   let lastIndex = 0;
   for (const match of normalized.matchAll(re)) {
@@ -228,23 +229,49 @@ export function chunkByParagraph(
     }
 
     parts.push(normalized.slice(lastIndex, idx));
+    separators.push(match[0]);
     lastIndex = idx + match[0].length;
   }
   parts.push(normalized.slice(lastIndex));
 
   const chunks: string[] = [];
-  for (const part of parts) {
+  let currentChunk = "";
+
+  const pushParagraph = (paragraph: string, separatorBefore?: string) => {
+    if (!currentChunk) {
+      if (paragraph.length <= limit) {
+        currentChunk = paragraph;
+        return;
+      }
+      if (!splitLongParagraphs) {
+        chunks.push(paragraph);
+        return;
+      }
+      chunks.push(...chunkText(paragraph, limit));
+      return;
+    }
+
+    const candidate = `${currentChunk}${separatorBefore ?? "\n\n"}${paragraph}`;
+    if (candidate.length <= limit) {
+      currentChunk = candidate;
+      return;
+    }
+
+    chunks.push(currentChunk);
+    currentChunk = "";
+    pushParagraph(paragraph);
+  };
+
+  for (const [index, part] of parts.entries()) {
     const paragraph = part.replace(/\s+$/g, "");
     if (!paragraph.trim()) {
       continue;
     }
-    if (paragraph.length <= limit) {
-      chunks.push(paragraph);
-    } else if (!splitLongParagraphs) {
-      chunks.push(paragraph);
-    } else {
-      chunks.push(...chunkText(paragraph, limit));
-    }
+    pushParagraph(paragraph, separators[index - 1]);
+  }
+
+  if (currentChunk) {
+    chunks.push(currentChunk);
   }
 
   return chunks;
@@ -266,13 +293,12 @@ export function chunkMarkdownTextWithMode(text: string, limit: number, mode: Chu
     // If a paragraph must be split by length, defer to the markdown-aware chunker.
     const paragraphChunks = chunkByParagraph(text, limit, { splitLongParagraphs: false });
     const out: string[] = [];
-    for (const chunk of paragraphChunks) {
-      const nested = chunkMarkdownText(chunk, limit);
-      if (!nested.length && chunk) {
-        out.push(chunk);
-      } else {
-        out.push(...nested);
-      }
+    for (const chunk of paragraphChunks.flatMap((paragraphChunk) =>
+      paragraphChunk.length > limit
+        ? splitPackedFenceParagraphChunk(paragraphChunk)
+        : paragraphChunk,
+    )) {
+      out.push(...chunkMarkdownText(chunk, limit));
     }
     return out;
   }
@@ -293,6 +319,34 @@ function splitByNewline(
   }
   lines.push(text.slice(start));
   return lines;
+}
+
+function splitPackedFenceParagraphChunk(chunk: string): string[] {
+  const chunks: string[] = [];
+  let start = 0;
+  for (const span of parseFenceSpans(chunk)) {
+    if (span.end <= start) {
+      continue;
+    }
+    const separator = chunk.slice(span.end).match(/^\n[\t ]*\n+/)?.[0];
+    if (!separator) {
+      continue;
+    }
+    const tail = chunk.slice(span.end + separator.length);
+    if (!tail.trim()) {
+      continue;
+    }
+    chunks.push(chunk.slice(start, span.end));
+    start = span.end + separator.length;
+  }
+  if (chunks.length === 0) {
+    return [chunk];
+  }
+  const tail = chunk.slice(start);
+  if (tail) {
+    chunks.push(tail);
+  }
+  return chunks;
 }
 
 function resolveChunkEarlyReturn(text: string, limit: number): string[] | undefined {

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -605,7 +605,7 @@ describe("deliverOutboundPayloads", () => {
     expect(results.map((r) => r.messageId)).toEqual(["w1", "w2"]);
   });
 
-  it("respects newline chunk mode for WhatsApp", async () => {
+  it("respects newline chunk mode for WhatsApp without splitting short messages", async () => {
     const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
     const cfg: OpenClawConfig = {
       channels: { whatsapp: { textChunkLimit: 4000, chunkMode: "newline" } },
@@ -619,17 +619,43 @@ describe("deliverOutboundPayloads", () => {
       deps: { whatsapp: sendWhatsApp },
     });
 
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(sendWhatsApp).toHaveBeenNthCalledWith(
+      1,
+      "+1555",
+      "Line one\n\nLine two",
+      expect.objectContaining({ verbose: false }),
+    );
+  });
+
+  it("splits long WhatsApp text on packed paragraph boundaries in newline mode", async () => {
+    const sendWhatsApp = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "w1", toJid: "jid" })
+      .mockResolvedValueOnce({ messageId: "w2", toJid: "jid" });
+    const cfg: OpenClawConfig = {
+      channels: { whatsapp: { textChunkLimit: 14, chunkMode: "newline" } },
+    };
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "Alpha\n\nBeta\n\nGamma" }],
+      deps: { whatsapp: sendWhatsApp },
+    });
+
     expect(sendWhatsApp).toHaveBeenCalledTimes(2);
     expect(sendWhatsApp).toHaveBeenNthCalledWith(
       1,
       "+1555",
-      "Line one",
+      "Alpha\n\nBeta",
       expect.objectContaining({ verbose: false }),
     );
     expect(sendWhatsApp).toHaveBeenNthCalledWith(
       2,
       "+1555",
-      "Line two",
+      "Gamma",
       expect.objectContaining({ verbose: false }),
     );
   });

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -2233,7 +2233,7 @@ describe("deliverOutboundPayloads", () => {
     expect(results.map((r) => r.messageId)).toEqual(["m1", "m2"]);
   });
 
-  it("respects newline chunk mode for plugin text", async () => {
+  it("respects newline chunk mode for plugin text without splitting short messages", async () => {
     const sendMatrix = vi.fn().mockResolvedValue({ messageId: "m1", roomId: "!room:example" });
     const cfg: OpenClawConfig = {
       channels: {
@@ -2249,14 +2249,40 @@ describe("deliverOutboundPayloads", () => {
       deps: { matrix: sendMatrix },
     });
 
+    expect(sendMatrix).toHaveBeenCalledTimes(1);
+    const firstChunkCall = requireMatrixSendCall(sendMatrix);
+    expect(firstChunkCall?.[0]).toBe("!room:example");
+    expect(firstChunkCall?.[1]).toBe("Line one\n\nLine two");
+    expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
+  });
+
+  it("splits long plugin text on packed paragraph boundaries in newline mode", async () => {
+    const sendMatrix = vi
+      .fn()
+      .mockResolvedValueOnce({ messageId: "m1", roomId: "!room:example" })
+      .mockResolvedValueOnce({ messageId: "m2", roomId: "!room:example" });
+    const cfg: OpenClawConfig = {
+      channels: {
+        matrix: { textChunkLimit: 14, chunkMode: "newline" },
+      } as OpenClawConfig["channels"],
+    };
+
+    await deliverOutboundPayloads({
+      cfg,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "Alpha\n\nBeta\n\nGamma" }],
+      deps: { matrix: sendMatrix },
+    });
+
     expect(sendMatrix).toHaveBeenCalledTimes(2);
     const firstChunkCall = requireMatrixSendCall(sendMatrix);
     expect(firstChunkCall?.[0]).toBe("!room:example");
-    expect(firstChunkCall?.[1]).toBe("Line one");
+    expect(firstChunkCall?.[1]).toBe("Alpha\n\nBeta");
     expect((firstChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
     const secondChunkCall = sendMatrix.mock.calls[1];
     expect(secondChunkCall?.[0]).toBe("!room:example");
-    expect(secondChunkCall?.[1]).toBe("Line two");
+    expect(secondChunkCall?.[1]).toBe("Gamma");
     expect((secondChunkCall?.[2] as { cfg?: unknown } | undefined)?.cfg).toBe(cfg);
   });
 


### PR DESCRIPTION
## Summary

- Problem: newline chunk mode split every blank-line-separated paragraph into its own outbound message, even when multiple paragraphs still fit under the limit.
- Why it matters: short messages were over-split, and longer messages underused the available chunk budget.
- What changed: pack adjacent paragraphs up to the limit in newline mode, preserve the markdown fence split guardrail, and update chunking plus delivery regressions.
- What did NOT change (scope boundary): this does not change line mode, general length chunking, transport APIs, or wider streaming/coalescing behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #42667
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `chunkByParagraph()` parsed safe paragraph boundaries, then emitted each paragraph directly instead of packing adjacent paragraphs until the configured limit.
- Missing detection / guardrail: current tests encoded the over-splitting behavior for both chunk helpers and outbound delivery.
- Contributing context: the old PR was stale, but the bug still reproduced on current `origin/main` (`3cfbc9e234`) on May 13, 2026.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/chunk.test.ts`, `src/infra/outbound/message-plan.test.ts`, `src/infra/outbound/deliver.test.ts`
- Scenario the test should lock in: short blank-line-separated newline-mode messages stay intact; longer newline-mode messages pack paragraphs up to the limit; fenced markdown still splits safely away from a following paragraph.
- Why this is the smallest reliable guardrail: the bug lives in shared chunking logic, and delivery-level assertions prove the user-visible outbound behavior.
- Existing test that already covers this (if any): None; existing delivery expectations asserted the wrong split.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

- Short newline-mode messages with blank-line-separated paragraphs stay in one outbound message when they fit.
- Longer newline-mode messages now pack multiple paragraphs into each chunk up to the configured limit.

## Diagram (if applicable)

```text
Before:
[Para 1]\n\n[Para 2] -> [send Para 1] + [send Para 2]

After:
[Para 1]\n\n[Para 2] -> [send combined chunk when <= limit]
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: NixOS Linux
- Runtime/container: Node.js v22.21.1, pnpm 11.1.0, OpenClaw package 2026.5.12-beta.1
- Base: `origin/main` at `3cfbc9e234`
- Head: `fix/whatsapp-newline-chunk-replacement` at `57629afbe5`
- Model/provider: N/A
- Integration/channel: outbound newline chunking through plugin delivery tests
- Relevant config: `channels.matrix.textChunkLimit`, `channels.matrix.chunkMode = "newline"`; same shared chunker path applies to WhatsApp newline mode

### Steps

1. On current `origin/main`, assert `chunkTextWithMode("Para one\n\nPara two", 1000, "newline")` should return one packed chunk.
2. On current `origin/main`, assert plugin delivery with `chunkMode: "newline"`, limit `4000`, and `Line one\n\nLine two` should send one outbound message.
3. Apply this patch and rerun the focused chunking and outbound delivery tests.

### Expected

- Short blank-line-separated text stays whole.
- Longer text sends packed paragraph chunks up to the configured limit.
- Fenced markdown still splits away from a following paragraph.

### Actual

- Before this change, current `main` returned `['Para one', 'Para two']` and sent two outbound messages for `Line one\n\nLine two`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Terminal output
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the current newline-mode packing bug on `origin/main`; rebased the PR onto current `main`; ran focused chunking/message-plan/delivery tests after the fix.
- Edge cases checked: fenced markdown still splits away from a following paragraph instead of staying packed into one chunk.
- What you did **not** verify: live WhatsApp transport against a real WhatsApp account; this patch is verified through the shared chunker and outbound delivery seam.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: packing paragraphs could accidentally suppress a required markdown split.
  - Mitigation: `splitPackedFenceParagraphChunk()` preserves the existing fence-boundary behavior, and tests lock that in.

## AI Assistance

- AI was used to reproduce the current bug on `main`, rebase/adapt the stale PR, implement the fix, run targeted tests, and draft this PR body.

## Real behavior proof

- **Behavior or issue addressed**: Newline-mode outbound chunking should pack adjacent blank-line-separated paragraphs into one message while the packed chunk remains under the configured limit, instead of sending one message per paragraph.
- **Real environment tested**: Local OpenClaw checkout on NixOS Linux; Node.js v22.21.1; pnpm 11.1.0; OpenClaw package version 2026.5.12-beta.1; base `origin/main` at `3cfbc9e234`; branch `fix/whatsapp-newline-chunk-replacement` at `57629afbe5`. This used the actual OpenClaw repo test runner and source tree.
- **Exact steps or command run after this patch**:

```bash
pnpm test src/auto-reply/chunk.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/deliver.test.ts
pnpm check:changed
pnpm exec oxfmt --check --threads=1 src/auto-reply/chunk.ts src/auto-reply/chunk.test.ts src/infra/outbound/deliver.test.ts
timeout -k5s 300s codex review --base origin/main
```

- **Evidence after fix**: Terminal capture from the local OpenClaw checkout:

```text
$ pnpm test src/auto-reply/chunk.test.ts src/infra/outbound/message-plan.test.ts src/infra/outbound/deliver.test.ts
[test] starting test/vitest/vitest.unit-fast.config.ts
Test Files  1 passed (1)
Tests  4 passed (4)
[test] starting test/vitest/vitest.infra.config.ts
Test Files  1 passed (1)
Tests  82 passed (82)
[test] starting test/vitest/vitest.auto-reply.config.ts
Test Files  1 passed (1)
Tests  57 passed (57)
[test] passed 3 Vitest shards in 17.00s

$ pnpm check:changed
[check:changed] lanes=core, coreTests, docs
Found 0 warnings and 0 errors.
Import cycle check: 0 runtime value cycle(s).
[check:changed] completed successfully

$ pnpm exec oxfmt --check --threads=1 src/auto-reply/chunk.ts src/auto-reply/chunk.test.ts src/infra/outbound/deliver.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 32ms on 3 files using 1 threads.

$ timeout -k5s 300s codex review --base origin/main
The changes consistently update newline-mode chunking to pack short paragraphs while preserving fence-aware markdown behavior, with focused tests covering the adjusted behavior. I did not find a discrete regression introduced by this diff.
```

- **Observed result after fix**: `Para one\n\nPara two` stays in one newline-mode chunk when under limit; `Alpha\n\nBeta\n\nGamma` with limit `14` sends `Alpha\n\nBeta` then `Gamma`; delivery sends one plugin message for short two-paragraph text under the limit.
- **What was not tested**: Live WhatsApp transport was not exercised; the verified path is the shared newline chunker and outbound delivery seam used by channel delivery.