### PR TITLE
CLI: complete positional args in zsh completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/zsh completion: keep generic `<path>` positionals such as config key paths out of file suggestions while preserving filesystem completions for explicit file and directory arguments. Repairs #69305. Thanks @sk7n4k3d.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -51,6 +51,18 @@ describe("completion-cli", () => {
     expect(script).toContain('"1:Local file path to ingest:_files"');
   });
 
+  it("does not force file completion for generic path arguments", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("config").description("Config commands").argument("<path>", "Config key path");
+
+    const script = getCompletionScript("zsh", program);
+
+    expect(script).toContain("_openclaw_config()");
+    expect(script).toContain('"1:Config key path: "');
+    expect(script).not.toContain('"1:Config key path:_files"');
+  });
+
   it("emits zsh positional directory completion when the argument name hints at a directory", () => {
     const script = getCompletionScript("zsh", createCompletionProgram());
 

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -62,9 +62,21 @@ describe("completion-cli", () => {
     const script = getCompletionScript("zsh", createCompletionProgram());
 
     expect(script).toContain("_openclaw_wiki_tag()");
-    // Non-file positional keeps a neutral action; variadic gets position `*`.
+    // Required positional keeps the single-colon form; optional variadic gets
+    // the `*::` head so zsh treats it as optional.
     expect(script).toContain('"1:Note id: "');
-    expect(script).toContain('"*:Tags to add: "');
+    expect(script).toContain('"*::Tags to add: "');
+  });
+
+  it("uses the optional positional form for commander [name] arguments", () => {
+    const program = new Command();
+    program.name("openclaw");
+    program.command("query").description("Run a query").argument("[term]", "Optional search term");
+
+    const script = getCompletionScript("zsh", program);
+
+    expect(script).toContain("_openclaw_query()");
+    expect(script).toContain('"1::Optional search term: "');
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -18,6 +18,19 @@ function createCompletionProgram(): Command {
   gateway.command("status").description("Show gateway status").option("--json", "JSON output");
   gateway.command("restart").description("Restart gateway");
 
+  const wiki = program.command("wiki").description("Wiki commands");
+  wiki
+    .command("ingest")
+    .description("Ingest a source")
+    .option("--title <title>", "Override title")
+    .argument("<path>", "Local file path to ingest");
+  wiki.command("scan").description("Scan a directory").argument("<directory>", "Directory to scan");
+  wiki
+    .command("tag")
+    .description("Tag a note")
+    .argument("<name>", "Note id")
+    .argument("[tags...]", "Tags to add");
+
   return program;
 }
 
@@ -29,6 +42,29 @@ describe("completion-cli", () => {
     expect(script).toContain("(status) _openclaw_gateway_status ;;");
     expect(script).toContain("(restart) _openclaw_gateway_restart ;;");
     expect(script).toContain("--force[Force the action]");
+  });
+
+  it("emits zsh positional file completion for leaf command path arguments", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("_openclaw_wiki_ingest()");
+    expect(script).toContain('"1:Local file path to ingest:_files"');
+  });
+
+  it("emits zsh positional directory completion when the argument name hints at a directory", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("_openclaw_wiki_scan()");
+    expect(script).toContain('"1:Directory to scan:_files -/"');
+  });
+
+  it("emits a variadic positional spec for trailing ...args", () => {
+    const script = getCompletionScript("zsh", createCompletionProgram());
+
+    expect(script).toContain("_openclaw_wiki_tag()");
+    // Non-file positional keeps a neutral action; variadic gets position `*`.
+    expect(script).toContain('"1:Note id: "');
+    expect(script).toContain('"*:Tags to add: "');
   });
 
   it("defers zsh registration until compinit is available", async () => {

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -207,16 +207,17 @@ function generateZshArgs(cmd: Command): string {
     .join(" \\\n    ");
 }
 
-// Argument names that hint at a filesystem path. Used to pick the correct
-// zsh completion action (_files / _path_files / _files -/) for a positional.
-const FILE_ARG_HINT = /(^|[_-])(path|file|source|target|src|dest|destination)s?($|[_-])/i;
+// Argument names/descriptions that hint at a filesystem path. Used to pick the
+// correct zsh completion action (_files / _files -/) for a positional.
+const FILE_ARG_HINT = /(^|[_-])(file|source|target|src|dest|destination)s?($|[_-])/i;
 const DIR_ARG_HINT = /(^|[_-])(dir|directory|folder)s?($|[_-])/i;
+const FILESYSTEM_DESCRIPTION_HINT = /\b(file|filesystem|directory|folder)s?\b/i;
 
-function zshPositionalAction(name: string): string {
-  if (DIR_ARG_HINT.test(name)) {
+function zshPositionalAction(name: string, description: string): string {
+  if (DIR_ARG_HINT.test(name) || /\b(directory|folder)s?\b/i.test(description)) {
     return "_files -/";
   }
-  if (FILE_ARG_HINT.test(name)) {
+  if (FILE_ARG_HINT.test(name) || FILESYSTEM_DESCRIPTION_HINT.test(description)) {
     return "_files";
   }
   return " ";
@@ -249,8 +250,9 @@ function generateZshPositionalArgs(cmd: Command): string[] {
       required?: boolean;
     };
     const name = typeof arg.name === "function" ? arg.name() : (arg._name ?? `arg${index + 1}`);
-    const label = escapeZshLabel(arg.description || name);
-    const action = zshPositionalAction(name);
+    const description = arg.description || name;
+    const label = escapeZshLabel(description);
+    const action = zshPositionalAction(name, description);
     const position = arg.variadic ? "*" : String(index + 1);
     // Commander's `<name>` = required, `[name]` / `[name...]` = optional. In
     // zsh `_arguments` specs only the first separator doubles up for optional

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -207,6 +207,62 @@ function generateZshArgs(cmd: Command): string {
     .join(" \\\n    ");
 }
 
+// Argument names that hint at a filesystem path. Used to pick the correct
+// zsh completion action (_files / _path_files / _files -/) for a positional.
+const FILE_ARG_HINT = /(^|[_-])(path|file|files|source|target|src|dest|destination)s?($|[_-])/i;
+const DIR_ARG_HINT = /(^|[_-])(dir|directory|folder)s?($|[_-])/i;
+
+function zshPositionalAction(name: string): string {
+  if (DIR_ARG_HINT.test(name)) {
+    return "_files -/";
+  }
+  if (FILE_ARG_HINT.test(name)) {
+    return "_files";
+  }
+  return " ";
+}
+
+function escapeZshLabel(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/'/g, "'\\''")
+    .replace(/:/g, "\\:")
+    .replace(/\[/g, "\\[")
+    .replace(/\]/g, "\\]");
+}
+
+function generateZshPositionalArgs(cmd: Command): string[] {
+  // Commander 14 exposes registeredArguments; fall back to _args for older versions.
+  const args =
+    (cmd as unknown as { registeredArguments?: ReadonlyArray<unknown> }).registeredArguments ??
+    (cmd as unknown as { _args?: ReadonlyArray<unknown> })._args ??
+    [];
+  return args.map((raw, index) => {
+    const arg = raw as {
+      _name?: string;
+      name?: () => string;
+      description?: string;
+      variadic?: boolean;
+    };
+    const name = typeof arg.name === "function" ? arg.name() : (arg._name ?? `arg${index + 1}`);
+    const label = escapeZshLabel(arg.description || name);
+    const action = zshPositionalAction(name);
+    const position = arg.variadic ? "*" : String(index + 1);
+    return `"${position}:${label}:${action}"`;
+  });
+}
+
+function generateZshLeafArgs(cmd: Command): string {
+  const optionSpecs = generateZshArgs(cmd);
+  const positionalSpecs = generateZshPositionalArgs(cmd);
+  if (positionalSpecs.length === 0) {
+    return optionSpecs;
+  }
+  const joinedPositionals = positionalSpecs.join(" \\\n    ");
+  return optionSpecs ? `${optionSpecs} \\\n    ${joinedPositionals}` : joinedPositionals;
+}
+
 function generateZshSubcmdList(cmd: Command): string {
   const list = cmd.commands
     .map((c) => {
@@ -260,7 +316,7 @@ ${funcName}() {
       segments.push(`
 ${funcName}() {
   _arguments -C \\
-    ${generateZshArgs(cmd)}
+    ${generateZshLeafArgs(cmd)}
 }
 `);
     }

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -209,7 +209,7 @@ function generateZshArgs(cmd: Command): string {
 
 // Argument names that hint at a filesystem path. Used to pick the correct
 // zsh completion action (_files / _path_files / _files -/) for a positional.
-const FILE_ARG_HINT = /(^|[_-])(path|file|files|source|target|src|dest|destination)s?($|[_-])/i;
+const FILE_ARG_HINT = /(^|[_-])(path|file|source|target|src|dest|destination)s?($|[_-])/i;
 const DIR_ARG_HINT = /(^|[_-])(dir|directory|folder)s?($|[_-])/i;
 
 function zshPositionalAction(name: string): string {
@@ -223,10 +223,12 @@ function zshPositionalAction(name: string): string {
 }
 
 function escapeZshLabel(value: string): string {
+  // The label is always embedded in a double-quoted zsh spec like
+  // `"<pos>:<label>:<action>"`, so single quotes pass through literally — we
+  // only need to escape backslash, double quote, colon, and bracket.
   return value
     .replace(/\\/g, "\\\\")
     .replace(/"/g, '\\"')
-    .replace(/'/g, "'\\''")
     .replace(/:/g, "\\:")
     .replace(/\[/g, "\\[")
     .replace(/\]/g, "\\]");
@@ -244,12 +246,17 @@ function generateZshPositionalArgs(cmd: Command): string[] {
       name?: () => string;
       description?: string;
       variadic?: boolean;
+      required?: boolean;
     };
     const name = typeof arg.name === "function" ? arg.name() : (arg._name ?? `arg${index + 1}`);
     const label = escapeZshLabel(arg.description || name);
     const action = zshPositionalAction(name);
     const position = arg.variadic ? "*" : String(index + 1);
-    return `"${position}:${label}:${action}"`;
+    // Commander's `<name>` = required, `[name]` / `[name...]` = optional. In
+    // zsh `_arguments` specs only the first separator doubles up for optional
+    // positionals: `n::MESSAGE:ACTION` / `*::MESSAGE:ACTION`.
+    const head = arg.required === false ? `${position}::` : `${position}:`;
+    return `"${head}${label}:${action}"`;
   });
 }
 


### PR DESCRIPTION
## Summary

- Problem: \`openclaw wiki ingest <file>\`, \`openclaw wiki scan <dir>\`, and every other leaf command with a positional argument emits a zsh completion function that lists options only. Typing \`openclaw wiki ingest T<Tab>\` triggers the terminal bell instead of completing filenames, reported in #69293.
- Why it matters: leaf commands with a \`<path>\`/\`<directory>\`/\`<files...>\` argument are the ones shell completion actually helps with. Today the generated zsh function skips that slot entirely.
- What changed: \`generateZshArgs\` still renders option flags; a new \`generateZshPositionalArgs\` walks \`cmd.registeredArguments\` and emits one \`\"<position>:<label>:<action>\"\` per argument, using \`_files\` when the argument name hints at a path/file/source/etc., \`_files -/\` for dir/folder hints, and a neutral action otherwise. Variadic trailing args (\`[tags...]\`) emit position \`*\`. Only leaf command blocks consume the new helper so the existing subcommand dispatch (\`_values 'command'\`) on non-leaf commands is unchanged.
- What did NOT change (scope boundary): bash / fish / powershell generators, option flag rendering, argument-less leaf commands, subcommand dispatch, \`completion-runtime\`, \`completion-fish\` helpers.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #69293
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: \`generateZshArgs\` only iterated \`cmd.options\`. The leaf-command template in \`generateZshSubcommands\` called \`_arguments -C\` with just those option specs, so Commander \`.argument(\"<path>\", ...)\` declarations were never exported to zsh.
- Missing detection / guardrail: the existing completion-cli tests exercised option flag rendering and compinit deferral, but never asserted that a positional argument reaches the generated function.
- Contributing context: Commander 14 exposes \`registeredArguments\` on every \`Command\`; earlier completion work used only \`cmd.options\`.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: \`src/cli/completion-cli.test.ts\`
- Scenario the test should lock in: for a leaf command declared with \`.argument(\"<path>\", \"Local file path to ingest\")\`, the generated zsh script must contain \`\"1:Local file path to ingest:_files\"\`. Equivalent assertions cover \`<directory>\` (\`_files -/\`) and variadic \`[tags...]\` (\`*:\` position).
- Why this is the smallest reliable guardrail: a single string-containment check against the emitted script deterministically detects the regression without needing a live zsh process.
- Existing test that already covers this (if any): none.

## User-visible / Behavior Changes

\`openclaw completion --shell zsh\` now emits positional argument specs for every leaf command. After sourcing the generated script, \`<Tab>\` on \`openclaw wiki ingest\`, \`openclaw wiki doctor\` (etc.) completes filesystem paths just like any other zsh file argument. No other shells are touched.

## Diagram (if applicable)

\`\`\`text
Before:
openclaw wiki ingest T<Tab>   -> terminal bell, no completion

After:
openclaw wiki ingest T<Tab>   -> Tone.md Topic.md ... (zsh _files)
\`\`\`

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Arch CachyOS); fix is shell-side, reproducer in the issue is macOS.
- Runtime/container: pnpm workspace, Node 22, vitest.
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config: none

### Steps

1. Build the program with a leaf command declaring \`.argument(\"<path>\", \"Local file path to ingest\")\` (done in \`createCompletionProgram\` in the test file).
2. Call \`getCompletionScript(\"zsh\", program)\`.
3. Assert the generated function \`_openclaw_wiki_ingest\` includes \`\"1:Local file path to ingest:_files\"\`.

### Expected

- Generated zsh function contains positional spec \`\"1:<description>:_files\"\` (or \`_files -/\` for dir hints, \`*\` position for variadic).

### Actual (before this change)

- Generated zsh function contained only option specs; no positional slot, so zsh file completion never fired on the argument.

## Evidence

- [x] Failing test/log before + passing after

New unit tests (3 scenarios: file hint, dir hint, variadic) fail on \`main\`, pass on this branch. Local commands run:

\`\`\`
pnpm test src/cli/completion-cli.test.ts
# 7 passed (4 pre-existing + 3 new)
pnpm lint src/cli/completion-cli.ts src/cli/completion-cli.test.ts
# 0 warnings, 0 errors
pnpm tsgo && pnpm tsgo:core:test
# clean
\`\`\`

Manual inspection of the generated script for a \`wiki ingest\` command produces exactly the shape the issue reporter asked for:

\`\`\`
_openclaw_wiki_ingest() {
  _arguments -C \\
    \"--title[Title]\" \\
    \"--json[JSON]\" \\
    \"1:Local file path to ingest:_files\"
}
\`\`\`

## Human Verification (required)

- Verified scenarios:
  - File-hint argument (\`<path>\`) emits \`_files\`.
  - Directory-hint argument (\`<directory>\`) emits \`_files -/\`.
  - Variadic trailing argument (\`[tags...]\`) emits position \`*\` with the argument description.
  - Non-hint argument (\`<name>\`) emits a neutral action so zsh does not over-complete with file names.
  - Option flag rendering is byte-identical (pre-existing test \`generates zsh functions for nested subcommands\` still passes unchanged).
- Edge cases checked:
  - Argument description is zsh-escaped (backslashes, quotes, colons, brackets) via \`escapeZshLabel\`.
  - Intermediate commands (\`wiki\`) continue to render subcommand dispatch; \`generateZshPositionalArgs\` only runs on the leaf-command branch.
  - Commander 14 exposes \`registeredArguments\`; fallback to \`_args\` kept for resilience.
- What you did **not** verify:
  - Live zsh \`compinit\` expansion was not run on this workstation (zsh not installed); the existing \`defers zsh registration until compinit is available\` test gates that on CI.
  - Bash / fish / powershell generators — intentionally out of scope for this PR.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (generated script is a strict superset of the previous one for leaf commands; users who re-run \`openclaw completion --shell zsh --write-state\` pick up the new specs).
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a positional argument with a file-like name but no filesystem semantics would wrongly suggest files.
  - Mitigation: the hint regex is narrow (path/file/files/source/target/src/dest/destination/dir/directory/folder with word boundaries); any other name defaults to a neutral action, not \`_files\`.

---

This PR is **AI-assisted** (Claude). Degree of testing: fully tested via new unit tests plus scoped \`pnpm lint\` / \`pnpm tsgo\` / \`pnpm tsgo:core:test\`. I read the generated output end-to-end and verified it matches the shape the issue reporter requested.