### PR TITLE
fix(control-ui): block remote image loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Auth/commands: require owner identity (an owner-candidate match or internal `operator.admin`) for owner-enforced commands instead of treating wildcard channel `allowFrom` or empty owner-candidate lists as sufficient, so non-owner senders can no longer reach owner-only commands through a permissive fallback when `enforceOwnerForCommands=true` and `commands.ownerAllowFrom` is unset. (#69774) Thanks @drobison00.
+- Control UI/CSP: tighten `img-src` to `'self' data:` only, and make Control UI avatar helpers drop remote `http(s)` and protocol-relative URLs so the UI falls back to the built-in logo/badge instead of issuing arbitrary remote image fetches. Same-origin avatar routes (relative paths) and `data:image/...` avatars still render. (#69773)
 
 ## 2026.4.20
 

--- a/src/gateway/control-ui-csp.test.ts
+++ b/src/gateway/control-ui-csp.test.ts
@@ -17,6 +17,12 @@ describe("buildControlUiCspHeader", () => {
     expect(csp).toContain("font-src 'self' https://fonts.gstatic.com");
   });
 
+  it("limits image loading to same-origin and data URLs", () => {
+    const csp = buildControlUiCspHeader();
+    expect(csp).toContain("img-src 'self' data:");
+    expect(csp).not.toContain("img-src 'self' data: https:");
+  });
+
   it("includes inline script hashes in script-src when provided", () => {
     const csp = buildControlUiCspHeader({
       inlineScriptHashes: ["sha256-abc123"],

--- a/src/gateway/control-ui-csp.ts
+++ b/src/gateway/control-ui-csp.ts
@@ -44,7 +44,7 @@ export function buildControlUiCspHeader(opts?: { inlineScriptHashes?: string[] }
     "frame-ancestors 'none'",
     scriptSrc,
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-    "img-src 'self' data: https:",
+    "img-src 'self' data:",
     "font-src 'self' https://fonts.gstatic.com",
     "connect-src 'self' ws: wss:",
   ].join("; ");

--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -130,6 +130,19 @@ describe("refreshChatAvatar", () => {
     expect(host.chatAvatarUrl).toBeNull();
   });
 
+  it("drops remote avatar metadata so the control UI can rely on same-origin images only", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ avatarUrl: "https://example.com/avatar.png" }),
+    });
+    vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+
+    const host = makeHost({ basePath: "", sessionKey: "agent:main" });
+    await refreshChatAvatar(host);
+
+    expect(host.chatAvatarUrl).toBeNull();
+  });
+
   it("ignores stale avatar responses after switching sessions", async () => {
     const mainRequest = createDeferred<{ avatarUrl?: string }>();
     const opsRequest = createDeferred<{ avatarUrl?: string }>();

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -21,6 +21,7 @@ import type { ChatModelOverride, ModelCatalogEntry } from "./types.ts";
 import type { SessionsListResult } from "./types.ts";
 import type { ChatAttachment, ChatQueueItem } from "./ui-types.ts";
 import { generateUUID } from "./uuid.ts";
+import { isRenderableControlUiAvatarUrl } from "./views/agents-utils.ts";
 
 export type ChatHost = {
   client: GatewayBrowserClient | null;
@@ -557,7 +558,7 @@ export async function refreshChatAvatar(host: ChatHost) {
       return;
     }
     const avatarUrl = typeof data.avatarUrl === "string" ? data.avatarUrl.trim() : "";
-    host.chatAvatarUrl = avatarUrl || null;
+    host.chatAvatarUrl = avatarUrl && isRenderableControlUiAvatarUrl(avatarUrl) ? avatarUrl : null;
   } catch {
     if (shouldApplyChatAvatarResult(host, requestVersion, sessionKey)) {
       host.chatAvatarUrl = null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -118,10 +118,11 @@ import {
   updateSkillEnabled,
 } from "./controllers/skills.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
-import "./components/dashboard-header.ts";
 import { icons } from "./icons.ts";
+import "./components/dashboard-header.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
 import { isPluginEnabledInConfigSnapshot } from "./plugin-activation.ts";
+import { isRenderableControlUiAvatarUrl } from "./views/agents-utils.ts";
 import { agentLogoUrl } from "./views/agents-utils.ts";
 import {
   resolveAgentConfig,
@@ -314,8 +315,6 @@ function dismissUpdateBanner(updateAvailable: unknown) {
   }
 }
 
-const AVATAR_DATA_RE = /^data:/i;
-const AVATAR_HTTP_RE = /^https?:\/\//i;
 const COMMUNICATION_SECTION_KEYS = ["channels", "messages", "broadcast", "talk", "audio"] as const;
 const APPEARANCE_SECTION_KEYS = ["__appearance__", "ui", "wizard"] as const;
 const AUTOMATION_SECTION_KEYS = [
@@ -413,10 +412,10 @@ function resolveAssistantAvatarUrl(state: AppViewState): string | undefined {
   if (!candidate) {
     return undefined;
   }
-  if (AVATAR_DATA_RE.test(candidate) || AVATAR_HTTP_RE.test(candidate)) {
+  if (isRenderableControlUiAvatarUrl(candidate)) {
     return candidate;
   }
-  return identity?.avatarUrl;
+  return undefined;
 }
 
 // ── Quick Settings data extraction helpers ──

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -17,6 +17,8 @@ vi.mock("../markdown.ts", () => ({
 
 vi.mock("../views/agents-utils.ts", () => ({
   agentLogoUrl: () => "/openclaw-logo.svg",
+  isRenderableControlUiAvatarUrl: (value: string) =>
+    /^data:image\//i.test(value) || value.startsWith("/"),
 }));
 
 vi.mock("./speech.ts", () => ({
@@ -184,6 +186,24 @@ describe("grouped chat rendering", () => {
     );
     expect(assistantConfirm).not.toBeNull();
     expect(assistantConfirm?.classList.contains("chat-delete-confirm--right")).toBe(true);
+  });
+
+  it("falls back to the local logo when the assistant avatar is a remote URL", () => {
+    const container = document.createElement("div");
+
+    renderAssistantMessage(
+      container,
+      {
+        role: "assistant",
+        content: "hello",
+        timestamp: 1000,
+      },
+      { assistantAvatar: "https://example.com/avatar.png" },
+    );
+
+    const avatar = container.querySelector<HTMLImageElement>(".chat-avatar.assistant");
+    expect(avatar).not.toBeNull();
+    expect(avatar?.getAttribute("src")).toBe("/openclaw-logo.svg");
   });
 
   it("keeps inline tool cards collapsed by default and renders expanded state", () => {

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -18,7 +18,7 @@ vi.mock("../markdown.ts", () => ({
 vi.mock("../views/agents-utils.ts", () => ({
   agentLogoUrl: () => "/openclaw-logo.svg",
   isRenderableControlUiAvatarUrl: (value: string) =>
-    /^data:image\//i.test(value) || value.startsWith("/"),
+    /^data:image\//i.test(value) || (value.startsWith("/") && !value.startsWith("//")),
 }));
 
 vi.mock("./speech.ts", () => ({

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -14,7 +14,7 @@ import type {
   NormalizedMessage,
   ToolCard,
 } from "../types/chat-types.ts";
-import { agentLogoUrl } from "../views/agents-utils.ts";
+import { agentLogoUrl, isRenderableControlUiAvatarUrl } from "../views/agents-utils.ts";
 import { renderCopyAsMarkdownButton } from "./copy-as-markdown.ts";
 import {
   extractTextCached,
@@ -665,9 +665,7 @@ function renderAvatar(
 }
 
 function isAvatarUrl(value: string): boolean {
-  return (
-    /^https?:\/\//i.test(value) || /^data:image\//i.test(value) || value.startsWith("/") // Relative paths from avatar endpoint
-  );
+  return isRenderableControlUiAvatarUrl(value);
 }
 
 function resolveRenderableMessageImages(

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -127,6 +127,14 @@ describe("resolveAgentAvatarUrl", () => {
     ).toBe("/avatar/main");
   });
 
+  it("ignores remote http avatars so the control UI falls back to a local badge", () => {
+    expect(
+      resolveAgentAvatarUrl({
+        identity: { avatarUrl: "https://example.com/avatar.png" },
+      }),
+    ).toBeNull();
+  });
+
   it("returns null for initials or emoji avatar values without a URL", () => {
     expect(resolveAgentAvatarUrl({ identity: { avatar: "A" } })).toBeNull();
     expect(resolveAgentAvatarUrl({ identity: { avatar: "🦞" } })).toBeNull();

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -135,6 +135,14 @@ describe("resolveAgentAvatarUrl", () => {
     ).toBeNull();
   });
 
+  it("ignores protocol-relative avatars so the control UI cannot be tricked into a cross-origin fetch", () => {
+    expect(
+      resolveAgentAvatarUrl({
+        identity: { avatarUrl: "//evil.example/avatar.png" },
+      }),
+    ).toBeNull();
+  });
+
   it("returns null for initials or emoji avatar values without a URL", () => {
     expect(resolveAgentAvatarUrl({ identity: { avatar: "A" } })).toBeNull();
     expect(resolveAgentAvatarUrl({ identity: { avatar: "🦞" } })).toBeNull();

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -198,7 +198,11 @@ export function normalizeAgentLabel(agent: {
   );
 }
 
-const AVATAR_URL_RE = /^(https?:\/\/|data:image\/|\/)/i;
+const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/)/i;
+
+export function isRenderableControlUiAvatarUrl(value: string): boolean {
+  return CONTROL_UI_AVATAR_URL_RE.test(value);
+}
 
 export function resolveAgentAvatarUrl(
   agent: { identity?: { avatar?: string; avatarUrl?: string } },
@@ -213,7 +217,7 @@ export function resolveAgentAvatarUrl(
     if (!candidate) {
       continue;
     }
-    if (AVATAR_URL_RE.test(candidate)) {
+    if (isRenderableControlUiAvatarUrl(candidate)) {
       return candidate;
     }
   }

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -198,7 +198,7 @@ export function normalizeAgentLabel(agent: {
   );
 }
 
-const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/)/i;
+const CONTROL_UI_AVATAR_URL_RE = /^(data:image\/|\/(?!\/))/i;
 
 export function isRenderableControlUiAvatarUrl(value: string): boolean {
   return CONTROL_UI_AVATAR_URL_RE.test(value);


### PR DESCRIPTION
# fix(control-ui): block remote image loads

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem: The Control UI CSP allowed `https:` image loads, so the browser could fetch remote images from rendered Control UI surfaces.
- Why it matters: A Control UI page should not be able to trigger arbitrary remote image fetches from untrusted rendered content or remote avatar metadata.
- What changed: `img-src` now allows only same-origin and `data:` images, and Control UI avatar helpers now ignore remote `http(s)` avatar URLs so the UI falls back to the built-in logo/badge instead of requesting them.
- What did NOT change (scope boundary): This branch does not change markdown sanitization rules, does not add a server-side avatar proxy, and does not alter Control UI auth or assistant-media routing.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<operator to fill>
- Related #<operator to fill>
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: The Control UI CSP builder explicitly allowed `https:` in `img-src`, and the Control UI avatar rendering path still treated remote `http(s)` avatar URLs as renderable image sources.
- Missing detection / guardrail: There was no focused test asserting that Control UI image loads stay same-origin/data-only or that avatar helpers reject remote avatar URLs.
- Contributing context (if known): Markdown image handling on `main` already flattened remote markdown images, so avatar rendering remained the practical external image-fetch path inside the Control UI.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/gateway/control-ui-csp.test.ts`, `ui/src/ui/views/agents-utils.test.ts`, `ui/src/ui/chat/grouped-render.test.ts`, `ui/src/ui/app-chat.test.ts`
- Scenario the test should lock in: The Control UI CSP must not allow `https:` images, and Control UI avatar helpers must treat only same-origin or `data:image/...` sources as renderable.
- Why this is the smallest reliable guardrail: The hardening lives in pure CSP construction and UI avatar helper logic, so unit tests catch the contract without needing browser orchestration.
- Existing test that already covers this (if any): Existing markdown tests already covered flattening remote markdown images.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The Control UI no longer renders remote `http(s)` avatars. Same-origin avatar routes and `data:image/...` avatars still render; remote avatars fall back to the built-in logo/badge.

## Diagram (if applicable)

```text
Before:
[Control UI render] -> [remote avatar/http image URL] -> [browser GET to remote origin]

After:
[Control UI render] -> [same-origin/data image only] -> [render]
                           |
                           +-> [remote avatar URL] -> [fallback logo/badge]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) Yes
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: The Control UI no longer permits browser image fetches to arbitrary remote HTTPS origins from this surface. Remote avatar URLs now degrade to a local fallback so the stricter CSP does not leave broken image requests behind.

## Repro + Verification

### Environment

- OS: Linux 6.8.0-110-generic x86_64
- Runtime/container: Node.js v22.14.0 in the task workspace container
- Model/provider: <operator to fill>
- Integration/channel (if any): Control UI
- Relevant config (redacted): Default Control UI CSP plus avatar rendering helpers; no special gateway auth or channel config required for the targeted tests

### Steps

1. Run `COREPACK_HOME=/tmp/corepack corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui-csp.test.ts`.
2. Run `COREPACK_HOME=/tmp/corepack corepack pnpm --dir ui exec vitest run --config vitest.config.ts src/ui/app-chat.test.ts src/ui/chat/grouped-render.test.ts src/ui/views/agents-utils.test.ts`.
3. Inspect the final diff to confirm the branch only tightens the Control UI CSP and avatar rendering path.

### Expected

- The CSP test should show `img-src 'self' data:` with no `https:` wildcard, and the UI tests should keep only same-origin/data avatar sources renderable.

### Actual

- `src/gateway/control-ui-csp.test.ts`: 1 file passed, 13 tests passed.
- `src/ui/app-chat.test.ts`, `src/ui/chat/grouped-render.test.ts`, `src/ui/views/agents-utils.test.ts`: 3 files passed, 47 tests passed.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the final diff removes `https:` from the Control UI `img-src` directive, rejects remote avatar URLs in the Control UI helper paths, and preserves same-origin/data avatar rendering.
- Edge cases checked: Route-relative avatar paths (`/avatar/...`) still render, `data:image/...` avatars remain allowed, and remote avatar metadata is dropped before UI rendering.
- What you did **not** verify: I did not run a manual browser session against a live gateway, and I did not treat the broader pre-commit changed-file test lane as signal for this branch because it failed in unrelated gateway auth/server baseline tests outside the touched files.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) No
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Operators who relied on remote `http(s)` avatars in the Control UI will see the fallback logo/badge instead of that remote image.
  - Mitigation: Same-origin avatar routes and `data:image/...` avatars still render, and the fallback keeps the UI usable while removing the remote fetch surface.