### PR TITLE
fix(plugins): defer undefined config validation in snapshot loads (Fixes #70658)

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
+++ b/apps/macos/Sources/OpenClaw/ExecAllowlistMatcher.swift
@@ -14,7 +14,8 @@ enum ExecAllowlistMatcher {
                     if self.matches(pattern: pattern, target: target) { return entry }
                 } else if pattern != "*",
                           !ExecApprovalHelpers.patternHasPathSelector(rawExecutable),
-                          self.matchesExecutableBasename(pattern: pattern, resolution: resolution) {
+                          self.matchesExecutableBasename(pattern: pattern, resolution: resolution)
+                {
                     return entry
                 }
             case .invalid:

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -618,7 +618,8 @@ enum ExecApprovalsStore {
 
         if !ExecApprovalHelpers.patternHasPathSelector(trimmedPattern),
            !trimmedResolved.isEmpty,
-           case let .valid(migratedPattern) = ExecApprovalHelpers.validateAllowlistPattern(trimmedResolved) {
+           case let .valid(migratedPattern) = ExecApprovalHelpers.validateAllowlistPattern(trimmedResolved)
+        {
             return ExecAllowlistEntry(
                 id: entry.id,
                 pattern: migratedPattern,

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -129,6 +129,63 @@ describe("plugin loader CLI metadata", () => {
     expect(registry.plugins.find((entry) => entry.id === "config-cli")?.status).toBe("loaded");
   });
 
+  it("skips undefined config validation during CLI metadata capture", async () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "config-cli-optional-preflight",
+      filename: "config-cli-optional-preflight.cjs",
+      body: `module.exports = {
+  id: "config-cli-optional-preflight",
+  register(api) {
+    api.registerCli(() => {}, {
+      descriptors: [
+        {
+          name: "cfg-optional-preflight",
+          description: "Config-optional CLI metadata command",
+          hasSubcommands: true,
+        },
+      ],
+    });
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "config-cli-optional-preflight",
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              token: { type: "string" },
+            },
+            required: ["token"],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = await loadOpenClawPluginCliRegistry({
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["config-cli-optional-preflight"],
+        },
+      },
+    });
+
+    expect(registry.cliRegistrars.flatMap((entry) => entry.commands)).toContain(
+      "cfg-optional-preflight",
+    );
+    expect(
+      registry.plugins.find((entry) => entry.id === "config-cli-optional-preflight")?.status,
+    ).toBe("loaded");
+  });
+
   it("uses the real channel entry in cli-metadata mode for CLI metadata capture", async () => {
     useNoBundledPlugins();
     const pluginDir = makeTempDir();

--- a/src/plugins/loader.cli-metadata.test.ts
+++ b/src/plugins/loader.cli-metadata.test.ts
@@ -137,6 +137,9 @@ describe("plugin loader CLI metadata", () => {
       body: `module.exports = {
   id: "config-cli-optional-preflight",
   register(api) {
+    if (!api.pluginConfig || typeof api.pluginConfig !== "object" || Array.isArray(api.pluginConfig)) {
+      throw new Error("plugin config should stay normalized");
+    }
     api.registerCli(() => {}, {
       descriptors: [
         {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -7007,6 +7007,55 @@ module.exports = {
     );
   });
 
+  it("applies schema defaults during non-activating snapshot loads with omitted config", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "config-default-snapshot",
+      filename: "config-default-snapshot.cjs",
+      body: `module.exports = {
+  id: "config-default-snapshot",
+  register(api) {
+    if (api.pluginConfig.mode !== "safe") {
+      throw new Error("plugin config defaults should be applied");
+    }
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "config-default-snapshot",
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              mode: { type: "string", default: "safe" },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["config-default-snapshot"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "config-default-snapshot")?.status).toBe(
+      "loaded",
+    );
+  });
+
   it("loads source TypeScript plugins that route through local runtime shims", () => {
     const plugin = writePlugin({
       id: "source-runtime-shim",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -6957,6 +6957,56 @@ module.exports = {
     });
   });
 
+  it("keeps pluginConfig normalized during non-activating snapshot loads with omitted config", () => {
+    useNoBundledPlugins();
+    const plugin = writePlugin({
+      id: "config-optional-snapshot",
+      filename: "config-optional-snapshot.cjs",
+      body: `module.exports = {
+  id: "config-optional-snapshot",
+  register(api) {
+    if (!api.pluginConfig || typeof api.pluginConfig !== "object" || Array.isArray(api.pluginConfig)) {
+      throw new Error("plugin config should stay normalized");
+    }
+  },
+};`,
+    });
+    fs.writeFileSync(
+      path.join(plugin.dir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "config-optional-snapshot",
+          configSchema: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              token: { type: "string" },
+            },
+            required: ["token"],
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+
+    const registry = loadOpenClawPlugins({
+      cache: false,
+      activate: false,
+      config: {
+        plugins: {
+          load: { paths: [plugin.file] },
+          allow: ["config-optional-snapshot"],
+        },
+      },
+    });
+
+    expect(registry.plugins.find((entry) => entry.id === "config-optional-snapshot")?.status).toBe(
+      "loaded",
+    );
+  });
+
   it("loads source TypeScript plugins that route through local runtime shims", () => {
     const plugin = writePlugin({
       id: "source-runtime-shim",

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2375,6 +2375,60 @@ module.exports = { id: "manifest-only-plugin", register() { throw new Error("man
       },
     },
     {
+      label: "skips undefined config validation during non-activating manifest-only snapshots",
+      run: () => {
+        useNoBundledPlugins();
+        const plugin = writePlugin({
+          id: "snapshot-required-config",
+          filename: "snapshot-required-config.cjs",
+          body: `module.exports = { id: "snapshot-required-config", register() {} };`,
+        });
+        fs.writeFileSync(
+          path.join(plugin.dir, "openclaw.plugin.json"),
+          JSON.stringify(
+            {
+              id: "snapshot-required-config",
+              configSchema: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  token: { type: "string" },
+                },
+                required: ["token"],
+              },
+            },
+            null,
+            2,
+          ),
+          "utf-8",
+        );
+
+        const registry = loadOpenClawPlugins({
+          cache: false,
+          activate: false,
+          loadModules: false,
+          config: {
+            plugins: {
+              load: { paths: [plugin.file] },
+              allow: ["snapshot-required-config"],
+              entries: {
+                "snapshot-required-config": { enabled: true },
+              },
+            },
+          },
+        });
+
+        expect(registry.plugins).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              id: "snapshot-required-config",
+              status: "loaded",
+            }),
+          ]),
+        );
+      },
+    },
+    {
       label: "marks a selected memory slot as matched during manifest-only snapshots",
       run: () => {
         useNoBundledPlugins();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1234,6 +1234,13 @@ function validatePluginConfig(params: {
   return { ok: false, errors: result.errors.map((error) => error.text) };
 }
 
+function shouldValidatePluginConfigForLoad(params: {
+  value?: unknown;
+  shouldActivate: boolean;
+}): boolean {
+  return params.shouldActivate || params.value !== undefined;
+}
+
 function resolvePluginModuleExport(moduleExport: unknown): {
   definition?: OpenClawPluginDefinition;
   register?: OpenClawPluginDefinition["register"];
@@ -2526,18 +2533,25 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         }
       }
 
-      const validatedConfig = validatePluginConfig({
-        schema: manifestRecord.configSchema,
-        cacheKey: manifestRecord.schemaCacheKey,
-        value: entry?.config,
-      });
+      if (
+        shouldValidatePluginConfigForLoad({
+          value: entry?.config,
+          shouldActivate,
+        })
+      ) {
+        const validatedConfig = validatePluginConfig({
+          schema: manifestRecord.configSchema,
+          cacheKey: manifestRecord.schemaCacheKey,
+          value: entry?.config,
+        });
 
-      if (!validatedConfig.ok) {
-        logger.error(
-          `[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`,
-        );
-        pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
-        continue;
+        if (!validatedConfig.ok) {
+          logger.error(
+            `[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`,
+          );
+          pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+          continue;
+        }
       }
 
       if (!shouldLoadModules) {
@@ -3176,15 +3190,22 @@ export async function loadOpenClawPluginCliRegistry(
       continue;
     }
 
-    const validatedConfig = validatePluginConfig({
-      schema: manifestRecord.configSchema,
-      cacheKey: manifestRecord.schemaCacheKey,
-      value: entry?.config,
-    });
-    if (!validatedConfig.ok) {
-      logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
-      pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
-      continue;
+    if (
+      shouldValidatePluginConfigForLoad({
+        value: entry?.config,
+        shouldActivate: false,
+      })
+    ) {
+      const validatedConfig = validatePluginConfig({
+        schema: manifestRecord.configSchema,
+        cacheKey: manifestRecord.schemaCacheKey,
+        value: entry?.config,
+      });
+      if (!validatedConfig.ok) {
+        logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+        pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
+        continue;
+      }
     }
 
     const pluginRoot = safeRealpathOrResolve(candidate.rootDir);

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2535,7 +2535,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
       let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
         ok: true,
-        value: entry?.config as Record<string, unknown> | undefined,
+        value: (entry?.config as Record<string, unknown> | undefined) ?? {},
       };
       if (
         shouldValidatePluginConfigForLoad({
@@ -3196,7 +3196,7 @@ export async function loadOpenClawPluginCliRegistry(
 
     let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
       ok: true,
-      value: entry?.config as Record<string, unknown> | undefined,
+      value: (entry?.config as Record<string, unknown> | undefined) ?? {},
     };
     if (
       shouldValidatePluginConfigForLoad({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1241,6 +1241,22 @@ function shouldValidatePluginConfigForLoad(params: {
   return params.shouldActivate || params.value !== undefined;
 }
 
+function resolveDeferredPluginConfigValue(params: {
+  schema: Record<string, unknown>;
+  cacheKey?: string;
+  value?: unknown;
+}): Record<string, unknown> {
+  if (params.value !== undefined) {
+    return params.value as Record<string, unknown>;
+  }
+  const defaultedConfig = validatePluginConfig({
+    schema: params.schema,
+    cacheKey: params.cacheKey,
+    value: {},
+  });
+  return defaultedConfig.ok ? (defaultedConfig.value ?? {}) : {};
+}
+
 function resolvePluginModuleExport(moduleExport: unknown): {
   definition?: OpenClawPluginDefinition;
   register?: OpenClawPluginDefinition["register"];
@@ -2535,7 +2551,11 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
       let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
         ok: true,
-        value: (entry?.config as Record<string, unknown> | undefined) ?? {},
+        value: resolveDeferredPluginConfigValue({
+          schema: manifestRecord.configSchema,
+          cacheKey: manifestRecord.schemaCacheKey,
+          value: entry?.config,
+        }),
       };
       if (
         shouldValidatePluginConfigForLoad({
@@ -3196,7 +3216,11 @@ export async function loadOpenClawPluginCliRegistry(
 
     let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
       ok: true,
-      value: (entry?.config as Record<string, unknown> | undefined) ?? {},
+      value: resolveDeferredPluginConfigValue({
+        schema: manifestRecord.configSchema,
+        cacheKey: manifestRecord.schemaCacheKey,
+        value: entry?.config,
+      }),
     };
     if (
       shouldValidatePluginConfigForLoad({

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -2533,13 +2533,17 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         }
       }
 
+      let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
+        ok: true,
+        value: entry?.config as Record<string, unknown> | undefined,
+      };
       if (
         shouldValidatePluginConfigForLoad({
           value: entry?.config,
           shouldActivate,
         })
       ) {
-        const validatedConfig = validatePluginConfig({
+        validatedConfig = validatePluginConfig({
           schema: manifestRecord.configSchema,
           cacheKey: manifestRecord.schemaCacheKey,
           value: entry?.config,
@@ -3190,19 +3194,25 @@ export async function loadOpenClawPluginCliRegistry(
       continue;
     }
 
+    let validatedConfig: { ok: boolean; value?: Record<string, unknown>; errors?: string[] } = {
+      ok: true,
+      value: entry?.config as Record<string, unknown> | undefined,
+    };
     if (
       shouldValidatePluginConfigForLoad({
         value: entry?.config,
         shouldActivate: false,
       })
     ) {
-      const validatedConfig = validatePluginConfig({
+      validatedConfig = validatePluginConfig({
         schema: manifestRecord.configSchema,
         cacheKey: manifestRecord.schemaCacheKey,
         value: entry?.config,
       });
       if (!validatedConfig.ok) {
-        logger.error(`[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`);
+        logger.error(
+          `[plugins] ${record.id} invalid config: ${validatedConfig.errors?.join(", ")}`,
+        );
         pushPluginLoadError(`invalid config: ${validatedConfig.errors?.join(", ")}`);
         continue;
       }


### PR DESCRIPTION
## Summary

- Problem: non-activating plugin loads were validating `entry?.config` even when that preflight or CLI path had not materialized plugin config yet, which produced false-positive `invalid config` errors for otherwise healthy plugins.
- Why it matters: the error shows up in `gateway.err.log` and on CLI subcommands, which makes real plugin failures harder to spot and sends users debugging valid config.
- What changed: non-activating loads now skip schema validation when plugin config is still `undefined`, while real activation paths and non-activating loads with explicit config still validate as before. Added focused regression coverage for manifest-only snapshot loads and CLI metadata capture.
- What did NOT change (scope boundary): this does not relax validation for real plugin activation, change plugin config schemas, or alter plugin runtime behavior once config is actually present.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70658
- Related #64946
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the plugin loader always ran `validatePluginConfig` before checking whether the current load was a real activation or a metadata/preflight path. In those non-activating paths, some plugins can be discovered before `plugins.entries.<id>.config` exists, so AJV validated `undefined` as `{}` and reported missing required root fields.
- Missing detection / guardrail: there was no branch that treated `undefined` config as "not materialized yet" for snapshot and CLI metadata loads.
- Contributing context (if known): the same validator is reused across activation, snapshot, and CLI metadata paths, so the false positive only showed up when a non-activating path reached a strict plugin schema first.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugins/loader.test.ts`, `src/plugins/loader.cli-metadata.test.ts`
- Scenario the test should lock in: non-activating snapshot and CLI metadata loads should not fail plugin discovery when a strict config schema exists but plugin config is still `undefined`.
- Why this is the smallest reliable guardrail: the regression happens entirely inside loader branching, so focused loader tests exercise the real decision point without needing gateway or CLI end-to-end setup.
- Existing test that already covers this (if any): `passes validated plugin config into non-activating CLI metadata loads` already covers the explicit-config side of this branch.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

CLI preflight and metadata paths stop emitting false `invalid config` errors for plugins whose real runtime config is valid but has not been materialized in that path yet.

## Diagram (if applicable)

```text
Before:
[snapshot or CLI metadata load] -> [config is undefined] -> [AJV validates {}] -> [false invalid config error]

After:
[snapshot or CLI metadata load] -> [config is undefined] -> [defer validation] -> [plugin metadata loads cleanly]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js repo test runner
- Model/provider: N/A
- Integration/channel (if any): external plugins with strict top-level `configSchema.required`
- Relevant config (redacted): plugin allowed and discoverable, but non-activating load path does not provide `plugins.entries.<id>.config`

### Steps

1. Install or discover a plugin whose manifest has a strict top-level required config field.
2. Trigger a non-activating plugin load path such as CLI metadata capture or a manifest-only snapshot while the plugin config for that path is still undefined.
3. Observe loader behavior before and after this change.

### Expected

- Non-activating loads should defer validation until real config exists and should not emit a false `invalid config` error.

### Actual

- Before this change, the loader validated `undefined` as an empty object and reported missing required properties.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: ran `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/plugins/loader.test.ts src/plugins/loader.cli-metadata.test.ts` and confirmed the focused loader tests pass with the new regression coverage.
- Edge cases checked: explicit-config non-activating validation is still covered by the existing CLI metadata test; real activation still keeps validation because the guard only skips `undefined` config on non-activating loads.
- What you did **not** verify: I did not reproduce against a live external plugin package or run the full plugin test suite.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a non-activating path could now tolerate an undefined config for a plugin that would still fail once actually activated.
  - Mitigation: real activation paths still validate, and non-activating paths continue validating whenever explicit config is present.
