### PR TITLE
fix(openrouter): make base URL normalization case-insensitive and add regression tests

### DIFF
--- a/extensions/arcee/provider-catalog.ts
+++ b/extensions/arcee/provider-catalog.ts
@@ -5,7 +5,7 @@ export const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 const OPENROUTER_LEGACY_BASE_URL = "https://openrouter.ai/v1";
 
 function normalizeBaseUrl(baseUrl: string | undefined): string {
-  return (baseUrl ?? "").trim().replace(/\/+$/, "");
+  return (baseUrl ?? "").trim().toLowerCase().replace(/\/+$/, "");
 }
 
 export function normalizeArceeOpenRouterBaseUrl(baseUrl: string | undefined): string | undefined {

--- a/extensions/openrouter/index.test.ts
+++ b/extensions/openrouter/index.test.ts
@@ -78,6 +78,42 @@ describe("openrouter provider hooks", () => {
     });
   });
 
+  it("canonicalizes case-insensitive and already-correct OpenRouter base URLs", async () => {
+    const provider = await registerSingleProviderPlugin(openrouterPlugin);
+
+    expect(
+      provider.normalizeConfig?.({
+        provider: "openrouter",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://OPENROUTER.AI/v1",
+          models: [],
+        },
+      } as never),
+    ).toMatchObject({
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+
+    expect(
+      provider.normalizeConfig?.({
+        provider: "openrouter",
+        providerConfig: {
+          api: "openai-completions",
+          baseUrl: "https://openrouter.ai/api/v1",
+          models: [],
+        },
+      } as never),
+    ).toBeUndefined();
+
+    expect(
+      provider.normalizeTransport?.({
+        provider: "openrouter",
+        api: "openai-completions",
+        baseUrl: "https://custom-proxy.example.com/v1",
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("injects provider routing into compat before applying stream wrappers", async () => {
     const provider = await registerSingleProviderPlugin(openrouterPlugin);
     const baseStreamFn = vi.fn(

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -13,7 +13,7 @@ const OPENROUTER_DEFAULT_COST = {
 };
 
 function normalizeBaseUrl(baseUrl: string | undefined): string {
-  return (baseUrl ?? "").trim().replace(/\/+$/, "");
+  return (baseUrl ?? "").trim().toLowerCase().replace(/\/+$/, "");
 }
 
 export function normalizeOpenRouterBaseUrl(baseUrl: string | undefined): string | undefined {

--- a/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
+++ b/src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts
@@ -71,7 +71,8 @@ function isNativeOpenAICodexBaseUrl(baseUrl?: string): boolean {
 }
 
 function normalizeOpenRouterBaseUrl(baseUrl?: string): string | undefined {
-  const normalized = typeof baseUrl === "string" ? baseUrl.trim().replace(/\/+$/, "") : "";
+  const normalized =
+    typeof baseUrl === "string" ? baseUrl.trim().toLowerCase().replace(/\/+$/, "") : "";
   if (!normalized) {
     return undefined;
   }


### PR DESCRIPTION
## Summary

This PR strengthens the OpenRouter base URL normalization introduced in #68574 to handle case-insensitive URL matching and adds regression tests for edge cases.

## Changes

- Make `normalizeBaseUrl` case-insensitive by adding `.toLowerCase()` in:
  - `extensions/openrouter/provider-catalog.ts`
  - `extensions/arcee/provider-catalog.ts`
  - `src/agents/pi-embedded-runner/model.provider-runtime.test-support.ts`
- Add regression tests covering:
  - Uppercase domain variants (e.g., `https://OPENROUTER.AI/v1`)
  - Already-correct URLs returning `undefined` (no-op)
  - Non-OpenRouter custom proxies returning `undefined` (no-op)

## Context

Issue #69646 reported that OpenRouter requests were using `/v1` instead of `/api/v1`, causing HTML error responses instead of JSON. The root fix was already landed in #68574 (2026.4.18). This PR tightens the normalization logic and adds coverage to prevent regressions.

## Test plan

- [x] `pnpm test extensions/openrouter` passes (8 tests)
- [x] `pnpm test extensions/arcee` passes (7 tests)
- [x] `pnpm test src/agents/pi-embedded-runner/model.test.ts` passes (50 tests)

Fixes #69646 