### PR TITLE
fix(memory): improve error message when node:sqlite is unavailable

### DIFF
--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -120,12 +120,24 @@ export function createMemoryTool(params: {
 export function buildMemorySearchUnavailableResult(error: string | undefined) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
   const isQuotaError = /insufficient_quota|quota|429/.test(normalizeLowercaseStringOrEmpty(reason));
-  const warning = isQuotaError
-    ? "Memory search is unavailable because the embedding provider quota is exhausted."
-    : "Memory search is unavailable due to an embedding/provider error.";
-  const action = isQuotaError
-    ? "Top up or switch embedding provider, then retry memory_search."
-    : "Check embedding provider configuration and retry memory_search.";
+  const isSqliteMissing =
+    /node:sqlite|no such built-in module.*sqlite|missing node:sqlite/i.test(reason);
+  let warning: string;
+  let action: string;
+  if (isSqliteMissing) {
+    warning =
+      "Memory search is unavailable because node:sqlite is not available in this Node.js runtime. " +
+      "The built-in SQLite module requires Node.js 22.5+ compiled with SQLite support.";
+    action =
+      "Upgrade to Node.js 22.5+ (with SQLite support). " +
+      "See https://docs.openclaw.ai/memory for setup instructions.";
+  } else if (isQuotaError) {
+    warning = "Memory search is unavailable because the embedding provider quota is exhausted.";
+    action = "Top up or switch embedding provider, then retry memory_search.";
+  } else {
+    warning = "Memory search is unavailable due to an embedding/provider error.";
+    action = "Check embedding provider configuration and retry memory_search.";
+  }
   return {
     results: [],
     disabled: true,

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -136,9 +136,9 @@ export function buildMemorySearchUnavailableResult(
   const normalizedReason = normalizeLowercaseStringOrEmpty(reason);
   const isQuotaError = /insufficient_quota|quota|429/.test(normalizedReason);
   const isNodeSqliteUnavailable =
-    /node:sqlite/.test(normalizedReason) ||
-    /no such built-in module.*sqlite/.test(normalizedReason) ||
-    /sqlite support is unavailable/.test(normalizedReason);
+    normalizedReason.includes("node:sqlite") ||
+    (normalizedReason.includes("no such built-in module") && normalizedReason.includes("sqlite")) ||
+    normalizedReason.includes("sqlite support is unavailable");
   let defaultWarning = "Memory search is unavailable due to an embedding/provider error.";
   let defaultAction = "Check embedding provider configuration and retry memory_search.";
   if (isNodeSqliteUnavailable) {

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -119,6 +119,12 @@ export function createMemoryTool(params: {
   };
 }
 
+const MEMORY_SEARCH_NODE_SQLITE_WARNING =
+  "Memory search is unavailable because node:sqlite is not available in this Node.js runtime.";
+const MEMORY_SEARCH_NODE_SQLITE_ACTION =
+  "Use OpenClaw with Node.js 22.19.0 or newer; " +
+  "Node.js 24 is recommended for memory search. See https://docs.openclaw.ai/cli/memory.";
+
 export function buildMemorySearchUnavailableResult(
   error: string | undefined,
   overrides?: {
@@ -127,17 +133,25 @@ export function buildMemorySearchUnavailableResult(
   },
 ) {
   const reason = (error ?? "memory search unavailable").trim() || "memory search unavailable";
-  const isQuotaError = /insufficient_quota|quota|429/.test(normalizeLowercaseStringOrEmpty(reason));
-  const warning =
-    overrides?.warning ??
-    (isQuotaError
-      ? "Memory search is unavailable because the embedding provider quota is exhausted."
-      : "Memory search is unavailable due to an embedding/provider error.");
-  const action =
-    overrides?.action ??
-    (isQuotaError
-      ? "Top up or switch embedding provider, then retry memory_search."
-      : "Check embedding provider configuration and retry memory_search.");
+  const normalizedReason = normalizeLowercaseStringOrEmpty(reason);
+  const isQuotaError = /insufficient_quota|quota|429/.test(normalizedReason);
+  const isNodeSqliteUnavailable =
+    /node:sqlite/.test(normalizedReason) ||
+    /no such built-in module.*sqlite/.test(normalizedReason) ||
+    /sqlite support is unavailable/.test(normalizedReason);
+  let defaultWarning = "Memory search is unavailable due to an embedding/provider error.";
+  let defaultAction = "Check embedding provider configuration and retry memory_search.";
+  if (isNodeSqliteUnavailable) {
+    defaultWarning = MEMORY_SEARCH_NODE_SQLITE_WARNING;
+    defaultAction = MEMORY_SEARCH_NODE_SQLITE_ACTION;
+  }
+  if (isQuotaError) {
+    defaultWarning =
+      "Memory search is unavailable because the embedding provider quota is exhausted.";
+    defaultAction = "Top up or switch embedding provider, then retry memory_search.";
+  }
+  const warning = overrides?.warning ?? defaultWarning;
+  const action = overrides?.action ?? defaultAction;
   return {
     results: [],
     disabled: true,

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -28,6 +28,24 @@ describe("memory_search unavailable payloads", () => {
     });
   });
 
+  it("returns explicit unavailable metadata for node:sqlite missing failures", async () => {
+    setMemorySearchImpl(async () => {
+      throw new Error("Cannot find module 'node:sqlite'");
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("sqlite-missing", { query: "hello" });
+    expectUnavailableMemorySearchDetails(result.details, {
+      error: "Cannot find module 'node:sqlite'",
+      warning:
+        "Memory search is unavailable because node:sqlite is not available in this Node.js runtime. " +
+        "The built-in SQLite module requires Node.js 22.5+ compiled with SQLite support.",
+      action:
+        "Upgrade to Node.js 22.5+ (with SQLite support). " +
+        "See https://docs.openclaw.ai/memory for setup instructions.",
+    });
+  });
+
   it("returns explicit unavailable metadata for non-quota failures", async () => {
     setMemorySearchImpl(async () => {
       throw new Error("embedding provider timeout");

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -13,7 +13,11 @@ import {
   setMemorySearchManagerImpl,
 } from "./memory-tool-manager-mock.js";
 import { createMemorySearchTool, testing as memoryToolsTesting } from "./tools.js";
-import { MemoryGetSchema, MemorySearchSchema } from "./tools.shared.js";
+import {
+  buildMemorySearchUnavailableResult,
+  MemoryGetSchema,
+  MemorySearchSchema,
+} from "./tools.shared.js";
 import {
   asOpenClawConfig,
   createMemorySearchToolOrThrow,
@@ -120,6 +124,23 @@ describe("memory_search unavailable payloads", () => {
     });
   });
 
+  it("returns explicit unavailable metadata when node:sqlite is missing", async () => {
+    setMemorySearchImpl(async () => {
+      throw new Error("No such built-in module: node:sqlite");
+    });
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("missing-sqlite", { query: "hello" });
+    expectUnavailableMemorySearchDetails(result.details, {
+      error: "No such built-in module: node:sqlite",
+      warning:
+        "Memory search is unavailable because node:sqlite is not available in this Node.js runtime.",
+      action:
+        "Use OpenClaw with Node.js 22.19.0 or newer; " +
+        "Node.js 24 is recommended for memory search. See https://docs.openclaw.ai/cli/memory.",
+    });
+  });
+
   it("returns explicit unavailable metadata for non-quota failures", async () => {
     setMemorySearchImpl(async () => {
       throw new Error("embedding provider timeout");
@@ -131,6 +152,27 @@ describe("memory_search unavailable payloads", () => {
       error: "embedding provider timeout",
       warning: "Memory search is unavailable due to an embedding/provider error.",
       action: "Check embedding provider configuration and retry memory_search.",
+    });
+  });
+
+  it("preserves explicit unavailable overrides for node:sqlite errors", () => {
+    expect(
+      buildMemorySearchUnavailableResult("No such built-in module: node:sqlite", {
+        warning: "custom warning",
+        action: "custom action",
+      }),
+    ).toEqual({
+      results: [],
+      disabled: true,
+      unavailable: true,
+      error: "No such built-in module: node:sqlite",
+      warning: "custom warning",
+      action: "custom action",
+      debug: {
+        warning: "custom warning",
+        action: "custom action",
+        error: "No such built-in module: node:sqlite",
+      },
     });
   });
 


### PR DESCRIPTION
## Summary

- Keeps the existing PR branch scoped to `extensions/memory-core`.
- Classifies `node:sqlite` / missing built-in sqlite runtime errors in `buildMemorySearchUnavailableResult(error, overrides?)`.
- Keeps the existing quota and generic branches, and keeps explicit `warning` / `action` overrides authoritative.
- Fixes the latest CI lint finding by using `String#includes()` for the sqlite-missing checks.

## Behavior

When the runtime cannot load `node:sqlite`, `memory_search` now returns the same unavailable result shape with a targeted warning/action instead of the generic embedding-provider message.

The action matches current OpenClaw support policy: Node.js `>=22.19.0`, with Node.js 24 recommended. The doc link uses the valid Memory CLI page: https://docs.openclaw.ai/cli/memory.

## Real Behavior Proof

- Behavior or issue addressed: `memory_search` unavailable payloads now classify missing `node:sqlite` runtime errors with targeted warning/action text while preserving quota, generic, and explicit override behavior.
- Real environment tested: Windows PowerShell in the OpenClaw repo; old-runtime missing-builtin reproduction plus Node.js v24.13.0 for helper output, tests, and lint.
- Exact steps or command run after this patch: `node -e "try { require('node:sqlite'); console.log('node:sqlite available'); } catch (error) { console.log(String(error.message)); }"`; `node --import tsx -e "import { buildMemorySearchUnavailableResult } from './extensions/memory-core/src/tools.shared.ts'; ..."`; `node scripts/test-projects.mjs extensions/memory-core/src/tools.test.ts`; `node node_modules/oxlint/bin/oxlint extensions/memory-core/src/tools.shared.ts extensions/memory-core/src/tools.test.ts`; `node node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output below shows the missing builtin error, the after-fix unavailable payload, override preservation, and targeted test/lint output.
- Observed result after fix: A missing `node:sqlite` error returns `disabled: true`, `unavailable: true`, the original error string, and targeted Node.js upgrade guidance; custom `warning` and `action` overrides still win; the targeted memory-core tests pass.
- What was not tested: No known gaps for this helper-level unavailable payload change; a full old-Node live memory index/search session was not run because the focused bug is the formatter branch and the old-runtime reproduction plus helper output exercise that behavior directly.
- Proof limitations or environment constraints: The old-runtime missing-builtin command demonstrates the source error; the current supported Node.js 24 runtime is used for the branch output and tests.

Old-runtime reproduction of the missing builtin:

```text
$ node -e "try { require('node:sqlite'); console.log('node:sqlite available'); } catch (error) { console.log(String(error.message)); }"
No such built-in module: node:sqlite
```

Current branch unavailable payload for that error:

```text
$ node --import tsx -e "import { buildMemorySearchUnavailableResult } from './extensions/memory-core/src/tools.shared.ts'; console.log(JSON.stringify(buildMemorySearchUnavailableResult('No such built-in module: node:sqlite'), null, 2));"
{
  "results": [],
  "disabled": true,
  "unavailable": true,
  "error": "No such built-in module: node:sqlite",
  "warning": "Memory search is unavailable because node:sqlite is not available in this Node.js runtime.",
  "action": "Use OpenClaw with Node.js 22.19.0 or newer; Node.js 24 is recommended for memory search. See https://docs.openclaw.ai/cli/memory.",
  "debug": {
    "warning": "Memory search is unavailable because node:sqlite is not available in this Node.js runtime.",
    "action": "Use OpenClaw with Node.js 22.19.0 or newer; Node.js 24 is recommended for memory search. See https://docs.openclaw.ai/cli/memory.",
    "error": "No such built-in module: node:sqlite"
  }
}
```

Override preservation check:

```text
$ node --import tsx -e "import { buildMemorySearchUnavailableResult } from './extensions/memory-core/src/tools.shared.ts'; console.log(JSON.stringify(buildMemorySearchUnavailableResult('No such built-in module: node:sqlite', { warning: 'custom warning', action: 'custom action' }), null, 2));"
{
  "results": [],
  "disabled": true,
  "unavailable": true,
  "error": "No such built-in module: node:sqlite",
  "warning": "custom warning",
  "action": "custom action",
  "debug": {
    "warning": "custom warning",
    "action": "custom action",
    "error": "No such built-in module: node:sqlite"
  }
}
```

Targeted test run on Node.js 24.13.0:

```text
$ node scripts/test-projects.mjs extensions/memory-core/src/tools.test.ts
Test Files  1 passed (1)
Tests       19 passed (19)
[test] passed 1 Vitest shard
```

Lint checks:

```text
$ node node_modules/oxlint/bin/oxlint extensions/memory-core/src/tools.shared.ts extensions/memory-core/src/tools.test.ts
# passed

$ node node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.extensions.json extensions/memory-core
# passed
```

Note: `node scripts/run-bundled-extension-oxlint.mjs` and `node scripts/run-oxlint-shards.mjs --threads=8` both timed out locally on Windows after 5 minutes with no diagnostics, but the CI failure was the two `prefer-includes` findings in `extensions/memory-core/src/tools.shared.ts`; the changed file and memory-core extension path now pass oxlint directly.

## Related

- Supersedes #59637
- Closes #59457
