### PR TITLE
fix(channels): disambiguate status --deep tip to top-level openclaw status

### DIFF
--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -105,7 +105,7 @@ export function registerChannelsCli(program: Command) {
 
   channels
     .command("status")
-    .description("Show gateway channel status (use status --deep for local)")
+    .description("Show gateway channel status (use `openclaw status --deep` for local health probes)")
     .option("--probe", "Probe channel credentials", false)
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--json", "Output JSON", false)

--- a/src/commands/channels/status-config-format.ts
+++ b/src/commands/channels/status-config-format.ts
@@ -82,7 +82,7 @@ export async function formatConfigChannelsStatusLines(
 
   lines.push("");
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: ${formatDocsLink("/cli#status", "openclaw status --deep")} adds gateway health probes to status output (requires a reachable gateway). The nested \`channels status\` command does not accept \`--deep\` — use the top-level \`openclaw status --deep\` instead.`,
   );
   return lines;
 }

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -139,7 +139,7 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
     lines.push("");
   }
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: ${formatDocsLink("/cli#status", "openclaw status --deep")} adds gateway health probes to status output (requires a reachable gateway). The nested \`channels status\` command does not accept \`--deep\` — use the top-level \`openclaw status --deep\` instead.`,
   );
   return lines;
 }


### PR DESCRIPTION
## Problem

\`openclaw channels status\` advertised a \`status --deep\` tip in two places (\`status.ts:142\`, \`status-config-format.ts:85\`) and in its own --help description (\`channels-cli.ts:108\`), but the nested command only accepts \`--json\`, \`--probe\`, \`--timeout\`. Users reading the tip and running \`openclaw channels status --deep\` got \`error: unknown option '--deep'\` (reported by @fabianfabian in #69341).

\`--deep\` does exist, but only on the top-level \`openclaw status\` (\`register.status-health-sessions.ts:59\`).

## Fix

Qualify every reference as \`openclaw status --deep\` instead of bare \`status --deep\`, and add one sentence explicitly noting the nested subcommand does not accept it. No behavior change; pure docs/text.

## Testing

- \`oxlint\` clean on touched files.
- No existing test strings reference the old tip text (grep confirmed).

Fixes #69341