### PR TITLE
fix(config): accept partial cliBackends overrides by making command optional

### DIFF
--- a/src/agents/cli-backends.test.ts
+++ b/src/agents/cli-backends.test.ts
@@ -477,6 +477,31 @@ describe("resolveCliBackendConfig claude-cli defaults", () => {
     expect(resolved?.config.clearEnv).toContain("CLAUDE_CODE_USE_COWORK_PLUGINS");
   });
 
+  it("accepts partial modelAliases override without a command field and inherits base command", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          cliBackends: {
+            "claude-cli": {
+              modelAliases: {
+                "claude-opus-4-7": "claude-opus-4-7",
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+
+    const resolved = resolveCliBackendConfig("claude-cli", cfg);
+
+    expect(resolved).not.toBeNull();
+    // Base command carries through when the override omits it — the point of
+    // making `command` optional at the schema level.
+    expect(resolved?.config.command?.trim()).toBeTruthy();
+    // User alias takes effect (was absent or mapped to "opus" in the base).
+    expect(resolved?.config.modelAliases?.["claude-opus-4-7"]).toBe("claude-opus-4-7");
+  });
+
   it("normalizes legacy skip-permissions overrides to permission-mode bypassPermissions", () => {
     const cfg = {
       agents: {

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -25,9 +25,17 @@ const defaultCliBackendsDeps: CliBackendsDeps = {
 
 let cliBackendsDeps: CliBackendsDeps = defaultCliBackendsDeps;
 
+// Once a backend has been resolved, `command` is guaranteed to be a non-empty
+// string — `resolveCliBackendConfig` returns null otherwise. Narrowing the
+// type here lets downstream consumers (e.g. the CLI runner spawning argv[0])
+// treat it as required without null-asserting.
+export type ResolvedCliBackendConfig = Omit<CliBackendConfig, "command"> & {
+  command: string;
+};
+
 export type ResolvedCliBackend = {
   id: string;
-  config: CliBackendConfig;
+  config: ResolvedCliBackendConfig;
   bundleMcp: boolean;
   bundleMcpMode?: CliBundleMcpMode;
   pluginId?: string;

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -184,6 +184,16 @@ export async function executePreparedCliRun(
     throw createCliAbortError();
   }
   const backend = context.preparedBackend.backend;
+  // Execution reaches this path only via `resolveCliBackendConfig`, which
+  // returns null unless `command` is a non-empty string. Narrow here so the
+  // spawn call (argv[0]) can treat it as required without bleeding the
+  // narrowed type up through every CliBackendConfig consumer.
+  const backendCommand = backend.command;
+  if (!backendCommand) {
+    throw new Error(
+      `cli-runner: backend "${context.backendResolved.id}" resolved without a command`,
+    );
+  }
   const { sessionId: resolvedSessionId, isNew } = resolveSessionIdToSend({
     backend,
     cliSessionId: cliSessionIdToUse,
@@ -313,7 +323,7 @@ export async function executePreparedCliRun(
             imageArg: backend.imageArg,
             argsPrompt,
           });
-          cliBackendLog.info(`cli argv: ${backend.command} ${logArgs.join(" ")}`);
+          cliBackendLog.info(`cli argv: ${backendCommand} ${logArgs.join(" ")}`);
           cliBackendLog.info(`cli env auth: ${buildCliEnvAuthLog(env)}`);
           if (
             env.OPENCLAW_MCP_TOKEN ||
@@ -365,7 +375,7 @@ export async function executePreparedCliRun(
           scopeKey,
           replaceExistingScope: Boolean(useResume && scopeKey),
           mode: "child",
-          argv: [backend.command, ...args],
+          argv: [backendCommand, ...args],
           timeoutMs: params.timeoutMs,
           noOutputTimeoutMs,
           cwd: context.workspaceDir,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -77,8 +77,14 @@ export type AgentContextLimitsConfig = {
 };
 
 export type CliBackendConfig = {
-  /** CLI command to execute (absolute path or on PATH). */
-  command: string;
+  /**
+   * CLI command to execute (absolute path or on PATH). Optional so that
+   * `agents.defaults.cliBackends.<backendId>` entries can be partial
+   * overrides — e.g. a `modelAliases`-only block that inherits the base
+   * command. Runtime resolution (`resolveCliBackendConfig`) guards on
+   * `config.command?.trim()` and returns null when unresolvable.
+   */
+  command?: string;
   /** Base args applied to every invocation. */
   args?: string[];
   /** Output parsing mode (default: json). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -526,9 +526,16 @@ const CliBackendWatchdogModeSchema = z
   .strict()
   .optional();
 
+// `command` is optional at the schema level so that users can supply partial
+// overrides in `agents.defaults.cliBackends.<backendId>` — e.g. just a
+// `modelAliases` block — while inheriting every other field (including the
+// executable name) from the base backend config. Runtime resolution
+// (`resolveCliBackendConfig`) already guards on `config.command?.trim()` and
+// skips backends without a resolvable command, so relaxing validation here
+// does not change runtime behavior for existing full overrides.
 export const CliBackendSchema = z
   .object({
-    command: z.string(),
+    command: z.string().optional(),
     args: z.array(z.string()).optional(),
     output: z.union([z.literal("json"), z.literal("text"), z.literal("jsonl")]).optional(),
     resumeOutput: z.union([z.literal("json"), z.literal("text"), z.literal("jsonl")]).optional(),


### PR DESCRIPTION
## Summary

- Make `agents.defaults.cliBackends.<backendId>.command` optional at both the zod schema level (`CliBackendSchema`) and the TS-type level (`CliBackendConfig`).
- Introduce `ResolvedCliBackendConfig` with `command: string` so downstream consumers don't lose the non-null guarantee after `resolveCliBackendConfig` validates it.
- Narrow in one place (`src/agents/cli-runner/execute.ts`) at the spawn site instead of propagating the stricter type up through the whole config plumbing.

## Why

Users cannot currently write a partial `cliBackends` override — e.g. remapping a single entry in the Claude CLI's `modelAliases` without duplicating the entire backend block:

```jsonc
{
  "agents": {
    "defaults": {
      "cliBackends": {
        "claude-cli": {
          "modelAliases": { "claude-opus-4-7": "claude-opus-4-7" }
        }
      }
    }
  }
}
```

This fails validation with `command: expected string, received undefined`, forcing the user to copy every arg, every `clearEnv` entry, every `reliability` setting, etc., just to override one alias mapping.

The runtime merge in `mergeBackendConfig` (`src/agents/cli-backends.ts`) already handles partials correctly via object spread, and `resolveCliBackendConfig` already guards on `config.command?.trim()` returning `null` when unresolvable. The validation constraint is out of sync with the actual runtime contract — every other field on `CliBackendSchema` is already optional, so this change aligns `command` with the rest.

## Approach

Two alternatives considered:

- **Introduce a separate `PartialCliBackendConfig` input type.** Cleaner on paper but requires churn: every caller currently takes the same type for both input and resolved backends.
- **Assertion at the spawn site.** What this PR does. Exports a `ResolvedCliBackendConfig` narrowed type for anyone who wants the tightened contract, and adds a single runtime guard in `cli-runner/execute.ts` that throws with a clear message if the invariant is violated. No changes to existing call sites; no new optional chaining anywhere else.

## Test plan

- [x] New regression test: partial `modelAliases`-only override parses, `resolveCliBackendConfig` returns non-null, inherits base `command`, and surfaces the user's alias entry
- [x] `pnpm exec vitest run src/agents/cli-backends.test.ts` → 19/19 passing
- [x] `pnpm tsgo:core` → clean
- [x] `pnpm check:import-cycles` / `pnpm check:madge-import-cycles` → 0 cycles
- [x] Existing tests that pass full backend blocks (with `command` set) continue to pass unchanged

## Motivating use case

Noticed while pinning an agent to a specific opus variant on a host where the CLI's family-alias resolves to an older minor version. The only ways to force the pin today are either a bundle patch on `dist/cli-shared-*.js` (brittle — file hashes change on every publish) or a partial `modelAliases` config override (blocked by this validation bug). The schema relaxation unblocks the config-only path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)