### PR TITLE
fix: normalize visible assistant output before delivery

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -639,4 +639,32 @@ describe("handleMessageEnd", () => {
 
     expect(onAgentEvent).not.toHaveBeenCalled();
   });
+
+  it("marks chunked message_end drains as final delivery", () => {
+    const emitBlockChunk = vi.fn();
+    const reset = vi.fn();
+    const ctx = createMessageEndContext({
+      state: {
+        blockReplyBreak: "message_end",
+      },
+    });
+    ctx.emitBlockChunk = emitBlockChunk;
+    ctx.blockChunker = {
+      hasBuffered: () => true,
+      drain: ({ emit }: { emit: (chunk: string) => void }) => emit("chunked reply"),
+      reset,
+    } as never;
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Need send." }],
+        usage: {},
+      },
+    } as never);
+
+    expect(emitBlockChunk).toHaveBeenCalledWith("chunked reply", { finalDelivery: true });
+    expect(reset).toHaveBeenCalled();
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -613,4 +613,30 @@ describe("handleMessageEnd", () => {
       },
     });
   });
+
+  it("sanitizes leaked channel delimiters before emitting a message_end replacement update", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createMessageEndContext({
+      onAgentEvent,
+      state: {
+        emittedAssistantUpdate: true,
+        lastStreamedAssistantCleaned: "Visible answer",
+        blockReplyBreak: "text_end",
+        deltaBuffer: "",
+        blockBuffer: "",
+      },
+    });
+
+    void handleMessageEnd(ctx, {
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "internal planning<channel|>Visible answer" }],
+        stopReason: "stop",
+        usage: {},
+      },
+    } as never);
+
+    expect(onAgentEvent).not.toHaveBeenCalled();
+  });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -12,7 +12,10 @@ import {
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
+import {
+  sanitizeAssistantVisibleText,
+  sanitizeAssistantVisibleTextForStreamUpdate,
+} from "../shared/text/assistant-visible-text.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -413,7 +416,10 @@ export function handleMessageUpdate(
     }
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
     const parsedFull = parseReplyDirectives(stripTrailingDirective(next));
-    const cleanedText = sanitizeAssistantVisibleText(parsedFull.text);
+    const cleanedText =
+      evtType === "text_end"
+        ? sanitizeAssistantVisibleText(parsedFull.text)
+        : sanitizeAssistantVisibleTextForStreamUpdate(parsedFull.text);
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedDelta ?? {});
     const hasAudio = Boolean(parsedDelta?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
@@ -495,7 +501,7 @@ export function handleMessageUpdate(
   ) {
     const assistantMessageIndex = ctx.state.assistantMessageIndex;
     void Promise.resolve()
-      .then(() => ctx.flushBlockReplyBuffer({ assistantMessageIndex }))
+      .then(() => ctx.flushBlockReplyBuffer({ assistantMessageIndex, finalDelivery: true }))
       .catch((err) => {
         ctx.log.debug(`text_end block reply flush failed: ${String(err)}`);
       });
@@ -724,7 +730,7 @@ export function handleMessageEnd(
     ctx.state.blockReplyBreak === "message_end" &&
     ctx.params.onBlockReplyFlush
   ) {
-    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer();
+    const flushBlockReplyBufferResult = ctx.flushBlockReplyBuffer({ finalDelivery: true });
     if (isPromiseLike<void>(flushBlockReplyBufferResult)) {
       return flushBlockReplyBufferResult
         .then(() => {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -699,11 +699,7 @@ export function handleMessageEnd(
     if (hasBufferedBlockReply && ctx.blockChunker?.hasBuffered()) {
       ctx.blockChunker.drain({
         force: true,
-        emit: (chunk) =>
-          ctx.emitBlockChunk(
-            chunk,
-            ctx.state.blockReplyBreak === "text_end" ? { finalDelivery: true } : undefined,
-          ),
+        emit: (chunk) => ctx.emitBlockChunk(chunk, { finalDelivery: true }),
       });
       ctx.blockChunker.reset();
     } else if (text !== ctx.state.lastBlockReplyText) {

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -495,7 +495,8 @@ export function handleMessageUpdate(
   ) {
     ctx.blockChunker?.drain({
       force: false,
-      emit: (text) => ctx.emitBlockChunk(text, { finalDelivery: true }),
+      emit: (text) =>
+        ctx.emitBlockChunk(text, evtType === "text_end" ? { finalDelivery: true } : undefined),
     });
   }
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -420,6 +420,7 @@ export function handleMessageUpdate(
       evtType === "text_end"
         ? sanitizeAssistantVisibleText(parsedFull.text)
         : sanitizeAssistantVisibleTextForStreamUpdate(parsedFull.text);
+    const finalBufferedText = evtType === "text_end" ? sanitizeAssistantVisibleText(next) : "";
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedDelta ?? {});
     const hasAudio = Boolean(parsedDelta?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";
@@ -447,11 +448,11 @@ export function handleMessageUpdate(
         appendBlockReplyChunk(ctx, blockReplyChunk);
       }
 
-      if (evtType === "text_end" && !ctx.state.lastBlockReplyText && cleanedText) {
-        replaceBlockReplyBuffer(ctx, cleanedText);
+      if (evtType === "text_end" && !ctx.state.lastBlockReplyText && finalBufferedText) {
+        replaceBlockReplyBuffer(ctx, finalBufferedText);
       }
-    } else if (evtType === "text_end" && cleanedText) {
-      replaceBlockReplyBuffer(ctx, cleanedText);
+    } else if (evtType === "text_end" && !ctx.state.lastBlockReplyText && finalBufferedText) {
+      replaceBlockReplyBuffer(ctx, finalBufferedText);
     }
 
     ctx.state.lastStreamedAssistant = next;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -135,6 +135,13 @@ function replaceBlockReplyBuffer(ctx: EmbeddedPiSubscribeContext, text: string) 
   ctx.state.blockBuffer = text;
 }
 
+function replaceFinalBlockReplyBuffer(ctx: EmbeddedPiSubscribeContext, text: string) {
+  replaceBlockReplyBuffer(ctx, text);
+  ctx.state.blockState.thinking = false;
+  ctx.state.blockState.final = false;
+  ctx.state.blockState.inlineCode = createInlineCodeState();
+}
+
 function resolveAssistantTextChunk(params: {
   evtType: "text_delta" | "text_start" | "text_end";
   delta: string;
@@ -449,10 +456,10 @@ export function handleMessageUpdate(
       }
 
       if (evtType === "text_end" && !ctx.state.lastBlockReplyText && finalBufferedText) {
-        replaceBlockReplyBuffer(ctx, finalBufferedText);
+        replaceFinalBlockReplyBuffer(ctx, finalBufferedText);
       }
     } else if (evtType === "text_end" && !ctx.state.lastBlockReplyText && finalBufferedText) {
-      replaceBlockReplyBuffer(ctx, finalBufferedText);
+      replaceFinalBlockReplyBuffer(ctx, finalBufferedText);
     }
 
     ctx.state.lastStreamedAssistant = next;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -12,6 +12,7 @@ import {
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -412,7 +413,7 @@ export function handleMessageUpdate(
     }
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
     const parsedFull = parseReplyDirectives(stripTrailingDirective(next));
-    const cleanedText = parsedFull.text;
+    const cleanedText = sanitizeAssistantVisibleText(parsedFull.text);
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedDelta ?? {});
     const hasAudio = Boolean(parsedDelta?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -450,6 +450,8 @@ export function handleMessageUpdate(
       if (evtType === "text_end" && !ctx.state.lastBlockReplyText && cleanedText) {
         replaceBlockReplyBuffer(ctx, cleanedText);
       }
+    } else if (evtType === "text_end" && cleanedText) {
+      replaceBlockReplyBuffer(ctx, cleanedText);
     }
 
     ctx.state.lastStreamedAssistant = next;
@@ -490,7 +492,10 @@ export function handleMessageUpdate(
     ctx.blockChunking &&
     ctx.state.blockReplyBreak === "text_end"
   ) {
-    ctx.blockChunker?.drain({ force: false, emit: ctx.emitBlockChunk });
+    ctx.blockChunker?.drain({
+      force: false,
+      emit: (text) => ctx.emitBlockChunk(text, { finalDelivery: true }),
+    });
   }
 
   if (

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -118,6 +118,10 @@ function shouldSuppressDeterministicApprovalOutput(
   return state.deterministicApprovalPromptPending || state.deterministicApprovalPromptSent;
 }
 
+function trimStreamVisibleTextPreservingIndentation(text: string): string {
+  return text.trimEnd().replace(/^(?:[ \t]*\r?\n)+/, "");
+}
+
 function appendBlockReplyChunk(ctx: EmbeddedPiSubscribeContext, chunk: string) {
   if (ctx.blockChunker) {
     ctx.blockChunker.append(chunk);
@@ -384,9 +388,9 @@ export function handleMessageUpdate(
   if (deliveryPhase === "commentary") {
     return;
   }
-  const phaseAwareVisibleText = coerceChatContentText(
-    extractAssistantVisibleText(partialAssistant),
-  ).trim();
+  const phaseAwareVisibleText = trimStreamVisibleTextPreservingIndentation(
+    coerceChatContentText(extractAssistantVisibleText(partialAssistant)),
+  );
   const shouldUsePhaseAwareBlockReply = Boolean(deliveryPhase);
 
   if (chunk) {
@@ -404,13 +408,13 @@ export function handleMessageUpdate(
     phaseAwareVisibleText ||
     (deliveryPhase === "final_answer"
       ? ""
-      : ctx
-          .stripBlockTags(ctx.state.deltaBuffer, {
+      : trimStreamVisibleTextPreservingIndentation(
+          ctx.stripBlockTags(ctx.state.deltaBuffer, {
             thinking: false,
             final: false,
             inlineCode: createInlineCodeState(),
-          })
-          .trim());
+          }),
+        ));
   if (next) {
     const wasThinking = ctx.state.partialBlockState.thinking;
     const visibleDelta = chunk ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState) : "";

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -500,11 +500,12 @@ export function handleMessageUpdate(
     ctx.blockChunking &&
     ctx.state.blockReplyBreak === "text_end"
   ) {
-    ctx.blockChunker?.drain({
-      force: false,
-      emit: (text) =>
-        ctx.emitBlockChunk(text, evtType === "text_end" ? { finalDelivery: true } : undefined),
-    });
+    if (evtType === "text_end") {
+      ctx.blockChunker?.drain({
+        force: false,
+        emit: (text) => ctx.emitBlockChunk(text, { finalDelivery: true }),
+      });
+    }
   }
 
   if (
@@ -554,7 +555,9 @@ export function handleMessageEnd(
   });
 
   const text = resolveSilentReplyFallbackText({
-    text: ctx.stripBlockTags(rawVisibleText, { thinking: false, final: false }),
+    text: sanitizeAssistantVisibleText(
+      ctx.stripBlockTags(rawVisibleText, { thinking: false, final: false }),
+    ),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
   const rawThinking =
@@ -694,7 +697,14 @@ export function handleMessageEnd(
       text !== ctx.state.lastBlockReplyText)
   ) {
     if (hasBufferedBlockReply && ctx.blockChunker?.hasBuffered()) {
-      ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });
+      ctx.blockChunker.drain({
+        force: true,
+        emit: (chunk) =>
+          ctx.emitBlockChunk(
+            chunk,
+            ctx.state.blockReplyBreak === "text_end" ? { finalDelivery: true } : undefined,
+          ),
+      });
       ctx.blockChunker.reset();
     } else if (text !== ctx.state.lastBlockReplyText) {
       // Guard: for text_end channels, if text_end already delivered content

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -104,8 +104,14 @@ export type EmbeddedPiSubscribeContext = {
     text: string,
     state: { thinking: boolean; final: boolean; inlineCode?: InlineCodeState },
   ) => string;
-  emitBlockChunk: (text: string, options?: { assistantMessageIndex?: number }) => void;
-  flushBlockReplyBuffer: (options?: { assistantMessageIndex?: number }) => void | Promise<void>;
+  emitBlockChunk: (
+    text: string,
+    options?: { assistantMessageIndex?: number; finalDelivery?: boolean },
+  ) => void;
+  flushBlockReplyBuffer: (options?: {
+    assistantMessageIndex?: number;
+    finalDelivery?: boolean;
+  }) => void | Promise<void>;
   emitReasoningStream: (text: string) => void;
   consumeReplyDirectives: (
     text: string,

--- a/src/agents/pi-embedded-subscribe.reply-tags.test.ts
+++ b/src/agents/pi-embedded-subscribe.reply-tags.test.ts
@@ -65,6 +65,25 @@ describe("subscribeEmbeddedPiSession reply tags", () => {
     expect(onBlockReply.mock.calls[1]?.[0]?.text).toBe("[[");
   });
 
+  it("preserves reply directives that arrive only in legacy text_end content", () => {
+    const { emit, onBlockReply } = createBlockReplyHarness();
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextEnd({ emit, content: "[[reply_to_current]]\nHello" });
+
+    const assistantMessage = {
+      role: "assistant",
+      content: [{ type: "text", text: "[[reply_to_current]]\nHello" }],
+    } as AssistantMessage;
+    emit({ type: "message_end", message: assistantMessage });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const payload = onBlockReply.mock.calls[0]?.[0];
+    expect(payload?.text).toBe("Hello");
+    expect(payload?.replyToCurrent).toBe(true);
+    expect(payload?.replyToTag).toBe(true);
+  });
+
   it("streams partial replies past reply_to tags split across chunks", () => {
     const { session, emit } = createStubSessionHarness();
 

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-duplicate-text-end-repeats-full.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.does-not-duplicate-text-end-repeats-full.test.ts
@@ -36,11 +36,17 @@ describe("subscribeEmbeddedPiSession", () => {
     await Promise.resolve();
 
     const callsAfterDelta = onBlockReply.mock.calls.length;
-    expect(callsAfterDelta).toBeGreaterThan(0);
+    expect(callsAfterDelta).toBe(0);
 
     emitAssistantTextEnd({ emit, content: fullText });
     await Promise.resolve();
 
-    expect(onBlockReply).toHaveBeenCalledTimes(callsAfterDelta);
+    const callsAfterEnd = onBlockReply.mock.calls.length;
+    expect(callsAfterEnd).toBeGreaterThan(0);
+
+    emitAssistantTextEnd({ emit, content: fullText });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(callsAfterEnd);
   });
 });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -282,6 +282,28 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["gemma-visible-ok"]);
   });
 
+  it("collapses repeated exact-text suffixes before emitting a text_end block reply", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string and nothing else.",
+        "I will output the text directly as the final response.",
+        "<channel|>dupcheck-a-1776635100573dupcheck-a-1776635100573",
+      ].join("\n"),
+      id: "item_repeated_suffix",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("dupcheck-a-1776635100573");
+    expect(subscription.assistantTexts).toEqual(["dupcheck-a-1776635100573"]);
+  });
+
   it("emits the final answer at message_end when commentary was streamed first", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -264,6 +264,24 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["Done."]);
   });
 
+  it("sanitizes leaked channel delimiters before emitting a text_end block reply", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: "Internal planning about the instruction and output formatting.<channel|>gemma-visible-ok",
+      id: "item_legacy",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("gemma-visible-ok");
+    expect(subscription.assistantTexts).toEqual(["gemma-visible-ok"]);
+  });
+
   it("emits the final answer at message_end when commentary was streamed first", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -375,6 +375,30 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts.join("")).toBe("gemma-visible-ok");
   });
 
+  it("keeps intermediate chunk drains in history mode before text_end", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({
+      onBlockReply,
+      blockReplyChunking: { minChars: 1, maxChars: 200 },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_delta",
+      text: "  nested list item",
+      delta: "  nested list item",
+      id: "item_intermediate_chunk_indent",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    const delivered = onBlockReply.mock.calls[0]?.[0]?.text ?? "";
+    expect(delivered.startsWith("  ")).toBe(true);
+    expect(delivered).toContain("nested");
+    expect(subscription.assistantTexts).toEqual([delivered]);
+  });
+
   it("preserves a repeated structured suffix when the preamble names the full repeated output literally", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -375,28 +375,51 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts.join("")).toBe("gemma-visible-ok");
   });
 
-  it("keeps intermediate chunk drains in history mode before text_end", async () => {
+  it("waits until text_end before draining chunked text_end replies", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({
       onBlockReply,
-      blockReplyChunking: { minChars: 1, maxChars: 200 },
+      blockReplyChunking: { minChars: 1, maxChars: 80 },
     });
 
     emit({ type: "message_start", message: { role: "assistant" } });
     emitOpenAiResponsesTextEvent({
       emit,
       type: "text_delta",
-      text: "  nested list item",
-      delta: "  nested list item",
-      id: "item_intermediate_chunk_indent",
+      text: [
+        "The user is instructing me to reply with a very specific string: `abc-123` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must output the text directly as the final response.",
+        "<channel|>abc-123abc-123",
+      ].join("\n\n"),
+      delta: [
+        "The user is instructing me to reply with a very specific string: `abc-123` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must output the text directly as the final response.",
+        "<channel|>abc-123abc-123",
+      ].join("\n\n"),
+      id: "item_chunked_text_end_exact_string",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string: `abc-123` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must output the text directly as the final response.",
+        "<channel|>abc-123abc-123",
+      ].join("\n\n"),
+      id: "item_chunked_text_end_exact_string",
     });
     await Promise.resolve();
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
-    const delivered = onBlockReply.mock.calls[0]?.[0]?.text ?? "";
-    expect(delivered.startsWith("  ")).toBe(true);
-    expect(delivered).toContain("nested");
-    expect(subscription.assistantTexts).toEqual([delivered]);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("abc-123");
+    expect(subscription.assistantTexts).toEqual(["abc-123"]);
   });
 
   it("preserves a repeated structured suffix when the preamble names the full repeated output literally", async () => {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -351,6 +351,30 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["visiblefix5-1776638721"]);
   });
 
+  it("uses the final-delivery sanitizer when chunked text_end replies are drained", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({
+      onBlockReply,
+      blockReplyChunking: { minChars: 8, maxChars: 200 },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: "Internal planning about the instruction.<channel|>gemma-visible-ok",
+      id: "item_chunked_text_end_visible",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply.mock.calls.length).toBeGreaterThan(0);
+    const delivered = onBlockReply.mock.calls.map((call) => call[0]?.text ?? "").join("");
+    expect(delivered).toBe("gemma-visible-ok");
+    expect(delivered.includes("Internal planning")).toBe(false);
+    expect(delivered.includes("<channel|>")).toBe(false);
+    expect(subscription.assistantTexts.join("")).toBe("gemma-visible-ok");
+  });
+
   it("preserves a repeated structured suffix when the preamble names the full repeated output literally", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
@@ -396,6 +420,24 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onBlockReply).toHaveBeenCalledTimes(1);
     expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("abc-123abc-123");
     expect(subscription.assistantTexts).toEqual(["abc-123abc-123"]);
+  });
+
+  it("preserves intentionally repeated structured output after a leaked delimiter without single-answer intent", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: "internal planning<channel|>abc-123abc-123abc-123",
+      id: "item_intentional_repeated_output",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("abc-123abc-123abc-123");
+    expect(subscription.assistantTexts).toEqual(["abc-123abc-123abc-123"]);
   });
 
   it("emits the final answer at message_end when commentary was streamed first", async () => {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -351,6 +351,53 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["visiblefix5-1776638721"]);
   });
 
+  it("preserves a repeated structured suffix when the preamble names the full repeated output literally", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must adhere to the instruction precisely.",
+        "I will output the text directly as the final response.",
+        "<channel|>abc-123abc-123",
+      ].join("\n"),
+      id: "item_literal_repeated_output",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("abc-123abc-123");
+    expect(subscription.assistantTexts).toEqual(["abc-123abc-123"]);
+  });
+
+  it("extracts the explicitly named final string when no delimiter was emitted and runaway junk followed", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must adhere to the instruction precisely.",
+        "I will output the text directly as the final response, as per the general instruction to reply in the current session.abc-123abc-123abc-123abc-123abc-123abc-123noise-999noise-999noise-9",
+      ].join("\n"),
+      id: "item_literal_repeated_output_no_delimiter",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("abc-123abc-123");
+    expect(subscription.assistantTexts).toEqual(["abc-123abc-123"]);
+  });
+
   it("emits the final answer at message_end when commentary was streamed first", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts
@@ -304,6 +304,53 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(subscription.assistantTexts).toEqual(["dupcheck-a-1776635100573"]);
   });
 
+  it("collapses repeated structured suffixes with a truncated final repeat before emitting a text_end block reply", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string: `visiblefix-1776638338` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must adhere to the instruction precisely.",
+        "I will output the text directly as the final response, as per the general instruction to reply in the current session.",
+        "<channel|>visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-177",
+      ].join("\n"),
+      id: "item_truncated_repeated_suffix",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("visiblefix-1776638338");
+    expect(subscription.assistantTexts).toEqual(["visiblefix-1776638338"]);
+  });
+
+  it("extracts a repeated structured suffix even when no control delimiter was emitted before text_end", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitOpenAiResponsesTextEvent({
+      emit,
+      type: "text_end",
+      text: [
+        "The user is instructing me to reply with a very specific string: `visiblefix5-1776638721` and nothing else.",
+        "This is a direct instruction for the output content.",
+        "I must adhere to the instruction precisely.",
+        "I will output the text directly as the final response, as per the general instruction to reply in the current session.visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visible",
+      ].join("\n"),
+      id: "item_missing_delimiter_repeated_suffix",
+    });
+    await Promise.resolve();
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply.mock.calls[0]?.[0]?.text).toBe("visiblefix5-1776638721");
+    expect(subscription.assistantTexts).toEqual(["visiblefix5-1776638721"]);
+  });
+
   it("emits the final answer at message_end when commentary was streamed first", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-indented-fenced-blocks-intact.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-indented-fenced-blocks-intact.test.ts
@@ -23,6 +23,29 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onBlockReply).toHaveBeenCalledTimes(3);
     expect(onBlockReply.mock.calls[1][0].text).toBe("  ```js\n  const x = 1;\n  ```");
   });
+
+  it("keeps leading indentation in non-fence block reply chunks", () => {
+    const onBlockReply = vi.fn();
+    const { emit } = createParagraphChunkedBlockReplyHarness({
+      onBlockReply,
+      chunking: {
+        minChars: 5,
+        maxChars: 30,
+      },
+    });
+
+    const text = "Intro\n\n  nested bullet\n  continued detail\n\nOutro";
+
+    emitAssistantTextDeltaAndEnd({ emit, text });
+
+    expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual([
+      "Intro",
+      "  nested bullet",
+      "  continued detail",
+      "Outro",
+    ]);
+  });
+
   it("accepts longer fence markers for close", () => {
     const onBlockReply = vi.fn();
     const { emit } = createParagraphChunkedBlockReplyHarness({

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -9,6 +9,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
   isMessagingToolDuplicateNormalized,
@@ -566,7 +567,9 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
+    const chunk = sanitizeAssistantVisibleText(
+      stripDowngradedToolCallText(stripBlockTags(text, state.blockState)),
+    );
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -561,7 +561,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     return output;
   };
 
-  const emitBlockChunk = (text: string, options?: { assistantMessageIndex?: number }) => {
+  const emitBlockChunk = (
+    text: string,
+    options?: { assistantMessageIndex?: number; finalDelivery?: boolean },
+  ) => {
     if (state.suppressBlockChunks || params.silentExpected) {
       return;
     }
@@ -569,7 +572,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
     const chunk = sanitizeAssistantVisibleTextWithProfile(
       stripBlockTags(text, state.blockState),
-      "history",
+      options?.finalDelivery ? "delivery" : "history",
     ).trimEnd();
     if (!chunk) {
       return;
@@ -633,6 +636,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
 
   const flushBlockReplyBuffer = (options?: {
     assistantMessageIndex?: number;
+    finalDelivery?: boolean;
   }): void | Promise<void> => {
     if (!params.onBlockReply) {
       return;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -30,7 +30,7 @@ import type {
 import { isPromiseLike } from "./pi-embedded-subscribe.promise.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
 import type { SubscribeEmbeddedPiSessionParams } from "./pi-embedded-subscribe.types.js";
-import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
+import { formatReasoningMessage } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -567,9 +567,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = sanitizeAssistantVisibleText(
-      stripDowngradedToolCallText(stripBlockTags(text, state.blockState)),
-    );
+    const chunk = sanitizeAssistantVisibleText(stripBlockTags(text, state.blockState));
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -9,7 +9,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { InlineCodeState } from "../markdown/code-spans.js";
 import { buildCodeSpanIndex, createInlineCodeState } from "../markdown/code-spans.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
-import { sanitizeAssistantVisibleText } from "../shared/text/assistant-visible-text.js";
+import { sanitizeAssistantVisibleTextWithProfile } from "../shared/text/assistant-visible-text.js";
 import { EmbeddedBlockChunker } from "./pi-embedded-block-chunker.js";
 import {
   isMessagingToolDuplicateNormalized,
@@ -567,7 +567,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
     // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
-    const chunk = sanitizeAssistantVisibleText(stripBlockTags(text, state.blockState));
+    const chunk = sanitizeAssistantVisibleTextWithProfile(
+      stripBlockTags(text, state.blockState),
+      "history",
+    ).trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -146,4 +146,8 @@ describe("stripModelSpecialTokens", () => {
       "Here is the explanation.\nMy plan: <channel|> is the separator token, not hidden scaffolding.",
     );
   });
+
+  it("preserves earlier visible text when a leaked delimiter trails it", () => {
+    expect(stripModelSpecialTokens("Visible answer\nplan: <channel|>")).toBe("Visible answer");
+  });
 });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -103,6 +103,18 @@ describe("stripModelSpecialTokens", () => {
     expect(stripModelSpecialTokens(input)).toBe("<channel|>");
   });
 
+  it("preserves an explicitly requested literal channel delimiter target when it is named in quotes", () => {
+    const input = [
+      'The user is instructing me to reply with a very specific string: "<channel|>" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|><channel|>",
+    ].join("\n");
+
+    expect(stripModelSpecialTokens(input)).toBe("<channel|>");
+  });
+
   it("treats plan-prefixed channel delimiters as leaked scaffolding", () => {
     expect(stripModelSpecialTokens("plan: <channel|>Visible answer")).toBe("Visible answer");
   });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -37,6 +37,9 @@ describe("stripModelSpecialTokens", () => {
     expect(stripModelSpecialTokens("Final response should contain <channel|> token")).toBe(
       "Final response should contain <channel|> token",
     );
+    expect(
+      stripModelSpecialTokens("internal planning<channel|>The marker <channel|> splits streams."),
+    ).toBe("The marker <channel|> splits streams.");
   });
 
   it("keeps the last non-empty visible segment when multiple leaked channel delimiters appear", () => {

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -28,5 +28,14 @@ describe("stripModelSpecialTokens", () => {
       "The marker <channel|> splits streams.",
     );
     expect(stripModelSpecialTokens("Before <channel|> after")).toBe("Before <channel|> after");
+    expect(stripModelSpecialTokens("Tell it to reply with <channel|> to split streams")).toBe(
+      "Tell it to reply with <channel|> to split streams",
+    );
+  });
+
+  it("keeps the last non-empty visible segment when multiple leaked channel delimiters appear", () => {
+    expect(stripModelSpecialTokens("internal planning<channel|>Visible answer<channel|>")).toBe(
+      "Visible answer",
+    );
   });
 });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -115,6 +115,18 @@ describe("stripModelSpecialTokens", () => {
     expect(stripModelSpecialTokens(input)).toBe("<channel|>");
   });
 
+  it("preserves an explicitly requested visible string that ends with a channel delimiter", () => {
+    const input = [
+      'The user is instructing me to reply with exactly "Print <channel|>" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>Print <channel|>",
+    ].join("\n");
+
+    expect(stripModelSpecialTokens(input)).toBe("Print <channel|>");
+  });
+
   it("treats plan-prefixed channel delimiters as leaked scaffolding", () => {
     expect(stripModelSpecialTokens("plan: <channel|>Visible answer")).toBe("Visible answer");
   });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -24,8 +24,10 @@ describe("stripModelSpecialTokens", () => {
   });
 
   it("preserves literal channel delimiter mentions when they are part of ordinary prose", () => {
-    expect(stripModelSpecialTokens("<channel|>Visible answer")).toBe("Visible answer");
-    expect(stripModelSpecialTokens("<channel|>\nVisible answer")).toBe("\nVisible answer");
+    expect(stripModelSpecialTokens("<channel|>Visible answer")).toBe("<channel|>Visible answer");
+    expect(stripModelSpecialTokens("<channel|>\nVisible answer")).toBe(
+      "<channel|>\nVisible answer",
+    );
     expect(stripModelSpecialTokens("internal planning <channel|> Visible answer")).toBe(
       " Visible answer",
     );
@@ -50,6 +52,17 @@ describe("stripModelSpecialTokens", () => {
     ).toBe("The marker <channel|> splits streams.");
   });
 
+  it("strips spaced leaked channel delimiters after a long internal-answer preamble", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must output the text directly as the final response.",
+      "<channel|> Visible answer",
+    ].join("\n");
+
+    expect(stripModelSpecialTokens(input)).toBe(" Visible answer");
+  });
+
   it("does not treat long explanatory prose as leaked planning just because it mentions literal channel delimiters", () => {
     const docExample = [
       "I will describe the token in detail over several sentences so that the prefix is definitely longer than one hundred and twenty characters.",
@@ -69,6 +82,12 @@ describe("stripModelSpecialTokens", () => {
   it("keeps the last non-empty visible segment when multiple leaked channel delimiters appear", () => {
     expect(stripModelSpecialTokens("internal planning<channel|>Visible answer<channel|>")).toBe(
       "Visible answer",
+    );
+  });
+
+  it("preserves a literal trailing channel delimiter inside recovered visible text", () => {
+    expect(stripModelSpecialTokens("internal planning<channel|>Use token <channel|>")).toBe(
+      "Use token <channel|>",
     );
   });
 

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -63,4 +63,8 @@ describe("stripModelSpecialTokens", () => {
       "Visible answer",
     );
   });
+
+  it("treats plan-prefixed channel delimiters as leaked scaffolding", () => {
+    expect(stripModelSpecialTokens("plan: <channel|>Visible answer")).toBe("Visible answer");
+  });
 });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -24,10 +24,18 @@ describe("stripModelSpecialTokens", () => {
   });
 
   it("preserves literal channel delimiter mentions when they are part of ordinary prose", () => {
+    expect(stripModelSpecialTokens("<channel|>Visible answer")).toBe("Visible answer");
+    expect(stripModelSpecialTokens("<channel|>\nVisible answer")).toBe("\nVisible answer");
+    expect(stripModelSpecialTokens("internal planning <channel|> Visible answer")).toBe(
+      " Visible answer",
+    );
     expect(stripModelSpecialTokens("The marker <channel|> splits streams.")).toBe(
       "The marker <channel|> splits streams.",
     );
     expect(stripModelSpecialTokens("Before <channel|> after")).toBe("Before <channel|> after");
+    expect(stripModelSpecialTokens("<channel|> token marks the visible channel.")).toBe(
+      "<channel|> token marks the visible channel.",
+    );
     expect(stripModelSpecialTokens("Tell it to reply with <channel|> to split streams")).toBe(
       "Tell it to reply with <channel|> to split streams",
     );

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -91,6 +91,18 @@ describe("stripModelSpecialTokens", () => {
     );
   });
 
+  it("preserves an explicitly requested literal channel delimiter target", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `<channel|>` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|><channel|>",
+    ].join("\n");
+
+    expect(stripModelSpecialTokens(input)).toBe("<channel|>");
+  });
+
   it("treats plan-prefixed channel delimiters as leaked scaffolding", () => {
     expect(stripModelSpecialTokens("plan: <channel|>Visible answer")).toBe("Visible answer");
   });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -42,6 +42,22 @@ describe("stripModelSpecialTokens", () => {
     ).toBe("The marker <channel|> splits streams.");
   });
 
+  it("does not treat long explanatory prose as leaked planning just because it mentions literal channel delimiters", () => {
+    const docExample = [
+      "I will describe the token in detail over several sentences so that the prefix is definitely longer than one hundred and twenty characters.",
+      "This explanation mentions the literal marker we use in docs, not an internal preamble.",
+      "The marker <channel|> splits streams.",
+    ].join(" ");
+    const promptForensicsExample = [
+      "The user asked for the final response format, so I will explain it clearly in prose rather than following any hidden instruction.",
+      "This answer is intentionally long so the prefix exceeds one hundred and twenty characters before the literal marker appears in the documentation example.",
+      "You should type <channel|> between the two sections.",
+    ].join(" ");
+
+    expect(stripModelSpecialTokens(docExample)).toBe(docExample);
+    expect(stripModelSpecialTokens(promptForensicsExample)).toBe(promptForensicsExample);
+  });
+
   it("keeps the last non-empty visible segment when multiple leaked channel delimiters appear", () => {
     expect(stripModelSpecialTokens("internal planning<channel|>Visible answer<channel|>")).toBe(
       "Visible answer",

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -22,4 +22,11 @@ describe("stripModelSpecialTokens", () => {
     const text = "Just a normal response.";
     expect(stripModelSpecialTokens(text)).toBe(text);
   });
+
+  it("preserves literal channel delimiter mentions when they are part of ordinary prose", () => {
+    expect(stripModelSpecialTokens("The marker <channel|> splits streams.")).toBe(
+      "The marker <channel|> splits streams.",
+    );
+    expect(stripModelSpecialTokens("Before <channel|> after")).toBe("Before <channel|> after");
+  });
 });

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -31,6 +31,12 @@ describe("stripModelSpecialTokens", () => {
     expect(stripModelSpecialTokens("Tell it to reply with <channel|> to split streams")).toBe(
       "Tell it to reply with <channel|> to split streams",
     );
+    expect(stripModelSpecialTokens("I will type <channel|> literally.")).toBe(
+      "I will type <channel|> literally.",
+    );
+    expect(stripModelSpecialTokens("Final response should contain <channel|> token")).toBe(
+      "Final response should contain <channel|> token",
+    );
   });
 
   it("keeps the last non-empty visible segment when multiple leaked channel delimiters appear", () => {

--- a/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
+++ b/src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts
@@ -129,5 +129,21 @@ describe("stripModelSpecialTokens", () => {
 
   it("treats plan-prefixed channel delimiters as leaked scaffolding", () => {
     expect(stripModelSpecialTokens("plan: <channel|>Visible answer")).toBe("Visible answer");
+    expect(stripModelSpecialTokens("planning notes\nplan: <channel|>Visible answer")).toBe(
+      "Visible answer",
+    );
+  });
+
+  it("does not treat ordinary prose with 'plan:' as leaked scaffolding", () => {
+    expect(stripModelSpecialTokens("My plan: <channel|> is the separator token.")).toBe(
+      "My plan: <channel|> is the separator token.",
+    );
+    expect(
+      stripModelSpecialTokens(
+        "Here is the explanation.\nMy plan: <channel|> is the separator token, not hidden scaffolding.",
+      ),
+    ).toBe(
+      "Here is the explanation.\nMy plan: <channel|> is the separator token, not hidden scaffolding.",
+    );
   });
 });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1010,6 +1010,14 @@ describe("createStreamingDirectiveAccumulator", () => {
 
     expect(result?.text).toBe("NO_REPLY: explanation");
   });
+
+  it("preserves leading indentation for plain streamed chunks without directives", () => {
+    const accumulator = createStreamingDirectiveAccumulator();
+
+    const result = accumulator.consume("  nested bullet");
+
+    expect(result?.text).toBe("  nested bullet");
+  });
 });
 
 describe("extractShortModelName", () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -1018,6 +1018,14 @@ describe("createStreamingDirectiveAccumulator", () => {
 
     expect(result?.text).toBe("  nested bullet");
   });
+
+  it("preserves spacing for literal double-bracket text without reply directives", () => {
+    const accumulator = createStreamingDirectiveAccumulator();
+
+    const result = accumulator.consume("  [[not-a-directive]]  keep   spacing");
+
+    expect(result?.text).toBe("  [[not-a-directive]]  keep   spacing");
+  });
 });
 
 describe("extractShortModelName", () => {

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -59,7 +59,9 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
         hasReplyTag: false,
       };
 
-  text = replyParsed.text;
+  if (replyParsed.hasReplyTag || replyParsed.hasAudioTag) {
+    text = replyParsed.text;
+  }
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent =

--- a/src/auto-reply/reply/streaming-directives.ts
+++ b/src/auto-reply/reply/streaming-directives.ts
@@ -44,14 +44,22 @@ const parseChunk = (raw: string, options?: { silentToken?: string }): ParsedChun
   const split = splitMediaFromOutput(raw);
   let text = split.text ?? "";
 
-  const replyParsed = parseInlineDirectives(text, {
-    stripAudioTag: false,
-    stripReplyTags: true,
-  });
+  const replyParsed = text.includes("[[")
+    ? parseInlineDirectives(text, {
+        stripAudioTag: false,
+        stripReplyTags: true,
+      })
+    : {
+        text,
+        audioAsVoice: false,
+        replyToId: undefined,
+        replyToExplicitId: undefined,
+        replyToCurrent: false,
+        hasAudioTag: false,
+        hasReplyTag: false,
+      };
 
-  if (replyParsed.hasReplyTag) {
-    text = replyParsed.text;
-  }
+  text = replyParsed.text;
 
   const silentToken = options?.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent =

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -399,6 +399,14 @@ describe("stripAssistantInternalScaffolding", () => {
       expectVisibleText("<｜begin▁of▁sentence｜>Hello world", "Hello world");
     });
 
+    it("keeps the visible suffix after a channel delimiter token", () => {
+      expectVisibleText("internal planning<channel|>Visible answer", "Visible answer");
+    });
+
+    it("strips later model control tokens after a channel delimiter token", () => {
+      expectVisibleText("internal planning<channel|><|assistant|>Visible answer", "Visible answer");
+    });
+
     it("strips special tokens mixed with normal text", () => {
       expectVisibleText(
         "Start <|tool_call_result_begin|>middle<|tool_call_result_end|> end",
@@ -462,6 +470,11 @@ describe("stripAssistantInternalScaffolding", () => {
       );
     });
 
+    it("preserves channel delimiter tokens inside fenced code blocks", () => {
+      const input = ["```text", "<channel|>Visible answer", "```", "", "Outside"].join("\n");
+      expectVisibleText(input, input);
+    });
+
     it("preserves malformed tokens that end inside inline code spans", () => {
       expectVisibleText("Before <|token `code|>` after", "Before <|token `code|>` after");
     });
@@ -501,6 +514,12 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("preserves indentation for a leading fenced block while trimming surrounding blank lines", () => {
+    const input = "\n\n  ```js\n  const x = 1;\n  ```\n";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("  ```js\n  const x = 1;\n  ```");
   });
 });
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -541,6 +541,12 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("hahaha");
   });
 
+  it("drops a bare trailing control delimiter with no visible suffix", () => {
+    const input = "Internal planning<channel|>";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("");
+  });
+
   it("preserves indentation for a leading fenced block while trimming surrounding blank lines", () => {
     const input = "\n\n  ```js\n  const x = 1;\n  ```\n";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -558,6 +558,15 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("visiblefix5-1776638721");
   });
 
+  it("does not collapse repeated structured text in ordinary prose without scaffolding", () => {
+    expect(sanitizeAssistantVisibleText("Here is the pattern: abc-123abc-123")).toBe(
+      "Here is the pattern: abc-123abc-123",
+    );
+    expect(sanitizeAssistantVisibleText("Repeat twice: 2024-04-202024-04-20")).toBe(
+      "Repeat twice: 2024-04-202024-04-20",
+    );
+  });
+
   it("does not collapse short unstructured repeated prose after a control delimiter", () => {
     const input = "Internal planning<channel|>hahaha";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -529,7 +529,8 @@ describe("sanitizeAssistantVisibleText", () => {
 
   it("collapses repeated visible suffixes even when the suffix is repeated more than twice", () => {
     const input = [
-      "Internal planning about the final response.",
+      "The user is instructing me to reply with a very specific string and nothing else.",
+      "I will output the text directly as the final response.",
       "<channel|>dupcheck-b-1776635100574dupcheck-b-1776635100574dupcheck-b-1776635100574dupcheck-b-1776635100574",
     ].join("\n");
 
@@ -614,6 +615,12 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText("Tell it to reply with <channel|> to split streams")).toBe(
       "Tell it to reply with <channel|> to split streams",
     );
+    expect(sanitizeAssistantVisibleText("I will type <channel|> literally.")).toBe(
+      "I will type <channel|> literally.",
+    );
+    expect(sanitizeAssistantVisibleText("Final response should contain <channel|> token")).toBe(
+      "Final response should contain <channel|> token",
+    );
   });
 
   it("keeps the last non-empty visible segment when multiple channel delimiters appear", () => {
@@ -626,6 +633,12 @@ describe("sanitizeAssistantVisibleText", () => {
     const input = "Examples: `noise-999noise-999`. Final output: noise-999noise-999";
 
     expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
+  it("preserves intentional repeated structured output after a leaked delimiter when the prompt did not ask for a single answer", () => {
+    const input = "internal planning<channel|>abc-123abc-123abc-123";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123abc-123");
   });
 
   it("drops a bare trailing control delimiter with no visible suffix", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -535,6 +535,29 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("dupcheck-b-1776635100574");
   });
 
+  it("collapses repeated structured suffixes even when the final repeat is truncated", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `visiblefix-1776638338` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.",
+      "<channel|>visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-1776638338visiblefix-177",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("visiblefix-1776638338");
+  });
+
+  it("extracts a repeated structured suffix even when no control delimiter was emitted", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `visiblefix5-1776638721` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visiblefix5-1776638721visible",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("visiblefix5-1776638721");
+  });
+
   it("does not collapse short unstructured repeated prose after a control delimiter", () => {
     const input = "Internal planning<channel|>hahaha";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -796,6 +796,17 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
+  it("does not collapse explanatory prose that ends with a repeated sample output", () => {
+    const input = [
+      'The user asked me to reply with exactly "Hello." and nothing else.',
+      "This is only an explanation of the failure and not hidden planning.",
+      "The sample duplicated output was:",
+      "Hello.Hello.Hello.",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("preserves intentional repeated structured output after a leaked delimiter when the prompt did not ask for a single answer", () => {
     const input = "internal planning<channel|>abc-123abc-123abc-123";
 
@@ -806,6 +817,12 @@ describe("sanitizeAssistantVisibleText", () => {
     const input = "Internal planning<channel|>";
 
     expect(sanitizeAssistantVisibleText(input)).toBe("");
+  });
+
+  it("preserves earlier visible text when a leaked delimiter trails it", () => {
+    const input = "Visible answer\nplan: <channel|>";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
   it("preserves an explicitly requested literal channel delimiter target", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -621,6 +621,11 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText("Final response should contain <channel|> token")).toBe(
       "Final response should contain <channel|> token",
     );
+    expect(
+      sanitizeAssistantVisibleText(
+        "internal planning<channel|>The marker <channel|> splits streams.",
+      ),
+    ).toBe("The marker <channel|> splits streams.");
   });
 
   it("keeps the last non-empty visible segment when multiple channel delimiters appear", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -834,6 +834,22 @@ describe("sanitizeAssistantVisibleText", () => {
 
   it("strips leaked plan-prefixed channel delimiters", () => {
     expect(sanitizeAssistantVisibleText("plan: <channel|>Visible answer")).toBe("Visible answer");
+    expect(sanitizeAssistantVisibleText("planning notes\nplan: <channel|>Visible answer")).toBe(
+      "Visible answer",
+    );
+  });
+
+  it("does not treat ordinary prose with 'plan:' as leaked scaffolding", () => {
+    expect(sanitizeAssistantVisibleText("My plan: <channel|> is the separator token.")).toBe(
+      "My plan: <channel|> is the separator token.",
+    );
+    expect(
+      sanitizeAssistantVisibleText(
+        "Here is the explanation.\nMy plan: <channel|> is the separator token, not hidden scaffolding.",
+      ),
+    ).toBe(
+      "Here is the explanation.\nMy plan: <channel|> is the separator token, not hidden scaffolding.",
+    );
   });
 
   it("preserves indentation for a leading fenced block while trimming surrounding blank lines", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -567,6 +567,15 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("does not collapse intentionally repeated structured suffixes after a delimiter without single-answer intent", () => {
+    expect(sanitizeAssistantVisibleText("internal planning<channel|>abc-123abc-123")).toBe(
+      "abc-123abc-123",
+    );
+    expect(sanitizeAssistantVisibleText("internal planning<channel|>2024-04-202024-04-20")).toBe(
+      "2024-04-202024-04-20",
+    );
+  });
+
   it("does not collapse short unstructured repeated prose after a control delimiter", () => {
     const input = "Internal planning<channel|>hahaha";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -714,6 +714,18 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("preserves an explicitly requested visible string that ends with a channel delimiter", () => {
+    const input = [
+      'The user is instructing me to reply with exactly "Print <channel|>" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>Print <channel|>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Print <channel|>");
+  });
+
   it("does not rewrite explanatory prose down to a single named literal", () => {
     const input = "Examples: `noise-999noise-999`. Final output: noise-999noise-999";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -767,8 +767,31 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Print <channel|>");
   });
 
+  it("does not invent missing characters when a leaked repeated suffix is truncated", () => {
+    const input = [
+      'The user is instructing me to reply with exactly "abc-123" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>abc-1abc-1abc-1",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-1abc-1abc-1");
+  });
+
   it("does not rewrite explanatory prose down to a single named literal", () => {
     const input = "Examples: `noise-999noise-999`. Final output: noise-999noise-999";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
+  it("does not collapse explanatory prose that mentions the quoted target multiple times", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "The previous attempt was wrong, because it first emitted abc-123abc-123, then switched to noise-999, and finally ended with extra trailer text.",
+    ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -827,6 +827,20 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
     expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe("Hi there");
   });
 
+  it("preserves meaningful leading indentation in delivery mode", () => {
+    const input = "\n\n  nested bullet\n  continued detail";
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "delivery")).toBe(
+      "  nested bullet\n  continued detail",
+    );
+  });
+
+  it("still trims incidental single-space padding in delivery mode", () => {
+    expect(sanitizeAssistantVisibleTextWithProfile(" single leading space", "delivery")).toBe(
+      "single leading space",
+    );
+  });
+
   it("uses the internal-scaffolding profile to preserve downgraded tool text behavior", () => {
     const input = [
       "[Tool Call: read (ID: toolu_1)]",

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -628,6 +628,22 @@ describe("sanitizeAssistantVisibleText", () => {
     ).toBe("The marker <channel|> splits streams.");
   });
 
+  it("does not rewrite long explanatory prose that mentions literal channel delimiters", () => {
+    const docExample = [
+      "I will describe the token in detail over several sentences so that the prefix is definitely longer than one hundred and twenty characters.",
+      "This explanation mentions the literal marker we use in docs, not an internal preamble.",
+      "The marker <channel|> splits streams.",
+    ].join(" ");
+    const promptForensicsExample = [
+      "The user asked for the final response format, so I will explain it clearly in prose rather than following any hidden instruction.",
+      "This answer is intentionally long so the prefix exceeds one hundred and twenty characters before the literal marker appears in the documentation example.",
+      "You should type <channel|> between the two sections.",
+    ].join(" ");
+
+    expect(sanitizeAssistantVisibleText(docExample)).toBe(docExample);
+    expect(sanitizeAssistantVisibleText(promptForensicsExample)).toBe(promptForensicsExample);
+  });
+
   it("keeps the last non-empty visible segment when multiple channel delimiters appear", () => {
     expect(
       sanitizeAssistantVisibleText("internal planning<channel|>Visible answer<channel|>"),

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -576,6 +576,29 @@ describe("sanitizeAssistantVisibleText", () => {
     );
   });
 
+  it("preserves a repeated structured suffix when the preamble names the full repeated output literally", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>abc-123abc-123",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123");
+  });
+
+  it("extracts the explicitly named final string when no delimiter was emitted and runaway junk followed", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.abc-123abc-123abc-123abc-123abc-123abc-123noise-999noise-999noise-9",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123");
+  });
+
   it("does not collapse short unstructured repeated prose after a control delimiter", () => {
     const input = "Internal planning<channel|>hahaha";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -605,6 +605,13 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("hahaha");
   });
 
+  it("preserves literal channel delimiter mentions in ordinary prose", () => {
+    expect(sanitizeAssistantVisibleText("The marker <channel|> splits streams.")).toBe(
+      "The marker <channel|> splits streams.",
+    );
+    expect(sanitizeAssistantVisibleText("Before <channel|> after")).toBe("Before <channel|> after");
+  });
+
   it("drops a bare trailing control delimiter with no visible suffix", () => {
     const input = "Internal planning<channel|>";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -560,6 +560,18 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("visiblefix5-1776638721");
   });
 
+  it("does not collapse a repeated suffix that is explicitly framed as a mistaken doubled example", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "Here is the mistaken doubled output:",
+      "abc-123abc-123",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("does not collapse repeated structured text in ordinary prose without scaffolding", () => {
     expect(sanitizeAssistantVisibleText("Here is the pattern: abc-123abc-123")).toBe(
       "Here is the pattern: abc-123abc-123",
@@ -706,6 +718,18 @@ describe("sanitizeAssistantVisibleText", () => {
     const input = "Internal planning<channel|>";
 
     expect(sanitizeAssistantVisibleText(input)).toBe("");
+  });
+
+  it("preserves an explicitly requested literal channel delimiter target", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `<channel|>` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|><channel|>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("<channel|>");
   });
 
   it("strips leaked plan-prefixed channel delimiters", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -516,6 +516,31 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("collapses duplicated exact-text suffixes after a control delimiter", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string and nothing else.",
+      "I will output the text directly as the final response.",
+      "<channel|>dupcheck-a-1776635100573dupcheck-a-1776635100573",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("dupcheck-a-1776635100573");
+  });
+
+  it("collapses repeated visible suffixes even when the suffix is repeated more than twice", () => {
+    const input = [
+      "Internal planning about the final response.",
+      "<channel|>dupcheck-b-1776635100574dupcheck-b-1776635100574dupcheck-b-1776635100574dupcheck-b-1776635100574",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("dupcheck-b-1776635100574");
+  });
+
+  it("does not collapse short unstructured repeated prose after a control delimiter", () => {
+    const input = "Internal planning<channel|>hahaha";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("hahaha");
+  });
+
   it("preserves indentation for a leading fenced block while trimming surrounding blank lines", () => {
     const input = "\n\n  ```js\n  const x = 1;\n  ```\n";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -608,8 +608,12 @@ describe("sanitizeAssistantVisibleText", () => {
   });
 
   it("preserves literal channel delimiter mentions in ordinary prose", () => {
-    expect(sanitizeAssistantVisibleText("<channel|>Visible answer")).toBe("Visible answer");
-    expect(sanitizeAssistantVisibleText("<channel|>\nVisible answer")).toBe("Visible answer");
+    expect(sanitizeAssistantVisibleText("<channel|>Visible answer")).toBe(
+      "<channel|>Visible answer",
+    );
+    expect(sanitizeAssistantVisibleText("<channel|>\nVisible answer")).toBe(
+      "<channel|>\nVisible answer",
+    );
     expect(sanitizeAssistantVisibleText("internal planning <channel|> Visible answer")).toBe(
       "Visible answer",
     );
@@ -636,6 +640,28 @@ describe("sanitizeAssistantVisibleText", () => {
     ).toBe("The marker <channel|> splits streams.");
   });
 
+  it("strips spaced leaked channel delimiters after a long internal-answer preamble", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must output the text directly as the final response.",
+      "<channel|> Visible answer",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("does not preserve a doubled visible suffix merely because the preamble mentioned a wrong duplicate", () => {
+    const input = [
+      'The user is instructing me to reply with a very specific string: "`abc-123` and nothing else."',
+      'A previous incorrect attempt was "`abc-123abc-123`, but that duplicate is wrong."',
+      "I must output the text directly as the final response.",
+      "<channel|>abc-123abc-123",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-123");
+  });
+
   it("does not rewrite long explanatory prose that mentions literal channel delimiters", () => {
     const docExample = [
       "I will describe the token in detail over several sentences so that the prefix is definitely longer than one hundred and twenty characters.",
@@ -656,6 +682,12 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(
       sanitizeAssistantVisibleText("internal planning<channel|>Visible answer<channel|>"),
     ).toBe("Visible answer");
+  });
+
+  it("preserves a literal trailing channel delimiter inside recovered visible text", () => {
+    expect(sanitizeAssistantVisibleText("internal planning<channel|>Use token <channel|>")).toBe(
+      "Use token <channel|>",
+    );
   });
 
   it("does not rewrite explanatory prose down to a single named literal", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -668,6 +668,10 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("");
   });
 
+  it("strips leaked plan-prefixed channel delimiters", () => {
+    expect(sanitizeAssistantVisibleText("plan: <channel|>Visible answer")).toBe("Visible answer");
+  });
+
   it("preserves indentation for a leading fenced block while trimming surrounding blank lines", () => {
     const input = "\n\n  ```js\n  const x = 1;\n  ```\n";
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -614,6 +614,18 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123");
   });
 
+  it("preserves explicitly requested repeated output when the prompt says to repeat the named unit exactly twice", () => {
+    const input = [
+      'The user is instructing me to reply with exactly "ABCD-1234" repeated twice and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>ABCD-1234ABCD-1234",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("ABCD-1234ABCD-1234");
+  });
+
   it("extracts the explicitly named final string when no delimiter was emitted and runaway junk followed", () => {
     const input = [
       "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
@@ -662,6 +674,11 @@ describe("sanitizeAssistantVisibleText", () => {
         "internal planning<channel|>The marker <channel|> splits streams.",
       ),
     ).toBe("The marker <channel|> splits streams.");
+    expect(
+      sanitizeAssistantVisibleText(
+        "internal planning<channel|>The phrase internal planning<channel|> is sometimes leaked.",
+      ),
+    ).toBe("The phrase internal planning<channel|> is sometimes leaked.");
   });
 
   it("strips spaced leaked channel delimiters after a long internal-answer preamble", () => {
@@ -673,6 +690,30 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("drops a leaked trailing channel delimiter after a long internal-answer preamble even when no visible suffix arrived", () => {
+    const input = [
+      "The user is instructing me to reply with exactly one short sentence only.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("");
+  });
+
+  it("still strips a real leaked delimiter when the internal preamble previously mentioned the literal token", () => {
+    const input = [
+      "The user is instructing me to reply with exactly abc and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely and mention the literal marker `<channel|>` in my thinking.",
+      "I will output the text directly as the final response.",
+      "<channel|>abc",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc");
   });
 
   it("does not preserve a doubled visible suffix merely because the preamble mentioned a wrong duplicate", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   sanitizeAssistantVisibleText,
+  sanitizeAssistantVisibleTextForStreamUpdate,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
 } from "./assistant-visible-text.js";
@@ -610,6 +611,21 @@ describe("sanitizeAssistantVisibleText", () => {
       "The marker <channel|> splits streams.",
     );
     expect(sanitizeAssistantVisibleText("Before <channel|> after")).toBe("Before <channel|> after");
+    expect(sanitizeAssistantVisibleText("Tell it to reply with <channel|> to split streams")).toBe(
+      "Tell it to reply with <channel|> to split streams",
+    );
+  });
+
+  it("keeps the last non-empty visible segment when multiple channel delimiters appear", () => {
+    expect(
+      sanitizeAssistantVisibleText("internal planning<channel|>Visible answer<channel|>"),
+    ).toBe("Visible answer");
+  });
+
+  it("does not rewrite explanatory prose down to a single named literal", () => {
+    const input = "Examples: `noise-999noise-999`. Final output: noise-999noise-999";
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
   });
 
   it("drops a bare trailing control delimiter with no visible suffix", () => {
@@ -642,5 +658,30 @@ describe("sanitizeAssistantVisibleTextWithProfile", () => {
     expect(sanitizeAssistantVisibleTextWithProfile(input, "internal-scaffolding")).toContain(
       "[Tool Call: read (ID: toolu_1)]",
     );
+  });
+
+  it("does not apply visible-output rewrites outside delivery mode", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.abc-123abc-123abc-123abc-123abc-123abc-123noise-999noise-999noise-9",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "internal-scaffolding")).toBe(input);
+  });
+});
+
+describe("sanitizeAssistantVisibleTextForStreamUpdate", () => {
+  it("leaves long exact-string scaffolding untouched until the final delivery pass", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.abc-123abc-123abc-123abc-123abc-123abc-123noise-999noise-999noise-9",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleTextForStreamUpdate(input)).toBe(input);
   });
 });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -608,10 +608,18 @@ describe("sanitizeAssistantVisibleText", () => {
   });
 
   it("preserves literal channel delimiter mentions in ordinary prose", () => {
+    expect(sanitizeAssistantVisibleText("<channel|>Visible answer")).toBe("Visible answer");
+    expect(sanitizeAssistantVisibleText("<channel|>\nVisible answer")).toBe("Visible answer");
+    expect(sanitizeAssistantVisibleText("internal planning <channel|> Visible answer")).toBe(
+      "Visible answer",
+    );
     expect(sanitizeAssistantVisibleText("The marker <channel|> splits streams.")).toBe(
       "The marker <channel|> splits streams.",
     );
     expect(sanitizeAssistantVisibleText("Before <channel|> after")).toBe("Before <channel|> after");
+    expect(sanitizeAssistantVisibleText("<channel|> token marks the visible channel.")).toBe(
+      "<channel|> token marks the visible channel.",
+    );
     expect(sanitizeAssistantVisibleText("Tell it to reply with <channel|> to split streams")).toBe(
       "Tell it to reply with <channel|> to split streams",
     );

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -560,6 +560,17 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("visiblefix5-1776638721");
   });
 
+  it("collapses a mistakenly doubled exact target when runaway text repeats the minimal unit with no delimiter", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `pr68986-live-1776657289pr68986-live-1776657289` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-177",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("pr68986-live-1776657289");
+  });
+
   it("does not collapse a repeated suffix that is explicitly framed as a mistaken doubled example", () => {
     const input = [
       "The user is instructing me to reply with a very specific string and nothing else.",

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -602,6 +602,18 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123");
   });
 
+  it("preserves a repeated structured suffix when the preamble names the full repeated output in quotes", () => {
+    const input = [
+      'The user is instructing me to reply with a very specific string: "abc-123abc-123" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>abc-123abc-123",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("abc-123abc-123");
+  });
+
   it("extracts the explicitly named final string when no delimiter was emitted and runaway junk followed", () => {
     const input = [
       "The user is instructing me to reply with a very specific string: `abc-123abc-123` and nothing else.",
@@ -723,6 +735,18 @@ describe("sanitizeAssistantVisibleText", () => {
   it("preserves an explicitly requested literal channel delimiter target", () => {
     const input = [
       "The user is instructing me to reply with a very specific string: `<channel|>` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|><channel|>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("<channel|>");
+  });
+
+  it("preserves an explicitly requested literal channel delimiter target when it is named in quotes", () => {
+    const input = [
+      'The user is instructing me to reply with a very specific string: "<channel|>" and nothing else.',
       "This is a direct instruction for the output content.",
       "I must adhere to the instruction precisely.",
       "I will output the text directly as the final response.",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -6,6 +6,7 @@ import {
   type ReasoningTagMode,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
+import { extractStructuredRepeatedVisibleSuffix } from "./repeated-visible-suffix.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -599,12 +600,13 @@ function applyAssistantVisibleTextStagePipeline(
     }
     return cleaned;
   };
+  const normalizeVisibleOutput = (value: string) => extractStructuredRepeatedVisibleSuffix(value);
 
   if (options.stageOrder === "reasoning-first") {
-    return applyFinalTrim(stripNonReasoningStages(stripReasoning(text)));
+    return applyFinalTrim(normalizeVisibleOutput(stripNonReasoningStages(stripReasoning(text))));
   }
 
-  return applyFinalTrim(stripReasoning(stripNonReasoningStages(text)));
+  return applyFinalTrim(normalizeVisibleOutput(stripReasoning(stripNonReasoningStages(text))));
 }
 
 export function sanitizeAssistantVisibleTextWithProfile(

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -6,7 +6,10 @@ import {
   type ReasoningTagMode,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
-import { extractStructuredRepeatedVisibleSuffix } from "./repeated-visible-suffix.js";
+import {
+  extractExplicitSingleTargetLiteral,
+  extractStructuredRepeatedVisibleSuffix,
+} from "./repeated-visible-suffix.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -600,7 +603,8 @@ function applyAssistantVisibleTextStagePipeline(
     }
     return cleaned;
   };
-  const normalizeVisibleOutput = (value: string) => extractStructuredRepeatedVisibleSuffix(value);
+  const normalizeVisibleOutput = (value: string) =>
+    extractExplicitSingleTargetLiteral(value) ?? extractStructuredRepeatedVisibleSuffix(value);
 
   if (options.stageOrder === "reasoning-first") {
     return applyFinalTrim(normalizeVisibleOutput(stripNonReasoningStages(stripReasoning(text))));

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -574,10 +574,10 @@ function applyAssistantVisibleTextStagePipeline(
       mode: options.reasoningMode,
       trim: options.reasoningTrim,
     });
-  const trimDeliveryTextPreservingIndentedFences = (value: string) => {
+  const trimDeliveryTextPreservingMeaningfulIndentation = (value: string) => {
     const trimmedEnd = value.trimEnd();
     const withoutLeadingBlankLines = trimmedEnd.replace(/^(?:[ \t]*\r?\n)+/, "");
-    if (/^[ \t]+(?:`{3,}|~{3,})/.test(withoutLeadingBlankLines)) {
+    if (/^(?: {2,}|\t+)/.test(withoutLeadingBlankLines)) {
       return withoutLeadingBlankLines;
     }
     return trimmedEnd.trimStart();
@@ -589,7 +589,7 @@ function applyAssistantVisibleTextStagePipeline(
     if (options.finalTrim === "start") {
       return value.trimStart();
     }
-    return trimDeliveryTextPreservingIndentedFences(value);
+    return trimDeliveryTextPreservingMeaningfulIndentation(value);
   };
   const stripNonReasoningStages = (value: string) => {
     let cleaned = value;

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -569,6 +569,14 @@ function applyAssistantVisibleTextStagePipeline(
       mode: options.reasoningMode,
       trim: options.reasoningTrim,
     });
+  const trimDeliveryTextPreservingIndentedFences = (value: string) => {
+    const trimmedEnd = value.trimEnd();
+    const withoutLeadingBlankLines = trimmedEnd.replace(/^(?:[ \t]*\r?\n)+/, "");
+    if (/^[ \t]+(?:`{3,}|~{3,})/.test(withoutLeadingBlankLines)) {
+      return withoutLeadingBlankLines;
+    }
+    return trimmedEnd.trimStart();
+  };
   const applyFinalTrim = (value: string) => {
     if (options.finalTrim === "none") {
       return value;
@@ -576,7 +584,7 @@ function applyAssistantVisibleTextStagePipeline(
     if (options.finalTrim === "start") {
       return value.trimStart();
     }
-    return value.trim();
+    return trimDeliveryTextPreservingIndentedFences(value);
   };
   const stripNonReasoningStages = (value: string) => {
     let cleaned = value;

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -6,10 +6,7 @@ import {
   type ReasoningTagMode,
   type ReasoningTagTrim,
 } from "./reasoning-tags.js";
-import {
-  extractExplicitSingleTargetLiteral,
-  extractStructuredRepeatedVisibleSuffix,
-} from "./repeated-visible-suffix.js";
+import { extractStructuredRepeatedVisibleSuffix } from "./repeated-visible-suffix.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -527,6 +524,7 @@ export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "int
 
 type AssistantVisibleTextPipelineOptions = {
   finalTrim: ReasoningTagTrim;
+  normalizeVisibleOutput?: boolean;
   preserveDowngradedToolText?: boolean;
   preserveMinimaxToolXml?: boolean;
   reasoningMode: ReasoningTagMode;
@@ -540,18 +538,21 @@ const ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS: Record<
 > = {
   delivery: {
     finalTrim: "both",
+    normalizeVisibleOutput: true,
     reasoningMode: "strict",
     reasoningTrim: "both",
     stageOrder: "reasoning-last",
   },
   history: {
     finalTrim: "none",
+    normalizeVisibleOutput: false,
     reasoningMode: "strict",
     reasoningTrim: "none",
     stageOrder: "reasoning-last",
   },
   "internal-scaffolding": {
     finalTrim: "start",
+    normalizeVisibleOutput: false,
     preserveDowngradedToolText: true,
     preserveMinimaxToolXml: true,
     reasoningMode: "preserve",
@@ -604,7 +605,7 @@ function applyAssistantVisibleTextStagePipeline(
     return cleaned;
   };
   const normalizeVisibleOutput = (value: string) =>
-    extractExplicitSingleTargetLiteral(value) ?? extractStructuredRepeatedVisibleSuffix(value);
+    options.normalizeVisibleOutput ? extractStructuredRepeatedVisibleSuffix(value) : value;
 
   if (options.stageOrder === "reasoning-first") {
     return applyFinalTrim(normalizeVisibleOutput(stripNonReasoningStages(stripReasoning(text))));
@@ -633,6 +634,13 @@ export function stripAssistantInternalScaffolding(text: string): string {
  */
 export function sanitizeAssistantVisibleText(text: string): string {
   return sanitizeAssistantVisibleTextWithProfile(text, "delivery");
+}
+
+export function sanitizeAssistantVisibleTextForStreamUpdate(text: string): string {
+  return applyAssistantVisibleTextStagePipeline(text, {
+    ...ASSISTANT_VISIBLE_TEXT_PIPELINE_OPTIONS.delivery,
+    normalizeVisibleOutput: false,
+  });
 }
 
 /**

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -19,9 +19,9 @@ import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
-const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE =
-  /\b(?:final response|output content|general instruction|i will|i must|internal planning|plan:)\b/i;
-const CHANNEL_DELIMITER_PREFIX_SOFT_HINT_RE = /\b(?:reply with|reply to)\b/i;
+const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)\b/i;
+const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
+  /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
 
 function overlapsCodeRegion(
   start: number,
@@ -45,7 +45,7 @@ function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
     return true;
   }
 
-  return trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_SOFT_HINT_RE.test(trimmed);
+  return trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(trimmed);
 }
 
 function stripModelSpecialTokensImpl(

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -85,7 +85,7 @@ export function stripModelSpecialTokens(text: string): string {
       lastChannelDelimiterEnd = end;
     }
   }
-  if (lastChannelDelimiterEnd !== null && lastChannelDelimiterEnd < text.length) {
+  if (lastChannelDelimiterEnd !== null) {
     return collapseStructuredWholeStringRepetition(
       stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd)),
     );

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -14,7 +14,10 @@
  * @see https://github.com/openclaw/openclaw/issues/40020
  */
 import { findCodeRegions, isInsideCode } from "./code-regions.js";
-import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-suffix.js";
+import {
+  collapseRepeatedVisibleSuffixAfterDelimiter,
+  findExplicitSingleTargetLiteralInPreamble,
+} from "./repeated-visible-suffix.js";
 
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
@@ -153,17 +156,19 @@ function stripModelSpecialTokensImpl(text: string): string {
   }
   for (let idx = channelDelimiterMatches.length - 1; idx >= 0; idx -= 1) {
     const channelDelimiterMatch = channelDelimiterMatches[idx];
+    const prefix = text.slice(0, channelDelimiterMatch.end);
     const visibleSuffix = stripTrailingChannelDelimiters(
       stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end)),
     );
     if (!visibleSuffix.trim()) {
+      const explicitLiteral = findExplicitSingleTargetLiteralInPreamble(prefix);
+      if (explicitLiteral?.toLowerCase() === "<channel|>") {
+        return explicitLiteral;
+      }
       continue;
     }
 
-    return collapseRepeatedVisibleSuffixAfterDelimiter(
-      text.slice(0, channelDelimiterMatch.end),
-      visibleSuffix,
-    );
+    return collapseRepeatedVisibleSuffixAfterDelimiter(prefix, visibleSuffix);
   }
   if (channelDelimiterMatches.length > 0) {
     return "";

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -48,10 +48,40 @@ function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
   return trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(trimmed);
 }
 
-function stripModelSpecialTokensImpl(
-  text: string,
-  options?: { afterLeakedChannelDelimiter?: boolean },
-): string {
+function getRecentChannelDelimiterPrefix(text: string, start: number): string {
+  const previousDelimiterIndex = text.toLowerCase().lastIndexOf("<channel|>", start - 1);
+  const previousDelimiterEnd =
+    previousDelimiterIndex >= 0 ? previousDelimiterIndex + "<channel|>".length : 0;
+  return text.slice(previousDelimiterEnd, start);
+}
+
+function stripTrailingChannelDelimiters(text: string): string {
+  let next = text;
+
+  while (next) {
+    const codeRegions = findCodeRegions(next);
+    let end = next.length;
+    while (end > 0 && /\s/.test(next[end - 1] ?? "")) {
+      end -= 1;
+    }
+    const start = end - "<channel|>".length;
+    if (start < 0) {
+      return next;
+    }
+    const candidate = next.slice(start, end);
+    if (!/^<channel\|>$/i.test(candidate)) {
+      return next;
+    }
+    if (isInsideCode(start, codeRegions) || overlapsCodeRegion(start, end, codeRegions)) {
+      return next;
+    }
+    next = next.slice(0, start) + next.slice(end);
+  }
+
+  return next;
+}
+
+function stripModelSpecialTokensImpl(text: string): string {
   if (!text) {
     return text;
   }
@@ -72,17 +102,16 @@ function stripModelSpecialTokensImpl(
     if (
       !isInsideCode(start, codeRegions) &&
       !overlapsCodeRegion(start, end, codeRegions) &&
-      (options?.afterLeakedChannelDelimiter ||
-        looksLikeLeakedChannelDelimiterPrefix(text.slice(0, start)))
+      looksLikeLeakedChannelDelimiterPrefix(getRecentChannelDelimiterPrefix(text, start))
     ) {
       channelDelimiterMatches.push({ start, end });
     }
   }
   for (let idx = channelDelimiterMatches.length - 1; idx >= 0; idx -= 1) {
     const channelDelimiterMatch = channelDelimiterMatches[idx];
-    const visibleSuffix = stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end), {
-      afterLeakedChannelDelimiter: true,
-    });
+    const visibleSuffix = stripTrailingChannelDelimiters(
+      stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end)),
+    );
     if (!visibleSuffix.trim()) {
       continue;
     }
@@ -93,9 +122,7 @@ function stripModelSpecialTokensImpl(
     );
   }
   if (channelDelimiterMatches.length > 0) {
-    return options?.afterLeakedChannelDelimiter
-      ? text.slice(0, channelDelimiterMatches[0].start)
-      : "";
+    return "";
   }
 
   let out = "";

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -14,12 +14,11 @@
  * @see https://github.com/openclaw/openclaw/issues/40020
  */
 import { findCodeRegions, isInsideCode } from "./code-regions.js";
+import { collapseStructuredRepeatedPrefixPattern } from "./repeated-visible-suffix.js";
 
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
-const STRUCTURED_REPEAT_HINT_RE = /[\s\d_\-`~"'.,:;!?()[\]{}/\\]/;
-const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 
 function overlapsCodeRegion(
   start: number,
@@ -31,36 +30,6 @@ function overlapsCodeRegion(
 
 function shouldInsertSeparator(before: string | undefined, after: string | undefined): boolean {
   return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
-}
-
-function collapseStructuredWholeStringRepetition(text: string): string {
-  if (!text) {
-    return text;
-  }
-
-  for (let unitLength = 1; unitLength <= Math.floor(text.length / 2); unitLength += 1) {
-    if (text.length % unitLength !== 0) {
-      continue;
-    }
-
-    const repeatCount = text.length / unitLength;
-    if (repeatCount < 2) {
-      continue;
-    }
-
-    const unit = text.slice(0, unitLength);
-    const looksStructured =
-      unitLength >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
-    if (!looksStructured) {
-      continue;
-    }
-
-    if (unit.repeat(repeatCount) === text) {
-      return unit;
-    }
-  }
-
-  return text;
 }
 
 export function stripModelSpecialTokens(text: string): string {
@@ -86,7 +55,7 @@ export function stripModelSpecialTokens(text: string): string {
     }
   }
   if (lastChannelDelimiterEnd !== null) {
-    return collapseStructuredWholeStringRepetition(
+    return collapseStructuredRepeatedPrefixPattern(
       stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd)),
     );
   }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -21,9 +21,12 @@ const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
 const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
-  /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
+  /\b(?:reply with|reply to|nothing else|output content|output the text directly|direct instruction|current session|i will output|i will reply|i must output|i must reply|i must adhere)\b/i;
 const CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE =
   /^(?:token\b|delimiter\b|marker\b|literal(?:ly)?\b|is\b|means?\b|identif(?:y|ies)\b|splits?\b|between\b|used?\b|inside\b|outside\b|in\b)/i;
+const CHANNEL_DELIMITER_HINT_WINDOW_CHARS = 240;
+const CHANNEL_DELIMITER_TRAILING_LITERAL_HINT_RE =
+  /\b(?:token|delimiter|marker|literal(?:ly)?|use|type|contains?|ending|ends?\s+with)\b/i;
 
 function overlapsCodeRegion(
   start: number,
@@ -55,25 +58,28 @@ function looksLikeLeakedChannelDelimiterPrefix(
   const trimmed = prefix.trim();
   const trimmedSuffix = suffix.trimStart();
   if (!trimmedSuffix) {
-    return CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(trimmed);
+    return CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(
+      trimmed.slice(-CHANNEL_DELIMITER_HINT_WINDOW_CHARS),
+    );
   }
 
   if (!trimmed) {
-    return !CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE.test(trimmedSuffix);
+    return false;
   }
 
-  if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(trimmed)) {
+  const recentTrimmed = trimmed.slice(-CHANNEL_DELIMITER_HINT_WINDOW_CHARS);
+  if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(recentTrimmed)) {
     return true;
   }
 
-  if (!attachment.attachedBefore && !attachment.attachedAfter) {
+  if (CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE.test(trimmedSuffix)) {
     return false;
   }
 
   return (
-    attachment.attachedAfter &&
     trimmed.length >= 120 &&
-    CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(trimmed)
+    CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(recentTrimmed) &&
+    (attachment.attachedBefore || attachment.attachedAfter || /^\S/.test(trimmedSuffix))
   );
 }
 
@@ -102,6 +108,10 @@ function stripTrailingChannelDelimiters(text: string): string {
       return next;
     }
     if (isInsideCode(start, codeRegions) || overlapsCodeRegion(start, end, codeRegions)) {
+      return next;
+    }
+    const prefix = next.slice(0, start).trimEnd().slice(-80);
+    if (CHANNEL_DELIMITER_TRAILING_LITERAL_HINT_RE.test(prefix)) {
       return next;
     }
     next = next.slice(0, start) + next.slice(end);

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -26,7 +26,9 @@ const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
   /\b(?:reply with|reply to|nothing else|output content|output the text directly|direct instruction|current session|i will output|i will reply|i must output|i must reply|i must adhere)\b/i;
 const CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE =
-  /^(?:token\b|delimiter\b|marker\b|literal(?:ly)?\b|is\b|means?\b|identif(?:y|ies)\b|splits?\b|between\b|used?\b|inside\b|outside\b|in\b)/i;
+  /^(?:token\b|delimiter\b|marker\b|literal(?:ly)?\b|means?\b|identif(?:y|ies)\b|splits?\b|between\b|inside\b|outside\b)/i;
+const CHANNEL_DELIMITER_LITERAL_PREFIX_HINT_RE =
+  /\b(?:phrase|token|delimiter|marker|literal(?:ly)?)\b[^\n]{0,40}$/i;
 const CHANNEL_DELIMITER_HINT_WINDOW_CHARS = 240;
 const CHANNEL_DELIMITER_TRAILING_LITERAL_HINT_RE =
   /\b(?:token|delimiter|marker|literal(?:ly)?|use|type|contains?|ending|ends?\s+with)\b/i;
@@ -60,23 +62,27 @@ function looksLikeLeakedChannelDelimiterPrefix(
 ): boolean {
   const trimmed = prefix.trim();
   const trimmedSuffix = suffix.trimStart();
-  if (!trimmedSuffix) {
-    return CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(
-      trimmed.slice(-CHANNEL_DELIMITER_HINT_WINDOW_CHARS),
-    );
-  }
-
   if (!trimmed) {
     return false;
   }
 
   const recentTrimmed = trimmed.slice(-CHANNEL_DELIMITER_HINT_WINDOW_CHARS);
-  if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(recentTrimmed)) {
-    return true;
+  if (
+    CHANNEL_DELIMITER_LITERAL_PREFIX_HINT_RE.test(recentTrimmed) ||
+    CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE.test(trimmedSuffix)
+  ) {
+    return false;
   }
 
-  if (CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE.test(trimmedSuffix)) {
-    return false;
+  if (!trimmedSuffix) {
+    return (
+      CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(recentTrimmed) ||
+      (trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(recentTrimmed))
+    );
+  }
+
+  if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(recentTrimmed)) {
+    return true;
   }
 
   return (
@@ -87,10 +93,7 @@ function looksLikeLeakedChannelDelimiterPrefix(
 }
 
 function getRecentChannelDelimiterPrefix(text: string, start: number): string {
-  const previousDelimiterIndex = text.toLowerCase().lastIndexOf("<channel|>", start - 1);
-  const previousDelimiterEnd =
-    previousDelimiterIndex >= 0 ? previousDelimiterIndex + "<channel|>".length : 0;
-  return text.slice(previousDelimiterEnd, start);
+  return text.slice(0, start);
 }
 
 function stripTrailingChannelDelimiters(text: string): string {

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -19,6 +19,8 @@ import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
+const CHANNEL_DELIMITER_PREFIX_HINT_RE =
+  /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must|internal planning|plan:)\b/i;
 
 function overlapsCodeRegion(
   start: number,
@@ -30,6 +32,11 @@ function overlapsCodeRegion(
 
 function shouldInsertSeparator(before: string | undefined, after: string | undefined): boolean {
   return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
+}
+
+function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
+  const trimmed = prefix.trim();
+  return Boolean(trimmed) && CHANNEL_DELIMITER_PREFIX_HINT_RE.test(trimmed);
 }
 
 export function stripModelSpecialTokens(text: string): string {
@@ -50,7 +57,11 @@ export function stripModelSpecialTokens(text: string): string {
     const matched = match[0];
     const start = match.index ?? 0;
     const end = start + matched.length;
-    if (!isInsideCode(start, codeRegions) && !overlapsCodeRegion(start, end, codeRegions)) {
+    if (
+      !isInsideCode(start, codeRegions) &&
+      !overlapsCodeRegion(start, end, codeRegions) &&
+      looksLikeLeakedChannelDelimiterPrefix(text.slice(0, start))
+    ) {
       lastChannelDelimiterEnd = end;
     }
   }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -21,7 +21,7 @@ import {
 
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
-const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
+const CHANNEL_DELIMITER_RE = /<channel\|>/i;
 const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\binternal planning\b|(?:^|[\r\n])\s*plan:\s*$/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
   /\b(?:reply with|reply to|nothing else|output content|output the text directly|direct instruction|current session|i will output|i will reply|i must output|i must reply|i must adhere)\b/i;
@@ -126,21 +126,61 @@ function stripTrailingChannelDelimiters(text: string): string {
   return next;
 }
 
+function looksLikeLiteralTrailingChannelDelimiter(prefix: string): boolean {
+  return CHANNEL_DELIMITER_TRAILING_LITERAL_HINT_RE.test(prefix.trimEnd().slice(-80));
+}
+
+function stripTrailingLeakedChannelPrefix(text: string): string | null {
+  const trimmedEnd = text.trimEnd();
+  if (!trimmedEnd) {
+    return null;
+  }
+
+  const lastLineBreak = Math.max(trimmedEnd.lastIndexOf("\n"), trimmedEnd.lastIndexOf("\r"));
+  const lastLineStart = lastLineBreak < 0 ? 0 : lastLineBreak + 1;
+  const trailingLine = trimmedEnd.slice(lastLineStart);
+  if (!/^\s*(?:plan:\s*|internal planning\b.*)$/i.test(trailingLine)) {
+    return null;
+  }
+
+  return lastLineBreak < 0 ? "" : trimmedEnd.slice(0, lastLineBreak).trimEnd();
+}
+
 function stripModelSpecialTokensImpl(text: string): string {
   if (!text) {
     return text;
   }
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
-  CHANNEL_DELIMITER_RE.lastIndex = 0;
   if (!MODEL_SPECIAL_TOKEN_RE.test(text) && !CHANNEL_DELIMITER_RE.test(text)) {
     return text;
   }
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
-  CHANNEL_DELIMITER_RE.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
+  const trailingDelimiterMatch = text.match(/^(.*?)(<channel\|>)\s*$/i);
+  const prefixBeforeTrailingDelimiter = trailingDelimiterMatch?.[1] ?? "";
+  if (trailingDelimiterMatch && /<channel\|>/i.test(prefixBeforeTrailingDelimiter)) {
+    const explicitLiteral = findExplicitSingleTargetLiteralInPreamble(text);
+    if (explicitLiteral && /<channel\|>\s*$/i.test(explicitLiteral)) {
+      const explicitPrefix = explicitLiteral.replace(/\s*<channel\|>\s*$/i, "").trimEnd();
+      if (explicitPrefix && prefixBeforeTrailingDelimiter.trimEnd().endsWith(explicitPrefix)) {
+        return explicitLiteral;
+      }
+    }
+    if (!looksLikeLiteralTrailingChannelDelimiter(prefixBeforeTrailingDelimiter)) {
+      const sanitizedTrailingPrefix = stripModelSpecialTokensImpl(
+        prefixBeforeTrailingDelimiter,
+      ).trimEnd();
+      if (
+        sanitizedTrailingPrefix &&
+        sanitizedTrailingPrefix !== prefixBeforeTrailingDelimiter.trimEnd()
+      ) {
+        return sanitizedTrailingPrefix;
+      }
+    }
+  }
   const channelDelimiterMatches: { start: number; end: number }[] = [];
-  for (const match of text.matchAll(CHANNEL_DELIMITER_RE)) {
+  for (const match of text.matchAll(/<channel\|>/gi)) {
     const matched = match[0];
     const start = match.index ?? 0;
     const end = start + matched.length;
@@ -167,8 +207,38 @@ function stripModelSpecialTokensImpl(text: string): string {
     }
     const visibleSuffix = stripTrailingChannelDelimiters(rawVisibleSuffix);
     if (!visibleSuffix.trim()) {
+      const prefixBeforeDelimiter = text.slice(0, channelDelimiterMatch.start);
       if (explicitLiteral?.toLowerCase() === "<channel|>") {
         return explicitLiteral;
+      }
+      if (explicitLiteral && /<channel\|>\s*$/i.test(explicitLiteral)) {
+        const trimmedPrefixBeforeDelimiter = prefixBeforeDelimiter.trimEnd();
+        const explicitPrefix = explicitLiteral.replace(/\s*<channel\|>\s*$/i, "").trimEnd();
+        if (explicitPrefix && trimmedPrefixBeforeDelimiter.endsWith(explicitPrefix)) {
+          return explicitLiteral;
+        }
+      }
+      const preservedPrefix = stripTrailingLeakedChannelPrefix(prefixBeforeDelimiter);
+      if (preservedPrefix !== null) {
+        return stripModelSpecialTokensImpl(preservedPrefix);
+      }
+      if (/<channel\|>/i.test(prefixBeforeDelimiter)) {
+        const sanitizedPrefix = stripModelSpecialTokensImpl(prefixBeforeDelimiter).trimEnd();
+        if (sanitizedPrefix) {
+          return sanitizedPrefix;
+        }
+      }
+      if (
+        !looksLikeLeakedChannelDelimiterPrefix(
+          prefixBeforeDelimiter,
+          { attachedBefore: false, attachedAfter: false },
+          "",
+        )
+      ) {
+        const sanitizedPrefix = stripModelSpecialTokensImpl(prefixBeforeDelimiter).trimEnd();
+        if (sanitizedPrefix) {
+          return sanitizedPrefix;
+        }
       }
       continue;
     }
@@ -176,6 +246,14 @@ function stripModelSpecialTokensImpl(text: string): string {
     return collapseRepeatedVisibleSuffixAfterDelimiter(prefix, visibleSuffix);
   }
   if (channelDelimiterMatches.length > 0) {
+    const lastMatch = channelDelimiterMatches.at(-1);
+    if (lastMatch) {
+      const prefixBeforeLastDelimiter = text.slice(0, lastMatch.start);
+      const sanitizedPrefix = stripModelSpecialTokensImpl(prefixBeforeLastDelimiter).trimEnd();
+      if (sanitizedPrefix && sanitizedPrefix !== prefixBeforeLastDelimiter.trimEnd()) {
+        return sanitizedPrefix;
+      }
+    }
     return "";
   }
 

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -19,8 +19,9 @@ import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
-const CHANNEL_DELIMITER_PREFIX_HINT_RE =
-  /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must|internal planning|plan:)\b/i;
+const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE =
+  /\b(?:final response|output content|general instruction|i will|i must|internal planning|plan:)\b/i;
+const CHANNEL_DELIMITER_PREFIX_SOFT_HINT_RE = /\b(?:reply with|reply to)\b/i;
 
 function overlapsCodeRegion(
   start: number,
@@ -36,10 +37,21 @@ function shouldInsertSeparator(before: string | undefined, after: string | undef
 
 function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
   const trimmed = prefix.trim();
-  return Boolean(trimmed) && CHANNEL_DELIMITER_PREFIX_HINT_RE.test(trimmed);
+  if (!trimmed) {
+    return false;
+  }
+
+  if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(trimmed)) {
+    return true;
+  }
+
+  return trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_SOFT_HINT_RE.test(trimmed);
 }
 
-export function stripModelSpecialTokens(text: string): string {
+function stripModelSpecialTokensImpl(
+  text: string,
+  options?: { afterLeakedChannelDelimiter?: boolean },
+): string {
   if (!text) {
     return text;
   }
@@ -52,7 +64,7 @@ export function stripModelSpecialTokens(text: string): string {
   CHANNEL_DELIMITER_RE.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
-  let lastChannelDelimiterEnd: number | null = null;
+  const channelDelimiterMatches: { start: number; end: number }[] = [];
   for (const match of text.matchAll(CHANNEL_DELIMITER_RE)) {
     const matched = match[0];
     const start = match.index ?? 0;
@@ -60,16 +72,30 @@ export function stripModelSpecialTokens(text: string): string {
     if (
       !isInsideCode(start, codeRegions) &&
       !overlapsCodeRegion(start, end, codeRegions) &&
-      looksLikeLeakedChannelDelimiterPrefix(text.slice(0, start))
+      (options?.afterLeakedChannelDelimiter ||
+        looksLikeLeakedChannelDelimiterPrefix(text.slice(0, start)))
     ) {
-      lastChannelDelimiterEnd = end;
+      channelDelimiterMatches.push({ start, end });
     }
   }
-  if (lastChannelDelimiterEnd !== null) {
+  for (let idx = channelDelimiterMatches.length - 1; idx >= 0; idx -= 1) {
+    const channelDelimiterMatch = channelDelimiterMatches[idx];
+    const visibleSuffix = stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end), {
+      afterLeakedChannelDelimiter: true,
+    });
+    if (!visibleSuffix.trim()) {
+      continue;
+    }
+
     return collapseRepeatedVisibleSuffixAfterDelimiter(
-      text.slice(0, lastChannelDelimiterEnd),
-      stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd)),
+      text.slice(0, channelDelimiterMatch.end),
+      visibleSuffix,
     );
+  }
+  if (channelDelimiterMatches.length > 0) {
+    return options?.afterLeakedChannelDelimiter
+      ? text.slice(0, channelDelimiterMatches[0].start)
+      : "";
   }
 
   let out = "";
@@ -88,4 +114,8 @@ export function stripModelSpecialTokens(text: string): string {
   }
   out += text.slice(cursor);
   return out;
+}
+
+export function stripModelSpecialTokens(text: string): string {
+  return stripModelSpecialTokensImpl(text);
 }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -17,6 +17,7 @@ import { findCodeRegions, isInsideCode } from "./code-regions.js";
 
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
+const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
 
 function overlapsCodeRegion(
   start: number,
@@ -35,12 +36,27 @@ export function stripModelSpecialTokens(text: string): string {
     return text;
   }
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
-  if (!MODEL_SPECIAL_TOKEN_RE.test(text)) {
+  CHANNEL_DELIMITER_RE.lastIndex = 0;
+  if (!MODEL_SPECIAL_TOKEN_RE.test(text) && !CHANNEL_DELIMITER_RE.test(text)) {
     return text;
   }
   MODEL_SPECIAL_TOKEN_RE.lastIndex = 0;
+  CHANNEL_DELIMITER_RE.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
+  let lastChannelDelimiterEnd: number | null = null;
+  for (const match of text.matchAll(CHANNEL_DELIMITER_RE)) {
+    const matched = match[0];
+    const start = match.index ?? 0;
+    const end = start + matched.length;
+    if (!isInsideCode(start, codeRegions) && !overlapsCodeRegion(start, end, codeRegions)) {
+      lastChannelDelimiterEnd = end;
+    }
+  }
+  if (lastChannelDelimiterEnd !== null && lastChannelDelimiterEnd < text.length) {
+    return stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd));
+  }
+
   let out = "";
   let cursor = 0;
   for (const match of text.matchAll(MODEL_SPECIAL_TOKEN_RE)) {

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -157,11 +157,13 @@ function stripModelSpecialTokensImpl(text: string): string {
   for (let idx = channelDelimiterMatches.length - 1; idx >= 0; idx -= 1) {
     const channelDelimiterMatch = channelDelimiterMatches[idx];
     const prefix = text.slice(0, channelDelimiterMatch.end);
-    const visibleSuffix = stripTrailingChannelDelimiters(
-      stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end)),
-    );
+    const explicitLiteral = findExplicitSingleTargetLiteralInPreamble(prefix);
+    const rawVisibleSuffix = stripModelSpecialTokensImpl(text.slice(channelDelimiterMatch.end));
+    if (explicitLiteral && rawVisibleSuffix.trim() === explicitLiteral.trim()) {
+      return explicitLiteral;
+    }
+    const visibleSuffix = stripTrailingChannelDelimiters(rawVisibleSuffix);
     if (!visibleSuffix.trim()) {
-      const explicitLiteral = findExplicitSingleTargetLiteralInPreamble(prefix);
       if (explicitLiteral?.toLowerCase() === "<channel|>") {
         return explicitLiteral;
       }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -18,6 +18,8 @@ import { findCodeRegions, isInsideCode } from "./code-regions.js";
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
+const STRUCTURED_REPEAT_HINT_RE = /[\s\d_\-`~"'.,:;!?()[\]{}/\\]/;
+const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 
 function overlapsCodeRegion(
   start: number,
@@ -29,6 +31,36 @@ function overlapsCodeRegion(
 
 function shouldInsertSeparator(before: string | undefined, after: string | undefined): boolean {
   return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
+}
+
+function collapseStructuredWholeStringRepetition(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  for (let unitLength = 1; unitLength <= Math.floor(text.length / 2); unitLength += 1) {
+    if (text.length % unitLength !== 0) {
+      continue;
+    }
+
+    const repeatCount = text.length / unitLength;
+    if (repeatCount < 2) {
+      continue;
+    }
+
+    const unit = text.slice(0, unitLength);
+    const looksStructured =
+      unitLength >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
+    if (!looksStructured) {
+      continue;
+    }
+
+    if (unit.repeat(repeatCount) === text) {
+      return unit;
+    }
+  }
+
+  return text;
 }
 
 export function stripModelSpecialTokens(text: string): string {
@@ -54,7 +86,9 @@ export function stripModelSpecialTokens(text: string): string {
     }
   }
   if (lastChannelDelimiterEnd !== null && lastChannelDelimiterEnd < text.length) {
-    return stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd));
+    return collapseStructuredWholeStringRepetition(
+      stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd)),
+    );
   }
 
   let out = "";

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -22,7 +22,7 @@ import {
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
-const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
+const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\binternal planning\b|(?:^|[\r\n])\s*plan:\s*$/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
   /\b(?:reply with|reply to|nothing else|output content|output the text directly|direct instruction|current session|i will output|i will reply|i must output|i must reply|i must adhere)\b/i;
 const CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE =

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -22,6 +22,8 @@ const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
 const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
   /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
+const CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE =
+  /^(?:token\b|delimiter\b|marker\b|literal(?:ly)?\b|is\b|means?\b|identif(?:y|ies)\b|splits?\b|between\b|used?\b|inside\b|outside\b|in\b)/i;
 
 function overlapsCodeRegion(
   start: number,
@@ -48,18 +50,24 @@ function getChannelDelimiterAttachment(text: string, start: number, end: number)
 function looksLikeLeakedChannelDelimiterPrefix(
   prefix: string,
   attachment: { attachedBefore: boolean; attachedAfter: boolean },
+  suffix: string,
 ): boolean {
   const trimmed = prefix.trim();
-  if (!trimmed) {
-    return false;
+  const trimmedSuffix = suffix.trimStart();
+  if (!trimmedSuffix) {
+    return CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(trimmed);
   }
 
-  if (!attachment.attachedBefore && !attachment.attachedAfter) {
-    return false;
+  if (!trimmed) {
+    return !CHANNEL_DELIMITER_LITERAL_SUFFIX_HINT_RE.test(trimmedSuffix);
   }
 
   if (CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE.test(trimmed)) {
     return true;
+  }
+
+  if (!attachment.attachedBefore && !attachment.attachedAfter) {
+    return false;
   }
 
   return (
@@ -127,6 +135,7 @@ function stripModelSpecialTokensImpl(text: string): string {
       looksLikeLeakedChannelDelimiterPrefix(
         getRecentChannelDelimiterPrefix(text, start),
         attachment,
+        text.slice(end),
       )
     ) {
       channelDelimiterMatches.push({ start, end });

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -35,9 +35,26 @@ function shouldInsertSeparator(before: string | undefined, after: string | undef
   return Boolean(before && after && !/\s/.test(before) && !/\s/.test(after));
 }
 
-function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
+function getChannelDelimiterAttachment(text: string, start: number, end: number) {
+  const before = text[start - 1];
+  const after = text[end];
+
+  return {
+    attachedBefore: Boolean(before && !/\s/.test(before)),
+    attachedAfter: Boolean(after && !/\s/.test(after)),
+  };
+}
+
+function looksLikeLeakedChannelDelimiterPrefix(
+  prefix: string,
+  attachment: { attachedBefore: boolean; attachedAfter: boolean },
+): boolean {
   const trimmed = prefix.trim();
   if (!trimmed) {
+    return false;
+  }
+
+  if (!attachment.attachedBefore && !attachment.attachedAfter) {
     return false;
   }
 
@@ -45,7 +62,11 @@ function looksLikeLeakedChannelDelimiterPrefix(prefix: string): boolean {
     return true;
   }
 
-  return trimmed.length >= 120 && CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(trimmed);
+  return (
+    attachment.attachedAfter &&
+    trimmed.length >= 120 &&
+    CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE.test(trimmed)
+  );
 }
 
 function getRecentChannelDelimiterPrefix(text: string, start: number): string {
@@ -99,10 +120,14 @@ function stripModelSpecialTokensImpl(text: string): string {
     const matched = match[0];
     const start = match.index ?? 0;
     const end = start + matched.length;
+    const attachment = getChannelDelimiterAttachment(text, start, end);
     if (
       !isInsideCode(start, codeRegions) &&
       !overlapsCodeRegion(start, end, codeRegions) &&
-      looksLikeLeakedChannelDelimiterPrefix(getRecentChannelDelimiterPrefix(text, start))
+      looksLikeLeakedChannelDelimiterPrefix(
+        getRecentChannelDelimiterPrefix(text, start),
+        attachment,
+      )
     ) {
       channelDelimiterMatches.push({ start, end });
     }

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -19,7 +19,7 @@ import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
 const CHANNEL_DELIMITER_RE = /<channel\|>/gi;
-const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)\b/i;
+const CHANNEL_DELIMITER_PREFIX_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
 const CHANNEL_DELIMITER_PREFIX_LONG_HINT_RE =
   /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
 

--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -14,7 +14,7 @@
  * @see https://github.com/openclaw/openclaw/issues/40020
  */
 import { findCodeRegions, isInsideCode } from "./code-regions.js";
-import { collapseStructuredRepeatedPrefixPattern } from "./repeated-visible-suffix.js";
+import { collapseRepeatedVisibleSuffixAfterDelimiter } from "./repeated-visible-suffix.js";
 
 // Match both ASCII pipe <|...|> and full-width pipe <｜...｜> (U+FF5C) variants.
 const MODEL_SPECIAL_TOKEN_RE = /<[|｜][^|｜]*[|｜]>/g;
@@ -55,7 +55,8 @@ export function stripModelSpecialTokens(text: string): string {
     }
   }
   if (lastChannelDelimiterEnd !== null) {
-    return collapseStructuredRepeatedPrefixPattern(
+    return collapseRepeatedVisibleSuffixAfterDelimiter(
+      text.slice(0, lastChannelDelimiterEnd),
       stripModelSpecialTokens(text.slice(lastChannelDelimiterEnd)),
     );
   }

--- a/src/shared/text/repeated-visible-suffix.test.ts
+++ b/src/shared/text/repeated-visible-suffix.test.ts
@@ -36,6 +36,17 @@ describe("collapseRepeatedVisibleSuffixAfterDelimiter", () => {
 });
 
 describe("extractStructuredRepeatedVisibleSuffix", () => {
+  it("prefers the minimal repeated unit when runaway text repeats a mistakenly doubled exact target", () => {
+    const input = [
+      "The user is instructing me to reply with a very specific string: `pr68986-live-1776657289pr68986-live-1776657289` and nothing else.",
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response, as per the general instruction to reply in the current session.pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-1776657289pr68986-live-177",
+    ].join("\n");
+
+    expect(extractStructuredRepeatedVisibleSuffix(input)).toBe("pr68986-live-1776657289");
+  });
+
   it("does not collapse a duplicated sample that appears before later explanation", () => {
     const input = [
       'The user asked me to reply with exactly "Hello." and nothing else.',

--- a/src/shared/text/repeated-visible-suffix.test.ts
+++ b/src/shared/text/repeated-visible-suffix.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  collapseRepeatedVisibleSuffixAfterDelimiter,
+  extractStructuredRepeatedVisibleSuffix,
+  findExplicitSingleTargetLiteralInPreamble,
+} from "./repeated-visible-suffix.js";
+
+describe("findExplicitSingleTargetLiteralInPreamble", () => {
+  it("ignores apostrophes inside ordinary prose", () => {
+    const input =
+      "The user's exact target can't change. I must reply with exactly abc-123 and nothing else. This is a direct instruction for the output content.";
+
+    expect(findExplicitSingleTargetLiteralInPreamble(input)).toBeNull();
+  });
+
+  it("still finds a real quoted target when apostrophes appear elsewhere in the preamble", () => {
+    const input =
+      "The user's exact target can't change. I must reply with exactly \"abc-123\" and nothing else. This is a direct instruction for the output content.";
+
+    expect(findExplicitSingleTargetLiteralInPreamble(input)).toBe("abc-123");
+  });
+});
+
+describe("collapseRepeatedVisibleSuffixAfterDelimiter", () => {
+  it("collapses a repeated suffix even when the visible text starts with a space", () => {
+    const prefix = [
+      'The user is instructing me to reply with exactly "abc-123" and nothing else.',
+      "This is a direct instruction for the output content.",
+      "I must adhere to the instruction precisely.",
+      "I will output the text directly as the final response.",
+      "<channel|>",
+    ].join("\n");
+
+    expect(collapseRepeatedVisibleSuffixAfterDelimiter(prefix, " abc-123abc-123")).toBe(" abc-123");
+  });
+});
+
+describe("extractStructuredRepeatedVisibleSuffix", () => {
+  it("does not collapse a duplicated sample that appears before later explanation", () => {
+    const input = [
+      'The user asked me to reply with exactly "Hello." and nothing else.',
+      "This is only an explanation of the failure and not hidden planning.",
+      "Here is a duplicated sample in the middle: Hello.Hello.Hello.",
+      "Later I explain what happened in plain prose.",
+    ].join("\n");
+
+    expect(extractStructuredRepeatedVisibleSuffix(input)).toBe(input);
+  });
+});

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -1,6 +1,8 @@
 const STRUCTURED_REPEAT_HINT_RE = /[\s\d_\-~"'.,:;!?()[\]{}/\\]/;
 const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
+const INTERNAL_PREAMBLE_HINT_RE =
+  /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
 
 function looksStructuredRepeatedUnit(unit: string): boolean {
   return unit.length >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
@@ -17,6 +19,17 @@ function endsAtVisibleSuffixBoundary(prefix: string): boolean {
   }
 
   return VISIBLE_SUFFIX_BOUNDARY_RE.test(trimmedPrefixEnd);
+}
+
+function looksLikeInternalPreamble(prefix: string): boolean {
+  const trimmed = prefix.trim();
+  if (trimmed.length < 120 || !INTERNAL_PREAMBLE_HINT_RE.test(trimmed)) {
+    return false;
+  }
+
+  const lines = trimmed.split(/\r?\n/).filter((line) => line.trim().length > 0);
+  const sentenceCount = (trimmed.match(/[.!?](?:\s|$)/g) ?? []).length;
+  return lines.length >= 2 || sentenceCount >= 3;
 }
 
 export function collapseStructuredRepeatedPrefixPattern(text: string): string {
@@ -83,7 +96,12 @@ export function extractStructuredRepeatedVisibleSuffix(text: string): string {
         start -= unitLength;
         fullRepeats += 1;
       }
-      if (fullRepeats < 2 || !endsAtVisibleSuffixBoundary(text.slice(0, start))) {
+      const prefix = text.slice(0, start);
+      if (
+        fullRepeats < 2 ||
+        !endsAtVisibleSuffixBoundary(prefix) ||
+        !looksLikeInternalPreamble(prefix)
+      ) {
         continue;
       }
 

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -95,7 +95,7 @@ function findExplicitVisibleSuffixTarget(
   prefix: string,
   match: RepeatedPatternMatch,
 ): string | null {
-  if (!prefix) {
+  if (!prefix || !looksLikeInternalPreamble(prefix)) {
     return null;
   }
 
@@ -112,6 +112,21 @@ function findExplicitVisibleSuffixTarget(
     if (prefix.includes(candidate)) {
       return candidate;
     }
+  }
+
+  const explicitlyNamedLiteral = findExplicitSingleTargetLiteralInPreamble(prefix);
+  if (!explicitlyNamedLiteral) {
+    return null;
+  }
+
+  if (
+    rawVisibleSuffix.startsWith(explicitlyNamedLiteral) ||
+    explicitlyNamedLiteral.startsWith(rawVisibleSuffix) ||
+    rawVisibleSuffix.includes(explicitlyNamedLiteral) ||
+    explicitlyNamedLiteral.includes(match.unit) ||
+    match.unit.includes(explicitlyNamedLiteral)
+  ) {
+    return explicitlyNamedLiteral;
   }
 
   return null;
@@ -147,7 +162,7 @@ export function collapseRepeatedVisibleSuffixAfterDelimiter(
   return selectVisibleSuffixReplacement({ prefix, match, context: "delimiter" }) ?? suffix;
 }
 
-export function extractExplicitSingleTargetLiteral(text: string): string | null {
+function findExplicitSingleTargetLiteralInPreamble(text: string): string | null {
   if (
     !text ||
     !looksLikeInternalPreamble(text) ||
@@ -166,6 +181,30 @@ export function extractExplicitSingleTargetLiteral(text: string): string | null 
   }
 
   return uniqueLiterals[0] ?? null;
+}
+
+function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | null {
+  const literal = findExplicitSingleTargetLiteralInPreamble(text);
+  if (!literal || !looksStructuredRepeatedUnit(literal)) {
+    return null;
+  }
+
+  const literalCount = text.split(literal).length - 1;
+  if (literalCount < 3) {
+    return null;
+  }
+
+  const lastLiteralIndex = text.lastIndexOf(literal);
+  if (lastLiteralIndex < 0) {
+    return null;
+  }
+
+  const trailingJunk = text.slice(lastLiteralIndex + literal.length);
+  if (!trailingJunk) {
+    return null;
+  }
+
+  return literal;
 }
 
 export function extractStructuredRepeatedVisibleSuffix(text: string): string {
@@ -216,5 +255,5 @@ export function extractStructuredRepeatedVisibleSuffix(text: string): string {
     }
   }
 
-  return text;
+  return extractExplicitRepeatedLiteralFromRunawayText(text) ?? text;
 }

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -3,7 +3,7 @@ const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
 const INTERNAL_PREAMBLE_HINT_RE =
   /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
-const DELIMITER_LEAK_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
+const DELIMITER_LEAK_HARD_HINT_RE = /\binternal planning\b|(?:^|[\r\n])\s*plan:\s*$/i;
 const DELIMITER_LEAK_LONG_HINT_RE =
   /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
 const SINGLE_ANSWER_INTENT_RE =

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -170,6 +170,9 @@ function selectVisibleSuffixReplacement(params: {
 
   const explicitTarget = findExplicitVisibleSuffixTarget(prefix, match);
   if (explicitTarget) {
+    if (context === "no-delimiter" && hasExcludedTrailingCollapseContext(prefix)) {
+      return null;
+    }
     return explicitTarget;
   }
   if (context === "delimiter" && findExplicitSingleTargetLiteralInPreamble(prefix)) {

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -1,0 +1,95 @@
+const STRUCTURED_REPEAT_HINT_RE = /[\s\d_\-~"'.,:;!?()[\]{}/\\]/;
+const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
+const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
+
+function looksStructuredRepeatedUnit(unit: string): boolean {
+  return unit.length >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
+}
+
+function endsAtVisibleSuffixBoundary(prefix: string): boolean {
+  if (!prefix) {
+    return true;
+  }
+
+  const trimmedPrefixEnd = prefix.trimEnd();
+  if (!trimmedPrefixEnd) {
+    return true;
+  }
+
+  return VISIBLE_SUFFIX_BOUNDARY_RE.test(trimmedPrefixEnd);
+}
+
+export function collapseStructuredRepeatedPrefixPattern(text: string): string {
+  if (!text) {
+    return text;
+  }
+
+  for (let unitLength = 1; unitLength <= Math.floor(text.length / 2); unitLength += 1) {
+    const unit = text.slice(0, unitLength);
+    if (!looksStructuredRepeatedUnit(unit)) {
+      continue;
+    }
+
+    let cursor = 0;
+    let fullRepeats = 0;
+    while (cursor + unitLength <= text.length && text.slice(cursor, cursor + unitLength) === unit) {
+      cursor += unitLength;
+      fullRepeats += 1;
+    }
+    if (fullRepeats < 2) {
+      continue;
+    }
+
+    const tail = text.slice(cursor);
+    if (!tail || unit.startsWith(tail)) {
+      return unit;
+    }
+  }
+
+  return text;
+}
+
+export function extractStructuredRepeatedVisibleSuffix(text: string): string {
+  const collapsedWholeText = collapseStructuredRepeatedPrefixPattern(text);
+  if (collapsedWholeText !== text) {
+    return collapsedWholeText;
+  }
+  if (!text) {
+    return text;
+  }
+
+  const maxUnitLength = Math.floor(text.length / 2);
+  for (let unitLength = 1; unitLength <= maxUnitLength; unitLength += 1) {
+    for (let tailLength = 0; tailLength < unitLength; tailLength += 1) {
+      const unitEnd = text.length - tailLength;
+      const unitStart = unitEnd - unitLength;
+      if (unitStart < 0) {
+        continue;
+      }
+
+      const unit = text.slice(unitStart, unitEnd);
+      if (!looksStructuredRepeatedUnit(unit)) {
+        continue;
+      }
+
+      const tail = text.slice(unitEnd);
+      if (tail && tail !== unit.slice(0, tail.length)) {
+        continue;
+      }
+
+      let start = unitStart;
+      let fullRepeats = 1;
+      while (start - unitLength >= 0 && text.slice(start - unitLength, start) === unit) {
+        start -= unitLength;
+        fullRepeats += 1;
+      }
+      if (fullRepeats < 2 || !endsAtVisibleSuffixBoundary(text.slice(0, start))) {
+        continue;
+      }
+
+      return unit;
+    }
+  }
+
+  return text;
+}

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -3,8 +3,13 @@ const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
 const INTERNAL_PREAMBLE_HINT_RE =
   /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
+const DELIMITER_LEAK_HARD_HINT_RE = /\b(?:internal planning|plan:)\b/i;
+const DELIMITER_LEAK_LONG_HINT_RE =
+  /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
 const SINGLE_ANSWER_INTENT_RE =
   /\b(?:exactly|nothing else|one word(?: only)?|one short sentence(?: only)?|single answer)\b/i;
+const INTENTIONAL_REPEAT_INTENT_RE =
+  /\b(?:repeat|repeated|twice|\d+\s+times|three times|four times|five times)\b/i;
 const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
@@ -47,6 +52,19 @@ function looksLikeInternalPreamble(prefix: string): boolean {
   return lines.length >= 2 || sentenceCount >= 3;
 }
 
+function looksLikeDelimiterLeakPrefix(prefix: string): boolean {
+  const trimmed = prefix.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  if (DELIMITER_LEAK_HARD_HINT_RE.test(trimmed)) {
+    return true;
+  }
+
+  return trimmed.length >= 120 && DELIMITER_LEAK_LONG_HINT_RE.test(trimmed);
+}
+
 function matchStructuredRepeatedPrefixPattern(text: string): RepeatedPatternMatch | null {
   if (!text) {
     return null;
@@ -83,12 +101,26 @@ function shouldCollapseRepeatedSuffix(params: {
   context: "delimiter" | "no-delimiter";
 }): boolean {
   const { prefix, match, context } = params;
+  const hasIntentionalRepeatRequest =
+    looksLikeInternalPreamble(prefix) &&
+    INTENTIONAL_REPEAT_INTENT_RE.test(prefix) &&
+    !SINGLE_ANSWER_INTENT_RE.test(prefix);
+  const hasSingleAnswerIntent =
+    looksLikeInternalPreamble(prefix) && SINGLE_ANSWER_INTENT_RE.test(prefix);
 
   if (match.tail.length > 0 || match.fullRepeats >= 3) {
-    return context === "delimiter" || looksLikeInternalPreamble(prefix);
+    if (hasIntentionalRepeatRequest) {
+      return false;
+    }
+    if (match.tail.length > 0) {
+      return context === "delimiter"
+        ? looksLikeDelimiterLeakPrefix(prefix)
+        : looksLikeInternalPreamble(prefix);
+    }
+    return hasSingleAnswerIntent;
   }
 
-  return looksLikeInternalPreamble(prefix) && SINGLE_ANSWER_INTENT_RE.test(prefix);
+  return hasSingleAnswerIntent;
 }
 
 function findExplicitVisibleSuffixTarget(

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -14,7 +14,7 @@ const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
 const DOUBLE_QUOTED_LITERAL_RE = /"([^"\r\n]{1,400})"/g;
-const SINGLE_QUOTED_LITERAL_RE = /'([^'\r\n]{1,400})'/g;
+const SINGLE_QUOTED_LITERAL_RE = /(?<![A-Za-z0-9_])'([^'\r\n]{1,400})'(?![A-Za-z0-9_])/g;
 const EXCLUDED_TARGET_HINT_SEGMENT_RE = /\b(?:incorrect|wrong|duplicate|previous|attempt)\b/i;
 const EXCLUDED_TRAILING_COLLAPSE_CONTEXT_RE =
   /\b(?:mistaken|example|examples|incorrect|wrong|previous attempt|doubled output|duplicate(?:d)? output)\b/i;
@@ -192,16 +192,19 @@ export function collapseRepeatedVisibleSuffixAfterDelimiter(
   prefix: string,
   suffix: string,
 ): string {
+  const leadingWhitespace = suffix.match(/^\s*/)?.[0] ?? "";
+  const normalizedSuffix = suffix.slice(leadingWhitespace.length);
   const scanSuffix =
-    suffix.length > MAX_DELIMITER_SUFFIX_SCAN_CHARS
-      ? suffix.slice(0, MAX_DELIMITER_SUFFIX_SCAN_CHARS)
-      : suffix;
+    normalizedSuffix.length > MAX_DELIMITER_SUFFIX_SCAN_CHARS
+      ? normalizedSuffix.slice(0, MAX_DELIMITER_SUFFIX_SCAN_CHARS)
+      : normalizedSuffix;
   const match = matchStructuredRepeatedPrefixPattern(scanSuffix);
   if (!match) {
     return suffix;
   }
 
-  return selectVisibleSuffixReplacement({ prefix, match, context: "delimiter" }) ?? suffix;
+  const replacement = selectVisibleSuffixReplacement({ prefix, match, context: "delimiter" });
+  return replacement ? `${leadingWhitespace}${replacement}` : suffix;
 }
 
 function splitPreambleHintSegments(text: string): string[] {
@@ -262,10 +265,19 @@ function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | n
     return null;
   }
 
-  const runawaySuffixMatch = text.match(
-    new RegExp(`(?:${escapeRegex(literal)}){3,}([^\\s][\\s\\S]*)$`),
-  );
+  const runawaySuffixMatches = [
+    ...text.matchAll(new RegExp(`(?:${escapeRegex(literal)}){3,}([^\\s][\\s\\S]*)$`, "g")),
+  ];
+  const runawaySuffixMatch = runawaySuffixMatches.at(-1);
   if (!runawaySuffixMatch) {
+    return null;
+  }
+  const matchStart = runawaySuffixMatch.index ?? -1;
+  if (matchStart < 0) {
+    return null;
+  }
+  const prefix = text.slice(0, matchStart);
+  if (!looksLikeInternalPreamble(prefix) || !endsAtVisibleSuffixBoundary(prefix)) {
     return null;
   }
 

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -13,7 +13,9 @@ const INTENTIONAL_REPEAT_INTENT_RE =
 const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
+const EXCLUDED_TARGET_HINT_SEGMENT_RE = /\b(?:incorrect|wrong|duplicate|previous|attempt)\b/i;
 const MAX_STRUCTURED_SUFFIX_SCAN_CHARS = 8_192;
+const MAX_DELIMITER_SUFFIX_SCAN_CHARS = 2_048;
 
 type RepeatedPatternMatch = {
   unit: string;
@@ -132,26 +134,12 @@ function findExplicitVisibleSuffixTarget(
     return null;
   }
 
-  const rawVisibleSuffix = buildRawVisibleSuffix(match);
-  if (rawVisibleSuffix && prefix.includes(rawVisibleSuffix)) {
-    return rawVisibleSuffix;
-  }
-
-  for (let repeats = match.fullRepeats; repeats >= 2; repeats -= 1) {
-    const candidate = match.unit.repeat(repeats);
-    if (candidate.length <= match.unit.length || !rawVisibleSuffix.startsWith(candidate)) {
-      continue;
-    }
-    if (prefix.includes(candidate)) {
-      return candidate;
-    }
-  }
-
   const explicitlyNamedLiteral = findExplicitSingleTargetLiteralInPreamble(prefix);
   if (!explicitlyNamedLiteral) {
     return null;
   }
 
+  const rawVisibleSuffix = buildRawVisibleSuffix(match);
   if (
     rawVisibleSuffix.startsWith(explicitlyNamedLiteral) ||
     explicitlyNamedLiteral.startsWith(rawVisibleSuffix) ||
@@ -187,12 +175,30 @@ export function collapseRepeatedVisibleSuffixAfterDelimiter(
   prefix: string,
   suffix: string,
 ): string {
-  const match = matchStructuredRepeatedPrefixPattern(suffix);
+  const scanSuffix =
+    suffix.length > MAX_DELIMITER_SUFFIX_SCAN_CHARS
+      ? suffix.slice(0, MAX_DELIMITER_SUFFIX_SCAN_CHARS)
+      : suffix;
+  const match = matchStructuredRepeatedPrefixPattern(scanSuffix);
   if (!match) {
     return suffix;
   }
 
   return selectVisibleSuffixReplacement({ prefix, match, context: "delimiter" }) ?? suffix;
+}
+
+function splitPreambleHintSegments(text: string): string[] {
+  return text
+    .split(/\r?\n+/)
+    .flatMap((line) => line.match(/[^.!?]+[.!?]?/g) ?? [line])
+    .map((segment) => segment.trim())
+    .filter((segment) => segment.length > 0);
+}
+
+function extractInlineCodeLiterals(text: string): string[] {
+  return [...text.matchAll(INLINE_CODE_LITERAL_RE)]
+    .map((match) => match[1]?.trim() ?? "")
+    .filter((literal) => literal.length > 0);
 }
 
 function findExplicitSingleTargetLiteralInPreamble(text: string): string | null {
@@ -205,10 +211,18 @@ function findExplicitSingleTargetLiteralInPreamble(text: string): string | null 
     return null;
   }
 
-  const literals = [...text.matchAll(INLINE_CODE_LITERAL_RE)]
-    .map((match) => match[1]?.trim() ?? "")
-    .filter((literal) => literal.length > 0);
-  const uniqueLiterals = [...new Set(literals)];
+  const hintedSegments = splitPreambleHintSegments(text).filter(
+    (segment) =>
+      (SINGLE_ANSWER_INTENT_RE.test(segment) || EXACT_TARGET_HINT_RE.test(segment)) &&
+      !EXCLUDED_TARGET_HINT_SEGMENT_RE.test(segment),
+  );
+  const hintedLiterals = hintedSegments.flatMap(extractInlineCodeLiterals);
+  const uniqueHintedLiterals = [...new Set(hintedLiterals)];
+  if (uniqueHintedLiterals.length === 1) {
+    return uniqueHintedLiterals[0] ?? null;
+  }
+
+  const uniqueLiterals = [...new Set(extractInlineCodeLiterals(text))];
   if (uniqueLiterals.length !== 1) {
     return null;
   }
@@ -242,6 +256,9 @@ function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | n
 
 export function extractStructuredRepeatedVisibleSuffix(text: string): string {
   if (!text) {
+    return text;
+  }
+  if (!looksLikeInternalPreamble(text)) {
     return text;
   }
 

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -102,23 +102,25 @@ function matchStructuredRepeatedPrefixPattern(text: string): RepeatedPatternMatc
   return null;
 }
 
+function hasIntentionalRepeatRequest(prefix: string): boolean {
+  return looksLikeInternalPreamble(prefix) && INTENTIONAL_REPEAT_INTENT_RE.test(prefix);
+}
+
 function shouldCollapseRepeatedSuffix(params: {
   prefix: string;
   match: RepeatedPatternMatch;
   context: "delimiter" | "no-delimiter";
 }): boolean {
   const { prefix, match, context } = params;
-  const hasIntentionalRepeatRequest =
-    looksLikeInternalPreamble(prefix) &&
-    INTENTIONAL_REPEAT_INTENT_RE.test(prefix) &&
-    !SINGLE_ANSWER_INTENT_RE.test(prefix);
+  const hasRepeatIntent = hasIntentionalRepeatRequest(prefix);
   const hasSingleAnswerIntent =
     looksLikeInternalPreamble(prefix) && SINGLE_ANSWER_INTENT_RE.test(prefix);
 
+  if (hasRepeatIntent) {
+    return false;
+  }
+
   if (match.tail.length > 0 || match.fullRepeats >= 3) {
-    if (hasIntentionalRepeatRequest) {
-      return false;
-    }
     if (match.tail.length > 0) {
       return context === "delimiter"
         ? looksLikeDelimiterLeakPrefix(prefix)
@@ -163,6 +165,10 @@ function selectVisibleSuffixReplacement(params: {
   context: "delimiter" | "no-delimiter";
 }): string | null {
   const { prefix, match, context } = params;
+
+  if (hasIntentionalRepeatRequest(prefix)) {
+    return null;
+  }
 
   const explicitTarget = findExplicitVisibleSuffixTarget(prefix, match);
   if (explicitTarget) {

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -157,6 +157,31 @@ function findExplicitVisibleSuffixTarget(
   return null;
 }
 
+function collapseExplicitStructuredRepeatTarget(params: {
+  explicitTarget: string;
+  match: RepeatedPatternMatch;
+  prefix: string;
+  context: "delimiter" | "no-delimiter";
+}): string {
+  const { explicitTarget, match, prefix, context } = params;
+  if (context !== "no-delimiter" || hasIntentionalRepeatRequest(prefix)) {
+    return explicitTarget;
+  }
+  if (match.tail.length === 0 && match.fullRepeats < 3) {
+    return explicitTarget;
+  }
+
+  const nestedMatch = matchStructuredRepeatedPrefixPattern(explicitTarget);
+  if (!nestedMatch || nestedMatch.tail.length > 0 || nestedMatch.fullRepeats < 2) {
+    return explicitTarget;
+  }
+  if (nestedMatch.unit !== match.unit) {
+    return explicitTarget;
+  }
+
+  return nestedMatch.unit;
+}
+
 function selectVisibleSuffixReplacement(params: {
   prefix: string;
   match: RepeatedPatternMatch;
@@ -173,7 +198,7 @@ function selectVisibleSuffixReplacement(params: {
     if (context === "no-delimiter" && hasExcludedTrailingCollapseContext(prefix)) {
       return null;
     }
-    return explicitTarget;
+    return collapseExplicitStructuredRepeatTarget({ explicitTarget, match, prefix, context });
   }
   if (context === "delimiter" && findExplicitSingleTargetLiteralInPreamble(prefix)) {
     return null;
@@ -281,7 +306,16 @@ function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | n
     return null;
   }
 
-  return literal;
+  return collapseExplicitStructuredRepeatTarget({
+    explicitTarget: literal,
+    match: matchStructuredRepeatedPrefixPattern(literal) ?? {
+      unit: literal,
+      fullRepeats: 1,
+      tail: "",
+    },
+    prefix,
+    context: "no-delimiter",
+  });
 }
 
 export function extractStructuredRepeatedVisibleSuffix(text: string): string {

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -5,12 +5,19 @@ const INTERNAL_PREAMBLE_HINT_RE =
   /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
 const SINGLE_ANSWER_INTENT_RE =
   /\b(?:exactly|nothing else|one word(?: only)?|one short sentence(?: only)?|single answer)\b/i;
+const EXACT_TARGET_HINT_RE =
+  /\b(?:specific string|reply with|output the text directly|output content)\b/i;
+const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
 
 type RepeatedPatternMatch = {
   unit: string;
   fullRepeats: number;
   tail: string;
 };
+
+function buildRawVisibleSuffix(match: RepeatedPatternMatch): string {
+  return match.unit.repeat(match.fullRepeats) + match.tail;
+}
 
 function looksStructuredRepeatedUnit(unit: string): boolean {
   return unit.length >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
@@ -84,16 +91,81 @@ function shouldCollapseRepeatedSuffix(params: {
   return looksLikeInternalPreamble(prefix) && SINGLE_ANSWER_INTENT_RE.test(prefix);
 }
 
+function findExplicitVisibleSuffixTarget(
+  prefix: string,
+  match: RepeatedPatternMatch,
+): string | null {
+  if (!prefix) {
+    return null;
+  }
+
+  const rawVisibleSuffix = buildRawVisibleSuffix(match);
+  if (rawVisibleSuffix && prefix.includes(rawVisibleSuffix)) {
+    return rawVisibleSuffix;
+  }
+
+  for (let repeats = match.fullRepeats; repeats >= 2; repeats -= 1) {
+    const candidate = match.unit.repeat(repeats);
+    if (candidate.length <= match.unit.length || !rawVisibleSuffix.startsWith(candidate)) {
+      continue;
+    }
+    if (prefix.includes(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function selectVisibleSuffixReplacement(params: {
+  prefix: string;
+  match: RepeatedPatternMatch;
+  context: "delimiter" | "no-delimiter";
+}): string | null {
+  const { prefix, match, context } = params;
+
+  const explicitTarget = findExplicitVisibleSuffixTarget(prefix, match);
+  if (explicitTarget) {
+    return explicitTarget;
+  }
+  if (!shouldCollapseRepeatedSuffix({ prefix, match, context })) {
+    return null;
+  }
+
+  return match.unit;
+}
+
 export function collapseRepeatedVisibleSuffixAfterDelimiter(
   prefix: string,
   suffix: string,
 ): string {
   const match = matchStructuredRepeatedPrefixPattern(suffix);
-  if (!match || !shouldCollapseRepeatedSuffix({ prefix, match, context: "delimiter" })) {
+  if (!match) {
     return suffix;
   }
 
-  return match.unit;
+  return selectVisibleSuffixReplacement({ prefix, match, context: "delimiter" }) ?? suffix;
+}
+
+export function extractExplicitSingleTargetLiteral(text: string): string | null {
+  if (
+    !text ||
+    !looksLikeInternalPreamble(text) ||
+    !SINGLE_ANSWER_INTENT_RE.test(text) ||
+    !EXACT_TARGET_HINT_RE.test(text)
+  ) {
+    return null;
+  }
+
+  const literals = [...text.matchAll(INLINE_CODE_LITERAL_RE)]
+    .map((match) => match[1]?.trim() ?? "")
+    .filter((literal) => literal.length > 0);
+  const uniqueLiterals = [...new Set(literals)];
+  if (uniqueLiterals.length !== 1) {
+    return null;
+  }
+
+  return uniqueLiterals[0] ?? null;
 }
 
 export function extractStructuredRepeatedVisibleSuffix(text: string): string {
@@ -127,19 +199,20 @@ export function extractStructuredRepeatedVisibleSuffix(text: string): string {
         fullRepeats += 1;
       }
       const prefix = text.slice(0, start);
-      if (
-        fullRepeats < 2 ||
-        !endsAtVisibleSuffixBoundary(prefix) ||
-        !shouldCollapseRepeatedSuffix({
-          prefix,
-          match: { unit, fullRepeats, tail },
-          context: "no-delimiter",
-        })
-      ) {
+      if (fullRepeats < 2 || !endsAtVisibleSuffixBoundary(prefix)) {
         continue;
       }
 
-      return unit;
+      const replacement = selectVisibleSuffixReplacement({
+        prefix,
+        match: { unit, fullRepeats, tail },
+        context: "no-delimiter",
+      });
+      if (!replacement) {
+        continue;
+      }
+
+      return replacement;
     }
   }
 

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -3,7 +3,7 @@ const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
 const INTERNAL_PREAMBLE_HINT_RE =
   /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
-const DELIMITER_LEAK_HARD_HINT_RE = /\b(?:internal planning|plan:)\b/i;
+const DELIMITER_LEAK_HARD_HINT_RE = /\b(?:internal planning|plan:)/i;
 const DELIMITER_LEAK_LONG_HINT_RE =
   /\b(?:reply with|reply to|final response|output content|general instruction|i will|i must)\b/i;
 const SINGLE_ANSWER_INTENT_RE =
@@ -13,6 +13,7 @@ const INTENTIONAL_REPEAT_INTENT_RE =
 const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
+const MAX_STRUCTURED_SUFFIX_SCAN_CHARS = 8_192;
 
 type RepeatedPatternMatch = {
   unit: string;
@@ -244,32 +245,36 @@ export function extractStructuredRepeatedVisibleSuffix(text: string): string {
     return text;
   }
 
-  const maxUnitLength = Math.floor(text.length / 2);
+  const scanText =
+    text.length > MAX_STRUCTURED_SUFFIX_SCAN_CHARS
+      ? text.slice(-MAX_STRUCTURED_SUFFIX_SCAN_CHARS)
+      : text;
+  const maxUnitLength = Math.floor(scanText.length / 2);
   for (let unitLength = 1; unitLength <= maxUnitLength; unitLength += 1) {
     for (let tailLength = 0; tailLength < unitLength; tailLength += 1) {
-      const unitEnd = text.length - tailLength;
+      const unitEnd = scanText.length - tailLength;
       const unitStart = unitEnd - unitLength;
       if (unitStart < 0) {
         continue;
       }
 
-      const unit = text.slice(unitStart, unitEnd);
+      const unit = scanText.slice(unitStart, unitEnd);
       if (!looksStructuredRepeatedUnit(unit)) {
         continue;
       }
 
-      const tail = text.slice(unitEnd);
+      const tail = scanText.slice(unitEnd);
       if (tail && tail !== unit.slice(0, tail.length)) {
         continue;
       }
 
       let start = unitStart;
       let fullRepeats = 1;
-      while (start - unitLength >= 0 && text.slice(start - unitLength, start) === unit) {
+      while (start - unitLength >= 0 && scanText.slice(start - unitLength, start) === unit) {
         start -= unitLength;
         fullRepeats += 1;
       }
-      const prefix = text.slice(0, start);
+      const prefix = scanText.slice(0, start);
       if (fullRepeats < 2 || !endsAtVisibleSuffixBoundary(prefix)) {
         continue;
       }

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -31,6 +31,10 @@ function buildRawVisibleSuffix(match: RepeatedPatternMatch): string {
   return match.unit.repeat(match.fullRepeats) + match.tail;
 }
 
+function escapeRegex(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 function looksStructuredRepeatedUnit(unit: string): boolean {
   return unit.length >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
 }
@@ -146,13 +150,7 @@ function findExplicitVisibleSuffixTarget(
   }
 
   const rawVisibleSuffix = buildRawVisibleSuffix(match);
-  if (
-    rawVisibleSuffix.startsWith(explicitlyNamedLiteral) ||
-    explicitlyNamedLiteral.startsWith(rawVisibleSuffix) ||
-    rawVisibleSuffix.includes(explicitlyNamedLiteral) ||
-    explicitlyNamedLiteral.includes(match.unit) ||
-    match.unit.includes(explicitlyNamedLiteral)
-  ) {
+  if (rawVisibleSuffix.includes(explicitlyNamedLiteral)) {
     return explicitlyNamedLiteral;
   }
 
@@ -173,6 +171,9 @@ function selectVisibleSuffixReplacement(params: {
   const explicitTarget = findExplicitVisibleSuffixTarget(prefix, match);
   if (explicitTarget) {
     return explicitTarget;
+  }
+  if (context === "delimiter" && findExplicitSingleTargetLiteralInPreamble(prefix)) {
+    return null;
   }
   if (context === "no-delimiter" && hasExcludedTrailingCollapseContext(prefix)) {
     return null;
@@ -258,18 +259,10 @@ function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | n
     return null;
   }
 
-  const literalCount = text.split(literal).length - 1;
-  if (literalCount < 3) {
-    return null;
-  }
-
-  const lastLiteralIndex = text.lastIndexOf(literal);
-  if (lastLiteralIndex < 0) {
-    return null;
-  }
-
-  const trailingJunk = text.slice(lastLiteralIndex + literal.length);
-  if (!trailingJunk) {
+  const runawaySuffixMatch = text.match(
+    new RegExp(`(?:${escapeRegex(literal)}){3,}([^\\s][\\s\\S]*)$`),
+  );
+  if (!runawaySuffixMatch) {
     return null;
   }
 

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -14,6 +14,8 @@ const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
 const EXCLUDED_TARGET_HINT_SEGMENT_RE = /\b(?:incorrect|wrong|duplicate|previous|attempt)\b/i;
+const EXCLUDED_TRAILING_COLLAPSE_CONTEXT_RE =
+  /\b(?:mistaken|example|examples|incorrect|wrong|previous attempt|doubled output|duplicate(?:d)? output)\b/i;
 const MAX_STRUCTURED_SUFFIX_SCAN_CHARS = 8_192;
 const MAX_DELIMITER_SUFFIX_SCAN_CHARS = 2_048;
 
@@ -164,6 +166,9 @@ function selectVisibleSuffixReplacement(params: {
   if (explicitTarget) {
     return explicitTarget;
   }
+  if (context === "no-delimiter" && hasExcludedTrailingCollapseContext(prefix)) {
+    return null;
+  }
   if (!shouldCollapseRepeatedSuffix({ prefix, match, context })) {
     return null;
   }
@@ -201,7 +206,7 @@ function extractInlineCodeLiterals(text: string): string[] {
     .filter((literal) => literal.length > 0);
 }
 
-function findExplicitSingleTargetLiteralInPreamble(text: string): string | null {
+export function findExplicitSingleTargetLiteralInPreamble(text: string): string | null {
   if (
     !text ||
     !looksLikeInternalPreamble(text) ||
@@ -228,6 +233,11 @@ function findExplicitSingleTargetLiteralInPreamble(text: string): string | null 
   }
 
   return uniqueLiterals[0] ?? null;
+}
+
+function hasExcludedTrailingCollapseContext(prefix: string): boolean {
+  const trailingSegment = splitPreambleHintSegments(prefix).at(-1) ?? "";
+  return EXCLUDED_TRAILING_COLLAPSE_CONTEXT_RE.test(trailingSegment);
 }
 
 function extractExplicitRepeatedLiteralFromRunawayText(text: string): string | null {

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -13,6 +13,8 @@ const INTENTIONAL_REPEAT_INTENT_RE =
 const EXACT_TARGET_HINT_RE =
   /\b(?:specific string|reply with|output the text directly|output content)\b/i;
 const INLINE_CODE_LITERAL_RE = /`([^`\r\n]{1,400})`/g;
+const DOUBLE_QUOTED_LITERAL_RE = /"([^"\r\n]{1,400})"/g;
+const SINGLE_QUOTED_LITERAL_RE = /'([^'\r\n]{1,400})'/g;
 const EXCLUDED_TARGET_HINT_SEGMENT_RE = /\b(?:incorrect|wrong|duplicate|previous|attempt)\b/i;
 const EXCLUDED_TRAILING_COLLAPSE_CONTEXT_RE =
   /\b(?:mistaken|example|examples|incorrect|wrong|previous attempt|doubled output|duplicate(?:d)? output)\b/i;
@@ -200,8 +202,12 @@ function splitPreambleHintSegments(text: string): string[] {
     .filter((segment) => segment.length > 0);
 }
 
-function extractInlineCodeLiterals(text: string): string[] {
-  return [...text.matchAll(INLINE_CODE_LITERAL_RE)]
+function extractTargetLiterals(text: string): string[] {
+  return [
+    ...text.matchAll(INLINE_CODE_LITERAL_RE),
+    ...text.matchAll(DOUBLE_QUOTED_LITERAL_RE),
+    ...text.matchAll(SINGLE_QUOTED_LITERAL_RE),
+  ]
     .map((match) => match[1]?.trim() ?? "")
     .filter((literal) => literal.length > 0);
 }
@@ -221,13 +227,13 @@ export function findExplicitSingleTargetLiteralInPreamble(text: string): string 
       (SINGLE_ANSWER_INTENT_RE.test(segment) || EXACT_TARGET_HINT_RE.test(segment)) &&
       !EXCLUDED_TARGET_HINT_SEGMENT_RE.test(segment),
   );
-  const hintedLiterals = hintedSegments.flatMap(extractInlineCodeLiterals);
+  const hintedLiterals = hintedSegments.flatMap(extractTargetLiterals);
   const uniqueHintedLiterals = [...new Set(hintedLiterals)];
   if (uniqueHintedLiterals.length === 1) {
     return uniqueHintedLiterals[0] ?? null;
   }
 
-  const uniqueLiterals = [...new Set(extractInlineCodeLiterals(text))];
+  const uniqueLiterals = [...new Set(extractTargetLiterals(text))];
   if (uniqueLiterals.length !== 1) {
     return null;
   }

--- a/src/shared/text/repeated-visible-suffix.ts
+++ b/src/shared/text/repeated-visible-suffix.ts
@@ -3,6 +3,14 @@ const MIN_STRUCTURED_REPEAT_UNIT_LENGTH = 8;
 const VISIBLE_SUFFIX_BOUNDARY_RE = /[.!?:;)\]}>`'"]$/;
 const INTERNAL_PREAMBLE_HINT_RE =
   /\b(?:the user|instruction|output content|reply with|reply to|final response|general instruction|i will|i must|internal planning|plan:)\b/i;
+const SINGLE_ANSWER_INTENT_RE =
+  /\b(?:exactly|nothing else|one word(?: only)?|one short sentence(?: only)?|single answer)\b/i;
+
+type RepeatedPatternMatch = {
+  unit: string;
+  fullRepeats: number;
+  tail: string;
+};
 
 function looksStructuredRepeatedUnit(unit: string): boolean {
   return unit.length >= MIN_STRUCTURED_REPEAT_UNIT_LENGTH || STRUCTURED_REPEAT_HINT_RE.test(unit);
@@ -32,9 +40,9 @@ function looksLikeInternalPreamble(prefix: string): boolean {
   return lines.length >= 2 || sentenceCount >= 3;
 }
 
-export function collapseStructuredRepeatedPrefixPattern(text: string): string {
+function matchStructuredRepeatedPrefixPattern(text: string): RepeatedPatternMatch | null {
   if (!text) {
-    return text;
+    return null;
   }
 
   for (let unitLength = 1; unitLength <= Math.floor(text.length / 2); unitLength += 1) {
@@ -55,18 +63,40 @@ export function collapseStructuredRepeatedPrefixPattern(text: string): string {
 
     const tail = text.slice(cursor);
     if (!tail || unit.startsWith(tail)) {
-      return unit;
+      return { unit, fullRepeats, tail };
     }
   }
 
-  return text;
+  return null;
+}
+
+function shouldCollapseRepeatedSuffix(params: {
+  prefix: string;
+  match: RepeatedPatternMatch;
+  context: "delimiter" | "no-delimiter";
+}): boolean {
+  const { prefix, match, context } = params;
+
+  if (match.tail.length > 0 || match.fullRepeats >= 3) {
+    return context === "delimiter" || looksLikeInternalPreamble(prefix);
+  }
+
+  return looksLikeInternalPreamble(prefix) && SINGLE_ANSWER_INTENT_RE.test(prefix);
+}
+
+export function collapseRepeatedVisibleSuffixAfterDelimiter(
+  prefix: string,
+  suffix: string,
+): string {
+  const match = matchStructuredRepeatedPrefixPattern(suffix);
+  if (!match || !shouldCollapseRepeatedSuffix({ prefix, match, context: "delimiter" })) {
+    return suffix;
+  }
+
+  return match.unit;
 }
 
 export function extractStructuredRepeatedVisibleSuffix(text: string): string {
-  const collapsedWholeText = collapseStructuredRepeatedPrefixPattern(text);
-  if (collapsedWholeText !== text) {
-    return collapsedWholeText;
-  }
   if (!text) {
     return text;
   }
@@ -100,7 +130,11 @@ export function extractStructuredRepeatedVisibleSuffix(text: string): string {
       if (
         fullRepeats < 2 ||
         !endsAtVisibleSuffixBoundary(prefix) ||
-        !looksLikeInternalPreamble(prefix)
+        !shouldCollapseRepeatedSuffix({
+          prefix,
+          match: { unit, fullRepeats, tail },
+          context: "no-delimiter",
+        })
       ) {
         continue;
       }


### PR DESCRIPTION

## Summary
Gemma was sometimes leaking hidden internal text into Discord replies.
This PR makes OpenClaw clean the final reply in one shared place before sending it.
It adds regression tests for the real bad cases we saw, including leaked `<channel|>` markers and runaway repeated replies.
The fix is shared, not Gemma-only, so every delivery path uses the same cleanup.


## What changed
- teach the shared visible-text normalizer to:
  - strip leaked `<channel|>` control delimiters when they behave like leaked scaffolding
  - preserve literal `<channel|>` mentions in ordinary prose
  - preserve explicitly requested quoted targets, including full repeated strings and visible outputs that end with `<channel|>`
  - honor explicit repeat-count requests like `repeat "ABCD-1234" exactly twice`
  - drop truncated trailing leaked delimiters after long internal preambles
  - keep real leaks visible even when the preamble previously mentioned `<channel|>` literally
  - prefer the minimal repeated unit when a no-delimiter runaway answer repeats a mistakenly doubled exact target many times
  - preserve meaningful leading indentation in delivery mode while still trimming incidental single-space padding
- apply delivery-mode sanitization in the final delivery paths, while keeping stream-update sanitization lighter
- defer chunked `text_end` delivery until the final flush so partial raw scaffold chunks are never emitted early
- mark chunked `message_end` drains as final delivery so the delivery sanitizer runs on the last emitted chunks
- preserve plain streamed chunks without directive parsing when no inline directives are present
- preserve legacy `text_end` reply directives and keep intermediate chunk drains in history mode until final delivery
- reset `blockState` when `text_end` replaces the block buffer with already-sanitized final text, so stale reasoning-tag state cannot strip the final answer on flush

## Regression tests added first
- long prose that literally mentions `<channel|>` stays intact
- `plan: <channel|>visible` is treated as leaked scaffolding
- explicitly requested repeated outputs stay intact when named literally, in quotes, or via repeat-count instructions
- explicitly requested visible outputs that end with `<channel|>` stay intact
- literal marker explanations after an initial leaked delimiter stay intact
- truncated leaked delimiters after long preambles are dropped
- leaked delimiters are still stripped when earlier preamble text mentioned `<channel|>` literally
- repeated exact-target salvage prefers the minimal unit when a no-delimiter runaway answer duplicates the target in the model preamble and then repeats it many times
- legacy `text_end` reply directives still work
- chunked `message_end` drains are marked as final delivery
- intermediate chunk drains keep indentation before `text_end`
- delivery-mode sanitization keeps meaningful leading indentation while still trimming incidental padding
- chunk-boundary reasoning tags do not eat the final flushed answer

## Verification
- failing regressions were added first and reproduced locally before the fixes
- focused tests:
  - `pnpm exec vitest run src/shared/text/repeated-visible-suffix.test.ts src/shared/text/assistant-visible-text.test.ts`
  - `pnpm exec vitest run src/shared/text/repeated-visible-suffix.test.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-utils.strip-model-special-tokens.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-subscribe.reply-tags.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.emits-block-replies-text-end-does-not.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.keeps-indented-fenced-blocks-intact.test.ts src/auto-reply/reply/reply-utils.test.ts`
- `pnpm build`
- live Discord probe on `vllm/gemma4-e4b` after restarting the local gateway on this branch:
  - Looper prompt: `reply with exactly pr68986-live2-1776657698 and nothing else`
  - Bob visible Discord reply: `pr68986-live2-1776657698`
