### PR TITLE
fix(gateway): exit non-zero on supervised restart so systemd Restart=on-failure recovers

### DIFF
--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -400,8 +400,8 @@ describe("runGatewayLoop", () => {
         const startedAt = Date.now();
 
         sigusr1();
-        await expect(exited).resolves.toBe(0);
-        expect(runtime.exit).toHaveBeenCalledWith(0);
+        await expect(exited).resolves.toBe(1);
+        expect(runtime.exit).toHaveBeenCalledWith(1);
         expect(Date.now() - startedAt).toBeGreaterThanOrEqual(1400);
       });
     } finally {

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -76,23 +76,23 @@ export async function runGatewayLoop(params: {
     const hadLock = await releaseLockIfHeld();
     // Release the lock BEFORE spawning so the child can acquire it immediately.
     const respawn = restartGatewayProcessWithFreshPid();
-    if (respawn.mode === "spawned" || respawn.mode === "supervised") {
-      const modeLabel =
-        respawn.mode === "spawned"
-          ? `spawned pid ${respawn.pid ?? "unknown"}`
-          : "supervisor restart";
-      gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
-      if (
-        respawn.mode === "supervised" &&
-        detectRespawnSupervisor(process.env, process.platform) === "launchd"
-      ) {
+    if (respawn.mode === "spawned") {
+      gatewayLog.info(`restart mode: full process restart (spawned pid ${respawn.pid ?? "unknown"})`);
+      exitProcess(0);
+      return;
+    }
+    if (respawn.mode === "supervised") {
+      gatewayLog.info("restart mode: full process restart (supervisor restart)");
+      if (detectRespawnSupervisor(process.env, process.platform) === "launchd") {
         // A short clean-exit pause keeps rapid SIGUSR1/config restarts from
         // tripping launchd crash-loop throttling before KeepAlive relaunches.
         await new Promise((resolve) => {
           setTimeout(resolve, LAUNCHD_SUPERVISED_RESTART_EXIT_DELAY_MS);
         });
       }
-      exitProcess(0);
+      // Exit non-zero so systemd Restart=on-failure restarts the service.
+      // KeepAlive on launchd ignores exit code and restarts regardless.
+      exitProcess(1);
       return;
     }
     if (respawn.mode === "failed") {


### PR DESCRIPTION
After update.run / SIGUSR1 supervisor restart, the gateway exited with code 0.
When running under systemd with Restart=on-failure (the default), a clean exit
does not trigger a restart, leaving the gateway dead until manual intervention.

Exit code 1 instead so Restart=on-failure restarts the service. KeepAlive on
launchd ignores exit code and is unaffected. The spawned (non-supervised) case
contin to exit 0 as the detached child takes over as the new gateway.

Closes #70354