### PR TITLE
[RFC] ACP everywhere: consolidate all LLM/agent launches behind a single ACP runtime seam

### DIFF
--- a/docs/refactor/acp-everywhere-richness-audit.md
+++ b/docs/refactor/acp-everywhere-richness-audit.md
@@ -1,0 +1,106 @@
+# ACP richness audit
+
+**Purpose.** Turn "is ACP rich enough for our existing contracts?" into a row-by-row checklist instead of a vibes discussion. Companion to `docs/refactor/acp-everywhere.md`.
+
+**Rating key.**
+
+- 🟢 Covered by ACP today, maps cleanly.
+- 🟡 Requires an additive Phase 1 extension (documented path, no protocol rewrite).
+- 🔴 Fundamentally missing, would require a redesign of the seam.
+
+**Headline.** 0 🔴, ~17 🟡, ~15 🟢. There are no hard blockers. The 🟡 list is the actual Phase 1 work and must land before Phase 3's parity gate.
+
+## Session lifecycle
+
+| Pi / existing contract              | ACP today                                              | After Phase 1                  | Fit |
+| ----------------------------------- | ------------------------------------------------------ | ------------------------------ | --- |
+| New session with workspace + auth   | `ensureSession({ sessionKey, agent, mode, cwd, env })` | same                           | 🟢  |
+| Resume by upstream session id       | `loadSession`, our `resumeSessionId`                   | same                           | 🟢  |
+| Set session mode mid-session        | `session/set_mode`, our `setMode`                      | same                           | 🟢  |
+| Per-session config options          | `session/set_config_option`, our `setConfigOption`     | keys advertised via capability | 🟢  |
+| Cancel in-flight run                | `cancel` + `AbortSignal` on turn                       | same                           | 🟢  |
+| Close with `discardPersistentState` | `close({ discardPersistentState })`                    | same                           | 🟢  |
+| Health probe                        | `doctor()`                                             | same                           | 🟢  |
+
+## Per-turn inputs
+
+| Pi / existing contract                                                                  | ACP today                                               | After Phase 1                                                                           | Fit |
+| --------------------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------- | --- |
+| Prompt text                                                                             | `session/prompt` text                                   | same                                                                                    | 🟢  |
+| Attachments (images)                                                                    | `AcpRuntimeTurnAttachment` (mediaType + data)           | same; may carry size/path metadata                                                      | 🟢  |
+| Run / request correlation id                                                            | `requestId` in `TurnInput`                              | same; echoed on every event                                                             | 🟡  |
+| Abort signal                                                                            | `signal` in `TurnInput`                                 | same                                                                                    | 🟢  |
+| Hard timeout                                                                            | via `AbortController` wrapping `signal`                 | same (no protocol-level timeout)                                                        | 🟢  |
+| Provider / model                                                                        | `ensureSession({ agent })` + `setConfigOption("model")` | same                                                                                    | 🟢  |
+| Auth profile id                                                                         | via `env` on `ensureSession` OR `setConfigOption`       | document the one chosen                                                                 | 🟡  |
+| Thinking level                                                                          | `setConfigOption("thinking")` or `setMode("plan")`      | same                                                                                    | 🟢  |
+| Verbose level                                                                           | `setConfigOption("verbose")`                            | same                                                                                    | 🟢  |
+| Extra system prompt                                                                     | NOT modeled                                             | add optional `systemPromptExtras` on `ensureSession`; gated by capability               | 🟡  |
+| Bootstrap context (mode + runKind)                                                      | NOT modeled                                             | add optional `bootstrapContext` on `ensureSession`; gated by capability                 | 🟡  |
+| Skills snapshot                                                                         | NOT modeled                                             | add optional `skills` on `ensureSession`; gated by capability                           | 🟡  |
+| Client tool surface                                                                     | Partially via `fs/*`, `terminal/*`                      | map OpenClaw client tools onto ACP client-tool methods                                  | 🟡  |
+| Messaging / delivery context (channel/to/thread)                                        | NOT a runtime concern in ACP                            | backend uses client-tool callbacks; OpenClaw supplies a `messaging` client-tool surface | 🟡  |
+| Provenance metadata                                                                     | `_meta` on ACP messages                                 | same                                                                                    | 🟢  |
+| senderIsOwner / elevated gating                                                         | Pi-local flag today                                     | part of `SandboxPolicy` or `setConfigOption`                                            | 🟡  |
+| Lane / queue                                                                            | OpenClaw-internal, stays in spawn module                | stays in spawn module                                                                   | 🟢  |
+| Fast mode                                                                               | Pi-local flag today                                     | `setConfigOption("fastMode")`                                                           | 🟢  |
+| `allowTransientCooldownProbe`, `cleanupBundleMcpOnRunEnd`, bootstrap warning signatures | Pi-specific flags                                       | `setConfigOption` or backend init; not protocol-level                                   | 🟢  |
+
+## Events emitted during a turn
+
+| Pi / existing contract             | ACP today                                | After Phase 1                                               | Fit |
+| ---------------------------------- | ---------------------------------------- | ----------------------------------------------------------- | --- |
+| Lifecycle start                    | —                                        | new `lifecycle({ phase: "start" })` variant                 | 🟡  |
+| Lifecycle end with stop reason     | `done({ stopReason })`                   | same                                                        | 🟢  |
+| Lifecycle error                    | `error({ message, code, retryable })`    | same                                                        | 🟢  |
+| Assistant text delta               | `text_delta({ stream: "output" })`       | same                                                        | 🟢  |
+| Reasoning / thought delta          | tag `agent_thought_chunk`, not a variant | first-class `text_delta({ stream: "thought" })`             | 🟡  |
+| Tool call start                    | `tool_call` (flat fields)                | extend with structured args + `phase: "start"`              | 🟡  |
+| Tool call update                   | tag `tool_call_update`, not a variant    | first-class `tool_call_update` variant                      | 🟡  |
+| Tool call end (with result)        | —                                        | `tool_call_update({ phase: "end", result })`                | 🟡  |
+| Exec approval request              | —                                        | new `approval_request` variant (or reuse ACP permissions)   | 🟡  |
+| Exec approval decision             | —                                        | new `approval_response` variant                             | 🟡  |
+| Compaction start                   | —                                        | new `compaction({ phase: "start" })` variant                | 🟡  |
+| Compaction progress                | —                                        | `compaction({ phase: "progress", used, size })`             | 🟡  |
+| Compaction end (with retry signal) | —                                        | `compaction({ phase: "end", retry?: boolean })`             | 🟡  |
+| Usage tick                         | tag `usage_update`, not a variant        | first-class `usage_update({ input, output, cache, total })` | 🟡  |
+| Plan update                        | tag `plan`, not a variant                | first-class `plan_update({ plan })`                         | 🟡  |
+| Session info update                | tag `session_info_update`, not a variant | first-class `session_info_update`                           | 🟡  |
+| Final assistant text               | Implicit via text deltas + `done`        | same                                                        | 🟢  |
+
+## Out-of-turn orchestration
+
+| Pi / existing contract         | ACP today                           | After Phase 1                                                        | Fit |
+| ------------------------------ | ----------------------------------- | -------------------------------------------------------------------- | --- |
+| Auth profile rotation          | Backend-internal (reads `agentDir`) | backend reads scope from `env`; rotation internal                    | 🟢  |
+| Transcript persistence         | Spawn-module concern                | stays in spawn module; driven by event stream                        | 🟢  |
+| Session store updates          | Spawn-module concern                | stays in spawn module                                                | 🟢  |
+| Announce / delivery to channel | Spawn-module concern                | stays in spawn module; fired on `done`                               | 🟢  |
+| Thread-binding lifecycle       | Channel plugin + spawn module       | stays in spawn module; backend oblivious                             | 🟢  |
+| Depth / concurrency limits     | Spawn-module concern                | stays in spawn module                                                | 🟢  |
+| Subagent registry              | Spawn-module concern                | stays in spawn module                                                | 🟢  |
+| Sandbox enforcement            | Boolean flag today                  | `SandboxCapability` + `SandboxPolicy` + `satisfies()` (see RFC Cons) | 🟡  |
+| Event ↔ run correlation        | Pi emits `runId` on each event      | `requestId` echoed on every event                                    | 🟡  |
+
+## Verdict
+
+- **🟢 ~15 rows** fit ACP as-is or are deliberately kept out of the seam (orchestration that stays in the spawn module).
+- **🟡 ~17 rows** need additive Phase 1 extensions — mostly new event variants, plus four optional `ensureSession` inputs (skills, bootstrap context, system-prompt extras, client-tool surface).
+- **🔴 0 rows** found that fundamentally don't fit. If the room identifies one during the meet, that's the RFC-killer signal and we should flag it hard.
+
+## Top 5 Phase 1 extensions this audit justifies
+
+These are the smallest concrete changes that turn all 🟡 rows green:
+
+1. Split `tool_call` into `tool_call` (start) + `tool_call_update` (progress/end) with a structured `args` / `result` payload.
+2. Add first-class event variants for `reasoning` (or `text_delta` with `stream: "thought"`), `compaction` (start/progress/end), `usage_update`, `plan_update`, `session_info_update`, `lifecycle` (start).
+3. Add `approval_request` / `approval_response` variants for exec-approval gating, or bind to ACP's existing permission flow — whichever the team prefers.
+4. Extend `AcpRuntimeEnsureInput` with optional, capability-gated `skills`, `systemPromptExtras`, `bootstrapContext` fields.
+5. Define how messaging / delivery context becomes a _client-tool_ surface (the way `fs/*` and `terminal/*` already are), not an `AcpRuntime` input. Draft a `messaging/*` method set and have the backend call into it during a turn.
+
+## How to use this at the meet
+
+- Display the three section tables; skip rows whose color isn't debated.
+- Ask the room: "anything here that you think is 🔴, not 🟡?" — any row promoted to red kills or reshapes the RFC.
+- Ask: "anything here that you think is 🟡 but is actually 🟢 (already covered)?" — green-ification shrinks Phase 1.
+- Rough time: 10 minutes to walk the three tables at high altitude; don't bikeshed individual event-variant naming in the meet, that's a Phase 1 PR review concern.

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -174,7 +174,7 @@ flowchart LR
 ### Sequence: what changes on a normal turn
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
@@ -196,7 +196,7 @@ sequenceDiagram
 ```
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
@@ -402,7 +402,7 @@ That is the whole transport: a thin adapter that hands typed objects from one fu
 Inside the `openclaw-pi` server, the pi subscription system produces events on a bounded in-memory queue; `runTurn` yields them as an async iterable of `AcpRuntimeEvent`. Under loopback, that iterable is returned to the caller directly — no `JSON.stringify`, no framing. Under stdio, the same iterable is wrapped by the stdio transport, which serializes and frames.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant SM as spawn module
     participant T as transport

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -248,9 +248,11 @@ sequenceDiagram
 ## Cons / tradeoffs
 
 - **`AcpRuntimeEvent` must be extended.** Today it does not cover pi's full event surface (lifecycle start/end/error, reasoning deltas, compaction, usage). That is a contract change, additive but real, and it affects `acpx`, any third-party ACP runtime backend, and the outward bridge.
-- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). A boolean `runsInSandbox` is too coarse — different backends offer different isolation grades (host / Docker / Podman / chroot / seccomp) with different guarantees (filesystem, network, process caps). The contract should carry a structured capability that the spawn module can policy-check against:
+- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). A boolean `runsInSandbox` is too coarse — different backends offer different isolation grades (host / Docker / Podman / chroot / seccomp) with different guarantees (filesystem, network, process caps). Also, what a backend _can_ enforce and what a particular run _requested_ are different concerns and must not share a single type. The contract separates them cleanly:
 
   ```ts path=null start=null
+  // What the backend CAN enforce. Advertised by the runtime via getCapabilities;
+  // does not change per run. Static facts about the runtime.
   type SandboxCapability = {
     mode: "host" | "docker" | "podman" | "chroot" | "seccomp" | "custom";
     guarantees: {
@@ -258,12 +260,21 @@ sequenceDiagram
       netIsolation: "none" | "restricted" | "denyAll";
       processCaps: boolean;
     };
-    // Optional operator hints the policy layer can match against.
-    policy?: { image?: string; setupCommand?: string };
+  };
+
+  // What THIS run requests. Per-spawn input the spawn module passes into
+  // ensureSession so the backend knows what the operator asked for. Not a
+  // capability — a request.
+  type SandboxPolicy = {
+    require: "any" | "host" | "sandboxed";
+    minFsIsolation?: "workspace" | "fullRoot";
+    minNetIsolation?: "restricted" | "denyAll";
+    image?: string; // operator-supplied runtime config
+    setupCommand?: string; // operator-supplied runtime config
   };
   ```
 
-  That lets `sandbox="require"` be a real policy predicate (for example `mode != "host" && guarantees.fsIsolation != "none"`) instead of a boolean. Without this we regress today's sandboxed-subagent guarantees and we can't express future stronger isolation (container-per-session, seccomp profiles, etc.) without another round of string-comparison plumbing.
+  Enforcement is a well-defined predicate `satisfies(capability, policy)` that the spawn module evaluates before starting a run (rough shape: `policy.require != "sandboxed" || capability.mode != "host"`, plus pairwise checks that `capability.guarantees` meets each `policy.min*`). That lets `sandbox="require"` be a real check instead of a boolean, keeps the capability surface stable across runs, and leaves room for stronger isolation grades (container-per-session, seccomp profiles, etc.) without another round of string-comparison plumbing. Without the split, capability and policy blur and matching gets hand-wavy fast.
 
 - **Announce / thread-binding migration is delicate.** Channel plugins expect exact historical announce shapes. Merging subagent-spawn and acp-spawn must preserve those bytes or we silently break agents and cron jobs that users already rely on.
 - **CLI backend features are non-trivial to move.** Session-expired retry, CLI-session reuse, bundle-MCP overlay, plugin-owned defaults. These need to come along when CLI backends become ACP backends.

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -1,0 +1,545 @@
+# ACP Everywhere
+
+## TL;DR
+
+OpenClaw currently has at least five different ways to start an LLM/agent turn (normal `agent` RPC, `sessions_spawn` subagent, `sessions_spawn` acp, cron, `openclaw acp` bridge) driving at least four different execution engines (pi-embedded, CLI backends, plugin `AgentHarness`, ACP runtime backends). Each path has its own spawn wrapper, lifecycle eventing, sandbox/announce rules, and slash-command surface. This document proposes making the existing `AcpRuntime` interface (`src/acp/runtime/types.ts`) the single internal execution contract that every path goes through, wrapping pi-embedded, CLI backends, and plugin harnesses as ACP backends behind it. Net effect: one spawn module, one event stream, one policy layer, one set of controls — without changing any external wire protocol.
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart LR
+    subgraph SRC["launch surfaces"]
+        direction TB
+        RPC["agent RPC"]
+        SS["sessions_spawn"]
+        SL["/subagents, /acp"]
+        CR["cron"]
+        BR["openclaw acp bridge"]
+    end
+    AR["AcpRuntime<br/>ensureSession / runTurn / cancel"]
+    subgraph BE["backends"]
+        direction TB
+        PI["openclaw-pi"]
+        AX["acpx"]
+        CLI["CLI backends"]
+        PL["plugin harnesses"]
+    end
+    RPC --> AR
+    SS --> AR
+    SL --> AR
+    CR --> AR
+    BR --> AR
+    AR --> PI
+    AR --> AX
+    AR --> CLI
+    AR --> PL
+```
+
+## Why ACP
+
+Before the problem statement and the mechanics, a short list of why ACP is the right protocol to standardize on. These properties are what make "one seam" actually work in practice and what separate ACP from a bespoke internal interface.
+
+- **Covers chat-style and agent-style interfaces with the same contract.** `session/prompt` handles the straight prompt-in / deltas-and-final-text-out shape that a Responses-API-style caller wants, and the same session can just as easily drive a full agent turn with tools, plans, thoughts, session modes, cwd, resume, and cancel. One contract; no separate API for "assistant turn" vs "agent turn".
+- **Tools can live on the client or on the server, or both.** Agent-side tools are the default (the backend exposes its own tool surface). Client-side tools are first-class too (for example `fs/read_text_file`, `fs/write_text_file`, `terminal/*`) and get called through the same JSON-RPC methods. Capability negotiation at `initialize` makes this explicit, so the spawn module can policy-check which side owns which tool.
+- **Sessions are first-class.** `newSession`, `loadSession`, `session/set_mode`, `session/status`, resume semantics, and cancel live in the protocol. Maps 1:1 onto OpenClaw's session keys and lifecycle.
+- **Streaming is structured, not a single opaque text stream.** Token deltas, reasoning/thought deltas, tool-call lifecycle updates, plan updates, status, usage, and (optionally) terminal output are each their own typed event.
+- **Capability negotiation is built in.** Backends advertise what they actually support (sandboxing, resume, attachments, client terminals, specific tool surfaces, config option keys) and callers policy-check against that.
+- **Permission handling is in the protocol.** Interactive and non-interactive permission flows for writes/exec/etc. are defined, so headless sessions don't have to invent their own approval path.
+- **Transport-agnostic.** The ACP JSON-RPC 2.0 messages are the same regardless of wire. stdio is the canonical transport, but the same messages can be carried over WebSocket, WebRTC, QUIC, TCP, in-process loopback, or any multiplexed transport. See [xumux-ACP](https://github.com/deftai/xumux/blob/openmux/docs/ext-acp-agent-client-protocol.md) for a concrete example that carries the exact same ACP payloads over a xumux multiplexer and picks up WebSocket / WebRTC / QUIC / TCP / stdio from one binding. OpenClaw's proposed loopback transport is another instance of the same principle.
+- **Existing ecosystem.** Codex, Claude Code, Gemini CLI, Cursor, OpenCode, and others already speak ACP. Choosing it as the internal seam means OpenClaw consumes that ecosystem cheaply and, through `openclaw acp`, exposes itself to it cheaply too.
+- **Additive evolution.** New capabilities (richer plans, structured diffs, embedded terminals, provenance receipts) land as additive protocol updates behind capability flags, not as invariant-breaking schema changes.
+- **Editor/IDE-native primitives.** Cancellation, plans, thoughts, diffs, terminals, and status updates are in the protocol rather than bolted on per-harness, which is why Zed-style IDE integrations work without a custom bridge.
+
+## Problem statement
+
+As OpenClaw has grown it has accumulated parallel launch and execution paths instead of converging on one. Concretely, today we have:
+
+- **Four execution engines** that each own their own loop: the embedded pi harness (`runEmbeddedPiAgent`), `runCliAgent` for Codex/Claude/Gemini CLIs, the plugin `AgentHarness` registry, and `AcpRuntime` backends registered via `registerAcpRuntimeBackend`.
+- **Two separate spawn modules** (`src/agents/subagent-spawn.ts` and `src/agents/acp-spawn.ts`) implementing overlapping-but-divergent versions of the same feature set: target resolution, workspace inheritance, sandbox policy, depth/concurrency limits, thread binding, announce, cleanup, registry tracking.
+- **A runtime switch on `sessions_spawn`** (`runtime: "subagent" | "acp"`) whose value silently changes which features are available: `resumeSessionId` requires `runtime=acp`, `attachments` and `lightContext` require `runtime=subagent`, `sandbox="require"` is rejected on `runtime=acp`, `streamTo="parent"` is only valid on `runtime=acp`.
+- **Two slash-command families** (`/subagents …` and `/acp …`) that are conceptually the same operator surface with slightly different verbs and flags.
+- **Two branching agent-entry paths**: `runAgentAttempt` in `src/agents/command/attempt-execution.ts` branches on `isCliProvider` to pick between `runCliAgent` and `runEmbeddedPiAgent`, and cron's `run-executor` does the same thing independently.
+- **Lifecycle event streams diverge**: pi emits `lifecycle`/`assistant`/`tool`/`compaction`/`usage` streams; `AcpRuntimeEvent` models a narrower `text_delta | status | tool_call | done | error` shape.
+
+The result is feature drift, duplicated bug surface, partial parity (every time we add a capability to one path we have to decide whether and how to mirror it on the others), and a muddled operator mental model. There is no single place to enforce a new safety policy, add a new audit field, instrument a new metric, or host a new runtime capability (sandbox, resume, attachments) so that it automatically works for normal turns, cron, subagents, and ACP sessions.
+
+## Current state (compact map)
+
+Launch surfaces that start an agent turn today:
+
+- Gateway `agent` RPC → `runAgentAttempt` (`src/agents/command/attempt-execution.ts:217`).
+- `sessions_spawn` tool (`src/agents/tools/sessions-spawn-tool.ts`), two branches.
+- `/subagents spawn` and `/acp spawn|steer|cancel|close|…` slash commands.
+- Cron isolated agents (`src/cron/isolated-agent/run-executor.ts`).
+- Top-level `bindings[].type="acp"` (channel inbound routed into an ACP session).
+- Stdio ACP bridge `openclaw acp` (`src/acp/server.ts`) — external ACP clients into Gateway.
+
+Execution engines those paths end up in:
+
+- `runEmbeddedPiAgent` (the default).
+- `runCliAgent` for Codex CLI / Claude CLI / Gemini CLI.
+- Plugin `AgentHarness` registry (`src/agents/harness/selection.ts`).
+- `AcpRuntime` backends (today only bundled `acpx`, which itself fans out to Codex/Claude/Gemini/Cursor/OpenCode/etc).
+
+### Before: tangled launch paths
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart LR
+    subgraph S["launch surfaces"]
+        S1["agent RPC"]
+        S2["sessions_spawn<br/>runtime=subagent"]
+        S3["sessions_spawn<br/>runtime=acp"]
+        S4["/subagents"]
+        S5["/acp"]
+        S6["cron"]
+        S7["openclaw acp bridge"]
+    end
+    subgraph W["spawn wrappers"]
+        W1["runAgentAttempt"]
+        W2["subagent-spawn"]
+        W3["acp-spawn"]
+        W4["cron run-executor"]
+    end
+    subgraph E["execution engines"]
+        E1["runEmbeddedPiAgent"]
+        E2["runCliAgent"]
+        E3["AgentHarness registry"]
+        E4["AcpRuntime (acpx)"]
+    end
+    S1 --> W1
+    S2 --> W2
+    S3 --> W3
+    S4 --> W2
+    S5 --> W3
+    S6 --> W4
+    S7 --> W1
+    W1 --> E1
+    W1 --> E2
+    W1 --> E3
+    W2 --> E1
+    W3 --> E4
+    W4 --> E1
+    W4 --> E2
+```
+
+## Target architecture
+
+Promote `AcpRuntime` (`src/acp/runtime/types.ts:118`) from "external harness driver" to the single internal execution contract. Every launch path calls `AcpRuntime.ensureSession` + `runTurn` + `cancel` / `close` / `setMode` / `setConfigOption` / `doctor`. The concrete backends become:
+
+- `openclaw-pi` — wraps `runEmbeddedPiAgent` and `compactEmbeddedPiSession`.
+- `acpx` — unchanged, still fronts Codex/Claude/Gemini/Cursor/OpenCode/etc.
+- CLI backends — either thin native ACP adapters (one per CLI) or folded under `acpx`.
+- Plugin harnesses — register directly as ACP backends.
+
+On top of that one contract:
+
+- `subagent-spawn.ts` and `acp-spawn.ts` collapse to one `spawn.ts` module.
+- `sessions_spawn` loses its `runtime` branch; `agentId` (optionally + a `backend` hint) fully determines which backend answers.
+- `runAgentAttempt` and cron's `run-executor` stop branching on `isCliProvider`; they call `AcpRuntime.runTurn`.
+- `/subagents` and `/acp` collapse into one `/agents …` command family (keep old slashes as aliases).
+- `openclaw acp` bridge stays as-is and becomes a clean ACP-in / ACP-out pipe.
+
+### After: unified ACP seam
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart LR
+    subgraph S["launch surfaces (unchanged)"]
+        S1["agent RPC"]
+        S2["sessions_spawn"]
+        S3["/agents (unified)"]
+        S4["cron"]
+        S5["openclaw acp bridge"]
+    end
+    WS["spawn.ts<br/>(single module)"]
+    AR["AcpRuntimeClient<br/>(protocol seam)"]
+    subgraph BE["ACP backends"]
+        B1["openclaw-pi"]
+        B2["acpx"]
+        B3["CLI backends"]
+        B4["plugin backend"]
+    end
+    S1 --> WS
+    S2 --> WS
+    S3 --> WS
+    S4 --> WS
+    S5 --> WS
+    WS --> AR
+    AR --> B1
+    AR --> B2
+    AR --> B3
+    AR --> B4
+```
+
+### Sequence: what changes on a normal turn
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+sequenceDiagram
+    participant U as channel
+    participant G as gateway RPC
+    participant A as runAgentAttempt
+    participant P as pi-embedded
+    participant C as runCliAgent
+    Note over A: BEFORE -- branch on isCliProvider
+    U->>G: message
+    G->>A: agent turn
+    alt CLI provider
+        A->>C: runCliAgent
+        C-->>A: payloads + events
+    else embedded
+        A->>P: runEmbeddedPiAgent
+        P-->>A: payloads + events
+    end
+    A-->>G: done
+    G-->>U: reply
+```
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+sequenceDiagram
+    participant U as channel
+    participant G as gateway RPC
+    participant SP as spawn module
+    participant T as transport
+    participant B as backend
+    Note over SP: AFTER -- no branching, one seam
+    U->>G: message
+    G->>SP: agent turn
+    SP->>T: ensureSession(input)
+    T->>B: ensureSession(input)
+    B-->>T: handle
+    T-->>SP: handle
+    SP->>T: runTurn(handle)
+    T->>B: runTurn(handle)
+    loop streaming
+        B-->>T: AcpRuntimeEvent
+        T-->>SP: AcpRuntimeEvent
+        SP-->>G: translated
+    end
+    B-->>T: done
+    T-->>SP: done
+    SP-->>G: done
+    G-->>U: reply
+```
+
+## Pros
+
+- **One contract to reason about.** A single `AcpRuntime` interface replaces four overlapping engines and two spawn wrappers.
+- **Feature matrix collapses.** `resumeSessionId`, `attachments`, `lightContext`, `sandbox`, `streamTo`, `mode=session`, `thread`, `cwd` become properties of the backend/contract, not of the spawn path. Every backend that supports a capability exposes it the same way.
+- **Smaller code surface.** Net LOC should go down, not up. Two spawn modules become one; two entry-branching functions become one seam; duplicate announce/thread-binding logic merges.
+- **Simpler mental model for operators.** "Sub-agent" and "ACP agent" stop being two concepts. One `/agents` command family, one set of flags.
+- **Plugin story improves.** Third-party runtimes implement one interface (`AcpRuntime`) instead of picking between `AgentHarness`, `cliBackend`, or an ACP adapter.
+- **Pi harness is preserved.** Wrapping `runEmbeddedPiAgent` as a backend keeps all of its hard-won behavior (lane serialization, compaction, heartbeat, auth profile rotation, transcript persistence) intact. An optional in-process transport can preserve today's call-cost for the hot path if benchmarks call for it (see [Optional: ACP loopback transport for hot-path performance](#optional-acp-loopback-transport-for-hot-path-performance)).
+- **The outward ACP bridge becomes natural.** `openclaw acp` already speaks ACP inbound; when the internals also speak ACP, there is no impedance mismatch to maintain.
+
+## Cons / tradeoffs
+
+- **`AcpRuntimeEvent` must be extended.** Today it does not cover pi's full event surface (lifecycle start/end/error, reasoning deltas, compaction, usage). That is a contract change, additive but real, and it affects `acpx`, any third-party ACP runtime backend, and the outward bridge.
+- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). The contract needs a runtime-capability flag (`runsInSandbox`) so the pi-backed path keeps working and we don't regress sandboxed-subagent guarantees.
+- **Announce / thread-binding migration is delicate.** Channel plugins expect exact historical announce shapes. Merging subagent-spawn and acp-spawn must preserve those bytes or we silently break agents and cron jobs that users already rely on.
+- **CLI backend features are non-trivial to move.** Session-expired retry, CLI-session reuse, bundle-MCP overlay, plugin-owned defaults. These need to come along when CLI backends become ACP backends.
+- **Migration is multi-release.** Feature flags, legacy aliases, and a period where both paths coexist are mandatory to avoid a big-bang regression.
+- **"Everything behind one interface" can mask bugs.** A subtle regression in a shared seam impacts every launch path at once. Mitigated by keeping the pi runner itself intact as the default backend and staging the rollout.
+
+## What this enables for architecture goals
+
+### Security
+
+- **One policy chokepoint.** Tool-policy, sandbox, permission-mode, approval, ACP-agent allowlist, and subagent depth/concurrency limits currently live on at least three paths (`subagent-spawn`, `acp-spawn`, `runAgentAttempt`). Behind one seam they become one set of checks that every launch path inherits automatically.
+- **Sandbox becomes a first-class capability.** `sandbox="require"` no longer has to reject `runtime=acp` — instead the backend declares whether it runs inside the sandbox, and the spawn module enforces the policy uniformly.
+- **Credential/auth isolation is easier to reason about.** ACP backends already have an explicit `ensureSession({ agent, cwd, env })` boundary. Routing pi and CLI through the same boundary means auth-profile scoping, per-agent `agentDir`, and delegate isolation (`docs/concepts/delegate-architecture.md`) apply the same way regardless of backend.
+- **Non-interactive permission handling unifies.** `permissionMode` / `nonInteractivePermissions` currently live on `acpx`. Once pi is a backend too, the same knobs extend naturally to every path (normal turn, cron, subagent, ACP session).
+
+### Auditing
+
+- **One event stream to record.** Collapsing pi and ACP lifecycle events into the extended `AcpRuntimeEvent` stream means every turn emits the same shape of `text_delta` / `tool_call` / `status` / `done` / `error` / lifecycle markers. Transcript persistence, session history, and audit export all read from one source.
+- **Stable correlation ids.** `AcpRuntimeHandle` already carries `sessionKey` + `backend` + `runtimeSessionName` + optional `backendSessionId` / `agentSessionId`. Moving every turn through that handle gives us a ready-made correlation key for logs, metrics, transcripts, and GHSA-style incident reconstruction.
+- **Consistent provenance.** The `openclaw acp --provenance meta|meta+receipt` flag already exists for the bridge. Making ACP the internal seam means provenance receipts can become a property of every turn, not just bridge turns.
+- **Delegate and cron audit trails merge.** `docs/concepts/delegate-architecture.md` already requires audit trails for cron-run history and session transcripts. One execution seam gives those trails one format and one writer.
+
+### Code re-use
+
+- **Spawn wrapper collapses.** Target resolution, workspace inheritance, requester-origin inference, subagent-registry tracking, depth/concurrency limits, cleanup, and announce all live once.
+- **Streaming glue is written once.** The translator that turns a runtime event iterable into channel output (assistant text, tool summaries, block replies) is implemented against one contract instead of per-engine.
+- **Abort and timeout are implemented once.** `AcpRuntime.cancel` plus `AbortSignal` propagation on `runTurn` replace today's per-engine abort logic (`abortEmbeddedPiRun`, CLI-side SIGTERM handling, ACP cancel).
+- **Compaction and session resume are uniform.** `compact?`, `prepareFreshSession?`, and `resumeSessionId` become optional capabilities on any backend, so `sessions_spawn` stops having to special-case them.
+- **Tests scale better.** Once the contract is the seam, a single contract test suite (`adapter-contract.testkit.ts` already exists for ACP) covers every backend, instead of reinventing test harnesses per engine.
+
+### Other architecture goals
+
+- **Observability parity.** One set of metrics (turn latency, queue wait, tokens, tool-call count, error class) naturally lights up for every launch path.
+- **Plugin SDK simplification.** Plugins that want to contribute a runtime implement `AcpRuntime`. `src/plugin-sdk/acp-runtime.ts` already exists for this — we just make it the recommended plugin surface.
+- **Clear extension points for future work.** Adding a new capability (richer thought streaming, structured tool diffs, ACP terminals) is one contract change + one implementation per backend, not an N×M retrofit.
+- **VISION.md alignment.** This is consolidation, not a new orchestration layer. The project's stated direction (lean core, optional capability in plugins, no nested-manager frameworks) is what this seam buys us.
+
+## Why a protocol seam, not just an API seam
+
+A reasonable counter-proposal would be "just introduce a shared TypeScript interface (an API seam) that pi, CLI, and ACP backends implement, and stop there." That would solve the in-process duplication, but it would leave most of the architectural wins on the table. Picking a _protocol_ interface — ACP, which has a wire format, an event schema, and a contract independent of any one language or process — is materially stronger than an in-process API interface for several reasons:
+
+- **Process isolation is free.** An API seam only works as long as every implementation lives in the same Node process. A protocol seam lets any backend run out-of-process (a sidecar, a subprocess, a container, a different host) with no change to the caller. That is already how `acpx` works today; extending the same pattern to pi and CLI backends means a misbehaving backend can be restarted, sandboxed, or resource-limited on its own without taking the gateway with it.
+- **Crash, hang, and leak blast-radius shrinks.** Language-level APIs share a heap, an event loop, and a process lifetime. A runaway backend that leaks memory, blocks the loop, or segfaults native code takes the whole gateway with it. A protocol seam gives us a real fault boundary: kill the backend process, the gateway keeps serving other sessions.
+- **Language and runtime choice opens up.** Third-party (or future first-party) backends can be written in Rust, Go, Python, or anything that can speak ACP over stdio or a socket. An API seam locks every implementation into TypeScript and the specific pi-coding-agent / OpenClaw build. This matters for high-performance harnesses, GPU-bound inference backends, and plugin authors who do not want to take a Node dependency.
+- **Cross-network is the same shape as cross-process.** ACP is already transportable over stdio, WebSocket, and (trivially) TCP/TLS. Once the seam is a protocol, "run the backend on another machine" is a configuration change, not a refactor. That unlocks remote harnesses, shared GPU pools, tenant isolation per host, and the kind of Tailnet/SSH topologies OpenClaw already uses for its Gateway.
+- **Versioning is explicit.** Protocols have schemas and version negotiation; APIs have function signatures and hope. ACP already has handshake/capabilities (`getCapabilities`, `session_info_update`, `available_commands_update`). Version skew between gateway and backend becomes a declared compatibility matrix instead of a silent duck-typing failure.
+- **Security boundaries become enforceable.** An in-process API backend has ambient authority: the whole Node `process.env`, `fs`, `net`, plus any globals OpenClaw has loaded. A protocol backend only sees what the gateway chose to pass into `ensureSession({ cwd, env })`. Least-privilege scoping, seccomp/landlock, Docker/Podman isolation, and per-backend credential injection all become mechanical to apply.
+- **Observability is first-class.** Every call across a protocol seam is a framed, schema'd message. We can tee it to a log, a debugger, a provenance receipt, a replay harness, or an audit sink without instrumenting each backend. In-process APIs require per-call wrappers and are easy to bypass.
+- **Contract tests replace cross-module test mazes.** Given a protocol, one conformance test suite proves that _any_ backend behaves correctly. With an API seam you end up writing ad-hoc mocks and re-testing the seam per implementation. `src/acp/runtime/adapter-contract.testkit.ts` already does this for ACP; extending it is cheaper than maintaining per-engine test harnesses.
+- **Third-party plugin distribution stops being a monorepo problem.** A protocol backend can be `npm i`'d, `brew install`'d, or shipped as a standalone binary and pointed at via `acp.backend.command`. An API backend has to be built against the exact OpenClaw version you are running. This is the same reason MCP won over bespoke tool APIs.
+- **Interop with the rest of the ACP ecosystem comes for free.** Zed, `openclaw acp`, `acpx openclaw`, and other ACP-speaking clients/servers already exist. A protocol seam means OpenClaw can both consume and expose ACP backends without an adapter layer. An API seam would only speak OpenClaw's dialect.
+- **Language-level "just add an interface" tends to rot.** Once you have three implementations, an API interface drifts: one caller peeks at an implementation-specific field, another short-circuits through a shared helper, tests couple to internals. Protocol seams resist this because the wire format is the only legal way to talk.
+
+### API seam vs protocol seam at a glance
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart LR
+    subgraph ApiSeam["API seam (TS interface)"]
+        direction TB
+        AC["caller"]
+        AB1["backend A<br/>TS module"]
+        AB2["backend B<br/>TS module"]
+        AC --> AB1
+        AC --> AB2
+    end
+    subgraph ProtoSeam["Protocol seam (ACP)"]
+        direction TB
+        PC["caller"]
+        PT["transport"]
+        PB1["backend A<br/>same Node"]
+        PB2["backend B<br/>subprocess"]
+        PB3["backend C<br/>remote host"]
+        PC --> PT
+        PT -->|loopback| PB1
+        PT -->|stdio| PB2
+        PT -->|ws or tcp| PB3
+    end
+```
+
+The baseline plan assumes the ordinary stdio transport for every backend (same model `acpx` uses today).
+
+## Optional: ACP loopback transport for hot-path performance
+
+**Status: exploratory / to investigate.** Everything in the plan above works with the standard stdio/socket ACP transport. The loopback transport is an optional future optimization for the `openclaw-pi` hot path. It is called out here so it is not mistaken for a required part of the seam and so the details live in one place.
+
+### What it is
+
+ACP has a protocol layer (typed message shapes and semantics: `AcpRuntimeEnsureInput`, `AcpRuntimeTurnInput`, `AcpRuntimeEvent`, `AcpRuntimeHandle`) and a transport layer (how those messages move between a client and a runtime). Today we only have one transport — the external stdio `@agentclientprotocol/sdk` one used by `acpx`. A loopback transport is a second transport that short-circuits serialization while keeping the same protocol types on both sides. Same contract, no wire.
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart LR
+    C["AcpRuntimeClient<br/>(spawn module)"]
+    subgraph StdioT["stdio transport"]
+        direction LR
+        S1["JSON encode"]
+        S2["frame"]
+        S3["pipe"]
+        S4["frame decode"]
+        S5["JSON decode"]
+        S1 --> S2
+        S2 --> S3
+        S3 --> S4
+        S4 --> S5
+    end
+    LB["loopback transport<br/>direct call, zero copy"]
+    H["AcpRuntimeServer<br/>(backend handler)"]
+    C -->|stdio| S1
+    S5 --> H
+    C -->|loopback| LB
+    LB --> H
+```
+
+### Why we might want it
+
+A normal LLM turn emits high-frequency events (token deltas, reasoning deltas, tool-call updates, compaction progress, usage ticks — easily 50–200+ events/sec) and occasionally large payloads (multi-megabyte tool results, attachments, transcripts). Over stdio each event is framed, JSON-serialized, piped, deserialized, re-dispatched. In-process it is a function call and a typed object passed by reference. For the `openclaw-pi` backend, which has always run in-process, mandating stdio pays real per-event cost and copies every tool result twice. The loopback transport lets us keep one contract everywhere without charging IPC cost on the path that runs 99% of turns.
+
+### How it works
+
+Each transport exposes the same two shapes: a client handle (what a spawn module talks to) and a server handler (what a backend implements).
+
+```ts path=null start=null
+// Identical regardless of transport.
+interface AcpRuntimeClient {
+  ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle>;
+  runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent>;
+  cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void>;
+  close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void>;
+  // getCapabilities, getStatus, setMode, setConfigOption, doctor, prepareFreshSession
+}
+interface AcpRuntimeServer extends AcpRuntimeClient {}
+```
+
+A transport connects a `Client` shape to a `Server` shape. stdio does framing + JSON + pipes. Loopback just calls the function.
+
+```ts path=null start=null
+export function createLoopbackTransport(
+  server: AcpRuntimeServer,
+  opts?: { validate?: boolean; queueLimit?: number },
+): AcpRuntimeClient {
+  return {
+    async ensureSession(input) {
+      if (opts?.validate) validateEnsureInput(input); // optional schema check
+      const result = await server.ensureSession(input); // direct call
+      if (opts?.validate) validateHandle(result);
+      return result; // same object, no copy
+    },
+    runTurn(input) {
+      if (opts?.validate) validateTurnInput(input);
+      return server.runTurn(input); // AsyncIterable passes straight through
+    },
+    cancel: (input) => server.cancel(input),
+    close: (input) => server.close(input),
+    // ...
+  };
+}
+```
+
+That is the whole transport: a thin adapter that hands typed objects from one function to another inside the same Node process.
+
+### Streaming
+
+Inside the `openclaw-pi` server, the pi subscription system produces events on a bounded in-memory queue; `runTurn` yields them as an async iterable of `AcpRuntimeEvent`. Under loopback, that iterable is returned to the caller directly — no `JSON.stringify`, no framing. Under stdio, the same iterable is wrapped by the stdio transport, which serializes and frames.
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+sequenceDiagram
+    participant SM as spawn module
+    participant T as transport
+    participant B as openclaw-pi
+    participant PI as pi subscription
+    SM->>T: runTurn(input)
+    T->>B: runTurn(input)
+    B->>PI: subscribeEmbeddedPiSession
+    PI-->>B: onAssistantDelta(text)
+    B-->>T: text_delta
+    T-->>SM: text_delta
+    PI-->>B: onToolCall(tc)
+    B-->>T: tool_call
+    T-->>SM: tool_call
+    PI-->>B: onLifecycleEnd
+    B-->>T: done
+    T-->>SM: done
+    Note over T,B: loopback -- direct yield<br/>stdio -- JSON + framed pipe
+```
+
+```ts path=null start=null
+async function* runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
+  const queue = new AcpEventQueue({ limit: 1024 }); // bounded ring
+  const abort = new AbortController();
+  input.signal?.addEventListener("abort", () => abort.abort(), { once: true });
+  const unsub = subscribeEmbeddedPiSession(sessionId, {
+    onAssistantDelta: (text) => queue.push({ type: "text_delta", text, stream: "output" }),
+    onToolCall: (tc) => queue.push({ type: "tool_call", ...tc }),
+    onLifecycleEnd: () => queue.push({ type: "done", stopReason: "stop" }),
+    onError: (err) => queue.push({ type: "error", message: err.message }),
+  });
+  const runPromise = runEmbeddedPiAgent({ ...mapped, signal: abort.signal })
+    .catch((err) => queue.push({ type: "error", message: err.message }))
+    .finally(() => {
+      unsub();
+      queue.close();
+    });
+  try {
+    for await (const evt of queue) yield evt; // zero-copy handoff under loopback
+  } finally {
+    abort.abort();
+    await runPromise;
+  }
+}
+```
+
+### Backpressure
+
+stdio gets backpressure from OS socket buffers. Loopback does it explicitly: `AcpEventQueue` has a high-water mark; pushing past it either awaits drain or drops with an explicit policy (same shape as today's `acp.stream.coalesceIdleMs` / `maxChunkChars`). The spawn module never sees the difference.
+
+### Cancellation
+
+- stdio: client sends a `cancel` RPC; server receives it and calls `AbortController.abort()` locally.
+- loopback: client calls `transport.cancel({ handle })`, which is literally `server.cancel(...)`. `AbortSignal` also passes through directly on `runTurn(input.signal)` without a message at all.
+  Same semantics, one less hop.
+
+### Errors
+
+- stdio: thrown errors are caught by the server framing layer and serialized as `{ type: "error", message, code }` events or JSON-RPC errors.
+- loopback: thrown errors are caught by the adapter, wrapped into `AcpRuntimeEvent` error events on the same queue, and rethrown as native `Error` objects for request/response calls. Continuous stack traces; no cross-process trace loss.
+
+### How it stays protocol-only and does not become a back door
+
+The risk of an in-process transport is that the backend reaches around the protocol (reads OpenClaw's config, mutates session state, imports internal helpers). Three mechanical rules — all already idiomatic in this codebase — prevent that:
+
+1. **Package-boundary lint.** The `openclaw-pi` backend lives behind the same package boundary as `acpx` (`extensions/*` style), so it can only import `openclaw/plugin-sdk/*` and its own locals. No `import from "../../src/agents/..."`.
+2. **No ambient inputs.** The backend receives `cwd`, `env`, session key, and everything else it needs through `ensureSession` / `runTurn` arguments — not via `loadConfig()` at the top of a module.
+3. **Contract tests target the client surface.** `src/acp/runtime/adapter-contract.testkit.ts` exercises every backend through `AcpRuntimeClient`. The same suite runs against both stdio and loopback transports. If a backend cheats and needs something off-protocol to pass, the contract test fails.
+   With those rules in place, loopback is a _transport choice for an already-legitimate ACP backend_, not an escape hatch.
+
+### Transport selection
+
+The spawn module resolves a transport and then uses it; it never branches on backend identity.
+
+```ts path=null start=null
+const backend = getAcpRuntimeBackend("openclaw-pi");
+const transport =
+  backend.deploy === "stdio"
+    ? createStdioTransport(backend.command)
+    : backend.deploy === "socket"
+      ? createSocketTransport(backend.endpoint)
+      : /* default */ createLoopbackTransport(backend.server);
+await transport.ensureSession({ sessionKey, agent, mode, cwd });
+for await (const evt of transport.runTurn({ handle, text, mode: "prompt", requestId })) {
+  translator.emit(evt);
+}
+```
+
+`openclaw-pi` can register with `deploy: "loopback"` for the hot path and be flipped to `stdio`/`socket` by configuration when process isolation is worth the IPC cost. A mixed fleet (`openclaw-pi` loopback, `acpx` stdio, a plugin backend on a socket) all speaks the same protocol at the same time.
+
+```mermaid
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+flowchart TD
+    A{"backend.deploy?"}
+    L["createLoopbackTransport<br/>same process"]
+    S["createStdioTransport<br/>subprocess"]
+    W["createSocketTransport<br/>remote host"]
+    U["uniform AcpRuntimeClient"]
+    X["spawn module<br/>(no branching)"]
+    A -->|loopback| L
+    A -->|stdio| S
+    A -->|socket| W
+    L --> U
+    S --> U
+    W --> U
+    U --> X
+```
+
+### Properties this gives us
+
+- Zero IPC cost on the hot path.
+- Same contract tests run against both transports — parity is proven, not asserted.
+- Debuggers step straight into the backend; stack traces are continuous.
+- Upgrading pi to out-of-process is a config flip, not a refactor.
+
+### Why this is still optional
+
+- The baseline plan already delivers every architectural win (single contract, one spawn module, one event stream, one policy layer).
+- stdio works for `acpx` today and would work for `openclaw-pi` tomorrow; IPC cost may be acceptable in practice and should be measured before investing in a second transport.
+- A second transport is additional surface area. Worth it only if benchmarks show the stdio hot path is a real bottleneck, or if we want the cross-process option but also refuse the per-event IPC cost.
+- If we keep stdio-only and find cost is fine, we save the complexity entirely.
+  Recommendation: land the baseline ACP seam first. Measure. Only build the loopback transport if measurements justify it.
+
+## Phasing (high level)
+
+1. Extend `AcpRuntimeEvent` / `AcpRuntime` to cover pi's full lifecycle surface; keep changes additive.
+2. Ship `openclaw-pi` backend wrapping `runEmbeddedPiAgent` + `compactEmbeddedPiSession` behind a feature flag.
+3. Route `runAgentAttempt` and cron through `AcpRuntime.runTurn` when the flag is on.
+4. Migrate `sessions_spawn runtime="subagent"` onto `openclaw-pi`, then merge `subagent-spawn.ts` and `acp-spawn.ts` into one module.
+5. Migrate CLI backends into ACP backends (native adapters or via `acpx`); remove `isCliProvider` branches.
+6. Move plugin `AgentHarness` entries onto `AcpRuntime`.
+7. Collapse `/subagents` and `/acp` into one `/agents …` command family (with aliases).
+8. Remove legacy code and flags one release after every surface is on the unified path.
+
+## Non-goals
+
+- No change to the outward Gateway WS protocol (channels, Swift clients, webchat).
+- No change to MCP integration strategy (`mcporter` still owns that surface per VISION.md).
+- No new nested-manager / agent-hierarchy framework; this is strictly a consolidation of the existing spawn/runtime landscape.
+- No forced migration of third-party plugins in the short term; legacy `AgentHarness` and `cliBackend` paths remain supported during the transition.

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -174,7 +174,7 @@ flowchart LR
 ### Sequence: what changes on a normal turn
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
@@ -196,7 +196,7 @@ sequenceDiagram
 ```
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
@@ -402,7 +402,7 @@ That is the whole transport: a thin adapter that hands typed objects from one fu
 Inside the `openclaw-pi` server, the pi subscription system produces events on a bounded in-memory queue; `runTurn` yields them as an async iterable of `AcpRuntimeEvent`. Under loopback, that iterable is returned to the caller directly — no `JSON.stringify`, no framing. Under stdio, the same iterable is wrapped by the stdio transport, which serializes and frames.
 
 ```mermaid
-%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'background':'#c0c0c0','primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
 sequenceDiagram
     participant SM as spawn module
     participant T as transport

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -49,6 +49,14 @@ Before the problem statement and the mechanics, a short list of why ACP is the r
 - **Additive evolution.** New capabilities (richer plans, structured diffs, embedded terminals, provenance receipts) land as additive protocol updates behind capability flags, not as invariant-breaking schema changes.
 - **Editor/IDE-native primitives.** Cancellation, plans, thoughts, diffs, terminals, and status updates are in the protocol rather than bolted on per-harness, which is why Zed-style IDE integrations work without a custom bridge.
 
+## Design principles
+
+Three principles keep this from drifting into protocol cargo-culting or a big-bang refactor:
+
+- **Contract is the deliverable, not the wire.** The unification goal is one protocol-typed contract (`AcpRuntime`) between the spawn module and every backend. The transport those messages flow over is orthogonal to the contract — stdio, socket, and in-process direct calls are all legal. The `openclaw-pi` backend is expected to run in-process by default; no IPC cost is mandated on the hot path. Forcing stdio everywhere would be cargo-culting — what we actually want is the typed, versioned, capability-negotiated interface.
+- **Smallest slice first, with explicit parity gates.** Phases 1–3 ship one backend (`openclaw-pi`) wired through one call-site (`runAgentAttempt`) and must prove byte-for-byte parity on transcript/announce/abort/compaction/resume before Phase 4 touches subagent spawn or anything else. CLI and plugin migrations only happen after the pi + main-turn slice is demonstrably boring. A maintainer can veto continuing at the gate if parity is not clean.
+- **Capability-driven policy over hard-coded runtime strings.** Backends advertise what they can and can't do (sandbox mode and isolation grade, resume, attachments, client terminals, config-option keys, etc.). The spawn module enforces policy by matching against those capabilities rather than branching on `runtime == "acp"` / `runtime == "subagent"`. This is the reason the `sandbox="require"` / `runtime="acp"` clash (see Cons) can be resolved cleanly instead of patched with another string.
+
 ## Problem statement
 
 As OpenClaw has grown it has accumulated parallel launch and execution paths instead of converging on one. Concretely, today we have:
@@ -240,7 +248,23 @@ sequenceDiagram
 ## Cons / tradeoffs
 
 - **`AcpRuntimeEvent` must be extended.** Today it does not cover pi's full event surface (lifecycle start/end/error, reasoning deltas, compaction, usage). That is a contract change, additive but real, and it affects `acpx`, any third-party ACP runtime backend, and the outward bridge.
-- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). The contract needs a runtime-capability flag (`runsInSandbox`) so the pi-backed path keeps working and we don't regress sandboxed-subagent guarantees.
+- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). A boolean `runsInSandbox` is too coarse — different backends offer different isolation grades (host / Docker / Podman / chroot / seccomp) with different guarantees (filesystem, network, process caps). The contract should carry a structured capability that the spawn module can policy-check against:
+
+  ```ts path=null start=null
+  type SandboxCapability = {
+    mode: "host" | "docker" | "podman" | "chroot" | "seccomp" | "custom";
+    guarantees: {
+      fsIsolation: "none" | "workspace" | "fullRoot";
+      netIsolation: "none" | "restricted" | "denyAll";
+      processCaps: boolean;
+    };
+    // Optional operator hints the policy layer can match against.
+    policy?: { image?: string; setupCommand?: string };
+  };
+  ```
+
+  That lets `sandbox="require"` be a real policy predicate (for example `mode != "host" && guarantees.fsIsolation != "none"`) instead of a boolean. Without this we regress today's sandboxed-subagent guarantees and we can't express future stronger isolation (container-per-session, seccomp profiles, etc.) without another round of string-comparison plumbing.
+
 - **Announce / thread-binding migration is delicate.** Channel plugins expect exact historical announce shapes. Merging subagent-spawn and acp-spawn must preserve those bytes or we silently break agents and cron jobs that users already rely on.
 - **CLI backend features are non-trivial to move.** Session-expired retry, CLI-session reuse, bundle-MCP overlay, plugin-owned defaults. These need to come along when CLI backends become ACP backends.
 - **Migration is multi-release.** Feature flags, legacy aliases, and a period where both paths coexist are mandatory to avoid a big-bang regression.
@@ -534,10 +558,10 @@ flowchart TD
 
 ## Phasing (high level)
 
-1. Extend `AcpRuntimeEvent` / `AcpRuntime` to cover pi's full lifecycle surface; keep changes additive.
-2. Ship `openclaw-pi` backend wrapping `runEmbeddedPiAgent` + `compactEmbeddedPiSession` behind a feature flag.
-3. Route `runAgentAttempt` and cron through `AcpRuntime.runTurn` when the flag is on.
-4. Migrate `sessions_spawn runtime="subagent"` onto `openclaw-pi`, then merge `subagent-spawn.ts` and `acp-spawn.ts` into one module.
+1. Extend `AcpRuntimeEvent` / `AcpRuntime` to cover pi's full lifecycle surface; keep changes additive. Include the `SandboxCapability` shape from the Cons section on the runtime's capability descriptor.
+2. Ship `openclaw-pi` backend wrapping `runEmbeddedPiAgent` + `compactEmbeddedPiSession` behind a feature flag. Runs in-process by default — no stdio, no IPC on the hot path; that's the contract-vs-wire distinction from Design principles.
+3. Route `runAgentAttempt` and cron through `AcpRuntime.runTurn` when the flag is on. **Parity gate before Phase 4 begins:** prove byte-for-byte parity with the legacy path on (a) transcript writes, (b) announce output, (c) abort/cancel behavior, (d) compaction and resume roundtrip, (e) sandbox-policy enforcement via the new `SandboxCapability`. A maintainer can hold the RFC here if parity is not clean.
+4. **Only after the Phase 3 parity gate passes:** migrate `sessions_spawn runtime="subagent"` onto `openclaw-pi`, then merge `subagent-spawn.ts` and `acp-spawn.ts` into one module.
 5. Migrate CLI backends into ACP backends (native adapters or via `acpx`); remove `isCliProvider` branches.
 6. Move plugin `AgentHarness` entries onto `AcpRuntime`.
 7. Collapse `/subagents` and `/acp` into one `/agents …` command family (with aliases).

--- a/docs/refactor/acp-everywhere.md
+++ b/docs/refactor/acp-everywhere.md
@@ -174,53 +174,57 @@ flowchart LR
 ### Sequence: what changes on a normal turn
 
 ```mermaid
-%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
     participant A as runAgentAttempt
     participant P as pi-embedded
     participant C as runCliAgent
-    Note over A: BEFORE -- branch on isCliProvider
-    U->>G: message
-    G->>A: agent turn
-    alt CLI provider
-        A->>C: runCliAgent
-        C-->>A: payloads + events
-    else embedded
-        A->>P: runEmbeddedPiAgent
-        P-->>A: payloads + events
+    rect rgb(224, 224, 224)
+      Note over A: BEFORE -- branch on isCliProvider
+      U->>G: message
+      G->>A: agent turn
+      alt CLI provider
+          A->>C: runCliAgent
+          C-->>A: payloads + events
+      else embedded
+          A->>P: runEmbeddedPiAgent
+          P-->>A: payloads + events
+      end
+      A-->>G: done
+      G-->>U: reply
     end
-    A-->>G: done
-    G-->>U: reply
 ```
 
 ```mermaid
-%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant U as channel
     participant G as gateway RPC
     participant SP as spawn module
     participant T as transport
     participant B as backend
-    Note over SP: AFTER -- no branching, one seam
-    U->>G: message
-    G->>SP: agent turn
-    SP->>T: ensureSession(input)
-    T->>B: ensureSession(input)
-    B-->>T: handle
-    T-->>SP: handle
-    SP->>T: runTurn(handle)
-    T->>B: runTurn(handle)
-    loop streaming
-        B-->>T: AcpRuntimeEvent
-        T-->>SP: AcpRuntimeEvent
-        SP-->>G: translated
+    rect rgb(224, 224, 224)
+      Note over SP: AFTER -- no branching, one seam
+      U->>G: message
+      G->>SP: agent turn
+      SP->>T: ensureSession(input)
+      T->>B: ensureSession(input)
+      B-->>T: handle
+      T-->>SP: handle
+      SP->>T: runTurn(handle)
+      T->>B: runTurn(handle)
+      loop streaming
+          B-->>T: AcpRuntimeEvent
+          T-->>SP: AcpRuntimeEvent
+          SP-->>G: translated
+      end
+      B-->>T: done
+      T-->>SP: done
+      SP-->>G: done
+      G-->>U: reply
     end
-    B-->>T: done
-    T-->>SP: done
-    SP-->>G: done
-    G-->>U: reply
 ```
 
 ## Pros
@@ -402,25 +406,27 @@ That is the whole transport: a thin adapter that hands typed objects from one fu
 Inside the `openclaw-pi` server, the pi subscription system produces events on a bounded in-memory queue; `runTurn` yields them as an async iterable of `AcpRuntimeEvent`. Under loopback, that iterable is returned to the caller directly — no `JSON.stringify`, no framing. Under stdio, the same iterable is wrapped by the stdio transport, which serializes and frames.
 
 ```mermaid
-%%{init: {'theme':'base','themeCSS':'svg{background:#e0e0e0;} .messageText{fill:#000000 !important;} .messageLine0,.messageLine1{stroke:#000000 !important;} text.actor{fill:#000000 !important;} .loopText,.loopText>tspan{fill:#000000 !important;} rect.actor{fill:#b0b0b0 !important;stroke:#000000 !important;}','themeVariables':{'background':'#e0e0e0','primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
+%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
 sequenceDiagram
     participant SM as spawn module
     participant T as transport
     participant B as openclaw-pi
     participant PI as pi subscription
-    SM->>T: runTurn(input)
-    T->>B: runTurn(input)
-    B->>PI: subscribeEmbeddedPiSession
-    PI-->>B: onAssistantDelta(text)
-    B-->>T: text_delta
-    T-->>SM: text_delta
-    PI-->>B: onToolCall(tc)
-    B-->>T: tool_call
-    T-->>SM: tool_call
-    PI-->>B: onLifecycleEnd
-    B-->>T: done
-    T-->>SM: done
-    Note over T,B: loopback -- direct yield<br/>stdio -- JSON + framed pipe
+    rect rgb(224, 224, 224)
+      SM->>T: runTurn(input)
+      T->>B: runTurn(input)
+      B->>PI: subscribeEmbeddedPiSession
+      PI-->>B: onAssistantDelta(text)
+      B-->>T: text_delta
+      T-->>SM: text_delta
+      PI-->>B: onToolCall(tc)
+      B-->>T: tool_call
+      T-->>SM: tool_call
+      PI-->>B: onLifecycleEnd
+      B-->>T: done
+      T-->>SM: done
+      Note over T,B: loopback -- direct yield<br/>stdio -- JSON + framed pipe
+    end
 ```
 
 ```ts path=null start=null

--- a/docs/refactor/acp-rfd-sandbox-capability-policy.mdx
+++ b/docs/refactor/acp-rfd-sandbox-capability-policy.mdx
@@ -1,0 +1,224 @@
+---
+title: "Sandbox Capability and Policy"
+---
+
+Author(s): [visionik](https://github.com/visionik) (OpenClaw)
+
+<Note>
+  **RFD draft status.** This file is authored in the OpenClaw repository as
+  `docs/refactor/acp-rfd-sandbox-capability-policy.mdx` for iteration and review with OpenClaw
+  maintainers and OpenClaw's upstream sponsors before being submitted to
+  `agentclientprotocol/agent-client-protocol` as `docs/rfds/sandbox-capability-policy.mdx` per the
+  [ACP RFD process](https://agentclientprotocol.com/rfds/about).
+</Note>
+
+## Relationship to in-flight ACP RFDs and maintainer work
+
+OpenClaw is building a consolidation of its internal agent-launch paths onto ACP as the sole internal execution contract (see OpenClaw's `docs/refactor/acp-everywhere.md`). While auditing what ACP already provides vs. what our consolidation needs, the overwhelming majority of our needs are already being addressed by current RFDs and maintainer priorities. This RFD introduces the one area we could not find any existing work on: typed sandbox modeling.
+
+Before the main proposal, a brief statement of how OpenClaw intends to consume adjacent in-flight work, so reviewers can see this RFD fits within the wider plan rather than competing with it:
+
+- **[Authentication Methods](https://agentclientprotocol.com/rfds/auth-methods)** — adopt directly; replaces OpenClaw's current ad-hoc auth-profile shuttling through `_meta`.
+- **[Session Close](https://agentclientprotocol.com/rfds/session-close)**, **[Session Delete](https://agentclientprotocol.com/rfds/session-delete)**, **[Session Fork](https://agentclientprotocol.com/rfds/session-fork)**, **[Session Resume](https://agentclientprotocol.com/rfds/session-resume)** — adopt directly; these cover every session-lifecycle need in OpenClaw's spawn/subagent registry.
+- **[Additional Workspace Roots](https://agentclientprotocol.com/rfds/additional-directories)** — adopt; aligns with OpenClaw's multi-workspace agent configurations.
+- **[Boolean Config Option](https://agentclientprotocol.com/rfds/boolean-config-option)** — adopt; needed for OpenClaw's fast-mode / verbose flags.
+- **[Configurable LLM Providers](https://agentclientprotocol.com/rfds/custom-llm-endpoint)** — adopt; replaces OpenClaw's provider/model plumbing through bespoke config.
+- **[Elicitation](https://agentclientprotocol.com/rfds/elicitation)** — adopt for URL elicitation during auth and for future approval flows.
+- **[Logout Method](https://agentclientprotocol.com/rfds/logout-method)** — adopt.
+- **[MCP-over-ACP](https://agentclientprotocol.com/rfds/mcp-over-acp)** — adopt; aligns with OpenClaw's existing `mcporter` bridge direction.
+- **[Message ID](https://agentclientprotocol.com/rfds/message-id)** — adopt; supplies the message-level correlation OpenClaw needs for transcript and audit.
+- **[Meta Field Propagation Conventions](https://agentclientprotocol.com/rfds/meta-propagation)** — adopt the W3C trace context keys; this is the right answer for OpenClaw's cross-tool tracing.
+- **[Agent Extensions via ACP Proxies](https://agentclientprotocol.com/rfds/proxy-chains)** — adopt as the extension mechanism for OpenClaw's domain-specific client surfaces (channel messaging, skills context, thread-binding) rather than proposing parallel spec additions.
+- **[Request Cancellation Mechanism](https://agentclientprotocol.com/rfds/request-cancellation)** — adopt.
+- **[Session Usage and Context Status](https://agentclientprotocol.com/rfds/session-usage)** — adopt directly; covers the token/context/cost side of what OpenClaw currently emits as ad-hoc `stream: "usage"` events.
+- **[Streamable HTTP & WebSocket Transport](https://agentclientprotocol.com/rfds/streamable-http-websocket-transport)** — adopt; supports OpenClaw's remote-gateway topologies and future loopback-transport experiments.
+- **Better Subagent Representation** (maintainer-meeting agenda item, 2026-04-02) — OpenClaw has production subagent semantics (depth/concurrency limits, announce-back, thread binding, cascade stop). We will contribute concrete requirements / implementation feedback to whichever maintainer drives that RFD rather than proposing a parallel one.
+- **New notification-based prompt format** (Ben Brandt in-progress, 2026-04-02) — wait and adopt; likely supersedes any independent "lifecycle start" proposal.
+- **Plan mode improvements** (maintainer agenda, 2026-04-02) — adopt once an RFD lands; aligns with OpenClaw's current plan-update work.
+
+The proposal below is scoped to the one identified gap: there is no structured model for what isolation a backend provides or what isolation a particular session requires. What follows is the full RFD for that gap.
+
+## Elevator pitch
+
+Add a typed `SandboxCapability` that an agent advertises in `AgentCapabilities`, a typed `SandboxPolicy` that a client can set per session as a `SessionConfigOption`, and a well-defined `satisfies` relation between them. This lets agents declare the isolation guarantees they actually enforce (host vs. container vs. chroot vs. seccomp, across filesystem / network / process-capability dimensions) and lets clients express per-session isolation requirements that the agent can validate or reject up-front, instead of clients guessing from implementation docs.
+
+## Status quo
+
+ACP today has no first-class model for sandboxing. Implementers are already reinventing this in incompatible ways:
+
+1. **Boolean or string knobs on `_meta`.** Some agents expose a `_meta.sandbox: true|false` or `_meta.sandboxMode: "docker"|"host"` at `session/new` time. These are not discoverable, not versioned, and collide in namespace across agents.
+2. **Silent host-only assumption.** Many agents simply run on the host, but do not declare that. Clients that care (audit, enterprise) have no way to verify before they route work.
+3. **Error-only signaling.** Clients that want a particular isolation mode typically find out at the permission-prompt layer (`RequestPermissionRequest`) when an operation is about to happen, rather than at session setup. If the agent can't honor the policy, the client has already wasted a session on work that will be blocked.
+4. **Boolean collapse.** A single bool cannot distinguish host-only from container from chroot from seccomp, cannot distinguish filesystem isolation from network isolation, and cannot express operator requirements like "must drop process capabilities" or "workspace-only write access." Projects that need those distinctions end up branching on provider/model/agent-id strings — i.e., hard-coding implementation names.
+
+This is not hypothetical. OpenClaw today rejects one legitimate configuration (`sessions_spawn sandbox="require"` with `runtime="acp"`) solely because the ACP runtime has no structured way to say "yes, I actually enforce workspace-scope filesystem isolation under Docker." The workaround is to forbid the combination, which forces users to drop from ACP to the native subagent runtime, which is itself the thing we're trying to unify on.
+
+More broadly, sandbox policy is the kind of decision that should be made once at session setup, verified once against declared capabilities, and then trusted for the rest of the session. A capability/policy split is the standard shape for that kind of check; the field has been reinventing it in LSP, MCP, WASI, and Kubernetes RBAC. ACP is an appropriate place to adopt the pattern before a dozen agents ship a dozen incompatible versions.
+
+## What we propose to do about it
+
+Two additive, capability-negotiated types and one relation.
+
+### 1. `SandboxCapability` — what the agent enforces
+
+Advertised by the agent in `AgentCapabilities.sandbox`. Static per agent; does not change across sessions. Encodes runtime-provable facts.
+
+```json
+{
+  "sandbox": {
+    "mode": "docker",
+    "guarantees": {
+      "fsIsolation": "workspace",
+      "netIsolation": "restricted",
+      "processCaps": true
+    }
+  }
+}
+```
+
+Field definitions (proposed enums; expandable over time):
+
+- `mode`: one of `"host"`, `"docker"`, `"podman"`, `"chroot"`, `"seccomp"`, `"custom"`.
+- `guarantees.fsIsolation`: one of `"none"`, `"workspace"`, `"fullRoot"`.
+- `guarantees.netIsolation`: one of `"none"`, `"restricted"`, `"denyAll"`.
+- `guarantees.processCaps`: `boolean` — whether the runtime drops process capabilities (setuid, ptrace, raw sockets, etc.) by default.
+
+Agents that run on the host (the common case today) advertise `{ mode: "host", guarantees: { fsIsolation: "none", netIsolation: "none", processCaps: false } }`. This is not a regression — it's explicit about what was previously implicit.
+
+### 2. `SandboxPolicy` — what the session requires
+
+Advertised by the client as a session configuration option via the existing [Session Config Options](https://agentclientprotocol.com/protocol/session-config-options) mechanism, under the well-known id `acp.sandbox`. Per-session; expresses the operator's requirement for this session's work.
+
+```json
+{
+  "sessionId": "sess_abc123",
+  "configOptions": [
+    {
+      "id": "acp.sandbox",
+      "value": {
+        "require": "sandboxed",
+        "minFsIsolation": "workspace",
+        "minNetIsolation": "restricted"
+      }
+    }
+  ]
+}
+```
+
+Field definitions:
+
+- `require`: `"any"` | `"host"` | `"sandboxed"`.
+- `minFsIsolation` (optional): `"workspace"` | `"fullRoot"`.
+- `minNetIsolation` (optional): `"restricted"` | `"denyAll"`.
+- `image` (optional, string): container image operator prefers when `mode` is container-like. Advisory — agent may reject or substitute.
+- `setupCommand` (optional, string): one-shot setup to run inside the sandbox before the session starts. Advisory.
+
+Clients MAY omit `SandboxPolicy` entirely, in which case the session runs under whatever the agent's `SandboxCapability` declares (compatible with today's behavior).
+
+### 3. `satisfies(capability, policy)` — the check
+
+A deterministic predicate the agent MUST evaluate when a client sets `acp.sandbox` (or fails-open if the client does not set one):
+
+```text
+satisfies(cap, pol) ⇔
+  (pol.require = "any")
+  ∨ (pol.require = "host" ∧ cap.mode = "host")
+  ∨ (pol.require = "sandboxed" ∧ cap.mode ≠ "host")
+  ∧ (pol.minFsIsolation absent ∨ cap.guarantees.fsIsolation ≥ pol.minFsIsolation)
+  ∧ (pol.minNetIsolation absent ∨ cap.guarantees.netIsolation ≥ pol.minNetIsolation)
+```
+
+Isolation grades are ordered: `none < workspace < fullRoot` for filesystem, `none < restricted < denyAll` for network. If `satisfies` returns false, the agent MUST reject the `setSessionConfigOption` with a typed error code `sandbox_policy_unsatisfiable`, returning its current `SandboxCapability` in the error payload so the client can explain the mismatch to the operator. If `satisfies` returns true, the session proceeds.
+
+### Why a Session Config Option rather than an ensureSession field
+
+`session/new` input is already crowded and has strong guarantees about backward compatibility. Session Config Options (already stabilized) is the designed extension point for structured, agent-negotiated per-session selectors. `acp.sandbox` slots in there cleanly, advertised via the same mechanism as any other config option, and the agent gets to accept or reject via the existing machinery. This keeps the proposal additive and re-uses an existing RFD's infrastructure rather than introducing a parallel one.
+
+### Extension dimension
+
+Future isolation dimensions (memory quotas, GPU access scoping, secrets isolation, etc.) can be added as new optional guarantee/policy fields without breaking existing agents or clients. The enum strings in `mode` can also be extended — agents that use an unknown `mode` value in `satisfies` simply match against `"host"` vs. "not host" as the coarse fallback.
+
+## Shiny future
+
+**For agent authors.** You declare once what your runtime actually enforces. No bespoke `_meta` conventions, no custom error strings when a client asks for a mode you don't do. Clients that want stronger isolation than you offer simply don't start sessions with you — which is the correct outcome.
+
+**For clients.** You declare, per session, what isolation matters for the work the user is about to do. You get upfront rejection instead of permission-prompt failures ten minutes into a turn, and the rejection carries structured data you can surface in the UI ("this agent runs on the host; your policy requires a container").
+
+**For operators in regulated environments.** Compliance stories ("all agent actions in this tenant run inside a container with no network access") become expressible in the protocol instead of in each client's config layer.
+
+**For the ecosystem.** The standard shape prevents the next six months of implementers each inventing their own `sandboxMode: "..."` string space on `_meta`.
+
+**For OpenClaw specifically.** Resolves the today-forbidden combination of `sandbox="require"` with an ACP backend. The OpenClaw spawn module sets `acp.sandbox.require = "sandboxed"` for sandbox-required child sessions, and backends that really run sandboxed accept it. Backends that run on the host correctly reject, and the spawn module falls back to OpenClaw's native sandboxed runtime for that specific child.
+
+## Implementation details and plan
+
+### Schema changes
+
+1. Add `SandboxCapability` to `schema.json` under `$defs`, referenced from `AgentCapabilities.sandbox?: SandboxCapability`.
+2. Register a new well-known Session Config Option id: `acp.sandbox`, with `value` type `SandboxPolicy` (also a new `$defs` entry). Registration is via whatever registry mechanism the [Session Config Options](https://agentclientprotocol.com/rfds/session-config-options) RFD settles on.
+3. Add error code `sandbox_policy_unsatisfiable` with a payload carrying the agent's `SandboxCapability`.
+
+### SDK changes (Rust reference, then propagated)
+
+- `AgentCapabilities` gets an optional `sandbox: Option<SandboxCapability>`.
+- `SandboxCapability` and `SandboxPolicy` are plain serde types.
+- Rust provides a helper `fn satisfies(cap: &SandboxCapability, pol: &SandboxPolicy) -> bool` with the exact predicate above, tested.
+- TypeScript, Python, Kotlin, Java SDKs mirror the types; each one gets the same `satisfies` helper.
+
+### Backward compatibility
+
+- Agents that do not advertise `SandboxCapability` behave exactly as today. Clients that set `acp.sandbox` on such agents receive the new error and can choose to proceed without the policy or fail fast.
+- Clients that do not set `acp.sandbox` behave exactly as today. Agents that advertise `SandboxCapability` incur no extra work for those clients.
+- No changes to session lifecycle, prompts, events, or transport.
+
+### Rollout
+
+1. RFD merges to Draft; Rust SDK implementation behind `unstable` feature flag, as per CONTRIBUTING.
+2. One editor client (Zed) and one agent (Claude Code or Codex) pilot the capability + policy path.
+3. RFD moves to Preview once two of each side implement and agree on the predicate.
+4. Stabilize after the preview period.
+
+### Open questions for dialog
+
+- Should the `fsIsolation` grade have a fourth level for "read-only workspace"? Would make it expressible that an agent can read the workspace but not write, which is what some analysis agents actually want. Probably yes; naming TBD.
+- Should `netIsolation` grow an `"allowlist"` grade with a list of allowed hosts in `guarantees`? Plausible for container-based agents that use a proxy, but complicates the capability surface.
+- Should `SandboxPolicy` also carry an optional list of required capability extensions (e.g., `["com.openclaw.workspaceOnly"]`) so operators can pin vendor-specific guarantees? Probably not — that's what proxies and capabilities are for; the core sandbox model should stay small.
+- How does this interact with `Elicitation`? Specifically, if a session needs to prompt the user to install or start a container, that is an elicitation concern and the sandbox RFD should not duplicate it.
+
+## FAQ
+
+### Why not model sandbox as a tool-level permission instead of a session-level policy?
+
+`RequestPermissionRequest` exists and handles fine-grained per-operation approval. That's the right layer for individual dangerous operations. Sandbox is different: it's a statement about the environment the whole session runs in. An operator who wants "container only" for this session does not want to answer 50 permission prompts to get there — they want to know up front that the agent will honor the requirement, and to reject the session if not.
+
+### Why a new top-level capability instead of nesting under `promptCapabilities` or similar?
+
+`promptCapabilities` describes what content the agent can ingest. `sessionCapabilities` is about session lifecycle (load, resume). Sandbox is an agent-level fact about runtime isolation — the session doesn't change it — so `AgentCapabilities.sandbox` is the right home.
+
+### Why three enums rather than freeform strings?
+
+Freeform strings let every agent advertise a different vocabulary, which defeats the purpose. Three short, carefully-chosen enums cover the isolation dimensions that actually matter in practice today, and the `"custom"` mode + extension fields (B.3 future-possibility) leave room for specialized cases without bloating core. See Open questions above for the dimensions worth considering.
+
+### Why is `satisfies` in the RFD rather than left to each implementation?
+
+Because if each SDK reimplements the predicate, clients and agents disagree on edge cases and the RFD becomes useless. The predicate is small, deterministic, and SHOULD be provided as a helper in every SDK (and should be included in the conformance test suite once that exists).
+
+### Does this replace OS-level isolation?
+
+No. The RFD does not mandate what agents use under the hood (Docker, Podman, chroot, seccomp, gVisor, Firecracker, WASI, a tenant with nothing but promises). It only standardizes how agents _describe_ what they use and how clients _require_ a minimum level. The enforcement is the agent's responsibility.
+
+### Why not just wait for the `Better Subagent Representation` RFD to cover this?
+
+That RFD (planned; not yet written as of 2026-04-02 maintainer notes) will likely cover how subagents are named, listed, and lifecycled. It's a different axis. A "subagent" can run on the host or in a container — the sandbox capability/policy split is orthogonal and applies equally to top-level agents and subagents.
+
+### Won't this let clients discriminate against agents that don't sandbox?
+
+Yes, and that is the point. Clients that need sandboxed execution can fail fast rather than route sensitive work to a host agent. Agents that want to serve such clients have a clear path: add isolation and advertise it. Clients that don't care (today's default) set no policy and continue to work with every agent unchanged.
+
+### Is the enum ordering (`none < workspace < fullRoot`) correct?
+
+`workspace` is a stronger guarantee than `none` — the agent cannot touch arbitrary files outside the workspace root. `fullRoot` is stronger again — the agent has a completely separate root filesystem, so even reads of `/etc/passwd` are isolated. The ordering matches the operator intuition that more isolation is higher. If there's disagreement, we can make the enum explicit as a numeric grade, but the string form is friendlier.
+
+## Revision history
+
+- **Date TBD (initial draft):** first version authored in OpenClaw's repo at `docs/refactor/acp-rfd-sandbox-capability-policy.mdx` for maintainer review before upstream submission.

--- a/docs/refactor/acp-spec-extensions.md
+++ b/docs/refactor/acp-spec-extensions.md
@@ -1,0 +1,389 @@
+# RFC: ACP spec extensions
+
+**Status.** Draft for upstream proposal to [agentclientprotocol.com](https://agentclientprotocol.com/) maintainers.
+**Authored in.** `openclaw/openclaw` — authored here because the motivation emerged from the ACP-everywhere consolidation work (`docs/refactor/acp-everywhere.md`), but the proposal itself is protocol-level and not OpenClaw-specific.
+**Scope.** Two tracks:
+
+- **Track A — Spec completeness.** Tighten ACP around gaps every consumer of the protocol feels once they try to drive a full coding-agent harness through it. Promote already-advertised tags to first-class variants, structure the tool-call lifecycle, formalize approval/compaction/lifecycle/correlation, and replace the boolean sandbox model with a typed capability/policy split.
+- **Track B — Foundational extension mechanism.** Add a small set of meta primitives (namespaced extensions, custom event variants, client method extensions, structured context bundles, session metadata) that let individual implementers carry their domain-specific needs through the protocol _without_ forking it. The goal is: once these primitives exist, no one ever has to modify the core spec just to thread their own state through.
+
+## Non-goals
+
+- Replacing JSON-RPC 2.0, the ACP handshake, or the stdio/socket transports.
+- Changing the session lifecycle primitives (`newSession`, `loadSession`, `setMode`, `setConfigOption`, `cancel`, `close`, `doctor`).
+- Mandating any particular backend architecture.
+- Adding domain-specific (e.g. messaging, memory, skills) vocabulary into core ACP. Those belong in extension namespaces (Track B).
+
+# Track A — Spec completeness
+
+## A1. First-class event variants for already-advertised tags
+
+**Problem.** The current `AcpSessionUpdateTag` / `AcpRuntimeEvent` landscape advertises a number of update types as _tags_ on loose events but does not model them as typed variants: `agent_thought_chunk`, `tool_call_update`, `usage_update`, `plan`, `current_mode_update`, `config_option_update`, `session_info_update`, `available_commands_update`. Consumers that want to pattern-match safely have to string-compare, which loses type-checker help and leaves the shape of each event's payload undocumented.
+
+**Proposal.** Promote each of these to a typed variant of the session update / runtime event stream with a stable payload shape:
+
+```ts
+type AcpRuntimeEvent =
+  | { type: "agent_message_chunk"; text: string }           // already effectively covered
+  | { type: "agent_thought_chunk"; text: string }           // NEW (promoted)
+  | { type: "tool_call"; ... }                              // see A2
+  | { type: "tool_call_update"; ... }                       // see A2
+  | { type: "usage_update"; usage: UsageCounters }          // NEW (promoted)
+  | { type: "plan_update"; plan: Plan }                     // NEW (promoted)
+  | { type: "current_mode_update"; mode: string }           // NEW (promoted)
+  | { type: "config_option_update"; key: string; value: unknown } // NEW (promoted)
+  | { type: "session_info_update"; info: SessionInfoSummary }     // NEW (promoted)
+  | { type: "available_commands_update"; commands: Command[] }    // NEW (promoted)
+  | { type: "lifecycle"; phase: "start" | "end" | "error"; ... }  // see A4
+  | { type: "compaction"; phase: "start" | "progress" | "end"; ... } // see A5
+  | { type: "approval_request"; ... } | { type: "approval_response"; ... } // see A3
+  | { type: "status"; ... }
+  | { type: "done"; stopReason?: string }
+  | { type: "error"; message: string; code?: string; retryable?: boolean };
+```
+
+Keep tags around for backward compatibility; new variants are additive.
+
+**Impact.** Any ACP client / agent benefits: stable types, type-checked handlers, clean pattern match.
+
+## A2. Structured tool-call lifecycle
+
+**Problem.** Today's `tool_call` is flat and conflates start / update / end. It does not model: structured arguments, structured results, intermediate progress, or canonical phases. Real coding harnesses emit tool work in three distinct phases and consumers need all three.
+
+**Proposal.** Split into two variants with a shared `toolCallId`:
+
+```ts
+type ToolCallStart = {
+  type: "tool_call";
+  toolCallId: string;
+  title?: string;
+  kind?: string; // treat as untrusted hint
+  args?: unknown; // structured, per-tool schema
+};
+
+type ToolCallUpdate = {
+  type: "tool_call_update";
+  toolCallId: string;
+  phase: "progress" | "end";
+  status?: "running" | "succeeded" | "failed" | "cancelled";
+  text?: string; // incremental output chunk (progress)
+  content?: ToolCallContent[]; // structured content (end)
+  result?: unknown; // structured result payload (end)
+  error?: { message: string; code?: string };
+  locations?: FileLocation[]; // files the tool touched, if known
+};
+```
+
+**Impact.** Consumers get a clean start/progress/end state machine per tool call without having to infer from flat tags.
+
+## A3. Formal approval request/response events
+
+**Problem.** ACP has a permissions concept but approval flow is not modeled as events on the turn stream. Non-interactive consumers (headless bridges, IDE automations) need a uniform way to intercept, log, and answer approval prompts.
+
+**Proposal.** Add two event variants:
+
+```ts
+type ApprovalRequest = {
+  type: "approval_request";
+  approvalId: string;
+  operation: "fs.write" | "fs.delete" | "exec" | "net" | string; // extensible
+  subject: string; // human-readable summary
+  details?: unknown; // operation-specific payload
+  defaultDecision?: "allow" | "deny";
+  timeoutMs?: number;
+};
+
+type ApprovalResponse = {
+  type: "approval_response";
+  approvalId: string;
+  decision: "allow" | "deny";
+  scope?: "once" | "session" | "always";
+  by?: "user" | "policy" | "timeout";
+};
+```
+
+Clients may also reply via an ACP request method (`session/approve`) instead of a streamed response, for symmetry with the existing permissions flow.
+
+**Impact.** Headless / bridged consumers get first-class approval handling; interactive clients can keep their current permission flow.
+
+## A4. Lifecycle variants
+
+**Problem.** `done` and `error` exist but there is no `start` or in-run phase marker. Observability tools (tracers, correlation, progress UIs) need a canonical `start` event with the run id.
+
+**Proposal.**
+
+```ts
+type Lifecycle =
+  | {
+      type: "lifecycle";
+      phase: "start";
+      requestId: string;
+      startedAt: number;
+      meta?: Record<string, unknown>;
+    }
+  | { type: "lifecycle"; phase: "end"; requestId: string; endedAt: number; stopReason?: string }
+  | {
+      type: "lifecycle";
+      phase: "error";
+      requestId: string;
+      endedAt: number;
+      error: { message: string; code?: string };
+    };
+```
+
+`done` / `error` remain as terminal events. `lifecycle` is additive and can be emitted alongside them.
+
+## A5. Compaction events
+
+**Problem.** Every mature agent backend compacts conversation state at some point; consumers currently have no way to tell the difference between "working on the turn" and "compacting and about to retry." Observability and UX around long runs suffers.
+
+**Proposal.**
+
+```ts
+type Compaction =
+  | { type: "compaction"; phase: "start"; reason?: string; estimateMs?: number }
+  | { type: "compaction"; phase: "progress"; used?: number; size?: number; note?: string }
+  | {
+      type: "compaction";
+      phase: "end";
+      retry?: boolean;
+      newContextSize?: number;
+      droppedTurns?: number;
+    };
+```
+
+Backends that don't compact simply never emit these. Clients that don't care can ignore them.
+
+## A6. Per-event `requestId` echo
+
+**Problem.** Turn events today carry no stable correlation token. Consumers that need to correlate logs / metrics / transcripts to a specific turn have to rely on the outer iterator identity, which doesn't survive serialization, logging, or multiplexing.
+
+**Proposal.** Every variant of the session update / runtime event stream carries an optional `requestId: string` field. Backends SHOULD populate it with the `requestId` from the originating `session/prompt`. Consumers MAY ignore it.
+
+**Impact.** Trivial for backends; significant quality-of-life for anyone writing a multiplexer, a proxy, a replay tool, or an audit sink.
+
+## A7. Sandbox capability and policy split
+
+**Problem.** There is no first-class way in ACP today to describe what isolation a backend offers or what isolation a particular run requires. Implementers end up bolting on booleans (`runsInSandbox`), which can't express grade (host / chroot / container / seccomp) or dimension (filesystem / network / process caps). Worse, "what the backend can enforce" and "what the operator requested" get blurred into one field.
+
+**Proposal.** Two distinct types, and a predicate:
+
+```ts
+// Backend-advertised (static). Returned from getCapabilities.
+type SandboxCapability = {
+  mode: "host" | "docker" | "podman" | "chroot" | "seccomp" | "custom";
+  guarantees: {
+    fsIsolation: "none" | "workspace" | "fullRoot";
+    netIsolation: "none" | "restricted" | "denyAll";
+    processCaps: boolean;
+  };
+};
+
+// Per-run request (dynamic). Optional field on ensureSession input.
+type SandboxPolicy = {
+  require: "any" | "host" | "sandboxed";
+  minFsIsolation?: "workspace" | "fullRoot";
+  minNetIsolation?: "restricted" | "denyAll";
+  image?: string;
+  setupCommand?: string;
+};
+
+// The client checks satisfies(capability, policy) before using the session
+// for a run whose policy demands sandboxing.
+function satisfies(capability: SandboxCapability, policy: SandboxPolicy): boolean;
+```
+
+Hosting a boolean is fine as a trivial case (`capability.mode === "host"` means "no sandbox"), but the shape leaves room for future stronger isolation.
+
+**Impact.** Backends can advertise real isolation grades; clients can make real policy decisions; operators stop seeing errors like "sandbox=require unsupported" without any diagnostic path.
+
+# Track B — Foundational extension mechanism
+
+The goal of Track B is that an implementer (OpenClaw, an IDE, a new harness, a third-party plugin author) can add their domain-specific needs — new event types, new ensureSession inputs, new client-side methods, new session state — without forking the protocol and without inflating the core spec. Existing ACP has `_meta` at the message level but no clean primitives for the other axes.
+
+## B1. Extension packages and namespaces
+
+**Proposal.** Formalize extensions as named, versioned packages. Each extension gets a reverse-DNS namespace:
+
+```ts
+type ExtensionId = string; // e.g. "com.openclaw.messaging"
+type ExtensionVersion = string; // semver
+
+type ExtensionCapability = {
+  id: ExtensionId;
+  version: ExtensionVersion;
+  methods?: string[]; // method namespaces this extension adds
+  eventTypes?: string[]; // event `type` values this extension emits
+  configOptionKeys?: string[]; // setConfigOption keys this extension reads
+  ensureSessionFields?: string[]; // optional ensureSession fields this extension consumes
+  clientMethods?: string[]; // client-side method namespaces the backend expects
+};
+```
+
+Backends advertise supported extensions via `getCapabilities().extensions: ExtensionCapability[]`. Clients advertise the extensions they offer similarly in `initialize`. The intersection is the set both ends may use.
+
+**Impact.** Extensions become discoverable, versioned, and composable. A backend that doesn't know an extension ignores its events and inputs; a client that doesn't support an extension simply doesn't advertise its client methods.
+
+## B2. Generic custom event variants
+
+**Proposal.** Add a typed custom-event variant to the session update / runtime event stream:
+
+```ts
+type CustomEvent = {
+  type: "custom";
+  extension: ExtensionId;
+  event: string; // extension-local event name
+  payload?: unknown; // schema is extension-defined
+  requestId?: string;
+};
+```
+
+Backends that need to emit extension-specific events do so under `custom` with an `extension` namespace. Consumers that don't recognize the extension simply discard the event. No spec change is needed to add a new event type.
+
+**Impact.** No more "please add an event variant for my use case" pressure on the core spec. Examples: OpenClaw's channel-delivery notifications, a memory-plugin's recall-hit events, an IDE's custom diff-preview events.
+
+## B3. Client method extensions
+
+**Problem.** ACP already supports client-side method namespaces like `fs/*`, `terminal/*`, approval prompts. There's no general mechanism to advertise a new namespace, so every new one (messaging, memory, secrets, notifications, ...) would require a spec change.
+
+**Proposal.** Allow clients to advertise additional JSON-RPC method namespaces at `initialize` time, each tagged with an extension id:
+
+```ts
+type ClientExtensionMethods = {
+  extension: ExtensionId;
+  methods: string[]; // e.g. ["messaging/send", "messaging/typing"]
+};
+
+type InitializeResult = {
+  // ... existing fields ...
+  clientExtensionMethods?: ClientExtensionMethods[];
+};
+```
+
+Backends then call these methods by their fully-qualified name over the standard ACP JSON-RPC transport. The semantics of each method are extension-defined.
+
+**Impact.** New client-side capability families (messaging, memory, secrets, telemetry, ...) can be added without touching the core protocol. Exactly the mechanism ACP already uses for `fs/*` and `terminal/*`, just made explicit.
+
+## B4. Named structured context bundles
+
+**Problem.** Different harnesses need different structured preamble at session setup: Codex reads `model_instructions_file`; Claude Code reads plugin directories; agents may want skill catalogs, bootstrap contexts, rule files, custom system prompt fragments. Ad-hoc per-backend flags multiply.
+
+**Proposal.** Add an optional typed bag on `ensureSession`:
+
+```ts
+type ContextBundle = {
+  kind: string; // extension-qualified id, e.g. "com.openclaw.skills"
+  version?: string;
+  encoding?: "json" | "text" | "base64";
+  payload: unknown; // schema determined by kind
+};
+
+type EnsureSessionInput = {
+  // ... existing fields ...
+  contextBundles?: ContextBundle[];
+};
+```
+
+Backends accept only the `kind`s they advertise in their `ExtensionCapability.ensureSessionFields`. Unknown `kind`s are ignored (or rejected, per capability) rather than causing failure.
+
+**Impact.** Any harness can carry structured initial context through the protocol using a single generic mechanism, rather than lobbying the spec for a new `skills` / `rules` / `plugins` field each time.
+
+## B5. Session metadata bag
+
+**Problem.** Clients often need to attach bookkeeping to a session that survives `loadSession` but is not part of the conversation. Today they have to serialize/deserialize out-of-band.
+
+**Proposal.** Optional `metadata: Record<string, unknown>` on the session that:
+
+- Is opaque to the backend (backends MUST round-trip it unchanged through `loadSession`).
+- Is namespaced by convention (`com.openclaw.bindingRecord`, `com.vendor.trace`, etc.).
+- Has a size cap declared by the backend via capabilities.
+
+**Impact.** Clients stop having to maintain parallel session stores just for extension-specific per-session state.
+
+## B6. Extension-scoped config options
+
+**Problem.** `setConfigOption(key, value)` is a flat string key space. Collisions between extensions and core are a matter of convention, not spec.
+
+**Proposal.** Encourage (and in capability advertisement, require) extension keys to be namespaced:
+
+```
+setConfigOption("com.openclaw.fastMode", true)
+setConfigOption("com.openclaw.elevatedActions", "owner-only")
+setConfigOption("model", "openai/gpt-5.4")           // core key, unnamespaced
+```
+
+Backends list their accepted keys in `ExtensionCapability.configOptionKeys`. Unknown keys return an error code distinguishable from "known key, bad value" (add `"config_option_unknown"` error code).
+
+**Impact.** Stable boundary between core config (model, temperature, approval policy, timeout) and extension config (fast mode, elevated actions, cache hints, experimental toggles). No string-space collisions across ecosystems.
+
+# How the two tracks combine
+
+Applied together, Tracks A and B give the protocol:
+
+- A richer, fully-typed core event stream (A1–A6) so type-safe clients stop losing information.
+- A real sandbox model (A7) so policy decisions stop being boolean vibes.
+- Clean extension primitives (B1–B6) so no one needs to ever propose another domain-specific addition to the core spec.
+
+A concrete example of the two tracks in concert: OpenClaw's messaging-context need (an open row on our internal richness audit) lands entirely in Track B — a `com.openclaw.messaging` extension that advertises client methods (`messaging/send`, `messaging/typing`), uses a `custom` event for delivery notifications, and stores thread-binding records in the session metadata bag. No changes to core ACP beyond the Track B primitives, which themselves are domain-neutral.
+
+# Rationale and alternatives
+
+## Why not just use `_meta` for everything?
+
+`_meta` at the message level is a loose escape hatch. It does not:
+
+- Discover or version extensions.
+- Carry typed event payloads.
+- Gate acceptance by capability.
+- Give clients a legal way to add new method namespaces.
+
+The extension mechanism in Track B makes extensions first-class citizens instead of free-text stowaways.
+
+## Why not vendor each harness's needs into core?
+
+Core bloat, naming fights, and slower evolution. Different backends (IDE-embedded vs. channel-relay vs. CI runner vs. GPU-bound harness) have different legitimate extensions; folding any of them into core privileges one category and penalizes the others. The foundational extension mechanism lets each category flourish without dragging the core spec along.
+
+## Why structured sandbox types now?
+
+Because boolean sandbox is already getting reinvented on top of `_meta` and `setConfigOption` by multiple implementers. Standardizing the capability/policy split early prevents three separate incompatible "sandbox" conventions emerging in parallel.
+
+## Why promote tags to variants rather than just publishing the tag vocabulary?
+
+Tags are stringly-typed and don't carry payload schemas. A consumer that sees `tag: "usage_update"` has to hope the rest of the event is shaped right. First-class variants make the shape legal and checkable.
+
+# Backwards compatibility
+
+- Tag-based events (A1) continue to work; variants are additive.
+- Existing `tool_call` shape (A2) remains valid; a backend that never emits `tool_call_update` is still conformant.
+- Approval via ACP's existing permissions flow (A3) remains valid; the event form is an alternative, not a replacement.
+- `lifecycle` / `compaction` (A4, A5) events are additive; backends that don't emit them are unchanged.
+- `requestId` echo (A6) is optional on the backend side; consumers that don't use it are unchanged.
+- Backends that don't opt into `SandboxCapability` (A7) keep today's implicit "host-only" behavior.
+- All Track B primitives are pure additions; backends and clients that don't opt into extensions are unaffected.
+
+No existing ACP deployment should break on adopting these extensions; the upgrade path is version-negotiated at `initialize` / `getCapabilities`.
+
+# Unresolved questions
+
+- Should `custom` events (B2) count as "session updates" for the purpose of `loadSession` replay, or be ephemeral by default? Suggest: ephemeral by default, with an extension capability flag `replayable: true` for extensions that want persistence.
+- Should `ContextBundle` payloads (B4) be size-capped at the protocol level or left to backend advertisement? Suggest: advertised cap per `kind`, with a core-spec recommended default.
+- Should approval flow (A3) be fully unified with ACP's existing permissions, or kept as a parallel event-based path? Suggest: unify, and deprecate the older shape in a minor version.
+- Is `requestId` the right name for per-event correlation, or should we pick something more neutral (`turnId`, `correlationId`)? Suggest: `requestId` for continuity with existing `TurnInput.requestId`.
+
+# Prior art
+
+- JSON-RPC 2.0 batch and notifications: the "ignore unknown" semantics we lean on.
+- Language Server Protocol `InitializeParams.capabilities` and `clientInfo` / `serverInfo` version negotiation.
+- Model Context Protocol (MCP) `serverCapabilities` / `clientCapabilities` — similar shape; ACP's extension advertisement should feel familiar to anyone who has implemented an MCP server.
+- OpenTelemetry resource / attribute semantic-conventions: the namespacing and extensibility pattern.
+- xumux-ACP (`https://github.com/deftai/xumux/blob/openmux/docs/ext-acp-agent-client-protocol.md`) for the "same ACP payloads over arbitrary transports" idea — supports the claim that the protocol surface is worth keeping clean and wire-agnostic.
+
+# Future possibilities
+
+- Conformance test suite that validates both core spec and any advertised extension (backend + client sides).
+- Extension registry so reverse-DNS ids don't collide across ecosystems (similar to MIME type assignments).
+- Per-extension semver compatibility policy so `com.openclaw.messaging@1.x` and `@2.x` can coexist cleanly.
+
+# What this does and doesn't enable for OpenClaw
+
+This RFC is not OpenClaw-specific. That said, within OpenClaw's concurrent `acp-everywhere` consolidation work (`docs/refactor/acp-everywhere.md`, `docs/refactor/acp-everywhere-richness-audit.md`), adopting Tracks A and B upstream would turn roughly 80% of our audit's 🟡 rows into pure spec-completeness wins rather than OpenClaw-flavored extensions, and the remaining 20% into clean Track B extensions carried under `com.openclaw.*` namespaces without core-protocol churn. That's the strategic case for proposing these upstream instead of building them as OpenClaw-only extensions.

--- a/docs/refactor/acp-spec-extensions.md
+++ b/docs/refactor/acp-spec-extensions.md
@@ -1,5 +1,11 @@
 # RFC: ACP spec extensions
 
+> **SUPERSEDED (2026-04-23).** This draft predates a comparison against the actual ACP repository, in-flight RFDs, and core-maintainer meeting notes. After that comparison most of the proposals here were found to already be implemented (`ExtRequest` / `ExtNotification` / `_meta`), already in-flight as dedicated RFDs (`auth-methods`, `session-close`, `session-resume`, `session-usage`, `message-id`, `meta-propagation`, `proxy-chains`, `elicitation`, `additional-directories`, `boolean-config-option`, `custom-llm-endpoint`, `request-cancellation`, `mcp-over-acp`, `streamable-http-websocket-transport`, `session-fork`, `session-delete`, `logout-method`, `next-edit-suggestions`, `agent-telemetry-export`), or planned by core maintainers (better subagent representation, notification-based prompt format, plan mode improvements). Keeping two parallel multi-track proposals alive would have contributed to spec fragmentation rather than prevented it.
+>
+> Replaced by **[`acp-rfd-sandbox-capability-policy.mdx`](./acp-rfd-sandbox-capability-policy.mdx)**, a single focused RFD scoped to the one area that was not already being addressed: typed sandbox capability/policy modeling. That doc also carries the brief "how OpenClaw will consume adjacent in-flight RFDs" summary so reviewers can see the wider context.
+>
+> The content below is preserved for traceability but should not be taken as a proposal.
+
 **Status.** Draft for upstream proposal to [agentclientprotocol.com](https://agentclientprotocol.com/) maintainers.
 **Authored in.** `openclaw/openclaw` — authored here because the motivation emerged from the ACP-everywhere consolidation work (`docs/refactor/acp-everywhere.md`), but the proposal itself is protocol-level and not OpenClaw-specific.
 **Scope.** Two tracks:


### PR DESCRIPTION
> **RFC — not a merge candidate.** This PR adds `docs/refactor/acp-everywhere.md` as a proposal. Please do not merge until (a) the direction is agreed and (b) sandbox-capability modeling (see Cons) is agreed. After merge, phasing issues will be filed from the doc's Phasing section, one per phase.
>
> **Narrow questions I'd like feedback on:**
> 1. Direction agree/disagree — does collapsing on `AcpRuntime` as the single internal execution contract make sense, or is there a hard blocker I'm missing?
> 2. Sandbox modeling — OK with the `SandboxCapability` (backend-enforced) + `SandboxPolicy` (per-run request) split and a `satisfies(capability, policy)` predicate?
> 3. CLI backend migration — native ACP adapters per CLI, or fold under `acpx`?
> 4. Optional loopback transport — worth exploring later, or plan stdio-only forever?
>
> Full plan inline below. Diff adds one file under `docs/refactor/` only; no `src/` / `extensions/` changes.

---

# ACP Everywhere

## TL;DR

OpenClaw currently has at least five different ways to start an LLM/agent turn (normal `agent` RPC, `sessions_spawn` subagent, `sessions_spawn` acp, cron, `openclaw acp` bridge) driving at least four different execution engines (pi-embedded, CLI backends, plugin `AgentHarness`, ACP runtime backends). Each path has its own spawn wrapper, lifecycle eventing, sandbox/announce rules, and slash-command surface. This document proposes making the existing `AcpRuntime` interface (`src/acp/runtime/types.ts`) the single internal execution contract that every path goes through, wrapping pi-embedded, CLI backends, and plugin harnesses as ACP backends behind it. Net effect: one spawn module, one event stream, one policy layer, one set of controls — without changing any external wire protocol.

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart LR
    subgraph SRC["launch surfaces"]
        direction TB
        RPC["agent RPC"]
        SS["sessions_spawn"]
        SL["/subagents, /acp"]
        CR["cron"]
        BR["openclaw acp bridge"]
    end
    AR["AcpRuntime<br/>ensureSession / runTurn / cancel"]
    subgraph BE["backends"]
        direction TB
        PI["openclaw-pi"]
        AX["acpx"]
        CLI["CLI backends"]
        PL["plugin harnesses"]
    end
    RPC --> AR
    SS --> AR
    SL --> AR
    CR --> AR
    BR --> AR
    AR --> PI
    AR --> AX
    AR --> CLI
    AR --> PL
```

## Why ACP

Before the problem statement and the mechanics, a short list of why ACP is the right protocol to standardize on. These properties are what make "one seam" actually work in practice and what separate ACP from a bespoke internal interface.

- **Covers chat-style and agent-style interfaces with the same contract.** `session/prompt` handles the straight prompt-in / deltas-and-final-text-out shape that a Responses-API-style caller wants, and the same session can just as easily drive a full agent turn with tools, plans, thoughts, session modes, cwd, resume, and cancel. One contract; no separate API for "assistant turn" vs "agent turn".
- **Tools can live on the client or on the server, or both.** Agent-side tools are the default (the backend exposes its own tool surface). Client-side tools are first-class too (for example `fs/read_text_file`, `fs/write_text_file`, `terminal/*`) and get called through the same JSON-RPC methods. Capability negotiation at `initialize` makes this explicit, so the spawn module can policy-check which side owns which tool.
- **Sessions are first-class.** `newSession`, `loadSession`, `session/set_mode`, `session/status`, resume semantics, and cancel live in the protocol. Maps 1:1 onto OpenClaw's session keys and lifecycle.
- **Streaming is structured, not a single opaque text stream.** Token deltas, reasoning/thought deltas, tool-call lifecycle updates, plan updates, status, usage, and (optionally) terminal output are each their own typed event.
- **Capability negotiation is built in.** Backends advertise what they actually support (sandboxing, resume, attachments, client terminals, specific tool surfaces, config option keys) and callers policy-check against that.
- **Permission handling is in the protocol.** Interactive and non-interactive permission flows for writes/exec/etc. are defined, so headless sessions don't have to invent their own approval path.
- **Transport-agnostic.** The ACP JSON-RPC 2.0 messages are the same regardless of wire. stdio is the canonical transport, but the same messages can be carried over WebSocket, WebRTC, QUIC, TCP, in-process loopback, or any multiplexed transport. See [xumux-ACP](https://github.com/deftai/xumux/blob/openmux/docs/ext-acp-agent-client-protocol.md) for a concrete example that carries the exact same ACP payloads over a xumux multiplexer and picks up WebSocket / WebRTC / QUIC / TCP / stdio from one binding. OpenClaw's proposed loopback transport is another instance of the same principle.
- **Existing ecosystem.** Codex, Claude Code, Gemini CLI, Cursor, OpenCode, and others already speak ACP. Choosing it as the internal seam means OpenClaw consumes that ecosystem cheaply and, through `openclaw acp`, exposes itself to it cheaply too.
- **Additive evolution.** New capabilities (richer plans, structured diffs, embedded terminals, provenance receipts) land as additive protocol updates behind capability flags, not as invariant-breaking schema changes.
- **Editor/IDE-native primitives.** Cancellation, plans, thoughts, diffs, terminals, and status updates are in the protocol rather than bolted on per-harness, which is why Zed-style IDE integrations work without a custom bridge.

## Design principles

Three principles keep this from drifting into protocol cargo-culting or a big-bang refactor:

- **Contract is the deliverable, not the wire.** The unification goal is one protocol-typed contract (`AcpRuntime`) between the spawn module and every backend. The transport those messages flow over is orthogonal to the contract — stdio, socket, and in-process direct calls are all legal. The `openclaw-pi` backend is expected to run in-process by default; no IPC cost is mandated on the hot path. Forcing stdio everywhere would be cargo-culting — what we actually want is the typed, versioned, capability-negotiated interface.
- **Smallest slice first, with explicit parity gates.** Phases 1–3 ship one backend (`openclaw-pi`) wired through one call-site (`runAgentAttempt`) and must prove byte-for-byte parity on transcript/announce/abort/compaction/resume before Phase 4 touches subagent spawn or anything else. CLI and plugin migrations only happen after the pi + main-turn slice is demonstrably boring. A maintainer can veto continuing at the gate if parity is not clean.
- **Capability-driven policy over hard-coded runtime strings.** Backends advertise what they can and can't do (sandbox mode and isolation grade, resume, attachments, client terminals, config-option keys, etc.). The spawn module enforces policy by matching against those capabilities rather than branching on `runtime == "acp"` / `runtime == "subagent"`. This is the reason the `sandbox="require"` / `runtime="acp"` clash (see Cons) can be resolved cleanly instead of patched with another string.

## Problem statement

As OpenClaw has grown it has accumulated parallel launch and execution paths instead of converging on one. Concretely, today we have:

- **Four execution engines** that each own their own loop: the embedded pi harness (`runEmbeddedPiAgent`), `runCliAgent` for Codex/Claude/Gemini CLIs, the plugin `AgentHarness` registry, and `AcpRuntime` backends registered via `registerAcpRuntimeBackend`.
- **Two separate spawn modules** (`src/agents/subagent-spawn.ts` and `src/agents/acp-spawn.ts`) implementing overlapping-but-divergent versions of the same feature set: target resolution, workspace inheritance, sandbox policy, depth/concurrency limits, thread binding, announce, cleanup, registry tracking.
- **A runtime switch on `sessions_spawn`** (`runtime: "subagent" | "acp"`) whose value silently changes which features are available: `resumeSessionId` requires `runtime=acp`, `attachments` and `lightContext` require `runtime=subagent`, `sandbox="require"` is rejected on `runtime=acp`, `streamTo="parent"` is only valid on `runtime=acp`.
- **Two slash-command families** (`/subagents …` and `/acp …`) that are conceptually the same operator surface with slightly different verbs and flags.
- **Two branching agent-entry paths**: `runAgentAttempt` in `src/agents/command/attempt-execution.ts` branches on `isCliProvider` to pick between `runCliAgent` and `runEmbeddedPiAgent`, and cron's `run-executor` does the same thing independently.
- **Lifecycle event streams diverge**: pi emits `lifecycle`/`assistant`/`tool`/`compaction`/`usage` streams; `AcpRuntimeEvent` models a narrower `text_delta | status | tool_call | done | error` shape.

The result is feature drift, duplicated bug surface, partial parity (every time we add a capability to one path we have to decide whether and how to mirror it on the others), and a muddled operator mental model. There is no single place to enforce a new safety policy, add a new audit field, instrument a new metric, or host a new runtime capability (sandbox, resume, attachments) so that it automatically works for normal turns, cron, subagents, and ACP sessions.

## Current state (compact map)

Launch surfaces that start an agent turn today:

- Gateway `agent` RPC → `runAgentAttempt` (`src/agents/command/attempt-execution.ts:217`).
- `sessions_spawn` tool (`src/agents/tools/sessions-spawn-tool.ts`), two branches.
- `/subagents spawn` and `/acp spawn|steer|cancel|close|…` slash commands.
- Cron isolated agents (`src/cron/isolated-agent/run-executor.ts`).
- Top-level `bindings[].type="acp"` (channel inbound routed into an ACP session).
- Stdio ACP bridge `openclaw acp` (`src/acp/server.ts`) — external ACP clients into Gateway.

Execution engines those paths end up in:

- `runEmbeddedPiAgent` (the default).
- `runCliAgent` for Codex CLI / Claude CLI / Gemini CLI.
- Plugin `AgentHarness` registry (`src/agents/harness/selection.ts`).
- `AcpRuntime` backends (today only bundled `acpx`, which itself fans out to Codex/Claude/Gemini/Cursor/OpenCode/etc).

### Before: tangled launch paths

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart LR
    subgraph S["launch surfaces"]
        S1["agent RPC"]
        S2["sessions_spawn<br/>runtime=subagent"]
        S3["sessions_spawn<br/>runtime=acp"]
        S4["/subagents"]
        S5["/acp"]
        S6["cron"]
        S7["openclaw acp bridge"]
    end
    subgraph W["spawn wrappers"]
        W1["runAgentAttempt"]
        W2["subagent-spawn"]
        W3["acp-spawn"]
        W4["cron run-executor"]
    end
    subgraph E["execution engines"]
        E1["runEmbeddedPiAgent"]
        E2["runCliAgent"]
        E3["AgentHarness registry"]
        E4["AcpRuntime (acpx)"]
    end
    S1 --> W1
    S2 --> W2
    S3 --> W3
    S4 --> W2
    S5 --> W3
    S6 --> W4
    S7 --> W1
    W1 --> E1
    W1 --> E2
    W1 --> E3
    W2 --> E1
    W3 --> E4
    W4 --> E1
    W4 --> E2
```

## Target architecture

Promote `AcpRuntime` (`src/acp/runtime/types.ts:118`) from "external harness driver" to the single internal execution contract. Every launch path calls `AcpRuntime.ensureSession` + `runTurn` + `cancel` / `close` / `setMode` / `setConfigOption` / `doctor`. The concrete backends become:

- `openclaw-pi` — wraps `runEmbeddedPiAgent` and `compactEmbeddedPiSession`.
- `acpx` — unchanged, still fronts Codex/Claude/Gemini/Cursor/OpenCode/etc.
- CLI backends — either thin native ACP adapters (one per CLI) or folded under `acpx`.
- Plugin harnesses — register directly as ACP backends.

On top of that one contract:

- `subagent-spawn.ts` and `acp-spawn.ts` collapse to one `spawn.ts` module.
- `sessions_spawn` loses its `runtime` branch; `agentId` (optionally + a `backend` hint) fully determines which backend answers.
- `runAgentAttempt` and cron's `run-executor` stop branching on `isCliProvider`; they call `AcpRuntime.runTurn`.
- `/subagents` and `/acp` collapse into one `/agents …` command family (keep old slashes as aliases).
- `openclaw acp` bridge stays as-is and becomes a clean ACP-in / ACP-out pipe.

### After: unified ACP seam

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart LR
    subgraph S["launch surfaces (unchanged)"]
        S1["agent RPC"]
        S2["sessions_spawn"]
        S3["/agents (unified)"]
        S4["cron"]
        S5["openclaw acp bridge"]
    end
    WS["spawn.ts<br/>(single module)"]
    AR["AcpRuntimeClient<br/>(protocol seam)"]
    subgraph BE["ACP backends"]
        B1["openclaw-pi"]
        B2["acpx"]
        B3["CLI backends"]
        B4["plugin backend"]
    end
    S1 --> WS
    S2 --> WS
    S3 --> WS
    S4 --> WS
    S5 --> WS
    WS --> AR
    AR --> B1
    AR --> B2
    AR --> B3
    AR --> B4
```

### Sequence: what changes on a normal turn

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
sequenceDiagram
    participant U as channel
    participant G as gateway RPC
    participant A as runAgentAttempt
    participant P as pi-embedded
    participant C as runCliAgent
    rect rgb(224, 224, 224)
      Note over A: BEFORE -- branch on isCliProvider
      U->>G: message
      G->>A: agent turn
      alt CLI provider
          A->>C: runCliAgent
          C-->>A: payloads + events
      else embedded
          A->>P: runEmbeddedPiAgent
          P-->>A: payloads + events
      end
      A-->>G: done
      G-->>U: reply
    end
```

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
sequenceDiagram
    participant U as channel
    participant G as gateway RPC
    participant SP as spawn module
    participant T as transport
    participant B as backend
    rect rgb(224, 224, 224)
      Note over SP: AFTER -- no branching, one seam
      U->>G: message
      G->>SP: agent turn
      SP->>T: ensureSession(input)
      T->>B: ensureSession(input)
      B-->>T: handle
      T-->>SP: handle
      SP->>T: runTurn(handle)
      T->>B: runTurn(handle)
      loop streaming
          B-->>T: AcpRuntimeEvent
          T-->>SP: AcpRuntimeEvent
          SP-->>G: translated
      end
      B-->>T: done
      T-->>SP: done
      SP-->>G: done
      G-->>U: reply
    end
```

## Pros

- **One contract to reason about.** A single `AcpRuntime` interface replaces four overlapping engines and two spawn wrappers.
- **Feature matrix collapses.** `resumeSessionId`, `attachments`, `lightContext`, `sandbox`, `streamTo`, `mode=session`, `thread`, `cwd` become properties of the backend/contract, not of the spawn path. Every backend that supports a capability exposes it the same way.
- **Smaller code surface.** Net LOC should go down, not up. Two spawn modules become one; two entry-branching functions become one seam; duplicate announce/thread-binding logic merges.
- **Simpler mental model for operators.** "Sub-agent" and "ACP agent" stop being two concepts. One `/agents` command family, one set of flags.
- **Plugin story improves.** Third-party runtimes implement one interface (`AcpRuntime`) instead of picking between `AgentHarness`, `cliBackend`, or an ACP adapter.
- **Pi harness is preserved.** Wrapping `runEmbeddedPiAgent` as a backend keeps all of its hard-won behavior (lane serialization, compaction, heartbeat, auth profile rotation, transcript persistence) intact. An optional in-process transport can preserve today's call-cost for the hot path if benchmarks call for it (see [Optional: ACP loopback transport for hot-path performance](#optional-acp-loopback-transport-for-hot-path-performance)).
- **The outward ACP bridge becomes natural.** `openclaw acp` already speaks ACP inbound; when the internals also speak ACP, there is no impedance mismatch to maintain.

## Cons / tradeoffs

- **`AcpRuntimeEvent` must be extended.** Today it does not cover pi's full event surface (lifecycle start/end/error, reasoning deltas, compaction, usage). That is a contract change, additive but real, and it affects `acpx`, any third-party ACP runtime backend, and the outward bridge.
- **Sandbox semantics differ.** Pi can run inside the OpenClaw sandbox; ACP backends today explicitly cannot (`docs/tools/acp-agents.md` — Sandbox compatibility). A boolean `runsInSandbox` is too coarse — different backends offer different isolation grades (host / Docker / Podman / chroot / seccomp) with different guarantees (filesystem, network, process caps). Also, what a backend _can_ enforce and what a particular run _requested_ are different concerns and must not share a single type. The contract separates them cleanly:

  ```ts path=null start=null
  // What the backend CAN enforce. Advertised by the runtime via getCapabilities;
  // does not change per run. Static facts about the runtime.
  type SandboxCapability = {
    mode: "host" | "docker" | "podman" | "chroot" | "seccomp" | "custom";
    guarantees: {
      fsIsolation: "none" | "workspace" | "fullRoot";
      netIsolation: "none" | "restricted" | "denyAll";
      processCaps: boolean;
    };
  };

  // What THIS run requests. Per-spawn input the spawn module passes into
  // ensureSession so the backend knows what the operator asked for. Not a
  // capability — a request.
  type SandboxPolicy = {
    require: "any" | "host" | "sandboxed";
    minFsIsolation?: "workspace" | "fullRoot";
    minNetIsolation?: "restricted" | "denyAll";
    image?: string; // operator-supplied runtime config
    setupCommand?: string; // operator-supplied runtime config
  };
  ```

  Enforcement is a well-defined predicate `satisfies(capability, policy)` that the spawn module evaluates before starting a run (rough shape: `policy.require != "sandboxed" || capability.mode != "host"`, plus pairwise checks that `capability.guarantees` meets each `policy.min*`). That lets `sandbox="require"` be a real check instead of a boolean, keeps the capability surface stable across runs, and leaves room for stronger isolation grades (container-per-session, seccomp profiles, etc.) without another round of string-comparison plumbing. Without the split, capability and policy blur and matching gets hand-wavy fast.

- **Announce / thread-binding migration is delicate.** Channel plugins expect exact historical announce shapes. Merging subagent-spawn and acp-spawn must preserve those bytes or we silently break agents and cron jobs that users already rely on.
- **CLI backend features are non-trivial to move.** Session-expired retry, CLI-session reuse, bundle-MCP overlay, plugin-owned defaults. These need to come along when CLI backends become ACP backends.
- **Migration is multi-release.** Feature flags, legacy aliases, and a period where both paths coexist are mandatory to avoid a big-bang regression.
- **"Everything behind one interface" can mask bugs.** A subtle regression in a shared seam impacts every launch path at once. Mitigated by keeping the pi runner itself intact as the default backend and staging the rollout.

## What this enables for architecture goals

### Security

- **One policy chokepoint.** Tool-policy, sandbox, permission-mode, approval, ACP-agent allowlist, and subagent depth/concurrency limits currently live on at least three paths (`subagent-spawn`, `acp-spawn`, `runAgentAttempt`). Behind one seam they become one set of checks that every launch path inherits automatically.
- **Sandbox becomes a first-class capability.** `sandbox="require"` no longer has to reject `runtime=acp` — instead the backend declares whether it runs inside the sandbox, and the spawn module enforces the policy uniformly.
- **Credential/auth isolation is easier to reason about.** ACP backends already have an explicit `ensureSession({ agent, cwd, env })` boundary. Routing pi and CLI through the same boundary means auth-profile scoping, per-agent `agentDir`, and delegate isolation (`docs/concepts/delegate-architecture.md`) apply the same way regardless of backend.
- **Non-interactive permission handling unifies.** `permissionMode` / `nonInteractivePermissions` currently live on `acpx`. Once pi is a backend too, the same knobs extend naturally to every path (normal turn, cron, subagent, ACP session).

### Auditing

- **One event stream to record.** Collapsing pi and ACP lifecycle events into the extended `AcpRuntimeEvent` stream means every turn emits the same shape of `text_delta` / `tool_call` / `status` / `done` / `error` / lifecycle markers. Transcript persistence, session history, and audit export all read from one source.
- **Stable correlation ids.** `AcpRuntimeHandle` already carries `sessionKey` + `backend` + `runtimeSessionName` + optional `backendSessionId` / `agentSessionId`. Moving every turn through that handle gives us a ready-made correlation key for logs, metrics, transcripts, and GHSA-style incident reconstruction.
- **Consistent provenance.** The `openclaw acp --provenance meta|meta+receipt` flag already exists for the bridge. Making ACP the internal seam means provenance receipts can become a property of every turn, not just bridge turns.
- **Delegate and cron audit trails merge.** `docs/concepts/delegate-architecture.md` already requires audit trails for cron-run history and session transcripts. One execution seam gives those trails one format and one writer.

### Code re-use

- **Spawn wrapper collapses.** Target resolution, workspace inheritance, requester-origin inference, subagent-registry tracking, depth/concurrency limits, cleanup, and announce all live once.
- **Streaming glue is written once.** The translator that turns a runtime event iterable into channel output (assistant text, tool summaries, block replies) is implemented against one contract instead of per-engine.
- **Abort and timeout are implemented once.** `AcpRuntime.cancel` plus `AbortSignal` propagation on `runTurn` replace today's per-engine abort logic (`abortEmbeddedPiRun`, CLI-side SIGTERM handling, ACP cancel).
- **Compaction and session resume are uniform.** `compact?`, `prepareFreshSession?`, and `resumeSessionId` become optional capabilities on any backend, so `sessions_spawn` stops having to special-case them.
- **Tests scale better.** Once the contract is the seam, a single contract test suite (`adapter-contract.testkit.ts` already exists for ACP) covers every backend, instead of reinventing test harnesses per engine.

### Other architecture goals

- **Observability parity.** One set of metrics (turn latency, queue wait, tokens, tool-call count, error class) naturally lights up for every launch path.
- **Plugin SDK simplification.** Plugins that want to contribute a runtime implement `AcpRuntime`. `src/plugin-sdk/acp-runtime.ts` already exists for this — we just make it the recommended plugin surface.
- **Clear extension points for future work.** Adding a new capability (richer thought streaming, structured tool diffs, ACP terminals) is one contract change + one implementation per backend, not an N×M retrofit.
- **VISION.md alignment.** This is consolidation, not a new orchestration layer. The project's stated direction (lean core, optional capability in plugins, no nested-manager frameworks) is what this seam buys us.

## Why a protocol seam, not just an API seam

A reasonable counter-proposal would be "just introduce a shared TypeScript interface (an API seam) that pi, CLI, and ACP backends implement, and stop there." That would solve the in-process duplication, but it would leave most of the architectural wins on the table. Picking a _protocol_ interface — ACP, which has a wire format, an event schema, and a contract independent of any one language or process — is materially stronger than an in-process API interface for several reasons:

- **Process isolation is free.** An API seam only works as long as every implementation lives in the same Node process. A protocol seam lets any backend run out-of-process (a sidecar, a subprocess, a container, a different host) with no change to the caller. That is already how `acpx` works today; extending the same pattern to pi and CLI backends means a misbehaving backend can be restarted, sandboxed, or resource-limited on its own without taking the gateway with it.
- **Crash, hang, and leak blast-radius shrinks.** Language-level APIs share a heap, an event loop, and a process lifetime. A runaway backend that leaks memory, blocks the loop, or segfaults native code takes the whole gateway with it. A protocol seam gives us a real fault boundary: kill the backend process, the gateway keeps serving other sessions.
- **Language and runtime choice opens up.** Third-party (or future first-party) backends can be written in Rust, Go, Python, or anything that can speak ACP over stdio or a socket. An API seam locks every implementation into TypeScript and the specific pi-coding-agent / OpenClaw build. This matters for high-performance harnesses, GPU-bound inference backends, and plugin authors who do not want to take a Node dependency.
- **Cross-network is the same shape as cross-process.** ACP is already transportable over stdio, WebSocket, and (trivially) TCP/TLS. Once the seam is a protocol, "run the backend on another machine" is a configuration change, not a refactor. That unlocks remote harnesses, shared GPU pools, tenant isolation per host, and the kind of Tailnet/SSH topologies OpenClaw already uses for its Gateway.
- **Versioning is explicit.** Protocols have schemas and version negotiation; APIs have function signatures and hope. ACP already has handshake/capabilities (`getCapabilities`, `session_info_update`, `available_commands_update`). Version skew between gateway and backend becomes a declared compatibility matrix instead of a silent duck-typing failure.
- **Security boundaries become enforceable.** An in-process API backend has ambient authority: the whole Node `process.env`, `fs`, `net`, plus any globals OpenClaw has loaded. A protocol backend only sees what the gateway chose to pass into `ensureSession({ cwd, env })`. Least-privilege scoping, seccomp/landlock, Docker/Podman isolation, and per-backend credential injection all become mechanical to apply.
- **Observability is first-class.** Every call across a protocol seam is a framed, schema'd message. We can tee it to a log, a debugger, a provenance receipt, a replay harness, or an audit sink without instrumenting each backend. In-process APIs require per-call wrappers and are easy to bypass.
- **Contract tests replace cross-module test mazes.** Given a protocol, one conformance test suite proves that _any_ backend behaves correctly. With an API seam you end up writing ad-hoc mocks and re-testing the seam per implementation. `src/acp/runtime/adapter-contract.testkit.ts` already does this for ACP; extending it is cheaper than maintaining per-engine test harnesses.
- **Third-party plugin distribution stops being a monorepo problem.** A protocol backend can be `npm i`'d, `brew install`'d, or shipped as a standalone binary and pointed at via `acp.backend.command`. An API backend has to be built against the exact OpenClaw version you are running. This is the same reason MCP won over bespoke tool APIs.
- **Interop with the rest of the ACP ecosystem comes for free.** Zed, `openclaw acp`, `acpx openclaw`, and other ACP-speaking clients/servers already exist. A protocol seam means OpenClaw can both consume and expose ACP backends without an adapter layer. An API seam would only speak OpenClaw's dialect.
- **Language-level "just add an interface" tends to rot.** Once you have three implementations, an API interface drifts: one caller peeks at an implementation-specific field, another short-circuits through a shared helper, tests couple to internals. Protocol seams resist this because the wire format is the only legal way to talk.

### API seam vs protocol seam at a glance

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart LR
    subgraph ApiSeam["API seam (TS interface)"]
        direction TB
        AC["caller"]
        AB1["backend A<br/>TS module"]
        AB2["backend B<br/>TS module"]
        AC --> AB1
        AC --> AB2
    end
    subgraph ProtoSeam["Protocol seam (ACP)"]
        direction TB
        PC["caller"]
        PT["transport"]
        PB1["backend A<br/>same Node"]
        PB2["backend B<br/>subprocess"]
        PB3["backend C<br/>remote host"]
        PC --> PT
        PT -->|loopback| PB1
        PT -->|stdio| PB2
        PT -->|ws or tcp| PB3
    end
```

The baseline plan assumes the ordinary stdio transport for every backend (same model `acpx` uses today).

## Optional: ACP loopback transport for hot-path performance

**Status: exploratory / to investigate.** Everything in the plan above works with the standard stdio/socket ACP transport. The loopback transport is an optional future optimization for the `openclaw-pi` hot path. It is called out here so it is not mistaken for a required part of the seam and so the details live in one place.

### What it is

ACP has a protocol layer (typed message shapes and semantics: `AcpRuntimeEnsureInput`, `AcpRuntimeTurnInput`, `AcpRuntimeEvent`, `AcpRuntimeHandle`) and a transport layer (how those messages move between a client and a runtime). Today we only have one transport — the external stdio `@agentclientprotocol/sdk` one used by `acpx`. A loopback transport is a second transport that short-circuits serialization while keeping the same protocol types on both sides. Same contract, no wire.

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart LR
    C["AcpRuntimeClient<br/>(spawn module)"]
    subgraph StdioT["stdio transport"]
        direction LR
        S1["JSON encode"]
        S2["frame"]
        S3["pipe"]
        S4["frame decode"]
        S5["JSON decode"]
        S1 --> S2
        S2 --> S3
        S3 --> S4
        S4 --> S5
    end
    LB["loopback transport<br/>direct call, zero copy"]
    H["AcpRuntimeServer<br/>(backend handler)"]
    C -->|stdio| S1
    S5 --> H
    C -->|loopback| LB
    LB --> H
```

### Why we might want it

A normal LLM turn emits high-frequency events (token deltas, reasoning deltas, tool-call updates, compaction progress, usage ticks — easily 50–200+ events/sec) and occasionally large payloads (multi-megabyte tool results, attachments, transcripts). Over stdio each event is framed, JSON-serialized, piped, deserialized, re-dispatched. In-process it is a function call and a typed object passed by reference. For the `openclaw-pi` backend, which has always run in-process, mandating stdio pays real per-event cost and copies every tool result twice. The loopback transport lets us keep one contract everywhere without charging IPC cost on the path that runs 99% of turns.

### How it works

Each transport exposes the same two shapes: a client handle (what a spawn module talks to) and a server handler (what a backend implements).

```ts path=null start=null
// Identical regardless of transport.
interface AcpRuntimeClient {
  ensureSession(input: AcpRuntimeEnsureInput): Promise<AcpRuntimeHandle>;
  runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent>;
  cancel(input: { handle: AcpRuntimeHandle; reason?: string }): Promise<void>;
  close(input: { handle: AcpRuntimeHandle; reason: string }): Promise<void>;
  // getCapabilities, getStatus, setMode, setConfigOption, doctor, prepareFreshSession
}
interface AcpRuntimeServer extends AcpRuntimeClient {}
```

A transport connects a `Client` shape to a `Server` shape. stdio does framing + JSON + pipes. Loopback just calls the function.

```ts path=null start=null
export function createLoopbackTransport(
  server: AcpRuntimeServer,
  opts?: { validate?: boolean; queueLimit?: number },
): AcpRuntimeClient {
  return {
    async ensureSession(input) {
      if (opts?.validate) validateEnsureInput(input); // optional schema check
      const result = await server.ensureSession(input); // direct call
      if (opts?.validate) validateHandle(result);
      return result; // same object, no copy
    },
    runTurn(input) {
      if (opts?.validate) validateTurnInput(input);
      return server.runTurn(input); // AsyncIterable passes straight through
    },
    cancel: (input) => server.cancel(input),
    close: (input) => server.close(input),
    // ...
  };
}
```

That is the whole transport: a thin adapter that hands typed objects from one function to another inside the same Node process.

### Streaming

Inside the `openclaw-pi` server, the pi subscription system produces events on a bounded in-memory queue; `runTurn` yields them as an async iterable of `AcpRuntimeEvent`. Under loopback, that iterable is returned to the caller directly — no `JSON.stringify`, no framing. Under stdio, the same iterable is wrapped by the stdio transport, which serializes and frames.

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#b0b0b0','secondaryColor':'#a0a0a0','tertiaryColor':'#909090','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#000000','actorLineColor':'#000000','signalColor':'#000000','actorBkg':'#b0b0b0','actorTextColor':'#000000','noteBkgColor':'#d0d0d0','stateLabelColor':'#000000','compositeBackground':'#c0c0c0'}}}%%
sequenceDiagram
    participant SM as spawn module
    participant T as transport
    participant B as openclaw-pi
    participant PI as pi subscription
    rect rgb(224, 224, 224)
      SM->>T: runTurn(input)
      T->>B: runTurn(input)
      B->>PI: subscribeEmbeddedPiSession
      PI-->>B: onAssistantDelta(text)
      B-->>T: text_delta
      T-->>SM: text_delta
      PI-->>B: onToolCall(tc)
      B-->>T: tool_call
      T-->>SM: tool_call
      PI-->>B: onLifecycleEnd
      B-->>T: done
      T-->>SM: done
      Note over T,B: loopback -- direct yield<br/>stdio -- JSON + framed pipe
    end
```

```ts path=null start=null
async function* runTurn(input: AcpRuntimeTurnInput): AsyncIterable<AcpRuntimeEvent> {
  const queue = new AcpEventQueue({ limit: 1024 }); // bounded ring
  const abort = new AbortController();
  input.signal?.addEventListener("abort", () => abort.abort(), { once: true });
  const unsub = subscribeEmbeddedPiSession(sessionId, {
    onAssistantDelta: (text) => queue.push({ type: "text_delta", text, stream: "output" }),
    onToolCall: (tc) => queue.push({ type: "tool_call", ...tc }),
    onLifecycleEnd: () => queue.push({ type: "done", stopReason: "stop" }),
    onError: (err) => queue.push({ type: "error", message: err.message }),
  });
  const runPromise = runEmbeddedPiAgent({ ...mapped, signal: abort.signal })
    .catch((err) => queue.push({ type: "error", message: err.message }))
    .finally(() => {
      unsub();
      queue.close();
    });
  try {
    for await (const evt of queue) yield evt; // zero-copy handoff under loopback
  } finally {
    abort.abort();
    await runPromise;
  }
}
```

### Backpressure

stdio gets backpressure from OS socket buffers. Loopback does it explicitly: `AcpEventQueue` has a high-water mark; pushing past it either awaits drain or drops with an explicit policy (same shape as today's `acp.stream.coalesceIdleMs` / `maxChunkChars`). The spawn module never sees the difference.

### Cancellation

- stdio: client sends a `cancel` RPC; server receives it and calls `AbortController.abort()` locally.
- loopback: client calls `transport.cancel({ handle })`, which is literally `server.cancel(...)`. `AbortSignal` also passes through directly on `runTurn(input.signal)` without a message at all.
  Same semantics, one less hop.

### Errors

- stdio: thrown errors are caught by the server framing layer and serialized as `{ type: "error", message, code }` events or JSON-RPC errors.
- loopback: thrown errors are caught by the adapter, wrapped into `AcpRuntimeEvent` error events on the same queue, and rethrown as native `Error` objects for request/response calls. Continuous stack traces; no cross-process trace loss.

### How it stays protocol-only and does not become a back door

The risk of an in-process transport is that the backend reaches around the protocol (reads OpenClaw's config, mutates session state, imports internal helpers). Three mechanical rules — all already idiomatic in this codebase — prevent that:

1. **Package-boundary lint.** The `openclaw-pi` backend lives behind the same package boundary as `acpx` (`extensions/*` style), so it can only import `openclaw/plugin-sdk/*` and its own locals. No `import from "../../src/agents/..."`.
2. **No ambient inputs.** The backend receives `cwd`, `env`, session key, and everything else it needs through `ensureSession` / `runTurn` arguments — not via `loadConfig()` at the top of a module.
3. **Contract tests target the client surface.** `src/acp/runtime/adapter-contract.testkit.ts` exercises every backend through `AcpRuntimeClient`. The same suite runs against both stdio and loopback transports. If a backend cheats and needs something off-protocol to pass, the contract test fails.
   With those rules in place, loopback is a _transport choice for an already-legitimate ACP backend_, not an escape hatch.

### Transport selection

The spawn module resolves a transport and then uses it; it never branches on backend identity.

```ts path=null start=null
const backend = getAcpRuntimeBackend("openclaw-pi");
const transport =
  backend.deploy === "stdio"
    ? createStdioTransport(backend.command)
    : backend.deploy === "socket"
      ? createSocketTransport(backend.endpoint)
      : /* default */ createLoopbackTransport(backend.server);
await transport.ensureSession({ sessionKey, agent, mode, cwd });
for await (const evt of transport.runTurn({ handle, text, mode: "prompt", requestId })) {
  translator.emit(evt);
}
```

`openclaw-pi` can register with `deploy: "loopback"` for the hot path and be flipped to `stdio`/`socket` by configuration when process isolation is worth the IPC cost. A mixed fleet (`openclaw-pi` loopback, `acpx` stdio, a plugin backend on a socket) all speaks the same protocol at the same time.

```mermaid
%%{init: {'theme':'base','themeVariables':{'primaryColor':'#909090','secondaryColor':'#808080','tertiaryColor':'#707070','primaryTextColor':'#000000','secondaryTextColor':'#000000','tertiaryTextColor':'#000000','noteTextColor':'#000000','lineColor':'#404040','actorLineColor':'#404040','signalColor':'#404040','actorBkg':'#808080','actorTextColor':'#000000','noteBkgColor':'#909090','stateLabelColor':'#000000','compositeBackground':'#a0a0a0'}}}%%
flowchart TD
    A{"backend.deploy?"}
    L["createLoopbackTransport<br/>same process"]
    S["createStdioTransport<br/>subprocess"]
    W["createSocketTransport<br/>remote host"]
    U["uniform AcpRuntimeClient"]
    X["spawn module<br/>(no branching)"]
    A -->|loopback| L
    A -->|stdio| S
    A -->|socket| W
    L --> U
    S --> U
    W --> U
    U --> X
```

### Properties this gives us

- Zero IPC cost on the hot path.
- Same contract tests run against both transports — parity is proven, not asserted.
- Debuggers step straight into the backend; stack traces are continuous.
- Upgrading pi to out-of-process is a config flip, not a refactor.

### Why this is still optional

- The baseline plan already delivers every architectural win (single contract, one spawn module, one event stream, one policy layer).
- stdio works for `acpx` today and would work for `openclaw-pi` tomorrow; IPC cost may be acceptable in practice and should be measured before investing in a second transport.
- A second transport is additional surface area. Worth it only if benchmarks show the stdio hot path is a real bottleneck, or if we want the cross-process option but also refuse the per-event IPC cost.
- If we keep stdio-only and find cost is fine, we save the complexity entirely.
  Recommendation: land the baseline ACP seam first. Measure. Only build the loopback transport if measurements justify it.

## Phasing (high level)

1. Extend `AcpRuntimeEvent` / `AcpRuntime` to cover pi's full lifecycle surface; keep changes additive. Include the `SandboxCapability` shape from the Cons section on the runtime's capability descriptor.
2. Ship `openclaw-pi` backend wrapping `runEmbeddedPiAgent` + `compactEmbeddedPiSession` behind a feature flag. Runs in-process by default — no stdio, no IPC on the hot path; that's the contract-vs-wire distinction from Design principles.
3. Route `runAgentAttempt` and cron through `AcpRuntime.runTurn` when the flag is on. **Parity gate before Phase 4 begins:** prove byte-for-byte parity with the legacy path on (a) transcript writes, (b) announce output, (c) abort/cancel behavior, (d) compaction and resume roundtrip, (e) sandbox-policy enforcement via the new `SandboxCapability`. A maintainer can hold the RFC here if parity is not clean.
4. **Only after the Phase 3 parity gate passes:** migrate `sessions_spawn runtime="subagent"` onto `openclaw-pi`, then merge `subagent-spawn.ts` and `acp-spawn.ts` into one module.
5. Migrate CLI backends into ACP backends (native adapters or via `acpx`); remove `isCliProvider` branches.
6. Move plugin `AgentHarness` entries onto `AcpRuntime`.
7. Collapse `/subagents` and `/acp` into one `/agents …` command family (with aliases).
8. Remove legacy code and flags one release after every surface is on the unified path.

## Non-goals

- No change to the outward Gateway WS protocol (channels, Swift clients, webchat).
- No change to MCP integration strategy (`mcporter` still owns that surface per VISION.md).
- No new nested-manager / agent-hierarchy framework; this is strictly a consolidation of the existing spawn/runtime landscape.
- No forced migration of third-party plugins in the short term; legacy `AgentHarness` and `cliBackend` paths remain supported during the transition.
