### PR TITLE
fix(ui): keep primary model selection stable in agent overview

### DIFF
--- a/ui/src/ui/views/agents-panels-overview.ts
+++ b/ui/src/ui/views/agents-panels-overview.ts
@@ -79,6 +79,7 @@ export function renderAgentOverview(params: {
   const skillFilter = Array.isArray(config.entry?.skills) ? config.entry?.skills : null;
   const skillCount = skillFilter?.length ?? null;
   const isDefault = Boolean(params.defaultId && agent.id === params.defaultId);
+  const selectedPrimary = isDefault ? (effectivePrimary ?? "") : (entryPrimary ?? "");
   const disabled = !configForm || configLoading || configSaving;
 
   const removeChip = (index: number) => {
@@ -141,19 +142,24 @@ export function renderAgentOverview(params: {
           <label class="field">
             <span>Primary model${isDefault ? " (default)" : ""}</span>
             <select
-              .value=${isDefault ? (effectivePrimary ?? "") : (entryPrimary ?? "")}
+              .value=${selectedPrimary}
               ?disabled=${disabled}
               @change=${(e: Event) =>
                 onModelChange(agent.id, (e.target as HTMLSelectElement).value || null)}
             >
               ${isDefault
-                ? html` <option value="">Not set</option> `
+                ? html` <option value="" ?selected=${selectedPrimary === ""}>Not set</option> `
                 : html`
-                    <option value="">
+                    <option value="" ?selected=${selectedPrimary === ""}>
                       ${defaultPrimary ? `Inherit default (${defaultPrimary})` : "Inherit default"}
                     </option>
                   `}
-              ${buildModelOptions(configForm, effectivePrimary ?? undefined, params.modelCatalog)}
+              ${buildModelOptions(
+                configForm,
+                effectivePrimary ?? undefined,
+                selectedPrimary,
+                params.modelCatalog,
+              )}
             </select>
           </label>
           <div class="field">

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -604,6 +604,7 @@ function resolveConfiguredModels(
 export function buildModelOptions(
   configForm: Record<string, unknown> | null,
   current?: string | null,
+  selected?: string | null,
   catalog?: ModelCatalogEntry[],
 ) {
   const seen = new Set<string>();
@@ -637,7 +638,12 @@ export function buildModelOptions(
   if (options.length === 0) {
     return nothing;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === (selected ?? "")}>
+        ${option.label}
+      </option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
# fix(ui): keep primary model selection stable in agent overview

## Summary

This PR fixes a Control UI regression where the agent `Primary model` could show `Not set` on first load even when a model was already configured. It makes user confused.

<img width="767" height="395" alt="image" src="https://github.com/user-attachments/assets/ff0ca4a4-9b89-4907-9e79-463775fea547" />


## Root Cause

The `<select>` state could lose alignment with the effective selected model value across render paths (initial render and agent switch), so the placeholder option was shown unexpectedly.

## What Changed

- `ui/src/ui/views/agents-panels-overview.ts`
  - Introduced a single `selectedPrimary` source of truth for the select value.
  - Bound both `<select>.value` and option selected states to that same value.
  - Passed `selectedPrimary` into model option rendering.
- `ui/src/ui/views/agents-utils.ts`
  - Extended `buildModelOptions` to accept `selected`.
  - Explicitly marks the matching model option as selected.

## User-visible Behavior

- On first entry, `Primary model` now correctly reflects the configured model (instead of incorrectly showing `Not set`).
- Switching across multiple agents and back keeps model selection display consistent.

## Validation

paas by human manually tests

## AI-assisted

- This PR is AI-assisted and manually reviewed.
