### PR TITLE
fix: prevent defaultAccountId leak in cross-provider message sends

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when: (1) searching or sending Gmail, (2) reading or creating Calendar events, (3) listing or uploading Drive files, (4) reading or editing Sheets or Docs. Triggers on phrases like "check my email", "what's on my calendar", "send an email to", "summarize today's inbox".
 homepage: https://gogcli.sh
 metadata:
   {

--- a/skills/session-logs/SKILL.md
+++ b/skills/session-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-logs
-description: Search and analyze your own session logs (older/parent conversations) using jq.
+description: Search and analyze your own session logs (older/parent conversations) using jq. Use when: (1) recalling what a prior session said or did, (2) auditing your own tool usage, (3) debugging cross-session state. Triggers on phrases like "what did I say earlier", "check my prior session", "search my conversation logs".
 metadata: { "openclaw": { "emoji": "📜", "requires": { "bins": ["jq", "rg"] } } }
 ---
 

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -8,6 +8,9 @@ export const ExecApprovalsAllowlistEntrySchema = Type.Object(
     lastUsedAt: Type.Optional(Type.Integer({ minimum: 0 })),
     lastUsedCommand: Type.Optional(Type.String()),
     lastResolvedPath: Type.Optional(Type.String()),
+    // Written by Telegram "Allow always" approval handler — retained on disk
+    // and accepted here so the gateway schema mirrors what is actually stored.
+    source: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1254,4 +1254,70 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.accountId).toBe("account-b");
     expect(ctx.params.accountId).toBe("account-b");
   });
+
+  it("does not leak defaultAccountId to target channel on cross-provider send", async () => {
+    const sourceHandleAction = vi.fn(async () => jsonResult({ ok: true }));
+    const targetHandleAction = vi.fn(async () => jsonResult({ ok: true }));
+
+    const sourcePlugin: ChannelPlugin = {
+      id: "telegram",
+      meta: {
+        id: "telegram",
+        label: "Telegram",
+        selectionLabel: "Telegram",
+        docsPath: "",
+        blurb: "",
+      },
+      capabilities: { chatTypes: ["direct"] },
+      config: { listAccountIds: () => ["default"], resolveAccount: () => ({}) },
+      actions: { listActions: () => ["send"], handleAction: sourceHandleAction },
+    };
+
+    const targetPlugin: ChannelPlugin = {
+      id: "feishu",
+      meta: { id: "feishu", label: "Feishu", selectionLabel: "Feishu", docsPath: "", blurb: "" },
+      capabilities: { chatTypes: ["direct"] },
+      config: { listAccountIds: () => ["feishu-account"], resolveAccount: () => ({}) },
+      actions: { listActions: () => ["send"], handleAction: targetHandleAction },
+    };
+
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "telegram", source: "test", plugin: sourcePlugin },
+        { pluginId: "feishu", source: "test", plugin: targetPlugin },
+      ]),
+    );
+
+    try {
+      await runMessageAction({
+        cfg: {
+          tools: {
+            message: {
+              crossContext: { allowAcrossProviders: true },
+            },
+          },
+        } as OpenClawConfig,
+        action: "send",
+        params: {
+          channel: "feishu",
+          target: "user:ou_123",
+          message: "hi",
+        },
+        defaultAccountId: "default",
+        toolContext: { currentChannelProvider: "telegram" },
+      });
+
+      expect(targetHandleAction).toHaveBeenCalled();
+      const ctx = (targetHandleAction.mock.calls as unknown as Array<[unknown]>)[0]?.[0] as
+        | { accountId?: string | null; params: Record<string, unknown> }
+        | undefined;
+      if (!ctx) {
+        throw new Error("expected action context");
+      }
+      // accountId must NOT be "default" — feishu has no account by that name
+      expect(ctx.accountId ?? ctx.params.accountId).not.toBe("default");
+    } finally {
+      setActivePluginRegistry(createTestRegistry([]));
+    }
+  });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -718,7 +718,19 @@ export async function runMessageAction(
   });
 
   const channel = await resolveChannel(cfg, params, input.toolContext);
-  let accountId = readStringParam(params, "accountId") ?? input.defaultAccountId;
+
+  // When sending cross-provider, do not leak the source session's defaultAccountId
+  // to the target channel — let the target resolve its own account instead.
+  const explicitlyProvidedAccountId = readStringParam(params, "accountId");
+  const allowAcrossProviders = cfg.tools?.message?.crossContext?.allowAcrossProviders === true;
+  const isCrossProvider = Boolean(
+    allowAcrossProviders &&
+    input.toolContext?.currentChannelProvider &&
+    input.toolContext.currentChannelProvider !== channel,
+  );
+
+  let accountId =
+    explicitlyProvidedAccountId ?? (isCrossProvider ? undefined : input.defaultAccountId);
   if (!accountId && resolvedAgentId) {
     const byAgent = buildChannelAccountBindings(cfg).get(channel);
     const boundAccountIds = byAgent?.get(normalizeAgentId(resolvedAgentId));


### PR DESCRIPTION
## Summary

Two bug fixes bundled in this PR:

---

### Fix 1: #69525 — Cross-provider message send leaks source session accountId to target channel

When sending messages across providers (e.g. Telegram → Feishu) with `allowAcrossProviders: true`, the source session's `defaultAccountId` was incorrectly propagated to the target channel plugin, which has no account registered under that name.

**File:** `src/infra/outbound/message-action-runner.ts`

```typescript
const explicitlyProvidedAccountId = readStringParam(params, "accountId");
const allowAcrossProviders = cfg.tools?.message?.crossContext?.allowAcrossProviders === true;
const isCrossProvider = Boolean(
  allowAcrossProviders &&
    input.toolContext?.currentChannelProvider &&
    input.toolContext.currentChannelProvider !== channel,
);
let accountId = explicitlyProvidedAccountId ?? (isCrossProvider ? undefined : input.defaultAccountId);
```

---

### Fix 2: #69482 — Telegram "Allow always" source field rejected by gateway

Telegram "Allow always" approval handler writes `source: "allow-always"`, but the gateway schema for `exec.approvals.set` didn't include this field, causing `openclaw approvals set --gateway` to reject entries with `unexpected property 'source'`.

**File:** `src/gateway/protocol/schema/exec-approvals.ts`

Added `source: Type.Optional(Type.String())` to `ExecApprovalsAllowlistEntrySchema`.

---

### Also included: #69475 (partial) — Skill description fixes

Updated SKILL.md `description` fields for `gog` and `session-logs` to include `Use when:` trigger conditions per the Anthropic skill spec.

**Files:** `skills/gog/SKILL.md`, `skills/session-logs/SKILL.md`