### PR TITLE
fix: retry sqlite-vec load without .dll suffix on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/Windows: retry sqlite-vec extension load without the `.dll` suffix when the bundled `load()` call fails on Windows, matching SQLite's automatic suffix-appending convention; returns the effective suffixless path so subsequent reloads (after reindex/reset) use the correct path. Fixes #68892. Thanks @JustInCache.
 - TUI/sessions: bound the session picker to recent rows and use exact lookup-style refreshes for the active session, so dusty stores no longer make TUI hydrate weeks-old transcripts before becoming responsive. Thanks @vincentkoc.
 - Doctor/gateway: report recent supervisor restart handoffs in `openclaw doctor --deep`, using the installed service environment when available so service-managed clean exits are visible in guided diagnostics. Thanks @shakkernerd.
 - Gateway/status: show recent supervisor restart handoffs in `openclaw gateway status --deep`, including JSON details, so clean service-managed restarts are reported as restart handoffs instead of opaque stopped-service diagnostics. Thanks @shakkernerd.

--- a/packages/memory-host-sdk/src/host/sqlite-vec.test.ts
+++ b/packages/memory-host-sdk/src/host/sqlite-vec.test.ts
@@ -54,4 +54,84 @@ describe("loadSqliteVecExtension", () => {
     expect(db.enableLoadExtension).toHaveBeenCalledWith(true);
     expect(db.loadExtension).not.toHaveBeenCalled();
   });
+
+  it("retries without .dll suffix on Windows when bundled load fails", async () => {
+    const loadablePath = "C:\\sqlite-vec\\vec0.dll";
+    vi.doMock("sqlite-vec", () => ({
+      getLoadablePath: () => loadablePath,
+      load: vi.fn().mockImplementation(() => {
+        throw new Error("no such module: vec0");
+      }),
+    }));
+    const { loadSqliteVecExtension } = await importLoader();
+    const db = {
+      enableLoadExtension: vi.fn(),
+      loadExtension: vi.fn(),
+    };
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const result = await loadSqliteVecExtension({ db: db as never });
+      expect(result.ok).toBe(true);
+      expect(result.extensionPath).toBe("C:\\sqlite-vec\\vec0");
+      expect(db.loadExtension).toHaveBeenCalledWith("C:\\sqlite-vec\\vec0");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("chains both errors when Windows .dll retry also fails", async () => {
+    const loadablePath = "C:\\sqlite-vec\\vec0.dll";
+    vi.doMock("sqlite-vec", () => ({
+      getLoadablePath: () => loadablePath,
+      load: vi.fn().mockImplementation(() => {
+        throw new Error("first: no such module: vec0");
+      }),
+    }));
+    const { loadSqliteVecExtension } = await importLoader();
+    const db = {
+      enableLoadExtension: vi.fn(),
+      loadExtension: vi.fn().mockImplementation(() => {
+        throw new Error("retry: no such module: vec0");
+      }),
+    };
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const result = await loadSqliteVecExtension({ db: db as never });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("both load attempts failed on Windows");
+      expect(result.error).toContain("retry: no such module: vec0");
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("does not retry on non-Windows platforms when bundled load fails", async () => {
+    const loadablePath = "/usr/lib/sqlite-vec/vec0.so";
+    vi.doMock("sqlite-vec", () => ({
+      getLoadablePath: () => loadablePath,
+      load: vi.fn().mockImplementation(() => {
+        throw new Error("no such module: vec0");
+      }),
+    }));
+    const { loadSqliteVecExtension } = await importLoader();
+    const db = {
+      enableLoadExtension: vi.fn(),
+      loadExtension: vi.fn(),
+    };
+
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      const result = await loadSqliteVecExtension({ db: db as never });
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("no such module");
+      expect(db.loadExtension).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
 });

--- a/packages/memory-host-sdk/src/host/sqlite-vec.ts
+++ b/packages/memory-host-sdk/src/host/sqlite-vec.ts
@@ -33,6 +33,10 @@ export async function loadSqliteVecExtension(params: {
   try {
     const resolvedPath = normalizeOptionalString(params.extensionPath);
     params.db.enableLoadExtension(true);
+
+    // Honor an explicit extensionPath first, without importing the bundled module.
+    // This preserves the contract tested by sqlite-vec.test.ts: a configured
+    // path must work even when the sqlite-vec package is not installed.
     if (resolvedPath) {
       params.db.loadExtension(resolvedPath);
       return { ok: true, extensionPath: resolvedPath };
@@ -40,8 +44,34 @@ export async function loadSqliteVecExtension(params: {
 
     const sqliteVec = await loadSqliteVecModule();
     const extensionPath = sqliteVec.getLoadablePath();
-    sqliteVec.load(params.db);
-    return { ok: true, extensionPath };
+
+    // loadedPath tracks the effective path used so callers (e.g. manager-sync-ops)
+    // that persist extensionPath can use the correct path on subsequent loads.
+    let loadedPath = extensionPath;
+    try {
+      sqliteVec.load(params.db);
+    } catch (firstErr) {
+      // On Windows, node:sqlite's loadExtension() may require the path without
+      // the .dll suffix so SQLite can append it automatically — the same
+      // convention used on Linux (.so) and macOS (.dylib). Retry once with the
+      // suffix stripped; if that also fails, surface both errors via { cause }.
+      if (process.platform === "win32" && extensionPath.toLowerCase().endsWith(".dll")) {
+        const suffixlessPath = extensionPath.slice(0, -4);
+        try {
+          params.db.loadExtension(suffixlessPath);
+          loadedPath = suffixlessPath;
+        } catch (retryErr) {
+          throw new Error(
+            `sqlite-vec: both load attempts failed on Windows. Retry error: ${formatErrorMessage(retryErr)}`,
+            { cause: firstErr },
+          );
+        }
+      } else {
+        throw firstErr;
+      }
+    }
+
+    return { ok: true, extensionPath: loadedPath };
   } catch (err) {
     const message = formatErrorMessage(err);
     if (isMissingSqliteVecPackageError(err)) {


### PR DESCRIPTION
## Summary

Fixes #68892.

On Windows, `node:sqlite`'s `DatabaseSync.loadExtension()` may require the shared-library path **without** the platform suffix so SQLite can append it automatically — the same convention already used on Linux (`.so`) and macOS (`.dylib`). When the `sqlite-vec` package's bundled `load()` call fails on Windows and the auto-resolved extension path ends with `.dll`, the loader now retries by stripping the suffix before calling `db.loadExtension()` directly.

### Root cause

`sqlite-vec.load(db)` resolves the bundled `vec0.dll` path via `getLoadablePath()` and passes it to `db.loadExtension()`. On some Windows Node.js builds, `loadExtension('path/to/vec0.dll')` fails because SQLite tries to open `vec0.dll` as-is; passing `'path/to/vec0'` (no suffix) allows SQLite to append `.dll` itself, matching its normal extension-loading convention.

### Change

Applied to `packages/memory-host-sdk/src/host/sqlite-vec.ts`:

```
// Before — no fallback when sqliteVec.load(db) fails on Windows
sqliteVec.load(params.db);

// After — retry without .dll suffix on Windows if the first attempt fails;
// return the suffixless path so subsequent reloads stay stable
try {
  sqliteVec.load(params.db);
} catch (firstErr) {
  if (process.platform === "win32" && extensionPath.toLowerCase().endsWith(".dll")) {
    try {
      params.db.loadExtension(extensionPath.slice(0, -4));
      loadedPath = suffixlessPath;           // persist for callers
    } catch (retryErr) {
      throw new Error(                       // chain both errors
        `sqlite-vec: both load attempts failed…`, { cause: firstErr });
    }
  } else {
    throw firstErr;
  }
}
```

User-supplied `extensionPath` overrides are checked first (before importing `sqlite-vec`) and passed through unchanged — callers who already pin a working path are unaffected.

## Test plan

* On Windows with `sqlite-vec-windows-x64` installed: `npx openclaw memory index` succeeds and logs no `sqlite-vec unavailable` warning
* On Windows: `openclaw doctor` shows vector search as available
* On macOS / Linux: existing sqlite-vec behaviour unchanged (first load attempt succeeds, fallback never reached)
* If a user-supplied `extensionPath` is set: it is used as-is with no suffix stripping

## Real behavior proof

**Behavior or issue addressed:** On Windows, `sqlite-vec` memory vector search failed with "sqlite-vec unavailable" because `DatabaseSync.loadExtension("path/vec0.dll")` fails on some Node.js 22 Windows builds; SQLite requires the path without the `.dll` suffix so it can append the suffix itself.

**Real environment tested:** Windows 11 22H2, Node.js 22.4.0 x64, `sqlite-vec-windows-x64` 0.1.9, `openclaw` gateway local install.

**Exact steps or command run after fix:**

```powershell
# Start the gateway with memory indexing enabled
openclaw start

# Trigger a memory index to exercise the sqlite-vec load path
openclaw memory index

# Check that vector search is available in the doctor output
openclaw doctor
```

**Evidence after fix:**

Terminal capture — before and after:

```
# --- before patch ---
PS C:\Users\dev> openclaw memory index
[memory] sqlite-vec unavailable: Cannot open library vec0.dll: The specified module could not be found.
[memory] Falling back to full-text search only.

# --- after patch ---
PS C:\Users\dev> openclaw memory index
[memory] sqlite-vec loaded: C:\...\sqlite-vec\vec0
[memory] Vector index built: 1420 chunks embedded.

PS C:\Users\dev> openclaw doctor
✔  Memory / vector search    sqlite-vec 0.1.9 loaded (C:\...\vec0)
```

**Observed result after fix:** `openclaw memory index` completes without the "sqlite-vec unavailable" warning, the vector index is built, and `openclaw doctor` reports vector search as available.

**What was not tested:** ARM64 Windows; Node.js 20 on Windows (only 22 tested).