### PR TITLE
fix(telegram): keep no-visible direct turns silent

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -2564,16 +2564,17 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
-  it("rewrites a no-visible-response DM turn through silent-reply fallback", async () => {
+  it("keeps a no-visible-response DM turn silent instead of sending silent-reply chatter", async () => {
     const draftStream = createDraftStream(999);
+    const statusReactionController = createStatusReactionController();
     createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
       queuedFinal: false,
     });
-    deliverReplies.mockResolvedValueOnce({ delivered: true });
 
     await dispatchWithContext({
       context: createContext({
+        statusReactionController: statusReactionController as never,
         ctxPayload: {
           SessionKey: "agent:main:telegram:direct:123",
         } as unknown as TelegramMessageContext["ctxPayload"],
@@ -2594,11 +2595,9 @@ describe("dispatchTelegramMessage draft streaming", () => {
       } as unknown as OpenClawConfig,
     });
 
-    expect(deliverReplies).toHaveBeenCalledTimes(1);
-    const deliveredReplies = deliverReplies.mock.calls[0]?.[0]?.replies;
-    expect(Array.isArray(deliveredReplies)).toBe(true);
-    expect(deliveredReplies?.[0]?.text).toEqual(expect.any(String));
-    expect(deliveredReplies?.[0]?.text?.trim()).not.toBe("NO_REPLY");
+    expect(deliverReplies).not.toHaveBeenCalled();
+    expect(statusReactionController.setDone).toHaveBeenCalledTimes(1);
+    expect(statusReactionController.setError).not.toHaveBeenCalled();
   });
 
   it("does not add silent-reply fallback after visible block delivery", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1202,7 +1202,7 @@ export const dispatchTelegramMessage = async ({
     const shouldKeepTurnSilent = !isGroup || silentReplyFallback.length === 0;
     if (shouldKeepTurnSilent) {
       handledSilentNoVisibleResponse = true;
-    } else if (silentReplyFallback.length > 0) {
+    } else {
       const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
         replies: silentReplyFallback,
         ...deliveryBaseOptions,

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -1168,6 +1168,7 @@ export const dispatchTelegramMessage = async ({
     return;
   }
   let sentFallback = false;
+  let handledSilentNoVisibleResponse = false;
   const deliverySummary = deliveryState.snapshot();
   if (
     dispatchError ||
@@ -1198,7 +1199,10 @@ export const dispatchTelegramMessage = async ({
         surface: "telegram",
       }),
     );
-    if (silentReplyFallback.length > 0) {
+    const shouldKeepTurnSilent = !isGroup || silentReplyFallback.length === 0;
+    if (shouldKeepTurnSilent) {
+      handledSilentNoVisibleResponse = true;
+    } else if (silentReplyFallback.length > 0) {
       const result = await (telegramDeps.deliverReplies ?? deliverReplies)({
         replies: silentReplyFallback,
         ...deliveryBaseOptions,
@@ -1212,10 +1216,12 @@ export const dispatchTelegramMessage = async ({
       hasChatId: chatId != null,
       queuedFinal,
       sentFallback,
+      handledSilentNoVisibleResponse,
     });
   }
 
-  const hasFinalResponse = queuedFinal || sentFallback || deliverySummary.delivered;
+  const hasFinalResponse =
+    queuedFinal || sentFallback || deliverySummary.delivered || handledSilentNoVisibleResponse;
 
   if (statusReactionController && !hasFinalResponse) {
     void finalizeTelegramStatusReaction({ outcome: "error", hasFinalResponse: false }).catch(


### PR DESCRIPTION
## Summary

This stops Telegram direct-message turns from fabricating silent-reply filler like `No added response from me.` when the turn ends with no visible final response and no actual error.

Closes #70628.

## Root cause

`extensions/telegram/src/bot-message-dispatch.ts` synthesized a `NO_REPLY` fallback whenever a Telegram turn ended with:
- `queuedFinal = false`
- `sentFallback = false`
- `dispatchError = false`
- `deliverySummary.delivered = false`

That synthetic `NO_REPLY` then flowed through outbound silent-reply rewriting for direct conversations, which turned it into visible chatter instead of true silence.

## What changed

- keep no-visible-response **Telegram direct** turns silent instead of sending synthetic `NO_REPLY` fallback
- mark that path as a handled silent turn so status reactions finalize as `done` rather than `error`
- keep the existing fallback send behavior for cases where a projected fallback should still be delivered
- update the Telegram dispatch regression test to assert silence for this DM path

## Validation

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/bot-message-dispatch.test.ts`
