### PR TITLE
fix(agents): derive overflow budgets from provider errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/media: send direct fallback for generated media still missing after an active requester wake fails. (#85489) Thanks @fuller-stack-dev.
+- Agents: derive overflow compaction budgets from provider-reported and synthetic over-budget token counts so confirmed context overflows compact before retrying. (#70473) Thanks @fuller-stack-dev.
 - Agent transcript: include OpenClaw agent session logs when finding local transcript candidates.
 - Sessions/doctor: load large session stores without clone amplification during read-only doctor checks and reclaim stale `sessions.json.*.tmp` sidecars. Fixes #56827. Thanks @openperf.
 - Tests: clean successful plugin gateway gauntlet isolated temp roots while keeping an explicit preservation switch for failed/debug runs.

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -234,6 +234,10 @@ In the embedded Pi agent, auto-compaction triggers in two cases:
 number of tokens`, `input token count exceeds the maximum number of input
 tokens`, `input is too long for the model`, `ollama error: context length
 exceeded`, and similar provider-shaped variants) → compact → retry.
+   When the provider reports the attempted token count, OpenClaw forwards that
+   observed count into overflow recovery compaction. If the provider confirms
+   overflow but does not expose a parseable count, OpenClaw still forces
+   budget-targeted compaction with a minimally over-budget synthetic count.
 2. **Threshold maintenance**: after a successful turn, when:
 
 `contextTokens > contextWindow - reserveTokens`

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -278,6 +278,10 @@ In the embedded Pi agent, auto-compaction triggers in two cases:
 number of tokens`, `input token count exceeds the maximum number of input
 tokens`, `input is too long for the model`, `ollama error: context length
 exceeded`, and similar provider-shaped variants) → compact → retry.
+   When the provider reports the attempted token count, OpenClaw forwards that
+   observed count into overflow recovery compaction. If the provider confirms
+   overflow but does not expose a parseable count, OpenClaw passes a minimally
+   over-budget synthetic count to compaction engines and diagnostics.
    If overflow recovery still fails, OpenClaw surfaces explicit guidance to the
    user and preserves the current session mapping instead of silently rotating
    the session key to a fresh session id. The next step is operator-controlled:

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -545,6 +545,21 @@ describe("extractObservedOverflowTokenCount", () => {
         "This model's maximum context length is 128000 tokens. However, your messages resulted in 145000 tokens.",
       ),
     ).toBe(145000);
+    expect(
+      extractObservedOverflowTokenCount(
+        "400 The prompt is too long: 203557, model maximum context length: 196607",
+      ),
+    ).toBe(203557);
+    expect(
+      extractObservedOverflowTokenCount(
+        "Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
+      ),
+    ).toBe(291351);
+    expect(
+      extractObservedOverflowTokenCount(
+        "input length and max_tokens exceed context limit (i.e 156321 + 48384 > 200000)",
+      ),
+    ).toBe(204705);
   });
 
   it("returns undefined when overflow counts are not present", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -575,10 +575,30 @@ describe("extractObservedOverflowTokenCount", () => {
         "This model's maximum context length is 128000 tokens. However, your messages resulted in 145000 tokens.",
       ),
     ).toBe(145000);
+    expect(
+      extractObservedOverflowTokenCount(
+        "400 The prompt is too long: 203557, model maximum context length: 196607",
+      ),
+    ).toBe(203557);
+    expect(
+      extractObservedOverflowTokenCount(
+        "Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",
+      ),
+    ).toBe(291351);
+    expect(
+      extractObservedOverflowTokenCount(
+        "input length and max_tokens exceed context limit (i.e 156321 + 48384 > 200000)",
+      ),
+    ).toBe(204705);
   });
 
   it("returns undefined when overflow counts are not present", () => {
     expect(extractObservedOverflowTokenCount("Prompt too large for this model")).toBeUndefined();
+    expect(
+      extractObservedOverflowTokenCount(
+        "The prompt is too long: 203557 characters, model maximum context length: 196607",
+      ),
+    ).toBeUndefined();
     expect(extractObservedOverflowTokenCount("rate limit exceeded")).toBeUndefined();
   });
 });

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -210,7 +210,6 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 const OBSERVED_OVERFLOW_TOKEN_PATTERNS = [
   /prompt is too long:\s*([\d,]+)(?:\s+tokens)?(?:\s*>\s*[\d,]+\s+maximum|\s*,\s*model maximum context length\s*:\s*[\d,]+)?/i,
   /requested\s+([\d,]+)\s+tokens/i,
-  /you requested\s+([\d,]+)\s+tokens/i,
   /requested\s*:\s*([\d,]+)/i,
   /resulted in\s+([\d,]+)\s+tokens/i,
   /request exceeded model token limit\s*:\s*[\d,]+\s*\(requested\s*:\s*([\d,]+)\)/i,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -208,14 +208,35 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 }
 
 const OBSERVED_OVERFLOW_TOKEN_PATTERNS = [
-  /prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i,
+  /prompt is too long:\s*([\d,]+)(?:\s+tokens)?(?:\s*>\s*[\d,]+\s+maximum|\s*,\s*model maximum context length\s*:\s*[\d,]+)?/i,
   /requested\s+([\d,]+)\s+tokens/i,
+  /you requested\s+([\d,]+)\s+tokens/i,
+  /requested\s*:\s*([\d,]+)/i,
   /resulted in\s+([\d,]+)\s+tokens/i,
+  /request exceeded model token limit\s*:\s*[\d,]+\s*\(requested\s*:\s*([\d,]+)\)/i,
+];
+
+const OBSERVED_OVERFLOW_TOKEN_SUM_PATTERNS = [
+  /input length(?:\s+and\s+max_tokens)?\s+exceed\s+context(?:\s+limit|\s+window)?\s*\(i\.e\s*([\d,]+)\s*\+\s*([\d,]+)\s*>\s*[\d,]+\)/i,
 ];
 
 export function extractObservedOverflowTokenCount(errorMessage?: string): number | undefined {
   if (!errorMessage) {
     return undefined;
+  }
+
+  for (const pattern of OBSERVED_OVERFLOW_TOKEN_SUM_PATTERNS) {
+    const match = errorMessage.match(pattern);
+    const lhs = match?.[1]?.replaceAll(",", "");
+    const rhs = match?.[2]?.replaceAll(",", "");
+    if (!lhs || !rhs) {
+      continue;
+    }
+    const left = Number(lhs);
+    const right = Number(rhs);
+    if (Number.isFinite(left) && left > 0 && Number.isFinite(right) && right >= 0) {
+      return Math.floor(left + right);
+    }
   }
 
   for (const pattern of OBSERVED_OVERFLOW_TOKEN_PATTERNS) {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -209,13 +209,33 @@ export function isCompactionFailureError(errorMessage?: string): boolean {
 
 const OBSERVED_OVERFLOW_TOKEN_PATTERNS = [
   /prompt is too long:\s*([\d,]+)\s+tokens\s*>\s*[\d,]+\s+maximum/i,
+  /prompt is too long:\s*([\d,]+)\s*,\s*model maximum context length\s*:\s*[\d,]+/i,
   /requested\s+([\d,]+)\s+tokens/i,
+  /token limit\s*:\s*[\d,]+\s*\(requested\s*:\s*([\d,]+)\)/i,
   /resulted in\s+([\d,]+)\s+tokens/i,
+];
+
+const OBSERVED_OVERFLOW_TOKEN_SUM_PATTERNS = [
+  /input length(?:\s+and\s+max_tokens)?\s+exceed\s+context(?:\s+limit|\s+window)?\s*\(i\.e\s*([\d,]+)\s*\+\s*([\d,]+)\s*>\s*[\d,]+\)/i,
 ];
 
 export function extractObservedOverflowTokenCount(errorMessage?: string): number | undefined {
   if (!errorMessage) {
     return undefined;
+  }
+
+  for (const pattern of OBSERVED_OVERFLOW_TOKEN_SUM_PATTERNS) {
+    const match = errorMessage.match(pattern);
+    const rawLeft = match?.[1]?.replaceAll(",", "");
+    const rawRight = match?.[2]?.replaceAll(",", "");
+    if (!rawLeft || !rawRight) {
+      continue;
+    }
+    const left = Number(rawLeft);
+    const right = Number(rawRight);
+    if (Number.isFinite(left) && left > 0 && Number.isFinite(right) && right >= 0) {
+      return Math.floor(left + right);
+    }
   }
 
   for (const pattern of OBSERVED_OVERFLOW_TOKEN_PATTERNS) {

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -13,6 +13,7 @@ import {
   mockedContextEngine,
   mockedDescribeFailoverError,
   mockedEvaluateContextWindowGuard,
+  mockedExtractObservedOverflowTokenCount,
   mockedGlobalHookRunner,
   mockedPickFallbackThinkingLevel,
   mockedResolveContextWindowInfo,
@@ -199,6 +200,39 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
     expect(mockedCompactDirect).toHaveBeenCalledWith(
       expect.objectContaining({
         currentTokenCount: 277403,
+      }),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("forces minimally over-budget compaction when overflow text is confirmed but unparseable", async () => {
+    mockedExtractObservedOverflowTokenCount.mockReturnValueOnce(undefined);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          lastAssistant: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: "Context window exceeded for this request.",
+            usage: { totalTokens: 0 },
+          } as never,
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-9",
+        tokensBefore: 200001,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expect(mockedCompactDirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentTokenCount: 200001,
       }),
     );
     expect(result.meta.error).toBeUndefined();

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.test.ts
@@ -20,6 +20,7 @@ import {
   mockedEvaluateContextWindowGuard,
   mockedEnsureAuthProfileStore,
   mockedEnsureAuthProfileStoreWithoutExternalProfiles,
+  mockedExtractObservedOverflowTokenCount,
   mockedGlobalHookRunner,
   mockedGetApiKeyForModel,
   mockedMarkAuthProfileSuccess,
@@ -1507,6 +1508,37 @@ describe("runEmbeddedPiAgent overflow compaction trigger routing", () => {
 
     expectMockCallFields(mockedCompactDirect, {
       currentTokenCount: 277403,
+    });
+    expect(result.meta.error).toBeUndefined();
+  });
+
+  it("passes minimally over-budget count when overflow text is confirmed but unparseable", async () => {
+    mockedExtractObservedOverflowTokenCount.mockReturnValueOnce(undefined);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          lastAssistant: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: "Context window exceeded for this request.",
+            usage: { totalTokens: 0 },
+          } as never,
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+    mockedCompactDirect.mockResolvedValueOnce(
+      makeCompactionSuccess({
+        summary: "Compacted session",
+        firstKeptEntryId: "entry-9",
+        tokensBefore: 200001,
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent(overflowBaseRunParams);
+
+    expectMockCallFields(mockedCompactDirect, {
+      currentTokenCount: 200001,
     });
     expect(result.meta.error).toBeUndefined();
   });

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1010,12 +1010,19 @@ export async function runEmbeddedPiAgent(
             const errorText = contextOverflowError.text;
             const msgCount = attempt.messagesSnapshot?.length ?? 0;
             const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+            const overflowTokenCountForCompaction =
+              observedOverflowTokens ??
+              (ctxInfo.tokens > 0
+                ? // Confirmed overflow with an unparseable provider message should still
+                  // force budget compaction instead of falling through as "nothing to compact".
+                  ctxInfo.tokens + 1
+                : undefined);
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
                 `messages=${msgCount} sessionFile=${params.sessionFile} ` +
                 `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
-                `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
+                `observedTokens=${overflowTokenCountForCompaction ?? "unknown"} ` +
                 `error=${errorText.slice(0, 200)}`,
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
@@ -1081,8 +1088,8 @@ export async function runEmbeddedPiAgent(
                   ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
                   runId: params.runId,
                   trigger: "overflow",
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
+                  ...(overflowTokenCountForCompaction !== undefined
+                    ? { currentTokenCount: overflowTokenCountForCompaction }
                     : {}),
                   diagId: overflowDiagId,
                   attempt: overflowCompactionAttempts,
@@ -1093,8 +1100,8 @@ export async function runEmbeddedPiAgent(
                   sessionKey: params.sessionKey,
                   sessionFile: params.sessionFile,
                   tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
+                  ...(overflowTokenCountForCompaction !== undefined
+                    ? { currentTokenCount: overflowTokenCountForCompaction }
                     : {}),
                   force: true,
                   compactionTarget: "budget",

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1889,12 +1889,20 @@ export async function runEmbeddedPiAgent(
             const errorText = contextOverflowError.text;
             const msgCount = attempt.messagesSnapshot?.length ?? 0;
             const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
+            const overflowTokenCountForCompaction =
+              observedOverflowTokens ??
+              (ctxInfo.tokens > 0
+                ? // Confirmed overflow with an unparseable provider message still carries a
+                  // minimally over-budget count for compaction engines and diagnostics.
+                  ctxInfo.tokens + 1
+                : undefined);
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
                 `messages=${msgCount} sessionFile=${activeSessionFile} ` +
                 `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
                 `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
+                `compactionTokens=${overflowTokenCountForCompaction ?? "unknown"} ` +
                 `error=${errorText.slice(0, 200)}`,
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
@@ -1978,8 +1986,8 @@ export async function runEmbeddedPiAgent(
                   ...(attempt.promptCache ? { promptCache: attempt.promptCache } : {}),
                   runId: params.runId,
                   trigger: "overflow",
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
+                  ...(overflowTokenCountForCompaction !== undefined
+                    ? { currentTokenCount: overflowTokenCountForCompaction }
                     : {}),
                   diagId: overflowDiagId,
                   attempt: overflowCompactionAttempts,
@@ -1997,8 +2005,8 @@ export async function runEmbeddedPiAgent(
                     sessionKey: params.sessionKey,
                     sessionFile: activeSessionFile,
                     tokenBudget: ctxInfo.tokens,
-                    ...(observedOverflowTokens !== undefined
-                      ? { currentTokenCount: observedOverflowTokens }
+                    ...(overflowTokenCountForCompaction !== undefined
+                      ? { currentTokenCount: overflowTokenCountForCompaction }
                       : {}),
                     force: true,
                     compactionTarget: "budget",


### PR DESCRIPTION
## Summary

- Broaden observed overflow token extraction across provider-shaped error formats used during overflow recovery.
- Pass a minimally over-budget `currentTokenCount` into overflow compaction when overflow is confirmed but the provider message does not expose a parseable count.
- Add regression coverage and compaction docs for the shared overflow-budget path.
- Refresh the PR on current `origin/main` (`c8a35c4645dcf926d8e2c8165a1b0a2e48d24296`) and resolve the previous merge conflicts.

## Relevance check

Still relevant. Current `main` still classified Kimi/MiniMax/additive provider overflow messages as context overflow, but `extractObservedOverflowTokenCount()` only parsed older `prompt is too long: N tokens > ...`, `requested N tokens`, and `resulted in N tokens` forms. The runner still omitted `currentTokenCount` unless extraction succeeded, so confirmed-but-unparseable overflow could still fall through to insufficient budget compaction.

## Review comments addressed

- Removed the redundant `you requested ... tokens` regex from the old review path; it is not present in the refreshed branch.
- Refreshed the branch against current `main`, resolving the dirty/conflicting state.
- Updated the overflow diagnostic log to report both `observedTokens` and the effective `compactionTokens` so synthetic fallback counts are distinguishable from provider-reported counts.
- Added runner-path proof below showing `runEmbeddedPiAgent` passing both parsed and synthetic overflow counts into context-engine compaction, then retrying successfully.

## Verification

- Current head: `0701ef671160c05f730a31c9f4d07218c08f2894`
- Rebasing target: `upstream/main` at `cd1cae5be9ba76763e696784ff2effa534e00052`
- `pnpm docs:list`
- `git diff --check upstream/main...HEAD`
- `pnpm exec oxfmt --check --threads=1 docs/reference/session-management-compaction.md src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts src/agents/pi-embedded-helpers/errors.ts src/agents/pi-embedded-runner/run.overflow-compaction.test.ts src/agents/pi-embedded-runner/run.ts`
- Focused Vitest through `scripts/run-vitest.mjs` for `src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts` and `src/agents/pi-embedded-runner/run.overflow-compaction.test.ts`
  - Result: `Test Files 3 passed (3)`, `Tests 201 passed (201)`.
- `AUTOREVIEW_AUTO_TESTS=0 .agents/skills/autoreview/scripts/autoreview --mode branch --base upstream/main`
  - Result: `autoreview clean: no accepted/actionable findings reported`.
- Runner-path proof through `pnpm exec tsx - <<'EOF' ... EOF` in a local OpenClaw checkout with a temporary proof harness/context engine, invoking `runEmbeddedPiAgent` twice.
  - Result: both parsed provider-count and synthetic fallback overflow paths compacted and retried successfully.

## Real behavior proof

Behavior addressed: Provider-shaped context-overflow errors that already trigger overflow recovery now provide an effective overflow budget to compaction. Parseable provider counts are forwarded as `currentTokenCount`; confirmed overflow with no parseable count uses `ctxInfo.tokens + 1` so budget-targeted compaction has an over-budget count.

Real environment tested: Real local OpenClaw source checkout at PR head `0701ef671160c05f730a31c9f4d07218c08f2894` on Node `v24.14.0`. The terminal probe used the production `runEmbeddedPiAgent` runner, production overflow classifier/parser, production context-overflow diagnostic logging, and a temporary registered proof agent harness/context engine. This was not a Vitest unit test; it exercised the runner overflow-recovery path through `ContextEngine.compact()` and the retry loop without calling a live external provider.

Exact steps or command run after this patch: Installed dependencies in an isolated PR worktree with `pnpm install`, then ran `pnpm exec tsx - <<'EOF' ... EOF`. The inline script registered a temporary `proof-harness`, registered a temporary `proof-context` context engine, invoked `runEmbeddedPiAgent` for a parseable provider-count overflow message and an unparseable confirmed-overflow message, printed the runner diagnostic output plus the `compact()` parameters, and printed the final retry result.

Evidence after fix: Redacted terminal output from the local OpenClaw runner-path probe:

```text
[proof:provider-count] harness attempt=1 provider=proof-provider/proof-model
[agent/embedded] [context-overflow-diag] sessionKey=proof-provider-count provider=proof-provider/proof-model source=promptError messages=1 sessionFile=<temp>/provider-count.jsonl diagId=<redacted> compactionAttempts=0 observedTokens=203557 compactionTokens=203557 error=context window exceeded: token limit: 200000 (requested: 203557)
[agent/embedded] context overflow detected (attempt 1/3); attempting auto-compaction for proof-provider/proof-model
[proof:provider-count] compact observedTokens=203557 compactionTokens=203557 runtimeContext.currentTokenCount=203557 tokenBudget=200000 target=budget trigger=overflow
[agent/embedded] auto-compaction succeeded for proof-provider/proof-model; retrying prompt
[proof:provider-count] harness attempt=2 provider=proof-provider/proof-model
[proof:provider-count] retry result attempts=2 payload="retry ok after overflow compaction (provider-count)" compactionCount=1 tokensAfter=80000
[proof:synthetic-fallback] harness attempt=1 provider=proof-provider/proof-model
[agent/embedded] [context-overflow-diag] sessionKey=proof-synthetic-fallback provider=proof-provider/proof-model source=promptError messages=1 sessionFile=<temp>/synthetic-fallback.jsonl diagId=<redacted> compactionAttempts=0 observedTokens=unknown compactionTokens=200001 error=provider rejected request: context window exceeded after request assembly
[agent/embedded] context overflow detected (attempt 1/3); attempting auto-compaction for proof-provider/proof-model
[proof:synthetic-fallback] compact observedTokens=unknown compactionTokens=200001 runtimeContext.currentTokenCount=200001 tokenBudget=200000 target=budget trigger=overflow
[agent/embedded] auto-compaction succeeded for proof-provider/proof-model; retrying prompt
[proof:synthetic-fallback] harness attempt=2 provider=proof-provider/proof-model
[proof:synthetic-fallback] retry result attempts=2 payload="retry ok after overflow compaction (synthetic-fallback)" compactionCount=1 tokensAfter=80000
```

Observed result after fix: `runEmbeddedPiAgent` emitted overflow diagnostics with `observedTokens=203557` and `compactionTokens=203557` for the provider-count case, passed `currentTokenCount=203557` into `ContextEngine.compact()`, then retried successfully. For confirmed overflow with no parseable provider count, the runner emitted `observedTokens=unknown` and `compactionTokens=200001`, passed `currentTokenCount=200001` into `ContextEngine.compact()`, then retried successfully.

What was not tested: A fresh live provider overflow against MiniMax/Kimi/opencode-go was not rerun, and the full repository build/check suite was not run locally. The proof used a local synthetic provider harness so the overflow/retry path could be exercised deterministically without external credentials or secret-bearing provider logs.

## Notes

- Related to #70472, but does not fully resolve later session-rotation/orphaning behavior after failed compaction.
