### PR TITLE
fix: stream reasoning in live chat

### DIFF
--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -11,8 +11,8 @@ export type BuildChatItemsProps = {
   sessionKey: string;
   messages: unknown[];
   toolMessages: unknown[];
-  streamSegments: Array<{ text: string; ts: number }>;
-  stream: string | null;
+  streamSegments: Array<{ text: string; ts: number; message?: unknown }>;
+  stream: string | Record<string, unknown> | null;
   streamStartedAt: number | null;
   showToolCalls: boolean;
   searchOpen?: boolean;
@@ -278,11 +278,15 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
   const segments = props.streamSegments ?? [];
   const maxLen = Math.max(segments.length, tools.length);
   for (let i = 0; i < maxLen; i++) {
-    if (i < segments.length && segments[i].text.trim().length > 0) {
+    if (
+      i < segments.length &&
+      (segments[i].text.trim().length > 0 || Boolean(segments[i].message))
+    ) {
       items.push({
         kind: "stream",
         key: `stream-seg:${props.sessionKey}:${i}`,
         text: segments[i].text,
+        ...(segments[i].message ? { message: segments[i].message } : {}),
         startedAt: segments[i].ts,
       });
     }
@@ -297,11 +301,14 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
 
   if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
+    const hasStreamText = typeof props.stream === "string" && props.stream.trim().length > 0;
+    const hasStreamMessage = !!props.stream && typeof props.stream === "object";
+    if (hasStreamText || hasStreamMessage) {
       items.push({
         kind: "stream",
         key,
-        text: props.stream,
+        text: typeof props.stream === "string" ? props.stream : extractTextCached(props.stream) ?? "",
+        ...(hasStreamMessage ? { message: props.stream } : {}),
         startedAt: props.streamStartedAt ?? Date.now(),
       });
     } else {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -3,6 +3,7 @@
 import { html, render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MessageGroup } from "../types/chat-types.ts";
+import { buildChatItems } from "./build-chat-items.ts";
 import {
   formatChatTimestampForDisplay,
   renderMessageGroup,
@@ -1667,5 +1668,51 @@ describe("grouped chat rendering", () => {
       message: streamMessage,
       text: "",
     });
+  });
+
+  it("preserves reasoning for structured streaming messages and keeps plain text fallback", () => {
+    const container = document.createElement("div");
+
+    render(
+      renderStreamingGroup(
+        "Structured reply",
+        1,
+        undefined,
+        { name: "OpenClaw", avatar: null },
+        undefined,
+        null,
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Plan A" },
+            { type: "text", text: "Structured reply" },
+          ],
+          timestamp: 1,
+        },
+        true,
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+    expect(container.textContent).toContain("Plan A");
+    expect(container.textContent).toContain("Structured reply");
+
+    render(
+      renderStreamingGroup(
+        "Plain fallback",
+        2,
+        undefined,
+        { name: "OpenClaw", avatar: null },
+        undefined,
+        null,
+        undefined,
+        true,
+      ),
+      container,
+    );
+
+    expect(container.querySelector(".chat-thinking")).toBeNull();
+    expect(container.textContent).toContain("Plain fallback");
   });
 });

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1598,4 +1598,58 @@ describe("grouped chat rendering", () => {
       }),
     );
   });
+
+  it("keeps structured streaming assistant messages with their message payload", () => {
+    const streamMessage = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "Reasoning:\nInspecting state" },
+        { type: "text", text: "Structured reply" },
+      ],
+      timestamp: 1,
+    };
+
+    const items = buildChatItems({
+      sessionKey: "main",
+      messages: [],
+      toolMessages: [],
+      streamSegments: [],
+      stream: streamMessage,
+      streamStartedAt: 1,
+      showToolCalls: true,
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "stream",
+      message: streamMessage,
+      text: "Structured reply",
+    });
+  });
+
+  it("adds thinking-only streaming assistant messages to the timeline", () => {
+    const streamMessage = {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "Reasoning:\nCalculating simple arithmetic" }],
+      timestamp: 1,
+    };
+
+    const items = buildChatItems({
+      sessionKey: "main",
+      messages: [],
+      toolMessages: [],
+      streamSegments: [],
+      stream: streamMessage,
+      streamStartedAt: 1,
+      showToolCalls: true,
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      kind: "stream",
+      message: streamMessage,
+      text: "",
+    });
+  });
+
 });

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -1000,6 +1000,23 @@ describe("grouped chat rendering", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("renders assistant reasoning-only messages when reasoning is visible", () => {
+    const container = document.createElement("div");
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Plan A" }],
+        timestamp: Date.now(),
+      },
+      { showReasoning: true, showToolCalls: false },
+    );
+
+    expect(container.querySelector(".chat-bubble")).not.toBeNull();
+    expect(container.querySelector(".chat-thinking")).not.toBeNull();
+    expect(container.textContent).toContain("Plan A");
+  });
+
   it("renders canvas-only [embed] shortcodes inside the assistant bubble", () => {
     const container = document.createElement("div");
     renderAssistantMessage(
@@ -1651,5 +1668,4 @@ describe("grouped chat rendering", () => {
       text: "",
     });
   });
-
 });

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -339,21 +339,31 @@ export function renderStreamingGroup(
   assistant?: AssistantIdentity,
   basePath?: string,
   authToken?: string | null,
+  message?: unknown,
+  showReasoning = false,
 ) {
   const name = assistant?.name ?? "Assistant";
+  const streamingMessage =
+    message && typeof message === "object"
+      ? {
+          role: "assistant",
+          timestamp: startedAt,
+          ...(message as Record<string, unknown>),
+        }
+      : {
+          role: "assistant",
+          content: [{ type: "text", text }],
+          timestamp: startedAt,
+        };
 
   return html`
     <div class="chat-group assistant">
       ${renderChatAvatar("assistant", assistant, undefined, basePath, authToken)}
       <div class="chat-group-messages">
         ${renderGroupedMessage(
-          {
-            role: "assistant",
-            content: [{ type: "text", text }],
-            timestamp: startedAt,
-          },
+          streamingMessage,
           `stream:${startedAt}`,
-          { isStreaming: true, showReasoning: false },
+          { isStreaming: true, showReasoning },
           onOpenSidebar,
         )}
         <div class="chat-group-footer">

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -1361,6 +1361,7 @@ function renderGroupedMessage(
   const visibleToolCards = hasToolCards && (opts.showToolCalls ?? true);
   if (
     !markdown &&
+    !reasoningMarkdown &&
     !visibleToolCards &&
     !hasImages &&
     visibleAttachments.length === 0 &&

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -964,6 +964,8 @@ export function renderChat(props: ChatProps) {
                 assistantIdentity,
                 props.basePath,
                 props.assistantAttachmentAuthToken ?? null,
+                "message" in item ? item.message : undefined,
+                showReasoning,
               );
             }
             if (item.kind === "group") {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -193,6 +193,13 @@ export function resetChatViewState() {
 
 export const cleanupChatModuleState = resetChatViewState;
 
+export function resolveStreamingReasoningLevel(
+  sessionReasoningLevel: string | null | undefined,
+  thinkingLevel: string | null | undefined,
+): string {
+  return sessionReasoningLevel ?? thinkingLevel ?? "off";
+}
+
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
   el.style.height = `${Math.min(el.scrollHeight, 150)}px`;
@@ -793,7 +800,10 @@ export function renderChat(props: ChatProps) {
   const compactBusy =
     props.compactionStatus?.phase === "active" || props.compactionStatus?.phase === "retrying";
   const activeSession = props.sessions?.sessions?.find((row) => row.key === props.sessionKey);
-  const reasoningLevel = activeSession?.reasoningLevel ?? "off";
+  const reasoningLevel = resolveStreamingReasoningLevel(
+    activeSession?.reasoningLevel,
+    props.thinkingLevel,
+  );
   const showReasoning = props.showThinking && reasoningLevel !== "off";
   const assistantIdentity = {
     name: props.assistantName,


### PR DESCRIPTION
## Summary
- preserve assistant streaming message payloads so live chat can carry `thinking` and `text` together
- wire reasoning stream events through gateway chat delta/final payloads
- allow thinking-only streaming bubbles to render in Control UI
- add focused gateway and UI regression coverage, plus runtime compatibility for legacy delta broadcast bookkeeping

## Validation
- node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/server-chat.agent-events.test.ts src/gateway/server.chat.gateway-server-chat.test.ts src/gateway/server-methods/chat.directive-tags.test.ts
- cd ui && node ../scripts/run-vitest.mjs run --config vitest.config.ts src/ui/chat-event-reload.test.ts src/ui/controllers/chat.test.ts src/ui/views/chat.test.ts
- node --check src/gateway/server-chat.ts
- node --check src/gateway/server-methods/chat.ts
- node --check ui/src/ui/controllers/chat.ts
- node --check ui/src/ui/chat/grouped-render.ts
- node --check ui/src/ui/views/chat.ts