### PR TITLE
docs(acp): clarify thread-bound follow-up orchestration

### DIFF
--- a/docs/acp-followup-orchestration.md
+++ b/docs/acp-followup-orchestration.md
@@ -1,0 +1,34 @@
+# ACP follow-up orchestration
+
+## Rule
+
+Thread-bound ACP session continuity does not imply verbatim forwarding.
+
+When an ACP session is bound to a thread, the parent assistant should remain the default interpreter for user follow-ups. The child session stays alive for continuity, but shorthand follow-ups should be rewritten into explicit child instructions unless the user clearly requests exact relay.
+
+## Default behavior
+
+For a follow-up like:
+
+- "do that"
+- "continue with what you suggested"
+- "ok implement phase 2"
+- "bắt nó làm tiếp như m suggest đi"
+
+The parent assistant should:
+
+1. resolve the reference from parent-thread context
+2. synthesize a self-contained task prompt
+3. send the rewritten task to the bound ACP child session
+
+## Verbatim relay
+
+Exact forwarding should happen only when the user explicitly asks for it, for example:
+
+- "send this exact prompt"
+- "forward this verbatim"
+- "gửi nguyên văn block này"
+
+## Why
+
+Users speak to the parent orchestrator in shorthand. If raw text is passed through directly, the child harness receives low-context prompts and overall ACP orchestration quality degrades.

--- a/docs/acp-followup-orchestration.md
+++ b/docs/acp-followup-orchestration.md
@@ -1,3 +1,10 @@
+---
+summary: "ACP thread-bound follow-up orchestration, parent assistant should rewrite shorthand follow-ups before sending to child session"
+title: "ACP follow-up orchestration"
+read_when:
+  - ACP session is thread-bound and you need to handle user follow-ups
+---
+
 # ACP follow-up orchestration
 
 ## Rule
@@ -13,7 +20,7 @@ For a follow-up like:
 - "do that"
 - "continue with what you suggested"
 - "ok implement phase 2"
-- "bắt nó làm tiếp như m suggest đi"
+- "have it continue with what you suggested"
 
 The parent assistant should:
 
@@ -27,7 +34,7 @@ Exact forwarding should happen only when the user explicitly asks for it, for ex
 
 - "send this exact prompt"
 - "forward this verbatim"
-- "gửi nguyên văn block này"
+- "send this block verbatim"
 
 ## Why
 

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -157,7 +157,7 @@ export function isSpawnAcpAcceptedResult(result: SpawnAcpResult): result is Spaw
 export const ACP_SPAWN_ACCEPTED_NOTE =
   "initial ACP task queued in isolated session; follow-ups continue in the bound thread.";
 export const ACP_SPAWN_SESSION_ACCEPTED_NOTE =
-  "thread-bound ACP session stays active after this task; continue in-thread for follow-ups.";
+  "thread-bound ACP session stays active after this task; continue in-thread for follow-ups through the parent assistant unless exact relay is explicitly requested.";
 
 export function resolveAcpSpawnRuntimePolicyError(params: {
   cfg: OpenClawConfig;


### PR DESCRIPTION
## Summary
- clarify ACP thread-bound follow-up semantics
- document that thread continuity does not imply verbatim relay
- note that parent assistant should remain the default interpreter unless exact relay is explicitly requested

## Why
In thread-bound ACP workflows, users often send shorthand follow-ups like "continue with what you suggested" or "bắt nó làm tiếp như m suggest đi".

The parent assistant is expected to interpret those follow-ups and synthesize a concrete child prompt. Without this clarification, thread continuity can be misread as permission for raw pass-through, which degrades orchestration quality.

## Changes
- update `ACP_SPAWN_SESSION_ACCEPTED_NOTE` in `src/agents/acp-spawn.ts`
- add `docs/acp-followup-orchestration.md`

## Scope
This PR is a semantics/docs clarification pass only. It does not yet implement the deeper runtime behavior change in `sessions.send` / session continuation logic.

## Follow-up work
A future runtime patch should make parent-orchestrated follow-up rewriting the default for bound ACP sessions, with verbatim relay only when explicitly requested.
