### PR TITLE
Filter internal compaction artifacts from chat history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -943,6 +943,59 @@ function hasAssistantNonTextContent(message: unknown): boolean {
   );
 }
 
+function extractHistoryMessageText(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const entry = message as { text?: unknown; content?: unknown };
+  if (typeof entry.text === "string") {
+    return entry.text;
+  }
+  if (typeof entry.content === "string") {
+    return entry.content;
+  }
+  if (!Array.isArray(entry.content) || entry.content.length === 0) {
+    return undefined;
+  }
+
+  const texts: string[] = [];
+  for (const block of entry.content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") {
+      texts.push(typed.text);
+    }
+  }
+  return texts.length > 0 ? texts.join("\n") : undefined;
+}
+
+function isCompactionHistoryMarker(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const openclaw = (message as { __openclaw?: unknown }).__openclaw;
+  if (!openclaw || typeof openclaw !== "object" || Array.isArray(openclaw)) {
+    return false;
+  }
+  return (openclaw as { kind?: unknown }).kind === "compaction";
+}
+
+function shouldDropInternalHistoryMessage(message: unknown): boolean {
+  if (isCompactionHistoryMarker(message)) {
+    return true;
+  }
+  const text = extractHistoryMessageText(message)?.trim();
+  if (!text) {
+    return false;
+  }
+  return (
+    text.startsWith("Pre-compaction memory flush.") ||
+    text.startsWith("[Post-compaction context refresh]")
+  );
+}
+
 function shouldDropAssistantHistoryMessage(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
@@ -971,12 +1024,20 @@ export function sanitizeChatHistoryMessages(
   let changed = false;
   const next: unknown[] = [];
   for (const message of messages) {
+    if (shouldDropInternalHistoryMessage(message)) {
+      changed = true;
+      continue;
+    }
     if (shouldDropAssistantHistoryMessage(message)) {
       changed = true;
       continue;
     }
     const res = sanitizeChatHistoryMessage(message, maxChars);
     changed ||= res.changed;
+    if (shouldDropInternalHistoryMessage(res.message)) {
+      changed = true;
+      continue;
+    }
     if (shouldDropAssistantHistoryMessage(res.message)) {
       changed = true;
       continue;

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -301,6 +301,50 @@ describe("sanitizeChatHistoryMessages", () => {
       },
     ]);
   });
+
+  it("drops compaction and internal memory recovery artifacts from chat history", () => {
+    const result = sanitizeChatHistoryMessages([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "system",
+        content: [{ type: "text", text: "Compaction" }],
+        __openclaw: { kind: "compaction" },
+        timestamp: 2,
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Pre-compaction memory flush.\nNO_REPLY" }],
+        timestamp: 3,
+      },
+      {
+        role: "system",
+        content: [{ type: "text", text: "[Post-compaction context refresh]\n\nreload state" }],
+        timestamp: 4,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 5,
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+        timestamp: 5,
+      },
+    ]);
+  });
 });
 
 describe("resolveEffectiveChatHistoryMaxChars", () => {

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -565,6 +565,52 @@ describe("gateway server chat", () => {
     expect(collectHistoryTextValues(historyMessages)).toEqual(["hello", "real reply"]);
   });
 
+  test("chat.history hides compaction and memory recovery artifacts", async () => {
+    const historyMessages = await withMainSessionStore(async (dir) => {
+      await fs.writeFile(
+        path.join(dir, "sess-main.jsonl"),
+        [
+          JSON.stringify({ message: { role: "user", content: [{ type: "text", text: "hello" }] } }),
+          JSON.stringify({
+            type: "compaction",
+            id: "comp-1",
+            timestamp: "2026-02-07T00:00:00.000Z",
+            summary: "Compacted history",
+          }),
+          JSON.stringify({
+            message: {
+              role: "user",
+              content: [{ type: "text", text: "Pre-compaction memory flush.\nNO_REPLY" }],
+            },
+          }),
+          JSON.stringify({
+            message: {
+              role: "system",
+              content: [
+                {
+                  type: "text",
+                  text: "[Post-compaction context refresh]\n\nReload workspace state.",
+                },
+              ],
+            },
+          }),
+          JSON.stringify({
+            message: { role: "assistant", content: [{ type: "text", text: "real reply" }] },
+          }),
+        ].join("\n"),
+        "utf-8",
+      );
+
+      const res = await rpcReq<{ messages?: unknown[] }>(ws, "chat.history", {
+        sessionKey: "main",
+      });
+      expect(res.ok).toBe(true);
+      return res.payload?.messages ?? [];
+    });
+
+    expect(collectHistoryTextValues(historyMessages)).toEqual(["hello", "real reply"]);
+  });
+
   test("chat.history hides assistant announce/reply skip-only entries", async () => {
     const historyMessages = await loadChatHistoryWithMessages([
       {


### PR DESCRIPTION
## Summary
This patch addresses the dominant `chat.history` visibility path where internal compaction and memory-flush artifacts leak back into normal chat history.

## What This Fix Does
- filters synthetic compaction markers from `chat.history`
- filters internal `Pre-compaction memory flush.` prompts from `chat.history`
- filters `[Post-compaction context refresh]` artifacts from `chat.history`
- adds targeted sanitizer and gateway history tests for this path

## Explicitly Not Part Of This Fix
- `audio payload removed during overflow recovery` is not part of this patch

## Why This Scope
The patch is intentionally limited to the dominant `chat.history` / compaction / flush visibility path. It does not touch Route A/B, step 1b, step 2, approval, heartbeat, or think-level behavior.

## Optional Follow-up
- optional end-to-end oversize regression coverage to guard the full overflow-to-history path
