### PR TITLE
fix(cron): record status=error on run-level error, not just isError payloads

### DIFF
--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -5,6 +5,7 @@ import {
   pickLastDeliverablePayload,
   pickLastNonEmptyTextFromPayloads,
   pickSummaryFromPayloads,
+  resolveCronPayloadOutcome,
 } from "./helpers.js";
 
 describe("pickSummaryFromPayloads", () => {
@@ -167,5 +168,64 @@ describe("isHeartbeatOnlyResponse", () => {
         ACK_MAX,
       ),
     ).toBe(false);
+  });
+});
+
+describe("resolveCronPayloadOutcome — runLevelError handling (#69889)", () => {
+  it("treats a run-level error as fatal even when no payload has isError", () => {
+    // Reporter scenario: Gemini returns HTTP 400 with no body on quota
+    // exhaustion. The assistant message ends with stopReason:"error" and
+    // errorMessage set, but the outbound delivery payload is empty content
+    // with no isError flag. Without this fix, cron stores status="ok"
+    // delivered=false and operators chase the delivery layer.
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "" }],
+      runLevelError: "400 status code (no body)",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe("400 status code (no body)");
+  });
+
+  it("prefers the error-payload text over runLevelError when both are present", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "tool call rate limited", isError: true }],
+      runLevelError: "generic run error",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(true);
+    expect(outcome.embeddedRunError).toBe("tool call rate limited");
+  });
+
+  it("keeps status=ok when neither runLevelError nor isError is set", () => {
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [{ text: "Here is your summary." }],
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+    expect(outcome.embeddedRunError).toBeUndefined();
+  });
+
+  it("still ignores a successful payload after an isError one only when runLevelError is absent", () => {
+    // Prior invariant: a successful text after the error means the run
+    // recovered — status stays ok. Must not regress this when runLevelError
+    // is undefined.
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "retrying…", isError: true },
+        { text: "Final answer: 42" },
+      ],
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(false);
+  });
+
+  it("runLevelError overrides the successful-payload-after-error recovery path", () => {
+    // If the run itself errored (runLevelError set), a trailing successful
+    // text shouldn't paper over it — the run is still fatal.
+    const outcome = resolveCronPayloadOutcome({
+      payloads: [
+        { text: "retrying…", isError: true },
+        { text: "Partial answer" },
+      ],
+      runLevelError: "stream aborted",
+    });
+    expect(outcome.hasFatalErrorPayload).toBe(true);
   });
 });

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -157,7 +157,14 @@ export function resolveCronPayloadOutcome(params: {
     params.payloads
       .slice(lastErrorPayloadIndex + 1)
       .some((payload) => payload?.isError !== true && Boolean(payload?.text?.trim()));
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  // A run-level error (e.g. assistant message stopReason:"error" with
+  // errorMessage set and empty content, seen when Gemini returns HTTP 400
+  // with no body due to quota exhaustion) must also mark the run as
+  // fatally errored — otherwise cron records status="ok", delivered=false
+  // and operators chase the delivery layer for hours when the real
+  // failure was at the model call. (#69889)
+  const hasFatalErrorPayload =
+    Boolean(params.runLevelError) || (hasErrorPayload && !hasSuccessfulPayloadAfterLastError);
   const normalizedFinalAssistantVisibleText = normalizeOptionalString(
     params.finalAssistantVisibleText,
   );
@@ -189,6 +196,9 @@ export function resolveCronPayloadOutcome(params: {
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))
     ?.text?.trim();
+  const runLevelErrorText = normalizeOptionalString(
+    typeof params.runLevelError === "string" ? params.runLevelError : undefined,
+  );
   return {
     summary,
     outputText,
@@ -198,7 +208,9 @@ export function resolveCronPayloadOutcome(params: {
     deliveryPayloadHasStructuredContent,
     hasFatalErrorPayload,
     embeddedRunError: hasFatalErrorPayload
-      ? (lastErrorPayloadText ?? "cron isolated run returned an error payload")
+      ? (lastErrorPayloadText ??
+          runLevelErrorText ??
+          "cron isolated run returned an error payload")
       : undefined,
   };
 }


### PR DESCRIPTION
## Summary

Fixes #69889. When a cron job's assistant message ends with \`stopReason: \"error\"\` and a non-empty \`errorMessage\` (e.g. Gemini returning HTTP 400 with no body on quota exhaustion), the outbound delivery payload can be empty content with **no** \`isError\` flag. \`resolveCronPayloadOutcome\` inferred fatal-error status only from per-payload \`isError\`, so the cron run record got \`status: ok, delivered: false, deliveryStatus: not-delivered\`.

Downstream that reads as *delivery broken* rather than *model call failed*. The reporter chased the delivery layer for 5 days before realizing the real fault was at the model-call layer.

## Fix

In \`src/cron/isolated-agent/helpers.ts\`:

1. Treat \`runLevelError\` (already threaded in from \`finalRunResult.meta?.error\`) as another fatal-error trigger alongside per-payload \`isError\`.
2. When no per-payload error text is available but \`runLevelError\` is a string, propagate it into \`embeddedRunError\` so the cron run record carries the real reason.

## Preserved invariants

- A successful text after an isError payload still recovers when \`runLevelError\` is undefined (original behavior).
- \`runLevelError\` overrides that recovery path when set — a run-level error is authoritative.

## Test

5 new test cases in \`TestResolveCronPayloadOutcome — runLevelError handling\`:
1. runLevelError alone ⇒ fatal, embeddedRunError matches
2. isError payload preferred over runLevelError for the error text
3. no error anywhere ⇒ not fatal
4. successful-payload-after-error recovery still works when runLevelError absent
5. runLevelError overrides the recovery path

oxlint passes.

Closes #69889.