### PR TITLE
fix(tui): show commentary-phase text when no final_answer blocks present

### DIFF
--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -184,5 +184,11 @@ export function extractAssistantVisibleText(message: unknown): string | undefine
   if (finalAnswerText) {
     return finalAnswerText;
   }
+  // Fall back to commentary-phase text when no final_answer blocks exist yet
+  // (streaming in progress, or model omits <final> tags entirely).
+  const commentaryText = extractAssistantTextForPhase(message, { phase: "commentary" });
+  if (commentaryText) {
+    return commentaryText;
+  }
   return extractAssistantTextForPhase(message);
 }


### PR DESCRIPTION
## Summary

- `extractAssistantVisibleText` returned `undefined` when a message had phased text blocks but no `final_answer` block yet, causing TUI to display nothing during streaming and for models that omit `<final>` tags
- Add a commentary-phase fallback between the `final_answer` check and the legacy unphased fallback so streaming deltas and fully-commentary messages are rendered correctly

## Root cause

Commit `22d8e47a50` tightened phase handling: when `hasExplicitPhasedTextBlocks` is `true`, unphased extraction returns `undefined`. This correctly prevents mixing phased and legacy content, but accidentally made all commentary-only windows invisible — the common state during streaming and the only state for models without `<final>` tags.

## Affected issues

Fixes #34513, #35523, #37647, #40824, #34537

## Test plan

- [ ] Send a message to TUI; assistant reply should appear as it streams (before `<final>` tag arrives)
- [ ] Send a message using a model configuration that omits `<final>` tags; reply should be visible in TUI
- [ ] Webchat path unaffected (only commentary-phase fallback added, final_answer still takes priority)
- [ ] `pnpm test src/shared/` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)