### PR TITLE
fix(gateway): accept Rabbit token payloads in password mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/Agents: redact tool-call args, partial/final results, derived exec output, and configured custom secret patterns before streaming tool events to the Control UI, so tool output cannot expose provider or channel credentials. Fixes #72283. (#72319) Thanks @volcano303 and @BunsDev.
+- Gateway/auth: keep password-mode gateway auth compatible with Rabbit clients that send the shared secret in `connectAuth.token`, and cover wrong-token and password-precedence edge cases. (#69638) Thanks @creativerezz.
 - Models/fallbacks: treat user-selected session models as exact choices, so `/model ollama/...` and model-picker switches fail visibly when the selected provider is unreachable instead of answering from an unrelated configured fallback. Fixes #73023. Thanks @pavelyortho-cyber.
 - CLI/model probes: fail local `infer model run` probes when the provider returns no text output, so unreachable local providers and empty completions no longer look like successful smoke tests. Refs #73023. Thanks @pavelyortho-cyber.
 - CLI/Ollama: run local `infer model run` through the lean provider completion path and skip global model discovery for one-shot local probes, so Ollama smoke tests no longer pay full chat-agent/tool startup cost or hang before the native `/api/chat` request. Fixes #72851. Thanks @TotalRes2020.

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -359,6 +359,16 @@ describe("gateway auth", () => {
     expect(res.reason).toBe("password_mismatch");
   });
 
+  it("accepts password over wrong token when both are supplied in password mode", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { password: "secret", token: "wrong" },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("password");
+  });
+
   it("reports missing password config reason", async () => {
     const res = await authorizeGatewayConnect({
       auth: { mode: "password", allowTailscale: false },

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -328,6 +328,37 @@ describe("gateway auth", () => {
     expect(mismatch.reason).toBe("password_mismatch");
   });
 
+  it("accepts Rabbit clawdbot-gateway token payloads in password mode", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      // Rabbit R1 sends the QR secret in `token` during the wss handshake.
+      connectAuth: { token: "secret" },
+    });
+
+    expect(res.ok).toBe(true);
+    expect(res.method).toBe("password");
+  });
+
+  it("rejects wrong Rabbit token payloads in password mode", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { token: "wrong" },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+  });
+
+  it("prefers password over token when both are supplied in password mode", async () => {
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { password: "wrong", token: "secret" },
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+  });
+
   it("reports missing password config reason", async () => {
     const res = await authorizeGatewayConnect({
       auth: { mode: "password", allowTailscale: false },

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -349,6 +349,19 @@ describe("gateway auth", () => {
     expect(res.reason).toBe("password_mismatch");
   });
 
+  it("records wrong Rabbit token payloads as password-mode failures", async () => {
+    const limiter = createLimiterSpy();
+    const res = await authorizeGatewayConnect({
+      auth: { mode: "password", password: "secret", allowTailscale: false },
+      connectAuth: { token: "wrong" },
+      rateLimiter: limiter,
+    });
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe("password_mismatch");
+    expect(limiter.recordFailure).toHaveBeenCalledWith(undefined, "shared-secret");
+  });
+
   it("prefers password over token when both are supplied in password mode", async () => {
     const res = await authorizeGatewayConnect({
       auth: { mode: "password", password: "secret", allowTailscale: false },

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -533,7 +533,8 @@ async function authorizeGatewayConnectCore(
   if (auth.mode === "password") {
     return authorizePasswordAuth({
       authPassword: auth.password,
-      connectPassword: connectAuth?.password,
+      // Rabbit's clawdbot-gateway QR schema carries the shared secret in `token`.
+      connectPassword: connectAuth?.password ?? connectAuth?.token,
       limiter,
       ip,
       rateLimitScope,


### PR DESCRIPTION
## Summary
- allow password-mode gateway auth to fall back to `connectAuth.token` when `connectAuth.password` is absent, which matches Rabbit R1 `clawdbot-gateway` QR handshakes over Funnel + `wss`
- add a regression test that covers the Rabbit/Funnel path so password-mode gateways stay compatible with token-only device clients
- fixes #51953

## Test plan
- [x] `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/auth.test.ts`
- [x] pre-commit `check:changed` suite (triggered automatically during `git commit`)

## Follow-up
- longer term, Rabbit QR onboarding should prefer device-specific bootstrap tokens instead of reusing the shared gateway password

Made with [Cursor](https://cursor.com)