### PR TITLE
fix: preserve cron silent NO_REPLY tool completions

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -760,6 +760,32 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toBeNull();
   });
 
+  it("treats an exact NO_REPLY tool result as a deliberate silent completion", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "NO_REPLY" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toBeNull();
+  });
+
   it("suppresses the incomplete-turn warning when a messaging tool delivered and the turn ended cleanly", () => {
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
       payloadCount: 0,

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -786,6 +786,40 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(incompleteTurnText).toBeNull();
   });
 
+  it("ignores NO_REPLY tool results from earlier turns", () => {
+    const incompleteTurnText = resolveIncompleteTurnPayloadText({
+      payloadCount: 0,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: [],
+        prePromptMessageCount: 1,
+        messagesSnapshot: [
+          {
+            role: "toolResult",
+            content: [{ type: "text", text: "NO_REPLY" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+          {
+            role: "assistant",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.4",
+            content: [{ type: "text", text: "" }],
+          } as unknown as EmbeddedRunAttemptResult["messagesSnapshot"][number],
+        ],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "openai",
+          model: "gpt-5.4",
+          content: [{ type: "text", text: "" }],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    });
+
+    expect(incompleteTurnText).toContain("Please try again");
+  });
+
   it("suppresses the incomplete-turn warning when a messaging tool delivered and the turn ended cleanly", () => {
     const incompleteTurnText = resolveIncompleteTurnPayloadText({
       payloadCount: 0,

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.fixture.ts
@@ -44,6 +44,7 @@ export function makeAttemptResult(
     assistantTexts: ["Hello!"],
     toolMetas,
     lastAssistant: undefined,
+    prePromptMessageCount: 0,
     messagesSnapshot: [],
     replayMetadata:
       overrides.replayMetadata ??

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2772,6 +2772,7 @@ export async function runEmbeddedAttempt(
         bootstrapPromptWarningSignature: bootstrapPromptWarning.signature,
         systemPromptReport,
         finalPromptText,
+        prePromptMessageCount,
         messagesSnapshot,
         assistantTexts,
         toolMetas: toolMetasNormalized,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -23,6 +23,7 @@ type IncompleteTurnAttempt = Pick<
   | "didSendViaMessagingTool"
   | "lastToolError"
   | "lastAssistant"
+  | "messagesSnapshot"
   | "replayMetadata"
   | "promptErrorSource"
   | "timedOutDuringCompaction"
@@ -178,6 +179,9 @@ export function resolveIncompleteTurnPayloadText(params: {
   if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
     return null;
   }
+  if (hasLatestSilentToolResult(params.attempt.messagesSnapshot)) {
+    return null;
+  }
 
   const stopReason = params.attempt.lastAssistant?.stopReason;
   // If the assistant already delivered user-visible content via a messaging
@@ -221,6 +225,44 @@ function hasOnlySilentAssistantReply(assistantTexts: readonly string[]): boolean
     nonEmptyTexts.length > 0 &&
     nonEmptyTexts.every((text) => isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN))
   );
+}
+
+function hasLatestSilentToolResult(messagesSnapshot: readonly AgentMessage[]): boolean {
+  for (let index = messagesSnapshot.length - 1; index >= 0; index -= 1) {
+    const message = messagesSnapshot[index] as
+      | {
+          role?: string;
+          content?: unknown;
+          isError?: boolean;
+        }
+      | undefined;
+    if (!message || (message.role !== "toolResult" && message.role !== "tool")) {
+      continue;
+    }
+    if (message.isError === true) {
+      return false;
+    }
+    const text = extractMessageText(message.content).trim();
+    return Boolean(text) && isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN);
+  }
+  return false;
+}
+
+function extractMessageText(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .flatMap((part) =>
+      part && typeof part === "object" && (part as { type?: unknown }).type === "text"
+        ? [(part as { text?: unknown }).text]
+        : [],
+    )
+    .filter((value): value is string => typeof value === "string")
+    .join("\n\n");
 }
 
 export function resolveReplayInvalidFlag(params: {

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -23,6 +23,7 @@ type IncompleteTurnAttempt = Pick<
   | "didSendViaMessagingTool"
   | "lastToolError"
   | "lastAssistant"
+  | "prePromptMessageCount"
   | "messagesSnapshot"
   | "replayMetadata"
   | "promptErrorSource"
@@ -179,7 +180,12 @@ export function resolveIncompleteTurnPayloadText(params: {
   if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
     return null;
   }
-  if (hasLatestSilentToolResult(params.attempt.messagesSnapshot)) {
+  if (
+    hasLatestSilentToolResult(
+      params.attempt.messagesSnapshot,
+      params.attempt.prePromptMessageCount ?? 0,
+    )
+  ) {
     return null;
   }
 
@@ -227,9 +233,13 @@ function hasOnlySilentAssistantReply(assistantTexts: readonly string[]): boolean
   );
 }
 
-function hasLatestSilentToolResult(messagesSnapshot: readonly AgentMessage[]): boolean {
-  for (let index = messagesSnapshot.length - 1; index >= 0; index -= 1) {
-    const message = messagesSnapshot[index] as
+function hasLatestSilentToolResult(
+  messagesSnapshot: readonly AgentMessage[],
+  prePromptMessageCount: number,
+): boolean {
+  const currentAttemptMessages = messagesSnapshot.slice(Math.max(0, prePromptMessageCount));
+  for (let index = currentAttemptMessages.length - 1; index >= 0; index -= 1) {
+    const message = currentAttemptMessages[index] as
       | {
           role?: string;
           content?: unknown;

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -74,6 +74,7 @@ export type EmbeddedRunAttemptResult = {
   bootstrapPromptWarningSignature?: string;
   systemPromptReport?: SessionSystemPromptReport;
   finalPromptText?: string;
+  prePromptMessageCount?: number;
   messagesSnapshot: AgentMessage[];
   assistantTexts: string[];
   toolMetas: Array<{ toolName: string; meta?: string }>;


### PR DESCRIPTION
## Summary

- Problem: isolated agent turns can treat a valid exact `NO_REPLY` tool result as an incomplete turn when the model ends with an empty final assistant message.
- Why it matters: cron runs that are supposed to stay silent can be surfaced as errors or duplicate failure announcements.
- What changed: incomplete-turn resolution now also trusts the latest non-error tool result when it is exact `NO_REPLY`, and a regression test locks in that quiet-success path.
- What did NOT change (scope boundary): this does not change visible reply handling, tool-error paths, or non-silent tool results.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #68452
- Related #
- [x] This PR fixes a bug or regression

## Root Cause / Regression History (if applicable)

- Root cause: `resolveIncompleteTurnPayloadText()` only treated assistant-authored exact `NO_REPLY` as a deliberate silent success. If a tool already returned exact `NO_REPLY` and the final assistant message was empty, the runner still surfaced an incomplete-turn error.
- Missing detection / guardrail: the incomplete-turn path did not inspect the latest successful tool result before classifying the turn as abandoned.
- Prior context (`git blame`, prior PR, issue, or refactor if known): issue #68452 documents the failing cron shape; I did not trace a specific introducing PR.
- Why this regressed now: this appears to be a latent silent-turn gap rather than a brand-new refactor regression.
- If unknown, what was ruled out: ruled out assistant-side `NO_REPLY` handling; that path already had coverage and worked.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
- Scenario the test should lock in: the latest successful tool result is exact `NO_REPLY`, the final assistant message is empty, and incomplete-turn classification stays silent.
- Why this is the smallest reliable guardrail: the bug lives in incomplete-turn classification, so a focused unit test covers the exact decision seam without broad cron setup.
- Existing test that already covers this (if any): assistant-authored exact `NO_REPLY` was already covered.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Cron-style silent-success turns no longer surface false incomplete-turn errors when the tool already returned exact `NO_REPLY` and the final assistant message is empty.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): cron / embedded runner path
- Relevant config (redacted): isolated or embedded silent-turn path

### Steps

1. Run an embedded turn where a tool returns exact `NO_REPLY`.
2. Let the assistant end with an empty final message.
3. Finalize the embedded run.

### Expected

- The run is treated as a deliberate quiet success.

### Actual

- Before this fix, the run could be classified as an incomplete turn and surface an error.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Ran `pnpm test -- src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`
  - Verified exact `NO_REPLY` tool results suppress incomplete-turn errors when the final assistant message is empty
- Edge cases checked:
  - non-error latest tool result only
  - existing assistant-authored `NO_REPLY` path still passes
- What you did **not** verify:
  - a full cron end-to-end repro through delivery dispatch
  - unrelated visible-reply cron flows

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: a non-error latest tool result containing exact `NO_REPLY` now wins over an empty final assistant message.
  - Mitigation: the check is intentionally narrow to the latest tool result and exact silent sentinel handling only.
