### PR TITLE
fix: refresh control-ui canvas capabilities

### DIFF
--- a/ui/src/ui/canvas-url.test.ts
+++ b/ui/src/ui/canvas-url.test.ts
@@ -2,10 +2,26 @@ import { describe, expect, it } from "vitest";
 import { resolveCanvasIframeUrl } from "./canvas-url.ts";
 
 describe("resolveCanvasIframeUrl", () => {
-  it("allows same-origin hosted canvas document paths", () => {
-    expect(resolveCanvasIframeUrl("/__openclaw__/canvas/documents/cv_demo/index.html")).toBe(
-      "/__openclaw__/canvas/documents/cv_demo/index.html",
-    );
+  it("fails closed for protected canvas and a2ui paths when the scoped host is missing", () => {
+    expect(
+      resolveCanvasIframeUrl("/__openclaw__/canvas/documents/cv_demo/index.html"),
+    ).toBeUndefined();
+    expect(resolveCanvasIframeUrl("/__openclaw__/a2ui/apps/demo/index.html")).toBeUndefined();
+  });
+
+  it("fails closed for protected canvas paths when the scoped host is unscoped", () => {
+    expect(
+      resolveCanvasIframeUrl(
+        "/__openclaw__/canvas/documents/cv_demo/index.html",
+        "http://127.0.0.1:19003/__openclaw__/canvas",
+      ),
+    ).toBeUndefined();
+    expect(
+      resolveCanvasIframeUrl(
+        "/__openclaw__/canvas/documents/cv_demo/index.html",
+        "http://127.0.0.1:19003/__openclaw__/cap",
+      ),
+    ).toBeUndefined();
   });
 
   it("rewrites safe canvas paths through the scoped canvas host", () => {

--- a/ui/src/ui/canvas-url.ts
+++ b/ui/src/ui/canvas-url.ts
@@ -15,22 +15,56 @@ function isExternalHttpUrl(entry: URL): boolean {
   return entry.protocol === "http:" || entry.protocol === "https:";
 }
 
+type SanitizedCanvasEntry =
+  | {
+      kind: "external";
+      url: string;
+    }
+  | {
+      kind: "protected-canvas";
+      url: string;
+    };
+
 function sanitizeCanvasEntryUrl(
   rawEntryUrl: string,
   allowExternalEmbedUrls = false,
-): string | undefined {
+): SanitizedCanvasEntry | undefined {
   try {
     const entry = new URL(rawEntryUrl, "http://localhost");
     if (entry.origin !== "http://localhost") {
       if (!allowExternalEmbedUrls || !isExternalHttpUrl(entry)) {
         return undefined;
       }
-      return entry.toString();
+      return {
+        kind: "external",
+        url: entry.toString(),
+      };
     }
     if (!isCanvasHttpPath(entry.pathname)) {
       return undefined;
     }
-    return `${entry.pathname}${entry.search}${entry.hash}`;
+    return {
+      kind: "protected-canvas",
+      url: `${entry.pathname}${entry.search}${entry.hash}`,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveScopedCanvasHostUrl(canvasHostUrl: string): URL | undefined {
+  try {
+    const scopedHostUrl = new URL(canvasHostUrl);
+    const scopedPrefix = scopedHostUrl.pathname.replace(/\/+$/, "");
+    const capabilityPrefix = `${CANVAS_CAPABILITY_PATH_PREFIX}/`;
+    if (!scopedPrefix.startsWith(capabilityPrefix)) {
+      return undefined;
+    }
+    const capability = scopedPrefix.slice(capabilityPrefix.length);
+    if (!capability || capability.includes("/")) {
+      return undefined;
+    }
+    return scopedHostUrl;
   } catch {
     return undefined;
   }
@@ -49,26 +83,21 @@ export function resolveCanvasIframeUrl(
   if (!safeEntryUrl) {
     return undefined;
   }
-  if (!canvasHostUrl?.trim()) {
-    return safeEntryUrl;
+  if (safeEntryUrl.kind === "external") {
+    return safeEntryUrl.url;
   }
-  try {
-    const scopedHostUrl = new URL(canvasHostUrl);
-    const scopedPrefix = scopedHostUrl.pathname.replace(/\/+$/, "");
-    if (!scopedPrefix.startsWith(CANVAS_CAPABILITY_PATH_PREFIX)) {
-      return safeEntryUrl;
-    }
-    const entry = new URL(safeEntryUrl, scopedHostUrl.origin);
-    if (!isCanvasHttpPath(entry.pathname)) {
-      return safeEntryUrl;
-    }
-    entry.protocol = scopedHostUrl.protocol;
-    entry.username = scopedHostUrl.username;
-    entry.password = scopedHostUrl.password;
-    entry.host = scopedHostUrl.host;
-    entry.pathname = `${scopedPrefix}${entry.pathname}`;
-    return entry.toString();
-  } catch {
-    return safeEntryUrl;
+  const scopedHostUrl = canvasHostUrl?.trim()
+    ? resolveScopedCanvasHostUrl(canvasHostUrl)
+    : undefined;
+  if (!scopedHostUrl) {
+    return undefined;
   }
+  const scopedPrefix = scopedHostUrl.pathname.replace(/\/+$/, "");
+  const entry = new URL(safeEntryUrl.url, scopedHostUrl.origin);
+  entry.protocol = scopedHostUrl.protocol;
+  entry.username = scopedHostUrl.username;
+  entry.password = scopedHostUrl.password;
+  entry.host = scopedHostUrl.host;
+  entry.pathname = `${scopedPrefix}${entry.pathname}`;
+  return entry.toString();
 }

--- a/ui/src/ui/gateway.node.test.ts
+++ b/ui/src/ui/gateway.node.test.ts
@@ -123,6 +123,14 @@ function parseLatestConnectFrame(ws: MockWebSocket): ConnectFrame {
   return JSON.parse(ws.sent.at(-1) ?? "{}") as ConnectFrame;
 }
 
+async function flushAsyncWork() {
+  if (vi.isFakeTimers()) {
+    await vi.advanceTimersByTimeAsync(0);
+  } else {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 async function continueConnect(ws: MockWebSocket, nonce = "nonce-1") {
   ws.emitOpen();
   ws.emitMessage({
@@ -130,17 +138,31 @@ async function continueConnect(ws: MockWebSocket, nonce = "nonce-1") {
     event: "connect.challenge",
     payload: { nonce },
   });
-  if (vi.isFakeTimers()) {
-    await vi.advanceTimersByTimeAsync(0);
-  } else {
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
+  await flushAsyncWork();
   expect(ws.sent.length).toBeGreaterThan(0);
   return { ws, connectFrame: parseLatestConnectFrame(ws) };
 }
 
 async function expectSocketClosed(ws: MockWebSocket) {
   await vi.waitFor(() => expect(ws.readyState).toBe(3), { interval: 1, timeout: 50 });
+}
+
+async function emitConnectHello(
+  ws: MockWebSocket,
+  connectId: string | undefined,
+  payload: Record<string, unknown> = {},
+) {
+  ws.emitMessage({
+    type: "res",
+    id: connectId,
+    ok: true,
+    payload: {
+      type: "hello-ok",
+      protocol: 3,
+      ...payload,
+    },
+  });
+  await flushAsyncWork();
 }
 
 async function startConnect(client: InstanceType<typeof GatewayBrowserClient>, nonce = "nonce-1") {
@@ -396,6 +418,83 @@ describe("GatewayBrowserClient", () => {
     vi.useRealTimers();
   });
 
+  it("reconnects before the canvas capability expires when hello.canvasHostUrl is present", async () => {
+    vi.useFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws: ws1, connectFrame } = await startConnect(client);
+    await emitConnectHello(ws1, connectFrame.id, {
+      canvasHostUrl: "http://127.0.0.1:18789/__openclaw__/cap/cap_123",
+    });
+
+    await vi.advanceTimersByTimeAsync(539_999);
+    expect(wsInstances).toHaveLength(1);
+    expect(ws1.readyState).toBe(MockWebSocket.OPEN);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await expectSocketClosed(ws1);
+    ws1.emitClose(4000, "canvas capability refresh");
+
+    await vi.advanceTimersByTimeAsync(800);
+    expect(wsInstances).toHaveLength(2);
+
+    client.stop();
+    vi.useRealTimers();
+  });
+
+  it("clears the scheduled canvas capability refresh when stopped", async () => {
+    vi.useFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws, connectFrame } = await startConnect(client);
+    await emitConnectHello(ws, connectFrame.id, {
+      canvasHostUrl: "http://127.0.0.1:18789/__openclaw__/cap/cap_123",
+    });
+
+    client.stop();
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+
+    expect(ws.readyState).toBe(3);
+    expect(wsInstances).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it("clears the scheduled canvas capability refresh after the socket closes", async () => {
+    vi.useFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws: ws1, connectFrame } = await startConnect(client);
+    await emitConnectHello(ws1, connectFrame.id, {
+      canvasHostUrl: "http://127.0.0.1:18789/__openclaw__/cap/cap_123",
+    });
+
+    ws1.emitClose(1006, "socket lost");
+    await vi.advanceTimersByTimeAsync(800);
+
+    const ws2 = getLatestWebSocket();
+    expect(ws2).not.toBe(ws1);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(wsInstances).toHaveLength(2);
+    expect(ws2.readyState).toBe(MockWebSocket.OPEN);
+
+    client.stop();
+    vi.useRealTimers();
+  });
+
   it("cancels a queued connect send when stopped before the timeout fires", async () => {
     vi.useFakeTimers();
 
@@ -433,6 +532,25 @@ describe("GatewayBrowserClient", () => {
 
     expect(wsInstances).toHaveLength(1);
 
+    vi.useRealTimers();
+  });
+
+  it("does not schedule a canvas capability refresh when canvasHostUrl is absent", async () => {
+    vi.useFakeTimers();
+
+    const client = new GatewayBrowserClient({
+      url: "ws://127.0.0.1:18789",
+      token: "shared-auth-token",
+    });
+
+    const { ws, connectFrame } = await startConnect(client);
+    await emitConnectHello(ws, connectFrame.id);
+
+    await vi.advanceTimersByTimeAsync(10 * 60_000);
+    expect(wsInstances).toHaveLength(1);
+    expect(ws.readyState).toBe(MockWebSocket.OPEN);
+
+    client.stop();
     vi.useRealTimers();
   });
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -225,6 +225,31 @@ export type GatewayBrowserClientOptions = {
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
 const CONNECT_FAILED_CLOSE_CODE = 4008;
+const CANVAS_CAPABILITY_PATH_PREFIX = "/__openclaw__/cap";
+const CONTROL_UI_CANVAS_CAPABILITY_TTL_MS = 10 * 60_000;
+const CONTROL_UI_CANVAS_CAPABILITY_REFRESH_LEAD_MS = 60_000;
+const CONTROL_UI_CANVAS_CAPABILITY_REFRESH_DELAY_MS = Math.max(
+  1_000,
+  CONTROL_UI_CANVAS_CAPABILITY_TTL_MS - CONTROL_UI_CANVAS_CAPABILITY_REFRESH_LEAD_MS,
+);
+
+function hasScopedCanvasHostUrl(canvasHostUrl: string | null | undefined): boolean {
+  const trimmed = canvasHostUrl?.trim();
+  if (!trimmed) {
+    return false;
+  }
+  try {
+    const pathname = new URL(trimmed).pathname.replace(/\/+$/, "");
+    const capabilityPrefix = `${CANVAS_CAPABILITY_PATH_PREFIX}/`;
+    if (!pathname.startsWith(capabilityPrefix)) {
+      return false;
+    }
+    const capability = pathname.slice(capabilityPrefix.length);
+    return Boolean(capability) && !capability.includes("/");
+  } catch {
+    return false;
+  }
+}
 
 function buildGatewayConnectAuth(
   selectedAuth: SelectedConnectAuth,
@@ -294,6 +319,7 @@ export class GatewayBrowserClient {
   private connectNonce: string | null = null;
   private connectSent = false;
   private connectTimer: number | null = null;
+  private canvasCapabilityRefreshTimer: number | null = null;
   private backoffMs = 800;
   private pendingConnectError: GatewayErrorInfo | undefined;
   private pendingDeviceTokenRetry = false;
@@ -309,6 +335,7 @@ export class GatewayBrowserClient {
   stop() {
     this.closed = true;
     this.clearConnectTimer();
+    this.clearCanvasCapabilityRefreshTimer();
     this.ws?.close();
     this.ws = null;
     this.pendingConnectError = undefined;
@@ -332,6 +359,7 @@ export class GatewayBrowserClient {
       const reason = ev.reason ?? "";
       const connectError = this.pendingConnectError;
       this.pendingConnectError = undefined;
+      this.clearCanvasCapabilityRefreshTimer();
       this.ws = null;
       this.flushPending(new Error(`gateway closed (${ev.code}): ${reason}`));
       this.opts.onClose?.({ code: ev.code, reason, error: connectError });
@@ -363,6 +391,20 @@ export class GatewayBrowserClient {
       this.connectTimer = null;
       this.connect();
     }, delay);
+  }
+
+  private scheduleCanvasCapabilityRefresh() {
+    if (this.closed || this.ws?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    this.clearCanvasCapabilityRefreshTimer();
+    this.canvasCapabilityRefreshTimer = window.setTimeout(() => {
+      this.canvasCapabilityRefreshTimer = null;
+      if (this.closed || this.ws?.readyState !== WebSocket.OPEN) {
+        return;
+      }
+      this.ws.close(4000, "canvas capability refresh");
+    }, CONTROL_UI_CANVAS_CAPABILITY_REFRESH_DELAY_MS);
   }
 
   private flushPending(err: Error) {
@@ -448,6 +490,7 @@ export class GatewayBrowserClient {
   private handleConnectHello(hello: GatewayHelloOk, plan: ConnectPlan) {
     this.pendingDeviceTokenRetry = false;
     this.deviceTokenRetryBudgetUsed = false;
+    this.clearCanvasCapabilityRefreshTimer();
     if (hello?.auth?.deviceToken && plan.deviceIdentity) {
       storeDeviceAuthToken({
         deviceId: plan.deviceIdentity.deviceId,
@@ -457,6 +500,9 @@ export class GatewayBrowserClient {
       });
     }
     this.backoffMs = 800;
+    if (hasScopedCanvasHostUrl(hello.canvasHostUrl)) {
+      this.scheduleCanvasCapabilityRefresh();
+    }
     this.opts.onHello?.(hello);
   }
 
@@ -639,6 +685,13 @@ export class GatewayBrowserClient {
     if (this.connectTimer !== null) {
       window.clearTimeout(this.connectTimer);
       this.connectTimer = null;
+    }
+  }
+
+  private clearCanvasCapabilityRefreshTimer() {
+    if (this.canvasCapabilityRefreshTimer !== null) {
+      window.clearTimeout(this.canvasCapabilityRefreshTimer);
+      this.canvasCapabilityRefreshTimer = null;
     }
   }
 }

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -718,9 +718,7 @@ describe("chat view", () => {
     let iframe = container.querySelector<HTMLIFrameElement>(".chat-tool-card__preview-frame");
     expect(iframe).not.toBeNull();
     expect(iframe?.getAttribute("sandbox")).toBe("allow-scripts");
-    expect(iframe?.getAttribute("src")).toBe(
-      "/__openclaw__/canvas/documents/cv_inline_default/index.html",
-    );
+    expect(iframe?.getAttribute("src")).toBeNull();
     expect(container.textContent).toContain("Inline canvas result.");
     expect(container.textContent).toContain("Inline demo");
     expect(container.textContent).toContain("Raw details");


### PR DESCRIPTION
## Summary
- fail closed for protected canvas/a2ui iframe URLs when a scoped canvas capability host is unavailable
- refresh `hello.canvasHostUrl` before the 10-minute capability TTL expires by reconnecting the Control UI websocket shortly before expiry
- cover the new behavior with UI and node-side tests, including the blank iframe src fallback when no scoped host is available

## Problem
Control UI inline canvas embeds could render a raw protected `/__openclaw__/canvas/...` URL when `canvasHostUrl` was missing or unscoped. Once the scoped canvas capability expired, embeds would start showing `Unauthorized` until the whole page was refreshed and the websocket handshake minted a fresh scoped host URL.

## Fix
`resolveCanvasIframeUrl(...)` now treats same-origin canvas and a2ui URLs as protected resources and returns `undefined` unless it can safely rewrite them through a scoped `/__openclaw__/cap/<token>` host URL.

`GatewayBrowserClient` now schedules a single reconnect one minute before the known 10-minute canvas capability TTL expires whenever `hello.canvasHostUrl` is scoped. The timer is cleared on `stop()` and socket close so the reconnect stays bounded.

## Testing
- `pnpm --dir ui exec vitest run --config vitest.config.ts --project unit src/ui/views/chat.test.ts src/ui/canvas-url.test.ts`
- `pnpm --dir ui exec vitest run --config vitest.config.ts --project unit-node src/ui/gateway.node.test.ts`
- commit hook `check:changed` (passed), including the affected UI test suite
