### PR TITLE
fix(acp): avoid false zero-diff failures and append session messages

### DIFF
--- a/src/acp/control-plane/manager.core.ts
+++ b/src/acp/control-plane/manager.core.ts
@@ -1,3 +1,4 @@
+import { verifyAcpWorktreeDiff } from "../../agents/acp-verification-gate.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { logVerbose } from "../../globals.js";
@@ -11,6 +12,8 @@ import {
   failTaskRunByRunId,
   startTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
+import { findTaskByRunId } from "../../tasks/runtime-internal.js";
+import { getTaskFlowById } from "../../tasks/task-flow-runtime-internal.js";
 import type { DeliveryContext } from "../../utils/delivery-context.js";
 import {
   AcpRuntimeError,
@@ -855,8 +858,9 @@ export class AcpSessionManager {
             });
             if (taskContext) {
               const terminalResult = resolveBackgroundTaskTerminalResult(taskProgressSummary);
-              this.markBackgroundTaskTerminal(taskContext.runId, {
+              await this.markBackgroundTaskTerminal(taskContext.runId, {
                 sessionKey,
+                sessionMode: resolvedMeta.mode,
                 status: "succeeded",
                 endedAt: Date.now(),
                 lastEventAt: Date.now(),
@@ -898,8 +902,9 @@ export class AcpSessionManager {
               errorCode: acpError.code,
             });
             if (taskContext) {
-              this.markBackgroundTaskTerminal(taskContext.runId, {
+              await this.markBackgroundTaskTerminal(taskContext.runId, {
                 sessionKey,
+                sessionMode: resolvedMeta.mode,
                 status: resolveBackgroundTaskFailureStatus(acpError),
                 endedAt: Date.now(),
                 lastEventAt: Date.now(),
@@ -2176,10 +2181,11 @@ export class AcpSessionManager {
     }
   }
 
-  private markBackgroundTaskTerminal(
+  private async markBackgroundTaskTerminal(
     runId: string,
     params: {
       sessionKey?: string;
+      sessionMode?: AcpRuntimeSessionMode;
       status: "succeeded" | "failed" | "timed_out";
       endedAt: number;
       lastEventAt?: number;
@@ -2188,9 +2194,62 @@ export class AcpSessionManager {
       terminalSummary?: string | null;
       terminalOutcome?: "succeeded" | "blocked" | null;
     },
-  ): void {
+  ): Promise<void> {
     try {
-      if (params.status === "succeeded") {
+      // Verification gate: for succeeded oneshot tasks, check that the worktree
+      // has actual tracked file changes before we accept the result as a real
+      // coding completion.
+      //
+      // Exemptions:
+      // - Persistent sessions: a turn may legitimately complete without file
+      //   changes (analysis, planning, iterative investigation) and the session
+      //   stays alive for follow-up turns.
+      // - Explicit blocked outcomes: permission / write-access blockers can be
+      //   real even when no tracked diff exists, so preserve the blocked state.
+      //
+      // For non-blocked oneshot runs that produced output but no tracked diff,
+      // degrade to BLOCKED instead of FAILED. That keeps the false-completion
+      // safeguard in place without surfacing an overly harsh hard-failure banner
+      // for exploratory first-turn replies.
+      let effectiveStatus = params.status;
+      let effectiveTerminalSummary = params.terminalSummary;
+      let effectiveTerminalOutcome = params.terminalOutcome;
+      let effectiveError = params.error;
+      if (
+        params.status === "succeeded" &&
+        params.sessionMode !== "persistent" &&
+        effectiveTerminalOutcome !== "blocked"
+      ) {
+        const cwd = this.resolveWorktreeCwdFromTask(runId);
+        if (cwd) {
+          const verification = await verifyAcpWorktreeDiff(cwd);
+          if (!verification.hasChanges) {
+            logVerbose(
+              `acp-manager: verification gate failed for ${runId}: no file changes detected in ${cwd}`,
+            );
+            const hasProgressSummary = Boolean(normalizeText(params.progressSummary)?.trim());
+            if (hasProgressSummary) {
+              effectiveStatus = "succeeded";
+              effectiveTerminalOutcome = "blocked";
+              effectiveTerminalSummary =
+                effectiveTerminalSummary ??
+                "No tracked file changes landed. Use a persistent ACP session for exploratory work or steer a concrete follow-up turn.";
+              effectiveError = undefined;
+            } else {
+              effectiveStatus = "failed";
+              effectiveTerminalSummary = "no_file_changes";
+              effectiveTerminalOutcome = undefined;
+              effectiveError =
+                "Verification gate: agent reported success but produced no file changes";
+            }
+          }
+        } else {
+          logVerbose(
+            `acp-manager: skipping verification gate for ${runId}: no cwd available (legacy flow)`,
+          );
+        }
+      }
+      if (effectiveStatus === "succeeded") {
         completeTaskRunByRunId({
           runId,
           runtime: "acp",
@@ -2198,8 +2257,8 @@ export class AcpSessionManager {
           endedAt: params.endedAt,
           lastEventAt: params.lastEventAt,
           progressSummary: params.progressSummary,
-          terminalSummary: params.terminalSummary,
-          terminalOutcome: params.terminalOutcome,
+          terminalSummary: effectiveTerminalSummary,
+          terminalOutcome: effectiveTerminalOutcome,
         });
         return;
       }
@@ -2207,15 +2266,37 @@ export class AcpSessionManager {
         runId,
         runtime: "acp",
         sessionKey: params.sessionKey,
-        status: params.status,
+        status: effectiveStatus,
         endedAt: params.endedAt,
         lastEventAt: params.lastEventAt,
-        error: params.error,
+        error: effectiveError,
         progressSummary: params.progressSummary,
-        terminalSummary: params.terminalSummary,
+        terminalSummary: effectiveTerminalSummary,
       });
     } catch (error) {
       logVerbose(`acp-manager: failed updating background task for ${runId}: ${String(error)}`);
     }
+  }
+
+  /**
+   * Resolve the worktree cwd for a task by looking up its parent flow's
+   * stateJson.workflowIntent.cwd. Returns undefined if the flow or cwd
+   * is not available (e.g. legacy flows without workflowIntent.cwd).
+   */
+  private resolveWorktreeCwdFromTask(runId: string): string | undefined {
+    const task = findTaskByRunId(runId);
+    if (!task?.parentFlowId) {
+      return undefined;
+    }
+    const flow = getTaskFlowById(task.parentFlowId);
+    if (!flow?.stateJson || typeof flow.stateJson !== "object" || Array.isArray(flow.stateJson)) {
+      return undefined;
+    }
+    const workflowIntent = (flow.stateJson as Record<string, unknown>).workflowIntent;
+    if (!workflowIntent || typeof workflowIntent !== "object" || Array.isArray(workflowIntent)) {
+      return undefined;
+    }
+    const cwd = (workflowIntent as Record<string, unknown>).cwd;
+    return typeof cwd === "string" && cwd.length > 0 ? cwd : undefined;
   }
 }

--- a/src/acp/control-plane/manager.test.ts
+++ b/src/acp/control-plane/manager.test.ts
@@ -14,12 +14,14 @@ const hoisted = vi.hoisted(() => {
   const upsertAcpSessionMetaMock = vi.fn();
   const getAcpRuntimeBackendMock = vi.fn();
   const requireAcpRuntimeBackendMock = vi.fn();
+  const verifyAcpWorktreeDiffMock = vi.fn();
   return {
     listAcpSessionEntriesMock,
     readAcpSessionEntryMock,
     upsertAcpSessionMetaMock,
     getAcpRuntimeBackendMock,
     requireAcpRuntimeBackendMock,
+    verifyAcpWorktreeDiffMock,
   };
 });
 
@@ -32,6 +34,10 @@ vi.mock("../runtime/session-meta.js", () => ({
 vi.mock("../runtime/registry.js", () => ({
   getAcpRuntimeBackend: (backendId?: string) => hoisted.getAcpRuntimeBackendMock(backendId),
   requireAcpRuntimeBackend: (backendId?: string) => hoisted.requireAcpRuntimeBackendMock(backendId),
+}));
+
+vi.mock("../../agents/acp-verification-gate.js", () => ({
+  verifyAcpWorktreeDiff: (cwd: string) => hoisted.verifyAcpWorktreeDiffMock(cwd),
 }));
 
 let AcpSessionManager: typeof import("./manager.js").AcpSessionManager;
@@ -229,6 +235,10 @@ describe("AcpSessionManager", () => {
         return null;
       }
     });
+    hoisted.verifyAcpWorktreeDiffMock.mockReset().mockResolvedValue({
+      hasChanges: true,
+      stat: "",
+    });
   });
 
   afterEach(() => {
@@ -354,6 +364,11 @@ describe("AcpSessionManager", () => {
         return null;
       });
 
+      hoisted.verifyAcpWorktreeDiffMock.mockResolvedValue({
+        hasChanges: false,
+        stat: "",
+      });
+
       const manager = new AcpSessionManager();
       await manager.runTurn({
         cfg: baseCfg,
@@ -364,6 +379,7 @@ describe("AcpSessionManager", () => {
       });
       await flushMicrotasks();
 
+      expect(hoisted.verifyAcpWorktreeDiffMock).not.toHaveBeenCalled();
       expect(findTaskByRunId("direct-parented-run")).toMatchObject({
         runtime: "acp",
         ownerKey: "agent:quant:telegram:quant:direct:822430204",
@@ -378,6 +394,289 @@ describe("AcpSessionManager", () => {
       });
     });
   }, 300_000);
+
+  it("skips verification gate for persistent sessions with zero diffs", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runTurn.mockImplementation(async function* () {
+        yield {
+          type: "text_delta" as const,
+          stream: "output" as const,
+          text: "I analyzed the codebase and found the root cause.",
+        };
+        yield { type: "done" as const };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-persistent") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-persistent",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:discord:channel:persistent-parent",
+              label: "Debug investigation",
+            },
+            acp: readySessionMeta({ mode: "persistent" }),
+          };
+        }
+        if (sessionKey === "agent:quant:discord:channel:persistent-parent") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-persistent",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      // Simulate zero diffs — persistent session should still succeed.
+      hoisted.verifyAcpWorktreeDiffMock.mockResolvedValue({
+        hasChanges: false,
+        stat: "",
+      });
+
+      const { createManagedTaskFlow } = await import("../../tasks/task-flow-registry.js");
+      const { createRunningTaskRun } = await import("../../tasks/task-executor.js");
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:quant:discord:channel:persistent-parent",
+        controllerId: "agents/acp-spawn",
+        goal: "Debug investigation",
+        currentStep: "await-child",
+        stateJson: {
+          workflowIntent: {
+            kind: "acp_parent_prompt",
+            cwd: "/tmp/test-worktree-persistent",
+          },
+        },
+      });
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:quant:discord:channel:persistent-parent",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:codex:acp:child-persistent",
+        runId: "persistent-zero-diff-run",
+        label: "Debug investigation",
+        task: "Analyze the codebase and find the root cause",
+        startedAt: 100,
+        deliveryStatus: "pending",
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-persistent",
+        text: "Analyze the codebase and find the root cause",
+        mode: "prompt",
+        requestId: "persistent-zero-diff-run",
+      });
+      await flushMicrotasks();
+
+      // Persistent session: zero diffs should NOT trigger the verification gate.
+      expect(hoisted.verifyAcpWorktreeDiffMock).not.toHaveBeenCalled();
+      expect(findTaskByRunId("persistent-zero-diff-run")).toMatchObject({
+        status: "succeeded",
+      });
+    });
+  });
+
+  it("downgrades oneshot zero-diff runs with progress output to blocked follow-up", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runTurn.mockImplementation(async function* () {
+        yield {
+          type: "text_delta" as const,
+          stream: "output" as const,
+          text: "I tried to apply the fix but nothing changed.",
+        };
+        yield { type: "done" as const };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-oneshot") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-oneshot",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:discord:channel:oneshot-parent",
+              label: "Apply fix",
+            },
+            acp: readySessionMeta({ mode: "oneshot" }),
+          };
+        }
+        if (sessionKey === "agent:quant:discord:channel:oneshot-parent") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-oneshot",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      hoisted.verifyAcpWorktreeDiffMock.mockResolvedValue({
+        hasChanges: false,
+        stat: "",
+      });
+
+      const { createManagedTaskFlow } = await import("../../tasks/task-flow-registry.js");
+      const { createRunningTaskRun } = await import("../../tasks/task-executor.js");
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:quant:discord:channel:oneshot-parent",
+        controllerId: "agents/acp-spawn",
+        goal: "Apply fix",
+        currentStep: "await-child",
+        stateJson: {
+          workflowIntent: {
+            kind: "acp_parent_prompt",
+            cwd: "/tmp/test-worktree-oneshot",
+          },
+        },
+      });
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:quant:discord:channel:oneshot-parent",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:codex:acp:child-oneshot",
+        runId: "oneshot-zero-diff-run",
+        label: "Apply fix",
+        task: "Apply the fix to the codebase",
+        startedAt: 100,
+        deliveryStatus: "pending",
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-oneshot",
+        text: "Apply the fix to the codebase",
+        mode: "prompt",
+        requestId: "oneshot-zero-diff-run",
+      });
+      await flushMicrotasks();
+
+      expect(hoisted.verifyAcpWorktreeDiffMock).toHaveBeenCalledWith("/tmp/test-worktree-oneshot");
+      expect(findTaskByRunId("oneshot-zero-diff-run")).toMatchObject({
+        status: "succeeded",
+        terminalOutcome: "blocked",
+        terminalSummary:
+          "No tracked file changes landed. Use a persistent ACP session for exploratory work or steer a concrete follow-up turn.",
+      });
+    });
+  });
+
+  it("still fails oneshot zero-diff runs that produced no progress output", async () => {
+    await withAcpManagerTaskStateDir(async () => {
+      const runtimeState = createRuntime();
+      runtimeState.runTurn.mockImplementation(async function* () {
+        yield { type: "done" as const };
+      });
+      hoisted.requireAcpRuntimeBackendMock.mockReturnValue({
+        id: "acpx",
+        runtime: runtimeState.runtime,
+      });
+      hoisted.readAcpSessionEntryMock.mockImplementation((paramsUnknown: unknown) => {
+        const sessionKey = (paramsUnknown as { sessionKey?: string }).sessionKey;
+        if (sessionKey === "agent:codex:acp:child-empty-oneshot") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "child-empty-oneshot",
+              updatedAt: Date.now(),
+              spawnedBy: "agent:quant:discord:channel:oneshot-parent-empty",
+              label: "Apply fix",
+            },
+            acp: readySessionMeta({ mode: "oneshot" }),
+          };
+        }
+        if (sessionKey === "agent:quant:discord:channel:oneshot-parent-empty") {
+          return {
+            sessionKey,
+            storeSessionKey: sessionKey,
+            entry: {
+              sessionId: "parent-oneshot-empty",
+              updatedAt: Date.now(),
+            },
+          };
+        }
+        return null;
+      });
+
+      hoisted.verifyAcpWorktreeDiffMock.mockResolvedValue({
+        hasChanges: false,
+        stat: "",
+      });
+
+      const { createManagedTaskFlow } = await import("../../tasks/task-flow-registry.js");
+      const { createRunningTaskRun } = await import("../../tasks/task-executor.js");
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:quant:discord:channel:oneshot-parent-empty",
+        controllerId: "agents/acp-spawn",
+        goal: "Apply fix",
+        currentStep: "await-child",
+        stateJson: {
+          workflowIntent: {
+            kind: "acp_parent_prompt",
+            cwd: "/tmp/test-worktree-oneshot-empty",
+          },
+        },
+      });
+      createRunningTaskRun({
+        runtime: "acp",
+        ownerKey: "agent:quant:discord:channel:oneshot-parent-empty",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:codex:acp:child-empty-oneshot",
+        runId: "oneshot-zero-diff-empty-run",
+        label: "Apply fix",
+        task: "Apply the fix to the codebase",
+        startedAt: 100,
+        deliveryStatus: "pending",
+      });
+
+      const manager = new AcpSessionManager();
+      await manager.runTurn({
+        cfg: baseCfg,
+        sessionKey: "agent:codex:acp:child-empty-oneshot",
+        text: "Apply the fix to the codebase",
+        mode: "prompt",
+        requestId: "oneshot-zero-diff-empty-run",
+      });
+      await flushMicrotasks();
+
+      expect(hoisted.verifyAcpWorktreeDiffMock).toHaveBeenCalledWith(
+        "/tmp/test-worktree-oneshot-empty",
+      );
+      expect(findTaskByRunId("oneshot-zero-diff-empty-run")).toMatchObject({
+        status: "failed",
+        error: "Verification gate: agent reported success but produced no file changes",
+        terminalSummary: "no_file_changes",
+      });
+    });
+  });
 
   it("serializes concurrent turns for the same ACP session", async () => {
     const runtimeState = createRuntime();

--- a/src/agents/acp-verification-gate.ts
+++ b/src/agents/acp-verification-gate.ts
@@ -1,0 +1,34 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export type AcpWorktreeDiffResult = {
+  hasChanges: boolean;
+  stat: string;
+};
+
+/**
+ * Verify that an ACP worktree has actual file changes relative to HEAD.
+ *
+ * Fail closed: any error (missing cwd, git failure, timeout) returns
+ * hasChanges=false so the caller can decide how to treat the run.
+ */
+export async function verifyAcpWorktreeDiff(cwd: string): Promise<AcpWorktreeDiffResult> {
+  try {
+    const { stdout } = await execFileAsync("git", ["diff", "--stat", "HEAD"], {
+      cwd,
+      timeout: 10_000,
+    });
+    const stat = stdout.trim();
+    return {
+      hasChanges: stat.length > 0,
+      stat,
+    };
+  } catch {
+    return {
+      hasChanges: false,
+      stat: "",
+    };
+  }
+}

--- a/ui/src/ui/app-gateway.sessions.node.test.ts
+++ b/ui/src/ui/app-gateway.sessions.node.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 const loadSessionsMock = vi.fn();
 const loadChatHistoryMock = vi.fn();
+const appendTranscriptMessageMock = vi.fn(() => true);
 
 vi.mock("./app-chat.ts", () => ({
   CHAT_SESSIONS_ACTIVE_MINUTES: 10,
@@ -25,6 +26,7 @@ vi.mock("./controllers/assistant-identity.ts", () => ({
   loadAssistantIdentity: vi.fn(),
 }));
 vi.mock("./controllers/chat.ts", () => ({
+  appendTranscriptMessage: appendTranscriptMessageMock,
   loadChatHistory: loadChatHistoryMock,
   handleChatEvent: vi.fn(() => "idle"),
 }));
@@ -105,6 +107,7 @@ function createHost() {
     execApprovalQueue: [],
     execApprovalError: null,
     updateAvailable: null,
+    chatMessages: [],
   } as unknown as Parameters<typeof handleGatewayEvent>[0];
 }
 
@@ -128,6 +131,7 @@ describe("handleGatewayEvent sessions.changed", () => {
 describe("handleGatewayEvent session.message", () => {
   it("reloads chat history for the active session", () => {
     loadChatHistoryMock.mockReset();
+    appendTranscriptMessageMock.mockReset().mockReturnValue(true);
     const host = createHost();
     host.sessionKey = "agent:qa:main";
 
@@ -140,10 +144,45 @@ describe("handleGatewayEvent session.message", () => {
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+    expect(appendTranscriptMessageMock).not.toHaveBeenCalled();
   });
 
-  it("skips history reload while a chat run is active", () => {
+  it("appends transcript payloads while a chat run is active", () => {
     loadChatHistoryMock.mockReset();
+    appendTranscriptMessageMock.mockReset().mockReturnValue(true);
+    const host = createHost();
+    host.sessionKey = "agent:qa:main";
+    host.chatRunId = "run-123";
+
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Second completion arrived" }],
+      __openclaw: { id: "msg-2", seq: 2 },
+    };
+
+    handleGatewayEvent(host, {
+      type: "event",
+      event: "session.message",
+      payload: {
+        sessionKey: "agent:qa:main",
+        message,
+        messageId: "msg-2",
+        messageSeq: 2,
+      },
+      seq: 1,
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(appendTranscriptMessageMock).toHaveBeenCalledTimes(1);
+    expect(appendTranscriptMessageMock).toHaveBeenCalledWith(host, message, {
+      messageId: "msg-2",
+      messageSeq: 2,
+    });
+  });
+
+  it("still defers reload while a chat run is active when no payload message is provided", () => {
+    loadChatHistoryMock.mockReset();
+    appendTranscriptMessageMock.mockReset().mockReturnValue(true);
     const host = createHost();
     host.sessionKey = "agent:qa:main";
     host.chatRunId = "run-123";
@@ -156,10 +195,12 @@ describe("handleGatewayEvent session.message", () => {
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(appendTranscriptMessageMock).not.toHaveBeenCalled();
   });
 
   it("ignores transcript updates for other sessions", () => {
     loadChatHistoryMock.mockReset();
+    appendTranscriptMessageMock.mockReset().mockReturnValue(true);
     const host = createHost();
     host.sessionKey = "agent:qa:main";
 
@@ -171,6 +212,7 @@ describe("handleGatewayEvent session.message", () => {
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(appendTranscriptMessageMock).not.toHaveBeenCalled();
   });
 });
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -25,6 +25,7 @@ import {
   type AssistantIdentityState,
 } from "./controllers/assistant-identity.ts";
 import {
+  appendTranscriptMessage,
   loadChatHistory,
   handleChatEvent,
   type ChatEventPayload,
@@ -441,7 +442,9 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
 
 function handleSessionMessageGatewayEvent(
   host: GatewayHost,
-  payload: { sessionKey?: string } | undefined,
+  payload:
+    | { sessionKey?: string; message?: unknown; messageId?: string; messageSeq?: number }
+    | undefined,
 ) {
   const deferredReloadHost = host as GatewayHostWithDeferredSessionMessageReload;
   const sessionKey = payload?.sessionKey?.trim();
@@ -454,6 +457,12 @@ function handleSessionMessageGatewayEvent(
   // chatStream, which delays the user message card from appearing until the
   // first LLM delta arrives.
   if (host.chatRunId) {
+    if (payload?.message !== undefined) {
+      appendTranscriptMessage(host as unknown as ChatState, payload.message, {
+        messageId: typeof payload.messageId === "string" ? payload.messageId : undefined,
+        messageSeq: typeof payload.messageSeq === "number" ? payload.messageSeq : undefined,
+      });
+    }
     deferredReloadHost.pendingSessionMessageReloadSessionKey = sessionKey;
     return;
   }
@@ -498,7 +507,12 @@ function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   }
 
   if (evt.event === "session.message") {
-    handleSessionMessageGatewayEvent(host, evt.payload as { sessionKey?: string } | undefined);
+    handleSessionMessageGatewayEvent(
+      host,
+      evt.payload as
+        | { sessionKey?: string; message?: unknown; messageId?: string; messageSeq?: number }
+        | undefined,
+    );
     return;
   }
 

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { GatewayRequestError } from "../gateway.ts";
 import {
   abortChatRun,
+  appendTranscriptMessage,
   handleChatEvent,
   loadChatHistory,
   sendChatMessage,
@@ -518,6 +519,62 @@ describe("handleChatEvent", () => {
     // entry.text takes precedence — "real reply" is NOT silent, so the message is kept.
     expect(handleChatEvent(state, payload)).toBe("final");
     expect(state.chatMessages).toHaveLength(1);
+  });
+});
+
+describe("appendTranscriptMessage", () => {
+  it("appends a new transcript payload when it is not already present", () => {
+    const state = createState();
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Child completion" }],
+      __openclaw: { id: "msg-1", seq: 1 },
+    };
+
+    expect(appendTranscriptMessage(state, message)).toBe(true);
+    expect(state.chatMessages).toEqual([message]);
+  });
+
+  it("deduplicates transcript payloads by OpenClaw message id", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "Child completion" }],
+      __openclaw: { id: "msg-1", seq: 1 },
+    };
+    const state = createState({ chatMessages: [message] });
+
+    expect(appendTranscriptMessage(state, message)).toBe(false);
+    expect(state.chatMessages).toEqual([message]);
+  });
+
+  it("replaces the optimistic user echo with the server-backed transcript message", () => {
+    const optimistic = {
+      role: "user",
+      content: [{ type: "text", text: "Please keep working" }],
+      timestamp: 1,
+    };
+    const serverMessage = {
+      role: "user",
+      content: [{ type: "text", text: "Please keep working" }],
+      __openclaw: { id: "msg-user-1", seq: 4 },
+      timestamp: 2,
+    };
+    const state = createState({ chatMessages: [optimistic] });
+
+    expect(appendTranscriptMessage(state, serverMessage)).toBe(true);
+    expect(state.chatMessages).toEqual([serverMessage]);
+  });
+
+  it("hides silent assistant transcript payloads", () => {
+    const state = createState();
+    const message = {
+      role: "assistant",
+      content: [{ type: "text", text: "NO_REPLY" }],
+      __openclaw: { id: "msg-silent", seq: 2 },
+    };
+
+    expect(appendTranscriptMessage(state, message)).toBe(false);
+    expect(state.chatMessages).toEqual([]);
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -75,6 +75,87 @@ function shouldHideHistoryMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
 }
 
+function resolveTranscriptMessageIdentity(
+  message: unknown,
+  fallback?: { messageId?: string; messageSeq?: number },
+): string | null {
+  if (typeof fallback?.messageId === "string" && fallback.messageId.trim()) {
+    return `id:${fallback.messageId.trim()}`;
+  }
+  if (!message || typeof message !== "object") {
+    if (typeof fallback?.messageSeq === "number" && Number.isFinite(fallback.messageSeq)) {
+      return `seq:${fallback.messageSeq}`;
+    }
+    return null;
+  }
+  const entry = message as Record<string, unknown>;
+  if (typeof entry.id === "string" && entry.id.trim()) {
+    return `id:${entry.id.trim()}`;
+  }
+  const meta = entry.__openclaw;
+  if (meta && typeof meta === "object") {
+    const transcriptMeta = meta as { id?: unknown; seq?: unknown };
+    if (typeof transcriptMeta.id === "string" && transcriptMeta.id.trim()) {
+      return `id:${transcriptMeta.id.trim()}`;
+    }
+    if (typeof transcriptMeta.seq === "number" && Number.isFinite(transcriptMeta.seq)) {
+      return `seq:${transcriptMeta.seq}`;
+    }
+  }
+  if (typeof fallback?.messageSeq === "number" && Number.isFinite(fallback.messageSeq)) {
+    return `seq:${fallback.messageSeq}`;
+  }
+  return null;
+}
+
+function canReplaceOptimisticTranscriptEcho(existing: unknown, incoming: unknown): boolean {
+  if (!existing || typeof existing !== "object" || !incoming || typeof incoming !== "object") {
+    return false;
+  }
+  if (resolveTranscriptMessageIdentity(existing)) {
+    return false;
+  }
+  const existingRole = normalizeLowercaseStringOrEmpty((existing as Record<string, unknown>).role);
+  const incomingRole = normalizeLowercaseStringOrEmpty((incoming as Record<string, unknown>).role);
+  if (existingRole !== "user" || incomingRole !== "user") {
+    return false;
+  }
+  const existingText = extractText(existing)?.trim() ?? "";
+  const incomingText = extractText(incoming)?.trim() ?? "";
+  return Boolean(existingText) && existingText === incomingText;
+}
+
+export function appendTranscriptMessage(
+  state: Pick<ChatState, "chatMessages">,
+  message: unknown,
+  options?: { messageId?: string; messageSeq?: number },
+): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if (shouldHideHistoryMessage(message)) {
+    return false;
+  }
+  const messageIdentity = resolveTranscriptMessageIdentity(message, options);
+  if (
+    messageIdentity &&
+    state.chatMessages.some((entry) => resolveTranscriptMessageIdentity(entry) === messageIdentity)
+  ) {
+    return false;
+  }
+  const nextMessages = [...state.chatMessages];
+  if (
+    nextMessages.length > 0 &&
+    canReplaceOptimisticTranscriptEcho(nextMessages[nextMessages.length - 1], message)
+  ) {
+    nextMessages[nextMessages.length - 1] = message;
+  } else {
+    nextMessages.push(message);
+  }
+  state.chatMessages = nextMessages;
+  return true;
+}
+
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
   if (!(err instanceof GatewayRequestError)) {
     return false;


### PR DESCRIPTION
## Summary
- skip the zero-diff ACP verification gate for persistent sessions and downgrade oneshot zero-diff runs with real progress output to blocked follow-up instead of hard failure
- add the ACP worktree diff verifier and regression coverage for persistent and oneshot task handling
- append `session.message` payloads directly in the control UI during active runs, with chat-side dedupe and optimistic echo replacement tests

## Testing
- pnpm vitest run src/acp/control-plane/manager.test.ts ui/src/ui/controllers/chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts

## Notes
- local full `pnpm check` is currently blocked on an unrelated existing `extensions/qa-lab` typecheck issue on `origin/main` (`@copilotkit/aimock` missing), so I used the focused suite above for verification here