### PR TITLE
fix(anthropic): clamp low/minimal effort to medium for github-copilot/opus-4.7

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -40,6 +40,7 @@ function makeAnthropicTransportModel(
   params: {
     id?: string;
     name?: string;
+    provider?: string;
     reasoning?: boolean;
     maxTokens?: number;
     headers?: Record<string, string>;
@@ -51,7 +52,7 @@ function makeAnthropicTransportModel(
       id: params.id ?? "claude-sonnet-4-6",
       name: params.name ?? "Claude Sonnet 4.6",
       api: "anthropic-messages",
-      provider: "anthropic",
+      provider: params.provider ?? "anthropic",
       baseUrl: "https://api.anthropic.com",
       reasoning: params.reasoning ?? true,
       input: ["text"],
@@ -411,6 +412,93 @@ describe("anthropic transport stream", () => {
     expect(latestAnthropicRequest().payload).toMatchObject({
       thinking: { type: "adaptive" },
       output_config: { effort: "xhigh" },
+    });
+  });
+
+  it("clamps low/minimal effort to medium for github-copilot/claude-opus-4.7 (#70322)", async () => {
+    // Regression: github-copilot rejects output_config.effort="low" for
+    // claude-opus-4.7 with 400 invalid_reasoning_effort, which poisons the
+    // auth profile until cooldown clears. Clamp to medium instead of sending
+    // the unsupported value through.
+    for (const reasoning of ["minimal", "low"] as const) {
+      const model = makeAnthropicTransportModel({
+        id: "claude-opus-4-7",
+        name: "Claude Opus 4.7",
+        provider: "github-copilot",
+        maxTokens: 8192,
+      });
+
+      await runTransportStream(
+        model,
+        {
+          messages: [{ role: "user", content: "Quick answer please." }],
+        } as AnthropicStreamContext,
+        {
+          apiKey: "copilot-token",
+          reasoning,
+        } as AnthropicStreamOptions,
+      );
+
+      expect(latestAnthropicRequest().payload).toMatchObject({
+        thinking: { type: "adaptive" },
+        output_config: { effort: "medium" },
+      });
+    }
+  });
+
+  it("does not clamp effort for non-github-copilot providers on claude-opus-4.7", async () => {
+    // The anthropic direct API accepts low/minimal on opus-4.7 — only the
+    // github-copilot surface rejects them. Preserve the user's chosen effort
+    // on the direct path.
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      provider: "anthropic",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Quick." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "low",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+    });
+  });
+
+  it("does not clamp effort for github-copilot on non-opus-4.7 adaptive models", async () => {
+    // Clamp is scoped to opus-4.7 specifically — other adaptive models on
+    // github-copilot may or may not have the same constraint; this fix
+    // doesn't assume they do.
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-6",
+      name: "Claude Opus 4.6",
+      provider: "github-copilot",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Quick." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "copilot-token",
+        reasoning: "low",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
     });
   });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -123,6 +123,31 @@ function supportsAdaptiveThinking(modelId: string): boolean {
   );
 }
 
+/**
+ * Adaptive-thinking models that only accept `medium` effort on some provider
+ * surfaces. GitHub Copilot rejects `low`/`minimal` for claude-opus-4.7 with
+ * 400 invalid_reasoning_effort, which cascades into auth-profile poisoning.
+ * Clamp to the nearest supported value before sending. (#70322)
+ */
+function clampAdaptiveEffortForProvider(params: {
+  provider: string | null | undefined;
+  modelId: string;
+  effort: string;
+}): string {
+  const provider = normalizeLowercaseStringOrEmpty(params.provider ?? "");
+  if (provider !== "github-copilot") {
+    return params.effort;
+  }
+  if (!isClaudeOpus47Model(params.modelId)) {
+    return params.effort;
+  }
+  const effort = normalizeLowercaseStringOrEmpty(params.effort);
+  if (effort === "low" || effort === "minimal") {
+    return "medium";
+  }
+  return params.effort;
+}
+
 function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
   switch (level) {
     case "minimal":
@@ -658,7 +683,13 @@ function buildAnthropicParams(
       if (supportsAdaptiveThinking(model.id)) {
         params.thinking = { type: "adaptive" };
         if (options.effort) {
-          params.output_config = { effort: options.effort };
+          params.output_config = {
+            effort: clampAdaptiveEffortForProvider({
+              provider: model.provider,
+              modelId: model.id,
+              effort: options.effort,
+            }),
+          };
         }
       } else {
         params.thinking = {


### PR DESCRIPTION
## Summary

Fixes #70322. GitHub Copilot's \`claude-opus-4.7\` surface rejects \`output_config.effort\` values of \`low\` or \`minimal\` with:

\`\`\`
400 invalid_reasoning_effort
output_config.effort 'low' is not supported by model claude-opus-4.7; supported values: [medium]
\`\`\`

Any cron-scheduled agentTurn or subagent spawned with reasoning effort = low hits this; the 400 poisons the github-copilot auth profile; every subsequent request on that profile fails with *all in cooldown or unavailable* until cooldown clears. **A single incompatible request effectively takes the whole provider down for a while.**

## Fix

Added \`clampAdaptiveEffortForProvider\` in \`src/agents/anthropic-transport-stream.ts\` — a scoped helper that coerces \`low\`/\`minimal\` to \`medium\` only on the \`github-copilot\` + \`opus-4.7\` combo. Direct-API anthropic callers and other adaptive models (opus-4.6, sonnet-4.6) retain their current behavior.

Mirrors the existing \`OPENAI_MEDIUM_ONLY_REASONING_MODEL_IDS\` remap in \`openai-reasoning-compat.ts\` for the OpenAI-completions path.

## Test

Added 3 regression tests:
1. Clamp applies for both \`low\` and \`minimal\` on \`github-copilot/opus-4.7\` → sends \`medium\`
2. No clamp for \`anthropic/opus-4.7\` (direct API accepts low) → preserves \`low\`
3. No clamp for \`github-copilot/opus-4.6\` (scope guard) → preserves \`low\`

All existing tests pass (extended the test model factory to accept \`provider\` without breaking existing call sites). oxlint clean.

Closes #70322.