### PR TITLE
fix(synology): validate webhook file urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Auth/commands: require owner identity (an owner-candidate match or internal `operator.admin`) for owner-enforced commands instead of treating wildcard channel `allowFrom` or empty owner-candidate lists as sufficient, so non-owner senders can no longer reach owner-only commands through a permissive fallback when `enforceOwnerForCommands=true` and `commands.ownerAllowFrom` is unset. (#69774) Thanks @drobison00.
 - Control UI/CSP: tighten `img-src` to `'self' data:` only, and make Control UI avatar helpers drop remote `http(s)` and protocol-relative URLs so the UI falls back to the built-in logo/badge instead of issuing arbitrary remote image fetches. Same-origin avatar routes (relative paths) and `data:image/...` avatars still render. (#69773)
 - CLI/channels: keep `status`, `health`, `channels list`, and `channels status` on read-only channel metadata when Telegram, Slack, Discord, or third-party channel plugins are configured, avoiding full bundled plugin runtime imports on those cold paths. Fixes #69042. (#69479) Thanks @gumadeiras.
+- Synology Chat: validate outbound webhook `file_url` values against the shared SSRF policy before forwarding to the NAS, rejecting malformed URLs, non-`http(s)` schemes, and private/blocked network targets so the NAS cannot be used as a confused deputy to fetch internal addresses. (#69784) Thanks @eleqtrizit.
 
 ## 2026.4.20
 

--- a/docs/channels/synology-chat.md
+++ b/docs/channels/synology-chat.md
@@ -113,6 +113,7 @@ openclaw message send --channel synology-chat --target synology-chat:123456 --te
 ```
 
 Media sends are supported by URL-based file delivery.
+Outbound file URLs must use `http` or `https`, and private or otherwise blocked network targets are rejected before OpenClaw forwards the URL to the NAS webhook.
 
 ## Multi-account
 

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -2,6 +2,10 @@ import { EventEmitter } from "node:events";
 import type { ClientRequest, IncomingMessage, RequestOptions } from "node:http";
 import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 
+const ssrfMocks = {
+  resolvePinnedHostnameWithPolicy: vi.fn(),
+};
+
 // Mock http and https modules before importing the client
 vi.mock("node:https", () => {
   const httpsRequest = vi.fn();
@@ -15,6 +19,11 @@ vi.mock("node:http", () => {
   const httpGet = vi.fn();
   return { default: { request: httpRequest, get: httpGet }, request: httpRequest, get: httpGet };
 });
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
+  formatErrorMessage: (err: unknown) => (err instanceof Error ? err.message : String(err)),
+  resolvePinnedHostnameWithPolicy: ssrfMocks.resolvePinnedHostnameWithPolicy,
+}));
 
 const https = await import("node:https");
 let fakeNowMs = 1_700_000_000_000;
@@ -33,7 +42,7 @@ type MockRequestHandler = (
 function createMockResponseEmitter(statusCode: number): IncomingMessage {
   const res = new EventEmitter() as Partial<IncomingMessage>;
   res.statusCode = statusCode;
-  return res as IncomingMessage;
+  return res as unknown as IncomingMessage;
 }
 
 function createMockRequestEmitter(): ClientRequest {
@@ -41,7 +50,7 @@ function createMockRequestEmitter(): ClientRequest {
   req.write = vi.fn() as ClientRequest["write"];
   req.end = vi.fn() as ClientRequest["end"];
   req.destroy = vi.fn() as ClientRequest["destroy"];
-  return req as ClientRequest;
+  return req as unknown as ClientRequest;
 }
 
 async function settleTimers<T>(promise: Promise<T>): Promise<T> {
@@ -83,6 +92,10 @@ function installFakeTimerHarness() {
     vi.useFakeTimers();
     fakeNowMs += 10_000;
     vi.setSystemTime(fakeNowMs);
+    ssrfMocks.resolvePinnedHostnameWithPolicy.mockResolvedValue({
+      hostname: "example.com",
+      addresses: ["93.184.216.34"],
+    });
   });
 
   afterEach(() => {
@@ -155,6 +168,34 @@ describe("sendFileUrl", () => {
     );
     const httpsRequest = vi.mocked(https.request);
     expect(httpsRequest.mock.calls[0]?.[1]).toMatchObject({ rejectUnauthorized: true });
+  });
+
+  it("rejects malformed file URLs before making a request", async () => {
+    const result = await settleTimers(sendFileUrl("https://nas.example.com/incoming", "not-a-url"));
+    expect(result).toBe(false);
+    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-http file URLs before making a request", async () => {
+    const result = await settleTimers(
+      sendFileUrl("https://nas.example.com/incoming", "file:///tmp/secret.txt"),
+    );
+    expect(result).toBe(false);
+    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).not.toHaveBeenCalled();
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+  });
+
+  it("rejects SSRF-blocked hosts before making a request", async () => {
+    ssrfMocks.resolvePinnedHostnameWithPolicy.mockRejectedValueOnce(
+      new Error("Blocked private network target"),
+    );
+    const result = await settleTimers(
+      sendFileUrl("https://nas.example.com/incoming", "http://169.254.169.254/latest/meta-data"),
+    );
+    expect(result).toBe(false);
+    expect(ssrfMocks.resolvePinnedHostnameWithPolicy).toHaveBeenCalledWith("169.254.169.254");
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/synology-chat/src/client.test.ts
+++ b/extensions/synology-chat/src/client.test.ts
@@ -170,6 +170,23 @@ describe("sendFileUrl", () => {
     expect(httpsRequest.mock.calls[0]?.[1]).toMatchObject({ rejectUnauthorized: true });
   });
 
+  it("respects the shared send interval before posting a file URL", async () => {
+    mockSuccessResponse();
+    await settleTimers(sendMessage("https://nas.example.com/incoming", "hello"));
+    vi.mocked(https.request).mockClear();
+
+    const promise = sendFileUrl("https://nas.example.com/incoming", "https://example.com/file.png");
+    await Promise.resolve();
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(vi.mocked(https.request)).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(vi.mocked(https.request)).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects malformed file URLs before making a request", async () => {
     const result = await settleTimers(sendFileUrl("https://nas.example.com/incoming", "not-a-url"));
     expect(result).toBe(false);

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -6,6 +6,10 @@
 import * as http from "node:http";
 import * as https from "node:https";
 import { safeParseJsonWithSchema, safeParseWithSchema } from "openclaw/plugin-sdk/extension-shared";
+import {
+  formatErrorMessage,
+  resolvePinnedHostnameWithPolicy,
+} from "openclaw/plugin-sdk/ssrf-runtime";
 import { z } from "zod";
 
 const MIN_SEND_INTERVAL_MS = 500;
@@ -131,9 +135,9 @@ export async function sendFileUrl(
   userId?: string | number,
   allowInsecureSsl = false,
 ): Promise<boolean> {
-  const body = buildWebhookBody({ file_url: fileUrl }, userId);
-
   try {
+    const safeFileUrl = await assertSafeWebhookFileUrl(fileUrl);
+    const body = buildWebhookBody({ file_url: safeFileUrl }, userId);
     const ok = await doPost(incomingUrl, body, allowInsecureSsl);
     lastSendTime = Date.now();
     return ok;
@@ -207,6 +211,22 @@ export async function fetchChatUsers(
         resolve(cached?.users ?? []);
       });
   });
+}
+
+async function assertSafeWebhookFileUrl(fileUrl: string): Promise<string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(fileUrl);
+  } catch (err) {
+    throw new Error(`Invalid Synology Chat file URL: ${formatErrorMessage(err)}`, { cause: err });
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("Synology Chat file URL must use HTTP or HTTPS");
+  }
+
+  await resolvePinnedHostnameWithPolicy(parsed.hostname);
+  return parsed.toString();
 }
 
 /**

--- a/extensions/synology-chat/src/client.ts
+++ b/extensions/synology-chat/src/client.ts
@@ -138,6 +138,13 @@ export async function sendFileUrl(
   try {
     const safeFileUrl = await assertSafeWebhookFileUrl(fileUrl);
     const body = buildWebhookBody({ file_url: safeFileUrl }, userId);
+
+    const now = Date.now();
+    const elapsed = now - lastSendTime;
+    if (elapsed < MIN_SEND_INTERVAL_MS) {
+      await sleep(MIN_SEND_INTERVAL_MS - elapsed);
+    }
+
     const ok = await doPost(incomingUrl, body, allowInsecureSsl);
     lastSendTime = Date.now();
     return ok;


### PR DESCRIPTION
## Summary
- validate Synology Chat outbound `file_url` values before they are forwarded to the NAS webhook
- keep the change limited to the existing webhook-based media path

## Changes
- add a shared SSRF-policy check in `extensions/synology-chat/src/client.ts` for outbound file URLs
- reject malformed and non-`http(s)` file URLs before request construction
- add targeted regression coverage in `extensions/synology-chat/src/client.test.ts`
- document the outbound file URL requirement in `docs/channels/synology-chat.md`

## Validation
- ran `corepack pnpm install`
- ran `corepack pnpm test extensions/synology-chat/src/client.test.ts`
- ran `corepack pnpm test extensions/synology-chat/src/channel.test.ts`
- ran `corepack pnpm check:changed --staged`
- attempted local agentic review with `claude -p \"/review\"`; the CLI requested an explicit target instead of returning findings

## Notes
- this keeps existing public `http(s)` media URLs working while blocking malformed or SSRF-unsafe targets before the NAS fetches them
- no new config, proxy path, or transport behavior was added
