### PR TITLE
feat: add gateway.nodes.invokeTimeoutMs config option

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -375,6 +375,8 @@ export type GatewayNodesConfig = {
   allowCommands?: string[];
   /** Commands to deny even if they appear in the defaults or node claims. */
   denyCommands?: string[];
+  /** Default timeout in milliseconds for node.invoke calls when no per-call timeout is specified (default: 30000). */
+  invokeTimeoutMs?: number;
 };
 
 export type GatewayToolsConfig = {

--- a/src/gateway/node-registry.ts
+++ b/src/gateway/node-registry.ts
@@ -41,6 +41,7 @@ export class NodeRegistry {
   private nodesById = new Map<string, NodeSession>();
   private nodesByConn = new Map<string, string>();
   private pendingInvokes = new Map<string, PendingInvoke>();
+  defaultInvokeTimeoutMs = 30_000;
 
   register(client: GatewayWsClient, opts: { remoteIp?: string | undefined }) {
     const connect = client.connect;
@@ -139,7 +140,8 @@ export class NodeRegistry {
         error: { code: "UNAVAILABLE", message: "failed to send invoke to node" },
       };
     }
-    const timeoutMs = typeof params.timeoutMs === "number" ? params.timeoutMs : 30_000;
+    const timeoutMs =
+      typeof params.timeoutMs === "number" ? params.timeoutMs : this.defaultInvokeTimeoutMs;
     return await new Promise<NodeInvokeResult>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.pendingInvokes.delete(requestId);

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -485,6 +485,9 @@ export async function startGatewayServer(
     broadcastVoiceWakeChanged,
     hasMobileNodeConnected,
   } = createGatewayNodeSessionRuntime({ broadcast });
+  if (typeof cfgAtStart.gateway?.nodes?.invokeTimeoutMs === "number") {
+    nodeRegistry.defaultInvokeTimeoutMs = cfgAtStart.gateway.nodes.invokeTimeoutMs;
+  }
   applyGatewayLaneConcurrency(cfgAtStart);
 
   runtimeState = createGatewayServerLiveState({


### PR DESCRIPTION
Fixes #68090

## Summary

The `node.invoke` timeout was hardcoded to 30 seconds with no way to configure it. Users running long operations through node commands had to accept the fixed timeout.

## Changes

1. **`src/config/types.gateway.ts`** — Added `invokeTimeoutMs?: number` to `GatewayNodesConfig`
2. **`src/gateway/node-registry.ts`** — Added `defaultInvokeTimeoutMs` property (default 30000), used as fallback when no per-call timeout is specified
3. **`src/gateway/server.impl.ts`** — Wires `gateway.nodes.invokeTimeoutMs` config to the node registry at startup

## Usage

```json
{
  "gateway": {
    "nodes": {
      "invokeTimeoutMs": 60000
    }
  }
}
```

## Test Plan

- Without config: verify default 30s timeout behavior is unchanged
- With `gateway.nodes.invokeTimeoutMs: 60000`: verify node.invoke uses 60s timeout
- With per-call `timeoutMs`: verify per-call value takes precedence over config default