### PR TITLE
fix(gateway): clean up store and set running=false on stop timeout

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -227,7 +227,7 @@ describe("server-channels auto restart", () => {
     }
   });
 
-  it("does not allow a second account task to start when stop times out", async () => {
+  it("cleans up store and allows restart after stop timeout", async () => {
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>
         await new Promise<void>(() => {
@@ -245,14 +245,20 @@ describe("server-channels auto restart", () => {
     const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
     await vi.advanceTimersByTimeAsync(5_000);
     await stopTask;
-    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
 
-    const snapshot = manager.getRuntimeSnapshot();
-    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
-    expect(startAccount).toHaveBeenCalledTimes(1);
-    expect(account?.running).toBe(true);
-    expect(account?.restartPending).toBe(false);
-    expect(account?.lastError).toContain("channel stop timed out");
+    // After timeout, runtime should reflect stopped state (not lie about running)
+    const snapshotAfterStop = manager.getRuntimeSnapshot();
+    const accountAfterStop = snapshotAfterStop.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(accountAfterStop?.running).toBe(false);
+    expect(accountAfterStop?.restartPending).toBe(false);
+    expect(accountAfterStop?.lastError).toContain("channel stop timed out");
+
+    // A subsequent start should succeed (not blocked by stale store.tasks entry)
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    const snapshotAfterRestart = manager.getRuntimeSnapshot();
+    const accountAfterRestart = snapshotAfterRestart.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(accountAfterRestart?.running).toBe(true);
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -575,10 +575,13 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
+          store.aborts.delete(id);
+          store.tasks.delete(id);
           setRuntime(channelId, id, {
             accountId: id,
-            running: true,
+            running: false,
             restartPending: false,
+            lastStopAt: Date.now(),
             lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
           });
           return;


### PR DESCRIPTION
## Summary

- `stopChannel` timeout path set `running: true` and skipped `store.aborts`/`store.tasks` cleanup, leaving a dead promise that blocked all future starts and fooled the health monitor
- Fix: set `running: false`, clean up store entries, and add `lastStopAt` in the timeout branch so subsequent `startChannel` calls and health recovery work correctly
- Update existing test to verify cleanup + restart succeeds after timeout

## Test plan

- [x] `server-channels.test.ts`: updated test verifies `running: false` after timeout and successful restart (18/18 pass)
- [x] `channel-health-monitor.test.ts` + `channel-health-policy.test.ts`: no regression (46/46 pass)
- [x] Full changed-lane suite: 2560/2560 pass, lint + typecheck clean

Closes #70024

[AI-assisted]