### PR TITLE
Fix: skip Homebrew prompt on platforms brew doesn't support (Resolves #68893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/onboarding: keep the skills Homebrew recommendation limited to macOS and Linux so FreeBSD and other unsupported hosts can configure skills without brew install prompts. Fixes #68893. (#69002) Thanks @Mlightsnow, @JustInCache, and @nnish16.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -186,4 +186,29 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
   });
+
+  it("does not recommend Homebrew on platforms brew doesn't support (e.g. FreeBSD)", async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+    Object.defineProperty(process, "platform", { value: "freebsd", configurable: true });
+    try {
+      mockMissingBrewStatus([
+        createBundledSkill({
+          name: "video-frames",
+          description: "ffmpeg",
+          bins: ["ffmpeg"],
+          installLabel: "Install ffmpeg (brew)",
+        }),
+      ]);
+
+      const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+      const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+      expect(brewNote).toBeUndefined();
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, "platform", originalPlatform);
+      }
+    }
+  });
 });

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -28,6 +28,22 @@ vi.mock("./onboard-helpers.js", () => ({
 
 import { setupSkills } from "./onboard-skills.js";
 
+function platformSupportsBrewRecommendation(platform: NodeJS.Platform = process.platform): boolean {
+  return platform === "darwin" || platform === "linux";
+}
+
+async function withMockedPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+  try {
+    return await fn();
+  } finally {
+    if (originalPlatform) {
+      Object.defineProperty(process, "platform", originalPlatform);
+    }
+  }
+}
+
 function createBundledSkill(params: {
   name: string;
   description: string;
@@ -135,7 +151,7 @@ const runtime: RuntimeEnv = {
 
 describe("setupSkills", () => {
   it("does not recommend Homebrew when user skips installing brew-backed deps", async () => {
-    if (process.platform === "win32") {
+    if (!platformSupportsBrewRecommendation()) {
       return;
     }
 
@@ -167,7 +183,7 @@ describe("setupSkills", () => {
   });
 
   it("recommends Homebrew when user selects a brew-backed install and brew is missing", async () => {
-    if (process.platform === "win32") {
+    if (!platformSupportsBrewRecommendation()) {
       return;
     }
 
@@ -187,28 +203,51 @@ describe("setupSkills", () => {
     expect(brewNote).toBeDefined();
   });
 
-  it("does not recommend Homebrew on platforms brew doesn't support (e.g. FreeBSD)", async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-    Object.defineProperty(process, "platform", { value: "freebsd", configurable: true });
-    try {
-      mockMissingBrewStatus([
-        createBundledSkill({
-          name: "video-frames",
-          description: "ffmpeg",
-          bins: ["ffmpeg"],
-          installLabel: "Install ffmpeg (brew)",
-        }),
-      ]);
+  it.each(["freebsd", "openbsd", "sunos"] as const)(
+    "does not recommend Homebrew on unsupported %s hosts",
+    async (platform) => {
+      await withMockedPlatform(platform, async () => {
+        expect(platformSupportsBrewRecommendation()).toBe(false);
 
-      const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
-      await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+        mockMissingBrewStatus([
+          createBundledSkill({
+            name: "video-frames",
+            description: "ffmpeg",
+            bins: ["ffmpeg"],
+            installLabel: "Install ffmpeg (brew)",
+          }),
+        ]);
 
-      const brewNote = notes.find((n) => n.title === "Homebrew recommended");
-      expect(brewNote).toBeUndefined();
-    } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, "platform", originalPlatform);
-      }
-    }
-  });
+        const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+        await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+        const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+        expect(brewNote).toBeUndefined();
+      });
+    },
+  );
+
+  it.each(["darwin", "linux"] as const)(
+    "recognizes %s hosts as Homebrew recommendation targets",
+    async (platform) => {
+      await withMockedPlatform(platform, async () => {
+        expect(platformSupportsBrewRecommendation()).toBe(true);
+
+        mockMissingBrewStatus([
+          createBundledSkill({
+            name: "video-frames",
+            description: "ffmpeg",
+            bins: ["ffmpeg"],
+            installLabel: "Install ffmpeg (brew)",
+          }),
+        ]);
+
+        const { prompter, notes } = createPrompter({ multiselect: ["video-frames"] });
+        await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+        const brewNote = notes.find((n) => n.title === "Homebrew recommended");
+        expect(brewNote).toBeDefined();
+      });
+    },
+  );
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -108,8 +108,11 @@ export async function setupSkills(
       .map((name) => installable.find((s) => s.name === name))
       .filter((item): item is (typeof installable)[number] => Boolean(item));
 
+    // Homebrew officially supports macOS and Linux only; don't recommend it on
+    // FreeBSD/OpenBSD/other BSDs where it isn't available.
+    const platformSupportsBrew = process.platform === "darwin" || process.platform === "linux";
     const needsBrewPrompt =
-      process.platform !== "win32" &&
+      platformSupportsBrew &&
       selectedSkills.some((skill) => skill.install.some((option) => option.kind === "brew")) &&
       !(await detectBinary("brew"));
 


### PR DESCRIPTION
Fixes #68893.

## Problem

Running `openclaw onboard` on FreeBSD shows a "Homebrew recommended" note
and offers the Homebrew install shell command, even though Homebrew is not
available on FreeBSD (it only officially supports macOS and Linux).

## Fix

In `setupSkills`, gate the brew prompt on the platform actually supporting
Homebrew (`darwin` or `linux`) instead of just excluding Windows. FreeBSD,
OpenBSD, and other BSDs now skip the brew recommendation, consistent with
Homebrew's supported platforms.

## Testing

- Added a scoped test that stubs `process.platform = "freebsd"` and asserts
  the "Homebrew recommended" note is not emitted when a brew-backed skill
  is selected.
- `pnpm test src/commands/onboard-skills.test.ts` — 3 tests pass.
- `pnpm lint` on the touched files — clean.
- `pnpm format` — clean.

AI-assisted (Claude), lightly tested.