### PR TITLE
Feishu: harden comment reply delivery and bot identity refresh

### DIFF
--- a/extensions/feishu/src/comment-delivery-guard.test.ts
+++ b/extensions/feishu/src/comment-delivery-guard.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  hasFeishuCommentConversationDelivery,
+  recordFeishuCommentConversationDelivery,
+  resetFeishuCommentConversationDeliveriesForTest,
+} from "./comment-delivery-guard.js";
+
+describe("comment delivery guard", () => {
+  beforeEach(() => {
+    resetFeishuCommentConversationDeliveriesForTest();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-23T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    resetFeishuCommentConversationDeliveriesForTest();
+    vi.useRealTimers();
+  });
+
+  it("trims the soonest-to-expire entries first when the guard exceeds its cap", () => {
+    for (let index = 0; index < 100; index += 1) {
+      recordFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: `comment:docx:doc_token_1:early_${index}`,
+        threadId: `reply_early_${index}`,
+      });
+    }
+
+    vi.setSystemTime(new Date("2026-04-23T00:00:20.000Z"));
+    recordFeishuCommentConversationDelivery({
+      accountId: "default",
+      to: "comment:docx:doc_token_1:keep_late",
+      threadId: "reply_keep_late",
+    });
+
+    vi.setSystemTime(new Date("2026-04-23T00:00:10.000Z"));
+    recordFeishuCommentConversationDelivery({
+      accountId: "default",
+      to: "comment:docx:doc_token_1:drop_soon",
+      threadId: "reply_drop_soon",
+    });
+
+    vi.setSystemTime(new Date("2026-04-23T00:00:30.000Z"));
+    for (let index = 0; index < 899; index += 1) {
+      recordFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: `comment:docx:doc_token_1:filler_${index}`,
+        threadId: `reply_filler_${index}`,
+      });
+    }
+
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_token_1:drop_soon",
+        threadId: "reply_drop_soon",
+      }),
+    ).toBe(false);
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_token_1:keep_late",
+        threadId: "reply_keep_late",
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/feishu/src/comment-delivery-guard.ts
+++ b/extensions/feishu/src/comment-delivery-guard.ts
@@ -1,0 +1,117 @@
+/**
+ * Process-local TTL guard for Feishu comment delivery deduplication.
+ *
+ * This only suppresses duplicate deliveries within the current Node.js process.
+ * Single-instance deployments are covered by this in-memory map. If Feishu
+ * comment handling ever runs across multiple replicas, cross-instance dedup
+ * needs a distributed backend instead of this local guard.
+ */
+const COMMENT_DELIVERY_GUARD_TTL_MS = 10 * 60 * 1000;
+const COMMENT_DELIVERY_GUARD_MAX_ENTRIES = 1000;
+const COMMENT_DELIVERY_GUARD_TRIM_TO_ENTRIES = 900;
+
+function normalizeCommentDeliveryGuardValue(value: string | number | undefined | null): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function buildCommentDeliveryGuardKey(params: {
+  accountId?: string | null;
+  to?: string | null;
+  threadId?: string | number | null;
+}): string | null {
+  const accountId = normalizeCommentDeliveryGuardValue(params.accountId);
+  const to = normalizeCommentDeliveryGuardValue(params.to);
+  const threadId = normalizeCommentDeliveryGuardValue(params.threadId) || "_";
+  if (!accountId || !to) {
+    return null;
+  }
+  return `${accountId}::${to}::${threadId}`;
+}
+
+const completedCommentConversationDeliveries = new Map<string, number>();
+
+function pruneExpiredCommentConversationDeliveries(now: number): void {
+  for (const [key, expiresAt] of completedCommentConversationDeliveries) {
+    if (expiresAt > now) {
+      continue;
+    }
+    completedCommentConversationDeliveries.delete(key);
+  }
+}
+
+function enforceCommentConversationDeliveryCap(): void {
+  if (completedCommentConversationDeliveries.size <= COMMENT_DELIVERY_GUARD_MAX_ENTRIES) {
+    return;
+  }
+
+  const entriesByExpiry = [...completedCommentConversationDeliveries.entries()].toSorted(
+    ([, leftExpiresAt], [, rightExpiresAt]) => leftExpiresAt - rightExpiresAt,
+  );
+  const entriesToDelete =
+    completedCommentConversationDeliveries.size - COMMENT_DELIVERY_GUARD_TRIM_TO_ENTRIES;
+
+  for (let index = 0; index < entriesToDelete; index += 1) {
+    const next = entriesByExpiry[index];
+    if (!next) {
+      break;
+    }
+    completedCommentConversationDeliveries.delete(next[0]);
+  }
+}
+
+export function recordFeishuCommentConversationDelivery(params: {
+  accountId?: string | null;
+  to?: string | null;
+  threadId?: string | number | null;
+}): void {
+  const key = buildCommentDeliveryGuardKey(params);
+  if (!key) {
+    return;
+  }
+  const now = Date.now();
+  pruneExpiredCommentConversationDeliveries(now);
+  completedCommentConversationDeliveries.delete(key);
+  completedCommentConversationDeliveries.set(key, now + COMMENT_DELIVERY_GUARD_TTL_MS);
+  enforceCommentConversationDeliveryCap();
+}
+
+export function hasFeishuCommentConversationDelivery(params: {
+  accountId?: string | null;
+  to?: string | null;
+  threadId?: string | number | null;
+}): boolean {
+  const key = buildCommentDeliveryGuardKey(params);
+  if (!key) {
+    return false;
+  }
+  const now = Date.now();
+  pruneExpiredCommentConversationDeliveries(now);
+  const expiresAt = completedCommentConversationDeliveries.get(key);
+  if (!expiresAt) {
+    return false;
+  }
+  if (expiresAt <= now) {
+    completedCommentConversationDeliveries.delete(key);
+    return false;
+  }
+  return true;
+}
+
+export function clearFeishuCommentConversationDelivery(params: {
+  accountId?: string | null;
+  to?: string | null;
+  threadId?: string | number | null;
+}): void {
+  const key = buildCommentDeliveryGuardKey(params);
+  if (!key) {
+    return;
+  }
+  completedCommentConversationDeliveries.delete(key);
+}
+
+export function resetFeishuCommentConversationDeliveriesForTest(): void {
+  completedCommentConversationDeliveries.clear();
+}

--- a/extensions/feishu/src/comment-dispatcher.test.ts
+++ b/extensions/feishu/src/comment-dispatcher.test.ts
@@ -1,4 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  recordFeishuCommentConversationDelivery,
+  resetFeishuCommentConversationDeliveriesForTest,
+} from "./comment-delivery-guard.js";
 
 const resolveFeishuRuntimeAccountMock = vi.hoisted(() => vi.fn());
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
@@ -64,6 +68,7 @@ describe("createFeishuCommentReplyDispatcher", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetFeishuCommentConversationDeliveriesForTest();
     resolveFeishuRuntimeAccountMock.mockReturnValue({
       accountId: "main",
       appId: "app_id",
@@ -165,5 +170,30 @@ describe("createFeishuCommentReplyDispatcher", () => {
     await options.onReplyStart?.();
 
     expect(start).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses automatic final comment text after tool-driven delivery in the same comment flow", async () => {
+    recordFeishuCommentConversationDelivery({
+      accountId: "main",
+      to: "comment:docx:doc_token_1:comment_1",
+      threadId: "reply_1",
+    });
+
+    createFeishuCommentReplyDispatcher({
+      cfg: {} as never,
+      agentId: "main",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      accountId: "main",
+      fileToken: "doc_token_1",
+      fileType: "docx",
+      commentId: "comment_1",
+      replyId: "reply_1",
+      isWholeComment: false,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0];
+    await options.deliver({ text: "should be suppressed" }, { kind: "final" });
+
+    expect(deliverCommentThreadTextMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/comment-dispatcher.ts
+++ b/extensions/feishu/src/comment-dispatcher.ts
@@ -1,6 +1,7 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { hasFeishuCommentConversationDelivery } from "./comment-delivery-guard.js";
 import {
   createReplyPrefixContext,
   type ClawdbotConfig,
@@ -8,6 +9,7 @@ import {
   type RuntimeEnv,
 } from "./comment-dispatcher-runtime-api.js";
 import { createCommentTypingReactionLifecycle } from "./comment-reaction.js";
+import { buildFeishuCommentTarget } from "./comment-target.js";
 import type { CommentFileType } from "./comment-target.js";
 import { deliverCommentThreadText } from "./drive.js";
 import { getFeishuRuntime } from "./runtime.js";
@@ -28,6 +30,11 @@ export function createFeishuCommentReplyDispatcher(
   params: CreateFeishuCommentReplyDispatcherParams,
 ) {
   const core = getFeishuRuntime();
+  const commentTarget = buildFeishuCommentTarget({
+    fileType: params.fileType,
+    fileToken: params.fileToken,
+    commentId: params.commentId,
+  });
   const prefixContext = createReplyPrefixContext({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -73,6 +80,19 @@ export function createFeishuCommentReplyDispatcher(
               `feishu[${params.accountId ?? "default"}]: comment reply ignored media-only payload for comment=${params.commentId}`,
             );
           }
+          return;
+        }
+        if (
+          hasFeishuCommentConversationDelivery({
+            accountId: params.accountId,
+            to: commentTarget,
+            threadId: params.replyId,
+          })
+        ) {
+          params.runtime.log?.(
+            `feishu[${params.accountId ?? "default"}]: suppressing automatic comment final reply ` +
+              `after successful tool delivery for comment=${params.commentId}`,
+          );
           return;
         }
         const chunks = core.channel.text.chunkTextWithMode(reply.text, textChunkLimit, chunkMode);

--- a/extensions/feishu/src/comment-handler.ts
+++ b/extensions/feishu/src/comment-handler.ts
@@ -1,6 +1,7 @@
 import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { clearFeishuCommentConversationDelivery } from "./comment-delivery-guard.js";
 import { createFeishuCommentReplyDispatcher } from "./comment-dispatcher.js";
 import {
   createChannelPairingController,
@@ -90,9 +91,9 @@ export async function handleFeishuCommentEvent(
     dmPolicy !== "allowlist" && dmPolicy !== "open"
       ? await pairing.readAllowFromStore().catch(() => [])
       : [];
-  const effectiveDmAllowFrom = [...configAllowFrom, ...storeAllowFrom];
+  const effectiveAllowFrom = [...configAllowFrom, ...storeAllowFrom];
   const senderAllowed = resolveFeishuAllowlistMatch({
-    allowFrom: effectiveDmAllowFrom,
+    allowFrom: effectiveAllowFrom,
     senderId: turn.senderId,
     senderIds: [turn.senderUserId],
   }).allowed;
@@ -252,6 +253,11 @@ export async function handleFeishuCommentEvent(
         `(queuedFinal=${queuedFinal}, replies=${counts.final}, session=${commentSessionKey})`,
     );
   } finally {
+    clearFeishuCommentConversationDelivery({
+      accountId: account.accountId,
+      to: commentTarget,
+      threadId: turn.replyId,
+    });
     markRunComplete();
     markDispatchIdle();
     void cleanupTypingReaction();

--- a/extensions/feishu/src/comment-reaction.test.ts
+++ b/extensions/feishu/src/comment-reaction.test.ts
@@ -43,6 +43,7 @@ describe("createCommentTypingReactionLifecycle", () => {
       fileToken: "doc_token_1",
       fileType: "docx",
       replyId: args.length === 0 ? "reply_1" : args[0],
+      accountId: "default",
       runtime: {
         log: vi.fn(),
       } as never,
@@ -55,6 +56,7 @@ describe("createCommentTypingReactionLifecycle", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doc_token_1:comment_1",
+        accountId: "default",
         threadId: "reply_1",
       },
     });
@@ -139,6 +141,153 @@ describe("createCommentTypingReactionLifecycle", () => {
 
     await lifecycle.start();
     await cleanupAmbientReply();
+    await lifecycle.cleanup();
+
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: {
+          action: "delete",
+          reply_id: "reply_1",
+          reaction_type: "Typing",
+        },
+      }),
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        data: {
+          action: "delete",
+          reply_id: "reply_1",
+          reaction_type: "Typing",
+        },
+      }),
+    );
+  });
+
+  it("isolates typing cleanup state per account for the same reply", async () => {
+    resolveFeishuRuntimeAccountMock
+      .mockReturnValueOnce({
+        accountId: "backup",
+        configured: true,
+        config: {
+          typingIndicator: true,
+        },
+      })
+      .mockReturnValueOnce({
+        accountId: "default",
+        configured: true,
+        config: {
+          typingIndicator: true,
+        },
+      })
+      .mockReturnValueOnce({
+        accountId: "default",
+        configured: true,
+        config: {
+          typingIndicator: true,
+        },
+      })
+      .mockReturnValueOnce({
+        accountId: "backup",
+        configured: true,
+        config: {
+          typingIndicator: true,
+        },
+      });
+
+    const backupLifecycle = createCommentTypingReactionLifecycle({
+      cfg: {} as ClawdbotConfig,
+      fileToken: "doc_token_1",
+      fileType: "docx",
+      replyId: "reply_1",
+      accountId: "backup",
+      runtime: {
+        log: vi.fn(),
+      } as never,
+    });
+    const defaultLifecycle = createCommentTypingReactionLifecycle({
+      cfg: {} as ClawdbotConfig,
+      fileToken: "doc_token_1",
+      fileType: "docx",
+      replyId: "reply_1",
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+      } as never,
+    });
+
+    await backupLifecycle.start();
+    await defaultLifecycle.start();
+    await cleanupAmbientCommentTypingReaction({
+      client: { request } as never,
+      deliveryContext: {
+        channel: "feishu",
+        to: "comment:docx:doc_token_1:comment_1",
+        accountId: "default",
+        threadId: "reply_1",
+      },
+    });
+    await backupLifecycle.cleanup();
+
+    expect(request).toHaveBeenCalledTimes(4);
+    expect(request).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        data: {
+          action: "delete",
+          reply_id: "reply_1",
+          reaction_type: "Typing",
+        },
+      }),
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        data: {
+          action: "delete",
+          reply_id: "reply_1",
+          reaction_type: "Typing",
+        },
+      }),
+    );
+    expect(resolveFeishuRuntimeAccountMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ accountId: "backup" }),
+    );
+    expect(resolveFeishuRuntimeAccountMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ accountId: "default" }),
+    );
+    expect(resolveFeishuRuntimeAccountMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ accountId: "backup" }),
+    );
+  });
+
+  it("falls back to direct ambient cleanup when accountId is missing", async () => {
+    const lifecycle = createCommentTypingReactionLifecycle({
+      cfg: {} as ClawdbotConfig,
+      fileToken: "doc_token_1",
+      fileType: "docx",
+      replyId: "reply_1",
+      runtime: {
+        log: vi.fn(),
+      } as never,
+    });
+
+    await lifecycle.start();
+    await expect(
+      cleanupAmbientCommentTypingReaction({
+        client: { request } as never,
+        deliveryContext: {
+          channel: "feishu",
+          to: "comment:docx:doc_token_1:comment_1",
+          threadId: "reply_1",
+        },
+      }),
+    ).resolves.toBe(true);
     await lifecycle.cleanup();
 
     expect(request).toHaveBeenCalledTimes(3);

--- a/extensions/feishu/src/comment-reaction.ts
+++ b/extensions/feishu/src/comment-reaction.ts
@@ -25,11 +25,16 @@ type FeishuCommentReactionClient = ReturnType<typeof createFeishuClient> & {
 };
 
 function buildCommentTypingReactionKey(params: {
+  accountId?: string;
   fileToken: string;
   fileType: CommentFileType;
   replyId: string;
-}): string {
-  return `${params.fileType}:${params.fileToken}:${params.replyId}`;
+}): string | null {
+  const accountId = params.accountId?.trim();
+  if (!accountId) {
+    return null;
+  }
+  return `${accountId}:${params.fileType}:${params.fileToken}:${params.replyId}`;
 }
 
 function ensureCommentTypingReactionState(key: string) {
@@ -163,6 +168,7 @@ export async function cleanupAmbientCommentTypingReaction(params: {
   deliveryContext?: {
     channel?: string;
     to?: string;
+    accountId?: string;
     threadId?: string | number;
   };
   runtime?: RuntimeEnv;
@@ -184,10 +190,26 @@ export async function cleanupAmbientCommentTypingReaction(params: {
     return false;
   }
   const key = buildCommentTypingReactionKey({
+    accountId: deliveryContext?.accountId,
     fileToken: target.fileToken,
     fileType: target.fileType,
     replyId,
   });
+  if (!key) {
+    // Preserve visible Typing cleanup for older callers that still omit
+    // accountId from deliveryContext. Shared-state dedupe is unavailable
+    // without an account-scoped key, but a direct delete still clears the
+    // remote reaction for the current client.
+    return await requestCommentTypingReactionWithClient({
+      client: params.client,
+      fileToken: target.fileToken,
+      fileType: target.fileType,
+      replyId,
+      action: "delete",
+      runtime: params.runtime,
+      logPrefix: "[feishu]",
+    });
+  }
   return cleanupCommentTypingReactionByKey({
     key,
     performDelete: () =>
@@ -211,19 +233,35 @@ export function createCommentTypingReactionLifecycle(params: {
   accountId?: string;
   runtime?: RuntimeEnv;
 }) {
-  const key = params.replyId?.trim()
+  const replyId = params.replyId?.trim();
+  const key = replyId
     ? buildCommentTypingReactionKey({
+        accountId: params.accountId,
         fileToken: params.fileToken,
         fileType: params.fileType,
-        replyId: params.replyId.trim(),
+        replyId,
       })
-    : undefined;
+    : null;
   const state = key ? ensureCommentTypingReactionState(key) : undefined;
 
   return {
     start: async (): Promise<void> => {
-      const replyId = params.replyId?.trim();
-      if (!state || state.cleaned || state.active || !replyId) {
+      if (!replyId) {
+        return;
+      }
+      if (!state) {
+        await requestCommentTypingReaction({
+          cfg: params.cfg,
+          fileToken: params.fileToken,
+          fileType: params.fileType,
+          replyId,
+          action: "add",
+          accountId: params.accountId,
+          runtime: params.runtime,
+        });
+        return;
+      }
+      if (state.cleaned || state.active) {
         return;
       }
       state.active = await requestCommentTypingReaction({
@@ -237,8 +275,19 @@ export function createCommentTypingReactionLifecycle(params: {
       });
     },
     cleanup: async (): Promise<void> => {
-      const replyId = params.replyId?.trim();
-      if (!key || !replyId) {
+      if (!replyId) {
+        return;
+      }
+      if (!key) {
+        await requestCommentTypingReaction({
+          cfg: params.cfg,
+          fileToken: params.fileToken,
+          fileType: params.fileType,
+          replyId,
+          action: "delete",
+          accountId: params.accountId,
+          runtime: params.runtime,
+        });
         return;
       }
       await cleanupCommentTypingReactionByKey({

--- a/extensions/feishu/src/drive-schema.test.ts
+++ b/extensions/feishu/src/drive-schema.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { FeishuDriveSchema } from "./drive-schema.js";
+
+type SchemaObjectWithProperties = {
+  properties?: Record<string, { const?: string; description?: string } | undefined>;
+};
+
+describe("FeishuDriveSchema", () => {
+  it("documents add_comment ambient thread compatibility", () => {
+    const addCommentSchema = FeishuDriveSchema.anyOf.find(
+      (item) => item?.properties?.action?.const === "add_comment",
+    ) as SchemaObjectWithProperties | undefined;
+
+    expect(addCommentSchema).toBeDefined();
+    expect(addCommentSchema?.properties?.file_type?.description).toContain(
+      "may be delivered as a follow-up reply",
+    );
+    expect(addCommentSchema?.properties?.block_id?.description).toContain(
+      "outside an ambient comment-thread flow",
+    );
+  });
+});

--- a/extensions/feishu/src/drive-schema.ts
+++ b/extensions/feishu/src/drive-schema.ts
@@ -69,14 +69,15 @@ export const FeishuDriveSchema = Type.Union([
     file_token: Type.String({ description: "Document token" }),
     file_type: Type.Optional(
       Type.Union([Type.Literal("doc"), Type.Literal("docx")], {
-        description: "Document type. Defaults to docx when omitted.",
+        description:
+          "Document type. Defaults to docx when omitted. In the current local comment-thread context on the same doc/docx file without block_id, add_comment may be delivered as a follow-up reply instead of a new top-level comment.",
       }),
     ),
     content: Type.String({ description: "Comment text content" }),
     block_id: Type.Optional(
       Type.String({
         description:
-          "Optional docx block id for a local comment. Omit to create a full-document comment.",
+          "Optional docx block id for a local comment. When omitted outside an ambient comment-thread flow, this creates a whole-document comment.",
       }),
     ),
   }),

--- a/extensions/feishu/src/drive.test.ts
+++ b/extensions/feishu/src/drive.test.ts
@@ -1,6 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTestPluginApi } from "../../../test/helpers/plugins/plugin-api.js";
 import type { OpenClawPluginApi, PluginRuntime } from "../runtime-api.js";
+import {
+  hasFeishuCommentConversationDelivery,
+  resetFeishuCommentConversationDeliveriesForTest,
+} from "./comment-delivery-guard.js";
 
 const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
 const resolveAnyEnabledFeishuToolsConfigMock = vi.hoisted(() => vi.fn());
@@ -45,6 +49,7 @@ describe("registerFeishuDriveTools", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetFeishuCommentConversationDeliveriesForTest();
     resolveAnyEnabledFeishuToolsConfigMock.mockReturnValue({
       doc: false,
       chat: false,
@@ -265,6 +270,91 @@ describe("registerFeishuDriveTools", () => {
     );
     expect(replyCommentResult.details).toEqual(
       expect.objectContaining({ success: true, reply_id: "r4" }),
+    );
+  });
+
+  it("escapes angle brackets in add_comment and reply_comment content", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({ agentAccountId: undefined });
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: { comment_id: "c-escaped" },
+    });
+    await tool.execute("call-add-escaped", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      content: "before <tag> after",
+    });
+
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "before &lt;tag&gt; after" }],
+        },
+      }),
+    );
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ comment_id: "c1", is_whole: false }],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { reply_id: "r-escaped" },
+      });
+    await tool.execute("call-reply-escaped", {
+      action: "reply_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      comment_id: "c1",
+      content: "before <tag> after",
+    });
+
+    expect(requestMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
+        params: { file_type: "docx" },
+        data: {
+          content: {
+            elements: [
+              {
+                type: "text_run",
+                text_run: {
+                  text: "before &lt;tag&gt; after",
+                },
+              },
+            ],
+          },
+        },
+      }),
     );
   });
 
@@ -521,6 +611,7 @@ describe("registerFeishuDriveTools", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doc_1:c1",
+        accountId: "default",
         threadId: "reply_ambient_1",
       },
     });
@@ -590,18 +681,29 @@ describe("registerFeishuDriveTools", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doc_1:c1",
+        accountId: "default",
         threadId: "reply_ambient_1",
       },
     });
     const replyCommentResult = await replyCommentPromise;
     expect(replyCommentResult.details).toEqual(
-      expect.objectContaining({ success: true, reply_id: "r6" }),
+      expect.objectContaining({
+        success: true,
+        reply_id: "r6",
+      }),
     );
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_1:c1",
+        threadId: "reply_ambient_1",
+      }),
+    ).toBe(true);
 
     resolveCleanup?.(false);
   });
 
-  it("does not wait for ambient typing cleanup before add_comment sends visible output", async () => {
+  it("rewrites ambient local-comment add_comment calls into reply_comment delivery", async () => {
     const registerTool = vi.fn();
     registerFeishuDriveTools(
       createDriveToolApi({
@@ -625,14 +727,22 @@ describe("registerFeishuDriveTools", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doc_1:c1",
+        accountId: "default",
         threadId: "reply_ambient_1",
       },
     });
 
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { comment_id: "c_add" },
-    });
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ comment_id: "c1", is_whole: false }],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { reply_id: "r_add_ambient" },
+      });
 
     let resolveCleanup: ((value: boolean) => void) | undefined;
     cleanupAmbientCommentTypingReactionMock.mockImplementationOnce(
@@ -644,7 +754,7 @@ describe("registerFeishuDriveTools", () => {
 
     const addCommentPromise = tool.execute("call-add-ambient", {
       action: "add_comment",
-      content: "ambient top-level comment",
+      content: "ambient comment follow-up",
     });
     const status = await Promise.race([
       addCommentPromise.then(() => "done"),
@@ -652,13 +762,33 @@ describe("registerFeishuDriveTools", () => {
     ]);
 
     expect(status).toBe("done");
-    expect(requestMock).toHaveBeenCalledWith(
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         method: "POST",
-        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
         data: {
-          file_type: "docx",
-          reply_elements: [{ type: "text", text: "ambient top-level comment" }],
+          comment_ids: ["c1"],
+        },
+      }),
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/c1/replies",
+        params: { file_type: "docx" },
+        data: {
+          content: {
+            elements: [
+              {
+                type: "text_run",
+                text_run: {
+                  text: "ambient comment follow-up",
+                },
+              },
+            ],
+          },
         },
       }),
     );
@@ -667,15 +797,265 @@ describe("registerFeishuDriveTools", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doc_1:c1",
+        accountId: "default",
         threadId: "reply_ambient_1",
       },
     });
     const addCommentResult = await addCommentPromise;
     expect(addCommentResult.details).toEqual(
-      expect.objectContaining({ success: true, comment_id: "c_add" }),
+      expect.objectContaining({
+        success: true,
+        reply_id: "r_add_ambient",
+        delivery_mode: "reply_comment",
+      }),
     );
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_1:c1",
+        threadId: "reply_ambient_1",
+      }),
+    ).toBe(true);
 
     resolveCleanup?.(false);
+  });
+
+  it("keeps add_comment delivery for ambient whole-comment follow-ups", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({
+      agentAccountId: undefined,
+      deliveryContext: {
+        channel: "feishu",
+        to: "comment:docx:doc_1:c1",
+        accountId: "default",
+        threadId: "reply_ambient_1",
+      },
+    });
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ comment_id: "c1", is_whole: true }],
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { comment_id: "c_whole_followup" },
+      });
+
+    const result = await tool.execute("call-add-ambient-whole", {
+      action: "add_comment",
+      content: "whole comment follow-up",
+    });
+
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/comments/batch_query?file_type=docx&user_id_type=open_id",
+        data: {
+          comment_ids: ["c1"],
+        },
+      }),
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "whole comment follow-up" }],
+        },
+      }),
+    );
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        success: true,
+        comment_id: "c_whole_followup",
+        delivery_mode: "add_comment",
+      }),
+    );
+  });
+
+  it("falls back to add_comment for ambient local-comment add_comment calls when reply is not allowed", async () => {
+    const registerTool = vi.fn();
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({
+      agentAccountId: undefined,
+      deliveryContext: {
+        channel: "feishu",
+        to: "comment:docx:doc_1:c1",
+        accountId: "default",
+        threadId: "reply_ambient_1",
+      },
+    });
+
+    requestMock
+      .mockResolvedValueOnce({
+        code: 0,
+        data: {
+          items: [{ comment_id: "c1", is_whole: false }],
+        },
+      })
+      .mockRejectedValueOnce({
+        message: "Request failed with status code 400",
+        code: "ERR_BAD_REQUEST",
+        config: {
+          method: "post",
+          url: "https://open.feishu.cn/open-apis/drive/v1/files/doc_1/comments/c1/replies",
+          params: { file_type: "docx" },
+        },
+        response: {
+          status: 400,
+          data: {
+            code: 1069302,
+            msg: "param error",
+            log_id: "log_reply_forbidden",
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { comment_id: "c3" },
+      });
+
+    const result = await tool.execute("call-add-ambient-reply-forbidden", {
+      action: "add_comment",
+      content: "compat follow-up",
+    });
+
+    expect(requestMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "compat follow-up" }],
+        },
+      }),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("reply-not-allowed compatibility path"),
+    );
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        success: true,
+        comment_id: "c3",
+        delivery_mode: "add_comment",
+      }),
+    );
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_1:c1",
+        threadId: "reply_ambient_1",
+      }),
+    ).toBe(true);
+  });
+
+  it("does not record current-thread delivery for block-scoped ambient add_comment writes", async () => {
+    const registerTool = vi.fn();
+    registerFeishuDriveTools(
+      createDriveToolApi({
+        config: {
+          channels: {
+            feishu: {
+              enabled: true,
+              appId: "app_id",
+              appSecret: "app_secret", // pragma: allowlist secret
+              tools: { drive: true },
+            },
+          },
+        },
+        registerTool,
+      }),
+    );
+
+    const toolFactory = registerTool.mock.calls[0]?.[0];
+    const tool = toolFactory?.({
+      agentAccountId: undefined,
+      deliveryContext: {
+        channel: "feishu",
+        to: "comment:docx:doc_1:c1",
+        accountId: "default",
+        threadId: "reply_ambient_1",
+      },
+    });
+
+    requestMock.mockResolvedValueOnce({
+      code: 0,
+      data: { comment_id: "c_block_scoped" },
+    });
+
+    const result = await tool.execute("call-add-block-scoped-ambient", {
+      action: "add_comment",
+      file_token: "doc_1",
+      file_type: "docx",
+      block_id: "blk_1",
+      content: "new local comment",
+    });
+
+    expect(requestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "/open-apis/drive/v1/files/doc_1/new_comments",
+        data: {
+          file_type: "docx",
+          reply_elements: [{ type: "text", text: "new local comment" }],
+          anchor: { block_id: "blk_1" },
+        },
+      }),
+    );
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        success: true,
+        comment_id: "c_block_scoped",
+      }),
+    );
+    expect(
+      hasFeishuCommentConversationDelivery({
+        accountId: "default",
+        to: "comment:docx:doc_1:c1",
+        threadId: "reply_ambient_1",
+      }),
+    ).toBe(false);
   });
 
   it("does not inherit non-doc ambient file types for add_comment", async () => {

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -2,6 +2,7 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { listEnabledFeishuAccounts } from "./accounts.js";
+import { recordFeishuCommentConversationDelivery } from "./comment-delivery-guard.js";
 import { cleanupAmbientCommentTypingReaction } from "./comment-reaction.js";
 import {
   encodeQuery,
@@ -111,6 +112,7 @@ type FeishuDriveToolContext = {
   deliveryContext?: {
     channel?: string;
     to?: string;
+    accountId?: string;
     threadId?: string | number;
   };
 };
@@ -122,7 +124,12 @@ function getDriveInternalClient(client: Lark.Client): FeishuDriveInternalClient 
 }
 
 function buildReplyElements(content: string) {
-  return [{ type: "text", text: content }];
+  return [{ type: "text", text: escapeFeishuCommentText(content) }];
+}
+
+function escapeFeishuCommentText(text: string): string {
+  // Feishu Drive comment write APIs reject raw angle brackets in text payloads.
+  return text.replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 async function requestDriveApi<T>(params: {
@@ -268,6 +275,66 @@ function applyCommentFileTypeDefault<
   return {
     ...params,
     file_type: fileType,
+  };
+}
+
+function maybeRecordCurrentCommentConversationDelivery(params: {
+  context: FeishuDriveToolContext | undefined;
+  fileToken: string | undefined;
+  fileType: CommentFileType | "doc" | "docx" | undefined;
+  commentId?: string;
+  blockId?: string;
+}): void {
+  if (params.blockId?.trim()) {
+    return;
+  }
+  const deliveryContext = params.context?.deliveryContext;
+  if (deliveryContext?.channel && deliveryContext.channel !== "feishu") {
+    return;
+  }
+  const ambient = resolveAmbientCommentTarget(params.context);
+  const currentConversationTarget = deliveryContext?.to?.trim();
+  if (!ambient || !currentConversationTarget) {
+    return;
+  }
+  if (params.fileToken?.trim() !== ambient.fileToken || params.fileType !== ambient.fileType) {
+    return;
+  }
+  if (params.commentId && params.commentId.trim() !== ambient.commentId) {
+    return;
+  }
+  recordFeishuCommentConversationDelivery({
+    accountId: deliveryContext?.accountId,
+    to: currentConversationTarget,
+    threadId: deliveryContext?.threadId,
+  });
+}
+
+function resolveAmbientCommentFollowUpTargetForAddComment(params: {
+  context: FeishuDriveToolContext | undefined;
+  fileToken: string | undefined;
+  fileType: "doc" | "docx" | undefined;
+  blockId?: string;
+}): {
+  fileToken: string;
+  fileType: "doc" | "docx";
+  commentId: string;
+} | null {
+  const ambient = resolveAmbientCommentTarget(params.context);
+  // Preserve backwards compatibility for agents that still call add_comment
+  // during a local comment-thread follow-up. In that specific ambient context,
+  // add_comment behaves like "reply to the current comment" unless the caller
+  // explicitly anchors a new local comment via block_id.
+  if (!ambient || params.blockId?.trim()) {
+    return null;
+  }
+  if (params.fileToken?.trim() !== ambient.fileToken || params.fileType !== ambient.fileType) {
+    return null;
+  }
+  return {
+    fileToken: ambient.fileToken,
+    fileType: ambient.fileType,
+    commentId: ambient.commentId,
   };
 }
 
@@ -604,7 +671,7 @@ export async function replyComment(
             {
               type: "text_run",
               text_run: {
-                text: params.content,
+                text: escapeFeishuCommentText(params.content),
               },
             },
           ],
@@ -796,7 +863,35 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
               case "add_comment": {
                 const resolved = applyAddCommentDefaults(applyAddCommentAmbientDefaults(p, ctx));
                 try {
-                  return jsonToolResult(await addComment(client, resolved));
+                  const ambientFollowUpTarget = resolveAmbientCommentFollowUpTargetForAddComment({
+                    context: ctx,
+                    fileToken: resolved.file_token,
+                    fileType: resolved.file_type,
+                    blockId: resolved.block_id,
+                  });
+                  // Keep add_comment compatible with existing agent behavior in
+                  // local comment-thread flows. When the tool call already has
+                  // an ambient comment target on the same doc/docx file and no
+                  // block_id override, deliver it as a follow-up to that thread
+                  // instead of creating an unrelated top-level comment.
+                  const result = ambientFollowUpTarget
+                    ? await deliverCommentThreadText(client, {
+                        file_token: ambientFollowUpTarget.fileToken,
+                        file_type: ambientFollowUpTarget.fileType,
+                        comment_id: ambientFollowUpTarget.commentId,
+                        content: resolved.content,
+                      })
+                    : await addComment(client, resolved);
+                  // add_comment may create a new whole-document comment instead of replying to
+                  // the ambient comment id directly. Any visible delivery in the current ambient
+                  // comment flow should still suppress the later automatic final reply.
+                  maybeRecordCurrentCommentConversationDelivery({
+                    context: ctx,
+                    fileToken: resolved.file_token,
+                    fileType: resolved.file_type,
+                    blockId: resolved.block_id,
+                  });
+                  return jsonToolResult(result);
                 } finally {
                   void cleanupAmbientCommentTypingReaction({
                     client: getDriveInternalClient(client),
@@ -810,7 +905,14 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
                   "reply_comment",
                 );
                 try {
-                  return jsonToolResult(await deliverCommentThreadText(client, resolved));
+                  const result = await deliverCommentThreadText(client, resolved);
+                  maybeRecordCurrentCommentConversationDelivery({
+                    context: ctx,
+                    fileToken: resolved.file_token,
+                    fileType: resolved.file_type,
+                    commentId: resolved.comment_id,
+                  });
+                  return jsonToolResult(result);
                 } finally {
                   void cleanupAmbientCommentTypingReaction({
                     client: getDriveInternalClient(client),

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -626,7 +626,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const botIdentity =
     botOpenIdSource.kind === "prefetched"
       ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
-      : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
+      : await fetchBotIdentityForMonitor(account, { runtime, abortSignal, forceFresh: true });
   const { botOpenId } = applyBotIdentityState(accountId, botIdentity);
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 

--- a/extensions/feishu/src/monitor.comment.ordering.test.ts
+++ b/extensions/feishu/src/monitor.comment.ordering.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClawdbotConfig } from "../runtime-api.js";
+
+const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./accounts.js", async () => {
+  const actual = await vi.importActual<typeof import("./accounts.js")>("./accounts.js");
+  return {
+    ...actual,
+    resolveFeishuAccount: resolveFeishuAccountMock,
+  };
+});
+
+vi.mock("./client.js", async () => {
+  const actual = await vi.importActual<typeof import("./client.js")>("./client.js");
+  return {
+    ...actual,
+    createFeishuClient: createFeishuClientMock,
+  };
+});
+
+import {
+  resolveDriveCommentEventTurn,
+  type FeishuDriveCommentNoticeEvent,
+} from "./monitor.comment.js";
+
+function buildMonitorConfig(): ClawdbotConfig {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+      },
+    },
+  } as ClawdbotConfig;
+}
+
+function makeDriveCommentEvent(
+  overrides: Partial<FeishuDriveCommentNoticeEvent> = {},
+): FeishuDriveCommentNoticeEvent {
+  return {
+    comment_id: "7623358762119646411",
+    event_id: "10d9d60b990db39f96a4c2fd357fb877",
+    is_mentioned: true,
+    notice_meta: {
+      file_token: "doc_token_1",
+      file_type: "docx",
+      from_user_id: {
+        open_id: "ou_sender",
+      },
+      notice_type: "add_comment",
+      to_user_id: {
+        open_id: "ou_bot",
+      },
+    },
+    reply_id: "7623358762136374451",
+    timestamp: "1774951528000",
+    type: "drive.notice.comment_add_v1",
+    ...overrides,
+  };
+}
+
+describe("resolveDriveCommentEventTurn lazy account resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveFeishuAccountMock.mockImplementation(() => {
+      throw new Error("resolveFeishuAccount should not be called");
+    });
+    createFeishuClientMock.mockImplementation(() => {
+      throw new Error("createFeishuClient should not be called");
+    });
+  });
+
+  it("returns early for self-authored notices before resolving the account", async () => {
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          from_user_id: {
+            open_id: "ou_bot",
+          },
+          to_user_id: {
+            open_id: "ou_bot",
+          },
+        },
+      }),
+      botOpenId: "ou_bot",
+    });
+
+    expect(turn).toBeNull();
+    expect(resolveFeishuAccountMock).not.toHaveBeenCalled();
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  it("returns early when recipient info is missing before resolving the account", async () => {
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          to_user_id: undefined,
+        },
+      }),
+      botOpenId: "ou_bot",
+    });
+
+    expect(turn).toBeNull();
+    expect(resolveFeishuAccountMock).not.toHaveBeenCalled();
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/monitor.comment.test.ts
+++ b/extensions/feishu/src/monitor.comment.test.ts
@@ -867,6 +867,60 @@ describe("resolveDriveCommentEventTurn", () => {
 
     expect(turn).toBeNull();
   });
+
+  it("skips comment notices when to_user_id.open_id is missing", async () => {
+    const logger = vi.fn();
+
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          to_user_id: undefined,
+        },
+      }),
+      botOpenId: "ou_bot",
+      logger,
+      createClient: () => {
+        throw new Error("createClient should not be called");
+      },
+    });
+
+    expect(turn).toBeNull();
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "skipping drive comment notice because to_user_id.open_id is missing",
+      ),
+    );
+  });
+
+  it("skips comment notices not addressed to the bot", async () => {
+    const logger = vi.fn();
+
+    const turn = await resolveDriveCommentEventTurn({
+      cfg: buildMonitorConfig(),
+      accountId: "default",
+      event: makeDriveCommentEvent({
+        notice_meta: {
+          ...makeDriveCommentEvent().notice_meta,
+          to_user_id: {
+            open_id: "ou_someone_else",
+          },
+        },
+      }),
+      botOpenId: "ou_bot",
+      logger,
+      createClient: () => {
+        throw new Error("createClient should not be called");
+      },
+    });
+
+    expect(turn).toBeNull();
+    expect(logger).toHaveBeenCalledWith(
+      expect.stringContaining("skipping drive comment notice not addressed to bot"),
+    );
+  });
 });
 
 describe("drive.notice.comment_add_v1 monitor handler", () => {

--- a/extensions/feishu/src/monitor.comment.ts
+++ b/extensions/feishu/src/monitor.comment.ts
@@ -1145,9 +1145,9 @@ function buildDriveCommentSurfacePrompt(params: {
     "Do not use another comment card or document-session output as the main reference.",
     "If you need comment thread context, use feishu_drive.list_comments or feishu_drive.list_comment_replies.",
     "If you modify the document, post a user-visible follow-up in the comment thread.",
-    "Use feishu_drive.reply_comment or feishu_drive.add_comment for that follow-up.",
+    "For local comment threads, use feishu_drive.reply_comment for that follow-up.",
     "Whole-document comments do not support direct replies.",
-    "For whole-document comments, use feishu_drive.add_comment.",
+    "Only for whole-document comments, use feishu_drive.add_comment.",
     'Only treat URLs listed under "Referenced documents from current user comment" as structured Feishu document references.',
     "URLs that appear only in comment text are plain links unless you verify them.",
     "If the user asks about a linked Feishu document or wiki page, treat that linked document as the read target.",
@@ -1238,6 +1238,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
   const fileType = normalizeCommentFileType(event.notice_meta?.file_type);
   const senderId = event.notice_meta?.from_user_id?.open_id?.trim();
   const senderUserId = normalizeString(event.notice_meta?.from_user_id?.user_id);
+  const recipientId = event.notice_meta?.to_user_id?.open_id?.trim();
   if (!eventId || !commentId || !noticeType || !fileToken || !fileType || !senderId) {
     logger?.(
       `feishu[${accountId}]: drive comment notice missing required fields event=${eventId ?? "unknown"} comment=${commentId ?? "unknown"}`,
@@ -1248,14 +1249,32 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     logger?.(`feishu[${accountId}]: unsupported drive comment notice type ${noticeType}`);
     return null;
   }
-  if (!botOpenId) {
+  // Feishu Drive comment notices addressed to a bot include to_user_id.open_id.
+  // Keep this strict to avoid routing another bot's notice into the current account.
+  if (!recipientId) {
+    logger?.(
+      `feishu[${accountId}]: skipping drive comment notice because to_user_id.open_id is missing ` +
+        `event=${eventId} comment=${commentId}`,
+    );
+    return null;
+  }
+  const effectiveBotOpenId = normalizeString(botOpenId);
+
+  if (!effectiveBotOpenId) {
     logger?.(
       `feishu[${accountId}]: skipping drive comment notice because bot open_id is unavailable ` +
         `event=${eventId}`,
     );
     return null;
   }
-  if (senderId === botOpenId) {
+  if (recipientId !== effectiveBotOpenId) {
+    logger?.(
+      `feishu[${accountId}]: skipping drive comment notice not addressed to bot ` +
+        `event=${eventId} comment=${commentId} to=${recipientId} bot=${effectiveBotOpenId}`,
+    );
+    return null;
+  }
+  if (senderId === effectiveBotOpenId) {
     logger?.(
       `feishu[${accountId}]: ignoring self-authored drive comment notice event=${eventId} sender=${senderId}`,
     );
@@ -1270,7 +1289,7 @@ async function resolveDriveCommentEventCore(params: ResolveDriveCommentEventPara
     fileType,
     commentId,
     replyId,
-    botOpenIds: [botOpenId, event.notice_meta?.to_user_id?.open_id],
+    botOpenIds: [effectiveBotOpenId, event.notice_meta?.to_user_id?.open_id],
     timeoutMs: verificationTimeoutMs,
     logger,
     accountId,

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -79,6 +79,10 @@ describe("Feishu monitor startup preflight", () => {
 
       expect(started).toEqual(["alpha"]);
       expect(maxInFlight).toBe(1);
+      expect(probeFeishuMock).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: "alpha" }),
+        expect.objectContaining({ forceFresh: true }),
+      );
     } finally {
       releaseProbes();
       abortController.abort();
@@ -150,6 +154,35 @@ describe("Feishu monitor startup preflight", () => {
       );
     } finally {
       releaseBetaProbe();
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
+
+  it("logs when startup falls back to a recent cached bot identity", async () => {
+    probeFeishuMock.mockResolvedValue({
+      ok: true,
+      botOpenId: "ou_cached",
+      botName: "Cached Bot",
+      usedCachedIdentityFallback: true,
+      cachedIdentityFallbackError: "probe timed out after 10000ms",
+    });
+
+    const abortController = new AbortController();
+    const runtime = createNonExitingRuntimeEnv();
+    const monitorPromise = monitorFeishuProvider({
+      config: buildMultiAccountWebsocketConfig(["alpha"]),
+      runtime,
+      abortSignal: abortController.signal,
+    });
+
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("fresh bot info probe failed; using recent cached identity"),
+      );
+    } finally {
       abortController.abort();
       await monitorPromise;
     }

--- a/extensions/feishu/src/monitor.startup.ts
+++ b/extensions/feishu/src/monitor.startup.ts
@@ -26,6 +26,7 @@ type FetchBotOpenIdOptions = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   timeoutMs?: number;
+  forceFresh?: boolean;
 };
 
 export type FeishuMonitorBotIdentity = {
@@ -54,8 +55,17 @@ export async function fetchBotIdentityForMonitor(
   const result = await probeFeishu(account, {
     timeoutMs,
     abortSignal: options.abortSignal,
+    forceFresh: options.forceFresh,
   });
   if (result.ok) {
+    if (result.usedCachedIdentityFallback) {
+      const error = options.runtime?.error ?? console.error;
+      error(
+        `feishu[${account.accountId}]: fresh bot info probe failed; using recent cached identity` +
+          (result.botOpenId ? ` ${result.botOpenId}` : "") +
+          (result.cachedIdentityFallbackError ? ` (${result.cachedIdentityFallbackError})` : ""),
+      );
+    }
     return { botOpenId: result.botOpenId, botName: result.botName };
   }
 

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -72,6 +72,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      forceFresh: true,
     });
 
     if (opts.abortSignal?.aborted) {

--- a/extensions/feishu/src/outbound.test.ts
+++ b/extensions/feishu/src/outbound.test.ts
@@ -367,6 +367,7 @@ describe("feishuOutbound comment-thread routing", () => {
       deliveryContext: {
         channel: "feishu",
         to: "comment:docx:doxcn123:7623358762119646411",
+        accountId: "main",
         threadId: "reply_ambient_1",
       },
     });

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -113,6 +113,7 @@ async function sendCommentThreadReply(params: {
         deliveryContext: {
           channel: "feishu",
           to: params.to,
+          accountId: params.accountId,
           threadId: replyId,
         },
       });

--- a/extensions/feishu/src/probe.test.ts
+++ b/extensions/feishu/src/probe.test.ts
@@ -252,6 +252,62 @@ describe("probeFeishu", () => {
     expect(requestFn).toHaveBeenCalledTimes(2);
   });
 
+  it("does not reuse a cached result when the same accountId changes credentials", async () => {
+    const requestFn = setupClient(BOT1_RESPONSE);
+
+    await probeFeishu({ accountId: "acct-1", appId: "cli_123", appSecret: "secret_a" }); // pragma: allowlist secret
+    expect(requestFn).toHaveBeenCalledTimes(1);
+
+    await probeFeishu({ accountId: "acct-1", appId: "cli_456", appSecret: "secret_b" }); // pragma: allowlist secret
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("bypasses a warm cache when forceFresh is enabled", async () => {
+    const requestFn = setupClient(BOT1_RESPONSE);
+
+    await probeFeishu({ accountId: "acct-1", appId: "cli_123", appSecret: "secret" }); // pragma: allowlist secret
+    expect(requestFn).toHaveBeenCalledTimes(1);
+
+    await probeFeishu(
+      { accountId: "acct-1", appId: "cli_123", appSecret: "secret" }, // pragma: allowlist secret
+      { forceFresh: true },
+    );
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to a recent cached success when forceFresh probe fails", async () => {
+    const requestFn = vi
+      .fn()
+      .mockResolvedValueOnce(BOT1_RESPONSE)
+      .mockRejectedValueOnce(new Error("network error"));
+    createFeishuClientMock.mockReturnValue({ request: requestFn });
+
+    const cached = await probeFeishu({
+      accountId: "acct-1",
+      appId: "cli_123",
+      appSecret: "secret",
+    }); // pragma: allowlist secret
+    const fallback = await probeFeishu(
+      { accountId: "acct-1", appId: "cli_123", appSecret: "secret" }, // pragma: allowlist secret
+      { forceFresh: true },
+    );
+    const reused = await probeFeishu({
+      accountId: "acct-1",
+      appId: "cli_123",
+      appSecret: "secret",
+    }); // pragma: allowlist secret
+
+    expect(cached).toMatchObject({ ok: true, botOpenId: "ou_1" });
+    expect(fallback).toMatchObject({
+      ok: true,
+      botOpenId: "ou_1",
+      usedCachedIdentityFallback: true,
+      cachedIdentityFallbackError: "network error",
+    });
+    expect(reused).toMatchObject({ ok: true, botOpenId: "ou_1" });
+    expect(requestFn).toHaveBeenCalledTimes(2);
+  });
+
   it("clearProbeCache forces fresh API call", async () => {
     const requestFn = setupSuccessClient();
 

--- a/extensions/feishu/src/probe.ts
+++ b/extensions/feishu/src/probe.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import { createFeishuClient, type FeishuClientCredentials } from "./client.js";
@@ -16,6 +17,7 @@ export const FEISHU_PROBE_REQUEST_TIMEOUT_MS = 10_000;
 export type ProbeFeishuOptions = {
   timeoutMs?: number;
   abortSignal?: AbortSignal;
+  forceFresh?: boolean;
 };
 
 type FeishuPingResponse = {
@@ -48,6 +50,30 @@ function setCachedProbeResult(
   return result;
 }
 
+function getValidCachedProbeResult(
+  cacheKey: string,
+  now = Date.now(),
+): { result: FeishuProbeResult; expiresAt: number } | undefined {
+  const cached = probeCache.get(cacheKey);
+  if (!cached || cached.expiresAt <= now) {
+    return undefined;
+  }
+  return cached;
+}
+
+function buildProbeCacheKey(creds: FeishuClientCredentials): string {
+  const fingerprint = crypto
+    .createHash("sha256")
+    .update(JSON.stringify([creds.domain ?? "feishu", creds.appId, creds.appSecret]))
+    .digest("hex")
+    .slice(0, 16);
+
+  // Keep accountId in the key so same-credential aliases do not cross-pollute,
+  // but also include a credential fingerprint so hot-reloaded account updates
+  // trigger a fresh probe instead of reusing stale bot identity.
+  return creds.accountId ? `${creds.accountId}:${fingerprint}` : `${creds.appId}:${fingerprint}`;
+}
+
 export async function probeFeishu(
   creds?: FeishuClientCredentials,
   options: ProbeFeishuOptions = {},
@@ -69,13 +95,27 @@ export async function probeFeishu(
   const timeoutMs = options.timeoutMs ?? FEISHU_PROBE_REQUEST_TIMEOUT_MS;
 
   // Return cached result if still valid.
-  // Use accountId when available; otherwise include appSecret prefix so two
-  // accounts sharing the same appId (e.g. after secret rotation) don't
-  // pollute each other's cache entry.
-  const cacheKey = creds.accountId ?? `${creds.appId}:${creds.appSecret.slice(0, 8)}`;
-  const cached = probeCache.get(cacheKey);
-  if (cached && cached.expiresAt > Date.now()) {
+  // Include both logical account identity and a credential fingerprint so a
+  // renamed or hot-reloaded account keeps its own cache bucket while a
+  // credential change forces a fresh bot-identity probe.
+  const cacheKey = buildProbeCacheKey(creds);
+  const cached = getValidCachedProbeResult(cacheKey);
+  if (!options.forceFresh && cached) {
     return cached.result;
+  }
+  const cachedSuccessFallback = options.forceFresh && cached?.result.ok ? cached.result : undefined;
+
+  function maybeUseCachedIdentityFallback(error: string): FeishuProbeResult | null {
+    if (!cachedSuccessFallback) {
+      return null;
+    }
+    // Startup/reload should prefer a live probe, but transient probe failures
+    // should not discard the last known-good bot identity immediately.
+    return {
+      ...cachedSuccessFallback,
+      usedCachedIdentityFallback: true,
+      cachedIdentityFallbackError: error,
+    };
   }
 
   try {
@@ -104,6 +144,10 @@ export async function probeFeishu(
       };
     }
     if (responseResult.status === "timeout") {
+      const fallback = maybeUseCachedIdentityFallback(`probe timed out after ${timeoutMs}ms`);
+      if (fallback) {
+        return fallback;
+      }
       return setCachedProbeResult(
         cacheKey,
         {
@@ -125,12 +169,17 @@ export async function probeFeishu(
     }
 
     if (response.code !== 0) {
+      const errorMessage = `API error: ${response.msg || `code ${response.code}`}`;
+      const fallback = maybeUseCachedIdentityFallback(errorMessage);
+      if (fallback) {
+        return fallback;
+      }
       return setCachedProbeResult(
         cacheKey,
         {
           ok: false,
           appId: creds.appId,
-          error: `API error: ${response.msg || `code ${response.code}`}`,
+          error: errorMessage,
         },
         PROBE_ERROR_TTL_MS,
       );
@@ -148,12 +197,17 @@ export async function probeFeishu(
       PROBE_SUCCESS_TTL_MS,
     );
   } catch (err) {
+    const formattedError = formatErrorMessage(err);
+    const fallback = maybeUseCachedIdentityFallback(formattedError);
+    if (fallback) {
+      return fallback;
+    }
     return setCachedProbeResult(
       cacheKey,
       {
         ok: false,
         appId: creds.appId,
-        error: formatErrorMessage(err),
+        error: formattedError,
       },
       PROBE_ERROR_TTL_MS,
     );

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -80,6 +80,8 @@ export interface FeishuProbeResult extends BaseProbeResult {
   appId?: string;
   botName?: string;
   botOpenId?: string;
+  usedCachedIdentityFallback?: boolean;
+  cachedIdentityFallbackError?: string;
 }
 
 export type FeishuMediaInfo = {


### PR DESCRIPTION
 ## Summary

  - Problem: Feishu comment handling could process notices not meant for the current bot, duplicate replies after tool-visible replies, fail on raw `<` / `>` text, and reuse stale bot identity.
  - Why it matters: This caused misrouted comment handling, duplicate user-visible replies, comment write failures, and unstable multi-account behavior.
  - What changed: Added recipient gating for comment notices, suppressed automatic final replies after successful tool delivery in the same comment flow, escaped angle brackets in comment writes, isolated typing-reaction state by `accountId`, and forced fresh bot identity probes on startup/reload with a credential-aware cache key.

  ## Change Type (select all)

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [x] Skills / tool execution
  - [x] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #
  - [x] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  - Root cause: Comment handling lacked strict recipient validation, stale identity invalidation, and cross-path guards between tool-visible replies and automatic final replies.
  - Missing detection / guardrail: No regression coverage for recipient gating, duplicate-reply suppression, escaping, multi-account typing isolation, or fresh probe behavior.
  - Contributing context (if known): Comment threads mix automatic final replies, tool-visible replies, and multi-account runtime state.

  ## Regression Test Plan (if applicable)

  - Coverage level that should have caught this:
    - [x] Unit test
    - [x] Seam / integration test
    - [ ] End-to-end test
    - [ ] Existing coverage already sufficient
  - Target test or file:
    - `extensions/feishu/src/comment-dispatcher.test.ts`
    - `extensions/feishu/src/comment-reaction.test.ts`
    - `extensions/feishu/src/drive.test.ts`
    - `extensions/feishu/src/monitor.comment.test.ts`
    - `extensions/feishu/src/probe.test.ts`
    - `extensions/feishu/src/monitor.startup.test.ts`
  - Scenario the test should lock in: Recipient-gated comment notices, tool-reply suppression of duplicate automatic finals, angle-bracket escaping, multi-account typing isolation, and fresh bot identity probes.
  - If no new test is added, why not: N/A

  ## User-visible / Behavior Changes

  - Feishu comment notices are handled only when addressed to the current bot.
  - Tool-visible replies in the same comment flow now suppress later duplicate automatic final replies.
  - Raw `<` / `>` in comment text no longer fail Feishu comment writes.
  - Multi-account comment typing reactions no longer interfere with each other.
  - Startup/reload now refreshes bot identity more reliably.

  ## Diagram (if applicable)

  ```text
  Before:
  [comment notice] -> [broad/stale bot match] -> [tool reply] -> [automatic final] -> [duplicate/misdirected reply]

  After:
  [comment notice] -> [current bot match] -> [tool reply or automatic final] -> [delivery guard] -> [single intended reply]
`````
  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No) No
  - Secrets/tokens handling changed? (Yes/No) Yes
  - New/changed network calls? (Yes/No) No
  - Command/tool execution surface changed? (Yes/No) No
  - Data access scope changed? (Yes/No) No
  - If any Yes, explain risk + mitigation:
      - Bot probe cache keys now include a credential fingerprint in memory only.
      - Startup/reload can force a fresh call to the existing Feishu bot ping endpoint.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: local dev shell
  - Integration/channel (if any): Feishu Drive comments

  ### Steps

  1. Trigger Feishu Drive comment notices, including one not addressed to the current bot.
  2. Trigger tool-visible replies in the same comment thread.
  3. Test angle-bracket comment text, multi-account typing cleanup, and startup/reload identity refresh.

  ### Expected

  - Only intended comment notices are handled.
  - No duplicate automatic final reply after a tool-visible reply.
  - Comment writes with < / > succeed.
  - Multi-account typing state stays isolated.

  ### Actual

  - Before this change, misrouted events, duplicate replies, write failures, and stale/mixed state could happen.

  ## Evidence

  - [x] Failing test/log before + passing after
  - [ ] Trace/log snippets
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)
  - pnpm test extensions/feishu/src/comment-dispatcher.test.ts extensions/feishu/src/comment-reaction.test.ts extensions/feishu/src/drive.test.ts extensions/feishu/src/monitor.comment.test.ts extensions/feishu/src/probe.test.ts extensions/feishu/src/monitor.startup.test.ts
  - Result: Test Files 6 passed (6), Tests 67 passed (67)

  ## Human Verification (required)

  - Verified scenarios: Manually verified Feishu comment recipient gating, duplicate-reply suppression after tool-visible replies, angle-bracket comment writes, multi-account typing-reaction isolation, and bot identity refresh behavior; also reran targeted Feishu regression tests locally.
  - Edge cases checked: Wrong-recipient notices, missing `to_user_id.open_id`, whole-comment fallback, reply-forbidden fallback, missing `accountId` ambient cleanup, and changed credentials with fresh probe.

  ## Review Conversations

  - [ ] I replied to or resolved every bot review conversation I addressed in this PR.
  - [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No) Yes
  - Config/env changes? (Yes/No) No
  - Migration needed? (Yes/No) No
  - If yes, exact upgrade steps:
  
  No config or environment changes are required.

  Compatibility note: in the current ambient local comment-thread context on the same `doc`/`docx` file, `feishu_drive.add_comment` may be delivered as a follow-up reply to the current comment thread when `block_id` is omitted. This is a compatibility behavior for existing comment-thread follow-up flows and does not  require caller migration.

  ## Risks and Mitigations

  - Risk: Stricter recipient gating may skip unusual Feishu notices missing recipient data.
      - Mitigation: Skip reasons are logged, and targeted tests cover the gated paths.