### PR TITLE
fix(gateway): drain pending replies before restart shutdown

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -868,6 +868,41 @@ describe("qa mock openai server", () => {
     });
   });
 
+  it("plans thread memory search when the trigger appears outside the last user text", async () => {
+    const server = await startMockServer();
+
+    const responseText = await expectResponsesText(server, {
+      stream: true,
+      instructions:
+        "Runtime context: @openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first.",
+      input: [makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan.")],
+    });
+
+    expect(responseText).toContain('"name":"memory_search"');
+    expect(responseText).toContain("hidden thread codename ORBIT-22");
+  });
+
+  it("answers thread memory prompts after memory tool output", async () => {
+    const server = await startMockServer();
+
+    const response = await expectResponsesJson<Record<string, unknown>>(server, {
+      stream: false,
+      instructions:
+        "Runtime context: @openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first.",
+      input: [
+        makeUserInput("Protocol note: acknowledged. Continue with the QA scenario plan."),
+        {
+          type: "function_call_output",
+          output: JSON.stringify({ text: "Thread-hidden codename: ORBIT-22." }),
+        },
+      ],
+    });
+
+    expect(JSON.stringify(response)).toContain(
+      "Protocol note: I checked memory in-thread and the hidden thread codename is ORBIT-22.",
+    );
+  });
+
   it("plans memory tools and serves mock image generations", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -747,7 +747,7 @@ function buildAssistantText(
   if (/session memory ranking check/i.test(prompt) && orbitCode) {
     return `Protocol note: I checked memory and the current Project Nebula codename is ${orbitCode}.`;
   }
-  if (/thread memory check/i.test(prompt) && orbitCode) {
+  if (/(thread memory check|hidden thread codename)/i.test(allInputText) && orbitCode) {
     return `Protocol note: I checked memory in-thread and the hidden thread codename is ${orbitCode}.`;
   }
   if (/switch(?:ing)? models?/i.test(prompt)) {
@@ -1457,7 +1457,7 @@ async function buildResponsesPayload(
       });
     }
   }
-  if (/thread memory check/i.test(prompt)) {
+  if (/(thread memory check|hidden thread codename)/i.test(allInputText)) {
     if (!toolOutput) {
       return buildToolCallEventsWithArgs("memory_search", {
         query: "hidden thread codename ORBIT-22",

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import type { GatewayServer } from "../../gateway/server.impl.js";
 import type { GatewayBonjourBeacon } from "../../infra/bonjour-discovery.js";
 import { pickBeaconHost, pickGatewayPort } from "./discover.js";
 
@@ -161,7 +162,7 @@ function createRuntimeWithExitSignal(exitCallOrder?: string[]) {
   return { runtime, exited };
 }
 
-type GatewayCloseFn = (...args: unknown[]) => Promise<void>;
+type GatewayCloseFn = GatewayServer["close"];
 type LoopRuntime = {
   log: (...args: unknown[]) => void;
   error: (...args: unknown[]) => void;
@@ -200,8 +201,12 @@ async function waitForStart(started: Promise<void>) {
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
+function createCloseMock() {
+  return vi.fn<GatewayCloseFn>(async (_opts) => {});
+}
+
 async function createSignaledLoopHarness(exitCallOrder?: string[]) {
-  const close = vi.fn(async () => {});
+  const close = createCloseMock();
   const { start, started } = createSignaledStart(close);
   const { runtime, exited } = createRuntimeWithExitSignal(exitCallOrder);
   const { loopPromise } = await runLoopWithStart({ start, runtime });
@@ -234,8 +239,8 @@ describe("runGatewayLoop", () => {
     getActiveTaskCount.mockReturnValueOnce(1).mockReturnValue(0);
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const closeFirst = vi.fn(async () => {});
-      const closeSecond = vi.fn(async () => {});
+      const closeFirst = createCloseMock();
+      const closeSecond = createCloseMock();
       const { runtime, exited } = createRuntimeWithExitSignal();
       const start = vi
         .fn()
@@ -257,10 +262,16 @@ describe("runGatewayLoop", () => {
       expect(consumeGatewayRestartIntentSync).toHaveBeenCalledOnce();
       expect(markGatewayDraining).toHaveBeenCalledOnce();
       expect(waitForActiveTasks).toHaveBeenCalledWith(90_000);
-      expect(closeFirst).toHaveBeenCalledWith({
-        reason: "gateway restarting",
-        restartExpectedMs: 1500,
-      });
+      expect(closeFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+          drainTimeoutMs: expect.any(Number),
+        }),
+      );
+      const closeFirstArgs = closeFirst.mock.calls[0]?.[0];
+      expect(closeFirstArgs?.drainTimeoutMs).toBeLessThanOrEqual(90_000);
+      expect(closeFirstArgs?.drainTimeoutMs).toBeGreaterThanOrEqual(0);
       expect(start).toHaveBeenCalledTimes(2);
 
       sigint();
@@ -289,12 +300,16 @@ describe("runGatewayLoop", () => {
       waitForActiveEmbeddedRuns.mockResolvedValueOnce({ drained: true });
 
       type StartServer = () => Promise<{
-        close: (opts: { reason: string; restartExpectedMs: number | null }) => Promise<void>;
+        close: (opts: {
+          reason: string;
+          restartExpectedMs: number | null;
+          drainTimeoutMs?: number;
+        }) => Promise<void>;
       }>;
 
-      const closeFirst = vi.fn(async () => {});
-      const closeSecond = vi.fn(async () => {});
-      const closeThird = vi.fn(async () => {});
+      const closeFirst = createCloseMock();
+      const closeSecond = createCloseMock();
+      const closeThird = createCloseMock();
       const { runtime, exited } = createRuntimeWithExitSignal();
 
       const start = vi.fn<StartServer>();
@@ -349,10 +364,17 @@ describe("runGatewayLoop", () => {
       expect(abortEmbeddedPiRun).toHaveBeenCalledWith(undefined, { mode: "all" });
       expect(markGatewayDraining).toHaveBeenCalledTimes(1);
       expect(gatewayLog.warn).toHaveBeenCalledWith(DRAIN_TIMEOUT_LOG);
-      expect(closeFirst).toHaveBeenCalledWith({
-        reason: "gateway restarting",
-        restartExpectedMs: 1500,
-      });
+      expect(closeFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+          drainTimeoutMs: expect.any(Number),
+        }),
+      );
+      const closeFirstArgs = closeFirst.mock.calls[0]?.[0];
+      expect(closeFirstArgs).toBeDefined();
+      expect(closeFirstArgs?.drainTimeoutMs).toBeLessThanOrEqual(1_234);
+      expect(closeFirstArgs?.drainTimeoutMs).toBeGreaterThanOrEqual(0);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
 
@@ -360,10 +382,17 @@ describe("runGatewayLoop", () => {
 
       await startedThird;
       await new Promise<void>((resolve) => setImmediate(resolve));
-      expect(closeSecond).toHaveBeenCalledWith({
-        reason: "gateway restarting",
-        restartExpectedMs: 1500,
-      });
+      expect(closeSecond).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+          drainTimeoutMs: expect.any(Number),
+        }),
+      );
+      const closeSecondArgs = closeSecond.mock.calls[0]?.[0];
+      expect(closeSecondArgs).toBeDefined();
+      expect(closeSecondArgs?.drainTimeoutMs).toBeLessThanOrEqual(1_234);
+      expect(closeSecondArgs?.drainTimeoutMs).toBeGreaterThanOrEqual(0);
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
@@ -375,6 +404,52 @@ describe("runGatewayLoop", () => {
         reason: "gateway stopping",
         restartExpectedMs: null,
       });
+    });
+  });
+
+  it("passes the remaining restart drain budget through to server.close", async () => {
+    vi.clearAllMocks();
+    loadConfig.mockReturnValue({
+      gateway: {
+        reload: {
+          deferralTimeoutMs: 1_234,
+        },
+      },
+    });
+
+    await withIsolatedSignals(async ({ captureSignal }) => {
+      const close = createCloseMock();
+      const { start, started } = createSignaledStart(close);
+      const { runtime, exited } = createRuntimeWithExitSignal();
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+        mode: "spawned",
+        pid: 9999,
+      });
+
+      const { runGatewayLoop } = await import("./run-loop.js");
+      void runGatewayLoop({
+        start: start as unknown as Parameters<typeof runGatewayLoop>[0]["start"],
+        runtime: runtime as unknown as Parameters<typeof runGatewayLoop>[0]["runtime"],
+      });
+
+      await waitForStart(started);
+      const sigusr1 = captureSignal("SIGUSR1");
+
+      sigusr1();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      const closeArgs = close.mock.calls[0]?.[0];
+      expect(closeArgs).toEqual(
+        expect.objectContaining({
+          reason: "gateway restarting",
+          restartExpectedMs: 1500,
+          drainTimeoutMs: expect.any(Number),
+        }),
+      );
+      expect(closeArgs?.drainTimeoutMs).toBeLessThanOrEqual(1_234);
+      expect(closeArgs?.drainTimeoutMs).toBeGreaterThanOrEqual(0);
+
+      await expect(exited).resolves.toBe(0);
     });
   });
 
@@ -462,9 +537,9 @@ describe("runGatewayLoop", () => {
     vi.clearAllMocks();
 
     await withIsolatedSignals(async ({ captureSignal }) => {
-      const closeFirst = vi.fn(async () => {});
-      const closeSecond = vi.fn(async () => {});
-      const closeThird = vi.fn(async () => {});
+      const closeFirst = createCloseMock();
+      const closeSecond = createCloseMock();
+      const closeThird = createCloseMock();
       const { runtime, exited } = createRuntimeWithExitSignal();
 
       const start = vi

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -147,6 +147,10 @@ export async function runGatewayLoop(params: {
     shuttingDown = true;
     const isRestart = action === "restart";
     const restartDrainTimeoutMs = isRestart ? resolveRestartDrainTimeoutMs() : 0;
+    const restartDrainDeadlineAt =
+      isRestart && restartDrainTimeoutMs !== undefined
+        ? Date.now() + restartDrainTimeoutMs
+        : undefined;
     gatewayLog.info(`received ${signal}; ${isRestart ? "restarting" : "shutting down"}`);
 
     let forceExitTimer: ReturnType<typeof setTimeout> | null = null;
@@ -242,6 +246,9 @@ export async function runGatewayLoop(params: {
         await server?.close({
           reason: isRestart ? "gateway restarting" : "gateway stopping",
           restartExpectedMs: isRestart ? 1500 : null,
+          ...(isRestart && restartDrainDeadlineAt !== undefined
+            ? { drainTimeoutMs: Math.max(0, restartDrainDeadlineAt - Date.now()) }
+            : {}),
         });
       } catch (err) {
         gatewayLog.error(`shutdown error: ${String(err)}`);

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = {
+  totalPendingReplies: 0,
+  logInfo: vi.fn(),
   logWarn: vi.fn(),
   disposeAgentHarnesses: vi.fn(async () => undefined),
   disposeAllSessionMcpRuntimes: vi.fn(async () => undefined),
@@ -21,6 +23,10 @@ vi.mock("../hooks/gmail-watcher.js", () => ({
   stopGmailWatcher: vi.fn(async () => undefined),
 }));
 
+vi.mock("../auto-reply/reply/dispatcher-registry.js", () => ({
+  getTotalPendingReplies: () => mocks.totalPendingReplies,
+}));
+
 vi.mock("../agents/harness/registry.js", () => ({
   disposeRegisteredAgentHarnesses: mocks.disposeAgentHarnesses,
 }));
@@ -34,6 +40,7 @@ vi.mock("../agents/pi-bundle-mcp-tools.js", async () => ({
 
 vi.mock("../logging/subsystem.js", () => ({
   createSubsystemLogger: vi.fn(() => ({
+    info: mocks.logInfo,
     warn: mocks.logWarn,
   })),
 }));
@@ -66,7 +73,14 @@ function createGatewayCloseTestDeps(
     heartbeatUnsub: null,
     transcriptUnsub: null,
     lifecycleUnsub: null,
-    chatRunState: { clear: vi.fn() },
+    chatRunState: { clear: vi.fn(), abortedRuns: new Map() },
+    chatRunBuffers: new Map(),
+    chatDeltaSentAt: new Map(),
+    chatDeltaLastBroadcastLen: new Map(),
+    removeChatRun: vi.fn(),
+    agentRunSeq: new Map(),
+    nodeSendToSession: vi.fn(),
+    chatAbortControllers: new Map(),
     clients: new Set<GatewayCloseClient>(),
     configReloader: { stop: vi.fn(async () => undefined) },
     wss: {
@@ -84,6 +98,8 @@ function createGatewayCloseTestDeps(
 describe("createGatewayCloseHandler", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    mocks.totalPendingReplies = 0;
+    mocks.logInfo.mockClear();
     mocks.logWarn.mockClear();
     mocks.disposeAgentHarnesses.mockClear();
     mocks.disposeAllSessionMcpRuntimes.mockClear();
@@ -122,6 +138,174 @@ describe("createGatewayCloseHandler", () => {
         String(message).includes("bundle-mcp runtime disposal exceeded 5000ms"),
       ),
     ).toBe(true);
+  });
+
+  it("waits for pending replies to settle before shutdown when a drain budget is provided", async () => {
+    vi.useFakeTimers();
+    mocks.totalPendingReplies = 1;
+
+    const close = createGatewayCloseHandler(createGatewayCloseTestDeps());
+    const closePromise = close({ reason: "test shutdown", drainTimeoutMs: 200 });
+
+    await vi.advanceTimersByTimeAsync(100);
+    mocks.totalPendingReplies = 0;
+    await vi.advanceTimersByTimeAsync(100);
+    await closePromise;
+
+    expect(
+      mocks.logInfo.mock.calls.some(([message]) =>
+        String(message).includes("waiting for 1 reply(ies) to settle before shutdown"),
+      ),
+    ).toBe(true);
+    expect(
+      mocks.logInfo.mock.calls.some(([message]) =>
+        String(message).includes("pending replies settled after"),
+      ),
+    ).toBe(true);
+  });
+
+  it("aborts active chat runs when reply drain times out during shutdown", async () => {
+    vi.useFakeTimers();
+
+    const controller = new AbortController();
+    const broadcast = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller,
+          sessionId: "run-1",
+          sessionKey: "session-1",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        broadcast,
+        nodeSendToSession,
+        chatRunBuffers: new Map([["run-1", "partial reply"]]),
+        chatAbortControllers,
+      }),
+    );
+
+    const closePromise = close({ reason: "test shutdown", drainTimeoutMs: 100 });
+    await vi.advanceTimersByTimeAsync(100);
+    await closePromise;
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("reply drain timeout after 100ms with 1 chat run(s) still active"),
+      ),
+    ).toBe(true);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("aborted 1 active chat run(s) during shutdown"),
+      ),
+    ).toBe(true);
+    expect(
+      mocks.logInfo.mock.calls.some(([message]) =>
+        String(message).includes("pending replies settled after shutdown abort cleanup"),
+      ),
+    ).toBe(true);
+    expect(broadcast).toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted", stopReason: "shutdown" }),
+    );
+    expect(nodeSendToSession).toHaveBeenCalledWith(
+      "session-1",
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted", stopReason: "shutdown" }),
+    );
+  });
+
+  it("does not abort active chat runs on shutdown when no reply drain budget is provided", async () => {
+    const controller = new AbortController();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller,
+          sessionId: "run-1",
+          sessionKey: "session-1",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        chatRunBuffers: new Map([["run-1", "partial reply"]]),
+        chatAbortControllers,
+      }),
+    );
+
+    await close({ reason: "test shutdown" });
+
+    expect(controller.signal.aborted).toBe(false);
+    expect(chatAbortControllers.size).toBe(1);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) => String(message).includes("reply drain timeout")),
+    ).toBe(false);
+  });
+
+  it("aborts active chat runs immediately when the drain budget is already exhausted", async () => {
+    const controller = new AbortController();
+    const broadcast = vi.fn();
+    const nodeSendToSession = vi.fn();
+    const chatAbortControllers = new Map([
+      [
+        "run-1",
+        {
+          controller,
+          sessionId: "run-1",
+          sessionKey: "session-1",
+          startedAtMs: Date.now(),
+          expiresAtMs: Date.now() + 60_000,
+        },
+      ],
+    ]);
+    const close = createGatewayCloseHandler(
+      createGatewayCloseTestDeps({
+        broadcast,
+        nodeSendToSession,
+        chatRunBuffers: new Map([["run-1", "partial reply"]]),
+        chatAbortControllers,
+      }),
+    );
+
+    await close({ reason: "test shutdown", drainTimeoutMs: 0 });
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(chatAbortControllers.size).toBe(0);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("reply drain timeout after 0ms with 1 chat run(s) still active"),
+      ),
+    ).toBe(true);
+    expect(
+      mocks.logWarn.mock.calls.some(([message]) =>
+        String(message).includes("aborted 1 active chat run(s) during shutdown"),
+      ),
+    ).toBe(true);
+    expect(
+      mocks.logInfo.mock.calls.some(([message]) =>
+        String(message).includes("pending replies settled after shutdown abort cleanup"),
+      ),
+    ).toBe(true);
+    expect(broadcast).toHaveBeenCalledWith(
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted", stopReason: "shutdown" }),
+    );
+    expect(nodeSendToSession).toHaveBeenCalledWith(
+      "session-1",
+      "chat",
+      expect.objectContaining({ runId: "run-1", state: "aborted", stopReason: "shutdown" }),
+    );
   });
 
   it("terminates lingering websocket clients when websocket close exceeds the grace window", async () => {
@@ -254,10 +438,17 @@ describe("createGatewayCloseHandler", () => {
       heartbeatUnsub: null,
       transcriptUnsub: null,
       lifecycleUnsub: null,
-      chatRunState: { clear: vi.fn() },
+      chatRunState: { clear: vi.fn(), abortedRuns: new Map() },
+      chatRunBuffers: new Map(),
+      chatDeltaSentAt: new Map(),
+      chatDeltaLastBroadcastLen: new Map(),
+      removeChatRun: vi.fn(),
+      agentRunSeq: new Map(),
+      nodeSendToSession: vi.fn(),
+      chatAbortControllers: new Map(),
       clients: new Set(),
       configReloader: { stop: vi.fn(async () => undefined) },
-      wss: { close: (cb: () => void) => cb() } as never,
+      wss: { clients: new Set(), close: (cb: () => void) => cb() } as never,
       httpServer: {
         close: (cb: (err?: NodeJS.ErrnoException | null) => void) =>
           cb(

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -2,6 +2,7 @@ import type { Server as HttpServer } from "node:http";
 import type { WebSocketServer } from "ws";
 import { disposeRegisteredAgentHarnesses } from "../agents/harness/registry.js";
 import { disposeAllSessionMcpRuntimes } from "../agents/pi-bundle-mcp-tools.js";
+import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostHandler, CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { stopGmailWatcher } from "../hooks/gmail-watcher.js";
@@ -9,6 +10,7 @@ import type { HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { abortChatRunById, type ChatAbortControllerEntry } from "./chat-abort.js";
 
 const shutdownLog = createSubsystemLogger("gateway/shutdown");
 const WEBSOCKET_CLOSE_GRACE_MS = 1_000;
@@ -16,6 +18,118 @@ const WEBSOCKET_CLOSE_FORCE_CONTINUE_MS = 250;
 const HTTP_CLOSE_GRACE_MS = 1_000;
 const HTTP_CLOSE_FORCE_WAIT_MS = 5_000;
 const MCP_RUNTIME_CLOSE_GRACE_MS = 5_000;
+
+function getGatewayPendingReplyDrainCounts(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+}) {
+  return {
+    pendingReplies: getTotalPendingReplies(),
+    activeChatRuns: params.chatAbortControllers.size,
+  };
+}
+
+function formatGatewayPendingReplyDrainDetails(counts: {
+  pendingReplies: number;
+  activeChatRuns: number;
+}): string[] {
+  const details: string[] = [];
+  if (counts.pendingReplies > 0) {
+    details.push(`${counts.pendingReplies} reply(ies)`);
+  }
+  if (counts.activeChatRuns > 0) {
+    details.push(`${counts.activeChatRuns} chat run(s)`);
+  }
+  return details;
+}
+
+async function sleepForDrainPoll(delayMs: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, delayMs);
+    timer.unref?.();
+  });
+}
+
+async function waitForGatewayPendingRepliesToDrain(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  timeoutMs: number;
+  pollMs?: number;
+}): Promise<{
+  drained: boolean;
+  elapsedMs: number;
+  counts: { pendingReplies: number; activeChatRuns: number };
+}> {
+  const timeoutMs = Math.max(0, Math.floor(params.timeoutMs));
+  const pollMs = Math.max(25, Math.floor(params.pollMs ?? 100));
+  let counts = getGatewayPendingReplyDrainCounts(params);
+  if (counts.pendingReplies <= 0 && counts.activeChatRuns <= 0) {
+    return { drained: true, elapsedMs: 0, counts };
+  }
+  if (timeoutMs <= 0) {
+    return { drained: false, elapsedMs: 0, counts };
+  }
+  const startedAt = Date.now();
+  for (;;) {
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= timeoutMs) {
+      return { drained: false, elapsedMs, counts };
+    }
+    await sleepForDrainPoll(Math.min(pollMs, timeoutMs - elapsedMs));
+    counts = getGatewayPendingReplyDrainCounts(params);
+    if (counts.pendingReplies <= 0 && counts.activeChatRuns <= 0) {
+      return {
+        drained: true,
+        elapsedMs: Date.now() - startedAt,
+        counts,
+      };
+    }
+  }
+}
+
+function abortActiveChatRunsForShutdown(params: {
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
+  chatRunBuffers: Map<string, string>;
+  chatDeltaSentAt: Map<string, number>;
+  chatDeltaLastBroadcastLen: Map<string, number>;
+  chatRunState: { abortedRuns: Map<string, number> };
+  removeChatRun: (
+    sessionId: string,
+    clientRunId: string,
+    sessionKey?: string,
+  ) => { sessionKey: string; clientRunId: string } | undefined;
+  agentRunSeq: Map<string, number>;
+  broadcast: (event: string, payload: unknown, opts?: { dropIfSlow?: boolean }) => void;
+  nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+}): number {
+  let aborted = 0;
+  for (const [runId, entry] of Array.from(params.chatAbortControllers.entries())) {
+    if (!entry.sessionKey) {
+      continue;
+    }
+    if (
+      abortChatRunById(
+        {
+          chatAbortControllers: params.chatAbortControllers,
+          chatRunBuffers: params.chatRunBuffers,
+          chatDeltaSentAt: params.chatDeltaSentAt,
+          chatDeltaLastBroadcastLen: params.chatDeltaLastBroadcastLen,
+          chatAbortedRuns: params.chatRunState.abortedRuns,
+          removeChatRun: params.removeChatRun,
+          agentRunSeq: params.agentRunSeq,
+          broadcast: params.broadcast,
+          nodeSendToSession: params.nodeSendToSession,
+        },
+        {
+          runId,
+          sessionKey: entry.sessionKey,
+          stopReason: "shutdown",
+        },
+      ).aborted
+    ) {
+      aborted += 1;
+    }
+  }
+  return aborted;
+}
 
 function createTimeoutRace<T>(timeoutMs: number, onTimeout: () => T) {
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -98,14 +212,29 @@ export function createGatewayCloseHandler(params: {
   heartbeatUnsub: (() => void) | null;
   transcriptUnsub: (() => void) | null;
   lifecycleUnsub: (() => void) | null;
-  chatRunState: { clear: () => void };
+  chatRunState: { clear: () => void; abortedRuns: Map<string, number> };
+  chatRunBuffers: Map<string, string>;
+  chatDeltaSentAt: Map<string, number>;
+  chatDeltaLastBroadcastLen: Map<string, number>;
+  removeChatRun: (
+    sessionId: string,
+    clientRunId: string,
+    sessionKey?: string,
+  ) => { sessionKey: string; clientRunId: string } | undefined;
+  agentRunSeq: Map<string, number>;
+  nodeSendToSession: (sessionKey: string, event: string, payload: unknown) => void;
+  chatAbortControllers: Map<string, ChatAbortControllerEntry>;
   clients: Set<{ socket: { close: (code: number, reason: string) => void } }>;
   configReloader: { stop: () => Promise<void> };
   wss: WebSocketServer;
   httpServer: HttpServer;
   httpServers?: HttpServer[];
 }) {
-  return async (opts?: { reason?: string; restartExpectedMs?: number | null }) => {
+  return async (opts?: {
+    reason?: string;
+    restartExpectedMs?: number | null;
+    drainTimeoutMs?: number;
+  }) => {
     try {
       const reasonRaw = normalizeOptionalString(opts?.reason) ?? "";
       const reason = reasonRaw || "gateway stopping";
@@ -113,6 +242,60 @@ export function createGatewayCloseHandler(params: {
         typeof opts?.restartExpectedMs === "number" && Number.isFinite(opts.restartExpectedMs)
           ? Math.max(0, Math.floor(opts.restartExpectedMs))
           : null;
+      const hasReplyDrainBudget =
+        typeof opts?.drainTimeoutMs === "number" && Number.isFinite(opts.drainTimeoutMs);
+      const drainTimeoutMs = hasReplyDrainBudget
+        ? Math.max(0, Math.floor(opts.drainTimeoutMs as number))
+        : 0;
+      const initialReplyDrainCounts = hasReplyDrainBudget
+        ? getGatewayPendingReplyDrainCounts(params)
+        : { pendingReplies: 0, activeChatRuns: 0 };
+      if (
+        hasReplyDrainBudget &&
+        (initialReplyDrainCounts.pendingReplies > 0 || initialReplyDrainCounts.activeChatRuns > 0)
+      ) {
+        let drainResult: {
+          drained: boolean;
+          elapsedMs: number;
+          counts: { pendingReplies: number; activeChatRuns: number };
+        } = {
+          drained: false,
+          elapsedMs: 0,
+          counts: initialReplyDrainCounts,
+        };
+        if (drainTimeoutMs > 0) {
+          const initialDetails = formatGatewayPendingReplyDrainDetails(initialReplyDrainCounts);
+          shutdownLog.info(
+            `waiting for ${initialDetails.join(", ")} to settle before shutdown (timeout ${drainTimeoutMs}ms)`,
+          );
+          drainResult = await waitForGatewayPendingRepliesToDrain({
+            chatAbortControllers: params.chatAbortControllers,
+            timeoutMs: drainTimeoutMs,
+          });
+        }
+        if (drainResult.drained) {
+          shutdownLog.info(`pending replies settled after ${drainResult.elapsedMs}ms`);
+        } else {
+          const remainingDetails = formatGatewayPendingReplyDrainDetails(drainResult.counts);
+          shutdownLog.warn(
+            `reply drain timeout after ${drainResult.elapsedMs}ms with ${remainingDetails.join(", ")} still active; continuing shutdown`,
+          );
+          if (drainResult.counts.activeChatRuns > 0) {
+            const abortedRuns = abortActiveChatRunsForShutdown(params);
+            if (abortedRuns > 0) {
+              shutdownLog.warn(`aborted ${abortedRuns} active chat run(s) during shutdown`);
+              const postAbortDrain = await waitForGatewayPendingRepliesToDrain({
+                chatAbortControllers: params.chatAbortControllers,
+                timeoutMs: 1_000,
+                pollMs: 50,
+              });
+              if (postAbortDrain.drained) {
+                shutdownLog.info("pending replies settled after shutdown abort cleanup");
+              }
+            }
+          }
+        }
+      }
       if (params.bonjourStop) {
         try {
           await params.bonjourStop();

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -179,7 +179,11 @@ function createGatewayAuthRateLimiters(rateLimitConfig: AuthRateLimitConfig | un
 }
 
 export type GatewayServer = {
-  close: (opts?: { reason?: string; restartExpectedMs?: number | null }) => Promise<void>;
+  close: (opts?: {
+    reason?: string;
+    restartExpectedMs?: number | null;
+    drainTimeoutMs?: number;
+  }) => Promise<void>;
 };
 
 export type GatewayServerOptions = {
@@ -612,6 +616,13 @@ export async function startGatewayServer(
       transcriptUnsub: runtimeState.transcriptUnsub,
       lifecycleUnsub: runtimeState.lifecycleUnsub,
       chatRunState,
+      chatRunBuffers,
+      chatDeltaSentAt,
+      chatDeltaLastBroadcastLen,
+      removeChatRun,
+      agentRunSeq,
+      nodeSendToSession,
+      chatAbortControllers,
       clients,
       configReloader: runtimeState.configReloader,
       wss,


### PR DESCRIPTION
## Summary

Restart deferral already waits for queued work before the gateway begins shutting down, but there is still a second race during `server.close()`: pending reply dispatchers and active chat runs can still be in flight while the restart teardown closes sockets and channels.

This change gives restart shutdown a bounded reply-drain phase before the gateway finishes closing.

## What changes

- pass the remaining restart drain budget from `run-loop.ts` into `server.close()`
- in `server-close.ts`, wait briefly for:
  - pending reply dispatchers (`getTotalPendingReplies()`)
  - active chat runs (`chatAbortControllers.size`)
- if the drain budget expires, log the remaining work and abort any still-active chat runs before continuing shutdown
- wire the close handler to the existing chat-run registries so abort cleanup uses the normal chat abort path
- add regression coverage for both the shutdown drain logic and the run-loop handoff

## Why this is separate

This is distinct from:
- pre-restart deferral before SIGUSR1 is emitted
- shutdown error visibility or per-subsystem timeout work in other open PRs

It specifically fixes the last gap between "restart requested" and `server.close()` finishing.

## Validation performed locally

- `./node_modules/.bin/oxlint -f unix src/gateway/server-close.ts src/gateway/server-close.test.ts src/cli/gateway-cli/run-loop.ts src/cli/gateway-cli/run-loop.test.ts src/gateway/server.impl.ts src/agents/subagent-registry.steer-restart.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `corepack pnpm exec oxfmt --check src/gateway/server-close.ts src/gateway/server-close.test.ts src/cli/gateway-cli/run-loop.ts src/cli/gateway-cli/run-loop.test.ts src/gateway/server.impl.ts src/agents/subagent-registry.steer-restart.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `corepack pnpm exec vitest run src/gateway/server-close.test.ts src/cli/gateway-cli/run-loop.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run --config test/vitest/vitest.agents.config.ts src/agents/subagent-registry.steer-restart.test.ts --reporter=verbose`
- `corepack pnpm exec vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts --reporter=verbose`

## Notes

This keeps the change tightly scoped to restart shutdown behavior. It does not change normal stop semantics or widen the shutdown timeout.

## Review Focus
- `src/cli/gateway-cli/run-loop.ts`
- `src/gateway/server-close.ts`
- `src/gateway/server-close.test.ts`
- `src/gateway/server.impl.ts`

## Scope Boundary
- restart shutdown behavior only
- does not change normal stop semantics
- does not widen global shutdown timeouts outside the bounded restart path

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Human Verification
- Verified scenarios: pending reply drain before shutdown, timeout abort of active chat runs, zero-budget shutdown path, restart handoff coverage
- Edge cases checked: remaining drain budget reaches zero before `server.close()` starts, current-main close handler wiring after rebase
- What I did not verify: live gateway restart smoke against a running instance
