### PR TITLE
docs(gog): include Google Tasks clear command

### DIFF
--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -60,6 +60,7 @@ Common commands
 - Tasks list tasklists: `gog tasks lists list --json`
 - Tasks create tasklist: `gog tasks lists create "Sprint Inbox" --json`
 - Tasks list: `gog tasks list <tasklistId> --json`
+- Tasks list completed: `gog tasks list <tasklistId> --show-completed --show-hidden --json`
 - Tasks get: `gog tasks get <tasklistId> <taskId> --json`
 - Tasks add: `gog tasks add <tasklistId> --title "Title" --notes "Description" --due 2026-04-26`
 - Tasks update: `gog tasks update <tasklistId> <taskId> --title "New title" --status completed`

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -57,6 +57,8 @@ Common commands
 - Sheets metadata: `gog sheets metadata <sheetId> --json`
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
+- Docs write markdown: `gog docs write <docId> --markdown-file ./notes.md`
+- Docs find/replace: `gog docs edit <docId> "Old text" "New text"`
 - Tasks list tasklists: `gog tasks lists list --json`
 - Tasks create tasklist: `gog tasks lists create "Sprint Inbox" --json`
 - Tasks list: `gog tasks list <tasklistId> --json`
@@ -123,6 +125,6 @@ Notes
 - Set `GOG_ACCOUNT=you@gmail.com` to avoid repeating `--account`.
 - For scripting, prefer `--json` plus `--no-input`.
 - Sheets values can be passed via `--values-json` (recommended) or as inline rows.
-- Docs supports export/cat/copy. In-place edits require a Docs API client (not in gog).
+- Docs also supports native create/copy/write/edit/find-replace/clear flows; use `gog docs --help` to inspect the full command set.
 - Confirm before sending mail or creating events.
 - `gog gmail search` returns one row per thread; use `gog gmail messages search` when you need every individual email returned separately.

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -57,8 +57,10 @@ Common commands
 - Sheets metadata: `gog sheets metadata <sheetId> --json`
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
-- Docs write markdown: `gog docs write <docId> --markdown-file ./notes.md`
+- Docs write markdown: `gog docs write <docId> --file ./notes.md --markdown --replace`
 - Docs find/replace: `gog docs edit <docId> "Old text" "New text"`
+- Docs list comments: `gog docs comments list <docId> --json`
+- Docs reply to comment: `gog docs comments reply <docId> <commentId> "Thanks, fixed"`
 - Tasks list tasklists: `gog tasks lists list --json`
 - Tasks create tasklist: `gog tasks lists create "Sprint Inbox" --json`
 - Tasks list: `gog tasks list <tasklistId> --json`

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -58,7 +58,9 @@ Common commands
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
 - Tasks list tasklists: `gog tasks lists list --json`
+- Tasks create tasklist: `gog tasks lists create "Sprint Inbox" --json`
 - Tasks list: `gog tasks list <tasklistId> --json`
+- Tasks get: `gog tasks get <tasklistId> <taskId> --json`
 - Tasks add: `gog tasks add <tasklistId> --title "Title" --notes "Description" --due 2026-04-26`
 - Tasks update: `gog tasks update <tasklistId> <taskId> --title "New title" --status completed`
 - Tasks done: `gog tasks done <tasklistId> <taskId>`

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, Docs, and Tasks.
 homepage: https://gogcli.sh
 metadata:
   {
@@ -24,12 +24,12 @@ metadata:
 
 # gog
 
-Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs. Requires OAuth setup.
+Use `gog` for Gmail/Calendar/Drive/Contacts/Sheets/Docs/Tasks. Requires OAuth setup.
 
 Setup (once)
 
 - `gog auth credentials /path/to/client_secret.json`
-- `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets`
+- `gog auth add you@gmail.com --services gmail,calendar,drive,contacts,docs,sheets,tasks`
 - `gog auth list`
 
 Common commands
@@ -108,6 +108,7 @@ Email Formatting
   ```
 
 - Example (HTML list):
+
   ```bash
   gog gmail send --to recipient@example.com \
     --subject "Meeting Follow-up" \

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -57,6 +57,13 @@ Common commands
 - Sheets metadata: `gog sheets metadata <sheetId> --json`
 - Docs export: `gog docs export <docId> --format txt --out /tmp/doc.txt`
 - Docs cat: `gog docs cat <docId>`
+- Tasks list tasklists: `gog tasks lists list --json`
+- Tasks list: `gog tasks list <tasklistId> --json`
+- Tasks add: `gog tasks add <tasklistId> --title "Title" --notes "Description" --due 2026-04-26`
+- Tasks update: `gog tasks update <tasklistId> <taskId> --title "New title" --status completed`
+- Tasks done: `gog tasks done <tasklistId> <taskId>`
+- Tasks undo: `gog tasks undo <tasklistId> <taskId>`
+- Tasks delete: `gog tasks delete <tasklistId> <taskId>`
 
 Calendar Colors
 

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -64,6 +64,7 @@ Common commands
 - Tasks done: `gog tasks done <tasklistId> <taskId>`
 - Tasks undo: `gog tasks undo <tasklistId> <taskId>`
 - Tasks delete: `gog tasks delete <tasklistId> <taskId>`
+- Tasks clear done: `gog tasks clear <tasklistId>`
 
 Calendar Colors
 

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -61,7 +61,7 @@ Common commands
 - Docs find/replace: `gog docs edit <docId> "Old text" "New text"`
 - Docs list comments: `gog docs comments list <docId> --json`
 - Docs reply to comment: `gog docs comments reply <docId> <commentId> "Thanks, fixed"`
-- Tasks list tasklists: `gog tasks lists list --json`
+- Tasks list task lists: `gog tasks lists --json`
 - Tasks create tasklist: `gog tasks lists create "Sprint Inbox" --json`
 - Tasks list: `gog tasks list <tasklistId> --json`
 - Tasks list completed: `gog tasks list <tasklistId> --show-completed --show-hidden --json`
@@ -71,7 +71,7 @@ Common commands
 - Tasks done: `gog tasks done <tasklistId> <taskId>`
 - Tasks undo: `gog tasks undo <tasklistId> <taskId>`
 - Tasks delete: `gog tasks delete <tasklistId> <taskId>`
-- Tasks clear done: `gog tasks clear <tasklistId>`
+- Tasks clear completed: `gog tasks clear <tasklistId>`
 
 Calendar Colors
 


### PR DESCRIPTION
## Summary
- add missing `gog tasks clear <tasklistId>` example to `skills/gog/SKILL.md`
- keep the Tasks command set complete in one place for agent discovery

Closes #69094

## Validation
- `pnpm check`

## Targeted tests
- N/A (docs-only change)
