### PR TITLE
fix(msteams): paginate thread replies and keep recent context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- MS Teams: paginate Graph thread replies and keep the most recent reply context for long Teams conversations. (#69428) Thanks @hkalkoti1.
 - Cron/agents: recognize same-target `edit`↔`write` recovery in `isSameToolMutationAction`, so a successful `write` to a path clears an earlier failed `edit` on the same path. Stops cron from reporting fatal failures when an agent self-heals across `edit` and `write`, while preserving same-tool fingerprint matching, blocking different-target writes, and excluding tools (including `apply_patch`) whose real call args do not produce a stable `path` fingerprint segment. Fixes #79024. Thanks @RenzoMXD.
 - Gateway/Tailscale: add opt-in `gateway.tailscale.preserveFunnel` so when `tailscale.mode = "serve"` and an externally configured Tailscale Funnel route already covers the gateway port, OpenClaw skips re-applying `tailscale serve` on startup and skips the `resetOnExit` teardown for that run, keeping operator-managed Funnel exposure alive across gateway restarts. Fixes #57241. Thanks @RenzoMXD.
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -195,6 +195,19 @@ describe("fetchThreadReplies", () => {
     expect(result).toHaveLength(10);
     expect(fetchGraphAbsoluteUrl).toHaveBeenCalledTimes(9);
   });
+
+  it("returns already-fetched replies when a later page fails", async () => {
+    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
+      value: [{ id: "reply-1" }, { id: "reply-2" }],
+      "@odata.nextLink": "https://graph.microsoft.com/v1.0/replies?page=2",
+    } as never);
+    vi.mocked(fetchGraphAbsoluteUrl).mockRejectedValueOnce(new Error("timeout") as never);
+
+    const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1", 50);
+
+    expect(result).toEqual([{ id: "reply-1" }, { id: "reply-2" }]);
+    expect(fetchGraphAbsoluteUrl).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("formatThreadContext", () => {

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -7,9 +7,10 @@ import {
   resolveTeamGroupId,
   stripHtmlFromTeamsMessage,
 } from "./graph-thread.js";
-import { fetchGraphJson } from "./graph.js";
+import { fetchGraphAbsoluteUrl, fetchGraphJson } from "./graph.js";
 
 vi.mock("./graph.js", () => ({
+  fetchGraphAbsoluteUrl: vi.fn(),
   fetchGraphJson: vi.fn(),
 }));
 
@@ -117,6 +118,7 @@ describe("fetchChannelMessage", () => {
 describe("fetchThreadReplies", () => {
   beforeEach(() => {
     vi.mocked(fetchGraphJson).mockReset();
+    vi.mocked(fetchGraphAbsoluteUrl).mockReset();
   });
 
   it("fetches replies with correct path and default limit", async () => {
@@ -156,6 +158,42 @@ describe("fetchThreadReplies", () => {
 
     const result = await fetchThreadReplies("tok", "g", "c", "m");
     expect(result).toEqual([]);
+  });
+
+  it("follows pagination and keeps the most recent replies", async () => {
+    vi.mocked(fetchGraphJson).mockResolvedValueOnce({
+      value: [{ id: "reply-1" }, { id: "reply-2" }],
+      "@odata.nextLink":
+        "https://graph.microsoft.com/v1.0/teams/group-1/channels/channel-1/messages/msg-1/replies?$skiptoken=page2",
+    } as never);
+    vi.mocked(fetchGraphAbsoluteUrl).mockResolvedValueOnce({
+      value: [{ id: "reply-3" }, { id: "reply-4" }],
+    } as never);
+
+    const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1", 2);
+
+    expect(result).toEqual([{ id: "reply-3" }, { id: "reply-4" }]);
+    expect(fetchGraphAbsoluteUrl).toHaveBeenCalledWith({
+      token: "tok",
+      url: "https://graph.microsoft.com/v1.0/teams/group-1/channels/channel-1/messages/msg-1/replies?$skiptoken=page2",
+    });
+  });
+
+  it("stops paginating after the hard page cap", async () => {
+    const makePageResponse = (pageNum: number) => ({
+      value: [{ id: `reply-${pageNum}` }],
+      "@odata.nextLink": `https://graph.microsoft.com/v1.0/replies?page=${pageNum + 1}`,
+    });
+
+    vi.mocked(fetchGraphJson).mockResolvedValueOnce(makePageResponse(1) as never);
+    for (let i = 2; i <= 10; i++) {
+      vi.mocked(fetchGraphAbsoluteUrl).mockResolvedValueOnce(makePageResponse(i) as never);
+    }
+
+    const result = await fetchThreadReplies("tok", "g", "c", "m", 50);
+
+    expect(result).toHaveLength(10);
+    expect(fetchGraphAbsoluteUrl).toHaveBeenCalledTimes(9);
   });
 });
 

--- a/extensions/msteams/src/graph-thread.test.ts
+++ b/extensions/msteams/src/graph-thread.test.ts
@@ -162,17 +162,26 @@ describe("fetchThreadReplies", () => {
 
   it("follows pagination and keeps the most recent replies", async () => {
     vi.mocked(fetchGraphJson).mockResolvedValueOnce({
-      value: [{ id: "reply-1" }, { id: "reply-2" }],
+      value: [
+        { id: "reply-newest", createdDateTime: "2026-05-08T12:04:00Z" },
+        { id: "reply-older", createdDateTime: "2026-05-08T12:01:00Z" },
+      ],
       "@odata.nextLink":
         "https://graph.microsoft.com/v1.0/teams/group-1/channels/channel-1/messages/msg-1/replies?$skiptoken=page2",
     } as never);
     vi.mocked(fetchGraphAbsoluteUrl).mockResolvedValueOnce({
-      value: [{ id: "reply-3" }, { id: "reply-4" }],
+      value: [
+        { id: "reply-oldest", createdDateTime: "2026-05-08T12:00:00Z" },
+        { id: "reply-newer", createdDateTime: "2026-05-08T12:03:00Z" },
+      ],
     } as never);
 
     const result = await fetchThreadReplies("tok", "group-1", "channel-1", "msg-1", 2);
 
-    expect(result).toEqual([{ id: "reply-3" }, { id: "reply-4" }]);
+    expect(result).toEqual([
+      { id: "reply-newer", createdDateTime: "2026-05-08T12:03:00Z" },
+      { id: "reply-newest", createdDateTime: "2026-05-08T12:04:00Z" },
+    ]);
     expect(fetchGraphAbsoluteUrl).toHaveBeenCalledWith({
       token: "tok",
       url: "https://graph.microsoft.com/v1.0/teams/group-1/channels/channel-1/messages/msg-1/replies?$skiptoken=page2",

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -123,10 +123,16 @@ export async function fetchThreadReplies(
       break;
     }
 
-    res = await fetchGraphAbsoluteUrl<GraphPagedResponse<GraphThreadMessage>>({
-      token,
-      url: nextLink,
-    });
+    try {
+      res = await fetchGraphAbsoluteUrl<GraphPagedResponse<GraphThreadMessage>>({
+        token,
+        url: nextLink,
+      });
+    } catch {
+      // Preserve already-fetched replies so thread enrichment stays best-effort
+      // even when a later pagination request fails.
+      break;
+    }
     pages++;
   }
 

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,4 +1,4 @@
-import { fetchGraphJson, type GraphResponse } from "./graph.js";
+import { fetchGraphAbsoluteUrl, fetchGraphJson, type GraphPagedResponse } from "./graph.js";
 
 export type GraphThreadMessage = {
   id?: string;
@@ -9,6 +9,9 @@ export type GraphThreadMessage = {
   body?: { content?: string; contentType?: string };
   createdDateTime?: string;
 };
+
+/** Maximum number of reply pages to follow so thread enrichment stays bounded. */
+const THREAD_REPLIES_MAX_PAGES = 10;
 
 // TTL cache for team ID -> group GUID mapping.
 const teamGroupIdCache = new Map<string, { groupId: string; expiresAt: number }>();
@@ -93,12 +96,10 @@ export async function fetchChannelMessage(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * **Limitation:** The Graph API replies endpoint (`/messages/{id}/replies`) does not
- * support `$orderby`, so results are always returned in ascending (oldest-first) order.
- * Combined with the `$top` cap of 50, this means only the **oldest 50 replies** are
- * returned for long threads — newer replies are silently omitted. There is currently no
- * Graph API workaround for this; pagination via `@odata.nextLink` can retrieve more
- * replies but still in ascending order only.
+ * Graph returns replies oldest-first and does not support `$orderby`, so this helper
+ * follows `@odata.nextLink` pagination under a hard page cap, then keeps the most
+ * recent `limit` replies from the collected window. This favors the newest thread
+ * context without turning one inbound message into unbounded Graph traffic.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -108,12 +109,31 @@ export async function fetchThreadReplies(
   limit = 50,
 ): Promise<GraphThreadMessage[]> {
   const top = Math.min(Math.max(limit, 1), 50);
-  // NOTE: Graph replies endpoint returns oldest-first and does not support $orderby.
-  // For threads with >50 replies, only the oldest 50 are returned. The most recent
-  // replies (often the most relevant context) may be truncated.
   const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
-  const res = await fetchGraphJson<GraphResponse<GraphThreadMessage>>({ token, path });
-  return res.value ?? [];
+  const replies: GraphThreadMessage[] = [];
+
+  let res = await fetchGraphJson<GraphPagedResponse<GraphThreadMessage>>({ token, path });
+  let pages = 1;
+
+  while (true) {
+    replies.push(...(res.value ?? []));
+
+    const nextLink = res["@odata.nextLink"];
+    if (!nextLink || pages >= THREAD_REPLIES_MAX_PAGES) {
+      break;
+    }
+
+    res = await fetchGraphAbsoluteUrl<GraphPagedResponse<GraphThreadMessage>>({
+      token,
+      url: nextLink,
+    });
+    pages++;
+  }
+
+  if (replies.length <= top) {
+    return replies;
+  }
+  return replies.slice(-top);
 }
 
 /**

--- a/extensions/msteams/src/graph-thread.ts
+++ b/extensions/msteams/src/graph-thread.ts
@@ -1,4 +1,4 @@
-import { fetchGraphAbsoluteUrl, fetchGraphJson, type GraphPagedResponse } from "./graph.js";
+import { fetchGraphAbsoluteUrl, fetchGraphJson } from "./graph.js";
 
 export type GraphThreadMessage = {
   id?: string;
@@ -8,6 +8,11 @@ export type GraphThreadMessage = {
   };
   body?: { content?: string; contentType?: string };
   createdDateTime?: string;
+};
+
+type GraphThreadRepliesResponse = {
+  value?: GraphThreadMessage[];
+  "@odata.nextLink"?: string;
 };
 
 /** Maximum number of reply pages to follow so thread enrichment stays bounded. */
@@ -96,10 +101,9 @@ export async function fetchChannelMessage(
 /**
  * Fetch thread replies for a channel message, ordered chronologically.
  *
- * Graph returns replies oldest-first and does not support `$orderby`, so this helper
- * follows `@odata.nextLink` pagination under a hard page cap, then keeps the most
- * recent `limit` replies from the collected window. This favors the newest thread
- * context without turning one inbound message into unbounded Graph traffic.
+ * Graph does not support `$orderby` for replies, so this helper follows
+ * `@odata.nextLink` pagination under a hard page cap, then keeps the most
+ * recent `limit` replies by timestamp from the collected window.
  */
 export async function fetchThreadReplies(
   token: string,
@@ -112,7 +116,7 @@ export async function fetchThreadReplies(
   const path = `/teams/${encodeURIComponent(groupId)}/channels/${encodeURIComponent(channelId)}/messages/${encodeURIComponent(messageId)}/replies?$top=${top}&$select=id,from,body,createdDateTime`;
   const replies: GraphThreadMessage[] = [];
 
-  let res = await fetchGraphJson<GraphPagedResponse<GraphThreadMessage>>({ token, path });
+  let res = await fetchGraphJson<GraphThreadRepliesResponse>({ token, path });
   let pages = 1;
 
   while (true) {
@@ -124,7 +128,7 @@ export async function fetchThreadReplies(
     }
 
     try {
-      res = await fetchGraphAbsoluteUrl<GraphPagedResponse<GraphThreadMessage>>({
+      res = await fetchGraphAbsoluteUrl<GraphThreadRepliesResponse>({
         token,
         url: nextLink,
       });
@@ -139,7 +143,57 @@ export async function fetchThreadReplies(
   if (replies.length <= top) {
     return replies;
   }
-  return replies.slice(-top);
+  return selectRecentThreadReplies(replies, top);
+}
+
+function selectRecentThreadReplies(
+  replies: GraphThreadMessage[],
+  limit: number,
+): GraphThreadMessage[] {
+  return replies
+    .map((reply, index) => ({
+      reply,
+      index,
+      createdAt: parseGraphTimestamp(reply.createdDateTime),
+    }))
+    .toSorted(compareRecentReplies)
+    .slice(0, limit)
+    .toSorted(compareThreadContextOrder)
+    .map(({ reply }) => reply);
+}
+
+function parseGraphTimestamp(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+type RankedThreadReply = {
+  reply: GraphThreadMessage;
+  index: number;
+  createdAt: number | undefined;
+};
+
+function compareRecentReplies(a: RankedThreadReply, b: RankedThreadReply): number {
+  if (a.createdAt !== undefined && b.createdAt !== undefined && a.createdAt !== b.createdAt) {
+    return b.createdAt - a.createdAt;
+  }
+  if (a.createdAt !== undefined && b.createdAt === undefined) {
+    return -1;
+  }
+  if (a.createdAt === undefined && b.createdAt !== undefined) {
+    return 1;
+  }
+  return b.index - a.index;
+}
+
+function compareThreadContextOrder(a: RankedThreadReply, b: RankedThreadReply): number {
+  if (a.createdAt !== undefined && b.createdAt !== undefined && a.createdAt !== b.createdAt) {
+    return a.createdAt - b.createdAt;
+  }
+  return a.index - b.index;
 }
 
 /**


### PR DESCRIPTION
Title: fix(msteams): paginate thread replies and keep recent context

## Summary

- Problem: Teams thread context enrichment only used the first Graph replies page, so long threads could skew toward the oldest replies.
- Why it matters: the bot could miss the newest thread context, which is usually the most relevant context for a channel-thread reply.
- What changed: `fetchThreadReplies` now follows `@odata.nextLink` under a hard page cap and returns the most recent bounded reply window instead of only the first page.
- What did NOT change (scope boundary): no live-tenant Graph validation, no changes to higher-level message-handler behavior, and no prompt-formatting changes beyond the selected reply window.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Teams thread helper fetched only the initial Graph replies page even when Graph exposed additional pages via `@odata.nextLink`.
- Missing detection / guardrail: there was no unit coverage for paginated reply retrieval or for preferring the newest bounded reply window.
- Contributing context (if known): the Graph replies endpoint is oldest-first and does not support `$orderby`, so a single-page implementation silently favors stale context on long threads.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/msteams/src/graph-thread.test.ts`
- Scenario the test should lock in: when Graph returns multiple reply pages for a channel thread, the helper follows pagination and keeps the most recent bounded reply window rather than only the first page.
- Why this is the smallest reliable guardrail: the bug is isolated to the Graph reply helper and can be reproduced deterministically with mocked paginated Graph responses.
- Existing test that already covers this (if any): none before this change.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Long Teams channel threads can now contribute newer reply context to the bot instead of only the oldest reply page.
- Behavior stays best-effort: if Graph pagination or fetches fail, the surrounding handler still degrades gracefully as before.

## Diagram (if applicable)

```text
Before:
[long Teams thread] -> [fetch first replies page only] -> [oldest replies injected] -> [bot may miss latest context]

After:
[long Teams thread] -> [follow paginated replies with hard cap] -> [keep most recent bounded window] -> [bot sees newer thread context]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (Yes)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:
  - Risk: this can issue additional Graph requests for long threads.
  - Mitigation: pagination is capped at 10 pages and the helper still returns only the requested bounded reply window.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: repo-local Node via `pnpm openclaw`
- Model/provider: N/A
- Integration/channel (if any): MSTeams Graph helper unit tests
- Relevant config (redacted): N/A

### Steps

1. Mock the first Graph replies page with `reply-1`, `reply-2`, and an `@odata.nextLink`.
2. Mock the second page with `reply-3`, `reply-4`.
3. Call `fetchThreadReplies(..., limit=2)`.

### Expected

- The helper should follow the next link and return the newest bounded window: `reply-3`, `reply-4`.

### Actual

- Before the fix, the helper would only use the first page and return `reply-1`, `reply-2`, dropping the newer page entirely.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted unit run for `extensions/msteams/src/graph-thread.test.ts`; paginated reply path; hard page-cap path; existing thread-helper tests remained green.
- Edge cases checked: missing `value`, min/max limit clamping, bounded pagination cap.
- What you did **not** verify: live Microsoft Graph behavior against a real Teams tenant or real long thread pagination ordering/latency.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: Microsoft Graph pagination behavior for long Teams threads has not been validated against a real tenant in this change.
  - Mitigation: the PR makes the assumption explicit, keeps the change local to the helper, and adds deterministic regression tests around the intended pagination behavior.
- Risk: extra Graph fetches could increase latency on large threads.
  - Mitigation: page following is hard-capped and still returns only a bounded recent window.
