### PR TITLE
fix: surface dropped media to users instead of silently swallowing

### DIFF
--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -164,7 +164,9 @@ export function sanitizeMediaDisplayName(mediaSource: string): string {
   }
   // Normalize Windows backslash paths for cross-platform safety
   const normalized = mediaSource.replace(/\\/g, "/");
-  return path.basename(normalized) || mediaSource;
+  // Strip URL query/fragment to avoid leaking signed tokens or credentials
+  const withoutParams = normalized.replace(/[?#].*$/, "");
+  return path.basename(withoutParams) || mediaSource;
 }
 
 /** Derive a reason code from the error thrown during media normalization. */

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type {
   InteractiveReply,
   MessagePresentation,
@@ -53,6 +54,8 @@ export type ReplyPayload = {
   isFallbackNotice?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
+  /** Media items that were dropped during normalization (blocked, inaccessible, etc.). */
+  droppedMedia?: DroppedMediaItem[];
 };
 
 export type ReplyPayloadTtsSupplement = {
@@ -139,6 +142,47 @@ export function buildTtsSupplementMediaPayload(payload: ReplyPayload): ReplyPayl
     spokenText: supplement.spokenText,
     ttsSupplement: supplement,
   };
+}
+
+export type DroppedMediaReasonCode =
+  | "normalization-failed"
+  | "blocked-path"
+  | "file-not-accessible"
+  | "data-url-rejected"
+  | "unknown";
+
+export type DroppedMediaItem = {
+  displayName: string;
+  code: DroppedMediaReasonCode;
+};
+
+/** Strip directory components from a media source so user-facing notices
+ *  never expose full filesystem paths. */
+export function sanitizeMediaDisplayName(mediaSource: string): string {
+  return path.basename(mediaSource) || mediaSource;
+}
+
+/** Derive a reason code from the error thrown during media normalization. */
+export function resolveDroppedMediaCode(err: unknown): DroppedMediaReasonCode {
+  if (!(err instanceof Error)) {
+    return "unknown";
+  }
+  const msg = err.message.toLowerCase();
+  if (msg.includes("blocked")) {
+    return "blocked-path";
+  }
+  if (msg.includes("data url") || msg.includes("data:")) {
+    return "data-url-rejected";
+  }
+  if (
+    msg.includes("enoent") ||
+    msg.includes("not found") ||
+    msg.includes("no such file") ||
+    msg.includes("not accessible")
+  ) {
+    return "file-not-accessible";
+  }
+  return "unknown";
 }
 
 export type ReplyPayloadMetadata = {

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -166,7 +166,10 @@ export function sanitizeMediaDisplayName(mediaSource: string): string {
   const normalized = mediaSource.replace(/\\/g, "/");
   // Strip URL query/fragment to avoid leaking signed tokens or credentials
   const withoutParams = normalized.replace(/[?#].*$/, "");
-  return path.basename(withoutParams) || mediaSource;
+  const basename = path.basename(withoutParams) || mediaSource;
+  // Escape backticks, newlines, and carriage returns so the display name
+  // cannot break out of Markdown code spans in formatDroppedMediaNotice.
+  return basename.replace(/[`\n\r]/g, "_");
 }
 
 /** Derive a reason code from the error thrown during media normalization. */

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -162,6 +162,16 @@ export function sanitizeMediaDisplayName(mediaSource: string): string {
   if (/^data:/i.test(mediaSource)) {
     return "(inline data)";
   }
+  // For URLs, use URL parsing to safely extract the pathname and avoid
+  // leaking userinfo, query tokens, or fragment identifiers.
+  try {
+    const parsed = new URL(mediaSource);
+    const pathname = parsed.pathname;
+    const basename = path.basename(pathname) || "(url)";
+    return basename.replace(/[`\n\r]/g, "_");
+  } catch {
+    // Not a valid URL — treat as a filesystem path.
+  }
   // Normalize Windows backslash paths for cross-platform safety
   const normalized = mediaSource.replace(/\\/g, "/");
   // Strip URL query/fragment to avoid leaking signed tokens or credentials

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -166,9 +166,14 @@ export function sanitizeMediaDisplayName(mediaSource: string): string {
   // leaking userinfo, query tokens, or fragment identifiers.
   try {
     const parsed = new URL(mediaSource);
-    const pathname = parsed.pathname;
-    const basename = path.basename(pathname) || "(url)";
-    return basename.replace(/[`\n\r]/g, "_");
+    // Skip URL parsing for Windows drive-letter paths (e.g. "C:\..." parses
+    // with protocol "c:", but path.basename on POSIX won't split backslashes
+    // in the resulting pathname, leaking the full path).
+    if (parsed.protocol.length > 2) {
+      const pathname = parsed.pathname;
+      const basename = path.basename(pathname) || "(url)";
+      return basename.replace(/[`\n\r]/g, "_");
+    }
   } catch {
     // Not a valid URL — treat as a filesystem path.
   }

--- a/src/auto-reply/reply-payload.ts
+++ b/src/auto-reply/reply-payload.ts
@@ -159,7 +159,12 @@ export type DroppedMediaItem = {
 /** Strip directory components from a media source so user-facing notices
  *  never expose full filesystem paths. */
 export function sanitizeMediaDisplayName(mediaSource: string): string {
-  return path.basename(mediaSource) || mediaSource;
+  if (/^data:/i.test(mediaSource)) {
+    return "(inline data)";
+  }
+  // Normalize Windows backslash paths for cross-platform safety
+  const normalized = mediaSource.replace(/\\/g, "/");
+  return path.basename(normalized) || mediaSource;
 }
 
 /** Derive a reason code from the error thrown during media normalization. */
@@ -171,7 +176,7 @@ export function resolveDroppedMediaCode(err: unknown): DroppedMediaReasonCode {
   if (msg.includes("blocked")) {
     return "blocked-path";
   }
-  if (msg.includes("data url") || msg.includes("data:")) {
+  if (msg.includes("data url") || /\bdata:\s*[a-z]/i.test(err.message)) {
     return "data-url-rejected";
   }
   if (

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -3,6 +3,7 @@ import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers/sanitiz
 import type { MessagingToolSend } from "../../agents/pi-embedded-messaging.types.js";
 import type { ReplyToMode } from "../../config/types.js";
 import { logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { stripLegacyBracketToolCallBlocks } from "../../shared/text/assistant-visible-text.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
@@ -10,7 +11,9 @@ import {
   appendReplyMediaFailureWarning,
   copyReplyPayloadMetadata,
   getReplyPayloadMetadata,
+  sanitizeMediaDisplayName,
   setReplyPayloadMetadata,
+  type DroppedMediaItem,
 } from "../reply-payload.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
@@ -24,6 +27,8 @@ import {
 } from "./origin-routing.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
 import { applyReplyThreading, isRenderablePayload } from "./reply-payloads-base.js";
+
+const log = createSubsystemLogger("agent-runner-payloads");
 
 const replyPayloadsDedupeRuntimeLoader = createLazyImportLoader(
   () => import("./reply-payloads-dedupe.runtime.js"),
@@ -46,7 +51,12 @@ async function normalizeReplyPayloadMedia(params: {
     const normalized = await params.normalizeMediaPaths(params.payload);
     return copyReplyPayloadMetadata(params.payload, normalized);
   } catch (err) {
-    logVerbose(`reply payload media normalization failed: ${String(err)}`);
+    log.warn(`reply payload media normalization failed: ${String(err)}`);
+    const originalMediaUrls = resolveSendableOutboundReplyParts(params.payload).mediaUrls;
+    const droppedMedia: DroppedMediaItem[] = originalMediaUrls.map((media) => ({
+      displayName: sanitizeMediaDisplayName(media),
+      code: "normalization-failed" as const,
+    }));
     return copyReplyPayloadMetadata(params.payload, {
       ...params.payload,
       text: params.suppressMediaFailureWarning
@@ -55,6 +65,7 @@ async function normalizeReplyPayloadMedia(params: {
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
+      droppedMedia: droppedMedia.length > 0 ? droppedMedia : undefined,
     });
   }
 }

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -65,7 +65,10 @@ async function normalizeReplyPayloadMedia(params: {
       mediaUrl: undefined,
       mediaUrls: undefined,
       audioAsVoice: false,
-      droppedMedia: droppedMedia.length > 0 ? droppedMedia : undefined,
+      droppedMedia:
+        [...(params.payload.droppedMedia ?? []), ...droppedMedia].length > 0
+          ? [...(params.payload.droppedMedia ?? []), ...droppedMedia]
+          : undefined,
     });
   }
 }

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -50,9 +50,11 @@ async function normalizeReplyPayloadMedia(params: {
   try {
     const normalized = await params.normalizeMediaPaths(params.payload);
     return copyReplyPayloadMetadata(params.payload, normalized);
-  } catch (err) {
-    log.warn(`reply payload media normalization failed: ${String(err)}`);
+  } catch {
     const originalMediaUrls = resolveSendableOutboundReplyParts(params.payload).mediaUrls;
+    log.warn(`reply payload media normalization failed`, {
+      mediaCount: originalMediaUrls.length,
+    });
     const droppedMedia: DroppedMediaItem[] = originalMediaUrls.map((media) => ({
       displayName: sanitizeMediaDisplayName(media),
       code: "normalization-failed" as const,

--- a/src/auto-reply/reply/block-reply-pipeline.ts
+++ b/src/auto-reply/reply/block-reply-pipeline.ts
@@ -49,6 +49,7 @@ export function createBlockReplyPayloadKey(payload: ReplyPayload): string {
     interactive: payload.interactive ?? null,
     channelData: payload.channelData ?? null,
     replyToId: payload.replyToId ?? null,
+    dropped: payload.droppedMedia?.map((d) => `${d.code}:${d.displayName}`) ?? [],
   });
 }
 
@@ -63,6 +64,7 @@ export function createBlockReplyContentKey(payload: ReplyPayload): string {
     presentation: payload.presentation ?? null,
     interactive: payload.interactive ?? null,
     channelData: payload.channelData ?? null,
+    dropped: payload.droppedMedia?.map((d) => `${d.code}:${d.displayName}`) ?? [],
   });
 }
 

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -46,6 +46,24 @@ describe("DroppedMedia types and helpers", () => {
       expect(result).not.toContain("/secret");
       expect(result).not.toContain("/internal");
     });
+
+    it("strips URL query parameters to avoid leaking signed tokens", () => {
+      expect(
+        sanitizeMediaDisplayName(
+          "https://bucket.s3.amazonaws.com/image.png?X-Amz-Signature=abc123&Expires=999",
+        ),
+      ).toBe("image.png");
+    });
+
+    it("strips URL fragment identifiers", () => {
+      expect(sanitizeMediaDisplayName("https://example.com/doc.pdf#page=3")).toBe("doc.pdf");
+    });
+
+    it("strips query and fragment combined", () => {
+      expect(
+        sanitizeMediaDisplayName("https://cdn.example.com/path/photo.jpg?token=secret#anchor"),
+      ).toBe("photo.jpg");
+    });
   });
 
   describe("resolveDroppedMediaCode", () => {

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { formatDroppedMediaNotice } from "../../infra/outbound/deliver.js";
 import {
   normalizeOutboundPayloads,
@@ -23,9 +23,21 @@ describe("DroppedMedia types and helpers", () => {
       expect(sanitizeMediaDisplayName("file.txt")).toBe("file.txt");
     });
 
+    it("returns (inline data) for data: URLs", () => {
+      expect(sanitizeMediaDisplayName("data:image/png;base64,iVBORw0KGgo...")).toBe(
+        "(inline data)",
+      );
+      expect(sanitizeMediaDisplayName("DATA:text/plain;base64,abc")).toBe("(inline data)");
+    });
+
     it("handles paths with forward slashes in Windows-style input", () => {
       // On unix, path.basename only splits on '/' so we test with forward slashes.
       expect(sanitizeMediaDisplayName("C:/Users/docs/report.pdf")).toBe("report.pdf");
+    });
+
+    it("handles Windows backslash paths", () => {
+      expect(sanitizeMediaDisplayName("C:\\Users\\docs\\report.pdf")).toBe("report.pdf");
+      expect(sanitizeMediaDisplayName("\\\\server\\share\\file.txt")).toBe("file.txt");
     });
 
     it("never exposes full path in displayName", () => {
@@ -55,6 +67,16 @@ describe("DroppedMedia types and helpers", () => {
 
     it("returns unknown for unrecognized Error", () => {
       expect(resolveDroppedMediaCode(new Error("something unexpected"))).toBe("unknown");
+    });
+
+    it("returns data-url-rejected for data: prefix via regex", () => {
+      expect(resolveDroppedMediaCode(new Error("Rejected data:image/png;base64,abc"))).toBe(
+        "data-url-rejected",
+      );
+    });
+
+    it("does not false-positive on metadata: strings", () => {
+      expect(resolveDroppedMediaCode(new Error("invalid metadata: field missing"))).toBe("unknown");
     });
 
     it("returns unknown for non-Error values", () => {
@@ -201,9 +223,8 @@ describe("reply-media-paths normalizer droppedMedia collection", () => {
     const result = await normalizer(payload);
     expect(result.droppedMedia).toHaveLength(1);
     expect(result.droppedMedia![0].code).toBe("data-url-rejected");
-    // sanitizeMediaDisplayName strips directory components; the data URL basename
-    // should not expose a full path.
-    expect(result.droppedMedia![0].displayName).toBeDefined();
+    // sanitizeMediaDisplayName returns "(inline data)" for data: URLs.
+    expect(result.droppedMedia![0].displayName).toBe("(inline data)");
     // The valid remote URL should still be kept.
     expect(result.mediaUrls).toEqual(["https://example.com/ok.png"]);
   });

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -97,7 +97,7 @@ describe("formatDroppedMediaNotice", () => {
       { displayName: "screenshot.png", code: "file-not-accessible" },
     ];
     const result = formatDroppedMediaNotice(dropped);
-    expect(result).toBe("\u26a0 Attachment not sent: screenshot.png (file not accessible)");
+    expect(result).toBe("\u26a0 Attachment not sent: `screenshot.png` (file not accessible)");
   });
 
   it("formats multiple file notice", () => {
@@ -107,8 +107,8 @@ describe("formatDroppedMediaNotice", () => {
     ];
     const result = formatDroppedMediaNotice(dropped);
     expect(result).toContain("\u26a0 2 attachments not sent:");
-    expect(result).toContain("\u2022 file1.png \u2014 file path blocked");
-    expect(result).toContain("\u2022 file2.jpg \u2014 file not accessible");
+    expect(result).toContain("\u2022 `file1.png` \u2014 file path blocked");
+    expect(result).toContain("\u2022 `file2.jpg` \u2014 file not accessible");
   });
 
   it("uses user-friendly reason labels, not internal codes", () => {

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -73,6 +73,20 @@ describe("DroppedMedia types and helpers", () => {
       expect(sanitizeMediaDisplayName("/tmp/file\nname.png")).toBe("file_name.png");
       expect(sanitizeMediaDisplayName("/tmp/file\r\nname.png")).toBe("file__name.png");
     });
+
+    it("strips userinfo from credential-bearing URLs", () => {
+      expect(sanitizeMediaDisplayName("https://user:secret@example.com/files/doc.pdf")).toBe(
+        "doc.pdf",
+      );
+      expect(sanitizeMediaDisplayName("https://token@cdn.example.com/image.png?sig=abc")).toBe(
+        "image.png",
+      );
+    });
+
+    it("returns (url) for authority-only URLs with no pathname", () => {
+      expect(sanitizeMediaDisplayName("https://user:secret@example.com")).toBe("(url)");
+      expect(sanitizeMediaDisplayName("https://user:secret@example.com/")).toBe("(url)");
+    });
   });
 
   describe("resolveDroppedMediaCode", () => {

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from "vitest";
+import { formatDroppedMediaNotice } from "../../infra/outbound/deliver.js";
+import {
+  normalizeOutboundPayloads,
+  normalizeReplyPayloadsForDelivery,
+  summarizeOutboundPayloadForTransport,
+} from "../../infra/outbound/payloads.js";
+import type { DroppedMediaItem } from "../reply-payload.js";
+import { resolveDroppedMediaCode, sanitizeMediaDisplayName } from "../reply-payload.js";
+import type { ReplyPayload } from "../types.js";
+
+describe("DroppedMedia types and helpers", () => {
+  describe("sanitizeMediaDisplayName", () => {
+    it("strips directory components from absolute path", () => {
+      expect(sanitizeMediaDisplayName("/home/user/docs/screenshot.png")).toBe("screenshot.png");
+    });
+
+    it("strips directory components from relative path", () => {
+      expect(sanitizeMediaDisplayName("./images/photo.jpg")).toBe("photo.jpg");
+    });
+
+    it("returns filename as-is when no directory", () => {
+      expect(sanitizeMediaDisplayName("file.txt")).toBe("file.txt");
+    });
+
+    it("handles paths with forward slashes in Windows-style input", () => {
+      // On unix, path.basename only splits on '/' so we test with forward slashes.
+      expect(sanitizeMediaDisplayName("C:/Users/docs/report.pdf")).toBe("report.pdf");
+    });
+
+    it("never exposes full path in displayName", () => {
+      const result = sanitizeMediaDisplayName("/secret/internal/path/to/image.png");
+      expect(result).toBe("image.png");
+      expect(result).not.toContain("/secret");
+      expect(result).not.toContain("/internal");
+    });
+  });
+
+  describe("resolveDroppedMediaCode", () => {
+    it("returns blocked-path for blocked errors", () => {
+      expect(resolveDroppedMediaCode(new Error("file path blocked by policy"))).toBe(
+        "blocked-path",
+      );
+    });
+
+    it("returns data-url-rejected for data URL errors", () => {
+      expect(resolveDroppedMediaCode(new Error("data URL not allowed"))).toBe("data-url-rejected");
+    });
+
+    it("returns file-not-accessible for ENOENT", () => {
+      expect(resolveDroppedMediaCode(new Error("ENOENT: no such file"))).toBe(
+        "file-not-accessible",
+      );
+    });
+
+    it("returns unknown for unrecognized Error", () => {
+      expect(resolveDroppedMediaCode(new Error("something unexpected"))).toBe("unknown");
+    });
+
+    it("returns unknown for non-Error values", () => {
+      expect(resolveDroppedMediaCode("string error")).toBe("unknown");
+      expect(resolveDroppedMediaCode(42)).toBe("unknown");
+      expect(resolveDroppedMediaCode(null)).toBe("unknown");
+    });
+  });
+});
+
+describe("formatDroppedMediaNotice", () => {
+  it("returns empty string for empty array", () => {
+    expect(formatDroppedMediaNotice([])).toBe("");
+  });
+
+  it("formats single file notice", () => {
+    const dropped: DroppedMediaItem[] = [
+      { displayName: "screenshot.png", code: "file-not-accessible" },
+    ];
+    const result = formatDroppedMediaNotice(dropped);
+    expect(result).toBe("\u26a0 Attachment not sent: screenshot.png (file not accessible)");
+  });
+
+  it("formats multiple file notice", () => {
+    const dropped: DroppedMediaItem[] = [
+      { displayName: "file1.png", code: "blocked-path" },
+      { displayName: "file2.jpg", code: "file-not-accessible" },
+    ];
+    const result = formatDroppedMediaNotice(dropped);
+    expect(result).toContain("\u26a0 2 attachments not sent:");
+    expect(result).toContain("\u2022 file1.png \u2014 file path blocked");
+    expect(result).toContain("\u2022 file2.jpg \u2014 file not accessible");
+  });
+
+  it("uses user-friendly reason labels, not internal codes", () => {
+    const dropped: DroppedMediaItem[] = [
+      { displayName: "a.png", code: "normalization-failed" },
+      { displayName: "b.png", code: "data-url-rejected" },
+    ];
+    const result = formatDroppedMediaNotice(dropped);
+    expect(result).not.toContain("normalization-failed");
+    expect(result).not.toContain("data-url-rejected");
+    expect(result).toContain("file not accessible");
+    expect(result).toContain("data URL not supported");
+  });
+});
+
+describe("droppedMedia in payload pipeline", () => {
+  it("passes droppedMedia through summarizeOutboundPayloadForTransport", () => {
+    const payload: ReplyPayload = {
+      text: "hello",
+      droppedMedia: [{ displayName: "file.png", code: "file-not-accessible" }],
+    };
+    const summary = summarizeOutboundPayloadForTransport(payload);
+    expect(summary.droppedMedia).toEqual([
+      { displayName: "file.png", code: "file-not-accessible" },
+    ]);
+  });
+
+  it("does not include droppedMedia when absent", () => {
+    const payload: ReplyPayload = { text: "hello" };
+    const summary = summarizeOutboundPayloadForTransport(payload);
+    expect(summary.droppedMedia).toBeUndefined();
+  });
+
+  it("normalizeReplyPayloadsForDelivery preserves payloads that only have droppedMedia", () => {
+    const payloads: ReplyPayload[] = [
+      {
+        text: "",
+        droppedMedia: [{ displayName: "img.png", code: "blocked-path" }],
+      },
+    ];
+    const result = normalizeReplyPayloadsForDelivery(payloads);
+    expect(result).toHaveLength(1);
+    expect(result[0].droppedMedia).toEqual([{ displayName: "img.png", code: "blocked-path" }]);
+  });
+
+  it("normalizeOutboundPayloads preserves droppedMedia on payloads with text", () => {
+    const payloads: ReplyPayload[] = [
+      {
+        text: "Here is the file",
+        droppedMedia: [{ displayName: "doc.pdf", code: "file-not-accessible" }],
+      },
+    ];
+    const result = normalizeOutboundPayloads(payloads);
+    expect(result).toHaveLength(1);
+    expect(result[0].droppedMedia).toEqual([
+      { displayName: "doc.pdf", code: "file-not-accessible" },
+    ]);
+  });
+
+  it("does not skip block reply with empty text but droppedMedia", () => {
+    // This tests that payloads with only droppedMedia (no text, no media) are
+    // not filtered out by the outbound pipeline.
+    const payloads: ReplyPayload[] = [
+      {
+        text: "",
+        mediaUrl: undefined,
+        mediaUrls: undefined,
+        droppedMedia: [{ displayName: "secret.png", code: "blocked-path" }],
+      },
+    ];
+    const result = normalizeReplyPayloadsForDelivery(payloads);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("reply-media-paths normalizer droppedMedia collection", () => {
+  it("collects droppedMedia with sanitized displayName from catch block", async () => {
+    const { createReplyMediaPathNormalizer } = await import("./reply-media-paths.js");
+
+    const normalizer = createReplyMediaPathNormalizer({
+      cfg: {} as any,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    const payload: ReplyPayload = {
+      text: "check this",
+      mediaUrl: "https://example.com/valid.png",
+      mediaUrls: ["https://example.com/valid.png"],
+    };
+
+    // A remote passthrough URL should not be dropped.
+    const result = await normalizer(payload);
+    expect(result.droppedMedia).toBeUndefined();
+    expect(result.mediaUrls).toEqual(["https://example.com/valid.png"]);
+  });
+
+  it("populates droppedMedia when normalizeMediaSource throws for an item", async () => {
+    const { createReplyMediaPathNormalizer } = await import("./reply-media-paths.js");
+
+    const normalizer = createReplyMediaPathNormalizer({
+      cfg: {} as any,
+      workspaceDir: "/tmp/workspace",
+    });
+
+    // data: URLs trigger assertMediaNotDataUrl to throw inside normalizeMediaSource,
+    // exercising the per-item catch block in the normalizer loop.
+    const payload: ReplyPayload = {
+      text: "check this",
+      mediaUrls: ["data:image/png;base64,abc", "https://example.com/ok.png"],
+    };
+
+    const result = await normalizer(payload);
+    expect(result.droppedMedia).toHaveLength(1);
+    expect(result.droppedMedia![0].code).toBe("data-url-rejected");
+    // sanitizeMediaDisplayName strips directory components; the data URL basename
+    // should not expose a full path.
+    expect(result.droppedMedia![0].displayName).toBeDefined();
+    // The valid remote URL should still be kept.
+    expect(result.mediaUrls).toEqual(["https://example.com/ok.png"]);
+  });
+});

--- a/src/auto-reply/reply/dropped-media.test.ts
+++ b/src/auto-reply/reply/dropped-media.test.ts
@@ -64,6 +64,15 @@ describe("DroppedMedia types and helpers", () => {
         sanitizeMediaDisplayName("https://cdn.example.com/path/photo.jpg?token=secret#anchor"),
       ).toBe("photo.jpg");
     });
+
+    it("escapes backticks to prevent code-span breakout", () => {
+      expect(sanitizeMediaDisplayName("/tmp/foo`@everyone")).toBe("foo_@everyone");
+    });
+
+    it("escapes newlines and carriage returns", () => {
+      expect(sanitizeMediaDisplayName("/tmp/file\nname.png")).toBe("file_name.png");
+      expect(sanitizeMediaDisplayName("/tmp/file\r\nname.png")).toBe("file__name.png");
+    });
   });
 
   describe("resolveDroppedMediaCode", () => {

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -108,7 +108,8 @@ export function createFollowupRunner(params: {
 
     const sendablePayloads = payloads.filter(
       (payload): payload is ReplyPayload =>
-        hasOutboundReplyContent(payload) && !deliveryPlan.isSilentPayload(payload),
+        (hasOutboundReplyContent(payload) || (payload.droppedMedia?.length ?? 0) > 0) &&
+        !deliveryPlan.isSilentPayload(payload),
     );
 
     if (sendablePayloads.length === 0) {

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -36,6 +36,7 @@ export function normalizeReplyPayload(
   opts: NormalizeReplyOptions = {},
 ): ReplyPayload | null {
   const applyChannelTransforms = opts.applyChannelTransforms ?? true;
+  const hasDroppedMedia = Boolean(payload.droppedMedia?.length);
   const hasContent = (text: string | undefined) =>
     hasReplyPayloadContent(
       {
@@ -47,7 +48,7 @@ export function normalizeReplyPayload(
       },
     );
   const trimmed = normalizeOptionalString(payload.text) ?? "";
-  if (!hasContent(trimmed)) {
+  if (!hasContent(trimmed) && !hasDroppedMedia) {
     opts.onSkip?.("empty");
     return null;
   }
@@ -55,7 +56,7 @@ export function normalizeReplyPayload(
   const silentToken = opts.silentToken ?? SILENT_REPLY_TOKEN;
   let text = payload.text ?? undefined;
   if (text && isSilentReplyPayloadText(text, silentToken)) {
-    if (!hasContent("")) {
+    if (!hasContent("") && !hasDroppedMedia) {
       opts.onSkip?.("silent");
       return null;
     }
@@ -71,7 +72,7 @@ export function normalizeReplyPayload(
     }
     if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
       text = stripSilentToken(text, silentToken);
-      if (!hasContent(text)) {
+      if (!hasContent(text) && !hasDroppedMedia) {
         opts.onSkip?.("silent");
         return null;
       }
@@ -88,7 +89,7 @@ export function normalizeReplyPayload(
     if (stripped.didStrip) {
       opts.onHeartbeatStrip?.();
     }
-    if (stripped.shouldSkip && !hasContent(stripped.text)) {
+    if (stripped.shouldSkip && !hasContent(stripped.text) && !hasDroppedMedia) {
       opts.onSkip?.("heartbeat");
       return null;
     }
@@ -98,7 +99,7 @@ export function normalizeReplyPayload(
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
   }
-  if (!hasContent(text)) {
+  if (!hasContent(text) && !hasDroppedMedia) {
     opts.onSkip?.("empty");
     return null;
   }

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -86,7 +86,8 @@ export function createBlockReplyDeliveryHandler(params: {
 }): (payload: ReplyPayload) => Promise<void> {
   return async (payload) => {
     const { text, skip } = params.normalizeStreamingText(payload);
-    if (skip && !hasOutboundReplyContent({ ...payload, text: undefined })) {
+    const hasDroppedMedia = (payload.droppedMedia?.length ?? 0) > 0;
+    if (skip && !hasOutboundReplyContent({ ...payload, text: undefined }) && !hasDroppedMedia) {
       return;
     }
 
@@ -134,11 +135,12 @@ export function createBlockReplyDeliveryHandler(params: {
     );
     const blockHasNonTextContent = hasOutboundReplyContent({ ...blockPayload, text: undefined });
 
-    // Skip empty payloads unless they have audioAsVoice flag (need to track it).
-    if (!blockPayload.text && !blockHasNonTextContent && !blockPayload.audioAsVoice) {
+    const blockHasDroppedMedia = (blockPayload.droppedMedia?.length ?? 0) > 0;
+    // Skip empty payloads unless they have audioAsVoice flag or dropped media notice.
+    if (!blockPayload.text && !blockHasNonTextContent && !blockPayload.audioAsVoice && !blockHasDroppedMedia) {
       return;
     }
-    if (normalized.isSilent && !blockHasNonTextContent) {
+    if (normalized.isSilent && !blockHasNonTextContent && !blockHasDroppedMedia) {
       return;
     }
 

--- a/src/auto-reply/reply/reply-media-paths.test.ts
+++ b/src/auto-reply/reply/reply-media-paths.test.ts
@@ -475,6 +475,43 @@ describe("createReplyMediaPathNormalizer", () => {
     });
   });
 
+  it("preserves existing droppedMedia entries from prior normalization passes", async () => {
+    resolveOutboundAttachmentFromUrl.mockRejectedValueOnce(new Error("blocked"));
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["/blocked/new.png"],
+      droppedMedia: [{ displayName: "earlier.png", code: "file-not-accessible" as const }],
+    });
+
+    expect(result.droppedMedia).toHaveLength(2);
+    expect(result.droppedMedia![0]).toEqual({
+      displayName: "earlier.png",
+      code: "file-not-accessible",
+    });
+    expect(result.droppedMedia![1]).toMatchObject({ displayName: "new.png" });
+  });
+
+  it("keeps existing droppedMedia when current pass has no new drops", async () => {
+    const normalize = createReplyMediaPathNormalizer({
+      cfg: {},
+      sessionKey: "session-key",
+      workspaceDir: "/tmp/agent-workspace",
+    });
+
+    const result = await normalize({
+      mediaUrls: ["https://example.com/ok.png"],
+      droppedMedia: [{ displayName: "old.png", code: "blocked-path" as const }],
+    });
+
+    expect(result.droppedMedia).toEqual([{ displayName: "old.png", code: "blocked-path" }]);
+    expect(result.mediaUrls).toEqual(["https://example.com/ok.png"]);
+  });
+
   it("passes absolute local media sources into shared outbound media access", async () => {
     const absolutePath = "/Users/peter/Pictures/chart.png";
     const normalize = createReplyMediaPathNormalizer({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -213,7 +213,7 @@ export function createReplyMediaPathNormalizer(params: {
       try {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
-        log.warn(`dropping blocked reply media: ${String(err)}`, {
+        log.warn(`dropping blocked reply media: ${resolveDroppedMediaCode(err)}`, {
           media: sanitizeMediaDisplayName(media),
         });
         dropped.push({

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -9,14 +9,21 @@ import {
 } from "../../agents/sandbox-paths.js";
 import { ensureSandboxWorkspaceForSession } from "../../agents/sandbox.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { logVerbose } from "../../globals.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveChannelAccountMediaMaxMb } from "../../media/configured-max-bytes.js";
 import { isPassThroughRemoteMediaSource } from "../../media/media-source-url.js";
 import { resolveOutboundAttachmentFromUrl } from "../../media/outbound-attachment.js";
 import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { MEDIA_MAX_BYTES } from "../../media/store.js";
-import { appendReplyMediaFailureWarning } from "../reply-payload.js";
+import { resolveConfigDir } from "../../utils.js";
+import {
+  resolveDroppedMediaCode,
+  sanitizeMediaDisplayName,
+  type DroppedMediaItem,
+} from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
+
+const log = createSubsystemLogger("reply-media-paths");
 
 const FILE_URL_RE = /^file:\/\//i;
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
@@ -199,15 +206,18 @@ export function createReplyMediaPathNormalizer(params: {
     }
 
     const normalizedMedia: string[] = [];
+    const dropped: DroppedMediaItem[] = [];
     const seen = new Set<string>();
-    let firstMediaDropError: unknown;
     for (const media of mediaList) {
       let normalized: string;
       try {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
-        firstMediaDropError ??= err;
-        logVerbose(`dropping blocked reply media ${media}: ${String(err)}`);
+        log.warn(`dropping blocked reply media: ${String(err)}`, { media });
+        dropped.push({
+          displayName: sanitizeMediaDisplayName(media),
+          code: resolveDroppedMediaCode(err),
+        });
         continue;
       }
       if (!normalized || seen.has(normalized)) {
@@ -217,25 +227,22 @@ export function createReplyMediaPathNormalizer(params: {
       normalizedMedia.push(normalized);
     }
 
-    const text =
-      firstMediaDropError === undefined
-        ? payload.text
-        : appendReplyMediaFailureWarning(payload.text);
+    const droppedMedia = dropped.length > 0 ? dropped : undefined;
 
     if (normalizedMedia.length === 0) {
       return {
         ...payload,
-        text,
         mediaUrl: undefined,
         mediaUrls: undefined,
+        droppedMedia,
       };
     }
 
     return {
       ...payload,
-      text,
       mediaUrl: normalizedMedia[0],
       mediaUrls: normalizedMedia,
+      droppedMedia,
     };
   };
 }

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -213,7 +213,9 @@ export function createReplyMediaPathNormalizer(params: {
       try {
         normalized = await normalizeMediaSource(media);
       } catch (err) {
-        log.warn(`dropping blocked reply media: ${String(err)}`, { media });
+        log.warn(`dropping blocked reply media: ${String(err)}`, {
+          media: sanitizeMediaDisplayName(media),
+        });
         dropped.push({
           displayName: sanitizeMediaDisplayName(media),
           code: resolveDroppedMediaCode(err),

--- a/src/auto-reply/reply/reply-media-paths.ts
+++ b/src/auto-reply/reply/reply-media-paths.ts
@@ -227,7 +227,8 @@ export function createReplyMediaPathNormalizer(params: {
       normalizedMedia.push(normalized);
     }
 
-    const droppedMedia = dropped.length > 0 ? dropped : undefined;
+    const allDropped = [...(payload.droppedMedia ?? []), ...dropped];
+    const droppedMedia = allDropped.length > 0 ? allDropped : undefined;
 
     if (normalizedMedia.length === 0) {
       return {

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -80,7 +80,10 @@ export function applyReplyTagsToPayload(
 }
 
 export function isRenderablePayload(payload: ReplyPayload): boolean {
-  return hasReplyPayloadContent(payload, { extraContent: payload.audioAsVoice });
+  return (
+    hasReplyPayloadContent(payload, { extraContent: payload.audioAsVoice }) ||
+    (payload.droppedMedia?.length ?? 0) > 0
+  );
 }
 
 export function shouldSuppressReasoningPayload(payload: ReplyPayload): boolean {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -307,11 +307,11 @@ describe("normalizeReplyPayload", () => {
 
   it("preserves dropped-media-only payloads", () => {
     const result = normalizeReplyPayload({
-      droppedMedia: [{ displayName: "photo.jpg", reason: "normalization-failed" }],
+      droppedMedia: [{ displayName: "photo.jpg", code: "normalization-failed" }],
     });
     expect(result).not.toBeNull();
     expect(result!.droppedMedia).toEqual([
-      { displayName: "photo.jpg", reason: "normalization-failed" },
+      { displayName: "photo.jpg", code: "normalization-failed" },
     ]);
   });
 });

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -304,6 +304,16 @@ describe("normalizeReplyPayload", () => {
     );
     expect(reply.interactive).toBeUndefined();
   });
+
+  it("preserves dropped-media-only payloads", () => {
+    const result = normalizeReplyPayload({
+      droppedMedia: [{ displayName: "photo.jpg", reason: "normalization-failed" }],
+    });
+    expect(result).not.toBeNull();
+    expect(result!.droppedMedia).toEqual([
+      { displayName: "photo.jpg", reason: "normalization-failed" },
+    ]);
+  });
 });
 
 describe("typing controller", () => {

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -610,7 +610,7 @@ describe("routeReply", () => {
   it("does not skip dropped-media-only payloads", async () => {
     const res = await routeReply({
       payload: {
-        droppedMedia: [{ displayName: "photo.jpg", reason: "normalization-failed" }],
+        droppedMedia: [{ displayName: "photo.jpg", code: "normalization-failed" }],
       },
       channel: "slack",
       to: "channel:C123",

--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -606,4 +606,17 @@ describe("routeReply", () => {
       mirror: undefined,
     });
   });
+
+  it("does not skip dropped-media-only payloads", async () => {
+    const res = await routeReply({
+      payload: {
+        droppedMedia: [{ displayName: "photo.jpg", reason: "normalization-failed" }],
+      },
+      channel: "slack",
+      to: "channel:C123",
+      cfg: {} as never,
+    });
+    expect(res.ok).toBe(true);
+    expect(mocks.deliverOutboundPayloads).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -164,7 +164,8 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       {
         hasChannelData,
       },
-    )
+    ) &&
+    !externalPayload.droppedMedia?.length
   ) {
     return { ok: true };
   }

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -7,7 +7,15 @@ export type {
 } from "./get-reply-options.types.js";
 export {
   copyReplyPayloadMetadata,
+  getReplyPayloadMetadata,
   markReplyPayloadForSourceSuppressionDelivery,
+  resolveDroppedMediaCode,
+  sanitizeMediaDisplayName,
   setReplyPayloadMetadata,
 } from "./reply-payload.js";
-export type { ReplyPayload } from "./reply-payload.js";
+export type {
+  DroppedMediaItem,
+  DroppedMediaReasonCode,
+  ReplyPayload,
+  ReplyPayloadMetadata,
+} from "./reply-payload.js";

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1805,7 +1805,7 @@ async function deliverOutboundPayloadsCore(
         completeDeliveryDiagnostics(deliveredResults.length);
         emitMessageSent({
           success: results.length > beforeCount,
-          content: payloadSummary.hookContent ?? payloadSummary.text,
+          content: payloadSummary.hookContent ?? fallbackText,
           messageId,
         });
         continue;

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1481,8 +1481,10 @@ async function deliverOutboundPayloadsCore(
       },
     );
   }
+  const deliveredPayloadIndices = new Set<number>();
   for (const { index: payloadIndex, payload } of normalizedPayloads) {
     let payloadSummary = buildPayloadSummary(payload);
+    let payloadDelivered = false;
     let deliveryKind: DiagnosticMessageDeliveryKind = "other";
     let deliveryStartedAt = 0;
     let deliveryStarted = false;
@@ -1578,6 +1580,7 @@ async function deliverOutboundPayloadsCore(
         );
         continue;
       }
+      payloadDelivered = true;
       payloadSummary = buildPayloadSummary(effectivePayload);
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
 
@@ -1831,6 +1834,7 @@ async function deliverOutboundPayloadsCore(
         stage: "platform_send",
       });
       errorDeliveryDiagnostics(err);
+      payloadDelivered = false;
       emitMessageSent({
         success: false,
         content: payloadSummary.hookContent ?? payloadSummary.text,
@@ -1845,11 +1849,18 @@ async function deliverOutboundPayloadsCore(
         });
       }
       params.onError?.(err, payloadSummary);
+    } finally {
+      if (payloadDelivered) {
+        deliveredPayloadIndices.add(payloadIndex);
+      }
     }
   }
   if (params.mirror && results.length > 0) {
-    // Collect all dropped media notices across payloads for transcript mirror.
-    const allDropped = payloads.flatMap((p) => p.droppedMedia ?? []);
+    // Only collect dropped-media notices from payloads that were actually
+    // delivered (not cancelled by message_sending hooks or errored).
+    const allDropped = normalizedPayloads
+      .filter((_, i) => deliveredPayloadIndices.has(i))
+      .flatMap((p) => p.droppedMedia ?? []);
     const droppedNotice = allDropped.length > 0 ? formatDroppedMediaNotice(allDropped) : "";
     const mirrorText = resolveMirroredTranscriptText({
       text: params.mirror.text,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1669,6 +1669,20 @@ async function deliverOutboundPayloadsCore(
           content: payloadSummary.hookContent ?? payloadSummary.text,
           messageId: delivery.messageId,
         });
+        if (droppedMediaNotice) {
+          try {
+            await sendTextChunks(droppedMediaNotice, sendOverrides);
+          } catch (noticeErr) {
+            log.warn(
+              "Failed to send dropped-media notice after successful structured payload delivery",
+              {
+                channel,
+                to,
+                error: formatErrorMessage(noticeErr),
+              },
+            );
+          }
+        }
         continue;
       }
       if (payloadSummary.mediaUrls.length === 0) {
@@ -1799,8 +1813,18 @@ async function deliverOutboundPayloadsCore(
       }
       // Send dropped-media notice as a separate text message after media
       // to avoid oversizing captions on channels with strict limits.
+      // Wrapped in its own try-catch so a transient text-send failure
+      // does not mark the already-delivered media payload as failed.
       if (droppedMediaNotice) {
-        await sendTextChunks(droppedMediaNotice, sendOverrides);
+        try {
+          await sendTextChunks(droppedMediaNotice, sendOverrides);
+        } catch (noticeErr) {
+          log.warn("Failed to send dropped-media notice after successful media delivery", {
+            channel,
+            to,
+            error: formatErrorMessage(noticeErr),
+          });
+        }
       }
       await maybePinDeliveredMessage({
         handler,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1582,6 +1582,10 @@ async function deliverOutboundPayloadsCore(
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
 
       // Append dropped-media user notice to text before sending.
+      // Note: this runs after normalizePayloadsForChannelDelivery, so the notice
+      // bypasses channel-specific text normalization. This is acceptable because
+      // the notice is a short generated string with displayNames already sanitized
+      // by sanitizeMediaDisplayName (no raw user paths or data: payloads).
       if (payloadSummary.droppedMedia?.length) {
         const notice = formatDroppedMediaNotice(payloadSummary.droppedMedia);
         if (notice) {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1597,10 +1597,17 @@ async function deliverOutboundPayloadsCore(
       // text message after the media to avoid oversizing media captions (many
       // channels enforce strict caption length limits).
       // Only inline the notice when there are no surviving media items AND the
-      // payload is not a structured reply (interactive/channelData).  Structured
-      // adapters may not render payload.text, so the notice would be silently
-      // lost — keep it for the separate text-send path instead.
-      const isStructuredPayload = !!(effectivePayload.interactive || effectivePayload.channelData);
+      // payload will actually be delivered via the structured sendPayload path.
+      // Both conditions are required: the adapter must implement sendPayload AND
+      // the structured fields must contain real content (not empty objects).
+      // Otherwise the notice would be silently lost when delivery falls through
+      // to the plain-text path.
+      const isStructuredPayload =
+        !!handler.sendPayload &&
+        hasReplyPayloadContent({
+          interactive: effectivePayload.interactive,
+          channelData: effectivePayload.channelData,
+        });
       if (droppedMediaNotice && payloadSummary.mediaUrls.length === 0 && !isStructuredPayload) {
         const separator = payloadSummary.text.trim() ? "\n\n" : "";
         effectivePayload = {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1760,7 +1760,12 @@ async function deliverOutboundPayloadsCore(
             mediaCount: payloadSummary.mediaUrls.length,
           },
         );
-        const fallbackText = payloadSummary.text.trim();
+        const fallbackTextParts = [payloadSummary.text.trim()];
+        if (droppedMediaNotice) {
+          fallbackTextParts.push(droppedMediaNotice);
+          droppedMediaNotice = undefined;
+        }
+        const fallbackText = fallbackTextParts.filter(Boolean).join("\n\n");
         if (!fallbackText) {
           throw new Error(
             "Plugin outbound adapter does not implement sendMedia and no text fallback is available for media payload",

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1584,24 +1584,29 @@ async function deliverOutboundPayloadsCore(
       payloadSummary = buildPayloadSummary(effectivePayload);
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
 
-      // Append dropped-media user notice to text before sending.
+      // Build dropped-media user notice.
       // Note: this runs after normalizePayloadsForChannelDelivery, so the notice
       // bypasses channel-specific text normalization. This is acceptable because
       // the notice is a short generated string with displayNames already sanitized
       // by sanitizeMediaDisplayName (no raw user paths or data: payloads).
+      let droppedMediaNotice: string | undefined;
       if (payloadSummary.droppedMedia?.length) {
-        const notice = formatDroppedMediaNotice(payloadSummary.droppedMedia);
-        if (notice) {
-          const separator = payloadSummary.text.trim() ? "\n\n" : "";
-          effectivePayload = {
-            ...effectivePayload,
-            text: (effectivePayload.text ?? "") + separator + notice,
-          };
-          payloadSummary = {
-            ...payloadSummary,
-            text: payloadSummary.text + separator + notice,
-          };
-        }
+        droppedMediaNotice = formatDroppedMediaNotice(payloadSummary.droppedMedia);
+      }
+      // When there are surviving media items, the notice is sent as a separate
+      // text message after the media to avoid oversizing media captions (many
+      // channels enforce strict caption length limits).
+      if (droppedMediaNotice && payloadSummary.mediaUrls.length === 0) {
+        const separator = payloadSummary.text.trim() ? "\n\n" : "";
+        effectivePayload = {
+          ...effectivePayload,
+          text: (effectivePayload.text ?? "") + separator + droppedMediaNotice,
+        };
+        payloadSummary = {
+          ...payloadSummary,
+          text: payloadSummary.text + separator + droppedMediaNotice,
+        };
+        droppedMediaNotice = undefined;
       }
 
       params.onPayload?.(payloadSummary);
@@ -1791,6 +1796,11 @@ async function deliverOutboundPayloadsCore(
         results.push(delivery);
         firstMessageId ??= delivery.messageId;
         lastMessageId = delivery.messageId;
+      }
+      // Send dropped-media notice as a separate text message after media
+      // to avoid oversizing captions on channels with strict limits.
+      if (droppedMediaNotice) {
+        await sendTextChunks(droppedMediaNotice, sendOverrides);
       }
       await maybePinDeliveredMessage({
         handler,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1596,7 +1596,12 @@ async function deliverOutboundPayloadsCore(
       // When there are surviving media items, the notice is sent as a separate
       // text message after the media to avoid oversizing media captions (many
       // channels enforce strict caption length limits).
-      if (droppedMediaNotice && payloadSummary.mediaUrls.length === 0) {
+      // Only inline the notice when there are no surviving media items AND the
+      // payload is not a structured reply (interactive/channelData).  Structured
+      // adapters may not render payload.text, so the notice would be silently
+      // lost — keep it for the separate text-send path instead.
+      const isStructuredPayload = !!(effectivePayload.interactive || effectivePayload.channelData);
+      if (droppedMediaNotice && payloadSummary.mediaUrls.length === 0 && !isStructuredPayload) {
         const separator = payloadSummary.text.trim() ? "\n\n" : "";
         effectivePayload = {
           ...effectivePayload,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1,4 +1,11 @@
-import { resolveChunkMode, resolveTextChunkLimit } from "../../auto-reply/chunk.js";
+import { sendMediaWithLeadingCaption } from "openclaw/plugin-sdk/reply-payload";
+import {
+  chunkByParagraph,
+  chunkMarkdownTextWithMode,
+  resolveChunkMode,
+  resolveTextChunkLimit,
+} from "../../auto-reply/chunk.js";
+import type { DroppedMediaItem, DroppedMediaReasonCode } from "../../auto-reply/reply-payload.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createRenderedMessageBatchPlan } from "../../channels/message/rendered-batch.js";
 import type {
@@ -115,6 +122,29 @@ export type OutboundDurableDeliverySupport =
     };
 
 const log = createSubsystemLogger("outbound/deliver");
+
+const REASON_LABELS: Record<DroppedMediaReasonCode, string> = {
+  "normalization-failed": "file not accessible",
+  "blocked-path": "file path blocked",
+  "file-not-accessible": "file not accessible",
+  "data-url-rejected": "data URL not supported",
+  unknown: "file not accessible",
+};
+
+export function formatDroppedMediaNotice(dropped: readonly DroppedMediaItem[]): string {
+  if (dropped.length === 0) {
+    return "";
+  }
+  if (dropped.length === 1) {
+    const item = dropped[0];
+    return `\u26a0 Attachment not sent: ${item.displayName} (${REASON_LABELS[item.code]})`;
+  }
+  const lines = dropped.map(
+    (item) => `\u2022 ${item.displayName} \u2014 ${REASON_LABELS[item.code]}`,
+  );
+  return `\u26a0 ${dropped.length} attachments not sent:\n${lines.join("\n")}`;
+}
+
 let transcriptRuntimePromise:
   | Promise<typeof import("../../config/sessions/transcript.runtime.js")>
   | undefined;
@@ -747,7 +777,7 @@ function emitMessageDeliveryError(params: {
 function normalizeEmptyPayloadForDelivery(payload: ReplyPayload): ReplyPayload | null {
   const text = typeof payload.text === "string" ? payload.text : "";
   if (!text.trim()) {
-    if (!hasReplyPayloadContent({ ...payload, text })) {
+    if (!hasReplyPayloadContent({ ...payload, text }) && !payload.droppedMedia?.length) {
       return null;
     }
     if (text) {
@@ -1532,7 +1562,7 @@ async function deliverOutboundPayloadsCore(
       const normalizedEffectivePayload = handler.normalizePayload
         ? handler.normalizePayload(renderedPayload)
         : renderedPayload;
-      const effectivePayload = normalizedEffectivePayload
+      let effectivePayload = normalizedEffectivePayload
         ? normalizeEmptyPayloadForDelivery(
             stripInternalRuntimeScaffoldingFromPayload(normalizedEffectivePayload),
           )
@@ -1550,6 +1580,22 @@ async function deliverOutboundPayloadsCore(
       }
       payloadSummary = buildPayloadSummary(effectivePayload);
       startDeliveryDiagnostics(deliveryKindForPayload(effectivePayload, payloadSummary));
+
+      // Append dropped-media user notice to text before sending.
+      if (payloadSummary.droppedMedia?.length) {
+        const notice = formatDroppedMediaNotice(payloadSummary.droppedMedia);
+        if (notice) {
+          const separator = payloadSummary.text.trim() ? "\n\n" : "";
+          effectivePayload = {
+            ...effectivePayload,
+            text: (effectivePayload.text ?? "") + separator + notice,
+          };
+          payloadSummary = {
+            ...payloadSummary,
+            text: payloadSummary.text + separator + notice,
+          };
+        }
+      }
 
       params.onPayload?.(payloadSummary);
       const replyToResolution = resolveCurrentReplyTo(effectivePayload);
@@ -1798,16 +1844,21 @@ async function deliverOutboundPayloadsCore(
     }
   }
   if (params.mirror && results.length > 0) {
+    // Collect all dropped media notices across payloads for transcript mirror.
+    const allDropped = payloads.flatMap((p) => p.droppedMedia ?? []);
+    const droppedNotice = allDropped.length > 0 ? formatDroppedMediaNotice(allDropped) : "";
     const mirrorText = resolveMirroredTranscriptText({
       text: params.mirror.text,
       mediaUrls: params.mirror.mediaUrls,
     });
-    if (mirrorText) {
+    const combinedMirrorText =
+      [mirrorText, droppedNotice].filter(Boolean).join("\n\n") || undefined;
+    if (combinedMirrorText) {
       const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
       await appendAssistantMessageToSessionTranscript({
         agentId: params.mirror.agentId,
         sessionKey: params.mirror.sessionKey,
-        text: mirrorText,
+        text: combinedMirrorText,
         idempotencyKey: params.mirror.idempotencyKey,
         config: params.cfg,
       });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1901,12 +1901,12 @@ async function deliverOutboundPayloadsCore(
       }
     }
   }
-  if (params.mirror && results.length > 0) {
-    // Collect dropped-media from all payloads regardless of delivery status.
-    // A drop event means media was silently removed; that should always be
-    // recorded in the transcript for auditability even if the text payload
-    // itself failed or was cancelled.
-    const allDropped = normalizedPayloads.flatMap((p) => p.droppedMedia ?? []);
+  // Collect dropped-media from all payloads regardless of delivery status.
+  // A drop event means media was silently removed; that should always be
+  // recorded in the transcript for auditability even if the text payload
+  // itself failed or was cancelled.
+  const allDropped = normalizedPayloads.flatMap((p) => p.droppedMedia ?? []);
+  if (params.mirror && (results.length > 0 || allDropped.length > 0)) {
     const droppedNotice = allDropped.length > 0 ? formatDroppedMediaNotice(allDropped) : "";
     const mirrorText = resolveMirroredTranscriptText({
       text: params.mirror.text,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -137,10 +137,10 @@ export function formatDroppedMediaNotice(dropped: readonly DroppedMediaItem[]): 
   }
   if (dropped.length === 1) {
     const item = dropped[0];
-    return `\u26a0 Attachment not sent: ${item.displayName} (${REASON_LABELS[item.code]})`;
+    return `\u26a0 Attachment not sent: \`${item.displayName}\` (${REASON_LABELS[item.code]})`;
   }
   const lines = dropped.map(
-    (item) => `\u2022 ${item.displayName} \u2014 ${REASON_LABELS[item.code]}`,
+    (item) => `\u2022 \`${item.displayName}\` \u2014 ${REASON_LABELS[item.code]}`,
   );
   return `\u26a0 ${dropped.length} attachments not sent:\n${lines.join("\n")}`;
 }
@@ -1856,11 +1856,11 @@ async function deliverOutboundPayloadsCore(
     }
   }
   if (params.mirror && results.length > 0) {
-    // Only collect dropped-media notices from payloads that were actually
-    // delivered (not cancelled by message_sending hooks or errored).
-    const allDropped = normalizedPayloads
-      .filter((_, i) => deliveredPayloadIndices.has(i))
-      .flatMap((p) => p.droppedMedia ?? []);
+    // Collect dropped-media from all payloads regardless of delivery status.
+    // A drop event means media was silently removed; that should always be
+    // recorded in the transcript for auditability even if the text payload
+    // itself failed or was cancelled.
+    const allDropped = normalizedPayloads.flatMap((p) => p.droppedMedia ?? []);
     const droppedNotice = allDropped.length > 0 ? formatDroppedMediaNotice(allDropped) : "";
     const mirrorText = resolveMirroredTranscriptText({
       text: params.mirror.text,

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -1682,6 +1682,9 @@ async function deliverOutboundPayloadsCore(
           messageId: delivery.messageId,
         });
         if (droppedMediaNotice) {
+          // Preserve results length so the notice delivery does not
+          // shift results.at(-1) away from the primary reply id.
+          const preNoticeLen = results.length;
           try {
             await sendTextChunks(droppedMediaNotice, sendOverrides);
           } catch (noticeErr) {
@@ -1694,6 +1697,7 @@ async function deliverOutboundPayloadsCore(
               },
             );
           }
+          results.length = preNoticeLen;
         }
         continue;
       }
@@ -1828,6 +1832,9 @@ async function deliverOutboundPayloadsCore(
       // Wrapped in its own try-catch so a transient text-send failure
       // does not mark the already-delivered media payload as failed.
       if (droppedMediaNotice) {
+        // Preserve results length so the notice delivery does not
+        // shift results.at(-1) away from the primary reply id.
+        const preNoticeLen = results.length;
         try {
           await sendTextChunks(droppedMediaNotice, sendOverrides);
         } catch (noticeErr) {
@@ -1837,6 +1844,7 @@ async function deliverOutboundPayloadsCore(
             error: formatErrorMessage(noticeErr),
           });
         }
+        results.length = preNoticeLen;
       }
       await maybePinDeliveredMessage({
         handler,

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -432,7 +432,7 @@ describe("normalizeOutboundPayloadsForJson", () => {
   });
 
   it("includes droppedMedia in JSON projection", () => {
-    const droppedMedia = [{ displayName: "photo.jpg", reason: "normalization-failed" as const }];
+    const droppedMedia = [{ displayName: "photo.jpg", code: "normalization-failed" as const }];
     expect(normalizeOutboundPayloadsForJson([{ text: "warning", droppedMedia }])).toEqual([
       {
         text: "warning",

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -430,6 +430,19 @@ describe("normalizeOutboundPayloadsForJson", () => {
       { text: "final answer", mediaUrl: null, mediaUrls: undefined, audioAsVoice: undefined },
     ]);
   });
+
+  it("includes droppedMedia in JSON projection", () => {
+    const droppedMedia = [{ displayName: "photo.jpg", reason: "normalization-failed" as const }];
+    expect(normalizeOutboundPayloadsForJson([{ text: "warning", droppedMedia }])).toEqual([
+      {
+        text: "warning",
+        mediaUrl: null,
+        mediaUrls: undefined,
+        audioAsVoice: undefined,
+        droppedMedia,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,4 +1,5 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
+import type { DroppedMediaItem } from "../../auto-reply/reply-payload.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import {
   formatBtwTextForExternalDelivery,
@@ -28,6 +29,7 @@ export type NormalizedOutboundPayload = {
   channelData?: Record<string, unknown>;
   /** Hook-only content for audio-only TTS payloads. Never used as channel text/caption. */
   hookContent?: string;
+  droppedMedia?: DroppedMediaItem[];
 };
 
 export type OutboundPayloadJson = {
@@ -159,7 +161,7 @@ function createOutboundPayloadPlanEntry(
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
   };
-  if (!isRenderablePayload(normalizedPayload) && !isSilent) {
+  if (!isRenderablePayload(normalizedPayload) && !isSilent && !normalizedPayload.droppedMedia?.length) {
     return null;
   }
   const hasChannelData = hasReplyChannelData(normalizedPayload.channelData);
@@ -223,7 +225,8 @@ export function projectOutboundPayloadPlanForOutbound(
       !hasReplyPayloadContent(
         { ...payload, text, mediaUrls: entry.parts.mediaUrls },
         { hasChannelData: entry.hasChannelData },
-      )
+      ) &&
+      !payload.droppedMedia?.length
     ) {
       continue;
     }
@@ -235,6 +238,7 @@ export function projectOutboundPayloadPlanForOutbound(
       ...(payload.delivery ? { delivery: payload.delivery } : {}),
       ...(entry.hasInteractive ? { interactive: payload.interactive } : {}),
       ...(entry.hasChannelData ? { channelData: payload.channelData } : {}),
+      ...(payload.droppedMedia?.length ? { droppedMedia: payload.droppedMedia } : {}),
     });
   }
   return normalizedPayloads;
@@ -286,6 +290,7 @@ export function summarizeOutboundPayloadForTransport(
     interactive: payload.interactive,
     channelData: payload.channelData,
     ...(parts.text || !spokenText ? {} : { hookContent: spokenText }),
+    droppedMedia: payload.droppedMedia,
   };
 }
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -41,6 +41,7 @@ export type OutboundPayloadJson = {
   delivery?: ReplyPayloadDelivery;
   interactive?: InteractiveReply;
   channelData?: Record<string, unknown>;
+  droppedMedia?: DroppedMediaItem[];
 };
 
 export type OutboundPayloadPlan = {
@@ -259,6 +260,7 @@ export function projectOutboundPayloadPlanForJson(
       delivery: payload.delivery,
       interactive: payload.interactive,
       channelData: payload.channelData,
+      ...(payload.droppedMedia?.length ? { droppedMedia: payload.droppedMedia } : {}),
     });
   }
   return normalized;


### PR DESCRIPTION
## Summary

Fixes #69309

When a `MEDIA:` directive fails (path not in allowlist, file not found, etc.), OpenClaw Core silently drops the media item. Users and agents receive no feedback. This PR surfaces those failures as user-visible warnings.

## Changes

### Phase 1: Log visibility (2 files)
- `reply-media-paths.ts`: `logVerbose` → `log.warn` (removed `logVerbose` import — was only usage)
- `agent-runner-payloads.ts`: added `log.warn` at catch point (kept `logVerbose` import — used elsewhere)

### Phase 2: DroppedMedia pipeline (7 files)
- **`reply-payload.ts`**: New `DroppedMediaItem` type, `DroppedMediaReasonCode` union, `sanitizeMediaDisplayName()` (path.basename only), `resolveDroppedMediaCode()` helper
- **`types.ts`**: Re-exports new types
- **`reply-media-paths.ts`**: Per-item catch collects `droppedMedia` instead of silent `continue`
- **`agent-runner-payloads.ts`**: Catastrophic catch maps all `mediaUrls` to `droppedMedia` with `normalization-failed`
- **`reply-delivery.ts`**: Skip guards check `hasDroppedMedia` (3 guard points)
- **`reply-payloads-base.ts`**: `isRenderablePayload` considers `droppedMedia` as renderable
- **`payloads.ts`**: `NormalizedOutboundPayload` carries `droppedMedia`; pipeline preserves dropped-media-only payloads
- **`deliver.ts`**: `formatDroppedMediaNotice()` + `REASON_LABELS` appends sanitized warning to text + transcript mirror

### Tests (1 file, 21 cases)
- `dropped-media.test.ts`: sanitization, reason code resolution, notice formatting, pipeline preservation, catch-branch integration

## User-visible output

Single file:
```
⚠ Attachment not sent: screenshot.png (file not accessible)
```

Multiple files:
```
⚠ 2 attachments not sent:
  • screenshot.png — file not accessible
  • document.pdf — file not found
```

## Privacy

- `displayName` = `path.basename()` only — no internal paths exposed
- `REASON_LABELS` use generic descriptions — no policy details leaked

## Related Issues

- #54131, #68998, #42437, #53269, #66090