### PR TITLE
fix: drop stale transient async notices after session advance

### DIFF
--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -201,6 +201,12 @@ export function startAcpSpawnParentStreamRelay(params: {
       contextKey,
       deliveryContext: params.deliveryContext,
       trusted: false,
+      stalePolicy:
+        contextKey.endsWith(":error") ||
+        contextKey.endsWith(":timeout") ||
+        contextKey.endsWith(":blocked")
+          ? undefined
+          : "drop-on-session-advance",
     });
     wake();
   };

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -301,6 +301,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     sessionKey,
     deliveryContext: session.notifyDeliveryContext,
     trusted: false,
+    stalePolicy: status === "completed" ? "drop-on-session-advance" : undefined,
   });
   requestHeartbeatNow(
     scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event", coalesceMs: 0 }),

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -452,6 +452,7 @@ export async function runPreparedReply(
         sessionKey,
         isMainSession,
         isNewSession,
+        latestSessionUpdatedAt: sessionEntry?.updatedAt,
       });
       if (eventsBlock) {
         drainedSystemEventBlocks.push(eventsBlock);

--- a/src/auto-reply/reply/session-system-events.ts
+++ b/src/auto-reply/reply/session-system-events.ts
@@ -6,7 +6,10 @@ import {
   formatZonedTimestamp,
   resolveTimezone,
 } from "../../infra/format-time/format-datetime.ts";
-import { drainSystemEventEntries } from "../../infra/system-events.js";
+import {
+  discardStaleSystemEventEntries,
+  drainSystemEventEntries,
+} from "../../infra/system-events.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -18,6 +21,7 @@ export async function drainFormattedSystemEvents(params: {
   sessionKey: string;
   isMainSession: boolean;
   isNewSession: boolean;
+  latestSessionUpdatedAt?: number;
 }): Promise<string | undefined> {
   const compactSystemEvent = (line: string): string | null => {
     const trimmed = line.trim();
@@ -83,6 +87,7 @@ export async function drainFormattedSystemEvents(params: {
   };
 
   const systemLines: string[] = [];
+  discardStaleSystemEventEntries(params.sessionKey, params.latestSessionUpdatedAt);
   const queued = drainSystemEventEntries(params.sessionKey);
   systemLines.push(
     ...queued.flatMap((event) => {

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -600,6 +600,50 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
+  it("skips stale exec-event notices once the session already advanced", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const now = Date.now();
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "none",
+            },
+          },
+        },
+        session: { store: storePath },
+      };
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        updatedAt: now + 5_000,
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "should not run" });
+
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        stalePolicy: "drop-on-session-advance",
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+        },
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: "no-tasks-due" });
+      expect(getReplySpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("keeps Telegram topic routing for isolated scheduled heartbeats", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createLastTargetConfig({ tmpDir, storePath, isolatedSession: true });

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -5,6 +5,7 @@ import { resolveMainSessionKey } from "../config/sessions.js";
 import { runHeartbeatOnce } from "./heartbeat-runner.js";
 import {
   seedMainSessionStore,
+  seedSessionStore,
   setupTelegramHeartbeatPluginRuntimeForTests,
   withTempHeartbeatSandbox,
 } from "./heartbeat-runner.test-utils.js";
@@ -641,6 +642,66 @@ describe("Ghost reminder bug (issue #13317)", () => {
 
       expect(result).toEqual({ status: "skipped", reason: "no-tasks-due" });
       expect(getReplySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps cron reminders when a stale exec-event entry is filtered out", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      const { sendTelegram, getReplySpy } = createHeartbeatDeps("Relay this cron update now");
+
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        stalePolicy: "drop-on-session-advance",
+      });
+      await seedSessionStore(storePath, sessionKey, {
+        sessionId: "sid",
+        updatedAt: Date.now() + 1_000,
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      enqueueSystemEvent("Reminder: Check Base Scout results", {
+        sessionKey,
+        contextKey: "cron:reminder-job",
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+      const calledCtx = (getReplySpy.mock.calls[0]?.[0] ?? null) as {
+        Provider?: string;
+        Body?: string;
+      } | null;
+
+      expect(result.status).toBe("ran");
+      expectCronEventPrompt(calledCtx, "Reminder: Check Base Scout results");
+      expect(sendTelegram).toHaveBeenCalled();
     });
   });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -666,7 +666,7 @@ function resolveHeartbeatRunPrompt(params: {
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
 
-  if (params.preflight.isExecEventReason && !hasExecCompletion) {
+  if (params.preflight.isExecEventReason && !hasExecCompletion && !hasCronEvents) {
     return { prompt: null, hasExecCompletion: false, hasCronEvents: false };
   }
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -105,6 +105,7 @@ import {
 } from "./outbound/targets.js";
 import {
   consumeSystemEventEntries,
+  discardStaleSystemEventEntries,
   peekSystemEventEntries,
   resolveSystemEventDeliveryContext,
 } from "./system-events.js";
@@ -545,6 +546,7 @@ async function resolveHeartbeatPreflight(params: {
     params.heartbeat,
     params.forcedSessionKey,
   );
+  discardStaleSystemEventEntries(session.sessionKey, session.entry?.updatedAt);
   const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
@@ -663,6 +665,10 @@ function resolveHeartbeatRunPrompt(params: {
     .map((event) => event.text);
   const hasExecCompletion = pendingEvents.some(isExecCompletionEvent);
   const hasCronEvents = cronEvents.length > 0;
+
+  if (params.preflight.isExecEventReason && !hasExecCompletion) {
+    return { prompt: null, hasExecCompletion: false, hasCronEvents: false };
+  }
 
   // If tasks are defined, build a batched prompt with due tasks
   if (params.preflight.tasks && params.preflight.tasks.length > 0) {

--- a/src/infra/system-events.test.ts
+++ b/src/infra/system-events.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { drainFormattedSystemEvents } from "../auto-reply/reply/session-updates.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
@@ -216,6 +216,48 @@ describe("system events (session routing)", () => {
 
     const result = await drainFormattedEvents(key);
     expect(result).toMatch(/^System \(untrusted\): \[[^\]]+\] Notification posted:/);
+  });
+
+  it("drops transient async notices after the session has already advanced", async () => {
+    vi.useFakeTimers();
+    try {
+      const key = "agent:main:test-stale-async";
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      enqueueSystemEvent("Background task done: ACP background task (run run-1234).", {
+        sessionKey: key,
+        stalePolicy: "drop-on-session-advance",
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+      const result = await drainFormattedEvents(key, {
+        latestSessionUpdatedAt: Date.now(),
+      });
+
+      expect(result).toBeUndefined();
+      expect(peekSystemEvents(key)).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps durable failures even after later session activity", async () => {
+    vi.useFakeTimers();
+    try {
+      const key = "agent:main:test-durable-failure";
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      enqueueSystemEvent("Background task failed: ACP background task (run run-1234). Boom.", {
+        sessionKey: key,
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:05.000Z"));
+      const result = await drainFormattedEvents(key, {
+        latestSessionUpdatedAt: Date.now(),
+      });
+
+      expect(result).toContain("Background task failed: ACP background task");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("scrubs node last-input suffix", async () => {

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -19,6 +19,7 @@ export type SystemEvent = {
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
   trusted?: boolean;
+  stalePolicy?: "drop-on-session-advance";
 };
 
 const MAX_EVENTS = 20;
@@ -38,6 +39,7 @@ type SystemEventOptions = {
   contextKey?: string | null;
   deliveryContext?: DeliveryContext;
   trusted?: boolean;
+  stalePolicy?: SystemEvent["stalePolicy"];
 };
 
 function requireSessionKey(key?: string | null): string {
@@ -107,6 +109,7 @@ export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
     contextKey: normalizedContextKey,
     deliveryContext: normalizedDeliveryContext,
     trusted: options.trusted !== false,
+    stalePolicy: options.stalePolicy,
   });
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
@@ -148,8 +151,59 @@ function areSystemEventsEqual(left: SystemEvent, right: SystemEvent): boolean {
     left.ts === right.ts &&
     (left.contextKey ?? null) === (right.contextKey ?? null) &&
     (left.trusted ?? true) === (right.trusted ?? true) &&
+    (left.stalePolicy ?? null) === (right.stalePolicy ?? null) &&
     areDeliveryContextsEqual(left.deliveryContext, right.deliveryContext)
   );
+}
+
+function shouldDropSystemEventOnSessionAdvance(
+  event: SystemEvent,
+  latestSessionActivityAt?: number,
+): boolean {
+  return (
+    event.stalePolicy === "drop-on-session-advance" &&
+    typeof latestSessionActivityAt === "number" &&
+    Number.isFinite(latestSessionActivityAt) &&
+    latestSessionActivityAt > event.ts
+  );
+}
+
+function syncSessionQueueState(key: string, entry: SessionQueue) {
+  if (entry.queue.length === 0) {
+    entry.lastText = null;
+    entry.lastContextKey = null;
+    queues.delete(key);
+    return;
+  }
+  const newest = entry.queue[entry.queue.length - 1];
+  entry.lastText = newest.text;
+  entry.lastContextKey = newest.contextKey ?? null;
+}
+
+export function discardStaleSystemEventEntries(
+  sessionKey: string,
+  latestSessionActivityAt?: number,
+): SystemEvent[] {
+  const key = requireSessionKey(sessionKey);
+  const entry = getSessionQueue(key);
+  if (!entry || entry.queue.length === 0) {
+    return [];
+  }
+  const kept: SystemEvent[] = [];
+  const removed: SystemEvent[] = [];
+  for (const event of entry.queue) {
+    if (shouldDropSystemEventOnSessionAdvance(event, latestSessionActivityAt)) {
+      removed.push(cloneSystemEvent(event));
+      continue;
+    }
+    kept.push(event);
+  }
+  if (removed.length === 0) {
+    return [];
+  }
+  entry.queue = kept;
+  syncSessionQueueState(key, entry);
+  return removed;
 }
 
 export function consumeSystemEventEntries(
@@ -168,15 +222,7 @@ export function consumeSystemEventEntries(
     return [];
   }
   const removed = entry.queue.splice(0, consumedEntries.length).map(cloneSystemEvent);
-  if (entry.queue.length === 0) {
-    entry.lastText = null;
-    entry.lastContextKey = null;
-    queues.delete(key);
-  } else {
-    const newest = entry.queue[entry.queue.length - 1];
-    entry.lastText = newest.text;
-    entry.lastContextKey = newest.contextKey ?? null;
-  }
+  syncSessionQueueState(key, entry);
   return removed;
 }
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -985,6 +985,12 @@ function queueTaskSystemEvent(task: TaskRecord, text: string) {
     sessionKey: ownerKey,
     contextKey: `task:${task.taskId}`,
     deliveryContext: owner.requesterOrigin,
+    stalePolicy:
+      task.status === "succeeded" && task.terminalOutcome !== "blocked"
+        ? "drop-on-session-advance"
+        : shouldAutoDeliverTaskStateChange(task)
+          ? "drop-on-session-advance"
+          : undefined,
   });
   requestHeartbeatNow({
     reason: "background-task",

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -986,11 +986,10 @@ function queueTaskSystemEvent(task: TaskRecord, text: string) {
     contextKey: `task:${task.taskId}`,
     deliveryContext: owner.requesterOrigin,
     stalePolicy:
-      task.status === "succeeded" && task.terminalOutcome !== "blocked"
+      (task.status === "succeeded" && task.terminalOutcome !== "blocked") ||
+      shouldAutoDeliverTaskStateChange(task)
         ? "drop-on-session-advance"
-        : shouldAutoDeliverTaskStateChange(task)
-          ? "drop-on-session-advance"
-          : undefined,
+        : undefined,
   });
   requestHeartbeatNow({
     reason: "background-task",


### PR DESCRIPTION
## Summary

This narrows late async/system notices so transient success-style notices do not surface after the session has already advanced.

It keeps durable blocked, error, and timeout notices intact.

## What changed

- mark transient async completion notices with `stalePolicy: "drop-on-session-advance"`
- discard stale queued system-event entries when newer session activity already exists
- make heartbeat exec-event prompts skip themselves if stale completion events were filtered away
- add regression coverage for stale system-event filtering and heartbeat ghost-reminder behavior

## Files changed

- `src/agents/acp-spawn-parent-stream.ts`
- `src/agents/bash-tools.exec-runtime.ts`
- `src/auto-reply/reply/get-reply-run.ts`
- `src/auto-reply/reply/session-system-events.ts`
- `src/infra/heartbeat-runner.ghost-reminder.test.ts`
- `src/infra/heartbeat-runner.ts`
- `src/infra/system-events.test.ts`
- `src/infra/system-events.ts`
- `src/tasks/task-registry.ts`

## Validation

corepack pnpm exec vitest run --config test/vitest/vitest.infra.config.ts src/infra/system-events.test.ts src/infra/heartbeat-runner.ghost-reminder.test.ts

Result: 45 passed, 0 failed

## Reviewer notes

• This is intentionally limited to stale transient completion/success notices after session advance.
• It does not suppress durable blocked/error/timeout events.
• It does not try to solve the separate question of late failure alert presentation.
