### PR TITLE
fix: route wake hooks to explicit sessions

### DIFF
--- a/src/gateway/hooks-mapping.test.ts
+++ b/src/gateway/hooks-mapping.test.ts
@@ -227,6 +227,33 @@ describe("hooks mapping", () => {
     }
   });
 
+  it("preserves wake session routing metadata", async () => {
+    const mappings = resolveHookMappings({
+      mappings: [
+        {
+          id: "wake-session-key",
+          match: { path: "gmail" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Wake: {{messages[0].subject}}",
+          sessionKey: "hook:gmail:{{messages[0].subject}}",
+        },
+      ],
+    });
+    const result = await applyHookMappings(mappings, {
+      payload: gmailPayload,
+      headers: {},
+      url: baseUrl,
+      path: "gmail",
+    });
+    expect(result?.ok).toBe(true);
+    if (result?.ok && result.action?.kind === "wake") {
+      expect(result.action.agentId).toBe("hooks");
+      expect(result.action.sessionKey).toBe("hook:gmail:Hello");
+      expect(result.action.sessionKeySource).toBe("templated");
+    }
+  });
+
   it("runs transform module", async () => {
     const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-config-"));
     const transformsRoot = path.join(configDir, "hooks", "transforms");

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -44,6 +44,9 @@ export type HookAction =
       kind: "wake";
       text: string;
       mode: "now" | "next-heartbeat";
+      agentId?: string;
+      sessionKey?: string;
+      sessionKeySource?: "static" | "templated";
     }
   | {
       kind: "agent";
@@ -254,6 +257,9 @@ function buildActionFromMapping(
         kind: "wake",
         text,
         mode: mapping.wakeMode ?? "now",
+        agentId: mapping.agentId,
+        sessionKey: renderOptional(mapping.sessionKey, ctx),
+        sessionKeySource: getSessionKeyTemplateSource(mapping.sessionKey),
       },
     };
   }
@@ -292,7 +298,14 @@ function mergeAction(
     const baseWake = base.kind === "wake" ? base : undefined;
     const text = typeof override.text === "string" ? override.text : (baseWake?.text ?? "");
     const mode = override.mode === "next-heartbeat" ? "next-heartbeat" : (baseWake?.mode ?? "now");
-    return validateAction({ kind: "wake", text, mode });
+    return validateAction({
+      kind: "wake",
+      text,
+      mode,
+      agentId: override.agentId ?? baseWake?.agentId,
+      sessionKey: override.sessionKey ?? baseWake?.sessionKey,
+      sessionKeySource: resolveMergedSessionKeySource(baseWake, override),
+    });
   }
   const baseAgent = base.kind === "agent" ? base : undefined;
   const message =
@@ -344,7 +357,7 @@ function getSessionKeyTemplateSource(
 }
 
 function resolveMergedSessionKeySource(
-  baseAgent: Extract<HookAction, { kind: "agent" }> | undefined,
+  baseAction: Extract<HookAction, { sessionKeySource?: HookSessionKeyTemplateSource }> | undefined,
   override: Exclude<HookTransformResult, null>,
 ): HookSessionKeyTemplateSource | undefined {
   if (typeof override.sessionKey === "string") {
@@ -356,7 +369,7 @@ function resolveMergedSessionKeySource(
     }
     return override.sessionKeySource === "static" ? "static" : "templated";
   }
-  return baseAgent?.sessionKeySource;
+  return baseAction?.sessionKeySource;
 }
 
 export function hasHookTemplateExpressions(template: string): boolean {

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -366,6 +366,21 @@ describe("gateway hooks helpers", () => {
     ).toBe("agent:hooks:slack:channel:c123");
   });
 
+  test("normalizeHookDispatchSessionKey scopes legacy and non-agent keys to the target agent", () => {
+    expect(
+      normalizeHookDispatchSessionKey({
+        sessionKey: "hook:wake:custom",
+        targetAgentId: "hooks",
+      }),
+    ).toBe("agent:hooks:hook:wake:custom");
+    expect(
+      normalizeHookDispatchSessionKey({
+        sessionKey: "main",
+        targetAgentId: "hooks",
+      }),
+    ).toBe("agent:hooks:main");
+  });
+
   test("resolveHooksConfig validates defaultSessionKey and generated fallback against prefixes", () => {
     expect(() =>
       resolveHooksConfig({

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -413,6 +413,28 @@ describe("gateway hooks helpers", () => {
     );
   });
 
+  test("resolveHooksConfig requires prefixes for templated wake mapping session keys", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          allowRequestSessionKey: true,
+          mappings: [
+            {
+              match: { path: "github" },
+              action: "wake",
+              textTemplate: "CI: {{payload.conclusion}}",
+              sessionKey: "hook:github:{{payload.runId}}",
+            },
+          ],
+        },
+      } as OpenClawConfig),
+    ).toThrow(
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
+    );
+  });
+
   test("resolveHooksConfig allows a static explicit mapping to shadow the templated gmail preset", () => {
     expect(() =>
       resolveHooksConfig({
@@ -458,7 +480,7 @@ describe("gateway hooks helpers", () => {
     ).not.toThrow();
   });
 
-  test("resolveHooksConfig ignores templated session keys on wake mappings", () => {
+  test("resolveHooksConfig enforces templated session keys on wake mappings", () => {
     expect(() =>
       resolveHooksConfig({
         hooks: {
@@ -474,7 +496,9 @@ describe("gateway hooks helpers", () => {
           ],
         },
       } as OpenClawConfig),
-    ).not.toThrow();
+    ).toThrow(
+      "hooks.allowedSessionKeyPrefixes is required when a hook mapping sessionKey uses templates, even if hooks.allowRequestSessionKey=true",
+    );
   });
 
   test("resolveHooksConfig treats '/' match.path as a catch-all for shadowing", () => {

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -4,7 +4,11 @@ import { listAgentIds, resolveDefaultAgentId } from "../agents/agent-scope-confi
 import { listChannelPlugins } from "../channels/plugins/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readJsonBodyWithLimit, requestBodyErrorToText } from "../infra/http-body.js";
-import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+import {
+  normalizeAgentId,
+  parseAgentSessionKey,
+  toAgentStoreSessionKey,
+} from "../routing/session-key.js";
 import type { HookExternalContentSource } from "../security/external-content.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -400,12 +404,15 @@ export function normalizeHookDispatchSessionKey(params: {
   if (!trimmed || !params.targetAgentId) {
     return trimmed;
   }
-  const parsed = parseAgentSessionKey(trimmed);
-  if (!parsed) {
-    return trimmed;
-  }
   const targetAgentId = normalizeAgentId(params.targetAgentId);
-  return `agent:${targetAgentId}:${parsed.rest}`;
+  const parsed = parseAgentSessionKey(trimmed);
+  if (parsed) {
+    return `agent:${targetAgentId}:${parsed.rest}`;
+  }
+  return toAgentStoreSessionKey({
+    agentId: targetAgentId,
+    requestKey: trimmed,
+  });
 }
 
 export function normalizeAgentPayload(payload: Record<string, unknown>):

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -337,6 +337,7 @@ export function resolveHookSessionKey(params: {
   source: HookSessionKeySource;
   sessionKey?: string;
   idFactory?: () => string;
+  allowGlobalSessionKey?: boolean;
 }): { ok: true; value: string } | { ok: false; error: string } {
   const requested = resolveSessionKey(params.sessionKey);
   if (requested) {
@@ -347,7 +348,11 @@ export function resolveHookSessionKey(params: {
       return { ok: false, error: getHookSessionKeyRequestPolicyError() };
     }
     const allowedPrefixes = params.hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
-    if (allowedPrefixes && !isSessionKeyAllowedByPrefix(requested, allowedPrefixes)) {
+    if (
+      allowedPrefixes &&
+      !(params.allowGlobalSessionKey && requested === "global") &&
+      !isSessionKeyAllowedByPrefix(requested, allowedPrefixes)
+    ) {
       return { ok: false, error: getHookSessionKeyPrefixError(allowedPrefixes) };
     }
     return { ok: true, value: requested };

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -197,17 +197,29 @@ export function normalizeHookHeaders(req: IncomingMessage) {
   return headers;
 }
 
-export function normalizeWakePayload(
-  payload: Record<string, unknown>,
-):
-  | { ok: true; value: { text: string; mode: "now" | "next-heartbeat" } }
+export function normalizeWakePayload(payload: Record<string, unknown>):
+  | {
+      ok: true;
+      value: {
+        text: string;
+        mode: "now" | "next-heartbeat";
+        sessionKey?: string;
+      };
+    }
   | { ok: false; error: string } {
   const normalizedText = normalizeOptionalString(payload.text) ?? "";
   if (!normalizedText) {
     return { ok: false, error: "text required" };
   }
   const mode = payload.mode === "next-heartbeat" ? "next-heartbeat" : "now";
-  return { ok: true, value: { text: normalizedText, mode } };
+  return {
+    ok: true,
+    value: {
+      text: normalizedText,
+      mode,
+      sessionKey: resolveSessionKey(normalizeOptionalString(payload.sessionKey)),
+    },
+  };
 }
 
 export type HookAgentPayload = {
@@ -361,7 +373,7 @@ function hasEffectiveTemplatedHookSessionKeyMapping(mappings: HookMappingResolve
       continue;
     }
     effectiveMappings.push(mapping);
-    if (mapping.action === "agent" && hasTemplatedHookSessionKey(mapping.sessionKey)) {
+    if (hasTemplatedHookSessionKey(mapping.sessionKey)) {
       return true;
     }
   }

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -493,6 +493,63 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("allows global wake routing when prefix policy omits literal global", async () => {
+    testState.sessionConfig = { scope: "global" };
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:hooks:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-agent-global-prefix" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Mapped agent wake: {{payload.subject}}",
+        },
+        {
+          match: { path: "mapped-wake-explicit-global-prefix" },
+          action: "wake",
+          agentId: "hooks",
+          sessionKey: "global",
+          textTemplate: "Mapped explicit wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const direct = await postHook(port, "/hooks/wake", {
+        text: "Direct global wake",
+        sessionKey: "global",
+      });
+      expect(direct.status).toBe(200);
+
+      const mappedAgent = await postHook(port, "/hooks/mapped-wake-agent-global-prefix", {
+        subject: "Email",
+      });
+      expect(mappedAgent.status).toBe(200);
+
+      const mappedExplicit = await postHook(port, "/hooks/mapped-wake-explicit-global-prefix", {
+        subject: "Email",
+      });
+      expect(mappedExplicit.status).toBe(200);
+
+      await expect
+        .poll(() => peekSystemEventEntries("global"), {
+          timeout: 5_000,
+          interval: 10,
+        })
+        .toEqual([
+          expect.objectContaining({ text: "Direct global wake", trusted: false }),
+          expect.objectContaining({ text: "Mapped agent wake: Email", trusted: false }),
+          expect.objectContaining({ text: "Mapped explicit wake: Email", trusted: false }),
+        ]);
+      expect(peekSystemEventEntries("agent:hooks:main")).toEqual([]);
+      drainSystemEvents("global");
+    });
+  });
+
   test("rejects explicit wake session keys that cannot be drained in global session scope", async () => {
     testState.sessionConfig = { scope: "global" };
     testState.hooksConfig = {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -450,6 +450,100 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("routes mapped wake agent routing to global in global session scope", async () => {
+    testState.sessionConfig = { scope: "global" };
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      mappings: [
+        {
+          match: { path: "mapped-wake-agent-global" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Mapped agent wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const mapped = await postHook(port, "/hooks/mapped-wake-agent-global", {
+        subject: "Email",
+      });
+      expect(mapped.status).toBe(200);
+      await expect
+        .poll(() => peekSystemEventEntries("global"), {
+          timeout: 5_000,
+          interval: 10,
+        })
+        .toEqual([
+          expect.objectContaining({
+            text: "Mapped agent wake: Email",
+            trusted: false,
+          }),
+        ]);
+      expect(peekSystemEventEntries("agent:hooks:main")).toEqual([]);
+      expect(peekSystemEventEntries(resolveMainKey())).toEqual([
+        expect.objectContaining({
+          text: "Mapped agent wake: Email",
+          trusted: false,
+        }),
+      ]);
+      drainSystemEvents("global");
+    });
+  });
+
+  test("rejects explicit wake session keys that cannot be drained in global session scope", async () => {
+    testState.sessionConfig = { scope: "global" };
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+    };
+
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/wake", {
+        text: "Direct custom wake",
+        sessionKey: "hook:wake:custom",
+      });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("session.scope=global");
+      expect(peekSystemEventEntries("global")).toEqual([]);
+      expect(peekSystemEventEntries("agent:main:hook:wake:custom")).toEqual([]);
+    });
+  });
+
+  test("rejects mapped explicit wake session keys that cannot be drained in global session scope", async () => {
+    testState.sessionConfig = { scope: "global" };
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      mappings: [
+        {
+          match: { path: "mapped-wake-explicit-global-denied" },
+          action: "wake",
+          agentId: "hooks",
+          sessionKey: "hook:mapped:custom",
+          textTemplate: "Mapped explicit wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/mapped-wake-explicit-global-denied", {
+        subject: "Email",
+      });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("session.scope=global");
+      expect(peekSystemEventEntries("global")).toEqual([]);
+      expect(peekSystemEventEntries("agent:hooks:hook:mapped:custom")).toEqual([]);
+    });
+  });
+
   test("rejects request sessionKey unless hooks.allowRequestSessionKey is enabled", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -8,6 +8,7 @@ import {
   peekSystemEvents,
 } from "../infra/system-events.js";
 import { DEDUPE_TTL_MS } from "./server-constants.js";
+import { loadSessionEntry } from "./session-utils.js";
 import {
   cronIsolatedRun,
   installGatewayTestHooks,
@@ -319,18 +320,18 @@ describe("gateway server hooks", () => {
     });
   });
 
-  test("routes wake hooks to explicit sessions and mapped agent main sessions", async () => {
+  test("routes wake hooks to canonical explicit sessions and mapped agent sessions", async () => {
     testState.hooksConfig = {
       enabled: true,
       token: HOOK_TOKEN,
       allowRequestSessionKey: true,
-      allowedSessionKeyPrefixes: ["hook:"],
       mappings: [
         {
           match: { path: "mapped-wake-agent" },
           action: "wake",
           agentId: "hooks",
           textTemplate: "Mapped agent wake: {{payload.subject}}",
+          sessionKey: "hook:mapped:email",
         },
       ],
     };
@@ -338,26 +339,35 @@ describe("gateway server hooks", () => {
 
     await withGatewayServer(async ({ port }) => {
       const directSessionKey = "hook:wake:custom";
+      const directCanonicalKey = loadSessionEntry(directSessionKey).canonicalKey;
       const direct = await postHook(port, "/hooks/wake", {
         text: "Direct custom wake",
         sessionKey: directSessionKey,
       });
       expect(direct.status).toBe(200);
       await expect
-        .poll(() => peekSystemEventEntries(directSessionKey), { timeout: 5_000, interval: 10 })
+        .poll(() => peekSystemEventEntries(directCanonicalKey), {
+          timeout: 5_000,
+          interval: 10,
+        })
         .toEqual([
           expect.objectContaining({
             text: "Direct custom wake",
             trusted: false,
           }),
         ]);
+      expect(peekSystemEventEntries(directSessionKey)).toEqual([]);
       expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
-      drainSystemEvents(directSessionKey);
+      drainSystemEvents(directCanonicalKey);
 
-      const mapped = await postHook(port, "/hooks/mapped-wake-agent", { subject: "Email" });
+      const mappedSessionKey = "hook:mapped:email";
+      const mappedCanonicalKey = loadSessionEntry("agent:hooks:hook:mapped:email").canonicalKey;
+      const mapped = await postHook(port, "/hooks/mapped-wake-agent", {
+        subject: "Email",
+      });
       expect(mapped.status).toBe(200);
       await expect
-        .poll(() => peekSystemEventEntries("agent:hooks:main"), {
+        .poll(() => peekSystemEventEntries(mappedCanonicalKey), {
           timeout: 5_000,
           interval: 10,
         })
@@ -367,8 +377,9 @@ describe("gateway server hooks", () => {
             trusted: false,
           }),
         ]);
+      expect(peekSystemEventEntries(mappedSessionKey)).toEqual([]);
       expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
-      drainSystemEvents("agent:hooks:main");
+      drainSystemEvents(mappedCanonicalKey);
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -319,6 +319,59 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("routes wake hooks to explicit sessions and mapped agent main sessions", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-agent" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Mapped agent wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const directSessionKey = "hook:wake:custom";
+      const direct = await postHook(port, "/hooks/wake", {
+        text: "Direct custom wake",
+        sessionKey: directSessionKey,
+      });
+      expect(direct.status).toBe(200);
+      await expect
+        .poll(() => peekSystemEventEntries(directSessionKey), { timeout: 5_000, interval: 10 })
+        .toEqual([
+          expect.objectContaining({
+            text: "Direct custom wake",
+            trusted: false,
+          }),
+        ]);
+      expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
+      drainSystemEvents(directSessionKey);
+
+      const mapped = await postHook(port, "/hooks/mapped-wake-agent", { subject: "Email" });
+      expect(mapped.status).toBe(200);
+      await expect
+        .poll(() => peekSystemEventEntries("agent:hooks:main"), {
+          timeout: 5_000,
+          interval: 10,
+        })
+        .toEqual([
+          expect.objectContaining({
+            text: "Mapped agent wake: Email",
+            trusted: false,
+          }),
+        ]);
+      expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
+      drainSystemEvents("agent:hooks:main");
+    });
+  });
+
   test("rejects request sessionKey unless hooks.allowRequestSessionKey is enabled", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {
@@ -329,6 +382,14 @@ describe("gateway server hooks", () => {
       expect(denied.status).toBe(400);
       const deniedBody = (await denied.json()) as { error?: string };
       expect(deniedBody.error).toContain("hooks.allowRequestSessionKey");
+
+      const deniedWake = await postHook(port, "/hooks/wake", {
+        text: "Nope",
+        sessionKey: "hook:blocked",
+      });
+      expect(deniedWake.status).toBe(400);
+      const deniedWakeBody = (await deniedWake.json()) as { error?: string };
+      expect(deniedWakeBody.error).toContain("hooks.allowRequestSessionKey");
     });
   });
 

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -383,6 +383,73 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("allows mapped wake agent routing when the computed session prefix is whitelisted", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      defaultSessionKey: "hook:ingress",
+      allowedSessionKeyPrefixes: ["hook:", "agent:hooks:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-agent-allowed" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Mapped agent wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const mappedCanonicalKey = loadSessionEntry("agent:hooks:main").canonicalKey;
+      const allowed = await postHook(port, "/hooks/mapped-wake-agent-allowed", {
+        subject: "Email",
+      });
+      expect(allowed.status).toBe(200);
+      await expect
+        .poll(() => peekSystemEventEntries(mappedCanonicalKey), {
+          timeout: 5_000,
+          interval: 10,
+        })
+        .toEqual([
+          expect.objectContaining({
+            text: "Mapped agent wake: Email",
+            trusted: false,
+          }),
+        ]);
+      expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
+      drainSystemEvents(mappedCanonicalKey);
+    });
+  });
+
+  test("rejects mapped wake agent routing when the computed session prefix is disallowed", async () => {
+    testState.hooksConfig = {
+      enabled: true,
+      token: HOOK_TOKEN,
+      allowRequestSessionKey: true,
+      allowedSessionKeyPrefixes: ["hook:", "agent:main:"],
+      mappings: [
+        {
+          match: { path: "mapped-wake-agent-denied" },
+          action: "wake",
+          agentId: "hooks",
+          textTemplate: "Mapped agent wake: {{payload.subject}}",
+        },
+      ],
+    };
+    setMainAndHooksAgents();
+
+    await withGatewayServer(async ({ port }) => {
+      const denied = await postHook(port, "/hooks/mapped-wake-agent-denied", {
+        subject: "Email",
+      });
+      expect(denied.status).toBe(400);
+      const body = (await denied.json()) as { error?: string };
+      expect(body.error).toContain("sessionKey must start with one of");
+      expect(peekSystemEventEntries(resolveMainKey())).toEqual([]);
+    });
+  });
+
   test("rejects request sessionKey unless hooks.allowRequestSessionKey is enabled", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -47,6 +47,10 @@ function getGlobalWakeSessionKeyError(): string {
   return "wake hook sessionKey must be `global` or omitted when session.scope=global";
 }
 
+function shouldApplyWakeSessionKeyPrefix(sessionKey: string): boolean {
+  return !(isGlobalSessionScope() && sessionKey === "global");
+}
+
 export type HookClientIpConfig = Readonly<{
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
@@ -276,6 +280,7 @@ export function createHooksRequestHandler(
           hooksConfig,
           source: "request",
           sessionKey: normalized.value.sessionKey,
+          allowGlobalSessionKey: isGlobalSessionScope(),
         });
         if (!wakeSessionKey.ok) {
           sendJson(res, 400, { ok: false, error: wakeSessionKey.error });
@@ -396,15 +401,19 @@ export function createHooksRequestHandler(
                     ? "mapping-static"
                     : "mapping-templated",
                 sessionKey: mapped.action.sessionKey,
+                allowGlobalSessionKey: isGlobalSessionScope(),
               });
               if (!wakeSessionKey.ok) {
                 sendJson(res, 400, { ok: false, error: wakeSessionKey.error });
                 return true;
               }
-              normalizedWakeSessionKey = normalizeHookDispatchSessionKey({
-                sessionKey: wakeSessionKey.value,
-                targetAgentId,
-              });
+              normalizedWakeSessionKey =
+                isGlobalSessionScope() && wakeSessionKey.value === "global"
+                  ? "global"
+                  : normalizeHookDispatchSessionKey({
+                      sessionKey: wakeSessionKey.value,
+                      targetAgentId,
+                    });
               if (isGlobalSessionScope() && normalizedWakeSessionKey !== "global") {
                 sendJson(res, 400, { ok: false, error: getGlobalWakeSessionKeyError() });
                 return true;
@@ -412,6 +421,7 @@ export function createHooksRequestHandler(
               const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
               if (
                 allowedPrefixes &&
+                shouldApplyWakeSessionKeyPrefix(normalizedWakeSessionKey) &&
                 !isSessionKeyAllowedByPrefix(normalizedWakeSessionKey, allowedPrefixes)
               ) {
                 sendJson(res, 400, {
@@ -430,6 +440,7 @@ export function createHooksRequestHandler(
               const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
               if (
                 allowedPrefixes &&
+                shouldApplyWakeSessionKeyPrefix(normalizedWakeSessionKey) &&
                 !isSessionKeyAllowedByPrefix(normalizedWakeSessionKey, allowedPrefixes)
               ) {
                 sendJson(res, 400, {

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -1,5 +1,7 @@
 import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { loadConfig } from "../../config/config.js";
+import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveHookExternalContentSource as resolveHookExternalContentSourceFromSession } from "../../security/external-content.js";
 import { safeEqualSecret } from "../../security/secret-equal.js";
@@ -37,6 +39,14 @@ type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
 const HOOK_AUTH_FAILURE_LIMIT = 20;
 const HOOK_AUTH_FAILURE_WINDOW_MS = 60_000;
 
+function isGlobalSessionScope(): boolean {
+  return loadConfig().session?.scope === "global";
+}
+
+function getGlobalWakeSessionKeyError(): string {
+  return "wake hook sessionKey must be `global` or omitted when session.scope=global";
+}
+
 export type HookClientIpConfig = Readonly<{
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
@@ -45,7 +55,11 @@ export type HookClientIpConfig = Readonly<{
 export type HooksRequestHandler = (req: IncomingMessage, res: ServerResponse) => Promise<boolean>;
 
 type HookDispatchers = {
-  dispatchWakeHook: (value: { text: string; mode: "now" | "next-heartbeat" }) => void;
+  dispatchWakeHook: (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    sessionKey?: string;
+  }) => void;
   dispatchAgentHook: (value: HookAgentDispatchPayload) => string;
 };
 
@@ -256,7 +270,27 @@ export function createHooksRequestHandler(
         sendJson(res, 400, { ok: false, error: normalized.error });
         return true;
       }
-      dispatchWakeHook(normalized.value);
+      let normalizedWakeSessionKey: string | undefined;
+      if (normalized.value.sessionKey) {
+        const wakeSessionKey = resolveHookSessionKey({
+          hooksConfig,
+          source: "request",
+          sessionKey: normalized.value.sessionKey,
+        });
+        if (!wakeSessionKey.ok) {
+          sendJson(res, 400, { ok: false, error: wakeSessionKey.error });
+          return true;
+        }
+        normalizedWakeSessionKey = wakeSessionKey.value;
+        if (isGlobalSessionScope() && normalizedWakeSessionKey !== "global") {
+          sendJson(res, 400, { ok: false, error: getGlobalWakeSessionKeyError() });
+          return true;
+        }
+      }
+      dispatchWakeHook({
+        ...normalized.value,
+        sessionKey: normalizedWakeSessionKey,
+      });
       sendJson(res, 200, { ok: true, mode: normalized.value.mode });
       return true;
     }
@@ -348,9 +382,67 @@ export function createHooksRequestHandler(
             return true;
           }
           if (mapped.action.kind === "wake") {
+            if (!isHookAgentAllowed(hooksConfig, mapped.action.agentId)) {
+              sendJson(res, 400, { ok: false, error: getHookAgentPolicyError() });
+              return true;
+            }
+            const targetAgentId = resolveHookTargetAgentId(hooksConfig, mapped.action.agentId);
+            let normalizedWakeSessionKey: string | undefined;
+            if (mapped.action.sessionKey) {
+              const wakeSessionKey = resolveHookSessionKey({
+                hooksConfig,
+                source:
+                  mapped.action.sessionKeySource === "static"
+                    ? "mapping-static"
+                    : "mapping-templated",
+                sessionKey: mapped.action.sessionKey,
+              });
+              if (!wakeSessionKey.ok) {
+                sendJson(res, 400, { ok: false, error: wakeSessionKey.error });
+                return true;
+              }
+              normalizedWakeSessionKey = normalizeHookDispatchSessionKey({
+                sessionKey: wakeSessionKey.value,
+                targetAgentId,
+              });
+              if (isGlobalSessionScope() && normalizedWakeSessionKey !== "global") {
+                sendJson(res, 400, { ok: false, error: getGlobalWakeSessionKeyError() });
+                return true;
+              }
+              const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+              if (
+                allowedPrefixes &&
+                !isSessionKeyAllowedByPrefix(normalizedWakeSessionKey, allowedPrefixes)
+              ) {
+                sendJson(res, 400, {
+                  ok: false,
+                  error: getHookSessionKeyPrefixError(allowedPrefixes),
+                });
+                return true;
+              }
+            } else if (targetAgentId) {
+              normalizedWakeSessionKey = isGlobalSessionScope()
+                ? "global"
+                : normalizeHookDispatchSessionKey({
+                    sessionKey: resolveMainSessionKeyFromConfig(),
+                    targetAgentId,
+                  });
+              const allowedPrefixes = hooksConfig.sessionPolicy.allowedSessionKeyPrefixes;
+              if (
+                allowedPrefixes &&
+                !isSessionKeyAllowedByPrefix(normalizedWakeSessionKey, allowedPrefixes)
+              ) {
+                sendJson(res, 400, {
+                  ok: false,
+                  error: getHookSessionKeyPrefixError(allowedPrefixes),
+                });
+                return true;
+              }
+            }
             dispatchWakeHook({
               text: mapped.action.text,
               mode: mapped.action.mode,
+              sessionKey: normalizedWakeSessionKey,
             });
             sendJson(res, 200, { ok: true, mode: mapped.action.mode });
             return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { sanitizeInboundSystemTags } from "../../auto-reply/reply/inbound-text.js";
 import type { CliDeps } from "../../cli/deps.types.js";
+import { loadConfig } from "../../config/config.js";
 import { getRuntimeConfig } from "../../config/io.js";
 import { resolveMainSessionKeyFromConfig } from "../../config/sessions.js";
 import type { CronJob } from "../../cron/types.js";
@@ -29,7 +30,11 @@ export function createGatewayHooksRequestHandler(params: {
     mode: "now" | "next-heartbeat";
     sessionKey?: string;
   }) => {
-    const requestedSessionKey = value.sessionKey || resolveMainSessionKeyFromConfig();
+    const cfg = loadConfig();
+    const requestedSessionKey =
+      cfg.session?.scope === "global"
+        ? "global"
+        : value.sessionKey || resolveMainSessionKeyFromConfig();
     const { canonicalKey: sessionKey } = loadSessionEntry(requestedSessionKey);
     enqueueSystemEvent(value.text, { sessionKey, trusted: false });
     if (value.mode === "now") {

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -9,6 +9,7 @@ import { enqueueSystemEvent } from "../../infra/system-events.js";
 import type { createSubsystemLogger } from "../../logging/subsystem.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { type HookAgentDispatchPayload, type HooksConfigResolved } from "../hooks.js";
+import { loadSessionEntry } from "../session-utils.js";
 import { createHooksRequestHandler, type HookClientIpConfig } from "./hooks-request-handler.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -28,7 +29,8 @@ export function createGatewayHooksRequestHandler(params: {
     mode: "now" | "next-heartbeat";
     sessionKey?: string;
   }) => {
-    const sessionKey = value.sessionKey || resolveMainSessionKeyFromConfig();
+    const requestedSessionKey = value.sessionKey || resolveMainSessionKeyFromConfig();
+    const { canonicalKey: sessionKey } = loadSessionEntry(requestedSessionKey);
     enqueueSystemEvent(value.text, { sessionKey, trusted: false });
     if (value.mode === "now") {
       requestHeartbeatNow({ reason: "hook:wake", sessionKey });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -23,11 +23,15 @@ export function createGatewayHooksRequestHandler(params: {
 }) {
   const { deps, getHooksConfig, getClientIpConfig, bindHost, port, logHooks } = params;
 
-  const dispatchWakeHook = (value: { text: string; mode: "now" | "next-heartbeat" }) => {
-    const sessionKey = resolveMainSessionKeyFromConfig();
+  const dispatchWakeHook = (value: {
+    text: string;
+    mode: "now" | "next-heartbeat";
+    sessionKey?: string;
+  }) => {
+    const sessionKey = value.sessionKey || resolveMainSessionKeyFromConfig();
     enqueueSystemEvent(value.text, { sessionKey, trusted: false });
     if (value.mode === "now") {
-      requestHeartbeatNow({ reason: "hook:wake" });
+      requestHeartbeatNow({ reason: "hook:wake", sessionKey });
     }
   };
 


### PR DESCRIPTION
## Summary
- let direct `/hooks/wake` payloads carry an optional `sessionKey`
- honor `action: "wake"` mapping `sessionKey` / `agentId` routing instead of always waking `main`
- extend wake-hook tests and config guards so templated wake session keys follow the same policy as agent hooks

## Why
The current gateway silently ignores wake-hook session targeting and always enqueues into the default main session, even when the operator provided a wake session key or configured a wake mapping with agent/session routing.

This is what bit the GitHub webhook relay dogfood path: the relay could wake Howard, but not the intended existing session, so the signal was quieter than intended and could drift into the wrong place.

Fixes #64556.

## Notes
- mapped wake hooks with `agentId` and no explicit `sessionKey` now target that agent's main session instead of falling back to the default main agent session
- direct `/hooks/wake` treats `sessionKey` as an exact explicit target and does **not** do agent rebinding; mapped wake keeps the existing target-agent normalization path

## Validation
- `corepack pnpm exec vitest run --config test/vitest/vitest.gateway.config.ts src/gateway/hooks.test.ts src/gateway/hooks-mapping.test.ts src/gateway/server.hooks.test.ts`
- pre-commit `check:changed` gate (including typecheck, lint, import-cycle checks, and the gateway test shard)
- Cursor Composer (`composer-2-fast`) second-mind review on the final diff: ship, with the config-guard gap fixed before opening
