### PR TITLE
fix(agents): honor models.mode='replace' by skipping implicit provider discovery

### DIFF
--- a/src/agents/models-config.mode-replace.test.ts
+++ b/src/agents/models-config.mode-replace.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveProvidersForModelsJsonWithDeps } from "./models-config.plan.js";
+import type { ProviderConfig } from "./models-config.providers.secrets.js";
+
+function bailianProvider(): ProviderConfig {
+  return {
+    baseUrl: "https://coding.dashscope.aliyuncs.com/v1",
+    api: "openai-completions",
+    apiKey: "DASHSCOPE_API_KEY",
+    models: [
+      {
+        id: "qwen3-coder-plus",
+        name: "Qwen3 Coder Plus",
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128000,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
+function codexImplicitProvider(): ProviderConfig {
+  return {
+    baseUrl: "https://chatgpt.com/backend-api/v1",
+    api: "openai-codex-responses",
+    apiKey: "OPENAI_API_KEY",
+    models: [
+      {
+        id: "gpt-5.4-codex",
+        name: "GPT-5.4 Codex",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      },
+    ],
+  };
+}
+
+describe("resolveProvidersForModelsJsonWithDeps — models.mode", () => {
+  it("includes implicit providers when mode is undefined (default)", async () => {
+    const cfg: OpenClawConfig = {
+      models: { providers: { bailian: bailianProvider() } },
+    };
+    const resolveImplicit = vi.fn().mockResolvedValue({ codex: codexImplicitProvider() });
+
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      { cfg, agentDir: "/tmp/test-agent", env: {} },
+      { resolveImplicitProviders: resolveImplicit },
+    );
+
+    expect(resolveImplicit).toHaveBeenCalledTimes(1);
+    expect(Object.keys(providers).toSorted()).toEqual(["bailian", "codex"]);
+  });
+
+  it("includes implicit providers when mode is 'merge'", async () => {
+    const cfg: OpenClawConfig = {
+      models: { mode: "merge", providers: { bailian: bailianProvider() } },
+    };
+    const resolveImplicit = vi.fn().mockResolvedValue({ codex: codexImplicitProvider() });
+
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      { cfg, agentDir: "/tmp/test-agent", env: {} },
+      { resolveImplicitProviders: resolveImplicit },
+    );
+
+    expect(resolveImplicit).toHaveBeenCalledTimes(1);
+    expect(Object.keys(providers).toSorted()).toEqual(["bailian", "codex"]);
+  });
+
+  it("excludes implicit providers when mode is 'replace' — #68965", async () => {
+    const cfg: OpenClawConfig = {
+      models: { mode: "replace", providers: { bailian: bailianProvider() } },
+    };
+    const resolveImplicit = vi.fn().mockResolvedValue({ codex: codexImplicitProvider() });
+
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      { cfg, agentDir: "/tmp/test-agent", env: {} },
+      { resolveImplicitProviders: resolveImplicit },
+    );
+
+    // The fix: implicit fetch is skipped entirely, and the result contains
+    // ONLY the explicit providers from config.
+    expect(resolveImplicit).not.toHaveBeenCalled();
+    expect(Object.keys(providers)).toEqual(["bailian"]);
+    expect(providers.codex).toBeUndefined();
+  });
+});

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -45,6 +45,16 @@ export async function resolveProvidersForModelsJsonWithDeps(
 ): Promise<Record<string, ProviderConfig>> {
   const { cfg, agentDir, env } = params;
   const explicitProviders = cfg.models?.providers ?? {};
+  // `models.mode: "replace"` documents an intent to emit ONLY the explicit
+  // providers from config, excluding implicit providers discovered from
+  // bundled plugin catalog hooks (#68965). Skip the implicit fetch entirely
+  // in that case so bundled codex/etc. don't leak back into models.json.
+  if (cfg.models?.mode === "replace") {
+    return mergeProviders({
+      implicit: {},
+      explicit: explicitProviders,
+    });
+  }
   const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
   const implicitProviders = await resolveImplicitProvidersImpl({
     agentDir,


### PR DESCRIPTION
## Problem

\`resolveProvidersForModelsJsonWithDeps\` in \`src/agents/models-config.plan.ts\` always invoked \`resolveImplicitProviders\` and merged the result with the explicit providers from config. That meant \`models.mode: \"replace\"\` — documented as 'only use explicitly configured providers' — still pulled in implicit providers contributed by bundled plugin \`catalog\` hooks.

Reporter @Tony-ooo (#68965) traced this to the \`codex\` bundled plugin, which defines a \`catalog\` hook and ends up in \`models.json\` even when \`mode: \"replace\"\` is set. Other bundled plugins like \`anthropic\` aren't affected because they don't define a \`catalog\` hook, which is why the symptom looks codex-specific.

## Fix

In \`resolveProvidersForModelsJsonWithDeps\`, check \`cfg.models?.mode\` before the implicit fetch. When it's \`\"replace\"\`, skip \`resolveImplicitProviders\` entirely and return a \`mergeProviders\` result with \`implicit: {}\`. Default (undefined) and \`\"merge\"\` paths are unchanged.

This is a single edit at the one source of truth. Downstream \`mergeProviders\` keeps the same explicit-wins semantics.

## Testing

Added \`src/agents/models-config.mode-replace.test.ts\` with three cases:

- default (no mode) → implicit fetch runs, both providers emitted
- \`mode: \"merge\"\` → implicit fetch runs, both providers emitted
- \`mode: \"replace\"\` → **implicit fetch is never called**, only explicit providers emitted

\`tsc --noEmit\` and \`oxlint\` clean on the touched files.

Fixes #68965