### PR TITLE
fix(skills): add WHEN + trigger phrases to 4 skill descriptions

### DIFF
--- a/extensions/memory-wiki/skills/obsidian-vault-maintainer/SKILL.md
+++ b/extensions/memory-wiki/skills/obsidian-vault-maintainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-vault-maintainer
-description: Maintain an Obsidian-friendly memory wiki vault with wikilinks, frontmatter, and official Obsidian CLI awareness.
+description: Maintain an Obsidian-friendly memory wiki vault with wikilinks, frontmatter, and official Obsidian CLI awareness. Use when the memory-wiki vault render mode is `obsidian` or the user asks to create/edit/link notes in an Obsidian-compatible vault. Triggers on phrases like "update the wiki", "add a wikilink", "create a daily note", "link these vault pages", "open this note in Obsidian".
 ---
 
 Use this skill when the memory-wiki vault render mode is `obsidian` or the user wants the wiki to play nicely with Obsidian.

--- a/extensions/memory-wiki/skills/wiki-maintainer/SKILL.md
+++ b/extensions/memory-wiki/skills/wiki-maintainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wiki-maintainer
-description: Maintain the OpenClaw memory wiki vault with deterministic pages, managed blocks, and source-backed updates.
+description: Maintain the OpenClaw memory wiki vault with deterministic pages, managed blocks, and source-backed updates. Use when working inside a memory-wiki vault — compiling, ingesting, linting, or filing a synthesis. Triggers on phrases like "ingest this to the wiki", "compile the wiki", "add to the wiki", "file a synthesis", "update the managed block".
 ---
 
 Use this skill when working inside a memory-wiki vault.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when (1) searching/sending Gmail, (2) reading/creating Google Calendar events, (3) listing/uploading Drive files, (4) reading/editing Sheets or Docs. Triggers on phrases like "check my email", "what's on my calendar", "send an email to", "summarize today's inbox", "add a calendar event".
 homepage: https://gogcli.sh
 metadata:
   {

--- a/skills/session-logs/SKILL.md
+++ b/skills/session-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-logs
-description: Search and analyze your own session logs (older/parent conversations) using jq.
+description: Search and analyze your own session logs (older/parent conversations) using jq. Use when (1) recalling what a prior session said or did, (2) auditing your own tool usage history, (3) debugging cross-session state. Triggers on phrases like "what did I say earlier", "check my prior session", "search my conversation logs", "find the session where I", "look up previous context".
 metadata:
   {
     "openclaw":


### PR DESCRIPTION
## Problem

Per the Anthropic skill spec (which the OpenClaw skill router follows), every \`description\` field must include both **what** the skill does **and when** to use it (trigger conditions). Without WHEN, routing silently under-selects the skill.

Reporter @pescaohq-web audited 12 OpenClaw-distributed skills in #69475 and flagged 4 HIGH findings:

1. \`skills/gog\` — Google Workspace CLI
2. \`skills/session-logs\` — jq over prior sessions
3. \`extensions/memory-wiki/skills/obsidian-vault-maintainer\`
4. \`extensions/memory-wiki/skills/wiki-maintainer\`

## Fix

Added \`Use when (1)…(2)…\` + concrete trigger phrases to each, matching the pattern already used by \`skills/coding-agent\` and \`skills/github\` (which both pass the audit). Pure frontmatter text change.

## Scope

This PR is intentionally tight to the 4 HIGH items so it can land quickly. The issue's MEDIUM finding (\`skills/gh-issues\` exceeds the 5000-word cap) is a refactor into a \`references/\` subdir and better scoped as a separate change.

## Pre-implement audit

- **A (existing helper):** Pattern already exists in \`coding-agent\` and \`github\` — reused.
- **B (shared callers):** Frontmatter is routing input, not imported code — no caller-contract surface.
- **C (broader rival):** \`gh pr list --search \"69475\"\` returned zero rivals.

Partially addresses #69475 (HIGH items only; MEDIUM gh-issues size-cap left for a separate PR).