### PR TITLE
fix(config): add heartbeat skill allowlist

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1374,6 +1374,7 @@ Periodic heartbeat runs.
         every: "30m", // 0m disables
         model: "openai/gpt-5.4-mini",
         includeReasoning: false,
+        allowSkills: ["healthcheck", "web-access"], // optional: restrict heartbeat runs to these skills; unset keeps normal agent behavior
         includeSystemPromptSection: true, // default: true; false omits the Heartbeat section from the system prompt
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
@@ -1393,6 +1394,7 @@ Periodic heartbeat runs.
 
 - `every`: duration string (ms/s/m/h). Default: `30m` (API-key auth) or `1h` (OAuth auth). Set to `0m` to disable.
 - `includeSystemPromptSection`: when false, omits the Heartbeat section from the system prompt and skips `HEARTBEAT.md` injection into bootstrap context. Default: `true`.
+- `allowSkills`: optional heartbeat-specific skill allowlist. Leave unset to keep the agent's normal skill behavior; set `[]` to disable all skills during heartbeat runs.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `timeoutSeconds`: maximum time in seconds allowed for a heartbeat agent turn before it is aborted. Leave unset to use `agents.defaults.timeoutSeconds`.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -100,6 +100,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
         every: "30m", // default: 30m (0m disables)
         model: "anthropic/claude-opus-4-6",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
+        allowSkills: ["healthcheck", "web-access"], // optional: restrict heartbeat runs to these skills; unset keeps normal agent behavior
         lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         isolatedSession: false, // default: false; true runs each heartbeat in a fresh session (no conversation history)
         target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "bluebubbles")
@@ -223,6 +224,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 - `every`: heartbeat interval (duration string; default unit = minutes).
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
+- `allowSkills`: optional heartbeat-specific skill allowlist. Leave unset to keep the agent's normal skill behavior; set `[]` to disable all skills during heartbeat runs.
 - `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
 - `isolatedSession`: when true, each heartbeat runs in a fresh session with no prior conversation history. Uses the same isolation pattern as cron `sessionTarget: "isolated"`. Dramatically reduces per-heartbeat token cost. Combine with `lightContext: true` for maximum savings. Delivery routing still uses the main session context.
 - `session`: optional session key for heartbeat runs.

--- a/src/config/heartbeat-config-honor.inventory.test.ts
+++ b/src/config/heartbeat-config-honor.inventory.test.ts
@@ -12,6 +12,7 @@ const EXPECTED_HEARTBEAT_KEYS = [
   "every",
   "model",
   "prompt",
+  "allowSkills",
   "includeSystemPromptSection",
   "ackMaxChars",
   "suppressToolErrorWarnings",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5080,6 +5080,15 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                   prompt: {
                     type: "string",
                   },
+                  allowSkills: {
+                    type: "array",
+                    items: {
+                      type: "string",
+                    },
+                    title: "Heartbeat Allow Skills",
+                    description:
+                      "Restricts heartbeat runs to this skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns.",
+                  },
                   includeSystemPromptSection: {
                     type: "boolean",
                     title: "Heartbeat Include System Prompt Section",
@@ -6390,6 +6399,15 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     },
                     prompt: {
                       type: "string",
+                    },
+                    allowSkills: {
+                      type: "array",
+                      items: {
+                        type: "string",
+                      },
+                      title: "Heartbeat Allow Skills",
+                      description:
+                        "Per-agent override for the heartbeat skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns for that agent.",
                     },
                     includeSystemPromptSection: {
                       type: "boolean",
@@ -26012,6 +26030,16 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
       label: "Embedded Pi Execution Contract",
       help: 'Embedded Pi execution contract: "default" keeps the standard runner behavior, while "strict-agentic" keeps OpenAI/OpenAI Codex GPT-5-family runs acting until they hit a real blocker instead of stopping at plans or filler.',
       tags: ["advanced"],
+    },
+    "agents.defaults.heartbeat.allowSkills": {
+      label: "Heartbeat Allow Skills",
+      help: "Restricts heartbeat runs to this skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns.",
+      tags: ["access", "automation"],
+    },
+    "agents.list.*.heartbeat.allowSkills": {
+      label: "Heartbeat Allow Skills",
+      help: "Per-agent override for the heartbeat skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns for that agent.",
+      tags: ["access", "automation"],
     },
     "agents.defaults.heartbeat.includeSystemPromptSection": {
       label: "Heartbeat Include System Prompt Section",

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1580,6 +1580,10 @@ export const FIELD_HELP: Record<string, string> = {
     "Includes the default agent's ## Heartbeats system prompt section when true. Turn this off to keep heartbeat runtime behavior while omitting the heartbeat prompt instructions from the agent system prompt.",
   "agents.list.*.heartbeat.includeSystemPromptSection":
     "Per-agent override for whether the default agent's ## Heartbeats system prompt section is injected. Use false to keep heartbeat runtime behavior but omit the heartbeat prompt instructions from that agent's system prompt.",
+  "agents.defaults.heartbeat.allowSkills":
+    "Restricts heartbeat runs to this skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns.",
+  "agents.list.*.heartbeat.allowSkills":
+    "Per-agent override for the heartbeat skill allowlist. Leave unset to keep the agent's normal skill behavior; set [] to disable all skills during heartbeat turns for that agent.",
   "agents.defaults.heartbeat.directPolicy":
     'Controls whether heartbeat delivery may target direct/DM chats: "allow" (default) permits DM delivery and "block" suppresses direct-target sends.',
   "agents.list.*.heartbeat.directPolicy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -577,6 +577,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.embeddedPi": "Embedded Pi",
   "agents.defaults.embeddedPi.projectSettingsPolicy": "Embedded Pi Project Settings Policy",
   "agents.defaults.embeddedPi.executionContract": "Embedded Pi Execution Contract",
+  "agents.defaults.heartbeat.allowSkills": "Heartbeat Allow Skills",
+  "agents.list.*.heartbeat.allowSkills": "Heartbeat Allow Skills",
   "agents.defaults.heartbeat.includeSystemPromptSection": "Heartbeat Include System Prompt Section",
   "agents.list.*.heartbeat.includeSystemPromptSection": "Heartbeat Include System Prompt Section",
   "agents.list[].embeddedPi": "Agent Embedded Pi",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -355,6 +355,11 @@ export type AgentDefaultsConfig = {
     accountId?: string;
     /** Override the heartbeat prompt body (default: "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK."). */
     prompt?: string;
+    /**
+     * Restrict the skills available during heartbeat runs to this allowlist.
+     * Unset keeps the agent's normal skill behavior; [] disables all skills.
+     */
+    allowSkills?: string[];
     /** Include the ## Heartbeats system prompt section for the default agent (default: true). */
     includeSystemPromptSection?: boolean;
     /** Max chars allowed after HEARTBEAT_OK before delivery (default: 30). */

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -116,4 +116,17 @@ describe("agent defaults schema", () => {
     expect(() => AgentDefaultsSchema.parse({ heartbeat: { timeoutSeconds: 0 } })).toThrow();
     expect(() => AgentEntrySchema.parse({ id: "ops", heartbeat: { timeoutSeconds: 0 } })).toThrow();
   });
+
+  it("accepts heartbeat allowSkills on defaults and agent entries", () => {
+    const defaults = AgentDefaultsSchema.parse({
+      heartbeat: { allowSkills: ["healthcheck", "web-access"] },
+    })!;
+    const agent = AgentEntrySchema.parse({
+      id: "ops",
+      heartbeat: { allowSkills: ["healthcheck", "web-access"] },
+    });
+
+    expect(defaults.heartbeat?.allowSkills).toEqual(["healthcheck", "web-access"]);
+    expect(agent.heartbeat?.allowSkills).toEqual(["healthcheck", "web-access"]);
+  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -35,6 +35,7 @@ export const HeartbeatSchema = z
     to: z.string().optional(),
     accountId: z.string().optional(),
     prompt: z.string().optional(),
+    allowSkills: z.array(z.string()).optional(),
     includeSystemPromptSection: z.boolean().optional(),
     ackMaxChars: z.number().int().nonnegative().optional(),
     suppressToolErrorWarnings: z.boolean().optional(),

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -80,6 +80,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
 
   async function runDefaultsHeartbeat(params: {
     model?: string;
+    allowSkills?: string[];
     suppressToolErrorWarnings?: boolean;
     timeoutSeconds?: number;
     lightContext?: boolean;
@@ -94,6 +95,7 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
               every: "5m",
               target: "whatsapp",
               model: params.model,
+              allowSkills: params.allowSkills,
               suppressToolErrorWarnings: params.suppressToolErrorWarnings,
               timeoutSeconds: params.timeoutSeconds,
               lightContext: params.lightContext,
@@ -182,6 +184,26 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
       expect.objectContaining({
         isHeartbeat: true,
         suppressToolErrorWarnings: true,
+      }),
+    );
+  });
+
+  it("passes heartbeat skillFilter when allowSkills is configured", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ allowSkills: ["healthcheck", "web-access"] });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        skillFilter: ["healthcheck", "web-access"],
+      }),
+    );
+  });
+
+  it("passes an empty heartbeat skillFilter when allowSkills disables all skills", async () => {
+    const replyOpts = await runDefaultsHeartbeat({ allowSkills: [] });
+    expect(replyOpts).toEqual(
+      expect.objectContaining({
+        isHeartbeat: true,
+        skillFilter: [],
       }),
     );
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1062,6 +1062,8 @@ export async function runHeartbeatOnce(opts: {
   try {
     await heartbeatTyping?.onReplyStart();
     const heartbeatModelOverride = normalizeOptionalString(heartbeat?.model);
+    const heartbeatSkillFilter =
+      Array.isArray(heartbeat?.allowSkills) ? heartbeat.allowSkills : undefined;
     const suppressToolErrorWarnings = heartbeat?.suppressToolErrorWarnings === true;
     const timeoutOverrideSeconds =
       typeof heartbeat?.timeoutSeconds === "number" ? heartbeat.timeoutSeconds : undefined;
@@ -1070,6 +1072,7 @@ export async function runHeartbeatOnce(opts: {
     const replyOpts = {
       isHeartbeat: true,
       ...(heartbeatModelOverride ? { heartbeatModelOverride } : {}),
+      ...(heartbeatSkillFilter !== undefined ? { skillFilter: heartbeatSkillFilter } : {}),
       suppressToolErrorWarnings,
       // Heartbeat timeout is a per-run override so user turns keep the global default.
       timeoutOverrideSeconds,

--- a/test/helpers/config/heartbeat-config-honor.inventory.ts
+++ b/test/helpers/config/heartbeat-config-honor.inventory.ts
@@ -40,6 +40,18 @@ export const HEARTBEAT_CONFIG_HONOR_INVENTORY: ConfigHonorInventoryRow[] = [
     testPaths: ["src/infra/heartbeat-runner.returns-default-unset.test.ts"],
   },
   {
+    key: "allowSkills",
+    schemaPaths: ["agents.defaults.heartbeat.allowSkills", "agents.list.*.heartbeat.allowSkills"],
+    typePaths: ["src/config/types.agent-defaults.ts", "src/config/zod-schema.agent-runtime.ts"],
+    mergePaths: ["src/infra/heartbeat-runner.ts"],
+    consumerPaths: ["src/infra/heartbeat-runner.ts", "src/auto-reply/reply/get-reply.ts"],
+    reloadPaths: ["src/gateway/config-reload-plan.ts"],
+    testPaths: [
+      "src/config/zod-schema.agent-defaults.test.ts",
+      "src/infra/heartbeat-runner.model-override.test.ts",
+    ],
+  },
+  {
     key: "includeSystemPromptSection",
     schemaPaths: [
       "agents.defaults.heartbeat.includeSystemPromptSection",


### PR DESCRIPTION
## Summary

- Problem: heartbeat runs currently inherit the target agent's full skill set, even when heartbeat only needs a small subset or none.
- Why it matters: large skill catalogs inflate the skills prompt and waste input context on every heartbeat turn.
- What changed: added `agents.defaults.heartbeat.allowSkills` and `agents.list[].heartbeat.allowSkills`, and threaded that allowlist into heartbeat reply runs.
- What did NOT change (scope boundary): default behavior is unchanged when `allowSkills` is unset; normal non-heartbeat agent turns are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: heartbeat uses the agent's normal skill filter with no heartbeat-specific override, so it always inherits the full configured skill set.
- Missing detection / guardrail: there was no heartbeat config surface to narrow the loaded skills, and no heartbeat-specific regression coverage for that override path.
- Contributing context (if known): this shows up most on agents with large skill catalogs, where heartbeat prompt cost becomes disproportionately high.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/infra/heartbeat-runner.model-override.test.ts`
  - `src/config/zod-schema.agent-defaults.test.ts`
  - `src/config/heartbeat-config-honor.inventory.test.ts`
- Scenario the test should lock in: heartbeat-specific `allowSkills` values are accepted in config, passed into the heartbeat reply run, and preserved in the documented config surface.
- Why this is the smallest reliable guardrail: the behavior is config-driven and the narrow seam is the heartbeat runner's `getReplyFromConfig` options.
- Existing test that already covers this (if any): none
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Users can now set `agents.defaults.heartbeat.allowSkills` or `agents.list[].heartbeat.allowSkills` to restrict which skills load during heartbeat runs.
- Leaving `allowSkills` unset keeps the current behavior.
- Setting `allowSkills: []` disables all skills for heartbeat runs.

## Diagram (if applicable)

```text
Before:
[heartbeat run] -> [inherit full agent skill set] -> [large skills prompt / wasted context]

After:
[heartbeat run] -> [optional heartbeat allowSkills override] -> [only needed skills load]
```

## Security Impact (required)

- New permissions/capabilities? (Yes/No): No
- Secrets/tokens handling changed? (Yes/No): No
- New/changed network calls? (Yes/No): No
- Command/tool execution surface changed? (Yes/No): No
- Data access scope changed? (Yes/No): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): heartbeat runtime
- Relevant config (redacted): heartbeat config with `allowSkills` set / unset

### Steps

1. Configure an agent with a large skill set.
2. Run heartbeat for that agent.
3. Observe that heartbeat inherits all agent skills and spends prompt budget on the full skill catalog.
4. Set `heartbeat.allowSkills` to a narrow subset and rerun heartbeat.

### Expected

- Heartbeat should load only the explicitly allowed skills when configured.

### Actual

- Before this change, heartbeat always inherited the full agent skill set.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `allowSkills` is accepted in defaults and per-agent heartbeat config.
  - heartbeat passes the configured allowlist into `getReplyFromConfig` as `skillFilter`.
  - config inventory/schema surfaces include the new field.
- Edge cases checked:
  - unset `allowSkills` keeps current behavior
  - empty `allowSkills` passes an empty skill filter
- What you did **not** verify:
  - full end-to-end heartbeat token measurements against a live model

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes/No): Yes
- Config/env changes? (Yes/No): Yes
- Migration needed? (Yes/No): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: users may expect `allowSkills` to default to a narrow set instead of current full inheritance.
  - Mitigation: leave default behavior unchanged and document the new override explicitly.

## AI-assisted

- This PR is AI-assisted.
- Testing level: targeted local tests run for the touched heartbeat/config paths.
