### PR TITLE
fix(hooks/session-memory): sanitize chat-template tokens + tool_call XML before persisting (closes #69943)

### DIFF
--- a/src/hooks/bundled/session-memory/handler.test.ts
+++ b/src/hooks/bundled/session-memory/handler.test.ts
@@ -586,4 +586,45 @@ describe("session-memory hook", () => {
     expect(memoryContent).toContain("user: Only message 1");
     expect(memoryContent).toContain("assistant: Only message 2");
   });
+
+  it("elides assistant turns that are only chat-template garbage (transcript read path)", async () => {
+    const sessionContent = createMockSessionContent([
+      { role: "user", content: "Hello" },
+      {
+        role: "assistant",
+        content:
+          "<tool_call>\n<function=foo>\n<parameter=bar>\nbaz\n</parameter>\n</function>\n</tool_call><|im_end|>",
+      },
+      { role: "assistant", content: "NO_REPLY" },
+      { role: "assistant", content: "Legit reply after the noise." },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({ sessionContent });
+
+    expect(memoryContent).toContain("user: Hello");
+    expect(memoryContent).toContain("assistant: [malformed turn elided]");
+    expect(memoryContent).toContain("assistant: Legit reply after the noise.");
+    expect(memoryContent).not.toContain("<|im_end|>");
+    expect(memoryContent).not.toContain("<tool_call>");
+    expect(memoryContent).not.toContain("<function=foo>");
+  });
+
+  it("strips residual chat-template tokens in handler defense-in-depth pass", async () => {
+    // Model emitted `<|im_end|>` mid-sentence — not enough to elide the whole
+    // turn, but the token itself must not be persisted. The handler-level pass
+    // cleans any residue before writing to the memory file.
+    const sessionContent = createMockSessionContent([
+      {
+        role: "assistant",
+        content:
+          "Here is a long and substantive response that does not trip the elision heuristic at all. " +
+          "It explains the task in detail and then <|im_end|> continues with more content afterward " +
+          "so the surviving text stays well above the short-turn threshold.",
+      },
+    ]);
+    const { memoryContent } = await runNewWithPreviousSession({ sessionContent });
+
+    expect(memoryContent).not.toContain("<|im_end|>");
+    expect(memoryContent).toContain("long and substantive response");
+    expect(memoryContent).toContain("continues with more content afterward");
+  });
 });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -24,8 +24,8 @@ import {
 import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
-import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 import { sanitizeAssistantContent } from "./sanitize.js";
+import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
 
@@ -200,6 +200,18 @@ const saveSessionToMemory: HookHandler = async (event) => {
       const defensive = sanitizeAssistantContent(sessionContent);
       if (defensive.strippedRatio > 0) {
         log.debug("session-memory: defensive sanitization stripped residue", {
+          originalLength: defensive.originalLength,
+          strippedRatio: defensive.strippedRatio,
+        });
+      }
+      if (defensive.skipped) {
+        // Without this branch, a transcript that the defensive pass elides
+        // entirely (e.g. all-NO_REPLY, or pure chat-template scaffolding that
+        // the per-turn pass missed) is silently dropped — the memory file
+        // gets a header-only entry with no Conversation Summary and no log
+        // line explaining why. Surface it so operators can correlate empty
+        // memory files with the elision rate.
+        log.debug("session-memory: defensive pass skipped entire session content", {
           originalLength: defensive.originalLength,
           strippedRatio: defensive.strippedRatio,
         });

--- a/src/hooks/bundled/session-memory/handler.ts
+++ b/src/hooks/bundled/session-memory/handler.ts
@@ -25,6 +25,7 @@ import { resolveHookConfig } from "../../config.js";
 import type { HookHandler } from "../../hooks.js";
 import { generateSlugViaLLM } from "../../llm-slug-generator.js";
 import { findPreviousSessionFile, getRecentSessionContentWithResetFallback } from "./transcript.js";
+import { sanitizeAssistantContent } from "./sanitize.js";
 
 const log = createSubsystemLogger("hooks/session-memory");
 
@@ -192,7 +193,21 @@ const saveSessionToMemory: HookHandler = async (event) => {
 
     // Include conversation content if available
     if (sessionContent) {
-      entryParts.push("## Conversation Summary", "", sessionContent, "");
+      // Defense in depth: strip chat-template tokens and raw tool_call XML in
+      // case a future caller bypasses the transcript-layer sanitization. The
+      // per-turn elision has already happened in transcript.ts; this pass just
+      // catches any residual leaked tokens on otherwise-legit turns.
+      const defensive = sanitizeAssistantContent(sessionContent);
+      if (defensive.strippedRatio > 0) {
+        log.debug("session-memory: defensive sanitization stripped residue", {
+          originalLength: defensive.originalLength,
+          strippedRatio: defensive.strippedRatio,
+        });
+      }
+      const safeSessionContent = defensive.skipped ? "" : defensive.text;
+      if (safeSessionContent.length > 0) {
+        entryParts.push("## Conversation Summary", "", safeSessionContent, "");
+      }
     }
 
     const entry = entryParts.join("\n");

--- a/src/hooks/bundled/session-memory/sanitize.test.ts
+++ b/src/hooks/bundled/session-memory/sanitize.test.ts
@@ -49,6 +49,45 @@ describe("sanitizeAssistantContent", () => {
     expect(twoResult.text).toBe("pre  mid  post");
   });
 
+  it("strips an unclosed <tool_call> block that lost its closing tag mid-stream", () => {
+    // Mid-stream truncation: the model started emitting a tool_call but the
+    // stream cut before `</tool_call>`. Without the unclosed-block branch in
+    // the regex, the fragment used to be persisted verbatim and re-injected
+    // as scaffolding on the next /new.
+    const input = [
+      "This was a substantive response that should be preserved well above the short-turn elision threshold.",
+      "<tool_call>",
+      "<function=foo>",
+      "<parameter=bar>",
+      "baz",
+    ].join("\n");
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).not.toContain("<tool_call>");
+    expect(result.text).not.toContain("<function=foo>");
+    expect(result.text).not.toContain("<parameter=bar>");
+    expect(result.text).toContain("substantive response");
+    expect(result.skipped).toBe(false);
+  });
+
+  it("strips an unclosed <tool_call> with no preceding content (whole turn is the fragment)", () => {
+    const input = "<tool_call>\n<function=foo>\n";
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe("");
+    expect(result.skipped).toBe(true);
+  });
+
+  it("prefers the closing tag over the open-ended branch when both are available", () => {
+    // First non-greedy alternative must win so trailing legit content after
+    // a properly-closed block is preserved instead of being eaten by the
+    // open-ended fallback.
+    const input =
+      "<tool_call><function=a></function></tool_call>This trailing prose has plenty of substance to remain after sanitization, well past the short-turn threshold.";
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toContain("trailing prose");
+    expect(result.text).not.toContain("<tool_call>");
+    expect(result.text).not.toContain("<function=a>");
+  });
+
   it("strips orphaned role-label-only lines", () => {
     const input = ["This is a real reply.", "assistant:", "user", "system: ", "Another line."].join(
       "\n",
@@ -98,6 +137,20 @@ describe("sanitizeAssistantContent", () => {
     expect(result.text).not.toContain("<|im_end|>");
     expect(result.text.length).toBeGreaterThan(1000);
     expect(result.text).toContain("thoughtful paragraph");
+  });
+
+  it("strippedRatio is not inflated by blank-line collapse or trim", () => {
+    // The body is wrapped in leading/trailing whitespace and contains a run
+    // of blank lines. Phase 2 (blank-line collapse + trim) shrinks the
+    // string further, but the ratio is measured against the post-token-strip
+    // intermediate length, not the final cleaned length, so a clean payload
+    // surrounded by cosmetic whitespace must report a 0 ratio.
+    const body = "This is a perfectly legitimate paragraph of content.";
+    const input = `\n\n\n\n${body}\n\n\n\n`;
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe(body);
+    expect(result.strippedRatio).toBe(0);
+    expect(result.skipped).toBe(false);
   });
 
   it("is a no-op on clean markdown content", () => {

--- a/src/hooks/bundled/session-memory/sanitize.test.ts
+++ b/src/hooks/bundled/session-memory/sanitize.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { ELIDED_TURN_MARKER, sanitizeAssistantContent } from "./sanitize.js";
+
+describe("sanitizeAssistantContent", () => {
+  it("strips <|im_end|> and <|im_start|> chat template tokens", () => {
+    const input =
+      "<|im_start|>Hello, world. This is a longer legit response with enough content to survive the short-turn heuristic.<|im_end|>";
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe(
+      "Hello, world. This is a longer legit response with enough content to survive the short-turn heuristic.",
+    );
+    expect(result.skipped).toBe(false);
+  });
+
+  it("strips <|endoftext|>, <|eot_id|>, and bos/eos markers", () => {
+    const input =
+      "<bos>hello<|endoftext|> world<|eot_id|><|begin_of_text|> ok <eos><|end_of_text|> and still plenty of legit content remaining to avoid the elision heuristic.";
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).not.toContain("<|");
+    expect(result.text).not.toContain("<bos>");
+    expect(result.text).not.toContain("<eos>");
+    expect(result.text).toContain("hello");
+    expect(result.text).toContain("world");
+    expect(result.text).toContain("ok");
+    expect(result.skipped).toBe(false);
+  });
+
+  it("strips raw <tool_call>...</tool_call> XML blocks including multiline and multi-per-line", () => {
+    const multiline = [
+      "before",
+      "<tool_call>",
+      "<function=x>",
+      "<parameter=y>",
+      "z",
+      "</parameter>",
+      "</function>",
+      "</tool_call>",
+      "after",
+    ].join("\n");
+    const multilineResult = sanitizeAssistantContent(multiline);
+    expect(multilineResult.text).toContain("before");
+    expect(multilineResult.text).toContain("after");
+    expect(multilineResult.text).not.toContain("<tool_call>");
+    expect(multilineResult.text).not.toContain("<function=x>");
+
+    const twoOnOneLine =
+      "pre <tool_call><function=a></function></tool_call> mid <tool_call><function=b></function></tool_call> post";
+    const twoResult = sanitizeAssistantContent(twoOnOneLine);
+    expect(twoResult.text).toBe("pre  mid  post");
+  });
+
+  it("strips orphaned role-label-only lines", () => {
+    const input = ["This is a real reply.", "assistant:", "user", "system: ", "Another line."].join(
+      "\n",
+    );
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toContain("This is a real reply.");
+    expect(result.text).toContain("Another line.");
+    expect(result.text).not.toMatch(/^assistant:\s*$/m);
+    expect(result.text).not.toMatch(/^user\s*$/m);
+    expect(result.text).not.toMatch(/^system:\s*$/m);
+  });
+
+  it("preserves legit content mentioning roles in prose", () => {
+    const input = "The assistant then replied, and the user: asked another question.";
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe(input);
+    expect(result.skipped).toBe(false);
+  });
+
+  it("marks a turn as skipped when cleaned content is empty", () => {
+    const input = "<|im_start|><|im_end|><|endoftext|>";
+    const result = sanitizeAssistantContent(input);
+    expect(result.skipped).toBe(true);
+  });
+
+  it("marks a turn as skipped when cleaned content is only NO_REPLY", () => {
+    expect(sanitizeAssistantContent("NO_REPLY").skipped).toBe(true);
+    expect(sanitizeAssistantContent("no_reply").skipped).toBe(true);
+    expect(sanitizeAssistantContent("  NO_REPLY  ").skipped).toBe(true);
+    expect(sanitizeAssistantContent("<|im_end|>NO_REPLY<|im_end|>").skipped).toBe(true);
+  });
+
+  it("marks a turn as skipped when >50% was stripped and remainder is short", () => {
+    const tokens = "<|im_end|>".repeat(60); // 600 chars of tokens
+    const input = `${tokens}hi`;
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe("hi");
+    expect(result.strippedRatio).toBeGreaterThan(0.5);
+    expect(result.skipped).toBe(true);
+  });
+
+  it("does NOT mark long legit content as skipped even with a few tokens", () => {
+    const paragraph = "This is a thoughtful paragraph of legitimate content. ".repeat(40); // ~2200 chars
+    const input = `${paragraph}<|im_end|>`;
+    const result = sanitizeAssistantContent(input);
+    expect(result.skipped).toBe(false);
+    expect(result.text).not.toContain("<|im_end|>");
+    expect(result.text.length).toBeGreaterThan(1000);
+    expect(result.text).toContain("thoughtful paragraph");
+  });
+
+  it("is a no-op on clean markdown content", () => {
+    const input = [
+      "# Heading",
+      "",
+      "Some **bold** text and a [link](https://example.com).",
+      "",
+      "- item 1",
+      "- item 2",
+    ].join("\n");
+    const result = sanitizeAssistantContent(input);
+    expect(result.text).toBe(input);
+    expect(result.skipped).toBe(false);
+    expect(result.strippedRatio).toBe(0);
+  });
+
+  it("exports the elided-turn marker for caller use", () => {
+    expect(ELIDED_TURN_MARKER).toBe("[malformed turn elided]");
+  });
+});

--- a/src/hooks/bundled/session-memory/sanitize.ts
+++ b/src/hooks/bundled/session-memory/sanitize.ts
@@ -22,10 +22,14 @@ const CHAT_TEMPLATE_TOKENS =
 
 /**
  * Raw `<tool_call>...</tool_call>` XML blocks that leaked into the content
- * channel before the parser converted them. Non-greedy so multiple blocks on
- * the same line are handled independently.
+ * channel before the parser converted them. The first alternative is
+ * non-greedy so multiple closed blocks on the same line are handled
+ * independently. The second alternative covers mid-stream-truncated blocks
+ * that lost their closing tag (e.g. a stream cut after `<tool_call>\n<function=...>`),
+ * which would otherwise be persisted verbatim and re-injected as scaffolding
+ * on the next /new.
  */
-const TOOL_CALL_XML = /<tool_call>[\s\S]*?<\/tool_call>/g;
+const TOOL_CALL_XML = /<tool_call>(?:[\s\S]*?<\/tool_call>|[\s\S]*$)/g;
 
 /**
  * Lines that are nothing but a bare role label — either `role:` with optional
@@ -59,17 +63,22 @@ export interface SanitizeResult {
 export function sanitizeAssistantContent(raw: string): SanitizeResult {
   const originalLength = raw.length;
 
-  let cleaned = raw
+  // Phase 1: strip the structural artifacts (tokens, tool_call XML, orphan
+  // role lines). The ratio is measured against this intermediate length so
+  // it reflects only meaningful removals, not cosmetic blank-line collapse
+  // or trailing whitespace trim from phase 2.
+  const stripped = raw
     .replace(CHAT_TEMPLATE_TOKENS, "")
     .replace(TOOL_CALL_XML, "")
-    .replace(ORPHAN_ROLE_LINE, "")
-    .replace(EXCESS_BLANK_LINES, "\n\n");
+    .replace(ORPHAN_ROLE_LINE, "");
 
-  // Trim leading/trailing whitespace introduced by the stripping above,
-  // but preserve internal newlines.
+  // Phase 2: cosmetic cleanup — collapse 3+ blank lines to 2 and trim outer
+  // whitespace. These changes are not counted in `strippedRatio`.
+  let cleaned = stripped.replace(EXCESS_BLANK_LINES, "\n\n");
   cleaned = cleaned.replace(/^\s+|\s+$/g, "");
 
-  const strippedRatio = originalLength === 0 ? 0 : (originalLength - cleaned.length) / originalLength;
+  const strippedRatio =
+    originalLength === 0 ? 0 : (originalLength - stripped.length) / originalLength;
 
   let skipped = false;
   const trimmed = cleaned.trim();

--- a/src/hooks/bundled/session-memory/sanitize.ts
+++ b/src/hooks/bundled/session-memory/sanitize.ts
@@ -1,0 +1,93 @@
+/**
+ * Session memory sanitization.
+ *
+ * Quantized local model servers periodically leak chat-template control tokens
+ * (e.g. `<|im_end|>`, `<|endoftext|>`) and unparsed `<tool_call>` XML blocks into
+ * the assistant content channel. When those artifacts get persisted into the
+ * per-agent memory file and re-injected as "Conversation Summary" context on
+ * the next /new, the model interprets the embedded role markers as in-progress
+ * chat-template scaffolding and emits more malformed output. The hook then
+ * saves that malformed output, and the loop degrades the agent over time.
+ *
+ * This module strips the known artifact classes and flags structurally garbage
+ * turns so the caller can elide them rather than persisting poison.
+ */
+
+/**
+ * Chat-template control tokens emitted by common local-model chat templates
+ * (Qwen, Llama, Mistral, generic). Matched case-sensitive, exact form.
+ */
+const CHAT_TEMPLATE_TOKENS =
+  /<\|(?:im_start|im_end|endoftext|system|user|assistant|fim_prefix|fim_suffix|fim_middle|start_header_id|end_header_id|eot_id|begin_of_text|end_of_text|pad)\|>|<\/?(?:eos|bos)>/g;
+
+/**
+ * Raw `<tool_call>...</tool_call>` XML blocks that leaked into the content
+ * channel before the parser converted them. Non-greedy so multiple blocks on
+ * the same line are handled independently.
+ */
+const TOOL_CALL_XML = /<tool_call>[\s\S]*?<\/tool_call>/g;
+
+/**
+ * Lines that are nothing but a bare role label — either `role:` with optional
+ * trailing whitespace, or the role word alone on a line. These are leaked
+ * scaffolding, not legitimate content. In-sentence uses like "The user: asked
+ * me..." are unaffected because they have surrounding text on the same line.
+ */
+const ORPHAN_ROLE_LINE = /^[ \t]*(?:assistant|user|system)[:\s]*$/gm;
+
+/**
+ * Runs of 3+ blank lines collapse to 2. Stripping above tends to leave blank
+ * lines behind; this keeps the output tidy without changing paragraph breaks.
+ */
+const EXCESS_BLANK_LINES = /\n{3,}/g;
+
+export interface SanitizeResult {
+  /** Sanitized text. Meaningful only when `skipped` is false. */
+  text: string;
+  /** True when the caller should elide this turn entirely. */
+  skipped: boolean;
+  /** Ratio of content removed by sanitization; useful for observability. */
+  strippedRatio: number;
+  /** Original input length, in characters. */
+  originalLength: number;
+}
+
+/**
+ * Sanitize a raw assistant (or user) content string before it is persisted
+ * into a memory file or re-injected as context.
+ */
+export function sanitizeAssistantContent(raw: string): SanitizeResult {
+  const originalLength = raw.length;
+
+  let cleaned = raw
+    .replace(CHAT_TEMPLATE_TOKENS, "")
+    .replace(TOOL_CALL_XML, "")
+    .replace(ORPHAN_ROLE_LINE, "")
+    .replace(EXCESS_BLANK_LINES, "\n\n");
+
+  // Trim leading/trailing whitespace introduced by the stripping above,
+  // but preserve internal newlines.
+  cleaned = cleaned.replace(/^\s+|\s+$/g, "");
+
+  const strippedRatio = originalLength === 0 ? 0 : (originalLength - cleaned.length) / originalLength;
+
+  let skipped = false;
+  const trimmed = cleaned.trim();
+  if (trimmed === "") {
+    skipped = true;
+  } else if (trimmed.toUpperCase() === "NO_REPLY") {
+    // NO_REPLY is housekeeping, not conversation content. Persisting it into
+    // memory files re-injects it as "history" that makes the model think its
+    // last reply was NO_REPLY, encouraging the same behavior next turn.
+    skipped = true;
+  } else if (strippedRatio > 0.5 && cleaned.length < 80) {
+    // Most of the turn was garbage and what's left is too short to carry
+    // meaningful context. Elide rather than persist a fragment.
+    skipped = true;
+  }
+
+  return { text: cleaned, skipped, strippedRatio, originalLength };
+}
+
+/** Marker persisted in place of an elided turn, so operators can see the signal. */
+export const ELIDED_TURN_MARKER = "[malformed turn elided]";

--- a/src/hooks/bundled/session-memory/transcript.ts
+++ b/src/hooks/bundled/session-memory/transcript.ts
@@ -1,6 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { hasInterSessionUserProvenance } from "../../../sessions/input-provenance.js";
+import { ELIDED_TURN_MARKER, sanitizeAssistantContent } from "./sanitize.js";
+
+const log = createSubsystemLogger("hooks/session-memory");
 
 function extractTextMessageContent(content: unknown): string | undefined {
   if (typeof content === "string") {
@@ -46,7 +50,17 @@ export async function getRecentSessionContent(
             }
             const text = extractTextMessageContent(msg.content);
             if (text && !text.startsWith("/")) {
-              allMessages.push(`${role}: ${text}`);
+              const sanitized = sanitizeAssistantContent(text);
+              if (sanitized.skipped) {
+                log.debug("session-memory: elided malformed turn", {
+                  role,
+                  originalLength: sanitized.originalLength,
+                  strippedRatio: sanitized.strippedRatio,
+                });
+                allMessages.push(`${role}: ${ELIDED_TURN_MARKER}`);
+              } else {
+                allMessages.push(`${role}: ${sanitized.text}`);
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- **Problem:** The bundled `session-memory` hook persisted raw chat-template control tokens, unmatched role markers, and unparsed `<tool_call>` XML into `~/.openclaw/workspace-<agent>/memory/<date>.md`. On the next `/new`, the hook re-injected that file as **Conversation Summary** context — poisoning the next reply and feeding a self-reinforcing degradation loop until affected agents only emitted `NO_REPLY`.
- **Why it matters:** Quarantining a single memory file does not break the loop — the hook fires on the first `/new` after quarantine and re-poisons from the live session transcript. Disabling the hook globally was the only working workaround. Agents degrade silently over hours/days.
- **What changed:** New `sanitize.ts` module runs on both the transcript read path (per-turn, via `getRecentSessionContent`) and the handler write path (defense-in-depth). Chat-template tokens and `<tool_call>` XML blocks are stripped; turns that collapse to empty / `NO_REPLY` / mostly-garbage are replaced with a visible `[malformed turn elided]` sentinel.
- **What did NOT change (scope boundary):** No public config surface change. No change to the `## Conversation Summary` section format beyond the elision sentinel. The upstream parser leak (quantized local model servers leaking tokens into the content channel) is intentionally out of scope — this hook is made defensive regardless of upstream provider behavior.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage
- [x] Skills / tool execution

## Linked Issue/PR

- Closes #69943
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Neither the read path nor the write path had any sanitization. `src/hooks/bundled/session-memory/transcript.ts::extractTextMessageContent()` returns the raw model output string and `getRecentSessionContent()` pushes it directly to `allMessages`. `src/hooks/bundled/session-memory/handler.ts` then `entryParts.push(sessionContent)` writes the joined string verbatim under `## Conversation Summary`.
- **Missing detection / guardrail:** no per-turn validator in the hook, and no provider-level template-token filter — leaks that reached the content channel landed untouched in the memory file.
- **Contributing context:** quantized local model servers (e.g. `mlx-community/Qwen3.5-9B-OptiQ-4bit`, `Qwen3.5-27B-4bit-DWQ` via rapid-mlx) occasionally leak chat-template tokens and tool-call XML into the assistant content channel when the parser races the stream.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test (sanitizer pure function)
  - [x] Seam / integration test (transcript read path + handler write path)
- Target test or file: `src/hooks/bundled/session-memory/sanitize.test.ts` (new, 11 cases) + `src/hooks/bundled/session-memory/handler.test.ts` (+2 wiring cases).
- Scenario the test should lock in: malformed assistant turns (chat-template tokens, `<tool_call>` XML, `NO_REPLY`) are elided to a visible sentinel; legitimate prose — including content that happens to mention roles — is preserved without false positives.
- Why this is the smallest reliable guardrail: sanitization is a pure string transform and the hook's entry/exit points are well-defined; unit + wiring tests cover the only two call sites.
- Existing test that already covers this (if any): none — this was a greenfield concern.
- If no new test is added, why not: N/A (13 new tests added).

## User-visible / Behavior Changes

- Memory files may contain `[malformed turn elided]` sentinel lines where previously they contained raw chat-template garbage. No format change otherwise.
- New `session-memory: elided malformed turn` debug log line fires on every elision (with `originalLength` + `strippedRatio`) so operators can watch the rate.

## Diagram (if applicable)

```text
Before:
[model leak] -> transcript.ts (raw)
             -> handler.ts (writes verbatim)
             -> memory/<date>.md (poisoned)
             -> next /new re-injects poison -> degrade loop

After:
[model leak] -> transcript.ts -> sanitize() per turn -> [malformed turn elided]
             -> handler.ts -> sanitize() (defense in depth)
             -> memory/<date>.md (clean, sentinel visible)
             -> next /new stays clean
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Net: purely a string-sanitization pass on content that was already being read/written by the hook. If anything, this reduces risk by preventing re-injection of attacker/model-supplied chat-template scaffolding into future prompts.

## Repro + Verification

### Environment

- OS: macOS 26.5 (arm64)
- Runtime/container: Node v25.9.0, OpenClaw main
- Model/provider: quantized local (Qwen3.5 4bit via rapid-mlx) for the original repro; sanitizer tested with synthesized inputs in vitest
- Integration/channel (if any): Telegram
- Relevant config (redacted): default `session-memory` hook enabled

### Steps

1. Use a quantized local provider that occasionally leaks `<|im_end|>` / `<tool_call>` into the content channel.
2. Leave `session-memory` hook enabled. Send a few prompts across multiple `/new` sessions.
3. Observe `~/.openclaw/workspace-<agent>/memory/<date>.md` filling with raw template tokens and XML; next replies degrade to `NO_REPLY`.

### Expected

- Memory file contains only clean assistant prose; malformed turns replaced with `[malformed turn elided]`.

### Actual (before fix)

- Memory file contains `<|im_end|>`, `<tool_call>...</tool_call>` XML, orphaned `assistant:` lines — which re-inject on next `/new`.

### Actual (after fix)

- Memory file contains legit prose verbatim; garbage turns collapsed to the elision sentinel. Degradation loop broken.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

**Before — persisted verbatim and re-injected on next `/new`:**

```
assistant: Case subagent is active. Dispatching task.

<tool_call>
<function=sessions_send>
<parameter=message>Write a Python script to parse a CSV file.</parameter>
</function>
</tool_call><|im_end|>
assistant: <tool_call>
<function=sessions_spawn>
...
</function>
</tool_call><|im_end|>
assistant: Dispatched to case. Session spawned.<|im_end|>
assistant: Script's written. `csv_parser.py` is ready.
```

**After — same input through the sanitizer:**

```
assistant: Case subagent is active. Dispatching task.
assistant: [malformed turn elided]
assistant: [malformed turn elided]
assistant: Dispatched to case. Session spawned.
assistant: Script's written. `csv_parser.py` is ready.
```

**Test run:**

```
$ pnpm test -- src/hooks/bundled/session-memory/handler.test.ts src/hooks/bundled/session-memory/sanitize.test.ts
✓ sanitize.test.ts (11 tests)
✓ handler.test.ts (20 tests)
Test Files  2 passed (2)
     Tests  31 passed (31)
```

## Human Verification (required)

- **Verified scenarios:** ran the sanitizer against the reporter's evidence file locally; confirmed every `<|im_end|>` and `<tool_call>...</tool_call>` block is stripped, legit prose is preserved, empty/NO_REPLY turns collapse to the sentinel. Ran the full 31-test suite; all pass.
- **Edge cases checked:** long legit content with a single incidental token leak (not marked skipped, prose preserved); content that mentions roles in prose ("The assistant then replied, and the user: asked…") — preserved as-is; multi-block `<tool_call>` XML on a single line; blocks spanning 20+ lines; mixed legit + garbage turns; clean markdown (headings/bold/links/lists) is a no-op (`strippedRatio === 0`).
- **What I did NOT verify:** real-world re-running with the originally-affected quantized model on the reporter's deployment — prospective verification belongs to @reidperyam who offered to test post-merge.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- Existing memory files that already contain template-token garbage aren't rewritten by this PR (sanitization is applied on write, not retroactively). Operators who want a clean slate can quarantine the affected `memory/<date>.md` files — with the fix in place, the re-poisoning loop will not re-form.

## Risks and Mitigations

- **Risk:** false positives — legit assistant content that happens to contain an `<|…|>` substring or discusses tool-call XML could be stripped.
  - **Mitigation:** the token allowlist is explicit (no generic `<|…|>` wildcard); the `skipped` threshold requires both `strippedRatio > 0.5` **and** `cleaned.length < 80`, so long legit content with incidental noise is preserved. Covered by `does NOT mark long legit content as skipped` and `preserves legit content mentioning roles in prose` tests.
- **Risk:** silent drop of information — a poisoned turn that carried useful context is replaced wholesale.
  - **Mitigation:** the sentinel `[malformed turn elided]` is visible in the memory file and a debug log fires with `originalLength` + `strippedRatio` for rate observability. Operators can escalate the log level if they want to inspect elided turns.
