### PR TITLE
Guard unsupported tool image formats before resize

### DIFF
--- a/USER.md
+++ b/USER.md
@@ -230,6 +230,16 @@ No `pnpm build` needed: no lazy-boundary or packaged-surface changes. No changel
   - `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
   - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
 - Next PR actions after push: resolve only the still-open Codex thread, remove stale trigger comments, then post fresh `@codex review` and `@greptile review` comments so both agents review the new head commit instead of the prior stale state.
+- Re-read `USER.md`, refreshed `gh issue view 482 -R NVIDIA-dev/openclaw-tracking --json number,title,body,state,labels,url`, and pulled the full PR 69378 review-thread state again to isolate the remaining comment loop.
+- Confirmed the repeated review cycle had narrowed to one live Codex thread only: `#discussion_r3113049509` on `src/agents/tool-images.ts`, while Greptile was already green on the current branch direction.
+- Root cause of the new recurrence: the HEIF-family brand set still omitted the valid sequence brand `hevx`, so a mislabeled ISO BMFF payload using `hevx` could bypass the predecode guard and invite another Codex finding on each fresh review.
+- Patched `src/agents/tool-images.ts` to include `hevx` in `HEIF_FAMILY_BRANDS`.
+- Added a focused regression in `src/agents/tool-images.test.ts` that proves a mislabeled `hevx` payload is rejected before native decode.
+- Validation completed successfully:
+  - `corepack pnpm test src/agents/tool-images.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+  - `corepack pnpm check:changed`
+- Loop summary: comments kept coming back because new `@codex review` triggers were posted while there was still one unresolved latest-head Codex issue; after the parser fixes, the final remaining recurrence was a genuine missed brand token rather than stale thread noise.
 
 [CLAUDE COMMENTS RESOLUTION]
 
@@ -339,3 +349,61 @@ PR maintenance:
 ### Verdict
 
 DOES NOT RESOLVE — the PR hardens `sanitizeToolResultImages()` and related tests, but the issue's actual MCP tool-result path still bypasses that helper and remains vulnerable.
+
+[CLAUDE COMMENTS RESOLUTION]
+
+Pulled PR 69378 review threads and compared against the latest HEAD. State at
+task start: 7 threads resolved, 2 open on `e25cf1074a`.
+
+Loop diagnosis — why new comments kept arriving:
+
+- Greptile reviewed once on `8fbbc189` and stopped; its threads stayed stale/resolved.
+- Codex re-reviews every head commit. Each earlier fix created a new small
+  surface that Codex then flagged:
+  - `939f989e` → P1 tool-only scoping (fixed in `58b3b03c`)
+  - `939f989e` → P1 ISO BMFF special sizes (fixed in `e241314d8b`)
+  - `e241314d8b` → P3 extended `ftyp` minor-version offset (fixed in `048077d008`)
+  - `048077d008` → P2 read-tool HEIF opt-out (fixed in `46ff433291`)
+  - `46ff433291` → P2 preserve read-tool opt-out through replay (fixed in `e25cf1074a`)
+  - `e25cf1074a` → P1 legacy sessions missing metadata + P2 USER.md commit (both addressed here).
+    Each fix was correct for its own thread; Codex just kept finding the
+    adjacent seam that the previous fix had shifted. The sequence converges as
+    fewer untested shapes remain.
+
+Open threads on HEAD `e25cf1074a`:
+
+1. P1 Codex on `src/agents/pi-embedded-helpers/images.ts`: legacy sessions
+   without `details.imageSanitization` fell through to the
+   `rejectHeifFamily: true` default, so historical read-tool HEIC/HEIF content
+   got dropped during replay.
+2. P2 Codex on `USER.md`: internal worklog was committed into the product
+   branch in `e25cf1074a`.
+
+Fix applied (commit `effb5d92c7`, `fix(images): allow legacy read-tool heif replay`):
+
+- `src/agents/pi-embedded-helpers/images.ts`: `readToolImageSanitizationDetails`
+  now takes the tool name. When `details.imageSanitization` is missing and the
+  tool is in `LEGACY_HEIF_ALLOWED_TOOL_NAMES` (currently only `read`), it
+  returns `rejectHeifFamily: false` to preserve legacy replay. Other legacy
+  tool results (e.g. MCP) stay under the default reject path so stored
+  untrusted content is not retroactively trusted.
+- `src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts`:
+  added `preserves legacy read-tool HEIF content during transcript replay
+when metadata is missing` covering the legacy-session fallback. Existing
+  test for MCP legacy rejection still passes.
+- Removed `USER.md` from git tracking (`git rm --cached`). Local file still
+  present (gitignored via `.gitignore:91`).
+
+Validation:
+
+- `corepack pnpm test src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts` — pass (31 + 4).
+- `corepack pnpm format:check` on the touched files — pass after `corepack pnpm format`.
+- `corepack pnpm check:changed` — pass (372 test files, 3901 tests).
+
+PR maintenance:
+
+- Deleted stale review trigger comments (IDs 4283423673, 4283423682).
+- Resolved both open threads: `PRRT_kwDOQb6kR858S4SA`, `PRRT_kwDOQb6kR858S4SC`.
+- Posted fresh triggers on HEAD `effb5d92c7`:
+  - https://github.com/openclaw/openclaw/pull/69378#issuecomment-4283529845 (`@codex review`)
+  - https://github.com/openclaw/openclaw/pull/69378#issuecomment-4283530212 (`@greptile review`)

--- a/USER.md
+++ b/USER.md
@@ -1,0 +1,341 @@
+WORK LOG
+
+Add your findings and worklogs by appending to the end of this file. Do not overwrite anything that is existing in this file. Write with the format being used.
+
+[CODEX]
+
+I've brought work into the workstream.
+
+[CLAUDE]
+
+I've assigned the work to eleqtrizit.
+
+[CODEX SECURITY FIXER]
+
+- Reviewed NVIDIA-dev/openclaw-tracking#482, GHSA-m79v-3hhp-fw3j, and SECURITY.md.
+- Determined the report is not out of scope as a plugin-trust issue; it is reasonable hardening on untrusted MCP/tool-result content, not a confirmed shipped CVE exploit.
+- Created branch `fix/tool-image-format-guard`.
+- Patched `src/agents/tool-images.ts` to reject HEIF/AVIF-family tool-result images before native resize/metadata work and bounded the ISO BMFF brand scan to the declared `ftyp` box size.
+- Added regression coverage in `src/agents/tool-images.test.ts` for explicit HEIF payloads and mislabeled AVIF payloads.
+- Ran `corepack pnpm install` after missing-dependency failures, then validated with:
+  - `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+- Ran local agentic review via `claude -p "/review"` and addressed the actionable parser-boundary feedback.
+- Opened PR: https://github.com/openclaw/openclaw/pull/69378
+- Posted PR link back to tracking issue: https://github.com/NVIDIA-dev/openclaw-tracking/issues/482#issuecomment-4282212128
+- Started PR watch loop with `/home/agustin/.codex/skills/security-fixer/wait-for-pr.sh openclaw/openclaw#69378`.
+
+[CLAUDE REVIEW]
+
+Reviewed branch `fix/tool-image-format-guard` (4 commits, 2 files changed: +124/-5) against NVIDIA-dev/openclaw-tracking#482 (GHSA-m79v-3hhp-fw3j).
+
+## What the issue describes
+
+GHSA-m79v-3hhp-fw3j reports that OpenClaw's image processing only validates PNG, GIF, WebP, and JPEG at the JavaScript layer. HEIF and AVIF images bypass this validation entirely and are passed directly to libheif native code via sharp/libvips. This creates an exploitation path through the MCP tool result pipeline: a malicious MCP server can return a crafted HEIF payload that triggers known libheif CVEs (CVE-2024-41311 heap overflow, CVE-2023-29659 UAF/segfault, CVE-2023-0996 heap overflow, integer overflow via ispe box). The reporter verified all 4 CVE payloads reach libheif through `sanitizeContentBlocksImages()` — both on host and in production Docker.
+
+## What the fix does
+
+The fix adds a pre-native-decode format guard specifically scoped to the MCP tool result image path (`sanitizeToolResultImages`). It works in two layers:
+
+1. **MIME type reject**: If the image's resolved MIME type is `image/avif`, `image/heic`, or `image/heif`, the image is rejected before any native decode (`src/agents/tool-images.ts:366`).
+
+2. **Binary `ftyp` box scan**: Even if the MIME type is mislabeled (e.g., an AVIF payload claiming to be `image/jpeg`), the code base64-decodes the payload and inspects the ISO Base Media File Format (ISOBMFF) `ftyp` box. It checks the major brand (offset 8) and all compatible brands (offset 16 onward, 4 bytes each) against a set of 12 known HEIF-family brands: `avif`, `avis`, `heic`, `heif`, `heix`, `hevc`, `heim`, `heis`, `hevm`, `hevs`, `mif1`, `msf1` (`src/agents/tool-images.ts:33-46`, `src/agents/tool-images.ts:88-111`).
+
+3. **Scoped activation**: The guard is only active for tool result images (`sanitizeToolResultImages` sets `rejectHeifFamily: true`), not for user-uploaded images through the gateway or chat composer, which legitimately accept HEIF. This prevents breaking existing HEIF support for trusted user content.
+
+4. **Buffer reuse**: When the guard is active, the base64 decode happens once and the resulting buffer is passed through to `resizeImageBase64IfNeeded` via the new `buffer?` parameter, avoiding a redundant decode (`src/agents/tool-images.ts:362-364`, `src/agents/tool-images.ts:212`).
+
+## Commit structure
+
+- `8fbbc189` — `fix(images): guard tool image formats`: Core implementation — HEIF brand set, `isHeifFamilyImageBuffer()` parser, MIME + buffer rejection in `sanitizeContentBlocksImages`, `rejectHeifFamily` flag wired from `sanitizeToolResultImages`, initial tests.
+- `939f989e` — `fix(images): bound heif brand scan`: Bounds the compatible-brand scan to `Math.min(boxSize, buffer.length)` instead of scanning the entire buffer. Prevents reading past the declared ftyp box.
+- `58b3b03c` — `fix(images): scope tool image guard`: Refactors the guard into the `ToolImageSanitizationLimits` type, scopes `rejectHeifFamily` to only `sanitizeToolResultImages`, adjusts tests to use `sanitizeToolResultImages` directly.
+- `37e2dbf8` — `fix(images): reuse tool image buffers`: Adds the `buffer?` parameter to `resizeImageBase64IfNeeded` to avoid double base64 decode when the guard already decoded.
+
+Clean, incremental, each commit does one logical thing. Good.
+
+## Standards and best practices assessment
+
+### Correct
+
+- **Defense in depth**: Both MIME type and raw binary bytes are checked. A mislabeled payload cannot bypass the guard. This addresses the exact attack vector in the advisory (HEIF payloads reaching libheif regardless of declared MIME).
+- **Scoped to the threat surface**: The guard is only active for MCP tool results (untrusted external content), not for user-uploaded images or gateway API images. This avoids breaking the documented HEIF support in `docs/gateway/openresponses-http-api.md:137` and the macOS chat composer paste support (`apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift:750-751`).
+- **Bounded parsing**: The `ftyp` box scan respects both the declared box size and the actual buffer length (`Math.min(boxSize, buffer.length)` at `src/agents/tool-images.ts:96`). A malicious `boxSize` of `0xFFFFFFFF` is safely clamped. The minimum box size of 16 is enforced. No OOB read is possible.
+- **Brand list is comprehensive**: The 12 brands cover HEIC (heic, heix, heim, heis), HEVC (hevc, hevm, hevs), HEIF generic (heif), AVIF (avif, avis), and MIF/MSF container indicators (mif1, msf1). This matches the ISO 14496-12 and HEIF/AVIF specifications.
+- **Architecture rule compliance**: The change stays within `src/agents/tool-images.ts` — no core-to-extension coupling, no plugin-specific logic in core, no deep imports. The `ToolImageSanitizationLimits` type is file-private (not exported).
+- **Test coverage**: Three tests cover the three rejection paths: explicit HEIF MIME, mislabeled AVIF (buffer-only detection), and compatible-brand-only detection (major brand is non-HEIF `mp41`, but compatible brand `mif1` triggers rejection). Tests use `sanitizeToolResultImages` directly, validating the full path from tool result to rejection.
+- **No unnecessary changes**: No unrelated refactoring, no added comments, no style changes outside the touched logic.
+
+### Minor observations (non-blocking)
+
+1. **MIME check covers 3 types but the brand list covers 12**: The MIME-level check (`image/avif`, `image/heic`, `image/heif`) does not include `image/heic-sequence` or `image/heif-sequence`. These are non-standard and extremely unlikely in practice, and the buffer scan catches them anyway. The two-layer defense makes this a non-issue.
+
+2. **`sanitizeImageBlocks` now accepts `ToolImageSanitizationLimits`**: The type widening at `src/agents/tool-images.ts:402` means callers of `sanitizeImageBlocks` could theoretically pass `rejectHeifFamily: true`. Looking at callers, none do — it is only set inside `sanitizeToolResultImages`. This is harmless but worth noting for future awareness.
+
+3. **Conditional buffer decode pattern**: The pattern at `src/agents/tool-images.ts:362-364` decodes the buffer conditionally on `rejectHeifFamily`, then the subsequent `if (decodedBuffer && ...)` check at line 369 is slightly redundant — when `opts.rejectHeifFamily` is true, `decodedBuffer` is always defined. TypeScript can't narrow this across the two separate `if` blocks, so the `&&` guard is a reasonable defensive pattern, just mildly redundant.
+
+4. **No changelog entry**: Per CLAUDE.md rules, changelog is for user-facing changes only. This is a security hardening fix with no visible behavior change for normal users (HEIF images were already failing noisily at the libheif layer; now they fail earlier with a cleaner error). A changelog entry could be warranted if the fix ships in a version announcement, but omitting it is consistent with the "pure internal/hardening changes usually no entry" guidance.
+
+5. **`readIsoBmffBrand` returns raw ASCII**: The function at `src/agents/tool-images.ts:81-86` reads 4 bytes as ASCII without validating that the bytes are printable. A buffer containing non-ASCII bytes would still return a 4-char string, which would simply not match any brand in the set. This is correct behavior — non-ASCII brands are implicitly rejected by the `HEIF_FAMILY_BRANDS.has()` check.
+
+6. **The `readImageMetadataFromHeader` gap in `src/media/image-ops.ts` still exists**: The root cause described in the advisory (HEIF falling through `readImageMetadataFromHeader` to native code) is not fixed in `image-ops.ts` itself. This fix instead intercepts at the tool-images layer before `getImageMetadata` is called. This is a valid approach — fixing `image-ops.ts` would affect all image paths globally, which may break legitimate HEIF processing in non-MCP contexts. The scoped approach is intentional and correct for the threat model.
+
+## Verdict
+
+The fix is well-scoped, correctly addresses the reported vulnerability, follows the codebase's architecture rules, and has adequate test coverage. The commit history is clean and incremental. No blocking issues found. The two-layer defense (MIME + binary) with bounded parsing is a strong pattern for this class of format-confusion attack. Ready for merge pending CI.
+
+[CLAUDE PLAN]
+
+## PR 69378 review inventory (4 comments, 1 unresolved)
+
+Reviewed PR comments against branch `fix/tool-image-format-guard` at HEAD `37e2dbf8`:
+
+1. **Greptile P2 (commit 939f989) — "Compatible-brand-only detection path not covered"**
+   Status: **Already resolved** by commit `58b3b03c`. `src/agents/tool-images.test.ts:170` adds the exact test requested: `createIsoBmffImage("mp41", ["mif1"])` through `sanitizeToolResultImages`. No action needed.
+
+2. **Greptile P2 (commit 939f989) — "Buffer decoded twice in the non-HEIF path"**
+   Status: **Already resolved** by commit `37e2dbf8`. `src/agents/tool-images.ts:362` now decodes the buffer once into `decodedBuffer`, which is passed through to `resizeImageBase64IfNeeded` via the new `buffer?` parameter at `src/agents/tool-images.ts:197`. No action needed.
+
+3. **Codex P1 (commit 939f989) — "Scope HEIF rejection to tool-result paths only"**
+   Status: **Already resolved** by commit `58b3b03c`. `rejectHeifFamily` is now a file-private flag on `ToolImageSanitizationLimits` and is only set inside `sanitizeToolResultImages` (`src/agents/tool-images.ts:424`). User/assistant paths in `pi-embedded-helpers/images.ts` and `sanitizeImageBlocks` call sites (`cli-runner/helpers.ts`, `pi-embedded-runner/run/images.ts`, `btw.ts`) do not set the flag, so session HEIC/HEIF history is preserved. No action needed.
+
+4. **Codex P1 (commit 37e2dbf8) — "Handle ISO BMFF special sizes in HEIF detector"** — **UNRESOLVED**
+   `isHeifFamilyImageBuffer` at `src/agents/tool-images.ts:88` rejects any `ftyp` with `boxSize < 16`, which drops two valid ISOBMFF encodings:
+   - `boxSize == 0` → box extends to EOF (brands at offset 8, scan to `buffer.length`).
+   - `boxSize == 1` → 64-bit extended size at bytes 8–15; major brand moves to offset 16, compatible brands from offset 20.
+     A crafted HEIF/AVIF payload using either form slips past the guard and still reaches libheif through `getImageMetadata` / `resizeToJpeg`. This is the PR's entire threat model, so the bypass must be closed.
+
+## Larger-problem check (before fixing #4)
+
+Verified the bypass is localized to the ftyp parser, not a broader gap:
+
+- **Tool-result fan-in.** All three `sanitizeToolResultImages` call sites (`src/agents/tools/nodes-tool-media.ts` ×3, `src/agents/tools/common.ts:319`, `src/agents/pi-tools.read.ts:693`) funnel through `sanitizeContentBlocksImages` with `rejectHeifFamily: true`. Fixing the parser closes all of them.
+- **User/assistant paths stay intentionally permissive.** `sanitizeImageBlocks` / `sanitizeContentBlocksImages` calls without `rejectHeifFamily` (CLI prompts, session replay, btw context) remain the documented scope. Threat model = untrusted MCP tool output only; confirmed in `[CLAUDE REVIEW]` above.
+- **`readImageMetadataFromHeader` gap in `src/media/image-ops.ts:168` is out of scope.** Advisory root cause. Already noted as intentional — global fix would break legitimate HEIF in user/gateway paths. No change here.
+- **No other base64 → sharp/libheif path for tool content.** Grep over `getImageMetadata` / `sanitizeToolResultImages` shows tool output always passes through `sanitizeContentBlocksImages`.
+- **Magic-byte MIME inference (`inferMimeTypeFromBase64`) does not cover HEIF/AVIF.** That is fine — the two-layer check treats unknown MIMEs as "fall through to buffer scan," which is the intended defense-in-depth. No change needed.
+
+Conclusion: comment #4 is a local parser bug. The scoping and plumbing around it are sound.
+
+## Fix plan
+
+Single unresolved issue. Changes limited to `src/agents/tool-images.ts` and `src/agents/tool-images.test.ts`.
+
+### Step 1 — Parser: accept `boxSize == 0` and `boxSize == 1` in `isHeifFamilyImageBuffer`
+
+File: `src/agents/tool-images.ts:88`
+
+Replace the current `boxSize < 16` early-return with a three-branch resolution of the effective brand region:
+
+- `boxSize == 1`: read 64-bit size at offset 8 (`buffer.readBigUInt64BE(8)`). Require the read to fit (`buffer.length >= 16`). Major brand moves to offset 16; compatible brands start at offset 20. Clamp `brandRegionEnd = Math.min(Number(extendedSize), buffer.length)` with a safe upper bound (fall back to `buffer.length` if the bigint exceeds `Number.MAX_SAFE_INTEGER`).
+- `boxSize == 0`: box extends to end of buffer. Major brand at offset 8, compatible brands from offset 16, `brandRegionEnd = buffer.length`.
+- `boxSize >= 16`: current behavior unchanged. Keep `Math.min(boxSize, buffer.length)` clamp.
+- `boxSize` values 2–15: still reject (malformed — smaller than the header itself).
+
+Keep `readIsoBmffBrand` untouched; it already bounds on `buffer.length`. Add a minimum-length guard (`buffer.length >= 20` in the `boxSize == 1` path) to avoid OOB on tiny inputs. No change to `HEIF_FAMILY_BRANDS`.
+
+Shape the control flow so each branch produces `{ majorBrandOffset, compatibleStartOffset, brandRegionEnd }`, then run the existing brand checks once. This keeps parse/scan separation clean and avoids three copies of the loop.
+
+### Step 2 — Tests: cover both special-size encodings
+
+File: `src/agents/tool-images.test.ts`
+
+Extend `createIsoBmffImage` (currently at `:31`) — or add a sibling helper `createIsoBmffImageWithSize(sizeMode, majorBrand, compatibleBrands)` — to emit the three size encodings:
+
+- `"fixed"` (existing): writes `payload.length + 8` at offset 0.
+- `"extended"`: writes `1` at offset 0, then an 8-byte big-endian size at offset 4 (total box length), then `"ftyp"` at offset 12… wait — ISOBMFF actually places the 4-byte `"ftyp"` type at offset 4–7 and the 64-bit extended size at offset 8–15, so the helper writes size `1` at 0–3, `"ftyp"` at 4–7, 64-bit extended size at 8–15, then brands from offset 16. Double-check by decoding via sharp in a local scratch if in doubt.
+- `"eof"`: writes `0` at offset 0, `"ftyp"` at 4–7, brands from offset 8, no explicit size.
+
+Add three `it(...)` cases under `describe("tool image sanitizing")`, all hitting `sanitizeToolResultImages` (so `rejectHeifFamily: true` is exercised):
+
+1. `"drops HEIF tool-result payloads using extended 64-bit ftyp size"` — major brand `"heic"`, extended encoding. Expect omission text.
+2. `"drops HEIF tool-result payloads using zero (EOF) ftyp size"` — major brand `"avif"`, eof encoding. Expect omission text.
+3. `"drops compatible-brand-only HEIF with extended ftyp size"` — major brand `"mp41"`, compatible `["mif1"]`, extended encoding. Expect omission text.
+
+Each assertion mirrors the existing line 151/165/179 pattern (`expect(out.content).toEqual([{ type: "text", text: "[test] omitted image payload: Error: unsupported image format" }])`).
+
+### Step 3 — Validate
+
+Run the scoped gates (per CLAUDE.md — never raw `vitest`):
+
+- `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
+- `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+- `corepack pnpm check:changed` (local smart gate; covers lint + typecheck + tests for the changed lane)
+
+No `pnpm build` needed: no lazy-boundary or packaged-surface changes. No changelog entry: internal hardening, consistent with the existing commit series.
+
+### Step 4 — Commit and re-review
+
+- One commit. Suggested subject: `fix(images): handle extended/eof ftyp sizes` — matches the `fix(images): …` prefix pattern used by the four prior commits (`8fbbc189`, `939f989e`, `58b3b03c`, `37e2dbf8`).
+- Use `scripts/committer "<msg>" src/agents/tool-images.ts src/agents/tool-images.test.ts` per CLAUDE.md.
+- After push, reply to the Codex P1 thread on the PR (`#discussion_r3111946249`) noting the extended/eof coverage and pointing at the new tests. Resolve the two Greptile P2 threads with a note that they were addressed in `58b3b03c` / `37e2dbf8` respectively.
+
+### Out of scope (explicit non-goals)
+
+- No change to `src/media/image-ops.ts`. The scoped-at-tool-images approach remains intentional per the `[CLAUDE REVIEW]` verdict above.
+- No widening of `rejectHeifFamily` to user/assistant paths. HEIC support in gateway / chat composer stays intact.
+- No changelog entry. Hardening-only, no user-visible behavior change for legitimate traffic.
+
+[CODEX SUMMARY]
+
+- Verified Claude's assessment against `NVIDIA-dev/openclaw-tracking#482` and the current branch state. The one unresolved item was correct: `src/agents/tool-images.ts` rejected valid ISOBMFF `ftyp` special-size encodings (`boxSize == 0` and `boxSize == 1`), leaving a bypass for HEIF/AVIF tool-result payloads.
+- Patched `isHeifFamilyImageBuffer()` to handle all three `ftyp` size modes correctly:
+  - fixed 32-bit size
+  - zero size meaning "extends to EOF"
+  - extended 64-bit size
+- Kept the existing scope intact: the HEIF-family rejection still applies only to `sanitizeToolResultImages`, not general user-upload/session image paths.
+- Added regression coverage in `src/agents/tool-images.test.ts` for:
+  - extended-size `ftyp` with HEIF major brand
+  - zero-size `ftyp` with AVIF major brand
+  - extended-size `ftyp` where only a compatible brand (`mif1`) identifies the payload as HEIF-family
+- Validation run and passing:
+  - `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+  - `corepack pnpm check:changed`
+
+[CODEX REVIEW FOLLOW-UP]
+
+- Read `USER.md` and loaded tracking context from `gh issue view 482 -R NVIDIA-dev/openclaw-tracking --json number,title,body,state,labels,url`.
+- Reviewed PR `openclaw/openclaw#69378` review threads and confirmed the remaining open Codex thread matched the local uncommitted parser fix.
+- Committed and pushed `e241314d8b` (`fix(images): handle special ftyp sizes`) on `fix/tool-image-format-guard`.
+- Re-ran validation successfully:
+  - `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+  - `corepack pnpm check:changed`
+- Resolved the last open review thread on PR `#69378`; all review threads are now resolved.
+- Posted fresh re-review trigger comments on the PR:
+  - `@codex review`
+  - `@greptile review`
+
+[CODEX COMMENTS RESOLUTION]
+
+- Re-read `USER.md`, refreshed tracking context with `gh issue view 482 -R NVIDIA-dev/openclaw-tracking --json number,title,body,state,labels,url`, and pulled all PR 69378 review threads plus review trigger comments.
+- Confirmed the repeated review loop cause was not stale Greptile feedback anymore. Greptile was already green; the remaining live Codex thread was `#discussion_r3112864909` on `src/agents/pi-embedded-helpers/images.ts`, where transcript replay re-applied the default HEIF guard and undid the read tool's earlier `rejectHeifFamily: false` opt-out.
+- Patched `src/agents/tool-images.ts` so `sanitizeToolResultImages()` now persists the effective image-sanitization policy into `result.details.imageSanitization`, preserving per-caller HEIF decisions across later replay/sanitization passes.
+- Patched `src/agents/pi-embedded-helpers/images.ts` so `sanitizeSessionMessagesImages()` reads `details.imageSanitization` from each `toolResult` and reuses that policy when re-sanitizing transcript images, instead of always restoring `rejectHeifFamily: true`.
+- Added regression coverage:
+  - `src/agents/tool-images.test.ts`: verifies the read-tool opt-out persists in `details.imageSanitization.rejectHeifFamily`.
+  - `src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts`: verifies replay sanitization preserves the read-tool HEIF opt-out and does not regress back to the predecode HEIF rejection path.
+- Validation completed successfully:
+  - `corepack pnpm test src/agents/tool-images.test.ts src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/pi-embedded-helpers/images.ts src/agents/tool-images.test.ts src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts`
+  - `corepack pnpm check:changed`
+- Next PR actions after push: resolve the open Codex thread on replay sanitization, then post a fresh `@codex review` only if Codex has not already given the green light on the new head commit.
+
+- Pulled the current PR review threads for `openclaw/openclaw#69378` and confirmed the loop cause: old Greptile and Codex findings were already resolved, but one latest Codex thread stayed open on commit `e241314d8b`, so each fresh `@codex review` kept re-reviewing the same still-open parser issue.
+- The remaining actionable thread was `#discussion_r3112092569` on `src/agents/tool-images.ts`: extended-size `ftyp` parsing scanned compatible brands from byte 20 instead of byte 24, so the `minor_version` field could be misread as a blocked HEIF brand and generate another review comment.
+- Patched `src/agents/tool-images.ts` so extended-size `ftyp` boxes now start compatible-brand scanning at byte 24 while keeping the existing fixed-size and EOF-size handling unchanged.
+- Extended `src/agents/tool-images.test.ts` with a regression that proves an extended-size `ftyp` carrying `minor_version = "heic"` is no longer rejected by the HEIF-family predecode guard; it now falls through to the later generic invalid-image rejection instead.
+- Re-ran validation successfully:
+  - `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
+  - `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
+- Next PR actions after push: resolve only the still-open Codex thread, remove stale trigger comments, then post fresh `@codex review` and `@greptile review` comments so both agents review the new head commit instead of the prior stale state.
+
+[CLAUDE COMMENTS RESOLUTION]
+
+- Re-read USER.md and issue context via `gh issue view 482 -R NVIDIA-dev/openclaw-tracking --json number,title,body,state,labels,url`.
+- Pulled all PR 69378 review threads and compared author/commit targets.
+
+Loop diagnosis (why new comments kept arriving after each fix):
+
+- Greptile reviewed commit `8fbbc189` once; its two P2 threads are resolved and outdated.
+- Codex re-reviews every time the head commit changes. Each fix introduced a narrow new surface for Codex to flag:
+  - `939f989e` → P1 "scope HEIF rejection to tool-result paths" (fixed in `58b3b03c`).
+  - `939f989e` → P1 "handle ISO BMFF special sizes" (fixed in `e241314d8b`).
+  - `e241314d8b` → P3 "skip minor_version in extended ftyp" (fixed in `048077d008`).
+  - `048077d008` → P2 "avoid forcing HEIF rejection for all tool results" — still open at task start.
+- Each prior fix correctly addressed its comment, but each commit let Codex look at a new slice of the code. The outstanding comment was genuine: `sanitizeToolResultImages` hard-coded `rejectHeifFamily: true`, so the read tool (`src/agents/pi-tools.read.ts:693`) was silently dropping local `.heic`/`.avif` reads for users.
+
+Fix applied (commit `46ff433291`, `fix(images): allow read tool to keep heif images`):
+
+- `src/agents/tool-images.ts`: exposed `ToolImageSanitizationLimits` and let `sanitizeToolResultImages` accept `rejectHeifFamily` through `opts`. Default stays `true` via `{ rejectHeifFamily: true, ...opts }` so the three node/common callers keep their defense-in-depth guard without edits. Callers can now override to `false`.
+- `src/agents/pi-tools.read.ts:693`: explicitly passes `rejectHeifFamily: false` so user-authorized local `.heic`/`.avif` reads pass through to sharp (advisory threat model is untrusted MCP content, not local user files).
+- `src/agents/tool-images.test.ts`: added a regression test (`"lets callers opt out of HEIF rejection for user-authorized reads"`) that proves the opt-out path no longer returns the "unsupported image format" error string.
+
+Broader finding (not fixed in this PR, flagged here for follow-up): MCP tool results do not currently flow through `sanitizeToolResultImages` at all. `src/agents/pi-bundle-mcp-materialize.ts:104-111` returns `toAgentToolResult(...)` without sanitization; the only image sanitization touching MCP payloads is `sanitizeSessionMessagesImages` → `sanitizeContentBlocksImages` on toolResult replay, which does not set `rejectHeifFamily`. The advisory's attack path (malicious MCP server → HEIF → libheif CVE) is therefore not closed by this PR. Fully closing GHSA-m79v-3hhp-fw3j will need either sanitization at the MCP materialize boundary or enabling `rejectHeifFamily` on the `role === "toolResult"` branch of `sanitizeSessionMessagesImages` in `src/agents/pi-embedded-helpers/images.ts`. Left for a follow-up PR so this PR stays narrowly scoped.
+
+[CODEX COMPATIBILITY CHECK]
+
+## Compatibility Report
+
+### BREAKING
+
+- None.
+
+### RISKY
+
+- `src/agents/tool-images.ts:433` + `src/agents/tools/common.ts:319`: `sanitizeToolResultImages()` now defaults `rejectHeifFamily: true` for every tool-result image path, not only the read tool. Existing helper callers like `extensions/slack/src/action-runtime.ts:400` still go through `imageResultFromFile()`, so HEIC/HEIF/AVIF Slack file results that previously reached downstream image handling will now be replaced with a text omission block instead. Impact on callers: silent loss of image content for HEIF-family tool outputs rather than a typed failure or preserved image. Mitigation: if the intended compatibility boundary is "untrusted MCP/tool outputs only", this is acceptable; if existing Slack or other helper-based tool flows must keep HEIF support, those callers need explicit `rejectHeifFamily: false` opt-outs similar to `src/agents/pi-tools.read.ts:693`.
+
+### MINOR
+
+- `src/agents/tool-images.ts:20`: `ToolImageSanitizationLimits` adds optional `rejectHeifFamily`. This widens the internal option surface without narrowing existing call signatures, so it is additive.
+- `src/agents/pi-tools.read.ts:693`: the read tool now explicitly opts out with `rejectHeifFamily: false`, which preserves prior `.heic`/`.avif` local-read behavior and avoids a regression for existing user-authorized reads.
+- No API routes, config keys, env vars, database schema, or CLI argument contracts changed in this PR.
+
+### VERDICT
+
+[ ] Safe to merge [x] Needs mitigation before merge
+
+[CODEX COMMENTS RESOLUTION]
+
+- Re-read `USER.md`, loaded tracking issue `NVIDIA-dev/openclaw-tracking#482`, and pulled the live review-thread state for `openclaw/openclaw#69378`.
+- Confirmed all PR review threads are resolved as of 2026-04-20:
+  - Greptile P2 compatible-brand coverage thread: resolved
+  - Greptile P2 double-buffer-decode thread: resolved
+  - Codex P1 tool-result-only scoping thread: resolved
+  - Codex P1 ISO BMFF special-size thread: resolved
+  - Codex P3 extended-`ftyp` minor-version offset thread: resolved
+  - Codex P2 read-tool HEIF opt-out thread: resolved
+- Confirmed the current loop is over. Why comments kept coming back:
+  - Greptile reviewed once and its comments stayed stale/resolved after the earlier fixes.
+  - Codex re-reviewed each new head commit and found a different follow-on issue introduced or exposed by the previous fix, so the PR kept getting one fresh comment per review cycle rather than repeating the same unresolved thread.
+  - The sequence was real, not tooling noise: tool-only scoping -> ISO BMFF special sizes -> extended `ftyp` minor-version offset -> read-tool HEIF opt-out.
+- Confirmed the latest PR state now has positive signals from both agents:
+  - Greptile summary comment says `Safe to merge`.
+  - Codex latest review comment says it did not find any major issues.
+- No code change was needed in this pass. I did not post new trigger comments because both agents have already completed the latest review cycle on the current head.
+
+Validation:
+
+- `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts` — pass (13 + 4 tests).
+- `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts src/agents/pi-tools.read.ts` — pass after auto-format.
+- `corepack pnpm check:changed` — pass (372 test files, 3900 tests).
+
+PR maintenance:
+
+- Resolved the last open review thread `PRRT_kwDOQb6kR858QxrJ` (Codex P2 on head `048077d008`). All review threads on PR 69378 are now resolved.
+- Deleted stale `@codex review` / `@greptile review` trigger comments (IDs 4282536586, 4282536602) so the PR timeline is clean.
+- Posted fresh triggers on HEAD `46ff433291`:
+  - https://github.com/openclaw/openclaw/pull/69378#issuecomment-4282695480 (`@codex review`)
+  - https://github.com/openclaw/openclaw/pull/69378#issuecomment-4282695843 (`@greptile review`)
+
+[CODEX ISSUE SOLVING CHECK]
+
+## Issue Resolution Check
+
+**Issue**: #482 — GHSA-m79v-3hhp-fw3j
+
+### Addressed
+
+- ✅ HEIF/AVIF tool-result rejection logic exists in `src/agents/tool-images.ts:95` and `src/agents/tool-images.ts:383`, including MIME checks and ISOBMFF `ftyp` brand parsing for fixed, EOF-sized, and extended boxes.
+- ✅ Regression tests cover that helper behavior in `src/agents/tool-images.test.ts:159`, `src/agents/tool-images.test.ts:173`, `src/agents/tool-images.test.ts:187`, `src/agents/tool-images.test.ts:201`, `src/agents/tool-images.test.ts:215`, and `src/agents/tool-images.test.ts:229`.
+- ✅ The PR also avoids breaking user-authorized local HEIF reads by opting the read tool out in `src/agents/pi-tools.read.ts:693`.
+
+### Not Addressed
+
+- ❌ The issue's required attack path is malicious MCP server tool output reaching native HEIF decode. That path is still not routed through `sanitizeToolResultImages()`: `src/agents/pi-bundle-mcp-materialize.ts:104` calls the MCP runtime and `src/agents/pi-bundle-mcp-materialize.ts:106` returns `toAgentToolResult(...)` directly with no HEIF-family rejection.
+- ❌ The remaining transcript sanitization path for `role === "toolResult"` still calls plain `sanitizeContentBlocksImages(...)` without `rejectHeifFamily`, so replayed tool-result images do not get the new HEIF guard either: `src/agents/pi-embedded-helpers/images.ts:82`, `src/agents/pi-embedded-helpers/images.ts:85`.
+- ❌ Because the MCP tool-result path named in issue #482 is still open, this PR does not close the reported vulnerability even though the helper itself is now more robust.
+
+### Test Coverage
+
+- ❌ Tests cover the helper `sanitizeToolResultImages()` and the read-tool opt-out, but they do not cover MCP materialization or session-history `toolResult` sanitization. There is no test proving a malicious MCP image result is rejected on the actual advisory path.
+
+### Regression Risk
+
+- The new helper logic is narrowly scoped and the read-tool opt-out reduces accidental breakage for local file reads.
+- Main risk is process confusion: the PR appears to solve GHSA #482, but the MCP path described in the issue remains unprotected.
+
+### Verdict
+
+DOES NOT RESOLVE — the PR hardens `sanitizeToolResultImages()` and related tests, but the issue's actual MCP tool-result path still bypasses that helper and remains vulnerable.

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -10,6 +10,7 @@ import {
   TOOL_NAME_SEPARATOR,
 } from "./pi-bundle-mcp-names.js";
 import type { BundleMcpToolRuntime, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
+import { sanitizeToolResultImages } from "./tool-images.js";
 
 function toAgentToolResult(params: {
   serverName: string;
@@ -103,11 +104,14 @@ export async function materializeBundleMcpToolsForRun(params: {
       parameters: tool.inputSchema,
       execute: async (_toolCallId: string, input: unknown) => {
         const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
-        return toAgentToolResult({
-          serverName: tool.serverName,
-          toolName: tool.toolName,
-          result,
-        });
+        return await sanitizeToolResultImages(
+          toAgentToolResult({
+            serverName: tool.serverName,
+            toolName: tool.toolName,
+            result,
+          }),
+          `${tool.serverName}:${tool.toolName}`,
+        );
       },
     });
   }

--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -15,6 +15,18 @@ type RuntimeFactoryOptions = NonNullable<
 >;
 type RuntimeFactory = NonNullable<RuntimeFactoryOptions["createRuntime"]>;
 
+function createIsoBmffImage(
+  majorBrand: string,
+  compatibleBrands: string[] = [],
+  minorVersion = "\0\0\0\0",
+): Buffer {
+  const brands = [majorBrand, minorVersion, ...compatibleBrands];
+  const payload = Buffer.concat(brands.map((brand) => Buffer.from(brand, "ascii")));
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(payload.length + 8, 0);
+  return Buffer.concat([size, Buffer.from("ftyp", "ascii"), payload]);
+}
+
 function makeRuntime(
   tools: Array<{ toolName: string; description: string }>,
   serverName = "bundleProbe",
@@ -252,6 +264,27 @@ describe("session MCP runtime", () => {
     expect(runtimeA).not.toBe(runtimeB);
     expect(resultA.content[0]).toMatchObject({ type: "text", text: "FROM-CONFIG-A" });
     expect(resultB.content[0]).toMatchObject({ type: "text", text: "FROM-CONFIG-B" });
+  });
+
+  it("rejects HEIF-family MCP image tool results on the materialized execution path", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"]);
+    const runtime: SessionMcpRuntime = {
+      ...makeRuntime([{ toolName: "bundle_probe", description: "Bundle MCP probe" }]),
+      callTool: async () => ({
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/jpeg" }],
+        isError: false,
+      }),
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const result = await materialized.tools[0].execute("call-heif", {}, undefined, undefined);
+
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: "[bundleProbe:bundle_probe] omitted image payload: Error: unsupported image format",
+      },
+    ]);
   });
 
   it("disposes catalog startup in-flight without leaving cached runtimes", async () => {

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -297,6 +297,43 @@ describe("sanitizeSessionMessagesImages", () => {
     }
   });
 
+  it("preserves read-tool HEIF opt-outs during transcript replay sanitization", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"]);
+    const input = castAgentMessages([
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/heic" }],
+        details: {
+          imageSanitization: {
+            rejectHeifFamily: false,
+          },
+        },
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("toolResult");
+    if (out[0]?.role === "toolResult") {
+      expect(out[0].content).not.toEqual([
+        {
+          type: "text",
+          text: "[test] omitted image payload: Error: unsupported image format",
+        },
+      ]);
+      expect(out[0].details).toMatchObject({
+        imageSanitization: {
+          rejectHeifFamily: false,
+        },
+      });
+    }
+  });
+
   describe("thought_signature stripping", () => {
     it("strips msg_-prefixed thought_signature from assistant message content blocks", async () => {
       const input = castAgentMessages([

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -297,6 +297,33 @@ describe("sanitizeSessionMessagesImages", () => {
     }
   });
 
+  it("preserves legacy read-tool HEIF content during transcript replay when metadata is missing", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"]);
+    const input = castAgentMessages([
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/heic" }],
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("toolResult");
+    if (out[0]?.role === "toolResult") {
+      expect(out[0].content).not.toEqual([
+        {
+          type: "text",
+          text: "[test] omitted image payload: Error: unsupported image format",
+        },
+      ]);
+    }
+  });
+
   it("preserves read-tool HEIF opt-outs during transcript replay sanitization", async () => {
     const heif = createIsoBmffImage("heic", ["mif1"]);
     const input = castAgentMessages([

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage, ToolResultMessage, UserMessage } from "@mariozechner/pi-ai";
+import sharp from "sharp";
 import { describe, expect, it } from "vitest";
 import {
   sanitizeGoogleTurnOrdering,
@@ -323,6 +324,49 @@ describe("sanitizeSessionMessagesImages", () => {
       ]);
     }
   });
+
+  it("does not let stored sanitization metadata wipe configured replay limits", async () => {
+    const maxBytes = 64 * 1024;
+    const width = 900;
+    const height = 900;
+    const raw = Buffer.alloc(width * height * 3, 0xff);
+    const bigPng = await sharp(raw, {
+      raw: { width, height, channels: 3 },
+    })
+      .png({ compressionLevel: 0 })
+      .toBuffer();
+    expect(bigPng.byteLength).toBeGreaterThan(maxBytes);
+
+    const input = castAgentMessages([
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "read",
+        isError: false,
+        content: [{ type: "image", data: bigPng.toString("base64"), mimeType: "image/png" }],
+        details: {
+          imageSanitization: {
+            rejectHeifFamily: false,
+          },
+        },
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test", { maxBytes });
+
+    expect(out).toHaveLength(1);
+    const tool = out[0];
+    expect(tool?.role).toBe("toolResult");
+    if (tool?.role !== "toolResult") {
+      return;
+    }
+    const image = tool.content?.find((block) => (block as { type?: string }).type === "image") as
+      | { type: "image"; data: string; mimeType?: string }
+      | undefined;
+    expect(image).toBeDefined();
+    expect(Buffer.from(image?.data ?? "", "base64").byteLength).toBeLessThanOrEqual(maxBytes);
+  }, 20_000);
 
   it("preserves read-tool HEIF opt-outs during transcript replay sanitization", async () => {
     const heif = createIsoBmffImage("heic", ["mif1"]);

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -13,6 +13,18 @@ import {
 let testTimestamp = 1;
 const nextTimestamp = () => testTimestamp++;
 
+function createIsoBmffImage(
+  majorBrand: string,
+  compatibleBrands: string[] = [],
+  minorVersion = "\0\0\0\0",
+): Buffer {
+  const brands = [majorBrand, minorVersion, ...compatibleBrands];
+  const payload = Buffer.concat(brands.map((brand) => Buffer.from(brand, "ascii")));
+  const size = Buffer.alloc(4);
+  size.writeUInt32BE(payload.length + 8, 0);
+  return Buffer.concat([size, Buffer.from("ftyp", "ascii"), payload]);
+}
+
 function makeToolCallResultPairInput(): Array<AssistantMessage | ToolResultMessage> {
   return [
     makeAgentAssistantMessage({
@@ -256,6 +268,33 @@ describe("sanitizeSessionMessagesImages", () => {
     expect(out).toHaveLength(2);
     expect(out[0]?.role).toBe("user");
     expect(out[1]?.role).toBe("toolResult");
+  });
+
+  it("rejects HEIF-family images inside toolResult transcript messages", async () => {
+    const heif = createIsoBmffImage("avif", ["mif1"]);
+    const input = castAgentMessages([
+      {
+        role: "toolResult",
+        toolCallId: "tool-1",
+        toolName: "mcp_image",
+        isError: false,
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/jpeg" }],
+        timestamp: nextTimestamp(),
+      } satisfies ToolResultMessage,
+    ]);
+
+    const out = await sanitizeSessionMessagesImages(input, "test");
+
+    expect(out).toHaveLength(1);
+    expect(out[0]?.role).toBe("toolResult");
+    if (out[0]?.role === "toolResult") {
+      expect(out[0].content).toEqual([
+        {
+          type: "text",
+          text: "[test] omitted image payload: Error: unsupported image format",
+        },
+      ]);
+    }
   });
 
   describe("thought_signature stripping", () => {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -33,12 +33,21 @@ function readToolImageSanitizationDetails(
     }
     return {};
   }
-  return {
-    maxDimensionPx: typeof record.maxDimensionPx === "number" ? record.maxDimensionPx : undefined,
-    maxBytes: typeof record.maxBytes === "number" ? record.maxBytes : undefined,
-    rejectHeifFamily:
-      typeof record.rejectHeifFamily === "boolean" ? record.rejectHeifFamily : undefined,
-  };
+  // Omit absent keys so the spread in sanitizeSessionMessagesImages does not
+  // overwrite caller-configured limits with undefined.
+  const result: Pick<ImageSanitizationLimits, "maxDimensionPx" | "maxBytes"> & {
+    rejectHeifFamily?: boolean;
+  } = {};
+  if (typeof record.maxDimensionPx === "number") {
+    result.maxDimensionPx = record.maxDimensionPx;
+  }
+  if (typeof record.maxBytes === "number") {
+    result.maxBytes = record.maxBytes;
+  }
+  if (typeof record.rejectHeifFamily === "boolean") {
+    result.rejectHeifFamily = record.rejectHeifFamily;
+  }
+  return result;
 }
 
 function isThinkingOrRedactedBlock(block: unknown): boolean {

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -7,24 +7,32 @@ import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 
-function readToolImageSanitizationDetails(details: unknown): Pick<
-  ImageSanitizationLimits,
-  "maxDimensionPx" | "maxBytes"
-> & {
+const LEGACY_HEIF_ALLOWED_TOOL_NAMES = new Set(["read"]);
+
+function readToolImageSanitizationDetails(
+  details: unknown,
+  toolName: unknown,
+): Pick<ImageSanitizationLimits, "maxDimensionPx" | "maxBytes"> & {
   rejectHeifFamily?: boolean;
 } {
-  if (!details || typeof details !== "object") {
+  const record =
+    details && typeof details === "object"
+      ? (((details as { imageSanitization?: unknown }).imageSanitization ?? undefined) as
+          | Record<string, unknown>
+          | undefined)
+      : undefined;
+  const hasSanitizationRecord = !!record && typeof record === "object" && !Array.isArray(record);
+  if (!hasSanitizationRecord) {
+    // Legacy sessions were persisted before the replay guard existed and do
+    // not carry imageSanitization metadata. Preserve historical replay for
+    // tools that were known to pass HEIF-family content through (the read
+    // tool); leave other legacy tool results under the default reject path so
+    // untrusted MCP-style legacy content is not retroactively trusted.
+    if (typeof toolName === "string" && LEGACY_HEIF_ALLOWED_TOOL_NAMES.has(toolName)) {
+      return { rejectHeifFamily: false };
+    }
     return {};
   }
-  const imageSanitization = (details as { imageSanitization?: unknown }).imageSanitization;
-  if (
-    !imageSanitization ||
-    typeof imageSanitization !== "object" ||
-    Array.isArray(imageSanitization)
-  ) {
-    return {};
-  }
-  const record = imageSanitization as Record<string, unknown>;
   return {
     maxDimensionPx: typeof record.maxDimensionPx === "number" ? record.maxDimensionPx : undefined,
     maxBytes: typeof record.maxBytes === "number" ? record.maxBytes : undefined,
@@ -107,7 +115,10 @@ export async function sanitizeSessionMessagesImages(
     const role = (msg as { role?: unknown }).role;
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
-      const toolImageSanitization = readToolImageSanitizationDetails(toolMsg.details);
+      const toolImageSanitization = readToolImageSanitizationDetails(
+        toolMsg.details,
+        (toolMsg as { toolName?: unknown }).toolName,
+      );
       const sanitized = await sanitizeToolResultImages(
         {
           content: Array.isArray(toolMsg.content) ? toolMsg.content : [],

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -7,6 +7,32 @@ import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 
+function readToolImageSanitizationDetails(details: unknown): Pick<
+  ImageSanitizationLimits,
+  "maxDimensionPx" | "maxBytes"
+> & {
+  rejectHeifFamily?: boolean;
+} {
+  if (!details || typeof details !== "object") {
+    return {};
+  }
+  const imageSanitization = (details as { imageSanitization?: unknown }).imageSanitization;
+  if (
+    !imageSanitization ||
+    typeof imageSanitization !== "object" ||
+    Array.isArray(imageSanitization)
+  ) {
+    return {};
+  }
+  const record = imageSanitization as Record<string, unknown>;
+  return {
+    maxDimensionPx: typeof record.maxDimensionPx === "number" ? record.maxDimensionPx : undefined,
+    maxBytes: typeof record.maxBytes === "number" ? record.maxBytes : undefined,
+    rejectHeifFamily:
+      typeof record.rejectHeifFamily === "boolean" ? record.rejectHeifFamily : undefined,
+  };
+}
+
 function isThinkingOrRedactedBlock(block: unknown): boolean {
   if (!block || typeof block !== "object") {
     return false;
@@ -81,17 +107,22 @@ export async function sanitizeSessionMessagesImages(
     const role = (msg as { role?: unknown }).role;
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
+      const toolImageSanitization = readToolImageSanitizationDetails(toolMsg.details);
       const sanitized = await sanitizeToolResultImages(
         {
           content: Array.isArray(toolMsg.content) ? toolMsg.content : [],
           details: toolMsg.details,
         },
         label,
-        imageSanitization,
+        {
+          ...imageSanitization,
+          ...toolImageSanitization,
+        },
       );
       out.push({
         ...toolMsg,
         content: sanitized.content as unknown as typeof toolMsg.content,
+        details: sanitized.details as typeof toolMsg.details,
       });
       continue;
     }

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -2,7 +2,7 @@ import type { AgentMessage, AgentToolResult } from "@mariozechner/pi-agent-core"
 import type { ImageSanitizationLimits } from "../image-sanitization.js";
 import type { ToolCallIdMode } from "../tool-call-id.js";
 import { sanitizeToolCallIdsForCloudCodeAssist } from "../tool-call-id.js";
-import { sanitizeContentBlocksImages } from "../tool-images.js";
+import { sanitizeContentBlocksImages, sanitizeToolResultImages } from "../tool-images.js";
 import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
@@ -81,13 +81,18 @@ export async function sanitizeSessionMessagesImages(
     const role = (msg as { role?: unknown }).role;
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
-      const content = Array.isArray(toolMsg.content) ? toolMsg.content : [];
-      const nextContent = (await sanitizeContentBlocksImages(
-        content,
+      const sanitized = await sanitizeToolResultImages(
+        {
+          content: Array.isArray(toolMsg.content) ? toolMsg.content : [],
+          details: toolMsg.details,
+        },
         label,
         imageSanitization,
-      )) as unknown as typeof toolMsg.content;
-      out.push({ ...toolMsg, content: nextContent });
+      );
+      out.push({
+        ...toolMsg,
+        content: sanitized.content as unknown as typeof toolMsg.content,
+      });
       continue;
     }
 

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -690,11 +690,10 @@ export function createOpenClawReadTool(
       const filePath = typeof record?.path === "string" ? record.path : "<unknown>";
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
-      return sanitizeToolResultImages(
-        normalizedResult,
-        `read:${filePath}`,
-        options?.imageSanitization,
-      );
+      return sanitizeToolResultImages(normalizedResult, `read:${filePath}`, {
+        ...options?.imageSanitization,
+        rejectHeifFamily: false,
+      });
     },
   };
 }

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -1,6 +1,10 @@
 import sharp from "sharp";
 import { describe, expect, it } from "vitest";
-import { sanitizeContentBlocksImages, sanitizeImageBlocks } from "./tool-images.js";
+import {
+  sanitizeContentBlocksImages,
+  sanitizeImageBlocks,
+  sanitizeToolResultImages,
+} from "./tool-images.js";
 
 describe("tool image sanitizing", () => {
   const getImageBlock = (
@@ -135,31 +139,45 @@ describe("tool image sanitizing", () => {
     ]);
   });
 
-  it("drops HEIF tool image payloads before native decode", async () => {
+  it("drops HEIF tool-result image payloads before native decode", async () => {
     const heif = createIsoBmffImage("heic", ["mif1"]);
-    const out = await sanitizeContentBlocksImages(
-      [{ type: "image", data: heif.toString("base64"), mimeType: "image/heif" }],
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/heif" }],
+        details: {},
+      },
       "test",
     );
-    expect(out).toEqual([
-      {
-        type: "text",
-        text: "[test] omitted image payload: Error: unsupported image format",
-      },
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
     ]);
   });
 
-  it("drops AVIF payloads even when mislabeled as jpeg", async () => {
+  it("drops AVIF tool-result payloads even when mislabeled as jpeg", async () => {
     const avif = createIsoBmffImage("avif", ["mif1"]);
-    const out = await sanitizeContentBlocksImages(
-      [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
       "test",
     );
-    expect(out).toEqual([
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
+  it("drops HEIF-family payloads detected only via compatible brand on tool results", async () => {
+    const avif = createIsoBmffImage("mp41", ["mif1"]);
+    const out = await sanitizeToolResultImages(
       {
-        type: "text",
-        text: "[test] omitted image payload: Error: unsupported image format",
+        content: [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
       },
+      "test",
+    );
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
     ]);
   });
 });

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -28,9 +28,25 @@ describe("tool image sanitizing", () => {
       .toBuffer();
   };
 
-  const createIsoBmffImage = (majorBrand: string, compatibleBrands: string[] = []) => {
+  const createIsoBmffImage = (
+    majorBrand: string,
+    compatibleBrands: string[] = [],
+    sizeMode: "fixed" | "extended" | "eof" = "fixed",
+  ) => {
     const brands = [majorBrand, "\0\0\0\0", ...compatibleBrands];
     const payload = Buffer.concat(brands.map((brand) => Buffer.from(brand, "ascii")));
+    if (sizeMode === "extended") {
+      const size = Buffer.alloc(4);
+      size.writeUInt32BE(1, 0);
+      const extendedSize = Buffer.alloc(8);
+      extendedSize.writeBigUInt64BE(BigInt(payload.length + 16), 0);
+      return Buffer.concat([size, Buffer.from("ftyp", "ascii"), extendedSize, payload]);
+    }
+    if (sizeMode === "eof") {
+      const size = Buffer.alloc(4);
+      size.writeUInt32BE(0, 0);
+      return Buffer.concat([size, Buffer.from("ftyp", "ascii"), payload]);
+    }
     const size = Buffer.alloc(4);
     size.writeUInt32BE(payload.length + 8, 0);
     return Buffer.concat([size, Buffer.from("ftyp", "ascii"), payload]);
@@ -169,6 +185,48 @@ describe("tool image sanitizing", () => {
 
   it("drops HEIF-family payloads detected only via compatible brand on tool results", async () => {
     const avif = createIsoBmffImage("mp41", ["mif1"]);
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
+      "test",
+    );
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
+  it("drops HEIF tool-result payloads using extended ftyp size", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"], "extended");
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
+      "test",
+    );
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
+  it("drops HEIF tool-result payloads using zero-sized ftyp boxes", async () => {
+    const avif = createIsoBmffImage("avif", ["mif1"], "eof");
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
+      "test",
+    );
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
+  it("drops HEIF compatible-brand payloads using extended ftyp size", async () => {
+    const avif = createIsoBmffImage("mp41", ["mif1"], "extended");
     const out = await sanitizeToolResultImages(
       {
         content: [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -271,5 +271,10 @@ describe("tool image sanitizing", () => {
     if (block && block.type === "text") {
       expect(block.text).not.toBe("[test] omitted image payload: Error: unsupported image format");
     }
+    expect(out.details).toMatchObject({
+      imageSanitization: {
+        rejectHeifFamily: false,
+      },
+    });
   });
 });

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -240,6 +240,20 @@ describe("tool image sanitizing", () => {
     ]);
   });
 
+  it("drops mislabeled HEIF sequence-brand payloads before native decode", async () => {
+    const hevx = createIsoBmffImage("hevx", ["mif1"]);
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: hevx.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
+      "test",
+    );
+    expect(out.content).toEqual([
+      { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
   it("does not treat extended ftyp minor version as a compatible brand", async () => {
     const mp4 = createIsoBmffImage("mp41", [], "extended", "heic");
     const out = await sanitizeToolResultImages(

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -32,8 +32,9 @@ describe("tool image sanitizing", () => {
     majorBrand: string,
     compatibleBrands: string[] = [],
     sizeMode: "fixed" | "extended" | "eof" = "fixed",
+    minorVersion = "\0\0\0\0",
   ) => {
-    const brands = [majorBrand, "\0\0\0\0", ...compatibleBrands];
+    const brands = [majorBrand, minorVersion, ...compatibleBrands];
     const payload = Buffer.concat(brands.map((brand) => Buffer.from(brand, "ascii")));
     if (sizeMode === "extended") {
       const size = Buffer.alloc(4);
@@ -236,6 +237,23 @@ describe("tool image sanitizing", () => {
     );
     expect(out.content).toEqual([
       { type: "text", text: "[test] omitted image payload: Error: unsupported image format" },
+    ]);
+  });
+
+  it("does not treat extended ftyp minor version as a compatible brand", async () => {
+    const mp4 = createIsoBmffImage("mp41", [], "extended", "heic");
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: mp4.toString("base64"), mimeType: "image/jpeg" }],
+        details: {},
+      },
+      "test",
+    );
+    expect(out.content).toEqual([
+      {
+        type: "text",
+        text: "[test] omitted image payload: Error: Input buffer contains unsupported image format",
+      },
     ]);
   });
 });

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -256,4 +256,20 @@ describe("tool image sanitizing", () => {
       },
     ]);
   });
+
+  it("lets callers opt out of HEIF rejection for user-authorized reads", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"]);
+    const out = await sanitizeToolResultImages(
+      {
+        content: [{ type: "image", data: heif.toString("base64"), mimeType: "image/heic" }],
+        details: {},
+      },
+      "test",
+      { rejectHeifFamily: false },
+    );
+    const block = out.content[0];
+    if (block && block.type === "text") {
+      expect(block.text).not.toBe("[test] omitted image payload: Error: unsupported image format");
+    }
+  });
 });

--- a/src/agents/tool-images.test.ts
+++ b/src/agents/tool-images.test.ts
@@ -24,6 +24,14 @@ describe("tool image sanitizing", () => {
       .toBuffer();
   };
 
+  const createIsoBmffImage = (majorBrand: string, compatibleBrands: string[] = []) => {
+    const brands = [majorBrand, "\0\0\0\0", ...compatibleBrands];
+    const payload = Buffer.concat(brands.map((brand) => Buffer.from(brand, "ascii")));
+    const size = Buffer.alloc(4);
+    size.writeUInt32BE(payload.length + 8, 0);
+    return Buffer.concat([size, Buffer.from("ftyp", "ascii"), payload]);
+  };
+
   it("shrinks oversized images to the configured byte limit", async () => {
     const maxBytes = 128 * 1024;
     const width = 900;
@@ -123,6 +131,34 @@ describe("tool image sanitizing", () => {
       {
         type: "text",
         text: "[test] omitted image payload: invalid base64",
+      },
+    ]);
+  });
+
+  it("drops HEIF tool image payloads before native decode", async () => {
+    const heif = createIsoBmffImage("heic", ["mif1"]);
+    const out = await sanitizeContentBlocksImages(
+      [{ type: "image", data: heif.toString("base64"), mimeType: "image/heif" }],
+      "test",
+    );
+    expect(out).toEqual([
+      {
+        type: "text",
+        text: "[test] omitted image payload: Error: unsupported image format",
+      },
+    ]);
+  });
+
+  it("drops AVIF payloads even when mislabeled as jpeg", async () => {
+    const avif = createIsoBmffImage("avif", ["mif1"]);
+    const out = await sanitizeContentBlocksImages(
+      [{ type: "image", data: avif.toString("base64"), mimeType: "image/jpeg" }],
+      "test",
+    );
+    expect(out).toEqual([
+      {
+        type: "text",
+        text: "[test] omitted image payload: Error: unsupported image format",
       },
     ]);
   });

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -17,6 +17,9 @@ import {
 type ToolContentBlock = AgentToolResult<unknown>["content"][number];
 type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
+type ToolImageSanitizationLimits = ImageSanitizationLimits & {
+  rejectHeifFamily?: boolean;
+};
 
 // Anthropic Messages API limitations (observed in OpenClaw sessions):
 // - Images over ~2000px per side can fail in multi-image requests.
@@ -315,7 +318,7 @@ async function resizeImageBase64IfNeeded(params: {
 export async function sanitizeContentBlocksImages(
   blocks: ToolContentBlock[],
   label: string,
-  opts: ImageSanitizationLimits = {},
+  opts: ToolImageSanitizationLimits = {},
 ): Promise<ToolContentBlock[]> {
   const maxDimensionPx = Math.max(opts.maxDimensionPx ?? MAX_IMAGE_DIMENSION_PX, 1);
   const maxBytes = Math.max(opts.maxBytes ?? MAX_IMAGE_BYTES, 1);
@@ -355,12 +358,14 @@ export async function sanitizeContentBlocksImages(
     try {
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
-      if (mimeType === "image/avif" || mimeType === "image/heic" || mimeType === "image/heif") {
-        throw new Error("unsupported image format");
-      }
-      const buffer = Buffer.from(canonicalData, "base64");
-      if (isHeifFamilyImageBuffer(buffer)) {
-        throw new Error("unsupported image format");
+      if (opts.rejectHeifFamily) {
+        if (mimeType === "image/avif" || mimeType === "image/heic" || mimeType === "image/heif") {
+          throw new Error("unsupported image format");
+        }
+        const buffer = Buffer.from(canonicalData, "base64");
+        if (isHeifFamilyImageBuffer(buffer)) {
+          throw new Error("unsupported image format");
+        }
       }
       const fileName = inferImageFileName({ block, label, mediaPathHint });
       const resized = await resizeImageBase64IfNeeded({
@@ -390,7 +395,7 @@ export async function sanitizeContentBlocksImages(
 export async function sanitizeImageBlocks(
   images: ImageContent[],
   label: string,
-  opts: ImageSanitizationLimits = {},
+  opts: ToolImageSanitizationLimits = {},
 ): Promise<{ images: ImageContent[]; dropped: number }> {
   if (images.length === 0) {
     return { images, dropped: 0 };
@@ -410,6 +415,9 @@ export async function sanitizeToolResultImages(
     return result;
   }
 
-  const next = await sanitizeContentBlocksImages(content, label, opts);
+  const next = await sanitizeContentBlocksImages(content, label, {
+    ...opts,
+    rejectHeifFamily: true,
+  });
   return { ...result, content: next };
 }

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -195,6 +195,7 @@ function inferImageFileName(params: {
 }
 
 async function resizeImageBase64IfNeeded(params: {
+  buffer?: Buffer;
   base64: string;
   mimeType: string;
   maxDimensionPx: number;
@@ -208,7 +209,7 @@ async function resizeImageBase64IfNeeded(params: {
   width?: number;
   height?: number;
 }> {
-  const buf = Buffer.from(params.base64, "base64");
+  const buf = params.buffer ?? Buffer.from(params.base64, "base64");
   const meta = await getImageMetadata(buf);
   const width = meta?.width;
   const height = meta?.height;
@@ -358,17 +359,20 @@ export async function sanitizeContentBlocksImages(
     try {
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
+      const decodedBuffer = opts.rejectHeifFamily
+        ? Buffer.from(canonicalData, "base64")
+        : undefined;
       if (opts.rejectHeifFamily) {
         if (mimeType === "image/avif" || mimeType === "image/heic" || mimeType === "image/heif") {
           throw new Error("unsupported image format");
         }
-        const buffer = Buffer.from(canonicalData, "base64");
-        if (isHeifFamilyImageBuffer(buffer)) {
+        if (decodedBuffer && isHeifFamilyImageBuffer(decodedBuffer)) {
           throw new Error("unsupported image format");
         }
       }
       const fileName = inferImageFileName({ block, label, mediaPathHint });
       const resized = await resizeImageBase64IfNeeded({
+        buffer: decodedBuffer,
         base64: canonicalData,
         mimeType,
         maxDimensionPx,

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -108,7 +108,7 @@ function isHeifFamilyImageBuffer(buffer: Buffer): boolean {
       return false;
     }
     majorBrandOffset = 16;
-    compatibleBrandOffset = 20;
+    compatibleBrandOffset = 24;
     brandRegionEnd = clampIsoBmffBoxEnd(buffer, buffer.readBigUInt64BE(8));
   } else if (boxSize >= 16) {
     brandRegionEnd = Math.min(boxSize, buffer.length);

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -85,22 +85,43 @@ function readIsoBmffBrand(buffer: Buffer, offset: number): string | undefined {
   return buffer.toString("ascii", offset, offset + 4);
 }
 
+function clampIsoBmffBoxEnd(buffer: Buffer, boxSize: bigint): number {
+  if (boxSize > BigInt(Number.MAX_SAFE_INTEGER)) {
+    return buffer.length;
+  }
+  return Math.min(Number(boxSize), buffer.length);
+}
+
 function isHeifFamilyImageBuffer(buffer: Buffer): boolean {
   if (buffer.length < 16 || buffer.toString("ascii", 4, 8) !== "ftyp") {
     return false;
   }
   const boxSize = buffer.readUInt32BE(0);
-  if (boxSize < 16) {
+  let majorBrandOffset = 8;
+  let compatibleBrandOffset = 16;
+  let brandRegionEnd = buffer.length;
+
+  if (boxSize === 0) {
+    brandRegionEnd = buffer.length;
+  } else if (boxSize === 1) {
+    if (buffer.length < 20) {
+      return false;
+    }
+    majorBrandOffset = 16;
+    compatibleBrandOffset = 20;
+    brandRegionEnd = clampIsoBmffBoxEnd(buffer, buffer.readBigUInt64BE(8));
+  } else if (boxSize >= 16) {
+    brandRegionEnd = Math.min(boxSize, buffer.length);
+  } else {
     return false;
   }
-  const brandRegionEnd = Math.min(boxSize, buffer.length);
 
-  const majorBrand = readIsoBmffBrand(buffer, 8);
+  const majorBrand = readIsoBmffBrand(buffer, majorBrandOffset);
   if (majorBrand && HEIF_FAMILY_BRANDS.has(majorBrand)) {
     return true;
   }
 
-  for (let offset = 16; offset + 4 <= brandRegionEnd; offset += 4) {
+  for (let offset = compatibleBrandOffset; offset + 4 <= brandRegionEnd; offset += 4) {
     const brand = readIsoBmffBrand(buffer, offset);
     if (brand && HEIF_FAMILY_BRANDS.has(brand)) {
       return true;

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -86,13 +86,18 @@ function isHeifFamilyImageBuffer(buffer: Buffer): boolean {
   if (buffer.length < 16 || buffer.toString("ascii", 4, 8) !== "ftyp") {
     return false;
   }
+  const boxSize = buffer.readUInt32BE(0);
+  if (boxSize < 16) {
+    return false;
+  }
+  const brandRegionEnd = Math.min(boxSize, buffer.length);
 
   const majorBrand = readIsoBmffBrand(buffer, 8);
   if (majorBrand && HEIF_FAMILY_BRANDS.has(majorBrand)) {
     return true;
   }
 
-  for (let offset = 16; offset + 4 <= buffer.length; offset += 4) {
+  for (let offset = 16; offset + 4 <= brandRegionEnd; offset += 4) {
     const brand = readIsoBmffBrand(buffer, offset);
     if (brand && HEIF_FAMILY_BRANDS.has(brand)) {
       return true;
@@ -348,12 +353,12 @@ export async function sanitizeContentBlocksImages(
     }
 
     try {
-      const buffer = Buffer.from(canonicalData, "base64");
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
       if (mimeType === "image/avif" || mimeType === "image/heic" || mimeType === "image/heif") {
         throw new Error("unsupported image format");
       }
+      const buffer = Buffer.from(canonicalData, "base64");
       if (isHeifFamilyImageBuffer(buffer)) {
         throw new Error("unsupported image format");
       }

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -37,6 +37,7 @@ const HEIF_FAMILY_BRANDS = new Set([
   "heif",
   "heix",
   "hevc",
+  "hevx",
   "heim",
   "heis",
   "hevm",

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -27,6 +27,20 @@ type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
 const MAX_IMAGE_DIMENSION_PX = DEFAULT_IMAGE_MAX_DIMENSION_PX;
 const MAX_IMAGE_BYTES = DEFAULT_IMAGE_MAX_BYTES;
 const log = createSubsystemLogger("agents/tool-images");
+const HEIF_FAMILY_BRANDS = new Set([
+  "avif",
+  "avis",
+  "heic",
+  "heif",
+  "heix",
+  "hevc",
+  "heim",
+  "heis",
+  "hevm",
+  "hevs",
+  "mif1",
+  "msf1",
+]);
 
 function isImageBlock(block: unknown): block is ImageContentBlock {
   if (!block || typeof block !== "object") {
@@ -59,6 +73,33 @@ function inferMimeTypeFromBase64(base64: string): string | undefined {
     return "image/gif";
   }
   return undefined;
+}
+
+function readIsoBmffBrand(buffer: Buffer, offset: number): string | undefined {
+  if (offset < 0 || offset + 4 > buffer.length) {
+    return undefined;
+  }
+  return buffer.toString("ascii", offset, offset + 4);
+}
+
+function isHeifFamilyImageBuffer(buffer: Buffer): boolean {
+  if (buffer.length < 16 || buffer.toString("ascii", 4, 8) !== "ftyp") {
+    return false;
+  }
+
+  const majorBrand = readIsoBmffBrand(buffer, 8);
+  if (majorBrand && HEIF_FAMILY_BRANDS.has(majorBrand)) {
+    return true;
+  }
+
+  for (let offset = 16; offset + 4 <= buffer.length; offset += 4) {
+    const brand = readIsoBmffBrand(buffer, offset);
+    if (brand && HEIF_FAMILY_BRANDS.has(brand)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function formatBytesShort(bytes: number): string {
@@ -307,8 +348,15 @@ export async function sanitizeContentBlocksImages(
     }
 
     try {
+      const buffer = Buffer.from(canonicalData, "base64");
       const inferredMimeType = inferMimeTypeFromBase64(canonicalData);
       const mimeType = inferredMimeType ?? block.mimeType;
+      if (mimeType === "image/avif" || mimeType === "image/heic" || mimeType === "image/heif") {
+        throw new Error("unsupported image format");
+      }
+      if (isHeifFamilyImageBuffer(buffer)) {
+        throw new Error("unsupported image format");
+      }
       const fileName = inferImageFileName({ block, label, mediaPathHint });
       const resized = await resizeImageBase64IfNeeded({
         base64: canonicalData,

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -17,7 +17,7 @@ import {
 type ToolContentBlock = AgentToolResult<unknown>["content"][number];
 type ImageContentBlock = Extract<ToolContentBlock, { type: "image" }>;
 type TextContentBlock = Extract<ToolContentBlock, { type: "text" }>;
-type ToolImageSanitizationLimits = ImageSanitizationLimits & {
+export type ToolImageSanitizationLimits = ImageSanitizationLimits & {
   rejectHeifFamily?: boolean;
 };
 
@@ -433,7 +433,7 @@ export async function sanitizeImageBlocks(
 export async function sanitizeToolResultImages(
   result: AgentToolResult<unknown>,
   label: string,
-  opts: ImageSanitizationLimits = {},
+  opts: ToolImageSanitizationLimits = {},
 ): Promise<AgentToolResult<unknown>> {
   const content = Array.isArray(result.content) ? result.content : [];
   if (!content.some((b) => isImageBlock(b) || isTextBlock(b))) {
@@ -441,8 +441,8 @@ export async function sanitizeToolResultImages(
   }
 
   const next = await sanitizeContentBlocksImages(content, label, {
-    ...opts,
     rejectHeifFamily: true,
+    ...opts,
   });
   return { ...result, content: next };
 }

--- a/src/agents/tool-images.ts
+++ b/src/agents/tool-images.ts
@@ -444,5 +444,24 @@ export async function sanitizeToolResultImages(
     rejectHeifFamily: true,
     ...opts,
   });
-  return { ...result, content: next };
+  const details =
+    result.details && typeof result.details === "object"
+      ? (result.details as Record<string, unknown>)
+      : undefined;
+  const imageSanitization = {
+    ...(details?.imageSanitization &&
+    typeof details.imageSanitization === "object" &&
+    !Array.isArray(details.imageSanitization)
+      ? (details.imageSanitization as Record<string, unknown>)
+      : {}),
+    rejectHeifFamily: opts.rejectHeifFamily ?? true,
+  };
+  return {
+    ...result,
+    content: next,
+    details: {
+      ...details,
+      imageSanitization,
+    },
+  };
 }


### PR DESCRIPTION
## Summary
- Rejects HEIF-family tool image payloads before tool-result sanitization reaches native image decoding
- Bounds the ISO BMFF brand scan to the declared `ftyp` box size

## Changes
- Added a lightweight HEIF/AVIF brand check in `src/agents/tool-images.ts`
- Omit HEIF/AVIF tool-result images instead of passing them into resize/metadata work
- Added regression coverage for explicit HEIF payloads and mislabeled AVIF payloads

## Validation
- Ran `corepack pnpm test src/agents/tool-images.test.ts src/media/image-ops.input-guard.test.ts`
- Ran `corepack pnpm format:check src/agents/tool-images.ts src/agents/tool-images.test.ts`
- Ran local agentic review with `claude -p "/review"` and addressed the actionable parser-boundary feedback

## Notes
- Scope is intentionally limited to untrusted tool-result image sanitization to avoid changing shared HEIC conversion behavior
