### PR TITLE
fix: Remove comments from tsconfig.json to resolve JSON parsing error

### DIFF
--- a/qa/convex-credential-broker/convex/tsconfig.json
+++ b/qa/convex-credential-broker/convex/tsconfig.json
@@ -1,18 +1,11 @@
 {
-  /* This TypeScript project config describes the environment that
-   * Convex functions run in and is used to typecheck them.
-   * You can modify it, but some settings are required to use Convex.
-   */
   "compilerOptions": {
-    /* These settings are not required by Convex and can be modified. */
     "allowJs": true,
     "strict": true,
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
     "skipLibCheck": true,
     "allowSyntheticDefaultImports": true,
-
-    /* These compiler options are required by Convex */
     "target": "ESNext",
     "lib": ["ES2023", "dom"],
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Problem
The `qa/convex-credential-broker/convex/tsconfig.json` file contains `/* */` style comments, which cause JSON parsing errors in strict JSON parsers:
```
Expected ',' or '}' after property value in JSON at position 70
```

## Solution
- Removed all comments from the tsconfig.json file
- Kept all compiler options and configuration intact
- TypeScript still supports the config file without comments

## Testing
- Validated JSON syntax with `jq`
- All compiler options remain unchanged

Fixes the JSON parsing error while maintaining TypeScript configuration.