### PR TITLE
Telegram: unskip sticker e2e tests

### DIFF
--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -239,12 +239,18 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
   })),
 }));
 
-vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
-  findModelInCatalog: vi.fn(() => undefined),
-  loadModelCatalog: vi.fn(async () => []),
-  modelSupportsVision: vi.fn(() => false),
-  resolveDefaultModelForAgent: vi.fn(() => ({
-    provider: "openai",
-    model: "gpt-test",
-  })),
-}));
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
+    "openclaw/plugin-sdk/agent-runtime",
+  );
+  return {
+    ...actual,
+    findModelInCatalog: vi.fn(() => undefined),
+    loadModelCatalog: vi.fn(async () => []),
+    modelSupportsVision: vi.fn(() => false),
+    resolveDefaultModelForAgent: vi.fn(() => ({
+      provider: "openai",
+      model: "gpt-test",
+    })),
+  };
+});

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -238,3 +238,13 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
     model: "gpt-test",
   })),
 }));
+
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  findModelInCatalog: vi.fn(() => undefined),
+  loadModelCatalog: vi.fn(async () => []),
+  modelSupportsVision: vi.fn(() => false),
+  resolveDefaultModelForAgent: vi.fn(() => ({
+    provider: "openai",
+    model: "gpt-test",
+  })),
+}));

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -253,3 +253,13 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
     model: "gpt-test",
   })),
 }));
+
+vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
+  findModelInCatalog: vi.fn(() => undefined),
+  loadModelCatalog: vi.fn(async () => []),
+  modelSupportsVision: vi.fn(() => false),
+  resolveDefaultModelForAgent: vi.fn(() => ({
+    provider: "openai",
+    model: "gpt-test",
+  })),
+}));

--- a/extensions/telegram/src/bot.media.e2e-harness.ts
+++ b/extensions/telegram/src/bot.media.e2e-harness.ts
@@ -254,12 +254,18 @@ vi.mock("./bot-message-dispatch.agent.runtime.js", () => ({
   })),
 }));
 
-vi.mock("openclaw/plugin-sdk/agent-runtime", () => ({
-  findModelInCatalog: vi.fn(() => undefined),
-  loadModelCatalog: vi.fn(async () => []),
-  modelSupportsVision: vi.fn(() => false),
-  resolveDefaultModelForAgent: vi.fn(() => ({
-    provider: "openai",
-    model: "gpt-test",
-  })),
-}));
+vi.mock("openclaw/plugin-sdk/agent-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/agent-runtime")>(
+    "openclaw/plugin-sdk/agent-runtime",
+  );
+  return {
+    ...actual,
+    findModelInCatalog: vi.fn(() => undefined),
+    loadModelCatalog: vi.fn(async () => []),
+    modelSupportsVision: vi.fn(() => false),
+    resolveDefaultModelForAgent: vi.fn(() => ({
+      provider: "openai",
+      model: "gpt-test",
+    })),
+  };
+});

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -33,7 +33,7 @@ describe("telegram stickers", () => {
   });
 
   // Skipped pending #50185: deterministic static sticker fetch injection.
-  it.skip(
+  it(
     "downloads static sticker (WEBP) and includes sticker metadata",
     async () => {
       const { handler, proxyFetch, replySpy, runtimeError } = await createStaticStickerHarness();
@@ -76,7 +76,7 @@ describe("telegram stickers", () => {
   );
 
   // Skipped pending #50185: deterministic cache-refresh assertions in CI.
-  it.skip(
+  it(
     "refreshes cached sticker metadata on cache hit",
     async () => {
       const { handler, proxyFetch, replySpy, runtimeError } = await createStaticStickerHarness();

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -32,7 +32,6 @@ describe("telegram stickers", () => {
     describeStickerImageSpy.mockReturnValue(undefined);
   });
 
-  // Skipped pending #50185: deterministic static sticker fetch injection.
   it(
     "downloads static sticker (WEBP) and includes sticker metadata",
     async () => {
@@ -75,7 +74,6 @@ describe("telegram stickers", () => {
     STICKER_TEST_TIMEOUT_MS,
   );
 
-  // Skipped pending #50185: deterministic cache-refresh assertions in CI.
   it(
     "refreshes cached sticker metadata on cache hit",
     async () => {

--- a/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts
@@ -66,6 +66,49 @@ describe("telegram stickers", () => {
   });
 
   it(
+    "downloads static sticker (WEBP) and includes sticker metadata",
+    async () => {
+      const { handler, proxyFetch, replySpy, runtimeError } = await createStaticStickerHarness();
+
+      await handler({
+        message: {
+          message_id: 100,
+          chat: { id: 1234, type: "private" },
+          from: { id: 777, is_bot: false, first_name: "Ada" },
+          sticker: {
+            file_id: "sticker_file_id_123",
+            file_unique_id: "sticker_unique_123",
+            type: "regular",
+            width: 512,
+            height: 512,
+            is_animated: false,
+            is_video: false,
+            emoji: "🎉",
+            set_name: "TestStickerPack",
+          },
+          date: 1736380800,
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "stickers/sticker.webp" }),
+      });
+
+      expect(runtimeError).not.toHaveBeenCalled();
+      expect(proxyFetch).toHaveBeenCalledWith(
+        "https://api.telegram.org/file/bottok/stickers/sticker.webp",
+        expect.objectContaining({ redirect: "manual" }),
+      );
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0][0];
+      expect(payload.Body).toContain("<media:sticker>");
+      expect(payload.Sticker?.emoji).toBe("🎉");
+      expect(payload.Sticker?.setName).toBe("TestStickerPack");
+      expect(payload.Sticker?.fileId).toBe("sticker_file_id_123");
+    },
+    STICKER_TEST_TIMEOUT_MS,
+  );
+
+
+  it(
     "refreshes cached sticker metadata on cache hit",
     async () => {
       const proxyFetch = vi.fn().mockResolvedValue(


### PR DESCRIPTION
## Summary

- unskip the two quarantined Telegram sticker e2e tests tracked in #50185
- mock `openclaw/plugin-sdk/agent-runtime` in the Telegram media e2e harness so sticker-only flows stay deterministic in CI
- keep the existing assertions for sticker payload metadata and cache refresh behavior intact

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #50185

## User-visible / Behavior Changes

- No user-facing behavior changes.
- Restores CI coverage for Telegram static sticker downloads and cache-hit metadata refresh.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22.22.2, pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram extension tests
- Relevant config (redacted): Test harness defaults only

### Steps

1. `npx -y node@22 ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts --reporter=verbose --testTimeout=30000 --hookTimeout=30000`
2. `npx -y node@22 ./node_modules/vitest/vitest.mjs run --config test/vitest/vitest.e2e.config.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts -t "prefers proxyFetch over global fetch|handles file_path media downloads and missing file_path safely" --reporter=verbose --testTimeout=30000 --hookTimeout=30000`
3. Commit hook verification during `git commit`:
   - `pnpm check`
   - repo lint / import-cycle checks

### Expected

- The two sticker tests tracked in #50185 are enabled and pass deterministically.
- Related Telegram media harness tests continue to pass.

### Actual

- Both sticker tests now run and pass locally.
- The touched Telegram media checks also pass after the harness mock is added.
- `pnpm check` and the commit-time repo checks passed.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
- Before: the unskipped sticker tests stalled in the sticker-only path because `openclaw/plugin-sdk/agent-runtime` was not mocked by the Telegram media e2e harness.
- After: the harness now mocks that runtime module, and the full sticker e2e file passes with both tests enabled.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `downloads static sticker (WEBP) and includes sticker metadata`
  - `refreshes cached sticker metadata on cache hit`
  - full `bot.media.stickers-and-fragments.e2e.test.ts` file
  - targeted regression checks in `bot.media.downloads-media-file-path-no-file-download.e2e.test.ts`
  - `pnpm check` + repo lint/import-cycle checks via commit hook
- Edge cases checked:
  - animated/video sticker skip path still passes in the full sticker suite
- What you did **not** verify:
  - full Linux + Windows CI lanes yet

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `e228c8df`.
- Files/config to restore: `extensions/telegram/src/bot.media.e2e-harness.ts`, `extensions/telegram/src/bot.media.stickers-and-fragments.e2e.test.ts`
- Known bad symptoms reviewers should watch for:
  - sticker e2e tests hanging again on the sticker-only path
  - regressions in Telegram media e2e harness mocking

## Risks and Mitigations

- Risk: the added agent-runtime mock could hide future sticker-vision integration regressions in this specific e2e harness.
  - Mitigation: the mock only applies to the Telegram media e2e harness, and the tests here are specifically asserting deterministic non-vision sticker behavior.
