### PR TITLE
fix(gateway): add SSE heartbeat to keep /v1/responses and /v1/chat/completions streams alive through idle-timeout proxies

### DIFF
--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -420,6 +420,49 @@ describe("startSseHeartbeat", () => {
     expect(write).toHaveBeenCalledTimes(3);
     stop();
   });
+
+  it("stops gracefully when res.write() throws synchronously", () => {
+    const { res } = makeMockHttpResponse();
+    // Simulate the write-after-end race: the underlying socket closes
+    // between the writableEnded check and the actual write, causing Node to
+    // throw ERR_STREAM_WRITE_AFTER_END synchronously.
+    const write = vi.spyOn(res, "write").mockImplementation(() => {
+      throw new Error("write after end");
+    });
+    startSseHeartbeat(res, { intervalMs: 1000 });
+
+    // First tick triggers the throw — must not escape the interval callback.
+    expect(() => vi.advanceTimersByTime(1000)).not.toThrow();
+    expect(write).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks must not attempt another write (helper has stopped).
+    vi.advanceTimersByTime(10_000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops gracefully when res emits an async error event", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    startSseHeartbeat(res, { intervalMs: 1000 });
+
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+
+    // Simulate an async socket failure: Node emits 'error' on the response.
+    // Without a listener, this would crash the process; the helper registers
+    // one that stops the heartbeat.
+    expect(() => res.emit("error", new Error("ECONNRESET"))).not.toThrow();
+    vi.advanceTimersByTime(10_000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not leak the error listener after stop()", () => {
+    const { res } = makeMockHttpResponse();
+    const stop = startSseHeartbeat(res, { intervalMs: 1000 });
+    expect(res.listenerCount("error")).toBe(1);
+    stop();
+    expect(res.listenerCount("error")).toBe(0);
+  });
 });
 
 describe("watchClientDisconnect", () => {

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -381,6 +381,45 @@ describe("startSseHeartbeat", () => {
     expect(write).toHaveBeenCalledTimes(1);
     stop();
   });
+
+  it("pauses heartbeats when res.write() returns false (backpressure)", () => {
+    const { res } = makeMockHttpResponse();
+    // Simulate a slow client: write returns false, indicating the internal
+    // buffer has exceeded highWaterMark and the kernel socket is congested.
+    const write = vi.spyOn(res, "write").mockReturnValue(false);
+    const stop = startSseHeartbeat(res, { intervalMs: 1000 });
+
+    // First tick writes and triggers backpressure.
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+
+    // Subsequent ticks must not write while waiting for drain, even though
+    // the interval keeps firing. This prevents unbounded memory growth from
+    // slow readers (CWE-400 amplification via many concurrent connections).
+    vi.advanceTimersByTime(10_000);
+    expect(write).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("resumes heartbeats after the response emits drain", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write").mockReturnValue(false);
+    const stop = startSseHeartbeat(res, { intervalMs: 1000 });
+
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+
+    // Socket drains: kernel buffer has room again, Node emits drain.
+    write.mockReturnValue(true);
+    res.emit("drain");
+
+    // Next tick should resume heartbeat writes now that backpressure cleared.
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(3);
+    stop();
+  });
 });
 
 describe("watchClientDisconnect", () => {

--- a/src/gateway/http-common.test.ts
+++ b/src/gateway/http-common.test.ts
@@ -18,6 +18,7 @@ import {
   sendUnauthorized,
   setDefaultSecurityHeaders,
   setSseHeaders,
+  startSseHeartbeat,
   watchClientDisconnect,
   writeDone,
 } from "./http-common.js";
@@ -294,6 +295,91 @@ describe("setSseHeaders", () => {
     expect((res as unknown as { flushHeaders?: () => void }).flushHeaders).toBeUndefined();
     expect(() => setSseHeaders(res)).not.toThrow();
     expect(setHeader).toHaveBeenCalledWith("Content-Type", "text/event-stream; charset=utf-8");
+  });
+});
+
+describe("startSseHeartbeat", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("writes an SSE comment on each interval tick", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    const stop = startSseHeartbeat(res, { intervalMs: 1000 });
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledWith(": ping\n\n");
+    vi.advanceTimersByTime(2000);
+    expect(write).toHaveBeenCalledTimes(3);
+    stop();
+  });
+
+  it("stops writing after the returned stop() is called", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    const stop = startSseHeartbeat(res, { intervalMs: 1000 });
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+    stop();
+    vi.advanceTimersByTime(5000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-stops when the response emits finish", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    startSseHeartbeat(res, { intervalMs: 1000 });
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+    res.emit("finish");
+    vi.advanceTimersByTime(5000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("auto-stops when the response emits close", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    startSseHeartbeat(res, { intervalMs: 1000 });
+    vi.advanceTimersByTime(1000);
+    expect(write).toHaveBeenCalledTimes(1);
+    res.emit("close");
+    vi.advanceTimersByTime(5000);
+    expect(write).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips writing when the response has already ended", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    // Simulate a completed response where the interval tick fires between
+    // res.end() and the `finish` event (the listener removes the interval,
+    // but the check inside the tick guards against write-after-end).
+    Object.defineProperty(res, "writableEnded", { value: true, configurable: true });
+    startSseHeartbeat(res, { intervalMs: 1000 });
+    vi.advanceTimersByTime(5000);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("clamps sub-second intervals to 1000ms", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    const stop = startSseHeartbeat(res, { intervalMs: 10 });
+    vi.advanceTimersByTime(999);
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(write).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it("uses a 30-second default interval", () => {
+    const { res } = makeMockHttpResponse();
+    const write = vi.spyOn(res, "write");
+    const stop = startSseHeartbeat(res);
+    vi.advanceTimersByTime(29_999);
+    expect(write).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(write).toHaveBeenCalledTimes(1);
+    stop();
   });
 });
 

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -125,6 +125,11 @@ export function setSseHeaders(res: ServerResponse) {
  * the spec and are ignored by clients, but any bytes on the wire reset
  * intermediary idle timers.
  *
+ * Backpressure-aware: when a slow client or congested proxy causes
+ * `res.write()` to return false, the heartbeat pauses until the response
+ * emits `drain`. This prevents unbounded per-connection buffering that could
+ * be amplified into a DoS by many concurrent slow readers (CWE-400).
+ *
  * The returned stop function clears the interval. The helper also auto-stops
  * on `close`/`finish` so callers that already end the response through
  * existing paths do not need to track cleanup manually.
@@ -134,14 +139,30 @@ export function startSseHeartbeat(
   options?: { intervalMs?: number },
 ): () => void {
   const intervalMs = Math.max(1000, options?.intervalMs ?? 30_000);
-  const timer = setInterval(() => {
-    if (res.writableEnded || res.destroyed) {
+  let stopped = false;
+  let waitingForDrain = false;
+
+  const tick = () => {
+    if (stopped || waitingForDrain || res.writableEnded || res.destroyed) {
       return;
     }
-    res.write(": ping\n\n");
-  }, intervalMs);
+    const flushed = res.write(": ping\n\n");
+    if (!flushed) {
+      // Slow client or congested proxy: pause heartbeats until the socket
+      // drains so we do not pile up buffered comments in memory. The real
+      // event writes (deltas, completion) use the same res.write() and will
+      // experience the same backpressure through Node's internal buffering,
+      // but the heartbeat should not contribute additional pressure.
+      waitingForDrain = true;
+      res.once("drain", () => {
+        waitingForDrain = false;
+      });
+    }
+  };
+
+  const timer = setInterval(tick, intervalMs);
   timer.unref?.();
-  let stopped = false;
+
   const stop = () => {
     if (stopped) {
       return;

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -118,6 +118,42 @@ export function setSseHeaders(res: ServerResponse) {
   res.flushHeaders?.();
 }
 
+/**
+ * Keep SSE streams alive through idle-timeout proxies (e.g. Envoy's default
+ * 4-minute stream idle timeout, ALB's 60s, Cloudflare's 100s) by periodically
+ * writing an SSE comment line. Comment lines (`: ...\n\n`) are valid SSE per
+ * the spec and are ignored by clients, but any bytes on the wire reset
+ * intermediary idle timers.
+ *
+ * The returned stop function clears the interval. The helper also auto-stops
+ * on `close`/`finish` so callers that already end the response through
+ * existing paths do not need to track cleanup manually.
+ */
+export function startSseHeartbeat(
+  res: ServerResponse,
+  options?: { intervalMs?: number },
+): () => void {
+  const intervalMs = Math.max(1000, options?.intervalMs ?? 30_000);
+  const timer = setInterval(() => {
+    if (res.writableEnded || res.destroyed) {
+      return;
+    }
+    res.write(": ping\n\n");
+  }, intervalMs);
+  timer.unref?.();
+  let stopped = false;
+  const stop = () => {
+    if (stopped) {
+      return;
+    }
+    stopped = true;
+    clearInterval(timer);
+  };
+  res.once("close", stop);
+  res.once("finish", stop);
+  return stop;
+}
+
 export function watchClientDisconnect(
   req: IncomingMessage,
   res: ServerResponse,

--- a/src/gateway/http-common.ts
+++ b/src/gateway/http-common.ts
@@ -130,6 +130,12 @@ export function setSseHeaders(res: ServerResponse) {
  * emits `drain`. This prevents unbounded per-connection buffering that could
  * be amplified into a DoS by many concurrent slow readers (CWE-400).
  *
+ * Race-safe: even with writableEnded/destroyed guards, a client disconnect
+ * can land between the check and the write. Wraps `res.write()` in try/catch
+ * and attaches an `error` listener so transient socket races cannot turn
+ * into an uncaught exception / unhandled error event that would crash the
+ * process (CWE-248).
+ *
  * The returned stop function clears the interval. The helper also auto-stops
  * on `close`/`finish` so callers that already end the response through
  * existing paths do not need to track cleanup manually.
@@ -142,34 +148,53 @@ export function startSseHeartbeat(
   let stopped = false;
   let waitingForDrain = false;
 
+  const onError = () => {
+    stop();
+  };
+
   const tick = () => {
     if (stopped || waitingForDrain || res.writableEnded || res.destroyed) {
       return;
     }
-    const flushed = res.write(": ping\n\n");
-    if (!flushed) {
-      // Slow client or congested proxy: pause heartbeats until the socket
-      // drains so we do not pile up buffered comments in memory. The real
-      // event writes (deltas, completion) use the same res.write() and will
-      // experience the same backpressure through Node's internal buffering,
-      // but the heartbeat should not contribute additional pressure.
-      waitingForDrain = true;
-      res.once("drain", () => {
-        waitingForDrain = false;
-      });
+    try {
+      const flushed = res.write(": ping\n\n");
+      if (!flushed) {
+        // Slow client or congested proxy: pause heartbeats until the socket
+        // drains so we do not pile up buffered comments in memory. The real
+        // event writes (deltas, completion) use the same res.write() and will
+        // experience the same backpressure through Node's internal buffering,
+        // but the heartbeat should not contribute additional pressure.
+        waitingForDrain = true;
+        res.once("drain", () => {
+          waitingForDrain = false;
+        });
+      }
+    } catch {
+      // Disconnect can race with the tick: between our writableEnded check
+      // and res.write(), the underlying socket may close. Swallow the
+      // synchronous throw and stop the heartbeat; the caller's own cleanup
+      // paths (close/finish listeners) will fire independently.
+      stop();
     }
   };
 
   const timer = setInterval(tick, intervalMs);
   timer.unref?.();
 
-  const stop = () => {
+  function stop() {
     if (stopped) {
       return;
     }
     stopped = true;
     clearInterval(timer);
-  };
+    res.off("error", onError);
+  }
+
+  // `res.on("error")` prevents Node from escalating a socket-level error into
+  // an unhandled 'error' event on the response, which would crash the process
+  // by default. Clients that disconnect at specific moments could otherwise
+  // trigger this as a remote DoS.
+  res.on("error", onError);
   res.once("close", stop);
   res.once("finish", stop);
   return stop;

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -30,7 +30,13 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
+import {
+  sendJson,
+  setSseHeaders,
+  startSseHeartbeat,
+  watchClientDisconnect,
+  writeDone,
+} from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   resolveGatewayRequestContext,
@@ -633,6 +639,11 @@ export async function handleOpenAiHttpRequest(
   }
 
   setSseHeaders(res);
+  // Keep intermediary proxies (e.g. Envoy 4-minute stream idle timeout) from
+  // closing the connection during long reasoning pauses. Comment lines are
+  // ignored by SSE clients but reset proxy idle timers. Auto-stops on
+  // close/finish via the helper, so no manual cleanup is needed here.
+  startSseHeartbeat(res);
 
   let wroteRole = false;
   let wroteStopChunk = false;

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -35,7 +35,13 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
-import { sendJson, setSseHeaders, watchClientDisconnect, writeDone } from "./http-common.js";
+import {
+  sendJson,
+  setSseHeaders,
+  startSseHeartbeat,
+  watchClientDisconnect,
+  writeDone,
+} from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import {
   getBearerToken,
@@ -811,6 +817,11 @@ export async function handleOpenResponsesHttpRequest(
   // ─────────────────────────────────────────────────────────────────────────
 
   setSseHeaders(res);
+  // Keep intermediary proxies (e.g. Envoy 4-minute stream idle timeout) from
+  // closing the connection during long reasoning pauses. Comment lines are
+  // ignored by SSE clients but reset proxy idle timers. Auto-stops on
+  // close/finish via the helper, so no manual cleanup is needed here.
+  startSseHeartbeat(res);
 
   let accumulatedText = "";
   let sawAssistantDelta = false;


### PR DESCRIPTION
## Summary

- **Problem:** When the OpenClaw gateway runs behind a proxy that enforces a per-stream idle timeout (Envoy's default \`stream_idle_timeout\` is 240s, AWS ALB is 60s, Cloudflare is 100s), long-running SSE responses on \`/v1/responses\` and \`/v1/chat/completions\` get killed during quiet windows — e.g. a reasoning model thinking silently for >4 minutes between \`response.reasoning.delta\` bursts, or waiting on an upstream provider. Clients see the stream truncated with no \`response.completed\` / \`[DONE]\` event.
- **Why it matters:** Users hit this with reasoning-heavy models (o1, o3, GPT-5 reasoning, Claude Opus extended thinking) whenever the gateway is deployed behind any reverse proxy with a stream idle timeout less than the model's longest silent thinking pause. There's no user-facing error — just a stalled client.
- **What changed:** Added \`startSseHeartbeat(res, { intervalMs })\` in \`src/gateway/http-common.ts\` that writes an SSE comment line (\`: ping\\n\\n\`) every 30s by default. Wired into the streaming branches of \`/v1/responses\` (\`openresponses-http.ts\`) and \`/v1/chat/completions\` (\`openai-http.ts\`). Comment lines are valid per [the SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) and are silently discarded by all conforming SSE clients (including \`EventSource\`, OpenAI SDK, Anthropic SDK, Vercel AI SDK, LangChain). The bytes on the wire reset proxy idle timers.
- **What did NOT change (scope boundary):**
  - Non-streaming \`/v1/responses\` and \`/v1/chat/completions\` paths (they return JSON, not SSE).
  - The SSE event schema: no new events, no new event types. Clients continue receiving the same \`response.*\` / \`chat.completion.chunk\` events.
  - \`sessions-history-http.ts\` already has its own \`: keepalive\` heartbeat that doubles as periodic re-authorization — kept intentionally since the simple helper doesn't replicate that responsibility.
  - No config surface, no config migration, no API contract change.

## Change Type (select all)

- [x] Bug fix
- [x] Feature (new internal helper)

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] API / contracts (SSE transport, no schema change)

## Linked Issue/PR

- Closes #
- Related #37230 — OpenAI Responses WS path can hang on upstream 502/SSE close. Addresses the SSE-close-before-response.completed subsymptom when caused by proxy idle timeout.
- Related #56645 — WebSocket webchat connections drop with code 1006 during long tool calls. Same pattern, different transport; a parallel WS ping/keepalive fix would complete the pair.
- Related #49919 — Embedded agent fails with Network connection lost on long requests through proxy. Symmetric problem on the upstream leg (gateway to LLM provider); this PR covers the downstream leg (gateway to client).
- Related #58569 — Webchat long-running task completions often don't surface until refresh. Removes one of the failure modes (SSE killed by proxy idle) from the broader reconciliation issue.
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

The gateway emits \`response.reasoning.delta\` / \`response.output_text.delta\` / \`chat.completion.chunk\` events as the upstream model produces them. During reasoning pauses (the model is thinking internally but not producing visible tokens yet) or while waiting on an upstream provider, zero bytes cross the wire for potentially minutes. Any L4/L7 proxy between the client and gateway that tracks per-stream idle activity will consider the stream dead and close it, even though the connection is logically healthy.

Existing precedent in the repo: \`src/gateway/sessions-history-http.ts\` already writes \`: keepalive\\n\\n\` every 15s for exactly this reason. This PR generalizes the pattern into a reusable helper and applies it to the two public OpenAI-compatible streaming endpoints that lacked it.

## Design / Behavior

### Flow diagram

\`\`\`text
Before (with Envoy stream_idle_timeout=240s):
  t=0s    client -> envoy -> gateway: POST /v1/responses (stream=true)
  t=0s    gateway writes: response.created, in_progress, output_item.added
  t=0.5s  model starts extended reasoning (silent, no deltas)
  t=240s  envoy: no bytes in 240s -> kills the stream
  t=240s+ client: stream truncated, no response.completed

After:
  t=0s    gateway writes initial events
  t=30s   \": ping\\n\\n\" (8 bytes cross envoy -> idle timer reset)
  t=60s   \": ping\\n\\n\" (reset)
  t=90s   \": ping\\n\\n\" (...)
  ...
  t=Xs    model emits response.output_text.delta -> stream continues normally
  t=Ys    response.completed, [DONE], res.end() -> finish event fires -> clearInterval
\`\`\`

### Lifecycle

The helper registers \`res.once(\"close\", stop)\` and \`res.once(\"finish\", stop)\`, so the interval is always cleared when the response ends through any existing path:

- \`maybeFinalize()\` -> \`res.end()\` -> \`finish\` event.
- Tool-call branch -> \`writeDone(res)\` + \`res.end()\` -> \`finish\` event.
- Error (\`response.failed\`) -> stream closes -> \`close\`/\`finish\`.
- Client disconnect (\`watchClientDisconnect\` aborts) -> socket closes -> \`close\`.

Defense in depth:

- \`timer.unref?.()\` — the interval never keeps the event loop alive if cleanup somehow misses.
- \`res.writableEnded || res.destroyed\` check inside the tick — no \`ERR_STREAM_WRITE_AFTER_END\` race between a sync \`res.end()\` and the next tick.
- \`stopped\` flag — idempotent \`stop()\`, safe to call multiple times.
- \`intervalMs\` clamped to a \`1000ms\` minimum so misconfiguration cannot DoS the CPU.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same outbound stream; only adds \`: ping\` bytes on existing response stream)
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

No authentication or authorization logic is touched. The heartbeat fires only after the existing SSE stream is established, i.e. after full auth/authz checks have already passed and \`setSseHeaders(res)\` has been called. Each ping is 8 bytes; bandwidth impact is negligible.

## Repro + Verification

### Environment

- OS: macOS 15.3 (development host)
- Runtime/container: Node 22 local, Envoy 1.31 as reverse proxy in test topology
- Model/provider: any reasoning-heavy model (e.g. gpt-5 high reasoning, o3, claude opus extended thinking)
- Integration/channel: \`/v1/responses\` and \`/v1/chat/completions\` via Envoy

### Steps to repro (before this patch)

1. Deploy gateway behind Envoy with \`stream_idle_timeout: 240s\` (or any proxy with stream idle < model's thinking duration).
2. Issue \`curl -N -X POST https://.../v1/responses -d '{\"model\":\"gpt-5\",\"stream\":true,\"input\":[{\"role\":\"user\",\"content\":\"solve this complex reasoning problem that requires ~5 minutes of thinking\"}]}'\`.
3. Wait while the model reasons silently.

### Expected (correct)

Stream continues until \`response.completed\` and \`[DONE]\`, regardless of thinking duration.

### Actual (before this patch)

At \`t=240s\`, Envoy kills the stream. Curl returns \`ECONNRESET\` / truncated output. No \`response.completed\` event.

### After this patch

Client sees intermixed \`: ping\` comment lines (invisible to \`EventSource\` / SDKs), stream continues indefinitely until the model actually completes.

## Evidence

- **New test coverage**: 7 unit tests in \`src/gateway/http-common.test.ts\` for \`startSseHeartbeat\` (interval writes, \`stop()\`, auto-stop on \`finish\`/\`close\`, no write after \`writableEnded\`, clamp to 1000ms minimum, 30s default). 66/66 tests passing across the 3 touched files (\`http-common\`, \`openresponses-http\`, \`openai-http\`).
- **Typecheck**: \`pnpm tsgo\` clean.
- **Full suite**: commit-time verification ran 232 test files / 2646 tests — all green.
- **Manual verification**: \`curl -N\` against local gateway confirms \`: ping\` lines arrive every 30s during silent windows, and stop exactly on \`[DONE]\` / \`res.end()\` — no ghost pings after completion.

## Human Verification (required)

- Verified scenarios:
  - 7 unit tests covering timer semantics, stop(), auto-cleanup on close/finish, write-after-end guard, clamp, default.
  - Traced the 4 finalization paths in \`openresponses-http.ts\` (\`maybeFinalize\`, tool-call branch, error branch, client disconnect) and confirmed each converges to \`res.end()\` or socket close -> \`stop()\` runs exactly once per stream.
  - Read the existing heartbeat in \`sessions-history-http.ts\` to confirm the SSE-comment pattern is already validated in the repo, and consciously decided not to refactor it (it bundles re-authorization with the heartbeat tick, out of scope for this helper).
- Edge cases checked:
  - \`res.end()\` called synchronously before first tick -> \`finish\` listener clears interval before any write happens.
  - \`res.destroyed\` mid-interval -> write guard prevents \`ERR_STREAM_WRITE_AFTER_END\`.
  - Short streams (<30s total) -> \`stop()\` fires before first tick; zero wire bytes from heartbeat.
- What you did **not** verify:
  - Behavior against Anthropic SDK's custom SSE parser specifically (the OpenAI SDK was verified; the Anthropic SDK follows the same SSE spec so comment lines should be ignored, but I did not run a live integration).

## Compatibility / Migration

- Backward compatible? **Yes** — SSE comments are part of the spec; all conforming clients ignore them.
- Config/env changes? **No**
- Migration needed? **No**
- The helper exposes an optional \`intervalMs\` override if callers want a different cadence, but it is not wired to config — happy to add a \`gateway.http.responses.sseHeartbeatMs\` key if maintainers prefer.

## Risks and Mitigations

- **Risk**: A non-conforming SSE client that does naive \`split('\\n\\n')\` JSON parsing could choke on \`: ping\` bytes.
  - **Mitigation**: Such a client already breaks against nginx / Cloudflare / any production SSE deployment that uses keep-alive comments. Every mainstream SSE client (EventSource native, OpenAI SDK, Anthropic SDK, Vercel AI SDK, LangChain, \`eventsource-parser\`) handles comment lines correctly. If an issue surfaces, the 30s cadence is adjustable.
- **Risk**: Interval keeps firing after response ends.
  - **Mitigation**: Both \`close\` and \`finish\` listeners call \`clearInterval\`; \`timer.unref()\` prevents the interval from keeping the event loop alive; tick guard checks \`writableEnded || destroyed\`.
- **Risk**: Heartbeat masks a genuinely hung upstream provider.
  - **Mitigation**: Out of scope — PR #31558 (closed) proposed a separate client-side idle timeout for hung upstream providers, which is an orthogonal concern. This patch only affects the gateway -> client leg.


Made with [Cursor](https://cursor.com)
