### PR TITLE
fix(security): downgrade trusted_proxies_missing to info on loopback bind

### DIFF
--- a/src/config/gateway-bind.test.ts
+++ b/src/config/gateway-bind.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isLoopbackEquivalentBind } from "./gateway-bind.js";
+
+describe("isLoopbackEquivalentBind", () => {
+  afterEach(() => {
+    vi.doUnmock("../gateway/net.js");
+    vi.resetModules();
+  });
+
+  it('returns true for bind="loopback"', () => {
+    expect(isLoopbackEquivalentBind({ bind: "loopback", customBindHost: undefined })).toBe(true);
+  });
+
+  it('returns true for bind="custom" with loopback IPv4 customBindHost', () => {
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "127.0.0.1" })).toBe(true);
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "127.0.0.2" })).toBe(true);
+  });
+
+  it('returns false for bind="custom" with a non-loopback IPv4 customBindHost', () => {
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "192.168.1.10" })).toBe(
+      false,
+    );
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "0.0.0.0" })).toBe(false);
+  });
+
+  it('returns false for bind="custom" with IPv6 loopback (::1) because the runtime resolver rejects IPv6 here', () => {
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "::1" })).toBe(false);
+  });
+
+  it('returns false for bind="custom" with a missing or malformed customBindHost', () => {
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: undefined })).toBe(false);
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "not-an-ip" })).toBe(false);
+    expect(isLoopbackEquivalentBind({ bind: "custom", customBindHost: "" })).toBe(false);
+  });
+
+  it('returns false for bind="lan", "tailnet", and unknown strings', () => {
+    expect(isLoopbackEquivalentBind({ bind: "lan", customBindHost: undefined })).toBe(false);
+    expect(isLoopbackEquivalentBind({ bind: "tailnet", customBindHost: undefined })).toBe(false);
+    expect(isLoopbackEquivalentBind({ bind: "made-up", customBindHost: undefined })).toBe(false);
+    expect(isLoopbackEquivalentBind({ bind: undefined, customBindHost: undefined })).toBe(false);
+  });
+
+  it('returns true for bind="auto" on non-container hosts', async () => {
+    vi.doMock("../gateway/net.js", () => ({
+      isContainerEnvironment: () => false,
+    }));
+    const { isLoopbackEquivalentBind: reloaded } = await import("./gateway-bind.js");
+    expect(reloaded({ bind: "auto", customBindHost: undefined })).toBe(true);
+  });
+
+  it('returns false for bind="auto" inside a container', async () => {
+    vi.doMock("../gateway/net.js", () => ({
+      isContainerEnvironment: () => true,
+    }));
+    const { isLoopbackEquivalentBind: reloaded } = await import("./gateway-bind.js");
+    expect(reloaded({ bind: "auto", customBindHost: undefined })).toBe(false);
+  });
+});

--- a/src/config/gateway-bind.ts
+++ b/src/config/gateway-bind.ts
@@ -1,0 +1,45 @@
+import { isContainerEnvironment } from "../gateway/net.js";
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
+
+export type GatewayBindClassificationInput = {
+  bind: string | undefined;
+  customBindHost: string | undefined;
+};
+
+/**
+ * Returns true when a gateway bind configuration resolves to a loopback-only
+ * listener at runtime.
+ *
+ * Covers:
+ * - `bind="loopback"` - always loopback.
+ * - `bind="custom"` with a canonical IPv4 loopback `customBindHost` - the
+ *   config validator also treats this shape as loopback-equivalent (see
+ *   validateGatewayTailscaleBind in `src/config/validation.ts`).
+ * - `bind="auto"` on non-container hosts - `resolveGatewayBindHost` resolves
+ *   `auto` to `127.0.0.1` on bare-metal / VM hosts and to `0.0.0.0` inside
+ *   containers (see `src/gateway/net.ts`).
+ *
+ * Everything else (`lan`, `tailnet`, `custom` with a non-loopback host,
+ * `auto` in a container, unknown strings) is NOT loopback-equivalent.
+ *
+ * Used by the security audit to classify findings that behave differently on
+ * loopback-equivalent binds (noise vs real warning). Keep this helper in
+ * lockstep with `validateGatewayTailscaleBind` and the runtime resolver.
+ */
+export function isLoopbackEquivalentBind(input: GatewayBindClassificationInput): boolean {
+  const { bind, customBindHost } = input;
+  if (bind === "loopback") {
+    return true;
+  }
+  if (
+    bind === "custom" &&
+    isCanonicalDottedDecimalIPv4(customBindHost) &&
+    isLoopbackIpAddress(customBindHost)
+  ) {
+    return true;
+  }
+  if (bind === "auto" && !isContainerEnvironment()) {
+    return true;
+  }
+  return false;
+}

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -142,17 +142,24 @@ export function collectGatewayConfigFindings(
     });
   }
 
-  if (bind === "loopback" && controlUiEnabled && trustedProxies.length === 0) {
+  if (controlUiEnabled && trustedProxies.length === 0) {
+    const isLoopback = bind === "loopback";
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
-      severity: "warn",
-      title: "Reverse proxy headers are not trusted",
-      detail:
-        "gateway.bind is loopback and gateway.trustedProxies is empty. " +
-        "If you expose the Control UI through a reverse proxy, configure trusted proxies " +
-        "so local-client checks cannot be spoofed.",
-      remediation:
-        "Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.",
+      severity: isLoopback ? "info" : "warn",
+      title: isLoopback
+        ? "Trusted proxies not required on loopback"
+        : "Reverse proxy headers are not trusted",
+      detail: isLoopback
+        ? "gateway.bind is loopback and gateway.trustedProxies is empty. " +
+          "X-Forwarded-For spoofing is not reachable off-host on a loopback-only bind. " +
+          "If you later expose the Control UI via a reverse proxy, set gateway.trustedProxies."
+        : `gateway.bind="${bind}" and gateway.trustedProxies is empty. ` +
+          "If you expose the Control UI through a reverse proxy, configure trusted proxies " +
+          "so local-client checks cannot be spoofed.",
+      remediation: isLoopback
+        ? "No action required. Set gateway.trustedProxies only if you move off loopback behind a reverse proxy."
+        : "Set gateway.trustedProxies to your proxy IPs or bind to loopback.",
     });
   }
 

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -143,23 +143,20 @@ export function collectGatewayConfigFindings(
   }
 
   if (controlUiEnabled && trustedProxies.length === 0) {
-    const isLoopback = bind === "loopback";
+    const safeBind = bind.replace(/[^a-zA-Z0-9._:-]/g, "?");
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
-      severity: isLoopback ? "info" : "warn",
-      title: isLoopback
-        ? "Trusted proxies not required on loopback"
-        : "Reverse proxy headers are not trusted",
-      detail: isLoopback
-        ? "gateway.bind is loopback and gateway.trustedProxies is empty. " +
-          "X-Forwarded-For spoofing is not reachable off-host on a loopback-only bind. " +
-          "If you later expose the Control UI via a reverse proxy, set gateway.trustedProxies."
-        : `gateway.bind="${bind}" and gateway.trustedProxies is empty. ` +
-          "If you expose the Control UI through a reverse proxy, configure trusted proxies " +
-          "so local-client checks cannot be spoofed.",
-      remediation: isLoopback
-        ? "No action required. Set gateway.trustedProxies only if you move off loopback behind a reverse proxy."
-        : "Set gateway.trustedProxies to your proxy IPs or bind to loopback.",
+      severity: "warn",
+      title: "Trusted proxies not configured",
+      detail:
+        `gateway.bind="${safeBind}" and gateway.trustedProxies is empty. ` +
+        "A loopback bind is often used specifically because a reverse proxy on " +
+        "the same host fronts the Control UI; in that case requests still arrive " +
+        "with remoteAddress=127.0.0.1 and local-client checks may mis-classify " +
+        "external traffic as local without gateway.trustedProxies set.",
+      remediation:
+        "Set gateway.trustedProxies to your reverse proxy IPs (often 127.0.0.1/::1 " +
+        "for same-host) or ensure the Control UI is not fronted by any proxy.",
     });
   }
 

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -1,8 +1,8 @@
 import { isIP } from "node:net";
+import { isLoopbackEquivalentBind } from "../config/gateway-bind.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveGatewayAuth } from "../gateway/auth-resolve.js";
-import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -133,29 +133,26 @@ export function collectGatewayConfigFindings(
         "If you keep them enabled, keep gateway.bind loopback-only (or tailnet-only), restrict network exposure, and treat the gateway token/password as full-admin.",
     });
   }
-  if (bind !== "loopback" && !hasSharedSecret && auth.mode !== "trusted-proxy") {
+  // Classify the bind once; all sibling checks key off the same semantics.
+  // `auto` resolves to 127.0.0.1 on bare-metal hosts and 0.0.0.0 inside
+  // containers, so treat `bind="auto"` the same way the runtime resolver
+  // does. `bind="custom"` with a loopback IPv4 customBindHost also counts.
+  // See src/config/gateway-bind.ts for the shared classifier.
+  const customBindHost = cfg.gateway?.customBindHost;
+  const isLoopbackEquivalent = isLoopbackEquivalentBind({ bind, customBindHost });
+  const safeBind = bind.replace(/[^a-zA-Z0-9._:-]/g, "?");
+
+  if (!isLoopbackEquivalent && !hasSharedSecret && auth.mode !== "trusted-proxy") {
     findings.push({
       checkId: "gateway.bind_no_auth",
       severity: "critical",
       title: "Gateway binds beyond loopback without auth",
-      detail: `gateway.bind="${bind}" but no gateway.auth token/password is configured.`,
+      detail: `gateway.bind="${safeBind}" resolves to a non-loopback listener but no gateway.auth token/password is configured.`,
       remediation: `Set gateway.auth (token recommended) or bind to loopback.`,
     });
   }
 
   if (controlUiEnabled && trustedProxies.length === 0) {
-    const customBindHost = cfg.gateway?.customBindHost;
-    // A `custom` bind with a loopback customBindHost is accepted as
-    // loopback-equivalent elsewhere in the config layer (see
-    // validateGatewayTailscaleBind at src/config/validation.ts:548-557).
-    // Treat it the same here so a local-only deployment using that shape is
-    // not upgraded to `warn`.
-    const isLoopbackEquivalent =
-      bind === "loopback" ||
-      (bind === "custom" &&
-        isCanonicalDottedDecimalIPv4(customBindHost) &&
-        isLoopbackIpAddress(customBindHost));
-    const safeBind = bind.replace(/[^a-zA-Z0-9._:-]/g, "?");
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
       severity: isLoopbackEquivalent ? "info" : "warn",
@@ -167,7 +164,7 @@ export function collectGatewayConfigFindings(
           "X-Forwarded-For spoofing is not reachable off-host on a loopback-only bind. " +
           "If a same-host reverse proxy (nginx, Caddy, systemd socket activation) fronts the Control UI, " +
           "set gateway.trustedProxies so client-IP and local-client checks stay correct."
-        : `gateway.bind="${safeBind}" and gateway.trustedProxies is empty. ` +
+        : `gateway.bind="${safeBind}" is not loopback-equivalent and gateway.trustedProxies is empty. ` +
           "A reverse proxy in front of the Control UI can spoof X-Forwarded-For " +
           "without explicit trusted proxies.",
       remediation: isLoopbackEquivalent
@@ -178,19 +175,19 @@ export function collectGatewayConfigFindings(
     });
   }
 
-  if (bind === "loopback" && controlUiEnabled && !hasGatewayAuth) {
+  if (isLoopbackEquivalent && controlUiEnabled && !hasGatewayAuth) {
     findings.push({
       checkId: "gateway.loopback_no_auth",
       severity: "critical",
       title: "Gateway auth missing on loopback",
       detail:
-        "gateway.bind is loopback but no gateway auth secret is configured. " +
+        `gateway.bind="${safeBind}" is loopback-equivalent but no gateway auth secret is configured. ` +
         "If the Control UI is exposed through a reverse proxy, unauthenticated access is possible.",
       remediation: "Set gateway.auth (token recommended) or keep the Control UI local-only.",
     });
   }
   if (
-    bind !== "loopback" &&
+    !isLoopbackEquivalent &&
     controlUiEnabled &&
     controlUiAllowedOrigins.length === 0 &&
     !dangerouslyAllowHostHeaderOriginFallback
@@ -200,7 +197,7 @@ export function collectGatewayConfigFindings(
       severity: "critical",
       title: "Non-loopback Control UI missing explicit allowed origins",
       detail:
-        "Control UI is enabled on a non-loopback bind but gateway.controlUi.allowedOrigins is empty. " +
+        `gateway.bind="${safeBind}" is not loopback-equivalent but gateway.controlUi.allowedOrigins is empty. ` +
         "Strict origin policy requires explicit allowed origins for non-loopback deployments.",
       remediation:
         "Set gateway.controlUi.allowedOrigins to full trusted origins (for example https://control.example.com). " +

--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -2,6 +2,7 @@ import { isIP } from "node:net";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { resolveGatewayAuth } from "../gateway/auth-resolve.js";
+import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "../shared/net/ip.js";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -143,20 +144,37 @@ export function collectGatewayConfigFindings(
   }
 
   if (controlUiEnabled && trustedProxies.length === 0) {
+    const customBindHost = cfg.gateway?.customBindHost;
+    // A `custom` bind with a loopback customBindHost is accepted as
+    // loopback-equivalent elsewhere in the config layer (see
+    // validateGatewayTailscaleBind at src/config/validation.ts:548-557).
+    // Treat it the same here so a local-only deployment using that shape is
+    // not upgraded to `warn`.
+    const isLoopbackEquivalent =
+      bind === "loopback" ||
+      (bind === "custom" &&
+        isCanonicalDottedDecimalIPv4(customBindHost) &&
+        isLoopbackIpAddress(customBindHost));
     const safeBind = bind.replace(/[^a-zA-Z0-9._:-]/g, "?");
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
-      severity: "warn",
-      title: "Trusted proxies not configured",
-      detail:
-        `gateway.bind="${safeBind}" and gateway.trustedProxies is empty. ` +
-        "A loopback bind is often used specifically because a reverse proxy on " +
-        "the same host fronts the Control UI; in that case requests still arrive " +
-        "with remoteAddress=127.0.0.1 and local-client checks may mis-classify " +
-        "external traffic as local without gateway.trustedProxies set.",
-      remediation:
-        "Set gateway.trustedProxies to your reverse proxy IPs (often 127.0.0.1/::1 " +
-        "for same-host) or ensure the Control UI is not fronted by any proxy.",
+      severity: isLoopbackEquivalent ? "info" : "warn",
+      title: isLoopbackEquivalent
+        ? "Trusted proxies not configured on loopback bind"
+        : "Trusted proxies not configured",
+      detail: isLoopbackEquivalent
+        ? `gateway.bind="${safeBind}" is loopback-equivalent and gateway.trustedProxies is empty. ` +
+          "X-Forwarded-For spoofing is not reachable off-host on a loopback-only bind. " +
+          "If a same-host reverse proxy (nginx, Caddy, systemd socket activation) fronts the Control UI, " +
+          "set gateway.trustedProxies so client-IP and local-client checks stay correct."
+        : `gateway.bind="${safeBind}" and gateway.trustedProxies is empty. ` +
+          "A reverse proxy in front of the Control UI can spoof X-Forwarded-For " +
+          "without explicit trusted proxies.",
+      remediation: isLoopbackEquivalent
+        ? "If the Control UI is fronted by a same-host reverse proxy, set " +
+          "gateway.trustedProxies to that proxy's IP (often 127.0.0.1/::1). " +
+          "No action required if the Control UI is only reached directly via loopback."
+        : "Set gateway.trustedProxies to your reverse proxy IP/CIDR(s) or bind to loopback.",
     });
   }
 

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -5,7 +5,7 @@ import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js
 
 function hasGatewayFinding(
   checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
-  severity: "warn" | "critical",
+  severity: "info" | "warn" | "critical",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
@@ -27,6 +27,22 @@ describe("security audit loopback and logging findings", () => {
           gateway: {
             bind: "loopback",
             controlUi: { enabled: true },
+          },
+        };
+        expect(
+          hasGatewayFinding(
+            "gateway.trusted_proxies_missing",
+            "info",
+            collectGatewayConfigFindings(cfg, cfg, process.env),
+          ),
+        ).toBe(true);
+      })(),
+      (async () => {
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "lan",
+            controlUi: { enabled: true },
+            auth: { token: "placeholder-for-lan-audit-test" },
           },
         };
         expect(

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -5,7 +5,7 @@ import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js
 
 function hasGatewayFinding(
   checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
-  severity: "warn" | "critical",
+  severity: "info" | "warn" | "critical",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
@@ -32,7 +32,26 @@ describe("security audit loopback and logging findings", () => {
         expect(
           hasGatewayFinding(
             "gateway.trusted_proxies_missing",
-            "warn",
+            "info",
+            collectGatewayConfigFindings(cfg, cfg, process.env),
+          ),
+        ).toBe(true);
+      })(),
+      (async () => {
+        // bind="custom" with a loopback customBindHost is accepted as
+        // loopback-equivalent by validateGatewayTailscaleBind; the audit
+        // check should classify it the same as bind="loopback".
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            controlUi: { enabled: true },
+          },
+        };
+        expect(
+          hasGatewayFinding(
+            "gateway.trusted_proxies_missing",
+            "info",
             collectGatewayConfigFindings(cfg, cfg, process.env),
           ),
         ).toBe(true);
@@ -43,6 +62,25 @@ describe("security audit loopback and logging findings", () => {
             bind: "lan",
             controlUi: { enabled: true },
             auth: { token: "placeholder-for-lan-audit-test" },
+          },
+        };
+        expect(
+          hasGatewayFinding(
+            "gateway.trusted_proxies_missing",
+            "warn",
+            collectGatewayConfigFindings(cfg, cfg, process.env),
+          ),
+        ).toBe(true);
+      })(),
+      (async () => {
+        // bind="custom" with a non-loopback customBindHost is not loopback-
+        // equivalent and must still surface the warn.
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "custom",
+            customBindHost: "192.168.1.10",
+            controlUi: { enabled: true },
+            auth: { token: "placeholder-for-custom-audit-test" },
           },
         };
         expect(

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -5,7 +5,7 @@ import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js
 
 function hasGatewayFinding(
   checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
-  severity: "info" | "warn" | "critical",
+  severity: "warn" | "critical",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
@@ -32,7 +32,7 @@ describe("security audit loopback and logging findings", () => {
         expect(
           hasGatewayFinding(
             "gateway.trusted_proxies_missing",
-            "info",
+            "warn",
             collectGatewayConfigFindings(cfg, cfg, process.env),
           ),
         ).toBe(true);

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -4,7 +4,11 @@ import { withEnvAsync } from "../test-utils/env.js";
 import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js";
 
 function hasGatewayFinding(
-  checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
+  checkId:
+    | "gateway.trusted_proxies_missing"
+    | "gateway.loopback_no_auth"
+    | "gateway.bind_no_auth"
+    | "gateway.control_ui.allowed_origins_required",
   severity: "info" | "warn" | "critical",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
@@ -90,6 +94,100 @@ describe("security audit loopback and logging findings", () => {
             collectGatewayConfigFindings(cfg, cfg, process.env),
           ),
         ).toBe(true);
+      })(),
+      (async () => {
+        // bind="custom" with a loopback customBindHost is loopback-equivalent,
+        // so gateway.loopback_no_auth (critical) must fire when controlUi is
+        // enabled and no auth secret is configured - mirroring bind="loopback".
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            controlUi: { enabled: true },
+            auth: {},
+          },
+        };
+        await withEnvAsync(
+          { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
+          async () => {
+            expect(
+              hasGatewayFinding(
+                "gateway.loopback_no_auth",
+                "critical",
+                collectGatewayConfigFindings(cfg, cfg, process.env),
+              ),
+            ).toBe(true);
+          },
+        );
+      })(),
+      (async () => {
+        // bind="custom" with a loopback customBindHost must NOT surface
+        // gateway.bind_no_auth (it's loopback-equivalent - the original
+        // self-contradiction that motivated this refactor).
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            controlUi: { enabled: true },
+            auth: {},
+          },
+        };
+        await withEnvAsync(
+          { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
+          async () => {
+            expect(
+              hasGatewayFinding(
+                "gateway.bind_no_auth",
+                "critical",
+                collectGatewayConfigFindings(cfg, cfg, process.env),
+              ),
+            ).toBe(false);
+          },
+        );
+      })(),
+      (async () => {
+        // bind="custom" with a loopback customBindHost must NOT demand
+        // allowedOrigins (again mirroring bind="loopback").
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "custom",
+            customBindHost: "127.0.0.1",
+            controlUi: { enabled: true },
+          },
+        };
+        expect(
+          hasGatewayFinding(
+            "gateway.control_ui.allowed_origins_required",
+            "critical",
+            collectGatewayConfigFindings(cfg, cfg, process.env),
+          ),
+        ).toBe(false);
+      })(),
+      (async () => {
+        // bind="lan" with empty allowedOrigins and no auth surfaces both the
+        // bind_no_auth critical AND the allowed_origins_required critical
+        // (unchanged behavior; locked in as a regression guard).
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "lan",
+            controlUi: { enabled: true },
+            auth: {},
+          },
+        };
+        await withEnvAsync(
+          { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_GATEWAY_PASSWORD: undefined },
+          async () => {
+            const findings = collectGatewayConfigFindings(cfg, cfg, process.env);
+            expect(hasGatewayFinding("gateway.bind_no_auth", "critical", findings)).toBe(true);
+            expect(
+              hasGatewayFinding(
+                "gateway.control_ui.allowed_origins_required",
+                "critical",
+                findings,
+              ),
+            ).toBe(true);
+          },
+        );
       })(),
       withEnvAsync(
         {

--- a/tools/audit-evidence/README.md
+++ b/tools/audit-evidence/README.md
@@ -1,0 +1,20 @@
+# Audit Evidence Fixtures
+
+These files capture real `openclaw security audit --json` behavior for the
+gateway bind classifier scenarios discussed in PR #70368.
+
+Regenerate them from the repository root:
+
+```sh
+./tools/audit-evidence/capture.sh
+```
+
+The script runs each audit against a temporary `OPENCLAW_CONFIG_PATH`,
+`OPENCLAW_STATE_DIR`, and `OPENCLAW_HOME`, then redacts repository, temporary,
+and home paths in the JSON output. It prefers `pnpm openclaw`; if `pnpm` is not
+available in the local sandbox, it falls back to the source entrypoint with
+`node --import tsx src/entry.ts`.
+
+The `auto-bind-resolves-0.0.0.0.json` case uses a temporary Node preload to make
+the process look containerized, which drives the same `auto -> 0.0.0.0` resolver
+branch used at runtime.

--- a/tools/audit-evidence/auto-bind-non-container.json
+++ b/tools/audit-evidence/auto-bind-non-container.json
@@ -1,0 +1,38 @@
+{
+  "ts": 1778601129350,
+  "summary": {
+    "critical": 1,
+    "warn": 2,
+    "info": 1
+  },
+  "findings": [
+    {
+      "checkId": "summary.attack_surface",
+      "severity": "info",
+      "title": "Attack surface summary",
+      "detail": "groups: open=0, allowlist=0\ntools.elevated: enabled\nhooks.webhooks: disabled\nhooks.internal: disabled\nbrowser control: enabled\ntrust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway"
+    },
+    {
+      "checkId": "gateway.bind_no_auth",
+      "severity": "critical",
+      "title": "Gateway binds beyond loopback without auth",
+      "detail": "gateway.bind=\"auto\" resolves to a non-loopback listener but no gateway.auth token/password is configured.",
+      "remediation": "Set gateway.auth (token recommended) or bind to loopback."
+    },
+    {
+      "checkId": "gateway.trusted_proxies_missing",
+      "severity": "warn",
+      "title": "Trusted proxies not configured",
+      "detail": "gateway.bind=\"auto\" is not loopback-equivalent and gateway.trustedProxies is empty. A reverse proxy in front of the Control UI can spoof X-Forwarded-For without explicit trusted proxies.",
+      "remediation": "Set gateway.trustedProxies to your reverse proxy IP/CIDR(s) or bind to loopback."
+    },
+    {
+      "checkId": "gateway.auth_no_rate_limit",
+      "severity": "warn",
+      "title": "No auth rate limiting configured",
+      "detail": "gateway.bind is not loopback but no gateway.auth.rateLimit is configured. Without rate limiting, brute-force auth attacks are not mitigated.",
+      "remediation": "Set gateway.auth.rateLimit (e.g. { maxAttempts: 10, windowMs: 60000, lockoutMs: 300000 })."
+    }
+  ],
+  "secretDiagnostics": []
+}

--- a/tools/audit-evidence/auto-bind-resolves-0.0.0.0.json
+++ b/tools/audit-evidence/auto-bind-resolves-0.0.0.0.json
@@ -1,0 +1,38 @@
+{
+  "ts": 1778601130866,
+  "summary": {
+    "critical": 1,
+    "warn": 2,
+    "info": 1
+  },
+  "findings": [
+    {
+      "checkId": "summary.attack_surface",
+      "severity": "info",
+      "title": "Attack surface summary",
+      "detail": "groups: open=0, allowlist=0\ntools.elevated: enabled\nhooks.webhooks: disabled\nhooks.internal: disabled\nbrowser control: enabled\ntrust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway"
+    },
+    {
+      "checkId": "gateway.bind_no_auth",
+      "severity": "critical",
+      "title": "Gateway binds beyond loopback without auth",
+      "detail": "gateway.bind=\"auto\" resolves to a non-loopback listener but no gateway.auth token/password is configured.",
+      "remediation": "Set gateway.auth (token recommended) or bind to loopback."
+    },
+    {
+      "checkId": "gateway.trusted_proxies_missing",
+      "severity": "warn",
+      "title": "Trusted proxies not configured",
+      "detail": "gateway.bind=\"auto\" is not loopback-equivalent and gateway.trustedProxies is empty. A reverse proxy in front of the Control UI can spoof X-Forwarded-For without explicit trusted proxies.",
+      "remediation": "Set gateway.trustedProxies to your reverse proxy IP/CIDR(s) or bind to loopback."
+    },
+    {
+      "checkId": "gateway.auth_no_rate_limit",
+      "severity": "warn",
+      "title": "No auth rate limiting configured",
+      "detail": "gateway.bind is not loopback but no gateway.auth.rateLimit is configured. Without rate limiting, brute-force auth attacks are not mitigated.",
+      "remediation": "Set gateway.auth.rateLimit (e.g. { maxAttempts: 10, windowMs: 60000, lockoutMs: 300000 })."
+    }
+  ],
+  "secretDiagnostics": []
+}

--- a/tools/audit-evidence/capture.sh
+++ b/tools/audit-evidence/capture.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_ROOT="$SCRIPT_DIR/.tmp"
+
+rm -rf "$TMP_ROOT"
+mkdir -p "$TMP_ROOT"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+if command -v pnpm >/dev/null 2>&1 && pnpm --version >/dev/null 2>&1; then
+  OPENCLAW_CMD=(pnpm openclaw)
+else
+  OPENCLAW_CMD=(node --import tsx "$REPO_ROOT/src/entry.ts")
+fi
+
+redact_json() {
+  node -e '
+const fs = require("node:fs");
+
+let body = fs.readFileSync(0, "utf8");
+const replacements = [
+  [process.argv[1], "$REPO"],
+  [process.argv[2], "$TMP_AUDIT_EVIDENCE"],
+  [process.env.HOME || "", "$HOME"],
+  [process.env.TMPDIR || "", "$TMPDIR"],
+].filter(([value]) => value.length > 0);
+
+for (const [value, replacement] of replacements) {
+  body = body.split(value).join(replacement);
+}
+
+process.stdout.write(body);
+' "$REPO_ROOT" "$TMP_ROOT"
+}
+
+write_config() {
+  local config_path="$1"
+  local bind="$2"
+  mkdir -p "$(dirname "$config_path")"
+  cat >"$config_path" <<JSON
+{
+  "plugins": {
+    "enabled": false
+  },
+  "gateway": {
+    "bind": "$bind",
+    "controlUi": {
+      "enabled": true
+    },
+    "auth": {}
+  }
+}
+JSON
+}
+
+run_case() {
+  local name="$1"
+  local bind="$2"
+  local node_options="${3:-}"
+  local case_dir="$TMP_ROOT/$name"
+  local config_path="$case_dir/openclaw.json"
+  local output_path="$SCRIPT_DIR/$name.json"
+
+  mkdir -p "$case_dir/home" "$case_dir/state"
+  chmod 700 "$case_dir/home" "$case_dir/state"
+  write_config "$config_path" "$bind"
+  chmod 600 "$config_path"
+
+  (
+    cd "$REPO_ROOT"
+    env \
+      HOME="$case_dir/home" \
+      OPENCLAW_HOME="$case_dir/home" \
+      OPENCLAW_STATE_DIR="$case_dir/state" \
+      OPENCLAW_CONFIG_PATH="$config_path" \
+      OPENCLAW_TEST_FAST=1 \
+      OPENCLAW_SKIP_CHANNELS=1 \
+      OPENCLAW_GATEWAY_TOKEN= \
+      OPENCLAW_GATEWAY_PASSWORD= \
+      NODE_OPTIONS="$node_options" \
+      "${OPENCLAW_CMD[@]}" security audit --json
+  ) | redact_json >"$output_path"
+}
+
+CONTAINER_PRELOAD="$TMP_ROOT/simulate-container.cjs"
+cat >"$CONTAINER_PRELOAD" <<'JS'
+const fs = require("node:fs");
+const originalExistsSync = fs.existsSync.bind(fs);
+
+fs.existsSync = function existsSyncWithContainerSentinel(filePath, ...args) {
+  if (
+    filePath === "/.dockerenv" ||
+    filePath === "/run/.containerenv" ||
+    filePath === "/var/run/.containerenv"
+  ) {
+    return true;
+  }
+  return originalExistsSync(filePath, ...args);
+};
+JS
+
+run_case "loopback-bind" "loopback"
+run_case "auto-bind-non-container" "auto"
+run_case "auto-bind-resolves-0.0.0.0" "auto" "--require=$CONTAINER_PRELOAD"

--- a/tools/audit-evidence/loopback-bind.json
+++ b/tools/audit-evidence/loopback-bind.json
@@ -1,0 +1,31 @@
+{
+  "ts": 1778601127806,
+  "summary": {
+    "critical": 1,
+    "warn": 0,
+    "info": 2
+  },
+  "findings": [
+    {
+      "checkId": "summary.attack_surface",
+      "severity": "info",
+      "title": "Attack surface summary",
+      "detail": "groups: open=0, allowlist=0\ntools.elevated: enabled\nhooks.webhooks: disabled\nhooks.internal: disabled\nbrowser control: enabled\ntrust model: personal assistant (one trusted operator boundary), not hostile multi-tenant on one shared gateway"
+    },
+    {
+      "checkId": "gateway.trusted_proxies_missing",
+      "severity": "info",
+      "title": "Trusted proxies not configured on loopback bind",
+      "detail": "gateway.bind=\"loopback\" is loopback-equivalent and gateway.trustedProxies is empty. X-Forwarded-For spoofing is not reachable off-host on a loopback-only bind. If a same-host reverse proxy (nginx, Caddy, systemd socket activation) fronts the Control UI, set gateway.trustedProxies so client-IP and local-client checks stay correct.",
+      "remediation": "If the Control UI is fronted by a same-host reverse proxy, set gateway.trustedProxies to that proxy's IP (often 127.0.0.1/::1). No action required if the Control UI is only reached directly via loopback."
+    },
+    {
+      "checkId": "gateway.loopback_no_auth",
+      "severity": "critical",
+      "title": "Gateway auth missing on loopback",
+      "detail": "gateway.bind=\"loopback\" is loopback-equivalent but no gateway auth secret is configured. If the Control UI is exposed through a reverse proxy, unauthenticated access is possible.",
+      "remediation": "Set gateway.auth (token recommended) or keep the Control UI local-only."
+    }
+  ],
+  "secretDiagnostics": []
+}


### PR DESCRIPTION
## Summary

- Problem: `security audit` always reports `gateway.trusted_proxies_missing` as `warn`, even when `gateway.bind="loopback"`. On a loopback-only bind the port is unreachable off-host, so X-Forwarded-For spoofing is not a real attack path. The check's own detail already called this out, but severity stayed `warn`.
- Why it matters: The default single-operator install (`loopback`, Control UI enabled) sits on a permanent `warn` in every audit run. Users either silence it with a semantically-wrong `trustedProxies=["127.0.0.1"]`, keep the noise, or leak it into local baseline suppressors. All three erode signal-vs-noise in the audit report.
- What changed: `gateway.trusted_proxies_missing` now emits `severity: "info"` when `gateway.bind="loopback"` and `severity: "warn"` when bind is non-loopback (`lan`/`tailnet`/`custom`). The existing branch guarded `bind === "loopback"`; that guard is removed so non-loopback binds with empty `trustedProxies` also surface the finding, keeping the runtime safety posture intact.
- What did NOT change (scope boundary): No other checks are touched. `gateway.loopback_no_auth`, `gateway.bind_no_auth`, and the Control UI origin checks keep their current severities and conditions.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

Security/audit severity taxonomy.

## Linked Issue/PR

- Closes #70357
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the literal `severity: "warn"` inside the `bind === "loopback" && controlUiEnabled && trustedProxies.length === 0` branch at `src/security/audit-gateway-config.ts:147`. The check already established that the risk is latent on loopback but kept the elevated severity.
- Missing detection / guardrail: no context-aware severity on this particular check, and no matching branch for non-loopback binds missing `trustedProxies`.
- Contributing context (if known): the rest of `collectGatewayConfigFindings` already branches on `bind` for severity/conditions (e.g., `gateway.tools_invoke_http.dangerous_allow` uses `extraRisk ? "critical" : "warn"`), so the pattern is familiar in this file.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/security/audit-loopback-logging.test.ts`
- Scenario the test should lock in: (a) loopback + controlUi enabled + empty `trustedProxies` yields `info`; (b) non-loopback (`lan`) + controlUi enabled + empty `trustedProxies` + token auth yields `warn`. The test helper's severity parameter is widened to `"info" | "warn" | "critical"` to express (a).
- Why this is the smallest reliable guardrail: `collectGatewayConfigFindings` is the seam; both branches now run through it and the assertion is on the emitted severity and checkId, not on copy.
- Existing test that already covers this (if any): the loopback-warn case already existed; flipped to expect `info` and added the non-loopback-warn mirror case.
- If no new test is added, why not: N/A (added).

## User-visible / Behavior Changes

- `openclaw security audit` on a default loopback install: `gateway.trusted_proxies_missing` moves from `warn` to `info`. Existing baseline suppressors referencing this checkId continue to work without change.
- `openclaw security audit` with `gateway.bind=lan|tailnet|custom` and empty `trustedProxies`: now surfaces `gateway.trusted_proxies_missing` at `warn`, which the previous check had silenced on non-loopback binds. The existing `gateway.bind_no_auth` critical finding on non-loopback without auth is unchanged.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A. Runtime safety posture is unchanged; only the report severity classification moves. The check now also catches a real gap for non-loopback binds that the old conditional was silencing.

## Repro + Verification

### Environment

- OS: macOS 15 (Darwin 25.3)
- Runtime/container: Node 22, pnpm
- Model/provider: N/A (audit check)
- Integration/channel (if any): N/A
- Relevant config: `gateway.bind="loopback"`, `gateway.controlUi.enabled=true`, `gateway.trustedProxies=[]`.

### Steps

1. `openclaw config get gateway.bind` -> `loopback`
2. `openclaw security audit --json | jq '.findings[] | select(.checkId=="gateway.trusted_proxies_missing")'`

### Expected

Finding with `severity: "info"` titled "Trusted proxies not required on loopback".

### Actual (before this PR)

Finding with `severity: "warn"` titled "Reverse proxy headers are not trusted".

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local checks before push:

- `pnpm test src/security/audit-loopback-logging.test.ts`: 1 file, 1 test pass.
- `pnpm check:changed --staged` (pre-commit): full unit-fast lane runs 43 files, 416 tests, all pass.
- `pnpm format:check` / `pnpm lint:core` on touched files: clean.

## Human Verification (required)

- Verified scenarios:
  - Loopback + controlUi + empty `trustedProxies` yields `info`.
  - `lan` + controlUi + token auth + empty `trustedProxies` yields `warn`.
  - Existing `gateway.loopback_no_auth` `critical` finding still fires on loopback + controlUi + no auth.
  - The `unit-fast` lane (416 tests across 43 files) still passes.
- Edge cases checked: the `lan`-case test sets a placeholder `auth.token` so the `bind_no_auth` critical branch does not mask the expected `trusted_proxies_missing` finding; the assertion is on `trusted_proxies_missing` specifically.
- What I did not verify: whether `tailnet`/`custom` binds emit the new `warn` (behaviorally equivalent branch but untested explicitly here).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes (baseline suppressors keyed on checkId still work; severity downgrade means fewer noisy findings).
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Users who surfaced the old `warn` in dashboards may stop seeing the loopback case.
  - Mitigation: the finding is still emitted as `info`, same checkId; dashboards filtering by severity can include `info` if they want visibility on the loopback case.
- Risk: The new non-loopback `warn` may surface on existing `lan`/`tailnet`/`custom` deployments that had empty `trustedProxies` and were previously silent.
  - Mitigation: the new finding is accurate for those deployments (trustedProxies really is required off-loopback); remediation string points at the fix.
