### PR TITLE
fix(plugins): grant admin scope to synthetic subagent deleteSession

### DIFF
--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -772,14 +772,17 @@ describe("loadGatewayPlugins", () => {
     expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");
   });
 
-  test("rejects fallback session deletion without minting admin scope", async () => {
+  test("allows fallback session deletion by minting admin scope on the synthetic client (#69886)", async () => {
+    // Regression for #69886: deleteSession runs in plugin `finally` blocks
+    // (e.g. memory-core narrative cleanup) that can outlive the cron's
+    // request scope. Without an explicit admin scope on the synthetic
+    // fallback, sessions.delete is rejected with `missing scope:
+    // operator.admin` and narrative sessions are orphaned every night.
     const serverPlugins = serverPluginsModule;
     const runtime = await createSubagentRuntime(serverPlugins);
     serverPlugins.setFallbackGatewayContext(createTestContext("synthetic-delete-session"));
 
     handleGatewayRequest.mockImplementationOnce(async (opts: HandleGatewayRequestOptions) => {
-      // Re-run the gateway scope check here so the test proves fallback dispatch
-      // does not smuggle admin into the request client.
       const scopes = Array.isArray(opts.client?.connect?.scopes) ? opts.client.connect.scopes : [];
       const auth = methodScopesModule.authorizeOperatorScopesForMethod("sessions.delete", scopes);
       if (!auth.allowed) {
@@ -797,10 +800,12 @@ describe("loadGatewayPlugins", () => {
         sessionKey: "s-delete",
         deleteTranscript: true,
       }),
-    ).rejects.toThrow("missing scope: operator.admin");
+    ).resolves.toBeUndefined();
 
-    expect(getLastDispatchedClientScopes()).toEqual(["operator.write"]);
-    expect(getLastDispatchedClientScopes()).not.toContain("operator.admin");
+    // The synthetic client used for fallback dispatch must have admin
+    // scope (and only admin, not a broader bundle) so plugins cannot
+    // escalate beyond what the specific method requires.
+    expect(getLastDispatchedClientScopes()).toEqual(["operator.admin"]);
   });
 
   test("allows session deletion when the request scope already has admin", async () => {

--- a/src/gateway/server-plugins.ts
+++ b/src/gateway/server-plugins.ts
@@ -376,10 +376,22 @@ export function createGatewaySubagentRuntime(): PluginRuntime["subagent"] {
       return getSessionMessages(params);
     },
     async deleteSession(params) {
-      await dispatchGatewayMethod("sessions.delete", {
-        key: params.sessionKey,
-        deleteTranscript: params.deleteTranscript ?? true,
-      });
+      // sessions.delete is gated under ADMIN_SCOPE in method-scopes.ts.
+      // Plugins that call deleteSession from a finally-block (e.g. the
+      // memory-core narrative cleanup) can outlive the original request
+      // scope — at which point createSyntheticOperatorClient defaults to
+      // ["operator.write"] and the delete is rejected with
+      // `missing scope: operator.admin`. Pass ADMIN_SCOPE explicitly so
+      // the synthetic fallback retains enough privilege to complete the
+      // cleanup instead of leaving orphaned narrative sessions. (#69886)
+      await dispatchGatewayMethod(
+        "sessions.delete",
+        {
+          key: params.sessionKey,
+          deleteTranscript: params.deleteTranscript ?? true,
+        },
+        { syntheticScopes: [ADMIN_SCOPE] },
+      );
     },
   };
 }


### PR DESCRIPTION
## Summary

Fixes #69886. memory-core's Memory Dreaming Promotion cron invokes narrative cleanup in a \`finally\` block after the narrative run settles. By that point the cron's original request scope has unwound, so \`createGatewaySubagentRuntime().deleteSession\` falls through to \`createSyntheticOperatorClient\`, which defaults to \`[\"operator.write\"]\`.

\`sessions.delete\` is gated under \`ADMIN_SCOPE\` in \`method-scopes.ts\` (line 165), so the synthetic fallback fails nightly with:

\`\`\`
[plugins] memory-core: narrative session cleanup failed for light phase: missing scope: operator.admin
[plugins] memory-core: narrative session cleanup failed for rem phase: missing scope: operator.admin
[plugins] memory-core: narrative session cleanup failed for deep phase: missing scope: operator.admin
\`\`\`

Dream diary entries are written fine — only the spawned narrative sessions end up orphaned.

## Fix

Pass \`{ syntheticScopes: [ADMIN_SCOPE] }\` to the \`dispatchGatewayMethod\` call for \`sessions.delete\` — the surgical patch from the issue report's option 1. Other methods on the subagent runtime (\`run\`, \`getSession\`, etc.) still use their default write scope; only the admin-gated one asks for admin.

## Test

The existing test \`rejects fallback session deletion without minting admin scope\` asserted the buggy behavior (it locked in the regression). Updated it to the regression test for #69886: asserts \`resolves.toBeUndefined()\` and that \`getLastDispatchedClientScopes()\` returns exactly \`[\"operator.admin\"]\` — admin-only, not a broader bundle, so plugins cannot escalate beyond the specific method requirement.

oxlint passes on both changed files.

Closes #69886.