### PR TITLE
fix(security): downgrade trusted_proxies_missing to info on loopback bind

### DIFF
--- a/src/security/audit-gateway-config.ts
+++ b/src/security/audit-gateway-config.ts
@@ -143,9 +143,14 @@ export function collectGatewayConfigFindings(
   }
 
   if (bind === "loopback" && controlUiEnabled && trustedProxies.length === 0) {
+    // On loopback-only bind, X-Forwarded-For spoofing requires local-host
+    // access, so the risk is latent rather than active. Report as info to
+    // avoid a permanent warn for single-operator installs that follow the
+    // recommended local-only config. Non-loopback binds keep warn via a
+    // parallel check below. (#70357)
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
-      severity: "warn",
+      severity: "info",
       title: "Reverse proxy headers are not trusted",
       detail:
         "gateway.bind is loopback and gateway.trustedProxies is empty. " +
@@ -153,6 +158,21 @@ export function collectGatewayConfigFindings(
         "so local-client checks cannot be spoofed.",
       remediation:
         "Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.",
+    });
+  }
+  if (bind !== "loopback" && controlUiEnabled && trustedProxies.length === 0) {
+    // Non-loopback bind exposes the Control UI beyond the host, so an empty
+    // trustedProxies allowlist is an active (not latent) spoofing risk.
+    findings.push({
+      checkId: "gateway.trusted_proxies_missing",
+      severity: "warn",
+      title: "Reverse proxy headers are not trusted",
+      detail:
+        `gateway.bind is ${bind} and gateway.trustedProxies is empty. ` +
+        "Local-client checks can be spoofed via X-Forwarded-For when the Control UI is " +
+        "reachable off-host without a vetted reverse-proxy allowlist.",
+      remediation:
+        "Set gateway.trustedProxies to your proxy IPs or switch gateway.bind to loopback.",
     });
   }
 

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -5,7 +5,7 @@ import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js
 
 function hasGatewayFinding(
   checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
-  severity: "warn" | "critical",
+  severity: "info" | "warn" | "critical",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
@@ -23,9 +23,29 @@ describe("security audit loopback and logging findings", () => {
   it("evaluates loopback control UI and logging exposure findings", async () => {
     await Promise.all([
       (async () => {
+        // Regression for #70357: loopback bind downgrades the missing-
+        // trusted-proxies finding to `info` because X-Forwarded-For
+        // spoofing requires local-host access, so the risk is latent.
         const cfg: OpenClawConfig = {
           gateway: {
             bind: "loopback",
+            controlUi: { enabled: true },
+          },
+        };
+        const findings = collectGatewayConfigFindings(cfg, cfg, process.env);
+        expect(
+          hasGatewayFinding("gateway.trusted_proxies_missing", "info", findings),
+        ).toBe(true);
+        expect(
+          hasGatewayFinding("gateway.trusted_proxies_missing", "warn", findings),
+        ).toBe(false);
+      })(),
+      (async () => {
+        // Non-loopback bind keeps warn — off-host exposure makes the
+        // missing allowlist an active spoofing risk.
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "lan",
             controlUi: { enabled: true },
           },
         };


### PR DESCRIPTION
## Summary

Fixes #70357. On \`gateway.bind=loopback\`, the Control UI endpoint is unreachable off-host, so X-Forwarded-For spoofing requires local-host access. The check's own remediation already acknowledges this (*'or keep the Control UI local-only'*), but the severity stays at \`warn\` — leaving single-operator installs that follow the recommended local-only config with a permanent warn.

## Fix

Split the check by bind mode:
- **loopback** → \`info\` (latent risk, user already mitigated)
- **non-loopback** → \`warn\` (active risk, off-host exposure)

Both branches keep the same checkId so existing filters/automation still match.

## Test

Updated the regression test in \`audit-loopback-logging.test.ts\` to lock in the new split:
1. Loopback bind → \`info\` present, \`warn\` absent
2. \`bind: lan\` → \`warn\` present (new case)

The other assertions in the same test (loopback_no_auth, logging.redact_off) unchanged.

Closes #70357.