### PR TITLE
fix(gateway): prefer current route delivery context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/agent routing: prefer the current request route over stale persisted delivery context, preserve unchanged same-channel target fields, and compare channel targets canonically before treating them as changed. (#69010) Thanks @cgdusek.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { BARE_SESSION_RESET_PROMPT } from "../../auto-reply/reply/session-reset-prompt.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   getDetachedTaskLifecycleRuntime,
   resetDetachedTaskLifecycleRuntimeForTests,
@@ -12,6 +13,7 @@ import {
   resetTaskRegistryForTests,
 } from "../../tasks/task-registry.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { agentHandlers } from "./agent.js";
 import { chatHandlers } from "./chat.js";
 import { expectSubagentFollowupReactivation } from "./subagent-followup.test-helpers.js";
@@ -204,6 +206,42 @@ function buildExistingMainStoreEntry(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function setAgentTargetParsingRegistry() {
+  setActivePluginRegistry(
+    createTestRegistry([
+      {
+        pluginId: "slack",
+        source: "test",
+        plugin: {
+          id: "slack",
+          meta: {
+            id: "slack",
+            label: "Slack",
+            selectionLabel: "Slack",
+            docsPath: "/channels/slack",
+            blurb: "test stub",
+          },
+          capabilities: { chatTypes: ["channel"] },
+          config: {
+            listAccountIds: () => [],
+            resolveAccount: () => ({}),
+          },
+          messaging: {
+            parseExplicitTarget: ({ raw }: { raw: string }) => {
+              const trimmed = raw.trim();
+              const channelMatch = /^channel:(.+)$/i.exec(trimmed);
+              return {
+                to: channelMatch?.[1]?.trim() ?? trimmed,
+                chatType: "channel" as const,
+              };
+            },
+          },
+        },
+      },
+    ]),
+  );
+}
+
 function setupNewYorkTimeConfig(isoDate: string) {
   vi.useFakeTimers();
   vi.setSystemTime(new Date(isoDate)); // Wed Jan 28, 8:30 PM EST
@@ -366,6 +404,7 @@ describe("gateway agent handler", () => {
     resetTaskRegistryForTests();
     mocks.loadConfigReturn = {};
     mocks.resolveExplicitAgentSessionKey.mockReset().mockReturnValue(undefined);
+    setActivePluginRegistry(createTestRegistry());
     mocks.resolveBareResetBootstrapFileAccess.mockReset().mockReturnValue(true);
     mocks.listAgentIds.mockReset().mockReturnValue(["main"]);
   });
@@ -1215,6 +1254,357 @@ describe("gateway agent handler", () => {
     expect(callArgs.channel).toBe("telegram");
     expect(callArgs.messageChannel).toBe("webchat");
     expect(callArgs.runContext?.messageChannel).toBe("webchat");
+  });
+
+  it("uses the current request route over stale session delivery context", async () => {
+    const existingEntry = buildExistingMainStoreEntry({
+      deliveryContext: {
+        channel: "feishu",
+        to: "user:ou_stale",
+        accountId: "feishu-account",
+      },
+      lastChannel: "feishu",
+      lastTo: "user:ou_stale",
+      lastAccountId: "feishu-account",
+    });
+    mockMainSessionEntry(existingEntry);
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "discord turn",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        channel: "discord",
+        to: "channel:1472577149004283935",
+        accountId: "discord-account",
+        idempotencyKey: "test-discord-current-route",
+      },
+      { reqId: "discord-current-route-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      messageChannel?: string;
+      runContext?: {
+        messageChannel?: string;
+        currentChannelId?: string;
+        accountId?: string;
+      };
+    };
+    expect(callArgs.channel).toBe("discord");
+    expect(callArgs.to).toBe("channel:1472577149004283935");
+    expect(callArgs.accountId).toBe("discord-account");
+    expect(callArgs.messageChannel).toBe("discord");
+    expect(callArgs.runContext).toMatchObject({
+      messageChannel: "discord",
+      currentChannelId: "channel:1472577149004283935",
+      accountId: "discord-account",
+    });
+    expect(capturedEntry).toMatchObject({
+      deliveryContext: {
+        channel: "discord",
+        to: "channel:1472577149004283935",
+        accountId: "discord-account",
+      },
+      lastChannel: "discord",
+      lastTo: "channel:1472577149004283935",
+      lastAccountId: "discord-account",
+    });
+  });
+
+  it("uses a deliver-time same-channel request route over a stale session target", async () => {
+    const existingEntry = buildExistingMainStoreEntry({
+      deliveryContext: {
+        channel: "discord",
+        to: "channel:stale",
+        accountId: "discord-old",
+        threadId: "thread-old",
+      },
+      lastChannel: "discord",
+      lastTo: "channel:stale",
+      lastAccountId: "discord-old",
+      lastThreadId: "thread-old",
+    });
+    mockMainSessionEntry(existingEntry);
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "discord same-channel turn",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        channel: "discord",
+        to: "channel:fresh",
+        accountId: "discord-new",
+        idempotencyKey: "test-discord-same-channel-current-route",
+      },
+      { reqId: "discord-same-channel-current-route-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+      runContext?: {
+        currentChannelId?: string;
+        accountId?: string;
+      };
+    };
+    expect(callArgs.channel).toBe("discord");
+    expect(callArgs.to).toBe("channel:fresh");
+    expect(callArgs.accountId).toBe("discord-new");
+    expect(callArgs.threadId).toBeUndefined();
+    expect(callArgs.runContext).toMatchObject({
+      currentChannelId: "channel:fresh",
+      accountId: "discord-new",
+    });
+    const deliveryContext = capturedEntry?.deliveryContext as
+      | { channel?: string; to?: string; accountId?: string; threadId?: string }
+      | undefined;
+    expect(deliveryContext).toMatchObject({
+      channel: "discord",
+      to: "channel:fresh",
+      accountId: "discord-new",
+    });
+    expect(deliveryContext?.threadId).toBeUndefined();
+    expect(capturedEntry?.lastChannel).toBe("discord");
+    expect(capturedEntry?.lastTo).toBe("channel:fresh");
+    expect(capturedEntry?.lastAccountId).toBe("discord-new");
+    expect(capturedEntry?.lastThreadId).toBeUndefined();
+  });
+
+  it("preserves same-channel target fields when only the request thread changes", async () => {
+    const existingEntry = buildExistingMainStoreEntry({
+      deliveryContext: {
+        channel: "discord",
+        to: "channel:fresh",
+        accountId: "discord-account",
+        threadId: "thread-old",
+      },
+      lastChannel: "discord",
+      lastTo: "channel:fresh",
+      lastAccountId: "discord-account",
+      lastThreadId: "thread-old",
+    });
+    mockMainSessionEntry(existingEntry);
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "discord same-channel thread turn",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        channel: "discord",
+        threadId: "thread-new",
+        idempotencyKey: "test-discord-same-channel-thread-route",
+      },
+      { reqId: "discord-same-channel-thread-route-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+    };
+    expect(callArgs.channel).toBe("discord");
+    expect(callArgs.to).toBeUndefined();
+    expect(callArgs.accountId).toBeUndefined();
+    expect(callArgs.threadId).toBe("thread-new");
+    const deliveryContext = capturedEntry?.deliveryContext as
+      | { channel?: string; to?: string; accountId?: string; threadId?: string }
+      | undefined;
+    expect(deliveryContext).toMatchObject({
+      channel: "discord",
+      to: "channel:fresh",
+      accountId: "discord-account",
+      threadId: "thread-new",
+    });
+    expect(capturedEntry?.lastChannel).toBe("discord");
+    expect(capturedEntry?.lastTo).toBe("channel:fresh");
+    expect(capturedEntry?.lastAccountId).toBe("discord-account");
+    expect(capturedEntry?.lastThreadId).toBe("thread-new");
+  });
+
+  it("preserves the stored thread when the request target is canonically equivalent", async () => {
+    setAgentTargetParsingRegistry();
+    const existingEntry = buildExistingMainStoreEntry({
+      deliveryContext: {
+        channel: "slack",
+        to: "channel:C1",
+        accountId: "slack-account",
+        threadId: "1700.1",
+      },
+      lastChannel: "slack",
+      lastTo: "channel:C1",
+      lastAccountId: "slack-account",
+      lastThreadId: "1700.1",
+    });
+    mockMainSessionEntry(existingEntry);
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "slack equivalent route turn",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        channel: "slack",
+        to: "C1",
+        accountId: "slack-account",
+        idempotencyKey: "test-slack-equivalent-target-route",
+      },
+      { reqId: "slack-equivalent-target-route-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+    };
+    expect(callArgs.channel).toBe("slack");
+    expect(callArgs.to).toBe("C1");
+    expect(callArgs.accountId).toBe("slack-account");
+    expect(callArgs.threadId).toBe("1700.1");
+    const deliveryContext = capturedEntry?.deliveryContext as
+      | { channel?: string; to?: string; accountId?: string; threadId?: string }
+      | undefined;
+    expect(deliveryContext).toMatchObject({
+      channel: "slack",
+      to: "channel:C1",
+      accountId: "slack-account",
+      threadId: "1700.1",
+    });
+    expect(capturedEntry?.lastChannel).toBe("slack");
+    expect(capturedEntry?.lastTo).toBe("channel:C1");
+    expect(capturedEntry?.lastAccountId).toBe("slack-account");
+    expect(capturedEntry?.lastThreadId).toBe("1700.1");
+  });
+
+  it("keeps stored route fields when a channel-only request switches channel", async () => {
+    const existingEntry = buildExistingMainStoreEntry({
+      deliveryContext: {
+        channel: "feishu",
+        to: "user:ou_stale",
+        accountId: "feishu-account",
+        threadId: "feishu-thread",
+      },
+      lastChannel: "feishu",
+      lastTo: "user:ou_stale",
+      lastAccountId: "feishu-account",
+      lastThreadId: "feishu-thread",
+    });
+    mockMainSessionEntry(existingEntry);
+    let capturedEntry: Record<string, unknown> | undefined;
+    mocks.updateSessionStore.mockImplementation(async (_path, updater) => {
+      const store: Record<string, unknown> = {
+        "agent:main:main": { ...existingEntry },
+      };
+      const result = await updater(store);
+      capturedEntry = result as Record<string, unknown>;
+      return result;
+    });
+    mocks.agentCommand.mockResolvedValue({
+      payloads: [{ text: "ok" }],
+      meta: { durationMs: 100 },
+    });
+
+    await invokeAgent(
+      {
+        message: "discord channel-only turn",
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        deliver: true,
+        channel: "discord",
+        idempotencyKey: "test-discord-channel-only",
+      },
+      { reqId: "discord-channel-only-1" },
+    );
+
+    await waitForAssertion(() => expect(mocks.agentCommand).toHaveBeenCalled());
+    const callArgs = mocks.agentCommand.mock.calls.at(-1)?.[0] as {
+      channel?: string;
+      to?: string;
+      accountId?: string;
+      threadId?: string;
+    };
+    expect(callArgs.channel).toBe("discord");
+    expect(callArgs.to).toBeUndefined();
+    expect(callArgs.accountId).toBeUndefined();
+    expect(callArgs.threadId).toBeUndefined();
+    const deliveryContext = capturedEntry?.deliveryContext as
+      | { channel?: string; to?: string; accountId?: string; threadId?: string }
+      | undefined;
+    expect(deliveryContext).toMatchObject({
+      channel: "feishu",
+      to: "user:ou_stale",
+      accountId: "feishu-account",
+      threadId: "feishu-thread",
+    });
+    expect(capturedEntry?.lastChannel).toBe("feishu");
+    expect(capturedEntry?.lastTo).toBe("user:ou_stale");
+    expect(capturedEntry?.lastAccountId).toBe("feishu-account");
+    expect(capturedEntry?.lastThreadId).toBe("feishu-thread");
   });
 
   it("terminalizes successful async gateway agent runs in the shared task registry", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -23,6 +23,7 @@ import {
   buildSessionStartupContextPrelude,
   shouldApplyStartupContext,
 } from "../../auto-reply/reply/startup-context.js";
+import { resolveComparableTargetForChannel } from "../../channels/plugins/target-parsing.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import {
   evaluateSessionFreshness,
@@ -133,6 +134,45 @@ function resolveAllowModelOverrideFromClient(
 
 function resolveCanResetSessionFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   return resolveSenderIsOwnerFromClient(client);
+}
+
+function resolveComparableRouteTarget(params: {
+  channel?: string;
+  target?: string;
+}): string | undefined {
+  const rawTarget = normalizeOptionalString(params.target);
+  if (!rawTarget) {
+    return undefined;
+  }
+  if (!params.channel) {
+    return rawTarget;
+  }
+  try {
+    return (
+      resolveComparableTargetForChannel({
+        channel: params.channel,
+        rawTarget,
+      })?.to ?? rawTarget
+    );
+  } catch {
+    return rawTarget;
+  }
+}
+
+function routeTargetDiffers(params: {
+  channel?: string;
+  requestTo?: string;
+  sessionTo?: string;
+}): boolean {
+  const requestTarget = resolveComparableRouteTarget({
+    channel: params.channel,
+    target: params.requestTo,
+  });
+  const sessionTarget = resolveComparableRouteTarget({
+    channel: params.channel,
+    target: params.sessionTo,
+  });
+  return requestTarget != null && sessionTarget != null && requestTarget !== sessionTarget;
 }
 
 async function runSessionResetFromAgent(params: {
@@ -857,13 +897,61 @@ export const agentHandlers: GatewayRequestHandlers = {
         // string and numeric threadIds (e.g., Matrix uses integers).
         threadId: request.threadId,
       });
-      const effectiveDelivery = mergeDeliveryContext(
-        deliveryFields.deliveryContext,
-        requestDeliveryHint,
-      );
+      const requestChannel =
+        requestDeliveryHint?.channel && requestDeliveryHint.channel !== "last"
+          ? requestDeliveryHint.channel
+          : undefined;
+      const sessionDelivery = deliveryFields.deliveryContext;
+      const sessionChannel = sessionDelivery?.channel;
+      const requestHasConcreteTarget = requestDeliveryHint?.to != null;
+      const requestHasConcreteRoute =
+        requestHasConcreteTarget || requestDeliveryHint?.threadId != null;
+      const routeValueDiffers = (
+        requestValue: string | number | undefined,
+        sessionValue: string | number | undefined,
+      ) =>
+        requestValue != null &&
+        sessionValue != null &&
+        String(requestValue) !== String(sessionValue);
+      const channelConflictsWithSession =
+        requestChannel != null && sessionChannel != null && requestChannel !== sessionChannel;
+      const requestTargetDiffers = routeTargetDiffers({
+        channel: requestChannel ?? sessionChannel,
+        requestTo: requestDeliveryHint?.to,
+        sessionTo: sessionDelivery?.to,
+      });
+      const deliverRouteConflictsWithSession =
+        request.deliver === true &&
+        requestChannel != null &&
+        sessionChannel === requestChannel &&
+        requestHasConcreteRoute &&
+        (requestTargetDiffers ||
+          routeValueDiffers(requestDeliveryHint?.accountId, sessionDelivery?.accountId) ||
+          routeValueDiffers(requestDeliveryHint?.threadId, sessionDelivery?.threadId));
+      // Preserve existing session routes for normal follow-ups and channel-only
+      // turns. A request must include a concrete target before it can replace a
+      // conflicting persisted route.
+      const requestReplacesSessionRoute =
+        (channelConflictsWithSession && requestHasConcreteTarget) ||
+        deliverRouteConflictsWithSession;
+      const effectiveDelivery = channelConflictsWithSession
+        ? requestHasConcreteTarget
+          ? requestDeliveryHint
+          : sessionDelivery
+        : deliverRouteConflictsWithSession
+          ? requestTargetDiffers
+            ? normalizeDeliveryContext({
+                channel: requestDeliveryHint?.channel ?? sessionDelivery?.channel,
+                to: requestDeliveryHint?.to ?? sessionDelivery?.to,
+                accountId: requestDeliveryHint?.accountId ?? sessionDelivery?.accountId,
+                threadId: requestDeliveryHint?.threadId,
+              })
+            : mergeDeliveryContext(requestDeliveryHint, sessionDelivery)
+          : mergeDeliveryContext(sessionDelivery, requestDeliveryHint);
       const effectiveDeliveryFields = normalizeSessionDeliveryFields({
         deliveryContext: effectiveDelivery,
       });
+      const existingRouteFallback = requestReplacesSessionRoute ? undefined : entry;
       const nextEntryPatch: SessionEntry = {
         sessionId,
         updatedAt: now,
@@ -885,10 +973,11 @@ export const agentHandlers: GatewayRequestHandlers = {
         sendPolicy: entry?.sendPolicy,
         skillsSnapshot: entry?.skillsSnapshot,
         deliveryContext: effectiveDeliveryFields.deliveryContext,
-        lastChannel: effectiveDeliveryFields.lastChannel ?? entry?.lastChannel,
-        lastTo: effectiveDeliveryFields.lastTo ?? entry?.lastTo,
-        lastAccountId: effectiveDeliveryFields.lastAccountId ?? entry?.lastAccountId,
-        lastThreadId: effectiveDeliveryFields.lastThreadId ?? entry?.lastThreadId,
+        lastChannel: effectiveDeliveryFields.lastChannel ?? existingRouteFallback?.lastChannel,
+        lastTo: effectiveDeliveryFields.lastTo ?? existingRouteFallback?.lastTo,
+        lastAccountId:
+          effectiveDeliveryFields.lastAccountId ?? existingRouteFallback?.lastAccountId,
+        lastThreadId: effectiveDeliveryFields.lastThreadId ?? existingRouteFallback?.lastThreadId,
         modelOverride: entry?.modelOverride,
         providerOverride: entry?.providerOverride,
         label: labelValue,
@@ -1178,6 +1267,7 @@ export const agentHandlers: GatewayRequestHandlers = {
             groupId: resolvedGroupId,
             groupChannel: resolvedGroupChannel,
             groupSpace: resolvedGroupSpace,
+            currentChannelId: resolvedTo,
             currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
           },
           groupId: resolvedGroupId,


### PR DESCRIPTION
## Summary

- Fixes gateway agent delivery resolution so a concrete current request route (`channel`, `to`, `accountId`, `threadId`) wins over stale persisted session `deliveryContext` fields when the channels conflict.
- Clears stale route fields on channel switches when the new request does not provide replacement `to`/`accountId`/`threadId` values, avoiding mixed-channel routes.
- Preserves existing session-route behavior for normal follow-ups, `channel=last`, and same-channel existing-session routes.
- Compares same-channel targets through the channel parser so equivalent encodings do not clear stored threads.
- Populates `runContext.currentChannelId` from the resolved delivery target so downstream message-tool fallback inference sees the active route.
- Adds regression tests for the #68378 shape, channel-only stale-route clearing, same-channel partial updates, and canonical equivalent targets.

## Linked Issue/PR

- Closes #68378
- Related prior art: #22205 identified the missing `resolvedTo` -> `runContext.currentChannelId` propagation, but that PR is closed unmerged and does not address stale delivery-context precedence.
- Related but not duplicates: #45514, #65847, #33619, #39557, #51812, #52204 all describe adjacent multi-channel/stale-routing problems or other delivery paths; none is an open satisfactory PR for this gateway agent route-precedence bug.

## Root Cause / Diagnosis

`src/gateway/server-methods/agent.ts` built `requestDeliveryHint` from the active gateway request, but then merged it with the stored session `deliveryContext` in a way that made persisted fields authoritative. That let stale persisted fields, such as Feishu `channel`/`to`, override a current Discord request before the agent command and session update were assembled. The same path also did not pass the resolved target into `runContext.currentChannelId`, so tool fallback routing could miss the current route even when `resolvedTo` was known.

A second edge case appears when the request changes only `channel`: route-field fallback must not pair a new channel with stale `lastTo`/`lastAccountId`/`lastThreadId` from the old channel.

A third edge case appears when the request and session refer to the same target with different channel-owned encodings, such as Slack `C1` and `channel:C1`: raw string comparison can falsely treat that as a target change and clear the stored thread.

## Fix

- Detect when a concrete request channel conflicts with the stored session delivery channel.
- In that cross-channel conflict case, let the current request delivery hint win and use persisted delivery metadata only as fallback for fields provided by the current route.
- Clear stale last-route fields when the current channel conflicts and no replacement field is available.
- For same-channel route conflicts, preserve unchanged target/account/thread fields unless the concrete target itself changes.
- Compare request/session targets using the channel parser before treating `to` as a target change, preserving stored threads for equivalent target spellings.
- For non-conflict cases, keep existing session delivery precedence so `channel=last`, normal follow-ups, and existing subagent routes behave as before.
- Pass `resolvedTo` into `runContext.currentChannelId` alongside the existing channel/account/thread context.
- Lock the behavior with regression tests that start from stale Feishu metadata, assert Discord wins or stale route fields are cleared, preserve partial same-channel updates, and keep Slack threads when `C1` and `channel:C1` are equivalent.

## Duplicate Sweep

Searched GitHub issues/PRs for combinations of `#68378`, Discord/Feishu wrong-channel delivery, stale `deliveryContext`, gateway agent delivery, `currentChannelId`, and multi-channel session routing. Closest results:

- #22205: overlapping `currentChannelId` propagation only; closed unmerged; no stale context precedence fix or regression for #68378.
- #35451: broader `chat.send`/cron canonical route derivation; closed unmerged; different call sites.
- #67508: target-agent bound account propagation for Matrix subagent spawns; adjacent account routing, different bug.
- #45514, #65847, #33619, #39557, #51812, #52204: related issue reports/bug class, not acceptable duplicate PRs for this exact gateway agent request-route overwrite.

Conclusion: no duplicate or already-satisfactory PR found for #68378.

## Attribution

- Thanks @Suidge for the #68378 report and follow-up logs that isolated Discord input being delivered through Feishu outbound.
- Thanks @Galygious for prior analysis in #22205 around forwarding `resolvedTo` into `runContext.currentChannelId`; this PR incorporates that same missing-context piece and adds the route-precedence fix needed for #68378.

## Testing

Fresh `origin/main` base: `64089fd15ed4ba8296612b1a622d11b5662c8b96`

- `pnpm test -- src/gateway/server-methods/agent.test.ts -t "uses the current request route"`
- `pnpm test -- src/gateway/server-methods/agent.test.ts`
- `pnpm test -- src/gateway/server-methods/agent.test.ts -t "preserves the stored thread when the request target is canonically equivalent"`
- `pnpm test -- src/gateway/server-methods/agent.test.ts src/gateway/server.agent.gateway-server-agent-a.test.ts src/gateway/server.agent.gateway-server-agent-b.test.ts src/gateway/server.agent.subagent-delivery-context.test.ts`

The final command covers the CI shard failures observed after the first draft and now passes locally with 71 tests.

Scoped lint note: `pnpm lint -- src/gateway/server-methods/agent.ts src/gateway/server-methods/agent.test.ts` is currently blocked before linting these files by the existing `src/agents/skills/*` plugin SDK boundary type errors already present on `origin/main`.

## Review Follow-up

- Addressed and resolved Codex review thread about clearing stale route fields on channel-switch merges in `5825aede6c7568f8cec2af2653d4851bf3296d78`.
- Addressed and resolved Codex review thread about preserving unchanged same-channel route fields in `d8f4d09a343f30d82df2bdeea9541a707923a72d`.
- Addressed and resolved Codex review thread about canonical target comparison in `af7506771a0fd734024ecc2b51b23b7945f27b21`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

The change narrows routing behavior to prefer the active request route only when it conflicts with stale persisted delivery metadata, and preserves stored thread context for equivalent same-channel target spellings.
