### PR TITLE
fix(cli): respect OPENCLAW_GATEWAY_TOKEN env var in gateway RPC calls

### DIFF
--- a/src/cli/gateway-rpc.runtime.test.ts
+++ b/src/cli/gateway-rpc.runtime.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: callGatewayMock,
+}));
+
+vi.mock("./progress.js", () => ({
+  withProgress: async (_opts: unknown, run: () => Promise<unknown>) => await run(),
+}));
+
+let callGatewayFromCliRuntime: typeof import("./gateway-rpc.runtime.js").callGatewayFromCliRuntime;
+
+describe("callGatewayFromCliRuntime token resolution (#70365)", () => {
+  const originalEnvToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+
+  beforeEach(async () => {
+    ({ callGatewayFromCliRuntime } = await import("./gateway-rpc.runtime.js"));
+    callGatewayMock.mockReset();
+    callGatewayMock.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    if (originalEnvToken === undefined) {
+      delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    } else {
+      process.env.OPENCLAW_GATEWAY_TOKEN = originalEnvToken;
+    }
+  });
+
+  it("uses OPENCLAW_GATEWAY_TOKEN when --token flag is not passed", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token-123";
+    await callGatewayFromCliRuntime("status", { json: true });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ token: "env-token-123" });
+  });
+
+  it("prefers explicit --token flag over OPENCLAW_GATEWAY_TOKEN env var", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    await callGatewayFromCliRuntime("status", { json: true, token: "flag-token" });
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ token: "flag-token" });
+  });
+
+  it("treats empty-string --token as unset and still falls back to env var", async () => {
+    process.env.OPENCLAW_GATEWAY_TOKEN = "env-token";
+    await callGatewayFromCliRuntime("status", { json: true, token: "" });
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ token: "env-token" });
+  });
+
+  it("passes undefined when neither flag nor env is set", async () => {
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    await callGatewayFromCliRuntime("status", { json: true });
+    expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ token: undefined });
+  });
+});

--- a/src/cli/gateway-rpc.runtime.ts
+++ b/src/cli/gateway-rpc.runtime.ts
@@ -1,7 +1,23 @@
 import { callGateway } from "../gateway/call.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../gateway/protocol/client-info.js";
+import { normalizeOptionalString } from "../shared/string-coerce.js";
 import type { GatewayRpcOpts } from "./gateway-rpc.types.js";
 import { withProgress } from "./progress.js";
+
+/**
+ * Resolve the gateway auth token for a CLI RPC call, preferring the
+ * explicit --token flag and falling back to OPENCLAW_GATEWAY_TOKEN.
+ * The embedded agent already reads this env var at runtime; without
+ * this fallback the CLI side hangs for ~16s before failing unless
+ * users pass --token manually. (#70365)
+ */
+function resolveCliGatewayToken(flagToken: string | undefined): string | undefined {
+  const explicit = normalizeOptionalString(flagToken);
+  if (explicit !== undefined) {
+    return explicit;
+  }
+  return normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN);
+}
 
 export async function callGatewayFromCliRuntime(
   method: string,
@@ -10,6 +26,7 @@ export async function callGatewayFromCliRuntime(
   extra?: { expectFinal?: boolean; progress?: boolean },
 ) {
   const showProgress = extra?.progress ?? opts.json !== true;
+  const token = resolveCliGatewayToken(opts.token);
   return await withProgress(
     {
       label: `Gateway ${method}`,
@@ -19,7 +36,7 @@ export async function callGatewayFromCliRuntime(
     async () =>
       await callGateway({
         url: opts.url,
-        token: opts.token,
+        token,
         method,
         params,
         expectFinal: extra?.expectFinal ?? Boolean(opts.expectFinal),


### PR DESCRIPTION
## Summary

Fixes #70365 (part 1: env-var propagation). The CLI's \`callGatewayFromCliRuntime\` passed the \`--token\` flag value through to \`callGateway\` verbatim, with no fallback to the \`OPENCLAW_GATEWAY_TOKEN\` env var that the embedded agent and much of the rest of the runtime already read (\`src/pairing/setup-code.ts\`, \`src/cli/qr-cli.ts\`, \`src/cli/gateway-cli/run.ts\`).

Result: when the token lives in env, \`openclaw status\` and friends hang for ~16s before failing. The documented workaround is to append \`--token \"\$OPENCLAW_GATEWAY_TOKEN\"\` to every command.

## Fix

Add \`resolveCliGatewayToken(flagToken)\` that falls back to the env var:
1. explicit \`--token\` flag (unchanged behavior when passed)
2. \`OPENCLAW_GATEWAY_TOKEN\` env var (new fallback)
3. undefined (unchanged behavior when nothing is set)

Empty-string \`--token\` is treated as unset so the env fallback still applies — matches how other token-resolver sites in the codebase handle missing values.

## Test

4 new regression tests in \`src/cli/gateway-rpc.runtime.test.ts\` cover: env used when flag absent, flag preferred over env, empty-string flag falls through, both absent ⇒ undefined.

oxlint clean.

## Scope note

Part 2 of #70365 (TLS detection for empty \`gateway.tls: {}\`) is a separate concern in a different file — deliberately scoped out of this PR to keep the diff surgical. Happy to follow up if you'd like both fixed in one land.

Closes #70365 (partial — env propagation only).