### PR TITLE
fix: suppress thinking narration leaking into channel messages for Anthropic/Bedrock

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -430,6 +430,7 @@ export function handleMessageUpdate(
   if (evtType === "thinking_start" || evtType === "thinking_delta" || evtType === "thinking_end") {
     if (evtType === "thinking_start" || evtType === "thinking_delta") {
       openReasoningStream(ctx);
+      ctx.state.hadThinkingInMessage = true;
     }
     const thinkingDelta = typeof assistantRecord?.delta === "string" ? assistantRecord.delta : "";
     const thinkingContent =
@@ -485,7 +486,18 @@ export function handleMessageUpdate(
     assistantRecord?.partial && typeof assistantRecord.partial === "object"
       ? (assistantRecord.partial as AssistantMessage)
       : msg;
-  const deliveryPhase = resolveAssistantMessagePhase(partialAssistant);
+  const providerPhase = resolveAssistantMessagePhase(partialAssistant);
+  // When the provider doesn't set a phase (Anthropic/Bedrock), derive it from
+  // thinking state: if thinking blocks were seen in this assistant message, text
+  // that follows is the final answer. Scoped to non-OpenAI-Responses streams
+  // since those attach phase metadata at text_end (providerPhase is temporarily
+  // undefined during text_delta, and forcing final_answer would bypass the
+  // pending-phase guard).
+  const deliveryPhase =
+    providerPhase ??
+    (ctx.state.hadThinkingInMessage && !isOpenAiResponsesAssistantMessage(partialAssistant)
+      ? "final_answer"
+      : undefined);
   const streamItemId = resolveAssistantStreamItemId({
     contentIndex: assistantRecord?.contentIndex,
     message: partialAssistant,

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -63,6 +63,7 @@ export type EmbeddedPiSubscribeState = {
   lastStreamedReasoning?: string;
   lastBlockReplyText?: string;
   reasoningStreamOpen: boolean;
+  hadThinkingInMessage: boolean;
   assistantMessageIndex: number;
   lastAssistantStreamItemId?: string;
   lastAssistantTextMessageIndex: number;

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -148,6 +148,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     lastStreamedReasoning: undefined,
     lastBlockReplyText: undefined,
     reasoningStreamOpen: false,
+    hadThinkingInMessage: false,
     assistantMessageIndex: 0,
     lastAssistantStreamItemId: undefined,
     lastAssistantTextMessageIndex: -1,
@@ -270,6 +271,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     state.lastStreamedReasoning = undefined;
     state.lastReasoningSent = undefined;
     state.reasoningStreamOpen = false;
+    state.hadThinkingInMessage = false;
     state.suppressBlockChunks = false;
     state.pendingAssistantUsage = undefined;
     state.assistantUsageCommitted = false;


### PR DESCRIPTION
## Summary

When an Anthropic or Bedrock model has extended thinking enabled (e.g. `thinking=low`), the structured thinking blocks are correctly intercepted via `thinking_start`/`thinking_delta`/`thinking_end` events and never reach `assistantTexts`. However, any text the model writes as **regular assistant content** alongside thinking — narration like "Let me check..." or reasoning preambles — leaks into the final channel message.

**Root cause:** Anthropic/Bedrock providers don't set the `phase` field on assistant messages. Without a phase, `shouldUsePhaseAwareBlockReply` is `false`, and the streaming path pushes raw `text_delta` chunks directly to block replies and `assistantTexts` without running them through `extractAssistantVisibleText`. This bypasses the phase-aware delivery that would otherwise filter narration from the final answer.

**Fix:** Track whether thinking events were seen in the current assistant message (`hadThinkingInMessage` state flag). When thinking was present and the provider didn't set a phase, derive `deliveryPhase` as `"final_answer"` to activate phase-aware delivery. This causes the `text_end` handler to use `extractAssistantVisibleText` for text extraction, which properly separates thinking blocks from visible text content.

This is a 3-file, 14-line change:
- `pi-embedded-subscribe.handlers.types.ts` — add `hadThinkingInMessage` to state type
- `pi-embedded-subscribe.ts` — initialize and reset the flag
- `pi-embedded-subscribe.handlers.messages.ts` — set flag on `thinking_start`, derive phase from thinking state

## Affected channels

All messaging channels (Slack, Discord, Telegram, etc.) when using Anthropic or Bedrock providers with extended thinking enabled and reasoning visibility set to "off".

## Reproduction

1. Configure an agent with `thinkingDefault: "low"` using an Anthropic model on Bedrock
2. Reasoning visibility is off (default)
3. Trigger a multi-tool-call turn
4. Observe: reasoning/narration text appears at the start of the final Slack message

After this fix, only the model's actual response text is delivered.

## Test plan

- [ ] Verify thinking blocks still route to reasoning stream correctly
- [ ] Verify narration text between tool calls no longer appears in final channel messages
- [ ] Verify non-thinking turns (no thinking blocks) are unaffected (deliveryPhase stays `undefined`)
- [ ] Verify OpenAI transport (which sets `phase` natively) is unaffected (providerPhase takes precedence)
- [ ] Run existing `pi-embedded-subscribe` test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)