### PR TITLE
fix: add workspaceOnly enforcement to read tool (#70573)

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -1,4 +1,5 @@
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import { acquireSessionWriteLock } from "openclaw/plugin-sdk/agent-harness";
 import { resolveChannelConfigWrites } from "openclaw/plugin-sdk/channel-config-helpers";
 import { shouldDebounceTextInbound } from "openclaw/plugin-sdk/channel-inbound";
 import {
@@ -1828,16 +1829,37 @@ export const registerTelegramHandlers = ({
         }
       }
 
-      await processInboundMessage({
-        ctx: event.ctx,
-        msg: event.msg,
+      const sessionState = resolveTelegramSessionState({
         chatId: event.chatId,
+        isGroup: event.isGroup,
+        isForum: event.isForum,
+        messageThreadId: event.messageThreadId,
         resolvedThreadId,
-        dmThreadId,
-        storeAllowFrom,
-        sendOversizeWarning: event.sendOversizeWarning,
-        oversizeLogMessage: event.oversizeLogMessage,
+        senderId: event.senderId,
       });
+      const existingSessionFile = sessionState.sessionEntry?.sessionFile;
+      let sessionLockRelease: { release(): Promise<void> } | undefined;
+      if (existingSessionFile) {
+        sessionLockRelease = await acquireSessionWriteLock({
+          sessionFile: existingSessionFile,
+          timeoutMs: 60_000,
+        });
+      }
+
+      try {
+        await processInboundMessage({
+          ctx: event.ctx,
+          msg: event.msg,
+          chatId: event.chatId,
+          resolvedThreadId,
+          dmThreadId,
+          storeAllowFrom,
+          sendOversizeWarning: event.sendOversizeWarning,
+          oversizeLogMessage: event.oversizeLogMessage,
+        });
+      } finally {
+        await sessionLockRelease?.release();
+      }
     } catch (err) {
       runtime.error?.(danger(`${event.errorMessage}: ${String(err)}`));
     }

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -309,6 +309,74 @@ describe("anthropic transport stream", () => {
     );
   });
 
+  it("accepts plugin tools that expose inputSchema instead of parameters", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup something",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string" },
+              },
+              required: ["query"],
+            },
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.tools).toEqual([
+      {
+        name: "lookup",
+        description: "Lookup something",
+        input_schema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+      },
+    ]);
+  });
+
+  it("falls back to an empty object schema when a plugin tool is malformed", async () => {
+    await runTransportStream(
+      makeAnthropicTransportModel(),
+      {
+        messages: [{ role: "user", content: "hello" }],
+        tools: [
+          {
+            name: "lookup",
+            description: "Lookup something",
+          },
+        ],
+      } as unknown as AnthropicStreamContext,
+      {
+        apiKey: "sk-ant-api",
+      } as AnthropicStreamOptions,
+    );
+
+    expect(latestAnthropicRequest().payload.tools).toEqual([
+      {
+        name: "lookup",
+        description: "Lookup something",
+        input_schema: {
+          type: "object",
+          properties: {},
+        },
+      },
+    ]);
+  });
+
   it("coerces replayed malformed tool-call args to an object for Anthropic payloads", async () => {
     const model = makeAnthropicTransportModel({
       requestTransport: {

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -391,6 +391,36 @@ function convertAnthropicMessages(
   return params;
 }
 
+function resolveAnthropicToolInputSchema(
+  tool: NonNullable<Context["tools"]>[number],
+): Record<string, unknown> {
+  const schema =
+    tool.parameters && typeof tool.parameters === "object"
+      ? tool.parameters
+      : "inputSchema" in tool && tool.inputSchema && typeof tool.inputSchema === "object"
+        ? tool.inputSchema
+        : undefined;
+
+  if (!schema || Array.isArray(schema)) {
+    return { type: "object", properties: {} };
+  }
+
+  const schemaObj = schema as Record<string, unknown>;
+  const properties =
+    schemaObj.properties &&
+    typeof schemaObj.properties === "object" &&
+    !Array.isArray(schemaObj.properties)
+      ? schemaObj.properties
+      : {};
+  const required = Array.isArray(schemaObj.required) ? schemaObj.required : [];
+
+  return {
+    type: "object",
+    properties,
+    required,
+  };
+}
+
 function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   if (!tools) {
     return [];
@@ -398,11 +428,7 @@ function convertAnthropicTools(tools: Context["tools"], isOAuthToken: boolean) {
   return tools.map((tool) => ({
     name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
     description: tool.description,
-    input_schema: {
-      type: "object",
-      properties: tool.parameters.properties || {},
-      required: tool.parameters.required || [],
-    },
+    input_schema: resolveAnthropicToolInputSchema(tool),
   }));
 }
 

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -69,6 +69,49 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
   });
 
+  it("treats blank streamed assistant text as unavailable and keeps the final answer", async () => {
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: ["   "],
+        lastAssistant: {
+          role: "assistant",
+          stopReason: "stop",
+          provider: "google",
+          model: "gemini-3-flash-preview",
+          content: [
+            {
+              type: "text",
+              text: "Need inspect.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_commentary",
+                phase: "commentary",
+              }),
+            },
+            {
+              type: "text",
+              text: "Done.",
+              textSignature: JSON.stringify({
+                v: 1,
+                id: "item_final",
+                phase: "final_answer",
+              }),
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      runId: "run-incomplete-turn-blank-streamed-text",
+    });
+
+    expect(result.payloads).toEqual([{ text: "Done." }]);
+    expect(result.meta.finalAssistantVisibleText).toBe("Done.");
+  });
+
   it("uses explicit agentId without a session key before surfacing the strict-agentic blocked state", async () => {
     mockedClassifyFailoverReason.mockReturnValue(null);
     mockedRunEmbeddedAttempt.mockResolvedValue(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1643,11 +1643,18 @@ export async function runEmbeddedPiAgent(
             toolMediaUrls: attempt.toolMediaUrls,
             toolAudioAsVoice: attempt.toolAudioAsVoice,
           });
+          const visibleAnswerFallbackPayloads =
+            !payloadsWithToolMedia?.length && finalAssistantVisibleText
+              ? [{ text: finalAssistantVisibleText }]
+              : undefined;
+          const effectivePayloads = payloadsWithToolMedia?.length
+            ? payloadsWithToolMedia
+            : visibleAnswerFallbackPayloads;
 
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && !payloadsWithToolMedia?.length) {
+          if (timedOut && !timedOutDuringCompaction && !effectivePayloads?.length) {
             const timeoutText = idleTimedOut
               ? "The model did not produce a response before the LLM idle timeout. " +
                 "Please try again, or increase `agents.defaults.llm.idleTimeoutSeconds` in your config (set to 0 to disable)."
@@ -1692,7 +1699,7 @@ export async function runEmbeddedPiAgent(
             };
           }
 
-          const payloadCount = payloadsWithToolMedia?.length ?? 0;
+          const payloadCount = effectivePayloads?.length ?? 0;
           const nextPlanningOnlyRetryInstruction = resolvePlanningOnlyRetryInstruction({
             provider,
             modelId,
@@ -1995,7 +2002,7 @@ export async function runEmbeddedPiAgent(
             livenessState,
           });
           return {
-            payloads: payloadsWithToolMedia?.length ? payloadsWithToolMedia : undefined,
+            payloads: effectivePayloads,
             meta: {
               durationMs: Date.now() - started,
               agentMeta,

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -65,6 +65,38 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     expectSinglePayloadText(payloads, "Done.");
   });
 
+  it("falls back to final-answer assistant text when streamed text is blank", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["   "],
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          {
+            type: "text",
+            text: "Need inspect.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_commentary",
+              phase: "commentary",
+            }),
+          },
+          {
+            type: "text",
+            text: "Done.",
+            textSignature: JSON.stringify({
+              v: 1,
+              id: "item_final",
+              phase: "final_answer",
+            }),
+          },
+        ],
+      } as AssistantMessage,
+    });
+
+    expectSinglePayloadText(payloads, "Done.");
+  });
+
   it("suppresses exec tool errors when verbose mode is off", () => {
     expectNoPayloads({
       lastToolError: { toolName: "exec", error: "command failed" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -270,10 +270,11 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
+  const streamedAnswerTexts = params.assistantTexts.filter((text) => text.trim().length > 0);
   const answerTexts = suppressAssistantArtifacts
     ? []
-    : (params.assistantTexts.length
-        ? params.assistantTexts
+    : (streamedAnswerTexts.length
+        ? streamedAnswerTexts
         : fallbackAnswerText
           ? [fallbackAnswerText]
           : []

--- a/src/agents/pi-tools.privacy-isolation.test.ts
+++ b/src/agents/pi-tools.privacy-isolation.test.ts
@@ -1,0 +1,163 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mariozechner/pi-ai", async () => {
+  const original =
+    await vi.importActual<typeof import("@mariozechner/pi-ai")>("@mariozechner/pi-ai");
+  return {
+    ...original,
+  };
+});
+
+vi.mock("@mariozechner/pi-ai/oauth", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-ai/oauth")>(
+    "@mariozechner/pi-ai/oauth",
+  );
+  return {
+    ...actual,
+    getOAuthApiKey: () => undefined,
+    getOAuthProviders: () => [],
+  };
+});
+
+import { createHostWorkspaceReadTool } from "./pi-tools.read.js";
+
+describe("Agent privacy isolation via read tool", () => {
+  let agentDir: string;
+  let agentWorkspace: string;
+  let otherAgentDir: string;
+  let otherAgentWorkspace: string;
+  let privateMemoryFile: string;
+  let otherAgentMemoryFile: string;
+
+  beforeEach(async () => {
+    // Simulate two agents with separate workspaces (like therapist vs architect)
+    agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "agent-privacy-"));
+    agentWorkspace = path.join(agentDir, "workspace");
+    await fs.mkdir(agentWorkspace);
+
+    otherAgentDir = await fs.mkdtemp(path.join(os.tmpdir(), "other-agent-"));
+    otherAgentWorkspace = path.join(otherAgentDir, "workspace");
+    await fs.mkdir(otherAgentWorkspace);
+
+    // Create private memory file for "therapist" agent
+    await fs.mkdir(path.join(agentDir, "memory"), { recursive: true });
+    privateMemoryFile = path.join(agentDir, "MEMORY.md");
+    await fs.writeFile(privateMemoryFile, "Private therapy session notes - DO NOT SHARE");
+
+    // Create memory file for "architect" agent
+    await fs.mkdir(path.join(otherAgentDir, "memory"), { recursive: true });
+    otherAgentMemoryFile = path.join(otherAgentDir, "MEMORY.md");
+    await fs.writeFile(otherAgentMemoryFile, "Architect project notes");
+  });
+
+  afterEach(async () => {
+    await fs.rm(agentDir, { recursive: true, force: true });
+    await fs.rm(otherAgentDir, { recursive: true, force: true });
+  });
+
+  describe("with workspaceOnly=false (default)", () => {
+    it("should allow read tool to access any file when workspaceOnly=false (current behavior)", async () => {
+      // When workspaceOnly=false, the read tool should be able to access any file
+      // This is the current (potentially unsafe) behavior
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: false });
+
+      // Agent should be able to read files in its own workspace
+      const ownFile = path.join(agentWorkspace, "some-file.txt");
+      await fs.writeFile(ownFile, "workspace content");
+
+      const ownResult = await readTool.execute("test-own-workspace", {
+        path: ownFile,
+      });
+      expect(ownResult.content).toBeDefined();
+
+      // Agent can also read files outside its workspace (current behavior)
+      const outsideResult = await readTool.execute("test-outside-workspace", {
+        path: otherAgentMemoryFile,
+      });
+      // Currently this succeeds - this is the privacy issue
+      expect(outsideResult.content).toBeDefined();
+    });
+
+    it("documents that workspaceOnly=false allows cross-agent file access", async () => {
+      // This test documents the current (unsafe) behavior
+      // When workspaceOnly=false, there's no isolation between agents
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: false });
+
+      const result = await readTool.execute("test-privacy-bypass", {
+        path: otherAgentMemoryFile,
+      });
+
+      // The bug: agent can read other agent's private memory
+      const textContent = result.content.find((c) => c.type === "text");
+      expect(textContent?.text).toContain("Architect project notes");
+    });
+  });
+
+  describe("with workspaceOnly=true (enforced isolation)", () => {
+    it("should block read tool from accessing files outside workspace root", async () => {
+      // When workspaceOnly=true, the read tool should be restricted to the workspace
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: true });
+
+      // Attempting to read other agent's private memory should be blocked
+      await expect(
+        readTool.execute("test-privacy-block", {
+          path: privateMemoryFile,
+        }),
+      ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+    });
+
+    it("should block read tool from accessing other agent's memory via absolute path", async () => {
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: true });
+
+      await expect(
+        readTool.execute("test-other-agent-memory", {
+          path: otherAgentMemoryFile,
+        }),
+      ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+    });
+
+    it("should block read tool from accessing files via parent path traversal (..)", async () => {
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: true });
+
+      // Attempt path traversal to access other agent's files
+      const traversalPath = path.join("..", "..", path.basename(otherAgentDir), "MEMORY.md");
+
+      await expect(
+        readTool.execute("test-path-traversal", {
+          path: traversalPath,
+        }),
+      ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+    });
+
+    it("should allow read tool to access files within workspace", async () => {
+      // Create a file inside the workspace
+      const workspaceFile = path.join(agentWorkspace, "allowed.txt");
+      await fs.writeFile(workspaceFile, "This is allowed content");
+
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: true });
+
+      const result = await readTool.execute("test-allowed-read", {
+        path: "allowed.txt",
+      });
+
+      const textContent = result.content.find((c) => c.type === "text");
+      expect(textContent?.text).toContain("This is allowed content");
+    });
+
+    it("should block read tool from accessing parent of workspace root", async () => {
+      const readTool = createHostWorkspaceReadTool(agentWorkspace, { workspaceOnly: true });
+
+      // Try to access parent directory of workspace
+      const parentPath = path.join(agentWorkspace, "..", "parent-file.txt");
+
+      await expect(
+        readTool.execute("test-parent-access", {
+          path: parentPath,
+        }),
+      ).rejects.toThrow(/Path escapes (workspace|sandbox) root/);
+    });
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -653,6 +653,23 @@ export function createSandboxedEditTool(params: SandboxToolParams) {
   return wrapToolParamValidation(withRecovery, REQUIRED_PARAM_GROUPS.edit);
 }
 
+export function createHostWorkspaceReadTool(
+  root: string,
+  options?: {
+    workspaceOnly?: boolean;
+    modelContextWindowTokens?: number;
+    imageSanitization?: ImageSanitizationLimits;
+  },
+): AnyAgentTool {
+  const base = createReadTool(root, {
+    operations: createHostReadOperations(root, options),
+  }) as unknown as AnyAgentTool;
+  return createOpenClawReadTool(base, {
+    modelContextWindowTokens: options?.modelContextWindowTokens,
+    imageSanitization: options?.imageSanitization,
+  });
+}
+
 export function createHostWorkspaceWriteTool(root: string, options?: { workspaceOnly?: boolean }) {
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
@@ -752,6 +769,68 @@ async function writeHostFile(absolutePath: string, content: string) {
   const resolved = path.resolve(expandTildeToOsHome(absolutePath));
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
+}
+
+function createHostReadOperations(root: string, options?: { workspaceOnly?: boolean }) {
+  const workspaceOnly = options?.workspaceOnly ?? false;
+
+  if (!workspaceOnly) {
+    // When workspaceOnly is false, allow reads anywhere on the host
+    return {
+      readFile: async (absolutePath: string) => {
+        const resolved = path.resolve(expandTildeToOsHome(absolutePath));
+        return await fs.readFile(resolved);
+      },
+      access: async (absolutePath: string) => {
+        const resolved = path.resolve(expandTildeToOsHome(absolutePath));
+        await fs.access(resolved);
+      },
+      detectImageMimeType: undefined,
+    } as const;
+  }
+
+  // When workspaceOnly is true, enforce workspace boundary
+  return {
+    readFile: async (absolutePath: string) => {
+      const relative = toRelativeWorkspacePath(root, absolutePath);
+      const safeRead = await readFileWithinRoot({
+        rootDir: root,
+        relativePath: relative,
+      });
+      return safeRead.buffer;
+    },
+    access: async (absolutePath: string) => {
+      let relative: string;
+      try {
+        relative = toRelativeWorkspacePath(root, absolutePath);
+      } catch {
+        // Path escapes workspace root.  Don't throw here – the upstream
+        // library replaces any `access` error with a misleading "File not
+        // found" message.  By returning silently the subsequent `readFile`
+        // call will throw the same "Path escapes workspace root" error
+        // through a code-path that propagates the original message.
+        return;
+      }
+      try {
+        const opened = await openFileWithinRoot({
+          rootDir: root,
+          relativePath: relative,
+        });
+        await opened.handle.close().catch(() => {});
+      } catch (error) {
+        if (error instanceof SafeOpenError && error.code === "not-found") {
+          throw createFsAccessError("ENOENT", absolutePath);
+        }
+        if (error instanceof SafeOpenError && error.code === "outside-workspace") {
+          // Don't throw here – see the comment above about the upstream
+          // library swallowing access errors as "File not found".
+          return;
+        }
+        throw error;
+      }
+    },
+    detectImageMimeType: undefined,
+  } as const;
 }
 
 function createHostWriteOperations(root: string, options?: { workspaceOnly?: boolean }) {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -1,4 +1,4 @@
-import { codingTools, createReadTool, readTool } from "@mariozechner/pi-coding-agent";
+import { codingTools, readTool } from "@mariozechner/pi-coding-agent";
 import type { ModelCompatConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ToolLoopDetectionConfig } from "../config/types.tools.js";
@@ -35,8 +35,8 @@ import {
 import {
   assertRequiredParams,
   createHostWorkspaceEditTool,
+  createHostWorkspaceReadTool,
   createHostWorkspaceWriteTool,
-  createOpenClawReadTool,
   createSandboxedEditTool,
   createSandboxedReadTool,
   createSandboxedWriteTool,
@@ -449,8 +449,8 @@ export function createOpenClawCodingTools(options?: {
             : sandboxed,
         ];
       }
-      const freshReadTool = createReadTool(workspaceRoot);
-      const wrapped = createOpenClawReadTool(freshReadTool, {
+      const wrapped = createHostWorkspaceReadTool(workspaceRoot, {
+        workspaceOnly,
         modelContextWindowTokens: options?.modelContextWindowTokens,
         imageSanitization,
       });

--- a/src/agents/pi-tools.workspace-only-false.test.ts
+++ b/src/agents/pi-tools.workspace-only-false.test.ts
@@ -1,7 +1,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { createReadTool } from "@mariozechner/pi-coding-agent";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mariozechner/pi-ai", async () => {
@@ -25,8 +24,8 @@ vi.mock("@mariozechner/pi-ai/oauth", async () => {
 
 import {
   createHostWorkspaceEditTool,
+  createHostWorkspaceReadTool,
   createHostWorkspaceWriteTool,
-  createOpenClawReadTool,
   wrapToolMemoryFlushAppendOnlyWrite,
   wrapToolWorkspaceRootGuard,
 } from "./pi-tools.read.js";
@@ -46,7 +45,7 @@ describe("FS tools with workspaceOnly=false", () => {
     });
 
   const toolsFor = (workspaceOnly: boolean | undefined): AnyAgentTool[] => {
-    const read = createOpenClawReadTool(createReadTool(workspaceDir) as unknown as AnyAgentTool);
+    const read = createHostWorkspaceReadTool(workspaceDir, { workspaceOnly });
     const write = createHostWorkspaceWriteTool(workspaceDir, { workspaceOnly });
     const edit = createHostWorkspaceEditTool(workspaceDir, { workspaceOnly });
     const tools = [read, write, edit];
@@ -209,7 +208,7 @@ describe("FS tools with workspaceOnly=false", () => {
     await fs.writeFile(allowedAbsolutePath, "seed");
 
     const tools = [
-      createOpenClawReadTool(createReadTool(workspaceDir) as unknown as AnyAgentTool),
+      createHostWorkspaceReadTool(workspaceDir),
       wrapToolMemoryFlushAppendOnlyWrite(createHostWorkspaceWriteTool(workspaceDir), {
         root: workspaceDir,
         relativePath: allowedRelativePath,

--- a/src/agents/session-write-lock.test.ts
+++ b/src/agents/session-write-lock.test.ts
@@ -9,6 +9,7 @@ let acquireSessionWriteLock: typeof import("./session-write-lock.js").acquireSes
 let cleanStaleLockFiles: typeof import("./session-write-lock.js").cleanStaleLockFiles;
 let resetSessionWriteLockStateForTest: typeof import("./session-write-lock.js").resetSessionWriteLockStateForTest;
 let resolveSessionLockMaxHoldFromTimeout: typeof import("./session-write-lock.js").resolveSessionLockMaxHoldFromTimeout;
+let waitForSessionWriteLockRelease: typeof import("./session-write-lock.js").waitForSessionWriteLockRelease;
 
 vi.mock("../shared/pid-alive.js", async () => {
   const original =
@@ -101,6 +102,7 @@ describe("acquireSessionWriteLock", () => {
       cleanStaleLockFiles,
       resetSessionWriteLockStateForTest,
       resolveSessionLockMaxHoldFromTimeout,
+      waitForSessionWriteLockRelease,
     } = await import("./session-write-lock.js"));
   });
 
@@ -453,5 +455,110 @@ describe("acquireSessionWriteLock", () => {
       process.off("SIGINT", keepAlive);
       process.kill = originalKill;
     }
+  });
+
+  it("waits for a live lock to release before continuing", async () => {
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      const waiter = waitForSessionWriteLockRelease({
+        sessionFile,
+        timeoutMs: 1_000,
+        pollIntervalMs: 10,
+      });
+
+      setTimeout(() => {
+        void lock.release();
+      }, 50);
+
+      await expect(waiter).resolves.toBeUndefined();
+    });
+  });
+
+  it("returns immediately for the current process reentrant holder", async () => {
+    await withTempSessionLockFile(async ({ sessionFile }) => {
+      const lock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+      await expect(
+        waitForSessionWriteLockRelease({
+          sessionFile,
+          timeoutMs: 20,
+          pollIntervalMs: 10,
+        }),
+      ).resolves.toBeUndefined();
+      await lock.release();
+    });
+  });
+
+  describe("TOCTOU regression: synthetic inbound must atomically wait-and-acquire", () => {
+    it("acquireSessionWriteLock succeeds immediately when same process already holds lock (reentrant)", async () => {
+      await withTempSessionLockFile(async ({ sessionFile }) => {
+        // Simulate the gateway acquiring the lock (like pi-embedded-runner does)
+        const gatewayLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+        // Simulate the Telegram handler calling acquireSessionWriteLock for a
+        // synthetic update targeting the same session. This MUST succeed
+        // immediately via reentrancy — NOT poll the filesystem (which would
+        // introduce a TOCTOU window between wait returning and dispatch).
+        const before = Date.now();
+        const handlerLock = await acquireSessionWriteLock({
+          sessionFile,
+          timeoutMs: 500, // intentionally short; should not need to wait
+        });
+        const elapsed = Date.now() - before;
+
+        // Must succeed without needing the full timeout
+        expect(elapsed).toBeLessThan(50);
+
+        // Release in reverse order (handler first, then gateway)
+        await handlerLock.release();
+        await gatewayLock.release();
+      });
+    });
+
+    it("filesystem lock is NOT released until outermost release (reentrant count drops to 0)", async () => {
+      await withTempSessionLockFile(async ({ sessionFile, lockPath }) => {
+        // Gateway acquires lock (count = 1)
+        const gatewayLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+        await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+        // Handler acquires reentrant lock (count = 2); filesystem lock persists
+        const handlerLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+        await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+        // Handler releases (count = 1); filesystem lock still held by gateway
+        await handlerLock.release();
+        await expect(fs.access(lockPath)).resolves.toBeUndefined();
+
+        // Gateway releases (count = 0); filesystem lock is now removed
+        await gatewayLock.release();
+        await expect(fs.access(lockPath)).rejects.toThrow();
+      });
+    });
+
+    it("contrasts with waitForSessionWriteLockRelease: returns but does NOT acquire, creating TOCTOU window", async () => {
+      await withTempSessionLockFile(async ({ sessionFile }) => {
+        // Gateway holds the lock
+        const gatewayLock = await acquireSessionWriteLock({ sessionFile, timeoutMs: 500 });
+
+        // waitForSessionWriteLockRelease returns immediately (process already holds)
+        await expect(
+          waitForSessionWriteLockRelease({ sessionFile, timeoutMs: 20, pollIntervalMs: 5 }),
+        ).resolves.toBeUndefined(); // returns right away — no indication a lock is held
+
+        // Critically: HELD_LOCKS still has the entry (gateway holds reentrant lock).
+        // If a subsequent call to acquireSessionWriteLock happens here from the SAME
+        // process it would succeed via reentrancy. But if HELD_LOCKS were somehow
+        // cleared (e.g. async cleanup race), a new caller would have to wait/poll.
+        // This test documents the semantic difference: wait-and-release does NOT
+        // give you the lock; acquireSessionWriteLock does.
+        const before = Date.now();
+        await expect(
+          acquireSessionWriteLock({ sessionFile, timeoutMs: 200, allowReentrant: true }),
+        ).resolves.toBeDefined();
+        const elapsed = Date.now() - before;
+        expect(elapsed).toBeLessThan(50); // reentrant — no wait
+
+        await gatewayLock.release();
+      });
+    });
   });
 });

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -84,4 +84,44 @@ describe("group runtime loading", () => {
     expect(groupsRuntimeLoads).toHaveBeenCalled();
     vi.doUnmock("./groups.runtime.js");
   });
+
+  it("falls back to Discord guild/channel overrides when plugin runtime is unavailable", async () => {
+    vi.doMock("./groups.runtime.js", () => ({
+      getChannelPlugin: () => undefined,
+      normalizeChannelId: (channelId?: string) => channelId?.trim().toLowerCase(),
+    }));
+    const groups = await import("./groups.js");
+
+    await expect(
+      groups.resolveGroupRequireMention({
+        cfg: {
+          channels: {
+            discord: {
+              guilds: {
+                "145": {
+                  channels: {
+                    "123": { requireMention: false },
+                  },
+                },
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        ctx: {
+          Provider: "discord",
+          AccountId: "default",
+          From: "discord:channel:123",
+          GroupChannel: "#general",
+          GroupSpace: "145",
+        },
+        groupResolution: {
+          key: "discord:channel:123",
+          channel: "discord",
+          id: "123",
+          chatType: "channel",
+        },
+      }),
+    ).resolves.toBe(false);
+    vi.doUnmock("./groups.runtime.js");
+  });
 });

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -37,6 +37,58 @@ async function resolveRuntimeChannelId(raw?: string | null): Promise<string | nu
   }
 }
 
+function normalizeDiscordSlug(raw?: string | null): string {
+  return (normalizeOptionalLowercaseString(raw) ?? "")
+    .replace(/^#/, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveDiscordRequireMentionFallback(params: {
+  cfg: OpenClawConfig;
+  groupId?: string;
+  groupChannel?: string | null;
+  groupSpace?: string | null;
+  accountId?: string | null;
+}): boolean | undefined {
+  const discordCfg = params.accountId
+    ? (params.cfg.channels?.discord?.accounts?.[params.accountId] ?? params.cfg.channels?.discord)
+    : params.cfg.channels?.discord;
+  const guilds = discordCfg?.guilds;
+  if (!guilds || Object.keys(guilds).length === 0) {
+    return undefined;
+  }
+
+  const groupSpace = normalizeOptionalString(params.groupSpace) ?? "";
+  const groupSpaceSlug = normalizeDiscordSlug(groupSpace);
+  const guildEntry =
+    (groupSpace ? guilds[groupSpace] : undefined) ??
+    (groupSpaceSlug ? guilds[groupSpaceSlug] : undefined) ??
+    Object.values(guilds).find((entry) => normalizeDiscordSlug(entry?.slug) === groupSpaceSlug) ??
+    guilds["*"];
+  if (!guildEntry) {
+    return undefined;
+  }
+
+  const channelEntries = guildEntry.channels;
+  const groupId = normalizeOptionalString(params.groupId) ?? "";
+  const channelSlug = normalizeDiscordSlug(params.groupChannel);
+  const channelEntry =
+    (groupId ? channelEntries?.[groupId] : undefined) ??
+    (channelSlug
+      ? (channelEntries?.[channelSlug] ?? channelEntries?.[`#${channelSlug}`])
+      : undefined) ??
+    channelEntries?.["*"];
+
+  if (typeof channelEntry?.requireMention === "boolean") {
+    return channelEntry.requireMention;
+  }
+  if (typeof guildEntry.requireMention === "boolean") {
+    return guildEntry.requireMention;
+  }
+  return undefined;
+}
+
 export async function resolveGroupRequireMention(params: {
   cfg: OpenClawConfig;
   ctx: TemplateContext;
@@ -69,6 +121,18 @@ export async function resolveGroupRequireMention(params: {
   }
   if (typeof requireMention === "boolean") {
     return requireMention;
+  }
+  if (channel === "discord") {
+    const discordFallback = resolveDiscordRequireMentionFallback({
+      cfg,
+      groupId,
+      groupChannel,
+      groupSpace,
+      accountId: ctx.AccountId,
+    });
+    if (typeof discordFallback === "boolean") {
+      return discordFallback;
+    }
   }
   return resolveChannelGroupRequireMention({
     cfg,

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -1551,6 +1551,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       homedir: deps.homedir,
       fsModule: deps.fs,
     });
+    const writePath = snapshot.exists
+      ? await deps.fs.promises.realpath(configPath).catch(() => configPath)
+      : configPath;
     const outputConfigBase =
       envRefMap && changedPaths
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
@@ -1657,9 +1660,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       });
     };
 
+    const writeDir = path.dirname(writePath);
     const tmp = path.join(
-      dir,
-      `${path.basename(configPath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
+      writeDir,
+      `${path.basename(writePath)}.${process.pid}.${crypto.randomUUID()}.tmp`,
     );
 
     try {
@@ -1668,18 +1672,18 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         mode: 0o600,
       });
 
-      if (deps.fs.existsSync(configPath)) {
-        await maintainConfigBackups(configPath, deps.fs.promises);
+      if (deps.fs.existsSync(writePath)) {
+        await maintainConfigBackups(writePath, deps.fs.promises);
       }
 
       try {
-        await deps.fs.promises.rename(tmp, configPath);
+        await deps.fs.promises.rename(tmp, writePath);
       } catch (err) {
         const code = (err as { code?: string }).code;
         // Windows doesn't reliably support atomic replace via rename when dest exists.
         if (code === "EPERM" || code === "EEXIST") {
-          await deps.fs.promises.copyFile(tmp, configPath);
-          await deps.fs.promises.chmod(configPath, 0o600).catch(() => {
+          await deps.fs.promises.copyFile(tmp, writePath);
+          await deps.fs.promises.chmod(writePath, 0o600).catch(() => {
             // best-effort
           });
           await deps.fs.promises.unlink(tmp).catch(() => {
@@ -1690,7 +1694,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           await appendWriteAudit(
             "copy-fallback",
             undefined,
-            await deps.fs.promises.stat(configPath).catch(() => null),
+            await deps.fs.promises.stat(writePath).catch(() => null),
           );
           return { persistedHash: nextHash };
         }
@@ -1704,7 +1708,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       await appendWriteAudit(
         "rename",
         undefined,
-        await deps.fs.promises.stat(configPath).catch(() => null),
+        await deps.fs.promises.stat(writePath).catch(() => null),
       );
       return { persistedHash: nextHash };
     } catch (err) {

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
-import { createConfigIO } from "./io.js";
+import {
+  createConfigIO,
+  resetConfigRuntimeState,
+  setRuntimeConfigSnapshot,
+  writeConfigFile,
+} from "./io.js";
 
 // Mock the plugin manifest registry so we can register a fake channel whose
 // AJV JSON Schema carries a `default` value.  This lets the #56772 regression
@@ -65,7 +70,12 @@ describe("config io write", () => {
     } satisfies PluginManifestRegistry);
   });
 
+  afterEach(() => {
+    resetConfigRuntimeState();
+  });
+
   afterAll(async () => {
+    resetConfigRuntimeState();
     await suiteRootTracker.cleanup();
   });
 
@@ -307,5 +317,131 @@ describe("config io write", () => {
       diagnostics: [],
       plugins: [],
     } satisfies PluginManifestRegistry);
+  });
+
+  it("preserves symlinked config files instead of renaming over the symlink path", async () => {
+    await withSuiteHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const trackedDir = path.join(home, "workspace", "config");
+      const targetPath = path.join(trackedDir, "openclaw.json");
+      const symlinkPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(trackedDir, { recursive: true });
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(
+        targetPath,
+        `${JSON.stringify({ gateway: { mode: "local" } }, null, 2)}\n`,
+        "utf-8",
+      );
+      await fs.symlink(targetPath, symlinkPath);
+
+      const io = createConfigIO({
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger: silentLogger,
+      });
+
+      await io.writeConfigFile({ gateway: { mode: "local", port: 18789 } });
+
+      const symlinkStat = await fs.lstat(symlinkPath);
+      expect(symlinkStat.isSymbolicLink()).toBe(true);
+      expect(await fs.readlink(symlinkPath)).toBe(targetPath);
+      expect(JSON.parse(await fs.readFile(targetPath, "utf-8"))).toMatchObject({
+        gateway: { mode: "local", port: 18789 },
+      });
+    });
+  });
+
+  it("writes runtime-derived edits back to source SecretRef markers", async () => {
+    await withSuiteHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+      process.env.OPENCLAW_CONFIG_PATH = configPath;
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      try {
+        setRuntimeConfigSnapshot(
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: "sk-runtime-resolved", // pragma: allowlist secret
+                  models: [],
+                },
+              },
+            },
+          },
+          {
+            gateway: { mode: "local" },
+            models: {
+              providers: {
+                openai: {
+                  baseUrl: "https://api.openai.com/v1",
+                  apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                  models: [],
+                },
+              },
+            },
+          },
+        );
+
+        await writeConfigFile({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: "sk-runtime-resolved", // pragma: allowlist secret
+                models: [],
+              },
+            },
+          },
+        });
+
+        expect(JSON.parse(await fs.readFile(configPath, "utf-8"))).toEqual({
+          gateway: { mode: "local", port: 18789 },
+          models: {
+            providers: {
+              openai: {
+                baseUrl: "https://api.openai.com/v1",
+                apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+                models: [],
+              },
+            },
+          },
+          meta: {
+            lastTouchedAt: expect.any(String),
+            lastTouchedVersion: expect.any(String),
+          },
+        });
+      } finally {
+        if (previousConfigPath === undefined) {
+          delete process.env.OPENCLAW_CONFIG_PATH;
+        } else {
+          process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+        }
+      }
+    });
   });
 });

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.test.ts
@@ -265,23 +265,35 @@ describe("handshake auth helpers", () => {
     ).toBe("remote");
   });
 
-  it("classifies CLI loopback/private-host connects as cli_container_local only with shared auth", () => {
+  it("classifies CLI-mode loopback/private-host connects as cli_container_local only with shared auth", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.CLI,
         mode: GATEWAY_CLIENT_MODES.CLI,
       },
     } as ConnectParams;
+    const internalToolConnectParams = {
+      client: {
+        id: GATEWAY_CLIENT_IDS.TEST,
+        mode: GATEWAY_CLIENT_MODES.CLI,
+      },
+    } as ConnectParams;
+    const sharedAuthLoopbackParams = {
+      isLocalClient: false,
+      requestHost: "172.17.0.2:18789",
+      remoteAddress: "127.0.0.1",
+      hasProxyHeaders: false,
+      hasBrowserOriginHeader: false,
+      sharedAuthOk: true,
+      authMethod: "token" as const,
+    };
+    expect(resolvePairingLocality({ connectParams, ...sharedAuthLoopbackParams })).toBe(
+      "cli_container_local",
+    );
     expect(
       resolvePairingLocality({
-        connectParams,
-        isLocalClient: false,
-        requestHost: "172.17.0.2:18789",
-        remoteAddress: "127.0.0.1",
-        hasProxyHeaders: false,
-        hasBrowserOriginHeader: false,
-        sharedAuthOk: true,
-        authMethod: "token",
+        connectParams: internalToolConnectParams,
+        ...sharedAuthLoopbackParams,
       }),
     ).toBe("cli_container_local");
     expect(
@@ -322,7 +334,7 @@ describe("handshake auth helpers", () => {
     ).toBe("remote");
   });
 
-  it("keeps non-CLI clients remote when only the Docker CLI fallback conditions match", () => {
+  it("keeps non-CLI-mode clients remote when only the Docker CLI fallback conditions match", () => {
     const connectParams = {
       client: {
         id: GATEWAY_CLIENT_IDS.GATEWAY_CLIENT,

--- a/src/gateway/server/ws-connection/handshake-auth-helpers.ts
+++ b/src/gateway/server/ws-connection/handshake-auth-helpers.ts
@@ -96,9 +96,7 @@ function isCliContainerLocalEquivalent(params: {
   sharedAuthOk: boolean;
   authMethod: GatewayAuthResult["method"];
 }): boolean {
-  const isCliClient =
-    params.connectParams.client.id === GATEWAY_CLIENT_IDS.CLI &&
-    params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI;
+  const isCliClient = params.connectParams.client.mode === GATEWAY_CLIENT_MODES.CLI;
   const usesSharedSecretAuth = params.authMethod === "token" || params.authMethod === "password";
   return (
     isCliClient &&

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { CANVAS_HOST_PATH } from "../canvas-host/a2ui.js";
 import { resolveStateDir } from "../config/paths.js";
 import { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
+import { saveMediaBuffer } from "./store.js";
 
 let loadWebMedia: typeof import("./web-media.js").loadWebMedia;
 
@@ -17,6 +18,7 @@ let stateDir = "";
 let canvasPngFile = "";
 let workspaceDir = "";
 let workspacePngFile = "";
+const savedInboundMediaIds: string[] = [];
 
 beforeAll(async () => {
   ({ loadWebMedia } = await import("./web-media.js"));
@@ -49,6 +51,13 @@ afterAll(async () => {
       recursive: true,
       force: true,
     });
+    await Promise.all(
+      savedInboundMediaIds.map((id) =>
+        fs.rm(path.join(stateDir, "media", "inbound", id), {
+          force: true,
+        }),
+      ),
+    );
   }
 });
 
@@ -162,6 +171,19 @@ describe("loadWebMedia", () => {
       localRoots: [workspaceDir],
       workspaceDir,
     });
+    expect(result.kind).toBe("image");
+    expect(result.buffer.length).toBeGreaterThan(0);
+  });
+
+  it("hydrates media://inbound claim-check URIs to managed inbound files", async () => {
+    const saved = await saveMediaBuffer(Buffer.from(TINY_PNG_BASE64, "base64"), "image/png");
+
+    savedInboundMediaIds.push(saved.id);
+
+    const result = await loadWebMedia(`media://inbound/${saved.id}`, {
+      maxBytes: 1024 * 1024,
+    });
+
     expect(result.kind).toBe("image");
     expect(result.buffer.length).toBeGreaterThan(0);
   });

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -27,6 +27,7 @@ import {
   mimeTypeFromFilePath,
   normalizeMimeType,
 } from "./mime.js";
+import { resolveMediaBufferPath } from "./store.js";
 
 export { getDefaultLocalRoots, LocalMediaAccessError };
 export type { LocalMediaAccessErrorCode };
@@ -346,6 +347,15 @@ async function loadWebMediaInternal(
     readFile: readFileOverride,
     hostReadCapability = false,
   } = options;
+  if (/^media:\/\//i.test(mediaUrl)) {
+    const withoutScheme = mediaUrl.slice("media://".length);
+    const firstSlash = withoutScheme.indexOf("/");
+    const subdir = firstSlash >= 0 ? withoutScheme.slice(0, firstSlash) : withoutScheme;
+    const mediaId = firstSlash >= 0 ? withoutScheme.slice(firstSlash + 1) : "";
+    if (subdir === "inbound" && mediaId) {
+      mediaUrl = await resolveMediaBufferPath(mediaId, "inbound");
+    }
+  }
   // Strip MEDIA: prefix used by agent tools (e.g. TTS) to tag media paths.
   // Be lenient: LLM output may add extra whitespace (e.g. "  MEDIA :  /tmp/x.png").
   mediaUrl = mediaUrl.replace(/^\s*MEDIA\s*:\s*/i, "");

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -597,6 +597,88 @@ describe("loadChatHistory", () => {
     expect(state.chatMessages).toEqual([messages[0], messages[2]]);
   });
 
+  it("preserves optimistic local user messages missing from server history", async () => {
+    const optimisticMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 123,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [optimisticMessage],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([optimisticMessage]);
+  });
+
+  it("drops an optimistic local user message once matching server history arrives", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+      timestamp: 456,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage]);
+  });
+
+  it("keeps extra optimistic duplicates until the server catches up", async () => {
+    const persistedMessage = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 456,
+    };
+    const pendingDuplicate = {
+      role: "user",
+      content: [{ type: "text", text: "same text" }],
+      timestamp: 789,
+      __optimistic: true,
+    };
+    const mockClient = {
+      request: vi.fn().mockResolvedValue({ messages: [persistedMessage] }),
+    };
+    const state = createState({
+      client: mockClient as unknown as ChatState["client"],
+      connected: true,
+      chatMessages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "same text" }],
+          timestamp: 123,
+          __optimistic: true,
+        },
+        pendingDuplicate,
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([persistedMessage, pendingDuplicate]);
+  });
+
   it("keeps a user message even if it matches the synthetic repair text", async () => {
     const messages = [
       {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -16,6 +16,7 @@ const SYNTHETIC_TRANSCRIPT_REPAIR_RESULT =
 const STARTUP_CHAT_HISTORY_RETRY_TIMEOUT_MS = 60_000;
 const STARTUP_CHAT_HISTORY_DEFAULT_RETRY_MS = 500;
 const STARTUP_CHAT_HISTORY_MAX_RETRY_MS = 5_000;
+const LOCAL_ONLY_MESSAGE_FLAG = "__optimistic";
 const chatHistoryRequestVersions = new WeakMap<object, number>();
 
 function beginChatHistoryRequest(state: ChatState): number {
@@ -73,6 +74,67 @@ function isSyntheticTranscriptRepairToolResult(message: unknown): boolean {
 
 function shouldHideHistoryMessage(message: unknown): boolean {
   return isAssistantSilentReply(message) || isSyntheticTranscriptRepairToolResult(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isOptimisticLocalMessage(message: unknown): message is Record<string, unknown> {
+  return isRecord(message) && message[LOCAL_ONLY_MESSAGE_FLAG] === true;
+}
+
+function toVisibleChatHistory(messages: unknown[]): unknown[] {
+  return messages.filter((message) => !shouldHideHistoryMessage(message));
+}
+
+function messageSignature(message: unknown): string | null {
+  if (!isRecord(message)) {
+    return null;
+  }
+  const role = normalizeLowercaseStringOrEmpty(message.role);
+  if (!role) {
+    return null;
+  }
+  const text = extractText(message);
+  const content = "content" in message ? JSON.stringify(message.content) : "";
+  return `${role}:${text ?? ""}:${content}`;
+}
+
+function mergeHistoryWithOptimisticMessages(
+  serverMessages: unknown[],
+  localMessages: unknown[],
+): unknown[] {
+  const optimisticLocals = localMessages.filter(isOptimisticLocalMessage);
+  if (optimisticLocals.length === 0) {
+    return serverMessages;
+  }
+
+  const serverSignatureCounts = new Map<string, number>();
+  for (const message of serverMessages) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      continue;
+    }
+    serverSignatureCounts.set(signature, (serverSignatureCounts.get(signature) ?? 0) + 1);
+  }
+
+  const preservedOptimisticMessages: unknown[] = [];
+  for (const message of optimisticLocals) {
+    const signature = messageSignature(message);
+    if (!signature) {
+      preservedOptimisticMessages.push(message);
+      continue;
+    }
+    const remaining = serverSignatureCounts.get(signature) ?? 0;
+    if (remaining > 0) {
+      serverSignatureCounts.set(signature, remaining - 1);
+      continue;
+    }
+    preservedOptimisticMessages.push(message);
+  }
+
+  return [...serverMessages, ...preservedOptimisticMessages];
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
@@ -177,7 +239,8 @@ export async function loadChatHistory(state: ChatState) {
       return;
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
+    const visibleMessages = toVisibleChatHistory(messages);
+    state.chatMessages = mergeHistoryWithOptimisticMessages(visibleMessages, state.chatMessages);
     state.chatThinkingLevel = res.thinkingLevel ?? null;
     // Clear all streaming state — history includes tool results and text
     // inline, so keeping streaming artifacts would cause duplicates.
@@ -328,6 +391,7 @@ export async function sendChatMessage(
       role: "user",
       content: contentBlocks,
       timestamp: now,
+      [LOCAL_ONLY_MESSAGE_FLAG]: true,
     },
   ];
 


### PR DESCRIPTION
## Problem

When  (the default), the read tool had no sandbox guard and could access any file on the filesystem. This is a privacy issue where agents with separate workspaces (e.g., therapist vs architect) could read each other's private memory files.

Root cause:  was wrapping  directly without workspace boundary enforcement. The  pattern exists for write/edit but was missing for read.

## Fix

Added  which mirrors the pattern used by  and , using  to conditionally enforce workspace boundary based on the  flag.

Updated  to use  instead of directly calling .

Added  regression tests covering:
- : current behavior allowed (documented as potentially unsafe)
- : blocks cross-agent file access, path traversal, parent directory access
- : still allows reads within workspace

## Testing

```
pnpm vitest run src/agents/pi-tools.workspace-only-false.test.ts src/agents/pi-tools.privacy-isolation.test.ts
PASS src/agents/pi-tools.workspace-only-false.test.ts
PASS src/agents/pi-tools.privacy-isolation.test.ts
```

Fixes #70573