### PR TITLE
fix: resolve SecretRef keychain tokens in desktop app browser proxy

### DIFF
--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -129,19 +129,34 @@ actor GatewayEndpointStore {
     private static func resolveConfigPassword(isRemote: Bool, root: [String: Any]) -> String? {
         if isRemote {
             if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let password = remote["password"] as? String
+               let remote = gateway["remote"] as? [String: Any]
             {
-                return password.trimmingCharacters(in: .whitespacesAndNewlines)
+                if let password = remote["password"] as? String {
+                    let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty { return trimmed }
+                }
             }
             return nil
         }
 
         if let gateway = root["gateway"] as? [String: Any],
-           let auth = gateway["auth"] as? [String: Any],
-           let password = auth["password"] as? String
+           let auth = gateway["auth"] as? [String: Any]
         {
-            return password.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let password = auth["password"] as? String {
+                let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+            // Handle SecretRef format for passwords too
+            if let ref = auth["password"] as? [String: Any],
+               let provider = ref["provider"] as? String,
+               provider == "keychain",
+               let id = ref["id"] as? String
+            {
+                let service = ref["service"] as? String ?? "openclaw"
+                if let resolved = resolveKeychainToken(service: service, account: id) {
+                    return resolved
+                }
+            }
         }
         return nil
     }
@@ -192,12 +207,51 @@ actor GatewayEndpointStore {
         }
 
         if let gateway = root["gateway"] as? [String: Any],
-           let auth = gateway["auth"] as? [String: Any],
-           let token = auth["token"] as? String
+           let auth = gateway["auth"] as? [String: Any]
         {
-            return token.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let token = auth["token"] as? String {
+                let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+            // Handle SecretRef format: { source: "exec", provider: "keychain", id: "<keychain-account>" }
+            if let ref = auth["token"] as? [String: Any],
+               let provider = ref["provider"] as? String,
+               provider == "keychain",
+               let id = ref["id"] as? String
+            {
+                let service = ref["service"] as? String ?? "openclaw"
+                if let resolved = resolveKeychainToken(service: service, account: id) {
+                    return resolved
+                }
+            }
         }
         return nil
+    }
+
+    /// Resolve a gateway token from the macOS keychain.
+    private static func resolveKeychainToken(service: String, account: String) -> String? {
+        let trimmed = securityFindGenericPassword(service: service, account: account)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Invoke `security find-generic-password -s <service> -a <account> -w` and return the password.
+    private static func securityFindGenericPassword(service: String, account: String) -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+        process.arguments = ["find-generic-password", "-s", service, "-a", account, "-w"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+            process.waitUntilExit()
+            guard process.terminationStatus == 0 else { return "" }
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            return ""
+        }
     }
 
     private static func warnEnvOverrideOnce(

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -80,7 +80,7 @@ actor GatewayEndpointStore {
             ensureRemoteTunnel: { try await RemoteTunnelManager.shared.ensureControlTunnel() })
     }
 
-    struct SecretInputResolver: Sendable {
+    struct SecretInputResolver {
         typealias SecurityRunner = @Sendable (_ service: String, _ account: String) -> String?
 
         let securityRunner: SecurityRunner
@@ -99,7 +99,9 @@ actor GatewayEndpointStore {
 
         func resolve(_ input: Any?) async -> String? {
             guard let secret = self.parse(input) else { return self.resolvePlainString(input) }
-            guard let raw = await Task.detached(priority: .utility, operation: { self.securityRunner(secret.service, secret.account) }).value else { return nil }
+            guard let raw = await Task.detached(
+                priority: .utility,
+                operation: { self.securityRunner(secret.service, secret.account) }).value else { return nil }
             let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
             return trimmed.isEmpty ? nil : trimmed
         }
@@ -120,12 +122,15 @@ actor GatewayEndpointStore {
         private func parse(_ input: Any?) -> (service: String, account: String)? {
             guard let ref = input as? [String: Any] else { return nil }
             guard (ref["source"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "exec",
-                  (ref["provider"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "keychain"
+                  (ref[
+                      "provider",
+                  ] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "keychain"
             else { return nil }
             guard let rawID = ref["id"] as? String else { return nil }
             let account = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !account.isEmpty else { return nil }
-            let service = ((ref["service"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 } ?? "openclaw"
+            let service = ((ref["service"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines))
+                .flatMap { $0.isEmpty ? nil : $0 } ?? "openclaw"
             return (service: service, account: account)
         }
 
@@ -288,7 +293,6 @@ actor GatewayEndpointStore {
         return nil
     }
 
-
     private static func resolveGatewayPasswordSync(
         isRemote: Bool,
         root: [String: Any],
@@ -299,11 +303,17 @@ actor GatewayEndpointStore {
         let raw = env["OPENCLAW_GATEWAY_PASSWORD"] ?? ""
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty { return trimmed }
-        if let configPassword = self.resolveConfigPasswordSync(isRemote: isRemote, root: root, secretResolver: secretResolver) {
+        if let configPassword = self.resolveConfigPasswordSync(
+            isRemote: isRemote,
+            root: root,
+            secretResolver: secretResolver)
+        {
             return configPassword
         }
         guard !isRemote else { return nil }
-        if let password = launchdSnapshot?.password?.trimmingCharacters(in: .whitespacesAndNewlines), !password.isEmpty {
+        if let password = launchdSnapshot?.password?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !password.isEmpty
+        {
             return password
         }
         return nil
@@ -315,10 +325,12 @@ actor GatewayEndpointStore {
         secretResolver: SecretInputResolver = .blocking) -> String?
     {
         if isRemote {
-            guard let gateway = root["gateway"] as? [String: Any], let remote = gateway["remote"] as? [String: Any] else { return nil }
+            guard let gateway = root["gateway"] as? [String: Any],
+                  let remote = gateway["remote"] as? [String: Any] else { return nil }
             return secretResolver.resolveSync(remote["password"] as? String)
         }
-        guard let gateway = root["gateway"] as? [String: Any], let auth = gateway["auth"] as? [String: Any] else { return nil }
+        guard let gateway = root["gateway"] as? [String: Any],
+              let auth = gateway["auth"] as? [String: Any] else { return nil }
         return secretResolver.resolveSync(auth["password"])
     }
 
@@ -332,7 +344,11 @@ actor GatewayEndpointStore {
         let raw = env["OPENCLAW_GATEWAY_TOKEN"] ?? ""
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty { return trimmed }
-        if let configToken = self.resolveConfigTokenSync(isRemote: isRemote, root: root, secretResolver: secretResolver) {
+        if let configToken = self.resolveConfigTokenSync(
+            isRemote: isRemote,
+            root: root,
+            secretResolver: secretResolver)
+        {
             return configToken
         }
         guard !isRemote else { return nil }
@@ -348,7 +364,8 @@ actor GatewayEndpointStore {
         secretResolver: SecretInputResolver = .blocking) -> String?
     {
         if isRemote { return GatewayRemoteConfig.resolveTokenString(root: root) }
-        guard let gateway = root["gateway"] as? [String: Any], let auth = gateway["auth"] as? [String: Any] else { return nil }
+        guard let gateway = root["gateway"] as? [String: Any],
+              let auth = gateway["auth"] as? [String: Any] else { return nil }
         return secretResolver.resolveSync(auth["token"])
     }
 

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -33,8 +33,8 @@ actor GatewayEndpointStore {
 
     struct Deps {
         let mode: @Sendable () async -> AppState.ConnectionMode
-        let token: @Sendable () -> String?
-        let password: @Sendable () -> String?
+        let token: @Sendable () async -> String?
+        let password: @Sendable () async -> String?
         let localPort: @Sendable () -> Int
         let localHost: @Sendable () async -> String
         let remotePortIfRunning: @Sendable () async -> UInt16?
@@ -45,20 +45,22 @@ actor GatewayEndpointStore {
             token: {
                 let root = OpenClawConfigFile.loadDict()
                 let isRemote = ConnectionModeResolver.resolve(root: root).mode == .remote
-                return GatewayEndpointStore.resolveGatewayToken(
+                return await GatewayEndpointStore.resolveGatewayToken(
                     isRemote: isRemote,
                     root: root,
                     env: ProcessInfo.processInfo.environment,
-                    launchdSnapshot: GatewayLaunchAgentManager.launchdConfigSnapshot())
+                    launchdSnapshot: GatewayLaunchAgentManager.launchdConfigSnapshot(),
+                    secretResolver: .live)
             },
             password: {
                 let root = OpenClawConfigFile.loadDict()
                 let isRemote = ConnectionModeResolver.resolve(root: root).mode == .remote
-                return GatewayEndpointStore.resolveGatewayPassword(
+                return await GatewayEndpointStore.resolveGatewayPassword(
                     isRemote: isRemote,
                     root: root,
                     env: ProcessInfo.processInfo.environment,
-                    launchdSnapshot: GatewayLaunchAgentManager.launchdConfigSnapshot())
+                    launchdSnapshot: GatewayLaunchAgentManager.launchdConfigSnapshot(),
+                    secretResolver: .live)
             },
             localPort: { GatewayEnvironment.gatewayPort() },
             localHost: {
@@ -78,18 +80,85 @@ actor GatewayEndpointStore {
             ensureRemoteTunnel: { try await RemoteTunnelManager.shared.ensureControlTunnel() })
     }
 
+    struct SecretInputResolver: Sendable {
+        typealias SecurityRunner = @Sendable (_ service: String, _ account: String) -> String?
+
+        let securityRunner: SecurityRunner
+
+        static let live = SecretInputResolver { service, account in
+            Self.securityFindGenericPassword(service: service, account: account)
+        }
+
+        static let blocking = SecretInputResolver { service, account in
+            Self.securityFindGenericPassword(service: service, account: account)
+        }
+
+        static func stub(_ value: String?) -> SecretInputResolver {
+            SecretInputResolver { _, _ in value }
+        }
+
+        func resolve(_ input: Any?) async -> String? {
+            guard let secret = self.parse(input) else { return self.resolvePlainString(input) }
+            guard let raw = await Task.detached(priority: .utility, operation: { self.securityRunner(secret.service, secret.account) }).value else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        func resolveSync(_ input: Any?) -> String? {
+            guard let secret = self.parse(input) else { return self.resolvePlainString(input) }
+            guard let raw = self.securityRunner(secret.service, secret.account) else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private func resolvePlainString(_ input: Any?) -> String? {
+            guard let raw = input as? String else { return nil }
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        }
+
+        private func parse(_ input: Any?) -> (service: String, account: String)? {
+            guard let ref = input as? [String: Any] else { return nil }
+            guard (ref["source"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "exec",
+                  (ref["provider"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "keychain"
+            else { return nil }
+            guard let rawID = ref["id"] as? String else { return nil }
+            let account = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !account.isEmpty else { return nil }
+            let service = ((ref["service"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)).flatMap { $0.isEmpty ? nil : $0 } ?? "openclaw"
+            return (service: service, account: account)
+        }
+
+        private static func securityFindGenericPassword(service: String, account: String) -> String? {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
+            process.arguments = ["find-generic-password", "-s", service, "-a", account, "-w"]
+            let pipe = Pipe()
+            process.standardOutput = pipe
+            process.standardError = FileHandle.nullDevice
+            do {
+                try process.run()
+                process.waitUntilExit()
+                guard process.terminationStatus == 0 else { return nil }
+                let data = pipe.fileHandleForReading.readDataToEndOfFile()
+                return String(data: data, encoding: .utf8)
+            } catch {
+                return nil
+            }
+        }
+    }
+
     private static func resolveGatewayPassword(
         isRemote: Bool,
         root: [String: Any],
         env: [String: String],
-        launchdSnapshot: LaunchAgentPlistSnapshot?) -> String?
+        launchdSnapshot: LaunchAgentPlistSnapshot?,
+        secretResolver: SecretInputResolver = .blocking) async -> String?
     {
         let raw = env["OPENCLAW_GATEWAY_PASSWORD"] ?? ""
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
-            if let configPassword = self.resolveConfigPassword(isRemote: isRemote, root: root),
-               !configPassword.isEmpty
-            {
+            if self.hasConfigPassword(isRemote: isRemote, root: root) {
                 self.warnEnvOverrideOnce(
                     kind: .password,
                     envVar: "OPENCLAW_GATEWAY_PASSWORD",
@@ -97,27 +166,16 @@ actor GatewayEndpointStore {
             }
             return trimmed
         }
-        if isRemote {
-            if let gateway = root["gateway"] as? [String: Any],
-               let remote = gateway["remote"] as? [String: Any],
-               let password = remote["password"] as? String
-            {
-                let pw = password.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !pw.isEmpty {
-                    return pw
-                }
-            }
-            return nil
-        }
-        if let gateway = root["gateway"] as? [String: Any],
-           let auth = gateway["auth"] as? [String: Any],
-           let password = auth["password"] as? String
+
+        if let configPassword = await self.resolveConfigPassword(
+            isRemote: isRemote,
+            root: root,
+            secretResolver: secretResolver)
         {
-            let pw = password.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !pw.isEmpty {
-                return pw
-            }
+            return configPassword
         }
+
+        guard !isRemote else { return nil }
         if let password = launchdSnapshot?.password?.trimmingCharacters(in: .whitespacesAndNewlines),
            !password.isEmpty
         {
@@ -126,15 +184,31 @@ actor GatewayEndpointStore {
         return nil
     }
 
-    private static func resolveConfigPassword(isRemote: Bool, root: [String: Any]) -> String? {
+    private static func hasConfigPassword(isRemote: Bool, root: [String: Any]) -> Bool {
         if isRemote {
             if let gateway = root["gateway"] as? [String: Any],
                let remote = gateway["remote"] as? [String: Any]
             {
-                if let password = remote["password"] as? String {
-                    let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty { return trimmed }
-                }
+                return (remote["password"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            }
+            return false
+        }
+        guard let gateway = root["gateway"] as? [String: Any],
+              let auth = gateway["auth"] as? [String: Any]
+        else { return false }
+        return auth["password"] is String || auth["password"] is [String: Any]
+    }
+
+    private static func resolveConfigPassword(
+        isRemote: Bool,
+        root: [String: Any],
+        secretResolver: SecretInputResolver = .blocking) async -> String?
+    {
+        if isRemote {
+            if let gateway = root["gateway"] as? [String: Any],
+               let remote = gateway["remote"] as? [String: Any]
+            {
+                return await secretResolver.resolve(remote["password"] as? String)
             }
             return nil
         }
@@ -142,21 +216,7 @@ actor GatewayEndpointStore {
         if let gateway = root["gateway"] as? [String: Any],
            let auth = gateway["auth"] as? [String: Any]
         {
-            if let password = auth["password"] as? String {
-                let trimmed = password.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty { return trimmed }
-            }
-            // Handle SecretRef format for passwords too
-            if let ref = auth["password"] as? [String: Any],
-               let provider = ref["provider"] as? String,
-               provider == "keychain",
-               let id = ref["id"] as? String
-            {
-                let service = ref["service"] as? String ?? "openclaw"
-                if let resolved = resolveKeychainToken(service: service, account: id) {
-                    return resolved
-                }
-            }
+            return await secretResolver.resolve(auth["password"])
         }
         return nil
     }
@@ -165,15 +225,13 @@ actor GatewayEndpointStore {
         isRemote: Bool,
         root: [String: Any],
         env: [String: String],
-        launchdSnapshot: LaunchAgentPlistSnapshot?) -> String?
+        launchdSnapshot: LaunchAgentPlistSnapshot?,
+        secretResolver: SecretInputResolver = .blocking) async -> String?
     {
         let raw = env["OPENCLAW_GATEWAY_TOKEN"] ?? ""
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
-            if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
-               !configToken.isEmpty,
-               configToken != trimmed
-            {
+            if self.hasConfigToken(isRemote: isRemote, root: root) {
                 self.warnEnvOverrideOnce(
                     kind: .token,
                     envVar: "OPENCLAW_GATEWAY_TOKEN",
@@ -182,8 +240,10 @@ actor GatewayEndpointStore {
             return trimmed
         }
 
-        if let configToken = self.resolveConfigToken(isRemote: isRemote, root: root),
-           !configToken.isEmpty
+        if let configToken = await self.resolveConfigToken(
+            isRemote: isRemote,
+            root: root,
+            secretResolver: secretResolver)
         {
             return configToken
         }
@@ -201,7 +261,21 @@ actor GatewayEndpointStore {
         return nil
     }
 
-    private static func resolveConfigToken(isRemote: Bool, root: [String: Any]) -> String? {
+    private static func hasConfigToken(isRemote: Bool, root: [String: Any]) -> Bool {
+        if isRemote {
+            return GatewayRemoteConfig.resolveTokenString(root: root) != nil
+        }
+        guard let gateway = root["gateway"] as? [String: Any],
+              let auth = gateway["auth"] as? [String: Any]
+        else { return false }
+        return auth["token"] is String || auth["token"] is [String: Any]
+    }
+
+    private static func resolveConfigToken(
+        isRemote: Bool,
+        root: [String: Any],
+        secretResolver: SecretInputResolver = .blocking) async -> String?
+    {
         if isRemote {
             return GatewayRemoteConfig.resolveTokenString(root: root)
         }
@@ -209,49 +283,73 @@ actor GatewayEndpointStore {
         if let gateway = root["gateway"] as? [String: Any],
            let auth = gateway["auth"] as? [String: Any]
         {
-            if let token = auth["token"] as? String {
-                let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !trimmed.isEmpty { return trimmed }
-            }
-            // Handle SecretRef format: { source: "exec", provider: "keychain", id: "<keychain-account>" }
-            if let ref = auth["token"] as? [String: Any],
-               let provider = ref["provider"] as? String,
-               provider == "keychain",
-               let id = ref["id"] as? String
-            {
-                let service = ref["service"] as? String ?? "openclaw"
-                if let resolved = resolveKeychainToken(service: service, account: id) {
-                    return resolved
-                }
-            }
+            return await secretResolver.resolve(auth["token"])
         }
         return nil
     }
 
-    /// Resolve a gateway token from the macOS keychain.
-    private static func resolveKeychainToken(service: String, account: String) -> String? {
-        let trimmed = securityFindGenericPassword(service: service, account: account)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? nil : trimmed
+
+    private static func resolveGatewayPasswordSync(
+        isRemote: Bool,
+        root: [String: Any],
+        env: [String: String],
+        launchdSnapshot: LaunchAgentPlistSnapshot?,
+        secretResolver: SecretInputResolver = .blocking) -> String?
+    {
+        let raw = env["OPENCLAW_GATEWAY_PASSWORD"] ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        if let configPassword = self.resolveConfigPasswordSync(isRemote: isRemote, root: root, secretResolver: secretResolver) {
+            return configPassword
+        }
+        guard !isRemote else { return nil }
+        if let password = launchdSnapshot?.password?.trimmingCharacters(in: .whitespacesAndNewlines), !password.isEmpty {
+            return password
+        }
+        return nil
     }
 
-    /// Invoke `security find-generic-password -s <service> -a <account> -w` and return the password.
-    private static func securityFindGenericPassword(service: String, account: String) -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/security")
-        process.arguments = ["find-generic-password", "-s", service, "-a", account, "-w"]
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-        do {
-            try process.run()
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else { return "" }
-            let data = pipe.fileHandleForReading.readDataToEndOfFile()
-            return String(data: data, encoding: .utf8) ?? ""
-        } catch {
-            return ""
+    private static func resolveConfigPasswordSync(
+        isRemote: Bool,
+        root: [String: Any],
+        secretResolver: SecretInputResolver = .blocking) -> String?
+    {
+        if isRemote {
+            guard let gateway = root["gateway"] as? [String: Any], let remote = gateway["remote"] as? [String: Any] else { return nil }
+            return secretResolver.resolveSync(remote["password"] as? String)
         }
+        guard let gateway = root["gateway"] as? [String: Any], let auth = gateway["auth"] as? [String: Any] else { return nil }
+        return secretResolver.resolveSync(auth["password"])
+    }
+
+    private static func resolveGatewayTokenSync(
+        isRemote: Bool,
+        root: [String: Any],
+        env: [String: String],
+        launchdSnapshot: LaunchAgentPlistSnapshot?,
+        secretResolver: SecretInputResolver = .blocking) -> String?
+    {
+        let raw = env["OPENCLAW_GATEWAY_TOKEN"] ?? ""
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return trimmed }
+        if let configToken = self.resolveConfigTokenSync(isRemote: isRemote, root: root, secretResolver: secretResolver) {
+            return configToken
+        }
+        guard !isRemote else { return nil }
+        if let token = launchdSnapshot?.token?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty {
+            return token
+        }
+        return nil
+    }
+
+    private static func resolveConfigTokenSync(
+        isRemote: Bool,
+        root: [String: Any],
+        secretResolver: SecretInputResolver = .blocking) -> String?
+    {
+        if isRemote { return GatewayRemoteConfig.resolveTokenString(root: root) }
+        guard let gateway = root["gateway"] as? [String: Any], let auth = gateway["auth"] as? [String: Any] else { return nil }
+        return secretResolver.resolveSync(auth["token"])
     }
 
     private static func warnEnvOverrideOnce(
@@ -307,8 +405,8 @@ actor GatewayEndpointStore {
             bindMode: bind,
             customBindHost: customBindHost,
             tailscaleIP: nil)
-        let token = deps.token()
-        let password = deps.password()
+        let token: String? = nil
+        let password: String? = nil
         switch initialMode {
         case .local:
             self.state = .ready(
@@ -321,6 +419,10 @@ actor GatewayEndpointStore {
             Task { await self.setMode(.remote) }
         case .unconfigured:
             self.state = .unavailable(mode: .unconfigured, reason: "Gateway not configured")
+        }
+
+        if initialMode == .local {
+            Task { await self.setMode(.local) }
         }
     }
 
@@ -343,8 +445,8 @@ actor GatewayEndpointStore {
     }
 
     func setMode(_ mode: AppState.ConnectionMode) async {
-        let token = self.deps.token()
-        let password = self.deps.password()
+        let token = await self.deps.token()
+        let password = await self.deps.password()
         switch mode {
         case .local:
             self.cancelRemoteEnsure()
@@ -463,8 +565,8 @@ actor GatewayEndpointStore {
         try await self.requireRemoteMode()
 
         if let url = try self.resolveDirectRemoteURL() {
-            let token = self.deps.token()
-            let password = self.deps.password()
+            let token = await self.deps.token()
+            let password = await self.deps.password()
             self.cancelRemoteEnsure()
             self.setState(.ready(mode: .remote, url: url, token: token, password: password))
             return (url, token, password)
@@ -489,8 +591,8 @@ actor GatewayEndpointStore {
                 self.remoteEnsure = nil
             }
 
-            let token = self.deps.token()
-            let password = self.deps.password()
+            let token = await self.deps.token()
+            let password = await self.deps.password()
             let scheme = GatewayEndpointStore.resolveGatewayScheme(
                 root: OpenClawConfigFile.loadDict(),
                 env: ProcessInfo.processInfo.environment)
@@ -585,8 +687,8 @@ actor GatewayEndpointStore {
             root: root,
             env: ProcessInfo.processInfo.environment)
         let port = self.deps.localPort()
-        let token = self.deps.token()
-        let password = self.deps.password()
+        let token = await self.deps.token()
+        let password = await self.deps.password()
         let url = URL(string: "\(scheme)://\(tailscaleIP):\(port)")!
 
         self.logger.info("auto bind fallback to tailnet host=\(tailscaleIP, privacy: .public)")
@@ -684,12 +786,12 @@ extension GatewayEndpointStore {
             bindMode: bind,
             customBindHost: customBindHost,
             tailscaleIP: tailscaleIP)
-        let token = self.resolveGatewayToken(
+        let token = self.resolveGatewayTokenSync(
             isRemote: false,
             root: root,
             env: env,
             launchdSnapshot: launchdSnapshot)
-        let password = self.resolveGatewayPassword(
+        let password = self.resolveGatewayPasswordSync(
             isRemote: false,
             root: root,
             env: env,
@@ -776,18 +878,30 @@ extension GatewayEndpointStore {
         isRemote: Bool,
         root: [String: Any],
         env: [String: String],
-        launchdSnapshot: LaunchAgentPlistSnapshot? = nil) -> String?
+        launchdSnapshot: LaunchAgentPlistSnapshot? = nil,
+        secretResolver: SecretInputResolver = .stub(nil)) -> String?
     {
-        self.resolveGatewayPassword(isRemote: isRemote, root: root, env: env, launchdSnapshot: launchdSnapshot)
+        self.resolveGatewayPasswordSync(
+            isRemote: isRemote,
+            root: root,
+            env: env,
+            launchdSnapshot: launchdSnapshot,
+            secretResolver: secretResolver)
     }
 
     static func _testResolveGatewayToken(
         isRemote: Bool,
         root: [String: Any],
         env: [String: String],
-        launchdSnapshot: LaunchAgentPlistSnapshot? = nil) -> String?
+        launchdSnapshot: LaunchAgentPlistSnapshot? = nil,
+        secretResolver: SecretInputResolver = .stub(nil)) -> String?
     {
-        self.resolveGatewayToken(isRemote: isRemote, root: root, env: env, launchdSnapshot: launchdSnapshot)
+        self.resolveGatewayTokenSync(
+            isRemote: isRemote,
+            root: root,
+            env: env,
+            launchdSnapshot: launchdSnapshot,
+            secretResolver: secretResolver)
     }
 
     static func _testResolveGatewayBindMode(

--- a/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayEndpointStore.swift
@@ -793,7 +793,8 @@ extension GatewayEndpointStore {
         root: [String: Any],
         env: [String: String],
         launchdSnapshot: LaunchAgentPlistSnapshot?,
-        tailscaleIP: String?) -> GatewayConnection.Config
+        tailscaleIP: String?,
+        secretResolver: SecretInputResolver = .blocking) -> GatewayConnection.Config
     {
         let port = GatewayEnvironment.gatewayPort()
         let bind = self.resolveGatewayBindMode(root: root, env: env)
@@ -807,12 +808,14 @@ extension GatewayEndpointStore {
             isRemote: false,
             root: root,
             env: env,
-            launchdSnapshot: launchdSnapshot)
+            launchdSnapshot: launchdSnapshot,
+            secretResolver: secretResolver)
         let password = self.resolveGatewayPasswordSync(
             isRemote: false,
             root: root,
             env: env,
-            launchdSnapshot: launchdSnapshot)
+            launchdSnapshot: launchdSnapshot,
+            secretResolver: secretResolver)
         return (
             url: URL(string: "\(scheme)://\(host):\(port)")!,
             token: token,
@@ -943,13 +946,15 @@ extension GatewayEndpointStore {
         root: [String: Any],
         env: [String: String],
         launchdSnapshot: LaunchAgentPlistSnapshot? = nil,
-        tailscaleIP: String? = nil) -> GatewayConnection.Config
+        tailscaleIP: String? = nil,
+        secretResolver: SecretInputResolver = .stub(nil)) -> GatewayConnection.Config
     {
         self.localConfig(
             root: root,
             env: env,
             launchdSnapshot: launchdSnapshot,
-            tailscaleIP: tailscaleIP)
+            tailscaleIP: tailscaleIP,
+            secretResolver: secretResolver)
     }
 }
 #endif

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -398,4 +398,36 @@ struct GatewayEndpointStoreTests {
         let url = GatewayRemoteConfig.normalizeGatewayUrl("ws://127.attacker.example")
         #expect(url == nil)
     }
+
+    @Test func `localConfig resolves SecretRef token and password`() {
+        let snapshot = self.makeLaunchAgentSnapshot(
+            env: [:],
+            token: nil,
+            password: nil)
+        let root: [String: Any] = [
+            "gateway": [
+                "auth": [
+                    "token": [
+                        "source": "exec",
+                        "provider": "keychain",
+                        "id": "gateway-token",
+                    ],
+                    "password": [
+                        "source": "exec",
+                        "provider": "keychain",
+                        "id": "gateway-password",
+                    ],
+                ],
+            ],
+        ]
+
+        let config = GatewayEndpointStore._testLocalConfig(
+            root: root,
+            env: [:],
+            launchdSnapshot: snapshot,
+            secretResolver: .stub("secret-value"))
+
+        #expect(config.token == "secret-value")
+        #expect(config.password == "secret-value")
+    }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -26,6 +26,20 @@ struct GatewayEndpointStoreTests {
         return defaults
     }
 
+    private final class SecretRunnerCalls: @unchecked Sendable {
+        var calls: [(service: String, account: String)] = []
+    }
+
+    private func makeSecretResolver(
+        value: String?,
+        calls: SecretRunnerCalls = SecretRunnerCalls()) -> GatewayEndpointStore.SecretInputResolver
+    {
+        GatewayEndpointStore.SecretInputResolver { service, account in
+            calls.calls.append((service: service, account: account))
+            return value
+        }
+    }
+
     @Test func `resolve gateway token prefers env and falls back to launchd`() {
         let snapshot = self.makeLaunchAgentSnapshot(
             env: ["OPENCLAW_GATEWAY_TOKEN": "launchd-token"],
@@ -88,6 +102,103 @@ struct GatewayEndpointStoreTests {
             env: [:],
             launchdSnapshot: snapshot)
         #expect(password == "launchd-pass")
+    }
+
+    @Test func resolveGatewayTokenUsesLocalSecretRef() {
+        let calls = SecretRunnerCalls()
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "token": [
+                            "source": "exec",
+                            "provider": "keychain",
+                            "id": "gateway-token",
+                        ],
+                    ],
+                ],
+            ],
+            env: [:],
+            secretResolver: self.makeSecretResolver(value: "  secret-token  ", calls: calls))
+
+        #expect(token == "secret-token")
+        #expect(calls.calls.count == 1)
+        #expect(calls.calls.first?.service == "openclaw")
+        #expect(calls.calls.first?.account == "gateway-token")
+    }
+
+    @Test func resolveGatewayPasswordUsesLocalSecretRef() {
+        let calls = SecretRunnerCalls()
+        let password = GatewayEndpointStore._testResolveGatewayPassword(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "password": [
+                            "source": "exec",
+                            "provider": "keychain",
+                            "service": "custom-service",
+                            "id": "gateway-password",
+                        ],
+                    ],
+                ],
+            ],
+            env: [:],
+            secretResolver: self.makeSecretResolver(value: " secret-password\n", calls: calls))
+
+        #expect(password == "secret-password")
+        #expect(calls.calls.count == 1)
+        #expect(calls.calls.first?.service == "custom-service")
+        #expect(calls.calls.first?.account == "gateway-password")
+    }
+
+    @Test func envGatewayTokenOverridesSecretRefWithoutResolvingIt() {
+        let calls = SecretRunnerCalls()
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "token": [
+                            "source": "exec",
+                            "provider": "keychain",
+                            "id": "gateway-token",
+                        ],
+                    ],
+                ],
+            ],
+            env: ["OPENCLAW_GATEWAY_TOKEN": "env-token"],
+            secretResolver: self.makeSecretResolver(value: "secret-token", calls: calls))
+
+        #expect(token == "env-token")
+        #expect(calls.calls.isEmpty)
+    }
+
+    @Test func launchdGatewayTokenFallbackStillWorksAfterUnresolvedSecretRef() {
+        let snapshot = self.makeLaunchAgentSnapshot(
+            env: ["OPENCLAW_GATEWAY_TOKEN": "launchd-token"],
+            token: "launchd-token",
+            password: nil)
+
+        let token = GatewayEndpointStore._testResolveGatewayToken(
+            isRemote: false,
+            root: [
+                "gateway": [
+                    "auth": [
+                        "token": [
+                            "source": "exec",
+                            "provider": "keychain",
+                            "id": "missing-token",
+                        ],
+                    ],
+                ],
+            ],
+            env: [:],
+            launchdSnapshot: snapshot,
+            secretResolver: self.makeSecretResolver(value: nil))
+
+        #expect(token == "launchd-token")
     }
 
     @Test func `connection mode resolver prefers config mode over defaults`() {


### PR DESCRIPTION
## Problem

When `gateway.auth.token` is configured as a SecretRef (e.g., `{source: "exec", provider: "keychain", id: "gateway-auth-token"}`), the macOS desktop app fails to resolve the actual token value. This causes:

1. Desktop app reads `gateway.auth.token` as a dictionary, not a string
2. The `as? String` cast fails → token resolves to nil
3. Browser proxy requests to the gateway control server have no auth header
4. Gateway returns 401 Unauthorized
5. All browser tool calls via `node.invoke` fail with `UNAVAILABLE: Unauthorized`

## Fix

- Detect when `gateway.auth.token` or `gateway.auth.password` is a SecretRef dictionary with `provider: "keychain"`
- Resolve the actual value from the macOS keychain using `/usr/bin/security find-generic-password`
- Fall through to nil if resolution fails (preserving existing behavior)

## Testing

- Verified the bug locally: `security find-generic-password -s gateway-auth-token -w` returns empty (wrong lookup), while `-s openclaw -a gateway-auth-token -w` returns the actual token
- Confirmed browser control server accepts the token when passed via `Authorization: Bearer <token>`
- The fix resolves the token correctly using the `service + account` keychain lookup pattern