### PR TITLE
fix(codex): declare codex-app-server as nonSecretAuthMarker to silence audit FP

### DIFF
--- a/extensions/codex/openclaw.plugin.json
+++ b/extensions/codex/openclaw.plugin.json
@@ -3,6 +3,7 @@
   "name": "Codex",
   "description": "Codex app-server harness and Codex-managed GPT model catalog.",
   "providers": ["codex"],
+  "nonSecretAuthMarkers": ["codex-app-server"],
   "activation": {
     "onAgentHarnesses": ["codex"]
   },

--- a/src/secrets/audit.test.ts
+++ b/src/secrets/audit.test.ts
@@ -442,6 +442,34 @@ describe("secrets audit", () => {
     });
   });
 
+  it("does not flag codex-app-server apiKey as plaintext (#69511)", async () => {
+    // codex's synthetic auth marker "codex-app-server" is declared in
+    // extensions/codex/openclaw.plugin.json under nonSecretAuthMarkers.
+    // Every agent with a codex provider block in models.json was emitting
+    // a false-positive PLAINTEXT_FOUND finding pre-fix.
+    await writeJsonFile(fixture.modelsPath, {
+      providers: {
+        codex: {
+          baseUrl: "https://chatgpt.com/backend-api/codex",
+          api: "codex-app-server",
+          apiKey: "codex-app-server", // pragma: allowlist secret
+          models: [{ id: "gpt-5-codex", name: "gpt-5-codex" }],
+        },
+      },
+    });
+
+    const report = await runSecretsAudit({ env: fixture.env });
+    expect(
+      hasFinding(
+        report,
+        (entry) =>
+          entry.code === "PLAINTEXT_FOUND" &&
+          entry.file === fixture.modelsPath &&
+          entry.jsonPath === "providers.codex.apiKey",
+      ),
+    ).toBe(false);
+  });
+
   it("flags arbitrary all-caps models.json apiKey values as plaintext", async () => {
     await writeModelsProvider({ apiKey: "ALLCAPS_SAMPLE" }); // pragma: allowlist secret
 


### PR DESCRIPTION
## Problem

\`openclaw secrets audit\` flags \`providers.codex.apiKey = \"codex-app-server\"\` in every agent's \`models.json\` as \`PLAINTEXT_FOUND\`. The value is a synthetic auth marker the codex extension writes via \`resolveSyntheticAuth\`, not a real API key. Reporter @joerod26 in #69511 showed it inflating the plaintext count by 7 entries on a single install, obscuring real findings.

The audit already supports filtering known markers: \`isNonSecretApiKeyMarker()\` in \`src/agents/model-auth-markers.ts\` reads \`plugin.nonSecretAuthMarkers\` from every bundled plugin's manifest. \`anthropic-vertex\`, \`minimax\`, \`lmstudio\`, \`ollama\` already use this pattern for \`gcp-vertex-credentials\`, \`minimax-oauth\`, \`lmstudio-local\`, \`ollama-local\` respectively.

Codex was the only bundled plugin emitting a synthetic marker **without declaring it** — so the audit couldn't distinguish it from a real plaintext key.

## Fix

Add \`\"nonSecretAuthMarkers\": [\"codex-app-server\"]\` to \`extensions/codex/openclaw.plugin.json\`.

**No source/runtime change** — the audit code path and the shared \`isNonSecretApiKeyMarker\` helper already handle this field correctly. This PR only fills the missing manifest declaration.

## Pre-implement audit

- **A (existing helper):** \`isNonSecretApiKeyMarker\` already reads \`plugin.nonSecretAuthMarkers\` from the manifest registry. Reusing. ✓
- **B (shared callers):** The helper is called from \`secrets/audit.ts:412\`, \`infra/provider-usage.auth.ts:79+85\`, and \`plugin-sdk/provider-auth.ts\`. Adding a marker strictly extends the \"not-a-secret\" set — contract preserved, no caller behavior change. ✓
- **C (broader rival):** Zero rivals for #69511. ✓

## Testing

Added \`src/secrets/audit.test.ts\` regression — writes a codex provider block with \`apiKey: \"codex-app-server\"\` and asserts no \`PLAINTEXT_FOUND\` finding on \`providers.codex.apiKey\`.

Fixes #69511