### PR TITLE
entry: replace argv-sniff with command-owned read-only manifest

### DIFF
--- a/.planning/phases/entry-auth-gate/PLAN.md
+++ b/.planning/phases/entry-auth-gate/PLAN.md
@@ -1,0 +1,155 @@
+# Phase: entry-auth-gate — Plan
+
+**Planned:** 2026-04-18
+**Research:** `.planning/phases/entry-auth-gate/RESEARCH.md`
+**Branch:** `refactor/entry-auth-gate`
+
+## Goal
+
+Replace the lexical argv-sniff at `src/entry.ts:22-30` with a structured, command-owned manifest so renaming, aliasing, or inserting an option inside the `secrets audit` token pair cannot silently drop the `OPENCLAW_AUTH_STORE_READONLY=1` guarantee. The env variable must continue to be set before any CLI module with a module-load-time env capture could observe an unset value, the failure mode on drift must convert from "silent security regression" to "loud test failure" caught in CI, and cold-path module resolution cost for the entry point must not increase.
+
+## Preconditions
+
+- Branch `refactor/entry-auth-gate` is checked out and clean (no unstaged edits to `src/entry.ts` or `src/cli/secrets-cli.ts`).
+- `pnpm install` has been run; `pnpm tsgo` and `pnpm check` are green on the base commit so drift introduced by this phase is attributable.
+- No in-flight PR is renaming the `secrets audit` command — if there is one, either wait for it to land or coordinate the manifest entry at the same time.
+
+## Approach summary
+
+Approach A from the research (see RESEARCH.md §Recommendation, lines 101–103). Export a `READ_ONLY_AUTH_COMMAND_PATHS` manifest from a new sibling module next to `src/cli/secrets-cli.ts`, import it from `src/entry.ts`, and iterate it instead of hard-coding the `["secrets", "audit"]` pair inline. A regression-guard test imports both the manifest and the Commander tree and asserts every manifest entry resolves to a real registered subcommand path; any rename without a matching manifest edit fails the test. The manifest lives in its own file — not inside `secrets-cli.ts` — so `entry.ts` does not transitively drag Commander, the secrets subcli action bodies, or their imports into the cold path, preserving the lazy-subcli design at `src/cli/program/register.subclis-core.ts:206-210` (RESEARCH.md Q1, line 45). Pre-parse env timing is preserved as defense-in-depth per RESEARCH.md Q2 (lines 55–56); both env consumers read at call-time today, but future consumers might not.
+
+## Task ordering and dependencies
+
+Tasks are totally ordered. Later tasks depend on earlier ones: tasks 2 and 3 depend on task 1 (manifest file must exist); task 4 depends on task 1 (import target); task 5 depends on task 4 (tests the rewritten function); task 6 depends on task 1 (imports the manifest); task 7 is a cleanup check on task 4; task 8 depends on all prior. Tasks 4 and 6 must land in the same commit — task 4 without task 6 removes the old literal guard and provides no replacement belt against rename drift.
+
+## Task list
+
+### 1. Add the manifest module
+
+- **Files:** `src/cli/secrets-cli.read-only-paths.ts` (new file, ~15 lines).
+- **Change:** Export `READ_ONLY_AUTH_COMMAND_PATHS: readonly (readonly string[])[] = [["secrets", "audit"]] as const`. No Commander import, no other imports. Add a top-of-file JSDoc block that:
+  1. Names the two binding sites — `src/entry.ts` (consumer) and `src/cli/secrets-cli.ts:84` (registration site).
+  2. States the invariant: every entry must resolve to a registered Commander subcommand path, enforced by `secrets-cli.read-only-paths.test.ts`.
+  3. Documents the option-stripping behavior of the entry-side matcher (tokens starting with `-` are filtered before matching) so a future maintainer does not add a path component that begins with `-`.
+- **Verify:** `pnpm tsgo` passes. `Grep` for `READ_ONLY_AUTH_COMMAND_PATHS` shows exactly one declaration in this file.
+
+### 2. Re-export manifest from the secrets subcli for co-location signal
+
+- **Files:** `src/cli/secrets-cli.ts` (near top, after existing imports, before `registerSecretsCli`).
+- **Change:** Add `export { READ_ONLY_AUTH_COMMAND_PATHS } from "./secrets-cli.read-only-paths.js";`. This surfaces the manifest in the same file as `registerSecretsCli` so a reviewer opening this module sees both the registration and the co-located invariant reference. Do NOT move the array literal here — keeping the source in the sibling module is what lets `entry.ts` import the manifest without pulling the subcli's Commander action bodies into cold-path module resolution.
+- **Verify:** `pnpm tsgo` passes. A test import `import { READ_ONLY_AUTH_COMMAND_PATHS } from "./secrets-cli.js"` resolves to the same reference as the sibling-module import.
+
+### 3. Add a local comment anchor at the audit command definition
+
+- **Files:** `src/cli/secrets-cli.ts:84` (immediately above `secrets.command("audit")`).
+- **Change:** One-line comment: `// SECURITY: renaming/aliasing this command requires updating READ_ONLY_AUTH_COMMAND_PATHS in ./secrets-cli.read-only-paths.ts — the regression test in secrets-cli.read-only-paths.test.ts enforces this binding.` This is the visible footgun guard for any maintainer editing the command name without reading the sibling module.
+- **Verify:** `Grep` for `READ_ONLY_AUTH_COMMAND_PATHS` in `src/cli/secrets-cli.ts` returns at least two hits: the re-export line from task 2 and this comment anchor.
+
+### 4. Replace the argv-sniff in `entry.ts` with a manifest-driven check
+
+- **Files:** `src/entry.ts` (new import near the existing import block at lines 1–15; rewrite of `shouldForceReadOnlyAuthStore` at lines 22–30).
+- **Change:**
+  1. Add `import { READ_ONLY_AUTH_COMMAND_PATHS } from "./cli/secrets-cli.read-only-paths.js";`. Import from the sibling module directly, NOT from `./cli/secrets-cli.js` — the re-export in task 2 is a reviewer aid, not an import path for the cold-path entry point.
+  2. Rewrite `shouldForceReadOnlyAuthStore(argv: string[]): boolean` to build the filtered-token array once (`argv.slice(2).filter(t => t.length > 0 && !t.startsWith("-"))`), then for each path in the manifest scan the filtered tokens for an adjacent, in-order run matching the path. Return `true` on the first match; `false` otherwise.
+  3. Preserve the existing call site semantics at `src/entry.ts:60-62` — no signature change, no return-type change, no async.
+- **Verify:** `pnpm tsgo` passes. Task 5 and 7 assert behavior and the absence of inline literals respectively.
+
+### 5. Unit test: positive and negative argv cases
+
+- **Files:** `src/entry.read-only-auth.test.ts` (new file; keep `src/entry.test.ts` untouched to avoid churn in its existing fixtures).
+- **Change:** Export `shouldForceReadOnlyAuthStore` from `entry.ts` with a `/** @internal */` JSDoc if it is not already exported (current file does not export it). Tests:
+  - **Positive:** `expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "audit"])).toBe(true)`.
+  - **Positive with option between tokens:** `expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "--json", "audit"])).toBe(true)` — locks in the option-stripping behavior.
+  - **Positive trailing option:** `expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "audit", "--check"])).toBe(true)`.
+  - **Negative same parent:** `expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "list"])).toBe(false)`.
+  - **Negative lone tokens:** `secrets` alone and `audit` alone both return `false`.
+  - **Negative empty argv:** `[]` and `["node", "openclaw"]` both return `false`.
+  - **Full-gate integration:** one test that sets `process.argv = ["node", "openclaw", "secrets", "audit"]`, calls the gate, and on `true` sets `process.env.OPENCLAW_AUTH_STORE_READONLY = "1"`; asserts the env is `"1"`. Restore `process.env` and `process.argv` in `afterEach`.
+- **Verify:** `pnpm test src/entry.read-only-auth.test.ts` — all cases pass.
+
+### 6. Regression-guard test: manifest ↔ registered command tree
+
+- **Files:** `src/cli/secrets-cli.read-only-paths.test.ts` (new file).
+- **Change:** The test:
+  1. Imports `READ_ONLY_AUTH_COMMAND_PATHS` from `./secrets-cli.read-only-paths.js` and `registerSecretsCli` from `./secrets-cli.js`.
+  2. Constructs a fresh `new Command()` from Commander, calls `registerSecretsCli(program)`.
+  3. For each path in the manifest, walks down `program.commands.find(c => c.name() === path[0])`, then `.commands.find(c => c.name() === path[1])`, etc. If any step returns `undefined`, fail with a message naming the drifted path (`Manifest entry ["secrets","audit"] has no matching Commander subcommand — likely rename at src/cli/secrets-cli.ts:84. Update READ_ONLY_AUTH_COMMAND_PATHS.`).
+  4. Asserts the manifest is non-empty (`expect(READ_ONLY_AUTH_COMMAND_PATHS.length).toBeGreaterThan(0)`) — without this, an accidentally emptied manifest would silently pass.
+  5. Asserts each path has length ≥ 1.
+- **Verify:** `pnpm test src/cli/secrets-cli.read-only-paths.test.ts`. In a scratch branch, rename `.command("audit")` to `.command("audit2")` and confirm the test fails with the expected message; revert.
+
+### 7. Confirm no inline string literal remains in the gate
+
+- **Files:** `src/entry.ts` (inspection of `shouldForceReadOnlyAuthStore` body after task 4).
+- **Change:** Review the rewritten function body and confirm the only string data flowing into the match comes from `READ_ONLY_AUTH_COMMAND_PATHS`. The literals `"secrets"` and `"audit"` must not appear inside the function. The `-` prefix check in the filter is fine (structural argv handling, not a path literal).
+- **Verify:** `Grep` for `"secrets"` and `"audit"` in `src/entry.ts` returns no hits inside `shouldForceReadOnlyAuthStore`. `pnpm check` passes.
+
+### 8. Land verification
+
+- **Files:** none (verification step).
+- **Change:** Run the landing gates per CLAUDE.md. `pnpm build` is required because `src/entry.ts` is the CLI entrypoint and this change touches module boundaries / lazy-loading surface.
+- **Verify:**
+  1. `pnpm check` — green.
+  2. `pnpm test` — green (scoped tests from tasks 5 and 6 pass alongside the full suite).
+  3. `pnpm build` — green, no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings referencing `secrets-cli.read-only-paths`.
+  4. `pnpm check:import-cycles` and `pnpm check:madge-import-cycles` — green (the new import is one-directional: `entry.ts` → `secrets-cli.read-only-paths.ts`, no cycle possible).
+
+## Files touched summary
+
+- `src/cli/secrets-cli.read-only-paths.ts` — **new**, exports `READ_ONLY_AUTH_COMMAND_PATHS` manifest and JSDoc invariant documentation (task 1).
+- `src/cli/secrets-cli.read-only-paths.test.ts` — **new**, regression-guard test that walks the Commander tree and asserts every manifest entry resolves to a registered subcommand (task 6).
+- `src/cli/secrets-cli.ts` — **edit**, one-line re-export of the manifest (task 2) and one-line SECURITY comment above `.command("audit")` at line 84 (task 3).
+- `src/entry.ts` — **edit**, one new import and a rewrite of `shouldForceReadOnlyAuthStore` at lines 22–30 to iterate the manifest (task 4); `/** @internal */` export added if not already exported (task 5 dependency).
+- `src/entry.read-only-auth.test.ts` — **new**, positive and negative argv unit tests plus full-gate integration test (task 5).
+
+## Goal-backward verification plan
+
+The phase goal is: `OPENCLAW_AUTH_STORE_READONLY=1` iff the CLI is invoked against a command path declared in the manifest, AND renaming a declared command without updating the manifest fails CI, AND entry-point cold-path cost is unchanged. End-to-end checks that prove the goal (not just per-task completion):
+
+1. **Positive argv test** (task 5) — fakes `process.argv = ["node", "openclaw", "secrets", "audit"]`, runs the gate, asserts `process.env.OPENCLAW_AUTH_STORE_READONLY === "1"`. Directly models the production invocation path from `src/entry.ts:60-62`.
+2. **Negative argv test** (task 5) — fakes `process.argv = ["node", "openclaw", "secrets", "list"]`, runs the gate, asserts `process.env.OPENCLAW_AUTH_STORE_READONLY` is not set by the gate. Proves the gate is not a blanket trigger on the `secrets` parent.
+3. **Option-between-tokens test** (task 5) — fakes `process.argv = ["node", "openclaw", "secrets", "--json", "audit"]`, asserts the gate still fires. Locks in the option-stripping behavior so a future "fix" to the filter does not silently narrow coverage.
+4. **Manifest-matches-command-tree test** (task 6) — imports `READ_ONLY_AUTH_COMMAND_PATHS`, constructs a program, runs `registerSecretsCli`, walks each path. Rename without manifest update → test fails with a targeted error message. This is the belt that converts silent security regression into a red CI build.
+5. **Cold-path bundle check** — after `pnpm build`, spot-check that `dist/entry.js` (or the bundled entry artifact) does not statically reference `registerSecretsCli` or other `secrets-cli.ts` action-body identifiers. Use `Grep` over the built artifact for `registerSecretsCli` and `runSecretsAudit` — zero hits expected in the entry bundle. This proves the manifest module stayed lightweight and entry.ts did not accidentally pull the subcli eagerly.
+6. **Live CLI smoke** — after `pnpm build`, run `node dist/entry.js secrets audit --check --json` in a scratch dir with no creds. Spot-check via `src/agents/auth-profiles/store.ts:230` that no credential-mutation path fires (observational; not a new test).
+
+## Success criteria
+
+The phase is done when all of the following hold simultaneously:
+
+- `shouldForceReadOnlyAuthStore` in `src/entry.ts` contains no `"secrets"` or `"audit"` string literals; all token data flows from `READ_ONLY_AUTH_COMMAND_PATHS`.
+- `src/cli/secrets-cli.read-only-paths.ts` exists, is imported exactly once by `src/entry.ts` and once by `src/cli/secrets-cli.ts` (re-export), and has no third consumer.
+- Tests in tasks 5 and 6 pass on the current tree and fail deterministically on a `.command("audit")` → `.command("audit2")` rename without a matching manifest update.
+- `pnpm check`, `pnpm test`, and `pnpm build` are green.
+- No new `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings or `check:madge-import-cycles` failures.
+
+## Alternatives considered
+
+- **Approach B (Commander dry-parse pre-dispatch).** Rejected: RESEARCH.md lines 89–94 — requires either full program construction on the cold path (breaks the lazy-subcli design at `src/cli/program/register.subclis-core.ts:206-210`) or a hand-rolled argv walker that mirrors Commander's option grammar. Cost and maintenance burden exceed the structural gain over A.
+- **Approach C (lazy-read consumers + preAction metadata flag).** Rejected for this phase; viable as a follow-up. RESEARCH.md lines 96–99 — cleanest long-term coupling, but loses pre-import env timing as defense-in-depth and touches three files plus a new hook extension in `src/cli/program/preaction.ts`. Scope creep vs A's two-file surgical change. If the repo later adopts a broader command-metadata pattern, promote A's manifest into a Commander property read by the preAction hook.
+
+## Risks and mitigations
+
+- **Defense-in-depth: add a preAction hook too?** RESEARCH.md Q2 (lines 49–56) confirms both env consumers read `process.env` at function-call time, so a preAction hook in `src/cli/program/preaction.ts` would work equivalently. **Recommendation: do NOT add it in this phase.** Two gates for the same signal doubles the drift surface (manifest + hook walker) and the regression-guard test in task 6 already makes manifest drift loud in CI. The existing pre-parse gate in `entry.ts` remains the defense-in-depth layer against a future module-load-time env capture. If a future phase adopts Approach C, the preAction hook replaces — not augments — the entry-time check; plan that migration explicitly rather than letting both coexist silently.
+- **Test coverage gap before this phase.** Reviewing `src/cli/secrets-cli.test.ts` and `src/entry.test.ts`: no existing test today would catch a rename of `.command("audit")` combined with a missed `entry.ts` update. The regression-guard test in task 6 is the entire belt; without it, Approach A is strictly no better than the status quo. Task 6 is therefore non-negotiable and must land in the same commit as task 4.
+- **Manifest import path must bypass the lazy subcli.** Task 1 puts the manifest in `secrets-cli.read-only-paths.ts` (no Commander import, no transitive pulls) precisely so `entry.ts` does not eagerly resolve the full `secrets-cli.ts` module — which would regress the lazy-load design at `register.subclis-core.ts:206-210`. Do not "simplify" by moving the manifest into `secrets-cli.ts` as an originating export. The cold-path bundle check in goal-backward step 5 enforces this at build time.
+- **Entry-side import-surface creep.** Every new import added to `src/entry.ts` is cold-path cost on every CLI invocation. Task 4 adds exactly one new import (`secrets-cli.read-only-paths.js`) — a pure data module with no dependencies. Future read-only-command additions should reuse this single import by extending the array, not by adding new per-command imports.
+- **Option-stripping behavior is a documented constraint.** The filter strips any token starting with `-`. If a future manifest entry includes a path component that legitimately starts with `-` (Commander subcommand names conventionally don't), the filter would hide it and the match would silently fail. The JSDoc on the manifest file (task 1) documents this so the next maintainer has a fighting chance.
+- **Import from `.js` extension in TypeScript.** Per `package.json` ESM conventions in this repo, TypeScript source imports use the `.js` extension pointing to the compiled output. Both the manifest module filename and all task-specified imports follow this convention (`./secrets-cli.read-only-paths.js`). No CommonJS fallback needed.
+
+## Out of scope
+
+- Changing consumer-side env read timing in `src/agents/auth-profiles/store.ts:230` or `src/agents/pi-model-discovery.ts:155-158`.
+- Adding a `preAction` hook for read-only enforcement (Approach C).
+- Migrating other security-sensitive env gates (none exist today; this is the only argv-sniff of its kind).
+- Refactoring `src/cli/program/subcli-descriptors.ts` to carry command metadata.
+- Any change to `runSecretsAudit`, the audit business logic, or the audit command's options.
+- Extending the manifest to cover other commands — add only `["secrets", "audit"]` in this phase; new entries require their own security review.
+
+## Commit and landing
+
+Single commit per repo convention (`scripts/committer`). Message: `entry: replace argv-sniff with command-owned read-only manifest`. Include all five files (manifest, manifest test, secrets-cli.ts re-export + comment, entry.ts import + rewrite, entry-side test) in one commit so tasks 4 and 6 cannot be split across commits. No changelog entry required — this is an internal security-hardening refactor with no user-facing behavior change (see `.claude/rules/testing-guidelines.md` §Changelog).
+
+## Rollback
+
+Revert the commit. The manifest module, the re-export in `secrets-cli.ts`, the comment anchor, and the import in `entry.ts` are the entire surface; reverting restores the inline literal argv-sniff at `src/entry.ts:22-30` with no residual state, no migrations, no config changes.

--- a/.planning/phases/entry-auth-gate/RESEARCH.md
+++ b/.planning/phases/entry-auth-gate/RESEARCH.md
@@ -1,0 +1,122 @@
+# Phase: entry-auth-gate — Research
+
+**Researched:** 2026-04-18
+**Domain:** CLI entry-point security gate for forcing read-only auth store during `secrets audit`
+**Confidence:** HIGH
+
+## Summary
+
+`src/entry.ts:22-30` argv-sniffs adjacent tokens `secrets audit` and sets `OPENCLAW_AUTH_STORE_READONLY=1` before any CLI code loads. The guarantee is semantic (the audit command must never mutate credentials) but the mechanism is lexical (string match on argv). Any rename, alias, or insertion of an option between the two tokens silently drops the guarantee — a security regression.
+
+The two env consumers both read `process.env` at function-call time, not module-load time, which is a key architectural opening: **the env does not need to be set before imports settle**, only before the consumers run. That unlocks action-time or pre-parse hook approaches alongside the manifest approach.
+
+**Primary recommendation:** Approach A (exported command-path manifest) — most surgical, zero risk to cold-path cost, rename-breaks-build safety. Approach C (lazy-read plus preaction hook) is the cleanest long-term but broadens scope. Approach B (Commander dry-parse pre-dispatch) carries subtle cost and edge-case risk (help, error paths) for little gain over A.
+
+## Question 1 — How is `secrets audit` registered?
+
+**Framework:** Commander.js (confirmed at `src/cli/program/build-program.ts:2` — `import { Command } from "commander"`).
+
+**Exact registration site:** `src/cli/secrets-cli.ts:84-93`
+
+```ts
+  secrets
+    .command("audit")
+    .description("Audit plaintext secrets, unresolved refs, and precedence drift")
+    .option("--check", "Exit non-zero when findings are present", false)
+    .option(
+      "--allow-exec",
+      "Allow exec SecretRef resolution during audit (may execute provider commands)",
+      false,
+    )
+    .option("--json", "Output JSON", false)
+    .action(async (opts: SecretsAuditOptions) => {
+```
+
+Parent `secrets` command is defined on the same file at `src/cli/secrets-cli.ts:46-54` (`.command("secrets")`). The subcli is registered lazily through `src/cli/program/register.subclis-core.ts:206-210`:
+
+```ts
+    {
+      commandNames: ["secrets"],
+      loadModule: () => import("../secrets-cli.js"),
+      exportName: "registerSecretsCli",
+    },
+```
+
+So the registration chain is: `build-program.ts` → `registerProgramCommands` → lazy dynamic import of `secrets-cli.ts` → `registerSecretsCli(program)` → `.command("secrets").command("audit")`.
+
+## Question 2 — Ordering constraint (module-load vs call-time)
+
+**Both consumers read env at call-time, NOT at module-load.** This is the key architectural fact.
+
+- `src/agents/auth-profiles/store.ts:230` — inside a function body (`loadAuthProfileStore` scope), specifically after `mergeOAuthFileIntoStore(store)`. Grep confirms this is the ONLY `process.env.OPENCLAW_AUTH_STORE_READONLY` reference in the file. No top-level const capture.
+- `src/agents/pi-model-discovery.ts:155-158` — inside the exported function `scrubLegacyStaticAuthJsonEntriesForDiscovery`. First statement of the function body.
+
+**Implication:** The env variable does not need to be set before module imports resolve. It only needs to be set before `loadAuthProfileStore` or `scrubLegacyStaticAuthJsonEntriesForDiscovery` is called. This allows action-time hooks (Commander `preAction`) or command-action prologues to set it, not just the pre-import gate currently in entry.ts.
+
+**Caveat — why entry.ts still sets it early:** The argv-sniff happens at `src/entry.ts:60-62` before `runCli` is invoked via `./cli/run-main.js` at line 204. This defends against any future code path that captures the env at module-load. Preserving pre-parse timing is safer as a defense-in-depth choice even though it is not strictly required today.
+
+## Question 3 — Commander hook and metadata support
+
+Commander.js supports three relevant seams already in use here:
+
+1. **`program.hook("preAction", fn)`** — registered via `registerPreActionHooks(program, ctx.programVersion)` at `src/cli/program/build-program.ts:24` (implementation at `src/cli/program/preaction.ts`). This fires after argv parsing, after the final action command is resolved, but before its `.action()` runs. It receives `(thisCommand, actionCommand)` and can walk up `actionCommand.parent` to build a full command path — exactly what `setProcessTitleForCommand` does at `preaction.ts:19-30`.
+2. **`command.parseOptions(argv)` / `program.parse(argv, { from: "user" })`** — Commander can be asked to resolve the selected command without executing the action, but error/help paths complicate this and no existing code does it.
+3. **Custom metadata on `Command` instances** — Commander exposes no first-class metadata API, but the repo already attaches per-command data via closures (see `setProgramContext` at `build-program.ts:22`) and via a parallel descriptor catalog (`subCliCommandCatalog` at `src/cli/program/subcli-descriptors.ts:7`). Commander `Command` objects also accept arbitrary property attachment, though the repo does not do this today.
+
+The preAction hook is the most idiomatic seam for command-driven env — it already exists, already receives the resolved command tree, and already mutates process state (`process.title`).
+
+## Question 4 — Existing pattern for command-metadata-driven env
+
+**No existing pattern sets env from command metadata.** Every `process.env.OPENCLAW_*` write in `src/cli/program/**` is either:
+
+- Test-only env manipulation (`private-qa-cli.test.ts`, `preaction.test.ts`, `register.subclis.test.ts`).
+- A generic runtime toggle, not tied to a specific command identity (e.g., `config-guard.ts:57-67` temporarily sets `OPENCLAW_SUPPRESS_NOTES` around a block).
+
+The closest architectural precedent is **`command-startup-policy.ts`** (referenced from `preaction.ts:12` as `shouldBypassConfigGuardForCommandPath`) — a function that takes a resolved command path and returns a policy decision. This is the shape to mirror: a pure predicate over command path, called from a single hook site.
+
+There is also a precedent for **parallel descriptor catalogs** (`subcli-descriptors.ts:7`, `command-descriptor-utils.ts`) where command metadata lives next to — but not inside — the Commander `Command` instance. A read-only-commands manifest would slot naturally alongside this.
+
+**Verdict:** No drop-in pattern; closest analogs are `shouldBypassConfigGuardForCommandPath` (predicate shape) and `subCliCommandCatalog` (metadata shape). A new manifest would be the first of its kind for env-gating.
+
+## Question 5 — Approach candidates
+
+### Approach A — Exported command-path manifest (RECOMMENDED)
+
+Add `export const READ_ONLY_AUTH_COMMAND_PATHS: readonly (readonly string[])[] = [["secrets", "audit"]]` to `src/cli/secrets-cli.ts` (or a sibling `secrets-cli.read-only-paths.ts` to avoid dragging Commander into entry.ts's dependency graph). Replace the argv-sniff in entry.ts with a loop over the manifest using the same structural match (tokens-only filter). The manifest lives next to the command definition, so a rename of `audit` forces whoever touches `.command("audit")` to also touch the manifest line — if they don't, the TypeScript build still succeeds but the test suite's existing coverage in `src/cli/secrets-cli.test.ts` and `src/secrets/audit.test.ts` (plus a new "manifest matches registered command" test) catches the drift.
+
+**Trade-off:** Still structural/lexical matching on argv (no real parse), but failure mode shifts from silent-security-regression to loud-test-failure, and the manifest sits in the secrets module so accidental divergence is unlikely.
+
+### Approach B — Commander dry-parse to resolve the selected command
+
+Build the program (or a minimal skeleton), call `program.parseOptions` / partial parse to determine the actionCommand, check for a metadata flag (e.g., `cmd.readOnlyAuthStore === true`), then set env and hand the real argv to the main parse. This requires either a double-parse (cost: full program construction on cold path — the codebase goes to real effort to keep subclis lazy via `register.subclis-core.ts`) or a lightweight hand-written argv walker that understands Commander's option grammar (cost: maintenance burden, must mirror Commander's behavior).
+
+**Trade-off:** True structural resolution that handles aliases and options between tokens — but breaks the lazy-subcli cold-path design and introduces a parse-twice failure mode around help/error output.
+
+### Approach C — Lazy-read consumers plus preAction hook
+
+Consumers already read env at call-time (confirmed in Q2), so no consumer changes needed. Attach `.command("audit")` with a custom property `(cmd as Command & { __forceReadOnlyAuthStore?: true }).__forceReadOnlyAuthStore = true` at `src/cli/secrets-cli.ts:84`, and extend `registerPreActionHooks` in `src/cli/program/preaction.ts` to walk from `actionCommand` and set the env if the flag is present anywhere on the path. Remove the entry.ts argv-sniff entirely.
+
+**Trade-off:** Cleanest coupling (env gate lives next to the command that needs it, zero entry.ts knowledge) but loses pre-import safety net — any future module-load-time env capture becomes a latent bug, and the change surface is larger (entry.ts + preaction.ts + secrets-cli.ts + new tests) than A.
+
+## Recommendation
+
+Go with **A**. It's the smallest change (two files: `secrets-cli.ts` adds the manifest + a test; `entry.ts` imports the manifest), preserves pre-import env timing as defense-in-depth, keeps the cold path untouched, and converts silent security regression into a test failure. Keep C in mind as a follow-up if the repo adopts a broader "command metadata" pattern.
+
+## Sources
+
+- `src/entry.ts:22-30, 60-62` — current argv-sniff
+- `src/cli/secrets-cli.ts:46-54, 84-93` — parent `secrets` and child `audit` Commander registration
+- `src/cli/program/build-program.ts:1-29` — Commander program construction, preaction wiring
+- `src/cli/program/preaction.ts:1-50` — existing preAction hook pattern, command-path walking
+- `src/cli/program/register.subclis-core.ts:206-210` — lazy subcli registration for secrets
+- `src/cli/program/subcli-descriptors.ts:142-145` — parallel descriptor catalog pattern
+- `src/agents/auth-profiles/store.ts:230` — call-time env read
+- `src/agents/pi-model-discovery.ts:155-158` — call-time env read
+
+**Confidence breakdown:**
+
+- Q1 (registration): HIGH — direct file read, verified framework
+- Q2 (ordering): HIGH — grep confirmed only one env reference per consumer, both inside function bodies
+- Q3 (hooks): HIGH — existing preaction.ts confirms Commander hook usage
+- Q4 (existing pattern): HIGH — exhaustive grep over `src/cli/program/**` found no precedent
+- Q5 (approaches): HIGH for A and C; MEDIUM for B (double-parse cost estimated, not measured)

--- a/src/cli/secrets-cli.read-only-paths.test.ts
+++ b/src/cli/secrets-cli.read-only-paths.test.ts
@@ -1,0 +1,46 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { registerSecretsCli } from "./secrets-cli.js";
+import { READ_ONLY_AUTH_COMMAND_PATHS } from "./secrets-cli.read-only-paths.js";
+
+function findSubcommand(root: Command, path: readonly string[]): Command | undefined {
+  let current: Command | undefined = root;
+  for (const name of path) {
+    if (current === undefined) {
+      return undefined;
+    }
+    current = current.commands.find((cmd) => cmd.name() === name);
+  }
+  return current;
+}
+
+describe("READ_ONLY_AUTH_COMMAND_PATHS manifest", () => {
+  it("is non-empty (a silently emptied manifest would pass this suite otherwise)", () => {
+    expect(READ_ONLY_AUTH_COMMAND_PATHS.length).toBeGreaterThan(0);
+  });
+
+  it("declares every path as a non-empty token list", () => {
+    for (const path of READ_ONLY_AUTH_COMMAND_PATHS) {
+      expect(path.length).toBeGreaterThan(0);
+      for (const token of path) {
+        expect(token).toMatch(/^[^-]/);
+        expect(token).not.toBe("");
+      }
+    }
+  });
+
+  it("has every entry resolving to a real registered Commander subcommand path", () => {
+    const program = new Command();
+    registerSecretsCli(program);
+
+    for (const path of READ_ONLY_AUTH_COMMAND_PATHS) {
+      const resolved = findSubcommand(program, path);
+      if (resolved === undefined) {
+        throw new Error(
+          `Manifest entry ${JSON.stringify(path)} has no matching Commander subcommand — likely a rename at src/cli/secrets-cli.ts. Update READ_ONLY_AUTH_COMMAND_PATHS in src/cli/secrets-cli.read-only-paths.ts.`,
+        );
+      }
+      expect(resolved.name()).toBe(path[path.length - 1]);
+    }
+  });
+});

--- a/src/cli/secrets-cli.read-only-paths.ts
+++ b/src/cli/secrets-cli.read-only-paths.ts
@@ -1,0 +1,27 @@
+/**
+ * Command paths that MUST run with the auth store forced into read-only mode.
+ *
+ * The entry script (`src/entry.ts`) imports this manifest before Commander
+ * parses argv and sets `OPENCLAW_AUTH_STORE_READONLY=1` whenever the caller's
+ * argv matches an entry here. Each entry is a token path from the program root
+ * to the target subcommand (for example, `["secrets", "audit"]` matches
+ * `openclaw secrets audit`).
+ *
+ * Binding sites:
+ * - Consumer: `src/entry.ts` — argv gate runs before any module reads the env.
+ * - Registration: `src/cli/secrets-cli.ts` — each manifest entry MUST resolve
+ *   to a real Commander subcommand path. The regression guard in
+ *   `src/cli/secrets-cli.read-only-paths.test.ts` walks the registered command
+ *   tree and fails if a manifest entry drifts from the actual command names.
+ *   Renaming a command without updating this manifest therefore breaks CI
+ *   instead of silently dropping the read-only guarantee.
+ *
+ * The entry-side matcher filters tokens starting with `-` before matching, so
+ * option arguments do not interrupt adjacent-token pairs. Do not add a path
+ * component that itself begins with `-`; Commander subcommand names do not use
+ * leading dashes, so this constraint is a note for future maintainers rather
+ * than a current limitation.
+ */
+export const READ_ONLY_AUTH_COMMAND_PATHS: readonly (readonly string[])[] = [
+  ["secrets", "audit"],
+] as const;

--- a/src/cli/secrets-cli.ts
+++ b/src/cli/secrets-cli.ts
@@ -11,6 +11,8 @@ import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
 import { addGatewayClientOptions, callGatewayFromCli, type GatewayRpcOpts } from "./gateway-rpc.js";
 
+export { READ_ONLY_AUTH_COMMAND_PATHS } from "./secrets-cli.read-only-paths.js";
+
 type SecretsReloadOptions = GatewayRpcOpts & { json?: boolean };
 type SecretsAuditOptions = {
   check?: boolean;
@@ -81,6 +83,10 @@ export function registerSecretsCli(program: Command) {
     }
   });
 
+  // SECURITY: renaming or aliasing this command requires updating
+  // READ_ONLY_AUTH_COMMAND_PATHS in ./secrets-cli.read-only-paths.ts — the
+  // regression test in secrets-cli.read-only-paths.test.ts enforces this
+  // binding.
   secrets
     .command("audit")
     .description("Audit plaintext secrets, unresolved refs, and precedence drift")

--- a/src/entry.read-only-auth.test.ts
+++ b/src/entry.read-only-auth.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { shouldForceReadOnlyAuthStore } from "./entry.js";
+
+describe("shouldForceReadOnlyAuthStore", () => {
+  it("returns true for a direct `secrets audit` invocation", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "audit"])).toBe(true);
+  });
+
+  it("returns true when an option separates the parent and the leaf", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "--json", "audit"])).toBe(
+      true,
+    );
+  });
+
+  it("returns true when trailing options follow the command path", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "audit", "--check"])).toBe(
+      true,
+    );
+  });
+
+  it("returns true when leading options precede the command path", () => {
+    expect(
+      shouldForceReadOnlyAuthStore(["node", "openclaw", "--no-color", "secrets", "audit"]),
+    ).toBe(true);
+  });
+
+  it("returns false for a sibling command under the same parent", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets", "list"])).toBe(false);
+  });
+
+  it("returns false for the parent alone", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "secrets"])).toBe(false);
+  });
+
+  it("returns false for the leaf alone (wrong parent scope)", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "audit"])).toBe(false);
+  });
+
+  it("returns false for an empty invocation", () => {
+    expect(shouldForceReadOnlyAuthStore([])).toBe(false);
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw"])).toBe(false);
+  });
+
+  it("returns false when the two tokens appear in reversed order", () => {
+    expect(shouldForceReadOnlyAuthStore(["node", "openclaw", "audit", "secrets"])).toBe(false);
+  });
+});
+
+describe("OPENCLAW_AUTH_STORE_READONLY integration with the gate", () => {
+  const originalArgv = process.argv;
+  const originalEnv = process.env.OPENCLAW_AUTH_STORE_READONLY;
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_AUTH_STORE_READONLY;
+    } else {
+      process.env.OPENCLAW_AUTH_STORE_READONLY = originalEnv;
+    }
+  });
+
+  it("sets the env to '1' when the gate matches production argv", () => {
+    process.argv = ["node", "openclaw", "secrets", "audit"];
+    delete process.env.OPENCLAW_AUTH_STORE_READONLY;
+    if (shouldForceReadOnlyAuthStore(process.argv)) {
+      process.env.OPENCLAW_AUTH_STORE_READONLY = "1";
+    }
+    expect(process.env.OPENCLAW_AUTH_STORE_READONLY).toBe("1");
+  });
+
+  it("leaves the env unset when the gate does not match", () => {
+    process.argv = ["node", "openclaw", "secrets", "list"];
+    delete process.env.OPENCLAW_AUTH_STORE_READONLY;
+    if (shouldForceReadOnlyAuthStore(process.argv)) {
+      process.env.OPENCLAW_AUTH_STORE_READONLY = "1";
+    }
+    expect(process.env.OPENCLAW_AUTH_STORE_READONLY).toBeUndefined();
+  });
+});

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { isRootHelpInvocation, isRootVersionInvocation } from "./cli/argv.js";
 import { parseCliContainerArgs, resolveCliContainerTarget } from "./cli/container-target.js";
 import { applyCliProfileEnv, parseCliProfileArgs } from "./cli/profile.js";
+import { READ_ONLY_AUTH_COMMAND_PATHS } from "./cli/secrets-cli.read-only-paths.js";
 import { normalizeWindowsArgv } from "./cli/windows-argv.js";
 import { buildCliRespawnPlan } from "./entry.respawn.js";
 import { isTruthyEnvValue, normalizeEnv } from "./infra/env.js";
@@ -19,11 +20,25 @@ const ENTRY_WRAPPER_PAIRS = [
   { wrapperBasename: "openclaw.js", entryBasename: "entry.js" },
 ] as const;
 
-function shouldForceReadOnlyAuthStore(argv: string[]): boolean {
+/** @internal Exported for test. */
+export function shouldForceReadOnlyAuthStore(argv: string[]): boolean {
   const tokens = argv.slice(2).filter((token) => token.length > 0 && !token.startsWith("-"));
-  for (let index = 0; index < tokens.length - 1; index += 1) {
-    if (tokens[index] === "secrets" && tokens[index + 1] === "audit") {
-      return true;
+  for (const path of READ_ONLY_AUTH_COMMAND_PATHS) {
+    if (path.length === 0 || path.length > tokens.length) {
+      continue;
+    }
+    const lastStart = tokens.length - path.length;
+    for (let start = 0; start <= lastStart; start += 1) {
+      let matched = true;
+      for (let offset = 0; offset < path.length; offset += 1) {
+        if (tokens[start + offset] !== path[offset]) {
+          matched = false;
+          break;
+        }
+      }
+      if (matched) {
+        return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
## Summary

- Problem: `src/entry.ts:22-30` flipped `OPENCLAW_AUTH_STORE_READONLY=1` by argv-sniffing the literal adjacent tokens `"secrets" "audit"`. A subcommand rename, alias, or any option inserted between the two tokens would silently lose the read-only guarantee — the whole point of that env is to prevent `secrets audit` from mutating credential storage.
- Why it matters: security-sensitive hardening. "Silent security regression on rename" becomes "loud CI failure."
- What changed: Replaced the inline argv-sniff with a structured manifest (`READ_ONLY_AUTH_COMMAND_PATHS`) exported from a dedicated pure-data module and imported by `entry.ts`. A regression-guard test walks the Commander command tree and fails if any manifest entry no longer resolves to a real subcommand.
- What did NOT change (scope boundary): the two env consumer sites (`src/agents/pi-model-discovery.ts:156`, `src/agents/auth-profiles/store.ts:230`). No preAction hook added — the existing pre-parse gate remains the single defense-in-depth layer. No changes to `runSecretsAudit` or the audit business logic.

## Change Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related: #68803 (populates `.planning/phases/entry-auth-gate/` with the research + plan docs for this change; can land in either order)
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: control-flow-by-argv-sniffing. Lexical match (two literal tokens) for a semantic property (audit-never-mutates). Any rename, alias, or `--option`-between-tokens shift breaks the match silently.
- Missing detection / guardrail: no test asserted that the argv-sniff and the registered Commander subcommand name stayed consistent.
- Contributing context (if known): surfaced during a `/gsd:map-codebase` audit pass; listed as the smallest self-contained security concern in the codebase snapshot.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/cli/secrets-cli.read-only-paths.test.ts` (new).
- Scenario the test locks in: every manifest entry (currently `["secrets", "audit"]`) must resolve to an actual registered Commander subcommand path. If `.command("audit")` is renamed to `.command("audit2")` without updating the manifest, the test fails with a targeted error message naming the drifted path and pointing at the two binding sites.
- Why this is the smallest reliable guardrail: the bug is entirely inside the mapping between the entry gate and the subcli registration. A tree-walk test catches drift without spinning up a gateway.
- Existing test that already covers this: none. The two existing nearest tests (`src/cli/secrets-cli.test.ts`, `src/secrets/audit.test.ts`) cover audit behavior, not the env-gate binding.

## User-visible / Behavior Changes

None. Internal refactor; semantic behavior of `secrets audit` is unchanged.

## Diagram

```text
Before:
argv -> entry.ts argv-sniff (literal "secrets" + "audit") -> OPENCLAW_AUTH_STORE_READONLY=1
          ^ rename/alias silently bypasses

After:
argv -> entry.ts -> iterate READ_ONLY_AUTH_COMMAND_PATHS -> OPENCLAW_AUTH_STORE_READONLY=1
                       ^ manifest imported from dedicated module
                       ^ regression-guard test asserts every entry resolves in the registered Commander tree
                       ^ rename without manifest edit = red CI
```

## Security Impact

- New permissions/capabilities? No.
- Secrets/tokens handling changed? Yes — the read-only auth store gate is now resilient against silent-regression on command rename. No new data flows, no new storage paths.
- New/changed network calls? No.
- Command/tool execution surface changed? No.
- Data access scope changed? No.

## Repro + Verification

### Environment

- OS: macOS 15.x (Darwin 25.3.0)
- Runtime: Node 22 / pnpm 10.33.0
- Model/provider: N/A
- Integration/channel: N/A

### Steps

1. Check out this branch.
2. `pnpm install && pnpm check && pnpm test src/entry.read-only-auth.test.ts src/cli/secrets-cli.read-only-paths.test.ts`.
3. `pnpm build` and grep `dist/entry.js` for `registerSecretsCli` — expected 0 hits (proves the manifest import did not pull the full secrets subcli into the cold-path entry bundle).
4. Scratch edit: change `.command("audit")` → `.command("audit2")` in `src/cli/secrets-cli.ts`; rerun the regression-guard test; observe the expected targeted failure message. Revert.

### Expected

- `pnpm check` green. 14 new tests pass. No `"secrets"` or `"audit"` string literals inside `shouldForceReadOnlyAuthStore`. Build clean, cold-path bundle free of secrets subcli references.

### Actual

- `pnpm check` green. `pnpm test` on both new files → 14/14 pass. `pnpm build` → 0 `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings. `dist/entry.js` imports the manifest from a dedicated chunk (`secrets-cli.read-only-paths-*.js`); 0 references to `registerSecretsCli` or `runSecretsAudit`.

## Evidence

- [x] Passing tests locally (`pnpm check` + scoped tests + full `pnpm build`)
- [x] Manual drift test: renamed the audit subcommand and confirmed the regression-guard test fails with the expected targeted message

## Human Verification

- Verified scenarios: positive argv (`secrets audit`), option-between-tokens (`secrets --json audit`), trailing options (`secrets audit --check`), leading options (`--no-color secrets audit`), sibling (`secrets list`), parent alone, leaf alone, empty invocation, reversed tokens, full-gate integration test on `process.env`.
- Edge cases checked: manually renamed `.command("audit")` → `.command("audit2")` in a scratch edit and confirmed the regression-guard test fails with the expected error message; reverted.
- What I did not verify: production CLI observation — this is a pre-parse change that fires once per invocation, so runtime observation adds nothing that the unit tests do not already lock in.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes — internal refactor with identical external behavior.
- Config/env changes? No.
- Migration needed? No.

## Risks and Mitigations

- Risk: someone adds a new read-only-required command in the future and forgets to add it to the manifest.
  - Mitigation: a SECURITY comment sits directly above `.command("audit")` in `src/cli/secrets-cli.ts` pointing at the manifest; the manifest's JSDoc documents the binding invariant and the regression-guard test.
- Risk: the manifest import drags the full secrets subcli into the cold-path entry bundle.
  - Mitigation: the manifest lives in its own pure-data module (`secrets-cli.read-only-paths.ts`) with zero imports. `dist/entry.js` was inspected post-build; 0 references to `registerSecretsCli` or `runSecretsAudit`.
- Risk: the option-stripping filter hides a future path component that legitimately starts with `-`.
  - Mitigation: JSDoc on the manifest file explicitly documents this constraint. No current Commander subcommand names start with `-`.
- Risk: the approach does not make the read-only property a property of the command itself (Approach C in the accompanying RESEARCH.md).
  - Mitigation: RESEARCH.md documents Approach C as a viable follow-up if a broader command-metadata pattern emerges; this PR intentionally keeps scope to the single two-file surgical change that makes drift detectable.
