### PR TITLE
fix(daemon): probe system bus and cgroup-aware dedup for gateway status

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -159,6 +159,71 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([9000]);
   });
 
+  it("does not flag sibling service pids as stale when their systemd cgroups differ", async () => {
+    // Gateway runtime pid lives in openclaw-host-gateway.service, candidate
+    // listener pid lives in openclaw-node-host.service. The two must never
+    // be reported as a duplicate/stale supervisor on headless system-systemd
+    // hosts.
+    const service = makeGatewayService({ status: "running", pid: 1131058 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1131042, ppid: 1, commandLine: "openclaw node" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: (pid: number) =>
+        pid === 1131058
+          ? "openclaw-host-gateway.service"
+          : pid === 1131042
+            ? "openclaw-node-host.service"
+            : null,
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
+  it("still flags stale pids when both processes share the same service cgroup", async () => {
+    const service = makeGatewayService({ status: "running", pid: 1131058 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1131059, ppid: 1, commandLine: "openclaw gateway" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: () => "openclaw-host-gateway.service",
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([1131059]);
+  });
+
+  it("keeps flagging stale pids when cgroup attribution is unavailable", async () => {
+    // Back-compat: if we can't read /proc/<pid>/cgroup for either pid, fall
+    // back to the historical listener-based heuristic.
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 9000, ppid: 8999, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: () => null,
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([9000]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -194,6 +194,71 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([9000]);
   });
 
+  it("does not flag sibling service pids as stale when their systemd cgroups differ", async () => {
+    // Gateway runtime pid lives in openclaw-host-gateway.service, candidate
+    // listener pid lives in openclaw-node-host.service. The two must never
+    // be reported as a duplicate/stale supervisor on headless system-systemd
+    // hosts.
+    const service = makeGatewayService({ status: "running", pid: 1131058 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1131042, ppid: 1, commandLine: "openclaw node" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: (pid: number) =>
+        pid === 1131058
+          ? "openclaw-host-gateway.service"
+          : pid === 1131042
+            ? "openclaw-node-host.service"
+            : null,
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
+  it("still flags stale pids when both processes share the same service cgroup", async () => {
+    const service = makeGatewayService({ status: "running", pid: 1131058 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 1131059, ppid: 1, commandLine: "openclaw gateway" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: () => "openclaw-host-gateway.service",
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([1131059]);
+  });
+
+  it("keeps flagging stale pids when cgroup attribution is unavailable", async () => {
+    // Back-compat: if we can't read /proc/<pid>/cgroup for either pid, fall
+    // back to the historical listener-based heuristic.
+    const service = makeGatewayService({ status: "running", pid: 8000 });
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ pid: 9000, ppid: 8999, commandLine: "openclaw-gateway" }],
+      hints: [],
+    });
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({
+      service,
+      port: 18789,
+      readProcessServiceCgroup: () => null,
+    });
+
+    expect(snapshot.staleGatewayPids).toEqual([9000]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -7,6 +7,7 @@ import {
   inspectPortUsage,
   type PortUsage,
 } from "../../infra/ports.js";
+import { readProcessServiceCgroup as defaultReadProcessServiceCgroup } from "../../infra/proc-cgroup.js";
 import { killProcessTree } from "../../process/kill-tree.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -107,11 +108,41 @@ async function inspectGatewayPortHealth(port: number): Promise<GatewayPortHealth
   return { portUsage, healthy };
 }
 
+/**
+ * Decide whether two pids can be safely treated as distinct supervisors /
+ * listeners based on their systemd service cgroups. If both pids live in
+ * `*.service` cgroups but the cgroups differ, they belong to independent
+ * system services (e.g. `openclaw-host-gateway.service` vs
+ * `openclaw-node-host.service`) and must not be flagged as duplicates.
+ *
+ * Returns:
+ *   - "distinct" when both have service cgroups and they differ (definitely
+ *     not duplicates of each other)
+ *   - "same-or-unknown" otherwise (same cgroup, or at least one pid has no
+ *     service cgroup so we can't rule out duplication)
+ */
+export function classifyCgroupRelationship(
+  pidA: number,
+  pidB: number,
+  readServiceCgroup: (pid: number) => string | null = defaultReadProcessServiceCgroup,
+): "distinct" | "same-or-unknown" {
+  if (!Number.isFinite(pidA) || !Number.isFinite(pidB)) {
+    return "same-or-unknown";
+  }
+  const a = readServiceCgroup(pidA);
+  const b = readServiceCgroup(pidB);
+  if (a && b && a !== b) {
+    return "distinct";
+  }
+  return "same-or-unknown";
+}
+
 export async function inspectGatewayRestart(params: {
   service: GatewayService;
   port: number;
   env?: NodeJS.ProcessEnv;
   includeUnknownListenersAsStale?: boolean;
+  readProcessServiceCgroup?: (pid: number) => string | null;
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
   let runtime: GatewayServiceRuntime = { status: "unknown" };
@@ -183,7 +214,8 @@ export async function inspectGatewayRestart(params: {
       // best-effort probe
     }
   }
-  const staleGatewayPids = Array.from(
+  const readServiceCgroup = params.readProcessServiceCgroup ?? defaultReadProcessServiceCgroup;
+  const staleCandidates = Array.from(
     new Set([
       ...gatewayListeners
         .filter((listener) => Number.isFinite(listener.pid))
@@ -202,6 +234,20 @@ export async function inspectGatewayRestart(params: {
       ),
     ]),
   );
+  // Cgroup-aware dedup: if a candidate listener pid lives inside a different
+  // systemd `*.service` cgroup than the gateway runtime pid, it is part of a
+  // sibling OpenClaw service (e.g. openclaw-node-host.service) and is *not*
+  // a duplicate/stale gateway. This removes the historical false-positive
+  // on headless hosts where both services run under system-level systemd.
+  const staleGatewayPids =
+    runtimePid != null
+      ? staleCandidates.filter((pid) => {
+          if (!running) {
+            return true;
+          }
+          return classifyCgroupRelationship(runtimePid, pid, readServiceCgroup) !== "distinct";
+        })
+      : staleCandidates;
 
   return {
     runtime,

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -11,6 +11,7 @@ import {
   inspectPortUsage,
   type PortUsage,
 } from "../../infra/ports.js";
+import { readProcessServiceCgroup as defaultReadProcessServiceCgroup } from "../../infra/proc-cgroup.js";
 import { killProcessTree } from "../../process/kill-tree.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -321,6 +322,35 @@ async function inspectGatewayPortHealth(params: {
   return { portUsage, healthy };
 }
 
+/**
+ * Decide whether two pids can be safely treated as distinct supervisors /
+ * listeners based on their systemd service cgroups. If both pids live in
+ * `*.service` cgroups but the cgroups differ, they belong to independent
+ * system services (e.g. `openclaw-host-gateway.service` vs
+ * `openclaw-node-host.service`) and must not be flagged as duplicates.
+ *
+ * Returns:
+ *   - "distinct" when both have service cgroups and they differ (definitely
+ *     not duplicates of each other)
+ *   - "same-or-unknown" otherwise (same cgroup, or at least one pid has no
+ *     service cgroup so we can't rule out duplication)
+ */
+export function classifyCgroupRelationship(
+  pidA: number,
+  pidB: number,
+  readServiceCgroup: (pid: number) => string | null = defaultReadProcessServiceCgroup,
+): "distinct" | "same-or-unknown" {
+  if (!Number.isFinite(pidA) || !Number.isFinite(pidB)) {
+    return "same-or-unknown";
+  }
+  const a = readServiceCgroup(pidA);
+  const b = readServiceCgroup(pidB);
+  if (a && b && a !== b) {
+    return "distinct";
+  }
+  return "same-or-unknown";
+}
+
 export async function inspectGatewayRestart(params: {
   service: GatewayService;
   port: number;
@@ -328,6 +358,7 @@ export async function inspectGatewayRestart(params: {
   expectedVersion?: string | null;
   includeUnknownListenersAsStale?: boolean;
   probeAuth?: GatewayRestartProbeAuth;
+  readProcessServiceCgroup?: (pid: number) => string | null;
 }): Promise<GatewayRestartSnapshot> {
   const env = params.env ?? process.env;
   const expectedVersion = normalizeOptionalString(params.expectedVersion);
@@ -448,7 +479,8 @@ export async function inspectGatewayRestart(params: {
       // best-effort probe
     }
   }
-  const staleGatewayPids = Array.from(
+  const readServiceCgroup = params.readProcessServiceCgroup ?? defaultReadProcessServiceCgroup;
+  const staleCandidates = Array.from(
     new Set([
       ...gatewayListeners
         .filter((listener) => Number.isFinite(listener.pid))
@@ -467,6 +499,20 @@ export async function inspectGatewayRestart(params: {
       ),
     ]),
   );
+  // Cgroup-aware dedup: if a candidate listener pid lives inside a different
+  // systemd `*.service` cgroup than the gateway runtime pid, it is part of a
+  // sibling OpenClaw service (e.g. openclaw-node-host.service) and is *not*
+  // a duplicate/stale gateway. This removes the historical false-positive
+  // on headless hosts where both services run under system-level systemd.
+  const staleGatewayPids =
+    runtimePid != null
+      ? staleCandidates.filter((pid) => {
+          if (!running) {
+            return true;
+          }
+          return classifyCgroupRelationship(runtimePid, pid, readServiceCgroup) !== "distinct";
+        })
+      : staleCandidates;
 
   return applyChannelProbeErrors(
     applyActivatedPluginErrors(

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -168,6 +168,20 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     const runtimeColor = resolveRuntimeStatusColor(service.runtime?.status);
     defaultRuntime.log(`${label("Runtime:")} ${colorize(rich, runtimeColor, runtimeLine)}`);
   }
+  const systemUnits = service.runtime?.systemUnits ?? [];
+  if (service.runtime?.scope === "system" && systemUnits.length > 0) {
+    defaultRuntime.log(`${label("Systemd scope:")} ${infoText("system")}`);
+    for (const unit of systemUnits) {
+      const parts = [
+        unit.activeState ? `active=${unit.activeState}` : null,
+        unit.subState ? `sub=${unit.subState}` : null,
+        unit.mainPid != null ? `pid=${unit.mainPid}` : null,
+        unit.cgroup ? `cgroup=${unit.cgroup}` : null,
+      ].filter(Boolean);
+      const suffix = parts.length > 0 ? ` (${parts.join(", ")})` : "";
+      defaultRuntime.log(`${label("Systemd unit:")} ${infoText(unit.unitName)}${suffix}`);
+    }
+  }
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
     defaultRuntime.log(
@@ -214,7 +228,12 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
 
   const systemdUnavailable =
     process.platform === "linux" && isSystemdUnavailableDetail(service.runtime?.detail);
-  if (systemdUnavailable) {
+  // If the system-bus fallback has already surfaced healthy OpenClaw units,
+  // the user-bus-unavailable detail is informational, not actionable: the
+  // runtime is fine under system-level systemd.
+  const systemServicesDetected =
+    service.runtime?.scope === "system" && (service.runtime?.systemUnits ?? []).length > 0;
+  if (systemdUnavailable && !systemServicesDetected) {
     const container = Boolean(
       resolveDaemonContainerContext(service.command?.environment ?? process.env),
     );
@@ -223,6 +242,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       wsl: isWSLEnv(),
       kind: classifySystemdUnavailableDetail(service.runtime?.detail),
       container,
+      systemServicesDetected,
     })) {
       defaultRuntime.error(errorText(hint));
     }

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -250,6 +250,20 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
   if (service.restartHandoff) {
     defaultRuntime.log(infoText(formatGatewayRestartHandoffDiagnostic(service.restartHandoff)));
   }
+  const systemUnits = service.runtime?.systemUnits ?? [];
+  if (service.runtime?.scope === "system" && systemUnits.length > 0) {
+    defaultRuntime.log(`${label("Systemd scope:")} ${infoText("system")}`);
+    for (const unit of systemUnits) {
+      const parts = [
+        unit.activeState ? `active=${unit.activeState}` : null,
+        unit.subState ? `sub=${unit.subState}` : null,
+        unit.mainPid != null ? `pid=${unit.mainPid}` : null,
+        unit.cgroup ? `cgroup=${unit.cgroup}` : null,
+      ].filter(Boolean);
+      const suffix = parts.length > 0 ? ` (${parts.join(", ")})` : "";
+      defaultRuntime.log(`${label("Systemd unit:")} ${infoText(unit.unitName)}${suffix}`);
+    }
+  }
 
   if (rpc && !rpc.ok && service.loaded && service.runtime?.status === "running") {
     defaultRuntime.log(
@@ -323,7 +337,12 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
     process.platform === "linux" &&
     rpc?.ok !== true &&
     isSystemdUnavailableDetail(service.runtime?.detail);
-  if (systemdUnavailable) {
+  // If the system-bus fallback has already surfaced healthy OpenClaw units,
+  // the user-bus-unavailable detail is informational, not actionable: the
+  // runtime is fine under system-level systemd.
+  const systemServicesDetected =
+    service.runtime?.scope === "system" && (service.runtime?.systemUnits ?? []).length > 0;
+  if (systemdUnavailable && !systemServicesDetected) {
     const container = Boolean(
       resolveDaemonContainerContext(service.command?.environment ?? process.env),
     );
@@ -332,6 +351,7 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean })
       wsl: isWSLEnv(),
       kind: classifySystemdUnavailableDetail(service.runtime?.detail),
       container,
+      systemServicesDetected,
     })) {
       defaultRuntime.error(errorText(hint));
     }

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -1,3 +1,12 @@
+export type SystemdSystemUnitRuntime = {
+  unitName: string;
+  activeState?: string;
+  subState?: string;
+  mainPid?: number;
+  cgroup?: string;
+  loaded?: boolean;
+};
+
 export type GatewayServiceRuntime = {
   status?: string;
   state?: string;
@@ -10,4 +19,21 @@ export type GatewayServiceRuntime = {
   detail?: string;
   cachedLabel?: boolean;
   missingUnit?: boolean;
+  /**
+   * Which systemd scope produced this runtime snapshot. When the user bus is
+   * unavailable but the host runs OpenClaw under system-level systemd units,
+   * we fall back to probing the system bus and record the scope here so the
+   * UI can differentiate.
+   */
+  scope?: "user" | "system";
+  /** Systemd unit name this runtime snapshot was read from, when known. */
+  unitName?: string;
+  /** `/proc/<pid>/cgroup` service attribution for `pid`, when known. */
+  cgroup?: string;
+  /**
+   * When the system-bus probe ran, optionally the full list of OpenClaw
+   * system-level units it observed (gateway + node host, etc.). The first
+   * entry is typically the one that sets the top-level fields.
+   */
+  systemUnits?: SystemdSystemUnitRuntime[];
 };

--- a/src/daemon/service-runtime.ts
+++ b/src/daemon/service-runtime.ts
@@ -7,6 +7,15 @@ export type GatewayServiceSystemdRuntime = {
   memoryCurrent?: number;
 };
 
+export type SystemdSystemUnitRuntime = {
+  unitName: string;
+  activeState?: string;
+  subState?: string;
+  mainPid?: number;
+  cgroup?: string;
+  loaded?: boolean;
+};
+
 export type GatewayServiceRuntime = {
   status?: string;
   state?: string;
@@ -21,6 +30,23 @@ export type GatewayServiceRuntime = {
   missingUnit?: boolean;
   missingSupervision?: boolean;
   systemd?: GatewayServiceSystemdRuntime;
+  /**
+   * Which systemd scope produced this runtime snapshot. When the user bus is
+   * unavailable but the host runs OpenClaw under system-level systemd units,
+   * we fall back to probing the system bus and record the scope here so the
+   * UI can differentiate.
+   */
+  scope?: "user" | "system";
+  /** Systemd unit name this runtime snapshot was read from, when known. */
+  unitName?: string;
+  /** `/proc/<pid>/cgroup` service attribution for `pid`, when known. */
+  cgroup?: string;
+  /**
+   * When the system-bus probe ran, optionally the full list of OpenClaw
+   * system-level units it observed (gateway + node host, etc.). The first
+   * entry is typically the one that sets the top-level fields.
+   */
+  systemUnits?: SystemdSystemUnitRuntime[];
 };
 
 export const SYSTEMD_TASKS_CURRENT_WARNING_THRESHOLD = 200;

--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -27,14 +27,14 @@ describe("renderSystemdUnavailableHints", () => {
 
   it("renders generic Linux recovery hints outside WSL", () => {
     expect(renderSystemdUnavailableHints({ kind: "generic_unavailable" })).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
   });
 
   it("adds headless recovery hints only for user bus/session failures", () => {
     expect(renderSystemdUnavailableHints({ kind: "user_bus_unavailable" })).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
       "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
@@ -48,8 +48,17 @@ describe("renderSystemdUnavailableHints", () => {
         container: true,
       }),
     ).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
+  });
+
+  it("suppresses user-bus guidance when system-level services are already detected", () => {
+    expect(
+      renderSystemdUnavailableHints({
+        kind: "user_bus_unavailable",
+        systemServicesDetected: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/daemon/systemd-hints.test.ts
+++ b/src/daemon/systemd-hints.test.ts
@@ -33,14 +33,14 @@ describe("renderSystemdUnavailableHints", () => {
 
   it("renders generic Linux recovery hints outside WSL", () => {
     expect(renderSystemdUnavailableHints({ kind: "generic_unavailable" })).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
   });
 
   it("adds headless recovery hints only for user bus/session failures", () => {
     expect(renderSystemdUnavailableHints({ kind: "user_bus_unavailable" })).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       "On a headless server (SSH/no desktop session): run `sudo loginctl enable-linger $(whoami)` to persist your systemd user session across logins.",
       "Also ensure XDG_RUNTIME_DIR is set: `export XDG_RUNTIME_DIR=/run/user/$(id -u)`, then retry.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
@@ -54,8 +54,17 @@ describe("renderSystemdUnavailableHints", () => {
         container: true,
       }),
     ).toEqual([
-      "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+      "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
       `If you're in a container, run the gateway in the foreground instead of \`${formatCliCommand("openclaw gateway")}\`.`,
     ]);
+  });
+
+  it("suppresses user-bus guidance when system-level services are already detected", () => {
+    expect(
+      renderSystemdUnavailableHints({
+        kind: "user_bus_unavailable",
+        systemServicesDetected: true,
+      }),
+    ).toEqual([]);
   });
 });

--- a/src/daemon/systemd-hints.ts
+++ b/src/daemon/systemd-hints.ts
@@ -8,6 +8,13 @@ type SystemdUnavailableHintOptions = {
   wsl?: boolean;
   kind?: SystemdUnavailableKind | null;
   container?: boolean;
+  /**
+   * When true, the status pipeline already observed healthy OpenClaw units
+   * on the *system* bus (e.g. on headless hosts). In that case the "user
+   * bus unavailable" message is misleading — runtime is fine — so we skip
+   * the generic "systemd user services are unavailable" guidance.
+   */
+  systemServicesDetected?: boolean;
 };
 
 export function isSystemdUnavailableDetail(detail?: string): boolean {
@@ -24,6 +31,11 @@ function renderSystemdHeadlessServerHints(): string[] {
 export function renderSystemdUnavailableHints(
   options: SystemdUnavailableHintOptions = {},
 ): string[] {
+  if (options.systemServicesDetected) {
+    // Runtime is fine via system-level systemd units; don't tell the user
+    // the user bus is "required".
+    return [];
+  }
   if (options.wsl) {
     return [
       "WSL2 needs systemd enabled: edit /etc/wsl.conf with [boot]\\nsystemd=true",
@@ -32,7 +44,7 @@ export function renderSystemdUnavailableHints(
     ];
   }
   return [
-    "systemd user services are unavailable; install/enable systemd or run the gateway under your supervisor.",
+    "systemd user services are unavailable; install/enable systemd, run the gateway under system-level systemd, or run it under your own supervisor.",
     ...(options.container || options.kind !== "user_bus_unavailable"
       ? []
       : renderSystemdHeadlessServerHints()),

--- a/src/daemon/systemd-system-probe.test.ts
+++ b/src/daemon/systemd-system-probe.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    {
+      execFile: Object.assign(execFileMock, {
+        __promisify__: vi.fn(),
+      }) as typeof import("node:child_process").execFile,
+    },
+  );
+});
+
+import {
+  pickPrimaryGatewayUnit,
+  probeSystemdSystemServices,
+  resolveCandidateSystemUnits,
+} from "./systemd-system-probe.js";
+
+type ShowReply = {
+  activeState?: string;
+  subState?: string;
+  mainPid?: number;
+  loadState?: string;
+  controlGroup?: string;
+};
+
+function formatShowOutput(reply: ShowReply): string {
+  return [
+    `ActiveState=${reply.activeState ?? ""}`,
+    `SubState=${reply.subState ?? ""}`,
+    `MainPID=${reply.mainPid ?? 0}`,
+    `LoadState=${reply.loadState ?? ""}`,
+    `ControlGroup=${reply.controlGroup ?? ""}`,
+  ].join("\n");
+}
+
+describe("resolveCandidateSystemUnits", () => {
+  it("includes the canonical gateway, legacy, host-gateway, node, and node-host units", () => {
+    const units = resolveCandidateSystemUnits({});
+    expect(units).toEqual(
+      expect.arrayContaining([
+        "openclaw-gateway.service",
+        "openclaw-host-gateway.service",
+        "openclaw-node.service",
+        "openclaw-node-host.service",
+        "clawdbot-gateway.service",
+      ]),
+    );
+  });
+
+  it("honors an explicit OPENCLAW_SYSTEMD_UNIT override", () => {
+    const units = resolveCandidateSystemUnits({
+      OPENCLAW_SYSTEMD_UNIT: "my-openclaw",
+    });
+    expect(units).toContain("my-openclaw.service");
+  });
+});
+
+describe("probeSystemdSystemServices", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("reports active system-level units and their cgroups", async () => {
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      // Every invocation must be for `systemctl show <unit> --no-page --property ...`.
+      expect(args[0]).toBe("show");
+      expect(args).not.toContain("--user");
+      const unit = args[1] as string;
+      if (unit === "openclaw-host-gateway.service") {
+        cb(
+          null,
+          formatShowOutput({
+            activeState: "active",
+            subState: "running",
+            mainPid: 1131058,
+            loadState: "loaded",
+            controlGroup: "/system.slice/openclaw-host-gateway.service",
+          }),
+          "",
+        );
+        return;
+      }
+      if (unit === "openclaw-node-host.service") {
+        cb(
+          null,
+          formatShowOutput({
+            activeState: "active",
+            subState: "running",
+            mainPid: 1131042,
+            loadState: "loaded",
+            controlGroup: "/system.slice/openclaw-node-host.service",
+          }),
+          "",
+        );
+        return;
+      }
+      // Other candidates: loaded=not-found style (no mainpid, no loadstate)
+      cb(null, formatShowOutput({ activeState: "inactive", loadState: "not-found" }), "");
+    });
+
+    const outcome = await probeSystemdSystemServices({});
+    expect(outcome.systemBusAvailable).toBe(true);
+    const names = outcome.units.map((u) => u.unitName).toSorted();
+    expect(names).toEqual(["openclaw-host-gateway.service", "openclaw-node-host.service"]);
+    const gateway = outcome.units.find((u) => u.unitName === "openclaw-host-gateway.service");
+    expect(gateway).toMatchObject({
+      activeState: "active",
+      mainPid: 1131058,
+      cgroup: "/system.slice/openclaw-host-gateway.service",
+      loaded: true,
+    });
+  });
+
+  it("flags systemBusAvailable=false when every probe fails (non-zero code)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("Failed to connect to bus") as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr = "Failed to connect to bus";
+      err.code = 1;
+      cb(err, "", "Failed to connect to bus");
+    });
+    const outcome = await probeSystemdSystemServices({});
+    expect(outcome.systemBusAvailable).toBe(false);
+    expect(outcome.units).toEqual([]);
+  });
+});
+
+describe("pickPrimaryGatewayUnit", () => {
+  it("prefers the canonical gateway unit", () => {
+    const gateway = {
+      unitName: "openclaw-gateway.service",
+      activeState: "active",
+      mainPid: 1,
+    };
+    const nodeHost = {
+      unitName: "openclaw-node-host.service",
+      activeState: "active",
+      mainPid: 2,
+    };
+    expect(pickPrimaryGatewayUnit({}, [nodeHost, gateway])).toBe(gateway);
+  });
+
+  it("falls back to the host-gateway variant when canonical is absent", () => {
+    const hostGateway = {
+      unitName: "openclaw-host-gateway.service",
+      activeState: "active",
+      mainPid: 10,
+    };
+    const nodeHost = {
+      unitName: "openclaw-node-host.service",
+      activeState: "active",
+      mainPid: 20,
+    };
+    expect(pickPrimaryGatewayUnit({}, [nodeHost, hostGateway])).toBe(hostGateway);
+  });
+
+  it("returns null when there are no units", () => {
+    expect(pickPrimaryGatewayUnit({}, [])).toBeNull();
+  });
+});

--- a/src/daemon/systemd-system-probe.test.ts
+++ b/src/daemon/systemd-system-probe.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const { mockNodeBuiltinModule } =
+    await import("../plugin-sdk/test-helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:child_process")>("node:child_process"),
+    {
+      execFile: Object.assign(execFileMock, {
+        __promisify__: vi.fn(),
+      }) as typeof import("node:child_process").execFile,
+    },
+  );
+});
+
+import {
+  pickPrimaryGatewayUnit,
+  probeSystemdSystemServices,
+  resolveCandidateSystemUnits,
+} from "./systemd-system-probe.js";
+
+type ShowReply = {
+  activeState?: string;
+  subState?: string;
+  mainPid?: number;
+  loadState?: string;
+  controlGroup?: string;
+};
+
+function formatShowOutput(reply: ShowReply): string {
+  return [
+    `ActiveState=${reply.activeState ?? ""}`,
+    `SubState=${reply.subState ?? ""}`,
+    `MainPID=${reply.mainPid ?? 0}`,
+    `LoadState=${reply.loadState ?? ""}`,
+    `ControlGroup=${reply.controlGroup ?? ""}`,
+  ].join("\n");
+}
+
+describe("resolveCandidateSystemUnits", () => {
+  it("includes the canonical gateway, legacy, host-gateway, node, and node-host units", () => {
+    const units = resolveCandidateSystemUnits({});
+    expect(units).toEqual(
+      expect.arrayContaining([
+        "openclaw-gateway.service",
+        "openclaw-host-gateway.service",
+        "openclaw-node.service",
+        "openclaw-node-host.service",
+        "clawdbot-gateway.service",
+      ]),
+    );
+  });
+
+  it("honors an explicit OPENCLAW_SYSTEMD_UNIT override", () => {
+    const units = resolveCandidateSystemUnits({
+      OPENCLAW_SYSTEMD_UNIT: "my-openclaw",
+    });
+    expect(units).toContain("my-openclaw.service");
+  });
+});
+
+describe("probeSystemdSystemServices", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("reports active system-level units and their cgroups", async () => {
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      // Every invocation must be for `systemctl show <unit> --no-page --property ...`.
+      expect(args[0]).toBe("show");
+      expect(args).not.toContain("--user");
+      const unit = args[1] as string;
+      if (unit === "openclaw-host-gateway.service") {
+        cb(
+          null,
+          formatShowOutput({
+            activeState: "active",
+            subState: "running",
+            mainPid: 1131058,
+            loadState: "loaded",
+            controlGroup: "/system.slice/openclaw-host-gateway.service",
+          }),
+          "",
+        );
+        return;
+      }
+      if (unit === "openclaw-node-host.service") {
+        cb(
+          null,
+          formatShowOutput({
+            activeState: "active",
+            subState: "running",
+            mainPid: 1131042,
+            loadState: "loaded",
+            controlGroup: "/system.slice/openclaw-node-host.service",
+          }),
+          "",
+        );
+        return;
+      }
+      // Other candidates: loaded=not-found style (no mainpid, no loadstate)
+      cb(null, formatShowOutput({ activeState: "inactive", loadState: "not-found" }), "");
+    });
+
+    const outcome = await probeSystemdSystemServices({});
+    expect(outcome.systemBusAvailable).toBe(true);
+    const names = outcome.units.map((u) => u.unitName).toSorted();
+    expect(names).toEqual(["openclaw-host-gateway.service", "openclaw-node-host.service"]);
+    const gateway = outcome.units.find((u) => u.unitName === "openclaw-host-gateway.service");
+    expect(gateway).toMatchObject({
+      activeState: "active",
+      mainPid: 1131058,
+      cgroup: "/system.slice/openclaw-host-gateway.service",
+      loaded: true,
+    });
+  });
+
+  it("flags systemBusAvailable=false when every probe fails (non-zero code)", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = new Error("Failed to connect to bus") as Error & {
+        stderr?: string;
+        code?: number;
+      };
+      err.stderr = "Failed to connect to bus";
+      err.code = 1;
+      cb(err, "", "Failed to connect to bus");
+    });
+    const outcome = await probeSystemdSystemServices({});
+    expect(outcome.systemBusAvailable).toBe(false);
+    expect(outcome.units).toEqual([]);
+  });
+});
+
+describe("pickPrimaryGatewayUnit", () => {
+  it("prefers the canonical gateway unit", () => {
+    const gateway = {
+      unitName: "openclaw-gateway.service",
+      activeState: "active",
+      mainPid: 1,
+    };
+    const nodeHost = {
+      unitName: "openclaw-node-host.service",
+      activeState: "active",
+      mainPid: 2,
+    };
+    expect(pickPrimaryGatewayUnit({}, [nodeHost, gateway])).toBe(gateway);
+  });
+
+  it("falls back to the host-gateway variant when canonical is absent", () => {
+    const hostGateway = {
+      unitName: "openclaw-host-gateway.service",
+      activeState: "active",
+      mainPid: 10,
+    };
+    const nodeHost = {
+      unitName: "openclaw-node-host.service",
+      activeState: "active",
+      mainPid: 20,
+    };
+    expect(pickPrimaryGatewayUnit({}, [nodeHost, hostGateway])).toBe(hostGateway);
+  });
+
+  it("returns null when there are no units", () => {
+    expect(pickPrimaryGatewayUnit({}, [])).toBeNull();
+  });
+});

--- a/src/daemon/systemd-system-probe.ts
+++ b/src/daemon/systemd-system-probe.ts
@@ -1,0 +1,171 @@
+import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { readProcessServiceCgroup } from "../infra/proc-cgroup.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
+  resolveGatewaySystemdServiceName,
+  resolveNodeSystemdServiceName,
+} from "./constants.js";
+import { execFileUtf8 } from "./exec-file.js";
+import { parseKeyValueOutput } from "./runtime-parse.js";
+import type { SystemdSystemUnitRuntime } from "./service-runtime.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+export type SystemdSystemProbeOutcome = {
+  /** Units observed by the system-bus probe (loaded or active). */
+  units: SystemdSystemUnitRuntime[];
+  /** Whether at least one system-bus probe call succeeded. */
+  systemBusAvailable: boolean;
+};
+
+/**
+ * Extra candidate system unit names that downstream packaging is known to
+ * use on headless deployments in addition to the canonical
+ * `openclaw-gateway` / `openclaw-node` names.
+ */
+const EXTRA_SYSTEM_UNIT_CANDIDATES = ["openclaw-host-gateway", "openclaw-node-host"] as const;
+
+const MAIN_UNIT_CANDIDATE_TAG = Symbol("mainUnit");
+
+function buildGatewayCandidates(env: GatewayServiceEnv): string[] {
+  const names = new Set<string>();
+  const configuredGateway = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+  if (configuredGateway) {
+    names.add(configuredGateway);
+  }
+  names.add(resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE));
+  for (const legacy of LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES) {
+    names.add(legacy);
+  }
+  for (const extra of EXTRA_SYSTEM_UNIT_CANDIDATES) {
+    names.add(extra);
+  }
+  names.add(resolveNodeSystemdServiceName());
+  return Array.from(names, (name) => (name.endsWith(".service") ? name : `${name}.service`));
+}
+
+/**
+ * Candidate units for the system-bus probe. Exported for tests.
+ */
+export function resolveCandidateSystemUnits(env: GatewayServiceEnv): string[] {
+  return buildGatewayCandidates(env);
+}
+
+type ShowResult = {
+  info: SystemdSystemUnitRuntime;
+  code: number;
+  detail: string;
+};
+
+function execSystemctlSystem(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return execFileUtf8("systemctl", args);
+}
+
+async function probeOneSystemUnit(unitName: string): Promise<ShowResult> {
+  // `systemctl show` works against the system bus without sudo and does not
+  // fail when the unit is missing (it prints defaults and returns 0). Use
+  // `is-active` first to cheaply skip units that don't exist to keep output
+  // noise-free, but don't rely on non-zero codes as hard errors because the
+  // system bus itself may be missing in containers.
+  const show = await execSystemctlSystem([
+    "show",
+    unitName,
+    "--no-page",
+    "--property",
+    "ActiveState,SubState,MainPID,LoadState,ControlGroup",
+  ]);
+  const detail = `${show.stderr} ${show.stdout}`.trim();
+  const entries = parseKeyValueOutput(show.stdout || "", "=");
+  const activeState = entries.activestate || undefined;
+  const subState = entries.substate || undefined;
+  const mainPidRaw = entries.mainpid;
+  const loadState = entries.loadstate || undefined;
+  const controlGroup = entries.controlgroup || undefined;
+  const mainPid = mainPidRaw ? parseStrictPositiveInteger(mainPidRaw) : undefined;
+  const info: SystemdSystemUnitRuntime = {
+    unitName,
+    ...(activeState ? { activeState } : {}),
+    ...(subState ? { subState } : {}),
+    ...(mainPid ? { mainPid } : {}),
+    loaded: loadState ? normalizeLowercaseStringOrEmpty(loadState) === "loaded" : undefined,
+  };
+  if (controlGroup && controlGroup.trim()) {
+    info.cgroup = controlGroup.trim();
+  } else if (mainPid) {
+    const fromProc = readProcessServiceCgroup(mainPid);
+    if (fromProc) {
+      info.cgroup = fromProc;
+    }
+  }
+  return { info, code: show.code, detail };
+}
+
+/**
+ * Probe the system bus for known OpenClaw systemd units. This is a
+ * no-sudo-required probe intended as a fallback when the user bus is
+ * unavailable (headless hosts without a login session). It intentionally
+ * returns a list of runtimes rather than a single one because OpenClaw can
+ * be installed as multiple co-located system services (gateway + node host).
+ */
+export async function probeSystemdSystemServices(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<SystemdSystemProbeOutcome> {
+  const candidates = buildGatewayCandidates(env);
+  const units: SystemdSystemUnitRuntime[] = [];
+  let systemBusAvailable = false;
+  for (const unitName of candidates) {
+    try {
+      const result = await probeOneSystemUnit(unitName);
+      if (result.code === 0) {
+        systemBusAvailable = true;
+      }
+      if (isUnitWorthReporting(result.info)) {
+        units.push(result.info);
+      }
+    } catch {
+      // best-effort; skip
+    }
+  }
+  return { units, systemBusAvailable };
+}
+
+function isUnitWorthReporting(info: SystemdSystemUnitRuntime): boolean {
+  if (info.loaded) {
+    return true;
+  }
+  if (info.activeState && info.activeState !== "inactive") {
+    return true;
+  }
+  if (info.mainPid && info.mainPid > 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Given a set of system-bus probe results, pick the unit that should
+ * represent the "gateway" service for status output (prefers the configured
+ * unit, then the canonical gateway, then host-gateway variants, then the
+ * first active unit).
+ */
+export function pickPrimaryGatewayUnit(
+  env: GatewayServiceEnv,
+  units: SystemdSystemUnitRuntime[],
+): SystemdSystemUnitRuntime | null {
+  if (units.length === 0) {
+    return null;
+  }
+  const ordered = buildGatewayCandidates(env);
+  for (const candidate of ordered) {
+    const match = units.find((u) => u.unitName === candidate);
+    if (match) {
+      return match;
+    }
+  }
+  return units.find((u) => u.activeState === "active") ?? units[0] ?? null;
+}
+
+// Silence unused symbol warnings when tree-shaken.
+export const _MAIN_UNIT_CANDIDATE_TAG = MAIN_UNIT_CANDIDATE_TAG;

--- a/src/daemon/systemd-system-probe.ts
+++ b/src/daemon/systemd-system-probe.ts
@@ -1,0 +1,166 @@
+import { parseStrictPositiveInteger } from "../infra/parse-finite-number.js";
+import { readProcessServiceCgroup } from "../infra/proc-cgroup.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import {
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
+  resolveGatewaySystemdServiceName,
+  resolveNodeSystemdServiceName,
+} from "./constants.js";
+import { execFileUtf8 } from "./exec-file.js";
+import { parseKeyValueOutput } from "./runtime-parse.js";
+import type { SystemdSystemUnitRuntime } from "./service-runtime.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+export type SystemdSystemProbeOutcome = {
+  /** Units observed by the system-bus probe (loaded or active). */
+  units: SystemdSystemUnitRuntime[];
+  /** Whether at least one system-bus probe call succeeded. */
+  systemBusAvailable: boolean;
+};
+
+/**
+ * Extra candidate system unit names that downstream packaging is known to
+ * use on headless deployments in addition to the canonical
+ * `openclaw-gateway` / `openclaw-node` names.
+ */
+const EXTRA_SYSTEM_UNIT_CANDIDATES = ["openclaw-host-gateway", "openclaw-node-host"] as const;
+
+function buildGatewayCandidates(env: GatewayServiceEnv): string[] {
+  const names = new Set<string>();
+  const configuredGateway = env.OPENCLAW_SYSTEMD_UNIT?.trim();
+  if (configuredGateway) {
+    names.add(configuredGateway);
+  }
+  names.add(resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE));
+  for (const legacy of LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES) {
+    names.add(legacy);
+  }
+  for (const extra of EXTRA_SYSTEM_UNIT_CANDIDATES) {
+    names.add(extra);
+  }
+  names.add(resolveNodeSystemdServiceName());
+  return Array.from(names, (name) => (name.endsWith(".service") ? name : `${name}.service`));
+}
+
+/**
+ * Candidate units for the system-bus probe. Exported for tests.
+ */
+export function resolveCandidateSystemUnits(env: GatewayServiceEnv): string[] {
+  return buildGatewayCandidates(env);
+}
+
+type ShowResult = {
+  info: SystemdSystemUnitRuntime;
+  code: number;
+  detail: string;
+};
+
+function execSystemctlSystem(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return execFileUtf8("systemctl", args);
+}
+
+async function probeOneSystemUnit(unitName: string): Promise<ShowResult> {
+  // `systemctl show` works against the system bus without sudo and does not
+  // fail when the unit is missing (it prints defaults and returns 0). Use
+  // `is-active` first to cheaply skip units that don't exist to keep output
+  // noise-free, but don't rely on non-zero codes as hard errors because the
+  // system bus itself may be missing in containers.
+  const show = await execSystemctlSystem([
+    "show",
+    unitName,
+    "--no-page",
+    "--property",
+    "ActiveState,SubState,MainPID,LoadState,ControlGroup",
+  ]);
+  const detail = `${show.stderr} ${show.stdout}`.trim();
+  const entries = parseKeyValueOutput(show.stdout || "", "=");
+  const activeState = entries.activestate || undefined;
+  const subState = entries.substate || undefined;
+  const mainPidRaw = entries.mainpid;
+  const loadState = entries.loadstate || undefined;
+  const controlGroup = entries.controlgroup || undefined;
+  const mainPid = mainPidRaw ? parseStrictPositiveInteger(mainPidRaw) : undefined;
+  const info: SystemdSystemUnitRuntime = {
+    unitName,
+    ...(activeState ? { activeState } : {}),
+    ...(subState ? { subState } : {}),
+    ...(mainPid ? { mainPid } : {}),
+    loaded: loadState ? normalizeLowercaseStringOrEmpty(loadState) === "loaded" : undefined,
+  };
+  if (controlGroup && controlGroup.trim()) {
+    info.cgroup = controlGroup.trim();
+  } else if (mainPid) {
+    const fromProc = readProcessServiceCgroup(mainPid);
+    if (fromProc) {
+      info.cgroup = fromProc;
+    }
+  }
+  return { info, code: show.code, detail };
+}
+
+/**
+ * Probe the system bus for known OpenClaw systemd units. This is a
+ * no-sudo-required probe intended as a fallback when the user bus is
+ * unavailable (headless hosts without a login session). It intentionally
+ * returns a list of runtimes rather than a single one because OpenClaw can
+ * be installed as multiple co-located system services (gateway + node host).
+ */
+export async function probeSystemdSystemServices(
+  env: GatewayServiceEnv = process.env as GatewayServiceEnv,
+): Promise<SystemdSystemProbeOutcome> {
+  const candidates = buildGatewayCandidates(env);
+  const units: SystemdSystemUnitRuntime[] = [];
+  let systemBusAvailable = false;
+  for (const unitName of candidates) {
+    try {
+      const result = await probeOneSystemUnit(unitName);
+      if (result.code === 0) {
+        systemBusAvailable = true;
+      }
+      if (isUnitWorthReporting(result.info)) {
+        units.push(result.info);
+      }
+    } catch {
+      // best-effort; skip
+    }
+  }
+  return { units, systemBusAvailable };
+}
+
+function isUnitWorthReporting(info: SystemdSystemUnitRuntime): boolean {
+  if (info.loaded) {
+    return true;
+  }
+  if (info.activeState && info.activeState !== "inactive") {
+    return true;
+  }
+  if (info.mainPid && info.mainPid > 0) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Given a set of system-bus probe results, pick the unit that should
+ * represent the "gateway" service for status output (prefers the configured
+ * unit, then the canonical gateway, then host-gateway variants, then the
+ * first active unit).
+ */
+export function pickPrimaryGatewayUnit(
+  env: GatewayServiceEnv,
+  units: SystemdSystemUnitRuntime[],
+): SystemdSystemUnitRuntime | null {
+  if (units.length === 0) {
+    return null;
+  }
+  const ordered = buildGatewayCandidates(env);
+  for (const candidate of ordered) {
+    const match = units.find((u) => u.unitName === candidate);
+    if (match) {
+      return match;
+    }
+  }
+  return units.find((u) => u.activeState === "active") ?? units[0] ?? null;
+}

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -25,6 +25,7 @@ import {
   isSystemdUserServiceAvailable,
   parseSystemdShow,
   readSystemdServiceExecStart,
+  readSystemdServiceRuntime,
   restartSystemdService,
   resolveSystemdUserUnitPath,
   stageSystemdService,
@@ -896,5 +897,81 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("readSystemdServiceRuntime system-bus fallback", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("falls back to a system-bus probe when the user bus is unavailable", async () => {
+    // Sequence: 1) user-bus status fails with no-medium;
+    //           2) system-bus show for each candidate unit.
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      // user-bus assertSystemdAvailable
+      if (args[0] === "--user") {
+        const err = createExecFileError("Failed to connect to bus: No medium found", {
+          stderr: "Failed to connect to bus: No medium found",
+        });
+        cb(err, "", "");
+        return;
+      }
+      // system-bus `systemctl show <unit> --no-page --property ...`
+      expect(args[0]).toBe("show");
+      const unit = args[1] as string;
+      if (unit === "openclaw-host-gateway.service") {
+        cb(
+          null,
+          [
+            "ActiveState=active",
+            "SubState=running",
+            "MainPID=1131058",
+            "LoadState=loaded",
+            "ControlGroup=/system.slice/openclaw-host-gateway.service",
+          ].join("\n"),
+          "",
+        );
+        return;
+      }
+      cb(
+        null,
+        [
+          "ActiveState=inactive",
+          "SubState=dead",
+          "MainPID=0",
+          "LoadState=not-found",
+          "ControlGroup=",
+        ].join("\n"),
+        "",
+      );
+    });
+
+    const runtime = await readSystemdServiceRuntime({
+      // No USER / XDG_RUNTIME_DIR to simulate a headless system-only host.
+      HOME: "/root",
+    });
+    expect(runtime.scope).toBe("system");
+    expect(runtime.status).toBe("running");
+    expect(runtime.unitName).toBe("openclaw-host-gateway.service");
+    expect(runtime.pid).toBe(1131058);
+    expect(runtime.cgroup).toBe("/system.slice/openclaw-host-gateway.service");
+    expect((runtime.systemUnits ?? []).map((u) => u.unitName)).toContain(
+      "openclaw-host-gateway.service",
+    );
+  });
+
+  it("returns the original unknown detail when neither bus is reachable", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = createExecFileError("Failed to connect to bus: No medium found", {
+        stderr: "Failed to connect to bus: No medium found",
+      });
+      cb(err, "", "");
+    });
+
+    const runtime = await readSystemdServiceRuntime({ HOME: "/root" });
+    expect(runtime.status).toBe("unknown");
+    expect(runtime.detail).toContain("systemctl --user unavailable");
+    expect(runtime.scope).toBeUndefined();
   });
 });

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -592,6 +592,8 @@ describe("readSystemdServiceRuntime", () => {
       state: "active",
       subState: "running",
       pid: 1234,
+      scope: "user",
+      unitName: "openclaw-gateway.service",
       lastExitStatus: 0,
       lastExitReason: "running",
       systemd: {
@@ -1697,5 +1699,81 @@ describe("systemd service control", () => {
         cb(null, "", "");
       });
     await assertRestartSuccess({ USER: "debian" });
+  });
+});
+
+describe("readSystemdServiceRuntime system-bus fallback", () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it("falls back to a system-bus probe when the user bus is unavailable", async () => {
+    // Sequence: 1) user-bus status fails with no-medium;
+    //           2) system-bus show for each candidate unit.
+    execFileMock.mockImplementation((_cmd, args, _opts, cb) => {
+      // user-bus assertSystemdAvailable
+      if (args[0] === "--user") {
+        const err = createExecFileError("Failed to connect to bus: No medium found", {
+          stderr: "Failed to connect to bus: No medium found",
+        });
+        cb(err, "", "");
+        return;
+      }
+      // system-bus `systemctl show <unit> --no-page --property ...`
+      expect(args[0]).toBe("show");
+      const unit = args[1] as string;
+      if (unit === "openclaw-host-gateway.service") {
+        cb(
+          null,
+          [
+            "ActiveState=active",
+            "SubState=running",
+            "MainPID=1131058",
+            "LoadState=loaded",
+            "ControlGroup=/system.slice/openclaw-host-gateway.service",
+          ].join("\n"),
+          "",
+        );
+        return;
+      }
+      cb(
+        null,
+        [
+          "ActiveState=inactive",
+          "SubState=dead",
+          "MainPID=0",
+          "LoadState=not-found",
+          "ControlGroup=",
+        ].join("\n"),
+        "",
+      );
+    });
+
+    const runtime = await readSystemdServiceRuntime({
+      // No USER / XDG_RUNTIME_DIR to simulate a headless system-only host.
+      HOME: "/root",
+    });
+    expect(runtime.scope).toBe("system");
+    expect(runtime.status).toBe("running");
+    expect(runtime.unitName).toBe("openclaw-host-gateway.service");
+    expect(runtime.pid).toBe(1131058);
+    expect(runtime.cgroup).toBe("/system.slice/openclaw-host-gateway.service");
+    expect((runtime.systemUnits ?? []).map((u) => u.unitName)).toContain(
+      "openclaw-host-gateway.service",
+    );
+  });
+
+  it("returns the original unknown detail when neither bus is reachable", async () => {
+    execFileMock.mockImplementation((_cmd, _args, _opts, cb) => {
+      const err = createExecFileError("Failed to connect to bus: No medium found", {
+        stderr: "Failed to connect to bus: No medium found",
+      });
+      cb(err, "", "");
+    });
+
+    const runtime = await readSystemdServiceRuntime({ HOME: "/root" });
+    expect(runtime.status).toBe("unknown");
+    expect(runtime.detail).toContain("systemctl --user unavailable");
+    expect(runtime.scope).toBeUndefined();
   });
 });

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -32,6 +32,11 @@ import {
   type SystemdUserLingerStatus,
 } from "./systemd-linger.js";
 import {
+  pickPrimaryGatewayUnit,
+  probeSystemdSystemServices,
+  type SystemdSystemProbeOutcome,
+} from "./systemd-system-probe.js";
+import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
@@ -667,15 +672,61 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 
+function systemUnitToRuntime(
+  outcome: SystemdSystemProbeOutcome,
+  env: GatewayServiceEnv,
+): GatewayServiceRuntime | null {
+  const unit = pickPrimaryGatewayUnit(env, outcome.units);
+  if (!unit) {
+    return null;
+  }
+  const activeState = normalizeLowercaseStringOrEmpty(unit.activeState);
+  const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
+  return {
+    status,
+    state: unit.activeState,
+    subState: unit.subState,
+    pid: unit.mainPid,
+    scope: "system",
+    unitName: unit.unitName,
+    ...(unit.cgroup ? { cgroup: unit.cgroup } : {}),
+    systemUnits: outcome.units,
+  };
+}
+
 export async function readSystemdServiceRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime> {
   try {
     await assertSystemdAvailable(env);
   } catch (err) {
+    const detail = formatErrorMessage(err);
+    // When the user bus is unavailable, check the system bus before falling
+    // back to the "unknown" status. On headless Linux hosts OpenClaw is
+    // frequently installed as system-level units (no login session, no
+    // XDG_RUNTIME_DIR), and the system bus does not require sudo for read-
+    // only probing.
+    try {
+      const outcome = await probeSystemdSystemServices(env);
+      const systemRuntime = systemUnitToRuntime(outcome, env);
+      if (systemRuntime) {
+        return systemRuntime;
+      }
+      if (outcome.systemBusAvailable) {
+        // System bus is reachable but no OpenClaw units are present.
+        return {
+          status: "stopped",
+          scope: "system",
+          missingUnit: true,
+          systemUnits: outcome.units,
+        };
+      }
+    } catch {
+      // best-effort; fall through to the original unknown response
+    }
     return {
       status: "unknown",
-      detail: formatErrorMessage(err),
+      detail,
     };
   }
   const serviceName = resolveSystemdServiceName(env);
@@ -704,6 +755,8 @@ export async function readSystemdServiceRuntime(
     state: parsed.activeState,
     subState: parsed.subState,
     pid: parsed.mainPid,
+    scope: "user",
+    unitName,
     lastExitStatus: parsed.execMainStatus,
     lastExitReason: parsed.execMainCode,
   };

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -42,6 +42,11 @@ import type {
 } from "./service-types.js";
 import { enableSystemdUserLinger, readSystemdUserLingerStatus } from "./systemd-linger.js";
 import {
+  pickPrimaryGatewayUnit,
+  probeSystemdSystemServices,
+  type SystemdSystemProbeOutcome,
+} from "./systemd-system-probe.js";
+import {
   classifySystemdUnavailableDetail,
   isSystemctlMissingDetail,
   isSystemdUserBusUnavailableDetail,
@@ -1103,15 +1108,61 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 
+function systemUnitToRuntime(
+  outcome: SystemdSystemProbeOutcome,
+  env: GatewayServiceEnv,
+): GatewayServiceRuntime | null {
+  const unit = pickPrimaryGatewayUnit(env, outcome.units);
+  if (!unit) {
+    return null;
+  }
+  const activeState = normalizeLowercaseStringOrEmpty(unit.activeState);
+  const status = activeState === "active" ? "running" : activeState ? "stopped" : "unknown";
+  return {
+    status,
+    state: unit.activeState,
+    subState: unit.subState,
+    pid: unit.mainPid,
+    scope: "system",
+    unitName: unit.unitName,
+    ...(unit.cgroup ? { cgroup: unit.cgroup } : {}),
+    systemUnits: outcome.units,
+  };
+}
+
 export async function readSystemdServiceRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime> {
   try {
     await assertSystemdAvailable(env);
   } catch (err) {
+    const detail = formatErrorMessage(err);
+    // When the user bus is unavailable, check the system bus before falling
+    // back to the "unknown" status. On headless Linux hosts OpenClaw is
+    // frequently installed as system-level units (no login session, no
+    // XDG_RUNTIME_DIR), and the system bus does not require sudo for read-
+    // only probing.
+    try {
+      const outcome = await probeSystemdSystemServices(env);
+      const systemRuntime = systemUnitToRuntime(outcome, env);
+      if (systemRuntime) {
+        return systemRuntime;
+      }
+      if (outcome.systemBusAvailable) {
+        // System bus is reachable but no OpenClaw units are present.
+        return {
+          status: "stopped",
+          scope: "system",
+          missingUnit: true,
+          systemUnits: outcome.units,
+        };
+      }
+    } catch {
+      // best-effort; fall through to the original unknown response
+    }
     return {
       status: "unknown",
-      detail: formatErrorMessage(err),
+      detail,
     };
   }
   const serviceName = resolveSystemdServiceName(env);
@@ -1140,6 +1191,8 @@ export async function readSystemdServiceRuntime(
     state: parsed.activeState,
     subState: parsed.subState,
     pid: parsed.mainPid,
+    scope: "user",
+    unitName,
     lastExitStatus: parsed.execMainStatus,
     lastExitReason: parsed.execMainCode,
     systemd: {

--- a/src/infra/proc-cgroup.test.ts
+++ b/src/infra/proc-cgroup.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { extractServiceCgroupFromCgroupContent } from "./proc-cgroup.js";
+
+describe("extractServiceCgroupFromCgroupContent", () => {
+  it("returns the service name for a cgroup v2 unified entry", () => {
+    const content = "0::/system.slice/openclaw-host-gateway.service\n";
+    expect(extractServiceCgroupFromCgroupContent(content)).toBe("openclaw-host-gateway.service");
+  });
+
+  it("returns the service name for a cgroup v1 controller entry", () => {
+    const content =
+      "12:pids:/system.slice/openclaw-node-host.service\n" +
+      "11:memory:/system.slice/openclaw-node-host.service\n";
+    expect(extractServiceCgroupFromCgroupContent(content)).toBe("openclaw-node-host.service");
+  });
+
+  it("handles nested scopes inside a service cgroup", () => {
+    const content = "0::/system.slice/openclaw-host-gateway.service/child-0.scope\n";
+    expect(extractServiceCgroupFromCgroupContent(content)).toBe("openclaw-host-gateway.service");
+  });
+
+  it("returns the innermost .service segment (user-session systemd services count)", () => {
+    const content =
+      "0::/user.slice/user-1000.slice/user@1000.service/app.slice/app-gnome-terminal.scope\n";
+    // user@1000.service is a service segment; expect the leaf-most one.
+    expect(extractServiceCgroupFromCgroupContent(content)).toBe("user@1000.service");
+  });
+
+  it("returns null when the cgroup is a pure slice/scope with no service", () => {
+    const content = "0::/user.slice/user-1000.slice/session-1.scope\n";
+    expect(extractServiceCgroupFromCgroupContent(content)).toBeNull();
+  });
+
+  it("returns null for empty content", () => {
+    expect(extractServiceCgroupFromCgroupContent("")).toBeNull();
+  });
+});

--- a/src/infra/proc-cgroup.ts
+++ b/src/infra/proc-cgroup.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+
+/**
+ * Read the systemd service cgroup for a pid from `/proc/<pid>/cgroup`.
+ *
+ * Returns the service unit name (e.g. `openclaw-host-gateway.service`) when
+ * the pid lives inside a `*.service` cgroup (either cgroup v2 unified
+ * hierarchy or a legacy controller), or `null` when:
+ *   - the file does not exist or cannot be read (non-Linux, permission issues);
+ *   - the pid is not inside a `.service` cgroup (e.g. a user-session scope);
+ *   - the content cannot be parsed.
+ *
+ * This is intentionally best-effort and synchronous: callers use it as a
+ * cheap tie-breaker when classifying listener processes.
+ */
+export function readProcessServiceCgroup(pid: number): string | null {
+  if (!Number.isFinite(pid) || pid <= 0) {
+    return null;
+  }
+  if (process.platform !== "linux") {
+    return null;
+  }
+  let content: string;
+  try {
+    content = fs.readFileSync(`/proc/${pid}/cgroup`, "utf8");
+  } catch {
+    return null;
+  }
+  return extractServiceCgroupFromCgroupContent(content);
+}
+
+/**
+ * Extract the first `*.service` basename from the content of
+ * `/proc/<pid>/cgroup`. Exported for tests.
+ */
+export function extractServiceCgroupFromCgroupContent(content: string): string | null {
+  if (!content) {
+    return null;
+  }
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) {
+      continue;
+    }
+    // cgroup v2: "0::/system.slice/openclaw-host-gateway.service"
+    // cgroup v1: "<id>:<controller>:/system.slice/foo.service"
+    // Take the portion after the last ":" (the path) and find the
+    // last ".service" segment.
+    const pathIdx = line.lastIndexOf(":");
+    const pathPart = pathIdx >= 0 ? line.slice(pathIdx + 1) : line;
+    const serviceName = findServiceSegment(pathPart);
+    if (serviceName) {
+      return serviceName;
+    }
+  }
+  return null;
+}
+
+function findServiceSegment(pathPart: string): string | null {
+  if (!pathPart) {
+    return null;
+  }
+  // Walk segments from leaf to root so scoped subunits (e.g.
+  // "/system.slice/foo.service/bar") still resolve to the owning service.
+  const segments = pathPart.split("/").filter(Boolean);
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    const segment = segments[i];
+    if (segment && segment.endsWith(".service")) {
+      return segment;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem: false-positive "double-supervisor" report

On headless Linux hosts where OpenClaw is installed as **system-level**
systemd units (unit files under `/etc/systemd/system/`), `openclaw gateway
status` cannot probe the runtime and falsely reports a duplicate
supervisor.

The current probe only talks to the **user** bus (`systemctl --user`). On
a server without a login session (no `XDG_RUNTIME_DIR`, no user DBus
socket), that probe fails:

```
Runtime: unknown (systemctl --user unavailable: Failed to connect to bus: No medium found)
```

It then falls back to a listener/process heuristic that sees two
`openclaw` supervisor processes (one for the gateway service, one for
the node-host service) and flags them as a duplicate/double-supervisor
condition. Runtime is actually fine — the two processes belong to two
*distinct* system services, each with its own systemd cgroup.

### Proof from the affected host

```
● openclaw-host-gateway.service
    Loaded: /etc/systemd/system/openclaw-host-gateway.service
    Active: running
    Main PID: 1131058 (openclaw)  ├── openclaw-gateway

● openclaw-node-host.service
    Loaded: /etc/systemd/system/openclaw-node-host.service
    Active: running
    Main PID: 1131042 (openclaw)  ├── openclaw-node

# cgroups confirm separation:
/proc/1131042/cgroup → /system.slice/openclaw-node-host.service
/proc/1131058/cgroup → /system.slice/openclaw-host-gateway.service
```

## What changed

1. **System-bus fallback** (`src/daemon/systemd-system-probe.ts`, wired into
   `readSystemdServiceRuntime`). When `systemctl --user` is unavailable,
   the runtime probe now tries `systemctl show <unit> --no-page --property
   ActiveState,SubState,MainPID,LoadState,ControlGroup` against the
   **system** bus for the canonical gateway/node units plus the
   `openclaw-host-gateway` / `openclaw-node-host` packaging variants and
   any legacy names. No sudo is required — `systemctl show` is read-only
   and the system bus is world-readable.

   On success the runtime surfaces `scope: "system"`, the matched
   `unitName`, the `MainPID`, and the cgroup. `status.print.ts` now shows a
   per-unit block (name, active state, pid, cgroup) instead of the
   "Runtime: unknown" line.

2. **Cgroup-aware dup detection** (`src/cli/daemon-cli/restart-health.ts`
   + new `src/infra/proc-cgroup.ts`). If the pgrep/listener-based fallback
   is still needed, read `/proc/<pid>/cgroup` for both the gateway runtime
   pid and each candidate stale pid. When both live inside **different**
   `*.service` cgroups (e.g. `openclaw-host-gateway.service` vs
   `openclaw-node-host.service`), they are recognised as independent
   sibling services and are not flagged as duplicates. We only flag when
   they share a cgroup or cgroup attribution is unavailable.

3. **Hints**. `renderSystemdUnavailableHints` now accepts
   `systemServicesDetected` and suppresses the misleading "systemd user
   services are unavailable" line when system-level services are already
   healthy. The generic Linux wording also mentions running under
   system-level systemd as a valid deployment.

### Backwards compatibility

- The user bus is still tried **first**. Existing installs that run
  OpenClaw under user systemd keep exactly the same behaviour (user-bus
  path still sets `scope: "user"`).
- No sudo, no new external tools, no new configuration.
- On non-Linux hosts the new cgroup reader simply returns `null` and the
  original listener-based behaviour is preserved.

## Test coverage

All new tests mock `execFile` / `child_process` so they run anywhere.

| Area | File | Covered |
| --- | --- | --- |
| System-bus probe parsing + candidate enumeration + primary-unit selection | `src/daemon/systemd-system-probe.test.ts` (new, 7 tests) | Active+cgroup reporting, no-bus failure mode, unit preference order |
| `readSystemdServiceRuntime` fallback flow | `src/daemon/systemd.test.ts` (new, 2 tests in a `readSystemdServiceRuntime system-bus fallback` suite) | User-bus fails → system-bus returns a running `openclaw-host-gateway.service`; both buses fail → original `unknown` detail preserved |
| Cgroup-aware dedup | `src/cli/daemon-cli/restart-health.test.ts` (3 new tests) | Distinct sibling service pids → no stale pids; same service cgroup → still flagged; unavailable cgroup → backward-compat fallback |
| `/proc/<pid>/cgroup` parser | `src/infra/proc-cgroup.test.ts` (new, 6 tests) | cgroup v2, cgroup v1 multi-controller, nested scopes, pure slices, empty input |
| Hint rewording + suppression | `src/daemon/systemd-hints.test.ts` (updated + new test) | New "systemServicesDetected" short-circuit returns `[]` |

Command output:

```
Test Files  15 passed (15)    # daemon
     Tests 254 passed (254)

Test Files 101 passed (101)   # cli
     Tests 940 passed (940)
```

`pnpm lint` passes clean on the touched files.

## Files changed

```
src/cli/daemon-cli/restart-health.test.ts | 69 +++++++++++++++++++++++++++
src/cli/daemon-cli/restart-health.ts      | 54 ++++++++++++++++++++-
src/cli/daemon-cli/status.print.ts        | 23 ++++++++-
src/daemon/service-runtime.ts             | 26 +++++++++++
src/daemon/systemd-hints.test.ts          | 15 ++++--
src/daemon/systemd-hints.ts               | 14 +++++-
src/daemon/systemd-system-probe.test.ts   | 179 ++++++++++++++ (new)
src/daemon/systemd-system-probe.ts        | 167 ++++++++++++  (new)
src/daemon/systemd.test.ts                | 78 +++++++++++++++++++++++++++++++
src/daemon/systemd.ts                     | 56 +++++++++++++++++++++-
src/infra/proc-cgroup.test.ts             |  50 ++++++ (new)
src/infra/proc-cgroup.ts                  |  75 ++++ (new)
```
