### PR TITLE
fix(synology-chat): block SSRF in sendFileUrl file_url parameter [AI-assisted]

### DIFF
--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -67,6 +67,7 @@ Minimal config:
       token: "synology-outgoing-token",
       incomingUrl: "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token=...",
       webhookPath: "/webhook/synology",
+      mediaUrlHostnameAllowlist: ["cdn.example.com"],
       dmPolicy: "allowlist",
       allowedUserIds: ["123456"],
       rateLimitPerMinute: 30,
@@ -84,6 +85,7 @@ For the default account, you can use env vars:
 - `SYNOLOGY_CHAT_INCOMING_URL`
 - `SYNOLOGY_NAS_HOST`
 - `SYNOLOGY_ALLOWED_USER_IDS` (comma-separated)
+- `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` (comma-separated trusted media hostnames)
 - `SYNOLOGY_RATE_LIMIT`
 - `OPENCLAW_BOT_NAME`
 
@@ -114,10 +116,29 @@ openclaw message send --channel synology-chat --target synology-chat:123456 --te
 
 Media sends are supported by URL-based file delivery.
 
+For security, Synology Chat hostname-based media URLs now require explicit trust
+configuration. Set `channels.synology-chat.mediaUrlHostnameAllowlist` or
+`SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` to the exact hostnames you want the NAS
+to fetch from. Public IP literal media URLs are still allowed if they pass the
+SSRF guard, but arbitrary hostname URLs are rejected by default.
+
+Example:
+
+```json5
+{
+  channels: {
+    "synology-chat": {
+      incomingUrl: "https://nas.example.com/webapi/entry.cgi?api=SYNO.Chat.External&method=incoming&version=2&token=...",
+      mediaUrlHostnameAllowlist: ["cdn.example.com", "media.example.net"],
+    },
+  },
+}
+```
+
 ## Multi-account
 
 Multiple Synology Chat accounts are supported under `channels.synology-chat.accounts`.
-Each account can override token, incoming URL, webhook path, DM policy, and limits.
+Each account can override token, incoming URL, webhook path, media hostname allowlist, DM policy, and limits.
 Direct-message sessions are isolated per account and user, so the same numeric `user_id`
 on two different Synology accounts does not share transcript state.
 Give each enabled account a distinct `webhookPath`. OpenClaw now rejects duplicate exact paths
@@ -140,6 +161,7 @@ but duplicate exact paths are still rejected fail-closed. Prefer explicit per-ac
           token: "token-b",
           incomingUrl: "https://nas-b.example.com/...token=...",
           webhookPath: "/webhook/synology-alerts",
+          mediaUrlHostnameAllowlist: ["alerts-cdn.example.com"],
           dmPolicy: "allowlist",
           allowedUserIds: ["987654"],
         },
@@ -156,6 +178,7 @@ but duplicate exact paths are still rejected fail-closed. Prefer explicit per-ac
 - Inbound webhook requests are token-verified and rate-limited per sender.
 - Invalid token checks use constant-time secret comparison and fail closed.
 - Prefer `dmPolicy: "allowlist"` for production.
+- Keep `mediaUrlHostnameAllowlist` narrow and operator-controlled. Hostname-based media URLs are rejected unless explicitly trusted.
 - Keep `dangerouslyAllowNameMatching` off unless you explicitly need legacy username-based reply delivery.
 - Keep `dangerouslyAllowInheritedWebhookPath` off unless you explicitly accept shared-path routing risk in a multi-account setup.
 
@@ -175,6 +198,10 @@ but duplicate exact paths are still rejected fail-closed. Prefer explicit per-ac
   - `dmPolicy="allowlist"` is enabled but no users are configured
 - `User not authorized`:
   - the sender's numeric `user_id` is not in `allowedUserIds`
+- `Synology Chat file_url hostname URLs require mediaUrlHostnameAllowlist...`:
+  - the media URL uses a hostname and that hostname is not explicitly trusted
+  - add the hostname to `channels.synology-chat.mediaUrlHostnameAllowlist`
+  - or set `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` for the default account
 
 ## Related
 

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -67,6 +67,19 @@ function parseAllowedUserIds(raw: string | string[] | undefined): string[] {
     .filter(Boolean);
 }
 
+function parseStringList(raw: string | string[] | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((entry) => entry.trim()).filter(Boolean);
+  }
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
 function parseRateLimitPerMinute(raw: string | undefined): number {
   if (raw == null) {
     return 30;
@@ -120,6 +133,7 @@ export function resolveAccount(
   const envIncomingUrl = process.env.SYNOLOGY_CHAT_INCOMING_URL ?? "";
   const envNasHost = process.env.SYNOLOGY_NAS_HOST ?? "localhost";
   const envAllowedUserIds = process.env.SYNOLOGY_ALLOWED_USER_IDS ?? "";
+  const envMediaUrlHostnameAllowlist = process.env.SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST ?? "";
   const envRateLimitValue = parseRateLimitPerMinute(process.env.SYNOLOGY_RATE_LIMIT);
   const envBotName = process.env.OPENCLAW_BOT_NAME ?? "OpenClaw";
   const webhookPathSource = resolveWebhookPathSource({ accountId: id, channelCfg, rawAccount });
@@ -137,6 +151,9 @@ export function resolveAccount(
     nasHost: merged.nasHost ?? envNasHost,
     webhookPath: merged.webhookPath ?? "/webhook/synology",
     webhookPathSource,
+    mediaUrlHostnameAllowlist: parseStringList(
+      merged.mediaUrlHostnameAllowlist ?? envMediaUrlHostnameAllowlist,
+    ),
     dangerouslyAllowNameMatching: resolveDangerousNameMatchingEnabled({
       providerConfig: channelCfg,
       accountConfig: accountOverrides,

--- a/extensions/synology-chat/src/channel.test-mocks.ts
+++ b/extensions/synology-chat/src/channel.test-mocks.ts
@@ -106,6 +106,7 @@ export function makeSecurityAccount(
     nasHost: "h",
     webhookPath: "/w",
     webhookPathSource: "default",
+    mediaUrlHostnameAllowlist: [],
     dangerouslyAllowNameMatching: false,
     dangerouslyAllowInheritedWebhookPath: false,
     dmPolicy: "allowlist" as const,

--- a/extensions/synology-chat/src/channel.test.ts
+++ b/extensions/synology-chat/src/channel.test.ts
@@ -13,6 +13,7 @@ function makeSecurityAccount(
     nasHost: "h",
     webhookPath: "/w",
     webhookPathSource: "default" as const,
+    mediaUrlHostnameAllowlist: [],
     dangerouslyAllowNameMatching: false,
     dangerouslyAllowInheritedWebhookPath: false,
     dmPolicy: "allowlist" as const,
@@ -27,6 +28,7 @@ function makeSecurityAccount(
 const clientModule = await import("./client.js");
 const gatewayRuntimeModule = await import("./gateway-runtime.js");
 const mockSendMessage = vi.spyOn(clientModule, "sendMessage").mockResolvedValue(true);
+const mockSendFileUrl = vi.spyOn(clientModule, "sendFileUrl").mockResolvedValue(true);
 const registerSynologyWebhookRouteMock = vi
   .spyOn(gatewayRuntimeModule, "registerSynologyWebhookRoute")
   .mockImplementation(() => vi.fn());
@@ -43,8 +45,10 @@ describe("createSynologyChatPlugin", () => {
     vi.stubEnv("SYNOLOGY_CHAT_TOKEN", "");
     vi.stubEnv("SYNOLOGY_CHAT_INCOMING_URL", "");
     mockSendMessage.mockClear();
+    mockSendFileUrl.mockClear();
     registerSynologyWebhookRouteMock.mockClear();
     mockSendMessage.mockResolvedValue(true);
+    mockSendFileUrl.mockResolvedValue(true);
     registerSynologyWebhookRouteMock.mockImplementation(() => vi.fn());
   });
 
@@ -100,6 +104,7 @@ describe("createSynologyChatPlugin", () => {
               office: {
                 token: "office-token",
                 allowInsecureSsl: true,
+                mediaUrlHostnameAllowlist: ["cdn.office.example"],
               },
             },
           },
@@ -116,6 +121,7 @@ describe("createSynologyChatPlugin", () => {
         rateLimitPerMinute: 45,
         botName: "Base Bot",
         allowInsecureSsl: true,
+        mediaUrlHostnameAllowlist: ["cdn.office.example"],
       });
     });
 
@@ -175,6 +181,7 @@ describe("createSynologyChatPlugin", () => {
         nasHost: "h",
         webhookPath: "/w",
         webhookPathSource: "default" as const,
+        mediaUrlHostnameAllowlist: [],
         dangerouslyAllowNameMatching: false,
         dangerouslyAllowInheritedWebhookPath: false,
         dmPolicy: "allowlist" as const,
@@ -424,6 +431,32 @@ describe("createSynologyChatPlugin", () => {
           to: "user1",
         }),
       ).rejects.toThrow("not configured");
+    });
+
+    it("sendMedia passes the trusted media hostname allowlist to sendFileUrl", async () => {
+      const plugin = createSynologyChatPlugin();
+      await plugin.outbound.sendMedia({
+        cfg: {
+          channels: {
+            "synology-chat": {
+              enabled: true,
+              token: "t",
+              incomingUrl: "https://nas/incoming",
+              mediaUrlHostnameAllowlist: ["cdn.example.com"],
+            },
+          },
+        },
+        mediaUrl: "https://cdn.example.com/img.png",
+        to: "user1",
+      });
+
+      expect(mockSendFileUrl).toHaveBeenCalledWith(
+        "https://nas/incoming",
+        "https://cdn.example.com/img.png",
+        "user1",
+        false,
+        { trustedFileUrlHostnames: ["cdn.example.com"] },
+      );
     });
   });
 

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -83,6 +83,7 @@ const synologyChatConfigAdapter = createHybridChannelConfigAdapter<ResolvedSynol
     "incomingUrl",
     "nasHost",
     "webhookPath",
+    "mediaUrlHostnameAllowlist",
     "dangerouslyAllowNameMatching",
     "dangerouslyAllowInheritedWebhookPath",
     "dmPolicy",
@@ -352,7 +353,9 @@ export function createSynologyChatPlugin(): SynologyChatPlugin {
           throw new Error("No media URL provided");
         }
 
-        const ok = await sendFileUrl(incomingUrl, mediaUrl, to, account.allowInsecureSsl);
+        const ok = await sendFileUrl(incomingUrl, mediaUrl, to, account.allowInsecureSsl, {
+          trustedFileUrlHostnames: account.mediaUrlHostnameAllowlist,
+        });
         if (!ok) {
           throw new Error("Failed to send media to Synology Chat");
         }

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -2,6 +2,14 @@ import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 
+const resolvePinnedHostnameWithPolicyMock = vi.hoisted(() =>
+  vi.fn(async (hostname: string) => ({
+    hostname,
+    addresses: ["93.184.216.34"],
+    lookup: vi.fn(),
+  })),
+);
+
 // Mock http and https modules before importing the client
 vi.mock("node:https", () => {
   const mockRequest = vi.fn();
@@ -13,6 +21,14 @@ vi.mock("node:http", () => {
   const mockRequest = vi.fn();
   const mockGet = vi.fn();
   return { default: { request: mockRequest, get: mockGet }, request: mockRequest, get: mockGet };
+});
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async () => {
+  const actual = await vi.importActual<object>("openclaw/plugin-sdk/ssrf-runtime");
+  return {
+    ...actual,
+    resolvePinnedHostnameWithPolicy: resolvePinnedHostnameWithPolicyMock,
+  };
 });
 
 const https = await import("node:https");
@@ -32,7 +48,7 @@ type MockRequestHandler = (
 function createMockResponseEmitter(statusCode: number): IncomingMessage {
   const res = new EventEmitter() as Partial<IncomingMessage>;
   res.statusCode = statusCode;
-  return res as IncomingMessage;
+  return res;
 }
 
 function createMockRequestEmitter(): ClientRequest {
@@ -40,7 +56,7 @@ function createMockRequestEmitter(): ClientRequest {
   req.write = vi.fn() as ClientRequest["write"];
   req.end = vi.fn() as ClientRequest["end"];
   req.destroy = vi.fn() as ClientRequest["destroy"];
-  return req as ClientRequest;
+  return req;
 }
 
 async function settleTimers<T>(promise: Promise<T>): Promise<T> {
@@ -79,6 +95,12 @@ function installFakeTimerHarness() {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resolvePinnedHostnameWithPolicyMock.mockReset();
+    resolvePinnedHostnameWithPolicyMock.mockImplementation(async (hostname: string) => ({
+      hostname,
+      addresses: ["93.184.216.34"],
+      lookup: vi.fn(),
+    }));
     vi.useFakeTimers();
     fakeNowMs += 10_000;
     vi.setSystemTime(fakeNowMs);
@@ -154,6 +176,34 @@ describe("sendFileUrl", () => {
     );
     const httpsRequest = vi.mocked(https.request);
     expect(httpsRequest.mock.calls[0]?.[1]).toMatchObject({ rejectUnauthorized: true });
+  });
+
+  it("validates the remote hostname before posting file_url", async () => {
+    mockSuccessResponse();
+    await settleTimers(
+      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+    );
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("example.com");
+  });
+
+  it("rejects non-http(s) file URLs", async () => {
+    await expect(
+      sendFileUrl("https://nas.example.com/incoming", "file:///etc/passwd"),
+    ).rejects.toThrow(/http or https/i);
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("blocks private/internal file URLs before posting to the NAS", async () => {
+    resolvePinnedHostnameWithPolicyMock.mockRejectedValueOnce(
+      new Error("Blocked: resolves to private/internal/special-use IP address"),
+    );
+    await expect(
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+      ),
+    ).rejects.toThrow(/private\/internal\/special-use IP address/i);
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -48,7 +48,7 @@ type MockRequestHandler = (
 function createMockResponseEmitter(statusCode: number): IncomingMessage {
   const res = new EventEmitter() as Partial<IncomingMessage>;
   res.statusCode = statusCode;
-  return res as IncomingMessage;
+  return res;
 }
 
 function createMockRequestEmitter(): ClientRequest {
@@ -56,7 +56,7 @@ function createMockRequestEmitter(): ClientRequest {
   req.write = vi.fn() as ClientRequest["write"];
   req.end = vi.fn() as ClientRequest["end"];
   req.destroy = vi.fn() as ClientRequest["destroy"];
-  return req as ClientRequest;
+  return req;
 }
 
 async function settleTimers<T>(promise: Promise<T>): Promise<T> {
@@ -275,6 +275,15 @@ describe("sendFileUrl", () => {
       sendFileUrl("https://nas.example.com/incoming", "https://93.184.216.34/file.png"),
     );
     expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("93.184.216.34");
+    expect(vi.mocked(https.request)).toHaveBeenCalled();
+  });
+
+  it("allows bracketed public IPv6 literal URLs without a hostname allowlist", async () => {
+    mockSuccessResponse();
+    await settleTimers(
+      sendFileUrl("https://nas.example.com/incoming", "https://[2001:db8::1]/file.png"),
+    );
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("2001:db8::1");
     expect(vi.mocked(https.request)).toHaveBeenCalled();
   });
 });

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -48,7 +48,7 @@ type MockRequestHandler = (
 function createMockResponseEmitter(statusCode: number): IncomingMessage {
   const res = new EventEmitter() as Partial<IncomingMessage>;
   res.statusCode = statusCode;
-  return res;
+  return res as IncomingMessage;
 }
 
 function createMockRequestEmitter(): ClientRequest {
@@ -56,7 +56,7 @@ function createMockRequestEmitter(): ClientRequest {
   req.write = vi.fn() as ClientRequest["write"];
   req.end = vi.fn() as ClientRequest["end"];
   req.destroy = vi.fn() as ClientRequest["destroy"];
-  return req;
+  return req as ClientRequest;
 }
 
 async function settleTimers<T>(promise: Promise<T>): Promise<T> {
@@ -156,7 +156,15 @@ describe("sendFileUrl", () => {
   it("returns true on success", async () => {
     mockSuccessResponse();
     const result = await settleTimers(
-      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "https://example.com/file.png",
+        undefined,
+        false,
+        {
+          trustedFileUrlHostnames: ["example.com"],
+        },
+      ),
     );
     expect(result).toBe(true);
   });
@@ -164,7 +172,15 @@ describe("sendFileUrl", () => {
   it("returns false on failure", async () => {
     mockFailureResponse(500);
     const result = await settleTimers(
-      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "https://example.com/file.png",
+        undefined,
+        false,
+        {
+          trustedFileUrlHostnames: ["example.com"],
+        },
+      ),
     );
     expect(result).toBe(false);
   });
@@ -172,7 +188,15 @@ describe("sendFileUrl", () => {
   it("verifies TLS by default", async () => {
     mockSuccessResponse();
     await settleTimers(
-      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "https://example.com/file.png",
+        undefined,
+        false,
+        {
+          trustedFileUrlHostnames: ["example.com"],
+        },
+      ),
     );
     const httpsRequest = vi.mocked(https.request);
     expect(httpsRequest.mock.calls[0]?.[1]).toMatchObject({ rejectUnauthorized: true });
@@ -181,9 +205,26 @@ describe("sendFileUrl", () => {
   it("validates the remote hostname before posting file_url", async () => {
     mockSuccessResponse();
     await settleTimers(
-      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "https://example.com/file.png",
+        undefined,
+        false,
+        {
+          trustedFileUrlHostnames: ["example.com"],
+        },
+      ),
     );
-    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("example.com");
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("example.com", {
+      policy: { hostnameAllowlist: ["example.com"] },
+    });
+  });
+
+  it("rejects malformed URLs with an actionable error", async () => {
+    await expect(sendFileUrl("https://nas.example.com/incoming", "not-a-url")).rejects.toThrow(
+      /not a valid URL/i,
+    );
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
   });
 
   it("rejects non-http(s) file URLs", async () => {
@@ -204,6 +245,37 @@ describe("sendFileUrl", () => {
       ),
     ).rejects.toThrow(/private\/internal\/special-use IP address/i);
     expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostname URLs when no trusted hostname allowlist is configured", async () => {
+    await expect(
+      sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png"),
+    ).rejects.toThrow(/require mediaUrlHostnameAllowlist/i);
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("rejects hostname URLs outside the trusted hostname allowlist", async () => {
+    await expect(
+      sendFileUrl(
+        "https://nas.example.com/incoming",
+        "https://example.com/file.png",
+        undefined,
+        false,
+        {
+          trustedFileUrlHostnames: ["cdn.example.com"],
+        },
+      ),
+    ).rejects.toThrow(/not in mediaUrlHostnameAllowlist/i);
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("allows public IP literal URLs without a hostname allowlist", async () => {
+    mockSuccessResponse();
+    await settleTimers(
+      sendFileUrl("https://nas.example.com/incoming", "https://93.184.216.34/file.png"),
+    );
+    expect(resolvePinnedHostnameWithPolicyMock).toHaveBeenCalledWith("93.184.216.34");
+    expect(vi.mocked(https.request)).toHaveBeenCalled();
   });
 });
 

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -5,6 +5,7 @@
 
 import * as http from "node:http";
 import * as https from "node:https";
+import { isIP } from "node:net";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
 import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "zod";
@@ -131,8 +132,9 @@ export async function sendFileUrl(
   fileUrl: string,
   userId?: string | number,
   allowInsecureSsl = false,
+  options?: { trustedFileUrlHostnames?: readonly string[] },
 ): Promise<boolean> {
-  await assertSafeWebhookFileUrl(fileUrl);
+  await assertSafeWebhookFileUrl(fileUrl, options);
   const body = buildWebhookBody({ file_url: fileUrl }, userId);
 
   try {
@@ -244,15 +246,55 @@ export async function resolveLegacyWebhookNameToChatUserId(params: {
   return undefined;
 }
 
-async function assertSafeWebhookFileUrl(fileUrl: string): Promise<void> {
-  const parsed = new URL(fileUrl);
+function normalizeHostnameForAllowlist(value: string): string {
+  return value.trim().toLowerCase().replace(/\.+$/, "");
+}
+
+async function assertSafeWebhookFileUrl(
+  fileUrl: string,
+  options?: { trustedFileUrlHostnames?: readonly string[] },
+): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = new URL(fileUrl);
+  } catch {
+    throw new Error("Synology Chat file_url is not a valid URL");
+  }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new Error("Synology Chat file_url must use http or https");
   }
   if (!parsed.hostname) {
     throw new Error("Synology Chat file_url must include a hostname");
   }
-  await resolvePinnedHostnameWithPolicy(parsed.hostname);
+
+  const normalizedHostname = normalizeHostnameForAllowlist(parsed.hostname);
+  if (isIP(normalizedHostname) !== 0) {
+    await resolvePinnedHostnameWithPolicy(parsed.hostname);
+    return;
+  }
+
+  const trustedHostnames = Array.from(
+    new Set(
+      (options?.trustedFileUrlHostnames ?? []).map(normalizeHostnameForAllowlist).filter(Boolean),
+    ),
+  );
+
+  // The NAS resolves hostname URLs independently when it later fetches file_url,
+  // so untrusted hostnames stay vulnerable to DNS rebinding after our preflight check.
+  if (trustedHostnames.length === 0) {
+    throw new Error(
+      "Synology Chat file_url hostname URLs require mediaUrlHostnameAllowlist; use a trusted hostname or a public IP literal",
+    );
+  }
+  if (!trustedHostnames.includes(normalizedHostname)) {
+    throw new Error(
+      `Synology Chat file_url hostname "${parsed.hostname}" is not in mediaUrlHostnameAllowlist`,
+    );
+  }
+
+  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
+    policy: { hostnameAllowlist: trustedHostnames },
+  });
 }
 
 function buildWebhookBody(payload: ChatWebhookPayload, userId?: string | number): string {

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -247,7 +247,11 @@ export async function resolveLegacyWebhookNameToChatUserId(params: {
 }
 
 function normalizeHostnameForAllowlist(value: string): string {
-  return value.trim().toLowerCase().replace(/\.+$/, "");
+  const normalized = value.trim().toLowerCase().replace(/\.+$/, "");
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
 }
 
 async function assertSafeWebhookFileUrl(
@@ -269,7 +273,7 @@ async function assertSafeWebhookFileUrl(
 
   const normalizedHostname = normalizeHostnameForAllowlist(parsed.hostname);
   if (isIP(normalizedHostname) !== 0) {
-    await resolvePinnedHostnameWithPolicy(parsed.hostname);
+    await resolvePinnedHostnameWithPolicy(normalizedHostname);
     return;
   }
 
@@ -292,7 +296,7 @@ async function assertSafeWebhookFileUrl(
     );
   }
 
-  await resolvePinnedHostnameWithPolicy(parsed.hostname, {
+  await resolvePinnedHostnameWithPolicy(normalizedHostname, {
     policy: { hostnameAllowlist: trustedHostnames },
   });
 }

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -6,6 +6,7 @@
 import * as http from "node:http";
 import * as https from "node:https";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
+import { resolvePinnedHostnameWithPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "zod";
 
 const MIN_SEND_INTERVAL_MS = 500;
@@ -131,6 +132,7 @@ export async function sendFileUrl(
   userId?: string | number,
   allowInsecureSsl = false,
 ): Promise<boolean> {
+  await assertSafeWebhookFileUrl(fileUrl);
   const body = buildWebhookBody({ file_url: fileUrl }, userId);
 
   try {
@@ -240,6 +242,17 @@ export async function resolveLegacyWebhookNameToChatUserId(params: {
   }
 
   return undefined;
+}
+
+async function assertSafeWebhookFileUrl(fileUrl: string): Promise<void> {
+  const parsed = new URL(fileUrl);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Synology Chat file_url must use http or https");
+  }
+  if (!parsed.hostname) {
+    throw new Error("Synology Chat file_url must include a hostname");
+  }
+  await resolvePinnedHostnameWithPolicy(parsed.hostname);
 }
 
 function buildWebhookBody(payload: ChatWebhookPayload, userId?: string | number): string {

--- a/extensions/synology-chat/src/config-schema.ts
+++ b/extensions/synology-chat/src/config-schema.ts
@@ -4,6 +4,7 @@ import { z } from "openclaw/plugin-sdk/zod";
 export const SynologyChatChannelConfigSchema = buildChannelConfigSchema(
   z
     .object({
+      mediaUrlHostnameAllowlist: z.union([z.array(z.string()), z.string()]).optional(),
       dangerouslyAllowNameMatching: z.boolean().optional(),
       dangerouslyAllowInheritedWebhookPath: z.boolean().optional(),
     })

--- a/extensions/synology-chat/src/types.ts
+++ b/extensions/synology-chat/src/types.ts
@@ -8,6 +8,7 @@ type SynologyChatConfigFields = {
   incomingUrl?: string;
   nasHost?: string;
   webhookPath?: string;
+  mediaUrlHostnameAllowlist?: string | string[];
   dangerouslyAllowNameMatching?: boolean;
   dangerouslyAllowInheritedWebhookPath?: boolean;
   dmPolicy?: "open" | "allowlist" | "disabled";
@@ -36,6 +37,7 @@ export interface ResolvedSynologyChatAccount {
   nasHost: string;
   webhookPath: string;
   webhookPathSource: SynologyWebhookPathSource;
+  mediaUrlHostnameAllowlist: string[];
   dangerouslyAllowNameMatching: boolean;
   dangerouslyAllowInheritedWebhookPath: boolean;
   dmPolicy: "open" | "allowlist" | "disabled";

--- a/extensions/synology-chat/src/webhook-handler.test.ts
+++ b/extensions/synology-chat/src/webhook-handler.test.ts
@@ -27,6 +27,7 @@ function makeAccount(
     nasHost: "nas.example.com",
     webhookPath: "/webhook/synology",
     webhookPathSource: "default",
+    mediaUrlHostnameAllowlist: [],
     dangerouslyAllowNameMatching: false,
     dangerouslyAllowInheritedWebhookPath: false,
     dmPolicy: "open",


### PR DESCRIPTION
## Summary

- **Problem:** The Synology Chat extension's `sendMedia` → `sendFileUrl` path passed attacker-controlled `mediaUrl` values directly to the Synology NAS incoming webhook as `file_url` with no URL or SSRF validation. The NAS then fetches the URL from its network position, enabling Server-Side Request Forgery against the NAS's internal network (cloud metadata endpoints, LAN services, localhost).
- **Why it matters:** Synology NAS devices are typically deployed on private internal networks, making SSRF from the NAS's vantage point particularly dangerous (IAM credential theft, internal service scanning).
- **What changed:** Added `assertSafeWebhookFileUrl()` in `extensions/synology-chat/src/client.ts` that validates URL shape, restricts schemes to `http`/`https`, allows public IP literals only after SSRF validation, and requires hostname-based media URLs to be explicitly trusted via `mediaUrlHostnameAllowlist` / `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` before the `file_url` is ever included in the webhook POST body. The allowlist is resolved per account and threaded through `sendMedia` into `sendFileUrl`.
- **What did NOT change:** `sendMessage`, `fetchChatUsers`, and the `incomingUrl` (operator-configured NAS webhook) paths are unaffected. This PR does not add a byte-upload path; the NAS still performs the final media fetch.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `sendFileUrl` in `extensions/synology-chat/src/client.ts` accepted an arbitrary `fileUrl` string and forwarded it verbatim as `file_url` in the NAS webhook payload without any URL validation or SSRF guard.
- Missing detection / guardrail: No call to `resolvePinnedHostnameWithPolicy` or equivalent; no scheme restriction, no hostname check, no private-IP block.
- Contributing context (if known): The same class of fix was applied to QQBot media paths in a prior release. The Synology Chat extension was missed by those fixes despite having the same code pattern.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/synology-chat/src/client.test.ts` — `describe("sendFileUrl")`
  - `extensions/synology-chat/src/channel.test.ts` — outbound allowlist threading
- Scenario the test should lock in:
  - protocol rejection for non-`http`/`https` URLs
  - malformed URL rejection with an actionable error
  - SSRF policy rejection for private/internal IPs
  - hostname URLs require explicit trust configuration
  - hostname allowlist is threaded from resolved account config into `sendFileUrl`
  - public IP literal URLs still pass the guarded path
- Why this is the smallest reliable guardrail: Tests stay scoped to the exact vulnerable helper and the single outbound caller that supplies trust policy, mock `resolvePinnedHostnameWithPolicy` at the module boundary, and assert that no HTTP request is made when validation fails.
- Existing test that already covers this (if any): None before this PR.
- If no new test is added, why not: N/A — targeted unit coverage was added for both the helper and the outbound call path.

## User-visible / Behavior Changes

Synology Chat `sendMedia` calls with malformed URLs, non-`http`/`https` URLs, or URLs resolving to private/internal IPs will now throw instead of forwarding the URL to the NAS.

Hostname-based media URLs now require explicit trust configuration via `channels.synology-chat.mediaUrlHostnameAllowlist` (or `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` for the default account). Public IP literal media URLs are still allowed if they pass SSRF validation.

## Diagram (if applicable)

```text
Before:
[mediaUrl] -> sendFileUrl() -> {file_url: mediaUrl} -> NAS webhook -> NAS fetches URL (no guard)

After:
[mediaUrl]
  -> assertSafeWebhookFileUrl()
     -> [valid URL check]
     -> [protocol check]
     -> [hostname present]
     -> [public IP literal? -> SSRF validate and allow]
     -> [hostname? -> require mediaUrlHostnameAllowlist + SSRF validate]
  -> sendFileUrl()
  -> {file_url: mediaUrl}
  -> NAS webhook
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — `resolvePinnedHostnameWithPolicy` performs a DNS lookup on hostname-based `file_url` values, and public IP literals are still validated through the same shared guard path.
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation:
  - The DNS lookup adds a small latency to `sendFileUrl`.
  - Because the NAS performs the final fetch itself, hostname-based media URLs now require explicit operator trust configuration via `mediaUrlHostnameAllowlist` / `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` instead of being allowed by default.
  - The implementation reuses the shared SSRF infrastructure (`src/infra/net/ssrf.ts`) for literal-host checks, resolved-address checks, legacy IPv4 format blocking, IPv6 special-use blocking, and blocked hostname patterns.

## Repro + Verification

### Environment

- OS: Linux (Ubuntu)
- Runtime/container: Node 22
- Integration/channel: Synology Chat extension
- Relevant config (redacted): N/A

### Steps

1. Review `extensions/synology-chat/src/client.ts` — `assertSafeWebhookFileUrl` is called at the top of `sendFileUrl` before any body construction or POST.
2. Review `extensions/synology-chat/src/channel.ts` and `extensions/synology-chat/src/accounts.ts` — `mediaUrlHostnameAllowlist` is resolved per account and threaded into `sendFileUrl`.
3. Run:
   - `pnpm test extensions/synology-chat/src/client.test.ts`
   - `pnpm test extensions/synology-chat/src/channel.test.ts`
4. Confirm `https.request` is not called when URL validation or the SSRF guard fires (asserted in tests).

### Expected

- `not-a-url` as `fileUrl` → throws `"Synology Chat file_url is not a valid URL"`, no request made.
- `file:///etc/passwd` as `fileUrl` → throws `"must use http or https"`, no request made.
- `http://169.254.169.254/...` as `fileUrl` → `resolvePinnedHostnameWithPolicy` rejects, no request made.
- `https://example.com/file.png` with no hostname allowlist → throws because hostname URLs require explicit trust configuration.
- `https://example.com/file.png` with `mediaUrlHostnameAllowlist: ["example.com"]` → validation passes, request proceeds.
- `https://93.184.216.34/file.png` as `fileUrl` → allowed if SSRF validation passes.

### Actual

- The branch behaves as expected per the targeted unit tests for both the helper and outbound call path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted unit coverage in `extensions/synology-chat/src/client.test.ts` and `extensions/synology-chat/src/channel.test.ts` covers the guard behavior, allowlist requirement, and outbound config threading.

## Human Verification (required)

> **Note:** This PR was generated by OpenAI Codex with no human code modifications. Review was performed by Claude Code.

- Verified scenarios: Code review confirmed `assertSafeWebhookFileUrl` runs before body construction and before the try/catch that handles network errors; hostname-based media URLs now require explicit trust configuration; public IP literals remain on the guarded path.
- Edge cases checked: malformed URLs, non-`http`/`https` schemes, empty hostname, private/internal IPs, hostname allowlist mismatch, public IP literals.
- What you did **not** verify: Live end-to-end test against a real Synology NAS device.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Partially. Public IP literal media URLs that pass SSRF validation remain allowed, but hostname-based media URLs now require explicit trust configuration.
- Config/env changes? Yes
  - `channels.synology-chat.mediaUrlHostnameAllowlist`
  - `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` (default account env fallback)
- Migration needed? Only if you currently rely on hostname-based Synology Chat media URLs. Add trusted hostnames to `mediaUrlHostnameAllowlist` (or set `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST` for the default account).

## Risks and Mitigations

- Risk: DNS lookup in `resolvePinnedHostnameWithPolicy` adds latency to each guarded hostname-based `sendFileUrl` call.
  - Mitigation: Latency is bounded and only applies when a media URL is sent.
- Risk: Hostname-based media URLs that previously worked will now fail unless explicitly trusted.
  - Mitigation: This is intentional hardening to avoid allowing arbitrary hostnames through a path where the NAS performs the final fetch. Operators can allow trusted hostnames via `mediaUrlHostnameAllowlist` or `SYNOLOGY_MEDIA_URL_HOSTNAME_ALLOWLIST`.
- Risk: Live end-to-end behavior against a real Synology NAS was not exercised in this PR.
  - Mitigation: The vulnerable helper and its outbound caller are both covered by targeted tests.

---

> 🤖 AI-assisted: Generated by OpenAI Codex, reviewed by Claude Code (`claude-sonnet-4-6`).