### PR TITLE
feat(memory): switch default local embedding model to bge-m3 Q8_0 🤖 AI-assisted

### DIFF
--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
+import { DEFAULT_LOCAL_MODEL } from "./embeddings.js";
 
 vi.mock("../agents/model-auth.js", () => ({
   resolveApiKeyForProvider: vi.fn(),
@@ -333,6 +334,10 @@ describe("local embedding normalization", () => {
     vi.resetModules();
     vi.unstubAllGlobals();
     vi.doUnmock("./node-llama.js");
+  });
+
+  it("uses bge-m3 Q8_0 as the default local embedding model", () => {
+    expect(DEFAULT_LOCAL_MODEL).toBe("hf:ggml-org/bge-m3-Q8_0-GGUF/bge-m3-q8_0.gguf");
   });
 
   it("normalizes local embeddings to magnitude ~1.0", async () => {

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -1,5 +1,5 @@
-import type { Llama, LlamaEmbeddingContext, LlamaModel } from "node-llama-cpp";
 import fsSync from "node:fs";
+import type { Llama, LlamaEmbeddingContext, LlamaModel } from "node-llama-cpp";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { createGeminiEmbeddingProvider, type GeminiEmbeddingClient } from "./embeddings-gemini.js";
@@ -54,7 +54,7 @@ export type EmbeddingProviderOptions = {
   };
 };
 
-const DEFAULT_LOCAL_MODEL = "hf:ggml-org/embeddinggemma-300M-GGUF/embeddinggemma-300M-Q8_0.gguf";
+export const DEFAULT_LOCAL_MODEL = "hf:ggml-org/bge-m3-Q8_0-GGUF/bge-m3-q8_0.gguf";
 
 function canAutoSelectLocal(options: EmbeddingProviderOptions): boolean {
   const modelPath = options.local?.modelPath?.trim();


### PR DESCRIPTION
## What

Replaces the default local embedding model for memory search from `embeddinggemma-300M-qat` (768 dims) to BAAI/bge-m3 Q8\_0 via `ggml-org/bge-m3-Q8_0-GGUF` (1024 dims).

## Why

With the current `embeddinggemma-300M` model, memory search frequently misses results that are conceptually related but lexically distant from the query — for example, searching for a topic using different wording than what was written in the indexed content. This is a known limitation of smaller token-matching-oriented models.

`bge-m3` (BAAI, 570M parameters, BERT-family architecture) ranks substantially higher on MTEB retrieval benchmarks and produces better cluster separation for semantically related but lexically distinct content. It is also multilingual, which benefits non-English memory content.

The download size is ~567 MB (Q8\_0) vs ~300 MB for embeddinggemma, which is a reasonable trade-off for the quality improvement.

## Migration

The existing atomic reindex path (`runAtomicFullReindex` + `ensureVectorTable`) already handles dimension changes (768→1024) automatically — it detects the dim mismatch, drops and recreates `chunks_vec`, and reindexes all chunks. No manual migration is required.

Users upgrading will trigger a one-time full reindex on next `openclaw memory index --force` (or on next startup with `onSessionStart` enabled). The embedding cache will naturally miss on the new model, forcing fresh embeddings.

## Changes

- `src/memory/embeddings.ts`: updated `DEFAULT_LOCAL_MODEL`, exported it for testability
- `src/memory/embeddings.test.ts`: added regression assertion for the model identifier

## Testing

- Unit tests pass (the embeddings.test.ts failure pre-exists on the upstream branch due to an unrelated OAuth mock issue)
- Build clean (`pnpm build`)
- Live reindex of ~900 chunks against a real memory DB confirmed successful with the new model at 1024 dims

🤖 AI-assisted