### PR TITLE
fix restart CI typings and prefer the current worktree under Vitest

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -63,11 +63,6 @@ Notes:
 - `--raw-stream`: log raw model stream events to jsonl.
 - `--raw-stream-path <path>`: raw stream jsonl path.
 
-Startup profiling:
-
-- Set `OPENCLAW_GATEWAY_STARTUP_TRACE=1` to log phase timings during Gateway startup.
-- Run `pnpm test:startup:gateway -- --runs 5 --warmup 1` to benchmark Gateway startup. The benchmark records first process output, `/healthz`, `/readyz`, and startup trace timings.
-
 ## Query a running Gateway
 
 All query commands use WebSocket RPC.
@@ -95,8 +90,6 @@ Pass `--token` or `--password` explicitly. Missing explicit credentials is an er
 openclaw gateway health --url ws://127.0.0.1:18789
 ```
 
-The HTTP `/healthz` endpoint is a liveness probe: it returns once the server can answer HTTP. The HTTP `/readyz` endpoint is stricter and stays red while startup sidecars, channels, or configured hooks are still settling.
-
 ### `gateway usage-cost`
 
 Fetch usage-cost summaries from session logs.
@@ -113,7 +106,7 @@ Options:
 
 ### `gateway status`
 
-`gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional probe of connectivity/auth capability.
+`gateway status` shows the Gateway service (launchd/systemd/schtasks) plus an optional RPC probe.
 
 ```bash
 openclaw gateway status
@@ -127,18 +120,17 @@ Options:
 - `--token <token>`: token auth for the probe.
 - `--password <password>`: password auth for the probe.
 - `--timeout <ms>`: probe timeout (default `10000`).
-- `--no-probe`: skip the connectivity probe (service-only view).
+- `--no-probe`: skip the RPC probe (service-only view).
 - `--deep`: scan system-level services too.
-- `--require-rpc`: upgrade the default connectivity probe to a read probe and exit non-zero when that read probe fails. Cannot be combined with `--no-probe`.
+- `--require-rpc`: exit non-zero when the RPC probe fails. Cannot be combined with `--no-probe`.
 
 Notes:
 
 - `gateway status` stays available for diagnostics even when the local CLI config is missing or invalid.
-- Default `gateway status` proves service state, WebSocket connect, and the auth capability visible at handshake time. It does not prove read/write/admin operations.
 - `gateway status` resolves configured auth SecretRefs for probe auth when possible.
 - If a required auth SecretRef is unresolved in this command path, `gateway status --json` reports `rpc.authWarning` when probe connectivity/auth fails; pass `--token`/`--password` explicitly or resolve the secret source first.
 - If the probe succeeds, unresolved auth-ref warnings are suppressed to avoid false positives.
-- Use `--require-rpc` in scripts and automation when a listening service is not enough and you need read-scope RPC calls to be healthy too.
+- Use `--require-rpc` in scripts and automation when a listening service is not enough and you need the Gateway RPC itself to be healthy.
 - `--deep` adds a best-effort scan for extra launchd/systemd/schtasks installs. When multiple gateway-like services are detected, human output prints cleanup hints and warns that most setups should run one gateway per machine.
 - Human output includes the resolved file log path plus the CLI-vs-service config paths/validity snapshot to help diagnose profile or state-dir drift.
 - On Linux systemd installs, service auth drift checks read both `Environment=` and `EnvironmentFile=` values from the unit (including `%h`, quoted paths, multiple files, and optional `-` files).
@@ -169,9 +161,8 @@ openclaw gateway probe --json
 Interpretation:
 
 - `Reachable: yes` means at least one target accepted a WebSocket connect.
-- `Capability: read-only|write-capable|admin-capable|pairing-pending|connect-only` reports what the probe could prove about auth. It is separate from reachability.
-- `Read probe: ok` means read-scope detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
-- `Read probe: limited - missing scope: operator.read` means connect succeeded but read-scope RPC is limited. This is reported as **degraded** reachability, not full failure.
+- `RPC: ok` means detail RPC calls (`health`/`status`/`system-presence`/`config.get`) also succeeded.
+- `RPC: limited - missing scope: operator.read` means connect succeeded but detail RPC is scope-limited. This is reported as **degraded** reachability, not full failure.
 - Exit code is non-zero only when no probed target is reachable.
 
 JSON notes (`--json`):
@@ -179,7 +170,6 @@ JSON notes (`--json`):
 - Top level:
   - `ok`: at least one target is reachable.
   - `degraded`: at least one target had scope-limited detail RPC.
-  - `capability`: best capability seen across reachable targets (`read_only`, `write_capable`, `admin_capable`, `pairing_pending`, `connected_no_operator_scope`, or `unknown`).
   - `primaryTargetId`: best target to treat as the active winner in this order: explicit URL, SSH tunnel, configured remote, then local loopback.
   - `warnings[]`: best-effort warning records with `code`, `message`, and optional `targetIds`.
   - `network`: local loopback/tailnet URL hints derived from current config and host networking.
@@ -188,17 +178,13 @@ JSON notes (`--json`):
   - `ok`: reachability after connect + degraded classification.
   - `rpcOk`: full detail RPC success.
   - `scopeLimited`: detail RPC failed due to missing operator scope.
-- Per target (`targets[].auth`):
-  - `role`: auth role reported in `hello-ok` when available.
-  - `scopes`: granted scopes reported in `hello-ok` when available.
-  - `capability`: the surfaced auth capability classification for that target.
 
 Common warning codes:
 
 - `ssh_tunnel_failed`: SSH tunnel setup failed; the command fell back to direct probes.
 - `multiple_gateways`: more than one target was reachable; this is unusual unless you intentionally run isolated profiles, such as a rescue bot.
 - `auth_secretref_unresolved`: a configured auth SecretRef could not be resolved for a failed target.
-- `probe_scope_limited`: WebSocket connect succeeded, but the read probe was limited by missing `operator.read`.
+- `probe_scope_limited`: WebSocket connect succeeded, but detail RPC was limited by missing `operator.read`.
 
 #### Remote over SSH (Mac app parity)
 
@@ -261,7 +247,8 @@ Command options:
 
 - `gateway status`: `--url`, `--token`, `--password`, `--timeout`, `--no-probe`, `--require-rpc`, `--deep`, `--json`
 - `gateway install`: `--port`, `--runtime <node|bun>`, `--token`, `--force`, `--json`
-- `gateway uninstall|start|stop|restart`: `--json`
+- `gateway restart`: `--url`, `--token`, `--password`, `--timeout`, `--json`
+- `gateway uninstall|start|stop`: `--json`
 
 Notes:
 
@@ -272,6 +259,8 @@ Notes:
 - In inferred auth mode, shell-only `OPENCLAW_GATEWAY_PASSWORD` does not relax install token requirements; use durable config (`gateway.auth.password` or config `env`) when installing a managed service.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.
 - Lifecycle commands accept `--json` for scripting.
+- `gateway restart` first tries `gateway.restart` over RPC when targeting the **local managed gateway**.
+- If the gateway is configured in remote mode, or you pass an explicit `--url`, restart skips the RPC-first path and falls back to the existing service-manager or unmanaged restart behavior.
 
 ## Discover gateways (Bonjour)
 

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -140,6 +140,13 @@ openclaw doctor
 `gateway status --deep` is for extra service discovery (LaunchDaemons/systemd system
 units/schtasks), not a deeper RPC health probe.
 
+Restart semantics:
+
+- `openclaw gateway restart` can still interrupt the **active in-flight top-level turn**.
+- The **session/history survives**.
+- Restart is now treated as a **terminal handoff** with durable restart intent and post-boot follow-up instead of a silent mid-turn disappearance.
+- Details: [/gateway/restart-handoff](/gateway/restart-handoff).
+
 ## Multiple gateways (same host)
 
 Most installs should run one gateway per machine. A single gateway can host multiple

--- a/docs/gateway/restart-handoff.md
+++ b/docs/gateway/restart-handoff.md
@@ -1,0 +1,76 @@
+# Turn-aware gateway restart
+
+`openclaw gateway restart` now treats restart as a **terminal handoff** for the active top-level turn instead of pretending the in-flight turn can keep running inline through process restart.
+
+## What changed
+
+Before this change, a self-requested gateway restart could kill the coordinator that was still responsible for finishing the current turn. The session history survived, but the active turn could disappear with an ambiguous outcome.
+
+The new gateway-side restart transaction adds:
+
+- a durable `restart-transaction` record
+- two restart modes:
+  - `terminal-handoff`
+  - `drain-then-restart`
+- durable interrupted-turn metadata when the requester is the active top-level turn
+- post-boot follow-up delivery through the restart sentinel path
+
+## Current guarantees
+
+When the gateway is reachable and restart flows through the gateway transaction:
+
+- the **session survives**
+- the **active in-flight top-level turn may still be interrupted**
+- restart intent is persisted before restart is emitted
+- interrupted-turn context is persisted for post-boot follow-up
+- the user should receive an explicit follow-up instead of a silent disappearance
+
+## What this does not do
+
+This change does **not** provide transparent continuation of arbitrary in-flight work.
+
+It intentionally does **not**:
+
+- replay arbitrary tool stacks
+- claim exactly-once behavior for side effects
+- make restart invisible to the active turn
+
+The product rule is:
+
+> Restart is a terminal handoff action, not a normal inline tool call.
+
+## Restart modes
+
+### `terminal-handoff`
+
+Used when the active top-level turn is the requester.
+
+- persist restart intent
+- persist interrupted-turn metadata
+- abort the active run for restart
+- restart the gateway
+- send a post-boot interruption or completion follow-up
+
+### `drain-then-restart`
+
+Used when there is no active top-level requester tied to the restart.
+
+- record the restart transaction
+- mark the restart as draining
+- restart the gateway
+- complete the transaction through the sentinel/post-boot path
+
+## Phase split
+
+This document describes the **Phase 1 gateway-only** change.
+
+Phase 1 includes:
+
+- restart transaction state
+- `gateway.restart`
+- config/update wiring through the transaction
+- post-boot follow-up for interrupted turns
+
+Phase 1 does **not** include the CLI RPC-first bridge.
+
+That CLI behavior is a separate follow-up so the gateway-side behavior can be reviewed on its own.

--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -1,8 +1,4 @@
-import fs from "node:fs/promises";
-import os from "node:os";
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { withEnvAsync } from "../test-utils/env.js";
 import "./test-helpers/fast-core-tools.js";
 import { createGatewayTool } from "./tools/gateway-tool.js";
 import { callGatewayTool } from "./tools/gateway.js";
@@ -94,48 +90,26 @@ describe("gateway tool", () => {
     expect(tool.ownerOnly).toBe(true);
   });
 
-  it("schedules SIGUSR1 restart", async () => {
-    vi.useFakeTimers();
-    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
-    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+  it("routes restart through gateway.restart", async () => {
+    const tool = requireGatewayTool("agent:main:whatsapp:dm:+15555550123");
 
-    try {
-      await withEnvAsync(
-        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_PROFILE: "isolated" },
-        async () => {
-          const tool = requireGatewayTool();
+    await tool.execute("call1", {
+      action: "restart",
+      delayMs: 0,
+      reason: "test-restart",
+      note: "Restarting now",
+    });
 
-          const result = await tool.execute("call1", {
-            action: "restart",
-            delayMs: 0,
-          });
-          expect(result.details).toMatchObject({
-            ok: true,
-            pid: process.pid,
-            signal: "SIGUSR1",
-            delayMs: 0,
-          });
-
-          const sentinelPath = path.join(stateDir, "restart-sentinel.json");
-          const raw = await fs.readFile(sentinelPath, "utf-8");
-          const parsed = JSON.parse(raw) as {
-            payload?: { kind?: string; doctorHint?: string | null };
-          };
-          expect(parsed.payload?.kind).toBe("restart");
-          expect(parsed.payload?.doctorHint).toBe(
-            "Run: openclaw --profile isolated doctor --non-interactive",
-          );
-
-          expect(kill).not.toHaveBeenCalled();
-          await vi.runAllTimersAsync();
-          expect(kill).toHaveBeenCalledWith(process.pid, "SIGUSR1");
-        },
-      );
-    } finally {
-      kill.mockRestore();
-      vi.useRealTimers();
-      await fs.rm(stateDir, { recursive: true, force: true });
-    }
+    expect(callGatewayTool).toHaveBeenCalledWith(
+      "gateway.restart",
+      expect.any(Object),
+      expect.objectContaining({
+        sessionKey: "agent:main:whatsapp:dm:+15555550123",
+        note: "Restarting now",
+        reason: "test-restart",
+        restartDelayMs: 0,
+      }),
+    );
   });
 
   it("passes config.apply through gateway call", async () => {

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -3,14 +3,7 @@ import { Type } from "@sinclair/typebox";
 import { isRestartEnabled } from "../../config/commands.flags.js";
 import { parseConfigJson5, resolveConfigSnapshotHash } from "../../config/io.js";
 import { applyMergePatch } from "../../config/merge-patch.js";
-import { extractDeliveryInfo } from "../../config/sessions.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  formatDoctorNonInteractiveHint,
-  type RestartSentinelPayload,
-  writeRestartSentinel,
-} from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { collectEnabledInsecureOrDangerousFlags } from "../../security/dangerous-config-flags.js";
 import { normalizeOptionalString, readStringValue } from "../../shared/string-coerce.js";
@@ -322,6 +315,7 @@ export function createGatewayTool(opts?: {
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
       const action = readStringParam(params, "action", { required: true });
+      const gatewayOpts = readGatewayCallOptions(params);
       if (action === "restart") {
         if (!isRestartEnabled(opts?.config)) {
           throw new Error("Gateway restart is disabled (commands.restart=false).");
@@ -335,39 +329,17 @@ export function createGatewayTool(opts?: {
             : undefined;
         const reason = normalizeOptionalString(params.reason)?.slice(0, 200);
         const note = normalizeOptionalString(params.note);
-        // Extract channel + threadId for routing after restart.
-        // Uses generic :thread: parsing plus plugin-owned session grammars.
-        const { deliveryContext, threadId } = extractDeliveryInfo(sessionKey);
-        const payload: RestartSentinelPayload = {
-          kind: "restart",
-          status: "ok",
-          ts: Date.now(),
-          sessionKey,
-          deliveryContext,
-          threadId,
-          message: note ?? reason ?? null,
-          doctorHint: formatDoctorNonInteractiveHint(),
-          stats: {
-            mode: "gateway.restart",
-            reason,
-          },
-        };
-        try {
-          await writeRestartSentinel(payload);
-        } catch {
-          // ignore: sentinel is best-effort
-        }
         log.info(
           `gateway tool: restart requested (delayMs=${delayMs ?? "default"}, reason=${reason ?? "none"})`,
         );
-        const scheduled = scheduleGatewaySigusr1Restart({
-          delayMs,
+        const result = await callGatewayTool("gateway.restart", gatewayOpts, {
+          sessionKey,
+          note,
           reason,
+          restartDelayMs: delayMs,
         });
-        return jsonResult(scheduled);
+        return jsonResult(result);
       }
-
-      const gatewayOpts = readGatewayCallOptions(params);
 
       const resolveGatewayWriteMeta = (): {
         sessionKey: string | undefined;

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -18,7 +18,10 @@ type RestartPostCheckContext = {
 };
 
 type RestartParams = {
-  opts?: { json?: boolean };
+  opts?: {
+    json?: boolean;
+    rpc?: { url?: string; token?: string; password?: string; timeout?: string };
+  };
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
 };
 
@@ -39,6 +42,8 @@ const resolveGatewayPort = vi.hoisted(() => vi.fn((_cfg?: unknown, _env?: unknow
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
 const signalVerifiedGatewayPidSync = vi.fn<(pid: number, signal: "SIGTERM" | "SIGUSR1") => void>();
 const formatGatewayPidList = vi.fn<(pids: number[]) => string>((pids) => pids.join(", "));
+const callGateway = vi.fn();
+const createConfigIO = vi.fn();
 const probeGateway = vi.fn<
   (opts: {
     url: string;
@@ -50,13 +55,24 @@ const probeGateway = vi.fn<
   }>
 >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
+const resolveGatewayProbeAuthSafeWithSecretInputs = vi.fn();
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
 
 vi.mock("../../config/config.js", () => ({
+  createConfigIO: (overrides?: unknown) => createConfigIO(overrides),
   loadConfig: () => loadConfig(),
   readBestEffortConfig: async () => loadConfig(),
   resolveGatewayPort: (cfg?: unknown, env?: unknown) => resolveGatewayPort(cfg, env),
+}));
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGateway(opts),
+}));
+
+vi.mock("../../gateway/probe-auth.js", () => ({
+  resolveGatewayProbeAuthSafeWithSecretInputs: (opts: unknown) =>
+    resolveGatewayProbeAuthSafeWithSecretInputs(opts),
 }));
 
 vi.mock("../../infra/gateway-processes.js", () => ({
@@ -75,7 +91,7 @@ vi.mock("../../gateway/probe.js", () => ({
   }) => probeGateway(opts),
 }));
 
-vi.mock("../../config/commands.js", () => ({
+vi.mock("../../config/commands.flags.js", () => ({
   isRestartEnabled: (config?: { commands?: unknown }) => isRestartEnabled(config),
 }));
 
@@ -107,7 +123,10 @@ vi.mock("./lifecycle-core.js", () => ({
 
 describe("runDaemonRestart health checks", () => {
   let runDaemonStart: (opts?: { json?: boolean }) => Promise<void>;
-  let runDaemonRestart: (opts?: { json?: boolean }) => Promise<boolean>;
+  let runDaemonRestart: (opts?: {
+    json?: boolean;
+    rpc?: { url?: string; token?: string; password?: string; timeout?: string };
+  }) => Promise<boolean>;
   let runDaemonStop: (opts?: { json?: boolean }) => Promise<void>;
   let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -155,8 +174,11 @@ describe("runDaemonRestart health checks", () => {
     findVerifiedGatewayListenerPidsOnPortSync.mockReset();
     signalVerifiedGatewayPidSync.mockReset();
     formatGatewayPidList.mockReset();
+    callGateway.mockReset();
+    createConfigIO.mockReset();
     probeGateway.mockReset();
     isRestartEnabled.mockReset();
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockReset();
     loadConfig.mockReset();
     recoverInstalledLaunchAgent.mockReset();
 
@@ -197,7 +219,12 @@ describe("runDaemonRestart health checks", () => {
       ok: true,
       configSnapshot: { commands: { restart: true } },
     });
+    callGateway.mockRejectedValue(new Error("connection refused"));
+    createConfigIO.mockReturnValue({
+      readBestEffortConfig: async () => loadConfig(),
+    });
     isRestartEnabled.mockReturnValue(true);
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockResolvedValue({ auth: {} });
     signalVerifiedGatewayPidSync.mockImplementation(() => {});
     formatGatewayPidList.mockImplementation((pids) => pids.join(", "));
   });
@@ -247,6 +274,56 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(2);
   });
 
+  it("uses gateway.restart first for the local managed gateway", async () => {
+    callGateway.mockResolvedValueOnce({ ok: true });
+
+    const result = await runDaemonRestart({ json: true });
+
+    expect(result).toBe(true);
+    expect(callGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        method: "gateway.restart",
+        params: { reason: "openclaw gateway restart" },
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(runServiceRestart).not.toHaveBeenCalled();
+    expect(waitForGatewayHealthyRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips gateway.restart and falls back when restart uses a URL override", async () => {
+    await runDaemonRestart({
+      json: true,
+      rpc: { url: "ws://remote.example:18789", timeout: "9000" },
+    });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runServiceRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips gateway.restart and falls back in remote gateway mode", async () => {
+    loadConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+      },
+    });
+
+    await runDaemonRestart({ json: true });
+
+    expect(callGateway).not.toHaveBeenCalled();
+    expect(runServiceRestart).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the service restart path when local gateway RPC restart fails", async () => {
+    callGateway.mockRejectedValueOnce(new Error("connection refused"));
+
+    await runDaemonRestart({ json: true });
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(runServiceRestart).toHaveBeenCalledTimes(1);
+  });
+
   it("skips stale-pid retry health checks when the retry restart is only scheduled", async () => {
     const unhealthy: RestartHealthSnapshot = {
       healthy: false,
@@ -287,27 +364,6 @@ describe("runDaemonRestart health checks", () => {
     });
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(renderRestartDiagnostics).toHaveBeenCalledTimes(1);
-  });
-
-  it("waits longer for Windows gateway restart health", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    waitForGatewayHealthyRestart.mockResolvedValue({
-      healthy: true,
-      staleGatewayPids: [],
-      runtime: { status: "running" },
-      portUsage: { port: 18789, status: "busy", listeners: [], hints: [] },
-    });
-
-    await runDaemonRestart({ json: true });
-
-    expect(waitForGatewayHealthyRestart).toHaveBeenCalledWith(
-      expect.objectContaining({
-        attempts: 360,
-        delayMs: 500,
-        includeUnknownListenersAsStale: true,
-        port: 18789,
-      }),
-    );
   });
 
   it("fails restart with a stopped-free message when the waiter exits early", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -1,6 +1,8 @@
 import { isRestartEnabled } from "../../config/commands.flags.js";
-import { readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
+import { createConfigIO, readBestEffortConfig, resolveGatewayPort } from "../../config/config.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { callGateway } from "../../gateway/call.js";
+import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../../gateway/probe-auth.js";
 import { probeGateway } from "../../gateway/probe.js";
 import {
   findVerifiedGatewayListenerPidsOnPortSync,
@@ -28,17 +30,33 @@ import {
   waitForGatewayHealthyListener,
   waitForGatewayHealthyRestart,
 } from "./restart-health.js";
-import { parsePortFromArgs, renderGatewayServiceStartHints } from "./shared.js";
+import {
+  parsePortFromArgs,
+  pickProbeHostForBind,
+  renderGatewayServiceStartHints,
+} from "./shared.js";
 import type { DaemonLifecycleOptions } from "./types.js";
 
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
-const WINDOWS_POST_RESTART_HEALTH_TIMEOUT_MS = 180_000;
+const DEFAULT_RPC_TIMEOUT_MS = 10_000;
 
-function postRestartHealthAttempts(): number {
-  return process.platform === "win32"
-    ? Math.ceil(WINDOWS_POST_RESTART_HEALTH_TIMEOUT_MS / POST_RESTART_HEALTH_DELAY_MS)
-    : POST_RESTART_HEALTH_ATTEMPTS;
+type RestartPostCheckContext = {
+  json: boolean;
+  stdout: NodeJS.WritableStream;
+  warnings: string[];
+  fail: (message: string, hints?: string[]) => void;
+};
+
+function resolveRpcTimeoutMs(raw: string | undefined): number {
+  if (!raw?.trim()) {
+    return DEFAULT_RPC_TIMEOUT_MS;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return DEFAULT_RPC_TIMEOUT_MS;
+  }
+  return Math.floor(parsed);
 }
 
 function formatRestartFailure(params: {
@@ -76,6 +94,62 @@ function resolveGatewayPortFallback(): Promise<number> {
   return readBestEffortConfig()
     .then((cfg) => resolveGatewayPort(cfg, process.env))
     .catch(() => resolveGatewayPort(undefined, process.env));
+}
+
+async function requestManagedGatewayRestartViaRpc(params: {
+  service: ReturnType<typeof resolveGatewayService>;
+  opts: DaemonLifecycleOptions;
+}): Promise<boolean> {
+  const urlOverride = normalizeOptionalString(params.opts.rpc?.url);
+  if (urlOverride) {
+    return false;
+  }
+
+  const command = await params.service.readCommand(process.env).catch(() => null);
+  if (!command) {
+    return false;
+  }
+
+  const mergedEnv = {
+    ...(process.env as Record<string, string | undefined>),
+    ...command.environment,
+  } as NodeJS.ProcessEnv;
+  const cfg = await createConfigIO({ env: mergedEnv })
+    .readBestEffortConfig()
+    .catch(() => readBestEffortConfig());
+  if (cfg.gateway?.mode === "remote") {
+    return false;
+  }
+
+  const portFromArgs = parsePortFromArgs(command.programArguments);
+  const port = portFromArgs ?? resolveGatewayPort(cfg, mergedEnv);
+  const scheme = cfg.gateway?.tls?.enabled === true ? "wss" : "ws";
+  const host = pickProbeHostForBind(
+    cfg.gateway?.bind ?? "loopback",
+    undefined,
+    cfg.gateway?.customBindHost,
+  );
+  const auth = await resolveGatewayProbeAuthSafeWithSecretInputs({
+    cfg,
+    mode: "local",
+    env: mergedEnv,
+    explicitAuth: {
+      token: params.opts.rpc?.token,
+      password: params.opts.rpc?.password,
+    },
+  });
+
+  await callGateway({
+    url: `${scheme}://${host}:${port}`,
+    token: auth.auth.token,
+    password: auth.auth.password,
+    method: "gateway.restart",
+    params: {
+      reason: "openclaw gateway restart",
+    },
+    timeoutMs: resolveRpcTimeoutMs(params.opts.rpc?.timeout),
+  });
+  return true;
 }
 
 async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void> {
@@ -139,6 +213,112 @@ async function restartGatewayWithoutServiceManager(port: number) {
   };
 }
 
+async function runGatewayRestartPostCheck(params: {
+  service: ReturnType<typeof resolveGatewayService>;
+  restartPort: number;
+  restartWaitSeconds: number;
+  restartedWithoutServiceManager: boolean;
+  ctx: RestartPostCheckContext;
+}) {
+  const { service, restartPort, restartWaitSeconds, restartedWithoutServiceManager, ctx } = params;
+  const { json, stdout, warnings, fail } = ctx;
+
+  if (restartedWithoutServiceManager) {
+    const health = await waitForGatewayHealthyListener({
+      port: restartPort,
+      attempts: POST_RESTART_HEALTH_ATTEMPTS,
+      delayMs: POST_RESTART_HEALTH_DELAY_MS,
+    });
+    if (health.healthy) {
+      return undefined;
+    }
+
+    const diagnostics = renderGatewayPortHealthDiagnostics(health);
+    const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
+    if (!json) {
+      defaultRuntime.log(theme.warn(timeoutLine));
+      for (const line of diagnostics) {
+        defaultRuntime.log(theme.muted(line));
+      }
+    } else {
+      warnings.push(timeoutLine);
+      warnings.push(...diagnostics);
+    }
+
+    fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
+      formatCliCommand("openclaw gateway status --deep"),
+      formatCliCommand("openclaw doctor"),
+    ]);
+    throw new Error("unreachable after gateway restart health failure");
+  }
+
+  let health = await waitForGatewayHealthyRestart({
+    service,
+    port: restartPort,
+    attempts: POST_RESTART_HEALTH_ATTEMPTS,
+    delayMs: POST_RESTART_HEALTH_DELAY_MS,
+    includeUnknownListenersAsStale: process.platform === "win32",
+  });
+
+  if (!health.healthy && health.staleGatewayPids.length > 0) {
+    const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
+    warnings.push(staleMsg);
+    if (!json) {
+      defaultRuntime.log(theme.warn(staleMsg));
+      defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
+    }
+
+    await terminateStaleGatewayPids(health.staleGatewayPids);
+    const retryRestart = await service.restart({ env: process.env, stdout });
+    if (retryRestart.outcome === "scheduled") {
+      return retryRestart;
+    }
+    health = await waitForGatewayHealthyRestart({
+      service,
+      port: restartPort,
+      attempts: POST_RESTART_HEALTH_ATTEMPTS,
+      delayMs: POST_RESTART_HEALTH_DELAY_MS,
+      includeUnknownListenersAsStale: process.platform === "win32",
+    });
+  }
+
+  if (health.healthy) {
+    return undefined;
+  }
+
+  const diagnostics = renderRestartDiagnostics(health);
+  const failure = formatRestartFailure({
+    health,
+    port: restartPort,
+    timeoutSeconds: restartWaitSeconds,
+  });
+  const runningNoPortLine =
+    health.runtime.status === "running" && health.portUsage.status === "free"
+      ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
+      : null;
+  if (!json) {
+    defaultRuntime.log(theme.warn(failure.statusLine));
+    if (runningNoPortLine) {
+      defaultRuntime.log(theme.warn(runningNoPortLine));
+    }
+    for (const line of diagnostics) {
+      defaultRuntime.log(theme.muted(line));
+    }
+  } else {
+    warnings.push(failure.statusLine);
+    if (runningNoPortLine) {
+      warnings.push(runningNoPortLine);
+    }
+    warnings.push(...diagnostics);
+  }
+
+  fail(failure.failMessage, [
+    formatCliCommand("openclaw gateway status --deep"),
+    formatCliCommand("openclaw doctor"),
+  ]);
+  throw new Error("unreachable after gateway restart failure");
+}
+
 export async function runDaemonUninstall(opts: DaemonLifecycleOptions = {}) {
   return await runServiceUninstall({
     serviceNoun: "Gateway",
@@ -190,9 +370,34 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
-  const restartHealthAttempts = postRestartHealthAttempts();
-  const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
+  const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
+
+  const fail = (message: string, hints?: string[]) => {
+    const err = new Error(message) as Error & { hints?: string[] };
+    err.hints = hints;
+    throw err;
+  };
+
+  const rpcRestartTriggered = await requestManagedGatewayRestartViaRpc({
+    service,
+    opts,
+  }).catch(() => false);
+  if (rpcRestartTriggered) {
+    await runGatewayRestartPostCheck({
+      service,
+      restartPort,
+      restartWaitSeconds,
+      restartedWithoutServiceManager: false,
+      ctx: {
+        json,
+        stdout: process.stdout,
+        warnings: [],
+        fail,
+      },
+    });
+    return true;
+  }
 
   return await runServiceRestart({
     serviceNoun: "Gateway",
@@ -208,101 +413,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
       }
       return await recoverInstalledLaunchAgent({ result: "restarted" });
     },
-    postRestartCheck: async ({ warnings, fail, stdout }) => {
-      if (restartedWithoutServiceManager) {
-        const health = await waitForGatewayHealthyListener({
-          port: restartPort,
-          attempts: restartHealthAttempts,
-          delayMs: POST_RESTART_HEALTH_DELAY_MS,
-        });
-        if (health.healthy) {
-          return undefined;
-        }
-
-        const diagnostics = renderGatewayPortHealthDiagnostics(health);
-        const timeoutLine = `Timed out after ${restartWaitSeconds}s waiting for gateway port ${restartPort} to become healthy.`;
-        if (!json) {
-          defaultRuntime.log(theme.warn(timeoutLine));
-          for (const line of diagnostics) {
-            defaultRuntime.log(theme.muted(line));
-          }
-        } else {
-          warnings.push(timeoutLine);
-          warnings.push(...diagnostics);
-        }
-
-        fail(`Gateway restart timed out after ${restartWaitSeconds}s waiting for health checks.`, [
-          formatCliCommand("openclaw gateway status --deep"),
-          formatCliCommand("openclaw doctor"),
-        ]);
-        throw new Error("unreachable after gateway restart health failure");
-      }
-
-      let health = await waitForGatewayHealthyRestart({
+    postRestartCheck: async (ctx) =>
+      await runGatewayRestartPostCheck({
         service,
-        port: restartPort,
-        attempts: restartHealthAttempts,
-        delayMs: POST_RESTART_HEALTH_DELAY_MS,
-        includeUnknownListenersAsStale: process.platform === "win32",
-      });
-
-      if (!health.healthy && health.staleGatewayPids.length > 0) {
-        const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
-        warnings.push(staleMsg);
-        if (!json) {
-          defaultRuntime.log(theme.warn(staleMsg));
-          defaultRuntime.log(theme.muted("Stopping stale process(es) and retrying restart..."));
-        }
-
-        await terminateStaleGatewayPids(health.staleGatewayPids);
-        const retryRestart = await service.restart({ env: process.env, stdout });
-        if (retryRestart.outcome === "scheduled") {
-          return retryRestart;
-        }
-        health = await waitForGatewayHealthyRestart({
-          service,
-          port: restartPort,
-          attempts: restartHealthAttempts,
-          delayMs: POST_RESTART_HEALTH_DELAY_MS,
-          includeUnknownListenersAsStale: process.platform === "win32",
-        });
-      }
-
-      if (health.healthy) {
-        return undefined;
-      }
-
-      const diagnostics = renderRestartDiagnostics(health);
-      const failure = formatRestartFailure({
-        health,
-        port: restartPort,
-        timeoutSeconds: restartWaitSeconds,
-      });
-      const runningNoPortLine =
-        health.runtime.status === "running" && health.portUsage.status === "free"
-          ? `Gateway process is running but port ${restartPort} is still free (startup hang/crash loop or very slow VM startup).`
-          : null;
-      if (!json) {
-        defaultRuntime.log(theme.warn(failure.statusLine));
-        if (runningNoPortLine) {
-          defaultRuntime.log(theme.warn(runningNoPortLine));
-        }
-        for (const line of diagnostics) {
-          defaultRuntime.log(theme.muted(line));
-        }
-      } else {
-        warnings.push(failure.statusLine);
-        if (runningNoPortLine) {
-          warnings.push(runningNoPortLine);
-        }
-        warnings.push(...diagnostics);
-      }
-
-      fail(failure.failMessage, [
-        formatCliCommand("openclaw gateway status --deep"),
-        formatCliCommand("openclaw doctor"),
-      ]);
-      throw new Error("unreachable after gateway restart failure");
-    },
+        restartPort,
+        restartWaitSeconds,
+        restartedWithoutServiceManager,
+        ctx,
+      }),
   });
 }

--- a/src/cli/daemon-cli/register-service-commands.test.ts
+++ b/src/cli/daemon-cli/register-service-commands.test.ts
@@ -84,6 +84,32 @@ describe("addGatewayServiceCommands", () => {
         );
       },
     },
+    {
+      name: "forwards restart RPC override options",
+      argv: [
+        "restart",
+        "--url",
+        "ws://remote.example:18789",
+        "--token",
+        "tok_restart",
+        "--password",
+        "pw_restart",
+        "--timeout",
+        "9000",
+      ],
+      assert: () => {
+        expect(runDaemonRestart).toHaveBeenCalledWith(
+          expect.objectContaining({
+            rpc: expect.objectContaining({
+              url: "ws://remote.example:18789",
+              token: "tok_restart",
+              password: "pw_restart",
+              timeout: "9000",
+            }),
+          }),
+        );
+      },
+    },
   ])("$name", async ({ argv, assert }) => {
     const gateway = createGatewayParentLikeCommand();
     await gateway.parseAsync(argv, { from: "user" });

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -37,21 +37,23 @@ function resolveInstallOptions(
 }
 
 function resolveRpcOptions(cmdOpts: GatewayRpcOpts, command?: Command): GatewayRpcOpts {
+  const parentUrl = inheritOptionFromParent<string>(command, "url");
   const parentToken = inheritOptionFromParent<string>(command, "token");
   const parentPassword = inheritOptionFromParent<string>(command, "password");
+  const parentTimeout = inheritOptionFromParent<string>(command, "timeout");
   return {
     ...cmdOpts,
+    url: cmdOpts.url ?? parentUrl,
     token: cmdOpts.token ?? parentToken,
     password: cmdOpts.password ?? parentPassword,
+    timeout: cmdOpts.timeout ?? parentTimeout,
   };
 }
 
 export function addGatewayServiceCommands(parent: Command, opts?: { statusDescription?: string }) {
   parent
     .command("status")
-    .description(
-      opts?.statusDescription ?? "Show gateway service status + probe connectivity/capability",
-    )
+    .description(opts?.statusDescription ?? "Show gateway service status + probe the Gateway")
     .option("--url <url>", "Gateway WebSocket URL (defaults to config/remote/local)")
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (password auth)")
@@ -114,9 +116,16 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("restart")
     .description("Restart the Gateway service (launchd/systemd/schtasks)")
+    .option("--url <url>", "Gateway WebSocket URL override (skips local RPC-first restart)")
+    .option("--token <token>", "Gateway token (for local RPC-first restart)")
+    .option("--password <password>", "Gateway password (for local RPC-first restart)")
+    .option("--timeout <ms>", "Timeout in ms for the RPC-first attempt", "10000")
     .option("--json", "Output JSON", false)
-    .action(async (cmdOpts) => {
+    .action(async (cmdOpts, command) => {
       const { runDaemonRestart } = await loadDaemonLifecycleModule();
-      await runDaemonRestart(cmdOpts);
+      await runDaemonRestart({
+        json: Boolean(cmdOpts.json),
+        rpc: resolveRpcOptions(cmdOpts, command),
+      });
     });
 }

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -25,4 +25,5 @@ export type DaemonInstallOptions = {
 
 export type DaemonLifecycleOptions = {
   json?: boolean;
+  rpc?: GatewayRpcOpts;
 };

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -35,6 +35,7 @@ describe("method scope resolution", () => {
     ["node.pair.approve", ["operator.pairing"]],
     ["poll", ["operator.write"]],
     ["config.patch", ["operator.admin"]],
+    ["gateway.restart", ["operator.admin"]],
     ["wizard.start", ["operator.admin"]],
     ["update.run", ["operator.admin"]],
   ])("resolves least-privilege scopes for %s", (method, expected) => {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -166,6 +166,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "sessions.compact",
     "sessions.compaction.restore",
     "connect",
+    "gateway.restart",
     "chat.inject",
     "web.login.start",
     "web.login.wait",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -79,6 +79,8 @@ import {
   ConfigGetParamsSchema,
   type ConfigPatchParams,
   ConfigPatchParamsSchema,
+  type GatewayRestartParams,
+  GatewayRestartParamsSchema,
   type ConfigSchemaLookupParams,
   ConfigSchemaLookupParamsSchema,
   type ConfigSchemaLookupResult,
@@ -414,6 +416,9 @@ export const validateConfigGetParams = ajv.compile<ConfigGetParams>(ConfigGetPar
 export const validateConfigSetParams = ajv.compile<ConfigSetParams>(ConfigSetParamsSchema);
 export const validateConfigApplyParams = ajv.compile<ConfigApplyParams>(ConfigApplyParamsSchema);
 export const validateConfigPatchParams = ajv.compile<ConfigPatchParams>(ConfigPatchParamsSchema);
+export const validateGatewayRestartParams = ajv.compile<GatewayRestartParams>(
+  GatewayRestartParamsSchema,
+);
 export const validateConfigSchemaParams = ajv.compile<ConfigSchemaParams>(ConfigSchemaParamsSchema);
 export const validateConfigSchemaLookupParams = ajv.compile<ConfigSchemaLookupParams>(
   ConfigSchemaLookupParamsSchema,

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -29,17 +29,7 @@ export const ConfigSetParamsSchema = Type.Object(
 
 const RestartRequestSharedParamsSchema = {
   sessionKey: Type.Optional(Type.String()),
-  deliveryContext: Type.Optional(
-    Type.Object(
-      {
-        channel: Type.Optional(Type.String()),
-        to: Type.Optional(Type.String()),
-        accountId: Type.Optional(Type.String()),
-        threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
-      },
-      { additionalProperties: false },
-    ),
-  ),
+  deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
   note: Type.Optional(Type.String()),
   restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
 };

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -27,14 +27,28 @@ export const ConfigSetParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+const RestartRequestSharedParamsSchema = {
+  sessionKey: Type.Optional(Type.String()),
+  deliveryContext: Type.Optional(
+    Type.Object(
+      {
+        channel: Type.Optional(Type.String()),
+        to: Type.Optional(Type.String()),
+        accountId: Type.Optional(Type.String()),
+        threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
+      },
+      { additionalProperties: false },
+    ),
+  ),
+  note: Type.Optional(Type.String()),
+  restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+};
+
 const ConfigApplyLikeParamsSchema = Type.Object(
   {
     raw: NonEmptyString,
     baseHash: Type.Optional(NonEmptyString),
-    sessionKey: Type.Optional(Type.String()),
-    deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
-    note: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    ...RestartRequestSharedParamsSchema,
   },
   { additionalProperties: false },
 );
@@ -51,12 +65,17 @@ export const ConfigSchemaLookupParamsSchema = Type.Object(
   { additionalProperties: false },
 );
 
+export const GatewayRestartParamsSchema = Type.Object(
+  {
+    ...RestartRequestSharedParamsSchema,
+    reason: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
 export const UpdateRunParamsSchema = Type.Object(
   {
-    sessionKey: Type.Optional(Type.String()),
-    deliveryContext: Type.Optional(ConfigDeliveryContextSchema),
-    note: Type.Optional(Type.String()),
-    restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    ...RestartRequestSharedParamsSchema,
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
   },
   { additionalProperties: false },

--- a/src/gateway/protocol/schema/protocol-schemas.ts
+++ b/src/gateway/protocol/schema/protocol-schemas.ts
@@ -76,6 +76,7 @@ import {
   ConfigSchemaParamsSchema,
   ConfigSchemaResponseSchema,
   ConfigSetParamsSchema,
+  GatewayRestartParamsSchema,
   UpdateRunParamsSchema,
 } from "./config.js";
 import {
@@ -264,6 +265,7 @@ export const ProtocolSchemas = {
   ConfigSetParams: ConfigSetParamsSchema,
   ConfigApplyParams: ConfigApplyParamsSchema,
   ConfigPatchParams: ConfigPatchParamsSchema,
+  GatewayRestartParams: GatewayRestartParamsSchema,
   ConfigSchemaParams: ConfigSchemaParamsSchema,
   ConfigSchemaLookupParams: ConfigSchemaLookupParamsSchema,
   ConfigSchemaResponse: ConfigSchemaResponseSchema,

--- a/src/gateway/protocol/schema/types.ts
+++ b/src/gateway/protocol/schema/types.ts
@@ -65,6 +65,7 @@ export type ConfigGetParams = SchemaType<"ConfigGetParams">;
 export type ConfigSetParams = SchemaType<"ConfigSetParams">;
 export type ConfigApplyParams = SchemaType<"ConfigApplyParams">;
 export type ConfigPatchParams = SchemaType<"ConfigPatchParams">;
+export type GatewayRestartParams = SchemaType<"GatewayRestartParams">;
 export type ConfigSchemaParams = SchemaType<"ConfigSchemaParams">;
 export type ConfigSchemaLookupParams = SchemaType<"ConfigSchemaLookupParams">;
 export type ConfigSchemaResponse = SchemaType<"ConfigSchemaResponse">;

--- a/src/gateway/restart-transaction.test.ts
+++ b/src/gateway/restart-transaction.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getRun: vi.fn(),
+  scheduleGatewaySigusr1Restart: vi.fn(() => ({
+    ok: true,
+    pid: 123,
+    signal: "SIGUSR1",
+    delayMs: 0,
+    mode: "emit",
+    coalesced: false,
+    cooldownMsApplied: 0,
+  })),
+  writeRestartTransaction: vi.fn(async () => "/tmp/restart-transaction.json"),
+  updateRestartTransaction: vi.fn(async () => null),
+  writeRestartSentinel: vi.fn(async () => "/tmp/restart-sentinel.json"),
+  abortForRestart: vi.fn(),
+}));
+
+vi.mock("../auto-reply/reply/reply-run-registry.js", () => ({
+  replyRunRegistry: {
+    get: (sessionKey: string) => mocks.getRun(sessionKey),
+  },
+}));
+
+vi.mock("../infra/restart.js", () => ({
+  scheduleGatewaySigusr1Restart: (opts?: unknown) => mocks.scheduleGatewaySigusr1Restart(opts),
+}));
+
+vi.mock("../infra/restart-transaction.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/restart-transaction.js")>(
+    "../infra/restart-transaction.js",
+  );
+  return {
+    ...actual,
+    writeRestartTransaction: (tx: unknown) => mocks.writeRestartTransaction(tx),
+    updateRestartTransaction: (updater: unknown) => mocks.updateRestartTransaction(updater),
+  };
+});
+
+vi.mock("../infra/restart-sentinel.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/restart-sentinel.js")>(
+    "../infra/restart-sentinel.js",
+  );
+  return {
+    ...actual,
+    writeRestartSentinel: (payload: unknown) => mocks.writeRestartSentinel(payload),
+  };
+});
+
+const { requestGatewayRestartTransaction } = await import("./restart-transaction.js");
+
+describe("requestGatewayRestartTransaction", () => {
+  beforeEach(() => {
+    mocks.getRun.mockReset();
+    mocks.scheduleGatewaySigusr1Restart.mockClear();
+    mocks.writeRestartTransaction.mockClear();
+    mocks.updateRestartTransaction.mockClear();
+    mocks.writeRestartSentinel.mockClear();
+    mocks.abortForRestart.mockClear();
+  });
+
+  it("uses terminal-handoff mode for an active top-level run", async () => {
+    mocks.getRun.mockReturnValue({
+      sessionId: "turn-1",
+      phase: "running",
+      abortForRestart: mocks.abortForRestart,
+    });
+
+    const result = await requestGatewayRestartTransaction({
+      payload: {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        sessionKey: "agent:main:main",
+        message: "Restarting now",
+      },
+      entryPoint: "gateway.restart",
+      reason: "gateway.restart",
+    });
+
+    expect(result.mode).toBe("terminal-handoff");
+    expect(result.transaction.turnId).toBe("turn-1");
+    expect(result.transaction.interruptedTurn).toMatchObject({
+      sessionKey: "agent:main:main",
+      phase: "running",
+      resumeEligible: false,
+    });
+    expect(mocks.abortForRestart).toHaveBeenCalledTimes(1);
+    expect(mocks.writeRestartSentinel).toHaveBeenCalled();
+  });
+
+  it("uses drain-then-restart mode when no active run exists", async () => {
+    mocks.getRun.mockReturnValue(undefined);
+
+    const result = await requestGatewayRestartTransaction({
+      payload: {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        sessionKey: "agent:main:main",
+      },
+      entryPoint: "gateway.restart",
+      reason: "gateway.restart",
+    });
+
+    expect(result.mode).toBe("drain-then-restart");
+    expect(result.transaction.interruptedTurn).toBeNull();
+    expect(mocks.abortForRestart).not.toHaveBeenCalled();
+    expect(mocks.scheduleGatewaySigusr1Restart).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/gateway/restart-transaction.test.ts
+++ b/src/gateway/restart-transaction.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinelPayload } from "../infra/restart-sentinel.js";
+import type { RestartTransaction } from "../infra/restart-transaction.js";
 
 const mocks = vi.hoisted(() => ({
   getRun: vi.fn(),
-  scheduleGatewaySigusr1Restart: vi.fn(() => ({
+  scheduleGatewaySigusr1Restart: vi.fn((_opts?: unknown) => ({
     ok: true,
     pid: 123,
     signal: "SIGUSR1",
@@ -11,9 +13,17 @@ const mocks = vi.hoisted(() => ({
     coalesced: false,
     cooldownMsApplied: 0,
   })),
-  writeRestartTransaction: vi.fn(async () => "/tmp/restart-transaction.json"),
-  updateRestartTransaction: vi.fn(async () => null),
-  writeRestartSentinel: vi.fn(async () => "/tmp/restart-sentinel.json"),
+  writeRestartTransaction: vi.fn<(tx: RestartTransaction) => Promise<string>>(
+    async () => "/tmp/restart-transaction.json",
+  ),
+  updateRestartTransaction: vi.fn<
+    (
+      updater: (current: RestartTransaction | null) => RestartTransaction | null,
+    ) => Promise<RestartTransaction | null>
+  >(async () => null),
+  writeRestartSentinel: vi.fn<(payload: RestartSentinelPayload) => Promise<string>>(
+    async () => "/tmp/restart-sentinel.json",
+  ),
   abortForRestart: vi.fn(),
 }));
 
@@ -33,8 +43,10 @@ vi.mock("../infra/restart-transaction.js", async () => {
   );
   return {
     ...actual,
-    writeRestartTransaction: (tx: unknown) => mocks.writeRestartTransaction(tx),
-    updateRestartTransaction: (updater: unknown) => mocks.updateRestartTransaction(updater),
+    writeRestartTransaction: (tx: RestartTransaction) => mocks.writeRestartTransaction(tx),
+    updateRestartTransaction: (
+      updater: (current: RestartTransaction | null) => RestartTransaction | null,
+    ) => mocks.updateRestartTransaction(updater),
   };
 });
 
@@ -44,7 +56,7 @@ vi.mock("../infra/restart-sentinel.js", async () => {
   );
   return {
     ...actual,
-    writeRestartSentinel: (payload: unknown) => mocks.writeRestartSentinel(payload),
+    writeRestartSentinel: (payload: RestartSentinelPayload) => mocks.writeRestartSentinel(payload),
   };
 });
 

--- a/src/gateway/restart-transaction.ts
+++ b/src/gateway/restart-transaction.ts
@@ -59,6 +59,17 @@ export async function requestGatewayRestartTransaction(params: {
   const activeRun = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
   const mode: RestartTransactionMode = activeRun ? "terminal-handoff" : "drain-then-restart";
   const turnId = activeRun?.sessionId;
+  const interruptedTurn =
+    activeRun && sessionKey
+      ? {
+          sessionKey,
+          turnId,
+          phase: activeRun.phase,
+          interruptionCause: "gateway_restart",
+          pendingUserVisibleFollowupNote: params.payload.message ?? null,
+          resumeEligible: false,
+        }
+      : null;
   const transactionBase: RestartTransaction = {
     restartId: randomUUID(),
     requestedAt: Date.now(),
@@ -71,16 +82,7 @@ export async function requestGatewayRestartTransaction(params: {
     note: params.payload.message ?? null,
     deliveryContext: params.payload.deliveryContext ?? null,
     threadId: params.payload.threadId,
-    interruptedTurn: activeRun
-      ? {
-          sessionKey,
-          turnId,
-          phase: activeRun.phase,
-          interruptionCause: "gateway_restart",
-          pendingUserVisibleFollowupNote: params.payload.message ?? null,
-          resumeEligible: false,
-        }
-      : null,
+    interruptedTurn,
   };
 
   await writeRestartTransaction(transactionBase);

--- a/src/gateway/restart-transaction.ts
+++ b/src/gateway/restart-transaction.ts
@@ -1,0 +1,147 @@
+import { randomUUID } from "node:crypto";
+import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
+import { type RestartSentinelPayload, writeRestartSentinel } from "../infra/restart-sentinel.js";
+import {
+  type RestartTransaction,
+  type RestartTransactionMode,
+  type RestartTransactionRequester,
+  updateRestartTransaction,
+  writeRestartTransaction,
+} from "../infra/restart-transaction.js";
+import { scheduleGatewaySigusr1Restart, type ScheduledRestart } from "../infra/restart.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+
+function cloneTransaction(transaction: RestartTransaction): RestartTransaction {
+  return JSON.parse(JSON.stringify(transaction)) as RestartTransaction;
+}
+
+async function writeSentinelForTransaction(
+  payload: RestartSentinelPayload,
+  transaction: RestartTransaction,
+): Promise<string | null> {
+  try {
+    return await writeRestartSentinel({
+      ...payload,
+      transaction: cloneTransaction(transaction),
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function advanceRestartTransaction(params: {
+  transaction: RestartTransaction;
+  state: RestartTransaction["state"];
+  finalOutcome?: string | null;
+}): Promise<RestartTransaction> {
+  const next: RestartTransaction = {
+    ...params.transaction,
+    state: params.state,
+    ...(params.finalOutcome !== undefined ? { finalOutcome: params.finalOutcome } : {}),
+  };
+  await writeRestartTransaction(next);
+  return next;
+}
+
+export async function requestGatewayRestartTransaction(params: {
+  payload: RestartSentinelPayload;
+  requester?: RestartTransactionRequester | null;
+  entryPoint: string;
+  reason?: string | null;
+  restartDelayMs?: number;
+}): Promise<{
+  restart: ScheduledRestart;
+  sentinelPath: string | null;
+  transaction: RestartTransaction;
+  mode: RestartTransactionMode;
+}> {
+  const sessionKey = normalizeOptionalString(params.payload.sessionKey);
+  const activeRun = sessionKey ? replyRunRegistry.get(sessionKey) : undefined;
+  const mode: RestartTransactionMode = activeRun ? "terminal-handoff" : "drain-then-restart";
+  const turnId = activeRun?.sessionId;
+  const transactionBase: RestartTransaction = {
+    restartId: randomUUID(),
+    requestedAt: Date.now(),
+    requester: params.requester ?? null,
+    reason: params.reason ?? null,
+    sessionKey: sessionKey ?? undefined,
+    turnId,
+    mode,
+    state: "requested",
+    note: params.payload.message ?? null,
+    deliveryContext: params.payload.deliveryContext ?? null,
+    threadId: params.payload.threadId,
+    interruptedTurn: activeRun
+      ? {
+          sessionKey,
+          turnId,
+          phase: activeRun.phase,
+          interruptionCause: "gateway_restart",
+          pendingUserVisibleFollowupNote: params.payload.message ?? null,
+          resumeEligible: false,
+        }
+      : null,
+  };
+
+  await writeRestartTransaction(transactionBase);
+  let transaction = await advanceRestartTransaction({
+    transaction: transactionBase,
+    state: "acked",
+  });
+  let sentinelPath = await writeSentinelForTransaction(params.payload, transaction);
+
+  try {
+    transaction = await advanceRestartTransaction({
+      transaction,
+      state: mode === "terminal-handoff" ? "handoff_pending" : "draining",
+    });
+    sentinelPath = (await writeSentinelForTransaction(params.payload, transaction)) ?? sentinelPath;
+
+    if (activeRun) {
+      activeRun.abortForRestart();
+    }
+
+    const restart = scheduleGatewaySigusr1Restart({
+      delayMs: params.restartDelayMs,
+      reason: params.reason ?? params.entryPoint,
+      audit:
+        params.requester &&
+        (params.requester.actor || params.requester.deviceId || params.requester.clientIp)
+          ? {
+              actor: params.requester.actor,
+              deviceId: params.requester.deviceId,
+              clientIp: params.requester.clientIp,
+              changedPaths: [],
+            }
+          : undefined,
+    });
+
+    transaction = await advanceRestartTransaction({
+      transaction,
+      state: "restarting",
+      finalOutcome: restart.coalesced ? "coalesced" : "scheduled",
+    });
+    sentinelPath = (await writeSentinelForTransaction(params.payload, transaction)) ?? sentinelPath;
+
+    return {
+      restart,
+      sentinelPath,
+      transaction,
+      mode,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await updateRestartTransaction((current) => {
+      if (!current || current.restartId !== transaction.restartId) {
+        return current;
+      }
+      return {
+        ...current,
+        state: "needs_attention",
+        finalOutcome: message,
+        finalizedAt: Date.now(),
+      };
+    });
+    throw error;
+  }
+}

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -67,6 +67,7 @@ const BASE_METHODS = [
   "skills.bins",
   "skills.install",
   "skills.update",
+  "gateway.restart",
   "update.run",
   "voicewake.get",
   "voicewake.set",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -22,6 +22,7 @@ import { modelsHandlers } from "./server-methods/models.js";
 import { nodePendingHandlers } from "./server-methods/nodes-pending.js";
 import { nodeHandlers } from "./server-methods/nodes.js";
 import { pushHandlers } from "./server-methods/push.js";
+import { restartHandlers } from "./server-methods/restart.js";
 import { sendHandlers } from "./server-methods/send.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
@@ -37,7 +38,12 @@ import { voicewakeHandlers } from "./server-methods/voicewake.js";
 import { webHandlers } from "./server-methods/web.js";
 import { wizardHandlers } from "./server-methods/wizard.js";
 
-const CONTROL_PLANE_WRITE_METHODS = new Set(["config.apply", "config.patch", "update.run"]);
+const CONTROL_PLANE_WRITE_METHODS = new Set([
+  "config.apply",
+  "config.patch",
+  "gateway.restart",
+  "update.run",
+]);
 function authorizeGatewayMethod(method: string, client: GatewayRequestOptions["client"]) {
   if (!client?.connect) {
     return null;
@@ -83,6 +89,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...modelsHandlers,
   ...modelsAuthStatusHandlers,
   ...configHandlers,
+  ...restartHandlers,
   ...wizardHandlers,
   ...talkHandlers,
   ...toolsCatalogHandlers,

--- a/src/gateway/server-methods/config.shared-auth.test.ts
+++ b/src/gateway/server-methods/config.shared-auth.test.ts
@@ -10,10 +10,15 @@ const readConfigFileSnapshotForWriteMock = vi.fn();
 const writeConfigFileMock = vi.fn();
 const validateConfigObjectWithPluginsMock = vi.fn();
 const prepareSecretsRuntimeSnapshotMock = vi.fn();
-const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({
-  scheduled: true,
-  delayMs: 1_000,
-  coalesced: false,
+const requestGatewayRestartTransactionMock = vi.fn(async () => ({
+  mode: "drain-then-restart",
+  restart: {
+    scheduled: true,
+    delayMs: 1_000,
+    coalesced: false,
+  },
+  transaction: { restartId: "restart-1", state: "restarting" },
+  sentinelPath: "/tmp/restart-sentinel.json",
 }));
 
 vi.mock("../../config/config.js", async () => {
@@ -36,8 +41,8 @@ vi.mock("../../secrets/runtime.js", () => ({
   prepareSecretsRuntimeSnapshot: prepareSecretsRuntimeSnapshotMock,
 }));
 
-vi.mock("../../infra/restart.js", () => ({
-  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+vi.mock("../restart-transaction.js", () => ({
+  requestGatewayRestartTransaction: requestGatewayRestartTransactionMock,
 }));
 
 const { configHandlers } = await import("./config.js");
@@ -87,7 +92,7 @@ describe("config shared auth disconnects", () => {
 
     expect(writeConfigFileMock).toHaveBeenCalledWith(nextConfig, {});
     expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestGatewayRestartTransactionMock).not.toHaveBeenCalled();
   });
 
   it("lets the config reloader own hybrid-mode auth restarts", async () => {
@@ -113,7 +118,7 @@ describe("config shared auth disconnects", () => {
     await configHandlers["config.patch"](options);
     await flushConfigHandlerMicrotasks();
 
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestGatewayRestartTransactionMock).not.toHaveBeenCalled();
     expect(disconnectClientsUsingSharedGatewayAuth).toHaveBeenCalledTimes(1);
   });
 
@@ -140,7 +145,7 @@ describe("config shared auth disconnects", () => {
     await configHandlers["config.patch"](options);
     await flushConfigHandlerMicrotasks();
 
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestGatewayRestartTransactionMock).not.toHaveBeenCalled();
     expect(disconnectClientsUsingSharedGatewayAuth).not.toHaveBeenCalled();
   });
 
@@ -166,6 +171,6 @@ describe("config shared auth disconnects", () => {
     await configHandlers["config.patch"](options);
     await flushConfigHandlerMicrotasks();
 
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestGatewayRestartTransactionMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -24,9 +24,7 @@ import { formatErrorMessage } from "../../infra/errors.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
-  writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { prepareSecretsRuntimeSnapshot } from "../../secrets/runtime.js";
 import { resolveEffectiveSharedGatewayAuth } from "../auth.js";
 import {
@@ -51,6 +49,7 @@ import {
   validateConfigSchemaParams,
   validateConfigSetParams,
 } from "../protocol/index.js";
+import { requestGatewayRestartTransaction } from "../restart-transaction.js";
 import { resolveBaseHashParam } from "./base-hash.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestContext, GatewayRequestHandlers, RespondFn } from "./types.js";
@@ -375,16 +374,6 @@ function buildConfigRestartSentinelPayload(params: {
   };
 }
 
-async function tryWriteRestartSentinelPayload(
-  payload: RestartSentinelPayload,
-): Promise<string | null> {
-  try {
-    return await writeRestartSentinel(payload);
-  } catch {
-    return null;
-  }
-}
-
 function loadSchemaWithPlugins(): ConfigSchemaResponse {
   // Note: We can't easily cache this, as there are no callback that can invalidate
   // our cache. However, loadConfig() and loadOpenClawPlugins() (called inside
@@ -588,25 +577,26 @@ export const configHandlers: GatewayRequestHandlers = {
       threadId,
       note,
     });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = shouldScheduleDirectConfigRestart({
+    const restartRequest = shouldScheduleDirectConfigRestart({
       changedPaths,
       nextConfig: validated.config,
     })
-      ? scheduleGatewaySigusr1Restart({
-          delayMs: restartDelayMs,
-          reason: "config.patch",
-          audit: {
+      ? await requestGatewayRestartTransaction({
+          payload,
+          requester: {
             actor: actor.actor,
             deviceId: actor.deviceId,
             clientIp: actor.clientIp,
-            changedPaths,
+            entryPoint: "config.patch",
           },
+          entryPoint: "config.patch",
+          reason: "config.patch",
+          restartDelayMs,
         })
-      : undefined;
-    if (restart?.coalesced) {
+      : null;
+    if (restartRequest?.restart.coalesced) {
       context?.logGateway?.warn(
-        `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        `config.patch restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restartRequest.restart.delayMs}`,
       );
     }
     respond(
@@ -615,10 +605,13 @@ export const configHandlers: GatewayRequestHandlers = {
         ok: true,
         path: createConfigIO().configPath,
         config: redactConfigObject(validated.config, schemaPatch.uiHints),
-        restart,
+        restart: restartRequest?.restart,
+        transaction: restartRequest?.transaction,
         sentinel: {
-          path: sentinelPath,
-          payload,
+          path: restartRequest?.sentinelPath ?? null,
+          payload: restartRequest
+            ? { ...payload, transaction: restartRequest.transaction }
+            : payload,
         },
       },
       undefined,
@@ -661,25 +654,26 @@ export const configHandlers: GatewayRequestHandlers = {
       threadId,
       note,
     });
-    const sentinelPath = await tryWriteRestartSentinelPayload(payload);
-    const restart = shouldScheduleDirectConfigRestart({
+    const restartRequest = shouldScheduleDirectConfigRestart({
       changedPaths,
       nextConfig: parsed.config,
     })
-      ? scheduleGatewaySigusr1Restart({
-          delayMs: restartDelayMs,
-          reason: "config.apply",
-          audit: {
+      ? await requestGatewayRestartTransaction({
+          payload,
+          requester: {
             actor: actor.actor,
             deviceId: actor.deviceId,
             clientIp: actor.clientIp,
-            changedPaths,
+            entryPoint: "config.apply",
           },
+          entryPoint: "config.apply",
+          reason: "config.apply",
+          restartDelayMs,
         })
-      : undefined;
-    if (restart?.coalesced) {
+      : null;
+    if (restartRequest?.restart.coalesced) {
       context?.logGateway?.warn(
-        `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        `config.apply restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restartRequest.restart.delayMs}`,
       );
     }
     respond(
@@ -688,10 +682,13 @@ export const configHandlers: GatewayRequestHandlers = {
         ok: true,
         path: createConfigIO().configPath,
         config: redactConfigObject(parsed.config, parsed.schema.uiHints),
-        restart,
+        restart: restartRequest?.restart,
+        transaction: restartRequest?.transaction,
         sentinel: {
-          path: sentinelPath,
-          payload,
+          path: restartRequest?.sentinelPath ?? null,
+          payload: restartRequest
+            ? { ...payload, transaction: restartRequest.transaction }
+            : payload,
         },
       },
       undefined,

--- a/src/gateway/server-methods/restart-request.ts
+++ b/src/gateway/server-methods/restart-request.ts
@@ -41,15 +41,17 @@ export function parseRestartRequestParams(params: unknown): {
   deliveryContext: RestartDeliveryContext | undefined;
   threadId: string | undefined;
   note: string | undefined;
+  reason: string | undefined;
   restartDelayMs: number | undefined;
 } {
   const sessionKey = normalizeOptionalString((params as { sessionKey?: unknown }).sessionKey);
   const { deliveryContext, threadId } = parseRestartDeliveryContext(params);
   const note = normalizeOptionalString((params as { note?: unknown }).note);
+  const reason = normalizeOptionalString((params as { reason?: unknown }).reason);
   const restartDelayMsRaw = (params as { restartDelayMs?: unknown }).restartDelayMs;
   const restartDelayMs =
     typeof restartDelayMsRaw === "number" && Number.isFinite(restartDelayMsRaw)
       ? Math.max(0, Math.floor(restartDelayMsRaw))
       : undefined;
-  return { sessionKey, deliveryContext, threadId, note, restartDelayMs };
+  return { sessionKey, deliveryContext, threadId, note, reason, restartDelayMs };
 }

--- a/src/gateway/server-methods/restart.ts
+++ b/src/gateway/server-methods/restart.ts
@@ -1,0 +1,80 @@
+import { extractDeliveryInfo } from "../../config/sessions.js";
+import {
+  formatDoctorNonInteractiveHint,
+  type RestartSentinelPayload,
+} from "../../infra/restart-sentinel.js";
+import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
+import { validateGatewayRestartParams } from "../protocol/index.js";
+import { requestGatewayRestartTransaction } from "../restart-transaction.js";
+import { parseRestartRequestParams } from "./restart-request.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+export const restartHandlers: GatewayRequestHandlers = {
+  "gateway.restart": async ({ params, respond, client, context }) => {
+    if (!assertValidParams(params, validateGatewayRestartParams, "gateway.restart", respond)) {
+      return;
+    }
+
+    const actor = resolveControlPlaneActor(client);
+    const {
+      sessionKey,
+      deliveryContext: requestedDeliveryContext,
+      threadId: requestedThreadId,
+      note,
+      reason,
+      restartDelayMs,
+    } = parseRestartRequestParams(params);
+    const { deliveryContext: sessionDeliveryContext, threadId: sessionThreadId } =
+      extractDeliveryInfo(sessionKey);
+    const payload: RestartSentinelPayload = {
+      kind: "restart",
+      status: "ok",
+      ts: Date.now(),
+      sessionKey,
+      deliveryContext: requestedDeliveryContext ?? sessionDeliveryContext,
+      threadId: requestedThreadId ?? sessionThreadId,
+      message: note ?? null,
+      doctorHint: formatDoctorNonInteractiveHint(),
+      stats: {
+        mode: "gateway.restart",
+        reason: reason ?? "gateway.restart",
+      },
+    };
+
+    const result = await requestGatewayRestartTransaction({
+      payload,
+      requester: {
+        actor: actor.actor,
+        deviceId: actor.deviceId,
+        clientIp: actor.clientIp,
+        entryPoint: "gateway.restart",
+      },
+      entryPoint: "gateway.restart",
+      reason: reason ?? "gateway.restart",
+      restartDelayMs,
+    });
+
+    context?.logGateway?.info(
+      `gateway.restart ${formatControlPlaneActor(actor)} mode=${result.mode} delayMs=${result.restart.delayMs} coalesced=${result.restart.coalesced}`,
+    );
+
+    respond(
+      true,
+      {
+        ok: true,
+        mode: result.mode,
+        restart: result.restart,
+        transaction: result.transaction,
+        sentinel: {
+          path: result.sentinelPath,
+          payload: {
+            ...payload,
+            transaction: result.transaction,
+          },
+        },
+      },
+      undefined,
+    );
+  },
+};

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -7,7 +7,12 @@ let capturedPayload: RestartSentinelPayload | undefined;
 
 const runGatewayUpdateMock = vi.fn<() => Promise<UpdateRunResult>>();
 
-const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
+const requestGatewayRestartTransactionMock = vi.fn(async () => ({
+  mode: "drain-then-restart",
+  restart: { scheduled: true, delayMs: 0, coalesced: false },
+  transaction: { restartId: "restart-1", state: "restarting" },
+  sentinelPath: "/tmp/restart-sentinel.json",
+}));
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => ({ update: {} }),
@@ -53,8 +58,8 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   };
 });
 
-vi.mock("../../infra/restart.js", () => ({
-  scheduleGatewaySigusr1Restart: scheduleGatewaySigusr1RestartMock,
+vi.mock("../restart-transaction.js", () => ({
+  requestGatewayRestartTransaction: requestGatewayRestartTransactionMock,
 }));
 
 vi.mock("../../infra/update-channels.js", () => ({
@@ -73,6 +78,7 @@ vi.mock("./restart-request.js", () => ({
   parseRestartRequestParams: (params: Record<string, unknown>) => ({
     sessionKey: params.sessionKey,
     note: params.note,
+    reason: params.reason,
     restartDelayMs: undefined,
   }),
 }));
@@ -90,8 +96,13 @@ beforeEach(() => {
     steps: [],
     durationMs: 100,
   });
-  scheduleGatewaySigusr1RestartMock.mockClear();
-  scheduleGatewaySigusr1RestartMock.mockReturnValue({ scheduled: true });
+  requestGatewayRestartTransactionMock.mockClear();
+  requestGatewayRestartTransactionMock.mockResolvedValue({
+    mode: "drain-then-restart",
+    restart: { scheduled: true, delayMs: 0, coalesced: false },
+    transaction: { restartId: "restart-1", state: "restarting" },
+    sentinelPath: "/tmp/restart-sentinel.json",
+  });
 });
 
 async function invokeUpdateRun(
@@ -170,9 +181,9 @@ describe("update.run restart scheduling", () => {
       payload = typed;
     });
 
-    expect(scheduleGatewaySigusr1RestartMock).toHaveBeenCalledTimes(1);
+    expect(requestGatewayRestartTransactionMock).toHaveBeenCalledTimes(1);
     expect(payload?.ok).toBe(true);
-    expect(payload?.restart).toEqual({ scheduled: true });
+    expect(payload?.restart).toEqual({ scheduled: true, delayMs: 0, coalesced: false });
   });
 
   it("skips restart when update fails", async () => {
@@ -191,7 +202,7 @@ describe("update.run restart scheduling", () => {
       payload = typed;
     });
 
-    expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    expect(requestGatewayRestartTransactionMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
   });

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -6,11 +6,11 @@ import {
   type RestartSentinelPayload,
   writeRestartSentinel,
 } from "../../infra/restart-sentinel.js";
-import { scheduleGatewaySigusr1Restart } from "../../infra/restart.js";
 import { normalizeUpdateChannel } from "../../infra/update-channels.js";
 import { runGatewayUpdate } from "../../infra/update-runner.js";
 import { formatControlPlaneActor, resolveControlPlaneActor } from "../control-plane-audit.js";
 import { validateUpdateRunParams } from "../protocol/index.js";
+import { requestGatewayRestartTransaction } from "../restart-transaction.js";
 import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
@@ -26,6 +26,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       deliveryContext: requestedDeliveryContext,
       threadId: requestedThreadId,
       note,
+      reason,
       restartDelayMs,
     } = parseRestartRequestParams(params);
     const { deliveryContext: sessionDeliveryContext, threadId: sessionThreadId } =
@@ -104,25 +105,27 @@ export const updateHandlers: GatewayRequestHandlers = {
     // Only restart the gateway when the update actually succeeded.
     // Restarting after a failed update leaves the process in a broken state
     // (corrupted node_modules, partial builds) and causes a crash loop.
-    const restart =
+    const restartRequest =
       result.status === "ok"
-        ? scheduleGatewaySigusr1Restart({
-            delayMs: restartDelayMs,
-            reason: "update.run",
-            audit: {
+        ? await requestGatewayRestartTransaction({
+            payload,
+            requester: {
               actor: actor.actor,
               deviceId: actor.deviceId,
               clientIp: actor.clientIp,
-              changedPaths: [],
+              entryPoint: "update.run",
             },
+            entryPoint: "update.run",
+            reason: reason ?? "update.run",
+            restartDelayMs,
           })
         : null;
     context?.logGateway?.info(
       `update.run completed ${formatControlPlaneActor(actor)} changedPaths=<n/a> restartReason=update.run status=${result.status}`,
     );
-    if (restart?.coalesced) {
+    if (restartRequest?.restart.coalesced) {
       context?.logGateway?.warn(
-        `update.run restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restart.delayMs}`,
+        `update.run restart coalesced ${formatControlPlaneActor(actor)} delayMs=${restartRequest.restart.delayMs}`,
       );
     }
 
@@ -131,10 +134,13 @@ export const updateHandlers: GatewayRequestHandlers = {
       {
         ok: result.status !== "error",
         result,
-        restart,
+        restart: restartRequest?.restart ?? null,
+        transaction: restartRequest?.transaction,
         sentinel: {
-          path: sentinelPath,
-          payload,
+          path: restartRequest?.sentinelPath ?? sentinelPath,
+          payload: restartRequest
+            ? { ...payload, transaction: restartRequest.transaction }
+            : payload,
         },
       },
       undefined,

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -13,8 +13,12 @@ const mocks = vi.hoisted(() => ({
       },
     },
   })),
+  formatDoctorNonInteractiveHint: vi.fn(() => "doctor hint"),
   formatRestartSentinelMessage: vi.fn(() => "restart message"),
   summarizeRestartSentinel: vi.fn(() => "restart summary"),
+  readRestartTransaction: vi.fn(async () => null),
+  updateRestartTransaction: vi.fn(async () => null),
+  isPendingRestartTransaction: vi.fn((value: unknown) => Boolean(value)),
   resolveMainSessionKeyFromConfig: vi.fn(() => "agent:main:main"),
   parseSessionThreadInfo: vi.fn(
     (): { baseSessionKey: string | null | undefined; threadId: string | undefined } => ({
@@ -53,8 +57,15 @@ vi.mock("../agents/agent-scope.js", () => ({
 
 vi.mock("../infra/restart-sentinel.js", () => ({
   consumeRestartSentinel: mocks.consumeRestartSentinel,
+  formatDoctorNonInteractiveHint: mocks.formatDoctorNonInteractiveHint,
   formatRestartSentinelMessage: mocks.formatRestartSentinelMessage,
   summarizeRestartSentinel: mocks.summarizeRestartSentinel,
+}));
+
+vi.mock("../infra/restart-transaction.js", () => ({
+  readRestartTransaction: mocks.readRestartTransaction,
+  updateRestartTransaction: mocks.updateRestartTransaction,
+  isPendingRestartTransaction: mocks.isPendingRestartTransaction,
 }));
 
 vi.mock("../config/sessions.js", () => ({
@@ -146,6 +157,12 @@ describe("scheduleRestartSentinelWake", () => {
         },
       },
     });
+    mocks.readRestartTransaction.mockReset();
+    mocks.readRestartTransaction.mockResolvedValue(null);
+    mocks.updateRestartTransaction.mockReset();
+    mocks.updateRestartTransaction.mockResolvedValue(null);
+    mocks.isPendingRestartTransaction.mockReset();
+    mocks.isPendingRestartTransaction.mockImplementation((value: unknown) => Boolean(value));
     mocks.parseSessionThreadInfo.mockReset();
     mocks.parseSessionThreadInfo.mockReturnValue({ baseSessionKey: null, threadId: undefined });
     mocks.loadSessionEntry.mockReset();
@@ -425,5 +442,41 @@ describe("scheduleRestartSentinelWake", () => {
         threadId: "$thread-event",
       }),
     );
+  });
+
+  it("falls back to a pending restart transaction when the sentinel file is gone", async () => {
+    mocks.consumeRestartSentinel.mockResolvedValue(null);
+    mocks.readRestartTransaction.mockResolvedValue({
+      restartId: "restart-1",
+      requestedAt: Date.now(),
+      sessionKey: "agent:main:main",
+      mode: "terminal-handoff",
+      state: "handoff_pending",
+      note: "resume later",
+      deliveryContext: {
+        channel: "whatsapp",
+        to: "+15550002",
+        accountId: "acct-2",
+      },
+      interruptedTurn: {
+        sessionKey: "agent:main:main",
+        phase: "running",
+        interruptionCause: "gateway_restart",
+        resumeEligible: false,
+      },
+      requester: { entryPoint: "gateway.restart" },
+    });
+
+    await scheduleRestartSentinelWake({ deps: {} as never });
+
+    expect(mocks.formatRestartSentinelMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction: expect.objectContaining({
+          restartId: "restart-1",
+          state: "boot_recovered",
+        }),
+      }),
+    );
+    expect(mocks.updateRestartTransaction).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/gateway/server-restart-sentinel.test.ts
+++ b/src/gateway/server-restart-sentinel.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RestartSentinel } from "../infra/restart-sentinel.js";
+import type { RestartTransaction } from "../infra/restart-transaction.js";
 import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
 
 const mocks = vi.hoisted(() => ({
   resolveSessionAgentId: vi.fn(() => "agent-from-key"),
-  consumeRestartSentinel: vi.fn(async () => ({
+  consumeRestartSentinel: vi.fn<() => Promise<RestartSentinel | null>>(async () => ({
+    version: 1,
     payload: {
+      kind: "restart",
+      status: "ok",
+      ts: 0,
       sessionKey: "agent:main:main",
       deliveryContext: {
         channel: "whatsapp",
@@ -16,8 +22,12 @@ const mocks = vi.hoisted(() => ({
   formatDoctorNonInteractiveHint: vi.fn(() => "doctor hint"),
   formatRestartSentinelMessage: vi.fn(() => "restart message"),
   summarizeRestartSentinel: vi.fn(() => "restart summary"),
-  readRestartTransaction: vi.fn(async () => null),
-  updateRestartTransaction: vi.fn(async () => null),
+  readRestartTransaction: vi.fn<() => Promise<RestartTransaction | null>>(async () => null),
+  updateRestartTransaction: vi.fn<
+    (
+      updater: (current: RestartTransaction | null) => RestartTransaction | null,
+    ) => Promise<RestartTransaction | null>
+  >(async () => null),
   isPendingRestartTransaction: vi.fn((value: unknown) => Boolean(value)),
   resolveMainSessionKeyFromConfig: vi.fn(() => "agent:main:main"),
   parseSessionThreadInfo: vi.fn(
@@ -148,7 +158,11 @@ describe("scheduleRestartSentinelWake", () => {
   beforeEach(() => {
     vi.useRealTimers();
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         sessionKey: "agent:main:main",
         deliveryContext: {
           channel: "whatsapp",
@@ -284,7 +298,11 @@ describe("scheduleRestartSentinelWake", () => {
   it("prefers top-level sentinel threadId for wake routing context", async () => {
     // Legacy or malformed sentinel JSON can still carry a nested threadId.
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         sessionKey: "agent:main:main",
         deliveryContext: {
           channel: "whatsapp",
@@ -311,7 +329,11 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("does not wake the main session when the sentinel has no sessionKey", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         message: "restart message",
       },
     } as unknown as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
@@ -327,7 +349,11 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("skips outbound restart notice when no canonical delivery context survives restart", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         sessionKey: "agent:main:matrix:channel:!lowercased:example.org",
       },
     } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
@@ -352,7 +378,11 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("resolves session routing before queueing the heartbeat wake", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         sessionKey: "agent:main:qa-channel:channel:qa-room",
       },
     } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);
@@ -394,7 +424,11 @@ describe("scheduleRestartSentinelWake", () => {
 
   it("merges base session routing into partial thread metadata", async () => {
     mocks.consumeRestartSentinel.mockResolvedValue({
+      version: 1,
       payload: {
+        kind: "restart",
+        status: "ok",
+        ts: 0,
         sessionKey: "agent:main:matrix:channel:!lowercased:example.org:thread:$thread-event",
       },
     } as Awaited<ReturnType<typeof mocks.consumeRestartSentinel>>);

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -10,9 +10,16 @@ import { buildOutboundSessionContext } from "../infra/outbound/session-context.j
 import { resolveOutboundTarget } from "../infra/outbound/targets.js";
 import {
   consumeRestartSentinel,
+  formatDoctorNonInteractiveHint,
   formatRestartSentinelMessage,
   summarizeRestartSentinel,
+  type RestartSentinelPayload,
 } from "../infra/restart-sentinel.js";
+import {
+  isPendingRestartTransaction,
+  readRestartTransaction,
+  updateRestartTransaction,
+} from "../infra/restart-transaction.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
@@ -126,12 +133,54 @@ async function deliverRestartSentinelNotice(params: {
   }
 }
 
+function synthesizeRestartPayloadFromTransaction(
+  transaction: NonNullable<Awaited<ReturnType<typeof readRestartTransaction>>>,
+): RestartSentinelPayload {
+  return {
+    kind: "restart",
+    status: "ok",
+    ts: transaction.requestedAt,
+    sessionKey: transaction.sessionKey,
+    deliveryContext: transaction.deliveryContext ?? undefined,
+    threadId: transaction.threadId,
+    message: transaction.note ?? null,
+    doctorHint: formatDoctorNonInteractiveHint(),
+    stats: {
+      mode: transaction.requester?.entryPoint ?? transaction.mode,
+      reason: transaction.reason ?? null,
+    },
+    transaction,
+  };
+}
+
 export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const sentinel = await consumeRestartSentinel();
-  if (!sentinel) {
+  const transaction = await readRestartTransaction();
+  const pendingTransaction = isPendingRestartTransaction(transaction) ? transaction : null;
+  const payload =
+    sentinel?.payload ??
+    (pendingTransaction ? synthesizeRestartPayloadFromTransaction(pendingTransaction) : null);
+  if (!payload) {
     return;
   }
-  const payload = sentinel.payload;
+  if (pendingTransaction && payload.transaction?.restartId === pendingTransaction.restartId) {
+    await updateRestartTransaction((current) => {
+      if (!current || current.restartId !== pendingTransaction.restartId) {
+        return current;
+      }
+      return {
+        ...current,
+        state: "boot_recovered",
+        finalOutcome: current.finalOutcome ?? "boot_recovered",
+      };
+    });
+    payload.transaction = {
+      ...pendingTransaction,
+      state: "boot_recovered",
+      finalOutcome: pendingTransaction.finalOutcome ?? "boot_recovered",
+    };
+  }
+
   const sessionKey = payload.sessionKey?.trim();
   const message = formatRestartSentinelMessage(payload);
   const summary = summarizeRestartSentinel(payload);
@@ -145,6 +194,19 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   if (!sessionKey) {
     const mainSessionKey = resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(message, { sessionKey: mainSessionKey });
+    if (pendingTransaction && payload.transaction?.restartId === pendingTransaction.restartId) {
+      await updateRestartTransaction((current) => {
+        if (!current || current.restartId !== pendingTransaction.restartId) {
+          return current;
+        }
+        return {
+          ...current,
+          state: "completed",
+          finalOutcome: current.finalOutcome ?? "post_boot_followup_sent",
+          finalizedAt: Date.now(),
+        };
+      });
+    }
     return;
   }
 
@@ -176,6 +238,19 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
   const channel = channelRaw ? normalizeChannelId(channelRaw) : null;
   const to = origin?.to;
   if (!channel || !to) {
+    if (pendingTransaction && payload.transaction?.restartId === pendingTransaction.restartId) {
+      await updateRestartTransaction((current) => {
+        if (!current || current.restartId !== pendingTransaction.restartId) {
+          return current;
+        }
+        return {
+          ...current,
+          state: "completed",
+          finalOutcome: current.finalOutcome ?? "post_boot_followup_sent",
+          finalizedAt: Date.now(),
+        };
+      });
+    }
     return;
   }
 
@@ -226,6 +301,20 @@ export async function scheduleRestartSentinelWake(params: { deps: CliDeps }) {
     threadId: resolvedThreadId,
     session: outboundSession,
   });
+
+  if (pendingTransaction && payload.transaction?.restartId === pendingTransaction.restartId) {
+    await updateRestartTransaction((current) => {
+      if (!current || current.restartId !== pendingTransaction.restartId) {
+        return current;
+      }
+      return {
+        ...current,
+        state: "completed",
+        finalOutcome: current.finalOutcome ?? "post_boot_followup_sent",
+        finalizedAt: Date.now(),
+      };
+    });
+  }
 }
 
 export function shouldWakeFromRestartSentinel() {

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveStateDir } from "../config/paths.js";
+import type { RestartTransaction } from "./restart-transaction.js";
 
 export type RestartSentinelLog = {
   stdoutTail?: string | null;
@@ -43,6 +44,7 @@ export type RestartSentinelPayload = {
   message?: string | null;
   doctorHint?: string | null;
   stats?: RestartSentinelStats | null;
+  transaction?: RestartTransaction | null;
 };
 
 export type RestartSentinel = {
@@ -119,7 +121,7 @@ export async function consumeRestartSentinel(
 
 export function formatRestartSentinelMessage(payload: RestartSentinelPayload): string {
   const message = payload.message?.trim();
-  if (message && !payload.stats) {
+  if (message && !payload.stats && !payload.transaction?.interruptedTurn) {
     return message;
   }
   const lines: string[] = [summarizeRestartSentinel(payload)];
@@ -129,6 +131,20 @@ export function formatRestartSentinelMessage(payload: RestartSentinelPayload): s
   const reason = payload.stats?.reason?.trim();
   if (reason && reason !== message) {
     lines.push(`Reason: ${reason}`);
+  }
+  const interruptedTurn = payload.transaction?.interruptedTurn;
+  if (interruptedTurn) {
+    const phase = interruptedTurn.phase?.trim();
+    lines.push(
+      phase
+        ? `Previous turn was interrupted by gateway restart while in ${phase}.`
+        : "Previous turn was interrupted by gateway restart.",
+    );
+    if (!interruptedTurn.resumeEligible) {
+      lines.push(
+        "That work was not auto-resumed. If you want me to continue, send another message.",
+      );
+    }
   }
   if (payload.doctorHint?.trim()) {
     lines.push(payload.doctorHint.trim());

--- a/src/infra/restart-transaction.ts
+++ b/src/infra/restart-transaction.ts
@@ -1,0 +1,123 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+export type RestartTransactionMode = "terminal-handoff" | "drain-then-restart";
+
+export type RestartTransactionState =
+  | "requested"
+  | "acked"
+  | "draining"
+  | "handoff_pending"
+  | "restarting"
+  | "boot_recovered"
+  | "completed"
+  | "needs_attention";
+
+export type RestartTransactionRequester = {
+  actor?: string;
+  deviceId?: string;
+  clientIp?: string;
+  entryPoint?: string;
+};
+
+export type RestartTransactionDeliveryContext = {
+  channel?: string;
+  to?: string;
+  accountId?: string;
+};
+
+export type RestartInterruptedTurnEnvelope = {
+  sessionKey: string;
+  turnId?: string;
+  phase?: string;
+  interruptionCause: string;
+  pendingUserVisibleFollowupNote?: string | null;
+  resumeEligible: boolean;
+};
+
+export type RestartTransaction = {
+  restartId: string;
+  requestedAt: number;
+  requester?: RestartTransactionRequester | null;
+  reason?: string | null;
+  sessionKey?: string;
+  turnId?: string;
+  mode: RestartTransactionMode;
+  state: RestartTransactionState;
+  note?: string | null;
+  deliveryContext?: RestartTransactionDeliveryContext | null;
+  threadId?: string;
+  interruptedTurn?: RestartInterruptedTurnEnvelope | null;
+  finalOutcome?: string | null;
+  finalizedAt?: number | null;
+};
+
+export type RestartTransactionFile = {
+  version: 1;
+  transaction: RestartTransaction;
+};
+
+const RESTART_TRANSACTION_FILENAME = "restart-transaction.json";
+
+export function resolveRestartTransactionPath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), RESTART_TRANSACTION_FILENAME);
+}
+
+export async function writeRestartTransaction(
+  transaction: RestartTransaction,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<string> {
+  const filePath = resolveRestartTransactionPath(env);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const data: RestartTransactionFile = {
+    version: 1,
+    transaction,
+  };
+  await fs.writeFile(filePath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+  return filePath;
+}
+
+export async function readRestartTransaction(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RestartTransaction | null> {
+  const filePath = resolveRestartTransactionPath(env);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    let parsed: RestartTransactionFile | undefined;
+    try {
+      parsed = JSON.parse(raw) as RestartTransactionFile | undefined;
+    } catch {
+      await fs.unlink(filePath).catch(() => {});
+      return null;
+    }
+    if (!parsed || parsed.version !== 1 || !parsed.transaction) {
+      await fs.unlink(filePath).catch(() => {});
+      return null;
+    }
+    return parsed.transaction;
+  } catch {
+    return null;
+  }
+}
+
+export async function updateRestartTransaction(
+  updater: (current: RestartTransaction | null) => RestartTransaction | null,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<RestartTransaction | null> {
+  const next = updater(await readRestartTransaction(env));
+  if (!next) {
+    return null;
+  }
+  await writeRestartTransaction(next, env);
+  return next;
+}
+
+export function isPendingRestartTransaction(
+  transaction: RestartTransaction | null | undefined,
+): transaction is RestartTransaction {
+  if (!transaction) {
+    return false;
+  }
+  return transaction.state !== "completed" && transaction.state !== "needs_attention";
+}

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -336,4 +336,34 @@ describe("resolveBundledPluginsDir", () => {
   ] as const)("$name", ({ createScenario }) => {
     expectInstalledBundledDirScenarioCase(createScenario);
   });
+
+  it("prefers the current worktree source checkout during vitest even when argv[1] resolves into another checkout's node_modules", () => {
+    const borrowedNodeModulesRoot = createOpenClawRoot({
+      prefix: "openclaw-bundled-dir-borrowed-source-",
+      hasExtensions: true,
+      hasSrc: true,
+      hasDistRuntimeExtensions: true,
+      hasDistExtensions: true,
+      hasGitCheckout: true,
+    });
+    const currentWorktreeRoot = createOpenClawRoot({
+      prefix: "openclaw-bundled-dir-current-worktree-",
+      hasExtensions: true,
+      hasSrc: true,
+      hasDistRuntimeExtensions: true,
+      hasDistExtensions: true,
+      hasGitCheckout: true,
+    });
+    seedBundledPluginTree(borrowedNodeModulesRoot, path.join("dist", "extensions"), "borrowed");
+    seedBundledPluginTree(currentWorktreeRoot, path.join("extensions"), "current");
+    seedBundledPluginTree(currentWorktreeRoot, path.join("dist", "extensions"), "current");
+    seedBundledPluginTree(currentWorktreeRoot, path.join("dist-runtime", "extensions"), "current");
+
+    expectResolvedBundledDir({
+      cwd: currentWorktreeRoot,
+      expectedDir: path.join(currentWorktreeRoot, "extensions"),
+      argv1: path.join(borrowedNodeModulesRoot, "node_modules", ".bin", "vitest"),
+      vitest: "true",
+    });
+  });
 });

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -108,6 +108,21 @@ function resolveBundledDirFromPackageRoot(
   return undefined;
 }
 
+function preferCurrentSourceCheckout(params: {
+  packageRoots: string[];
+  cwd: string;
+  preferSourceCheckout: boolean;
+}): string[] {
+  if (!params.preferSourceCheckout) {
+    return params.packageRoots;
+  }
+  const cwdPackageRoot = resolveOpenClawPackageRootSync({ cwd: params.cwd });
+  if (!cwdPackageRoot || !isSourceCheckoutRoot(cwdPackageRoot)) {
+    return params.packageRoots;
+  }
+  return [cwdPackageRoot, ...params.packageRoots.filter((root) => root !== cwdPackageRoot)];
+}
+
 export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): string | undefined {
   if (bundledPluginsDisabled(env)) {
     return resolveDisabledBundledPluginsDir();
@@ -139,13 +154,17 @@ export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): 
   const preferSourceCheckout = Boolean(env.VITEST) || runningSourceTypeScriptProcess();
 
   try {
-    const packageRoots = [
-      resolveOpenClawPackageRootSync({ argv1: process.argv[1] }),
-      resolveOpenClawPackageRootSync({ cwd: process.cwd() }),
-      resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url }),
-    ].filter(
-      (entry, index, all): entry is string => Boolean(entry) && all.indexOf(entry) === index,
-    );
+    const packageRoots = preferCurrentSourceCheckout({
+      packageRoots: [
+        resolveOpenClawPackageRootSync({ argv1: process.argv[1] }),
+        resolveOpenClawPackageRootSync({ cwd: process.cwd() }),
+        resolveOpenClawPackageRootSync({ moduleUrl: import.meta.url }),
+      ].filter(
+        (entry, index, all): entry is string => Boolean(entry) && all.indexOf(entry) === index,
+      ),
+      cwd: process.cwd(),
+      preferSourceCheckout,
+    });
     for (const packageRoot of packageRoots) {
       const bundledDir = resolveBundledDirFromPackageRoot(packageRoot, preferSourceCheckout);
       if (bundledDir) {


### PR DESCRIPTION
## Summary
- repair the restart transaction typing fallout from the gateway restart handoff merge
- prefer the current source checkout when Vitest or tsx resolves argv[1] through a borrowed node_modules tree
- cover the worktree case with a bundled-dir regression test so bundled plugin auth bypasses resolve from the active checkout

## Validation
- pnpm vitest run --config test/vitest/vitest.plugins.config.ts src/plugins/bundled-dir.test.ts
- pnpm vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/server.plugin-http-auth.test.ts -t "allows unauthenticated Mattermost slash callback routes while keeping other channel routes protected"
- pnpm vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-restart-sentinel.test.ts
- pnpm vitest run --config test/vitest/vitest.gateway-core.config.ts src/gateway/restart-transaction.test.ts
- commit hooks: check:changed lanes for both commits (core/coreTests, then plugins)