### PR TITLE
fix(ui): clean synthetic session selector labels

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -220,6 +220,30 @@ describe("resolveSessionDisplayName", () => {
     ).toBe("Discord Session");
   });
 
+  it("ignores synthetic transport display names for main agent sessions", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:control-tower:main",
+        row({
+          key: "agent:control-tower:main",
+          displayName: "webchat:g-agent-control-tower-main",
+        }),
+      ),
+    ).toBe("Main Session");
+  });
+
+  it("ignores synthetic transport display names for subagent sessions", () => {
+    expect(
+      resolveSessionDisplayName(
+        "agent:control-tower:subagent:abc-123",
+        row({
+          key: "agent:control-tower:subagent:abc-123",
+          displayName: "webchat:g-agent-control-tower-subagent-abc-123",
+        }),
+      ),
+    ).toBe("Subagent:");
+  });
+
   it("trims label and displayName", () => {
     expect(resolveSessionDisplayName("k", row({ key: "k", label: "  General  " }))).toBe("General");
     expect(resolveSessionDisplayName("k", row({ key: "k", displayName: "  My Chat  " }))).toBe(

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -818,15 +818,24 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+function isSyntheticTransportSessionName(value: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(value);
+  if (!normalized) {
+    return false;
+  }
+  return /^[a-z0-9_-]+:g-agent-[a-z0-9_-]+-(main|subagent-.+)$/.test(normalized);
+}
+
 /**
  * Parse a session key to extract type information and a human-readable
  * fallback display name.  Exported for testing.
  */
 export function parseSessionKey(key: string): SessionKeyInfo {
   const normalized = normalizeLowercaseStringOrEmpty(key);
+  const parsedAgentKey = parseAgentSessionKey(key);
 
   // ── Main session ─────────────────────────────────
-  if (key === "main" || key === "agent:main:main") {
+  if (key === "main" || key === "agent:main:main" || parsedAgentKey?.rest === "main") {
     return { prefix: "", fallbackName: "Main Session" };
   }
 
@@ -874,6 +883,8 @@ export function resolveSessionDisplayName(
 ): string {
   const label = normalizeOptionalString(row?.label) ?? "";
   const displayName = normalizeOptionalString(row?.displayName) ?? "";
+  const visibleLabel = isSyntheticTransportSessionName(label) ? "" : label;
+  const visibleDisplayName = isSyntheticTransportSessionName(displayName) ? "" : displayName;
   const { prefix, fallbackName } = parseSessionKey(key);
 
   const applyTypedPrefix = (name: string): string => {
@@ -884,11 +895,11 @@ export function resolveSessionDisplayName(
     return prefixPattern.test(name) ? name : `${prefix} ${name}`;
   };
 
-  if (label && label !== key) {
-    return applyTypedPrefix(label);
+  if (visibleLabel && visibleLabel !== key) {
+    return applyTypedPrefix(visibleLabel);
   }
-  if (displayName && displayName !== key) {
-    return applyTypedPrefix(displayName);
+  if (visibleDisplayName && visibleDisplayName !== key) {
+    return applyTypedPrefix(visibleDisplayName);
   }
   return fallbackName;
 }
@@ -1097,7 +1108,12 @@ function resolveSessionScopedOptionLabel(
 
   const label = normalizeOptionalString(row.label) ?? "";
   const displayName = normalizeOptionalString(row.displayName) ?? "";
-  if ((label && label !== key) || (displayName && displayName !== key)) {
+  const visibleLabel = isSyntheticTransportSessionName(label) ? "" : label;
+  const visibleDisplayName = isSyntheticTransportSessionName(displayName) ? "" : displayName;
+  if (
+    (visibleLabel && visibleLabel !== key) ||
+    (visibleDisplayName && visibleDisplayName !== key)
+  ) {
     return resolveSessionDisplayName(key, row);
   }
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1324,6 +1324,47 @@ describe("chat view", () => {
     expect(labels).not.toContain("Subagent:");
   });
 
+  it("hides synthetic transport display names in selector fallbacks", () => {
+    const { state } = createChatHeaderState({ omitSessionFromList: true });
+    state.sessionKey = "agent:control-tower:main";
+    state.settings.sessionKey = state.sessionKey;
+    state.sessionsResult = {
+      ts: 0,
+      path: "",
+      count: 2,
+      defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+      sessions: [
+        {
+          key: "agent:control-tower:main",
+          kind: "direct",
+          updatedAt: null,
+          displayName: "webchat:g-agent-control-tower-main",
+        },
+        {
+          key: "agent:control-tower:subagent:4f2146de-887b-4176-9abe-91140082959b",
+          kind: "direct",
+          updatedAt: null,
+          displayName:
+            "webchat:g-agent-control-tower-subagent-4f2146de-887b-4176-9abe-91140082959b",
+        },
+      ],
+    };
+    const container = document.createElement("div");
+    render(renderChatSessionSelect(state), container);
+
+    const [sessionSelect] = Array.from(container.querySelectorAll<HTMLSelectElement>("select"));
+    const labels = Array.from(sessionSelect?.querySelectorAll("option") ?? []).map((option) =>
+      option.textContent?.trim(),
+    );
+
+    expect(labels).toContain("main");
+    expect(labels).toContain("subagent:4f2146de-887b-4176-9abe-91140082959b");
+    expect(labels).not.toContain("webchat:g-agent-control-tower-main");
+    expect(labels).not.toContain(
+      "webchat:g-agent-control-tower-subagent-4f2146de-887b-4176-9abe-91140082959b",
+    );
+  });
+
   it("keeps a unique scoped fallback when a grouped session row has no label or displayName", () => {
     const { state } = createChatHeaderState({ omitSessionFromList: true });
     state.sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";


### PR DESCRIPTION
## Summary
- ignore synthetic transport names like `webchat:g-agent-...` when resolving visible session labels
- preserve existing human labels and fall back cleanly to `main` / `subagent:<id>`
- keep this change visual-only, without changing session selection, storage, reconnect, or runtime semantics

## Testing
- corepack pnpm test ui/src/ui/app-render.helpers.node.test.ts
- corepack pnpm test ui/src/ui/views/chat.test.ts
- node run-ui-build.cjs