### PR TITLE
feat(config): support per-agent compaction overrides

### DIFF
--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -21,8 +21,8 @@ jobs:
     permissions:
       contents: read
     name: "check"
-    runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 30
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 5
     steps:
       - name: Begin Testbox
         uses: useblacksmith/begin-testbox@v2

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -21,8 +21,8 @@ jobs:
     permissions:
       contents: read
     name: "check"
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 5
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
     steps:
       - name: Begin Testbox
         uses: useblacksmith/begin-testbox@v2

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import type {
+  AgentCompactionConfig,
   AgentContextLimitsConfig,
   AgentDefaultsConfig,
 } from "../config/types.agent-defaults.js";
@@ -28,6 +29,7 @@ export type ResolvedAgentConfig = {
   humanDelay?: AgentEntry["humanDelay"];
   contextLimits?: AgentContextLimitsConfig;
   heartbeat?: AgentEntry["heartbeat"];
+  compaction?: AgentCompactionConfig;
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
   subagents?: AgentEntry["subagents"];
@@ -125,6 +127,10 @@ export function resolveAgentConfig(
         ? { ...agentDefaults?.contextLimits, ...entry.contextLimits }
         : agentDefaults?.contextLimits,
     heartbeat: entry.heartbeat,
+    compaction:
+      typeof entry.compaction === "object" && entry.compaction
+        ? { ...agentDefaults?.compaction, ...entry.compaction }
+        : agentDefaults?.compaction,
     identity: entry.identity,
     groupChat: entry.groupChat,
     subagents: typeof entry.subagents === "object" && entry.subagents ? entry.subagents : undefined,

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -129,7 +129,26 @@ export function resolveAgentConfig(
     heartbeat: entry.heartbeat,
     compaction:
       typeof entry.compaction === "object" && entry.compaction
-        ? { ...agentDefaults?.compaction, ...entry.compaction }
+        ? {
+            ...agentDefaults?.compaction,
+            ...entry.compaction,
+            qualityGuard:
+              typeof agentDefaults?.compaction?.qualityGuard === "object" ||
+              typeof entry.compaction.qualityGuard === "object"
+                ? {
+                    ...agentDefaults?.compaction?.qualityGuard,
+                    ...entry.compaction.qualityGuard,
+                  }
+                : undefined,
+            memoryFlush:
+              typeof agentDefaults?.compaction?.memoryFlush === "object" ||
+              typeof entry.compaction.memoryFlush === "object"
+                ? {
+                    ...agentDefaults?.compaction?.memoryFlush,
+                    ...entry.compaction.memoryFlush,
+                  }
+                : undefined,
+          }
         : agentDefaults?.compaction,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -117,6 +117,34 @@ describe("resolveAgentConfig", () => {
     });
   });
 
+  it("merges compaction config from defaults with per-agent overrides", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          compaction: {
+            mode: "safeguard",
+            customInstructions: "Global compaction guidance.",
+            reserveTokensFloor: 20_000,
+          },
+        },
+        list: [
+          {
+            id: "main",
+            compaction: {
+              customInstructions: "Agent-specific compaction guidance.",
+            },
+          },
+        ],
+      },
+    };
+
+    expect(resolveAgentConfig(cfg, "main")?.compaction).toMatchObject({
+      mode: "safeguard",
+      reserveTokensFloor: 20_000,
+      customInstructions: "Agent-specific compaction guidance.",
+    });
+  });
+
   it("resolves explicit and effective model primary separately", () => {
     const cfgWithStringDefault = {
       agents: {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -637,6 +637,7 @@ export async function compactEmbeddedPiSessionDirect(
       sessionKey: params.sessionKey,
       config: params.config,
     });
+    const effectiveCompactionAgentId = params.agentId ?? sessionAgentId;
     // Resolve channel-specific message actions for system prompt
     const channelActions = runtimeChannel
       ? listChannelSupportedActions(
@@ -813,7 +814,7 @@ export async function compactEmbeddedPiSessionDirect(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
-        agentId: sessionAgentId,
+        agentId: effectiveCompactionAgentId,
         contextTokenBudget: ctxInfo.tokens,
       });
       // Sets compaction/pruning runtime state and returns extension factories
@@ -824,7 +825,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
-        agentId: sessionAgentId,
+        agentId: effectiveCompactionAgentId,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,
@@ -838,7 +839,7 @@ export async function compactEmbeddedPiSessionDirect(
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
-        agentId: sessionAgentId,
+        agentId: effectiveCompactionAgentId,
         contextTokenBudget: ctxInfo.tokens,
       });
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -813,7 +813,7 @@ export async function compactEmbeddedPiSessionDirect(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
-        agentId: params.agentId,
+        agentId: sessionAgentId,
         contextTokenBudget: ctxInfo.tokens,
       });
       // Sets compaction/pruning runtime state and returns extension factories
@@ -824,7 +824,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
-        agentId: params.agentId,
+        agentId: sessionAgentId,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,
@@ -838,7 +838,7 @@ export async function compactEmbeddedPiSessionDirect(
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
-        agentId: params.agentId,
+        agentId: sessionAgentId,
         contextTokenBudget: ctxInfo.tokens,
       });
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -813,6 +813,7 @@ export async function compactEmbeddedPiSessionDirect(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        agentId: params.agentId,
         contextTokenBudget: ctxInfo.tokens,
       });
       // Sets compaction/pruning runtime state and returns extension factories
@@ -823,6 +824,7 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        agentId: params.agentId,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,
@@ -836,6 +838,7 @@ export async function compactEmbeddedPiSessionDirect(
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
+        agentId: params.agentId,
         contextTokenBudget: ctxInfo.tokens,
       });
 

--- a/src/agents/pi-embedded-runner/compact.types.ts
+++ b/src/agents/pi-embedded-runner/compact.types.ts
@@ -8,6 +8,7 @@ export type CompactEmbeddedPiSessionParams = {
   sessionId: string;
   runId?: string;
   sessionKey?: string;
+  agentId?: string;
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -16,7 +16,7 @@ vi.mock("../../plugins/provider-hook-runtime.js", () => ({
   resolveProviderRuntimePlugin: () => undefined,
 }));
 
-function buildSafeguardFactories(cfg: OpenClawConfig) {
+function buildSafeguardFactories(cfg: OpenClawConfig, agentId?: string) {
   const sessionManager = {} as SessionManager;
   const model = {
     id: "claude-sonnet-4-20250514",
@@ -29,6 +29,7 @@ function buildSafeguardFactories(cfg: OpenClawConfig) {
     provider: "anthropic",
     modelId: "claude-sonnet-4-20250514",
     model,
+    agentId,
   });
 
   return { factories, sessionManager };
@@ -36,9 +37,14 @@ function buildSafeguardFactories(cfg: OpenClawConfig) {
 
 function expectSafeguardRuntime(
   cfg: OpenClawConfig,
-  expectedRuntime: { qualityGuardEnabled: boolean; qualityGuardMaxRetries?: number },
+  expectedRuntime: {
+    qualityGuardEnabled: boolean;
+    qualityGuardMaxRetries?: number;
+    customInstructions?: string;
+  },
+  agentId?: string,
 ) {
-  const { factories, sessionManager } = buildSafeguardFactories(cfg);
+  const { factories, sessionManager } = buildSafeguardFactories(cfg, agentId);
 
   expect(factories).toContain(compactionSafeguardExtension);
   expect(getCompactionSafeguardRuntime(sessionManager)).toMatchObject(expectedRuntime);
@@ -78,6 +84,35 @@ describe("buildEmbeddedExtensionFactories", () => {
       qualityGuardEnabled: true,
       qualityGuardMaxRetries: 2,
     });
+  });
+
+  it("prefers per-agent compaction custom instructions over defaults", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            mode: "safeguard",
+            customInstructions: "Global compaction guidance.",
+          },
+        },
+        list: [
+          {
+            id: "writer",
+            compaction: {
+              customInstructions: "Keep editorial decisions and pending asks.",
+            },
+          },
+        ],
+      },
+    } as OpenClawConfig;
+    expectSafeguardRuntime(
+      cfg,
+      {
+        qualityGuardEnabled: false,
+        customInstructions: "Keep editorial decisions and pending asks.",
+      },
+      "writer",
+    );
   });
 
   it("enables cache-ttl pruning for custom anthropic-messages providers", () => {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,6 +1,7 @@
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { resolveAgentConfig } from "../agent-scope.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { setCompactionSafeguardRuntime } from "../pi-hooks/compaction-safeguard-runtime.js";
@@ -68,8 +69,10 @@ function buildContextPruningFactory(params: {
   return contextPruningExtension;
 }
 
-function resolveCompactionMode(cfg?: OpenClawConfig): "default" | "safeguard" {
-  const compaction = cfg?.agents?.defaults?.compaction;
+function resolveCompactionMode(compaction?: {
+  mode?: string;
+  provider?: string;
+}): "default" | "safeguard" {
   // A registered compaction provider requires the safeguard extension path
   if (compaction?.provider) {
     return "safeguard";
@@ -83,10 +86,14 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  agentId?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
-  if (resolveCompactionMode(params.cfg) === "safeguard") {
-    const compactionCfg = params.cfg?.agents?.defaults?.compaction;
+  const compactionCfg =
+    params.cfg && params.agentId
+      ? resolveAgentConfig(params.cfg, params.agentId)?.compaction
+      : params.cfg?.agents?.defaults?.compaction;
+  if (resolveCompactionMode(compactionCfg) === "safeguard") {
     const qualityGuardCfg = compactionCfg?.qualityGuard;
     const contextWindowInfo = resolveContextWindowInfo({
       cfg: params.cfg,

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -91,7 +91,8 @@ export function buildEmbeddedExtensionFactories(params: {
   const factories: ExtensionFactory[] = [];
   const compactionCfg =
     params.cfg && params.agentId
-      ? resolveAgentConfig(params.cfg, params.agentId)?.compaction
+      ? (resolveAgentConfig(params.cfg, params.agentId)?.compaction ??
+        params.cfg?.agents?.defaults?.compaction)
       : params.cfg?.agents?.defaults?.compaction;
   if (resolveCompactionMode(compactionCfg) === "safeguard") {
     const qualityGuardCfg = compactionCfg?.qualityGuard;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1015,6 +1015,7 @@ export async function runEmbeddedAttempt(
         cwd: effectiveWorkspace,
         agentDir,
         cfg: params.config,
+        agentId: sessionAgentId,
         contextTokenBudget: params.contextTokenBudget,
       });
       applyPiAutoCompactionGuard({
@@ -1030,6 +1031,7 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        agentId: sessionAgentId,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,
@@ -1043,6 +1045,7 @@ export async function runEmbeddedAttempt(
       applyPiCompactionSettingsFromConfig({
         settingsManager,
         cfg: params.config,
+        agentId: sessionAgentId,
         contextTokenBudget: params.contextTokenBudget,
       });
 

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -41,6 +41,7 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   cwd: string;
   agentDir: string;
   cfg?: OpenClawConfig;
+  agentId?: string;
   /** Resolved context window budget so reserve-token floor can be capped for small models. */
   contextTokenBudget?: number;
 }): SettingsManager {
@@ -48,6 +49,7 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
   applyPiCompactionSettingsFromConfig({
     settingsManager,
     cfg: params.cfg,
+    agentId: params.agentId,
     contextTokenBudget: params.contextTokenBudget,
   });
   return settingsManager;

--- a/src/agents/pi-settings.test.ts
+++ b/src/agents/pi-settings.test.ts
@@ -127,6 +127,41 @@ describe("applyPiCompactionSettingsFromConfig", () => {
     });
   });
 
+  it("prefers per-agent compaction reserve token settings over defaults", () => {
+    const settingsManager = {
+      getCompactionReserveTokens: () => 20_000,
+      getCompactionKeepRecentTokens: () => 20_000,
+      applyOverrides: vi.fn(),
+    };
+
+    const result = applyPiCompactionSettingsFromConfig({
+      settingsManager,
+      agentId: "writer",
+      cfg: {
+        agents: {
+          defaults: {
+            compaction: {
+              keepRecentTokens: 15_000,
+            },
+          },
+          list: [
+            {
+              id: "writer",
+              compaction: {
+                keepRecentTokens: 12_000,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.compaction.keepRecentTokens).toBe(12_000);
+    expect(settingsManager.applyOverrides).toHaveBeenCalledWith({
+      compaction: { keepRecentTokens: 12_000 },
+    });
+  });
+
   it("preserves current keepRecentTokens when safeguard mode leaves it unset", () => {
     const settingsManager = {
       getCompactionReserveTokens: () => 25_000,

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -1,5 +1,6 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ContextEngineInfo } from "../context-engine/types.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { MIN_PROMPT_BUDGET_RATIO, MIN_PROMPT_BUDGET_TOKENS } from "./pi-compaction-constants.js";
 
 export const DEFAULT_PI_COMPACTION_RESERVE_TOKENS_FLOOR = 20_000;
@@ -40,8 +41,18 @@ export function ensurePiCompactionReserveTokens(params: {
   return { didOverride: true, reserveTokens: minReserveTokens };
 }
 
-export function resolveCompactionReserveTokensFloor(cfg?: OpenClawConfig): number {
-  const raw = cfg?.agents?.defaults?.compaction?.reserveTokensFloor;
+function resolveCompactionConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
+  if (params.cfg && params.agentId) {
+    return resolveAgentConfig(params.cfg, params.agentId)?.compaction;
+  }
+  return params.cfg?.agents?.defaults?.compaction;
+}
+
+export function resolveCompactionReserveTokensFloor(
+  cfg?: OpenClawConfig,
+  agentId?: string,
+): number {
+  const raw = resolveCompactionConfig({ cfg, agentId })?.reserveTokensFloor;
   if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
     return Math.floor(raw);
   }
@@ -65,6 +76,7 @@ function toPositiveInt(value: unknown): number | undefined {
 export function applyPiCompactionSettingsFromConfig(params: {
   settingsManager: PiSettingsManagerLike;
   cfg?: OpenClawConfig;
+  agentId?: string;
   /** When known, the resolved context window budget for the current model. */
   contextTokenBudget?: number;
 }): {
@@ -73,11 +85,14 @@ export function applyPiCompactionSettingsFromConfig(params: {
 } {
   const currentReserveTokens = params.settingsManager.getCompactionReserveTokens();
   const currentKeepRecentTokens = params.settingsManager.getCompactionKeepRecentTokens();
-  const compactionCfg = params.cfg?.agents?.defaults?.compaction;
+  const compactionCfg = resolveCompactionConfig({
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
 
   const configuredReserveTokens = toNonNegativeInt(compactionCfg?.reserveTokens);
   const configuredKeepRecentTokens = toPositiveInt(compactionCfg?.keepRecentTokens);
-  let reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg);
+  let reserveTokensFloor = resolveCompactionReserveTokensFloor(params.cfg, params.agentId);
 
   // Cap the floor to a safe fraction of the context window so that
   // small-context models (e.g. Ollama with 16 K tokens) are not starved of

--- a/src/agents/pi-settings.ts
+++ b/src/agents/pi-settings.ts
@@ -43,7 +43,10 @@ export function ensurePiCompactionReserveTokens(params: {
 
 function resolveCompactionConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
   if (params.cfg && params.agentId) {
-    return resolveAgentConfig(params.cfg, params.agentId)?.compaction;
+    return (
+      resolveAgentConfig(params.cfg, params.agentId)?.compaction ??
+      params.cfg?.agents?.defaults?.compaction
+    );
   }
   return params.cfg?.agents?.defaults?.compaction;
 }

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4630,12 +4630,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
                   },
-                  modelFallbacks: {
-                    type: "array",
-                    items: {
-                      type: "string",
-                    },
-                  },
                   timeoutSeconds: {
                     type: "integer",
                     exclusiveMinimum: 0,
@@ -6470,12 +6464,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     },
                     model: {
                       type: "string",
-                    },
-                    modelFallbacks: {
-                      type: "array",
-                      items: {
-                        type: "string",
-                      },
                     },
                     timeoutSeconds: {
                       type: "integer",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -4630,6 +4630,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     description:
                       "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
                   },
+                  modelFallbacks: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                  },
                   timeoutSeconds: {
                     type: "integer",
                     exclusiveMinimum: 0,
@@ -6368,6 +6374,147 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       type: "boolean",
                     },
                     isolatedSession: {
+                      type: "boolean",
+                    },
+                  },
+                  additionalProperties: false,
+                },
+                compaction: {
+                  type: "object",
+                  properties: {
+                    mode: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "default",
+                        },
+                        {
+                          type: "string",
+                          const: "safeguard",
+                        },
+                      ],
+                    },
+                    provider: {
+                      type: "string",
+                    },
+                    reserveTokens: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    keepRecentTokens: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    reserveTokensFloor: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    maxHistoryShare: {
+                      type: "number",
+                      minimum: 0.1,
+                      maximum: 0.9,
+                    },
+                    customInstructions: {
+                      type: "string",
+                    },
+                    identifierPolicy: {
+                      anyOf: [
+                        {
+                          type: "string",
+                          const: "strict",
+                        },
+                        {
+                          type: "string",
+                          const: "off",
+                        },
+                        {
+                          type: "string",
+                          const: "custom",
+                        },
+                      ],
+                    },
+                    identifierInstructions: {
+                      type: "string",
+                    },
+                    recentTurnsPreserve: {
+                      type: "integer",
+                      minimum: 0,
+                      maximum: 12,
+                    },
+                    qualityGuard: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        maxRetries: {
+                          type: "integer",
+                          minimum: 0,
+                          maximum: 9007199254740991,
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    postIndexSync: {
+                      type: "string",
+                      enum: ["off", "async", "await"],
+                    },
+                    postCompactionSections: {
+                      type: "array",
+                      items: {
+                        type: "string",
+                      },
+                    },
+                    model: {
+                      type: "string",
+                    },
+                    modelFallbacks: {
+                      type: "array",
+                      items: {
+                        type: "string",
+                      },
+                    },
+                    timeoutSeconds: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
+                    },
+                    memoryFlush: {
+                      type: "object",
+                      properties: {
+                        enabled: {
+                          type: "boolean",
+                        },
+                        softThresholdTokens: {
+                          type: "integer",
+                          minimum: 0,
+                          maximum: 9007199254740991,
+                        },
+                        forceFlushTranscriptBytes: {
+                          anyOf: [
+                            {
+                              type: "integer",
+                              minimum: 0,
+                              maximum: 9007199254740991,
+                            },
+                            {
+                              type: "string",
+                            },
+                          ],
+                        },
+                        prompt: {
+                          type: "string",
+                        },
+                        systemPrompt: {
+                          type: "string",
+                        },
+                      },
+                      additionalProperties: false,
+                    },
+                    notifyUser: {
                       type: "boolean",
                     },
                   },

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -1,5 +1,6 @@
 import type { ChatType } from "../channels/chat-type.js";
 import type {
+  AgentCompactionConfig,
   AgentContextLimitsConfig,
   AgentDefaultsConfig,
   EmbeddedPiExecutionContract,
@@ -97,6 +98,8 @@ export type AgentConfig = {
   contextLimits?: AgentContextLimitsConfig;
   /** Optional per-agent heartbeat overrides. */
   heartbeat?: AgentDefaultsConfig["heartbeat"];
+  /** Optional per-agent compaction overrides. */
+  compaction?: AgentCompactionConfig;
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
   subagents?: {

--- a/src/config/zod-schema.agent-compaction.ts
+++ b/src/config/zod-schema.agent-compaction.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { isValidNonNegativeByteSizeString } from "./byte-size.js";
+
+export const AgentCompactionSchema = z
+  .object({
+    mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+    provider: z.string().optional(),
+    reserveTokens: z.number().int().nonnegative().optional(),
+    keepRecentTokens: z.number().int().positive().optional(),
+    reserveTokensFloor: z.number().int().nonnegative().optional(),
+    maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
+    customInstructions: z.string().optional(),
+    identifierPolicy: z
+      .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
+      .optional(),
+    identifierInstructions: z.string().optional(),
+    recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
+    qualityGuard: z
+      .object({
+        enabled: z.boolean().optional(),
+        maxRetries: z.number().int().nonnegative().optional(),
+      })
+      .strict()
+      .optional(),
+    postIndexSync: z.enum(["off", "async", "await"]).optional(),
+    postCompactionSections: z.array(z.string()).optional(),
+    model: z.string().optional(),
+    modelFallbacks: z.array(z.string()).optional(),
+    timeoutSeconds: z.number().int().positive().optional(),
+    memoryFlush: z
+      .object({
+        enabled: z.boolean().optional(),
+        softThresholdTokens: z.number().int().nonnegative().optional(),
+        forceFlushTranscriptBytes: z
+          .union([
+            z.number().int().nonnegative(),
+            z
+              .string()
+              .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
+          ])
+          .optional(),
+        prompt: z.string().optional(),
+        systemPrompt: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    notifyUser: z.boolean().optional(),
+  })
+  .strict()
+  .optional();

--- a/src/config/zod-schema.agent-compaction.ts
+++ b/src/config/zod-schema.agent-compaction.ts
@@ -25,7 +25,6 @@ export const AgentCompactionSchema = z
     postIndexSync: z.enum(["off", "async", "await"]).optional(),
     postCompactionSections: z.array(z.string()).optional(),
     model: z.string().optional(),
-    modelFallbacks: z.array(z.string()).optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     memoryFlush: z
       .object({

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { DEFAULT_LLM_IDLE_TIMEOUT_SECONDS } from "./agent-timeout-defaults.js";
-import { isValidNonNegativeByteSizeString } from "./byte-size.js";
+import { AgentCompactionSchema } from "./zod-schema.agent-compaction.js";
 import {
   HeartbeatSchema,
   AgentSandboxSchema,
@@ -153,52 +153,7 @@ export const AgentDefaultsSchema = z
       })
       .strict()
       .optional(),
-    compaction: z
-      .object({
-        mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
-        provider: z.string().optional(),
-        reserveTokens: z.number().int().nonnegative().optional(),
-        keepRecentTokens: z.number().int().positive().optional(),
-        reserveTokensFloor: z.number().int().nonnegative().optional(),
-        maxHistoryShare: z.number().min(0.1).max(0.9).optional(),
-        customInstructions: z.string().optional(),
-        identifierPolicy: z
-          .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
-          .optional(),
-        identifierInstructions: z.string().optional(),
-        recentTurnsPreserve: z.number().int().min(0).max(12).optional(),
-        qualityGuard: z
-          .object({
-            enabled: z.boolean().optional(),
-            maxRetries: z.number().int().nonnegative().optional(),
-          })
-          .strict()
-          .optional(),
-        postIndexSync: z.enum(["off", "async", "await"]).optional(),
-        postCompactionSections: z.array(z.string()).optional(),
-        model: z.string().optional(),
-        timeoutSeconds: z.number().int().positive().optional(),
-        memoryFlush: z
-          .object({
-            enabled: z.boolean().optional(),
-            softThresholdTokens: z.number().int().nonnegative().optional(),
-            forceFlushTranscriptBytes: z
-              .union([
-                z.number().int().nonnegative(),
-                z
-                  .string()
-                  .refine(isValidNonNegativeByteSizeString, "Expected byte size string like 2mb"),
-              ])
-              .optional(),
-            prompt: z.string().optional(),
-            systemPrompt: z.string().optional(),
-          })
-          .strict()
-          .optional(),
-        notifyUser: z.boolean().optional(),
-      })
-      .strict()
-      .optional(),
+    compaction: AgentCompactionSchema,
     embeddedPi: z
       .object({
         projectSettingsPolicy: z

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -5,6 +5,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "../shared/string-coerce.js";
+import { AgentCompactionSchema } from "./zod-schema.agent-compaction.js";
 import { AgentModelSchema } from "./zod-schema.agent-model.js";
 import {
   GroupChatSchema,
@@ -829,6 +830,7 @@ export const AgentEntrySchema = z
     skillsLimits: AgentSkillsLimitsSchema,
     contextLimits: AgentContextLimitsSchema,
     heartbeat: HeartbeatSchema,
+    compaction: AgentCompactionSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
     subagents: z


### PR DESCRIPTION
## Summary

- Problem: compaction overrides were supported only at `agents.defaults.compaction`, so all agents had to share the same compaction instructions and runtime settings.
- Why it matters: specialized agents need different compaction guidance to preserve the right context during long-running sessions.
- What changed: added optional `agents.list[].compaction` support, merged it over defaults, and threaded effective per-agent compaction config through embedded runtime compaction paths.
- What did NOT change (scope boundary): default-only behavior remains unchanged when per-agent overrides are omitted; this PR does not redesign the broader config resolution model beyond compaction.

## Change Type (select all)

- [x] Feature
- [x] Refactor required for the fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Closes #69985
- Related #69987
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: compaction config existed only on the agent defaults surface, and runtime compaction paths read only `agents.defaults.compaction`.
- Missing detection / guardrail: there was no config/runtime path for agent-scoped compaction resolution.
- Contributing context (if known): upstream already had a mature compaction config shape, so the missing behavior was override placement and runtime wiring rather than compaction capability itself.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/agent-scope.test.ts`
  - `src/agents/pi-settings.test.ts`
  - `src/agents/pi-embedded-runner/extensions.test.ts`
- Scenario the test should lock in:
  - per-agent compaction config merges over defaults
  - per-agent `customInstructions` wins over default `customInstructions`
  - runtime compaction setup consumes the effective agent-specific config
- Why this is the smallest reliable guardrail:
  - these tests cover both config resolution and the embedded runtime handoff where compaction instructions are actually consumed
- Existing test that already covers this (if any): config schema and runtime-config suites cover the broader config surface
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- OpenClaw now accepts optional `agents.list[].compaction` entries.
- Per-agent compaction fields inherit from `agents.defaults.compaction` and override defaults when set.
- `agents.list[].compaction.customInstructions` now lets each agent provide its own compaction guidance.

## Diagram (if applicable)

```text
Before:
[agent run] -> [agents.defaults.compaction only] -> [shared compaction behavior for every agent]

After:
[agent run] -> [agents.list[].compaction if present] -> [fallback to agents.defaults.compaction] -> [agent-specific compaction behavior]
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local OpenClaw dev environment
- Model/provider: N/A (config/runtime path change)
- Integration/channel (if any): N/A
- Relevant config (redacted): multi-agent config with `agents.defaults.compaction` plus `agents.list[].compaction`

### Steps

1. Configure `agents.defaults.compaction.customInstructions`.
2. Add `agents.list[].compaction.customInstructions` for a specific agent.
3. Run config validation and embedded compaction/runtime tests.

### Expected

- Config validates.
- Effective compaction settings for that agent use the per-agent override.
- Other agents continue inheriting defaults.

### Actual

- Verified locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - staged typecheck/lint/import-cycle guards passed
  - generated schema baseline updated and validated
  - runtime-config and agents test suites passed in the changed-file gate
  - per-agent compaction merge and runtime precedence covered by added tests
- Edge cases checked:
  - per-agent override with inherited default fields
  - no per-agent override preserves prior defaults-only behavior
  - shared schema extraction did not leave runtime import cycles
- What you did **not** verify:
  - manual end-to-end interactive compaction against a live chat session

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: per-agent compaction schema could drift from defaults compaction schema over time.
  - Mitigation: this PR extracts the shared compaction schema into a dedicated config schema module and reuses it in both places.
- Risk: runtime compaction paths could accidentally keep reading defaults-only config.
  - Mitigation: this PR threads `agentId` through the affected embedded runtime setup paths and adds tests around the effective runtime behavior.
