### PR TITLE
fix(models): fingerprint auth profiles semantically

### DIFF
--- a/src/agents/models-config.auth-fingerprint.test.ts
+++ b/src/agents/models-config.auth-fingerprint.test.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,6 +27,10 @@ beforeEach(() => {
 async function writeJson(pathname: string, value: unknown): Promise<void> {
   await fs.mkdir(path.dirname(pathname), { recursive: true });
   await fs.writeFile(pathname, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  return `e30.${Buffer.from(JSON.stringify(payload)).toString("base64url")}.sig`;
 }
 
 async function prepareCachedEnsure(agentDir: string): Promise<{
@@ -285,6 +290,43 @@ describe("models-config auth profiles semantic fingerprint", () => {
       const second = await buildModelsJsonAuthProfilesFingerprint(agentDir);
 
       expect(second).not.toEqual(first);
+    });
+  });
+
+  it("normalizes mixed string and array OAuth audience claims without splitting strings", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const access = unsignedJwt({ aud: ["api-b", "api-a"] });
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            idToken: unsignedJwt({ aud: "id-audience" }),
+            access,
+            expires: Date.now() + 60 * 60 * 1000,
+          },
+        },
+      });
+      const mixedAudience = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            idToken: unsignedJwt({}),
+            access,
+            expires: Date.now() + 60 * 60 * 1000,
+          },
+        },
+      });
+      const accessArrayAudience = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      expect(mixedAudience).toEqual(accessArrayAudience);
     });
   });
 

--- a/src/agents/models-config.auth-fingerprint.test.ts
+++ b/src/agents/models-config.auth-fingerprint.test.ts
@@ -96,6 +96,52 @@ describe("models-config auth profiles semantic fingerprint", () => {
     });
   });
 
+  it("invalidates the models-config cache when auth profile order changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const modelsPath = path.join(agentDir, "models.json");
+      await writeJson(modelsPath, { providers: {} });
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test-default",
+          },
+          "openai:work": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test-work",
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({}, agentDir);
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:work": {
+            provider: "openai",
+            key: "sk-test-work",
+            type: "api_key",
+          },
+          "openai:default": {
+            provider: "openai",
+            key: "sk-test-default",
+            type: "api_key",
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it("continues to invalidate when models.json changes", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");

--- a/src/agents/models-config.auth-fingerprint.test.ts
+++ b/src/agents/models-config.auth-fingerprint.test.ts
@@ -101,6 +101,122 @@ describe("models-config auth profiles semantic fingerprint", () => {
     });
   });
 
+  it("invalidates the models-config cache when legacy apiKey changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const modelsPath = path.join(agentDir, "models.json");
+      await writeJson(modelsPath, { providers: {} });
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            apiKey: "sk-test-legacy-one",
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({}, agentDir);
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            apiKey: "sk-test-legacy-two",
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("invalidates the models-config cache when legacy key SecretRef identity changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const modelsPath = path.join(agentDir, "models.json");
+      await writeJson(modelsPath, { providers: {} });
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: { source: "env", provider: "default", id: "OPENCLAW_TEST_AUTH_KEY_ONE" },
+          },
+        },
+      });
+      await ensureOpenClawModelsJson({}, agentDir);
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: { source: "env", provider: "default", id: "OPENCLAW_TEST_AUTH_KEY_TWO" },
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("fingerprints equivalent normalized and legacy api key aliases identically", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            apiKey: "sk-test-legacy-one",
+          },
+          "env:default": {
+            type: "api_key",
+            provider: "env-provider",
+            key: { source: "env", provider: "default", id: "OPENCLAW_TEST_AUTH_KEY" },
+          },
+        },
+      });
+      const legacy = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+      expect(JSON.stringify(legacy)).not.toContain("sk-test-legacy-one");
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test-legacy-one",
+          },
+          "env:default": {
+            type: "api_key",
+            provider: "env-provider",
+            keyRef: { source: "env", provider: "default", id: "OPENCLAW_TEST_AUTH_KEY" },
+          },
+        },
+      });
+      const normalized = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      expect(normalized).toEqual(legacy);
+      expect(JSON.stringify(normalized)).not.toContain("sk-test-legacy-one");
+    });
+  });
+
   it("invalidates the models-config cache when auth profile order changes", async () => {
     await withModelsTempHome(async (home) => {
       const agentDir = path.join(home, "agent");

--- a/src/agents/models-config.auth-fingerprint.test.ts
+++ b/src/agents/models-config.auth-fingerprint.test.ts
@@ -1,0 +1,285 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildModelsJsonAuthProfilesFingerprint } from "./models-config.auth-fingerprint.js";
+import { installModelsConfigTestHooks, withModelsTempHome } from "./models-config.e2e-harness.js";
+
+const planOpenClawModelsJsonMock = vi.fn();
+
+installModelsConfigTestHooks();
+
+let ensureOpenClawModelsJson: typeof import("./models-config.js").ensureOpenClawModelsJson;
+let resetModelsJsonReadyCacheForTest: typeof import("./models-config.js").resetModelsJsonReadyCacheForTest;
+
+beforeAll(async () => {
+  vi.doMock("./models-config.plan.js", () => ({
+    planOpenClawModelsJson: (...args: unknown[]) => planOpenClawModelsJsonMock(...args),
+  }));
+  ({ ensureOpenClawModelsJson, resetModelsJsonReadyCacheForTest } =
+    await import("./models-config.js"));
+});
+
+beforeEach(() => {
+  planOpenClawModelsJsonMock.mockReset().mockResolvedValue({ action: "noop" });
+});
+
+async function writeJson(pathname: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(pathname), { recursive: true });
+  await fs.writeFile(pathname, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function prepareCachedEnsure(agentDir: string): Promise<{
+  authPath: string;
+  modelsPath: string;
+}> {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  const modelsPath = path.join(agentDir, "models.json");
+  await writeJson(modelsPath, { providers: {} });
+  await writeJson(authPath, {
+    version: 1,
+    profiles: {
+      "openai:default": {
+        type: "api_key",
+        provider: "openai",
+        key: "sk-test-one",
+      },
+    },
+  });
+  await ensureOpenClawModelsJson({}, agentDir);
+  expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+  return { authPath, modelsPath };
+}
+
+describe("models-config auth profiles semantic fingerprint", () => {
+  it("keeps the models-config cache warm when auth-profiles.json is rewritten without semantic changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const { authPath } = await prepareCachedEnsure(agentDir);
+
+      await writeJson(authPath, {
+        profiles: {
+          "openai:default": {
+            provider: "openai",
+            key: "sk-test-one",
+            type: "api_key",
+          },
+        },
+        version: 1,
+      });
+      await fs.utimes(authPath, new Date("2026-01-01T00:00:00Z"), new Date("2026-01-01T00:01:00Z"));
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("invalidates the models-config cache when auth semantics change", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const { authPath } = await prepareCachedEnsure(agentDir);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:default": {
+            type: "api_key",
+            provider: "openai",
+            key: "sk-test-two",
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("continues to invalidate when models.json changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const { modelsPath } = await prepareCachedEnsure(agentDir);
+
+      await writeJson(modelsPath, { providers: { changed: { models: [] } } });
+      await fs.utimes(
+        modelsPath,
+        new Date("2026-01-01T00:00:00Z"),
+        new Date("2026-01-01T00:01:00Z"),
+      );
+
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("fingerprints SecretRef identity and env values without exposing secret material", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const previousAuthKey = process.env.OPENCLAW_TEST_AUTH_KEY;
+      process.env.OPENCLAW_TEST_AUTH_KEY = "super-secret-one";
+      try {
+        await writeJson(authPath, {
+          version: 1,
+          profiles: {
+            "env:default": {
+              type: "api_key",
+              provider: "env-provider",
+              keyRef: { source: "env", provider: "default", id: "OPENCLAW_TEST_AUTH_KEY" },
+            },
+            "file:default": {
+              type: "api_key",
+              provider: "file-provider",
+              keyRef: { source: "file", provider: "vault", id: "/secret/openai" },
+            },
+            "exec:default": {
+              type: "token",
+              provider: "exec-provider",
+              tokenRef: { source: "exec", provider: "vault", id: "token/openai" },
+            },
+          },
+        });
+
+        const first = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+        const serializedFirst = JSON.stringify(first);
+        expect(serializedFirst).not.toContain("super-secret-one");
+
+        process.env.OPENCLAW_TEST_AUTH_KEY = "super-secret-two";
+        const second = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+        expect(second).not.toEqual(first);
+        expect(JSON.stringify(second)).not.toContain("super-secret-two");
+      } finally {
+        if (previousAuthKey === undefined) {
+          delete process.env.OPENCLAW_TEST_AUTH_KEY;
+        } else {
+          process.env.OPENCLAW_TEST_AUTH_KEY = previousAuthKey;
+        }
+      }
+    });
+  });
+
+  it("ignores idempotent OAuth token refreshes when stable identity and expiry bucket do not change", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const expires = Date.now() + 60 * 60 * 1000;
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            accountId: "acct_123",
+            email: "USER@example.com",
+            access: "access-token-one",
+            refresh: "refresh-token-one",
+            expires,
+          },
+        },
+      });
+      const first = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            accountId: "acct_123",
+            email: "user@example.com",
+            access: "access-token-two",
+            refresh: "refresh-token-two",
+            expires: expires + 1000,
+          },
+        },
+      });
+      const second = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      expect(second).toEqual(first);
+      expect(JSON.stringify(second)).not.toContain("access-token-two");
+      expect(JSON.stringify(second)).not.toContain("refresh-token-two");
+    });
+  });
+
+  it("changes OAuth fingerprint when stable identity changes", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            accountId: "acct_123",
+            access: "access-token-one",
+            refresh: "refresh-token-one",
+            expires: Date.now() + 60 * 60 * 1000,
+          },
+        },
+      });
+      const first = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      await writeJson(authPath, {
+        version: 1,
+        profiles: {
+          "openai:oauth": {
+            type: "oauth",
+            provider: "openai",
+            accountId: "acct_456",
+            access: "access-token-two",
+            refresh: "refresh-token-two",
+            expires: Date.now() + 60 * 60 * 1000,
+          },
+        },
+      });
+      const second = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      expect(second).not.toEqual(first);
+    });
+  });
+
+  it("uses raw content for parse errors and does not collapse read errors into a safe hit", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      await fs.mkdir(agentDir, { recursive: true });
+      await fs.writeFile(authPath, "{not-json", "utf8");
+      const parseError = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      await fs.writeFile(authPath, "{not-json-but-different", "utf8");
+      const changedParseError = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      await fs.rm(authPath, { force: true });
+      await fs.mkdir(authPath);
+      const readError = await buildModelsJsonAuthProfilesFingerprint(agentDir);
+
+      expect(parseError).toMatchObject({ status: "parse_error" });
+      expect(changedParseError).toMatchObject({ status: "parse_error" });
+      expect(changedParseError).not.toEqual(parseError);
+      expect(readError).toMatchObject({ status: "read_error", errorCode: "EISDIR" });
+    });
+  });
+
+  it("does not keep a ready-cache entry when ensure planning fails", async () => {
+    await withModelsTempHome(async (home) => {
+      const agentDir = path.join(home, "agent");
+      await writeJson(path.join(agentDir, "models.json"), { providers: {} });
+      await writeJson(path.join(agentDir, "auth-profiles.json"), {
+        version: 1,
+        profiles: {},
+      });
+      planOpenClawModelsJsonMock.mockRejectedValueOnce(new Error("planned failure"));
+
+      await expect(ensureOpenClawModelsJson({}, agentDir)).rejects.toThrow("planned failure");
+      planOpenClawModelsJsonMock.mockResolvedValueOnce({ action: "noop" });
+      await ensureOpenClawModelsJson({}, agentDir);
+
+      expect(planOpenClawModelsJsonMock).toHaveBeenCalledTimes(2);
+      resetModelsJsonReadyCacheForTest();
+    });
+  });
+});

--- a/src/agents/models-config.auth-fingerprint.ts
+++ b/src/agents/models-config.auth-fingerprint.ts
@@ -1,0 +1,241 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { coerceSecretRef } from "../config/types.secrets.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { isRecord } from "../utils.js";
+
+const AUTH_PROFILES_FINGERPRINT_VERSION = 1;
+const OAUTH_EXPIRING_MS = 5 * 60 * 1000;
+
+type FingerprintedString = { present: false } | { present: true; length: number; sha256: string };
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).toSorted(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  return `{${entries
+    .map(([key, entry]) => `${JSON.stringify(key)}:${stableStringify(entry)}`)
+    .join(",")}}`;
+}
+
+function fingerprintStringValue(value: unknown): FingerprintedString {
+  if (typeof value !== "string" || !value.trim()) {
+    return { present: false };
+  }
+  return {
+    present: true,
+    length: value.length,
+    sha256: sha256(value),
+  };
+}
+
+function fingerprintVolatileSecretValue(value: unknown): { present: boolean } {
+  return {
+    present: typeof value === "string" && value.trim().length > 0,
+  };
+}
+
+function fingerprintNormalizedString(value: unknown, lower = false): string | null {
+  const normalized = normalizeOptionalString(value);
+  if (!normalized) {
+    return null;
+  }
+  return sha256(lower ? normalized.toLowerCase() : normalized);
+}
+
+function fingerprintStringHashOrNull(value: unknown): string | null {
+  const fingerprint = fingerprintStringValue(value);
+  return fingerprint.present ? fingerprint.sha256 : null;
+}
+
+function resolveExpiryState(value: unknown, now = Date.now()): string {
+  if (value === undefined) {
+    return "missing";
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return "invalid";
+  }
+  const remainingMs = value - now;
+  if (remainingMs <= 0) {
+    return "expired";
+  }
+  if (remainingMs <= OAUTH_EXPIRING_MS) {
+    return "expiring";
+  }
+  return "valid";
+}
+
+function decodeJwtPayload(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parts = value.split(".");
+  if (parts.length < 2) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString("utf8"));
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeSecretRefFingerprint(value: unknown) {
+  const ref = coerceSecretRef(value);
+  if (!ref) {
+    return null;
+  }
+  return {
+    source: ref.source,
+    provider: ref.provider.trim(),
+    id: ref.id.trim(),
+  };
+}
+
+function fingerprintEnvValue(value: unknown): FingerprintedString {
+  return fingerprintStringValue(value);
+}
+
+function buildOAuthIdentityFingerprint(credential: Record<string, unknown>) {
+  const accessClaims = decodeJwtPayload(credential.access);
+  const idClaims = decodeJwtPayload(credential.idToken);
+  const audience =
+    Array.isArray(idClaims?.aud) || Array.isArray(accessClaims?.aud)
+      ? [...((idClaims?.aud as unknown[]) ?? (accessClaims?.aud as unknown[]) ?? [])]
+          .map((entry) => String(entry))
+          .toSorted((left, right) => left.localeCompare(right))
+          .join("\0")
+      : (idClaims?.aud ?? accessClaims?.aud);
+  const identity = {
+    accountId: fingerprintNormalizedString(
+      credential.accountId ?? idClaims?.account_id ?? accessClaims?.account_id,
+    ),
+    subject: fingerprintNormalizedString(idClaims?.sub ?? accessClaims?.sub),
+    email: fingerprintNormalizedString(
+      credential.email ?? idClaims?.email ?? accessClaims?.email,
+      true,
+    ),
+    issuer: fingerprintNormalizedString(idClaims?.iss ?? accessClaims?.iss),
+    audience: fingerprintNormalizedString(audience),
+  };
+  if (Object.values(identity).some(Boolean)) {
+    return identity;
+  }
+  return {
+    fallbackAccess: fingerprintStringHashOrNull(credential.access),
+  };
+}
+
+function buildAuthCredentialFingerprint(credential: unknown) {
+  if (!isRecord(credential)) {
+    return { kind: typeof credential };
+  }
+  const type = normalizeOptionalString(credential.type) ?? null;
+  const provider = normalizeOptionalString(credential.provider) ?? null;
+  const base = { type, provider };
+  if (type === "api_key") {
+    const keyRef = normalizeSecretRefFingerprint(credential.keyRef);
+    return {
+      ...base,
+      key: fingerprintStringValue(credential.key),
+      keyRef,
+      keyRefEnvValue:
+        keyRef?.source === "env" ? fingerprintEnvValue(process.env[keyRef.id]) : undefined,
+    };
+  }
+  if (type === "token") {
+    const tokenRef = normalizeSecretRefFingerprint(credential.tokenRef);
+    return {
+      ...base,
+      token: fingerprintStringValue(credential.token),
+      tokenRef,
+      tokenRefEnvValue:
+        tokenRef?.source === "env" ? fingerprintEnvValue(process.env[tokenRef.id]) : undefined,
+      expiresState: resolveExpiryState(credential.expires),
+    };
+  }
+  if (type === "oauth") {
+    return {
+      ...base,
+      identity: buildOAuthIdentityFingerprint(credential),
+      access: fingerprintVolatileSecretValue(credential.access),
+      refresh: fingerprintVolatileSecretValue(credential.refresh),
+      expiresState: resolveExpiryState(credential.expires),
+      enterpriseUrl: fingerprintNormalizedString(credential.enterpriseUrl),
+      projectId: fingerprintNormalizedString(credential.projectId),
+      clientId: fingerprintNormalizedString(credential.clientId),
+    };
+  }
+  return {
+    ...base,
+    valueHash: sha256(stableStringify(credential)),
+  };
+}
+
+async function readFileMtimeMs(pathname: string): Promise<number | null> {
+  try {
+    const stat = await fs.stat(pathname);
+    return Number.isFinite(stat.mtimeMs) ? stat.mtimeMs : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function buildModelsJsonAuthProfilesFingerprint(agentDir: string): Promise<unknown> {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  try {
+    const raw = await fs.readFile(authPath, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return {
+        version: AUTH_PROFILES_FINGERPRINT_VERSION,
+        status: "parse_error",
+        size: raw.length,
+        rawSha256: sha256(raw),
+      };
+    }
+    const profiles = isRecord(parsed) && isRecord(parsed.profiles) ? parsed.profiles : {};
+    return {
+      version: AUTH_PROFILES_FINGERPRINT_VERSION,
+      status: "ok",
+      storeVersion: isRecord(parsed) ? (parsed.version ?? null) : null,
+      profiles: Object.fromEntries(
+        Object.entries(profiles)
+          .toSorted(([left], [right]) => left.localeCompare(right))
+          .map(([profileId, credential]) => [
+            profileId,
+            buildAuthCredentialFingerprint(credential),
+          ]),
+      ),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") {
+      return {
+        version: AUTH_PROFILES_FINGERPRINT_VERSION,
+        status: "missing",
+      };
+    }
+    return {
+      version: AUTH_PROFILES_FINGERPRINT_VERSION,
+      status: "read_error",
+      errorCode: typeof code === "string" ? code : undefined,
+      mtimeMs: await readFileMtimeMs(authPath),
+    };
+  }
+}

--- a/src/agents/models-config.auth-fingerprint.ts
+++ b/src/agents/models-config.auth-fingerprint.ts
@@ -109,6 +109,32 @@ function fingerprintEnvValue(value: unknown): FingerprintedString {
   return fingerprintStringValue(value);
 }
 
+function hasOwnProperty(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function normalizeApiKeyCredentialInputs(credential: Record<string, unknown>): {
+  key: unknown;
+  keyRef: ReturnType<typeof normalizeSecretRefFingerprint>;
+} {
+  const rawKey = hasOwnProperty(credential, "key")
+    ? credential.key
+    : typeof credential.apiKey === "string"
+      ? credential.apiKey
+      : undefined;
+  const explicitKeyRef = normalizeSecretRefFingerprint(credential.keyRef);
+  if (rawKey == null || typeof rawKey === "string") {
+    return {
+      key: rawKey,
+      keyRef: explicitKeyRef,
+    };
+  }
+  return {
+    key: undefined,
+    keyRef: explicitKeyRef ?? normalizeSecretRefFingerprint(rawKey),
+  };
+}
+
 function normalizeJwtAudience(idAudience: unknown, accessAudience: unknown): unknown {
   const audience = Array.isArray(idAudience)
     ? idAudience
@@ -155,10 +181,10 @@ function buildAuthCredentialFingerprint(credential: unknown) {
   const provider = normalizeOptionalString(credential.provider) ?? null;
   const base = { type, provider };
   if (type === "api_key") {
-    const keyRef = normalizeSecretRefFingerprint(credential.keyRef);
+    const { key, keyRef } = normalizeApiKeyCredentialInputs(credential);
     return {
       ...base,
-      key: fingerprintStringValue(credential.key),
+      key: fingerprintStringValue(key),
       keyRef,
       keyRefEnvValue:
         keyRef?.source === "env" ? fingerprintEnvValue(process.env[keyRef.id]) : undefined,

--- a/src/agents/models-config.auth-fingerprint.ts
+++ b/src/agents/models-config.auth-fingerprint.ts
@@ -214,14 +214,10 @@ export async function buildModelsJsonAuthProfilesFingerprint(agentDir: string): 
       version: AUTH_PROFILES_FINGERPRINT_VERSION,
       status: "ok",
       storeVersion: isRecord(parsed) ? (parsed.version ?? null) : null,
-      profiles: Object.fromEntries(
-        Object.entries(profiles)
-          .toSorted(([left], [right]) => left.localeCompare(right))
-          .map(([profileId, credential]) => [
-            profileId,
-            buildAuthCredentialFingerprint(credential),
-          ]),
-      ),
+      profiles: Object.entries(profiles).map(([profileId, credential]) => ({
+        profileId,
+        credential: buildAuthCredentialFingerprint(credential),
+      })),
     };
   } catch (error) {
     const code = (error as NodeJS.ErrnoException)?.code;

--- a/src/agents/models-config.auth-fingerprint.ts
+++ b/src/agents/models-config.auth-fingerprint.ts
@@ -109,16 +109,24 @@ function fingerprintEnvValue(value: unknown): FingerprintedString {
   return fingerprintStringValue(value);
 }
 
+function normalizeJwtAudience(idAudience: unknown, accessAudience: unknown): unknown {
+  const audience = Array.isArray(idAudience)
+    ? idAudience
+    : Array.isArray(accessAudience)
+      ? accessAudience
+      : (idAudience ?? accessAudience);
+  return Array.isArray(audience)
+    ? audience
+        .map((entry) => String(entry))
+        .toSorted((left, right) => left.localeCompare(right))
+        .join("\0")
+    : audience;
+}
+
 function buildOAuthIdentityFingerprint(credential: Record<string, unknown>) {
   const accessClaims = decodeJwtPayload(credential.access);
   const idClaims = decodeJwtPayload(credential.idToken);
-  const audience =
-    Array.isArray(idClaims?.aud) || Array.isArray(accessClaims?.aud)
-      ? [...((idClaims?.aud as unknown[]) ?? (accessClaims?.aud as unknown[]) ?? [])]
-          .map((entry) => String(entry))
-          .toSorted((left, right) => left.localeCompare(right))
-          .join("\0")
-      : (idClaims?.aud ?? accessClaims?.aud);
+  const audience = normalizeJwtAudience(idClaims?.aud, accessClaims?.aud);
   const identity = {
     accountId: fingerprintNormalizedString(
       credential.accountId ?? idClaims?.account_id ?? accessClaims?.account_id,

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -9,6 +9,7 @@ import {
 import { createConfigRuntimeEnv } from "../config/env-vars.js";
 import { resolveOpenClawAgentDir } from "./agent-paths.js";
 import { MODELS_JSON_STATE } from "./models-config-state.js";
+import { buildModelsJsonAuthProfilesFingerprint } from "./models-config.auth-fingerprint.js";
 import { planOpenClawModelsJson } from "./models-config.plan.js";
 
 export { resetModelsJsonReadyCacheForTest } from "./models-config-state.js";
@@ -42,8 +43,8 @@ async function buildModelsJsonFingerprint(params: {
   sourceConfigForSecrets: OpenClawConfig;
   agentDir: string;
 }): Promise<string> {
-  const authProfilesMtimeMs = await readFileMtimeMs(
-    path.join(params.agentDir, "auth-profiles.json"),
+  const authProfilesSemanticFingerprint = await buildModelsJsonAuthProfilesFingerprint(
+    params.agentDir,
   );
   const modelsFileMtimeMs = await readFileMtimeMs(path.join(params.agentDir, "models.json"));
   const envShape = createConfigRuntimeEnv(params.config, {});
@@ -51,7 +52,7 @@ async function buildModelsJsonFingerprint(params: {
     config: params.config,
     sourceConfigForSecrets: params.sourceConfigForSecrets,
     envShape,
-    authProfilesMtimeMs,
+    authProfilesSemanticFingerprint,
     modelsFileMtimeMs,
   });
 }


### PR DESCRIPTION
## Summary

Replace the `auth-profiles.json` mtime component in the models config ready-cache fingerprint with a semantic fingerprint of auth profile state.

This avoids invalidating the ready cache when `auth-profiles.json` is rewritten without changing the auth state that affects generated `models.json` content, while still invalidating on meaningful auth, SecretRef, OAuth, parse/read, and `models.json` changes.

## Root cause

The previous fingerprint used `authProfilesMtimeMs`.

That meant any physical rewrite of `auth-profiles.json` changed the fingerprint, even when the relevant auth semantics were unchanged. In practice, this could force unnecessary `models.json` planning work after no-op auth profile rewrites.

## What changed

- replace `authProfilesMtimeMs` in the fingerprint input with a semantic auth-profile fingerprint
- keep `modelsFileMtimeMs` invalidation unchanged
- normalize auth profile inputs so non-semantic rewrites do not cause false cache misses
- preserve invalidation for meaningful auth changes, SecretRef changes, OAuth identity changes, parse/read errors, and `models.json` changes

## Tests

Added focused coverage for:

- unchanged auth semantics across file rewrites
- real auth semantic changes causing invalidation
- `models.json` changes still causing invalidation
- SecretRef/env/file/exec handling without leaking secrets
- OAuth refresh/idempotent volatile field changes
- parse/read error behavior