### PR TITLE
chore(observability): scope eslint/no-console rule to src with allowlist + mark FileReader listeners { once: true }

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -89,6 +89,72 @@
         "typescript/unbound-method": "off",
         "eslint/no-unsafe-optional-chaining": "off"
       }
+    },
+    {
+      "files": ["src/**/*.ts", "src/**/*.tsx"],
+      "rules": {
+        "eslint/no-console": "error"
+      }
+    },
+    {
+      "files": [
+        "src/acp/client.ts",
+        "src/acp/server.ts",
+        "src/agents/agent-command.ts",
+        "src/auto-reply/command-auth.ts",
+        "src/auto-reply/reply/model-selection.ts",
+        "src/channels/plugins/pairing-adapters.ts",
+        "src/channels/typing.ts",
+        "src/cli/completion-runtime.ts",
+        "src/cli/program/help.ts",
+        "src/cli/run-main.ts",
+        "src/commands/health.ts",
+        "src/config/defaults.ts",
+        "src/config/doc-baseline.ts",
+        "src/context-engine/registry.ts",
+        "src/entry.ts",
+        "src/entry.version-fast-path.ts",
+        "src/gateway/gateway-cli-backend.live-helpers.ts",
+        "src/gateway/mcp-http.request.ts",
+        "src/gateway/mcp-http.ts",
+        "src/gateway/server-http.ts",
+        "src/globals.ts",
+        "src/index.ts",
+        "src/infra/bonjour.ts",
+        "src/infra/diagnostic-events.ts",
+        "src/infra/dotenv.ts",
+        "src/infra/tailscale.ts",
+        "src/infra/temp-download.ts",
+        "src/infra/tmp-openclaw-dir.ts",
+        "src/infra/unhandled-rejections.ts",
+        "src/logger.ts",
+        "src/logging/console.ts",
+        "src/logging/subsystem.ts",
+        "src/logging/test-helpers/console-snapshot.ts",
+        "src/plugin-sdk/channel-entry-contract.ts",
+        "src/plugins/plugin-load-profile.ts",
+        "src/runtime.ts",
+        "src/security/windows-acl.ts",
+        "src/terminal/restore.ts",
+        "src/test-utils/generation-live-test-helpers.ts"
+      ],
+      "rules": {
+        "eslint/no-console": "off"
+      }
+    },
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.e2e.test.ts",
+        "**/*.live.test.ts",
+        "**/*test-harness.ts",
+        "**/*test-helpers.ts",
+        "**/*test-support.ts"
+      ],
+      "rules": {
+        "eslint/no-console": "off"
+      }
     }
   ]
 }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -215,16 +215,20 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
       continue;
     }
     const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment: ChatAttachment = {
-        id: generateAttachmentId(),
-        dataUrl,
-        mimeType: file.type,
-      };
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
-    });
+    reader.addEventListener(
+      "load",
+      () => {
+        const dataUrl = reader.result as string;
+        const newAttachment: ChatAttachment = {
+          id: generateAttachmentId(),
+          dataUrl,
+          mimeType: file.type,
+        };
+        const current = props.attachments ?? [];
+        props.onAttachmentsChange?.([...current, newAttachment]);
+      },
+      { once: true },
+    );
     reader.readAsDataURL(file);
   }
 }
@@ -243,17 +247,21 @@ function handleFileSelect(e: Event, props: ChatProps) {
     }
     pending++;
     const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      additions.push({
-        id: generateAttachmentId(),
-        dataUrl: reader.result as string,
-        mimeType: file.type,
-      });
-      pending--;
-      if (pending === 0) {
-        props.onAttachmentsChange?.([...current, ...additions]);
-      }
-    });
+    reader.addEventListener(
+      "load",
+      () => {
+        additions.push({
+          id: generateAttachmentId(),
+          dataUrl: reader.result as string,
+          mimeType: file.type,
+        });
+        pending--;
+        if (pending === 0) {
+          props.onAttachmentsChange?.([...current, ...additions]);
+        }
+      },
+      { once: true },
+    );
     reader.readAsDataURL(file);
   }
   input.value = "";
@@ -274,17 +282,21 @@ function handleDrop(e: DragEvent, props: ChatProps) {
     }
     pending++;
     const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      additions.push({
-        id: generateAttachmentId(),
-        dataUrl: reader.result as string,
-        mimeType: file.type,
-      });
-      pending--;
-      if (pending === 0) {
-        props.onAttachmentsChange?.([...current, ...additions]);
-      }
-    });
+    reader.addEventListener(
+      "load",
+      () => {
+        additions.push({
+          id: generateAttachmentId(),
+          dataUrl: reader.result as string,
+          mimeType: file.type,
+        });
+        pending--;
+        if (pending === 0) {
+          props.onAttachmentsChange?.([...current, ...additions]);
+        }
+      },
+      { once: true },
+    );
     reader.readAsDataURL(file);
   }
 }


### PR DESCRIPTION
## Summary

Additive observability hygiene — one new lint rule + a small listener cleanup clarity fix. No runtime behavior change.

**1. Scoped `eslint/no-console: error` rule**

Enabled for `src/**/*.{ts,tsx}` (excluding test files) in `.oxlintrc.json`. Prevents new `console.*` sites from landing in production paths without either (a) routing through the structured logger, or (b) adding an explicit allowlist entry.

Current-tree allowlist covers **38 files** with legitimate console use, grouped by reason:

- **CLI user-output** (intentional prints to stdout/stderr): `entry.ts`, `entry.version-fast-path.ts`, `cli/*`, `commands/health.ts`, `runtime.ts`, `globals.ts`, `logger.ts`, `terminal/restore.ts`, `acp/{client,server}.ts`, `infra/tailscale.ts`, `infra/dotenv.ts`.
- **Catastrophic / pre-logger fallbacks**: `infra/unhandled-rejections.ts`, `index.ts`, `infra/tmp-openclaw-dir.ts` (imminent-exit paths where the file logger may not be stable).
- **Logger internals**: `logging/console.ts`, `logging/subsystem.ts`, `logging/test-helpers/console-snapshot.ts`.
- **Default-fallback parameters**: `channels/plugins/pairing-adapters.ts`, `config/defaults.ts`.
- **Library noise suppression**: `infra/bonjour.ts` (monkey-patches `console.log` to silence ciao).
- **Scraper output contract**: `plugins/plugin-load-profile.ts`, `plugin-sdk/channel-entry-contract.ts` (profile probes emit a specific stderr format that tooling depends on per the module header).
- **Diagnostic paths covered by existing tests that spy on `console.*`** (not migrated here — follow-up migrations would need to update the test spies in the same change): `channels/typing.ts`, `context-engine/registry.ts`, `gateway/server-http.ts`, `auto-reply/command-auth.ts`, `infra/diagnostic-events.ts`.
- **Debug-gated diagnostics** (env-var-gated; migration would need a deliberate level choice — `.info` vs `.debug` — and is deferred): `gateway/mcp-http.{ts,request.ts}`, `gateway/gateway-cli-backend.live-helpers.ts`, `auto-reply/reply/model-selection.ts`, `config/doc-baseline.ts`, `agents/agent-command.ts`, `infra/temp-download.ts`.
- **Pending CODEOWNERS review**: `security/windows-acl.ts` (has an in-file TODO asking for a structured-logger migration; under `@openclaw/secops` ownership).
- **Test-utility**: `test-utils/generation-live-test-helpers.ts`.

Tests (`**/*.test.ts` etc.) get `no-console: off` via a trailing override so the rule never flags test fixtures or console-spy tests.

**2. FileReader `{ once: true }` cleanup in `ui/src/ui/views/chat.ts`**

Three `reader.addEventListener("load", ...)` call sites in the chat composer converted to `{ once: true }`. Not a leak fix — `FileReader` is GC'd after `readAsDataURL` completes anyway — but the explicit flag communicates intent and matches the rest of the codebase's listener-cleanup conventions.

## Test plan

- [x] `pnpm lint` — `no-console` enabled on `src/**`, 0 new errors across core + extensions lanes. (4 pre-existing `no-redundant-type-constituents` errors in `extensions/qa-lab/src/providers/aimock/server.ts` confirmed present on `origin/main`.)
- [x] Current-tree allowlist exactly covers every non-test `console.*` reference under `src/` on `origin/main`.

## Blast radius

- Zero runtime change.
- The rule is additive: existing code keeps working; new unjustified `console.*` in `src/**` will fail CI.
- Listener change is pure clarity — same observable behavior.

## Follow-ups (not in this PR)

- Migrate allowlisted diagnostic-path sites to the structured subsystem logger in per-owner follow-up PRs, updating the accompanying test spies in the same change (tests currently spy on `console.error`/`console.warn` as the contract).
- Decide `.info` vs `.debug` level for each env-var-gated debug path as part of those migrations.
- Secops-owned: migrate `src/security/windows-acl.ts:281` per the in-file TODO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)