### PR TITLE
fix(memory-core): allow bounded dreaming session cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Memory-core/dreaming: reuse stable narrative subagent session keys per workspace and phase while keeping per-run idempotency and pre-run cleanup, bounding stale `dreaming-narrative-*` session accumulation. Fixes #68252, #69187, and #70402. (#70464) Thanks @chiyouYCH.
 - Docker: run the runtime image under `tini` so long-lived containers reap orphaned child processes and forward signals correctly. (#77885) Thanks @VintageAyu.
 - Google/Gemini: normalize retired `google/gemini-3-pro-preview` and `google-gemini-cli/gemini-3-pro-preview` selections to `google/gemini-3.1-pro-preview` before they are written to model config.
 - Amazon Bedrock: support `serviceTier` parameter for Bedrock models, configurable via `agents.defaults.params.serviceTier` or per-model in `agents.defaults.models`. Valid values: `default`, `flex`, `priority`, `reserved`. (#64512) Thanks @mobilinkd.

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -833,6 +833,7 @@ describe("generateAndAppendDreamNarrative", () => {
   it("falls back to a local narrative when subagent runtime is request-scoped", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");
+    subagent.deleteSession.mockRejectedValueOnce(new RequestScopedSubagentRuntimeError());
     subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
     const logger = createMockLogger();
 
@@ -850,6 +851,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining(workspaceDir));
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("narrative pre-cleanup"));
     expect(logger.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed"),
     );

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -600,7 +600,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
 
     await generateAndAppendDreamNarrative({
       subagent,
@@ -617,7 +617,7 @@ describe("generateAndAppendDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     expect(subagent.run.mock.calls[0][0]).toMatchObject({
-      idempotencyKey: expectedSessionKey,
+      idempotencyKey: `${expectedSessionKey}-${nowMs}`,
       sessionKey: expectedSessionKey,
       lane: `dreaming-narrative:${expectedSessionKey}`,
       lightContext: true,
@@ -625,7 +625,7 @@ describe("generateAndAppendDreamNarrative", () => {
       model: "anthropic/claude-sonnet-4-6",
     });
     expect(subagent.waitForRun).toHaveBeenCalledOnce();
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
 
     const content = await fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8");
     expect(content).toContain("The repository whispered of forgotten endpoints.");
@@ -639,7 +639,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await generateAndAppendDreamNarrative({
@@ -668,8 +668,10 @@ describe("generateAndAppendDreamNarrative", () => {
       sessionKey: retrySessionKey,
       limit: 5,
     });
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
-    expect(subagent.deleteSession).toHaveBeenCalledWith({ sessionKey: retrySessionKey });
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(3);
+    expect(subagent.deleteSession.mock.calls[0]?.[0]).toEqual({ sessionKey: expectedSessionKey });
+    expect(subagent.deleteSession.mock.calls[1]?.[0]).toEqual({ sessionKey: retrySessionKey });
+    expect(subagent.deleteSession.mock.calls[2]?.[0]).toEqual({ sessionKey: retrySessionKey });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("session default"));
   });
 
@@ -685,7 +687,7 @@ describe("generateAndAppendDreamNarrative", () => {
     const logger = createMockLogger();
     const nowMs = Date.parse("2026-04-05T03:00:00Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-rem-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-rem-${workspaceHash}`;
     const retrySessionKey = `${expectedSessionKey}-retry-1`;
 
     await generateAndAppendDreamNarrative({
@@ -706,9 +708,11 @@ describe("generateAndAppendDreamNarrative", () => {
       sessionKey: retrySessionKey,
       limit: 5,
     });
-    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(4);
     expect(subagent.deleteSession.mock.calls[0]?.[0]).toEqual({ sessionKey: expectedSessionKey });
     expect(subagent.deleteSession.mock.calls[1]?.[0]).toEqual({ sessionKey: retrySessionKey });
+    expect(subagent.deleteSession.mock.calls[2]?.[0]).toEqual({ sessionKey: expectedSessionKey });
+    expect(subagent.deleteSession.mock.calls[3]?.[0]).toEqual({ sessionKey: retrySessionKey });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("unknown model"));
   });
 
@@ -733,7 +737,7 @@ describe("generateAndAppendDreamNarrative", () => {
 
     expect(subagent.run).toHaveBeenCalledOnce();
     expect(subagent.waitForRun).not.toHaveBeenCalled();
-    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining("narrative generation failed"),
     );
@@ -849,7 +853,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(logger.warn).not.toHaveBeenCalledWith(
       expect.stringContaining("narrative session cleanup failed"),
     );
-    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
   });
 
   it("falls back when the request-scoped runtime error is detected by stable code", async () => {
@@ -876,7 +880,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(content).toContain("A durable candidate surfaced.");
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
     expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
-    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
   });
 
   it("does not fall back for non-Error objects that only spoof the stable code", async () => {
@@ -1013,8 +1017,11 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(firstSessionKey).not.toBe(secondSessionKey);
     expect(firstSessionKey).toContain("dreaming-narrative-light-");
     expect(secondSessionKey).toContain("dreaming-narrative-light-");
-    expect(subagent.deleteSession.mock.calls[0]?.[0]?.sessionKey).toBe(firstSessionKey);
-    expect(subagent.deleteSession.mock.calls[1]?.[0]?.sessionKey).toBe(secondSessionKey);
+    const deleteKeys = subagent.deleteSession.mock.calls.map(
+      (call: unknown[]) => (call[0] as { sessionKey: string })?.sessionKey,
+    );
+    expect(deleteKeys.filter((key: string) => key === firstSessionKey)).toHaveLength(2);
+    expect(deleteKeys.filter((key: string) => key === secondSessionKey)).toHaveLength(2);
   });
 });
 
@@ -1094,7 +1101,7 @@ describe("runDetachedDreamNarrative", () => {
       d.resolve({ runId: "drain" });
     }
     await vi.waitFor(() => {
-      expect(subagent.deleteSession).toHaveBeenCalledTimes(5);
+      expect(subagent.deleteSession).toHaveBeenCalledTimes(10);
     });
     expect(subagent.run).toHaveBeenCalledTimes(5);
     expect(subagent.waitForRun).toHaveBeenCalledTimes(5);

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -910,9 +910,11 @@ export async function generateAndAppendDreamNarrative(params: {
         try {
           await params.subagent.deleteSession({ sessionKey: attemptSessionKey });
         } catch (preCleanupErr) {
-          params.logger.warn(
-            `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(preCleanupErr)}`,
-          );
+          if (!isRequestScopedSubagentRuntimeError(preCleanupErr)) {
+            params.logger.warn(
+              `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(preCleanupErr)}`,
+            );
+          }
         }
 
         const runId = await startNarrativeRunOrFallback({

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -209,7 +209,7 @@ async function startNarrativeRunOrFallback(params: {
 }): Promise<string | null> {
   try {
     const run = await params.subagent.run({
-      idempotencyKey: params.sessionKey,
+      idempotencyKey: `${params.sessionKey}-${params.nowMs}`,
       sessionKey: params.sessionKey,
       message: params.message,
       ...(params.model ? { model: params.model } : {}),
@@ -248,10 +248,9 @@ async function startNarrativeRunOrFallback(params: {
 function buildNarrativeSessionKey(params: {
   workspaceDir: string;
   phase: NarrativePhaseData["phase"];
-  nowMs: number;
 }): string {
   const workspaceHash = createHash("sha1").update(params.workspaceDir).digest("hex").slice(0, 12);
-  return `dreaming-narrative-${params.phase}-${workspaceHash}-${params.nowMs}`;
+  return `dreaming-narrative-${params.phase}-${workspaceHash}`;
 }
 
 // ── Prompt building ────────────────────────────────────────────────────
@@ -894,7 +893,6 @@ export async function generateAndAppendDreamNarrative(params: {
   const sessionKey = buildNarrativeSessionKey({
     workspaceDir: params.workspaceDir,
     phase: params.data.phase,
-    nowMs,
   });
   const message = buildNarrativePrompt(params.data);
   const attempts: Array<{ sessionKey: string; runId: string | null }> = [];
@@ -908,6 +906,15 @@ export async function generateAndAppendDreamNarrative(params: {
       attempts.push(attempt);
 
       try {
+        // Clear stale context from a previous failed cleanup before reusing any stable attempt key.
+        try {
+          await params.subagent.deleteSession({ sessionKey: attemptSessionKey });
+        } catch (preCleanupErr) {
+          params.logger.warn(
+            `memory-core: narrative pre-cleanup failed for ${params.data.phase} phase: ${formatErrorMessage(preCleanupErr)}`,
+          );
+        }
+
         const runId = await startNarrativeRunOrFallback({
           subagent: params.subagent,
           sessionKey: attemptSessionKey,

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -347,6 +347,7 @@ describe("memory-core dreaming phases", () => {
     expect(dreams).toContain("Move backups to S3 Glacier.");
     expect(logger.error).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
+    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("narrative pre-cleanup"));
     expect(subagent.deleteSession).toHaveBeenCalledOnce();
   });
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -264,7 +264,7 @@ describe("memory-core dreaming phases", () => {
     };
     const nowMs = Date.parse("2026-04-05T10:05:00.000Z");
     const workspaceHash = createHash("sha1").update(workspaceDir).digest("hex").slice(0, 12);
-    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}-${nowMs}`;
+    const expectedSessionKey = `dreaming-narrative-light-${workspaceHash}`;
 
     await runDreamingSweepPhases({
       workspaceDir,
@@ -275,11 +275,12 @@ describe("memory-core dreaming phases", () => {
       nowMs,
     });
 
-    expect(subagent.deleteSession).toHaveBeenCalledOnce();
-    expect(subagent.deleteSession).toHaveBeenCalledWith({ sessionKey: expectedSessionKey });
+    expect(subagent.deleteSession).toHaveBeenCalledTimes(2);
+    expect(subagent.deleteSession).toHaveBeenNthCalledWith(1, { sessionKey: expectedSessionKey });
+    expect(subagent.deleteSession).toHaveBeenNthCalledWith(2, { sessionKey: expectedSessionKey });
   });
 
-  it("skips session cleanup after request-scoped narrative fallback", async () => {
+  it("swallows synchronous request-scoped cleanup failures after narrative fallback", async () => {
     const workspaceDir = await createDreamingWorkspace();
     await writeDailyNote(workspaceDir, [
       `# ${DREAMING_TEST_DAY}`,
@@ -346,11 +347,7 @@ describe("memory-core dreaming phases", () => {
     expect(dreams).toContain("Move backups to S3 Glacier.");
     expect(logger.error).not.toHaveBeenCalled();
     expect(logger.info).toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
-    expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining("request-scoped"));
-    expect(logger.warn).not.toHaveBeenCalledWith(
-      expect.stringContaining("narrative session cleanup failed"),
-    );
-    expect(subagent.deleteSession).not.toHaveBeenCalled();
+    expect(subagent.deleteSession).toHaveBeenCalledOnce();
   });
 
   it("does not re-ingest managed light dreaming blocks from daily notes", async () => {


### PR DESCRIPTION
## Summary

Fixes the remaining dreaming narrative session pollution path without changing the Gateway plugin-owned cleanup contract:

- keep `dreaming-narrative-*` session keys stable per workspace + phase, instead of embedding `nowMs` in the session key
- keep per-run deduplication by moving `nowMs` into the subagent `idempotencyKey`
- pre-clean the stable narrative session before each run so stale prior context cannot leak into the next dream narrative
- preserve the existing final best-effort cleanup and the current generic plugin-owned `sessions.delete` behavior; this revision intentionally does not touch `src/gateway/*`

This is intended to address the cleanup failure and UI/session-store leak reported in #68252, #69187, and #70402 while keeping the fix scoped to bundled `memory-core` behavior.

## Tests

- API dry-run transform against latest upstream `main` verified the final PR diff is limited to `CHANGELOG.md` and `extensions/memory-core/src/*`.
- GitHub Actions is the official validation path for this PR branch after rebasing onto latest `main`.
- Current `check-prod-types` / `check-test-types` failures are inherited from main commit `2e78fc57` in unrelated `extensions/codex` and `extensions/microsoft-foundry` files, matching the main-branch CI note on `d4e04f33`.

## Real behavior proof

Behavior or issue addressed: Memory-core dreaming narrative sessions should be bounded by workspace and phase. Repeated dreaming sweeps for the same workspace/phase should reuse the same `dreaming-narrative-*` session key while still using timestamp-specific idempotency keys so separate sweeps do not dedupe incorrectly. Stale prior narrative context should be removed before the next run.

Real environment tested: Isolated local OpenClaw workspace and session store used while preparing this repair, separate from my normal OpenClaw service. The local smoke used the installed package hotfix path equivalent to this PR's memory-core session-key/idempotency/pre-cleanup behavior.

Exact steps or command run after this patch:
1. Applied the equivalent memory-core hotfix in the isolated OpenClaw package/workspace.
2. Probed the narrative session-key builder with the same workspace/phase and different timestamps.
3. Probed the same phase across different workspaces.
4. Restarted the isolated OpenClaw gateway and checked daemon health/connectivity.
5. Deleted existing `dreaming-narrative-*` sessions through the plugin subagent `sessions.delete` path and recounted the session store.

Evidence after fix:
```text
openclaw daemon status => running
connectivity=ok
admin_capable=true
stable_key_same_workspace=true
isolated_key_across_workspaces=true
idempotency_key_1=dreaming-narrative-light-<workspace-hash>-1775338800000
idempotency_key_2=dreaming-narrative-light-<workspace-hash>-1775425200000
deleted_session_prefix=dreaming-narrative-
dreaming_session_count=0
```

Observed result after fix: The narrative session key stayed stable for the same workspace and phase across timestamps, remained different across workspaces, and the isolated session store reached `dreaming_session_count=0` after deleting stale `dreaming-narrative-*` sessions. This confirms the repair bounds session accumulation without removing per-run idempotency.

What was not tested: I did not run a full production dreaming cron sweep against a real user workspace in this PR because that would mutate private memory/dream diary state. The official GitHub Actions matrix covers type, lint, boundary, and unit-test validation for the submitted branch.