### PR TITLE
fix(ui): keep debug event log stable while viewing history

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -1730,6 +1730,12 @@
 }
 
 /* Debug event log payloads should use full width like other debug sections. */
+.debug-event-log {
+  max-height: min(55vh, 680px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .debug-event-log__item {
   grid-template-columns: minmax(0, 1fr);
 }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -463,9 +463,9 @@ function handleSessionMessageGatewayEvent(
 
 function handleGatewayEventUnsafe(host: GatewayHost, evt: GatewayEventFrame) {
   host.eventLogBuffer = [
-    { ts: Date.now(), event: evt.event, payload: evt.payload },
     ...host.eventLogBuffer,
-  ].slice(0, 250);
+    { ts: Date.now(), event: evt.event, payload: evt.payload },
+  ].slice(-250);
   if (host.tab === "debug" || host.tab === "overview") {
     host.eventLog = host.eventLogBuffer;
   }

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -7,7 +7,12 @@ import {
   startDebugPolling,
   stopDebugPolling,
 } from "./app-polling.ts";
-import { observeTopbar, scheduleChatScroll, scheduleLogsScroll } from "./app-scroll.ts";
+import {
+  observeTopbar,
+  scheduleChatScroll,
+  scheduleDebugEventLogScroll,
+  scheduleLogsScroll,
+} from "./app-scroll.ts";
 import {
   applySettingsFromUrl,
   detachThemeListener,
@@ -40,6 +45,8 @@ type LifecycleHost = {
   logsAutoFollow: boolean;
   logsAtBottom: boolean;
   logsEntries: unknown[];
+  eventLog: unknown[];
+  debugEventLogAtBottom: boolean;
   popStateHandler: () => void;
   topbarObserver: ResizeObserver | null;
 };
@@ -121,5 +128,11 @@ export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unk
         changed.has("tab") || changed.has("logsAutoFollow"),
       );
     }
+  }
+  if (host.tab === "debug" && (changed.has("eventLog") || changed.has("tab"))) {
+    scheduleDebugEventLogScroll(
+      host as unknown as Parameters<typeof scheduleDebugEventLogScroll>[0],
+      changed.has("tab") || host.debugEventLogAtBottom,
+    );
   }
 }

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -130,9 +130,11 @@ export function handleUpdated(host: LifecycleHost, changed: Map<PropertyKey, unk
     }
   }
   if (host.tab === "debug" && (changed.has("eventLog") || changed.has("tab"))) {
-    scheduleDebugEventLogScroll(
-      host as unknown as Parameters<typeof scheduleDebugEventLogScroll>[0],
-      changed.has("tab") || host.debugEventLogAtBottom,
-    );
+    if (changed.has("tab") || host.debugEventLogAtBottom) {
+      scheduleDebugEventLogScroll(
+        host as unknown as Parameters<typeof scheduleDebugEventLogScroll>[0],
+        changed.has("tab"),
+      );
+    }
   }
 }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -2315,6 +2315,7 @@ export function renderApp(state: AppViewState) {
                 onCallParamsChange: (next) => (state.debugCallParams = next),
                 onRefresh: () => loadDebug(state),
                 onCall: () => callDebugMethod(state),
+                onEventLogScroll: (event) => state.handleDebugEventLogScroll(event),
               }),
             )
           : nothing}

--- a/ui/src/ui/app-scroll.test.ts
+++ b/ui/src/ui/app-scroll.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { handleChatScroll, scheduleChatScroll, resetChatScroll } from "./app-scroll.ts";
+import {
+  handleChatScroll,
+  handleDebugEventLogScroll,
+  resetChatScroll,
+  scheduleChatScroll,
+  scheduleDebugEventLogScroll,
+} from "./app-scroll.ts";
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                            */
@@ -44,6 +50,8 @@ function createScrollHost(
     chatNewMessagesBelow: false,
     logsScrollFrame: null as number | null,
     logsAtBottom: true,
+    debugEventLogScrollFrame: null as number | null,
+    debugEventLogAtBottom: true,
     topbarObserver: null as ResizeObserver | null,
   };
 
@@ -271,5 +279,70 @@ describe("resetChatScroll", () => {
 
     expect(host.chatHasAutoScrolled).toBe(false);
     expect(host.chatUserNearBottom).toBe(true);
+  });
+});
+
+describe("debug event log scroll behavior", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 1;
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT auto-scroll debug event log when user scrolled up", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 400,
+      clientHeight: 400,
+    });
+    host.debugEventLogAtBottom = false;
+    const originalScrollTop = container.scrollTop;
+    host.querySelector = vi
+      .fn()
+      .mockImplementation((selector: string) =>
+        selector === ".debug-event-log" ? container : null,
+      );
+
+    scheduleDebugEventLogScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(originalScrollTop);
+  });
+
+  it("auto-scrolls debug event log when user is at bottom", async () => {
+    const { host, container } = createScrollHost({
+      scrollHeight: 2000,
+      scrollTop: 1600,
+      clientHeight: 400,
+    });
+    host.debugEventLogAtBottom = true;
+    host.querySelector = vi
+      .fn()
+      .mockImplementation((selector: string) =>
+        selector === ".debug-event-log" ? container : null,
+      );
+
+    scheduleDebugEventLogScroll(host);
+    await host.updateComplete;
+
+    expect(container.scrollTop).toBe(container.scrollHeight);
+  });
+
+  it("tracks debug event log bottom-follow state from scroll events", () => {
+    const { host } = createScrollHost({});
+    const event = createScrollEvent(2000, 400, 400);
+    handleDebugEventLogScroll(host, event);
+    expect(host.debugEventLogAtBottom).toBe(false);
+
+    const nearBottomEvent = createScrollEvent(2000, 1550, 400);
+    handleDebugEventLogScroll(host, nearBottomEvent);
+    expect(host.debugEventLogAtBottom).toBe(true);
   });
 });

--- a/ui/src/ui/app-scroll.ts
+++ b/ui/src/ui/app-scroll.ts
@@ -12,6 +12,8 @@ type ScrollHost = {
   chatNewMessagesBelow: boolean;
   logsScrollFrame: number | null;
   logsAtBottom: boolean;
+  debugEventLogScrollFrame: number | null;
+  debugEventLogAtBottom: boolean;
   topbarObserver: ResizeObserver | null;
 };
 
@@ -123,6 +125,29 @@ export function scheduleLogsScroll(host: ScrollHost, force = false) {
   });
 }
 
+export function scheduleDebugEventLogScroll(host: ScrollHost, force = false) {
+  if (host.debugEventLogScrollFrame) {
+    cancelAnimationFrame(host.debugEventLogScrollFrame);
+  }
+  void host.updateComplete.then(() => {
+    host.debugEventLogScrollFrame = requestAnimationFrame(() => {
+      host.debugEventLogScrollFrame = null;
+      const container = queryHost(host, ".debug-event-log") as HTMLElement | null;
+      if (!container) {
+        return;
+      }
+      const distanceFromBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight;
+      const shouldStick = force || host.debugEventLogAtBottom || distanceFromBottom < 80;
+      if (!shouldStick) {
+        return;
+      }
+      container.scrollTop = container.scrollHeight;
+      host.debugEventLogAtBottom = true;
+    });
+  });
+}
+
 export function handleChatScroll(host: ScrollHost, event: Event) {
   const container = event.currentTarget as HTMLElement | null;
   if (!container) {
@@ -143,6 +168,15 @@ export function handleLogsScroll(host: ScrollHost, event: Event) {
   }
   const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
   host.logsAtBottom = distanceFromBottom < 80;
+}
+
+export function handleDebugEventLogScroll(host: ScrollHost, event: Event) {
+  const container = event.currentTarget as HTMLElement | null;
+  if (!container) {
+    return;
+  }
+  const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
+  host.debugEventLogAtBottom = distanceFromBottom < 80;
 }
 
 export function resetChatScroll(host: ScrollHost) {

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -429,6 +429,7 @@ export type AppViewState = {
     resetChatScroll: () => void;
     exportLogs: (lines: string[], label: string) => void;
     handleLogsScroll: (event: Event) => void;
+    handleDebugEventLogScroll: (event: Event) => void;
     handleOpenSidebar: (content: SidebarContent) => void;
     handleCloseSidebar: () => void;
     handleSplitRatioChange: (ratio: number) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -33,6 +33,7 @@ import { renderApp } from "./app-render.ts";
 import {
   exportLogs as exportLogsInternal,
   handleChatScroll as handleChatScrollInternal,
+  handleDebugEventLogScroll as handleDebugEventLogScrollInternal,
   handleLogsScroll as handleLogsScrollInternal,
   resetChatScroll as resetChatScrollInternal,
   scheduleChatScroll as scheduleChatScrollInternal,
@@ -502,6 +503,7 @@ export class OpenClawApp extends LitElement {
   @state() logsLimit = 500;
   @state() logsMaxBytes = 250_000;
   @state() logsAtBottom = true;
+  @state() debugEventLogAtBottom = true;
 
   client: GatewayBrowserClient | null = null;
   private chatScrollFrame: number | null = null;
@@ -513,6 +515,7 @@ export class OpenClawApp extends LitElement {
   private logsPollInterval: number | null = null;
   private debugPollInterval: number | null = null;
   private logsScrollFrame: number | null = null;
+  private debugEventLogScrollFrame: number | null = null;
   private toolStreamById = new Map<string, ToolStreamEntry>();
   private toolStreamOrder: string[] = [];
   refreshSessionsAfterChat = new Set<string>();
@@ -603,6 +606,13 @@ export class OpenClawApp extends LitElement {
   handleLogsScroll(event: Event) {
     handleLogsScrollInternal(
       this as unknown as Parameters<typeof handleLogsScrollInternal>[0],
+      event,
+    );
+  }
+
+  handleDebugEventLogScroll(event: Event) {
+    handleDebugEventLogScrollInternal(
+      this as unknown as Parameters<typeof handleDebugEventLogScrollInternal>[0],
       event,
     );
   }

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -19,6 +19,7 @@ export type DebugProps = {
   onCallParamsChange: (next: string) => void;
   onRefresh: () => void;
   onCall: () => void;
+  onEventLogScroll: (event: Event) => void;
 };
 
 export function renderDebug(props: DebugProps) {
@@ -121,7 +122,11 @@ ${JSON.stringify(props.models ?? [], null, 2)}</pre
       ${props.eventLog.length === 0
         ? html` <div class="muted" style="margin-top: 12px">No events yet.</div> `
         : html`
-            <div class="list debug-event-log" style="margin-top: 12px;">
+            <div
+              class="list debug-event-log"
+              style="margin-top: 12px;"
+              @scroll=${props.onEventLogScroll}
+            >
               ${props.eventLog.map(
                 (evt) => html`
                   <div class="list-item debug-event-log__item">

--- a/ui/src/ui/views/overview-event-log.ts
+++ b/ui/src/ui/views/overview-event-log.ts
@@ -13,7 +13,9 @@ export function renderOverviewEventLog(props: OverviewEventLogProps) {
     return nothing;
   }
 
-  const visible = props.events.slice(0, 20);
+  // Keep overview focused on recent activity while preserving stable append order
+  // in the shared event log buffer.
+  const visible = props.events.slice(-20).toReversed();
 
   return html`
     <details class="card ov-event-log" open>


### PR DESCRIPTION
## Summary
- prevent the Debug page event log from auto-jumping when users scroll up to inspect older entries
- add sticky-at-bottom behavior for the debug event log, only auto-scrolling when the viewer is already near the bottom
- keep event ordering consistent across debug/overview views and add focused scroll behavior tests

## Test plan
- [x] pnpm --dir ui test -- ui/src/ui/app-scroll.test.ts
- [x] manual verification: open Debug page, scroll up in Event Log, confirm new events no longer steal focus
- [x] manual verification: stay at bottom of Event Log, confirm incoming events continue auto-following latest entries

Made with [Cursor](https://cursor.com)