### PR TITLE
fix(models): bypass catalog cache when building /models picker data

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -154,6 +154,19 @@ describe("handleModelsCommand", () => {
     expect(buttons?.length).toBeGreaterThan(0);
   });
 
+  it("loads the model catalog with useCache=false so newly-added models appear without a restart (#69750)", async () => {
+    // Regression for #69750: loadModelCatalog caches at module scope for
+    // the gateway lifetime with no TTL. If the /model picker doesn't pass
+    // useCache:false it shows a stale keyboard whenever the user edits
+    // openclaw.json to add models. The fix applies to all text-surface
+    // /models commands that go through buildModelsProviderData.
+    await handleModelsCommand(buildModelsParams("/models", cfg, "telegram"), true);
+    const calls = modelCatalogMocks.loadModelCatalog.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const lastCall = calls.at(-1);
+    expect(lastCall?.[0]?.useCache).toBe(false);
+  });
+
   it("handles provider pagination all mode and unknown providers", async () => {
     const cases = [
       {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -46,7 +46,11 @@ export async function buildModelsProviderData(
     agentId,
   });
 
-  const catalog = await loadModelCatalog({ config: cfg });
+  // Channel /model pickers must see newly-added models without a gateway
+  // restart. loadModelCatalog caches at module scope for the gateway
+  // lifetime with no TTL or config-change hook, so reuse would show a
+  // stale keyboard whenever the user adds models to openclaw.json. (#69750)
+  const catalog = await loadModelCatalog({ config: cfg, useCache: false });
   const allowed = buildAllowedModelSet({
     cfg,
     catalog,


### PR DESCRIPTION
## Summary

Fixes #69750. \`loadModelCatalog\` caches the resolved catalog at module scope for the lifetime of the gateway process with no TTL and no config-change hook. \`buildModelsProviderData\` — called by Telegram, Discord, and Mattermost \`/model\` picker paths via \`openclaw/plugin-sdk/models-provider-runtime\` — passed the config but not \`useCache: false\`, so newly-added models under \`models.providers.*\` or \`agents.defaults.models\` never appeared in the inline keyboard until a gateway restart.

The web UI path in \`src/flows/model-picker.ts:432,617\` already passes \`useCache: false\` for the same reason, so this aligns channel pickers with the established pattern.

## Fix

One-line change in \`src/auto-reply/reply/commands-models.ts:buildModelsProviderData\` — pass \`useCache: false\` when loading the catalog.

## Scope note (shared-helper rule)

\`buildModelsProviderData\` is imported by 3 channel adapters (Telegram, Discord, Mattermost) — all of them are \`/model\` pickers, all affected by the same bug, all benefit from the fix. Single-point fix is the right shape vs. three separate per-adapter wraps. Verified via \`grep -rn buildModelsProviderData\` — no non-picker callers.

## Test

Added a regression test in \`commands-models.test.ts\` asserting that \`loadModelCatalog\` is invoked with \`useCache: false\` when \`/models\` runs through the telegram surface. Existing 18 tests in the file pass locally (oxlint clean).

Closes #69750.