### PR TITLE
fix(tui): raise streaming watchdog threshold to 120s and suppress false-positive warning

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -721,7 +721,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledWith(expect.stringContaining("streaming watchdog"));
+    /* Message is now suppressed — only the internal reset fires */
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
 
     handlers.dispose?.();
   });
@@ -847,7 +848,8 @@ describe("tui-event-handlers: streaming watchdog", () => {
 
     expect(setActivityStatus).toHaveBeenLastCalledWith("idle");
     expect(state.activeChatRunId).toBeNull();
-    expect(chatLog.addSystem).toHaveBeenCalledTimes(2);
+    /* Messages are now suppressed — only the internal reset fires */
+    expect(chatLog.addSystem).not.toHaveBeenCalled();
 
     handlers.dispose?.();
   });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -45,7 +45,7 @@ type EventHandlerContext = {
   streamingWatchdogMs?: number;
 };
 
-const DEFAULT_STREAMING_WATCHDOG_MS = 30_000;
+const DEFAULT_STREAMING_WATCHDOG_MS = 120_000;
 
 export function createEventHandlers(context: EventHandlerContext) {
   const {
@@ -103,11 +103,11 @@ export function createEventHandlers(context: EventHandlerContext) {
       streamingWatchdogRunId = null;
       state.activeChatRunId = null;
       setActivityStatus("idle");
-      chatLog.addSystem(
-        `streaming watchdog: no stream updates for ${Math.round(
-          streamingWatchdogMs / 1000,
-        )}s; resetting status. The backend may have dropped this run silently — send a new message to resync.`,
-      );
+      /* Watchdog fires silently — the internal reset (clearing activeChatRunId,
+         setting status idle) still happens, but the user-visible warning is
+         suppressed to avoid false-positive noise during long-running agent
+         turns (tool calls, sub-agent work, code generation).  The user can
+         always send a new message to resync if something is truly stuck. */
       tui.requestRender();
     }, streamingWatchdogMs);
     const maybeUnref = (streamingWatchdogTimer as { unref?: () => void }).unref;


### PR DESCRIPTION
## Problem

The TUI streaming watchdog is set to 30 seconds, which triggers false-positive warnings during healthy long-running agent turns:

```
streaming watchdog: no stream updates for 30s; resetting status. The backend may have dropped this run silently — send a new message to resync.
```

This fires regularly during:
- Tool calls that take >30s (browser automation, file operations, code generation)
- Sub-agent work
- Long Claude thinking turns
- Any agent turn where the backend is working but hasn't sent a stream delta

The alarming "backend may have dropped this run" message causes unnecessary user confusion.

## Changes

### `src/tui/tui-event-handlers.ts`
1. **Threshold**: `DEFAULT_STREAMING_WATCHDOG_MS` changed from `30_000` (30s) → `120_000` (120s)
2. **Message**: `chatLog.addSystem()` call replaced with a comment — warning suppressed entirely

### What's preserved
- Internal reset behavior: `activeChatRunId` cleared, `activityStatus` set to `idle`, `tui.requestRender()` called
- The `context.streamingWatchdogMs` override still works for custom values
- Setting `streamingWatchdogMs: 0` still disables the watchdog entirely

### `src/tui/tui-event-handlers.test.ts`
- Updated two test assertions to match the suppressed message behavior
- All other watchdog tests unchanged (timer behavior, disposal, run isolation)

## Rationale

The watchdog's internal reset (clearing stale run state, returning status to idle) is valuable. But the user-facing warning creates more confusion than it solves — users can always send a new message to resync if something is truly stuck, and the 120s threshold means the reset only fires for genuinely stalled connections rather than healthy long operations.