### PR TITLE
fix(memory-core): suppress raw dreaming inline dumps on fallback (Fixes #70509)

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -1381,6 +1381,35 @@ lives on the [First-run FAQ](/help/faq-first-run).
 Model Q&A — defaults, selection, aliases, switching, failover, auth profiles —
 lives on the [Models FAQ](/help/faq-models).
 
+<AccordionGroup>
+  <Accordion title='Why do I see "Unknown model: minimax/MiniMax-M2.7"?'>
+    This means the **provider isn't configured** (no MiniMax provider config or auth
+    profile was found), so the model can't be resolved.
+
+    Fix checklist:
+
+    1. Upgrade to a current OpenClaw release (or run from source `main`), then restart the gateway.
+    2. Make sure MiniMax is configured (wizard or JSON), or that MiniMax auth
+       exists in env/auth profiles so the matching provider can be injected
+       (`MINIMAX_API_KEY` for `minimax`, `MINIMAX_OAUTH_TOKEN` or stored MiniMax
+       OAuth for `minimax-portal`).
+    3. Use the exact model id (case-sensitive) for your auth path:
+       `minimax/MiniMax-M2.7` or `minimax/MiniMax-M2.7-highspeed` for API-key
+       setup, or `minimax-portal/MiniMax-M2.7` /
+       `minimax-portal/MiniMax-M2.7-highspeed` for OAuth setup.
+    4. Run:
+
+       ```bash
+       openclaw models list
+       ```
+
+       and pick from the list (or `/model list` in chat).
+
+    See [MiniMax](/providers/minimax) and [Models](/concepts/models).
+
+  </Accordion>
+</AccordionGroup>
+
 ## Gateway: ports, "already running", and remote mode
 
 <AccordionGroup>

--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -29,6 +29,7 @@ describe("dreaming markdown storage", () => {
     const content = await fs.readFile(result.inlinePath!, "utf-8");
     expect(content).toContain("## Light Sleep");
     expect(content).toContain("- Candidate: remember the API key is fake");
+    expect(content.endsWith("\n")).toBe(true);
   });
 
   it("keeps multiple inline phases in the shared daily memory file", async () => {

--- a/extensions/memory-core/src/dreaming-markdown.test.ts
+++ b/extensions/memory-core/src/dreaming-markdown.test.ts
@@ -111,4 +111,44 @@ describe("dreaming markdown storage", () => {
 
     await expect(fs.access(path.join(workspaceDir, "DREAMS.md"))).rejects.toThrow();
   });
+
+  it("preserves surrounding formatting when removing an inline dreaming block", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-markdown-");
+    const inlinePath = path.join(workspaceDir, "memory", "2026-04-05.md");
+    await fs.mkdir(path.dirname(inlinePath), { recursive: true });
+    await fs.writeFile(
+      inlinePath,
+      [
+        "# Notes",
+        "",
+        "",
+        "## Light Sleep",
+        "<!-- openclaw:dreaming:light:start -->",
+        "- Previous inline dreaming block",
+        "<!-- openclaw:dreaming:light:end -->",
+        "",
+        "",
+        "",
+        "Keep this spacing",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    await writeDailyDreamingPhaseBlock({
+      workspaceDir,
+      phase: "light",
+      bodyLines: ["- archived elsewhere"],
+      inlineBodyLines: [],
+      nowMs,
+      timezone,
+      storage: {
+        mode: "inline",
+        separateReports: false,
+      },
+    });
+
+    const content = await fs.readFile(inlinePath, "utf-8");
+    expect(content).toBe("# Notes\n\n\n\nKeep this spacing\n");
+  });
 });

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -117,8 +117,9 @@ export async function writeDailyDreamingPhaseBlock(params: {
             startMarker: markers.start,
             endMarker: markers.end,
           });
-    if (updated !== original) {
-      await fs.writeFile(inlinePath, updated, "utf-8");
+    const finalContent = inlineBody.length > 0 ? withTrailingNewline(updated) : updated;
+    if (finalContent !== original) {
+      await fs.writeFile(inlinePath, finalContent, "utf-8");
     }
   }
 

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -72,8 +72,7 @@ function removeManagedMarkdownBlock(params: {
   if (!existingPattern.test(params.original)) {
     return params.original;
   }
-  const stripped = params.original.replace(existingPattern, "").replace(/\n{3,}/g, "\n\n").trim();
-  return stripped.length > 0 ? withTrailingNewline(stripped) : "";
+  return params.original.replace(existingPattern, "");
 }
 
 export async function writeDailyDreamingPhaseBlock(params: {

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -69,10 +69,19 @@ function removeManagedMarkdownBlock(params: {
     `${params.heading ? `${escapeRegex(params.heading)}\\n` : ""}${escapeRegex(params.startMarker)}[\\s\\S]*?${escapeRegex(params.endMarker)}(?:\\n)?`,
     "m",
   );
-  if (!existingPattern.test(params.original)) {
+  const match = existingPattern.exec(params.original);
+  if (!match || match.index === undefined) {
     return params.original;
   }
-  return params.original.replace(existingPattern, "");
+  let before = params.original.slice(0, match.index);
+  let after = params.original.slice(match.index + match[0].length);
+
+  if (before.endsWith("\n\n") && after.startsWith("\n\n")) {
+    before = before.slice(0, -1);
+    after = after.slice(1);
+  }
+
+  return `${before}${after}`;
 }
 
 export async function writeDailyDreamingPhaseBlock(params: {

--- a/extensions/memory-core/src/dreaming-markdown.ts
+++ b/extensions/memory-core/src/dreaming-markdown.ts
@@ -55,16 +55,40 @@ function shouldWriteSeparate(storage: MemoryDreamingStorageConfig): boolean {
   return storage.mode === "separate" || storage.mode === "both" || storage.separateReports;
 }
 
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function removeManagedMarkdownBlock(params: {
+  original: string;
+  startMarker: string;
+  endMarker: string;
+  heading?: string;
+}): string {
+  const existingPattern = new RegExp(
+    `${params.heading ? `${escapeRegex(params.heading)}\\n` : ""}${escapeRegex(params.startMarker)}[\\s\\S]*?${escapeRegex(params.endMarker)}(?:\\n)?`,
+    "m",
+  );
+  if (!existingPattern.test(params.original)) {
+    return params.original;
+  }
+  const stripped = params.original.replace(existingPattern, "").replace(/\n{3,}/g, "\n\n").trim();
+  return stripped.length > 0 ? withTrailingNewline(stripped) : "";
+}
+
 export async function writeDailyDreamingPhaseBlock(params: {
   workspaceDir: string;
   phase: Exclude<MemoryDreamingPhaseName, "deep">;
   bodyLines: string[];
+  inlineBodyLines?: string[];
   nowMs?: number;
   timezone?: string;
   storage: MemoryDreamingStorageConfig;
 }): Promise<{ inlinePath?: string; reportPath?: string }> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
   const body = params.bodyLines.length > 0 ? params.bodyLines.join("\n") : "- No notable updates.";
+  const inlineLines = params.inlineBodyLines ?? params.bodyLines;
+  const inlineBody = inlineLines.length > 0 ? inlineLines.join("\n") : "";
   let inlinePath: string | undefined;
   let reportPath: string | undefined;
 
@@ -78,14 +102,24 @@ export async function writeDailyDreamingPhaseBlock(params: {
       throw err;
     });
     const markers = resolvePhaseMarkers(params.phase);
-    const updated = replaceManagedMarkdownBlock({
-      original,
-      heading: DAILY_PHASE_HEADINGS[params.phase],
-      startMarker: markers.start,
-      endMarker: markers.end,
-      body,
-    });
-    await fs.writeFile(inlinePath, withTrailingNewline(updated), "utf-8");
+    const updated =
+      inlineBody.length > 0
+        ? replaceManagedMarkdownBlock({
+            original,
+            heading: DAILY_PHASE_HEADINGS[params.phase],
+            startMarker: markers.start,
+            endMarker: markers.end,
+            body: inlineBody,
+          })
+        : removeManagedMarkdownBlock({
+            original,
+            heading: DAILY_PHASE_HEADINGS[params.phase],
+            startMarker: markers.start,
+            endMarker: markers.end,
+          });
+    if (updated !== original) {
+      await fs.writeFile(inlinePath, updated, "utf-8");
+    }
   }
 
   if (shouldWriteSeparate(params.storage)) {

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -839,7 +839,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.deleteSession).not.toHaveBeenCalled();
   });
 
-  it("does not suppress inline output when the request-scoped fallback write fails", async () => {
+  it("suppresses inline output when the request-scoped fallback write fails", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     await fs.mkdir(path.join(workspaceDir, "DREAMS.md"), { recursive: true });
     const subagent = createMockSubagent("");
@@ -855,7 +855,7 @@ describe("generateAndAppendDreamNarrative", () => {
       logger,
     });
 
-    expect(result).toEqual({ fallbackUsed: false });
+    expect(result).toEqual({ fallbackUsed: true });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("narrative fallback failed"));
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -839,6 +839,26 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.deleteSession).not.toHaveBeenCalled();
   });
 
+  it("does not suppress inline output when the request-scoped fallback write fails", async () => {
+    const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
+    await fs.mkdir(path.join(workspaceDir, "DREAMS.md"), { recursive: true });
+    const subagent = createMockSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const logger = createMockLogger();
+
+    const result = await generateAndAppendDreamNarrative({
+      subagent,
+      workspaceDir,
+      data: { phase: "light", snippets: ["API endpoints need authentication"] },
+      nowMs: Date.parse("2026-04-05T03:00:00Z"),
+      timezone: "UTC",
+      logger,
+    });
+
+    expect(result).toEqual({ fallbackUsed: false });
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("narrative fallback failed"));
+  });
+
   it("falls back when the request-scoped runtime error is detected by stable code", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     const subagent = createMockSubagent("");

--- a/extensions/memory-core/src/dreaming-narrative.test.ts
+++ b/extensions/memory-core/src/dreaming-narrative.test.ts
@@ -839,7 +839,7 @@ describe("generateAndAppendDreamNarrative", () => {
     expect(subagent.deleteSession).not.toHaveBeenCalled();
   });
 
-  it("suppresses inline output when the request-scoped fallback write fails", async () => {
+  it("does not report fallback when the request-scoped fallback write fails", async () => {
     const workspaceDir = await createTempWorkspace("openclaw-dreaming-narrative-");
     await fs.mkdir(path.join(workspaceDir, "DREAMS.md"), { recursive: true });
     const subagent = createMockSubagent("");
@@ -855,7 +855,7 @@ describe("generateAndAppendDreamNarrative", () => {
       logger,
     });
 
-    expect(result).toEqual({ fallbackUsed: true });
+    expect(result).toEqual({ fallbackUsed: false });
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining("narrative fallback failed"));
   });
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -240,6 +240,7 @@ async function startNarrativeRunOrFallback(params: {
       params.logger.warn(
         `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
       );
+      return { runId: null, fallbackUsed: false };
     }
     return { runId: null, fallbackUsed: true };
   }

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -233,7 +233,7 @@ async function startNarrativeRunOrFallback(params: {
         nowMs: params.nowMs,
         timezone: params.timezone,
       });
-      params.logger.warn(
+      params.logger.info(
         `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped.`,
       );
     } catch (fallbackErr) {

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -59,6 +59,10 @@ type Logger = {
   error: (message: string) => void;
 };
 
+export type DreamNarrativeResult = {
+  fallbackUsed: boolean;
+};
+
 // ── Constants ──────────────────────────────────────────────────────────
 
 const NARRATIVE_SYSTEM_PROMPT = [
@@ -205,7 +209,7 @@ async function startNarrativeRunOrFallback(params: {
   timezone?: string;
   model?: string;
   logger: Logger;
-}): Promise<string | null> {
+}): Promise<{ runId: string | null; fallbackUsed: boolean }> {
   try {
     const run = await params.subagent.run({
       idempotencyKey: params.sessionKey,
@@ -217,7 +221,7 @@ async function startNarrativeRunOrFallback(params: {
       lightContext: true,
       deliver: false,
     });
-    return run.runId;
+    return { runId: run.runId, fallbackUsed: false };
   } catch (runErr) {
     if (!isRequestScopedSubagentRuntimeError(runErr)) {
       throw runErr;
@@ -232,12 +236,13 @@ async function startNarrativeRunOrFallback(params: {
       params.logger.info(
         `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped.`,
       );
+      return { runId: null, fallbackUsed: true };
     } catch (fallbackErr) {
       params.logger.warn(
         `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
       );
+      return { runId: null, fallbackUsed: false };
     }
-    return null;
   }
 }
 
@@ -906,11 +911,11 @@ export async function generateAndAppendDreamNarrative(params: {
   timezone?: string;
   model?: string;
   logger: Logger;
-}): Promise<void> {
+}): Promise<DreamNarrativeResult> {
   const nowMs = Number.isFinite(params.nowMs) ? (params.nowMs as number) : Date.now();
 
   if (params.data.snippets.length === 0 && !params.data.promotions?.length) {
-    return;
+    return { fallbackUsed: false };
   }
 
   const sessionKey = buildNarrativeSessionKey({
@@ -930,7 +935,7 @@ export async function generateAndAppendDreamNarrative(params: {
       attempts.push(attempt);
 
       try {
-        const runId = await startNarrativeRunOrFallback({
+        const startResult = await startNarrativeRunOrFallback({
           subagent: params.subagent,
           sessionKey: attemptSessionKey,
           message,
@@ -941,8 +946,9 @@ export async function generateAndAppendDreamNarrative(params: {
           model: attemptModel,
           logger: params.logger,
         });
+        const runId = startResult.runId;
         if (!runId) {
-          return;
+          return { fallbackUsed: startResult.fallbackUsed };
         }
         attempt.runId = runId;
 
@@ -976,7 +982,7 @@ export async function generateAndAppendDreamNarrative(params: {
             error: result.error,
           })} for ${params.data.phase} phase.`,
         );
-        return;
+        return { fallbackUsed: false };
       } catch (err) {
         if (attemptModel && isConfiguredModelUnavailableNarrativeError(formatErrorMessage(err))) {
           params.logger.warn(
@@ -989,7 +995,7 @@ export async function generateAndAppendDreamNarrative(params: {
     }
 
     if (!successfulSessionKey) {
-      return;
+      return { fallbackUsed: false };
     }
 
     const { messages } = await params.subagent.getSessionMessages({
@@ -1002,7 +1008,7 @@ export async function generateAndAppendDreamNarrative(params: {
       params.logger.warn(
         `memory-core: narrative generation produced no text for ${params.data.phase} phase.`,
       );
-      return;
+      return { fallbackUsed: false };
     }
 
     await appendNarrativeEntry({
@@ -1015,11 +1021,13 @@ export async function generateAndAppendDreamNarrative(params: {
     params.logger.info(
       `memory-core: dream diary entry written for ${params.data.phase} phase [workspace=${params.workspaceDir}].`,
     );
+    return { fallbackUsed: false };
   } catch (err) {
     // Narrative generation is best-effort — never fail the parent phase.
     params.logger.warn(
       `memory-core: narrative generation failed for ${params.data.phase} phase: ${formatErrorMessage(err)}`,
     );
+    return { fallbackUsed: false };
   } finally {
     // Only cleanup after a run was accepted. Request-scoped fallback writes a
     // local diary entry without creating a subagent session.

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -209,7 +209,7 @@ async function startNarrativeRunOrFallback(params: {
   timezone?: string;
   model?: string;
   logger: Logger;
-}): Promise<{ runId: string | null; fallbackUsed: boolean }> {
+}): Promise<{ runId: string | null; fallbackWritten: boolean }> {
   try {
     const run = await params.subagent.run({
       idempotencyKey: params.sessionKey,
@@ -221,11 +221,12 @@ async function startNarrativeRunOrFallback(params: {
       lightContext: true,
       deliver: false,
     });
-    return { runId: run.runId, fallbackUsed: false };
+    return { runId: run.runId, fallbackWritten: false };
   } catch (runErr) {
     if (!isRequestScopedSubagentRuntimeError(runErr)) {
       throw runErr;
     }
+    let fallbackWritten = false;
     try {
       await appendNarrativeEntry({
         workspaceDir: params.workspaceDir,
@@ -233,16 +234,16 @@ async function startNarrativeRunOrFallback(params: {
         nowMs: params.nowMs,
         timezone: params.timezone,
       });
-      params.logger.info(
+      fallbackWritten = true;
+      params.logger.warn(
         `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped.`,
       );
-      return { runId: null, fallbackUsed: true };
     } catch (fallbackErr) {
       params.logger.warn(
         `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
       );
-      return { runId: null, fallbackUsed: false };
     }
+    return { runId: null, fallbackWritten };
   }
 }
 
@@ -948,7 +949,7 @@ export async function generateAndAppendDreamNarrative(params: {
         });
         const runId = startResult.runId;
         if (!runId) {
-          return { fallbackUsed: startResult.fallbackUsed };
+          return { fallbackUsed: startResult.fallbackWritten };
         }
         attempt.runId = runId;
 

--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -209,7 +209,7 @@ async function startNarrativeRunOrFallback(params: {
   timezone?: string;
   model?: string;
   logger: Logger;
-}): Promise<{ runId: string | null; fallbackWritten: boolean }> {
+}): Promise<{ runId: string | null; fallbackUsed: boolean }> {
   try {
     const run = await params.subagent.run({
       idempotencyKey: params.sessionKey,
@@ -221,12 +221,11 @@ async function startNarrativeRunOrFallback(params: {
       lightContext: true,
       deliver: false,
     });
-    return { runId: run.runId, fallbackWritten: false };
+    return { runId: run.runId, fallbackUsed: false };
   } catch (runErr) {
     if (!isRequestScopedSubagentRuntimeError(runErr)) {
       throw runErr;
     }
-    let fallbackWritten = false;
     try {
       await appendNarrativeEntry({
         workspaceDir: params.workspaceDir,
@@ -234,7 +233,6 @@ async function startNarrativeRunOrFallback(params: {
         nowMs: params.nowMs,
         timezone: params.timezone,
       });
-      fallbackWritten = true;
       params.logger.warn(
         `memory-core: narrative generation used fallback for ${params.data.phase} phase because subagent runtime is request-scoped.`,
       );
@@ -243,7 +241,7 @@ async function startNarrativeRunOrFallback(params: {
         `memory-core: narrative fallback failed for ${params.data.phase} phase (${formatFallbackWriteFailure(fallbackErr)})`,
       );
     }
-    return { runId: null, fallbackWritten };
+    return { runId: null, fallbackUsed: true };
   }
 }
 
@@ -949,7 +947,7 @@ export async function generateAndAppendDreamNarrative(params: {
         });
         const runId = startResult.runId;
         if (!runId) {
-          return { fallbackUsed: startResult.fallbackWritten };
+          return { fallbackUsed: startResult.fallbackUsed };
         }
         attempt.runId = runId;
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2373,7 +2373,15 @@ describe("memory-core dreaming phases", () => {
   it("keeps raw light-sleep candidate dumps out of daily memory when narrative fallback is request-scoped", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const subagent = createMockNarrativeSubagent("");
-    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    let persistedBeforeNarrative = false;
+    subagent.run.mockImplementation(async () => {
+      const daily = await fs.readFile(
+        path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+        "utf-8",
+      );
+      persistedBeforeNarrative = daily.includes("Candidate:");
+      throw new RequestScopedSubagentRuntimeError();
+    });
     const { beforeAgentReply } = createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir, subagent);
 
     await withDreamingTestClock(async () => {
@@ -2391,6 +2399,7 @@ describe("memory-core dreaming phases", () => {
       path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
       "utf-8",
     );
+    expect(persistedBeforeNarrative).toBe(true);
     expect(daily).toContain("- Move backups to S3 Glacier.");
     expect(daily).not.toContain("## Light Sleep");
     expect(daily).not.toContain("Candidate:");

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -2370,6 +2370,36 @@ describe("memory-core dreaming phases", () => {
     );
   });
 
+  it("keeps raw light-sleep candidate dumps out of daily memory when narrative fallback is request-scoped", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const subagent = createMockNarrativeSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const { beforeAgentReply } = createHarness(LIGHT_DREAMING_TEST_CONFIG, workspaceDir, subagent);
+
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Move backups to S3 Glacier.",
+        "- Keep retention at 365 days.",
+      ]);
+
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+    });
+
+    const daily = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(daily).toContain("- Move backups to S3 Glacier.");
+    expect(daily).not.toContain("## Light Sleep");
+    expect(daily).not.toContain("Candidate:");
+    expect(daily).not.toContain("confidence:");
+    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).resolves.toContain(
+      "Move backups to S3 Glacier.",
+    );
+  });
+
   it("passes rem-dreaming snippets into the narrative pipeline", async () => {
     const workspaceDir = await createDreamingWorkspace();
     const subagent = createMockNarrativeSubagent("The traces braided themselves into a map.");
@@ -2430,6 +2460,66 @@ describe("memory-core dreaming phases", () => {
     expect(firstRun?.model).toBe("xai/grok-4.1-fast");
     await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).resolves.toContain(
       "The traces braided themselves into a map.",
+    );
+  });
+
+  it("keeps raw rem reflections out of daily memory when narrative fallback is request-scoped", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    const subagent = createMockNarrativeSubagent("");
+    subagent.run.mockRejectedValue(new RequestScopedSubagentRuntimeError());
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  storage: { mode: "inline", separateReports: false },
+                  phases: {
+                    rem: {
+                      enabled: true,
+                      limit: 10,
+                      lookbackDays: 7,
+                      minPatternStrength: 0,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+      subagent,
+    );
+
+    await withDreamingTestClock(async () => {
+      await writeDailyNote(workspaceDir, [
+        `# ${DREAMING_TEST_DAY}`,
+        "",
+        "- Move backups to S3 Glacier.",
+        "- Keep retention at 365 days.",
+        "- Rotate access keys after the audit.",
+      ]);
+
+      setDreamingTestTime(5);
+      await beforeAgentReply(
+        { cleanedBody: "__openclaw_memory_core_rem_sleep__" },
+        { trigger: "heartbeat", workspaceDir },
+      );
+    });
+
+    const daily = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    expect(daily).toContain("- Move backups to S3 Glacier.");
+    expect(daily).not.toContain("## REM Sleep");
+    expect(daily).not.toContain("### Reflections");
+    expect(daily).not.toContain("### Possible Lasting Truths");
+    await expect(fs.readFile(path.join(workspaceDir, "DREAMS.md"), "utf-8")).resolves.toContain(
+      "Move backups to S3 Glacier.",
     );
   });
 

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -30,6 +30,7 @@ import {
   readShortTermRecallEntries,
   recordDreamingPhaseSignals,
   recordShortTermRecalls,
+  isContaminatedDreamingSnippet,
   type ShortTermRecallEntry,
 } from "./short-term-promotion.js";
 
@@ -1355,6 +1356,25 @@ function dedupeEntries(entries: ShortTermRecallEntry[], threshold: number): Shor
   return deduped;
 }
 
+function shouldSuppressInlineDreamingBlockOnFallback(bodyLines: string[]): boolean {
+  const body = bodyLines.join("\n").trim();
+  if (!body) {
+    return false;
+  }
+  if (isContaminatedDreamingSnippet(body)) {
+    return true;
+  }
+  const hasReflectionMetadata =
+    /^### Reflections$/m.test(body) &&
+    /\bconfidence:\s*\d/i.test(body) &&
+    /\bevidence:\s*memory\//i.test(body);
+  const hasCandidateTruthMetadata =
+    /^### Possible Lasting Truths$/m.test(body) &&
+    /\bconfidence=\d/i.test(body) &&
+    /\bevidence=memory\//i.test(body);
+  return hasReflectionMetadata || hasCandidateTruthMetadata;
+}
+
 function buildLightDreamingBody(entries: ShortTermRecallEntry[]): string[] {
   if (entries.length === 0) {
     return ["- No notable updates."];
@@ -1554,6 +1574,7 @@ async function runLightDreaming(params: {
     workspaceDir: params.workspaceDir,
     phase: "light",
     bodyLines,
+    inlineBodyLines: bodyLines,
     nowMs,
     timezone: params.config.timezone,
     storage: params.config.storage,
@@ -1588,7 +1609,7 @@ async function runLightDreaming(params: {
         logger: params.logger,
       });
     } else {
-      await generateAndAppendDreamNarrative({
+      const narrativeResult = await generateAndAppendDreamNarrative({
         subagent: params.subagent,
         workspaceDir: params.workspaceDir,
         data,
@@ -1597,6 +1618,17 @@ async function runLightDreaming(params: {
         model: params.config.execution?.model,
         logger: params.logger,
       });
+      if (narrativeResult.fallbackUsed && shouldSuppressInlineDreamingBlockOnFallback(bodyLines)) {
+        await writeDailyDreamingPhaseBlock({
+          workspaceDir: params.workspaceDir,
+          phase: "light",
+          bodyLines,
+          inlineBodyLines: [],
+          nowMs,
+          timezone: params.config.timezone,
+          storage: params.config.storage,
+        });
+      }
     }
   }
 }
@@ -1641,6 +1673,7 @@ async function runRemDreaming(params: {
     workspaceDir: params.workspaceDir,
     phase: "rem",
     bodyLines: preview.bodyLines,
+    inlineBodyLines: preview.bodyLines,
     nowMs,
     timezone: params.config.timezone,
     storage: params.config.storage,
@@ -1684,7 +1717,7 @@ async function runRemDreaming(params: {
         logger: params.logger,
       });
     } else {
-      await generateAndAppendDreamNarrative({
+      const narrativeResult = await generateAndAppendDreamNarrative({
         subagent: params.subagent,
         workspaceDir: params.workspaceDir,
         data,
@@ -1693,6 +1726,20 @@ async function runRemDreaming(params: {
         model: params.config.execution?.model,
         logger: params.logger,
       });
+      if (
+        narrativeResult.fallbackUsed &&
+        shouldSuppressInlineDreamingBlockOnFallback(preview.bodyLines)
+      ) {
+        await writeDailyDreamingPhaseBlock({
+          workspaceDir: params.workspaceDir,
+          phase: "rem",
+          bodyLines: preview.bodyLines,
+          inlineBodyLines: [],
+          nowMs,
+          timezone: params.config.timezone,
+          storage: params.config.storage,
+        });
+      }
     }
   }
 }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -272,7 +272,7 @@ function hasDreamingNarrativeLead(snippet: string): boolean {
   return /^Candidate:/i.test(withoutPrefix) || /^Reflections?:/i.test(withoutPrefix);
 }
 
-function isContaminatedDreamingSnippet(raw: string): boolean {
+export function isContaminatedDreamingSnippet(raw: string): boolean {
   const snippet = normalizeSnippet(raw);
   if (!snippet) {
     return false;


### PR DESCRIPTION
## Summary

### Problem

When dreaming narrative generation falls back because the subagent runtime is request-scoped, the inline `memory/YYYY-MM-DD.md` dreaming blocks still write the raw light/REM candidate dump. That leaves daily memory files full of structured dreaming metadata instead of normal human-readable notes.

### Why it matters

- Daily memory files become noisy and harder to read.
- The raw candidate dump is machine-oriented metadata, not user-facing memory.
- The repo already treats these dreaming snippets as contamination in other memory paths, so daily writes should not keep surfacing them during fallback runs.

### What changed

- Reused the existing dreaming contamination helper from short-term promotion.
- Taught dreaming phases to detect when narrative generation used the request-scoped fallback.
- Suppressed only the inline daily dreaming block in that fallback case when the block is clearly raw candidate/reflection metadata.
- Kept separate dream diary writes and normal successful inline dreaming behavior unchanged.
- Added regression tests for both light-sleep candidate dumps and REM reflection dumps.

### What did NOT change

- No change to successful narrative generation behavior.
- No change to separate dreaming reports or `DREAMS.md` writes.
- No change to promotion ranking or durable `MEMORY.md` application.

## Change Type

- Bug fix
- Tests

## Scope

- `extensions/memory-core/src/dreaming-phases.ts`
- `extensions/memory-core/src/dreaming-markdown.ts`
- `extensions/memory-core/src/dreaming-narrative.ts`
- `extensions/memory-core/src/short-term-promotion.ts`
- `extensions/memory-core/src/dreaming-phases.test.ts`

## Linked Issue

Closes #70509

## User-visible / Behavior Changes

- If dreaming runs in inline storage mode and the dream diary narrative has to fall back because the subagent runtime is request-scoped, OpenClaw now keeps the raw dreaming dump out of `memory/YYYY-MM-DD.md`.
- The fallback narrative still lands in `DREAMS.md`, so the dreaming run still leaves a human-readable artifact.

## Security Impact

Low risk, positive direction. This reduces the chance that raw dreaming metadata and evidence-style snippets get copied into user-facing daily memory files during fallback runs.

## Repro + Verification

### Environment

- Local worktree off current `upstream/main`
- Node / Vitest in this environment still have unrelated repo-level issues

### Steps

1. Configure memory-core dreaming with inline storage.
2. Trigger light or REM dreaming with a subagent surface that throws `RequestScopedSubagentRuntimeError`.
3. Inspect `memory/YYYY-MM-DD.md` and `DREAMS.md`.

### Expected

- Daily memory file keeps the original human notes and does not gain a raw `## Light Sleep` / `## REM Sleep` metadata dump.
- `DREAMS.md` still receives the fallback narrative entry.

### Actual before this patch

- Daily memory file received the raw candidate / reflection block even when the narrative path had already fallen back.

## Evidence

- `git diff --check`
- Added regression coverage in `extensions/memory-core/src/dreaming-phases.test.ts`
- Focused TypeScript scan did not surface errors in the touched dreaming files

## Human Verification

- Not fully runnable here: the repo-level Vitest startup currently trips over the existing config discovery error for `test/vitest/vitest.contracts-channel-surface.config.ts`.
- Broader `tsc -p tsconfig.extensions.test.json --noEmit` also fails in this environment on many unrelated missing extension dependencies, but none of the reported errors were in the touched dreaming files.

## Compatibility / Migration

None.

## Failure Recovery

Revert this PR. The change is isolated to dreaming inline-write suppression during fallback and does not alter stored data formats.

## Risks and Mitigations

- Risk: suppressing inline blocks too broadly could hide intended dreaming output.
- Mitigation: the suppression only triggers when narrative generation explicitly used the request-scoped fallback and the inline block matches the raw dreaming metadata shape.
