### PR TITLE
fix(acpx): coerce non-string doctor details to avoid "[object Object]" in probe logs (#70825)

### DIFF
--- a/extensions/acpx/src/service.ts
+++ b/extensions/acpx/src/service.ts
@@ -26,7 +26,9 @@ type AcpxRuntimeLike = AcpRuntime & {
   doctor?(): Promise<{
     ok: boolean;
     message: string;
-    details?: string[];
+    // Upstream acpx doctor may include Error instances and plain objects
+    // alongside strings; treat everything as unknown and coerce on read.
+    details?: ReadonlyArray<unknown>;
   }>;
 };
 
@@ -79,8 +81,30 @@ function warnOnIgnoredLegacyCompatibilityConfig(params: {
   );
 }
 
-function formatDoctorFailureMessage(report: { message: string; details?: string[] }): string {
-  const detailText = report.details?.filter(Boolean).join("; ").trim();
+function coerceDoctorDetailToString(detail: unknown): string {
+  if (typeof detail === "string") {
+    return detail;
+  }
+  if (detail instanceof Error) {
+    return detail.message;
+  }
+  try {
+    return JSON.stringify(detail);
+  } catch {
+    return String(detail);
+  }
+}
+
+function formatDoctorFailureMessage(report: {
+  message: string;
+  details?: ReadonlyArray<unknown>;
+}): string {
+  const detailText = report.details
+    ?.filter((entry) => entry !== null && entry !== undefined && entry !== "")
+    .map(coerceDoctorDetailToString)
+    .filter((entry) => entry.length > 0)
+    .join("; ")
+    .trim();
   return detailText ? `${report.message} (${detailText})` : report.message;
 }
 


### PR DESCRIPTION
## Summary

Closes #70825.

`formatDoctorFailureMessage` in `extensions/acpx/src/service.ts` assumed `report.details` was `string[]`, but the upstream `acpx` `doctor()` can include `Error` instances and plain objects. `Array.prototype.join` then stringified them as the literal `[object Object]`, leaving operators with log lines like:

> embedded acpx runtime backend probe failed: embedded ACP runtime probe failed (agent=codex; command='…'; cwd=…; [object Object])

— no actionable signal for debugging ACP runtime issues.

## Change

- Widen the local `doctor()` return type to `details?: ReadonlyArray<unknown>` so the shape matches what upstream actually emits.
- Add `coerceDoctorDetailToString` — strings pass through, `Error` → `.message`, everything else → `JSON.stringify` (falling back to `String(x)` on circular structures).
- Drop empty-string entries after coercion so output stays the same for the well-behaved case.

Single file, single function plus a small helper; no behavior change when upstream hands us well-typed strings.

## Out of scope

Fixing upstream `acpx`'s `doctor()` to actually return `string[]` — that's part 2 in the reporter's suggested fix and lives in a different repo. This PR defensively unblocks diagnosis today.

## Test plan

- `pnpm oxlint extensions/acpx/src/service.ts` → 0 warnings, 0 errors
- Manual: seed `doctor()` with `details: ["agent=codex", new Error("spawn ENOENT"), { code: 42, hint: "install" }]` → log becomes `embedded acpx runtime backend probe failed: … (agent=codex; spawn ENOENT; {\"code\":42,\"hint\":\"install\"})` instead of `…; [object Object]; [object Object]`.