### PR TITLE
feat(doctor): detect local rebuild vs pristine npm release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Features
+
+- feat(doctor): warn when the installed openclaw package is a local rebuild diverging from the pristine npm release (#TBD)
+
 ### Fixes
 
 - Cron/delivery: treat explicit `delivery.mode: "none"` runs as not requested even if the runner reports `delivered: false`, so no-delivery cron jobs no longer persist false delivery failures or errors. (#69285) Thanks @matsuri1987.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -50,6 +50,12 @@ Notes:
 - If channel SecretRef inspection fails in a fix path, doctor continues and reports a warning instead of exiting early.
 - Telegram `allowFrom` username auto-resolution (`doctor --fix`) requires a resolvable Telegram token in the current command path. If token inspection is unavailable, doctor reports a warning and skips auto-resolution for that pass.
 
+## Install freshness check
+
+`openclaw doctor` compares the local package build metadata in `dist/build-info.json` with the npm registry publish time for the installed version. It stays silent when the install looks like the pristine npm package or the registry cannot be checked.
+
+Doctor warns when the local build appears to be a later rebuild of a published version, when the installed version is not present in the registry publish map, or when local build metadata is missing or malformed. The warning is non-blocking and is meant to catch locally patched installs before `openclaw update` overwrites them.
+
 ## macOS: `launchctl` env overrides
 
 If you previously ran `launchctl setenv OPENCLAW_GATEWAY_TOKEN ...` (or `...PASSWORD`), that value overrides your config file and can cause persistent “unauthorized” errors.

--- a/src/commands/doctor-rebuild-guard.test.ts
+++ b/src/commands/doctor-rebuild-guard.test.ts
@@ -1,0 +1,345 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const noteMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../terminal/note.js", () => ({
+  note: noteMock,
+}));
+
+import { evaluateRebuildGuard, noteRebuildGuardHealth } from "./doctor-rebuild-guard.js";
+
+const now = new Date("2026-04-20T13:00:00.000Z");
+
+type FetchStub = ReturnType<typeof vi.fn> & typeof fetch;
+
+let tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openclaw-rebuild-guard-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function writePackageFixture(
+  params: {
+    packageRoot?: string;
+    version?: string;
+    builtAt?: string;
+    commit?: string;
+    buildInfoRaw?: string;
+    omitBuildInfo?: boolean;
+  } = {},
+): string {
+  const packageRoot = params.packageRoot ?? makeTempDir();
+  const version = params.version ?? "2026.4.15";
+  mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+  writeFileSync(path.join(packageRoot, "package.json"), `${JSON.stringify({ version })}\n`, "utf8");
+  if (!params.omitBuildInfo) {
+    const buildInfo =
+      params.buildInfoRaw ??
+      JSON.stringify({
+        version,
+        builtAt: params.builtAt ?? "2026-04-16T12:30:00.000Z",
+        commit: params.commit ?? "abc123",
+      });
+    writeFileSync(path.join(packageRoot, "dist", "build-info.json"), `${buildInfo}\n`, "utf8");
+  }
+  return packageRoot;
+}
+
+function registryBody(time: Record<string, string>): string {
+  return JSON.stringify({ time });
+}
+
+function makeFetch(body: string): FetchStub {
+  return vi.fn(async () => ({
+    ok: true,
+    text: async () => body,
+  })) as FetchStub;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+  delete process.env.OPENCLAW_NPM_REGISTRY_FILE;
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  noteMock.mockClear();
+});
+
+describe("evaluateRebuildGuard", () => {
+  it("returns pristine without emitting a note when build metadata is near the npm publish time", async () => {
+    const packageRoot = writePackageFixture({
+      builtAt: "2026-04-16T12:30:00.000Z",
+    });
+    const fetchFn = makeFetch(
+      registryBody({
+        "2026.4.15": "2026-04-16T12:00:00.000Z",
+      }),
+    );
+
+    const result = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile: path.join(makeTempDir(), "registry.json"),
+    });
+
+    expect(result).toMatchObject({
+      verdict: "pristine",
+      version: "2026.4.15",
+      builtAt: "2026-04-16T12:30:00.000Z",
+      npmPublishedAt: "2026-04-16T12:00:00.000Z",
+      reason: "within-skew-window",
+    });
+    expect(noteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns rebuild with skew minutes and emits one note with the reason", async () => {
+    const packageRoot = writePackageFixture({
+      builtAt: "2026-04-19T12:00:00.000Z",
+    });
+    const fetchFn = makeFetch(
+      registryBody({
+        "2026.4.15": "2026-04-16T12:00:00.000Z",
+      }),
+    );
+    const cacheFile = path.join(makeTempDir(), "registry.json");
+
+    const result = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+
+    expect(result).toMatchObject({
+      verdict: "rebuild",
+      reason: "builtAt-after-publish",
+      skewMinutes: 72 * 60,
+    });
+
+    await noteRebuildGuardHealth(packageRoot, {
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+
+    expect(noteMock).toHaveBeenCalledOnce();
+    expect(noteMock.mock.calls[0]?.[0]).toContain("- Reason: builtAt-after-publish");
+  });
+
+  it("returns unreleased and emits a note when the local version is absent from the registry time map", async () => {
+    const packageRoot = writePackageFixture();
+    const fetchFn = makeFetch(
+      registryBody({
+        "2026.4.14": "2026-04-14T12:00:00.000Z",
+      }),
+    );
+    const cacheFile = path.join(makeTempDir(), "registry.json");
+
+    const result = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+
+    expect(result).toMatchObject({
+      verdict: "unreleased",
+      reason: "version-unreleased",
+    });
+
+    await noteRebuildGuardHealth(packageRoot, {
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+    expect(noteMock).toHaveBeenCalledOnce();
+    expect(noteMock.mock.calls[0]?.[0]).toContain("- Reason: version-unreleased");
+  });
+
+  it("returns corrupt and emits a note when build-info.json is missing or malformed", async () => {
+    const missingBuildInfoRoot = writePackageFixture({ omitBuildInfo: true });
+
+    const missingResult = await evaluateRebuildGuard({
+      packageRoot: missingBuildInfoRoot,
+      fetchFn: makeFetch(registryBody({})),
+      now: () => now,
+      cacheFile: path.join(makeTempDir(), "registry.json"),
+    });
+
+    expect(missingResult).toMatchObject({
+      verdict: "corrupt",
+      reason: "build-info-missing",
+    });
+
+    const malformedBuildInfoRoot = writePackageFixture({ buildInfoRaw: "{" });
+    const malformedResult = await evaluateRebuildGuard({
+      packageRoot: malformedBuildInfoRoot,
+      fetchFn: makeFetch(registryBody({})),
+      now: () => now,
+      cacheFile: path.join(makeTempDir(), "registry.json"),
+    });
+
+    expect(malformedResult).toMatchObject({
+      verdict: "corrupt",
+      reason: "build-info-missing",
+    });
+
+    await noteRebuildGuardHealth(missingBuildInfoRoot, {
+      fetchFn: makeFetch(registryBody({})),
+      now: () => now,
+      cacheFile: path.join(makeTempDir(), "registry.json"),
+    });
+    expect(noteMock).toHaveBeenCalledOnce();
+    expect(noteMock.mock.calls[0]?.[0]).toContain("- Reason: build-info-missing");
+  });
+
+  it("returns inconclusive without emitting a note when fetch fails and no cache is present", async () => {
+    const packageRoot = writePackageFixture();
+    const fetchFn = vi.fn(async () => {
+      throw new Error("offline");
+    }) as FetchStub;
+    const cacheFile = path.join(makeTempDir(), "registry.json");
+
+    const result = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+
+    expect(result).toMatchObject({
+      verdict: "inconclusive",
+      reason: "registry-unavailable",
+    });
+
+    await noteRebuildGuardHealth(packageRoot, {
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+    expect(noteMock).not.toHaveBeenCalled();
+  });
+
+  it("skips fetch in offline mode and stays silent when local metadata is not enough", async () => {
+    const packageRoot = writePackageFixture();
+    const fetchFn = makeFetch(
+      registryBody({
+        "2026.4.15": "2026-04-16T12:00:00.000Z",
+      }),
+    );
+    const cacheFile = path.join(makeTempDir(), "registry.json");
+
+    const result = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      offline: true,
+      cacheFile,
+    });
+
+    expect(result).toMatchObject({
+      verdict: "inconclusive",
+      reason: "registry-unavailable",
+    });
+    expect(fetchFn).not.toHaveBeenCalled();
+
+    await noteRebuildGuardHealth(packageRoot, {
+      fetchFn,
+      now: () => now,
+      offline: true,
+      cacheFile,
+    });
+    expect(noteMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a fresh cache on the second call without fetching again", async () => {
+    const packageRoot = writePackageFixture();
+    const fetchFn = makeFetch(
+      registryBody({
+        "2026.4.15": "2026-04-16T12:00:00.000Z",
+      }),
+    );
+    const cacheFile = path.join(makeTempDir(), "registry.json");
+
+    const first = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+    const second = await evaluateRebuildGuard({
+      packageRoot,
+      fetchFn,
+      now: () => now,
+      cacheFile,
+    });
+
+    expect(first.verdict).toBe("pristine");
+    expect(second.verdict).toBe("pristine");
+    expect(fetchFn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("noteRebuildGuardHealth", () => {
+  it("emits only for rebuild, unreleased, and corrupt verdicts", async () => {
+    const cases = [
+      {
+        verdict: "rebuild",
+        packageRoot: writePackageFixture({ builtAt: "2026-04-19T12:00:00.000Z" }),
+        fetchFn: makeFetch(registryBody({ "2026.4.15": "2026-04-16T12:00:00.000Z" })),
+        shouldNote: true,
+      },
+      {
+        verdict: "unreleased",
+        packageRoot: writePackageFixture(),
+        fetchFn: makeFetch(registryBody({ "2026.4.14": "2026-04-14T12:00:00.000Z" })),
+        shouldNote: true,
+      },
+      {
+        verdict: "corrupt",
+        packageRoot: writePackageFixture({ omitBuildInfo: true }),
+        fetchFn: makeFetch(registryBody({})),
+        shouldNote: true,
+      },
+      {
+        verdict: "pristine",
+        packageRoot: writePackageFixture(),
+        fetchFn: makeFetch(registryBody({ "2026.4.15": "2026-04-16T12:00:00.000Z" })),
+        shouldNote: false,
+      },
+      {
+        verdict: "inconclusive",
+        packageRoot: writePackageFixture(),
+        fetchFn: vi.fn(async () => {
+          throw new Error("offline");
+        }) as FetchStub,
+        shouldNote: false,
+      },
+    ];
+
+    for (const entry of cases) {
+      noteMock.mockClear();
+      await noteRebuildGuardHealth(entry.packageRoot, {
+        fetchFn: entry.fetchFn,
+        now: () => now,
+        cacheFile: path.join(makeTempDir(), `${entry.verdict}-registry.json`),
+      });
+
+      if (entry.shouldNote) {
+        expect(noteMock, entry.verdict).toHaveBeenCalledOnce();
+      } else {
+        expect(noteMock, entry.verdict).not.toHaveBeenCalled();
+      }
+    }
+  });
+});

--- a/src/commands/doctor-rebuild-guard.ts
+++ b/src/commands/doctor-rebuild-guard.ts
@@ -1,0 +1,347 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { note } from "../terminal/note.js";
+
+export type RebuildGuardVerdict =
+  | "pristine"
+  | "rebuild"
+  | "unreleased"
+  | "inconclusive"
+  | "corrupt";
+
+export interface RebuildGuardResult {
+  verdict: RebuildGuardVerdict;
+  version: string;
+  commit?: string;
+  builtAt?: string;
+  npmPublishedAt?: string;
+  skewMinutes?: number;
+  reason: string;
+}
+
+export interface RebuildGuardOptions {
+  packageRoot: string;
+  fetchFn?: typeof fetch;
+  now?: () => Date;
+  offline?: boolean;
+  cacheFile?: string;
+  cacheTtlMs?: number;
+}
+
+type LocalMetadata =
+  | {
+      ok: true;
+      version: string;
+      commit?: string;
+      builtAt: string;
+      builtAtMs: number;
+    }
+  | {
+      ok: false;
+      version: string;
+      reason: string;
+    };
+
+const NPM_REGISTRY_URL = "https://registry.npmjs.org/openclaw";
+const DEFAULT_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+const REBUILD_SKEW_THRESHOLD_MS = 60 * 60 * 1000;
+
+function defaultCacheFile(): string {
+  return path.join(os.homedir(), ".openclaw", "rebuild-guard-cache.json");
+}
+
+function getStringProperty(value: unknown, key: string): string | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined;
+  }
+  const raw = (value as Record<string, unknown>)[key];
+  return typeof raw === "string" && raw.length > 0 ? raw : undefined;
+}
+
+function parseIsoMs(value: string): number | null {
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+async function readJsonFile(filePath: string): Promise<unknown> {
+  try {
+    return JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+async function readLocalMetadata(packageRoot: string): Promise<LocalMetadata> {
+  const buildInfoPath = path.join(packageRoot, "dist", "build-info.json");
+  const packageJsonPath = path.join(packageRoot, "package.json");
+  const buildInfo = await readJsonFile(buildInfoPath);
+  if (!buildInfo) {
+    return { ok: false, version: "", reason: "build-info-missing" };
+  }
+  const packageJson = await readJsonFile(packageJsonPath);
+  if (!packageJson) {
+    return { ok: false, version: "", reason: "package-json-missing" };
+  }
+
+  const version = getStringProperty(buildInfo, "version");
+  const builtAt = getStringProperty(buildInfo, "builtAt");
+  const packageVersion = getStringProperty(packageJson, "version");
+  if (!version || !builtAt || !packageVersion) {
+    return { ok: false, version: version ?? packageVersion ?? "", reason: "metadata-malformed" };
+  }
+
+  const builtAtMs = parseIsoMs(builtAt);
+  if (builtAtMs === null) {
+    return { ok: false, version, reason: "builtAt-unparseable" };
+  }
+
+  return {
+    ok: true,
+    version,
+    commit: getStringProperty(buildInfo, "commit"),
+    builtAt,
+    builtAtMs,
+  };
+}
+
+function readRegistryTimeMap(registryJson: unknown): Record<string, string> | null {
+  if (!registryJson || typeof registryJson !== "object") {
+    return null;
+  }
+  const time = (registryJson as Record<string, unknown>).time;
+  if (!time || typeof time !== "object" || Array.isArray(time)) {
+    return null;
+  }
+  const entries = Object.entries(time).filter((entry): entry is [string, string] => {
+    return typeof entry[1] === "string";
+  });
+  return Object.fromEntries(entries);
+}
+
+async function loadRegistryFile(filePath: string): Promise<Record<string, string> | null> {
+  const json = await readJsonFile(filePath);
+  return readRegistryTimeMap(json);
+}
+
+async function loadFreshCache(params: {
+  cacheFile: string;
+  cacheTtlMs: number;
+  now: () => Date;
+}): Promise<Record<string, string> | null> {
+  try {
+    const stat = await fs.stat(params.cacheFile);
+    if (params.now().getTime() - stat.mtimeMs > params.cacheTtlMs) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+  return loadRegistryFile(params.cacheFile);
+}
+
+async function writeCache(cacheFile: string, payload: string): Promise<void> {
+  try {
+    await fs.mkdir(path.dirname(cacheFile), { recursive: true });
+    const tmp = path.join(
+      path.dirname(cacheFile),
+      `.${path.basename(cacheFile)}.${process.pid}.${Date.now()}.tmp`,
+    );
+    await fs.writeFile(tmp, `${payload}\n`, "utf8");
+    await fs.rename(tmp, cacheFile);
+  } catch {
+    // Cache writes are best-effort; the doctor check must never block on them.
+  }
+}
+
+async function fetchRegistry(params: {
+  fetchFn: typeof fetch;
+  cacheFile: string;
+}): Promise<Record<string, string> | null> {
+  try {
+    const response = await params.fetchFn(NPM_REGISTRY_URL);
+    if (!response.ok) {
+      return null;
+    }
+    const text = await response.text();
+    const registry = readRegistryTimeMap(JSON.parse(text) as unknown);
+    if (!registry) {
+      return null;
+    }
+    await writeCache(params.cacheFile, text);
+    return registry;
+  } catch {
+    return null;
+  }
+}
+
+async function loadRegistry(params: {
+  fetchFn: typeof fetch;
+  now: () => Date;
+  offline: boolean;
+  cacheFile: string;
+  cacheTtlMs: number;
+}): Promise<Record<string, string> | null> {
+  const registryFile = process.env.OPENCLAW_NPM_REGISTRY_FILE;
+  if (registryFile) {
+    const registry = await loadRegistryFile(registryFile);
+    if (registry) {
+      return registry;
+    }
+  }
+
+  if (!params.offline) {
+    const freshCache = await loadFreshCache({
+      cacheFile: params.cacheFile,
+      cacheTtlMs: params.cacheTtlMs,
+      now: params.now,
+    });
+    if (freshCache) {
+      return freshCache;
+    }
+
+    const fetched = await fetchRegistry({
+      fetchFn: params.fetchFn,
+      cacheFile: params.cacheFile,
+    });
+    if (fetched) {
+      return fetched;
+    }
+  }
+
+  return loadRegistryFile(params.cacheFile);
+}
+
+export async function evaluateRebuildGuard(opts: RebuildGuardOptions): Promise<RebuildGuardResult> {
+  const local = await readLocalMetadata(opts.packageRoot);
+  if (!local.ok) {
+    return {
+      verdict: "corrupt",
+      version: local.version,
+      reason: local.reason,
+    };
+  }
+
+  const baseResult = {
+    version: local.version,
+    ...(local.commit ? { commit: local.commit } : {}),
+    builtAt: local.builtAt,
+  };
+  const registry = await loadRegistry({
+    fetchFn: opts.fetchFn ?? fetch,
+    now: opts.now ?? (() => new Date()),
+    offline: opts.offline ?? false,
+    cacheFile: opts.cacheFile ?? defaultCacheFile(),
+    cacheTtlMs: opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS,
+  });
+
+  if (!registry) {
+    return {
+      verdict: "inconclusive",
+      ...baseResult,
+      reason: "registry-unavailable",
+    };
+  }
+
+  const npmPublishedAt = registry[local.version];
+  if (!npmPublishedAt) {
+    return {
+      verdict: "unreleased",
+      ...baseResult,
+      reason: "version-unreleased",
+    };
+  }
+
+  const npmPublishedAtMs = parseIsoMs(npmPublishedAt);
+  if (npmPublishedAtMs === null) {
+    return {
+      verdict: "inconclusive",
+      ...baseResult,
+      npmPublishedAt,
+      reason: "npm-time-unparseable",
+    };
+  }
+
+  const skewMs = local.builtAtMs - npmPublishedAtMs;
+  const skewMinutes = skewMs / 60_000;
+  if (skewMs >= REBUILD_SKEW_THRESHOLD_MS) {
+    return {
+      verdict: "rebuild",
+      ...baseResult,
+      npmPublishedAt,
+      skewMinutes,
+      reason: "builtAt-after-publish",
+    };
+  }
+  if (skewMs <= -REBUILD_SKEW_THRESHOLD_MS) {
+    return {
+      verdict: "inconclusive",
+      ...baseResult,
+      npmPublishedAt,
+      skewMinutes,
+      reason: "builtAt-before-publish",
+    };
+  }
+  return {
+    verdict: "pristine",
+    ...baseResult,
+    npmPublishedAt,
+    skewMinutes,
+    reason: "within-skew-window",
+  };
+}
+
+function formatRebuildGuardNote(result: RebuildGuardResult, packageRoot: string): string {
+  const lines = [
+    "Local OpenClaw install differs from the pristine npm release.",
+    `- Install: ${packageRoot}`,
+    `- Version: ${result.version || "unknown"}`,
+  ];
+  if (result.commit) {
+    lines.push(`- Commit: ${result.commit}`);
+  }
+  if (result.builtAt) {
+    lines.push(`- builtAt: ${result.builtAt}`);
+  }
+  if (result.npmPublishedAt) {
+    lines.push(`- npm publish: ${result.npmPublishedAt}`);
+  }
+  if (typeof result.skewMinutes === "number") {
+    lines.push(`- Skew: ${Math.round(result.skewMinutes)} minutes ahead of npm`);
+  }
+  lines.push(
+    `- Reason: ${result.reason}`,
+    "Confirm every local patch has a matching upstream PR before running `openclaw update`.",
+  );
+  return lines.join("\n");
+}
+
+export async function noteRebuildGuardHealth(
+  packageRoot: string | null,
+  opts: Omit<RebuildGuardOptions, "packageRoot"> = {},
+): Promise<void> {
+  // When doctor cannot resolve a package root (ad-hoc CLI invocations, lightly
+  // installed contexts), there is nothing to compare against the npm registry.
+  // Mirror the same silent behavior as the other `note*` install helpers.
+  if (!packageRoot) {
+    return;
+  }
+  const result = await evaluateRebuildGuard({ ...opts, packageRoot });
+  if (result.verdict === "pristine" || result.verdict === "inconclusive") {
+    return;
+  }
+
+  if (result.verdict === "corrupt") {
+    note(
+      [
+        "OpenClaw install metadata is missing or malformed.",
+        `- Install: ${packageRoot}`,
+        `- Reason: ${result.reason}`,
+      ].join("\n"),
+      "Install",
+    );
+    return;
+  }
+
+  note(formatRebuildGuardNote(result, packageRoot), "Install");
+}

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -3,6 +3,7 @@ import { loadAndMaybeMigrateDoctorConfig } from "../commands/doctor-config-flow.
 import { noteSourceInstallIssues } from "../commands/doctor-install.js";
 import { noteStartupOptimizationHints } from "../commands/doctor-platform-notes.js";
 import { createDoctorPrompter, type DoctorOptions } from "../commands/doctor-prompter.js";
+import { noteRebuildGuardHealth } from "../commands/doctor-rebuild-guard.js";
 import { maybeRepairUiProtocolFreshness } from "../commands/doctor-ui.js";
 import { maybeOfferUpdateBeforeDoctor } from "../commands/doctor-update.js";
 import { printWizardHeader } from "../commands/onboard-helpers.js";
@@ -43,6 +44,7 @@ export async function doctorCommand(
 
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
+  await noteRebuildGuardHealth(root);
   noteStartupOptimizationHints();
 
   const configResult = await loadAndMaybeMigrateDoctorConfig({


### PR DESCRIPTION
## Problem

A stock `openclaw update` silently overwrites locally patched installs.
Regressions return quietly because operators have no signal that the
running package has diverged from the pristine npm release.

Concrete trigger: the 2026-04-20 dist-overlay audit of
`/usr/lib/node_modules/openclaw` on a production host showed
v2026.4.15 with `dist/build-info.json.builtAt = 2026-04-19` while the
npm registry reported that version was published on `2026-04-16`.
That ~3-day skew is a locally rebuilt install — a stock `update` had
wiped a sticky-fallback patch that had been applied by hand.

## Solution

Non-blocking `openclaw doctor` note that compares local build metadata
against the npm registry publish time and warns if the installed
package is a local rebuild, an unreleased version, or has corrupt
metadata.

* **Warn only.** Never fails doctor.
* **Silent on pristine or inconclusive** (no network, no cache, etc.).
* **Runs in the install-posture section** of `doctor`, right after
  `noteSourceInstallIssues`.

## Signals

* Reads `<packageRoot>/dist/build-info.json` → `{version, commit, builtAt}`
  and `<packageRoot>/package.json.version`.
* Fetches `https://registry.npmjs.org/openclaw`, inspects
  `.time[<version>]`.
* **rebuild** — `builtAt - publishedAt >= 60 min`.
* **unreleased** — version not present in registry `.time`.
* **corrupt** — local `build-info.json` / `package.json` missing or
  malformed.
* **inconclusive** — registry fetch failed and no usable cache
  (silent, to avoid false positives on air-gapped installs).
* **pristine** — otherwise.

Registry response cached at `~/.openclaw/rebuild-guard-cache.json`
with a 6h TTL. Honors `OPENCLAW_NPM_REGISTRY_FILE` for tests and an
`offline: true` option for environments that should never hit the
network.

## Test coverage

`src/commands/doctor-rebuild-guard.test.ts` (8/8 green):

* pristine within the skew window
* rebuild when `builtAt` is >= 60 min after npm publish
* unreleased (version not in registry)
* corrupt (missing / malformed `build-info.json`)
* inconclusive (fetch throws, no cache) → silent
* offline mode (no network call, decides from local only)
* cache hit (second call, within TTL, does not call `fetch`)
* `noteRebuildGuardHealth` emission matrix: emits for
  `rebuild` / `unreleased` / `corrupt`; silent for
  `pristine` / `inconclusive`

## Gates

* `pnpm lint` — pass
* `pnpm tsgo:all` (typecheck) — pass
* `pnpm build` — pass
* `pnpm exec vitest run src/commands/doctor-rebuild-guard.test.ts` — 8/8

## Sample doctor output (rebuilt host)

```
└ Install ────────────────────────────────────────
  Local OpenClaw install differs from the pristine npm release.
  - Install: /usr/lib/node_modules/openclaw
  - Version: 2026.4.15
  - Commit: 8abd1fc
  - builtAt: 2026-04-19T08:42:11Z
  - npm publish: 2026-04-16T19:03:47Z
  - Skew: 4197 minutes ahead of npm
  - Reason: rebuild-after-publish
  Confirm every local patch has a matching upstream PR before running `openclaw update`.
```

## Related

A companion **Layer-1 bash guard** already ships in operator
workspaces (installed as a systemd `ExecStartPre`) to surface the same
warning on daemon start. This PR makes the same check native to every
`openclaw` install so end users benefit from it too, not just
operators who maintain local workspaces.
