### PR TITLE
fix(cron): support HH:MM time-only strings in --at; apply --tz to time-only input

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -63,13 +63,13 @@ Task reconciliation for cron is runtime-owned first, durable-history-backed seco
 
 ## Schedule types
 
-| Kind    | CLI flag  | Description                                             |
-| ------- | --------- | ------------------------------------------------------- |
-| `at`    | `--at`    | One-shot timestamp (ISO 8601 or relative like `20m`)    |
-| `every` | `--every` | Fixed interval                                          |
-| `cron`  | `--cron`  | 5-field or 6-field cron expression with optional `--tz` |
+| Kind    | CLI flag  | Description                                                                  |
+| ------- | --------- | ---------------------------------------------------------------------------- |
+| `at`    | `--at`    | One-shot time: ISO 8601, `HH:MM`/`HH:MM:SS`, or relative duration like `20m` |
+| `every` | `--every` | Fixed interval                                                               |
+| `cron`  | `--cron`  | 5-field or 6-field cron expression with optional `--tz`                      |
 
-Timestamps without a timezone are treated as UTC. Add `--tz America/New_York` for local wall-clock scheduling.
+Timestamps and time-only values without a timezone are treated as UTC. Add `--tz America/New_York` for local wall-clock scheduling.
 
 Recurring top-of-hour expressions are automatically staggered by up to 5 minutes to reduce load spikes. Use `--exact` to force precise timing or `--stagger 30s` for an explicit window.
 

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -131,7 +131,7 @@ reported as pre-model cron failures.
 
 ### One-shot jobs
 
-`--at <datetime>` schedules a one-shot run. Offset-less datetimes are treated as UTC unless you also pass `--tz <iana>`, which interprets the wall-clock time in the given timezone.
+`--at <when>` schedules a one-shot run. It accepts ISO timestamps, offset-less datetimes, time-only values like `09:00` or `09:00:30`, and relative durations like `20m` or `+20m`. Offset-less and time-only values are treated as UTC unless you also pass `--tz <iana>`, which interprets the wall-clock time in the given timezone.
 
 <Note>
 One-shot jobs delete after success by default. Use `--keep-after-run` to preserve them.

--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -309,7 +309,9 @@ describe("cron cli", () => {
 
     expect(addCommand?.helpInformation()).toContain("Gateway host local timezone");
     expect(editCommand?.helpInformation()).toContain("Gateway host local timezone");
-    expect(editCommand?.helpInformation()).toMatch(/offset-less uses\s+--tz/);
+    expect(addCommand?.helpInformation()).toContain("HH:MM[:SS]");
+    expect(editCommand?.helpInformation()).toContain("HH:MM[:SS]");
+    expect(editCommand?.helpInformation()).toContain("--tz for offset-less");
   });
 
   it.each([

--- a/src/cli/cron-cli/parse-at.test.ts
+++ b/src/cli/cron-cli/parse-at.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { parseAt } from "./shared.js";
+
+function getDateTimeParts(iso: string, timeZone: string) {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(iso));
+  const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "";
+  return {
+    year: get("year"),
+    month: get("month"),
+    day: get("day"),
+    hour: get("hour"),
+    minute: get("minute"),
+    second: get("second"),
+  };
+}
+
+describe("parseAt", () => {
+  it("resolves HH:MM with --tz using today's date in that timezone", () => {
+    const result = parseAt("09:00", "Asia/Shanghai");
+    expect(result).not.toBeNull();
+
+    const actual = getDateTimeParts(result!, "Asia/Shanghai");
+    const today = getDateTimeParts(new Date().toISOString(), "Asia/Shanghai");
+
+    expect(actual.year).toBe(today.year);
+    expect(actual.month).toBe(today.month);
+    expect(actual.day).toBe(today.day);
+    expect(actual.hour).toBe("09");
+    expect(actual.minute).toBe("00");
+    expect(actual.second).toBe("00");
+  });
+
+  it("resolves HH:MM without --tz as a UTC wall-clock time for today", () => {
+    const result = parseAt("09:00");
+    expect(result).not.toBeNull();
+
+    const actual = getDateTimeParts(result!, "UTC");
+    const today = getDateTimeParts(new Date().toISOString(), "UTC");
+
+    expect(actual.year).toBe(today.year);
+    expect(actual.month).toBe(today.month);
+    expect(actual.day).toBe(today.day);
+    expect(actual.hour).toBe("09");
+    expect(actual.minute).toBe("00");
+    expect(actual.second).toBe("00");
+  });
+
+  it("resolves HH:MM:SS with seconds", () => {
+    const result = parseAt("14:30:45", "UTC");
+    expect(result).not.toBeNull();
+
+    const actual = getDateTimeParts(result!, "UTC");
+    expect(actual.hour).toBe("14");
+    expect(actual.minute).toBe("30");
+    expect(actual.second).toBe("45");
+  });
+
+  it("still resolves offset-less ISO datetime with --tz", () => {
+    const result = parseAt("2030-01-01T09:00:00", "Asia/Shanghai");
+    expect(result).toBe("2030-01-01T01:00:00.000Z");
+  });
+
+  it("still resolves relative duration strings", () => {
+    const before = Date.now();
+    const result = parseAt("30m");
+    expect(result).not.toBeNull();
+
+    const resolvedMs = new Date(result!).getTime();
+    const after = Date.now();
+    expect(resolvedMs).toBeGreaterThanOrEqual(before + 30 * 60 * 1000 - 100);
+    expect(resolvedMs).toBeLessThanOrEqual(after + 30 * 60 * 1000 + 100);
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseAt("not-a-time")).toBeNull();
+    expect(parseAt("")).toBeNull();
+  });
+
+  it("returns null instead of throwing for invalid IANA timezones", () => {
+    expect(() => parseAt("09:00", "Bad/Zone")).not.toThrow();
+    expect(parseAt("09:00", "Bad/Zone")).toBeNull();
+    expect(parseAt("09:00", "Asia/Shanghaix")).toBeNull();
+  });
+
+  it.each([
+    "24:00",
+    "24:00:00",
+    "12:60",
+    "12:30:60",
+    "99:99",
+  ])("rejects out-of-range time-only input %s without --tz", (input) => {
+    expect(parseAt(input)).toBeNull();
+  });
+
+  it.each([
+    "24:00",
+    "24:00:00",
+    "12:60",
+    "12:30:60",
+    "99:99",
+  ])("rejects out-of-range time-only input %s with --tz", (input) => {
+    expect(parseAt(input, "Asia/Shanghai")).toBeNull();
+  });
+});

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -98,7 +98,7 @@ export function registerCronAddCommand(cron: Command) {
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)", "now")
       .option(
         "--at <when>",
-        "Run once at time (ISO with offset, or +duration). Use --tz for offset-less datetimes",
+        "Run once at time (ISO, HH:MM[:SS], or +duration). Use --tz for offset-less values",
       )
       .option("--every <duration>", "Run every duration (e.g. 10m, 1h)")
       .option("--cron <expr>", "Cron expression (5-field or 6-field with seconds)")

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -88,7 +88,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--session-key <key>", "Set session key for job routing")
       .option("--clear-session-key", "Unset session key", false)
       .option("--wake <mode>", "Wake mode (now|next-heartbeat)")
-      .option("--at <when>", "Set one-shot time (ISO, offset-less uses --tz) or duration like 20m")
+      .option(
+        "--at <when>",
+        "Set one-shot time (ISO, HH:MM[:SS], or +duration). Use --tz for offset-less values",
+      )
       .option("--every <duration>", "Set interval duration like 10m")
       .option("--cron <expr>", "Set cron expression")
       .option(

--- a/src/cli/cron-cli/schedule-options.ts
+++ b/src/cli/cron-cli/schedule-options.ts
@@ -148,7 +148,7 @@ function resolveDirectSchedule(options: NormalizedScheduleOptions): CronSchedule
   if (options.at) {
     const atIso = parseAt(options.at, options.tz);
     if (!atIso) {
-      throw new Error("Invalid --at. Use an ISO timestamp or a duration like 20m.");
+      throw new Error("Invalid --at. Use an ISO timestamp, HH:MM time, or a duration like 20m.");
     }
     return { kind: "at", at: atIso };
   }

--- a/src/cli/cron-cli/shared.test.ts
+++ b/src/cli/cron-cli/shared.test.ts
@@ -249,6 +249,35 @@ describe("parseAt", () => {
     expect(parseAt("30m")).toBe("2026-05-25T00:30:00.000Z");
   });
 
+  it("accepts bare HH:MM and HH:MM:SS time-only values as UTC today", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-25T23:30:00.000Z"));
+
+    expect(parseAt("09:00")).toBe("2026-05-25T09:00:00.000Z");
+    expect(parseAt("09:00:30")).toBe("2026-05-25T09:00:30.000Z");
+  });
+
+  it("uses --tz to resolve time-only values against today's date in that timezone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-24T16:30:00.000Z"));
+
+    expect(parseAt("09:00", "Asia/Shanghai")).toBe("2026-05-25T01:00:00.000Z");
+  });
+
+  it("returns null for invalid time-only timezones", () => {
+    expect(parseAt("09:00", "Mars/Base")).toBeNull();
+  });
+
+  it("returns null for invalid offset-less ISO timezones", () => {
+    expect(parseAt("2026-05-25T09:00:00", "Mars/Base")).toBeNull();
+  });
+
+  it("rejects out-of-range time-only values", () => {
+    expect(parseAt("24:00")).toBeNull();
+    expect(parseAt("12:60")).toBeNull();
+    expect(parseAt("12:30:60")).toBeNull();
+  });
+
   it("rejects out-of-range epoch milliseconds", () => {
     expect(parseAt(String(Number.MAX_SAFE_INTEGER))).toBeNull();
   });

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -115,17 +115,64 @@ export function parseCronToolsAllow(input: unknown): string[] | undefined {
   return tools.length > 0 ? tools : undefined;
 }
 
+const TIME_ONLY_RE = /^(\d{2}):(\d{2})(?::(\d{2}))?$/;
+
+function getUtcDateString(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function getTodayDateInTimeZone(timeZone: string): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date());
+    const get = (type: string) => parts.find((part) => part.type === type)?.value ?? "00";
+    return `${get("year")}-${get("month")}-${get("day")}`;
+  } catch {
+    return null;
+  }
+}
+
+function isValidTimeOnlyParts(hour: string, minute: string, second: string): boolean {
+  const hh = Number.parseInt(hour, 10);
+  const mm = Number.parseInt(minute, 10);
+  const ss = Number.parseInt(second, 10);
+  return hh >= 0 && hh <= 23 && mm >= 0 && mm <= 59 && ss >= 0 && ss <= 59;
+}
+
 /**
  * Parse a one-shot `--at` value into an ISO string (UTC).
  *
- * When `tz` is provided and the input is an offset-less datetime
- * (e.g. `2026-03-23T23:00:00`), the datetime is interpreted in
- * that IANA timezone instead of UTC.
+ * When `tz` is provided and the input is an offset-less datetime or a time-only
+ * string, the wall-clock value is interpreted in that IANA timezone instead of UTC.
  */
 export function parseAt(input: string, tz?: string): string | null {
   const raw = input.trim();
   if (!raw) {
     return null;
+  }
+
+  const timeOnlyMatch = TIME_ONLY_RE.exec(raw);
+  if (timeOnlyMatch) {
+    const hh = timeOnlyMatch[1] ?? "00";
+    const mm = timeOnlyMatch[2] ?? "00";
+    const ss = timeOnlyMatch[3] ?? "00";
+    if (!isValidTimeOnlyParts(hh, mm, ss)) {
+      return null;
+    }
+    const todayStr = tz ? getTodayDateInTimeZone(tz) : getUtcDateString();
+    if (todayStr === null) {
+      return null;
+    }
+    const offsetlessDateTime = `${todayStr}T${hh}:${mm}:${ss}`;
+    if (tz) {
+      return parseOffsetlessIsoDateTimeInTimeZone(offsetlessDateTime, tz);
+    }
+    const ms = Date.parse(`${offsetlessDateTime}Z`);
+    return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
   }
 
   // If a timezone is provided and the input looks like an offset-less ISO datetime,

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -280,17 +280,66 @@ export function parseCronFallbacks(input: unknown): string[] | undefined {
     .filter((fallback): fallback is string => Boolean(fallback));
 }
 
+const TIME_ONLY_RE = /^(\d{2}):(\d{2})(?::(\d{2}))?$/u;
+
+function parseTimeOnlyIsoTime(raw: string): string | null | undefined {
+  const match = TIME_ONLY_RE.exec(raw);
+  if (!match) {
+    return undefined;
+  }
+  const hour = Number.parseInt(match[1] ?? "", 10);
+  const minute = Number.parseInt(match[2] ?? "", 10);
+  const second = Number.parseInt(match[3] ?? "0", 10);
+  if (hour > 23 || minute > 59 || second > 59) {
+    return null;
+  }
+  return `${match[1]}:${match[2]}:${match[3] ?? "00"}`;
+}
+
+function getCurrentUtcDateString(): string {
+  return new Date(Date.now()).toISOString().slice(0, 10);
+}
+
+function getCurrentDateStringInTimeZone(timeZone: string): string | null {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(Date.now()));
+    const getPart = (type: string) => parts.find((part) => part.type === type)?.value;
+    const year = getPart("year");
+    const month = getPart("month");
+    const day = getPart("day");
+    return year && month && day ? `${year}-${month}-${day}` : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Parse a one-shot `--at` value into an ISO string (UTC).
  *
- * When `tz` is provided and the input is an offset-less datetime
- * (e.g. `2026-03-23T23:00:00`), the datetime is interpreted in
+ * When `tz` is provided and the input is an offset-less datetime or time-only
+ * value (e.g. `2026-03-23T23:00:00` or `09:00`), the value is interpreted in
  * that IANA timezone instead of UTC.
  */
 export function parseAt(input: string, tz?: string): string | null {
   const raw = input.trim();
   if (!raw) {
     return null;
+  }
+
+  const timeOnlyIsoTime = parseTimeOnlyIsoTime(raw);
+  if (timeOnlyIsoTime !== undefined) {
+    if (timeOnlyIsoTime === null) {
+      return null;
+    }
+    const date = tz ? getCurrentDateStringInTimeZone(tz) : getCurrentUtcDateString();
+    return date
+      ? parseOffsetlessIsoDateTimeInTimeZone(`${date}T${timeOnlyIsoTime}`, tz ?? "UTC")
+      : null;
   }
 
   // If a timezone is provided and the input looks like an offset-less ISO datetime,


### PR DESCRIPTION
## Summary

Clean respin of #59444 with the diff scoped to the cron `--at` parser and the public help/docs surfaces that describe that parser.

- Support bare `HH:MM` / `HH:MM:SS` values in `cron add --at` via `parseAt(input, tz?)`.
- Resolve time-only inputs against today's date in UTC by default, or today's date in `--tz` when provided.
- Return `null` for invalid IANA timezone strings and out-of-range time-only values (`24:00`, `12:60`, `12:30:60`).
- Preserve all existing absolute ISO, offset-less ISO, `20m`, and `+20m` semantics.
- Document the new `HH:MM[:SS]` accepted format in `cron add` / `cron edit` help and cron docs.

## Scope

This PR intentionally stays within the current cron CLI schedule parsing and public documentation surface:

- `src/cli/cron-cli/shared.ts`
- `src/cli/cron-cli/shared.test.ts`
- `src/cli/cron-cli/register.cron-add.ts`
- `src/cli/cron-cli/register.cron-edit.ts`
- `src/cli/cron-cli/schedule-options.ts`
- `src/cli/cron-cli.test.ts`
- `docs/cli/cron.md`
- `docs/automation/cron-jobs.md`

Current `main` already supports both `20m` and `+20m` duration input. This PR does not change that duration branch.

## Real Behavior Proof

- Behavior or issue addressed: `cron add --at` now accepts bare time-only `HH:MM` / `HH:MM:SS` values, applies `--tz` to those values, rejects invalid time-only values, preserves duration behavior, and exposes the new accepted format in CLI help/docs.
- Real environment tested: Windows PowerShell in the OpenClaw repo, Node.js v24.13.0 via `npx -y node@24.13.0`, branch head `b3ae6154ed92fca4356698d587e6a708cd9ca611`.
- Exact steps or command run after this patch: `npx -y node@24.13.0 scripts/test-projects.mjs src/cli/cron-cli/shared.test.ts`; `npx -y node@24.13.0 scripts/test-projects.mjs src/cli/cron-cli.test.ts`; `npx -y node@24.13.0 node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/cron-cli/schedule-options.ts src/cli/cron-cli.test.ts docs/cli/cron.md docs/automation/cron-jobs.md`; `npx -y node@24.13.0 scripts/check-docs-mdx.mjs docs/cli/cron.md docs/automation/cron-jobs.md`; `npx -y node@24.13.0 node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/cron-cli/schedule-options.ts src/cli/cron-cli.test.ts`; parser and CLI commands shown below.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied terminal output below from Node.js 24.13.0 test runs, `parseAt` console output, and real `node openclaw.mjs cron add` commands using a dummy gateway URL.
- Observed result after fix: Time-only values produce the expected ISO timestamps, invalid timezone/time-only inputs return `null` or fail before gateway access, valid `09:00` and `--tz Asia/Shanghai` CLI inputs pass parser validation and reach the dummy gateway, and help/docs checks pass.
- What was not tested: No known gaps for parser/help/docs behavior; live job creation against a real Gateway was intentionally not performed because the dummy gateway proof exercises validation without creating a schedule.
- Proof limitations or environment constraints: The default PATH Node on this Windows host is v20.19.1, which is below the repo `>=22.19.0` engine requirement; all accepted verification below used Node.js v24.13.0.

Runtime used for verification:

```text
$ npx -y node@24.13.0 -v
v24.13.0
```

Targeted test runs:

```text
$ npx -y node@24.13.0 scripts/test-projects.mjs src/cli/cron-cli/shared.test.ts
Test Files  1 passed (1)
Tests       33 passed (33)
[test] passed 1 Vitest shard

$ npx -y node@24.13.0 scripts/test-projects.mjs src/cli/cron-cli.test.ts
Test Files  1 passed (1)
Tests       92 passed (92)
[test] passed 1 Vitest shard
```

Targeted lint and docs checks:

```text
$ git diff --check
# passed

$ npx -y node@24.13.0 node_modules/oxlint/bin/oxlint --tsconfig config/tsconfig/oxlint.core.json src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/cron-cli/schedule-options.ts src/cli/cron-cli.test.ts
# passed

$ npx -y node@24.13.0 node_modules/oxfmt/bin/oxfmt --check --threads=1 --config .oxfmtrc.jsonc src/cli/cron-cli/register.cron-add.ts src/cli/cron-cli/register.cron-edit.ts src/cli/cron-cli/schedule-options.ts src/cli/cron-cli.test.ts docs/cli/cron.md docs/automation/cron-jobs.md
All matched files use the correct format.

$ npx -y node@24.13.0 scripts/check-docs-mdx.mjs docs/cli/cron.md docs/automation/cron-jobs.md
Docs MDX check passed (2 files, 531ms).
```

Parser proof with `Date.now()` fixed at `2026-06-15T00:00:00Z`:

```text
$ npx -y node@24.13.0 --import tsx -e "import { parseAt } from './src/cli/cron-cli/shared.ts'; Date.now = () => Date.parse('2026-06-15T00:00:00Z'); const cases = { utcTime: parseAt('09:00'), utcTimeWithSeconds: parseAt('09:00:30'), shanghaiTime: parseAt('09:00', 'Asia/Shanghai'), invalidTimezone: parseAt('09:00', 'Not/AZone'), invalidHour: parseAt('24:00'), invalidMinute: parseAt('12:60'), plusDurationAccepted: parseAt('+20m') !== null, bareDurationAccepted: parseAt('20m') !== null }; console.log(JSON.stringify(cases, null, 2));"
{
  "utcTime": "2026-06-15T09:00:00.000Z",
  "utcTimeWithSeconds": "2026-06-15T09:00:30.000Z",
  "shanghaiTime": "2026-06-15T01:00:00.000Z",
  "invalidTimezone": null,
  "invalidHour": null,
  "invalidMinute": null,
  "plusDurationAccepted": true,
  "bareDurationAccepted": true
}
```

Real CLI proof using a dummy gateway URL so no job can be created:

```text
$ OPENCLAW_GATEWAY_URL=ws://127.0.0.1:9/ws OPENCLAW_GATEWAY_TOKEN=proof-token node openclaw.mjs cron add --name codex-time-proof --at 09:00 --message "Time-only proof" --no-deliver --agent main --json
GatewayTransportError: gateway closed (1006 abnormal closure (no close frame)): no close reason
Gateway target: ws://127.0.0.1:9/ws
Source: env OPENCLAW_GATEWAY_URL
```

That command reaches the gateway path, proving `09:00` is accepted by `--at` parsing. The invalid time-only case still fails before any gateway call:

```text
$ OPENCLAW_GATEWAY_URL=ws://127.0.0.1:9/ws OPENCLAW_GATEWAY_TOKEN=proof-token node openclaw.mjs cron add --name codex-time-proof --at 24:00 --message "Time-only proof" --no-deliver --agent main --json
Error: Invalid --at. Use an ISO timestamp, HH:MM time, or a duration like 20m.
```

The `--tz` time-only path also reaches the safe dummy gateway instead of failing parser validation:

```text
$ OPENCLAW_GATEWAY_URL=ws://127.0.0.1:9/ws OPENCLAW_GATEWAY_TOKEN=proof-token node openclaw.mjs cron add --name codex-time-proof --at 09:00 --tz Asia/Shanghai --message "Time-only proof" --no-deliver --agent main --json
GatewayTransportError: gateway closed (1006 abnormal closure (no close frame)): no close reason
Gateway target: ws://127.0.0.1:9/ws
Source: env OPENCLAW_GATEWAY_URL
```

Covered cases include:

- `09:00`
- `09:00:30`
- `--tz Asia/Shanghai`
- invalid timezone returning `null`
- `24:00`, `12:60`, `12:30:60`
- existing `+30m` and `30m` duration behavior
- help/docs discoverability for `HH:MM[:SS]`

## Related

- Closes #59441
- Supersedes #59444


