### PR TITLE
fix(acp+gateway): clean final emit, fallback visibility, legacy unit resolve

### DIFF
--- a/src/agents/acp-spawn-parent-stream.final-output.test.ts
+++ b/src/agents/acp-spawn-parent-stream.final-output.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { mergeMockedModule } from "../test-utils/vitest-module-mocks.js";
+
+const enqueueSystemEventMock = vi.fn();
+const requestHeartbeatNowMock = vi.fn();
+
+vi.mock("../infra/system-events.js", () => ({
+  enqueueSystemEvent: (...args: unknown[]) => enqueueSystemEventMock(...args),
+}));
+
+vi.mock("../infra/heartbeat-wake.js", async () => {
+  return await mergeMockedModule(
+    await vi.importActual<typeof import("../infra/heartbeat-wake.js")>(
+      "../infra/heartbeat-wake.js",
+    ),
+    () => ({
+      requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
+    }),
+  );
+});
+
+let emitAgentEvent: typeof import("../infra/agent-events.js").emitAgentEvent;
+let startAcpSpawnParentStreamRelay: typeof import("./acp-spawn-parent-stream.js").startAcpSpawnParentStreamRelay;
+
+function collectedTexts(): string[] {
+  return enqueueSystemEventMock.mock.calls.map((call) => String(call[0] ?? ""));
+}
+
+function findText(predicate: (text: string) => boolean): string | undefined {
+  return collectedTexts().find(predicate);
+}
+
+describe("startAcpSpawnParentStreamRelay final-answer formatting", () => {
+  beforeAll(async () => {
+    ({ emitAgentEvent } = await import("../infra/agent-events.js"));
+    ({ startAcpSpawnParentStreamRelay } = await import("./acp-spawn-parent-stream.js"));
+  });
+
+  beforeEach(() => {
+    enqueueSystemEventMock.mockClear();
+    requestHeartbeatNowMock.mockClear();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-21T01:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // Reproduces the parent-visible bug where Codex-style multi-line k/v output
+  // arriving as separate deltas was collapsed into one line by compactWhitespace
+  // and then truncated, e.g. `cwd: /home/ubuntu/clawdpackage_version: missing...`.
+  it("preserves newlines across multi-delta key/value output in the final emit", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-final-kv",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:final-kv",
+      agentId: "codex",
+      streamFlushMs: 1_000,
+      noOutputNoticeMs: 120_000,
+    });
+
+    // Each delta as a separate line, mirroring how Codex tends to stream lines.
+    emitAgentEvent({
+      runId: "run-final-kv",
+      stream: "assistant",
+      data: { delta: "cwd: /home/ubuntu/clawd\n" },
+    });
+    emitAgentEvent({
+      runId: "run-final-kv",
+      stream: "assistant",
+      data: { delta: "package_version: missing\n" },
+    });
+    emitAgentEvent({
+      runId: "run-final-kv",
+      stream: "assistant",
+      data: { delta: "node: v22.5.1\n" },
+    });
+
+    emitAgentEvent({
+      runId: "run-final-kv",
+      stream: "lifecycle",
+      data: { phase: "end", startedAt: 0, endedAt: 1_000 },
+    });
+
+    const finalEmit = findText((text) => text.startsWith("codex final:"));
+    expect(
+      finalEmit,
+      `expected a 'codex final:' emit, got ${JSON.stringify(collectedTexts())}`,
+    ).toBeDefined();
+    // Must NOT collapse adjacent lines into one.
+    expect(finalEmit).not.toContain("clawdpackage_version");
+    // Each k/v line must survive on its own line.
+    expect(finalEmit).toContain("cwd: /home/ubuntu/clawd");
+    expect(finalEmit).toContain("package_version: missing");
+    expect(finalEmit).toContain("node: v22.5.1");
+    // The structure is multi-line.
+    expect(finalEmit?.split("\n").length).toBeGreaterThanOrEqual(4);
+
+    expect(findText((text) => text.includes("run completed in 1s"))).toBeDefined();
+    relay.dispose();
+  });
+
+  it("does not double up final emit when commentary precedes final_answer", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-cmt-then-final",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:cmt-then-final",
+      agentId: "codex",
+      streamFlushMs: 5,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-cmt-then-final",
+      stream: "assistant",
+      data: { delta: "thinking about the request...", phase: "commentary" },
+    });
+    emitAgentEvent({
+      runId: "run-cmt-then-final",
+      stream: "assistant",
+      data: { delta: "Result: 42\n", phase: "final_answer" },
+    });
+    vi.advanceTimersByTime(20);
+    emitAgentEvent({
+      runId: "run-cmt-then-final",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+
+    const finalEmit = findText((text) => text.startsWith("codex final:"));
+    expect(finalEmit).toBeDefined();
+    expect(finalEmit).toContain("Result: 42");
+    // Commentary must not appear in the final.
+    expect(finalEmit).not.toContain("thinking about the request");
+    relay.dispose();
+  });
+
+  it("hard-caps the final emit and adds a marker when output is huge", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-huge",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:huge",
+      agentId: "codex",
+      streamFlushMs: 10_000,
+      noOutputNoticeMs: 120_000,
+    });
+
+    // 8000 chars of valid lines — exceeds the 6000-char cap.
+    const lines: string[] = [];
+    for (let i = 0; i < 200; i += 1) {
+      lines.push(`line ${i}: ${"x".repeat(30)}`);
+    }
+    emitAgentEvent({
+      runId: "run-huge",
+      stream: "assistant",
+      data: { delta: `${lines.join("\n")}\n` },
+    });
+    emitAgentEvent({
+      runId: "run-huge",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+
+    const finalEmit = findText((text) => text.startsWith("codex final:"));
+    expect(finalEmit).toBeDefined();
+    // Final emit body (after the "codex final:\n" prefix) must not exceed
+    // the configured cap by more than the trailing "…" marker line.
+    const body = finalEmit!.replace(/^codex final:\n/, "");
+    expect(body.length).toBeLessThanOrEqual(6_000 + 4);
+    expect(body.endsWith("…")).toBe(true);
+    relay.dispose();
+  });
+
+  it("surfaces partial child output before an error so the parent isn't left blind", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-err-partial",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:err-partial",
+      agentId: "codex",
+      streamFlushMs: 10_000,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-err-partial",
+      stream: "assistant",
+      data: { delta: "step 1: ok\nstep 2: ok\n" },
+    });
+    emitAgentEvent({
+      runId: "run-err-partial",
+      stream: "lifecycle",
+      data: { phase: "error", error: "sandbox blocked write" },
+    });
+
+    const partialEmit = findText((text) => text.startsWith("codex partial output before failure:"));
+    expect(partialEmit).toBeDefined();
+    expect(partialEmit).toContain("step 1: ok");
+    expect(partialEmit).toContain("step 2: ok");
+    expect(findText((text) => text.includes("run failed: sandbox blocked write"))).toBeDefined();
+    relay.dispose();
+  });
+
+  it("emits no final block when the child produced nothing before completion", () => {
+    const relay = startAcpSpawnParentStreamRelay({
+      runId: "run-empty",
+      parentSessionKey: "agent:main:main",
+      childSessionKey: "agent:codex:acp:empty",
+      agentId: "codex",
+      streamFlushMs: 10,
+      noOutputNoticeMs: 120_000,
+    });
+
+    emitAgentEvent({
+      runId: "run-empty",
+      stream: "lifecycle",
+      data: { phase: "end" },
+    });
+
+    expect(findText((text) => text.startsWith("codex final:"))).toBeUndefined();
+    expect(findText((text) => text.includes("run completed"))).toBeDefined();
+    relay.dispose();
+  });
+});

--- a/src/agents/acp-spawn-parent-stream.ts
+++ b/src/agents/acp-spawn-parent-stream.ts
@@ -17,6 +17,9 @@ const DEFAULT_NO_OUTPUT_POLL_MS = 15_000;
 const DEFAULT_MAX_RELAY_LIFETIME_MS = 6 * 60 * 60 * 1000;
 const STREAM_BUFFER_MAX_CHARS = 4_000;
 const STREAM_SNIPPET_MAX_CHARS = 220;
+// Cap the normalized final-answer surfaced to the parent. Larger than the
+// snippet preview, but bounded so a runaway transcript cannot flood the parent.
+const FINAL_ANSWER_MAX_CHARS = 6_000;
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
@@ -30,6 +33,43 @@ function truncate(value: string, maxChars: number): string {
     return value.slice(0, maxChars);
   }
   return `${value.slice(0, maxChars - 1)}…`;
+}
+
+// Normalize a multi-delta accumulation for parent-visible final emit.
+// Preserves newlines (so multi-line key/value outputs survive), strips
+// per-line trailing whitespace, collapses runs of >2 blank lines, and
+// hard-caps total length at the line boundary nearest the limit.
+function normalizeFinalAnswerText(value: string, maxChars: number): string {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  const lines = trimmed
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/u, ""));
+  const compacted: string[] = [];
+  let consecutiveBlank = 0;
+  for (const line of lines) {
+    if (line === "") {
+      consecutiveBlank += 1;
+      if (consecutiveBlank > 1) {
+        continue;
+      }
+    } else {
+      consecutiveBlank = 0;
+    }
+    compacted.push(line);
+  }
+  const joined = compacted.join("\n").trim();
+  if (joined.length <= maxChars) {
+    return joined;
+  }
+  // Truncate at a line boundary when possible to avoid mid-line cuts.
+  const slice = joined.slice(0, maxChars - 1);
+  const lastNewline = slice.lastIndexOf("\n");
+  const cut = lastNewline > maxChars / 2 ? slice.slice(0, lastNewline).replace(/\s+$/u, "") : slice;
+  return `${cut}\n…`;
 }
 
 function toFiniteNumber(value: unknown): number | undefined {
@@ -220,6 +260,11 @@ export function startAcpSpawnParentStreamRelay(params: {
 
   let disposed = false;
   let pendingText = "";
+  // Accumulate the full child final-answer text so the parent can be handed a
+  // single coherent message at end-of-run, instead of relying on truncated
+  // mid-flight snippets. This is in-memory only and bounded by
+  // FINAL_ANSWER_MAX_CHARS at emit time.
+  let accumulatedFinalText = "";
   let lastProgressAt = Date.now();
   let stallNotified = false;
   let flushTimer: NodeJS.Timeout | undefined;
@@ -345,6 +390,12 @@ export function startAcpSpawnParentStreamRelay(params: {
 
       lastProgressAt = Date.now();
       pendingText += delta;
+      // Keep the full final-answer transcript with newlines preserved so the
+      // end-of-run emit can hand the parent a coherent message instead of a
+      // collapsed snippet. Bounded so a runaway transcript stays in memory.
+      if (accumulatedFinalText.length < FINAL_ANSWER_MAX_CHARS * 2) {
+        accumulatedFinalText += delta;
+      }
       if (pendingText.length > STREAM_BUFFER_MAX_CHARS) {
         pendingText = pendingText.slice(-STREAM_BUFFER_MAX_CHARS);
       }
@@ -363,7 +414,15 @@ export function startAcpSpawnParentStreamRelay(params: {
     const phase = normalizeOptionalString((event.data as { phase?: unknown } | undefined)?.phase);
     logEvent("lifecycle", { phase: phase ?? "unknown", data: event.data });
     if (phase === "end") {
-      flushPending();
+      // Drop the in-flight snippet (it would just be a noisy duplicate of the
+      // final emit) and surface the normalized full final answer instead.
+      pendingText = "";
+      clearFlushTimer();
+      const finalAnswer = normalizeFinalAnswerText(accumulatedFinalText, FINAL_ANSWER_MAX_CHARS);
+      if (finalAnswer) {
+        logEvent("final_answer", { text: finalAnswer });
+        emit(`${relayLabel} final:\n${finalAnswer}`, `${contextPrefix}:final`);
+      }
       const startedAt = toFiniteNumber(
         (event.data as { startedAt?: unknown } | undefined)?.startedAt,
       );
@@ -385,7 +444,19 @@ export function startAcpSpawnParentStreamRelay(params: {
     }
 
     if (phase === "error") {
-      flushPending();
+      pendingText = "";
+      clearFlushTimer();
+      // Surface whatever the child produced before the failure so the parent
+      // can decide whether to retry or fall back, instead of getting only a
+      // bare error string.
+      const partial = normalizeFinalAnswerText(accumulatedFinalText, FINAL_ANSWER_MAX_CHARS);
+      if (partial) {
+        logEvent("partial_answer", { text: partial });
+        emit(
+          `${relayLabel} partial output before failure:\n${partial}`,
+          `${contextPrefix}:partial`,
+        );
+      }
       const errorText = normalizeOptionalString(
         (event.data as { error?: unknown } | undefined)?.error,
       );

--- a/src/agents/harness/selection.test.ts
+++ b/src/agents/harness/selection.test.ts
@@ -6,7 +6,12 @@ import type {
   EmbeddedRunAttemptResult,
 } from "../pi-embedded-runner/run/types.js";
 import { clearAgentHarnesses, registerAgentHarness } from "./registry.js";
-import { runAgentHarnessAttemptWithFallback, selectAgentHarness } from "./selection.js";
+import {
+  clearHarnessSelectionDiagnosticsForTests,
+  readRecentHarnessSelectionDiagnostics,
+  runAgentHarnessAttemptWithFallback,
+  selectAgentHarness,
+} from "./selection.js";
 import type { AgentHarness } from "./types.js";
 
 const piRunAttempt = vi.fn(async () => createAttemptResult("pi"));
@@ -25,6 +30,7 @@ const originalHarnessFallback = process.env.OPENCLAW_AGENT_HARNESS_FALLBACK;
 
 afterEach(() => {
   clearAgentHarnesses();
+  clearHarnessSelectionDiagnosticsForTests();
   piRunAttempt.mockClear();
   if (originalRuntime == null) {
     delete process.env.OPENCLAW_AGENT_RUNTIME;
@@ -181,5 +187,55 @@ describe("selectAgentHarness", () => {
     expect(selectAgentHarness({ provider: "anthropic", modelId: "sonnet-4.6", config }).id).toBe(
       "pi",
     );
+  });
+});
+
+describe("harness selection diagnostics", () => {
+  it("records a fallback event when a forced harness is not registered", () => {
+    process.env.OPENCLAW_AGENT_RUNTIME = "codex";
+    const before = readRecentHarnessSelectionDiagnostics().length;
+
+    const harness = selectAgentHarness({
+      provider: "codex",
+      modelId: "gpt-5.4",
+      agentId: "codex",
+      sessionKey: "agent:codex:acp:abcd",
+    });
+
+    expect(harness.id).toBe("pi");
+    const diagnostics = readRecentHarnessSelectionDiagnostics();
+    expect(diagnostics.length).toBe(before + 1);
+    const last = diagnostics[diagnostics.length - 1];
+    expect(last?.requestedRuntime).toBe("codex");
+    expect(last?.selectedHarnessId).toBe("pi");
+    expect(last?.fallbackUsed).toBe(true);
+    expect(last?.fallbackReason).toBe("requested-not-registered");
+    expect(last?.agentId).toBe("codex");
+    expect(last?.sessionKey).toBe("agent:codex:acp:abcd");
+  });
+
+  it("records a non-fallback event when a forced harness is registered", () => {
+    process.env.OPENCLAW_AGENT_RUNTIME = "codex";
+    registerAgentHarness(
+      {
+        id: "codex",
+        label: "Codex",
+        supports: () => ({ supported: true, priority: 100 }),
+        runAttempt: vi.fn(async () => createAttemptResult("codex")),
+      },
+      { ownerPluginId: "codex" },
+    );
+
+    const harness = selectAgentHarness({
+      provider: "codex",
+      modelId: "gpt-5.4",
+    });
+
+    expect(harness.id).toBe("codex");
+    const diagnostics = readRecentHarnessSelectionDiagnostics();
+    const last = diagnostics[diagnostics.length - 1];
+    expect(last?.selectedHarnessId).toBe("codex");
+    expect(last?.fallbackUsed).toBe(false);
+    expect(last?.fallbackReason).toBeUndefined();
   });
 });

--- a/src/agents/harness/selection.ts
+++ b/src/agents/harness/selection.ts
@@ -28,6 +28,42 @@ type AgentHarnessPolicy = {
   fallback: EmbeddedAgentHarnessFallback;
 };
 
+// Operator-facing record of the most recent harness selections. Used by
+// `/acp doctor` and similar diagnostics to answer "did this actually run in
+// Codex or did it silently fall back to PI?" without parsing logs.
+export type HarnessSelectionDiagnostic = {
+  ts: number;
+  agentId?: string;
+  sessionKey?: string;
+  provider?: string;
+  modelId?: string;
+  requestedRuntime: EmbeddedAgentRuntime;
+  selectedHarnessId: string;
+  fallbackUsed: boolean;
+  fallbackReason?: string;
+};
+
+const HARNESS_SELECTION_DIAGNOSTIC_RING_SIZE = 16;
+const harnessSelectionDiagnostics: HarnessSelectionDiagnostic[] = [];
+
+function recordHarnessSelectionDiagnostic(entry: HarnessSelectionDiagnostic): void {
+  harnessSelectionDiagnostics.push(entry);
+  if (harnessSelectionDiagnostics.length > HARNESS_SELECTION_DIAGNOSTIC_RING_SIZE) {
+    harnessSelectionDiagnostics.splice(
+      0,
+      harnessSelectionDiagnostics.length - HARNESS_SELECTION_DIAGNOSTIC_RING_SIZE,
+    );
+  }
+}
+
+export function readRecentHarnessSelectionDiagnostics(): HarnessSelectionDiagnostic[] {
+  return harnessSelectionDiagnostics.slice();
+}
+
+export function clearHarnessSelectionDiagnosticsForTests(): void {
+  harnessSelectionDiagnostics.length = 0;
+}
+
 function listPluginAgentHarnesses(): AgentHarness[] {
   return listRegisteredAgentHarnesses().map((entry) => entry.harness);
 }
@@ -56,22 +92,41 @@ export function selectAgentHarness(params: {
   const pluginHarnesses = listPluginAgentHarnesses();
   const piHarness = createPiAgentHarness();
   const runtime = policy.runtime;
+  const recordSelection = (selectedHarnessId: string, fallbackReason?: string): void => {
+    recordHarnessSelectionDiagnostic({
+      ts: Date.now(),
+      agentId: params.agentId,
+      sessionKey: params.sessionKey,
+      provider: params.provider,
+      modelId: params.modelId,
+      requestedRuntime: runtime,
+      selectedHarnessId,
+      fallbackUsed: Boolean(fallbackReason),
+      ...(fallbackReason ? { fallbackReason } : {}),
+    });
+  };
   if (runtime === "pi") {
+    recordSelection("pi");
     return piHarness;
   }
   if (runtime !== "auto") {
     const forced = pluginHarnesses.find((entry) => entry.id === runtime);
     if (forced) {
+      recordSelection(forced.id);
       return forced;
     }
     if (policy.fallback === "none") {
+      recordSelection("pi", "requested-not-registered;fallback-disabled");
       throw new Error(
         `Requested agent harness "${runtime}" is not registered and PI fallback is disabled.`,
       );
     }
+    const reason = "requested-not-registered";
     log.warn("requested agent harness is not registered; falling back to embedded PI backend", {
       requestedRuntime: runtime,
+      fallbackReason: reason,
     });
+    recordSelection("pi", reason);
     return piHarness;
   }
 
@@ -96,13 +151,16 @@ export function selectAgentHarness(params: {
 
   const selected = supported[0]?.harness;
   if (selected) {
+    recordSelection(selected.id);
     return selected;
   }
   if (policy.fallback === "none") {
+    recordSelection("pi", "no-supporting-harness;fallback-disabled");
     throw new Error(
       `No registered agent harness supports ${formatProviderModel(params)} and PI fallback is disabled.`,
     );
   }
+  recordSelection("pi", "no-supporting-harness");
   return piHarness;
 }
 

--- a/src/auto-reply/reply/commands-acp/diagnostics.ts
+++ b/src/auto-reply/reply/commands-acp/diagnostics.ts
@@ -3,6 +3,7 @@ import { formatAcpRuntimeErrorText } from "../../../acp/runtime/error-text.js";
 import { toAcpRuntimeError } from "../../../acp/runtime/errors.js";
 import { getAcpRuntimeBackend, requireAcpRuntimeBackend } from "../../../acp/runtime/registry.js";
 import { resolveSessionStorePathForAcp } from "../../../acp/runtime/session-meta.js";
+import { readRecentHarnessSelectionDiagnostics } from "../../../agents/harness/selection.js";
 import { loadSessionStore } from "../../../config/sessions.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import { getSessionBindingService } from "../../../infra/outbound/session-binding-service.js";
@@ -55,6 +56,31 @@ export async function handleAcpDoctorAction(
     lines.push(`registeredBackend: ${registeredBackend.id}`);
   } else {
     lines.push("registeredBackend: (none)");
+  }
+
+  // Surface the most recent agent-harness selections so operators can quickly
+  // confirm whether requested harnesses (e.g. Codex) actually ran or silently
+  // fell back to the embedded PI backend.
+  const recentSelections = readRecentHarnessSelectionDiagnostics();
+  if (recentSelections.length === 0) {
+    lines.push("recentHarnessSelections: (none observed yet)");
+  } else {
+    lines.push(`recentHarnessSelections: ${recentSelections.length}`);
+    const fallbacks = recentSelections.filter((entry) => entry.fallbackUsed);
+    lines.push(`recentHarnessFallbacks: ${fallbacks.length}`);
+    const tail = recentSelections.slice(-5).toReversed();
+    for (const entry of tail) {
+      const ts = new Date(entry.ts).toISOString();
+      const fallback = entry.fallbackUsed
+        ? ` fallback=true reason=${entry.fallbackReason ?? "(unspecified)"}`
+        : " fallback=false";
+      const provider = entry.provider ? ` provider=${entry.provider}` : "";
+      const model = entry.modelId ? ` model=${entry.modelId}` : "";
+      const agent = entry.agentId ? ` agent=${entry.agentId}` : "";
+      lines.push(
+        `  ${ts} requested=${entry.requestedRuntime} selected=${entry.selectedHarnessId}${fallback}${provider}${model}${agent}`,
+      );
+    }
   }
 
   if (registeredBackend?.runtime.doctor) {

--- a/src/cli/update-cli/restart-helper.test.ts
+++ b/src/cli/update-cli/restart-helper.test.ts
@@ -134,6 +134,20 @@ exit 0
       await cleanupScript(scriptPath);
     });
 
+    // Legacy `clawdbot-gateway.service` units expose CLAWDBOT_SYSTEMD_UNIT but
+    // not the canonical OPENCLAW_SYSTEMD_UNIT. Restart scripts must hit the
+    // unit that actually exists on the host instead of the canonical name.
+    it("falls back to CLAWDBOT_SYSTEMD_UNIT when OPENCLAW_SYSTEMD_UNIT is unset", async () => {
+      Object.defineProperty(process, "platform", { value: "linux" });
+      const { scriptPath, content } = await prepareAndReadScript({
+        OPENCLAW_PROFILE: "default",
+        CLAWDBOT_SYSTEMD_UNIT: "clawdbot-gateway.service",
+      });
+      expect(content).toContain("systemctl --user restart 'clawdbot-gateway.service'");
+      expect(content).not.toContain("openclaw-gateway.service");
+      await cleanupScript(scriptPath);
+    });
+
     it("creates a launchd restart script on macOS", async () => {
       Object.defineProperty(process, "platform", { value: "darwin" });
       process.getuid = () => 501;

--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -36,6 +36,14 @@ function resolveSystemdUnit(env: NodeJS.ProcessEnv): string {
   if (override) {
     return override.endsWith(".service") ? override : `${override}.service`;
   }
+  // Match systemd.ts: legacy `clawdbot-gateway.service` units only set
+  // CLAWDBOT_SYSTEMD_UNIT, not the canonical OPENCLAW_SYSTEMD_UNIT. Restart the
+  // unit that is actually running rather than a canonical name that may not
+  // exist on this host.
+  const legacyOverride = normalizeOptionalString(env.CLAWDBOT_SYSTEMD_UNIT);
+  if (legacyOverride) {
+    return legacyOverride.endsWith(".service") ? legacyOverride : `${legacyOverride}.service`;
+  }
   return `${resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)}.service`;
 }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -54,6 +54,17 @@ function resolveSystemdServiceName(env: GatewayServiceEnv): string {
   if (override) {
     return override.endsWith(".service") ? override.slice(0, -".service".length) : override;
   }
+  // Legacy `clawdbot-gateway.service` units expose CLAWDBOT_SYSTEMD_UNIT but
+  // not the newer OPENCLAW_SYSTEMD_UNIT. Honor it for status/restart/stop so
+  // tooling and user-facing messages report the unit that actually ran instead
+  // of the canonical name. New installs continue to use the canonical name via
+  // resolveGatewaySystemdServiceName.
+  const legacyOverride = env.CLAWDBOT_SYSTEMD_UNIT?.trim();
+  if (legacyOverride) {
+    return legacyOverride.endsWith(".service")
+      ? legacyOverride.slice(0, -".service".length)
+      : legacyOverride;
+  }
   return resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
 }
 


### PR DESCRIPTION
## Problem

Three related rough edges in ACP/Codex orchestration and gateway ops:

1. Parent sessions could fail to surface a coherent final answer after `sessions_spawn(runtime="acp")`. Mid-flight snippet flushes compacted whitespace and truncated aggressively, so short multi-line Codex key/value output could collapse into a single line before any clean final answer reached the parent.
2. Harness fallback visibility was weak. Operators could not easily answer "did this actually run in Codex or fall back?" without grepping logs.
3. Legacy hosts running `clawdbot-gateway.service` exposed `CLAWDBOT_SYSTEMD_UNIT`, but the relevant resolver paths only honored `OPENCLAW_SYSTEMD_UNIT`, so status/restart tooling could target the canonical `openclaw-gateway.service` instead of the actual running unit.

## Solution

- `src/agents/acp-spawn-parent-stream.ts`
  - Accumulate non-commentary child output into a dedicated final buffer.
  - On `phase === "end"`, emit a single normalized `<agent> final:` system event with preserved newlines, line-aware truncation, and whitespace cleanup.
  - On `phase === "error"`, surface the partial transcript before the error text.
  - Keep the existing mid-flight snippet behavior for progress chatter.
- `src/agents/harness/selection.ts`
  - Record a 16-slot in-memory ring of harness selection diagnostics with requested runtime, selected harness, fallback usage, and reason.
- `src/auto-reply/reply/commands-acp/diagnostics.ts`
  - Extend `/acp doctor` to show recent harness selections, recent harness fallbacks, and the last 5 diagnostic entries.
- `src/daemon/systemd.ts` and `src/cli/update-cli/restart-helper.ts`
  - Fall back to `CLAWDBOT_SYSTEMD_UNIT` when `OPENCLAW_SYSTEMD_UNIT` is unset so legacy hosts resolve the actual running unit correctly.

## Files changed

- `src/agents/acp-spawn-parent-stream.ts`
- `src/agents/acp-spawn-parent-stream.final-output.test.ts` (new)
- `src/agents/harness/selection.ts`
- `src/agents/harness/selection.test.ts`
- `src/auto-reply/reply/commands-acp/diagnostics.ts`
- `src/cli/update-cli/restart-helper.ts`
- `src/cli/update-cli/restart-helper.test.ts`
- `src/daemon/systemd.ts`

## Tests run

- `pnpm test src/agents/acp-spawn-parent-stream.test.ts`
- `pnpm test src/agents/acp-spawn-parent-stream.final-output.test.ts`
- `pnpm test src/agents/harness/selection.test.ts`
- `pnpm test src/auto-reply/reply/commands-acp.test.ts`
- `pnpm test src/cli/update-cli/restart-helper.test.ts`
- `pnpm test src/daemon/inspect.test.ts`
- `pnpm tsgo`
- `pnpm format:check` on touched files
- repo pre-commit hook (`oxlint` / `oxfmt`) clean

## Limitations

- Parent follow-through is mitigated, not fully fixed.
- `sessions_spawn(runtime="acp")` still returns an accepted envelope immediately; the clean child final reaches the parent via the relay side-channel rather than the tool result itself.
- A true attach-and-wait or resume-on-child-completion primitive would be a larger behavior change and should land separately.
- The new smoke coverage is unit-test based, not a live Codex roundtrip.
- The harness diagnostic ring is process-local and resets on gateway restart.
- Docs / changelog are not updated here.

## Explicit note on parent follow-through

This change substantially improves the normal-path symptom where the parent appeared to "move on" without surfacing a clean final answer. The relay now emits a coherent final system event on completion, and the compact-whitespace collapse bug is covered by tests. However, the underlying architecture is unchanged: if the parent stops generating before the child-completion event arrives, the parent can still appear to move on. A true fix requires a larger orchestration change.
