### PR TITLE
signal: detect bot mentions from native envelope metadata

### DIFF
--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -26,7 +26,7 @@ vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
 const [
   { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
   { createSignalEventHandler },
-  { renderSignalMentions },
+  { doesSignalMentionTargetBot, renderSignalMentions },
 ] = await Promise.all([
   import("./event-handler.test-harness.js"),
   import("./event-handler.js"),
@@ -237,6 +237,75 @@ describe("signal mention gating", () => {
     expect(body).not.toContain(placeholder);
   });
 
+  it("treats native @mention of the bot's own uuid as a mention under requireMention", async () => {
+    const botUuid = "bot-uuid-aaaa";
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createSignalConfig({ requireMention: true, mentionPattern: "@caio" }),
+        account: "+15559990000",
+        accountUuid: botUuid,
+      }),
+    );
+
+    const placeholder = "\uFFFC";
+    const message = `${placeholder} ping`;
+
+    await handler(
+      makeGroupEvent({
+        message,
+        mentions: [{ uuid: botUuid, start: 0, length: placeholder.length }],
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    expect(getCapturedCtx()?.WasMentioned).toBe(true);
+  });
+
+  it("treats native @mention of the bot's own phone as a mention under requireMention", async () => {
+    const botPhone = "+15559990000";
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createSignalConfig({ requireMention: true, mentionPattern: "@caio" }),
+        account: botPhone,
+      }),
+    );
+
+    const placeholder = "\uFFFC";
+    const message = `${placeholder} ping`;
+
+    await handler(
+      makeGroupEvent({
+        message,
+        mentions: [{ number: botPhone, start: 0, length: placeholder.length }],
+      }),
+    );
+
+    expect(capturedCtx).toBeTruthy();
+    expect(getCapturedCtx()?.WasMentioned).toBe(true);
+  });
+
+  it("does not treat @mentions of other participants as bot mentions", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createSignalConfig({ requireMention: true, mentionPattern: "@caio" }),
+        account: "+15559990000",
+        accountUuid: "bot-uuid-aaaa",
+      }),
+    );
+
+    const placeholder = "\uFFFC";
+    const message = `${placeholder} hi`;
+
+    await handler(
+      makeGroupEvent({
+        message,
+        mentions: [{ uuid: "someone-else-uuid", start: 0, length: placeholder.length }],
+      }),
+    );
+
+    expect(capturedCtx).toBeUndefined();
+  });
+
   it("counts mention metadata replacements toward requireMention gating", async () => {
     const handler = createMentionHandler({
       requireMention: true,
@@ -295,5 +364,41 @@ describe("renderSignalMentions", () => {
     const normalized = renderSignalMentions(message, [{ uuid: "valid", start: -0.7, length: 1.9 }]);
 
     expect(normalized).toBe("@valid ping");
+  });
+});
+
+describe("doesSignalMentionTargetBot", () => {
+  it("returns false when no mentions are supplied", () => {
+    expect(doesSignalMentionTargetBot(undefined, { uuid: "u" })).toBe(false);
+    expect(doesSignalMentionTargetBot(null, { uuid: "u" })).toBe(false);
+    expect(doesSignalMentionTargetBot([], { uuid: "u" })).toBe(false);
+  });
+
+  it("returns false when the bot has no identity", () => {
+    expect(doesSignalMentionTargetBot([{ uuid: "u" }], {})).toBe(false);
+    expect(doesSignalMentionTargetBot([{ uuid: "u" }], { uuid: "", phone: "" })).toBe(false);
+  });
+
+  it("matches by bot uuid", () => {
+    expect(doesSignalMentionTargetBot([{ uuid: "bot-u" }], { uuid: "bot-u" })).toBe(true);
+    expect(doesSignalMentionTargetBot([{ uuid: "other" }], { uuid: "bot-u" })).toBe(false);
+  });
+
+  it("matches by bot phone with E.164 normalization", () => {
+    expect(
+      doesSignalMentionTargetBot([{ number: "15551234567" }], { phone: "+1 (555) 123-4567" }),
+    ).toBe(true);
+    expect(
+      doesSignalMentionTargetBot([{ number: "+15550009999" }], { phone: "+15551234567" }),
+    ).toBe(false);
+  });
+
+  it("matches when any of several mentions targets the bot", () => {
+    expect(
+      doesSignalMentionTargetBot(
+        [{ uuid: "someone" }, { uuid: "bot-u" }, { number: "+15550001111" }],
+        { uuid: "bot-u" },
+      ),
+    ).toBe(true);
   });
 });

--- a/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
+++ b/extensions/signal/src/monitor/event-handler.mention-gating.test.ts
@@ -368,6 +368,8 @@ describe("renderSignalMentions", () => {
 });
 
 describe("doesSignalMentionTargetBot", () => {
+  const PH = "\uFFFC";
+
   it("returns false when no mentions are supplied", () => {
     expect(doesSignalMentionTargetBot(undefined, { uuid: "u" })).toBe(false);
     expect(doesSignalMentionTargetBot(null, { uuid: "u" })).toBe(false);
@@ -375,30 +377,74 @@ describe("doesSignalMentionTargetBot", () => {
   });
 
   it("returns false when the bot has no identity", () => {
-    expect(doesSignalMentionTargetBot([{ uuid: "u" }], {})).toBe(false);
-    expect(doesSignalMentionTargetBot([{ uuid: "u" }], { uuid: "", phone: "" })).toBe(false);
+    expect(doesSignalMentionTargetBot([{ uuid: "u", start: 0, length: 1 }], {}, `${PH} hi`)).toBe(
+      false,
+    );
+    expect(
+      doesSignalMentionTargetBot(
+        [{ uuid: "u", start: 0, length: 1 }],
+        { uuid: "", phone: "" },
+        `${PH} hi`,
+      ),
+    ).toBe(false);
   });
 
-  it("matches by bot uuid", () => {
-    expect(doesSignalMentionTargetBot([{ uuid: "bot-u" }], { uuid: "bot-u" })).toBe(true);
-    expect(doesSignalMentionTargetBot([{ uuid: "other" }], { uuid: "bot-u" })).toBe(false);
+  it("matches by bot uuid when message contains placeholder", () => {
+    const msg = `${PH} ping`;
+    expect(
+      doesSignalMentionTargetBot([{ uuid: "bot-u", start: 0, length: 1 }], { uuid: "bot-u" }, msg),
+    ).toBe(true);
+    expect(
+      doesSignalMentionTargetBot([{ uuid: "other", start: 0, length: 1 }], { uuid: "bot-u" }, msg),
+    ).toBe(false);
   });
 
   it("matches by bot phone with E.164 normalization", () => {
+    const msg = `${PH} ping`;
     expect(
-      doesSignalMentionTargetBot([{ number: "15551234567" }], { phone: "+1 (555) 123-4567" }),
+      doesSignalMentionTargetBot(
+        [{ number: "15551234567", start: 0, length: 1 }],
+        { phone: "+1 (555) 123-4567" },
+        msg,
+      ),
     ).toBe(true);
     expect(
-      doesSignalMentionTargetBot([{ number: "+15550009999" }], { phone: "+15551234567" }),
+      doesSignalMentionTargetBot(
+        [{ number: "+15550009999", start: 0, length: 1 }],
+        { phone: "+15551234567" },
+        msg,
+      ),
     ).toBe(false);
   });
 
   it("matches when any of several mentions targets the bot", () => {
+    const msg = `${PH} ${PH} ${PH}`;
     expect(
       doesSignalMentionTargetBot(
-        [{ uuid: "someone" }, { uuid: "bot-u" }, { number: "+15550001111" }],
+        [
+          { uuid: "someone", start: 0, length: 1 },
+          { uuid: "bot-u", start: 2, length: 1 },
+          { number: "+15550001111", start: 4, length: 1 },
+        ],
         { uuid: "bot-u" },
+        msg,
       ),
     ).toBe(true);
+  });
+
+  it("rejects forged mentions whose text span has no placeholder", () => {
+    // Mention metadata claims bot uuid at offset 0, but message has plain text
+    expect(
+      doesSignalMentionTargetBot(
+        [{ uuid: "bot-u", start: 0, length: 5 }],
+        { uuid: "bot-u" },
+        "hello world",
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects mentions with missing start/length", () => {
+    const msg = `${PH} ping`;
+    expect(doesSignalMentionTargetBot([{ uuid: "bot-u" }], { uuid: "bot-u" }, msg)).toBe(false);
   });
 });

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -64,7 +64,7 @@ import type {
   SignalReceivePayload,
 } from "./event-handler.types.js";
 import { resolveSignalQuoteContext } from "./inbound-context.js";
-import { renderSignalMentions } from "./mentions.js";
+import { doesSignalMentionTargetBot, renderSignalMentions } from "./mentions.js";
 
 function formatAttachmentKindCount(kind: string, count: number): string {
   if (kind === "attachment") {
@@ -660,7 +660,18 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       senderPeerId,
     });
     const mentionRegexes = buildMentionRegexes(deps.cfg, route.agentId);
-    const wasMentioned = isGroup && matchesMentionPatterns(messageText, mentionRegexes);
+    // Signal renders native @mentions as @<uuid> or @<phone>, which won't match
+    // patterns derived from the agent's display name. Detect native mentions of
+    // the bot's own account from the envelope metadata so requireMention-gated
+    // groups don't drop valid @mentions of the bot.
+    const nativeBotMention =
+      isGroup &&
+      doesSignalMentionTargetBot(dataMessage.mentions, {
+        phone: deps.account,
+        uuid: deps.accountUuid,
+      });
+    const wasMentioned =
+      isGroup && (nativeBotMention || matchesMentionPatterns(messageText, mentionRegexes));
     const requireMention =
       isGroup &&
       resolveChannelGroupRequireMention({

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -666,10 +666,11 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     // groups don't drop valid @mentions of the bot.
     const nativeBotMention =
       isGroup &&
-      doesSignalMentionTargetBot(dataMessage.mentions, {
-        phone: deps.account,
-        uuid: deps.accountUuid,
-      });
+      doesSignalMentionTargetBot(
+        dataMessage.mentions,
+        { phone: deps.account, uuid: deps.accountUuid },
+        rawMessage,
+      );
     const wasMentioned =
       isGroup && (nativeBotMention || matchesMentionPatterns(messageText, mentionRegexes));
     const requireMention =

--- a/extensions/signal/src/monitor/mentions.ts
+++ b/extensions/signal/src/monitor/mentions.ts
@@ -1,3 +1,4 @@
+import { normalizeE164 } from "openclaw/plugin-sdk/text-runtime";
 import type { SignalMention } from "./event-handler.types.js";
 
 const OBJECT_REPLACEMENT = "\uFFFC";
@@ -23,6 +24,34 @@ function clampBounds(start: number, length: number, textLength: number) {
   const safeLength = Math.max(0, Math.trunc(length));
   const safeEnd = Math.min(textLength, safeStart + safeLength);
   return { start: safeStart, end: safeEnd };
+}
+
+export function doesSignalMentionTargetBot(
+  mentions: SignalMention[] | null | undefined,
+  botAccount: { phone?: string | null; uuid?: string | null },
+): boolean {
+  if (!mentions?.length) {
+    return false;
+  }
+  const botUuid = botAccount.uuid?.trim() || undefined;
+  const botPhone = botAccount.phone ? normalizeE164(botAccount.phone) : undefined;
+  if (!botUuid && !botPhone) {
+    return false;
+  }
+  for (const mention of mentions) {
+    if (!mention) {
+      continue;
+    }
+    const mentionUuid = mention.uuid?.trim();
+    if (botUuid && mentionUuid && mentionUuid === botUuid) {
+      return true;
+    }
+    const mentionNumber = mention.number?.trim();
+    if (botPhone && mentionNumber && normalizeE164(mentionNumber) === botPhone) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function renderSignalMentions(message: string, mentions?: SignalMention[] | null) {

--- a/extensions/signal/src/monitor/mentions.ts
+++ b/extensions/signal/src/monitor/mentions.ts
@@ -29,6 +29,7 @@ function clampBounds(start: number, length: number, textLength: number) {
 export function doesSignalMentionTargetBot(
   mentions: SignalMention[] | null | undefined,
   botAccount: { phone?: string | null; uuid?: string | null },
+  message?: string | null,
 ): boolean {
   if (!mentions?.length) {
     return false;
@@ -39,8 +40,16 @@ export function doesSignalMentionTargetBot(
     return false;
   }
   for (const mention of mentions) {
-    if (!mention) {
+    if (!isValidMention(mention)) {
       continue;
+    }
+    // Require the mention span to reference a real placeholder in the message
+    // text, matching the same structural check renderSignalMentions uses.
+    if (message != null) {
+      const { start, end } = clampBounds(mention.start!, mention.length!, message.length);
+      if (start >= end || !message.slice(start, end).includes(OBJECT_REPLACEMENT)) {
+        continue;
+      }
     }
     const mentionUuid = mention.uuid?.trim();
     if (botUuid && mentionUuid && mentionUuid === botUuid) {


### PR DESCRIPTION
 ## Summary

  - **Problem:** Signal renders native @mentions as `@<uuid>` or `@<phone>` after hydrating `\uFFFC` placeholders, but the  mention-gating regex patterns are derived from the agent's display name (e.g. `\b@?caio\b`). These never match, so `wasMentioned`  stays `false` and `requireMention`-gated groups silently drop valid bot mentions — no session is created and no fallback occurs.
  - **Why it matters:** Users who @mention the bot in a Signal group with `requireMention: true` get no response at all, with no  error or indication of failure.
  - **What changed:** Added `doesSignalMentionTargetBot` to detect native mentions by comparing  `dataMessage.mentions[].uuid/.number` against the bot's own identity. The result is OR'd into `wasMentioned` before mention-gating
   runs.
  - **What did NOT change:** Text-based mention pattern matching, routing/session-key logic, mention-gating decision logic, and  non-group message handling are all untouched.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - [ ] This PR fixes a bug or regression

  ## Root Cause

  - **Root cause:** `renderSignalMentions` replaces `\uFFFC` with `@<uuid>`, but `buildMentionRegexes` builds patterns from the
  agent's display name. The two representations never match, so native @mentions are invisible to the mention gate.
  - **Missing detection / guardrail:** No code path checked the structured `dataMessage.mentions[]` metadata against the bot's own
  account identity. Only text-regex matching existed.
  - **Contributing context:** Signal's mention system uses object-replacement characters in the message body with separate
  structured metadata — unlike platforms where mentions appear as literal `@name` text.

  ## Regression Test Plan

  - Coverage level that should have caught this:
    - [ ] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - **Target test or file:** `extensions/signal/src/monitor/event-handler.mention-gating.test.ts`
  - **Scenario the test should lock in:** Native @mention of the bot's own uuid or phone passes `requireMention` gating with
  `WasMentioned=true`; @mention of a different participant does not.
  - **Why this is the smallest reliable guardrail:** The integration tests exercise the full event handler pipeline including
  mention hydration, native detection, and gating — the exact path that was broken.
  - **Existing test that already covers this:** None before this PR.

  ## User-visible / Behavior Changes

  Signal group messages that @mention the bot via Signal's native mention UI now correctly reach the bot when `requireMention: true`   is configured. Previously these were silently dropped.

  ## Diagram

  ```text
  Before:
  [user @mentions bot in Signal group] -> renderSignalMentions -> "@<uuid> ping"
    -> mentionRegex(/\b@?caio\b/) -> no match -> wasMentioned=false -> DROPPED

  After:
  [user @mentions bot in Signal group] -> renderSignalMentions -> "@<uuid> ping"
    -> doesSignalMentionTargetBot(mentions, botAccount) -> match -> nativeBotMention=true
    -> wasMentioned=true -> DISPATCHED

## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No
  
## Repro + Verification

### Environment

  - OS: macOS
  - Runtime/container: Node 22 / pnpm
  - Integration/channel: Signal (signal-cli)
  - Relevant config: bindings[].match.peer targeting a specific Signal group with requireMention: true
  
### Steps

  1. Configure a Signal group binding with requireMention: true
  2. In that Signal group, use Signal's native @mention UI to mention the bot
  3. Observe whether a session is created and a reply is sent
  
### Expected
  - Bot receives the message, creates a session, and responds.
  
### Actual
  - Message silently dropped. No session created, no error logged.
  
## Evidence

  - Failing test/log before + passing after — 8 new tests in event-handler.mention-gating.test.ts covering native uuid mention,
  phone mention, non-bot mention rejection, and doesSignalMentionTargetBot unit cases. All pass.
  - Trace/log snippets
  - Screenshot/recording
  - Perf numbers (if relevant)
  
## Human Verification (required)

  - Verified scenarios: All 8 new tests pass; existing mention-gating tests remain green; pnpm check passes.
  - Edge cases checked: Bot with no uuid/phone identity returns false; mentions of other participants don't trigger; E.164 phone
  normalization works across formats.
  - What I did not verify: Live Signal group end-to-end (requires real Signal account and group).
  
## Review Conversations

  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.
  
## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No
  
## Risks and Mitigations

  - Risk: If deps.accountUuid is not populated in some deployments, native uuid matching won't fire.
    - Mitigation: Phone-based matching via deps.account serves as fallback; text-regex matching is unchanged as a second fallback.
  Behavior is strictly additive — no existing path is removed.