### PR TITLE
Agents: emit turn events from embedded sessions

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -14,6 +14,7 @@ import {
   handleToolExecutionStart,
   handleToolExecutionUpdate,
 } from "./pi-embedded-subscribe.handlers.tools.js";
+import { handleTurnEnd, handleTurnStart } from "./pi-embedded-subscribe.handlers.turn.js";
 import type {
   EmbeddedPiSubscribeContext,
   EmbeddedPiSubscribeEvent,
@@ -46,6 +47,12 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         handleToolExecutionEnd(ctx, evt as never).catch((err) => {
           ctx.log.debug(`tool_execution_end handler failed: ${String(err)}`);
         });
+        return;
+      case "turn_start":
+        handleTurnStart(ctx);
+        return;
+      case "turn_end":
+        handleTurnEnd(ctx, evt as never);
         return;
       case "agent_start":
         handleAgentStart(ctx);

--- a/src/agents/pi-embedded-subscribe.handlers.turn.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.turn.ts
@@ -1,0 +1,31 @@
+import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+
+export function handleTurnStart(ctx: EmbeddedPiSubscribeContext) {
+  emitAgentEvent({
+    runId: ctx.params.runId,
+    stream: "turn",
+    data: { phase: "start" },
+  });
+  void ctx.params.onAgentEvent?.({
+    stream: "turn",
+    data: { phase: "start" },
+  });
+}
+
+export function handleTurnEnd(
+  ctx: EmbeddedPiSubscribeContext,
+  evt: AgentEvent & { toolResults?: unknown },
+) {
+  const toolResultsCount = Array.isArray(evt.toolResults) ? evt.toolResults.length : 0;
+  emitAgentEvent({
+    runId: ctx.params.runId,
+    stream: "turn",
+    data: { phase: "end", toolResultsCount },
+  });
+  void ctx.params.onAgentEvent?.({
+    stream: "turn",
+    data: { phase: "end", toolResultsCount },
+  });
+}

--- a/src/agents/pi-embedded-subscribe.handlers.turn.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.turn.ts
@@ -22,6 +22,8 @@ export function handleTurnEnd(
   emitAgentEvent({
     runId: ctx.params.runId,
     stream: "turn",
+    data: { phase: "end", toolResultsCount, endedAt: Date.now() },
+  });
     data: { phase: "end", toolResultsCount },
   });
   void ctx.params.onAgentEvent?.({

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
+import { onAgentEvent } from "../infra/agent-events.js";
 import {
   THINKING_TAG_CASES,
   createStubSessionHarness,
@@ -291,6 +292,71 @@ describe("subscribeEmbeddedPiSession", () => {
     });
     emitMessageStartAndEndForAssistantText({ emit, text: "Hello world" });
     expectSingleAgentEventText(onAgentEvent.mock.calls, "Hello world");
+  });
+
+  it("emits turn events through the onAgentEvent callback", () => {
+    const { emit, onAgentEvent } = createAgentEventHarness();
+
+    emit({ type: "turn_start" });
+    emit({
+      type: "turn_end",
+      toolResults: [{ toolCallId: "tool-1" }],
+    });
+
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "turn",
+      data: {
+        phase: "start",
+      },
+    });
+    expect(onAgentEvent).toHaveBeenCalledWith({
+      stream: "turn",
+      data: {
+        phase: "end",
+        toolResultsCount: 1,
+      },
+    });
+  });
+
+  it("emits turn events on the global agent event bus", () => {
+    const { session, emit } = createStubSessionHarness();
+    const seen: Array<{ stream: string; phase?: unknown; toolResultsCount?: unknown }> = [];
+    const stop = onAgentEvent((evt) => {
+      if (evt.runId !== "run-turns") {
+        return;
+      }
+      seen.push({
+        stream: evt.stream,
+        phase: evt.data.phase,
+        toolResultsCount: evt.data.toolResultsCount,
+      });
+    });
+
+    subscribeEmbeddedPiSession({
+      session,
+      runId: "run-turns",
+    });
+
+    emit({ type: "turn_start" });
+    emit({
+      type: "turn_end",
+      toolResults: [{ toolCallId: "tool-1" }, { toolCallId: "tool-2" }],
+    });
+
+    stop();
+
+    expect(seen).toEqual([
+      {
+        stream: "turn",
+        phase: "start",
+        toolResultsCount: undefined,
+      },
+      {
+        stream: "turn",
+        phase: "end",
+        toolResultsCount: 2,
+      },
+    ]);
   });
 
   it("does not emit duplicate agent events when message_end repeats", () => {


### PR DESCRIPTION
## Summary

Emit embedded Pi `turn_start` / `turn_end` events through OpenClaw's agent event pipeline so external observers can detect stable loop boundaries.

## Changes

- handle `turn_start` and `turn_end` in `src/agents/pi-embedded-subscribe.handlers.ts`
- add `src/agents/pi-embedded-subscribe.handlers.turn.ts` to forward turn boundaries as `stream: "turn"`
- add regression tests covering both the per-run `onAgentEvent` callback and the global `agent-events` bus

## Why

`pi-agent-core` already emits turn boundary events, but OpenClaw's embedded subscription layer was dropping them. That made it hard for downstream observability systems to reconstruct per-loop model/tool timelines reliably.

## Verification

- `pnpm -C openclaw exec vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts -t "turn events"`
- `pnpm -C openclaw exec vitest run src/infra/agent-events.test.ts`
