### PR TITLE
feat(memory-core): add memory_add tool

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/Resources/tool-display.json
@@ -499,6 +499,13 @@
         "lines"
       ]
     },
+    "memory_add": {
+      "emoji": "🧠",
+      "title": "Memory Add",
+      "detailKeys": [
+        "text"
+      ]
+    },
     "web_search": {
       "emoji": "🔎",
       "title": "Web Search",

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -2222,7 +2222,7 @@ Local onboarding defaults new local configs to `tools.profile: "coding"` when un
 | `group:runtime`    | `exec`, `process`, `code_execution` (`bash` is accepted as an alias for `exec`)                                         |
 | `group:fs`         | `read`, `write`, `edit`, `apply_patch`                                                                                  |
 | `group:sessions`   | `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status` |
-| `group:memory`     | `memory_search`, `memory_get`                                                                                           |
+| `group:memory`     | `memory_search`, `memory_get`, `memory_add`                                                                             |
 | `group:web`        | `web_search`, `x_search`, `web_fetch`                                                                                   |
 | `group:ui`         | `browser`, `canvas`                                                                                                     |
 | `group:automation` | `cron`, `gateway`                                                                                                       |

--- a/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
+++ b/docs/gateway/sandbox-vs-tool-policy-vs-elevated.md
@@ -91,7 +91,7 @@ Available groups:
   an alias for `exec`)
 - `group:fs`: `read`, `write`, `edit`, `apply_patch`
 - `group:sessions`: `sessions_list`, `sessions_history`, `sessions_send`, `sessions_spawn`, `sessions_yield`, `subagents`, `session_status`
-- `group:memory`: `memory_search`, `memory_get`
+- `group:memory`: `memory_search`, `memory_get`, `memory_add`
 - `group:web`: `web_search`, `x_search`, `web_fetch`
 - `group:ui`: `browser`, `canvas`
 - `group:automation`: `cron`, `gateway`

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -153,7 +153,7 @@ Use `group:*` shorthands in allow/deny lists:
 | `group:runtime`    | exec, process, code_execution (`bash` is accepted as an alias for `exec`)                                 |
 | `group:fs`         | read, write, edit, apply_patch                                                                            |
 | `group:sessions`   | sessions_list, sessions_history, sessions_send, sessions_spawn, sessions_yield, subagents, session_status |
-| `group:memory`     | memory_search, memory_get                                                                                 |
+| `group:memory`     | memory_search, memory_get, memory_add                                                                     |
 | `group:web`        | web_search, x_search, web_fetch                                                                           |
 | `group:ui`         | browser, canvas                                                                                           |
 | `group:automation` | cron, gateway                                                                                             |

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -12,7 +12,7 @@ import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-a
 import { buildPromptSection } from "./src/prompt-section.js";
 import { listMemoryCorePublicArtifacts } from "./src/public-artifacts.js";
 import { memoryRuntime } from "./src/runtime-provider.js";
-import { createMemoryGetTool, createMemorySearchTool } from "./src/tools.js";
+import { createMemoryAddTool, createMemoryGetTool, createMemorySearchTool } from "./src/tools.js";
 export {
   buildMemoryFlushPlan,
   DEFAULT_MEMORY_FLUSH_FORCE_TRANSCRIPT_BYTES,
@@ -55,6 +55,15 @@ export default definePluginEntry({
           agentSessionKey: ctx.sessionKey,
         }),
       { names: ["memory_get"] },
+    );
+
+    api.registerTool(
+      (ctx) =>
+        createMemoryAddTool({
+          config: ctx.config,
+          agentSessionKey: ctx.sessionKey,
+        }),
+      { names: ["memory_add"] },
     );
 
     api.registerCli(

--- a/extensions/memory-core/src/memory/add-memory-block.ts
+++ b/extensions/memory-core/src/memory/add-memory-block.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { resolveCronStyleNow } from "openclaw/plugin-sdk/memory-core-host-runtime-core";
+import { formatMemoryBlock, normalizeMemoryBlockText } from "./memory-blocks.js";
+
+export type MemoryAddResult =
+  | { action: "created"; path: string; text: string }
+  | { action: "failed"; error: "text_required" | "write_failed"; message?: string };
+
+type MemoryAddTimeConfig = {
+  agents?: {
+    defaults?: {
+      userTimezone?: string;
+    };
+  };
+};
+
+function formatMemoryDate(date = new Date(), cfg?: MemoryAddTimeConfig): string {
+  const { userTimezone } = resolveCronStyleNow(cfg ?? {}, date.getTime());
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: userTimezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(date);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+async function appendMemoryBlock(params: {
+  workspaceDir: string;
+  normalizedText: string;
+  cfg?: MemoryAddTimeConfig;
+  now?: Date;
+}): Promise<{ relPath: string; normalizedText: string }> {
+  const relPath = `memory/${formatMemoryDate(params.now, params.cfg)}.md`;
+  const absPath = path.join(params.workspaceDir, relPath);
+  await fs.mkdir(path.dirname(absPath), { recursive: true });
+  let prefix = "";
+  try {
+    const existing = await fs.readFile(absPath, "utf-8");
+    if (existing.length > 0 && !existing.endsWith("\n\n")) {
+      prefix = existing.endsWith("\n") ? "\n" : "\n\n";
+    }
+  } catch {}
+  await fs.appendFile(absPath, `${prefix}${formatMemoryBlock(params.normalizedText)}`, "utf-8");
+  return { relPath, normalizedText: params.normalizedText };
+}
+
+export async function addMemoryBlock(params: {
+  workspaceDir: string;
+  text: string;
+  cfg?: MemoryAddTimeConfig;
+  now?: Date;
+}): Promise<MemoryAddResult> {
+  const normalizedText = normalizeMemoryBlockText(params.text);
+  if (!normalizedText) {
+    return { action: "failed", error: "text_required" };
+  }
+
+  try {
+    const written = await appendMemoryBlock({
+      workspaceDir: params.workspaceDir,
+      normalizedText,
+      cfg: params.cfg,
+      now: params.now,
+    });
+    return {
+      action: "created",
+      path: written.relPath,
+      text: written.normalizedText,
+    };
+  } catch (error) {
+    return {
+      action: "failed",
+      error: "write_failed",
+      message: formatErrorMessage(error),
+    };
+  }
+}

--- a/extensions/memory-core/src/memory/index.test.ts
+++ b/extensions/memory-core/src/memory/index.test.ts
@@ -330,6 +330,48 @@ describe("memory index", () => {
     }
   });
 
+  it("indexes daily memory blocks as separate searchable chunks", async () => {
+    await fs.writeFile(
+      path.join(memoryDir, "2026-01-12.md"),
+      [
+        "Beta raw evergreen note.",
+        "",
+        "----",
+        "",
+        "Alpha block body for this workspace.",
+        "",
+        "----",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const cfg = createCfg({
+      storePath: path.join(workspaceDir, "index-memory-blocks.sqlite"),
+      minScore: 0,
+      hybrid: { enabled: false },
+    });
+    const manager = await getPersistentManager(cfg);
+    await manager.sync({ reason: "test", force: true });
+
+    const blockResults = await manager.search("alpha", {
+      maxResults: 3,
+      minScore: 0,
+    });
+    const blockHit = blockResults.find((result) => result.snippet.includes("Alpha block body"));
+    expect(blockHit).toBeDefined();
+    expect(blockHit?.startLine).toBe(5);
+    expect(blockHit?.endLine).toBe(5);
+    expect(blockResults.every((result) => !result.snippet.includes("----"))).toBe(true);
+
+    const rawResults = await manager.search("beta", {
+      maxResults: 3,
+      minScore: 0,
+    });
+    const rawHit = rawResults.find((result) => result.snippet.includes("Beta raw evergreen note."));
+    expect(rawHit).toBeDefined();
+    expect(rawHit?.snippet).not.toContain("Alpha block body");
+  });
+
   it("indexes multimodal image and audio files from extra paths with Gemini structured inputs", async () => {
     const mediaDir = path.join(workspaceDir, "media-memory");
     await fs.mkdir(mediaDir, { recursive: true });

--- a/extensions/memory-core/src/memory/manager-embedding-ops.ts
+++ b/extensions/memory-core/src/memory/manager-embedding-ops.ts
@@ -38,6 +38,7 @@ import { deleteMemoryFtsRows } from "./manager-fts-state.js";
 import { MemoryManagerSyncOps } from "./manager-sync-ops.js";
 import { logMemoryVectorDegradedWrite } from "./manager-vector-warning.js";
 import { replaceMemoryVectorRow } from "./manager-vector-write.js";
+import { parseMemoryBlocks } from "./memory-blocks.js";
 
 const VECTOR_TABLE = "chunks_vec";
 const FTS_TABLE = "chunks_fts";
@@ -53,6 +54,42 @@ const EMBEDDING_BATCH_TIMEOUT_REMOTE_MS = 2 * 60_000;
 const EMBEDDING_BATCH_TIMEOUT_LOCAL_MS = 10 * 60_000;
 
 const log = createSubsystemLogger("memory");
+
+function shouldParseMemoryBlockMarkdown(
+  entry: MemoryFileEntry | SessionFileEntry,
+  source: MemorySource,
+): boolean {
+  return (
+    source === "memory" &&
+    !("kind" in entry && entry.kind === "multimodal") &&
+    /^memory\/\d{4}-\d{2}-\d{2}\.md$/.test(entry.path)
+  );
+}
+
+function buildMemoryBlockChunks(
+  content: string,
+  settings: { tokens: number; overlap: number },
+): MemoryChunk[] {
+  const chunks: MemoryChunk[] = [];
+  for (const block of parseMemoryBlocks(content)) {
+    const blockChunks = filterNonEmptyMemoryChunks(chunkMarkdown(block.text, settings));
+    remapChunkLines(blockChunks, block.lineNumbers);
+    chunks.push(...blockChunks);
+  }
+  return chunks;
+}
+
+function chunkMemoryTextForIndex(params: {
+  entry: MemoryFileEntry | SessionFileEntry;
+  source: MemorySource;
+  content: string;
+  settings: { tokens: number; overlap: number };
+}): MemoryChunk[] {
+  if (shouldParseMemoryBlockMarkdown(params.entry, params.source)) {
+    return buildMemoryBlockChunks(params.content, params.settings);
+  }
+  return filterNonEmptyMemoryChunks(chunkMarkdown(params.content, params.settings));
+}
 
 export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureCount: number;
@@ -591,7 +628,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
         return;
       }
       const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
-      const chunks = filterNonEmptyMemoryChunks(chunkMarkdown(content, this.settings.chunking));
+      const chunks = chunkMemoryTextForIndex({
+        entry,
+        source: options.source,
+        content,
+        settings: this.settings.chunking,
+      });
       if (options.source === "sessions" && "lineMap" in entry) {
         remapChunkLines(chunks, entry.lineMap);
       }
@@ -621,7 +663,12 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       chunks = [multimodalChunk.chunk];
     } else {
       const content = options.content ?? (await fs.readFile(entry.absPath, "utf-8"));
-      const baseChunks = filterNonEmptyMemoryChunks(chunkMarkdown(content, this.settings.chunking));
+      const baseChunks = chunkMemoryTextForIndex({
+        entry,
+        source: options.source,
+        content,
+        settings: this.settings.chunking,
+      });
       chunks = this.provider
         ? enforceEmbeddingMaxInputTokens(this.provider, baseChunks, EMBEDDING_BATCH_MAX_TOKENS)
         : baseChunks;

--- a/extensions/memory-core/src/memory/memory-blocks.test.ts
+++ b/extensions/memory-core/src/memory/memory-blocks.test.ts
@@ -1,0 +1,38 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+import { formatMemoryBlock, normalizeMemoryBlockText, parseMemoryBlocks } from "./memory-blocks.js";
+
+describe("memory block markdown format", () => {
+  it("parses and formats semantic block separators", () => {
+    const blocks = parseMemoryBlocks(
+      ["Raw", "---", "Still raw", "", "----", "", "Use pnpm.", "", "----"].join("\n"),
+    );
+
+    expect(blocks).toEqual([
+      {
+        startLine: 1,
+        endLine: 3,
+        lineNumbers: [1, 2, 3],
+        text: "Raw\n---\nStill raw",
+      },
+      {
+        startLine: 7,
+        endLine: 7,
+        lineNumbers: [7],
+        text: "Use pnpm.",
+      },
+    ]);
+    expect(parseMemoryBlocks(["----", "", "----"].join("\n"))).toEqual([]);
+    expect(parseMemoryBlocks(["----", "", "Unclosed"].join("\n"))).toEqual([
+      {
+        startLine: 3,
+        endLine: 3,
+        lineNumbers: [3],
+        text: "Unclosed",
+      },
+    ]);
+    expect(formatMemoryBlock(" Remember qmd safety. ")).toBe("Remember qmd safety.\n\n----\n");
+    expect(normalizeMemoryBlockText("alpha\n----\nbeta")).toBe("alpha\n---\nbeta");
+    expect(new MarkdownIt().render("---\n")).toBe("<hr>\n");
+  });
+});

--- a/extensions/memory-core/src/memory/memory-blocks.ts
+++ b/extensions/memory-core/src/memory/memory-blocks.ts
@@ -1,0 +1,81 @@
+export type MemoryBlock = {
+  startLine: number;
+  endLine: number;
+  lineNumbers: number[];
+  text: string;
+};
+
+export const MEMORY_BLOCK_SEPARATOR = "----";
+export const ESCAPED_MEMORY_BLOCK_SEPARATOR = "---";
+
+function normalizeLineEndings(value: string): string {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+function isMemoryBlockSeparator(line: string): boolean {
+  return line.trim() === MEMORY_BLOCK_SEPARATOR;
+}
+
+function trimLineEntries(entries: Array<{ line: string; lineNumber: number }>): Array<{
+  line: string;
+  lineNumber: number;
+}> {
+  let start = 0;
+  let end = entries.length;
+  while (start < end && entries[start]?.line.trim() === "") {
+    start += 1;
+  }
+  while (end > start && entries[end - 1]?.line.trim() === "") {
+    end -= 1;
+  }
+  return entries.slice(start, end);
+}
+
+function appendMemoryBlock(
+  blocks: MemoryBlock[],
+  entries: Array<{ line: string; lineNumber: number }>,
+): void {
+  const trimmed = trimLineEntries(entries);
+  if (trimmed.length === 0) {
+    return;
+  }
+  blocks.push({
+    startLine: trimmed[0]?.lineNumber ?? 1,
+    endLine: trimmed[trimmed.length - 1]?.lineNumber ?? 1,
+    lineNumbers: trimmed.map((entry) => entry.lineNumber),
+    text: trimmed.map((entry) => entry.line).join("\n"),
+  });
+}
+
+export function normalizeMemoryBlockText(input: string): string {
+  const normalized = normalizeLineEndings(input).trim();
+  return normalized
+    .split("\n")
+    .map((line) => (isMemoryBlockSeparator(line) ? ESCAPED_MEMORY_BLOCK_SEPARATOR : line))
+    .join("\n")
+    .trim();
+}
+
+export function formatMemoryBlock(input: string): string {
+  const text = normalizeMemoryBlockText(input);
+  return `${text}\n\n${MEMORY_BLOCK_SEPARATOR}\n`;
+}
+
+export function parseMemoryBlocks(content: string): MemoryBlock[] {
+  const lines = normalizeLineEndings(content).split("\n");
+  const blocks: MemoryBlock[] = [];
+  let entries: Array<{ line: string; lineNumber: number }> = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    if (isMemoryBlockSeparator(line)) {
+      appendMemoryBlock(blocks, entries);
+      entries = [];
+      continue;
+    }
+    entries.push({ line, lineNumber: index + 1 });
+  }
+
+  appendMemoryBlock(blocks, entries);
+  return blocks;
+}

--- a/extensions/memory-core/src/tools.shared.ts
+++ b/extensions/memory-core/src/tools.shared.ts
@@ -31,6 +31,10 @@ export const MemorySearchSchema = Type.Object({
   ),
 });
 
+export const MemoryAddSchema = Type.Object({
+  text: Type.String(),
+});
+
 export const MemoryGetSchema = Type.Object({
   path: Type.String(),
   from: Type.Optional(Type.Number()),
@@ -101,7 +105,7 @@ export function createMemoryTool(params: {
   label: string;
   name: string;
   description: string;
-  parameters: typeof MemorySearchSchema | typeof MemoryGetSchema;
+  parameters: typeof MemorySearchSchema | typeof MemoryAddSchema | typeof MemoryGetSchema;
   execute: (ctx: { cfg: OpenClawConfig; agentId: string }) => AnyAgentTool["execute"];
 }): AnyAgentTool | null {
   const ctx = resolveMemoryToolContext(params.options);

--- a/extensions/memory-core/src/tools.test-helpers.ts
+++ b/extensions/memory-core/src/tools.test-helpers.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import type { OpenClawConfig } from "../api.js";
-import { createMemoryGetTool, createMemorySearchTool } from "./tools.js";
+import { createMemoryAddTool, createMemoryGetTool, createMemorySearchTool } from "./tools.js";
 
 export function asOpenClawConfig(config: Partial<OpenClawConfig>): OpenClawConfig {
   return config;
@@ -15,6 +15,20 @@ export function createMemorySearchToolOrThrow(params?: {
   agentSessionKey?: string;
 }) {
   const tool = createMemorySearchTool({
+    config: params?.config ?? createDefaultMemoryToolConfig(),
+    ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
+  });
+  if (!tool) {
+    throw new Error("tool missing");
+  }
+  return tool;
+}
+
+export function createMemoryAddToolOrThrow(params?: {
+  config?: OpenClawConfig;
+  agentSessionKey?: string;
+}) {
+  const tool = createMemoryAddTool({
     config: params?.config ?? createDefaultMemoryToolConfig(),
     ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
   });

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,13 +1,70 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
+  setMemoryWorkspaceDir,
 } from "./memory-tool-manager-mock.js";
 import {
+  createMemoryAddToolOrThrow,
   createMemorySearchToolOrThrow,
   expectUnavailableMemorySearchDetails,
 } from "./tools.test-helpers.js";
+
+describe("memory_add", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  beforeEach(() => {
+    resetMemoryToolMockState({ searchImpl: async () => [] });
+  });
+
+  async function createWorkspace() {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-memory-add-"));
+    setMemoryWorkspaceDir(dir);
+    return dir;
+  }
+
+  it("writes daily markdown memory blocks", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T16:30:00.000Z"));
+    const workspaceDir = await createWorkspace();
+    setMemorySearchImpl(async () => {
+      throw new Error("search should not be called");
+    });
+    const tool = createMemoryAddToolOrThrow({
+      config: {
+        agents: {
+          defaults: { userTimezone: "Asia/Tokyo" },
+          list: [{ id: "main", default: true }],
+        },
+      },
+    });
+
+    const result = await tool.execute("add", { text: "alpha\n----\nbeta" });
+
+    expect(result.details).toEqual({
+      action: "created",
+      path: "memory/2026-01-02.md",
+      text: "alpha\n---\nbeta",
+    });
+    expect(JSON.stringify(result)).not.toContain("memoryId");
+    await expect(
+      fs.readFile(path.join(workspaceDir, "memory/2026-01-02.md"), "utf-8"),
+    ).resolves.toBe("alpha\n---\nbeta\n\n----\n");
+
+    await expect(tool.execute("empty", { text: "   " })).resolves.toMatchObject({
+      details: {
+        action: "failed",
+        error: "text_required",
+      },
+    });
+  });
+});
 
 describe("memory_search unavailable payloads", () => {
   beforeEach(() => {

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -14,6 +14,7 @@ import {
   resolveMemoryCorePluginConfig,
   resolveMemoryDeepDreamingConfig,
 } from "openclaw/plugin-sdk/memory-core-host-status";
+import { addMemoryBlock } from "./memory/add-memory-block.js";
 import { recordShortTermRecalls } from "./short-term-promotion.js";
 import {
   clampResultsByInjectedChars,
@@ -28,6 +29,7 @@ import {
   getMemoryManagerContext,
   getMemoryManagerContextWithPurpose,
   loadMemoryToolRuntime,
+  MemoryAddSchema,
   MemoryGetSchema,
   MemorySearchSchema,
   searchMemoryCorpusSupplements,
@@ -316,6 +318,48 @@ export function createMemorySearchTool(options: {
           const message = formatErrorMessage(err);
           return jsonResult(buildMemorySearchUnavailableResult(message));
         }
+      },
+  });
+}
+
+export function createMemoryAddTool(options: {
+  config?: OpenClawConfig;
+  agentSessionKey?: string;
+}) {
+  return createMemoryTool({
+    options,
+    label: "Memory Add",
+    name: "memory_add",
+    description:
+      "Add one durable semantic memory block to memory/YYYY-MM-DD.md. Does not return a memoryId.",
+    parameters: MemoryAddSchema,
+    execute:
+      ({ cfg, agentId }) =>
+      async (_toolCallId, params) => {
+        const rawParams = asToolParamsRecord(params);
+        const text = readStringParam(rawParams, "text") ?? "";
+        if (!text.trim()) {
+          return jsonResult({ action: "failed", error: "text_required" });
+        }
+        const memory = await getMemoryManagerContext({ cfg, agentId });
+        if ("error" in memory) {
+          return jsonResult({ action: "failed", error: "write_failed", message: memory.error });
+        }
+        const workspaceDir = memory.manager.status().workspaceDir;
+        if (!workspaceDir) {
+          return jsonResult({
+            action: "failed",
+            error: "write_failed",
+            message: "memory workspace unavailable",
+          });
+        }
+        return jsonResult(
+          await addMemoryBlock({
+            workspaceDir,
+            text,
+            cfg,
+          }),
+        );
       },
   });
 }

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -105,13 +105,14 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
       tools: {
         subagents: {
           tools: {
-            deny: ["memory_search", "memory_get"],
+            deny: ["group:memory"],
           },
         },
       },
     } as unknown as OpenClawConfig;
     const policy = resolveSubagentToolPolicy(cfg, 1);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("memory_add", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
   });
 

--- a/src/agents/tool-catalog.test.ts
+++ b/src/agents/tool-catalog.test.ts
@@ -9,6 +9,7 @@ describe("tool-catalog", () => {
     expect(policy!.allow).toContain("web_search");
     expect(policy!.allow).toContain("x_search");
     expect(policy!.allow).toContain("web_fetch");
+    expect(policy!.allow).toContain("memory_add");
     expect(policy!.allow).toContain("image_generate");
     expect(policy!.allow).toContain("music_generate");
     expect(policy!.allow).toContain("video_generate");

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -142,6 +142,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "memory_add",
+    label: "memory_add",
+    description: "Add durable memory",
+    sectionId: "memory",
+    profiles: ["coding"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_list",
     label: "sessions_list",
     description: SESSIONS_LIST_TOOL_DISPLAY_SUMMARY,

--- a/src/agents/tool-display-config.ts
+++ b/src/agents/tool-display-config.ts
@@ -347,6 +347,11 @@ export const TOOL_DISPLAY_CONFIG: ToolDisplayConfig = {
       title: "Memory Get",
       detailKeys: ["path", "from", "lines"],
     },
+    memory_add: {
+      emoji: "🧠",
+      title: "Memory Add",
+      detailKeys: ["text"],
+    },
     web_search: {
       emoji: "🔎",
       title: "Web Search",

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -157,6 +157,25 @@ vi.mock("../agents/openclaw-tools.js", () => {
         return { ok: true };
       },
     },
+    ...(lastCreateOpenClawToolsContext?.disablePluginTools
+      ? []
+      : [
+          {
+            name: "memory_add",
+            parameters: {
+              type: "object",
+              properties: {
+                text: { type: "string" },
+              },
+              required: ["text"],
+              additionalProperties: false,
+            },
+            execute: async (_toolCallId: string, args: unknown) => ({
+              ok: true,
+              text: (args as { text?: unknown }).text,
+            }),
+          },
+        ]),
     {
       name: "diffs_compat_test",
       parameters: {
@@ -425,7 +444,7 @@ describe("POST /tools/invoke", () => {
     expect(lastCreateOpenClawToolsContext?.allowGatewaySubagentBinding).toBe(true);
   });
 
-  it("keeps plugin tools enabled for non-core tool invokes", async () => {
+  it("keeps plugin tools enabled for plugin-backed tool invokes", async () => {
     setMainAllowedTools({ allow: ["tools_invoke_test"] });
 
     const res = await invokeToolAuthed({
@@ -435,6 +454,16 @@ describe("POST /tools/invoke", () => {
     });
 
     expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
+    setMainAllowedTools({ allow: ["memory_add"] });
+
+    const memoryRes = await invokeToolAuthed({
+      tool: "memory_add",
+      args: { text: "remember this" },
+      sessionKey: "main",
+    });
+
+    expect(memoryRes.status).toBe(200);
     expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
   });
 

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -31,7 +31,8 @@ import {
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 const DEFAULT_BODY_BYTES = 2 * 1024 * 1024;
-const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get"]);
+const MEMORY_TOOL_NAMES = new Set(["memory_search", "memory_get", "memory_add"]);
+const PLUGIN_BACKED_CATALOG_TOOL_NAMES = new Set(["memory_add"]);
 
 type ToolsInvokeBody = {
   tool?: unknown;
@@ -236,7 +237,8 @@ export async function handleToolsInvokeHttpRequest(
     allowGatewaySubagentBinding: true,
     allowMediaInvokeCommands: true,
     surface: "http",
-    disablePluginTools: isKnownCoreToolId(toolName),
+    disablePluginTools:
+      isKnownCoreToolId(toolName) && !PLUGIN_BACKED_CATALOG_TOOL_NAMES.has(toolName),
     senderIsOwner,
   });
   const gatewayFiltered = applyOwnerOnlyToolPolicy(tools, senderIsOwner);


### PR DESCRIPTION
## Context

Refs #70049

This PR adds the first minimal `memory_add` write primitive for durable semantic memories. It stores each write as a markdown-native memory block in `memory/YYYY-MM-DD.md`:

```md
Remember this semantic memory.

----
```

`----` is both a readable Markdown horizontal rule and OpenClaw's semantic block separator. User text lines that exactly equal `----` are written as `---`, which still renders as a horizontal rule but does not create a false OpenClaw block boundary.

## What This PR Implements

- Adds `memory_add` in the `memory-core` plugin.
- Accepts a single `text` field and validates empty input as `text_required`.
- Uses the configured user timezone for the daily file name.
- Appends one memory block to the daily memory markdown file.
- Does not perform semantic duplicate detection in this first slice; duplicate management is left for future list/replace/remove flows.

## Backend Behavior

- Builtin: for daily memory files, indexing parses `----` as a hard semantic boundary. Chunks are built from one memory block at a time, so builtin chunks do not cross memory blocks. The separator line is excluded from snippets and embedding text.
- QMD: consumes the same markdown files as source of truth. Because `----` renders as a normal horizontal rule, QMD can use it as a natural chunk-boundary signal without any OpenClaw-specific metadata text.
- Index refresh continues to use the existing watcher/search/manual sync mechanisms.
- Other markdown files such as `MEMORY.md`, `memory.md`, and non-daily memory files remain raw markdown.

## Fallback Behavior

If a daily memory file is manually edited incorrectly, the fallback is still acceptable: malformed or separator-free content is indexed as normal markdown memory text rather than failing the index. The worst case is less precise chunking, not data loss or an unreadable memory file.

## Validation

- `pnpm test extensions/memory-core/src/memory/memory-blocks.test.ts extensions/memory-core/src/tools.test.ts extensions/memory-core/src/memory/index.test.ts src/gateway/tools-invoke-http.test.ts src/agents/tool-catalog.test.ts src/agents/pi-tools.policy.test.ts`
- `pnpm test:changed`
- `pnpm check:changed` passed conflict marker checks, core/core-test typecheck, extension/extension-test typecheck, core lint, and extension lint. It stops at app lint locally because `swiftlint` is not installed: `sh: swiftlint: command not found`.
