### PR TITLE
fix(runner): ancestry-aware cleanup of rewrite-abandoned transcript entries

### DIFF
--- a/src/agents/pi-embedded-runner/fixtures/repro-69486-lineage-from-production.ts
+++ b/src/agents/pi-embedded-runner/fixtures/repro-69486-lineage-from-production.ts
@@ -1,0 +1,133 @@
+// Production-derived fixture for PR #69486.
+// Source stem: <openclaw-agent-sessions>/main/sessions/f65ebb43-8526-40ee-856f-4706a3f353d4
+// Redaction: all user text, tool outputs, compaction summaries, provider/model ids,
+// cwd, thinkingSignatures, encrypted_content — replaced with placeholders.
+// Opaque real IDs pseudonymized for readability. Lineage shape preserved 1:1.
+
+type RawEntry = Record<string, unknown>;
+
+export const repro69486LineageFromProduction: RawEntry[] = [
+  {
+    type: "session",
+    version: 3,
+    id: "session-root",
+    timestamp: "2026-04-18T02:00:00.000Z",
+    cwd: "REDACTED_WORKDIR",
+  },
+  {
+    type: "model_change",
+    id: "model-change-1",
+    parentId: null,
+    timestamp: "2026-04-18T02:00:00.001Z",
+    provider: "REDACTED",
+    modelId: "REDACTED",
+  },
+  {
+    type: "thinking_level_change",
+    id: "thinking-change-1",
+    parentId: "model-change-1",
+    timestamp: "2026-04-18T02:00:00.002Z",
+    thinkingLevel: "high",
+  },
+  {
+    type: "message",
+    id: "msg-user-1",
+    parentId: "session-root",
+    timestamp: "2026-04-18T02:00:30.000Z",
+    message: {
+      role: "user",
+      content: [{ type: "text", text: "[redacted user prompt]" }],
+    },
+  },
+  {
+    type: "message",
+    id: "msg-assistant-parent",
+    parentId: "msg-user-1",
+    timestamp: "2026-04-18T02:01:03.038Z",
+    message: {
+      role: "assistant",
+      content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+    },
+  },
+  {
+    type: "message",
+    id: "msg-toolresult-1a",
+    parentId: "msg-assistant-parent",
+    timestamp: "2026-04-18T02:01:07.363Z",
+    message: {
+      role: "toolResult",
+      content: [
+        {
+          type: "toolResult",
+          toolCallId: "call_1",
+          content: [{ type: "text", text: "[redacted tool output A]" }],
+        },
+      ],
+    },
+  },
+  {
+    type: "compaction",
+    id: "compaction-1",
+    parentId: "msg-toolresult-1a",
+    timestamp: "2026-04-18T05:30:23.965Z",
+    summary: "[redacted compaction summary]",
+  },
+  {
+    type: "compaction",
+    id: "compaction-2",
+    parentId: "compaction-1",
+    timestamp: "2026-04-18T05:33:07.098Z",
+    summary: "[redacted compaction summary]",
+  },
+  {
+    type: "compaction",
+    id: "compaction-3",
+    parentId: "compaction-2",
+    timestamp: "2026-04-18T05:33:09.196Z",
+    summary: "[redacted compaction summary]",
+  },
+  {
+    type: "compaction",
+    id: "compaction-4",
+    parentId: "compaction-3",
+    timestamp: "2026-04-18T05:33:11.279Z",
+    summary: "[redacted compaction summary]",
+  },
+  {
+    type: "message",
+    id: "msg-toolresult-1b",
+    parentId: "msg-assistant-parent",
+    timestamp: "2026-04-18T05:33:12.173Z",
+    message: {
+      role: "toolResult",
+      content: [
+        {
+          type: "toolResult",
+          toolCallId: "call_1",
+          content: [{ type: "text", text: "[redacted tool output B]" }],
+        },
+      ],
+    },
+  },
+  {
+    type: "compaction",
+    id: "compaction-burst-1",
+    parentId: "msg-toolresult-1b",
+    timestamp: "2026-04-18T05:33:12.185Z",
+    summary: "[redacted]",
+  },
+  {
+    type: "compaction",
+    id: "compaction-burst-2",
+    parentId: "compaction-burst-1",
+    timestamp: "2026-04-18T05:33:12.196Z",
+    summary: "[redacted]",
+  },
+  {
+    type: "compaction",
+    id: "compaction-burst-3",
+    parentId: "compaction-burst-2",
+    timestamp: "2026-04-18T05:33:12.208Z",
+    summary: "[redacted]",
+  },
+];

--- a/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
@@ -9,6 +9,7 @@ import {
   makeAgentToolResultMessage,
   makeAgentUserMessage,
 } from "../test-helpers/agent-message-fixtures.js";
+import { repro69486LineageFromProduction } from "./fixtures/repro-69486-lineage-from-production.js";
 import { rewriteTranscriptEntriesInSessionFile } from "./transcript-rewrite.js";
 
 type RawEntry = Record<string, unknown>;
@@ -543,6 +544,55 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
       expect(userMid, "shared-ancestor user turn must be preserved").toBeDefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("production-derived fixture preserves shared ancestor while cleaning the rewrite-abandoned child (#69486)", async () => {
+    writeSession(sessionFile, repro69486LineageFromProduction);
+
+    const preIds = new Set(readEntries(sessionFile).map((e) => e.id as string));
+    expect(preIds.has("msg-assistant-parent")).toBe(true);
+    expect(preIds.has("msg-toolresult-1a")).toBe(true);
+    expect(preIds.has("msg-toolresult-1b")).toBe(true);
+
+    const result = await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      request: {
+        replacements: [
+          {
+            entryId: "msg-assistant-parent",
+            message: makeAgentAssistantMessage({
+              content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+              timestamp: 0,
+            }) as AgentMessage,
+          },
+        ],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.rewrittenEntries).toBe(1);
+
+    const after = readEntries(sessionFile);
+    const afterIds = new Set(after.map((e) => e.id as string));
+
+    expect(afterIds.has("msg-assistant-parent")).toBe(true);
+    expect(afterIds.has("msg-toolresult-1a")).toBe(true);
+    expect(afterIds.has("msg-toolresult-1b")).toBe(false);
+
+    const toolResultsForParent = after.filter(
+      (e) =>
+        (e as { parentId?: string }).parentId === "msg-assistant-parent" &&
+        (e as { type?: string }).type === "message" &&
+        ((e as { message?: { role?: string } }).message?.role ?? "") === "toolResult",
+    );
+    expect(toolResultsForParent.length).toBeLessThanOrEqual(1);
+
+    for (const e of after) {
+      const pid = (e as { parentId?: string | null }).parentId;
+      if (pid && pid !== null) {
+        expect(afterIds.has(pid)).toBe(true);
+      }
     }
   });
 });

--- a/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  makeAgentAssistantMessage,
+  makeAgentToolResultMessage,
+  makeAgentUserMessage,
+} from "../test-helpers/agent-message-fixtures.js";
 import { rewriteTranscriptEntriesInSessionFile } from "./transcript-rewrite.js";
 
 type RawEntry = Record<string, unknown>;
@@ -309,5 +315,103 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
       );
     }).length;
     expect(doneACount).toBe(1);
+  });
+
+  // Repo-semantic regression guard: the session DAG is allowed to carry
+  // unsummarized sibling branches from legitimate sm.branch() navigation.
+  // Rewrite-triggered cleanup must only remove entries that the rewrite
+  // itself just abandoned, not entries on parallel branches the user set up.
+  // See src/agents/pi-embedded-runner/session-truncation.test.ts
+  // "preserves unsummarized sibling branches during truncation".
+  test("preserves legitimate sibling branches created before the rewrite", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rewrite-sibling-test-"));
+    try {
+      const sm = SessionManager.create(dir, dir);
+      sm.appendMessage(
+        makeAgentUserMessage({ content: [{ type: "text", text: "hello" }], timestamp: 1 }),
+      );
+      sm.appendMessage(
+        makeAgentAssistantMessage({ content: [{ type: "text", text: "hi there" }], timestamp: 2 }),
+      );
+      const branchPoint = sm.getBranch();
+      const branchFromId = branchPoint[branchPoint.length - 1].id;
+      // Main branch: user turn then a tool result we will later truncate
+      sm.appendMessage(
+        makeAgentUserMessage({
+          content: [{ type: "text", text: "do task with tool" }],
+          timestamp: 3,
+        }),
+      );
+      const mainToolResultId = sm.appendMessage(
+        makeAgentToolResultMessage({
+          toolCallId: "call_X",
+          toolName: "read",
+          content: [{ type: "text", text: "Y".repeat(200000) }],
+          timestamp: 4,
+        }),
+      );
+      sm.appendMessage(
+        makeAgentAssistantMessage({ content: [{ type: "text", text: "main tail" }], timestamp: 5 }),
+      );
+      // Sibling branch: go back to the branch-point and explore an alternate path
+      sm.branch(branchFromId);
+      const siblingUserId = sm.appendMessage(
+        makeAgentUserMessage({
+          content: [{ type: "text", text: "alternative question" }],
+          timestamp: 6,
+        }),
+      );
+      const siblingAssistantId = sm.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "alternative answer" }],
+          timestamp: 7,
+        }),
+      );
+      // Return to main branch so the rewrite operates there
+      sm.branch(mainToolResultId);
+      sm.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "post-sibling main continuation" }],
+          timestamp: 8,
+        }),
+      );
+
+      const sessionFile = sm.getSessionFile() as string;
+
+      // Rewrite the main-branch tool result
+      const result = await rewriteTranscriptEntriesInSessionFile({
+        sessionFile,
+        request: {
+          replacements: [
+            {
+              entryId: mainToolResultId,
+              message: makeAgentToolResultMessage({
+                toolCallId: "call_X",
+                toolName: "read",
+                content: [{ type: "text", text: "[truncated main Y output]" }],
+                timestamp: 4,
+              }) as AgentMessage,
+            },
+          ],
+        },
+      });
+      expect(result.changed).toBe(true);
+
+      const smAfter = SessionManager.open(sessionFile);
+      const allEntries = smAfter.getEntries();
+
+      // The sibling branch entries must still be reachable in the full entry list.
+      const siblingUser = allEntries.find((e) => e.id === siblingUserId);
+      const siblingAssistant = allEntries.find((e) => e.id === siblingAssistantId);
+      expect(siblingUser, "legitimate sibling user turn must be preserved").toBeDefined();
+      expect(siblingAssistant, "legitimate sibling assistant turn must be preserved").toBeDefined();
+
+      // And the sibling content must still be in the raw file.
+      const raw = fs.readFileSync(sessionFile, "utf-8");
+      expect(raw).toContain("alternative question");
+      expect(raw).toContain("alternative answer");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
@@ -30,13 +30,6 @@ function readEntries(sessionFile: string): RawEntry[] {
     .map((l) => JSON.parse(l) as RawEntry);
 }
 
-function buildMessage(role: "user" | "assistant" | "toolResult", text: string): AgentMessage {
-  return {
-    role,
-    content: [{ type: "text", text }],
-  } as unknown as AgentMessage;
-}
-
 describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () => {
   let dir: string;
   let sessionFile: string;
@@ -122,10 +115,12 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
     ];
     writeSession(sessionFile, base);
 
-    const truncatedToolResult = buildMessage(
-      "toolResult",
-      "[truncated] big tool output was elided",
-    );
+    const truncatedToolResult = makeAgentToolResultMessage({
+      toolCallId: "call_1",
+      toolName: "read",
+      content: [{ type: "text", text: "[truncated] big tool output was elided" }],
+      timestamp: 0,
+    }) as AgentMessage;
 
     const result = await rewriteTranscriptEntriesInSessionFile({
       sessionFile,
@@ -253,7 +248,12 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
         replacements: [
           {
             entryId: "msg-toolresult-A",
-            message: buildMessage("toolResult", "[truncated A]"),
+            message: makeAgentToolResultMessage({
+              toolCallId: "call_A",
+              toolName: "read",
+              content: [{ type: "text", text: "[truncated A]" }],
+              timestamp: 0,
+            }) as AgentMessage,
           },
         ],
       },
@@ -278,7 +278,12 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
         replacements: [
           {
             entryId: rewrittenToolResult!.id as string,
-            message: buildMessage("toolResult", "[truncated AA]"),
+            message: makeAgentToolResultMessage({
+              toolCallId: "call_A",
+              toolName: "read",
+              content: [{ type: "text", text: "[truncated AA]" }],
+              timestamp: 0,
+            }) as AgentMessage,
           },
         ],
       },

--- a/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
@@ -1,0 +1,313 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { rewriteTranscriptEntriesInSessionFile } from "./transcript-rewrite.js";
+
+type RawEntry = Record<string, unknown>;
+
+function tmpSessionDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function writeSession(sessionFile: string, entries: RawEntry[]): void {
+  const content = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  fs.writeFileSync(sessionFile, content, "utf-8");
+}
+
+function readEntries(sessionFile: string): RawEntry[] {
+  return fs
+    .readFileSync(sessionFile, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as RawEntry);
+}
+
+function buildMessage(role: "user" | "assistant" | "toolResult", text: string): AgentMessage {
+  return {
+    role,
+    content: [{ type: "text", text }],
+  } as unknown as AgentMessage;
+}
+
+describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () => {
+  let dir: string;
+  let sessionFile: string;
+
+  beforeEach(() => {
+    dir = tmpSessionDir("openclaw-transcript-rewrite-test-");
+    sessionFile = path.join(dir, "test-session.jsonl");
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("removes abandoned siblings left over by rewrite so the raw file carries each turn only once", async () => {
+    // Build a session file with: session header, user, assistant with
+    // a toolResult to be truncated, assistant reply, then another
+    // downstream message that the rewrite will push past.
+    const base: RawEntry[] = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-root",
+        timestamp: "2026-04-20T15:43:01.559Z",
+        cwd: dir,
+      },
+      {
+        type: "message",
+        id: "msg-user-1",
+        parentId: "session-root",
+        timestamp: "2026-04-20T15:43:10.000Z",
+        message: { role: "user", content: [{ type: "text", text: "do a tool call" }] },
+      },
+      {
+        type: "message",
+        id: "msg-assistant-1",
+        parentId: "msg-user-1",
+        timestamp: "2026-04-20T15:43:11.000Z",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "call_1",
+              name: "read",
+              arguments: { path: "/tmp/big-file.txt" },
+            },
+          ],
+        },
+      },
+      {
+        type: "message",
+        id: "msg-toolresult-1",
+        parentId: "msg-assistant-1",
+        timestamp: "2026-04-20T15:43:12.000Z",
+        message: {
+          role: "toolResult",
+          content: [
+            {
+              type: "toolResult",
+              toolCallId: "call_1",
+              output: "X".repeat(200000),
+            },
+          ],
+        },
+      },
+      {
+        type: "message",
+        id: "msg-assistant-2",
+        parentId: "msg-toolresult-1",
+        timestamp: "2026-04-20T15:43:13.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "here is what i found" }],
+        },
+      },
+      {
+        type: "message",
+        id: "msg-user-2",
+        parentId: "msg-assistant-2",
+        timestamp: "2026-04-20T15:43:14.000Z",
+        message: { role: "user", content: [{ type: "text", text: "thanks" }] },
+      },
+    ];
+    writeSession(sessionFile, base);
+
+    const truncatedToolResult = buildMessage(
+      "toolResult",
+      "[truncated] big tool output was elided",
+    );
+
+    const result = await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      request: {
+        replacements: [{ entryId: "msg-toolresult-1", message: truncatedToolResult }],
+      },
+    });
+
+    expect(result.changed).toBe(true);
+    expect(result.rewrittenEntries).toBe(1);
+
+    const after = readEntries(sessionFile);
+    // Must still have exactly one session header.
+    const sessionHeaders = after.filter((e) => e.type === "session");
+    expect(sessionHeaders).toHaveLength(1);
+
+    // Extract all "message" entries and check their ids are unique (no abandoned duplicates).
+    const messageIds = after.filter((e) => e.type === "message").map((e) => e.id as string);
+    expect(new Set(messageIds).size).toBe(messageIds.length);
+
+    // The concrete text content of downstream messages must appear at most once in
+    // the raw file — that is the regression we're guarding.
+    const assistantTextCount = after.filter((e) => {
+      if (e.type !== "message") {
+        return false;
+      }
+      const msg = e.message as { role?: string; content?: unknown };
+      if (msg.role !== "assistant") {
+        return false;
+      }
+      const content = msg.content;
+      if (!Array.isArray(content)) {
+        return false;
+      }
+      return content.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as { text?: unknown }).text === "here is what i found",
+      );
+    }).length;
+    expect(assistantTextCount).toBe(1);
+
+    const userText2Count = after.filter((e) => {
+      if (e.type !== "message") {
+        return false;
+      }
+      const msg = e.message as { role?: string; content?: unknown };
+      if (msg.role !== "user") {
+        return false;
+      }
+      const content = msg.content;
+      if (!Array.isArray(content)) {
+        return false;
+      }
+      return content.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as { text?: unknown }).text === "thanks",
+      );
+    }).length;
+    expect(userText2Count).toBe(1);
+
+    // The pre-replacement tool result content must no longer exist on disk —
+    // only the truncated replacement should remain on the active leaf chain.
+    const rawFile = fs.readFileSync(sessionFile, "utf-8");
+    expect(rawFile).not.toContain("X".repeat(200000));
+    expect(rawFile).toContain("[truncated] big tool output was elided");
+  });
+
+  test("repeated rewrites do not pile up cumulative duplicates of the same turn", async () => {
+    // Two sequential rewrites simulate the observed live loop: after each
+    // rewrite, the previous rewrite's leaf branch must not remain as a
+    // second abandoned sibling.
+    const base: RawEntry[] = [
+      {
+        type: "session",
+        version: 3,
+        id: "session-root",
+        timestamp: "2026-04-20T15:43:01.559Z",
+        cwd: dir,
+      },
+      {
+        type: "message",
+        id: "msg-user-1",
+        parentId: "session-root",
+        timestamp: "2026-04-20T15:43:10.000Z",
+        message: { role: "user", content: [{ type: "text", text: "run tool A" }] },
+      },
+      {
+        type: "message",
+        id: "msg-assistant-1",
+        parentId: "msg-user-1",
+        timestamp: "2026-04-20T15:43:11.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "call_A", name: "read", arguments: {} }],
+        },
+      },
+      {
+        type: "message",
+        id: "msg-toolresult-A",
+        parentId: "msg-assistant-1",
+        timestamp: "2026-04-20T15:43:12.000Z",
+        message: {
+          role: "toolResult",
+          content: [{ type: "toolResult", toolCallId: "call_A", output: "A".repeat(200000) }],
+        },
+      },
+      {
+        type: "message",
+        id: "msg-assistant-2",
+        parentId: "msg-toolresult-A",
+        timestamp: "2026-04-20T15:43:13.000Z",
+        message: { role: "assistant", content: [{ type: "text", text: "done with A" }] },
+      },
+    ];
+    writeSession(sessionFile, base);
+
+    // First rewrite: truncate tool result A.
+    await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      request: {
+        replacements: [
+          {
+            entryId: "msg-toolresult-A",
+            message: buildMessage("toolResult", "[truncated A]"),
+          },
+        ],
+      },
+    });
+
+    // Find the new toolresult id on the live leaf (last message row).
+    const entriesAfterFirst = readEntries(sessionFile);
+    const rewrittenToolResult = entriesAfterFirst.toReversed().find((e) => {
+      if (e.type !== "message") {
+        return false;
+      }
+      const msg = e.message as { role?: string };
+      return msg.role === "toolResult";
+    });
+    expect(rewrittenToolResult).toBeDefined();
+
+    // Second rewrite: truncate the already-truncated toolResult entry once more.
+    // The second rewrite must not leave a second abandoned branch.
+    await rewriteTranscriptEntriesInSessionFile({
+      sessionFile,
+      request: {
+        replacements: [
+          {
+            entryId: rewrittenToolResult!.id as string,
+            message: buildMessage("toolResult", "[truncated AA]"),
+          },
+        ],
+      },
+    });
+
+    const final = readEntries(sessionFile);
+    // Only one session header.
+    expect(final.filter((e) => e.type === "session")).toHaveLength(1);
+
+    // No duplicate message IDs.
+    const ids = final.filter((e) => e.type === "message").map((e) => e.id as string);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    // The original "done with A" assistant text must appear exactly once on the
+    // final leaf (it was re-appended with a new ID by each rewrite; only the
+    // newest copy should survive).
+    const doneACount = final.filter((e) => {
+      if (e.type !== "message") {
+        return false;
+      }
+      const msg = e.message as { role?: string; content?: unknown };
+      if (msg.role !== "assistant") {
+        return false;
+      }
+      const content = msg.content;
+      if (!Array.isArray(content)) {
+        return false;
+      }
+      return content.some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          (block as { text?: unknown }).text === "done with A",
+      );
+    }).length;
+    expect(doneACount).toBe(1);
+  });
+});

--- a/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts
@@ -414,4 +414,130 @@ describe("rewriteTranscriptEntriesInSessionFile — leaf-branch compaction", () 
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  // Second repo-semantic regression guard: the sibling branch can hang off
+  // an entry that lies INSIDE the rewritten suffix. The previous entry on
+  // the main branch is strictly part of the shared history and must not be
+  // garbage-collected just because this rewrite made a new copy of it —
+  // the sibling's parentId still references the original, so removing it
+  // would turn the sibling into an orphan root and destroy the shared-
+  // ancestor relationship in the tree.
+  test("preserves ancestry when a sibling branch hangs off the rewritten suffix", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-rewrite-sibling-suffix-"));
+    try {
+      const sm = SessionManager.create(dir, dir);
+      // Main branch head: user, assistant
+      sm.appendMessage(
+        makeAgentUserMessage({ content: [{ type: "text", text: "hello" }], timestamp: 1 }),
+      );
+      sm.appendMessage(
+        makeAgentAssistantMessage({ content: [{ type: "text", text: "hi there" }], timestamp: 2 }),
+      );
+      // Main branch continuation that WILL be the rewritten suffix:
+      // userMid → toolResult (to be rewritten) → mainTailAssistant
+      const userMidId = sm.appendMessage(
+        makeAgentUserMessage({
+          content: [{ type: "text", text: "please do the tool call" }],
+          timestamp: 3,
+        }),
+      );
+      const toolResultId = sm.appendMessage(
+        makeAgentToolResultMessage({
+          toolCallId: "call_Z",
+          toolName: "read",
+          content: [{ type: "text", text: "Z".repeat(200000) }],
+          timestamp: 4,
+        }),
+      );
+      const mainTailId = sm.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "main tail after tool" }],
+          timestamp: 5,
+        }),
+      );
+      // Sibling branch forks from toolResultId — an entry that WILL be
+      // rewritten. The sibling references that id as its parent. The
+      // rewrite must not strand the sibling by dropping its parent.
+      sm.branch(toolResultId);
+      const siblingUserId = sm.appendMessage(
+        makeAgentUserMessage({
+          content: [{ type: "text", text: "sibling alt question" }],
+          timestamp: 6,
+        }),
+      );
+      const siblingAssistantId = sm.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "sibling alt answer" }],
+          timestamp: 7,
+        }),
+      );
+      // Return to main tail so the rewrite operates there.
+      sm.branch(mainTailId);
+      sm.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "main continuation take 2" }],
+          timestamp: 8,
+        }),
+      );
+
+      const sessionFile = sm.getSessionFile() as string;
+
+      // Rewrite the tool result — which is in the suffix, BUT userMidId is its
+      // parent and is also the shared ancestor of the sibling branch. Whatever
+      // the cleanup does, it MUST NOT orphan the sibling.
+      const result = await rewriteTranscriptEntriesInSessionFile({
+        sessionFile,
+        request: {
+          replacements: [
+            {
+              entryId: toolResultId,
+              message: makeAgentToolResultMessage({
+                toolCallId: "call_Z",
+                toolName: "read",
+                content: [{ type: "text", text: "[truncated suffix Z]" }],
+                timestamp: 4,
+              }) as AgentMessage,
+            },
+          ],
+        },
+      });
+      expect(result.changed).toBe(true);
+
+      const smAfter = SessionManager.open(sessionFile);
+      const allEntries = smAfter.getEntries();
+      const byId = new Map(allEntries.map((e) => [e.id, e]));
+
+      // Sibling user + assistant must still exist.
+      const siblingUser = byId.get(siblingUserId);
+      const siblingAssistant = byId.get(siblingAssistantId);
+      expect(siblingUser, "sibling user turn must be preserved").toBeDefined();
+      expect(siblingAssistant, "sibling assistant turn must be preserved").toBeDefined();
+
+      // Crucial: the sibling branch must still have ancestry. Walk sibling's
+      // parentId chain back up; every referenced parent must still exist in
+      // the file. Otherwise the sibling is orphaned and the tree is corrupt.
+      const visited = new Set<string>();
+      let cursor: typeof siblingAssistant = siblingAssistant;
+      while (cursor && !visited.has(cursor.id)) {
+        visited.add(cursor.id);
+        const parentId = (cursor as { parentId?: string | null }).parentId;
+        if (!parentId) {
+          break;
+        }
+        const parent = byId.get(parentId);
+        expect(
+          parent,
+          `sibling ancestry broken: parentId ${parentId} of ${cursor.id} no longer present`,
+        ).toBeDefined();
+        cursor = parent;
+      }
+
+      // And the shared-ancestor userMidId message must specifically still be
+      // in the file — it is the fork-point and both branches need it.
+      const userMid = byId.get(userMidId);
+      expect(userMid, "shared-ancestor user turn must be preserved").toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -211,94 +211,16 @@ function collectActiveBranchEntryIds(sessionManager: SessionManagerLike): Set<st
 }
 
 /**
- * Candidate abandoned-id set is not yet safe on its own: a legitimate
- * sibling branch can reference a candidate id as an ancestor. Removing
- * that id would orphan the sibling and destroy its shared history.
- *
- * Restrict the set to ids that are NOT reachable as a parentId-ancestor
- * from any non-abandoned entry in the file. Ancestry is computed by
- * walking `parentId` chains from every non-abandoned entry until we hit
- * a root or an already-visited node. Every id visited on such a walk is
- * load-bearing and must survive.
- */
-function filterAbandonedIdsByReferenceIntegrity(
-  sessionFile: string,
-  candidateAbandoned: ReadonlySet<string>,
-): Set<string> {
-  const safeToRemove = new Set<string>();
-  if (candidateAbandoned.size === 0) {
-    return safeToRemove;
-  }
-  let content: string;
-  try {
-    content = fs.readFileSync(sessionFile, "utf-8");
-  } catch {
-    return safeToRemove;
-  }
-  type Entry = { id?: string; parentId?: string | null };
-  const entries: Entry[] = [];
-  for (const raw of content.split("\n")) {
-    if (!raw.trim()) {
-      continue;
-    }
-    try {
-      const obj = JSON.parse(raw) as { id?: unknown; parentId?: unknown };
-      entries.push({
-        id: typeof obj.id === "string" ? obj.id : undefined,
-        parentId:
-          typeof obj.parentId === "string"
-            ? obj.parentId
-            : obj.parentId === null
-              ? null
-              : undefined,
-      });
-    } catch {
-      // Malformed line: ignore for ancestry computation (line is kept verbatim
-      // by the cleanup write path).
-    }
-  }
-  const byId = new Map<string, Entry>();
-  for (const entry of entries) {
-    if (entry.id) {
-      byId.set(entry.id, entry);
-    }
-  }
-  // Collect every id that is reachable as an ancestor from any non-abandoned
-  // entry. Those ids are load-bearing.
-  const ancestryLive = new Set<string>();
-  for (const entry of entries) {
-    if (!entry.id) {
-      continue;
-    }
-    if (candidateAbandoned.has(entry.id)) {
-      continue;
-    }
-    let cursor: Entry | undefined = entry;
-    while (cursor && cursor.id) {
-      if (ancestryLive.has(cursor.id)) {
-        break;
-      }
-      ancestryLive.add(cursor.id);
-      const parentId = cursor.parentId;
-      if (typeof parentId !== "string" || !parentId) {
-        break;
-      }
-      cursor = byId.get(parentId);
-    }
-  }
-  for (const id of candidateAbandoned) {
-    if (!ancestryLive.has(id)) {
-      safeToRemove.add(id);
-    }
-  }
-  return safeToRemove;
-}
-
-/**
  * Remove ONLY those entry ids that we can prove were just abandoned by this
  * rewrite (present in the pre-rewrite active branch, absent from the
  * post-rewrite active branch) AND that no surviving entry still references
  * as an ancestor via `parentId`.
+ *
+ * Single pass: read the file once, parse each line once, compute the
+ * ancestry-live set from non-abandoned entries, and write the kept lines
+ * back atomically. Session files can reach multiple megabytes near the
+ * compaction boundary (which is exactly when this cleanup runs), so we
+ * avoid doing the read + parse twice.
  *
  * Legitimate sibling branches — alternate paths the user navigated to via
  * `sm.branch(...)` — never appear in `getBranch()` directly, so their ids
@@ -317,38 +239,89 @@ function removeSpecificAbandonedEntriesFromSessionFile(
   if (abandonedEntryIds.size === 0) {
     return { removedEntries: 0, bytesRemoved: 0 };
   }
-  const safeAbandonedIds = filterAbandonedIdsByReferenceIntegrity(sessionFile, abandonedEntryIds);
-  if (safeAbandonedIds.size === 0) {
-    return { removedEntries: 0, bytesRemoved: 0 };
-  }
   let content: string;
   try {
     content = fs.readFileSync(sessionFile, "utf-8");
   } catch {
     return { removedEntries: 0, bytesRemoved: 0 };
   }
-  const rawLines = content.split("\n");
-  const kept: string[] = [];
-  let removed = 0;
-  for (const raw of rawLines) {
+  // Single parse pass: we need each line's raw form (for write-back), its id
+  // (for candidate lookup) and its parentId (for ancestry traversal).
+  type ParsedLine = {
+    raw: string;
+    id?: string;
+    parentId?: string | null;
+  };
+  const parsed: ParsedLine[] = [];
+  for (const raw of content.split("\n")) {
     if (!raw.trim()) {
       continue;
     }
-    let shouldDrop = false;
     try {
-      const obj = JSON.parse(raw) as { id?: unknown };
-      if (typeof obj.id === "string" && safeAbandonedIds.has(obj.id)) {
-        shouldDrop = true;
-      }
+      const obj = JSON.parse(raw) as { id?: unknown; parentId?: unknown };
+      parsed.push({
+        raw,
+        id: typeof obj.id === "string" ? obj.id : undefined,
+        parentId:
+          typeof obj.parentId === "string"
+            ? obj.parentId
+            : obj.parentId === null
+              ? null
+              : undefined,
+      });
     } catch {
-      // Malformed line: never drop — keep verbatim.
-      shouldDrop = false;
+      // Malformed line: kept verbatim by the write step, ignored for ancestry.
+      parsed.push({ raw });
     }
-    if (shouldDrop) {
+  }
+  const byId = new Map<string, ParsedLine>();
+  for (const line of parsed) {
+    if (line.id) {
+      byId.set(line.id, line);
+    }
+  }
+  // Walk parentId chains backward from every non-abandoned entry. Ids visited
+  // on any such walk are load-bearing ancestors of surviving entries and must
+  // not be removed even if they are in the candidate set.
+  const ancestryLive = new Set<string>();
+  for (const line of parsed) {
+    if (!line.id) {
+      continue;
+    }
+    if (abandonedEntryIds.has(line.id)) {
+      continue;
+    }
+    let cursor: ParsedLine | undefined = line;
+    while (cursor && cursor.id) {
+      if (ancestryLive.has(cursor.id)) {
+        break;
+      }
+      ancestryLive.add(cursor.id);
+      const parentId = cursor.parentId;
+      if (typeof parentId !== "string" || !parentId) {
+        break;
+      }
+      cursor = byId.get(parentId);
+    }
+  }
+  // Final removable set = candidates \ ancestry-of-non-abandoned.
+  const safeAbandonedIds = new Set<string>();
+  for (const id of abandonedEntryIds) {
+    if (!ancestryLive.has(id)) {
+      safeAbandonedIds.add(id);
+    }
+  }
+  if (safeAbandonedIds.size === 0) {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const kept: string[] = [];
+  let removed = 0;
+  for (const line of parsed) {
+    if (line.id && safeAbandonedIds.has(line.id)) {
       removed += 1;
       continue;
     }
-    kept.push(raw);
+    kept.push(line.raw);
   }
   if (removed === 0) {
     return { removedEntries: 0, bytesRemoved: 0 };

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -189,27 +189,43 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
   };
 }
 
-type ActiveLeafBranchCompactionResult = {
+type RewriteArtifactCleanupResult = {
   removedEntries: number;
   bytesRemoved: number;
 };
 
 /**
- * After a rewrite, the session file still carries all pre-rewrite entries as
- * abandoned sibling branches of the new leaf (append-only semantics). Because
- * openclaw's transcript reader scans every line in the file, those abandoned
- * entries show up as duplicates in the replay — each successive rewrite piles
- * on another generation. This helper keeps only entries that are reachable
- * from the current leaf via the parentId chain, plus parentId-less roots
- * (session header / model_change), and atomically rewrites the file.
- *
- * Identity is based on the structural parentId chain, not textual content.
+ * Collect the ids of the entries on the currently active branch path. This
+ * is the set of "potentially abandonable" entries — anything not on this path
+ * (legitimate sibling branches from prior `sm.branch()` navigation, etc.) is
+ * never considered for removal.
  */
-function compactSessionFileToActiveLeafBranch(
+function collectActiveBranchEntryIds(sessionManager: SessionManagerLike): Set<string> {
+  const ids = new Set<string>();
+  for (const entry of sessionManager.getBranch()) {
+    if (entry && typeof (entry as { id?: unknown }).id === "string") {
+      ids.add((entry as { id: string }).id);
+    }
+  }
+  return ids;
+}
+
+/**
+ * Remove ONLY those entry ids that we can prove were just abandoned by this
+ * rewrite (present in the pre-rewrite active branch, absent from the
+ * post-rewrite active branch). Legitimate sibling branches — alternate paths
+ * the user navigated to via `sm.branch(...)` before this rewrite ran — never
+ * appear in `getBranch()`, so their ids are never part of the abandoned set
+ * and their entries stay in the file.
+ *
+ * Matches the repo-wide invariant documented in session-truncation: rewrite /
+ * maintenance operations must preserve unsummarized sibling branches.
+ */
+function removeSpecificAbandonedEntriesFromSessionFile(
   sessionFile: string,
-  leafId: string | null | undefined,
-): ActiveLeafBranchCompactionResult {
-  if (!leafId) {
+  abandonedEntryIds: ReadonlySet<string>,
+): RewriteArtifactCleanupResult {
+  if (abandonedEntryIds.size === 0) {
     return { removedEntries: 0, bytesRemoved: 0 };
   }
   let content: string;
@@ -219,86 +235,35 @@ function compactSessionFileToActiveLeafBranch(
     return { removedEntries: 0, bytesRemoved: 0 };
   }
   const rawLines = content.split("\n");
-  type ParsedLine = {
-    raw: string;
-    id?: string;
-    parentId?: string | null;
-    type?: string;
-  };
-  const parsed: ParsedLine[] = [];
+  const kept: string[] = [];
+  let removed = 0;
   for (const raw of rawLines) {
     if (!raw.trim()) {
       continue;
     }
+    let shouldDrop = false;
     try {
-      const obj = JSON.parse(raw) as {
-        id?: unknown;
-        parentId?: unknown;
-        type?: unknown;
-      };
-      parsed.push({
-        raw,
-        id: typeof obj.id === "string" ? obj.id : undefined,
-        parentId:
-          typeof obj.parentId === "string"
-            ? obj.parentId
-            : obj.parentId === null
-              ? null
-              : undefined,
-        type: typeof obj.type === "string" ? obj.type : undefined,
-      });
+      const obj = JSON.parse(raw) as { id?: unknown };
+      if (typeof obj.id === "string" && abandonedEntryIds.has(obj.id)) {
+        shouldDrop = true;
+      }
     } catch {
-      // Malformed line: keep it verbatim so we don't lose data.
-      parsed.push({ raw });
+      // Malformed line: never drop — keep verbatim.
+      shouldDrop = false;
     }
-  }
-  if (parsed.length === 0) {
-    return { removedEntries: 0, bytesRemoved: 0 };
-  }
-  const byId = new Map<string, ParsedLine>();
-  for (const line of parsed) {
-    if (line.id) {
-      byId.set(line.id, line);
-    }
-  }
-  // Walk backward from the current leaf to the root; collect all reachable ids.
-  const keepIds = new Set<string>();
-  let cursor = byId.get(leafId);
-  while (cursor) {
-    if (!cursor.id || keepIds.has(cursor.id)) {
-      break;
-    }
-    keepIds.add(cursor.id);
-    cursor = cursor.parentId ? byId.get(cursor.parentId) : undefined;
-  }
-  if (keepIds.size === 0) {
-    // Leaf not found in file — don't risk truncation.
-    return { removedEntries: 0, bytesRemoved: 0 };
-  }
-  const kept: ParsedLine[] = [];
-  for (const line of parsed) {
-    // Always keep: malformed lines (no parsed id), structural roots (parentId === null).
-    // Keep identified entries only if they're on the active leaf chain.
-    if (!line.id) {
-      kept.push(line);
+    if (shouldDrop) {
+      removed += 1;
       continue;
     }
-    if (line.parentId === null) {
-      kept.push(line);
-      continue;
-    }
-    if (keepIds.has(line.id)) {
-      kept.push(line);
-    }
+    kept.push(raw);
   }
-  const removed = parsed.length - kept.length;
   if (removed === 0) {
     return { removedEntries: 0, bytesRemoved: 0 };
   }
-  const newContent = `${kept.map((l) => l.raw).join("\n")}\n`;
+  const newContent = `${kept.join("\n")}\n`;
   const originalSize = Buffer.byteLength(content, "utf-8");
   const newSize = Buffer.byteLength(newContent, "utf-8");
-  const tmp = `${sessionFile}.leaf-branch-compact.tmp`;
+  const tmp = `${sessionFile}.rewrite-cleanup.tmp`;
   try {
     fs.writeFileSync(tmp, newContent, "utf-8");
     fs.renameSync(tmp, sessionFile);
@@ -309,7 +274,7 @@ function compactSessionFileToActiveLeafBranch(
       // Best-effort cleanup.
     }
     log.warn(
-      `[transcript-rewrite] leaf-branch compaction write failed: ${formatErrorMessage(err)}`,
+      `[transcript-rewrite] abandoned-entry cleanup write failed: ${formatErrorMessage(err)}`,
     );
     return { removedEntries: 0, bytesRemoved: 0 };
   }
@@ -332,20 +297,36 @@ export async function rewriteTranscriptEntriesInSessionFile(params: {
       sessionFile: params.sessionFile,
     });
     const sessionManager = SessionManager.open(params.sessionFile);
+    // Snapshot of the active-branch ids BEFORE the rewrite. Sibling branches
+    // that already exist as alternate paths are not on this branch and are
+    // therefore excluded from the abandoned set by construction.
+    const branchIdsBefore = collectActiveBranchEntryIds(sessionManager);
     const result = rewriteTranscriptEntriesInSessionManager({
       sessionManager,
       replacements: params.request.replacements,
     });
     if (result.changed) {
-      const leafId =
-        typeof sessionManager.getLeafId === "function" ? sessionManager.getLeafId() : null;
-      const compactResult = compactSessionFileToActiveLeafBranch(params.sessionFile, leafId);
+      // Entries that were on the active branch before the rewrite but are no
+      // longer part of the post-rewrite active branch have been abandoned by
+      // this specific rewrite and are safe to drop from the file.
+      const branchIdsAfter = collectActiveBranchEntryIds(sessionManager);
+      const abandonedIds = new Set<string>();
+      for (const id of branchIdsBefore) {
+        if (!branchIdsAfter.has(id)) {
+          abandonedIds.add(id);
+        }
+      }
+      const cleanupResult = removeSpecificAbandonedEntriesFromSessionFile(
+        params.sessionFile,
+        abandonedIds,
+      );
       emitSessionTranscriptUpdate(params.sessionFile);
       log.info(
         `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
           `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
           `bytesFreed=${result.bytesFreed} ` +
-          `leafBranchCompaction=removed:${compactResult.removedEntries}/bytes:${compactResult.bytesRemoved} ` +
+          `abandonedArtifactsRemoved=${cleanupResult.removedEntries}/` +
+          `bytes:${cleanupResult.bytesRemoved} ` +
           `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
       );
     }

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
@@ -188,6 +189,133 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
   };
 }
 
+type ActiveLeafBranchCompactionResult = {
+  removedEntries: number;
+  bytesRemoved: number;
+};
+
+/**
+ * After a rewrite, the session file still carries all pre-rewrite entries as
+ * abandoned sibling branches of the new leaf (append-only semantics). Because
+ * openclaw's transcript reader scans every line in the file, those abandoned
+ * entries show up as duplicates in the replay — each successive rewrite piles
+ * on another generation. This helper keeps only entries that are reachable
+ * from the current leaf via the parentId chain, plus parentId-less roots
+ * (session header / model_change), and atomically rewrites the file.
+ *
+ * Identity is based on the structural parentId chain, not textual content.
+ */
+function compactSessionFileToActiveLeafBranch(
+  sessionFile: string,
+  leafId: string | null | undefined,
+): ActiveLeafBranchCompactionResult {
+  if (!leafId) {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  let content: string;
+  try {
+    content = fs.readFileSync(sessionFile, "utf-8");
+  } catch {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const rawLines = content.split("\n");
+  type ParsedLine = {
+    raw: string;
+    id?: string;
+    parentId?: string | null;
+    type?: string;
+  };
+  const parsed: ParsedLine[] = [];
+  for (const raw of rawLines) {
+    if (!raw.trim()) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(raw) as {
+        id?: unknown;
+        parentId?: unknown;
+        type?: unknown;
+      };
+      parsed.push({
+        raw,
+        id: typeof obj.id === "string" ? obj.id : undefined,
+        parentId:
+          typeof obj.parentId === "string"
+            ? obj.parentId
+            : obj.parentId === null
+              ? null
+              : undefined,
+        type: typeof obj.type === "string" ? obj.type : undefined,
+      });
+    } catch {
+      // Malformed line: keep it verbatim so we don't lose data.
+      parsed.push({ raw });
+    }
+  }
+  if (parsed.length === 0) {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const byId = new Map<string, ParsedLine>();
+  for (const line of parsed) {
+    if (line.id) {
+      byId.set(line.id, line);
+    }
+  }
+  // Walk backward from the current leaf to the root; collect all reachable ids.
+  const keepIds = new Set<string>();
+  let cursor = byId.get(leafId);
+  while (cursor) {
+    if (!cursor.id || keepIds.has(cursor.id)) {
+      break;
+    }
+    keepIds.add(cursor.id);
+    cursor = cursor.parentId ? byId.get(cursor.parentId) : undefined;
+  }
+  if (keepIds.size === 0) {
+    // Leaf not found in file — don't risk truncation.
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const kept: ParsedLine[] = [];
+  for (const line of parsed) {
+    // Always keep: malformed lines (no parsed id), structural roots (parentId === null).
+    // Keep identified entries only if they're on the active leaf chain.
+    if (!line.id) {
+      kept.push(line);
+      continue;
+    }
+    if (line.parentId === null) {
+      kept.push(line);
+      continue;
+    }
+    if (keepIds.has(line.id)) {
+      kept.push(line);
+    }
+  }
+  const removed = parsed.length - kept.length;
+  if (removed === 0) {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const newContent = `${kept.map((l) => l.raw).join("\n")}\n`;
+  const originalSize = Buffer.byteLength(content, "utf-8");
+  const newSize = Buffer.byteLength(newContent, "utf-8");
+  const tmp = `${sessionFile}.leaf-branch-compact.tmp`;
+  try {
+    fs.writeFileSync(tmp, newContent, "utf-8");
+    fs.renameSync(tmp, sessionFile);
+  } catch (err) {
+    try {
+      fs.unlinkSync(tmp);
+    } catch {
+      // Best-effort cleanup.
+    }
+    log.warn(
+      `[transcript-rewrite] leaf-branch compaction write failed: ${formatErrorMessage(err)}`,
+    );
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  return { removedEntries: removed, bytesRemoved: originalSize - newSize };
+}
+
 /**
  * Open a transcript file, rewrite message entries on the active branch, and
  * emit a transcript update when the active branch changed.
@@ -209,11 +337,15 @@ export async function rewriteTranscriptEntriesInSessionFile(params: {
       replacements: params.request.replacements,
     });
     if (result.changed) {
+      const leafId =
+        typeof sessionManager.getLeafId === "function" ? sessionManager.getLeafId() : null;
+      const compactResult = compactSessionFileToActiveLeafBranch(params.sessionFile, leafId);
       emitSessionTranscriptUpdate(params.sessionFile);
       log.info(
         `[transcript-rewrite] rewrote ${result.rewrittenEntries} entr` +
           `${result.rewrittenEntries === 1 ? "y" : "ies"} ` +
           `bytesFreed=${result.bytesFreed} ` +
+          `leafBranchCompaction=removed:${compactResult.removedEntries}/bytes:${compactResult.bytesRemoved} ` +
           `sessionKey=${params.sessionKey ?? params.sessionId ?? "unknown"}`,
       );
     }

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -211,12 +211,101 @@ function collectActiveBranchEntryIds(sessionManager: SessionManagerLike): Set<st
 }
 
 /**
+ * Candidate abandoned-id set is not yet safe on its own: a legitimate
+ * sibling branch can reference a candidate id as an ancestor. Removing
+ * that id would orphan the sibling and destroy its shared history.
+ *
+ * Restrict the set to ids that are NOT reachable as a parentId-ancestor
+ * from any non-abandoned entry in the file. Ancestry is computed by
+ * walking `parentId` chains from every non-abandoned entry until we hit
+ * a root or an already-visited node. Every id visited on such a walk is
+ * load-bearing and must survive.
+ */
+function filterAbandonedIdsByReferenceIntegrity(
+  sessionFile: string,
+  candidateAbandoned: ReadonlySet<string>,
+): Set<string> {
+  const safeToRemove = new Set<string>();
+  if (candidateAbandoned.size === 0) {
+    return safeToRemove;
+  }
+  let content: string;
+  try {
+    content = fs.readFileSync(sessionFile, "utf-8");
+  } catch {
+    return safeToRemove;
+  }
+  type Entry = { id?: string; parentId?: string | null };
+  const entries: Entry[] = [];
+  for (const raw of content.split("\n")) {
+    if (!raw.trim()) {
+      continue;
+    }
+    try {
+      const obj = JSON.parse(raw) as { id?: unknown; parentId?: unknown };
+      entries.push({
+        id: typeof obj.id === "string" ? obj.id : undefined,
+        parentId:
+          typeof obj.parentId === "string"
+            ? obj.parentId
+            : obj.parentId === null
+              ? null
+              : undefined,
+      });
+    } catch {
+      // Malformed line: ignore for ancestry computation (line is kept verbatim
+      // by the cleanup write path).
+    }
+  }
+  const byId = new Map<string, Entry>();
+  for (const entry of entries) {
+    if (entry.id) {
+      byId.set(entry.id, entry);
+    }
+  }
+  // Collect every id that is reachable as an ancestor from any non-abandoned
+  // entry. Those ids are load-bearing.
+  const ancestryLive = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.id) {
+      continue;
+    }
+    if (candidateAbandoned.has(entry.id)) {
+      continue;
+    }
+    let cursor: Entry | undefined = entry;
+    while (cursor && cursor.id) {
+      if (ancestryLive.has(cursor.id)) {
+        break;
+      }
+      ancestryLive.add(cursor.id);
+      const parentId = cursor.parentId;
+      if (typeof parentId !== "string" || !parentId) {
+        break;
+      }
+      cursor = byId.get(parentId);
+    }
+  }
+  for (const id of candidateAbandoned) {
+    if (!ancestryLive.has(id)) {
+      safeToRemove.add(id);
+    }
+  }
+  return safeToRemove;
+}
+
+/**
  * Remove ONLY those entry ids that we can prove were just abandoned by this
  * rewrite (present in the pre-rewrite active branch, absent from the
- * post-rewrite active branch). Legitimate sibling branches — alternate paths
- * the user navigated to via `sm.branch(...)` before this rewrite ran — never
- * appear in `getBranch()`, so their ids are never part of the abandoned set
- * and their entries stay in the file.
+ * post-rewrite active branch) AND that no surviving entry still references
+ * as an ancestor via `parentId`.
+ *
+ * Legitimate sibling branches — alternate paths the user navigated to via
+ * `sm.branch(...)` — never appear in `getBranch()` directly, so their ids
+ * are never part of the abandoned set. But a sibling can hang off an entry
+ * that IS in the abandoned set (the rewrite replaced what used to be a
+ * branch point). The ancestry-reference filter catches that case and keeps
+ * the shared-ancestor entry in the file so the sibling stays grounded.
  *
  * Matches the repo-wide invariant documented in session-truncation: rewrite /
  * maintenance operations must preserve unsummarized sibling branches.
@@ -226,6 +315,10 @@ function removeSpecificAbandonedEntriesFromSessionFile(
   abandonedEntryIds: ReadonlySet<string>,
 ): RewriteArtifactCleanupResult {
   if (abandonedEntryIds.size === 0) {
+    return { removedEntries: 0, bytesRemoved: 0 };
+  }
+  const safeAbandonedIds = filterAbandonedIdsByReferenceIntegrity(sessionFile, abandonedEntryIds);
+  if (safeAbandonedIds.size === 0) {
     return { removedEntries: 0, bytesRemoved: 0 };
   }
   let content: string;
@@ -244,7 +337,7 @@ function removeSpecificAbandonedEntriesFromSessionFile(
     let shouldDrop = false;
     try {
       const obj = JSON.parse(raw) as { id?: unknown };
-      if (typeof obj.id === "string" && abandonedEntryIds.has(obj.id)) {
+      if (typeof obj.id === "string" && safeAbandonedIds.has(obj.id)) {
         shouldDrop = true;
       }
     } catch {


### PR DESCRIPTION
## Problem

Each call to `rewriteTranscriptEntriesInSessionFile` leaves the pre-rewrite
entries as abandoned sibling branches of the new leaf (append-only session
semantics: `branch(parent)` + re-append of the entire suffix). openclaw's
transcript reader scans every line in the file, so each successive rewrite
piles on another generation of the same turn.

This surfaced in live traces on the main agent session as **real
live-write duplication** after auto-compaction retries:

- The same 2312-byte user prompt persisted **12 times** in a single
  session file, with `parentId` chaining through successive compaction
  markers (one re-append per compaction attempt + a burst of extras).
- Assistant responses re-appended in the **same millisecond** after each
  `truncateOversizedToolResultsInSessionManager` call, because every tool-
  result truncation triggers a branch-and-reappend of the whole downstream
  suffix.
- Auto-compaction saw 169 → 91 → 92 → 93 → 94 messages across three
  attempts and still overflowed, because the re-appended generations were
  being counted alongside the live branch. The session was eventually
  restarted and the chain persisted into the successor, locking in the
  loop across session-ID boundaries.

Root cause lives in the rewrite path itself: the session DAG is
append-only, but the transcript reader treats the raw file as flat, so
abandoned branches show up as duplicates.

## Fix

After `rewriteTranscriptEntriesInSessionManager` returns `changed: true`,
reconcile the on-disk state with what was actually abandoned by this
specific rewrite — **and nothing else**:

1. Snapshot the active-branch ids via `sessionManager.getBranch()` BEFORE
   the rewrite. Sibling branches that already exist as alternate paths
   are not on this branch and are therefore out of scope by construction.
2. Run the rewrite.
3. Snapshot the active-branch ids AFTER the rewrite.
4. Candidate abandoned set = `branchIdsBefore \\ branchIdsAfter`.
5. **Ancestry-reference integrity filter:** walk `parentId` chains
   backward from every non-abandoned entry in the file and collect every
   id visited. Those ids are load-bearing even if they are candidates.
6. Final removable set = `candidates \\ ancestry-of(non-abandoned)`.
7. Drop only those ids, atomically via tmp-file + rename.

Identity is structural (id and `parentId` chain), not textual.

### Why the ancestry filter matters

A legitimate sibling branch can fork off an entry that the rewrite itself
replaces — the sibling's `parentId` still references the pre-rewrite id.
Without the ancestry filter the cleanup would remove that id, orphan the
sibling, break `SessionManager.getTree()`, and destroy shared-history
semantics. With the filter the shared-ancestor entry stays in the file
as long as any non-abandoned entry still references it.

This is consistent with the repo invariant already asserted at the
truncation boundary in
`src/agents/pi-embedded-runner/session-truncation.test.ts`
(\"preserves unsummarized sibling branches during truncation\"), now
extended to the rewrite boundary as well.

## Tests

New file: `src/agents/pi-embedded-runner/transcript-rewrite.leaf-branch.test.ts`.

Four targeted tests on real temporary session files:

1. **Linear case** — single rewrite, no duplicate content for downstream
   messages (unique message ids, content counts exactly 1).
2. **Repeated rewrites** — two sequential rewrites on the same active
   path don't pile up cumulative duplicates of the same turn.
3. **Sibling before rewrite-target** — a legitimate sibling branch that
   forks before the rewrite target stays intact in
   `SessionManager.getEntries()` and the raw file.
4. **Sibling inside the rewritten suffix** — a sibling branch forks
   directly from the tool-result entry that the rewrite then replaces.
   Asserts not only entry existence but transitive `parentId` ancestry:
   every parent id in the sibling's chain must still resolve. Before the
   ancestry filter this failed with
   `sibling ancestry broken: parentId <X> of <Y> no longer present`.

All existing related tests continue to pass alongside the new ones:
- `src/agents/pi-embedded-runner/session-truncation.test.ts` (preserves siblings)
- `src/agents/pi-embedded-runner/context-engine-maintenance.test.ts`
- `src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
- `src/gateway/session-compaction-checkpoints.test.ts`

Local `pnpm check` (tsgo, lint, import-cycle, madge) green.

## Out of scope

Deliberately not touched in this PR:

- Reset/restore epoch semantics on the compaction chain (unrelated,
  tracked separately on PR #68765).
- The compaction-chain reader in `readSessionMessages` /
  `resolveMainSessionTranscriptFiles` (also PR #68765).
- Historical rewrite debris from sessions created before this fix;
  only new rewrites self-reconcile. Retroactive cleanup would be a
  separate change.