### PR TITLE
ui(approval): refresh overview and tighten approval actions

### DIFF
--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -92,6 +92,7 @@ import type {
   HealthSummary,
   LogEntry,
   LogLevel,
+  ModelAuthStatusResult,
   ModelCatalogEntry,
   PresenceEntry,
   ChannelsStatusSnapshot,
@@ -250,6 +251,7 @@ export class OpenClawApp extends LitElement {
   @state() wikiMemoryPalaceError: string | null = null;
   @state() wikiMemoryPalace: WikiMemoryPalace | null = null;
   @state() configFormDirty = false;
+  @state() configSettingsMode: "quick" | "advanced" = "quick";
   @state() configFormMode: "form" | "raw" = "form";
   @state() configSearchQuery = "";
   @state() configActiveSection: string | null = null;
@@ -395,6 +397,11 @@ export class OpenClawApp extends LitElement {
   usageQueryDebounceTimer: number | null = null;
 
   @state() cronLoading = false;
+  @state() cronQuickCreateOpen = false;
+  @state() cronQuickCreateStep: import("./views/cron-quick-create.ts").CronQuickCreateStep = "what";
+  @state() cronQuickCreateDraft:
+    | import("./views/cron-quick-create.ts").CronQuickCreateDraft
+    | null = null;
   @state() cronJobsLoadingMore = false;
   @state() cronJobs: CronJob[] = [];
   @state() cronJobsTotal = 0;
@@ -465,6 +472,10 @@ export class OpenClawApp extends LitElement {
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;
   @state() healthError: string | null = null;
+
+  @state() modelAuthStatusLoading = false;
+  @state() modelAuthStatusResult: ModelAuthStatusResult | null = null;
+  @state() modelAuthStatusError: string | null = null;
 
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;
@@ -657,8 +668,8 @@ export class OpenClawApp extends LitElement {
     return [active, ...rest];
   }
 
-  async loadOverview() {
-    await loadOverviewInternal(this as unknown as Parameters<typeof loadOverviewInternal>[0]);
+  async loadOverview(opts?: { refresh?: boolean }) {
+    await loadOverviewInternal(this as unknown as Parameters<typeof loadOverviewInternal>[0], opts);
   }
 
   async loadCron() {

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -92,7 +92,6 @@ import type {
   HealthSummary,
   LogEntry,
   LogLevel,
-  ModelAuthStatusResult,
   ModelCatalogEntry,
   PresenceEntry,
   ChannelsStatusSnapshot,
@@ -251,7 +250,6 @@ export class OpenClawApp extends LitElement {
   @state() wikiMemoryPalaceError: string | null = null;
   @state() wikiMemoryPalace: WikiMemoryPalace | null = null;
   @state() configFormDirty = false;
-  @state() configSettingsMode: "quick" | "advanced" = "quick";
   @state() configFormMode: "form" | "raw" = "form";
   @state() configSearchQuery = "";
   @state() configActiveSection: string | null = null;
@@ -397,11 +395,6 @@ export class OpenClawApp extends LitElement {
   usageQueryDebounceTimer: number | null = null;
 
   @state() cronLoading = false;
-  @state() cronQuickCreateOpen = false;
-  @state() cronQuickCreateStep: import("./views/cron-quick-create.ts").CronQuickCreateStep = "what";
-  @state() cronQuickCreateDraft:
-    | import("./views/cron-quick-create.ts").CronQuickCreateDraft
-    | null = null;
   @state() cronJobsLoadingMore = false;
   @state() cronJobs: CronJob[] = [];
   @state() cronJobsTotal = 0;
@@ -472,10 +465,6 @@ export class OpenClawApp extends LitElement {
   @state() healthLoading = false;
   @state() healthResult: HealthSummary | null = null;
   @state() healthError: string | null = null;
-
-  @state() modelAuthStatusLoading = false;
-  @state() modelAuthStatusResult: ModelAuthStatusResult | null = null;
-  @state() modelAuthStatusError: string | null = null;
 
   @state() debugLoading = false;
   @state() debugStatus: StatusSummary | null = null;
@@ -668,8 +657,8 @@ export class OpenClawApp extends LitElement {
     return [active, ...rest];
   }
 
-  async loadOverview(opts?: { refresh?: boolean }) {
-    await loadOverviewInternal(this as unknown as Parameters<typeof loadOverviewInternal>[0], opts);
+  async loadOverview() {
+    await loadOverviewInternal(this as unknown as Parameters<typeof loadOverviewInternal>[0]);
   }
 
   async loadCron() {
@@ -751,11 +740,25 @@ export class OpenClawApp extends LitElement {
     this.execApprovalError = null;
     try {
       const method = active.kind === "plugin" ? "plugin.approval.resolve" : "exec.approval.resolve";
-      await this.client.request(method, {
+      const resolved = await this.client.request<{ id?: string; decision?: string }>(method, {
         id: active.id,
         decision,
       });
-      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== active.id);
+      const resolvedId = resolved?.id ?? active.id;
+      this.execApprovalQueue = this.execApprovalQueue.filter((entry) => entry.id !== resolvedId);
+      this.eventLog.unshift({
+        ts: Date.now(),
+        event: "approval-resolved",
+        payload: { id: resolvedId, decision, kind: active.kind },
+      });
+      void this.loadOverview();
+      this.dispatchEvent(
+        new CustomEvent("openclaw-approval-resolved", {
+          bubbles: true,
+          composed: true,
+          detail: { id: resolvedId, decision, kind: active.kind },
+        }),
+      );
     } catch (err) {
       this.execApprovalError = `Approval failed: ${String(err)}`;
     } finally {

--- a/ui/src/ui/views/exec-approval.ts
+++ b/ui/src/ui/views/exec-approval.ts
@@ -88,21 +88,21 @@ export function renderExecApprovalPrompt(state: AppViewState) {
             ?disabled=${state.execApprovalBusy}
             @click=${() => state.handleExecApprovalDecision("allow-once")}
           >
-            Allow once
+            Approve
           </button>
           <button
             class="btn"
             ?disabled=${state.execApprovalBusy}
             @click=${() => state.handleExecApprovalDecision("allow-always")}
           >
-            Always allow
+            Approve and remember
           </button>
           <button
             class="btn danger"
             ?disabled=${state.execApprovalBusy}
             @click=${() => state.handleExecApprovalDecision("deny")}
           >
-            Deny
+            Reject
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- rename approval actions to clearer labels
- remove resolved approvals from the queue using the returned id
- log `approval-resolved` events
- refresh overview state after approval resolution

## Why
This makes approval handling clearer and makes the UI feel trustworthy after an approval is resolved.

## Validation
- `corepack pnpm build` in `ui/`

## Notes
- follow-up commit restores the manual refresh cache-bypass path and the reactive overview/config state fields that were unintentionally dropped