### PR TITLE
fix(auto-reply): suppress entire payload when trailing NO_REPLY token present

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -70,8 +70,13 @@ export function normalizeReplyPayload(
       text = stripLeadingSilentToken(text, silentToken);
     }
     if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
-      text = stripSilentToken(text, silentToken);
-      if (!hasContent(text)) {
+      const stripped = stripSilentToken(text, silentToken);
+      const hadTrailingToken = stripped.length < text.length;
+      text = stripped;
+      // A trailing NO_REPLY means the model intended to suppress the entire
+      // turn — the preamble is internal reasoning, not user-facing content.
+      // Suppress the full message to prevent CoT/reasoning leaks. (#TBD)
+      if (!hasContent(text) || hadTrailingToken) {
         opts.onSkip?.("silent");
         return null;
       }

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -109,20 +109,23 @@ describe("normalizeReplyPayload", () => {
     }
   });
 
-  it("strips NO_REPLY from mixed emoji message (#30916)", () => {
+  it("suppresses message when trailing NO_REPLY follows emoji content (#30916)", () => {
     const result = normalizeReplyPayload({ text: "😄 NO_REPLY" });
-    expect(result).not.toBeNull();
-    expect(result!.text).toContain("😄");
-    expect(result!.text).not.toContain("NO_REPLY");
+    expect(result).toBeNull();
   });
 
-  it("strips NO_REPLY appended after substantive text (#30916)", () => {
+  it("suppresses message when trailing NO_REPLY follows substantive text (#30916)", () => {
     const result = normalizeReplyPayload({
       text: "File's there. Not urgent.\n\nNO_REPLY",
     });
-    expect(result).not.toBeNull();
-    expect(result!.text).toContain("File's there");
-    expect(result!.text).not.toContain("NO_REPLY");
+    expect(result).toBeNull();
+  });
+
+  it("suppresses message when trailing NO_REPLY follows internal reasoning (CoT leak fix)", () => {
+    const result = normalizeReplyPayload({
+      text: "Here's my analysis: user is asking X, the right move is Y.\n\nNO_REPLY",
+    });
+    expect(result).toBeNull();
   });
 
   it("strips glued leading NO_REPLY text without leaking the token", () => {


### PR DESCRIPTION
Fixes #66701

## Summary

`normalizeReplyPayload` in `src/auto-reply/reply/normalize-reply.ts` leaks chain-of-thought / internal reasoning to channel when the assistant body ends with a trailing `NO_REPLY` token.

## Repro

Assistant response of the form:

```
Here's my analysis: user is asking X. The right move is Y because Z.

NO_REPLY
```

**Expected:** nothing posted to channel (agent signaled silent reply via trailing token).

**Observed:** the preamble text (`Here's my analysis: user is asking X. The right move is Y because Z.`) ships to the channel as a visible bot message. The `NO_REPLY` token itself is stripped, but the preamble is delivered.

This matches the symptom reported in #66701: agents with reasoning-then-suppress behavior emit internal monologue followed by `NO_REPLY`, and the monologue is delivered to the channel as a visible bot message.

## Bug introduction (commit lineage)

The leak shape is touched by two commits visible in current `git blame upstream/main -L 60,79 -- src/auto-reply/reply/normalize-reply.ts`:

1. `153e3add68` ([#63068](https://github.com/openclaw/openclaw/pull/63068), 2026-04-09) — refactored the silent-token handling block into the current `isSilentReplyText` + `stripSilentToken` + `hasContent` shape. The trailing-strip-then-check-leftover pattern that leaks preamble dates from this rewrite.

2. `16c608e393` ([#65016](https://github.com/openclaw/openclaw/pull/65016), 2026-04-16) — widened the trigger guard to case-insensitive (`text.toLowerCase().includes(silentToken.toLowerCase())`). Most recent touch on the affected branch. Leak shape unchanged.

This PR continues the hardening trajectory of #56612 (`17479ceb43`, 2026-03-28, JSON-envelope NO_REPLY suppression) / #63068 / #65016 to cover the remaining trailing-token-with-preamble case.

## Root cause

`src/auto-reply/reply/normalize-reply.ts` (lines 67-77 on main at the time of this PR):

```typescript
if (text && !isSilentReplyText(text, silentToken)) {
  const hasLeadingSilentToken = startsWithSilentToken(text, silentToken);
  if (hasLeadingSilentToken) {
    text = stripLeadingSilentToken(text, silentToken);
  }
  if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
    text = stripSilentToken(text, silentToken);   // ← strips trailing NO_REPLY
    if (!hasContent(text)) {                       // ← checks if REMAINING text is empty
      opts.onSkip?.("silent");
      return null;
    }
    // ← when preamble is non-empty, the function returns the preamble text
    //   as a deliverable payload, and the dispatcher ships it to channel
  }
}
```

The function correctly strips the trailing `NO_REPLY` token, then checks whether the *remaining* text has content. When it does (the preamble/reasoning before the token), the payload is returned with the preamble text, which the dispatcher delivers to channel.

The buggy behavior is *explicitly encoded* by two existing tests in `src/auto-reply/reply/reply-utils.test.ts` under issue #30916:

```typescript
it("strips NO_REPLY appended after substantive text (#30916)", () => {
  const result = normalizeReplyPayload({
    text: "File's there. Not urgent.\n\nNO_REPLY",
  });
  expect(result).not.toBeNull();           // ← asserts preamble is KEPT
  expect(result!.text).toContain("File's there");
  expect(result!.text).not.toContain("NO_REPLY");
});
```

Those tests encode the original #30916 intent — "strip the trailing token, deliver the real text" — which assumed the token was accidental emoji-flavored noise. In practice, agents use trailing `NO_REPLY` as a deliberate signal to suppress the entire turn, and the preamble is internal reasoning that should not reach end users. This PR flips those tests and adds an explicit CoT-leak test.

## Fix

One guard in `src/auto-reply/reply/normalize-reply.ts`:

```diff
     if (hasLeadingSilentToken || text.toLowerCase().includes(silentToken.toLowerCase())) {
-      text = stripSilentToken(text, silentToken);
-      if (!hasContent(text)) {
+      const stripped = stripSilentToken(text, silentToken);
+      const hadTrailingToken = stripped.length < text.length;
+      text = stripped;
+      // A trailing NO_REPLY means the model intended to suppress the entire
+      // turn — the preamble is internal reasoning, not user-facing content.
+      // Suppress the full message to prevent CoT/reasoning leaks.
+      if (!hasContent(text) || hadTrailingToken) {
         opts.onSkip?.("silent");
         return null;
       }
     }
```

Plus two flipped `#30916` tests (they encoded the buggy behavior) and one new test covering the CoT leak case explicitly:

```typescript
it("suppresses message when trailing NO_REPLY follows internal reasoning (CoT leak fix)", () => {
  const result = normalizeReplyPayload({
    text: "Here's my analysis: user is asking X, the right move is Y.\n\nNO_REPLY",
  });
  expect(result).toBeNull();
});
```

## Tests

**Before the fix** (new CoT-leak test added alone, no fix):
```
 ❯ auto-reply/reply/reply-utils.test.ts (53 tests | 1 failed)
 × suppresses message when trailing NO_REPLY follows internal reasoning (CoT leak fix)

AssertionError: expected { Object (text) } to be null
- Expected: null
+ Received: { "text": "Here's my analysis: user is asking X, the right move is Y." }
```

**After the fix**:
```
Test Files  1 passed (1)
     Tests  53 passed (53)
```

Test run against `openclaw/openclaw` main at `cb2fc70741` (the PR base). Independently reproduced on three hosts (x86_64 WSL2, x86_64 bare Ubuntu, arm64) — same pre-fix failure, same post-fix pass.

## Relationship to other open work

Two prior open PRs target the same bug. This PR acknowledges them and explains why a third proposal is being submitted rather than reviving the existing two:

- **#49854** (2026-03-18) — patches `normalizeReplyPayload` in the same file with the same suppress-whole-message direction. Status: OPEN, CONFLICTING (DIRTY merge state) for ~33 days, no maintainer review. Uses `text.includes(silentToken)` as the trigger — Greptile flagged this as too broad (mid-sentence false-positives).

  This PR uses `stripped.length < text.length` (the `hadTrailingToken` guard) — fires *only* when stripping actually removed something, which avoids the mid-sentence false-positive concern. Two-file diff vs four-file. Failing-test-first methodology.

- **#66755** (2026-04-14) — patches `isSilentReplyText` in `src/auto-reply/tokens.ts` with a different philosophical position: only suppress when reasoning is wrapped in `<think>...</think>` or bare `think\n` markers. Explicitly preserves the leak shape for non-reasoning-marker preambles ("substantive replies that happen to end with NO_REPLY are still NOT suppressed").

  This PR takes the opposite position: any trailing NO_REPLY signals intent-to-suppress regardless of whether the preamble is wrapped in a reasoning marker. Models that emit raw reasoning without `<think>` markers (most non-Anthropic models, including Gemini and many OpenAI configurations) leak under #66755 but are suppressed under this PR.

If maintainers prefer #49854's direction with cleaner trigger logic, the `hadTrailingToken` guard could be cherry-picked onto that PR and #69394 closed. If maintainers prefer #66755's narrower scope, this PR can be closed in favor of it. Submitted as a third option to give maintainers a clear technical comparison.

## Scope

✅ Fixes: non-streaming delivery path — where `normalizeReplyPayload` is the final gate before dispatch. This is the common case for chat integrations configured with `streaming.mode: "off"` or `block.enabled: false`.

❌ Does **not** fix: streaming-on with intermediate block delivery. In that path, block messages may be dispatched to the channel *before* the final `NO_REPLY` token arrives. The fix in this PR operates at the final-payload normalization stage and cannot retroactively suppress already-sent blocks. That case requires turn-level buffering and is out of scope for this PR.

## Risk

- **Low.** Five-line change gated on `hadTrailingToken`. The existing exact-match silent path (`isSilentReplyText` early-return) and the leading-token strip path are unchanged.
- **Behavior change:** agents that previously relied on `"text NO_REPLY"` delivering just `"text"` will now get full suppression. This matches the long-standing documented intent of `NO_REPLY` — agent guidance (`AGENTS.md` in many deployments) already specifies that `NO_REPLY` must be the entire message when used.

## Commits

Single commit: `fix(auto-reply): suppress entire payload when trailing NO_REPLY token present`
