### PR TITLE
fix(memory): harden dreaming diary pipeline

### DIFF
--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1642,13 +1642,24 @@ describe("memory cli", () => {
 
   it("prints conceptual promotion signals", async () => {
     await withTempWorkspace(async (workspaceDir) => {
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(
+        path.join(workspaceDir, "memory", "2026-05-01.md"),
+        [
+          "# 2026-05-01",
+          "",
+          "Infra notes",
+          "Configured router VLAN 10 and Glacier backup notes for QMD.",
+        ].join("\n"),
+        "utf-8",
+      );
       await recordShortTermRecalls({
         workspaceDir,
         query: "router vlan",
-        nowMs: Date.parse("2026-04-01T00:00:00.000Z"),
+        nowMs: Date.parse("2026-05-01T00:00:00.000Z"),
         results: [
           {
-            path: "memory/2026-04-01.md",
+            path: "memory/2026-05-01.md",
             startLine: 4,
             endLine: 8,
             score: 0.9,
@@ -1660,10 +1671,10 @@ describe("memory cli", () => {
       await recordShortTermRecalls({
         workspaceDir,
         query: "glacier backup",
-        nowMs: Date.parse("2026-04-03T00:00:00.000Z"),
+        nowMs: Date.parse("2026-05-03T00:00:00.000Z"),
         results: [
           {
-            path: "memory/2026-04-01.md",
+            path: "memory/2026-05-01.md",
             startLine: 4,
             endLine: 8,
             score: 0.88,

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -319,6 +319,25 @@ describe("appendNarrativeEntry", () => {
     expect(secondIdx).toBeLessThan(end);
   });
 
+  it("does not append a duplicate diary body on a later day", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    await appendNarrativeEntry({
+      workspaceDir,
+      narrative: "The compass was there before I was.",
+      nowMs: Date.parse("2026-04-04T03:00:00Z"),
+      timezone: "UTC",
+    });
+    await appendNarrativeEntry({
+      workspaceDir,
+      narrative: "The compass was there before I was.",
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+    });
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content.match(/The compass was there before I was\./g)?.length).toBe(1);
+  });
+
   it("prepends diary before existing managed blocks", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const dreamsPath = path.join(workspaceDir, "DREAMS.md");
@@ -395,7 +414,7 @@ describe("appendNarrativeEntry", () => {
     expect(stat.mode & 0o777).toBe(0o600);
   });
 
-  it("dedupes only exact diary duplicates while keeping distinct timestamps", async () => {
+  it("dedupes identical diary bodies even when timestamps differ", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-dedupe-");
     const dreamsPath = path.join(workspaceDir, "DREAMS.md");
     await fs.writeFile(
@@ -422,7 +441,7 @@ describe("appendNarrativeEntry", () => {
         "",
         "*April 11, 2026, 8:30 AM*",
         "",
-        "The server room smelled like rain.",
+        "A different lantern blinked by the door.",
         "",
         "<!-- openclaw:dreaming:diary:end -->",
         "",
@@ -435,9 +454,9 @@ describe("appendNarrativeEntry", () => {
     expect(result.removed).toBe(1);
     expect(result.kept).toBe(2);
     const content = await fs.readFile(dreamsPath, "utf-8");
-    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(2);
+    expect(content.match(/The server room smelled like rain\./g)?.length).toBe(1);
     expect(content).toContain("*April 11, 2026, 8:00 AM*");
-    expect(content).toContain("*April 11, 2026, 8:30 AM*");
+    expect(content).toContain("A different lantern blinked by the door.");
   });
 
   it("serializes append and dedupe so concurrent rewrites keep the new entry", async () => {
@@ -722,6 +741,36 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
     expect(subagent.deleteSession).toHaveBeenCalledOnce();
+  });
+
+  it("turns request-scoped fallback fragments into diary prose instead of raw headings", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    const subagent = createMockSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const logger = createMockLogger();
+
+    await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: {
+        phase: "rem",
+        snippets: [
+          "Reflections: Theme: `assistant` kept surfacing across 40 memories.",
+          "Possible Lasting Truths: First contact in February, a compass on the desk.",
+        ],
+        promotions: ["Reflections: Metadata is just memory with a timestamp attached."],
+        themes: ["assistant", "memory"],
+      },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
+    expect(content).toContain("Tonight felt stitched together");
+    expect(content).toContain("Themes circling in the dark: assistant · memory.");
+    expect(content).not.toContain("Reflections:");
+    expect(content).not.toContain("Possible Lasting Truths:");
   });
 
   it("falls back when the request-scoped runtime error is detected by stable code", async () => {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -127,12 +127,60 @@ function formatFallbackWriteFailure(err: unknown): string {
   return "unknown error";
 }
 
+function stripFallbackDreamPrefix(value: string): string {
+  return value.replace(/^(?:possible lasting truths|reflections)\s*:\s*/i, "").trim();
+}
+
+function cleanFallbackDreamFragment(value: string): string {
+  return stripFallbackDreamPrefix(value)
+    .replace(/\s*\[[^\]]*confidence=[^\]]+\]\s*$/i, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncateFallbackDreamText(value: string, max = 220): string {
+  if (value.length <= max) {
+    return value;
+  }
+  return `${value.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function buildPoeticFallbackNarrative(data: NarrativePhaseData): string {
+  const fragments = [...data.snippets, ...(data.promotions ?? [])]
+    .map((value) => cleanFallbackDreamFragment(value))
+    .filter((value, index, all) => value.length > 0 && all.indexOf(value) === index)
+    .slice(0, 3);
+  const themeBits = (data.themes ?? [])
+    .map((value) => value.replace(/^-+\s*/, "").trim())
+    .filter(Boolean)
+    .slice(0, 2);
+
+  if (fragments.length === 0 && themeBits.length === 0) {
+    return "A memory trace surfaced, but details were unavailable in this run.";
+  }
+
+  const lines: string[] = [];
+  if (fragments.length > 0) {
+    lines.push(
+      `Tonight felt stitched together from ${fragments.length === 1 ? "one" : fragments.length === 2 ? "two" : "three"} bright fragments: ${truncateFallbackDreamText(fragments[0] ?? "")}`,
+    );
+    if (fragments[1]) {
+      lines.push(`Another thread lingered nearby: ${truncateFallbackDreamText(fragments[1])}`);
+    }
+    if (fragments[2]) {
+      lines.push(
+        `And beneath it all, this kept glowing: ${truncateFallbackDreamText(fragments[2])}`,
+      );
+    }
+  }
+  if (themeBits.length > 0) {
+    lines.push(`Themes circling in the dark: ${themeBits.join(" · ")}.`);
+  }
+  return lines.join("\n\n");
+}
+
 function buildRequestScopedFallbackNarrative(data: NarrativePhaseData): string {
-  return (
-    data.snippets.map((value) => value.trim()).find((value) => value.length > 0) ??
-    (data.promotions ?? []).map((value) => value.trim()).find((value) => value.length > 0) ??
-    "A memory trace surfaced, but details were unavailable in this run."
-  );
+  return buildPoeticFallbackNarrative(data);
 }
 
 async function startNarrativeRunOrFallback(params: {
@@ -337,11 +385,9 @@ function normalizeDiaryBlockFingerprint(block: string): string {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  let dateLine = "";
   const bodyLines: string[] = [];
   for (const line of lines) {
-    if (!dateLine && line.startsWith("*") && line.endsWith("*") && line.length > 2) {
-      dateLine = line.slice(1, -1).trim();
+    if (line.startsWith("*") && line.endsWith("*") && line.length > 2) {
       continue;
     }
     if (line.startsWith("<!--") || line.startsWith("#")) {
@@ -349,12 +395,11 @@ function normalizeDiaryBlockFingerprint(block: string): string {
     }
     bodyLines.push(line);
   }
-  const normalizedDate = dateLine.replace(/\s+/g, " ").trim();
   const normalizedBody = bodyLines
     .join("\n")
     .replace(/[ \t]+\n/g, "\n")
     .trim();
-  return `${normalizedDate}\n${normalizedBody}`;
+  return normalizedBody;
 }
 
 function joinDiaryBlocks(blocks: string[]): string {
@@ -622,6 +667,25 @@ export async function appendNarrativeEntry(params: {
   return await updateDreamsFile({
     workspaceDir: params.workspaceDir,
     updater: (existing, dreamsPath) => {
+      const ensured = ensureDiarySection(existing);
+      const startIdx = ensured.indexOf(DIARY_START_MARKER);
+      const endIdx = ensured.indexOf(DIARY_END_MARKER);
+      const newFingerprint = normalizeDiaryBlockFingerprint(`*${dateStr}*\n\n${params.narrative}`);
+      if (startIdx >= 0 && endIdx > startIdx) {
+        const currentBlocks = splitDiaryBlocks(
+          ensured.slice(startIdx + DIARY_START_MARKER.length, endIdx),
+        );
+        if (
+          currentBlocks.some((block) => normalizeDiaryBlockFingerprint(block) === newFingerprint)
+        ) {
+          return {
+            content: ensured,
+            result: dreamsPath,
+            shouldWrite: false,
+          };
+        }
+      }
+
       let updated: string;
       if (existing.includes(DIARY_START_MARKER) && existing.includes(DIARY_END_MARKER)) {
         const endIdx = existing.lastIndexOf(DIARY_END_MARKER);

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -10,7 +10,11 @@ import {
   resolveMemoryRemDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
 import { describe, expect, it, vi } from "vitest";
-import { __testing, runDreamingSweepPhases } from "./dreaming-phases.js";
+import {
+  __testing,
+  runDreamingSweepPhases,
+  seedHistoricalDailyMemorySignals,
+} from "./dreaming-phases.js";
 import {
   rankShortTermPromotionCandidates,
   recordShortTermRecalls,
@@ -189,6 +193,64 @@ async function readCandidateSnippets(workspaceDir: string, nowIso: string): Prom
 }
 
 describe("memory-core dreaming phases", () => {
+  it("strips managed dream blocks with nested subheadings before seeding daily recall", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const currentPath = path.join(workspaceDir, "memory", "2026-04-05.md");
+    const legacyPath = path.join(workspaceDir, "memory", "2026-04-04.md");
+
+    await fs.writeFile(
+      currentPath,
+      [
+        "## REM Sleep",
+        "<!-- openclaw:dreaming:rem:start -->",
+        "### Reflections",
+        "- Theme: `assistant` kept surfacing across 40 memories.",
+        "### Possible Lasting Truths",
+        "- First contact in February, a compass on the desk.",
+        "<!-- openclaw:dreaming:rem:end -->",
+        "",
+        "## Notes",
+        "North keeps shifting.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await fs.writeFile(
+      legacyPath,
+      [
+        "## REM Sleep",
+        "### Reflections",
+        "- Theme: `metadata` kept surfacing across 36 memories.",
+        "### Possible Lasting Truths",
+        "- A nearly-perfect certainty glowed at 0.99.",
+        "",
+        "## Notes",
+        "A real note remains.",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await seedHistoricalDailyMemorySignals({
+      workspaceDir,
+      filePaths: [currentPath, legacyPath],
+      limit: 20,
+      nowMs: Date.parse("2026-04-05T10:00:00.000Z"),
+      timezone: "UTC",
+    });
+
+    const snippets = await readCandidateSnippets(workspaceDir, "2026-04-05T10:00:00.000Z");
+
+    expect(snippets).toContain("Notes: North keeps shifting.");
+    expect(snippets).toContain("Notes: A real note remains.");
+    expect(
+      snippets.some((snippet) =>
+        /Reflections|Possible Lasting Truths|assistant kept surfacing|nearly-perfect certainty/i.test(
+          snippet,
+        ),
+      ),
+    ).toBe(false);
+  });
+
   it("uses the hashed narrative session key for sweep-level fallback cleanup", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -302,24 +302,39 @@ function findManagedDailyDreamingHeadingIndex(
   return null;
 }
 
+function getDailyHeadingLevel(line: string): number | null {
+  const match = line.trim().match(/^(#{1,6})\s+/);
+  return match?.[1]?.length ?? null;
+}
+
 function isManagedDailyDreamingBoundary(
   line: string,
   blockByStartMarker: ReadonlyMap<string, (typeof MANAGED_DAILY_DREAMING_BLOCKS)[number]>,
+  blockHeadingLevel: number,
 ): boolean {
   const trimmed = line.trim();
-  return /^#{1,6}\s+/.test(trimmed) || blockByStartMarker.has(trimmed);
+  if (blockByStartMarker.has(trimmed)) {
+    return true;
+  }
+  const headingLevel = getDailyHeadingLevel(trimmed);
+  return headingLevel !== null && headingLevel <= blockHeadingLevel;
 }
 
 function stripManagedDailyDreamingLines(lines: string[]): string[] {
   const blockByStartMarker: ReadonlyMap<string, (typeof MANAGED_DAILY_DREAMING_BLOCKS)[number]> =
     new Map(MANAGED_DAILY_DREAMING_BLOCKS.map((block) => [block.startMarker, block]));
+  const blockByHeading: ReadonlyMap<string, (typeof MANAGED_DAILY_DREAMING_BLOCKS)[number]> =
+    new Map(MANAGED_DAILY_DREAMING_BLOCKS.map((block) => [block.heading, block]));
   const sanitized = [...lines];
   for (let index = 0; index < sanitized.length; index += 1) {
-    const block = blockByStartMarker.get(sanitized[index]?.trim() ?? "");
+    const trimmedLine = sanitized[index]?.trim() ?? "";
+    const block = blockByStartMarker.get(trimmedLine) ?? blockByHeading.get(trimmedLine);
     if (!block) {
       continue;
     }
 
+    const isHeadingStart = trimmedLine === block.heading;
+    const blockHeadingLevel = getDailyHeadingLevel(block.heading) ?? 2;
     let stripUntilIndex = -1;
     for (let cursor = index + 1; cursor < sanitized.length; cursor += 1) {
       const line = sanitized[cursor];
@@ -328,7 +343,7 @@ function stripManagedDailyDreamingLines(lines: string[]): string[] {
         stripUntilIndex = cursor;
         break;
       }
-      if (line && isManagedDailyDreamingBoundary(line, blockByStartMarker)) {
+      if (line && isManagedDailyDreamingBoundary(line, blockByStartMarker, blockHeadingLevel)) {
         stripUntilIndex = cursor - 1;
         break;
       }
@@ -337,7 +352,9 @@ function stripManagedDailyDreamingLines(lines: string[]): string[] {
       continue;
     }
 
-    const headingIndex = findManagedDailyDreamingHeadingIndex(lines, index, block.heading);
+    const headingIndex = isHeadingStart
+      ? index
+      : findManagedDailyDreamingHeadingIndex(lines, index, block.heading);
     const startIndex = headingIndex ?? index;
     for (let cursor = startIndex; cursor <= stripUntilIndex; cursor += 1) {
       sanitized[cursor] = "";

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1093,6 +1093,14 @@ describe("short-term promotion", () => {
     ).toBe(true);
   });
 
+  it("treats evidence-prefixed dreaming staging snippets as contaminated", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "- evidence: memory/.dreams/session-corpus/2026-04-08.txt:1-1 recalls: 3 status: staged Candidate: Default to action. confidence: 0.76",
+      ),
+    ).toBe(true);
+  });
+
   it("does not treat ordinary candidate notes with daily-memory evidence as contaminated", () => {
     expect(
       __testing.isContaminatedDreamingSnippet(

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -284,14 +284,17 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
     return true;
   }
 
+  const withoutPrefix = consumeDreamingLeadPrefix(snippet);
   const hasNarrativeLead = hasDreamingNarrativeLead(snippet);
+  const hasEvidenceLead = /^evidence:/i.test(withoutPrefix);
   const hasConfidence = /\bconfidence:\s*\d/i.test(snippet);
   const hasEvidence = /\bevidence:\s*(?:memory\/\.dreams\/session-corpus\/|memory\/)/i.test(
     snippet,
   );
   const hasStatus = /\bstatus:\s*staged\b/i.test(snippet);
   const hasRecalls = /\brecalls:\s*\d+\b/i.test(snippet);
-  return hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls;
+  const hasDreamingMetadataCluster = hasConfidence && hasEvidence && hasStatus && hasRecalls;
+  return hasDreamingMetadataCluster && (hasNarrativeLead || hasEvidenceLead);
 }
 
 function normalizeMemoryPath(rawPath: string): string {

--- a/src/memory-host-sdk/host/session-files.test.ts
+++ b/src/memory-host-sdk/host/session-files.test.ts
@@ -411,6 +411,78 @@ describe("buildSessionEntry", () => {
     expect(entry?.lineMap).toEqual([]);
   });
 
+  it("flags system-managed heartbeat transcripts from the sibling session store", async () => {
+    const sessionsDir = path.join(tmpDir, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, "heartbeat-session.jsonl");
+    await fs.writeFile(
+      filePath,
+      [
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "user",
+            content: "[OpenClaw heartbeat poll]",
+          },
+        }),
+        JSON.stringify({
+          type: "message",
+          message: {
+            role: "assistant",
+            content: "HEARTBEAT_OK",
+          },
+        }),
+      ].join("\n"),
+    );
+    await fs.writeFile(
+      path.join(sessionsDir, "sessions.json"),
+      JSON.stringify({
+        "agent:main:main:heartbeat": {
+          sessionId: "heartbeat-session",
+          sessionFile: filePath,
+          updatedAt: Date.now(),
+          systemSent: true,
+        },
+      }),
+      "utf-8",
+    );
+
+    const entry = await buildSessionEntry(filePath);
+
+    expect(entry).not.toBeNull();
+    expect(entry?.generatedBySystemAutomation).toBe(true);
+    expect(entry?.content).toBe("");
+    expect(entry?.lineMap).toEqual([]);
+  });
+
+  it("flags heartbeat transcripts from runtime context even without a session store entry", async () => {
+    const jsonlLines = [
+      JSON.stringify({
+        type: "custom_message",
+        customType: "openclaw.runtime-context",
+        content:
+          "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. If nothing needs attention, reply HEARTBEAT_OK.",
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: "[OpenClaw heartbeat poll]" },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "assistant", content: "HEARTBEAT_OK" },
+      }),
+    ];
+    const filePath = path.join(tmpDir, "heartbeat-runtime-context.jsonl");
+    await fs.writeFile(filePath, jsonlLines.join("\n"));
+
+    const entry = await buildSessionEntry(filePath);
+
+    expect(entry).not.toBeNull();
+    expect(entry?.generatedBySystemAutomation).toBe(true);
+    expect(entry?.content).toBe("");
+    expect(entry?.lineMap).toEqual([]);
+  });
+
   it("does not flag ordinary transcripts that quote the dream-diary prompt", async () => {
     const jsonlLines = [
       JSON.stringify({

--- a/src/memory-host-sdk/host/session-files.ts
+++ b/src/memory-host-sdk/host/session-files.ts
@@ -10,6 +10,7 @@ import { hashText } from "./internal.js";
 
 const log = createSubsystemLogger("memory");
 const DREAMING_NARRATIVE_RUN_PREFIX = "dreaming-narrative-";
+const HEARTBEAT_POLL_MESSAGE = "[OpenClaw heartbeat poll]";
 // Keep the historical one-line-per-message export shape for normal turns, but
 // wrap pathological long messages so downstream indexers never ingest a single
 // toxic line. Wrapped continuation lines still map back to the same JSONL line.
@@ -29,11 +30,15 @@ export type SessionFileEntry = {
   messageTimestampsMs: number[];
   /** True when this transcript belongs to an internal dreaming narrative run. */
   generatedByDreamingNarrative?: boolean;
+  /** True when this transcript belongs to an internal system-managed run. */
+  generatedBySystemAutomation?: boolean;
 };
 
 export type BuildSessionEntryOptions = {
   /** Optional preclassification from a caller-managed dreaming transcript lookup. */
   generatedByDreamingNarrative?: boolean;
+  /** Optional preclassification from a caller-managed system-session lookup. */
+  generatedBySystemAutomation?: boolean;
 };
 
 function isDreamingNarrativeBootstrapRecord(record: unknown): boolean {
@@ -163,6 +168,51 @@ function isDreamingNarrativeTranscriptFromSessionStore(absPath: string): boolean
   return dreamingTranscriptPaths.has(normalizedAbsPath);
 }
 
+function isSystemManagedSessionStoreKey(
+  sessionKey: string,
+  entry: { systemSent?: unknown } | undefined,
+): boolean {
+  if (entry?.systemSent === true) {
+    return true;
+  }
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const firstSeparator = trimmed.indexOf(":");
+  if (firstSeparator < 0) {
+    return trimmed === "heartbeat" || trimmed.startsWith("cron:");
+  }
+  const secondSeparator = trimmed.indexOf(":", firstSeparator + 1);
+  const sessionSegment = secondSeparator < 0 ? trimmed : trimmed.slice(secondSeparator + 1);
+  return sessionSegment === "main:heartbeat" || sessionSegment.startsWith("cron:");
+}
+
+function loadSystemManagedTranscriptPathSetForSessionsDir(
+  sessionsDir: string,
+): ReadonlySet<string> {
+  const storePath = path.join(sessionsDir, "sessions.json");
+  const store = loadSessionStore(storePath);
+  const transcriptPaths = new Set<string>();
+  for (const [sessionKey, entry] of Object.entries(store)) {
+    if (!isSystemManagedSessionStoreKey(sessionKey, entry)) {
+      continue;
+    }
+    const transcriptPath = resolveSessionStoreTranscriptPath(sessionsDir, entry);
+    if (transcriptPath) {
+      transcriptPaths.add(transcriptPath);
+    }
+  }
+  return transcriptPaths;
+}
+
+function isSystemManagedTranscriptFromSessionStore(absPath: string): boolean {
+  const sessionsDir = path.dirname(absPath);
+  const normalizedAbsPath = normalizeComparablePath(absPath);
+  const transcriptPaths = loadSystemManagedTranscriptPathSetForSessionsDir(sessionsDir);
+  return transcriptPaths.has(normalizedAbsPath);
+}
+
 export async function listSessionFilesForAgent(agentId: string): Promise<string[]> {
   const dir = resolveSessionTranscriptsDirForAgent(agentId);
   try {
@@ -206,6 +256,33 @@ function collectRawSessionText(content: unknown): string | null {
     }
   }
   return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function isHeartbeatPollRecord(record: unknown): boolean {
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return false;
+  }
+  const candidate = record as {
+    type?: unknown;
+    customType?: unknown;
+    content?: unknown;
+    message?: unknown;
+  };
+  if (candidate.type === "custom_message" && candidate.customType === "openclaw.runtime-context") {
+    return (
+      typeof candidate.content === "string" &&
+      candidate.content.includes("Read HEARTBEAT.md if it exists") &&
+      candidate.content.includes("reply HEARTBEAT_OK")
+    );
+  }
+  if (candidate.type !== "message") {
+    return false;
+  }
+  const message = candidate.message as { role?: unknown; content?: unknown } | undefined;
+  if (!message || message.role !== "user") {
+    return false;
+  }
+  return collectRawSessionText(message.content)?.trim() === HEARTBEAT_POLL_MESSAGE;
 }
 
 function isHighSurrogate(code: number): boolean {
@@ -335,6 +412,8 @@ export async function buildSessionEntry(
     const messageTimestampsMs: number[] = [];
     let generatedByDreamingNarrative =
       opts.generatedByDreamingNarrative ?? isDreamingNarrativeTranscriptFromSessionStore(absPath);
+    let generatedBySystemAutomation =
+      opts.generatedBySystemAutomation ?? isSystemManagedTranscriptFromSessionStore(absPath);
     for (let jsonlIdx = 0; jsonlIdx < lines.length; jsonlIdx++) {
       const line = lines[jsonlIdx];
       if (!line.trim()) {
@@ -348,6 +427,12 @@ export async function buildSessionEntry(
       }
       if (!generatedByDreamingNarrative && isDreamingNarrativeGeneratedRecord(record)) {
         generatedByDreamingNarrative = true;
+      }
+      if (!generatedBySystemAutomation && isHeartbeatPollRecord(record)) {
+        generatedBySystemAutomation = true;
+      }
+      if (generatedByDreamingNarrative || generatedBySystemAutomation) {
+        continue;
       }
       if (
         !record ||
@@ -394,6 +479,7 @@ export async function buildSessionEntry(
       lineMap,
       messageTimestampsMs,
       ...(generatedByDreamingNarrative ? { generatedByDreamingNarrative: true } : {}),
+      ...(generatedBySystemAutomation ? { generatedBySystemAutomation: true } : {}),
     };
   } catch (err) {
     log.debug(`Failed reading session file ${absPath}: ${String(err)}`);


### PR DESCRIPTION
## Summary
- strip managed dream blocks even when they contain nested subheadings or legacy heading-only sections
- turn request-scoped dream fallbacks back into diary-style prose instead of raw `Reflections:` fragments
- dedupe diary entries by body so identical dream text does not repeat across days, and skip duplicate appends
- add regression coverage for the strip, fallback, and dedupe paths

## Validation
- node scripts/test-projects.mjs extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/dreaming-narrative.test.ts extensions/memory-core/src/short-term-promotion.test.ts
- pnpm build