### PR TITLE
fix(sandbox): make no-new-privileges configurable

### DIFF
--- a/docs/cli/sandbox.md
+++ b/docs/cli/sandbox.md
@@ -178,6 +178,7 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
         "docker": {
           "image": "openclaw-sandbox:bookworm-slim",
           "containerPrefix": "openclaw-sbx-",
+          "noNewPrivileges": true,
           // ... more Docker options
         },
         "prune": {
@@ -189,6 +190,24 @@ Sandbox settings live in `~/.openclaw/openclaw.json` under `agents.defaults.sand
   },
 }
 ```
+
+If your Docker host/kernel rejects `--security-opt no-new-privileges` (for example, sandbox containers exit immediately with `exec /usr/bin/sleep: operation not permitted`), you can explicitly opt out:
+
+```jsonc
+{
+  "agents": {
+    "defaults": {
+      "sandbox": {
+        "docker": {
+          "noNewPrivileges": false,
+        },
+      },
+    },
+  },
+}
+```
+
+Treat this as a host-compatibility escape hatch: it weakens sandbox hardening and should only be used on trusted single-tenant setups where the default flag is known to be incompatible.
 
 ## See Also
 

--- a/src/agents/sandbox-create-args.test.ts
+++ b/src/agents/sandbox-create-args.test.ts
@@ -48,6 +48,7 @@ describe("buildSandboxCreateArgs", () => {
       network: "none",
       user: "1000:1000",
       capDrop: ["ALL"],
+      noNewPrivileges: true,
       env: { LANG: "C.UTF-8" },
       pidsLimit: 256,
       memory: "512m",
@@ -162,6 +163,20 @@ describe("buildSandboxCreateArgs", () => {
         `OPENCLAW_CLI=${OPENCLAW_CLI_ENV_VALUE}`,
       ]),
     );
+  });
+
+  it("omits no-new-privileges when sandbox config disables it", () => {
+    const args = buildSandboxCreateArgs({
+      name: "openclaw-sbx-no-nnp",
+      cfg: createSandboxConfig({
+        capDrop: ["ALL"],
+        noNewPrivileges: false,
+      }),
+      scopeKey: "main",
+      createdAtMs: 1700000000000,
+    });
+
+    expect(args).not.toEqual(expect.arrayContaining(["--security-opt", "no-new-privileges"]));
   });
 
   it("emits -v flags for safe custom binds", () => {

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -110,6 +110,7 @@ export function resolveSandboxDockerConfig(params: {
     network: agentDocker?.network ?? globalDocker?.network ?? "none",
     user: agentDocker?.user ?? globalDocker?.user,
     capDrop: agentDocker?.capDrop ?? globalDocker?.capDrop ?? ["ALL"],
+    noNewPrivileges: agentDocker?.noNewPrivileges ?? globalDocker?.noNewPrivileges ?? true,
     env,
     setupCommand: agentDocker?.setupCommand ?? globalDocker?.setupCommand,
     pidsLimit: agentDocker?.pidsLimit ?? globalDocker?.pidsLimit,

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -413,7 +413,9 @@ export function buildSandboxCreateArgs(params: {
   for (const cap of params.cfg.capDrop) {
     args.push("--cap-drop", cap);
   }
-  args.push("--security-opt", "no-new-privileges");
+  if (params.cfg.noNewPrivileges !== false) {
+    args.push("--security-opt", "no-new-privileges");
+  }
   if (params.cfg.seccompProfile) {
     args.push("--security-opt", `seccomp=${params.cfg.seccompProfile}`);
   }

--- a/src/config/config.sandbox-docker.test.ts
+++ b/src/config/config.sandbox-docker.test.ts
@@ -133,6 +133,36 @@ describe("sandbox docker config", () => {
     }
   });
 
+  it("uses agent override precedence for noNewPrivileges and defaults it to true", () => {
+    const defaulted = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: {},
+      agentDocker: {},
+    });
+    expect(defaulted.noNewPrivileges).toBe(true);
+
+    const inherited = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { noNewPrivileges: false },
+      agentDocker: {},
+    });
+    expect(inherited.noNewPrivileges).toBe(false);
+
+    const overridden = resolveSandboxDockerConfig({
+      scope: "agent",
+      globalDocker: { noNewPrivileges: true },
+      agentDocker: { noNewPrivileges: false },
+    });
+    expect(overridden.noNewPrivileges).toBe(false);
+
+    const sharedScope = resolveSandboxDockerConfig({
+      scope: "shared",
+      globalDocker: { noNewPrivileges: true },
+      agentDocker: { noNewPrivileges: false },
+    });
+    expect(sharedScope.noNewPrivileges).toBe(true);
+  });
+
   it("rejects seccomp unconfined via Zod schema validation", () => {
     const res = validateConfigObject({
       agents: {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5349,6 +5349,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           type: "string",
                         },
                       },
+                      noNewPrivileges: {
+                        type: "boolean",
+                        title: "Sandbox Docker No New Privileges",
+                        description:
+                          "Enable Docker no-new-privileges hardening for sandbox containers (default: true). Disable only on trusted hosts where this flag is known to break container exec.",
+                      },
                       dangerouslyAllowReservedContainerTargets: {
                         type: "boolean",
                       },
@@ -6682,6 +6688,12 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                           items: {
                             type: "string",
                           },
+                        },
+                        noNewPrivileges: {
+                          type: "boolean",
+                          title: "Agent Sandbox Docker No New Privileges",
+                          description:
+                            "Per-agent override for Docker no-new-privileges sandbox hardening. Disable only on trusted hosts where this flag is known to break container exec.",
                         },
                         dangerouslyAllowReservedContainerTargets: {
                           type: "boolean",
@@ -26007,6 +26019,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       help: "Optional CIDR allowlist for container-edge CDP ingress (for example 172.21.0.1/32).",
       tags: ["storage"],
     },
+    "agents.defaults.sandbox.docker.noNewPrivileges": {
+      label: "Sandbox Docker No New Privileges",
+      help: "Enable Docker no-new-privileges hardening for sandbox containers (default: true). Disable only on trusted hosts where this flag is known to break container exec.",
+      tags: ["security", "storage", "advanced"],
+    },
     "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin": {
       label: "Sandbox Docker Allow Container Namespace Join",
       help: "DANGEROUS break-glass override that allows sandbox Docker network mode container:<id>. This joins another container namespace and weakens sandbox isolation.",
@@ -27074,6 +27091,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Agent Sandbox Browser CDP Source Port Range",
       help: "Per-agent override for CDP source CIDR allowlist.",
       tags: ["storage"],
+    },
+    "agents.list[].sandbox.docker.noNewPrivileges": {
+      label: "Agent Sandbox Docker No New Privileges",
+      help: "Per-agent override for Docker no-new-privileges sandbox hardening. Disable only on trusted hosts where this flag is known to break container exec.",
+      tags: ["security", "storage", "advanced"],
     },
     "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin": {
       label: "Agent Sandbox Docker Allow Container Namespace Join",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5352,8 +5352,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                       noNewPrivileges: {
                         type: "boolean",
                         title: "Sandbox Docker No New Privileges",
-                        description:
-                          "Enable Docker no-new-privileges hardening for sandbox containers (default: true). Disable only on trusted hosts where this flag is known to break container exec.",
                       },
                       dangerouslyAllowReservedContainerTargets: {
                         type: "boolean",
@@ -6692,8 +6690,6 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         noNewPrivileges: {
                           type: "boolean",
                           title: "Agent Sandbox Docker No New Privileges",
-                          description:
-                            "Per-agent override for Docker no-new-privileges sandbox hardening. Disable only on trusted hosts where this flag is known to break container exec.",
                         },
                         dangerouslyAllowReservedContainerTargets: {
                           type: "boolean",
@@ -26021,8 +26017,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "agents.defaults.sandbox.docker.noNewPrivileges": {
       label: "Sandbox Docker No New Privileges",
-      help: "Enable Docker no-new-privileges hardening for sandbox containers (default: true). Disable only on trusted hosts where this flag is known to break container exec.",
-      tags: ["security", "storage", "advanced"],
+      tags: ["storage"],
     },
     "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin": {
       label: "Sandbox Docker Allow Container Namespace Join",
@@ -27094,8 +27089,7 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
     },
     "agents.list[].sandbox.docker.noNewPrivileges": {
       label: "Agent Sandbox Docker No New Privileges",
-      help: "Per-agent override for Docker no-new-privileges sandbox hardening. Disable only on trusted hosts where this flag is known to break container exec.",
-      tags: ["security", "storage", "advanced"],
+      tags: ["storage"],
     },
     "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin": {
       label: "Agent Sandbox Docker Allow Container Namespace Join",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -586,6 +586,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list.*.heartbeat.timeoutSeconds": "Heartbeat Timeout (Seconds)",
   "agents.defaults.sandbox.browser.network": "Sandbox Browser Network",
   "agents.defaults.sandbox.browser.cdpSourceRange": "Sandbox Browser CDP Source Port Range",
+  "agents.defaults.sandbox.docker.noNewPrivileges": "Sandbox Docker No New Privileges",
   "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Sandbox Docker Allow Container Namespace Join",
   commands: "Commands",
@@ -817,6 +818,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.list[].heartbeat.timeoutSeconds": "Agent Heartbeat Timeout (Seconds)",
   "agents.list[].sandbox.browser.network": "Agent Sandbox Browser Network",
   "agents.list[].sandbox.browser.cdpSourceRange": "Agent Sandbox Browser CDP Source Port Range",
+  "agents.list[].sandbox.docker.noNewPrivileges": "Agent Sandbox Docker No New Privileges",
   "agents.list[].sandbox.docker.dangerouslyAllowContainerNamespaceJoin":
     "Agent Sandbox Docker Allow Container Namespace Join",
   "discovery.mdns.mode": "mDNS Discovery Mode",

--- a/src/config/types.sandbox.ts
+++ b/src/config/types.sandbox.ts
@@ -17,6 +17,8 @@ export type SandboxDockerSettings = {
   user?: string;
   /** Drop Linux capabilities. */
   capDrop?: string[];
+  /** Enable Docker no-new-privileges hardening (default: true). Set false only for known-incompatible hosts. */
+  noNewPrivileges?: boolean;
   /** Extra environment variables for sandbox exec. */
   env?: Record<string, string>;
   /** Optional setup command run once after container creation (array entries are joined by newline). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -109,6 +109,7 @@ export const SandboxDockerSchema = z
     network: z.string().optional(),
     user: z.string().optional(),
     capDrop: z.array(z.string()).optional(),
+    noNewPrivileges: z.boolean().optional(),
     env: z.record(z.string(), z.string()).optional(),
     setupCommand: z
       .union([z.string(), z.array(z.string())])

--- a/src/security/dangerous-config-flags.test.ts
+++ b/src/security/dangerous-config-flags.test.ts
@@ -89,6 +89,7 @@ describe("collectEnabledInsecureOrDangerousFlags", () => {
                 docker: {
                   dangerouslyAllowReservedContainerTargets: true,
                   dangerouslyAllowContainerNamespaceJoin: true,
+                  noNewPrivileges: false,
                 },
               },
             },
@@ -122,6 +123,7 @@ describe("collectEnabledInsecureOrDangerousFlags", () => {
       expect.arrayContaining([
         "agents.defaults.sandbox.docker.dangerouslyAllowReservedContainerTargets=true",
         "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin=true",
+        "agents.defaults.sandbox.docker.noNewPrivileges=false",
         'agents.list[id="worker"].sandbox.docker.dangerouslyAllowExternalBindSources=true',
         "hooks.allowRequestSessionKey=true",
         "browser.ssrfPolicy.dangerouslyAllowPrivateNetwork=true",

--- a/src/security/dangerous-config-flags.test.ts
+++ b/src/security/dangerous-config-flags.test.ts
@@ -99,6 +99,7 @@ describe("collectEnabledInsecureOrDangerousFlags", () => {
                 sandbox: {
                   docker: {
                     dangerouslyAllowExternalBindSources: true,
+                    noNewPrivileges: false,
                   },
                 },
               },
@@ -125,6 +126,7 @@ describe("collectEnabledInsecureOrDangerousFlags", () => {
         "agents.defaults.sandbox.docker.dangerouslyAllowContainerNamespaceJoin=true",
         "agents.defaults.sandbox.docker.noNewPrivileges=false",
         'agents.list[id="worker"].sandbox.docker.dangerouslyAllowExternalBindSources=true',
+        'agents.list[id="worker"].sandbox.docker.noNewPrivileges=false',
         "hooks.allowRequestSessionKey=true",
         "browser.ssrfPolicy.dangerouslyAllowPrivateNetwork=true",
         "tools.fs.workspaceOnly=false",

--- a/src/security/dangerous-config-flags.ts
+++ b/src/security/dangerous-config-flags.ts
@@ -38,6 +38,9 @@ export function collectEnabledInsecureOrDangerousFlags(cfg: OpenClawConfig): str
         enabledFlags.push(`${pathPrefix}.${key}=true`);
       }
     }
+    if (docker.noNewPrivileges === false) {
+      enabledFlags.push(`${pathPrefix}.noNewPrivileges=false`);
+    }
   };
 
   if (cfg.gateway?.controlUi?.allowInsecureAuth === true) {


### PR DESCRIPTION
Add sandbox.docker.noNewPrivileges with a secure default of true, so hosts that reject Docker no-new-privileges can opt out explicitly without patching dist output by hand.

Also add tests, docs, and dangerous-config reporting for the security-weaker noNewPrivileges=false override.

Fixes #43996

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
