### PR TITLE
fix(agents): scope attempt-execution session-history guard to latest-user-answered

### DIFF
--- a/src/agents/command/attempt-execution.helpers.ts
+++ b/src/agents/command/attempt-execution.helpers.ts
@@ -12,9 +12,16 @@ import {
 const SESSION_FILE_MAX_RECORDS = 500;
 
 /**
- * Check whether a session transcript file exists and contains at least one
- * assistant message, indicating that the SessionManager has flushed the
- * initial user+assistant exchange to disk.
+ * Check whether a session transcript shows that the latest user message has
+ * already been answered — that is, there exists an assistant message **after**
+ * the most recent user message in the flushed session file.
+ *
+ * This is narrower than "has any assistant message anywhere in the transcript":
+ * the fallback-retry path in attempt-execution needs to decide whether to treat
+ * the current turn as a "continue where you left off" follow-up. A transcript
+ * with only prior-turn assistant messages (and a fresh unanswered user turn on
+ * top) must NOT count as "already answered" — otherwise the retry context gets
+ * injected and the fallback model re-answers a stale turn (#69086).
  */
 export async function sessionFileHasContent(sessionFile: string | undefined): Promise<boolean> {
   if (!sessionFile) {
@@ -31,6 +38,7 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
     try {
       const rl = readline.createInterface({ input: fh.createReadStream({ encoding: "utf-8" }) });
       let recordCount = 0;
+      let hasAssistantAfterLatestUser = false;
       for await (const line of rl) {
         if (!line.trim()) {
           continue;
@@ -46,14 +54,21 @@ export async function sessionFileHasContent(sessionFile: string | undefined): Pr
           continue;
         }
         const rec = obj as Record<string, unknown> | null;
-        if (
-          rec?.type === "message" &&
-          (rec.message as Record<string, unknown> | undefined)?.role === "assistant"
-        ) {
-          return true;
+        if (rec?.type !== "message") {
+          continue;
+        }
+        const role = (rec.message as Record<string, unknown> | undefined)?.role;
+        if (role === "user") {
+          // A newer user turn has not been answered yet. Reset the guard so
+          // only an assistant message AFTER this line flips it back to true.
+          hasAssistantAfterLatestUser = false;
+          continue;
+        }
+        if (role === "assistant") {
+          hasAssistantAfterLatestUser = true;
         }
       }
-      return false;
+      return hasAssistantAfterLatestUser;
     } finally {
       await fh.close();
     }

--- a/src/agents/command/attempt-execution.test.ts
+++ b/src/agents/command/attempt-execution.test.ts
@@ -149,6 +149,43 @@ describe("sessionFileHasContent", () => {
     expect(await sessionFileHasContent(file)).toBe(true);
   });
 
+  it("returns false when a fresh user turn follows a prior answered turn (#69086)", async () => {
+    // Prior round-trip (answered), then a new user message with no assistant
+    // response yet. The guard must NOT mis-classify this as "already
+    // answered" — the reporter's setup had the fallback-retry path injecting
+    // a continuation prompt over a fresh unanswered user question.
+    const file = path.join(tmpDir, "newest-user-unanswered.jsonl");
+    await fs.writeFile(
+      file,
+      [
+        '{"type":"session","id":"s1"}',
+        '{"type":"message","message":{"role":"user","content":"first question"}}',
+        '{"type":"message","message":{"role":"assistant","content":"first answer"}}',
+        '{"type":"message","message":{"role":"user","content":"second question"}}',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(false);
+  });
+
+  it("returns true when an assistant message follows the latest user turn", async () => {
+    const file = path.join(tmpDir, "latest-user-answered.jsonl");
+    await fs.writeFile(
+      file,
+      [
+        '{"type":"session","id":"s1"}',
+        '{"type":"message","message":{"role":"user","content":"q1"}}',
+        '{"type":"message","message":{"role":"assistant","content":"a1"}}',
+        '{"type":"message","message":{"role":"user","content":"q2"}}',
+        '{"type":"message","message":{"role":"assistant","content":"a2"}}',
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    expect(await sessionFileHasContent(file)).toBe(true);
+  });
+
   it("returns false when session file is a symbolic link", async () => {
     const realFile = path.join(tmpDir, "real.jsonl");
     await fs.writeFile(


### PR DESCRIPTION
## Problem

\`sessionFileHasContent\` in \`src/agents/command/attempt-execution.helpers.ts\` returned \`true\` as soon as it saw ANY assistant message anywhere in the flushed session transcript. The fallback-retry path uses that boolean as \"has the newest user turn already been answered?\" — but the semantics didn't match: a transcript with a prior answered turn plus a fresh unanswered user message still returned \`true\`.

Consequence, as reported by @kenners22 in #69086:

- The fallback-retry path prepended \`[Retry after the previous model attempt failed or timed out]\` over a fresh unanswered question.
- The fallback model treated the fresh turn as a retry of a prior one and re-issued a stale response.
- In the reporter's logs, this fired hundreds of times on a box hitting timeout-retry loops (\`628 occurrences in gateway.err.log + 370 in the rotated log\`).

## Fix

Track \`hasAssistantAfterLatestUser\` instead of \`hasAnyAssistant\`. A newer user message resets the flag; only an assistant message AFTER that user message flips it back to true. Matches the semantics the caller actually wants.

The retry-prompt wording itself (Bug 2 in the issue) is intentionally out of scope here — the repo already shifted from full-body replacement to the prepend shape via #65760, and the hook/override ask is a separate feature discussion.

## Testing

\`tsc --noEmit\` and \`oxlint\` clean on touched files.

Added 2 new regression tests in \`attempt-execution.test.ts\`:

- \`returns false when a fresh user turn follows a prior answered turn\` — the exact shape from #69086 (user → assistant → user with no trailing assistant).
- \`returns true when an assistant message follows the latest user turn\` — guards against over-correcting the narrower check.

All existing tests in the file still pass (the \"has assistant message\" case now also has a matching \"answered\" pattern).

Fixes #69086