### PR TITLE
fix(agent): pass --timeout to session write lock and expose SessionWriteLockError

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -459,6 +459,7 @@ export async function runEmbeddedAttempt(
 
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
+      timeoutMs: params.timeoutMs,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
         timeoutMs: resolveRunTimeoutWithCompactionGraceMs({
           runTimeoutMs: params.timeoutMs,

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -454,4 +454,28 @@ describe("acquireSessionWriteLock", () => {
       process.kill = originalKill;
     }
   });
+
+  it("throws SessionWriteLockError with reason session_busy on timeout", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-lock-"));
+    try {
+      const sessionFile = path.join(root, "sessions.json");
+      const lockA = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+      await expect(
+        acquireSessionWriteLock({ sessionFile, timeoutMs: 5, allowReentrant: false }),
+      ).rejects.toSatisfy((err: unknown) => {
+        return (
+          err instanceof Error &&
+          err.name === "SessionWriteLockError" &&
+          (err as { reason?: unknown }).reason === "session_busy" &&
+          typeof (err as { timeoutMs?: unknown }).timeoutMs === "number" &&
+          typeof (err as { lockPath?: unknown }).lockPath === "string"
+        );
+      });
+
+      await lockA.release();
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/session-write-lock.ts
+++ b/src/agents/session-write-lock.ts
@@ -4,6 +4,23 @@ import path from "node:path";
 import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
 
+export class SessionWriteLockError extends Error {
+  readonly reason = "session_busy";
+  readonly timeoutMs: number;
+  readonly lockPath: string;
+  readonly owner: string;
+
+  constructor(params: { timeoutMs: number; lockPath: string; owner: string }) {
+    super(
+      `session file locked (timeout ${params.timeoutMs}ms): ${params.owner} ${params.lockPath}`,
+    );
+    this.name = "SessionWriteLockError";
+    this.timeoutMs = params.timeoutMs;
+    this.lockPath = params.lockPath;
+    this.owner = params.owner;
+  }
+}
+
 type LockFilePayload = {
   pid?: number;
   createdAt?: string;
@@ -577,7 +594,7 @@ export async function acquireSessionWriteLock(params: {
 
   const payload = await readLockPayload(lockPath);
   const owner = typeof payload?.pid === "number" ? `pid=${payload.pid}` : "unknown";
-  throw new Error(`session file locked (timeout ${timeoutMs}ms): ${owner} ${lockPath}`);
+  throw new SessionWriteLockError({ timeoutMs, lockPath, owner });
 }
 
 export const __testing = {


### PR DESCRIPTION
## Summary

Fixes concurrent callers being silently dropped when `--session-id` is used and a turn is in progress.

- `acquireSessionWriteLock` now receives `timeoutMs` from `params.timeoutMs` so the lock wait time aligns with the agent turn timeout (`--timeout`). Previously the lock used a hardcoded 10s default, causing concurrent callers to timeout and be dropped when a turn took longer than 10s.
- Introduce `SessionWriteLockError` with `reason: "session_busy"` so callers can distinguish "session locked" from fatal errors programmatically.

## Changes

- `src/agents/pi-embedded-runner/run/attempt.ts`: pass `timeoutMs` to `acquireSessionWriteLock`
- `src/agents/session-write-lock.ts`: add `SessionWriteLockError` class; throw it on lock timeout
- `src/agents/session-write-lock.test.ts`: add test verifying `SessionWriteLockError` properties

## Test plan

- [x] `pnpm test src/agents/session-write-lock.test.ts` — 21 passed
- [x] `pnpm test src/agents/pi-embedded-runner/run/attempt.test.ts` — 113 passed
- [x] `pnpm test src/commands/agent-via-gateway.test.ts` — 5 passed
- [x] `pnpm test src/gateway/server-methods/agent.test.ts` — 31 passed
- [x] `pnpm test src/agents/session-store-lock.test.ts` — 2 passed
- [x] `pnpm build` — passed

Fixes #69112