### PR TITLE
fix(ui): avoid redundant reload after final chat event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
-- Control UI/WebChat: skip redundant final-event history reloads only when the final payload has an explicit renderable assistant message, while replaying deferred `session.message` reloads for silent or missing final payloads. (#70391) Thanks @cholaolu-boop.
+- Control UI/WebChat: skip redundant final-event history reloads only when the final payload has an explicit renderable assistant message, while replaying deferred same-session `session.message` reloads after final events. (#70391) Thanks @cholaolu-boop / PAAI.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.
 - Onboarding: pin the final QuickStart health check to the just-configured setup token so stale `OPENCLAW_GATEWAY_TOKEN` values or older config tokens do not produce false gateway-token-mismatch failures after setup. Fixes #72203. Thanks @galiniliev.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
+- Control UI/WebChat: skip redundant final-event history reloads only when the final payload has an explicit renderable assistant message, while replaying deferred `session.message` reloads for silent or missing final payloads. (#70391) Thanks @cholaolu-boop.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.
 - Onboarding: pin the final QuickStart health check to the just-configured setup token so stale `OPENCLAW_GATEWAY_TOKEN` values or older config tokens do not produce false gateway-token-mismatch failures after setup. Fixes #72203. Thanks @galiniliev.

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -874,9 +874,10 @@ describe("connectGateway", () => {
     },
   );
 
-  it("does not reload chat history after final assistant payload reconciles an active run", () => {
+  it("does not replay deferred session.message reloads after a locally appendable final assistant event", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "main-run-4";
+    host.chatStream = "Done";
     loadChatHistoryMock.mockClear();
 
     client.emitEvent({
@@ -885,6 +886,9 @@ describe("connectGateway", () => {
         sessionKey: "main",
       },
     });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+
     client.emitEvent({
       event: "chat",
       payload: {
@@ -893,19 +897,19 @@ describe("connectGateway", () => {
         state: "final",
         message: {
           role: "assistant",
-          content: [{ type: "text", text: "Final answer" }],
+          content: [{ type: "text", text: "Done" }],
         },
       },
     });
 
     expect(host.chatRunId).toBeNull();
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
     expect(host.chatMessages).toEqual([
       {
         role: "assistant",
-        content: [{ type: "text", text: "Final answer" }],
+        content: [{ type: "text", text: "Done" }],
       },
     ]);
-    expect(loadChatHistoryMock).not.toHaveBeenCalled();
   });
 
   it("replays deferred session.message reloads after legacy silent final payload", () => {
@@ -938,9 +942,37 @@ describe("connectGateway", () => {
     expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
   });
 
-  it("keeps deferred session.message reload pending across unrelated terminal events", () => {
+  it("replays deferred session.message reloads after a final event without assistant payload", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "main-run-5";
+    loadChatHistoryMock.mockClear();
+
+    client.emitEvent({
+      event: "session.message",
+      payload: {
+        sessionKey: "main",
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "main-run-5",
+        sessionKey: "main",
+        state: "final",
+      },
+    });
+
+    expect(host.chatRunId).toBeNull();
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
+  });
+
+  it("keeps deferred session.message reload pending across unrelated terminal events", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "main-run-6";
     host.chatStream = "still streaming";
     loadChatHistoryMock.mockClear();
 
@@ -950,6 +982,9 @@ describe("connectGateway", () => {
         sessionKey: "main",
       },
     });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+
     client.emitEvent({
       event: "chat",
       payload: {
@@ -960,13 +995,13 @@ describe("connectGateway", () => {
     });
 
     expect(loadChatHistoryMock).not.toHaveBeenCalled();
-    expect(host.chatRunId).toBe("main-run-5");
+    expect(host.chatRunId).toBe("main-run-6");
     expect(host.chatStream).toBe("still streaming");
 
     client.emitEvent({
       event: "chat",
       payload: {
-        runId: "main-run-5",
+        runId: "main-run-6",
         sessionKey: "main",
         state: "aborted",
       },
@@ -1099,6 +1134,33 @@ describe("connectGateway", () => {
     });
 
     expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload chat history after a locally appendable final assistant event", () => {
+    const { host, client } = connectHostGateway();
+    host.chatRunId = "engine-run-2";
+    host.chatStream = "Done";
+
+    client.emitEvent({
+      event: "chat",
+      payload: {
+        runId: "engine-run-2",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+        },
+      },
+    });
+
+    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(host.chatMessages).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "Done" }],
+      },
+    ]);
   });
 });
 

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -874,7 +874,7 @@ describe("connectGateway", () => {
     },
   );
 
-  it("does not replay deferred session.message reloads after a locally appendable final assistant event", () => {
+  it("replays deferred session.message reloads after a locally appendable final assistant event", () => {
     const { host, client } = connectHostGateway();
     host.chatRunId = "main-run-4";
     host.chatStream = "Done";
@@ -903,7 +903,8 @@ describe("connectGateway", () => {
     });
 
     expect(host.chatRunId).toBeNull();
-    expect(loadChatHistoryMock).not.toHaveBeenCalled();
+    expect(loadChatHistoryMock).toHaveBeenCalledTimes(1);
+    expect(loadChatHistoryMock).toHaveBeenCalledWith(host);
     expect(host.chatMessages).toEqual([
       {
         role: "assistant",

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -625,9 +625,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
     payloadSessionKey === host.sessionKey &&
     !host.chatRunId,
   );
-  const shouldReplayDeferredSessionMessageReload =
-    shouldResolveDeferredSessionMessageReload &&
-    (state !== "final" || finalEventNeedsHistoryReload);
+  const shouldReplayDeferredSessionMessageReload = shouldResolveDeferredSessionMessageReload;
   if (shouldResolveDeferredSessionMessageReload) {
     deferredReloadHost.pendingSessionMessageReloadSessionKey = null;
   }

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -45,6 +45,17 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(true);
   });
 
+  it("returns true when final event message has content but no assistant role", () => {
+    expect(
+      shouldReloadHistoryForFinalEvent({
+        runId: "run-1",
+        sessionKey: "main",
+        state: "final",
+        message: { content: [{ type: "text", text: "done" }] },
+      }),
+    ).toBe(true);
+  });
+
   it("returns true when final event includes legacy silent assistant payload", () => {
     expect(
       shouldReloadHistoryForFinalEvent({

--- a/ui/src/ui/chat-event-reload.test.ts
+++ b/ui/src/ui/chat-event-reload.test.ts
@@ -34,7 +34,7 @@ describe("shouldReloadHistoryForFinalEvent", () => {
     ).toBe(false);
   });
 
-  it("returns false when final event includes a legacy assistant text payload without role", () => {
+  it("returns true when final event message has visible text but no assistant role", () => {
     expect(
       shouldReloadHistoryForFinalEvent({
         runId: "run-1",
@@ -42,7 +42,7 @@ describe("shouldReloadHistoryForFinalEvent", () => {
         state: "final",
         message: { text: "done" },
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("returns true when final event includes legacy silent assistant payload", () => {

--- a/ui/src/ui/chat-event-reload.ts
+++ b/ui/src/ui/chat-event-reload.ts
@@ -10,7 +10,7 @@ function hasRenderableAssistantFinalMessage(message: unknown): boolean {
   }
   const entry = message as Record<string, unknown>;
   const role = normalizeLowercaseStringOrEmpty(entry.role);
-  if (role && role !== "assistant") {
+  if (role !== "assistant") {
     return false;
   }
   if (!("content" in entry) && !("text" in entry)) {


### PR DESCRIPTION
## Summary
- keep #70348 as the separate Gateway sanitizer fix
- this patch addresses the remaining UI reload/resync amplifier
- Gateway oversize/placeholder remains separately open as a possible second lever
- the edge cases from review are follow-up items, but not blockers for this patch

## Testing
- pnpm vitest ui/src/ui/chat-event-reload.test.ts ui/src/ui/app-gateway.node.test.ts
