### PR TITLE
feat(auto-reply): preserve TTS transcript on audio-as-voice payloads

### DIFF
--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -27,6 +27,11 @@ export type ReplyPayload = {
   replyToCurrent?: boolean;
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
+  /** Original text that was synthesized into this media (TTS audio). Surfaced to
+   *  hook consumers (conversation archive, analytics) as the message content when
+   *  the payload has no visible text, so voice replies preserve a searchable
+   *  transcript. Never rendered to the channel. */
+  spokenText?: string;
   isError?: boolean;
   /** Marks this payload as a reasoning/thinking block. Channels that do not
    *  have a dedicated reasoning lane (e.g. WhatsApp, web) should suppress it. */

--- a/src/auto-reply/reply/commands-tts.ts
+++ b/src/auto-reply/reply/commands-tts.ts
@@ -168,6 +168,7 @@ export const handleTtsCommands: CommandHandler = async (params, allowTextCommand
         mediaUrl: result.audioPath,
         audioAsVoice: result.voiceCompatible === true,
         trustedLocalMedia: true,
+        spokenText: args,
       };
       return { shouldContinue: false, reply: payload };
     }

--- a/src/auto-reply/reply/dispatch-acp.ts
+++ b/src/auto-reply/reply/dispatch-acp.ts
@@ -213,6 +213,7 @@ async function finalizeAcpTurnOutput(params: {
         const delivered = await params.delivery.deliver("final", {
           mediaUrl: ttsSyntheticReply.mediaUrl,
           audioAsVoice: ttsSyntheticReply.audioAsVoice,
+          spokenText: accumulatedBlockText,
         });
         queuedFinal = queuedFinal || delivered;
         finalMediaDelivered = delivered;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -1118,10 +1118,13 @@ export async function dispatchReplyFromConfig(
           });
           // Only send if TTS was actually applied (mediaUrl exists)
           if (ttsSyntheticReply.mediaUrl) {
-            // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content
+            // Send TTS-only payload (no text, just audio) so it doesn't duplicate the block content.
+            // spokenText keeps the original text on the payload for hook consumers (e.g. archive)
+            // without rendering it to the channel.
             const ttsOnlyPayload: ReplyPayload = {
               mediaUrl: ttsSyntheticReply.mediaUrl,
               audioAsVoice: ttsSyntheticReply.audioAsVoice,
+              spokenText: accumulatedBlockText,
             };
             const result = await routeReplyToOriginating(ttsOnlyPayload);
             if (result) {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -590,7 +590,7 @@ async function applyMessageSendingHook(params: {
     const sendingResult = await params.hookRunner!.runMessageSending(
       {
         to: params.to,
-        content: params.payloadSummary.text,
+        content: params.payloadSummary.hookContent ?? params.payloadSummary.text,
         replyToId: params.payload.replyToId ?? params.replyToId ?? undefined,
         threadId: params.threadId ?? undefined,
         metadata: {
@@ -629,6 +629,7 @@ async function applyMessageSendingHook(params: {
       payloadSummary: {
         ...params.payloadSummary,
         text: sendingResult.content,
+        hookContent: undefined,
       },
     };
   } catch {
@@ -891,7 +892,7 @@ async function deliverOutboundPayloadsCore(
         });
         emitMessageSent({
           success: true,
-          content: payloadSummary.text,
+          content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId: delivery.messageId,
         });
         continue;
@@ -914,7 +915,7 @@ async function deliverOutboundPayloadsCore(
         });
         emitMessageSent({
           success: results.length > beforeCount,
-          content: payloadSummary.text,
+          content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });
         continue;
@@ -948,7 +949,7 @@ async function deliverOutboundPayloadsCore(
         });
         emitMessageSent({
           success: results.length > beforeCount,
-          content: payloadSummary.text,
+          content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId,
         });
         continue;
@@ -986,13 +987,13 @@ async function deliverOutboundPayloadsCore(
       });
       emitMessageSent({
         success: true,
-        content: payloadSummary.text,
+        content: payloadSummary.hookContent ?? payloadSummary.text,
         messageId: lastMessageId,
       });
     } catch (err) {
       emitMessageSent({
         success: false,
-        content: payloadSummary.text,
+        content: payloadSummary.hookContent ?? payloadSummary.text,
         error: formatErrorMessage(err),
       });
       if (!params.bestEffort) {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -13,6 +13,7 @@ import {
   projectOutboundPayloadPlanForJson,
   projectOutboundPayloadPlanForMirror,
   projectOutboundPayloadPlanForOutbound,
+  summarizeOutboundPayloadForTransport,
 } from "./payloads.js";
 import { registerPendingSpawnedChildrenQuery } from "./pending-spawn-query.js";
 
@@ -684,5 +685,48 @@ describe("formatOutboundPayloadLog", () => {
         mediaUrls: [...input.mediaUrls],
       }),
     ).toBe(expected);
+  });
+});
+
+describe("summarizeOutboundPayloadForTransport", () => {
+  it("returns the rendered text and no hookContent when the payload has visible text", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      text: "hello",
+      spokenText: "fallback",
+    });
+    expect(summary.text).toBe("hello");
+    expect(summary.hookContent).toBeUndefined();
+  });
+
+  it("keeps summary.text empty for audio-only payloads and exposes spokenText only via hookContent", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      spokenText: "Hi Ivy! 早上好。",
+    });
+    // summary.text must stay empty so channel delivery (captions) never picks up the transcript.
+    expect(summary.text).toBe("");
+    expect(summary.hookContent).toBe("Hi Ivy! 早上好。");
+    expect(summary.audioAsVoice).toBe(true);
+    expect(summary.mediaUrls).toEqual(["/tmp/reply.opus"]);
+  });
+
+  it("leaves text and hookContent unset when neither visible text nor spokenText is present", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+    });
+    expect(summary.text).toBe("");
+    expect(summary.hookContent).toBeUndefined();
+  });
+
+  it("ignores whitespace-only spokenText", () => {
+    const summary = summarizeOutboundPayloadForTransport({
+      mediaUrl: "/tmp/reply.opus",
+      audioAsVoice: true,
+      spokenText: "   ",
+    });
+    expect(summary.text).toBe("");
+    expect(summary.hookContent).toBeUndefined();
   });
 });

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -31,6 +31,10 @@ export type NormalizedOutboundPayload = {
   delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
+  /** Text to surface to hook consumers (e.g. conversation archive) when the
+   *  rendered payload has no visible text — populated from ReplyPayload.spokenText.
+   *  MUST NOT be used for channel delivery (captions, message bodies). */
+  hookContent?: string;
 };
 
 export type OutboundPayloadJson = {
@@ -333,6 +337,11 @@ export function summarizeOutboundPayloadForTransport(
   payload: ReplyPayload,
 ): NormalizedOutboundPayload {
   const parts = resolveSendableOutboundReplyParts(payload);
+  // Keep summary.text strictly the rendered text so channel delivery paths
+  // (captions, message bodies) never surface the spokenText transcript.
+  // Hook emitters read payloadSummary.hookContent to pick up the transcript
+  // for audio-only payloads.
+  const trimmedSpoken = payload.spokenText?.trim() ? payload.spokenText : undefined;
   return {
     text: parts.text,
     mediaUrls: parts.mediaUrls,
@@ -341,6 +350,7 @@ export function summarizeOutboundPayloadForTransport(
     delivery: payload.delivery,
     interactive: payload.interactive,
     channelData: payload.channelData,
+    ...(parts.text || !trimmedSpoken ? {} : { hookContent: trimmedSpoken }),
   };
 }
 


### PR DESCRIPTION
## Summary

When the assistant reply is synthesized to speech — final-block auto-TTS, ACP dispatch, or the `/tts audio` command — the delivered payload is stripped down to `{mediaUrl, audioAsVoice}` only. The text is intentionally dropped so Telegram's voice bubble doesn't ship with a caption, but that also leaves the `message:sending` / `message:sent` hook context with empty `content`. Plugin consumers that rely on that content — most visibly the conversation-archive plugin — fall back to `[Assistant sent media]` and the spoken transcript is lost.

This is independent of and complementary to #68869 (which fixed the same kind of text loss inside the `tts` agent tool's result): this PR covers the other TTS path, where synthesis runs as part of auto-reply delivery rather than as a tool call.

## Fix

Introduce `ReplyPayload.spokenText`: a channel-invisible field carrying the text that was synthesized. `summarizeOutboundPayloadForTransport` falls back to `spokenText` only when the rendered payload has no visible text, so hooks see a searchable transcript while channel delivery keeps reading `payload.text` and still ships the voice bubble without a caption.

Three TTS-synth sites now set `spokenText` before dispatch:
- `src/auto-reply/reply/dispatch-acp.ts` — ACP final-block TTS
- `src/auto-reply/reply/dispatch-from-config.ts` — auto-reply final-block TTS
- `src/auto-reply/reply/commands-tts.ts` — `/tts audio` command

## Non-goals

- No change to channel rendering. Telegram, Discord, Slack, etc. all read `payload.text`, which stays empty on these audio-only payloads. Voice bubbles ship without a caption as before.
- No new SDK export. `spokenText` is an additive optional field on the existing `ReplyPayload` type.

## Test plan

- [x] `pnpm test src/infra/outbound/payloads.test.ts` — new unit coverage on `summarizeOutboundPayloadForTransport` (4 cases: visible text wins, spokenText fallback, both empty, whitespace-only spokenText).
- [x] `pnpm test src/auto-reply/reply/dispatch-acp.test.ts src/auto-reply/reply/dispatch-from-config.test.ts src/auto-reply/reply/commands-tts.test.ts` — 108 + 4 = 112 tests green.
- [x] `pnpm tsgo` on touched surface (the unrelated `extensions/qa-lab/**` and `ui/src/ui/controllers/cron.ts` failures already exist on `upstream/main`).
- [x] `pnpm lint` on touched files — 0 warnings / 0 errors (same upstream pre-existing failures elsewhere).