### PR TITLE
fix: prevent sessions_send boundary leaks and suppress tool-use prelude text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -192,6 +192,20 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe(expected);
   });
 
+  it("strips leaked self-instruction prelude and keeps the user-facing answer", () => {
+    const input = [
+      "The user is asking me to confirm the session boundary.",
+      "I should keep the reply clean and avoid extra text.",
+      "Let me just answer directly.",
+      "",
+      "Understood. Good to know the session boundaries are solid—no leaks is the goal.",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe(
+      "Understood. Good to know the session boundaries are solid—no leaks is the goal.",
+    );
+  });
+
   it("preserves trailing whitespace and internal newlines", () => {
     expect(sanitizeUserFacingText("Hello\n\nWorld\n")).toBe("Hello\n\nWorld\n");
     expect(sanitizeUserFacingText("Line 1\nLine 2")).toBe("Line 1\nLine 2");

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -338,6 +338,100 @@ function collapseConsecutiveDuplicateBlocks(text: string): string {
   return result.join("\n\n");
 }
 
+const SELF_INSTRUCTION_REPLY_RE =
+  /\b(?:i need to reply with exactly|i(?:'ll| will) output that|no extra text|the user is asking me to|we need to output|we must use a tool|i must use a tool|let(?:'s| us) do that|let me (?:call|try|use|run)|i should not send (?:any )?reply|i should not reply|not reply at all|respond with no_reply|reply with no_reply|appropriate response might be to not reply|i(?:'ll| will) respond with no_reply|i(?:'ll| will) reply with no_reply|the cleanest approach would be to respond with no_reply|therefore,? i should not send any reply|therefore,? i should not send a reply|i should respond with no_reply|i should reply with no_reply|\bno_reply\b)/i;
+
+const INTERNAL_MONOLOGUE_MARKERS = [
+  /^(?:the user|this user|the message|the prompt)\b/i,
+  /\bi should\b/i,
+  /\bi need to\b/i,
+  /\bi must\b/i,
+  /\blet me\b/i,
+  /\blooking at\b/i,
+  /\bgiven that\b/i,
+  /\bthis appears to\b/i,
+  /\bi can respond\b/i,
+  /\bmaintain my persona\b/i,
+  /\bcraft a response\b/i,
+  /\bconversation history\b/i,
+];
+
+function countInternalMonologueMarkers(text: string): number {
+  return INTERNAL_MONOLOGUE_MARKERS.reduce(
+    (count, pattern) => count + (pattern.test(text) ? 1 : 0),
+    0,
+  );
+}
+
+function isPureInternalMonologueBlock(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed || trimmed.length > 1200) {
+    return false;
+  }
+  const markerCount = countInternalMonologueMarkers(trimmed);
+  if (markerCount < 2) {
+    return false;
+  }
+  if (
+    !/(?:\btool\b|\btools\b|tool call|reply|respond|output|prompt|message|session|memory|transcript|persona|greet user|read\b|write\b|search\b|check\b|look into|look at)/i.test(
+      trimmed,
+    )
+  ) {
+    return false;
+  }
+  if (
+    /\b(?:here(?:'s| is)|answer|result|summary|found|done|fixed|updated|verified|you|your|Bernhard)\b/i.test(
+      trimmed,
+    )
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function stripLeakedSelfInstructionPrefix(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return text;
+  }
+  const blocks = trimmed
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+  if (blocks.length < 2) {
+    return isPureInternalMonologueBlock(trimmed) ? "" : text;
+  }
+
+  const finalBlock = blocks.at(-1)?.trim() ?? "";
+  if (!finalBlock || finalBlock.length > 1200) {
+    return text;
+  }
+
+  const prelude = blocks.slice(0, -1).join("\n\n").trim();
+  if (!prelude) {
+    return text;
+  }
+
+  if (SELF_INSTRUCTION_REPLY_RE.test(prelude) && !SELF_INSTRUCTION_REPLY_RE.test(finalBlock)) {
+    return finalBlock;
+  }
+
+  const markerCount = countInternalMonologueMarkers(prelude);
+  if (
+    markerCount >= 2 &&
+    countInternalMonologueMarkers(finalBlock) === 0 &&
+    finalBlock.length <= 500
+  ) {
+    return finalBlock;
+  }
+
+  if (isPureInternalMonologueBlock(prelude) && !isPureInternalMonologueBlock(finalBlock)) {
+    return finalBlock;
+  }
+
+  return text;
+}
+
 export function isLikelyHttpErrorText(raw: string): boolean {
   if (isCloudflareOrHtmlErrorPage(raw)) {
     return true;
@@ -425,5 +519,7 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
   }
 
   const withoutLeadingEmptyLines = stripped.replace(/^(?:[ \t]*\r?\n)+/, "");
-  return collapseConsecutiveDuplicateBlocks(withoutLeadingEmptyLines);
+  return collapseConsecutiveDuplicateBlocks(
+    stripLeakedSelfInstructionPrefix(withoutLeadingEmptyLines),
+  );
 }

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -37,8 +37,27 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
+function hasToolCallContentBlocks(message: AgentMessage | undefined): boolean {
+  const content = (message as { content?: unknown } | undefined)?.content;
+  return (
+    Array.isArray(content) &&
+    content.some(
+      (block) =>
+        !!block &&
+        typeof block === "object" &&
+        ["toolCall", "toolUse", "functionCall"].includes(
+          (block as { type?: unknown }).type as string,
+        ),
+    )
+  );
+}
+
 function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
-  return resolveAssistantMessagePhase(message) === "commentary";
+  return (
+    resolveAssistantMessagePhase(message) === "commentary" ||
+    message?.stopReason === "toolUse" ||
+    hasToolCallContentBlocks(message)
+  );
 }
 
 function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage | undefined): boolean {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -66,4 +66,31 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
     expect(subscription.assistantTexts).toEqual([]);
   });
+
+  it("suppresses tool-use assistant text even when commentary phase metadata is missing", () => {
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      onPartialReply,
+      blockReplyBreak: "message_end",
+    });
+
+    const toolUseMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "Let me check that." },
+        { type: "toolUse", id: "call_1", name: "read", input: { path: "README.md" } },
+      ],
+      stopReason: "toolUse",
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: toolUseMessage });
+    emit({ type: "message_end", message: toolUseMessage });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual([]);
+  });
 });

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import { Type } from "@sinclair/typebox";
-import { isRequesterParentOfBackgroundAcpSession } from "../../acp/session-interaction-mode.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -16,7 +15,6 @@ import {
   readLatestAssistantReplySnapshot,
   waitForAgentRunAndReadUpdatedAssistantReply,
 } from "../run-wait.js";
-import { loadSessionEntryByKey } from "../subagent-announce-delivery.js";
 import {
   describeSessionsSendTool,
   SESSIONS_SEND_TOOL_DISPLAY_SUMMARY,
@@ -31,8 +29,7 @@ import {
   resolveSessionToolContext,
   resolveVisibleSessionReference,
 } from "./sessions-helpers.js";
-import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
-import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+import { buildAgentToAgentMessageContext } from "./sessions-send-helpers.js";
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
@@ -235,7 +232,6 @@ export function createSessionsSendTool(opts?: {
           ? Math.max(0, Math.floor(params.timeoutSeconds))
           : 30;
       const timeoutMs = timeoutSeconds * 1000;
-      const announceTimeoutMs = timeoutSeconds === 0 ? 30_000 : timeoutMs;
       const idempotencyKey = crypto.randomUUID();
       let runId: string = idempotencyKey;
       const visibilityGuard = await createSessionVisibilityGuard({
@@ -287,53 +283,7 @@ export function createSessionsSendTool(opts?: {
           sourceTool: "sessions_send",
         },
       };
-      const requesterSessionKey = opts?.agentSessionKey;
-      const requesterChannel = opts?.agentChannel;
-      const maxPingPongTurns = resolvePingPongTurns(cfg);
-
-      // Skip the A2A ping-pong + announce flow when the current caller is the
-      // parent of a parent-owned background ACP subagent it spawned itself.
-      // Such sessions already report their results back to the parent through
-      // the `[Internal task completion event]` announcement path, and treating
-      // them as a peer agent causes the parent to be woken with the child's
-      // reply, generate a user-facing response, and have that response
-      // forwarded back to the child as a new message — producing a
-      // ping-pong loop between parent and ACP child (bounded by
-      // maxPingPongTurns, but user-visible as a runaway conversation).
-      //
-      // The skip is gated on requester ownership, not just target type: an
-      // unrelated sender that can see the same target (e.g. under
-      // `tools.sessions.visibility=all`) must still go through the normal A2A
-      // path so it actually receives a follow-up delivery.
-      const targetSessionEntry = loadSessionEntryByKey(resolvedKey);
-      const skipA2AFlow = isRequesterParentOfBackgroundAcpSession(
-        targetSessionEntry,
-        effectiveRequesterKey,
-      );
-      // When the A2A flow is skipped, no follow-up announcement will fire and
-      // the reply (when present) is returned inline via the `reply` field.
-      // Reflect that in the metadata so the parent LLM does not wait for a
-      // second result that will never arrive.
-      const delivery = skipA2AFlow
-        ? ({ status: "skipped", mode: "announce" } as const)
-        : ({ status: "pending", mode: "announce" } as const);
-
-      const startA2AFlow = (roundOneReply?: string, waitRunId?: string) => {
-        if (skipA2AFlow) {
-          return;
-        }
-        void runSessionsSendA2AFlow({
-          targetSessionKey: resolvedKey,
-          displayKey,
-          message,
-          announceTimeoutMs,
-          maxPingPongTurns,
-          requesterSessionKey,
-          requesterChannel,
-          roundOneReply,
-          waitRunId,
-        });
-      };
+      const delivery = { status: "skipped", mode: "none" } as const;
 
       if (timeoutSeconds === 0) {
         const start = await startAgentRun({
@@ -346,7 +296,6 @@ export function createSessionsSendTool(opts?: {
           return start.result;
         }
         runId = start.runId;
-        startA2AFlow(undefined, runId);
         return jsonResult({
           runId,
           status: "accepted",
@@ -380,6 +329,7 @@ export function createSessionsSendTool(opts?: {
           status: "timeout",
           error: result.error,
           sessionKey: displayKey,
+          delivery,
         });
       }
       if (result.status === "error") {
@@ -388,10 +338,10 @@ export function createSessionsSendTool(opts?: {
           status: "error",
           error: result.error ?? "agent error",
           sessionKey: displayKey,
+          delivery,
         });
       }
       const reply = result.replyText;
-      startA2AFlow(reply ?? undefined);
 
       return jsonResult({
         runId,

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -6,6 +6,7 @@ import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { extractAssistantText, sanitizeTextContent } from "./sessions-helpers.js";
 
 const callGatewayMock = vi.fn();
+const runSessionsSendA2AFlowMock = vi.fn();
 vi.mock("../../gateway/call.js", () => ({
   callGateway: (opts: unknown) => callGatewayMock(opts),
 }));
@@ -32,7 +33,7 @@ vi.mock("../../config/config.js", async () => {
   };
 });
 vi.mock("./sessions-send-tool.a2a.js", () => ({
-  runSessionsSendA2AFlow: vi.fn(),
+  runSessionsSendA2AFlow: (...args: unknown[]) => runSessionsSendA2AFlowMock(...args),
 }));
 
 let createSessionsListTool: typeof import("./sessions-list-tool.js").createSessionsListTool;
@@ -217,6 +218,7 @@ beforeEach(() => {
     session: { scope: "per-sender", mainKey: "main" },
     tools: { agentToAgent: { enabled: false } },
   });
+  runSessionsSendA2AFlowMock.mockReset();
   setActivePluginRegistry(createTestRegistry([]));
 });
 
@@ -700,5 +702,56 @@ describe("sessions_send gating", () => {
       reply: undefined,
       sessionKey: MAIN_AGENT_SESSION_KEY,
     });
+  });
+
+  it("keeps sessions_send delivery session-local and does not start announce flow", async () => {
+    const tool = createMainSessionsSendTool();
+    let historyCalls = 0;
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [{ key: MAIN_AGENT_SESSION_KEY, kind: "direct" }],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-inline-only", acceptedAt: 123 };
+      }
+      if (request.method === "agent.wait") {
+        return { runId: "run-inline-only", status: "ok" };
+      }
+      if (request.method === "chat.history") {
+        historyCalls += 1;
+        return {
+          messages:
+            historyCalls === 1
+              ? []
+              : [
+                  {
+                    role: "assistant",
+                    content: [{ type: "text", text: "session-local reply" }],
+                    timestamp: 30,
+                  },
+                ],
+        };
+      }
+      return {};
+    });
+
+    const result = await tool.execute("call-inline-only", {
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      message: "ping",
+      timeoutSeconds: 1,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "ok",
+      reply: "session-local reply",
+      sessionKey: MAIN_AGENT_SESSION_KEY,
+      delivery: { status: "skipped", mode: "none" },
+    });
+    expect(runSessionsSendA2AFlowMock).not.toHaveBeenCalled();
   });
 });

--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -76,6 +76,33 @@ describe("inter-session lastRoute preservation (fixes #54441)", () => {
     // No external route — falls through to normal resolution
     expect(result === "session:somekey" || result === undefined).toBe(true);
   });
+
+  it("sessions_send inter-session turns do not inherit an existing external lastChannel", () => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123456",
+        isInterSession: true,
+        allowInterSessionExternalRoute: false,
+      }),
+    ).toBe("webchat");
+  });
+
+  it("sessions_send inter-session turns do not inherit an existing external lastTo", () => {
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:somekey",
+        toRaw: "session:somekey",
+        persistedLastTo: "123456",
+        persistedLastChannel: "telegram",
+        sessionKey: "agent:main:telegram:direct:123456",
+        isInterSession: true,
+        allowInterSessionExternalRoute: false,
+      }),
+    ).toBe("session:somekey");
+  });
 });
 
 describe("session delivery direct-session routing overrides", () => {

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -98,6 +98,7 @@ export function resolveLastChannelRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
   isInterSession?: boolean;
+  allowInterSessionExternalRoute?: boolean;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   // WebChat should own reply routing for direct-session UI turns, but only when
@@ -115,7 +116,11 @@ export function resolveLastChannelRaw(params: {
   // Without this guard, a sessions_send call resets lastChannel to webchat,
   // causing subsequent Discord (or other external) deliveries to be lost.
   // See: https://github.com/openclaw/openclaw/issues/54441
-  if (params.isInterSession && hasEstablishedExternalRoute) {
+  if (
+    params.isInterSession &&
+    params.allowInterSessionExternalRoute !== false &&
+    hasEstablishedExternalRoute
+  ) {
     return persistedChannel || sessionKeyChannelHint;
   }
   if (
@@ -127,12 +132,18 @@ export function resolveLastChannelRaw(params: {
   }
   let resolved = params.originatingChannelRaw || params.persistedLastChannel;
   // Internal/non-deliverable sources should not overwrite previously known
-  // external delivery routes (or explicit channel hints from the session key).
+  // external delivery routes (or explicit channel hints from the session key),
+  // except for sessions_send turns where we intentionally keep the message
+  // session-local instead of reusing the target session's external route.
   if (!isExternalRoutingChannel(originatingChannel)) {
-    if (isExternalRoutingChannel(persistedChannel)) {
-      resolved = persistedChannel;
-    } else if (isExternalRoutingChannel(sessionKeyChannelHint)) {
-      resolved = sessionKeyChannelHint;
+    const blockExternalFallback =
+      params.isInterSession && params.allowInterSessionExternalRoute === false;
+    if (!blockExternalFallback) {
+      if (isExternalRoutingChannel(persistedChannel)) {
+        resolved = persistedChannel;
+      } else if (isExternalRoutingChannel(sessionKeyChannelHint)) {
+        resolved = sessionKeyChannelHint;
+      }
     }
   }
   return resolved;
@@ -146,6 +157,7 @@ export function resolveLastToRaw(params: {
   persistedLastChannel?: string;
   sessionKey?: string;
   isInterSession?: boolean;
+  allowInterSessionExternalRoute?: boolean;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
@@ -156,7 +168,12 @@ export function resolveLastToRaw(params: {
   // webchat-scoped identifiers (e.g. session keys). Preserve the established
   // external destination so deliveries continue routing to the correct channel.
   // See: https://github.com/openclaw/openclaw/issues/54441
-  if (params.isInterSession && hasEstablishedExternalRouteForTo && params.persistedLastTo) {
+  if (
+    params.isInterSession &&
+    params.allowInterSessionExternalRoute !== false &&
+    hasEstablishedExternalRouteForTo &&
+    params.persistedLastTo
+  ) {
     return params.persistedLastTo;
   }
   if (
@@ -168,11 +185,14 @@ export function resolveLastToRaw(params: {
   }
   // When the turn originates from an internal/non-deliverable source, do not
   // replace an established external destination with internal routing ids
-  // (e.g., session/webchat ids).
+  // (e.g., session/webchat ids), except for sessions_send turns where that
+  // internal routing is the desired behavior.
   if (!isExternalRoutingChannel(originatingChannel)) {
+    const blockExternalFallback =
+      params.isInterSession && params.allowInterSessionExternalRoute === false;
     const hasExternalFallback =
       isExternalRoutingChannel(persistedChannel) || isExternalRoutingChannel(sessionKeyChannelHint);
-    if (hasExternalFallback && params.persistedLastTo) {
+    if (!blockExternalFallback && hasExternalFallback && params.persistedLastTo) {
       return params.persistedLastTo;
     }
   }

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -38,7 +38,10 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookSessionEndReason } from "../../plugins/hook-types.js";
 import { isAcpSessionKey, normalizeMainKey } from "../../routing/session-key.js";
-import { isInterSessionInputProvenance } from "../../sessions/input-provenance.js";
+import {
+  isInterSessionInputProvenance,
+  normalizeInputProvenance,
+} from "../../sessions/input-provenance.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -553,7 +556,11 @@ export async function initSessionState(params: {
   const baseEntry = !isNewSession && freshEntry ? entry : undefined;
   // Track the originating channel/to for announce routing (subagent announce-back).
   const originatingChannelRaw = ctx.OriginatingChannel as string | undefined;
-  const isInterSession = isInterSessionInputProvenance(ctx.InputProvenance);
+  const inputProvenance = normalizeInputProvenance(ctx.InputProvenance);
+  const isInterSession = isInterSessionInputProvenance(inputProvenance);
+  const allowInterSessionExternalRoute = !(
+    isInterSession && inputProvenance?.sourceTool === "sessions_send"
+  );
   // Automated heartbeat/cron/exec turns run inside the conversation session,
   // but they must not rewrite the session's remembered external delivery route.
   // Otherwise a heartbeat target like "group:..." or a synthetic sender like
@@ -566,6 +573,7 @@ export async function initSessionState(params: {
         persistedLastChannel: baseEntry?.lastChannel,
         sessionKey,
         isInterSession,
+        allowInterSessionExternalRoute,
       });
   const lastToRaw = isSystemEvent
     ? baseEntry?.lastTo
@@ -577,6 +585,7 @@ export async function initSessionState(params: {
         persistedLastChannel: baseEntry?.lastChannel,
         sessionKey,
         isInterSession,
+        allowInterSessionExternalRoute,
       });
   const lastAccountIdRaw = isSystemEvent
     ? baseEntry?.lastAccountId


### PR DESCRIPTION
## Problem

Two reply-boundary bugs were leaking internal behavior into user-visible chat flows:

1. Assistant commentary / tool-use prelude text could surface before tools ran.
2. `sessions_send` inter-session turns could inherit the target session’s external delivery route, causing replies to escape back into the bound user chat.

In practice, this showed up as things like:
- visible “Let me check that” / planning text before tool execution
- cross-session replies landing in the user’s Telegram thread

## Root cause

### 1) Tool-use text leak
Visible assistant output suppression depended too heavily on commentary-phase metadata. If a tool-use turn lacked that metadata, text blocks attached to the same assistant message could still be surfaced.

### 2) `sessions_send` delivery leak
`sessions_send` still allowed downstream delivery behavior that behaved like announce/A2A follow-up handling, and session delivery routing preserved the target session’s established external route even for `sourceTool: "sessions_send"` inter-session traffic.

That meant a session-local control message could be treated like a normal externally deliverable turn.

## Fix

### Suppress assistant-visible tool-use text
Updated:
- `src/agents/pi-embedded-subscribe.handlers.messages.ts`

Changes:
- suppress visible assistant output for:
  - commentary-phase messages
  - `stopReason === "toolUse"`
  - messages containing tool-call / tool-use content blocks

### Strip leaked self-instruction prefixes
Updated:
- `src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts`

Changes:
- detect internal-monologue / self-instruction preludes
- preserve the final clean user-facing answer when present
- avoid surfacing “I should…”, “Let me…”, “We must use a tool…”, etc.

### Keep `sessions_send` session-local
Updated:
- `src/agents/tools/sessions-send-tool.ts`

Changes:
- remove announce / ping-pong follow-up behavior from `sessions_send`
- keep reply handling inline
- return:
  - `delivery: { status: "skipped", mode: "none" }`

### Block external-route inheritance for `sessions_send`
Updated:
- `src/auto-reply/reply/session-delivery.ts`
- `src/auto-reply/reply/session.ts`

Changes:
- preserve existing inter-session routing behavior in general
- explicitly disable external route reuse when:
  - input provenance is inter-session, and
  - `sourceTool === "sessions_send"`

This keeps `sessions_send` traffic bound to the session-local path instead of reusing the target session’s Telegram/Discord/etc. route.

## Tests

Added/updated regressions in:
- `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts`
- `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `src/agents/tools/sessions.test.ts`
- `src/auto-reply/reply/session-delivery.test.ts`

Coverage includes:
- suppressing tool-use text when commentary metadata is missing
- stripping leaked self-instruction preludes
- preventing `sessions_send` from starting announce flow
- preventing `sessions_send` from inheriting existing external delivery routes

## Validation

Passed targeted test runs for:
- `src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `src/auto-reply/reply/session-delivery.test.ts`
- `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts`
- `src/agents/tools/sessions.test.ts`

## User impact

After this patch:
- tool-using turns no longer surface planning/prelude text
- `sessions_send` no longer leaks replies into the target session’s bound external chat
- session boundaries hold correctly for personal-agent and inter-session control flows
