### PR TITLE
fix(security): allow quoted heredocs in allowlist mode without extra approval

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -399,7 +399,7 @@ describe("processGatewayAllowlist", () => {
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: true,
-      segments: [{ resolution: null, argv: ["cat", "<<'EOF'"] }],
+      segments: [{ resolution: null, raw: "cat <<'EOF'", argv: ["cat", "<<'EOF'"] }],
       segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
     });
 
@@ -430,7 +430,7 @@ describe("processGatewayAllowlist", () => {
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: true,
-      segments: [{ resolution: null, argv: ["cat", "<<EOF"] }],
+      segments: [{ resolution: null, raw: "cat <<EOF", argv: ["cat", "<<EOF"] }],
       segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
     });
 
@@ -463,7 +463,7 @@ describe("processGatewayAllowlist", () => {
       allowlistMatches: [],
       analysisOk: true,
       allowlistSatisfied: true,
-      segments: [{ resolution: null, argv: ["cat", "<<\\EOF"] }],
+      segments: [{ resolution: null, raw: "cat <<\\EOF", argv: ["cat", "\\EOF"] }],
       segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
     });
 

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -393,4 +393,99 @@ describe("processGatewayAllowlist", () => {
     });
     expect(runExecProcessMock).not.toHaveBeenCalled();
   });
+
+  it("auto-approves quoted heredocs in allowlist mode when binary is in allowlist", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: true,
+      segments: [{ resolution: null, argv: ["cat", "<<'EOF'"] }],
+      segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
+    });
+
+    const result = await processGatewayAllowlist({
+      command: "cat <<'EOF'\nhello\nEOF",
+      workdir: process.cwd(),
+      env: process.env as Record<string, string>,
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "allowlist",
+      ask: "off",
+      safeBins: new Set(),
+      safeBinProfiles: {},
+      warnings: [],
+      approvalRunningNoticeMs: 0,
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+    });
+
+    // Quoted heredoc should NOT trigger extra approval
+    expect(result.pendingResult).toBeUndefined();
+    expect(warnings).toEqual([]);
+    expect(runExecProcessMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still requires approval for unquoted heredocs in allowlist mode", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: true,
+      segments: [{ resolution: null, argv: ["cat", "<<EOF"] }],
+      segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
+    });
+
+    const result = await processGatewayAllowlist({
+      command: "cat <<EOF\n$HOME\nEOF",
+      workdir: process.cwd(),
+      env: process.env as Record<string, string>,
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "allowlist",
+      ask: "off",
+      safeBins: new Set(),
+      safeBinProfiles: {},
+      warnings: [],
+      approvalRunningNoticeMs: 0,
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+    });
+
+    // Unquoted heredoc should still require approval
+    expect(result.pendingResult?.details.status).toBe("approval-pending");
+    expect(warnings).toContain(
+      "Warning: unquoted heredoc may expand $()/` commands; explicit approval required in allowlist mode.",
+    );
+    expect(runExecProcessMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-approves backslash-quoted heredocs in allowlist mode", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: true,
+      allowlistSatisfied: true,
+      segments: [{ resolution: null, argv: ["cat", "<<\\EOF"] }],
+      segmentAllowlistEntries: [{ pattern: "/usr/bin/cat", source: "allow-always" }],
+    });
+
+    const result = await processGatewayAllowlist({
+      command: "cat <<\\EOF\nhello\nEOF",
+      workdir: process.cwd(),
+      env: process.env as Record<string, string>,
+      pty: false,
+      defaultTimeoutSec: 30,
+      security: "allowlist",
+      ask: "off",
+      safeBins: new Set(),
+      safeBinProfiles: {},
+      warnings: [],
+      approvalRunningNoticeMs: 0,
+      maxOutput: 1000,
+      pendingMaxOutput: 1000,
+    });
+
+    // Backslash-quoted heredoc should NOT trigger extra approval
+    expect(result.pendingResult).toBeUndefined();
+    expect(warnings).toEqual([]);
+    expect(runExecProcessMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -161,11 +161,11 @@ export async function processGatewayAllowlist(
   const hasUnquotedHeredocSegment = allowlistEval.segments.some((segment) =>
     segment.argv.some((token) => {
       if (!token.startsWith("<<")) return false;
-      // Quoted heredocs (<<'EOF', <<"EOF", <<-'EOF', <<-"EOF") are safe:
+      // Quoted heredocs (<<'EOF', <<"EOF", <<-'EOF', <<-"EOF", <<\EOF) are safe:
       // no variable/command expansion, just literal stdin content.
       // Only unquoted heredocs need extra approval since $() and `cmd`
       // inside the body get evaluated by the shell.
-      return !/^-?\s*['"]/.test(token.slice(2));
+      return !/^-?\s*['"\\]/.test(token.slice(2));
     }),
   );
   const requiresHeredocApproval =

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -158,11 +158,18 @@ export async function processGatewayAllowlist(
       command: params.command,
       resolvedPath,
     });
-  const hasHeredocSegment = allowlistEval.segments.some((segment) =>
-    segment.argv.some((token) => token.startsWith("<<")),
+  const hasUnquotedHeredocSegment = allowlistEval.segments.some((segment) =>
+    segment.argv.some((token) => {
+      if (!token.startsWith("<<")) return false;
+      // Quoted heredocs (<<'EOF', <<"EOF", <<-'EOF', <<-"EOF") are safe:
+      // no variable/command expansion, just literal stdin content.
+      // Only unquoted heredocs need extra approval since $() and `cmd`
+      // inside the body get evaluated by the shell.
+      return !/^-?\s*['"]/.test(token.slice(2));
+    }),
   );
   const requiresHeredocApproval =
-    hostSecurity === "allowlist" && analysisOk && allowlistSatisfied && hasHeredocSegment;
+    hostSecurity === "allowlist" && analysisOk && allowlistSatisfied && hasUnquotedHeredocSegment;
   const requiresInlineEvalApproval = inlineEvalHit !== null;
   const requiresAllowlistPlanApproval =
     hostSecurity === "allowlist" &&
@@ -183,7 +190,7 @@ export async function processGatewayAllowlist(
     requiresInlineEvalApproval;
   if (requiresHeredocApproval) {
     params.warnings.push(
-      "Warning: heredoc execution requires explicit approval in allowlist mode.",
+      "Warning: unquoted heredoc may expand $()/` commands; explicit approval required in allowlist mode.",
     );
   }
   if (requiresAllowlistPlanApproval) {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -158,15 +158,11 @@ export async function processGatewayAllowlist(
       command: params.command,
       resolvedPath,
     });
+  // Check raw segment text (not normalized argv) so quote characters
+  // are still present: splitShellArgs strips '"/\ before argv is built,
+  // making a post-hoc argv quote check unreliable.
   const hasUnquotedHeredocSegment = allowlistEval.segments.some((segment) =>
-    segment.argv.some((token) => {
-      if (!token.startsWith("<<")) return false;
-      // Quoted heredocs (<<'EOF', <<"EOF", <<-'EOF', <<-"EOF", <<\EOF) are safe:
-      // no variable/command expansion, just literal stdin content.
-      // Only unquoted heredocs need extra approval since $() and `cmd`
-      // inside the body get evaluated by the shell.
-      return !/^-?\s*['"\\]/.test(token.slice(2));
-    }),
+    /<<\s*(?!['"\\])(?:[a-zA-Z_]\w*)/.test(segment.raw),
   );
   const requiresHeredocApproval =
     hostSecurity === "allowlist" && analysisOk && allowlistSatisfied && hasUnquotedHeredocSegment;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -467,7 +467,7 @@ describe("handleToolExecutionEnd exec approval prompts", () => {
             host: "gateway",
             command: "npm view diver name version description",
             cwd: "/tmp/work",
-            warningText: "Warning: heredoc execution requires explicit approval in allowlist mode.",
+            warningText: "Warning: unquoted heredoc may expand $()/` commands; explicit approval required in allowlist mode.",
           },
         },
       } as never,


### PR DESCRIPTION
## Summary

Fixes #68661

Commands with `<<` heredoc syntax trigger an approval prompt in allowlist mode even when the target binary is in the allowlist. This regressed from the original fix (#13811) after a security hardening (f23da067).

## Root Cause

The hardening commit added `requiresHeredocApproval` that triggers for **any** heredoc token (`token.startsWith("<<")`), without distinguishing between safe (quoted) and potentially unsafe (unquoted) heredocs.

## Fix

- **Quoted heredocs** (`<<'EOF'`, `<<"EOF"`, `<<-'EOF'`, `<<-"EOF"`): No longer require extra approval. The shell treats the body as literal text — no variable expansion, no command substitution.
- **Unquoted heredocs** (`<<EOF`, `<<-EOF`): Still require explicit approval. `$()` and backtick commands inside the body get evaluated by the shell, which is a real security concern.

## Examples

| Command | Before | After |
|---------|--------|-------|
| `cat <<'EOF'\nhello\nEOF` | ❌ Approval required | ✅ Auto-approved (binary in allowlist + quoted heredoc) |
| `cat <<EOF\n\$HOME\nEOF` | ❌ Approval required | ❌ Approval required (unquoted = expansion) |
| `echo hello` | ✅ Auto-approved | ✅ Auto-approved (no change) |

## Testing

- Updated warning message test to match new wording
- Existing ReDoS guard test still passes (uses quoted heredoc)