### PR TITLE
fix(exec): resolve Windows PowerShell cmdlet allowlist miss

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
+import { resetPowerShellPathCache } from "../infra/executable-path.js";
 import {
   detectRuntimeShell,
   getShellConfig,
@@ -188,6 +189,7 @@ describe("resolvePowerShellPath", () => {
   const tempDirs: string[] = [];
 
   beforeEach(() => {
+    resetPowerShellPathCache();
     envSnapshot = captureEnv([
       "ProgramFiles",
       "PROGRAMFILES",
@@ -200,6 +202,7 @@ describe("resolvePowerShellPath", () => {
 
   afterEach(() => {
     envSnapshot.restore();
+    resetPowerShellPathCache();
     for (const dir of tempDirs.splice(0)) {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -1,42 +1,10 @@
-import fs from "node:fs";
 import path from "node:path";
+import {
+  resolvePowerShellPath,
+  resolveShellFromPath,
+} from "../infra/executable-path.js";
 
-export function resolvePowerShellPath(): string {
-  // Prefer PowerShell 7 when available; PS 5.1 lacks "&&" support.
-  const programFiles = process.env.ProgramFiles || process.env.PROGRAMFILES || "C:\\Program Files";
-  const pwsh7 = path.join(programFiles, "PowerShell", "7", "pwsh.exe");
-  if (fs.existsSync(pwsh7)) {
-    return pwsh7;
-  }
-
-  const programW6432 = process.env.ProgramW6432;
-  if (programW6432 && programW6432 !== programFiles) {
-    const pwsh7Alt = path.join(programW6432, "PowerShell", "7", "pwsh.exe");
-    if (fs.existsSync(pwsh7Alt)) {
-      return pwsh7Alt;
-    }
-  }
-
-  const pwshInPath = resolveShellFromPath("pwsh");
-  if (pwshInPath) {
-    return pwshInPath;
-  }
-
-  const systemRoot = process.env.SystemRoot || process.env.WINDIR;
-  if (systemRoot) {
-    const candidate = path.join(
-      systemRoot,
-      "System32",
-      "WindowsPowerShell",
-      "v1.0",
-      "powershell.exe",
-    );
-    if (fs.existsSync(candidate)) {
-      return candidate;
-    }
-  }
-  return "powershell.exe";
-}
+export { resolvePowerShellPath, resolveShellFromPath };
 
 // Non-interactive placeholder shells that reject "-c"-style invocations.
 // macOS LaunchDaemon service users commonly use /usr/bin/false so login sessions
@@ -85,24 +53,6 @@ export function getShellConfig(): { shell: string; args: string[] } {
   // re-invoke the placeholder and get a spurious exitCode=1.
   const sh = resolveShellFromPath("sh") ?? resolveShellFromPath("bash");
   return { shell: sh ?? "sh", args: ["-c"] };
-}
-
-export function resolveShellFromPath(name: string): string | undefined {
-  const envPath = process.env.PATH ?? "";
-  if (!envPath) {
-    return undefined;
-  }
-  const entries = envPath.split(path.delimiter).filter(Boolean);
-  for (const entry of entries) {
-    const candidate = path.join(entry, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch {
-      // ignore missing or non-executable entries
-    }
-  }
-  return undefined;
 }
 
 function normalizeShellName(value: string): string {

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -40,6 +40,7 @@ import {
   POWERSHELL_WRAPPERS,
 } from "./exec-wrapper-resolution.js";
 import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
+import { resolvePowerShellPath } from "./executable-path.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
 
@@ -407,6 +408,42 @@ function resolveShellWrapperScriptArgv(params: {
   return [params.shellScriptCandidatePath, ...scriptArgs];
 }
 
+function isBareName(name: string): boolean {
+  return !name.includes("/") && !name.includes("\\");
+}
+
+function resolveWindowsCmdletAllowlistFallback(params: {
+  executableMatch: ExecAllowlistEntry | null;
+  resolution: ExecutableResolution | null;
+  effectiveArgv: string[];
+  context: ExecAllowlistContext;
+}): ExecAllowlistEntry | null {
+  if (params.executableMatch) {
+    return null;
+  }
+  if (!isWindowsPlatform(params.context.platform)) {
+    return null;
+  }
+  const rawExecutable = params.resolution?.rawExecutable?.trim();
+  if (!rawExecutable || !isBareName(rawExecutable) || params.resolution?.resolvedPath) {
+    return null;
+  }
+  const psPath = resolvePowerShellPath();
+  const syntheticResolution: ExecutableResolution = {
+    rawExecutable: psPath,
+    resolvedPath: psPath,
+    executableName: path.basename(psPath),
+  };
+  // Prepend PowerShell path so the cmdlet name lands in argv[1:] for argPattern matching.
+  const syntheticArgv = [psPath, ...params.effectiveArgv];
+  return matchAllowlist(
+    params.context.allowlist,
+    syntheticResolution,
+    syntheticArgv,
+    params.context.platform,
+  );
+}
+
 function resolveSegmentAllowlistMatch(params: {
   segment: ExecCommandSegment;
   context: ExecAllowlistContext;
@@ -483,10 +520,20 @@ function resolveSegmentAllowlistMatch(params: {
           params.context.platform,
         )
       : null;
+  // Windows cmdlet fallback: bare commands (Get-ChildItem, etc.) don't resolve to
+  // filesystem paths because they're PowerShell builtins.  Since all Windows exec runs
+  // through PowerShell, match against the PowerShell executable path with a synthetic
+  // argv that includes the cmdlet name for argPattern verification.
+  const windowsCmdletMatch = resolveWindowsCmdletAllowlistFallback({
+    executableMatch,
+    resolution: executableResolution,
+    effectiveArgv,
+    context: params.context,
+  });
   return {
     effectiveArgv,
     inlineCommand,
-    match: executableMatch ?? shellPositionalArgvMatch ?? shellScriptMatch,
+    match: executableMatch ?? windowsCmdletMatch ?? shellPositionalArgvMatch ?? shellScriptMatch,
   };
 }
 
@@ -960,6 +1007,17 @@ function collectAllowAlwaysPatterns(params: {
 
   const candidatePath = resolveExecutionTargetCandidatePath(segment.resolution, params.cwd);
   if (!candidatePath) {
+    // Windows cmdlet fallback: bare commands that don't resolve to a path are treated
+    // as PowerShell cmdlets.  Generate an allow-always entry against the PowerShell
+    // executable with an argPattern that includes the cmdlet name.
+    const execution = resolveExecutionTargetResolution(segment.resolution);
+    const rawExe = execution?.rawExecutable?.trim();
+    if (isWindowsPlatform(params.platform) && rawExe && isBareName(rawExe)) {
+      const psPath = resolvePowerShellPath();
+      const syntheticArgv = [psPath, ...segment.argv];
+      const argPattern = buildArgPatternFromArgv(syntheticArgv, params.platform);
+      addAllowAlwaysPattern(params.out, psPath, argPattern);
+    }
     return;
   }
   if (isInterpreterLikeAllowlistPattern(candidatePath)) {

--- a/src/infra/exec-approvals-windows-cmdlet.test.ts
+++ b/src/infra/exec-approvals-windows-cmdlet.test.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
+import { evaluateShellAllowlist, resolveAllowAlwaysPatterns, resolveSafeBins } from "./exec-approvals.js";
+
+// Stable PowerShell path used for assertions.  The fallback resolves via
+// resolvePowerShellPath(); on CI or dev machines the resolved path varies,
+// so we call the same function to get the value tests will see.
+import { resolvePowerShellPath } from "./executable-path.js";
+
+const WINDOWS_PLATFORM = "win32";
+const safeBins = resolveSafeBins(undefined);
+
+function evalWindows(command: string, allowlist: Array<{ pattern: string; argPattern?: string }>) {
+  return evaluateShellAllowlist({
+    command,
+    allowlist,
+    safeBins,
+    cwd: process.cwd(),
+    platform: WINDOWS_PLATFORM,
+  });
+}
+
+describe("windows powershell cmdlet allowlist fallback", () => {
+  it("matches a bare cmdlet against a powershell allowlist entry with argPattern", () => {
+    const psPath = resolvePowerShellPath();
+    // Build the argPattern that collectAllowAlwaysPatterns would generate:
+    // argv.slice(1) of syntheticArgv [psPath, "Get-ChildItem", "-LiteralPath", "C:\\Users\\foo"]
+    // = ["Get-ChildItem", "-LiteralPath", "C:\\Users\\foo"]
+    // joined with \x00 and regex-escaped.  Note: - is not a regex metachar, so not escaped.
+    const argPattern = `^Get-ChildItem\x00-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+
+    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
+      { pattern: psPath, argPattern },
+    ]);
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(true);
+  });
+
+  it("rejects a bare cmdlet when argPattern does not include the cmdlet name", () => {
+    const psPath = resolvePowerShellPath();
+    // argPattern only matches args, not the cmdlet name — should NOT match
+    const argPattern = `^-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+
+    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
+      { pattern: psPath, argPattern },
+    ]);
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(false);
+  });
+
+  it("rejects a bare cmdlet when no powershell entry exists in the allowlist", () => {
+    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
+      { pattern: "/usr/bin/node" },
+    ]);
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(false);
+  });
+
+  it("matches a powershell-wrapped cmdlet after wrapper stripping", () => {
+    const psPath = resolvePowerShellPath();
+    const argPattern = `^Get-ChildItem\x00-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+
+    const result = evalWindows(
+      'powershell -NoProfile -Command "Get-ChildItem -LiteralPath C:\\Users\\foo"',
+      [{ pattern: psPath, argPattern }],
+    );
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(true);
+  });
+
+  it("matches a bare powershell path allowlist entry without argPattern (broad grant)", () => {
+    const psPath = resolvePowerShellPath();
+
+    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
+      { pattern: psPath },
+    ]);
+
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(true);
+  });
+
+  it("generates allow-always pattern with cmdlet name in argPattern", () => {
+    const psPath = resolvePowerShellPath();
+    const analysis = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", []);
+
+    const patterns = resolveAllowAlwaysPatterns({
+      segments: analysis.segments,
+      cwd: process.cwd(),
+      platform: WINDOWS_PLATFORM,
+    });
+
+    expect(patterns.length).toBe(1);
+    expect(patterns[0]).toBe(psPath);
+
+    // Verify that the full pattern entries include an argPattern with the cmdlet name
+    const entries = resolveAllowAlwaysPatternEntries({
+      segments: analysis.segments,
+      cwd: process.cwd(),
+      platform: WINDOWS_PLATFORM,
+    });
+
+    expect(entries.length).toBe(1);
+    expect(entries[0].pattern).toBe(psPath);
+    expect(entries[0].argPattern).toBeDefined();
+    // The argPattern should match the cmdlet name
+    expect(entries[0].argPattern).toContain("Get-ChildItem");
+  });
+
+  it("does not apply cmdlet fallback on non-windows platforms", () => {
+    const result = evaluateShellAllowlist({
+      command: "Get-ChildItem -LiteralPath /home/foo",
+      allowlist: [{ pattern: resolvePowerShellPath() }],
+      safeBins,
+      cwd: process.cwd(),
+      platform: "linux",
+    });
+
+    expect(result.allowlistSatisfied).toBe(false);
+  });
+});

--- a/src/infra/exec-approvals-windows-cmdlet.test.ts
+++ b/src/infra/exec-approvals-windows-cmdlet.test.ts
@@ -9,6 +9,7 @@ import { resolvePowerShellPath } from "./executable-path.js";
 
 const WINDOWS_PLATFORM = "win32";
 const safeBins = resolveSafeBins(undefined);
+const CMD = "Get-ChildItem -LiteralPath C:\\Users\\foo";
 
 function evalWindows(command: string, allowlist: Array<{ pattern: string; argPattern?: string }>) {
   return evaluateShellAllowlist({
@@ -20,52 +21,52 @@ function evalWindows(command: string, allowlist: Array<{ pattern: string; argPat
   });
 }
 
-describe("windows powershell cmdlet allowlist fallback", () => {
-  it("matches a bare cmdlet against a powershell allowlist entry with argPattern", () => {
-    const psPath = resolvePowerShellPath();
-    // Build the argPattern that collectAllowAlwaysPatterns would generate:
-    // argv.slice(1) of syntheticArgv [psPath, "Get-ChildItem", "-LiteralPath", "C:\\Users\\foo"]
-    // = ["Get-ChildItem", "-LiteralPath", "C:\\Users\\foo"]
-    // joined with \x00 and regex-escaped.  Note: - is not a regex metachar, so not escaped.
-    const argPattern = `^Get-ChildItem\x00-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+/** Derive the allow-always entry that production code would generate for a command. */
+function deriveAllowAlwaysEntry(command: string) {
+  const analysis = evalWindows(command, []);
+  const entries = resolveAllowAlwaysPatternEntries({
+    segments: analysis.segments,
+    cwd: process.cwd(),
+    platform: WINDOWS_PLATFORM,
+  });
+  expect(entries.length).toBe(1);
+  return entries[0];
+}
 
-    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
-      { pattern: psPath, argPattern },
-    ]);
+describe("windows powershell cmdlet allowlist fallback", () => {
+  it("matches a bare cmdlet against its derived allow-always entry", () => {
+    const entry = deriveAllowAlwaysEntry(CMD);
+
+    const result = evalWindows(CMD, [entry]);
 
     expect(result.analysisOk).toBe(true);
     expect(result.allowlistSatisfied).toBe(true);
   });
 
   it("rejects a bare cmdlet when argPattern does not include the cmdlet name", () => {
-    const psPath = resolvePowerShellPath();
-    // argPattern only matches args, not the cmdlet name — should NOT match
-    const argPattern = `^-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+    const entry = deriveAllowAlwaysEntry(CMD);
+    // Strip the cmdlet name from the argPattern — should no longer match
+    const tampered = { ...entry, argPattern: entry.argPattern!.replace("Get-ChildItem", "Remove-Item") };
 
-    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
-      { pattern: psPath, argPattern },
-    ]);
+    const result = evalWindows(CMD, [tampered]);
 
     expect(result.analysisOk).toBe(true);
     expect(result.allowlistSatisfied).toBe(false);
   });
 
   it("rejects a bare cmdlet when no powershell entry exists in the allowlist", () => {
-    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
-      { pattern: "/usr/bin/node" },
-    ]);
+    const result = evalWindows(CMD, [{ pattern: "/usr/bin/node" }]);
 
     expect(result.analysisOk).toBe(true);
     expect(result.allowlistSatisfied).toBe(false);
   });
 
   it("matches a powershell-wrapped cmdlet after wrapper stripping", () => {
-    const psPath = resolvePowerShellPath();
-    const argPattern = `^Get-ChildItem\x00-LiteralPath\x00C:\\\\Users\\\\foo\x00$`;
+    const entry = deriveAllowAlwaysEntry(CMD);
 
     const result = evalWindows(
       'powershell -NoProfile -Command "Get-ChildItem -LiteralPath C:\\Users\\foo"',
-      [{ pattern: psPath, argPattern }],
+      [entry],
     );
 
     expect(result.analysisOk).toBe(true);
@@ -75,9 +76,7 @@ describe("windows powershell cmdlet allowlist fallback", () => {
   it("matches a bare powershell path allowlist entry without argPattern (broad grant)", () => {
     const psPath = resolvePowerShellPath();
 
-    const result = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", [
-      { pattern: psPath },
-    ]);
+    const result = evalWindows(CMD, [{ pattern: psPath }]);
 
     expect(result.analysisOk).toBe(true);
     expect(result.allowlistSatisfied).toBe(true);
@@ -85,7 +84,7 @@ describe("windows powershell cmdlet allowlist fallback", () => {
 
   it("generates allow-always pattern with cmdlet name in argPattern", () => {
     const psPath = resolvePowerShellPath();
-    const analysis = evalWindows("Get-ChildItem -LiteralPath C:\\Users\\foo", []);
+    const analysis = evalWindows(CMD, []);
 
     const patterns = resolveAllowAlwaysPatterns({
       segments: analysis.segments,
@@ -96,7 +95,6 @@ describe("windows powershell cmdlet allowlist fallback", () => {
     expect(patterns.length).toBe(1);
     expect(patterns[0]).toBe(psPath);
 
-    // Verify that the full pattern entries include an argPattern with the cmdlet name
     const entries = resolveAllowAlwaysPatternEntries({
       segments: analysis.segments,
       cwd: process.cwd(),
@@ -106,13 +104,12 @@ describe("windows powershell cmdlet allowlist fallback", () => {
     expect(entries.length).toBe(1);
     expect(entries[0].pattern).toBe(psPath);
     expect(entries[0].argPattern).toBeDefined();
-    // The argPattern should match the cmdlet name
     expect(entries[0].argPattern).toContain("Get-ChildItem");
   });
 
   it("does not apply cmdlet fallback on non-windows platforms", () => {
     const result = evaluateShellAllowlist({
-      command: "Get-ChildItem -LiteralPath /home/foo",
+      command: CMD,
       allowlist: [{ pattern: resolvePowerShellPath() }],
       safeBins,
       cwd: process.cwd(),

--- a/src/infra/exec-approvals-windows-cmdlet.test.ts
+++ b/src/infra/exec-approvals-windows-cmdlet.test.ts
@@ -1,5 +1,4 @@
-import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveAllowAlwaysPatternEntries } from "./exec-approvals-allowlist.js";
 import { evaluateShellAllowlist, resolveAllowAlwaysPatterns, resolveSafeBins } from "./exec-approvals.js";
 

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -142,7 +142,23 @@ export function resolveShellFromPath(name: string): string | undefined {
   return undefined;
 }
 
+let cachedPsPath: string | undefined;
+
 export function resolvePowerShellPath(): string {
+  if (cachedPsPath !== undefined) {
+    return cachedPsPath;
+  }
+  const resolved = resolvePowerShellPathUncached();
+  cachedPsPath = resolved;
+  return resolved;
+}
+
+/** Reset the cached PowerShell path (for tests that override env/filesystem). */
+export function resetPowerShellPathCache(): void {
+  cachedPsPath = undefined;
+}
+
+function resolvePowerShellPathUncached(): string {
   // Prefer PowerShell 7 when available; PS 5.1 lacks "&&" support.
   const programFiles = process.env.ProgramFiles || process.env.PROGRAMFILES || "C:\\Program Files";
   const pwsh7 = path.join(programFiles, "PowerShell", "7", "pwsh.exe");

--- a/src/infra/executable-path.ts
+++ b/src/infra/executable-path.ts
@@ -123,3 +123,58 @@ export function resolveExecutablePath(
     options?.env?.PATH ?? options?.env?.Path ?? process.env.PATH ?? process.env.Path ?? "";
   return resolveExecutableFromPathEnv(candidate, envPath, options?.env);
 }
+
+export function resolveShellFromPath(name: string): string | undefined {
+  const envPath = process.env.PATH ?? "";
+  if (!envPath) {
+    return undefined;
+  }
+  const entries = envPath.split(path.delimiter).filter(Boolean);
+  for (const entry of entries) {
+    const candidate = path.join(entry, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {
+      // ignore missing or non-executable entries
+    }
+  }
+  return undefined;
+}
+
+export function resolvePowerShellPath(): string {
+  // Prefer PowerShell 7 when available; PS 5.1 lacks "&&" support.
+  const programFiles = process.env.ProgramFiles || process.env.PROGRAMFILES || "C:\\Program Files";
+  const pwsh7 = path.join(programFiles, "PowerShell", "7", "pwsh.exe");
+  if (fs.existsSync(pwsh7)) {
+    return pwsh7;
+  }
+
+  const programW6432 = process.env.ProgramW6432;
+  if (programW6432 && programW6432 !== programFiles) {
+    const pwsh7Alt = path.join(programW6432, "PowerShell", "7", "pwsh.exe");
+    if (fs.existsSync(pwsh7Alt)) {
+      return pwsh7Alt;
+    }
+  }
+
+  const pwshInPath = resolveShellFromPath("pwsh");
+  if (pwshInPath) {
+    return pwshInPath;
+  }
+
+  const systemRoot = process.env.SystemRoot || process.env.WINDIR;
+  if (systemRoot) {
+    const candidate = path.join(
+      systemRoot,
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    );
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return "powershell.exe";
+}


### PR DESCRIPTION
## Summary

Fixes #52952.

- PowerShell cmdlets (`Get-ChildItem`, `Set-Location`, etc.) are shell builtins without filesystem paths. The exec allowlist system assumed every command maps to a file, causing bare cmdlets on Windows to fail with `exec denied: allowlist miss`.
- Adds a cmdlet fallback in the allowlist evaluation layer: when a bare command has no resolved path on Windows, tries matching against the PowerShell executable path with a synthetic argv that includes the cmdlet name for argPattern verification.
- Extracts `resolvePowerShellPath`/`resolveShellFromPath` from `src/agents/shell-utils.ts` to `src/infra/executable-path.ts` so the allowlist code can resolve the PS path without a circular agents→infra dependency.

## Design decisions

- **Resolution layer stays honest**: `ExecutableResolution.resolvedPath` remains undefined for cmdlets — no fake path. The fallback is confined to the allowlist evaluation layer.
- **argPattern includes cmdlet name**: A PowerShell path allowlist entry only matches when the argPattern also verifies the specific cmdlet + arguments. No broad grant unless the user explicitly adds a bare PowerShell entry without argPattern.
- **Safe bins remain disabled on Windows**: No change to existing conservative policy.

## Test plan

- [x] Bare cmdlet matches PS path allowlist entry with correct argPattern
- [x] Bare cmdlet rejected when argPattern doesn't include cmdlet name
- [x] Bare cmdlet rejected when no PS entry in allowlist
- [x] Wrapped `powershell -Command "cmdlet"` matches after wrapper stripping
- [x] Broad PS path entry (no argPattern) matches bare cmdlets
- [x] Allow-always generates PS path pattern with cmdlet-inclusive argPattern
- [x] Non-Windows platforms don't trigger the fallback
- [x] All existing exec-approvals, allowlist-matching, and shell-utils tests pass
- [ ] Manual: verify on Windows gateway with Telegram-triggered exec

🤖 Generated with [Claude Code](https://claude.com/claude-code)