### PR TITLE
fix: cap tool-result details without false overflow

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -121,9 +121,7 @@ function estimateMessageChars(msg: AgentMessage): number {
 
   if (isToolResultMessage(msg)) {
     const content = getToolResultContent(msg);
-    let chars = estimateContentBlockChars(content);
-    const details = (msg as { details?: unknown }).details;
-    chars += estimateUnknownChars(details);
+    const chars = estimateContentBlockChars(content);
     const weightedChars = Math.ceil(
       chars * (CHARS_PER_TOKEN_ESTIMATE / TOOL_RESULT_CHARS_PER_TOKEN_ESTIMATE),
     );

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -69,6 +69,24 @@ function makeToolResultWithDetails(id: string, text: string, detailText: string)
   });
 }
 
+function makeToolResultWithAggregatedDetails(
+  id: string,
+  text: string,
+  aggregated: string,
+): AgentMessage {
+  return castAgentMessage({
+    role: "toolResult",
+    toolCallId: id,
+    toolName: "read",
+    content: [{ type: "text", text }],
+    details: {
+      aggregated,
+    },
+    isError: false,
+    timestamp: Date.now(),
+  });
+}
+
 function getToolResultText(msg: AgentMessage): string {
   const content = (msg as { content?: unknown }).content;
   if (typeof content === "string") {
@@ -190,6 +208,18 @@ describe("installToolResultContextGuard", () => {
     expectPiStyleTruncation(newResultText);
     expect(result.details).toBeUndefined();
     expect((contextForNextCall[0] as { details?: unknown }).details).toBeDefined();
+  });
+
+  it("does not count large tool-result details toward preemptive overflow estimation", async () => {
+    const agent = makeGuardableAgent();
+    const contextForNextCall = [
+      makeUser("u".repeat(3_000)),
+      makeToolResultWithAggregatedDetails("call_ok", "small output", "d".repeat(80_000)),
+    ];
+
+    const transformed = await applyGuardToContext(agent, contextForNextCall);
+
+    expect(transformed).toBe(contextForNextCall);
   });
 
   it("throws a preemptive overflow when total context still exceeds the high-water mark", async () => {

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -27,6 +27,25 @@ function appendToolResultText(sm: SessionManager, text: string) {
   );
 }
 
+function appendToolResultWithDetails(
+  sm: SessionManager,
+  details: Record<string, unknown>,
+  text = "ok",
+) {
+  sm.appendMessage(toolCallMessage);
+  sm.appendMessage(
+    asAppendMessage({
+      role: "toolResult",
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text }],
+      details,
+      isError: false,
+      timestamp: Date.now(),
+    }),
+  );
+}
+
 function appendAssistantToolCall(
   sm: SessionManager,
   params: { id: string; name: string; withArguments?: boolean },
@@ -386,6 +405,43 @@ describe("installSessionToolResultGuard", () => {
     const text = getToolResultText(getPersistedMessages(sm));
     expect(text.length).toBeLessThan(500_000);
     expect(text).toContain("truncated");
+  });
+
+  it("caps oversized top-level detail text fields during persistence", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      maxToolResultChars: 120,
+    });
+
+    appendToolResultWithDetails(sm, {
+      aggregated: "a".repeat(4_000),
+      stdout: "b".repeat(4_000),
+      stderr: "c".repeat(4_000),
+      output: "d".repeat(4_000),
+      untouched: "small",
+      nested: { stdout: "e".repeat(4_000) },
+    });
+
+    const toolResult = getPersistedMessages(sm).find(
+      (message) => message.role === "toolResult",
+    ) as {
+      details?: {
+        aggregated?: string;
+        stdout?: string;
+        stderr?: string;
+        output?: string;
+        untouched?: string;
+        nested?: { stdout?: string };
+      };
+    };
+
+    expect(toolResult.details?.aggregated?.length).toBeLessThanOrEqual(120);
+    expect(toolResult.details?.stdout?.length).toBeLessThanOrEqual(120);
+    expect(toolResult.details?.stderr?.length).toBeLessThanOrEqual(120);
+    expect(toolResult.details?.output?.length).toBeLessThanOrEqual(120);
+    expect(toolResult.details?.aggregated).toContain("truncated");
+    expect(toolResult.details?.untouched).toBe("small");
+    expect(toolResult.details?.nested?.stdout).toBe("e".repeat(4_000));
   });
 
   it("does not truncate tool results under the limit", () => {

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -10,6 +10,7 @@ import { formatContextLimitTruncationNotice } from "./pi-embedded-runner/tool-re
 import {
   DEFAULT_MAX_LIVE_TOOL_RESULT_CHARS,
   truncateToolResultMessage,
+  truncateToolResultText,
 } from "./pi-embedded-runner/tool-result-truncation.js";
 import {
   getRawSessionAppendMessage,
@@ -24,14 +25,61 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
  * Returns the original message if under the limit, or a new message with
  * truncated text blocks otherwise.
  */
+const TOOL_RESULT_DETAIL_TEXT_FIELDS = ["aggregated", "stdout", "stderr", "output"] as const;
+
+function capToolResultDetails(details: unknown, maxChars: number): unknown {
+  if (!details || typeof details !== "object" || Array.isArray(details)) {
+    return details;
+  }
+
+  const detailsRecord = details as Record<string, unknown>;
+  let changedDetails: Record<string, unknown> | null = null;
+
+  for (const field of TOOL_RESULT_DETAIL_TEXT_FIELDS) {
+    const value = detailsRecord[field];
+    if (typeof value !== "string" || value.length <= maxChars) {
+      continue;
+    }
+
+    const nextText = truncateToolResultText(value, maxChars, {
+      suffix: (truncatedChars) => formatContextLimitTruncationNotice(truncatedChars),
+      minKeepChars: 0,
+    });
+
+    if (!changedDetails) {
+      changedDetails = { ...detailsRecord };
+    }
+    changedDetails[field] = nextText;
+  }
+
+  return changedDetails ?? details;
+}
+
 function capToolResultSize(msg: AgentMessage, maxChars: number): AgentMessage {
   if ((msg as { role?: string }).role !== "toolResult") {
     return msg;
   }
-  return truncateToolResultMessage(msg, maxChars, {
+
+  const truncated = truncateToolResultMessage(msg, maxChars, {
     suffix: (truncatedChars) => formatContextLimitTruncationNotice(truncatedChars),
     minKeepChars: 2_000,
   });
+  const cappedDetails = capToolResultDetails(
+    (truncated as { details?: unknown }).details,
+    maxChars,
+  );
+
+  if (truncated === msg && cappedDetails === (truncated as { details?: unknown }).details) {
+    return msg;
+  }
+  if (cappedDetails === (truncated as { details?: unknown }).details) {
+    return truncated;
+  }
+
+  return {
+    ...(truncated as unknown as Record<string, unknown>),
+    details: cappedDetails,
+  } as AgentMessage;
 }
 
 function resolveMaxToolResultChars(opts?: { maxToolResultChars?: number }): number {


### PR DESCRIPTION
## Summary
- stop counting `toolResult.details` toward preemptive context overflow estimation
- cap oversized top-level detail payload fields during persistence using the same truncation notice path
- add regression coverage for the false-overflow case and persisted detail truncation

## Root cause
Visible `toolResult` content was already capped, but large hidden `details` payloads could still remain in the transcript. Those detail blobs were being counted by the context estimator, so sessions could trip the overflow guard even when the user-visible tool result content was already within budget.

## Testing
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/session-tool-result-guard.test.ts src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`
- `pnpm tsgo:all`
- `pnpm exec oxfmt --check src/agents/pi-embedded-runner/tool-result-char-estimator.ts src/agents/session-tool-result-guard.ts src/agents/pi-embedded-runner/tool-result-context-guard.test.ts src/agents/session-tool-result-guard.test.ts`
- `pnpm exec oxlint --type-aware --tsconfig tsconfig.oxlint.json --report-unused-disable-directives-severity error src`
- `pnpm exec oxlint --type-aware --tsconfig tsconfig.oxlint.json --report-unused-disable-directives-severity error test`
- `pnpm exec oxlint --type-aware --tsconfig tsconfig.oxlint.json --report-unused-disable-directives-severity error scripts`
- `pnpm exec oxlint --type-aware --tsconfig tsconfig.oxlint.json --report-unused-disable-directives-severity error extensions`

## Why it matters
- This fixes a false failure mode where sessions can trip the overflow guard even though the user-visible tool result content is already within budget.

## Scope Boundary
- tool-result overflow estimation and persisted detail truncation only
- does not expose more hidden tool payload content to the model

## Review Focus
- `src/agents/pi-embedded-runner/tool-result-char-estimator.ts`
- `src/agents/session-tool-result-guard.ts`
- `src/agents/pi-embedded-runner/tool-result-context-guard.test.ts`
- `src/agents/session-tool-result-guard.tool-result-persist-hook.test.ts`

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification
- Verified scenarios: false-overflow regression path and persisted top-level detail truncation path
- Edge cases checked: hidden `toolResult.details` remains large while visible tool result content is already capped
- What I did not verify: long-running live session smoke with a real oversized tool payload
