### PR TITLE
fix: clamp effort=low/minimal to medium for claude-opus-4.7

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -413,4 +413,78 @@ describe("anthropic transport stream", () => {
       output_config: { effort: "xhigh" },
     });
   });
+
+  it("clamps effort=low to effort=medium for Claude Opus 4.7 (only accepts medium+)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Hello." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "low",
+      } as AnthropicStreamOptions,
+    );
+
+    // Copilot proxy rejects effort="low" for claude-opus-4.7 with HTTP 400
+    // invalid_reasoning_effort. The supported values are [medium, high, xhigh].
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "medium" },
+    });
+  });
+
+  it("clamps effort=minimal to effort=medium for Claude Opus 4.7", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Hello." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "minimal",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "medium" },
+    });
+  });
+
+  it("does NOT clamp effort=low for Claude Opus 4.6 (accepts low)", async () => {
+    const model = makeAnthropicTransportModel({
+      id: "claude-opus-4-6",
+      name: "Claude Opus 4.6",
+      maxTokens: 8192,
+    });
+
+    await runTransportStream(
+      model,
+      {
+        messages: [{ role: "user", content: "Hello." }],
+      } as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+        reasoning: "low",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+    });
+  });
 });

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -124,10 +124,13 @@ function supportsAdaptiveThinking(modelId: string): boolean {
 }
 
 function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
+  // claude-opus-4.7 only accepts effort values of "medium" or higher via the Copilot proxy.
+  // Clamp "minimal" and "low" to "medium" to avoid HTTP 400 invalid_reasoning_effort errors.
+  const clampToMedium = isClaudeOpus47Model(modelId);
   switch (level) {
     case "minimal":
     case "low":
-      return "low";
+      return clampToMedium ? "medium" : "low";
     case "medium":
       return "medium";
     case "xhigh":


### PR DESCRIPTION
## Problem

Fixes #70322.

GitHub Copilot's proxy rejects `output_config.effort="low"` for `claude-opus-4.7` with:

```
HTTP 400 {"error":{"message":"output_config.effort \"low\" is not supported by model claude-opus-4.7; supported values: [medium]","code":"invalid_reasoning_effort"}}
```

The only accepted effort values for opus-4.7 via Copilot are `medium`, `high`, and `xhigh`.

## Impact

This breaks multiple common code paths that send `thinking="off"` or `thinking="low"`:

- **Subagent spawns** (default `agents.defaults.subagents.thinking: "off"`)
- **Dreaming phases** (light/deep/REM — runs as part of the nightly cron)
- **LCM summary expansion**
- **Context engine turn maintenance**

Each failure also poisons the Copilot auth profile (`window=cooldown`), triggering a cascade of `FailoverError: No available auth profile for github-copilot (all in cooldown or unavailable)` on every subsequent request until cooldown expires.

Attempting to work around this via a per-model `params.reasoning_effort: "medium"` override in `agents.defaults.models` does **not** help, because the adaptive-thinking code path writes `output_config.effort` directly from `options.reasoning` via `mapThinkingLevelToEffort` and never consults `params`.

## Root cause

In `src/agents/anthropic-transport-stream.ts`:

```ts
function mapThinkingLevelToEffort(level: ThinkingLevel, modelId: string): AnthropicAdaptiveEffort {
  switch (level) {
    case "minimal":
    case "low":
      return "low";
    ...
  }
}
```

`supportsAdaptiveThinking` matches `claude-opus-4-7`, so when a "low" level reaches it, `output_config.effort="low"` is emitted, and Copilot rejects. There is no override analogous to `OPENAI_MEDIUM_ONLY_REASONING_MODEL_IDS` for the Anthropic adaptive-thinking path.

## Fix

Clamp `"minimal"` and `"low"` to `"medium"` for `claude-opus-4.7` specifically (matches `isClaudeOpus47Model()` helper already used elsewhere in the file). `opus-4.6`, `sonnet-4.6`, and all other adaptive-thinking models are unaffected.

## Tests

Added 3 new tests to `src/agents/anthropic-transport-stream.test.ts`:

- `effort=low` → `effort=medium` for opus-4.7
- `effort=minimal` → `effort=medium` for opus-4.7
- `effort=low` still passes through as `low` for opus-4.6 (regression guard)

All 11 tests in the file pass:

```
✓ agents src/agents/anthropic-transport-stream.test.ts (11 tests) 366ms
Test Files 1 passed (1)
Tests      11 passed (11)
```

## Reproduced on

- OpenClaw 2026.4.21 (f788c88)
- github-copilot provider, claude-opus-4.7 model
- Individual GitHub Copilot subscription (`api.githubcopilot.com`)
- thinking="off" or thinking="low" on any subagent spawn, dreaming phase, or context-engine turn maintenance
