### PR TITLE
fix(cron): prevent premature session cleanup when subagents are running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1804,6 +1804,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 - macOS app: detect stale Gateway TLS certificate pins, automatically repair trusted Tailscale Serve rotations, and surface paired-but-disconnected Mac companion nodes so partial Gateway connections no longer look healthy. Thanks @guti.
 - Feishu: recreate WebSocket clients with monitor-owned backoff only after SDK reconnect exhaustion, preserving heartbeat defaults and shutdown cleanup without treating recoverable SDK callback errors as terminal, so persistent connections recover without manual gateway restart. Fixes #52618; duplicate evidence #59753; related #55532, #68766, #72411, and #73739. Thanks @vincentkoc, @schumilin, @alex-xuweilong, @120106835, @sirfengyu, and @tianhaocui.
+- Cron/delivery: defer isolated direct-delivery `deleteAfterRun` session cleanup until active subagents finish, then delete the session after the descendant run tree drains. (#69256, #67807) Thanks @lllyin and @MonkeyLeeT.
 
 ## 2026.4.27
 

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -105,6 +105,8 @@ This fires ~5–6 times per month instead of 0–1 times per month. OpenClaw use
 
     Isolated cron runs also dispose any bundled MCP runtime instances created for the job through the shared runtime-cleanup path. This matches how main-session and custom-session MCP clients are torn down, so isolated cron jobs do not leak stdio child processes or long-lived MCP connections across runs.
 
+    When isolated direct delivery also needs `deleteAfterRun` cleanup, OpenClaw waits for active subagents under that run to finish before deleting the cron session.
+
   </Accordion>
   <Accordion title="Subagent and Discord delivery">
     When isolated cron runs orchestrate subagents, delivery also prefers the final descendant output over stale parent interim text. If descendants are still running, OpenClaw suppresses that partial parent update instead of announcing it.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1210,7 +1210,8 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
-  it("preserves the direct cron session when descendants remain active after cleanup wait", async () => {
+  it("defers direct cron session cleanup when descendants drain after the first cleanup wait", async () => {
+    vi.useFakeTimers();
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
 
     const params = makeBaseParams({ synthesizedText: "HEARTBEAT_OK" });
@@ -1220,7 +1221,10 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       { text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" },
     ] as never;
     (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
-    vi.mocked(countActiveDescendantRuns).mockReturnValue(1);
+    vi.mocked(countActiveDescendantRuns)
+      .mockReturnValueOnce(1)
+      .mockReturnValueOnce(1)
+      .mockReturnValue(0);
 
     const state = await dispatchCronDelivery(params);
 
@@ -1236,6 +1240,18 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       expect.objectContaining({ method: "sessions.delete" }),
     );
     expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
+
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(callGateway).toHaveBeenCalledWith({
+      method: "sessions.delete",
+      params: {
+        key: "agent:main",
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
   });
 
   it("suppresses NO_REPLY payload with surrounding whitespace", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1165,6 +1165,79 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
+  it("waits for active descendants before deleteAfterRun cleanup after structured direct delivery", async () => {
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "HEARTBEAT_OK" });
+    params.agentSessionKey = "agent:main:cron:test-job";
+    params.runSessionKey = "agent:main:cron:test-job:run:test-session-id";
+    params.deliveryPayloadHasStructuredContent = true;
+    params.deliveryPayloads = [
+      { text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" },
+    ] as never;
+    (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    const activeCounts = [1, 0];
+    vi.mocked(countActiveDescendantRuns).mockImplementation((sessionKey) =>
+      sessionKey === params.runSessionKey ? (activeCounts.shift() ?? 0) : 0,
+    );
+    vi.mocked(waitForDescendantSubagentSummary).mockImplementation(async () => {
+      expect(callGateway).not.toHaveBeenCalledWith(
+        expect.objectContaining({ method: "sessions.delete" }),
+      );
+      return undefined;
+    });
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(countActiveDescendantRuns).toHaveBeenCalledWith(params.runSessionKey);
+    expect(countActiveDescendantRuns).not.toHaveBeenCalledWith(params.agentSessionKey);
+    expect(waitForDescendantSubagentSummary).toHaveBeenCalledWith({
+      sessionKey: params.runSessionKey,
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+    expect(callGateway).toHaveBeenCalledWith({
+      method: "sessions.delete",
+      params: {
+        key: "agent:main:cron:test-job",
+        deleteTranscript: true,
+        emitLifecycleHooks: false,
+      },
+      timeoutMs: 10_000,
+    });
+  });
+
+  it("preserves the direct cron session when descendants remain active after cleanup wait", async () => {
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "HEARTBEAT_OK" });
+    params.runSessionKey = "agent:main:cron:test-job:run:test-session-id";
+    params.deliveryPayloadHasStructuredContent = true;
+    params.deliveryPayloads = [
+      { text: "HEARTBEAT_OK", mediaUrl: "https://example.com/img.png" },
+    ] as never;
+    (params.job as { deleteAfterRun?: boolean }).deleteAfterRun = true;
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(1);
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+    expect(waitForDescendantSubagentSummary).toHaveBeenCalledWith({
+      sessionKey: params.runSessionKey,
+      timeoutMs: 30_000,
+      observedActiveDescendants: true,
+    });
+    expect(callGateway).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: "sessions.delete" }),
+    );
+    expect(retireSessionMcpRuntime).not.toHaveBeenCalled();
+  });
+
   it("suppresses NO_REPLY payload with surrounding whitespace", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -519,13 +519,33 @@ export async function dispatchCronDelivery(
 
     try {
       const subagentRegistryRuntime = await loadDeliverySubagentRegistryRuntime();
-      const activeSubagentRuns = subagentRegistryRuntime.countActiveDescendantRuns(
-        params.agentSessionKey,
+      const cleanupDescendantSessionKey = params.runSessionKey;
+      let activeSubagentRuns = subagentRegistryRuntime.countActiveDescendantRuns(
+        cleanupDescendantSessionKey,
       );
       if (activeSubagentRuns > 0) {
         // Parent orchestration is still in progress; preserve the session for
-        // subagent announcements.
-        return;
+        // subagent announcements, then retry cleanup after the run tree drains.
+        try {
+          const subagentFollowupRuntime = await loadSubagentFollowupRuntime();
+          await subagentFollowupRuntime.waitForDescendantSubagentSummary({
+            sessionKey: cleanupDescendantSessionKey,
+            timeoutMs: params.timeoutMs,
+            observedActiveDescendants: true,
+          });
+        } catch (err) {
+          await logCronDeliveryWarn(
+            `[cron:${params.job.id}] failed to wait for subagent cleanup before deleting cron session: ${formatErrorMessage(err)}`,
+          );
+          return;
+        }
+
+        activeSubagentRuns = subagentRegistryRuntime.countActiveDescendantRuns(
+          cleanupDescendantSessionKey,
+        );
+        if (activeSubagentRuns > 0) {
+          return;
+        }
       }
 
       const { callGateway } = await loadGatewayCallRuntime();

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -516,7 +516,18 @@ export async function dispatchCronDelivery(
     if (!params.job.deleteAfterRun || directCronSessionDeleted) {
       return;
     }
+
     try {
+      const subagentRegistryRuntime = await loadDeliverySubagentRegistryRuntime();
+      const activeSubagentRuns = subagentRegistryRuntime.countActiveDescendantRuns(
+        params.agentSessionKey,
+      );
+      if (activeSubagentRuns > 0) {
+        // Parent orchestration is still in progress; preserve the session for
+        // subagent announcements.
+        return;
+      }
+
       const { callGateway } = await loadGatewayCallRuntime();
       await callGateway({
         method: "sessions.delete",

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -155,6 +155,10 @@ const TRANSIENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /\b(econnreset|econnrefused|etimedout|enotfound|ehostunreach|network error)\b/i,
 ];
 
+const DIRECT_CRON_CLEANUP_RETRY_DELAY_MS = 30_000;
+const DIRECT_CRON_CLEANUP_MAX_DEFERRED_RETRIES = 3;
+const directCronCleanupRetryTimers = new Set<ReturnType<typeof setTimeout>>();
+
 const PERMANENT_DIRECT_CRON_DELIVERY_ERROR_PATTERNS: readonly RegExp[] = [
   /unsupported channel/i,
   /unknown channel/i,
@@ -417,6 +421,10 @@ async function queueCronAwarenessSystemEvent(params: {
 
 export function resetCompletedDirectCronDeliveriesForTests() {
   COMPLETED_DIRECT_CRON_DELIVERIES.clear();
+  for (const timer of directCronCleanupRetryTimers) {
+    clearTimeout(timer);
+  }
+  directCronCleanupRetryTimers.clear();
 }
 
 export function getCompletedDirectCronDeliveriesCountForTests(): number {
@@ -498,6 +506,8 @@ export async function dispatchCronDelivery(
   let delivered = skipMessagingToolDelivery;
   let deliveryAttempted = skipMessagingToolDelivery;
   let directCronSessionDeleted = false;
+  let deferredCleanupRetryScheduled = false;
+  let deferredCleanupRetryCount = 0;
   const formatDeliveryTargetError = (error: string) =>
     params.unverifiedMessagingToolDelivery === true
       ? `${error}; the agent used the message tool, but OpenClaw could not verify that message matched the cron delivery target`
@@ -516,6 +526,31 @@ export async function dispatchCronDelivery(
     if (!params.job.deleteAfterRun || directCronSessionDeleted) {
       return;
     }
+
+    const scheduleDeferredCleanupRetry = () => {
+      if (
+        deferredCleanupRetryScheduled ||
+        deferredCleanupRetryCount >= DIRECT_CRON_CLEANUP_MAX_DEFERRED_RETRIES
+      ) {
+        return;
+      }
+
+      deferredCleanupRetryScheduled = true;
+      deferredCleanupRetryCount += 1;
+      const timer = setTimeout(async () => {
+        directCronCleanupRetryTimers.delete(timer);
+        deferredCleanupRetryScheduled = false;
+        try {
+          await cleanupDirectCronSessionIfNeeded();
+        } catch (err) {
+          await logCronDeliveryWarn(
+            `[cron:${params.job.id}] deferred deleteAfterRun cleanup failed: ${formatErrorMessage(err)}`,
+          );
+        }
+      }, DIRECT_CRON_CLEANUP_RETRY_DELAY_MS);
+      timer.unref?.();
+      directCronCleanupRetryTimers.add(timer);
+    };
 
     try {
       const subagentRegistryRuntime = await loadDeliverySubagentRegistryRuntime();
@@ -544,6 +579,7 @@ export async function dispatchCronDelivery(
           cleanupDescendantSessionKey,
         );
         if (activeSubagentRuns > 0) {
+          scheduleDeferredCleanupRetry();
           return;
         }
       }


### PR DESCRIPTION
## Summary

- **Problem**: Isolated cron sessions with `deleteAfterRun: true` are being deleted prematurely during a run if a "Direct Delivery" (structured content or threaded reply) is triggered, even if subagents (workers) are still active.
- **Why it matters**: In orchestrator-worker patterns, the parent agent must survive to receive and aggregate results from its subagents. Premature cleanup orphans the workers and creates a fresh, context-less session, breaking the pipeline.
- **What changed**: Modified `cleanupDirectCronSessionIfNeeded` in `delivery-dispatch.ts` to check `countActiveDescendantRuns` before executing `sessions.delete`.
- **What did NOT change**: The cleanup logic for standard text-only deliveries (which already had subagent awareness via `finalizeTextDelivery`) was not altered.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #67807 
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: PR #67807 introduced automated session cleanup in the `finally` block of `deliverViaDirectAndCleanup` but missed the subagent-counting guardrail that exists in the sibling `finalizeTextDelivery` path.
- **Missing detection / guardrail**: Lack of `countActiveDescendantRuns` verification in the Direct Delivery cleanup wrapper.
- **Contributing context**: Complex workflows using Feishu or threaded replies trigger the `useDirectDelivery` path, bypassing the subagent waiting orchestration.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
- Target test or file: `src/cron/isolated-agent/delivery-dispatch.test.ts`
- Scenario the test should lock in: A cron job with `deleteAfterRun: true` that spawns a subagent and returns structured content should NOT trigger `sessions.delete` until the subagent completes.
- Why this is the smallest reliable guardrail: It directly asserts that the gateway call is suppressed in the presence of active runs.

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
[Main Agent Spawns 5 Workers] -> [Post Interim Update] -> [Direct Delivery Cleanup DELETES Session] -> [Worker finishes] -> [Context LOST]

After:
[Main Agent Spawns 5 Workers] -> [Post Interim Update] -> [Cleanup BLOCKED by active workers] -> [Session stays alive] -> [Worker finishes] -> [Final aggregation succeeds]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node 22
- Integration/channel: Feishu (triggers threaded direct delivery)

### Steps

1. Create a cron job with `session: isolated` and `deleteAfterRun: true`.
2. Instruction: "Spawn 5 subagents using sessions_spawn to do work and wait for them."
3. Ensure the main agent's reply triggers `useDirectDelivery` (e.g., long message or structured summary).

### Expected

Main session is preserved until all 5 workers finish and report back.

### Actual

Main session is deleted immediately after the "Spawning..." update is delivered, resulting in empty/fresh sessions for subsequent worker completion events.

## Evidence

- [x] Trace/log snippets (Verified sessions were renamed to `.deleted` exactly when the interim update was delivered).

## Human Verification (required)

- Verified scenarios: Local reproduction with a multi-worker scout pipeline.
- Edge cases checked: Silent replies and text-only replies still follow their respective successful delivery paths.
