### PR TITLE
gateway: expose per-agent memory status in doctor.memory.status

### DIFF
--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -271,7 +271,9 @@ implemented in `src/gateway/server-methods/*.ts`.
 - `usage.status` returns provider usage windows/remaining quota summaries.
 - `usage.cost` returns aggregated cost usage summaries for a date range.
 - `doctor.memory.status` returns vector-memory / embedding readiness for the
-  active default agent workspace.
+  active default agent workspace, plus a `perAgent: [{ agentId, dirty, files,
+chunks, error? }]` array covering every configured agent so dashboards can
+  render per-agent memory state without shelling out to the CLI.
 - `sessions.usage` returns per-session usage summaries.
 - `sessions.usage.timeseries` returns timeseries usage for one session.
 - `sessions.usage.logs` returns usage log entries for one session.

--- a/src/gateway/server-methods/doctor.test.ts
+++ b/src/gateway/server-methods/doctor.test.ts
@@ -9,6 +9,7 @@ const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "main"));
 const resolveAgentWorkspaceDir = vi.hoisted(() =>
   vi.fn((_cfg: OpenClawConfig, _agentId: string) => "/tmp/openclaw"),
 );
+const listAgentIds = vi.hoisted(() => vi.fn((_cfg: OpenClawConfig) => ["main"]));
 const resolveMemorySearchConfig = vi.hoisted(() =>
   vi.fn<(_cfg: OpenClawConfig, _agentId: string) => { enabled: boolean } | null>(() => ({
     enabled: true,
@@ -27,6 +28,7 @@ vi.mock("../../config/config.js", () => ({
 }));
 
 vi.mock("../../agents/agent-scope.js", () => ({
+  listAgentIds,
   resolveDefaultAgentId,
   resolveAgentWorkspaceDir,
 }));
@@ -158,6 +160,7 @@ describe("doctor.memory.status", () => {
     loadConfig.mockClear();
     resolveDefaultAgentId.mockClear();
     resolveAgentWorkspaceDir.mockReset().mockReturnValue("/tmp/openclaw");
+    listAgentIds.mockReset().mockReturnValue(["main"]);
     resolveMemorySearchConfig.mockReset().mockReturnValue({ enabled: true });
     getMemorySearchManager.mockReset();
     previewGroundedRemMarkdown.mockReset();
@@ -743,6 +746,112 @@ describe("doctor.memory.status", () => {
       readFileSpy.mockRestore();
       await fs.rm(workspaceRoot, { recursive: true, force: true });
     }
+  });
+
+  it("includes a perAgent entry for the default agent from manager.status()", async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+    getMemorySearchManager.mockResolvedValue({
+      manager: {
+        status: () => ({ provider: "gemini", files: 142, chunks: 3891, dirty: false }),
+        probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
+        close,
+      },
+    });
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        perAgent: [{ agentId: "main", dirty: false, files: 142, chunks: 3891 }],
+      }),
+      undefined,
+    );
+  });
+
+  it("collects perAgent entries for every configured agent", async () => {
+    listAgentIds.mockReturnValue(["main", "alpha", "beta"]);
+    const close = vi.fn().mockResolvedValue(undefined);
+    getMemorySearchManager.mockImplementation(
+      async ({ agentId }: { agentId: string }) =>
+        ({
+          main: {
+            manager: {
+              status: () => ({ provider: "gemini", files: 10, chunks: 100, dirty: true }),
+              probeEmbeddingAvailability: vi.fn().mockResolvedValue({ ok: true }),
+              close,
+            },
+          },
+          alpha: {
+            manager: {
+              status: () => ({ files: 5, chunks: 40, dirty: false }),
+              close,
+            },
+          },
+          beta: {
+            manager: null,
+            error: "memory search unavailable",
+          },
+        })[agentId] ?? { manager: null, error: "unknown agent" },
+    );
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        perAgent: [
+          { agentId: "main", dirty: true, files: 10, chunks: 100 },
+          { agentId: "alpha", dirty: false, files: 5, chunks: 40 },
+          {
+            agentId: "beta",
+            dirty: false,
+            files: 0,
+            chunks: 0,
+            error: "memory search unavailable",
+          },
+        ],
+      }),
+      undefined,
+    );
+  });
+
+  it("exposes perAgent entries even when the default agent manager is unavailable", async () => {
+    listAgentIds.mockReturnValue(["main", "alpha"]);
+    const close = vi.fn().mockResolvedValue(undefined);
+    getMemorySearchManager.mockImplementation(async ({ agentId }: { agentId: string }) =>
+      agentId === "main"
+        ? { manager: null, error: "memory plugin unavailable" }
+        : {
+            manager: {
+              status: () => ({ files: 7, chunks: 77, dirty: false }),
+              close,
+            },
+          },
+    );
+    const respond = vi.fn();
+
+    await invokeDoctorMemoryStatus(respond);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({
+        embedding: { ok: false, error: "memory plugin unavailable" },
+        perAgent: [
+          {
+            agentId: "main",
+            dirty: false,
+            files: 0,
+            chunks: 0,
+            error: "memory plugin unavailable",
+          },
+          { agentId: "alpha", dirty: false, files: 7, chunks: 77 },
+        ],
+      }),
+      undefined,
+    );
   });
 });
 

--- a/src/gateway/server-methods/doctor.ts
+++ b/src/gateway/server-methods/doctor.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import {
+  listAgentIds,
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "../../agents/agent-scope.js";
 import { loadConfig } from "../../config/config.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
@@ -107,6 +111,14 @@ type DoctorMemoryDreamingPayload = {
   };
 };
 
+export type DoctorMemoryAgentStatusPayload = {
+  agentId: string;
+  dirty: boolean;
+  files: number;
+  chunks: number;
+  error?: string;
+};
+
 export type DoctorMemoryStatusPayload = {
   agentId: string;
   provider?: string;
@@ -115,6 +127,7 @@ export type DoctorMemoryStatusPayload = {
     error?: string;
   };
   dreaming?: DoctorMemoryDreamingPayload;
+  perAgent?: DoctorMemoryAgentStatusPayload[];
 };
 
 export type DoctorMemoryDreamDiaryPayload = {
@@ -781,22 +794,74 @@ async function readDreamDiary(
   };
 }
 
+async function collectMemoryAgentStatus(
+  cfg: OpenClawConfig,
+  agentId: string,
+): Promise<DoctorMemoryAgentStatusPayload> {
+  const { manager, error } = await getActiveMemorySearchManager({
+    cfg,
+    agentId,
+    purpose: "status",
+  });
+  if (!manager) {
+    return {
+      agentId,
+      dirty: false,
+      files: 0,
+      chunks: 0,
+      error: error ?? "memory search unavailable",
+    };
+  }
+  try {
+    const status = manager.status();
+    return {
+      agentId,
+      dirty: Boolean(status.dirty),
+      files: status.files ?? 0,
+      chunks: status.chunks ?? 0,
+    };
+  } catch (err) {
+    return {
+      agentId,
+      dirty: false,
+      files: 0,
+      chunks: 0,
+      error: `gateway memory probe failed: ${formatError(err)}`,
+    };
+  } finally {
+    await manager.close?.().catch(() => {});
+  }
+}
+
 export const doctorHandlers: GatewayRequestHandlers = {
   "doctor.memory.status": async ({ respond, context }) => {
     const cfg = loadConfig();
     const agentId = resolveDefaultAgentId(cfg);
+    const configuredAgentIds = listAgentIds(cfg);
+    const otherAgentIds = configuredAgentIds.filter((id) => id !== agentId);
     const { manager, error } = await getActiveMemorySearchManager({
       cfg,
       agentId,
       purpose: "status",
     });
     if (!manager) {
+      const defaultEntry: DoctorMemoryAgentStatusPayload = {
+        agentId,
+        dirty: false,
+        files: 0,
+        chunks: 0,
+        error: error ?? "memory search unavailable",
+      };
+      const otherEntries = await Promise.all(
+        otherAgentIds.map((id) => collectMemoryAgentStatus(cfg, id)),
+      );
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         embedding: {
           ok: false,
           error: error ?? "memory search unavailable",
         },
+        perAgent: [defaultEntry, ...otherEntries],
       };
       respond(true, payload, undefined);
       return;
@@ -838,6 +903,15 @@ export const doctorHandlers: GatewayRequestHandlers = {
               promotedToday: 0,
             };
       const cronStatuses = await resolveAllManagedDreamingCronStatuses(context);
+      const defaultEntry: DoctorMemoryAgentStatusPayload = {
+        agentId,
+        dirty: Boolean(status.dirty),
+        files: status.files ?? 0,
+        chunks: status.chunks ?? 0,
+      };
+      const otherEntries = await Promise.all(
+        otherAgentIds.map((id) => collectMemoryAgentStatus(cfg, id)),
+      );
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         provider: status.provider,
@@ -860,15 +934,27 @@ export const doctorHandlers: GatewayRequestHandlers = {
             },
           },
         },
+        perAgent: [defaultEntry, ...otherEntries],
       };
       respond(true, payload, undefined);
     } catch (err) {
+      const defaultEntry: DoctorMemoryAgentStatusPayload = {
+        agentId,
+        dirty: false,
+        files: 0,
+        chunks: 0,
+        error: `gateway memory probe failed: ${formatError(err)}`,
+      };
+      const otherEntries = await Promise.all(
+        otherAgentIds.map((id) => collectMemoryAgentStatus(cfg, id)),
+      );
       const payload: DoctorMemoryStatusPayload = {
         agentId,
         embedding: {
           ok: false,
           error: `gateway memory probe failed: ${formatError(err)}`,
         },
+        perAgent: [defaultEntry, ...otherEntries],
       };
       respond(true, payload, undefined);
     } finally {


### PR DESCRIPTION
## Summary

Fixes #69295.

`doctor.memory.status` previously returned vector-memory readiness for the active
default agent only. Dashboards that want to show memory state for every
configured agent had to shell out to the CLI, which can hang on deep probes.

This change adds a `perAgent` array to the payload, one entry per configured
agent (default first), with `{ agentId, dirty, files, chunks, error? }` fields.
We reuse the already-acquired manager for the default agent and acquire a fresh
one per non-default agent via `Promise.all`. `manager.status()` is in-memory and
cheap; we skip the deep embedding probe that the CLI does.

## Changes

- `src/gateway/server-methods/doctor.ts`
  - Added `DoctorMemoryAgentStatusPayload` type and `perAgent?: DoctorMemoryAgentStatusPayload[]` on `DoctorMemoryStatusPayload`.
  - Added `collectMemoryAgentStatus` helper (acquires manager via `getActiveMemorySearchManager`, reads `manager.status()`, always closes the manager in `finally`).
  - Imported `listAgentIds` and wired `[defaultEntry, ...otherEntries]` into all three response branches of the `doctor.memory.status` handler (no-manager, success, catch-err).
- `src/gateway/server-methods/doctor.test.ts`
  - Added hoisted `listAgentIds` mock + vi.mock registration.
  - Added 3 tests: default perAgent entry, multi-agent perAgent (with `beta` routing to no-manager branch), and perAgent still populated when default manager is unavailable.
- `docs/gateway/protocol.md` — expanded the `doctor.memory.status` bullet to describe the new `perAgent` field.

## Test plan

- [x] `pnpm test src/gateway/server-methods/doctor.test.ts` — 19/19 passed
- [x] `pnpm tsgo:core` — clean
- [x] `pnpm tsgo:core:test` — clean
- [x] `pnpm tsgo:extensions` + `pnpm tsgo:extensions:test` — clean (via committer)
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] `pnpm format` — clean
- [x] Import cycle checks — 0 cycles

AI-assisted: yes (Claude, under sk7n4k3d supervision).