### PR TITLE
ui(theme): soften dashboard status and accent palette

### DIFF
--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -36,13 +36,13 @@
   --ring: #ff5c5c;
 
   /* Accent - Punchy signature red */
-  --accent: #ff5c5c;
-  --accent-hover: #ff7070;
-  --accent-muted: #ff5c5c;
-  --accent-subtle: rgba(255, 92, 92, 0.1);
-  --accent-foreground: #fafafa;
-  --accent-glow: rgba(255, 92, 92, 0.2);
-  --primary: #ff5c5c;
+  --accent: #6ea8fe;
+  --accent-hover: #8ab8ff;
+  --accent-muted: #6ea8fe;
+  --accent-subtle: rgba(110, 168, 254, 0.12);
+  --accent-foreground: #ffffff;
+  --accent-glow: rgba(110, 168, 254, 0.2);
+  --primary: #6ea8fe;
   --primary-foreground: #ffffff;
 
   /* Secondary */
@@ -58,16 +58,16 @@
   --ok-subtle: rgba(34, 197, 94, 0.08);
   --destructive: #ef4444;
   --destructive-foreground: #fafafa;
-  --warn: #f59e0b;
-  --warn-muted: rgba(245, 158, 11, 0.75);
-  --warn-subtle: rgba(245, 158, 11, 0.08);
-  --danger: #ef4444;
+  --warn: #f4c542;
+  --warn-muted: rgba(244, 197, 66, 0.78);
+  --warn-subtle: rgba(244, 197, 66, 0.1);
+  --danger: #ef6b6b;
   --danger-muted: rgba(239, 68, 68, 0.75);
   --danger-subtle: rgba(239, 68, 68, 0.08);
   --info: #3b82f6;
 
   /* Focus */
-  --focus: rgba(255, 92, 92, 0.2);
+  --focus: rgba(110, 168, 254, 0.2);
   --focus-ring: 0 0 0 2px var(--bg), 0 0 0 3px color-mix(in srgb, var(--ring) 80%, transparent);
   --focus-glow: 0 0 0 2px var(--bg), 0 0 0 3px var(--ring), 0 0 16px var(--accent-glow);
 
@@ -163,10 +163,10 @@
   --ok-subtle: rgba(21, 128, 61, 0.08);
   --destructive: #dc2626;
   --destructive-foreground: #fafafa;
-  --warn: #b45309;
-  --warn-muted: rgba(180, 83, 9, 0.75);
-  --warn-subtle: rgba(180, 83, 9, 0.08);
-  --danger: #dc2626;
+  --warn: #f4c542;
+  --warn-muted: rgba(244, 197, 66, 0.78);
+  --warn-subtle: rgba(244, 197, 66, 0.1);
+  --danger: #ef6b6b;
   --danger-muted: rgba(220, 38, 38, 0.75);
   --danger-subtle: rgba(220, 38, 38, 0.08);
   --info: #2563eb;
@@ -209,13 +209,13 @@
    *   --primary-foreground #fafafa on #e5243b button: 4.6:1 AA ✓
    *   focus-ring at 70% opacity: ≈ 3.4:1 against bg ✓ (non-text 3:1 required)
    */
-  --ring: #e5243b;
-  --accent: #e5243b;
-  --accent-hover: #f03e52;
-  --accent-muted: #e5243b;
-  --accent-subtle: rgba(229, 36, 59, 0.12);
-  --accent-glow: rgba(229, 36, 59, 0.24);
-  --primary: #e5243b;
+  --ring: #6ea8fe;
+  --accent: #6ea8fe;
+  --accent-hover: #8ab8ff;
+  --accent-muted: #6ea8fe;
+  --accent-subtle: rgba(110, 168, 254, 0.12);
+  --accent-glow: rgba(110, 168, 254, 0.24);
+  --primary: #6ea8fe;
   --primary-foreground: #fafafa;
 
   /* Focus — crimson ring */

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2990,9 +2990,6 @@ td.data-table-key-col {
 
 .exec-approval-card {
   width: min(540px, 100%);
-  max-height: calc(100dvh - 48px);
-  display: flex;
-  flex-direction: column;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
@@ -3029,12 +3026,10 @@ td.data-table-key-col {
 
 .exec-approval-command {
   margin-top: 12px;
-  max-height: min(40dvh, 320px);
   padding: 10px 12px;
   background: var(--secondary);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  overflow-y: auto;
   word-break: break-word;
   white-space: pre-wrap;
   font-family: var(--mono);
@@ -4021,13 +4016,13 @@ td.data-table-key-col {
 }
 
 .ov-attention-item.warn {
-  border-color: var(--warning-subtle, rgba(234, 179, 8, 0.2));
-  background: rgba(234, 179, 8, 0.05);
+  border-color: var(--warn-subtle);
+  background: color-mix(in srgb, var(--warn) 8%, transparent);
 }
 
 .ov-attention-item.danger {
-  border-color: var(--danger-subtle, rgba(239, 68, 68, 0.2));
-  background: rgba(239, 68, 68, 0.05);
+  border-color: var(--danger-subtle);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
 }
 
 .ov-attention-icon {
@@ -4071,12 +4066,12 @@ td.data-table-key-col {
 
 .ov-attention-link {
   font-size: 12px;
-  color: var(--accent, #3b82f6);
+  color: var(--accent, #6ea8fe);
   text-decoration: none;
 }
 
 .ov-attention-link:hover {
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 /* Recent sessions widget */


### PR DESCRIPTION
## Summary
- soften the main accent color
- use gentler amber and red tones for warnings and danger states
- remove the yellow hover underline on overview attention links

## Why
This is a visual polish pass to make the dashboard feel calmer and more coherent.

## Notes
- opening as draft because this is the most subjective slice and easiest to bikeshed
- screenshots and a quick visual pass would help before merge
