### PR TITLE
fix(mattermost): preserve streamed text across draft boundaries and tool starts

### DIFF
--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -31,9 +31,43 @@ export function normalizeMattermostDraftText(text: string, maxChars: number): st
   return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
-export function buildMattermostToolStatusText(params: { name?: string; phase?: string }): string {
-  const tool = params.name?.trim() ? ` \`${params.name.trim()}\`` : " tool";
-  return `Running${tool}…`;
+const TOOL_STATUS_VERBS: Record<string, string> = {
+  exec: "Running command",
+  read: "Reading file",
+  write: "Writing file",
+  edit: "Editing file",
+  message: "Sending message",
+  web_fetch: "Fetching web page",
+  browser: "Browsing",
+  canvas: "Updating canvas",
+  tts: "Generating speech",
+  process: "Managing process",
+  lcm_grep: "Searching memory",
+  lcm_describe: "Inspecting memory",
+  lcm_expand: "Expanding memory",
+  lcm_expand_query: "Recalling memory",
+  memory_search: "Searching notes",
+  memory_get: "Reading notes",
+  sessions_spawn: "Spawning sub-agent",
+  sessions_send: "Messaging session",
+  sessions_list: "Listing sessions",
+  sessions_history: "Reading session history",
+  subagents: "Managing sub-agents",
+  session_status: "Checking status",
+};
+
+export function buildMattermostToolStatusText(params: {
+  name?: string;
+  phase?: string;
+  title?: string;
+}): string {
+  const name = params.name?.trim();
+  const title = params.title?.trim();
+  if (!name) return "Running tool…";
+  const verb = TOOL_STATUS_VERBS[name] ?? "Running";
+  // If runtime supplied a richer title (e.g. "exec(ls *.md)"), surface it.
+  if (title && title !== name) return `${verb} \`${name}\` — ${title}…`;
+  return `${verb} \`${name}\`…`;
 }
 
 export function createMattermostDraftStream(params: {

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -32,7 +32,7 @@ export function normalizeMattermostDraftText(text: string, maxChars: number): st
 }
 
 const TOOL_STATUS_ICONS: Record<string, string> = {
-  exec: "▶",
+  exec: "⚡",
   read: "📖",
   write: "✏️",
   edit: "✏️",
@@ -63,8 +63,8 @@ export function buildMattermostToolStatusText(params: {
 }): string {
   const name = params.name?.trim();
   const title = params.title?.trim();
-  if (!name) return "▶ tool…";
-  const icon = TOOL_STATUS_ICONS[name] ?? "▶";
+  if (!name) return "⚡ tool…";
+  const icon = TOOL_STATUS_ICONS[name] ?? "⚡";
   // Avoid backticks: Mattermost desktop client hides text after inline code.
   // Use plain text with an emoji prefix so the title is always visible.
   if (title && title !== name) return `${icon} ${name} — ${title}…`;

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -31,29 +31,29 @@ export function normalizeMattermostDraftText(text: string, maxChars: number): st
   return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
 }
 
-const TOOL_STATUS_VERBS: Record<string, string> = {
-  exec: "Running command",
-  read: "Reading file",
-  write: "Writing file",
-  edit: "Editing file",
-  message: "Sending message",
-  web_fetch: "Fetching web page",
-  browser: "Browsing",
-  canvas: "Updating canvas",
-  tts: "Generating speech",
-  process: "Managing process",
-  lcm_grep: "Searching memory",
-  lcm_describe: "Inspecting memory",
-  lcm_expand: "Expanding memory",
-  lcm_expand_query: "Recalling memory",
-  memory_search: "Searching notes",
-  memory_get: "Reading notes",
-  sessions_spawn: "Spawning sub-agent",
-  sessions_send: "Messaging session",
-  sessions_list: "Listing sessions",
-  sessions_history: "Reading session history",
-  subagents: "Managing sub-agents",
-  session_status: "Checking status",
+const TOOL_STATUS_ICONS: Record<string, string> = {
+  exec: "▶",
+  read: "📖",
+  write: "✏️",
+  edit: "✏️",
+  message: "📨",
+  web_fetch: "🌐",
+  browser: "🌐",
+  canvas: "🎨",
+  tts: "🔊",
+  process: "⚙️",
+  lcm_grep: "🔍",
+  lcm_describe: "🔍",
+  lcm_expand: "🔍",
+  lcm_expand_query: "🔍",
+  memory_search: "📝",
+  memory_get: "📝",
+  sessions_spawn: "🤖",
+  sessions_send: "📨",
+  sessions_list: "📋",
+  sessions_history: "📜",
+  subagents: "🤖",
+  session_status: "📊",
 };
 
 export function buildMattermostToolStatusText(params: {
@@ -63,11 +63,12 @@ export function buildMattermostToolStatusText(params: {
 }): string {
   const name = params.name?.trim();
   const title = params.title?.trim();
-  if (!name) return "Running tool…";
-  const verb = TOOL_STATUS_VERBS[name] ?? "Running";
-  // If runtime supplied a richer title (e.g. "exec(ls *.md)"), surface it.
-  if (title && title !== name) return `${verb} \`${name}\` — ${title}…`;
-  return `${verb} \`${name}\`…`;
+  if (!name) return "▶ tool…";
+  const icon = TOOL_STATUS_ICONS[name] ?? "▶";
+  // Avoid backticks: Mattermost desktop client hides text after inline code.
+  // Use plain text with an emoji prefix so the title is always visible.
+  if (title && title !== name) return `${icon} ${name} — ${title}…`;
+  return `${icon} ${name}…`;
 }
 
 export function createMattermostDraftStream(params: {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1786,9 +1786,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     const callId = payload.itemId?.replace(/^(?:tool|command):/, "");
                     const callChanged = callId && callId !== lastToolItemId;
                     if (callChanged) {
-                      await onDraftBoundary();
+                      // Set lastToolItemId BEFORE awaiting so a racing onToolStart
+                      // (which checks lastToolItemId === undefined to decide whether
+                      // to write its no-title placeholder) cannot run between the
+                      // boundary await and the assignment.
                       lastToolItemId = callId;
                       lastToolItemTitle = undefined;
+                      await onDraftBoundary();
                     }
                     if (payload.name) lastToolItemName = payload.name;
                     // Same call may emit multiple item events (kind=tool wrapper +

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1629,6 +1629,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         });
         let lastPartialText = "";
         let hasStreamedMessage = false;
+        let lastToolItemId: string | undefined;
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1767,21 +1768,26 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     }
                   },
                   onToolStart: async (payload) => {
+                    // Each tool start opens a new draft post; reset itemId tracker.
                     await onDraftBoundary();
+                    lastToolItemId = undefined;
                     draftStream.update(buildMattermostToolStatusText(payload));
                     hasStreamedMessage = true;
                   },
                   onItemEvent: async (payload) => {
-                    // Runtime emits richer item events (e.g. with a human-readable title).
-                    // Use them to upgrade the current tool status post in-place.
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    const text = buildMattermostToolStatusText({
+                    // If a new item arrives without a preceding tool event, open a new post.
+                    if (payload.itemId && payload.itemId !== lastToolItemId) {
+                      if (lastToolItemId !== undefined) await onDraftBoundary();
+                      lastToolItemId = payload.itemId;
+                    }
+                    // Otherwise overwrite the current draft post with richer text.
+                    draftStream.update(buildMattermostToolStatusText({
                       name: payload.name,
                       title: payload.title,
                       phase: payload.phase,
-                    });
-                    draftStream.update(text);
+                    }));
                     hasStreamedMessage = true;
                   },
                 },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1771,6 +1771,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     draftStream.update(buildMattermostToolStatusText(payload));
                     hasStreamedMessage = true;
                   },
+                  onItemEvent: async (payload) => {
+                    // Runtime emits richer item events (e.g. with a human-readable title).
+                    // Use them to upgrade the current tool status post in-place.
+                    if (payload.kind !== "tool" && payload.kind !== "command") return;
+                    if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
+                    const text = buildMattermostToolStatusText({
+                      name: payload.name,
+                      title: payload.title,
+                      phase: payload.phase,
+                    });
+                    draftStream.update(text);
+                    hasStreamedMessage = true;
+                  },
                 },
               }),
           });

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1700,6 +1700,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             hasStreamedMessage = false;
           }
           lastPartialText = "";
+          lastToolItemId = undefined;
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1768,21 +1769,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     }
                   },
                   onToolStart: async (payload) => {
-                    // Each tool start opens a new draft post; reset itemId tracker.
+                    // Defer to onItemEvent if the runtime emitted a richer item event
+                    // for this tool call. Tracked via lastToolItemId set by onItemEvent.
+                    if (lastToolItemId !== undefined) return;
                     await onDraftBoundary();
-                    lastToolItemId = undefined;
                     draftStream.update(buildMattermostToolStatusText(payload));
                     hasStreamedMessage = true;
                   },
                   onItemEvent: async (payload) => {
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    // If a new item arrives without a preceding tool event, open a new post.
                     if (payload.itemId && payload.itemId !== lastToolItemId) {
+                      // First item of this run uses the boundary already created by
+                      // onAssistantMessageStart. Subsequent items open their own post.
                       if (lastToolItemId !== undefined) await onDraftBoundary();
                       lastToolItemId = payload.itemId;
                     }
-                    // Otherwise overwrite the current draft post with richer text.
                     draftStream.update(buildMattermostToolStatusText({
                       name: payload.name,
                       title: payload.title,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1769,6 +1769,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onToolStart: async (payload) => {
                     await onDraftBoundary();
                     draftStream.update(buildMattermostToolStatusText(payload));
+                    hasStreamedMessage = true;
                   },
                 },
               }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1781,14 +1781,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onItemEvent: async (payload) => {
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    // Dedupe by (itemId, name). Runtime sometimes emits two layered
-                    // item events for the same tool call (e.g. high-level 'exec' +
-                    // low-level 'command') with different itemIds. Only open a new
-                    // post when *both* differ from the last one.
+                    // Always boundary on a *new* item (different itemId AND name).
+                    // First item of a tool also opens a fresh post so we don't
+                    // overwrite preceding assistant text in the current draft.
                     const itemChanged = payload.itemId && payload.itemId !== lastToolItemId;
                     const nameChanged = payload.name && payload.name !== lastToolItemName;
                     if (itemChanged && nameChanged) {
-                      if (lastToolItemId !== undefined) await onDraftBoundary();
+                      await onDraftBoundary();
                     }
                     if (payload.itemId) lastToolItemId = payload.itemId;
                     if (payload.name) lastToolItemName = payload.name;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1688,8 +1688,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           hasStreamedMessage = true;
         };
 
-        const onDraftBoundary = () => {
+        const onDraftBoundary = async () => {
           if (hasStreamedMessage) {
+            try {
+              await draftStream.flush();
+            } catch (err) {
+              logVerboseMessage(`mattermost draft flush failed: ${String(err)}`);
+            }
             draftStream.forceNewMessage();
             hasStreamedMessage = false;
           }
@@ -1762,7 +1767,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     }
                   },
                   onToolStart: async (payload) => {
-                    onDraftBoundary();
+                    await onDraftBoundary();
                     draftStream.update(buildMattermostToolStatusText(payload));
                   },
                 },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1628,6 +1628,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           warn: logVerboseMessage,
         });
         let lastPartialText = "";
+        let hasStreamedMessage = false;
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1684,6 +1685,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           }
           lastPartialText = cleaned;
           draftStream.update(cleaned);
+          hasStreamedMessage = true;
+        };
+
+        const onDraftBoundary = () => {
+          if (hasStreamedMessage) {
+            draftStream.forceNewMessage();
+            hasStreamedMessage = false;
+          }
+          lastPartialText = "";
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1744,18 +1754,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onPartialReply: (payload) => {
                     updateDraftFromPartial(payload.text);
                   },
-                  onAssistantMessageStart: () => {
-                    lastPartialText = "";
-                  },
-                  onReasoningEnd: () => {
-                    lastPartialText = "";
-                  },
+                  onAssistantMessageStart: onDraftBoundary,
+                  onReasoningEnd: onDraftBoundary,
                   onReasoningStream: async () => {
                     if (!lastPartialText) {
                       draftStream.update("Thinking…");
                     }
                   },
                   onToolStart: async (payload) => {
+                    onDraftBoundary();
                     draftStream.update(buildMattermostToolStatusText(payload));
                   },
                 },

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1632,6 +1632,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         let lastToolItemId: string | undefined;
         let lastToolItemName: string | undefined;
         let lastToolItemTitle: string | undefined;
+        // Serialize onItemEvent invocations so concurrent kind=tool/kind=command
+        // events for the same call observe each other's state changes (in particular
+        // the lastToolItemId set, which guards against onToolStart writing a duplicate
+        // no-title placeholder post).
+        let itemEventChain: Promise<void> = Promise.resolve();
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1780,39 +1785,47 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                     draftStream.update(buildMattermostToolStatusText(payload));
                     hasStreamedMessage = true;
                   },
-                  onItemEvent: async (payload) => {
-                    if (payload.kind !== "tool" && payload.kind !== "command") return;
-                    if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    const callId = payload.itemId?.replace(/^(?:tool|command):/, "");
-                    const callChanged = callId && callId !== lastToolItemId;
-                    if (callChanged) {
-                      // Set lastToolItemId BEFORE awaiting so a racing onToolStart
-                      // (which checks lastToolItemId === undefined to decide whether
-                      // to write its no-title placeholder) cannot run between the
-                      // boundary await and the assignment.
-                      lastToolItemId = callId;
-                      lastToolItemTitle = undefined;
-                      await onDraftBoundary();
-                      // onDraftBoundary clears lastToolItemId; restore it after the
-                      // await so any onToolStart that races in afterwards still sees
-                      // a defined value and skips writing the no-title placeholder.
-                      lastToolItemId = callId;
-                    }
-                    if (payload.name) lastToolItemName = payload.name;
-                    // Same call may emit multiple item events (kind=tool wrapper +
-                    // kind=command inner + later phase=update). Some of them have an
-                    // empty title; remember the best non-empty title we've seen for
-                    // this call and prefer it. Inner kind=command titles are typically
-                    // richer ("command foo") so let them overwrite.
-                    if (payload.title && payload.title.trim()) {
-                      lastToolItemTitle = payload.title;
-                    }
-                    draftStream.update(buildMattermostToolStatusText({
-                      name: payload.name ?? lastToolItemName,
-                      title: lastToolItemTitle,
-                      phase: payload.phase,
-                    }));
-                    hasStreamedMessage = true;
+                  onItemEvent: (payload) => {
+                    // Chain handlers so concurrent kind=tool + kind=command events
+                    // for the same call don't both observe lastToolItemId=undefined
+                    // and each create their own status post.
+                    itemEventChain = itemEventChain
+                      .then(async () => {
+                        if (payload.kind !== "tool" && payload.kind !== "command") return;
+                        if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
+                        const callId = payload.itemId?.replace(/^(?:tool|command):/, "");
+                        const callChanged = callId && callId !== lastToolItemId;
+                        if (callChanged) {
+                          // Set lastToolItemId BEFORE awaiting so a racing onToolStart
+                          // (which checks lastToolItemId === undefined to decide whether
+                          // to write its no-title placeholder) cannot run between the
+                          // boundary await and the assignment.
+                          lastToolItemId = callId;
+                          lastToolItemTitle = undefined;
+                          await onDraftBoundary();
+                          // onDraftBoundary clears lastToolItemId; restore it after the
+                          // await so any onToolStart that races in afterwards still sees
+                          // a defined value and skips writing the no-title placeholder.
+                          lastToolItemId = callId;
+                        }
+                        if (payload.name) lastToolItemName = payload.name;
+                        // Same call may emit multiple item events (kind=tool wrapper +
+                        // kind=command inner + later phase=update). Some of them have an
+                        // empty title; remember the best non-empty title we've seen for
+                        // this call and prefer it. Inner kind=command titles are typically
+                        // richer ("command foo") so let them overwrite.
+                        if (payload.title && payload.title.trim()) {
+                          lastToolItemTitle = payload.title;
+                        }
+                        draftStream.update(buildMattermostToolStatusText({
+                          name: payload.name ?? lastToolItemName,
+                          title: lastToolItemTitle,
+                          phase: payload.phase,
+                        }));
+                        hasStreamedMessage = true;
+                      })
+                      .catch(() => {});
+                    return itemEventChain;
                   },
                 },
               }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1793,6 +1793,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                       lastToolItemId = callId;
                       lastToolItemTitle = undefined;
                       await onDraftBoundary();
+                      // onDraftBoundary clears lastToolItemId; restore it after the
+                      // await so any onToolStart that races in afterwards still sees
+                      // a defined value and skips writing the no-title placeholder.
+                      lastToolItemId = callId;
                     }
                     if (payload.name) lastToolItemName = payload.name;
                     // Same call may emit multiple item events (kind=tool wrapper +

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1781,16 +1781,18 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onItemEvent: async (payload) => {
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    // Always boundary on a *new* item (different itemId AND name).
-                    // First item of a tool also opens a fresh post so we don't
-                    // overwrite preceding assistant text in the current draft.
-                    const itemChanged = payload.itemId && payload.itemId !== lastToolItemId;
-                    const nameChanged = payload.name && payload.name !== lastToolItemName;
-                    if (itemChanged && nameChanged) {
+                    // Strip the kind prefix (tool: / command:) to get the underlying call id.
+                    // Runtime emits two layered events for one logical tool call (kind=tool
+                    // wrapper + kind=command inner) with the same name and same suffix.
+                    const callId = payload.itemId?.replace(/^(?:tool|command):/, "");
+                    const callChanged = callId && callId !== lastToolItemId;
+                    if (callChanged) {
                       await onDraftBoundary();
+                      lastToolItemId = callId;
                     }
-                    if (payload.itemId) lastToolItemId = payload.itemId;
                     if (payload.name) lastToolItemName = payload.name;
+                    // Prefer the inner (kind=command) event's richer title when available.
+                    // It usually arrives second; overwrite to surface the better description.
                     draftStream.update(buildMattermostToolStatusText({
                       name: payload.name,
                       title: payload.title,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1631,6 +1631,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         let hasStreamedMessage = false;
         let lastToolItemId: string | undefined;
         let lastToolItemName: string | undefined;
+        let lastToolItemTitle: string | undefined;
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1703,6 +1704,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           lastPartialText = "";
           lastToolItemId = undefined;
           lastToolItemName = undefined;
+          lastToolItemTitle = undefined;
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1781,21 +1783,25 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onItemEvent: async (payload) => {
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    // Strip the kind prefix (tool: / command:) to get the underlying call id.
-                    // Runtime emits two layered events for one logical tool call (kind=tool
-                    // wrapper + kind=command inner) with the same name and same suffix.
                     const callId = payload.itemId?.replace(/^(?:tool|command):/, "");
                     const callChanged = callId && callId !== lastToolItemId;
                     if (callChanged) {
                       await onDraftBoundary();
                       lastToolItemId = callId;
+                      lastToolItemTitle = undefined;
                     }
                     if (payload.name) lastToolItemName = payload.name;
-                    // Prefer the inner (kind=command) event's richer title when available.
-                    // It usually arrives second; overwrite to surface the better description.
+                    // Same call may emit multiple item events (kind=tool wrapper +
+                    // kind=command inner + later phase=update). Some of them have an
+                    // empty title; remember the best non-empty title we've seen for
+                    // this call and prefer it. Inner kind=command titles are typically
+                    // richer ("command foo") so let them overwrite.
+                    if (payload.title && payload.title.trim()) {
+                      lastToolItemTitle = payload.title;
+                    }
                     draftStream.update(buildMattermostToolStatusText({
-                      name: payload.name,
-                      title: payload.title,
+                      name: payload.name ?? lastToolItemName,
+                      title: lastToolItemTitle,
                       phase: payload.phase,
                     }));
                     hasStreamedMessage = true;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1630,6 +1630,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         let lastPartialText = "";
         let hasStreamedMessage = false;
         let lastToolItemId: string | undefined;
+        let lastToolItemName: string | undefined;
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
         };
@@ -1701,6 +1702,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           }
           lastPartialText = "";
           lastToolItemId = undefined;
+          lastToolItemName = undefined;
         };
 
         const { dispatcher, replyOptions, markDispatchIdle, markRunComplete } =
@@ -1779,12 +1781,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   onItemEvent: async (payload) => {
                     if (payload.kind !== "tool" && payload.kind !== "command") return;
                     if (payload.phase && payload.phase !== "start" && payload.phase !== "update") return;
-                    if (payload.itemId && payload.itemId !== lastToolItemId) {
-                      // First item of this run uses the boundary already created by
-                      // onAssistantMessageStart. Subsequent items open their own post.
+                    // Dedupe by (itemId, name). Runtime sometimes emits two layered
+                    // item events for the same tool call (e.g. high-level 'exec' +
+                    // low-level 'command') with different itemIds. Only open a new
+                    // post when *both* differ from the last one.
+                    const itemChanged = payload.itemId && payload.itemId !== lastToolItemId;
+                    const nameChanged = payload.name && payload.name !== lastToolItemName;
+                    if (itemChanged && nameChanged) {
                       if (lastToolItemId !== undefined) await onDraftBoundary();
-                      lastToolItemId = payload.itemId;
                     }
+                    if (payload.itemId) lastToolItemId = payload.itemId;
+                    if (payload.name) lastToolItemName = payload.name;
                     draftStream.update(buildMattermostToolStatusText({
                       name: payload.name,
                       title: payload.title,


### PR DESCRIPTION
## Summary

In Mattermost, the draft-stream preview overwrites already-streamed text on every assistant-message boundary, reasoning end, and tool start. As a result, any reply that involves tool calls visibly rewrites the same Mattermost post and earlier text disappears.

Two pieces of the existing implementation cause this:

1. `onAssistantMessageStart` and `onReasoningEnd` only reset `lastPartialText`. They do **not** call `draftStream.forceNewMessage()`, so successive assistant blocks keep editing the **same** post via `PUT /posts/{id}`.
2. `onToolStart` calls `draftStream.update(buildMattermostToolStatusText(payload))`, which **overwrites** the in-flight draft post body with `Running \`tool\`…`.

Slack already does the right thing: it has an `onDraftBoundary` helper that calls `draftStream.forceNewMessage()` when there is streamed content, and uses emoji reactions for tool status (see `extensions/slack/src/monitor/message-handler/dispatch.ts`).

This PR mirrors the Slack behaviour for Mattermost using the existing `draftStream.forceNewMessage()` helper.

## Repro

- `openclaw@2026.4.21`
- Send a chat message that prompts the agent to run multi-step work (multiple `exec` / `read` / `grep` between assistant text segments)
- Observe the bot's reply post: every tool start rewrites it to `Running \`tool\`…`, and each new assistant block replaces the previous text instead of starting a new post

## Fix

Minimal, mechanical change in `extensions/mattermost/src/mattermost/monitor.ts`:

- Track `hasStreamedMessage` next to `lastPartialText`.
- Add `onDraftBoundary()` that calls `draftStream.forceNewMessage()` when there is already-streamed content (and resets `lastPartialText`).
- Wire `onAssistantMessageStart` and `onReasoningEnd` to `onDraftBoundary`.
- Call `onDraftBoundary()` at the top of `onToolStart` so the prior assistant chunk is sealed into its own post before the tool status replaces the draft body.

```diff
         let lastPartialText = "";
+        let hasStreamedMessage = false;
@@
           lastPartialText = cleaned;
           draftStream.update(cleaned);
+          hasStreamedMessage = true;
+        };
+
+        const onDraftBoundary = () => {
+          if (hasStreamedMessage) {
+            draftStream.forceNewMessage();
+            hasStreamedMessage = false;
+          }
+          lastPartialText = "";
         };
@@
-                  onAssistantMessageStart: () => {
-                    lastPartialText = "";
-                  },
-                  onReasoningEnd: () => {
-                    lastPartialText = "";
-                  },
+                  onAssistantMessageStart: onDraftBoundary,
+                  onReasoningEnd: onDraftBoundary,
                   onReasoningStream: async () => {
                     if (!lastPartialText) {
                       draftStream.update("Thinking…");
                     }
                   },
                   onToolStart: async (payload) => {
+                    onDraftBoundary();
                     draftStream.update(buildMattermostToolStatusText(payload));
                   },
```

This is the conservative, behaviour-preserving fix: tool status still appears as text (matching today's UX), but it lands in its own post instead of erasing the previous assistant chunk.

## Possible follow-up (not in this PR)

Slack signals tool activity via emoji reactions (`statusReactions`) instead of writing tool-status text. Mattermost supports reactions via `POST /reactions`, so a future PR could remove tool-status text writes entirely and switch to reactions for full parity.

## Workaround for users on older versions

Set `mattermost.blockStreaming: false` in `openclaw.json` to disable the draft-stream preview path so replies are delivered as a single final post (loses streaming UX, but no overwrites).

## Environment

- openclaw: 2026.4.21
- Mattermost server: 11.4.x
- Node: v22.22.0
- OS: WSL2 (Linux 6.6.x)
