### PR TITLE
feat: enable cache-ttl context pruning for openai-completions providers

### DIFF
--- a/src/agents/pi-embedded-runner/cache-ttl.test.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.test.ts
@@ -84,6 +84,16 @@ describe("isCacheTtlEligibleProvider", () => {
       ),
     ).toBe(true);
   });
+
+  it("allows openai-completions providers", () => {
+    expect(isCacheTtlEligibleProvider("openai", "gpt-4o", "openai-completions")).toBe(true);
+    expect(
+      isCacheTtlEligibleProvider("astroncodingplan", "astron-code-latest", "openai-completions"),
+    ).toBe(true);
+    expect(isCacheTtlEligibleProvider("deepseek", "deepseek-r1", "openai-completions")).toBe(
+      true,
+    );
+  });
 });
 
 describe("readLastCacheTtlTimestamp", () => {

--- a/src/agents/pi-embedded-runner/cache-ttl.ts
+++ b/src/agents/pi-embedded-runner/cache-ttl.ts
@@ -49,7 +49,8 @@ export function isCacheTtlEligibleProvider(
       modelApi,
     }) ||
     (normalizedProvider === "kilocode" && isAnthropicModelRef(normalizedModelId)) ||
-    isGooglePromptCacheEligible({ modelApi, modelId: normalizedModelId })
+    isGooglePromptCacheEligible({ modelApi, modelId: normalizedModelId }) ||
+    modelApi === "openai-completions"
   );
 }
 


### PR DESCRIPTION
## Summary

Enable cache-ttl based context pruning for all providers using the \openai-completions\ API type.

Currently, \isCacheTtlEligibleProvider\ only returns \	rue\ for Anthropic-family and Google-family providers (plus those registered via provider plugins like Moonshot and ZAI). Providers using the \openai-completions\ API interface (e.g., DeepSeek, Xunfei Coding Plan, local OpenAI-compatible servers) are excluded from context pruning even when the feature is configured.

## Changes

- Add \modelApi === \openai-completions\\ check in \isCacheTtlEligibleProvider\ (\src/agents/pi-embedded-runner/cache-ttl.ts\)
- Add test cases for \openai-completions\ providers (\src/agents/pi-embedded-runner/cache-ttl.test.ts\)

## Motivation

OpenAI-compatible API providers are increasingly common (DeepSeek, Xunfei, local vLLM servers, etc.). Users who configure \contextPruning\ with these providers currently get no benefit because the eligibility check silently returns \alse\. Since these providers use the same OpenAI chat completion protocol, they should be eligible for cache-ttl based pruning when the user has configured it.

## Testing

- New unit tests for \openai-completions\ provider eligibility (openai, astroncodingplan, deepseek)
- Existing tests continue to pass (no change to Anthropic/Google logic)

## Impact

- Minimal: one additional \||\ condition in the eligibility check
- No breaking changes: only adds eligibility, never removes it
- Compatible with existing provider plugin mechanism (plugins take priority via early return)