### PR TITLE
fix(mcp): dispose transport before client so stdio children reclaim

### DIFF
--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -79,8 +79,15 @@ async function disposeSession(session: BundleMcpSession) {
   if (session.transportType === "streamable-http") {
     await (session.transport as StreamableHTTPClientTransport).terminateSession().catch(() => {});
   }
-  await session.client.close().catch(() => {});
+  // Close the transport before the client for stdio transports. Closing
+  // client first leaves the stdio child process unreclaimed in practice —
+  // under repeated subagent runs this accumulates minimax-mcp /
+  // minimax-coding-plan-mcp / codex mcp-server children and feeds OOM
+  // pressure. Transport.close() closes its end of the child's stdio pipes,
+  // which lets the child exit cleanly; the client.close() then tears down
+  // the MCP protocol state on a transport that's already dead. (#70389)
   await session.transport.close().catch(() => {});
+  await session.client.close().catch(() => {});
 }
 
 function createCatalogFingerprint(servers: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

Partial fix for #70389 (ordering side). In \`src/agents/pi-bundle-mcp-runtime.ts:disposeSession\`, closing \`session.client\` before \`session.transport\` leaves stdio transport children unreclaimed in practice — the client-level protocol close doesn't itself signal EOF on the child's stdio pipes, and the subsequent \`transport.close\` races the child's own shutdown.

Reporter observed:

\`\`\`json
{
  \"before\":              { \"minimax\": 0, \"minimax_coding\": 0, \"codex\": 0 },
  \"first.after_wait\":    { \"minimax\": 1, \"minimax_coding\": 1, \"codex\": 1 },
  \"second.after_wait\":   { \"minimax\": 2, \"minimax_coding\": 2, \"codex\": 2 }
}
\`\`\`

…with \`minimax-mcp\`, \`minimax-coding-plan-mcp\`, and \`codex mcp-server\` accumulating across subagent runs and feeding OOM pressure in production.

## Fix

Swap the close order:

\`\`\`ts
// before
await session.client.close().catch(() => {});
await session.transport.close().catch(() => {});

// after (this PR)
await session.transport.close().catch(() => {});
await session.client.close().catch(() => {});
\`\`\`

Closing the transport first closes the stdio pipes the child process reads from, letting it exit cleanly. The client.close() then tears down MCP protocol state on a transport that's already dead — safe because \`client.close()\` doesn't require a live transport to return. Reporter verified this makes bundle MCP child count return to zero after run completion in live testing.

## Scope note

The issue also identifies a separate gap — that \`cleanupBundleMcpOnRunEnd\` isn't reliably enabled for \`:subagent:\` sessions — which requires tracing the gateway-ingress agent-opts path and wiring a subagent-detection condition into the ingress layer. That's a broader change in a different file, deferred to a follow-up so this ordering fix lands clean.

## Test

The ordering fix is one line. I checked existing tests in \`pi-bundle-mcp-runtime.test.ts\` which use a mocked \`createRuntime\` so the internals of \`disposeSession\` are not unit-tested — adding coverage for the close order would require exposing \`disposeSession\` on \`__testing\`, which felt disproportionate. Reporter's live-test verification of the bundle-MCP child count returning to zero is the empirical proof.

oxlint clean.

Closes #70389 (ordering fix — the \`cleanupBundleMcpOnRunEnd\` subagent-detection side is intentionally scoped out).