### PR TITLE
fix(doctor): skip plugins.entries for installed plugins already auto-loaded via manifest channels

### DIFF
--- a/src/config/plugin-auto-enable.channels.test.ts
+++ b/src/config/plugin-auto-enable.channels.test.ts
@@ -305,3 +305,61 @@ describe("applyPluginAutoEnable channels", () => {
     });
   });
 });
+
+describe("applyPluginAutoEnable — globally-installed plugin auto-load skip (issue #37548)", () => {
+  afterEach(() => {
+    resetPluginAutoEnableTestState();
+  });
+
+  it("does not add plugins.entries for a globally-installed plugin already auto-loaded via its manifest channel", () => {
+    // A globally-installed third-party plugin declares channels: ["acme-chat"] in its
+    // manifest. The plugin loader auto-discovers and loads it from ~/.openclaw/extensions/.
+    // Doctor must NOT also write plugins.entries.acme-chat, which would produce a
+    // "duplicate plugin id" warning at startup.
+    // See: https://github.com/openclaw/openclaw/issues/37548
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { "acme-chat": { apiKey: "test-key" } },
+      },
+      env: makeIsolatedEnv(),
+      manifestRegistry: makeRegistry([
+        { id: "acme-chat", channels: ["acme-chat"], origin: "global" },
+      ]),
+    });
+
+    expect(result.config.plugins?.entries?.["acme-chat"]).toBeUndefined();
+    expect(result.changes).toEqual([]);
+  });
+
+  it("does not add plugins.entries for a workspace-installed plugin already auto-loaded via its manifest channel", () => {
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { "acme-chat": { apiKey: "test-key" } },
+      },
+      env: makeIsolatedEnv(),
+      manifestRegistry: makeRegistry([
+        { id: "acme-chat", channels: ["acme-chat"], origin: "workspace" },
+      ]),
+    });
+
+    expect(result.config.plugins?.entries?.["acme-chat"]).toBeUndefined();
+    expect(result.changes).toEqual([]);
+  });
+
+  it('still adds plugins.entries for a bundled plugin (origin "bundled", not auto-loaded from extensions directory)', () => {
+    // Bundled plugins are part of OpenClaw's own distribution. They are NOT
+    // auto-discovered from ~/.openclaw/extensions/, so they still require an
+    // explicit plugins.entries entry to be enabled.
+    const result = applyPluginAutoEnable({
+      config: {
+        channels: { "acme-chat": { apiKey: "test-key" } },
+      },
+      env: makeIsolatedEnv(),
+      manifestRegistry: makeRegistry([
+        { id: "acme-chat", channels: ["acme-chat"], origin: "bundled" },
+      ]),
+    });
+
+    expect(result.config.plugins?.entries?.["acme-chat"]?.enabled).toBe(true);
+  });
+});

--- a/src/config/plugin-auto-enable.shared.ts
+++ b/src/config/plugin-auto-enable.shared.ts
@@ -757,7 +757,27 @@ export function materializePluginAutoEnableCandidatesInternal(params: {
     const alreadyEnabled =
       builtInChannelId != null
         ? isBuiltInChannelAlreadyEnabled(next, builtInChannelId)
-        : next.plugins?.entries?.[entry.pluginId]?.enabled === true;
+        : (() => {
+            if (next.plugins?.entries?.[entry.pluginId]?.enabled === true) {
+              return true;
+            }
+            // A globally- or workspace-installed plugin that declares channels in its
+            // manifest will be auto-loaded by the plugin loader whenever one of those
+            // channels is configured — adding it to plugins.entries would create a
+            // "duplicate plugin id" warning at startup.  Bundled plugins (origin
+            // "bundled") are NOT auto-loaded this way and still need plugins.entries
+            // to be explicitly enabled.
+            // See: https://github.com/openclaw/openclaw/issues/37548
+            const pluginRecord = params.manifestRegistry.plugins.find(
+              (p) => p.id === entry.pluginId,
+            );
+            return (
+              pluginRecord != null &&
+              (pluginRecord.origin === "global" || pluginRecord.origin === "workspace") &&
+              (pluginRecord.channels ?? []).length > 0 &&
+              (pluginRecord.channels ?? []).some((ch) => isChannelConfigured(next, ch, params.env))
+            );
+          })();
     if (alreadyEnabled && !allowMissing) {
       continue;
     }

--- a/src/config/plugin-auto-enable.test-helpers.ts
+++ b/src/config/plugin-auto-enable.test-helpers.ts
@@ -66,6 +66,7 @@ export function makeRegistry(
     providers?: string[];
     configSchema?: Record<string, unknown>;
     channelConfigs?: Record<string, { schema: Record<string, unknown>; preferOver?: string[] }>;
+    origin?: "config" | "global" | "workspace" | "bundled";
   }>,
 ): PluginManifestRegistry {
   return {
@@ -82,7 +83,7 @@ export function makeRegistry(
       cliBackends: [],
       skills: [],
       hooks: [],
-      origin: "config" as const,
+      origin: plugin.origin ?? ("config" as const),
       rootDir: `/fake/${plugin.id}`,
       source: `/fake/${plugin.id}/index.js`,
       manifestPath: `/fake/${plugin.id}/openclaw.plugin.json`,


### PR DESCRIPTION
## Problem

When a globally- or workspace-installed plugin declares channels in its manifest (e.g. a third-party plugin declares `channels: ["acme-chat"]`), OpenClaw's plugin loader already auto-discovers and loads it from `~/.openclaw/extensions/`. Running `openclaw doctor --fix` would also write `plugins.entries.<id>.enabled = true`, causing the plugin to be registered twice and producing a startup warning:

```
plugins.entries.<id>: duplicate plugin id detected
```

Fixes #37548
See also #35884
Replaces #40537 (rebased onto latest main after plugin-auto-enable refactor)

## Root cause

In `applyPluginAutoEnable` / `materializePluginAutoEnableCandidatesInternal`, the `alreadyEnabled` check for non-built-in plugins only looked at `plugins.entries[pluginId].enabled === true`. It did not consider that a globally/workspace-installed plugin would already be auto-loaded by the plugin loader via filesystem discovery — so doctor would redundantly add it to `plugins.entries`.

## Fix

Skip writing `plugins.entries` for a plugin when **all** of the following are true:
1. The plugin is globally or workspace-installed (`origin === 'global' || origin === 'workspace'`)
2. The plugin declares one or more channels in its manifest
3. At least one of those declared channels is configured in `channels.<id>`

Bundled plugins (`origin === 'bundled'`) are intentionally excluded — they are part of OpenClaw's own distribution and still require an explicit `plugins.entries` entry.

## Changes

- **`src/config/plugin-auto-enable.shared.ts`**: Extended the `alreadyEnabled` check in `materializePluginAutoEnableCandidatesInternal` to also return true for globally/workspace-installed plugins that declare channels in their manifest
- **`src/config/plugin-auto-enable.test-helpers.ts`**: Extended `makeRegistry` helper to accept optional `origin` field (defaults to `"config"`)
- **`src/config/plugin-auto-enable.channels.test.ts`**: Added 3 test cases covering global, workspace, and bundled plugin scenarios

## Testing

All existing tests pass. Added 3 new tests:
- `does not add plugins.entries for a globally-installed plugin already auto-loaded via its manifest channel`
- `does not add plugins.entries for a workspace-installed plugin already auto-loaded via its manifest channel`
- `still adds plugins.entries for a bundled plugin (origin "bundled", not auto-loaded from extensions directory)`