### PR TITLE
fix(auth-profiles): silently skip aws-sdk SDK-managed markers during store load

### DIFF
--- a/src/agents/auth-profiles.ensureauthprofilestore.test.ts
+++ b/src/agents/auth-profiles.ensureauthprofilestore.test.ts
@@ -519,6 +519,88 @@ describe("ensureAuthProfileStore", () => {
     }
   });
 
+  it("silently skips SDK-managed marker profiles (#69708)", () => {
+    // aws-sdk profiles (notably Bedrock on EC2/IMDS) are not real credentials:
+    // the AWS SDK resolves them independently at call time. Accepting them
+    // into the credential store would be wrong (no key material), but the
+    // pre-fix behavior rejected them as "invalid_type" and logged a scary
+    // warning, hiding real invalid entries in the aggregate count.
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => undefined);
+    try {
+      withTempAgentDir("openclaw-auth-aws-sdk-marker-", (agentDir) => {
+        const storeWithSdkMarker = {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "amazon-bedrock:default": {
+              type: "aws-sdk",
+              provider: "amazon-bedrock",
+              createdAt: "2026-03-15T10:00:00.000Z",
+            },
+            "anthropic:default": {
+              type: "api_key",
+              provider: "anthropic",
+              key: "sk-ant-real-key", // pragma: allowlist secret
+            },
+          },
+        };
+        fs.writeFileSync(
+          path.join(agentDir, "auth-profiles.json"),
+          `${JSON.stringify(storeWithSdkMarker, null, 2)}\n`,
+          "utf8",
+        );
+
+        const store = ensureAuthProfileStore(agentDir);
+
+        // aws-sdk marker is silently skipped — not in the loaded store.
+        expect(Object.keys(store.profiles).toSorted()).toEqual(["anthropic:default"]);
+        expect(store.profiles["amazon-bedrock:default"]).toBeUndefined();
+        // No warning about "invalid auth profile entries" for the marker.
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("still warns about genuine invalid types alongside SDK markers (#69708)", () => {
+    // If both an aws-sdk marker AND a truly-invalid entry are present, the
+    // warning must surface only the real invalid entry — not count the
+    // intentional marker in the dropped total.
+    const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => undefined);
+    try {
+      withTempAgentDir("openclaw-auth-aws-sdk-mixed-", (agentDir) => {
+        const mixed = {
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "amazon-bedrock:default": {
+              type: "aws-sdk",
+              provider: "amazon-bedrock",
+            },
+            "brokenprovider:default": {
+              type: "wildcard-mystery", // genuinely invalid
+              provider: "brokenprovider",
+            },
+          },
+        };
+        fs.writeFileSync(
+          path.join(agentDir, "auth-profiles.json"),
+          `${JSON.stringify(mixed, null, 2)}\n`,
+          "utf8",
+        );
+
+        ensureAuthProfileStore(agentDir);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const [, details] = warnSpy.mock.calls[0] as [string, Record<string, unknown>];
+        expect(details.dropped).toBe(1); // ONLY the genuinely invalid entry
+        expect(details.reasons).toEqual({ invalid_type: 1 });
+        expect(details.keys).toEqual(["brokenprovider:default"]);
+      });
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it.each([
     {
       name: "migrates SecretRef object in `key` to `keyRef` and clears `key`",

--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -17,10 +17,29 @@ import type {
 
 export type LegacyAuthStore = Record<string, AuthProfileCredential>;
 
-type CredentialRejectReason = "non_object" | "invalid_type" | "missing_provider";
+type CredentialRejectReason =
+  | "non_object"
+  | "invalid_type"
+  | "missing_provider"
+  | "sdk_marker_skipped";
 type RejectedCredentialEntry = { key: string; reason: CredentialRejectReason };
 
 const AUTH_PROFILE_TYPES = new Set<AuthProfileCredential["type"]>(["api_key", "oauth", "token"]);
+
+/**
+ * Profile types that represent a non-secret-material marker rather than
+ * real credentials. These are silently skipped during store load: they are
+ * not rejected as "invalid_type" (which logs a scary warning and drops
+ * the entry), and they are not placed into the credential store where
+ * downstream resolvers would look for secret material.
+ *
+ * Amazon Bedrock on EC2/IMDS uses `"type": "aws-sdk"` as an informational
+ * marker in auth-profiles.json — the AWS SDK resolves real credentials
+ * independently at call time via its own chain. Other SDK-managed
+ * providers can be added here without touching the persisted store
+ * schema or downstream switches. (#69708)
+ */
+const AUTH_PROFILE_SDK_MARKER_TYPES = new Set<string>(["aws-sdk"]);
 
 function normalizeSecretBackedField(params: {
   entry: Record<string, unknown>;
@@ -59,6 +78,13 @@ function parseCredentialEntry(
     return { ok: false, reason: "non_object" };
   }
   const typed = normalizeRawCredentialEntry(raw as Record<string, unknown>);
+  const rawType = typeof typed.type === "string" ? typed.type : "";
+  // SDK-managed credential markers (Bedrock on EC2/IMDS, etc.) are not real
+  // credentials — skip them silently rather than rejecting as invalid_type.
+  // The AWS SDK resolves credentials independently at call time. (#69708)
+  if (AUTH_PROFILE_SDK_MARKER_TYPES.has(rawType)) {
+    return { ok: false, reason: "sdk_marker_skipped" };
+  }
   if (!AUTH_PROFILE_TYPES.has(typed.type as AuthProfileCredential["type"])) {
     return { ok: false, reason: "invalid_type" };
   }
@@ -76,10 +102,14 @@ function parseCredentialEntry(
 }
 
 function warnRejectedCredentialEntries(source: string, rejected: RejectedCredentialEntry[]): void {
-  if (rejected.length === 0) {
+  // SDK-managed credential markers are intentionally skipped, not broken —
+  // don't include them in the user-facing "invalid entries" warning, which
+  // suggested the user had a corrupt auth-profiles.json. (#69708)
+  const genuinelyInvalid = rejected.filter((entry) => entry.reason !== "sdk_marker_skipped");
+  if (genuinelyInvalid.length === 0) {
     return;
   }
-  const reasons = rejected.reduce(
+  const reasons = genuinelyInvalid.reduce(
     (acc, current) => {
       acc[current.reason] = (acc[current.reason] ?? 0) + 1;
       return acc;
@@ -88,9 +118,9 @@ function warnRejectedCredentialEntries(source: string, rejected: RejectedCredent
   );
   log.warn("ignored invalid auth profile entries during store load", {
     source,
-    dropped: rejected.length,
+    dropped: genuinelyInvalid.length,
     reasons,
-    keys: rejected.slice(0, 10).map((entry) => entry.key),
+    keys: genuinelyInvalid.slice(0, 10).map((entry) => entry.key),
   });
 }
 
@@ -233,6 +263,11 @@ export function applyLegacyAuthStore(store: AuthProfileStore, legacy: LegacyAuth
         ...(typeof cred.expires === "number" ? { expires: cred.expires } : {}),
         ...(cred.email ? { email: cred.email } : {}),
       };
+      continue;
+    }
+    // SDK-managed credential markers (aws-sdk) are not migrated into the
+    // credential store — the SDK resolves credentials independently. (#69708)
+    if (AUTH_PROFILE_SDK_MARKER_TYPES.has((cred as { type?: unknown }).type as string)) {
       continue;
     }
     store.profiles[profileId] = {


### PR DESCRIPTION
## Problem

Since 2026.4.1, auth-profiles.json entries with \`\"type\": \"aws-sdk\"\` are rejected as \`invalid_type\` and dropped during store load. This silently breaks Amazon Bedrock on EC2 instances that rely on IMDS (instance metadata) credentials — the gateway logs a generic \"ignored invalid auth profile entries\" warning, and Bedrock calls then fail with \`DispatchFailure: Could not load credentials from any providers\`.

Reported by @allamand in #69708 with complete EC2/IMDS repro.

## Fix

\`aws-sdk\` is not a real credential variant — it's a marker that records the presence of a Bedrock profile while letting the AWS SDK resolve credentials independently at call time via its own chain (env vars, shared config, IMDS, etc.). The marker should be **accepted silently**, not rejected.

Introduce \`AUTH_PROFILE_SDK_MARKER_TYPES = new Set([\"aws-sdk\"])\` and short-circuit \`parseCredentialEntry\` to return \`sdk_marker_skipped\` (a new reason code) for any marker type. The \"invalid entries\" warning filters these out so genuine invalid entries remain visible in the log.

## Why not widen \`AuthProfileCredential\` instead

Adding a real \`AwsSdkCredential\` variant to the union would require adjusting ~10 downstream type-narrowing switches (\`credential-state.ts\`, \`oauth.ts\`, \`persisted.ts\` migration path, etc.). That's a larger surface than the fix requires — the marker has no secret material for any of those switches to do anything with. The narrower \"skip silently\" shape both unblocks Bedrock and keeps the change scoped to one file of behavior.

## Pre-implement audit

- **A (existing helper):** \`AUTH_PROFILE_TYPES\` set already drives the allow/reject boundary. Added a parallel \`AUTH_PROFILE_SDK_MARKER_TYPES\` for non-credential markers rather than shoehorning into the credential type union. ✓
- **B (shared callers):** The parse helper is called from every auth-profile load path. The behavior change is strictly narrower (a previously-rejected marker is now cleanly skipped) — no switch downstream needs a new branch. ✓
- **C (broader rival):** No rival on #69708. ✓

## Testing

Two new regression tests in \`auth-profiles.ensureauthprofilestore.test.ts\`:

- \`silently skips SDK-managed marker profiles (#69708)\` — aws-sdk + a real api_key entry: asserts the marker is absent from the loaded store AND no warning is logged.
- \`still warns about genuine invalid types alongside SDK markers (#69708)\` — mixes an aws-sdk marker with a truly-invalid entry: asserts the warning surfaces only the real invalid entry (dropped: 1, reasons: {invalid_type: 1}), not inflated by the marker.

tsc clean on touched files, oxlint clean.

Fixes #69708