### PR TITLE
fix(exec-events): frame async exec completions as assistant-started

### DIFF
--- a/src/infra/heartbeat-events-filter.test.ts
+++ b/src/infra/heartbeat-events-filter.test.ts
@@ -66,6 +66,20 @@ describe("heartbeat event prompts", () => {
       expect(prompt).not.toContain(part);
     }
   });
+
+  it("frames exec events as assistant-started, not user-initiated (#70373)", () => {
+    // Regression: the previous wording ("An async command you ran earlier")
+    // trained the agent to parrot that phrasing back to the user, so
+    // assistant-started background work read as user-initiated in the
+    // Control UI transcript. The new wording must (a) mention the
+    // assistant as the originator, (b) NOT contain the old misleading
+    // phrase, for both delivery modes.
+    for (const deliverToUser of [true, false]) {
+      const prompt = buildExecEventPrompt({ deliverToUser });
+      expect(prompt).toContain("you (the assistant)");
+      expect(prompt).not.toContain("async command you ran earlier");
+    }
+  });
 });
 
 describe("heartbeat event classification", () => {

--- a/src/infra/heartbeat-events-filter.ts
+++ b/src/infra/heartbeat-events-filter.ts
@@ -39,17 +39,26 @@ export function buildCronEventPrompt(
 }
 
 export function buildExecEventPrompt(opts?: { deliverToUser?: boolean }): string {
+  // The agent is the one that kicked off the async command, not the user.
+  // Earlier wording ("An async command you ran earlier") trained the agent
+  // to parrot that phrasing into the user-facing reply, which made
+  // assistant-started background work read as user-initiated in the
+  // Control UI transcript. (#70373) Frame this explicitly as the
+  // assistant's own background work.
   const deliverToUser = opts?.deliverToUser ?? true;
   if (!deliverToUser) {
     return (
-      "An async command you ran earlier has completed. The result is shown in the system messages above. " +
+      "A background command you (the assistant) started earlier has completed. " +
+      "The result is shown in the system messages above. " +
       "Handle the result internally. Do not relay it to the user unless explicitly requested."
     );
   }
   return (
-    "An async command you ran earlier has completed. The result is shown in the system messages above. " +
-    "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +
-    "If it failed, explain what went wrong."
+    "A background command you (the assistant) started earlier has completed. " +
+    "The result is shown in the system messages above. " +
+    "Please relay the command output to the user in a helpful way, framing it as " +
+    "your own follow-up — not as something the user ran. If the command succeeded, " +
+    "share the relevant output. If it failed, explain what went wrong."
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #70373 (part — the wording side). The system-prompt fragment \`buildExecEventPrompt\` in \`src/infra/heartbeat-events-filter.ts\` told the agent:

> An async command you ran earlier has completed.

Read literally, *you* is the agent — but when the agent then relays the result to the user, it parrots that phrasing back into chat, which reads to the user as if *they* started the command:

> An async command you ran earlier has completed...

The assistant is the one that kicked off the background exec (via async tool call). Framing it as user-initiated is confusing in Control UI and can cause alarm when a \`SIGKILL\` surface appears without context.

## Fix

Rephrase both the deliver-to-user and internal-only prompt variants to explicitly frame the command as started by the assistant:

> A background command you (the assistant) started earlier has completed.

For the user-relay mode, also add a nudge asking the agent to frame the output as its own follow-up rather than something the user ran.

## Test

- Existing tests continue to pass unchanged (they assert on the delivery-mode-differentiating substrings \`Please relay the command output to the user\` and \`Handle the result internally\`, both preserved).
- Added one regression test asserting the new framing (\`you (the assistant)\`) is present and the old misleading phrase (\`async command you ran earlier\`) is gone, for both delivery modes.

oxlint clean.

## Scope note

The issue also suggests moving these events out of the main chat transcript entirely (or into a separate system area). That's a broader Control UI change; keeping this PR scoped to the wording fix that addresses the user-facing \"you\" confusion directly. Happy to follow up on the UI-layer separation if the wording fix isn't sufficient.

Closes #70373 (wording side).