### PR TITLE
fix(google): raise minimal thinkingBudget floor to 512 for Gemini 2.5 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/agents: avoid rebuilding core tools for plugin-only allowlists and keep the full plugin registry cache warm across scoped plugin loads, reducing per-turn latency spikes. Fixes #75882, #75907, #75906, #75887, and #75851. (#75922) Thanks @obviyus.
 - Agents/failover: classify bare `status: internal server error` provider messages as retryable server errors so model fallback can rotate instead of stopping. (#73844) Thanks @thesomewhatyou.
 - Gateway/startup: return the shared retryable startup-sidecars error for startup-gated control-plane RPCs such as sessions.create, sessions.send, sessions.abort, agent.wait, and tools.effective, so clients can retry early sidecar races. (#76012) Thanks @scoootscooob.
+- Providers/Google: fix Gemini 2.5 Flash-Lite `reasoning: "minimal"` rejections by raising its thinking-budget floor to 512 while preserving the existing Gemini 2.5 Pro and Flash minimal presets. (#70629) Thanks @ericberic.
 
 ## 2026.4.30
 

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -754,20 +754,17 @@ describe("google transport stream", () => {
     ["gemini-2.5-pro", "low", 2048],
     ["gemini-2.5-flash", "medium", 8192],
     ["gemini-2.5-pro", "medium", 8192],
-  ] as const)(
-    "uses thinkingBudget %i for %s with reasoning=%s",
-    (id, reasoning, expectedBudget) => {
-      const params = buildGoogleGenerativeAiParams(
-        buildGeminiModel({ id }),
-        {
-          messages: [{ role: "user", content: "hello", timestamp: 0 }],
-        } as never,
-        { reasoning },
-      );
+  ] as const)("%s with reasoning=%s uses thinkingBudget %i", (id, reasoning, expectedBudget) => {
+    const params = buildGoogleGenerativeAiParams(
+      buildGeminiModel({ id }),
+      {
+        messages: [{ role: "user", content: "hello", timestamp: 0 }],
+      } as never,
+      { reasoning },
+    );
 
-      expect(params.generationConfig).toMatchObject({
-        thinkingConfig: { includeThoughts: true, thinkingBudget: expectedBudget },
-      });
-    },
-  );
+    expect(params.generationConfig).toMatchObject({
+      thinkingConfig: { includeThoughts: true, thinkingBudget: expectedBudget },
+    });
+  });
 });

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -748,9 +748,9 @@ describe("google transport stream", () => {
   it.each([
     ["gemini-2.5-flash-lite", "minimal", 512],
     ["gemini-2.5-flash-lite", "low", 2048],
-    ["gemini-2.5-flash", "minimal", 512],
+    ["gemini-2.5-flash", "minimal", 128],
     ["gemini-2.5-flash", "low", 2048],
-    ["gemini-2.5-pro", "minimal", 512],
+    ["gemini-2.5-pro", "minimal", 128],
     ["gemini-2.5-pro", "low", 2048],
     ["gemini-2.5-flash", "medium", 8192],
     ["gemini-2.5-pro", "medium", 8192],

--- a/extensions/google/transport-stream.test.ts
+++ b/extensions/google/transport-stream.test.ts
@@ -744,4 +744,30 @@ describe("google transport stream", () => {
 
     expect(params.contents).toEqual([{ role: "user", parts: [{ text: " " }] }]);
   });
+
+  it.each([
+    ["gemini-2.5-flash-lite", "minimal", 512],
+    ["gemini-2.5-flash-lite", "low", 2048],
+    ["gemini-2.5-flash", "minimal", 512],
+    ["gemini-2.5-flash", "low", 2048],
+    ["gemini-2.5-pro", "minimal", 512],
+    ["gemini-2.5-pro", "low", 2048],
+    ["gemini-2.5-flash", "medium", 8192],
+    ["gemini-2.5-pro", "medium", 8192],
+  ] as const)(
+    "uses thinkingBudget %i for %s with reasoning=%s",
+    (id, reasoning, expectedBudget) => {
+      const params = buildGoogleGenerativeAiParams(
+        buildGeminiModel({ id }),
+        {
+          messages: [{ role: "user", content: "hello", timestamp: 0 }],
+        } as never,
+        { reasoning },
+      );
+
+      expect(params.generationConfig).toMatchObject({
+        thinkingConfig: { includeThoughts: true, thinkingBudget: expectedBudget },
+      });
+    },
+  );
 });

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -298,10 +298,13 @@ function getGoogleThinkingBudget(
     return customBudgets[normalizedEffort];
   }
   if (modelId.includes("2.5-pro")) {
-    return { minimal: 512, low: 2048, medium: 8192, high: 32768 }[normalizedEffort];
+    return { minimal: 128, low: 2048, medium: 8192, high: 32768 }[normalizedEffort];
+  }
+  if (modelId.includes("2.5-flash-lite")) {
+    return { minimal: 512, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
   }
   if (modelId.includes("2.5-flash")) {
-    return { minimal: 512, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
+    return { minimal: 128, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
   }
   return undefined;
 }

--- a/extensions/google/transport-stream.ts
+++ b/extensions/google/transport-stream.ts
@@ -298,10 +298,10 @@ function getGoogleThinkingBudget(
     return customBudgets[normalizedEffort];
   }
   if (modelId.includes("2.5-pro")) {
-    return { minimal: 128, low: 2048, medium: 8192, high: 32768 }[normalizedEffort];
+    return { minimal: 512, low: 2048, medium: 8192, high: 32768 }[normalizedEffort];
   }
   if (modelId.includes("2.5-flash")) {
-    return { minimal: 128, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
+    return { minimal: 512, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
   }
   return undefined;
 }


### PR DESCRIPTION
## What broke

Google's Generative AI API now rejects `thinkingBudget: 128` for Gemini 2.5 models with:

```
400 INVALID_ARGUMENT: The thinking budget 128 is invalid.
Please choose a value between 512 and 24576.
```

This started failing silently for any call using `reasoning: "minimal"` on `gemini-2.5-flash-lite`, `gemini-2.5-flash`, or `gemini-2.5-pro` — including background sessions and the main heartbeat agent.

## Root cause

`getGoogleThinkingBudget` in `extensions/google/transport-stream.ts` hardcoded `minimal: 128` in both the `2.5-pro` and `2.5-flash` budget tables. Google raised their API minimum from 128 to 512 for Gemini 2.5 thinking models.

Note: Gemini 2.5 Flash/Flash-Lite models don't match `isGoogleGemini3FlashModel` (which covers only gemini-3.x), so they fall through to the `thinkingBudget` integer path rather than the `thinkingLevel` string path — making this the exact code that was hit.

## Fix

```diff
- return { minimal: 128, low: 2048, medium: 8192, high: 32768 }[normalizedEffort]; // 2.5-pro
+ return { minimal: 512, low: 2048, medium: 8192, high: 32768 }[normalizedEffort];

- return { minimal: 128, low: 2048, medium: 8192, high: 24576 }[normalizedEffort]; // 2.5-flash
+ return { minimal: 512, low: 2048, medium: 8192, high: 24576 }[normalizedEffort];
```

All other tiers (`low`, `medium`, `high`) are unchanged.

## Test coverage

Added a parametrized test in `extensions/google/transport-stream.test.ts` asserting the correct `thinkingBudget` values across all budget tiers for `gemini-2.5-flash-lite`, `gemini-2.5-flash`, and `gemini-2.5-pro`. Covers the minimal=512 fix and regression-tests the unchanged tiers.

## Related

Follows the same area as #57683 (Gemini 2.5 Pro thinking mode fixes).