### PR TITLE
test: stabilize config validation tests and npm execpath handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1550,6 +1550,7 @@
     "jszip": "^3.10.1",
     "linkedom": "^0.18.12",
     "markdown-it": "14.1.1",
+    "markdown-it-task-lists": "^2.1.1",
     "openai": "^6.34.0",
     "osc-progress": "^0.3.0",
     "pdfjs-dist": "^5.6.205",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       markdown-it:
         specifier: 14.1.1
         version: 14.1.1
+      markdown-it-task-lists:
+        specifier: ^2.1.1
+        version: 2.1.1
       node-llama-cpp:
         specifier: 3.18.1
         version: 3.18.1(typescript@6.0.3)

--- a/src/config/config.schema-regressions.test.ts
+++ b/src/config/config.schema-regressions.test.ts
@@ -1,4 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/doctor-contract-registry.js")>();
+  return {
+    ...actual,
+    listPluginDoctorLegacyConfigRules: () => [],
+    applyPluginDoctorCompatibilityMigrations: () => ({ next: null, changes: [] }),
+  };
+});
+
 import { validateConfigObject } from "./validation.js";
 
 describe("config schema regressions", () => {

--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { __testing, validateConfigObjectRaw } from "./validation.js";
 
@@ -15,6 +15,15 @@ function mapFirstIssue(
   expect(issue).toBeDefined();
   return __testing.mapZodIssueToConfigIssue(issue);
 }
+
+vi.mock("../plugins/doctor-contract-registry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/doctor-contract-registry.js")>();
+  return {
+    ...actual,
+    listPluginDoctorLegacyConfigRules: () => [],
+    applyPluginDoctorCompatibilityMigrations: () => ({ next: null, changes: [] }),
+  };
+});
 
 describe("config validation allowed-values metadata", () => {
   it("adds allowed values for invalid union paths", () => {

--- a/src/config/validation.policy.test.ts
+++ b/src/config/validation.policy.test.ts
@@ -8,6 +8,7 @@ vi.mock("../channels/plugins/legacy-config.js", () => ({
 vi.mock("../plugins/doctor-contract-registry.js", () => ({
   collectRelevantDoctorPluginIds: () => [],
   listPluginDoctorLegacyConfigRules: () => [],
+  applyPluginDoctorCompatibilityMigrations: () => ({ next: null, changes: [] }),
 }));
 
 vi.mock("../secrets/unsupported-surface-policy.js", async () => {

--- a/test/openclaw-npm-release-check.test.ts
+++ b/test/openclaw-npm-release-check.test.ts
@@ -256,10 +256,18 @@ describe("resolveNpmCommandInvocation", () => {
   });
 
   it("uses the platform npm command when npm_execpath is missing", () => {
-    expect(resolveNpmCommandInvocation({ platform: "win32" })).toEqual({
-      command: "npm.cmd",
-      args: [],
-    });
+    const savedNpmExecPath = process.env.npm_execpath;
+    delete process.env.npm_execpath;
+    try {
+      expect(resolveNpmCommandInvocation({ platform: "win32" })).toEqual({
+        command: "npm.cmd",
+        args: [],
+      });
+    } finally {
+      if (savedNpmExecPath !== undefined) {
+        process.env.npm_execpath = savedNpmExecPath;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- isolate npm release command resolution test from host npm env (`npm_execpath`)
- mock doctor contract registry in config validation tests to avoid expensive plugin discovery
- add same registry mock to allowlist/webhook validation tests to prevent timeouts

## Validation
- `npm run test:unit`
  - unit-fast: 469 passed
  - unit: 159 passed
  - total: 0 failed

## Notes
- branch source: `alvian888/ready/test-fixes-only`
- upstream push is intentionally via PR from fork
