### PR TITLE
test(agents): pin empty-turn coverage for non-strict-agentic nemotron

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -505,6 +505,83 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     );
   });
 
+  // Regression coverage for NemoClaw issue #2099 (and the closely related
+  // #2051 / #1193). Nemotron-3 Super 120B has been observed to end a turn
+  // with stopReason="stop" while emitting only a thinking block (sometimes
+  // unsigned — no `thinkingSignature`/`signature` field, which means the
+  // assessment helper does not classify the turn as reasoning-only) or
+  // nothing at all. Before the shared `isEmptyResponseAssistantTurn` guard
+  // was added, the runner silently returned no payloads for this shape and
+  // the TUI spinner hung indefinitely. The tests below pin the shared guard
+  // so a regression in that path visibly fails before it reaches end users.
+  //
+  // Note: the empty-response retry instruction is gated on strict-agentic
+  // provider/model pairs (gpt-5-family on openai/openai-codex), so the
+  // nvidia lane must NOT trigger a retry. It must still produce a terminal,
+  // user-visible error payload instead of returning empty.
+  it("surfaces an error when nemotron returns unsigned-thinking-only with stopReason=stop (regression for #2099)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "nvidia",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          content: [
+            {
+              type: "thinking",
+              thinking:
+                "The user asked a simple question. I should answer but I'm unsure how to format it.",
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "nvidia",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      runId: "run-nemotron-unsigned-thinking-only-2099",
+    });
+
+    // Retry guard is strict-agentic only, so this lane does not retry.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    // But the run must still surface a visible terminal error — not silently
+    // resolve with empty payloads, which is what hangs the TUI spinner.
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Please try again");
+  });
+
+  it("surfaces an error when nemotron returns fully empty content with stopReason=stop (regression for #2099)", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "nvidia",
+          model: "nvidia/nemotron-3-super-120b-a12b",
+          content: [],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "nvidia",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      runId: "run-nemotron-empty-content-2099",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(result.payloads?.[0]?.isError).toBe(true);
+    expect(result.payloads?.[0]?.text).toContain("Please try again");
+  });
+
   it("detects structured bullet-only plans with intent cues as planning-only GPT turns", () => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       provider: "openai",


### PR DESCRIPTION
## Summary

Adds two regression tests around the existing `isEmptyResponseAssistantTurn`
guard to pin the current behavior for **non-strict-agentic** providers
(tested with the nvidia Nemotron-3 Super 120B shape). Today the shared
`resolveIncompleteTurnPayloadText` already turns these empty-turn shapes
into a user-visible \"⚠️ Agent couldn't generate a response\" payload, but
no test in this file exercises that path on a non-GPT-5 provider, so a
future tightening of the strict-agentic guard or the reasoning-only
detector could regress it without CI catching the break.

### The shapes

Both shapes have been reported against NemoClaw as \"TUI spinner hangs
indefinitely, no response\":

- NVIDIA/NemoClaw#2099 — TUI hangs 8+ minutes, 0 output tokens, spinner
  stuck on `flibbertigibbeting…`
- NVIDIA/NemoClaw#2051 — model ends the turn with only a thinking block,
  no tool call, no visible text, `stopReason: \"stop\"`, OpenClaw treats
  it as end-of-turn
- NVIDIA/NemoClaw#1193 — `payloads: []`, `stopReason: \"stop\"`, only ~11
  output tokens

Specifically covered by the new tests:

1. `stopReason=\"stop\"` + a single **unsigned** `thinking` content block.
   Unsigned thinking hits `assessLastAssistantMessage === \"incomplete-thinking\"`
   (not `\"incomplete-text\"`), so `isReasoningOnlyAssistantTurn` returns
   false. The empty-response fallback is what prevents the run from
   resolving with `payloads: undefined`.

2. `stopReason=\"stop\"` + fully empty `content: []`.

The retry instruction resolvers (`resolveEmptyResponseRetryInstruction`,
`resolveReasoningOnlyRetryInstruction`) are gated on the strict-agentic
supported provider/model set, so the nvidia lane must **not** retry —
the tests assert a single `runEmbeddedAttempt` call but still require a
terminal `isError: true` payload containing \"Please try again\".

## Why test-only

This is purely a regression pin, not a behavior change. The shared
guard already handles both shapes correctly on main; this PR just makes
that contract explicit for any non-strict-agentic provider that ends
turns with \"empty + terminal stopReason\".

## Test plan

- [x] \`node_modules/.bin/vitest run --config test/vitest/vitest.agents.config.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts\` — 53 passed
- [x] Filtered to the new cases — both pass: \`... -t \"nemotron\"\` → 2 passed

## AI-assisted

- [x] AI-assisted (Claude)
- [x] Fully tested locally (vitest on the affected file)
- [x] I understand the code: the tests pin existing behavior of
      `resolveIncompleteTurnPayloadText` falling through to the
      `emptyResponseAssistant` branch when the assistant turn has no
      visible text, no tool activity, and a terminal stopReason, for a
      provider/model pair outside the strict-agentic supported set.
- [x] No production code changed — test-only regression coverage for a
      previously-reported real-world hang