### PR TITLE
fix(bootstrap): recognize Bun error shape in isDirectModuleNotFoundError

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -60,11 +60,20 @@ const isDirectModuleNotFoundError = (err, specifier) => {
     return true;
   }
 
+  // Bun exposes the original import specifier in err.specifier
+  // and uses relative paths in its error message instead of resolved URLs.
+  if ("specifier" in err && err.specifier === specifier) {
+    return true;
+  }
+
   const message = "message" in err && typeof err.message === "string" ? err.message : "";
   const expectedPath = fileURLToPath(expectedUrl);
   return (
     message.includes(`Cannot find module '${expectedPath}'`) ||
-    message.includes(`Cannot find module "${expectedPath}"`)
+    message.includes(`Cannot find module "${expectedPath}"`) ||
+    // Bun uses the original relative specifier in its error message.
+    message.includes(`Cannot find module '${specifier}'`) ||
+    message.includes(`Cannot find module "${specifier}"`)
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes `bun openclaw.mjs` crashing on bootstrap when the optional `warning-filter` import is missing.

Bun does not set `err.url` on `ERR_MODULE_NOT_FOUND` errors and uses the original relative specifier in its error message instead of a resolved absolute path. The existing `isDirectModuleNotFoundError` helper relied on Node-specific properties (`err.url` and absolute path in `err.message`), causing the catch block to re-throw on Bun instead of swallowing the expected optional-import miss.

## Changes

- `openclaw.mjs`: add Bun-aware check for `err.specifier` (Bun's `ResolveMessage` exposes the original import specifier here)
- `openclaw.mjs`: add fallback message matching for relative specifiers so Bun's relative-path error messages are recognized

## Type of change

- [x] Bug fix

## Testing

- `pnpm format:check openclaw.mjs` — passed
- `pnpm lint:core openclaw.mjs` — 0 warnings, 0 errors
- `pnpm test src/infra/openclaw-root.test.ts` — 9 passed
- `pnpm test test/openclaw-launcher.e2e.test.ts` — 3 passed


## Related Issue

Fixes #69589

## Checklist

- [x] I have read the project contribution guidelines
- [x] My changes generate no new type errors in touched files
- [x] I have verified the fix addresses the reported issue