### PR TITLE
fix(cli-runner): make claude-cli stdout buffer limit configurable (#70766)

### DIFF
--- a/src/agents/cli-runner/claude-live-session.ts
+++ b/src/agents/cli-runner/claude-live-session.ts
@@ -53,7 +53,25 @@ type ClaudeLiveRunResult = {
 
 const CLAUDE_LIVE_IDLE_TIMEOUT_MS = 10 * 60 * 1_000;
 const CLAUDE_LIVE_MAX_SESSIONS = 16;
-const CLAUDE_LIVE_MAX_STDOUT_BUFFER_CHARS = 256 * 1024;
+
+// Extended-thinking turns on Opus 4.7 (high/xhigh/max) can emit single
+// stream-json lines well above the prior 256KB default, so allow operators
+// to raise the ceiling via OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES. Negative
+// or non-numeric values fall back to the default.
+const CLAUDE_LIVE_DEFAULT_MAX_STDOUT_BUFFER_CHARS = 256 * 1024;
+const CLAUDE_LIVE_MAX_STDOUT_BUFFER_CHARS = resolveClaudeLiveMaxStdoutBufferChars();
+
+function resolveClaudeLiveMaxStdoutBufferChars(): number {
+  const raw = process.env.OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES;
+  if (raw === undefined || raw === "") {
+    return CLAUDE_LIVE_DEFAULT_MAX_STDOUT_BUFFER_CHARS;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return CLAUDE_LIVE_DEFAULT_MAX_STDOUT_BUFFER_CHARS;
+  }
+  return parsed;
+}
 const CLAUDE_LIVE_MAX_STDERR_CHARS = 64 * 1024;
 const CLAUDE_LIVE_MAX_TURN_RAW_CHARS = 2 * 1024 * 1024;
 const CLAUDE_LIVE_MAX_TURN_LINES = 5_000;
@@ -419,7 +437,10 @@ function parseClaudeLiveJsonLine(
     closeLiveSession(
       session,
       "abort",
-      createOutputLimitError(session, "Claude CLI JSONL line exceeded output limit."),
+      createOutputLimitError(
+        session,
+        `Claude CLI JSONL line exceeded output limit (${trimmed.length} > ${CLAUDE_LIVE_MAX_STDOUT_BUFFER_CHARS} chars; raise OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES to adjust).`,
+      ),
     );
     return null;
   }
@@ -517,7 +538,10 @@ function handleClaudeStdout(session: ClaudeLiveSession, chunk: string) {
     closeLiveSession(
       session,
       "abort",
-      createOutputLimitError(session, "Claude CLI stdout buffer exceeded limit."),
+      createOutputLimitError(
+        session,
+        `Claude CLI stdout buffer exceeded limit (${session.stdoutBuffer.length} > ${CLAUDE_LIVE_MAX_STDOUT_BUFFER_CHARS} chars; raise OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES to adjust).`,
+      ),
     );
     return;
   }


### PR DESCRIPTION
## Summary

Closes #70766.

When a claude-cli turn on `claude-opus-4-7` with high/xhigh/max thinking emits a single stream-json line above the hard-coded 256KB ceiling, `handleClaudeStdout` / `parseClaudeLiveJsonLine` abort the live session with `Claude CLI stdout buffer exceeded limit.` and fall back to the next configured model. Users see inconsistent voice / model + perceived timeouts.

## Change

- Introduce `OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES` env var. Values are parsed via `Number.parseInt(..., 10)`:
  - unset / empty / non-numeric / zero / negative → **default 256KB** (current behavior, fully backward-compatible)
  - positive integer → that many characters
- Include the actual line/buffer length and current limit in both abort messages so operators can see how much headroom they need.

Single file, ~25 lines net.

## Test plan

- `pnpm oxlint src/agents/cli-runner/claude-live-session.ts` → 0 warnings, 0 errors
- Manual: set `OPENCLAW_CLAUDE_CLI_MAX_STDOUT_BYTES=4194304` (4MB), restart gateway, re-run previously aborting turn → no abort. Unset or set to `0` / `"abc"` → falls back to 256KB default (no behavior change).

## Out of scope

- Exposing this via `openclaw.json` (`agents.defaults.runners.claude-cli.maxStdoutBufferChars`) — deferred; env var alone is enough to unblock operators today.
- Raising the default — kept at 256KB to stay zero-surprise. Once the bundled runtime `execute.runtime-*.js` lands the same knob, the default can be bumped in a follow-up.