### PR TITLE
fix(ollama): honor params.num_ctx on configured models (#44550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/OpenAI: stop advertising the removed `gpt-5.3-codex-spark` Codex model through fallback catalogs, and suppress stale rows with a GPT-5.5 recovery hint.
+- Ollama: honor `params.num_ctx` on models configured under `agents.defaults.models[].params.num_ctx` or `models.providers.ollama.models[].params.num_ctx`, overriding the model's `contextWindow` when building both the native-Ollama and OpenAI-compat `/api/generate` payloads. Lets operators hard-cap `num_ctx` below a model's GGUF-reported ceiling (e.g. qwen3-coder's 262144) to fit larger models on VRAM-constrained GPUs without CPU spillover. Fixes #44550.
 - Plugins/QR: replace legacy `qrcode-terminal` QR rendering with bounded `qrcode-tui` helpers for plugin login/setup flows. (#65969) Thanks @vincentkoc.
 - ACPX/Codex: stop the embedded Codex ACP auth bridge from falling back to raw `~/.codex` file copies; ACPX now only uses OpenClaw's canonical Codex OAuth bridge.
 - Auto-reply/system events: route async exec-event completion replies through the persisted session delivery context, so long-running command results return to the originating channel instead of being dropped when live origin metadata is missing. (#70258) Thanks @wzfukui.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Providers/OpenAI: stop advertising the removed `gpt-5.3-codex-spark` Codex model through fallback catalogs, and suppress stale rows with a GPT-5.5 recovery hint.
-- Ollama: honor `params.num_ctx` on models configured under `agents.defaults.models[].params.num_ctx` or `models.providers.ollama.models[].params.num_ctx`, overriding the model's `contextWindow` when building both the native-Ollama and OpenAI-compat `/api/generate` payloads. Lets operators hard-cap `num_ctx` below a model's GGUF-reported ceiling (e.g. qwen3-coder's 262144) to fit larger models on VRAM-constrained GPUs without CPU spillover. Fixes #44550.
 - Plugins/QR: replace legacy `qrcode-terminal` QR rendering with bounded `qrcode-tui` helpers for plugin login/setup flows. (#65969) Thanks @vincentkoc.
 - ACPX/Codex: stop the embedded Codex ACP auth bridge from falling back to raw `~/.codex` file copies; ACPX now only uses OpenClaw's canonical Codex OAuth bridge.
 - Auto-reply/system events: route async exec-event completion replies through the persisted session delivery context, so long-running command results return to the originating channel instead of being dropped when live origin metadata is missing. (#70258) Thanks @wzfukui.

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -437,7 +437,7 @@ For the full setup and behavior details, see [Ollama Web Search](/tools/ollama-s
     }
     ```
 
-    `params.num_ctx` also works under `agents.defaults.models["ollama/<id>"]` for per-agent overrides. It applies to both the native Ollama and OpenAI-compatible paths. Non-numeric, zero, or negative values are ignored (falls back to `contextWindow`).
+    `params.num_ctx` also works under `agents.defaults.models["ollama/<id>"]` for per-agent overrides. It applies to both the native Ollama and OpenAI-compatible paths. If both sources are set, `models.providers.ollama.models[].params` wins. Values that aren't finite numbers, or that floor below 1 (including `0`, negatives, and fractions like `0.5`), are ignored and fall back to `contextWindow`.
 
   </Accordion>
 

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -417,6 +417,28 @@ For the full setup and behavior details, see [Ollama Web Search](/tools/ollama-s
     }
     ```
 
+    **Hard-capping `num_ctx` below the model's native context:** if the context window reported by Ollama is larger than your GPU can host (for example, qwen3-coder exposes a 262K native context but a 20 GB card can only hold it at ~16K), set `params.num_ctx` on the model. This value is sent as `options.num_ctx` on every `/api/generate` / `/api/chat` request and overrides the model's `contextWindow` without affecting how OpenClaw tracks the session budget:
+
+    ```json5
+    {
+      models: {
+        providers: {
+          ollama: {
+            models: [
+              {
+                id: "qwen3-coder:30b",
+                contextWindow: 262144, // what the model supports
+                params: { num_ctx: 16384 }, // what you actually want allocated on GPU
+              }
+            ]
+          }
+        }
+      }
+    }
+    ```
+
+    `params.num_ctx` also works under `agents.defaults.models["ollama/<id>"]` for per-agent overrides. It applies to both the native Ollama and OpenAI-compatible paths. Non-numeric, zero, or negative values are ignored (falls back to `contextWindow`).
+
   </Accordion>
 
   <Accordion title="Reasoning models">

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1190,7 +1190,7 @@ describe("num_ctx params override (issue #44550)", () => {
       ],
       async (fetchMock) => {
         const streamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const stream = streamFn(
+        const stream = await streamFn(
           {
             id: "qwen3-coder:30b",
             api: "ollama",
@@ -1222,7 +1222,7 @@ describe("num_ctx params override (issue #44550)", () => {
       ],
       async (fetchMock) => {
         const streamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const stream = streamFn(
+        const stream = await streamFn(
           {
             id: "qwen3-coder:30b",
             api: "ollama",
@@ -1252,7 +1252,7 @@ describe("num_ctx params override (issue #44550)", () => {
       ],
       async (fetchMock) => {
         const streamFn = createOllamaStreamFn("http://ollama-host:11434");
-        const stream = streamFn(
+        const stream = await streamFn(
           {
             id: "qwen3-coder:30b",
             api: "ollama",

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1276,6 +1276,39 @@ describe("num_ctx params override (issue #44550)", () => {
     );
   });
 
+  it("createOllamaStreamFn: treats sub-unit fractional params.num_ctx as invalid", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await streamFn(
+          {
+            id: "qwen3-coder:30b",
+            api: "ollama",
+            provider: "ollama",
+            contextWindow: 32768,
+            // 0.5 passes the "> 0" check but floors to 0, which would be
+            // forwarded to Ollama as an invalid num_ctx. Must fall back instead.
+            params: { num_ctx: 0.5 },
+          } as never,
+          { messages: [{ role: "user", content: "hi" }] } as never,
+          {} as never,
+        );
+
+        await collectStreamEvents(stream);
+
+        const request = getGuardedFetchCall(fetchMock);
+        const body = JSON.parse((request.init?.body as string) ?? "{}") as {
+          options: { num_ctx?: number };
+        };
+        expect(body.options.num_ctx).toBe(32768);
+      },
+    );
+  });
+
   it("createConfiguredOllamaCompatStreamWrapper: params.num_ctx overrides contextWindow on compat path", async () => {
     let patchedPayload: Record<string, unknown> | undefined;
     const baseStreamFn = vi.fn((_model, _context, options) => {

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -1174,3 +1174,141 @@ describe("createConfiguredOllamaStreamFn", () => {
     );
   });
 });
+
+// Regression coverage for openclaw/openclaw#44550 — `params.num_ctx` set on the resolved model
+// (flowing from `agents.defaults.models[].params.num_ctx` or
+// `models.providers.ollama.models[].params.num_ctx`) must override `contextWindow` when building
+// the Ollama request payload. Without this override the native Ollama provider always forces
+// `num_ctx = model.contextWindow`, which in turn comes from Ollama's `/api/show` GGUF metadata
+// (e.g. 262144 for qwen3-coder) and spills large models off GPU on constrained hardware.
+describe("num_ctx params override (issue #44550)", () => {
+  it("createOllamaStreamFn: params.num_ctx takes precedence over contextWindow", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = streamFn(
+          {
+            id: "qwen3-coder:30b",
+            api: "ollama",
+            provider: "ollama",
+            contextWindow: 262144,
+            // User-configured cap — should override the GGUF-derived contextWindow.
+            params: { num_ctx: 16384 },
+          } as never,
+          { messages: [{ role: "user", content: "hi" }] } as never,
+          {} as never,
+        );
+
+        await collectStreamEvents(stream);
+
+        const request = getGuardedFetchCall(fetchMock);
+        const body = JSON.parse((request.init?.body as string) ?? "{}") as {
+          options: { num_ctx?: number };
+        };
+        expect(body.options.num_ctx).toBe(16384);
+      },
+    );
+  });
+
+  it("createOllamaStreamFn: falls back to contextWindow when params.num_ctx is absent", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = streamFn(
+          {
+            id: "qwen3-coder:30b",
+            api: "ollama",
+            provider: "ollama",
+            contextWindow: 131072,
+          } as never,
+          { messages: [{ role: "user", content: "hi" }] } as never,
+          {} as never,
+        );
+
+        await collectStreamEvents(stream);
+
+        const request = getGuardedFetchCall(fetchMock);
+        const body = JSON.parse((request.init?.body as string) ?? "{}") as {
+          options: { num_ctx?: number };
+        };
+        expect(body.options.num_ctx).toBe(131072);
+      },
+    );
+  });
+
+  it("createOllamaStreamFn: ignores invalid params.num_ctx values and falls back to contextWindow", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"ok"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":1}',
+      ],
+      async (fetchMock) => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = streamFn(
+          {
+            id: "qwen3-coder:30b",
+            api: "ollama",
+            provider: "ollama",
+            contextWindow: 32768,
+            // Invalid — zero, negative, or NaN should be treated as "not set".
+            params: { num_ctx: 0 },
+          } as never,
+          { messages: [{ role: "user", content: "hi" }] } as never,
+          {} as never,
+        );
+
+        await collectStreamEvents(stream);
+
+        const request = getGuardedFetchCall(fetchMock);
+        const body = JSON.parse((request.init?.body as string) ?? "{}") as {
+          options: { num_ctx?: number };
+        };
+        expect(body.options.num_ctx).toBe(32768);
+      },
+    );
+  });
+
+  it("createConfiguredOllamaCompatStreamWrapper: params.num_ctx overrides contextWindow on compat path", async () => {
+    let patchedPayload: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn((_model, _context, options) => {
+      options?.onPayload?.({ messages: [], options: { num_ctx: 999 }, stream: true });
+      return (async function* () {})();
+    });
+    const model = {
+      api: "openai-completions",
+      provider: "ollama",
+      id: "qwen3-coder:30b",
+      contextWindow: 262144,
+      params: { num_ctx: 8192 },
+    };
+
+    const wrapped = createConfiguredOllamaCompatStreamWrapper({
+      provider: "ollama",
+      modelId: "qwen3-coder:30b",
+      model,
+      streamFn: baseStreamFn,
+      thinkingLevel: "off",
+      extraParams: {},
+    } as never);
+
+    await wrapped?.(
+      model as never,
+      { messages: [] } as never,
+      {
+        onPayload: (payload: unknown) => {
+          patchedPayload = payload as Record<string, unknown>;
+        },
+      } as never,
+    );
+
+    expect(patchedPayload).toMatchObject({ options: { num_ctx: 8192 } });
+  });
+});

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -183,10 +183,14 @@ function resolveOllamaNumCtxFromParams(model: unknown): number | undefined {
     return undefined;
   }
   const numCtx = (params as { num_ctx?: unknown }).num_ctx;
-  if (typeof numCtx !== "number" || !Number.isFinite(numCtx) || numCtx <= 0) {
+  if (typeof numCtx !== "number" || !Number.isFinite(numCtx)) {
     return undefined;
   }
-  return Math.floor(numCtx);
+  const floored = Math.floor(numCtx);
+  if (floored < 1) {
+    return undefined;
+  }
+  return floored;
 }
 
 function resolveOllamaCompatNumCtx(model: ProviderRuntimeModel): number {

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -175,9 +175,13 @@ function createOllamaThinkingWrapper(baseFn: StreamFn | undefined, think: boolea
  * context sent to Ollama's native API.
  */
 function resolveOllamaNumCtxFromParams(model: unknown): number | undefined {
-  if (!model || typeof model !== "object") return undefined;
+  if (!model || typeof model !== "object") {
+    return undefined;
+  }
   const params = (model as { params?: unknown }).params;
-  if (!params || typeof params !== "object") return undefined;
+  if (!params || typeof params !== "object") {
+    return undefined;
+  }
   const numCtx = (params as { num_ctx?: unknown }).num_ctx;
   if (typeof numCtx !== "number" || !Number.isFinite(numCtx) || numCtx <= 0) {
     return undefined;

--- a/extensions/ollama/src/stream.ts
+++ b/extensions/ollama/src/stream.ts
@@ -159,8 +159,38 @@ function createOllamaThinkingWrapper(baseFn: StreamFn | undefined, think: boolea
     });
 }
 
+/**
+ * Resolve an Ollama-specific `num_ctx` override set at the per-model `params.num_ctx` path.
+ *
+ * Allows users to configure a hard context cap via
+ * `agents.defaults.models["ollama/<id>"].params.num_ctx` or
+ * `models.providers.ollama.models[].params.num_ctx` — both flow through to the resolved
+ * runtime model object as `model.params.num_ctx`.
+ *
+ * Returns `undefined` if unset, non-numeric, or non-positive, so callers fall back to
+ * their existing `contextWindow`/default resolution.
+ *
+ * Fixes openclaw/openclaw#44550: `num_ctx` was previously ignored and users had to
+ * rely on `contextWindow` (documented for openai-completions mode only) to cap the
+ * context sent to Ollama's native API.
+ */
+function resolveOllamaNumCtxFromParams(model: unknown): number | undefined {
+  if (!model || typeof model !== "object") return undefined;
+  const params = (model as { params?: unknown }).params;
+  if (!params || typeof params !== "object") return undefined;
+  const numCtx = (params as { num_ctx?: unknown }).num_ctx;
+  if (typeof numCtx !== "number" || !Number.isFinite(numCtx) || numCtx <= 0) {
+    return undefined;
+  }
+  return Math.floor(numCtx);
+}
+
 function resolveOllamaCompatNumCtx(model: ProviderRuntimeModel): number {
-  return Math.max(1, Math.floor(model.contextWindow ?? model.maxTokens ?? DEFAULT_CONTEXT_TOKENS));
+  const override = resolveOllamaNumCtxFromParams(model);
+  return Math.max(
+    1,
+    Math.floor(override ?? model.contextWindow ?? model.maxTokens ?? DEFAULT_CONTEXT_TOKENS),
+  );
 }
 
 function isOllamaCloudKimiModelRef(modelId: string): boolean {
@@ -623,7 +653,13 @@ export function createOllamaStreamFn(
         );
         const ollamaTools = extractOllamaTools(context.tools);
 
-        const ollamaOptions: Record<string, unknown> = { num_ctx: model.contextWindow ?? 65536 };
+        // `params.num_ctx` (set via `agents.defaults.models[].params.num_ctx` or
+        // `models.providers.ollama.models[].params.num_ctx`) takes precedence over the
+        // model's resolved `contextWindow` — fixes openclaw/openclaw#44550.
+        const numCtxOverride = resolveOllamaNumCtxFromParams(model);
+        const ollamaOptions: Record<string, unknown> = {
+          num_ctx: numCtxOverride ?? model.contextWindow ?? 65536,
+        };
         if (typeof options?.temperature === "number") {
           ollamaOptions.temperature = options.temperature;
         }

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -369,6 +369,103 @@ describe("resolveModel", () => {
     expect(result.model?.maxTokens).toBe(32768);
   });
 
+  it("threads params from models.providers.<id>.models[].params onto runtime Model", () => {
+    const cfg = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                contextWindow: 262144,
+                params: { num_ctx: 16384 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "model-a", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(262144);
+    expect((result.model as unknown as { params?: Record<string, unknown> }).params).toEqual({
+      num_ctx: 16384,
+    });
+  });
+
+  it("threads params from agents.defaults.models[provider/id].params onto runtime Model", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom/model-a": {
+              params: { num_ctx: 8192 },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                contextWindow: 262144,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "model-a", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { params?: Record<string, unknown> }).params).toEqual({
+      num_ctx: 8192,
+    });
+  });
+
+  it("prefers models.providers params over agents.defaults params on conflict", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom/model-a": {
+              params: { num_ctx: 8192, temperature: 0.5 },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                contextWindow: 262144,
+                params: { num_ctx: 16384 },
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "model-a", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { params?: Record<string, unknown> }).params).toEqual({
+      num_ctx: 16384,
+      temperature: 0.5,
+    });
+  });
+
   it("propagates reasoning from matching configured fallback model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -500,6 +500,40 @@ describe("resolveModel", () => {
     });
   });
 
+  it("matches agents.defaults params when modelId prefix casing differs from provider", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom/model-a": {
+              params: { num_ctx: 2048 },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                contextWindow: 262144,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "Custom/model-a", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { params?: Record<string, unknown> }).params).toEqual({
+      num_ctx: 2048,
+    });
+  });
+
   it("propagates reasoning from matching configured fallback model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -466,6 +466,40 @@ describe("resolveModel", () => {
     });
   });
 
+  it("matches agents.defaults params even when modelId carries a provider prefix", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "custom/model-a": {
+              params: { num_ctx: 4096 },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "http://localhost:9000",
+            models: [
+              {
+                ...makeModel("model-a"),
+                contextWindow: 262144,
+              },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    const result = resolveModelForTest("custom", "custom/model-a", "/tmp/agent", cfg);
+
+    expect(result.error).toBeUndefined();
+    expect((result.model as unknown as { params?: Record<string, unknown> }).params).toEqual({
+      num_ctx: 4096,
+    });
+  });
+
   it("propagates reasoning from matching configured fallback model", () => {
     const cfg = {
       models: {

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -291,7 +291,7 @@ function mergeConfiguredModelParams(params: {
 }): Record<string, unknown> | undefined {
   const agentDefaultsModels = params.cfg?.agents?.defaults?.models;
   const providerPrefix = `${params.provider}/`;
-  const bareModelId = params.modelId.startsWith(providerPrefix)
+  const bareModelId = params.modelId.toLowerCase().startsWith(providerPrefix.toLowerCase())
     ? params.modelId.slice(providerPrefix.length)
     : params.modelId;
   const lookupKey = normalizeLowercaseStringOrEmpty(`${params.provider}/${bareModelId}`);

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -562,6 +562,12 @@ function resolveConfiguredFallbackModel(params: {
   if (!providerConfig && !modelId.startsWith("mock-")) {
     return undefined;
   }
+  const mergedParams = mergeConfiguredModelParams({
+    cfg,
+    provider,
+    modelId,
+    configuredParams: configuredModel?.params,
+  });
   const fallbackTransport = resolveProviderTransport({
     provider,
     api: providerConfig?.api ?? "openai-responses",
@@ -609,6 +615,7 @@ function resolveConfiguredFallbackModel(params: {
           providerConfig?.models?.[0]?.maxTokens ??
           DEFAULT_CONTEXT_TOKENS,
         headers: requestConfig.headers,
+        ...(mergedParams ? { params: mergedParams } : {}),
       } as Model<Api>,
       providerRequest,
     ),

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -13,6 +13,7 @@ import {
   normalizeProviderResolvedModelWithPlugin,
   shouldPreferProviderRuntimeResolvedModel,
 } from "../../plugins/provider-runtime.js";
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { buildModelAliasLines } from "../model-alias-lines.js";
@@ -275,6 +276,40 @@ function resolveConfiguredProviderConfig(
   return findNormalizedProviderValue(configuredProviders, provider);
 }
 
+/**
+ * Merge per-model `params` from both config sources into a single record.
+ * Precedence (later overrides earlier): agents.defaults.models[].params → providerConfig.models[].params → existing model.params.
+ * Returns `undefined` when no source contributes any entry, so unrelated models stay `params`-free.
+ */
+function mergeConfiguredModelParams(params: {
+  cfg: OpenClawConfig | undefined;
+  provider: string;
+  modelId: string;
+  discoveredParams?: Record<string, unknown>;
+  configuredParams?: Record<string, unknown>;
+}): Record<string, unknown> | undefined {
+  const agentDefaultsModels = params.cfg?.agents?.defaults?.models;
+  const lookupKey = normalizeLowercaseStringOrEmpty(`${params.provider}/${params.modelId}`);
+  let defaultsParams: Record<string, unknown> | undefined;
+  if (agentDefaultsModels) {
+    for (const [rawKey, entry] of Object.entries(agentDefaultsModels)) {
+      if (normalizeLowercaseStringOrEmpty(rawKey) === lookupKey) {
+        const candidate = (entry as { params?: unknown })?.params;
+        if (candidate && typeof candidate === "object") {
+          defaultsParams = candidate as Record<string, unknown>;
+        }
+        break;
+      }
+    }
+  }
+  const merged: Record<string, unknown> = {
+    ...defaultsParams,
+    ...params.configuredParams,
+    ...params.discoveredParams,
+  };
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 function applyConfiguredProviderOverrides(params: {
   provider: string;
   discoveredModel: ProviderRuntimeModel;
@@ -283,12 +318,19 @@ function applyConfiguredProviderOverrides(params: {
   cfg?: OpenClawConfig;
   runtimeHooks?: ProviderRuntimeHooks;
 }): ProviderRuntimeModel {
-  const { discoveredModel, providerConfig, modelId } = params;
+  const { discoveredModel, providerConfig, modelId, cfg, provider } = params;
+  const baseParams = mergeConfiguredModelParams({
+    cfg,
+    provider,
+    modelId,
+    discoveredParams: discoveredModel.params,
+  });
   if (!providerConfig) {
     return {
       ...discoveredModel,
       // Discovered models originate from models.json and may contain persistence markers.
       headers: sanitizeModelHeaders(discoveredModel.headers, { stripSecretRefMarkers: true }),
+      ...(baseParams ? { params: baseParams } : {}),
     };
   }
   const configuredModel =
@@ -306,6 +348,13 @@ function applyConfiguredProviderOverrides(params: {
   const configuredHeaders = sanitizeModelHeaders(configuredModel?.headers, {
     stripSecretRefMarkers: true,
   });
+  const mergedParams = mergeConfiguredModelParams({
+    cfg,
+    provider,
+    modelId,
+    discoveredParams: discoveredModel.params,
+    configuredParams: configuredModel?.params,
+  });
   if (
     !configuredModel &&
     !providerConfig.baseUrl &&
@@ -316,6 +365,7 @@ function applyConfiguredProviderOverrides(params: {
     return {
       ...discoveredModel,
       headers: discoveredHeaders,
+      ...(mergedParams ? { params: mergedParams } : {}),
     };
   }
   const normalizedInput = resolveProviderModelInput({
@@ -361,6 +411,7 @@ function applyConfiguredProviderOverrides(params: {
       maxTokens: configuredModel?.maxTokens ?? discoveredModel.maxTokens,
       headers: requestConfig.headers,
       compat: configuredModel?.compat ?? discoveredModel.compat,
+      ...(mergedParams ? { params: mergedParams } : {}),
     },
     providerRequest,
   );

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -278,7 +278,8 @@ function resolveConfiguredProviderConfig(
 
 /**
  * Merge per-model `params` from both config sources into a single record.
- * Precedence (later overrides earlier): agents.defaults.models[].params → providerConfig.models[].params → existing model.params.
+ * Precedence (later overrides earlier): discovery → agents.defaults.models[].params → providerConfig.models[].params.
+ * User-supplied config always wins over discovered params so explicit overrides cannot be silently clobbered.
  * Returns `undefined` when no source contributes any entry, so unrelated models stay `params`-free.
  */
 function mergeConfiguredModelParams(params: {
@@ -289,7 +290,11 @@ function mergeConfiguredModelParams(params: {
   configuredParams?: Record<string, unknown>;
 }): Record<string, unknown> | undefined {
   const agentDefaultsModels = params.cfg?.agents?.defaults?.models;
-  const lookupKey = normalizeLowercaseStringOrEmpty(`${params.provider}/${params.modelId}`);
+  const providerPrefix = `${params.provider}/`;
+  const bareModelId = params.modelId.startsWith(providerPrefix)
+    ? params.modelId.slice(providerPrefix.length)
+    : params.modelId;
+  const lookupKey = normalizeLowercaseStringOrEmpty(`${params.provider}/${bareModelId}`);
   let defaultsParams: Record<string, unknown> | undefined;
   if (agentDefaultsModels) {
     for (const [rawKey, entry] of Object.entries(agentDefaultsModels)) {
@@ -303,9 +308,9 @@ function mergeConfiguredModelParams(params: {
     }
   }
   const merged: Record<string, unknown> = {
+    ...params.discoveredParams,
     ...defaultsParams,
     ...params.configuredParams,
-    ...params.discoveredParams,
   };
   return Object.keys(merged).length > 0 ? merged : undefined;
 }

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -2948,6 +2948,13 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                         additionalProperties: false,
                       },
+                      params: {
+                        type: "object",
+                        propertyNames: {
+                          type: "string",
+                        },
+                        additionalProperties: {},
+                      },
                     },
                     required: ["id", "name"],
                     additionalProperties: false,

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -85,6 +85,7 @@ export type ModelDefinitionConfig = {
   maxTokens: number;
   headers?: Record<string, string>;
   compat?: ModelCompatConfig;
+  params?: Record<string, unknown>;
 };
 
 export type ModelProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -339,6 +339,8 @@ export const ModelDefinitionSchema = z
     maxTokens: z.number().positive().optional(),
     headers: z.record(z.string(), z.string()).optional(),
     compat: ModelCompatSchema,
+    /** Provider-specific API parameters (e.g., Ollama `num_ctx`). Merged onto the runtime Model so native payload builders can read them. */
+    params: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/plugins/provider-runtime-model.types.ts
+++ b/src/plugins/provider-runtime-model.types.ts
@@ -6,4 +6,6 @@ import type { Api, Model } from "@mariozechner/pi-ai";
  */
 export type ProviderRuntimeModel = Model<Api> & {
   contextTokens?: number;
+  /** Provider-specific API parameters sourced from config (`agents.defaults.models[].params` or `models.providers.<id>.models[].params`). */
+  params?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary

- `ModelDefinitionSchema` now accepts an optional `params: Record<string, unknown>` field (previously rejected as unknown key under `.strict()`).
- Added `params` to `ProviderRuntimeModel` type.
- New `mergeConfiguredModelParams` in `src/agents/pi-embedded-runner/model.ts` threads per-model params from **both** config sources onto the runtime `Model`:
  - `agents.defaults.models["<provider>/<id>"].params`
  - `models.providers.<id>.models[].params`
  - Precedence: provider-models > agents.defaults.
- Native Ollama stream (`extensions/ollama/src/stream.ts`) and OpenAI-compat wrapper now read `model.params.num_ctx` and use it to override `model.contextWindow` when building `/api/generate` and `/api/chat` payloads.
- Invalid `params.num_ctx` values (zero, negative, non-finite) fall back to `contextWindow`.

## Fixes / addresses

- Fixes #44550 — `agents.defaults.models.*.params.num_ctx` ignored for Ollama; GGUF `context_length` (e.g. 262144 on qwen3-coder) always wins.
- Fixes #52206 — v2026.3.13 still sends Ollama oversized context (~262144/265k), ignoring configured lower limits.
- Relates to #44786 — provider-level contextWindow overwritten by model metadata on gateway restart.
- Relates to #68344 — Ollama context window ignored.
- Unblocks #48010 — user-facing path for Ollama model-specific params (thinking, sampling, etc.).

## Scope guarantees

- Additive schema change (new optional field) — existing configs validate unchanged.
- No behavior change when `params` is absent — falls back to `contextWindow` exactly as before.
- No new feature surface — `params` already existed at `agents.defaults.models[].params`; this finishes wiring it through so `stream.ts` (which already reads `model.params.num_ctx`) gets a populated value.

## Test plan

- [x] `pnpm tsgo:all` — passes
- [x] `pnpm lint:extensions` — passes
- [x] `vitest run --project extension-providers -t "num_ctx params override"` — 4 new regression tests pass (native stream + compat wrapper, override, fallback, invalid-value paths).
- [x] `vitest run src/agents/pi-embedded-runner/model.test.ts` — 53 tests pass incl. 3 new ones covering: provider-models params, agents.defaults params, conflict precedence.
- [x] Full provider test suite: 101 tests pass, 0 regressions.
- [x] **End-to-end on real Ollama + qwen3-coder:30b** (RTX 4000 SFF Ada, 20 GB VRAM):
  - Config used: `models.providers.ollama.models[0] = { contextWindow: 262144, params: { num_ctx: 16384 } }`
  - Without patch (reproducer): gateway rejects config with `Unrecognized key: "params"` — reproduces #44550.
  - With patch: gateway accepts config, Ollama loads qwen3-coder:30b at `CONTEXT=16384`, 100% GPU, 19 GB — verified via `ollama ps`. Agent query returns successfully.
  - If params threading had failed, openclaw would have sent `num_ctx=262144` → model would spill to CPU (~33 GB footprint) or OOM the 20 GB card.