### PR TITLE
agents/context: unlock context1m on proxied Anthropic 1M-capable models (#69353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/context: honor `agents.defaults.models.*.params.context1m = true` on proxied Anthropic 1M-capable models (Claude Opus 4 / Sonnet 4 prefixes), so GitHub Copilot and other providers that route to the same underlying models unlock the 1M token context window when the operator opts in. Non-matching model prefixes still cap at the configured/fallback window. (#69353) [AI-assisted]
 - fix(security): block MINIMAX_API_HOST workspace env injection and remove env-driven URL routing [AI-assisted]. (#67300) Thanks @pgondhi987.
 - Cron/delivery: treat explicit `delivery.mode: "none"` runs as not requested even if the runner reports `delivered: false`, so no-delivery cron jobs no longer persist false delivery failures or errors. (#69285) Thanks @matsuri1987.
 - Plugins/install: repair active and default-enabled bundled plugin runtime dependencies before import in packaged installs, so bundled Discord, WhatsApp, Slack, Telegram, and provider plugins work without putting their dependency trees in core.

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -258,6 +258,66 @@ describe("resolveContextTokensForModel", () => {
     expect(result).toBe(200_000);
   });
 
+  it("returns 1M context when context1m is enabled on an Anthropic-capable model proxied through github-copilot (#69353)", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            "github-copilot": {
+              baseUrl: "https://api.enterprise.githubcopilot.com",
+              models: [testModelContextWindow("claude-opus-4-6", 200_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "github-copilot/claude-opus-4-6": {
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      },
+      provider: "github-copilot",
+      model: "claude-opus-4-6",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(ANTHROPIC_CONTEXT_1M_TOKENS);
+  });
+
+  it("still gates 1M context on the claude-opus/claude-sonnet prefix when proxied (#69353)", () => {
+    const result = resolveContextTokensForModel({
+      cfg: {
+        models: {
+          providers: {
+            "github-copilot": {
+              baseUrl: "https://api.enterprise.githubcopilot.com",
+              models: [testModelContextWindow("claude-haiku-3-5", 200_000)],
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            models: {
+              "github-copilot/claude-haiku-3-5": {
+                params: { context1m: true },
+              },
+            },
+          },
+        },
+      },
+      provider: "github-copilot",
+      model: "claude-haiku-3-5",
+      fallbackContextTokens: 200_000,
+      allowAsyncLoad: false,
+    });
+
+    expect(result).toBe(200_000);
+  });
+
   it("prefers per-model contextTokens config over contextWindow", () => {
     const result = resolveContextTokensForModel({
       cfg: {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -370,10 +370,7 @@ function resolveConfiguredProviderContextTokens(
   return findContextTokens((id) => normalizeProviderId(id) === normalizedProvider);
 }
 
-function isAnthropic1MModel(provider: string, model: string): boolean {
-  if (provider !== "anthropic") {
-    return false;
-  }
+function isAnthropic1MCapableModel(model: string): boolean {
   const normalized = normalizeLowercaseStringOrEmpty(model);
   const modelId = normalized.includes("/")
     ? (normalized.split("/").at(-1) ?? normalized)
@@ -400,7 +397,7 @@ export function resolveContextTokensForModel(params: {
   const explicitProvider = params.provider?.trim();
   if (ref) {
     const modelParams = resolveConfiguredModelParams(params.cfg, ref.provider, ref.model);
-    if (modelParams?.context1m === true && isAnthropic1MModel(ref.provider, ref.model)) {
+    if (modelParams?.context1m === true && isAnthropic1MCapableModel(ref.model)) {
       return ANTHROPIC_CONTEXT_1M_TOKENS;
     }
     // Only do the config direct scan when the caller explicitly passed a


### PR DESCRIPTION
Fixes #69353.

### Summary
`isAnthropic1MModel` in `src/agents/context.ts` gates the 1M context window on `provider === "anthropic"`, so `context1m: true` was a silent no-op for any provider proxying Claude Opus 4 / Sonnet 4 — notably the bundled `github-copilot` provider, which routes to the same underlying Anthropic models but identifies itself as `"github-copilot"`.

This change keeps the prefix check (`claude-opus-4*`, `claude-sonnet-4*`) but drops the provider guard, so `context1m: true` works across proxying providers. The model-id prefix is still the authoritative filter, so non-Anthropic-capable models (e.g. `claude-haiku-3-5`) stay at their configured / fallback window.

### Why
Users configuring `agents.defaults.models["github-copilot/claude-opus-4-6"].params.context1m = true` observed sessions still compacting at ~180k tokens. The user opt-in is an explicit trust signal; the provider guard was over-restrictive.

### Implementation
- `src/agents/context.ts`: rename helper to `isAnthropic1MCapableModel(model)` and drop the unused `provider` parameter. The prefix filter (`ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"]`) remains the source of truth. Precedent: `extensions/anthropic/stream-wrappers.ts` already defines an identically-scoped `isAnthropic1MModel(modelId)` that only looks at the model id.
- `src/agents/context.test.ts`: two regression tests.
  1. `github-copilot` + `claude-opus-4-6` + `context1m: true` → returns 1M.
  2. `github-copilot` + `claude-haiku-3-5` + `context1m: true` → still returns 200k (prefix gate intact).

### Verification
- `pnpm test src/agents/context.test.ts` → 15/15 (13 pre-existing + 2 new).
- No unintentional behavior change for `provider === "anthropic"` callers; all prior assertions in `context.test.ts` still pass unchanged.
- Pre-existing `src/security/skill-scanner.test.ts` type errors on `origin/main` are unrelated (upstream commit 16985aba4e, not in this diff).

### Notes
- Backwards compatible. `context1m` remains an explicit opt-in, the prefix filter is unchanged, and the fallback paths (per-model `contextTokens`, cached/discovery windows) are untouched.
- AI-assisted contribution.