### PR TITLE
bluebubbles: guard typing + mark-read at the outer function too

### DIFF
--- a/extensions/bluebubbles/src/chat.ts
+++ b/extensions/bluebubbles/src/chat.ts
@@ -75,6 +75,17 @@ export async function markBlueBubblesChatRead(
   chatGuid: string,
   opts: BlueBubblesChatOpts = {},
 ): Promise<void> {
+  // Mark-read is a Private-API-only BlueBubbles endpoint. When the BB
+  // server reports `private_api: false`, the call returns HTTP 500 with
+  // "iMessage Private API is not enabled!", which the channel runtime
+  // then logs as an error and surfaces as a fallback warning in the
+  // chat reply — even though mark-read is a nice-to-have, not a
+  // prerequisite for the conversation. Silently skip when we know
+  // Private API is off. Unknown state (null) falls through so first
+  // call after boot still probes.
+  if (getCachedBlueBubblesPrivateApiStatus(opts.accountId) === false) {
+    return;
+  }
   await sendBlueBubblesChatEndpointRequest({
     chatGuid,
     opts,
@@ -89,6 +100,13 @@ export async function sendBlueBubblesTyping(
   typing: boolean,
   opts: BlueBubblesChatOpts = {},
 ): Promise<void> {
+  // Typing indicators are Private-API-only on BlueBubbles — same story
+  // as `markBlueBubblesChatRead` above. Skip silently when we know
+  // Private API is off rather than hammering BB with a 500 on every
+  // reply.
+  if (getCachedBlueBubblesPrivateApiStatus(opts.accountId) === false) {
+    return;
+  }
   await sendBlueBubblesChatEndpointRequest({
     chatGuid,
     opts,


### PR DESCRIPTION
## Problem
Every inbound iMessage to an openclaw agent wired to BlueBubbles (without Private API enabled) is replied to with **two** delivered iMessages — a generic `⚠️ Something went wrong while processing your request. Please try again, or use /new to start a fresh session.` immediately followed (seconds later) by the real model reply.

Root cause: `sendBlueBubblesTyping` and `markBlueBubblesChatRead` hit Private-API-only endpoints on every webhook. The inner `sendBlueBubblesChatEndpointRequest` already has `if (getCachedBlueBubblesPrivateApiStatus(accountId) === false) return;`, but in practice that check returns `null` (never-probed race, or accountId resolution path difference) at call time on fresh session bootup — the null-fallthrough attempts the call, BlueBubbles returns `HTTP 500 "iMessage Private API is not enabled!"`, the channel runtime logs it at `error` level, and the error cascades into the agent-turn failure path that dispatches `buildExternalRunFailureText`.

The test files already assert the desired behaviour:
- `markBlueBubblesChatRead — does not send read receipt when private API is disabled`
- `sendBlueBubblesTyping — does not send typing when private API is disabled`

Both tests pass today (the mock path lets the inner check catch). Production doesn't match because the cache state at call time differs from the `mockReturnValueOnce(false)` in tests.

## Fix
Check the cached Private API status at the **outer** function entry too — symmetric belt-and-suspenders with the existing inner check. Same null-fallthrough semantics; no behaviour change for servers where Private API is enabled (both checks let the call through when the status is `true`).

```ts
export async function markBlueBubblesChatRead(
  chatGuid: string,
  opts: BlueBubblesChatOpts = {},
): Promise<void> {
  if (getCachedBlueBubblesPrivateApiStatus(opts.accountId) === false) {
    return;
  }
  await sendBlueBubblesChatEndpointRequest({...});
}

export async function sendBlueBubblesTyping(
  chatGuid: string,
  typing: boolean,
  opts: BlueBubblesChatOpts = {},
): Promise<void> {
  if (getCachedBlueBubblesPrivateApiStatus(opts.accountId) === false) {
    return;
  }
  await sendBlueBubblesChatEndpointRequest({...});
}
```

## Repro
1. Run openclaw `2026.4.15` or `2026.4.22` on macOS 15.6, Apple Silicon.
2. Configure `channels.bluebubbles` pointing at a BlueBubbles server with Private API **off** (`private_api: false` in `/api/v1/server/info`).
3. Register a webhook in BlueBubbles pointing at openclaw's `/bluebubbles-webhook` endpoint.
4. Send an iMessage from an allowlisted handle. Each reply is two delivered iMessages — the `⚠️` fallback and the real text, ~5s apart.
5. After this patch: one delivered iMessage per reply, no `⚠️`, no `mark read failed` / `typing start failed` in the openclaw log.

## Tested
- Both existing vitest cases pass unchanged.
- Live validation on one agent + one iMessage thread: 4 consecutive back-and-forth messages, all clean single-reply, zero `typing start failed` / `mark read failed` errors in `/tmp/openclaw/openclaw-YYYY-MM-DD.log`.

## Notes for maintainers
Happy to iterate on the approach — alternatives include:
- Deferring the probe so typing/mark-read never fire until status is known (bigger change to the boot sequence).
- Logging at `verbose` instead of `error` when the Private-API-only endpoints 500 (surface-level fix; underlying behaviour remains noisy).
- Investigating why `getCachedBlueBubblesPrivateApiStatus` returns `null` at the point `sendBlueBubblesChatEndpointRequest` is called, even after boot-time probe logs `Private API disabled` (the real root cause — belt-and-suspenders is only a surface fix).

This PR picks the minimum-footprint defensive change; happy to go deeper on root cause in a follow-up if that's preferable.