### PR TITLE
[codex] suppress heartbeat-isolated exec self-wake loop

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -16,6 +16,7 @@ const buildSessionLookup = (
     label?: string;
     spawnedBy?: string;
     parentSessionKey?: string;
+    heartbeatIsolatedBaseSessionKey?: string;
   } = {},
 ): ReturnType<typeof loadSessionEntryType> => ({
   cfg: { session: { mainKey: "agent:main:main" } } as OpenClawConfig,
@@ -33,6 +34,7 @@ const buildSessionLookup = (
     label: entry.label,
     spawnedBy: entry.spawnedBy,
     parentSessionKey: entry.parentSessionKey,
+    heartbeatIsolatedBaseSessionKey: entry.heartbeatIsolatedBaseSessionKey,
   },
   canonicalKey: sessionKey,
   legacyKey: undefined,
@@ -278,6 +280,28 @@ describe("node exec events", () => {
       reason: "exec-event",
       sessionKey: "agent:main:node-node-2",
     });
+  });
+
+  it("suppresses exec node events for synthetic heartbeat-isolated sessions", async () => {
+    loadSessionEntryMock.mockReturnValueOnce(
+      buildSessionLookup("agent:main:main:heartbeat", {
+        heartbeatIsolatedBaseSessionKey: "agent:main:main",
+      }),
+    );
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        sessionKey: "agent:main:main:heartbeat",
+        runId: "run-heartbeat-exec",
+        exitCode: 0,
+        timedOut: false,
+        output: "(no output)",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
+    expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
   });
 
   it("suppresses noisy exec.finished success events with empty output", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -627,7 +627,16 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
       if (!sessionKeyRaw) {
         return;
       }
-      const { canonicalKey: sessionKey } = loadSessionEntry(sessionKeyRaw);
+      const { canonicalKey: sessionKey, entry: sessionEntry } = loadSessionEntry(sessionKeyRaw);
+
+      // Heartbeat isolated sessions already contain the exec/tool transcript in-band.
+      // Re-enqueuing exec node events back into the same synthetic `:heartbeat`
+      // session creates a self-wake loop: heartbeat -> exec -> exec-event wake ->
+      // heartbeat. Suppress node-level exec system events for these synthetic
+      // heartbeat sessions and keep the exec result only in the current transcript.
+      if (sessionEntry?.heartbeatIsolatedBaseSessionKey) {
+        return;
+      }
 
       // Respect tools.exec.notifyOnExit setting (default: true)
       // When false, skip system event notifications for node exec events.


### PR DESCRIPTION
## Summary

Suppress node-level `exec` system-event replay for synthetic heartbeat-isolated sessions.

When a heartbeat run is already executing inside a synthetic `:heartbeat` session, any internal `exec.started` / `exec.finished` / `exec.denied` node event should stay in that transcript only. Re-enqueuing the same event as a system event and immediately calling `requestHeartbeatNow(...)` creates a self-wake loop:

```text
heartbeat -> exec -> exec-event wake -> heartbeat
```

This PR adds a narrow guard in `server-node-events` so entries tagged with `heartbeatIsolatedBaseSessionKey` do not enqueue another system event or request another heartbeat wake.

## Root cause

`server-node-events` currently canonicalizes the incoming session key and then treats every node `exec.*` event the same way:

- enqueue a system event on the canonical session key
- request an `exec-event` heartbeat wake

That is correct for normal agent sessions, but it is wrong for synthetic heartbeat-isolated sessions. Those sessions already contain the inline tool/exec transcript for the current run. Re-injecting the same exec lifecycle event through the system-event queue creates an unnecessary second heartbeat run against the same synthetic session.

The result is bursty extra heartbeat traffic and avoidable token spend, especially when a heartbeat falls back to small `exec` probes such as reading local state files.

## What changed

- In `src/gateway/server-node-events.ts`, load the full session entry alongside the canonical key.
- If the resolved entry has `heartbeatIsolatedBaseSessionKey`, return early for node `exec.started` / `exec.finished` / `exec.denied` handling.
- Add a focused regression test proving `exec.finished` on `agent:main:main:heartbeat` does **not** enqueue a system event or request another heartbeat wake.

## Scope boundary

This PR is intentionally narrow.

It does **not** change:

- normal node-exec notifications for non-heartbeat sessions
- isolated-heartbeat prompt construction
- isolated-heartbeat persona/bootstrap behavior
- wake coalescing or scheduler policy

It only suppresses the node-event feedback path for synthetic heartbeat sessions that already have the exec/tool transcript inline.

## Why this is distinct from nearby heartbeat fixes

This sits in the same bug family as recent isolated-heartbeat fixes, but it covers a different failure mode:

- `#59606` stabilizes repeated `:heartbeat` suffix growth after wake re-entry.
- `#67059` fixes isolated heartbeat exec prompts/persona once an exec event is already being relayed.

This PR prevents one specific class of redundant relays from being emitted in the first place.

## Validation

Ran on the PR branch:

- `pnpm exec vitest run --config test/vitest/vitest.gateway-server.config.ts src/gateway/server-node-events.test.ts`
- `pnpm exec oxlint src/gateway/server-node-events.ts src/gateway/server-node-events.test.ts`
- `pnpm exec tsc -p tsconfig.test.src.json --noEmit`
- `pnpm check:changed --staged`

`check:changed --staged` completed successfully for this diff, including the gateway-targeted changed test plan.
