### PR TITLE
fix(ui): hide internal sessions from the chat picker

### DIFF
--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -406,6 +406,37 @@ describe("isCronSessionKey", () => {
 });
 
 describe("resolveSessionOptionGroups", () => {
+  it("hides subagent, acp, and node-backed sessions from the picker by default", () => {
+    const labels = labelsForSessionOptions({
+      sessionKey: "agent:main:main",
+      sessions: [
+        row({ key: "agent:main:main", label: "main" }),
+        row({ key: "agent:main:subagent:child", label: "child task" }),
+        row({ key: "agent:codex:acp:session-1", label: "codex session" }),
+        row({ key: "agent:main:node-node-2", label: "node event lane" }),
+      ],
+    });
+
+    expect(labels).toContain("main");
+    expect(labels).not.toContain("Subagent: child task");
+    expect(labels).not.toContain("codex session");
+    expect(labels).not.toContain("node event lane");
+  });
+
+  it("keeps the active internal session visible when it is currently selected", () => {
+    const labels = labelsForSessionOptions({
+      sessionKey: "agent:main:subagent:child",
+      sessions: [
+        row({ key: "agent:main:main", label: "main" }),
+        row({ key: "agent:main:subagent:child", label: "child task" }),
+        row({ key: "agent:codex:acp:session-1", label: "codex session" }),
+      ],
+    });
+
+    expect(labels).toContain("Subagent: child task");
+    expect(labels).not.toContain("codex session");
+  });
+
   it("prefers grouped session labels over display names", () => {
     const sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
     const labels = labelsForSessionOptions({

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -431,6 +431,38 @@ export function isCronSessionKey(key: string): boolean {
   return rest.startsWith("cron:");
 }
 
+function isInternalSessionKey(key: string): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(key);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.includes(":subagent:")) {
+    return true;
+  }
+  if (normalized.includes(":acp:")) {
+    return true;
+  }
+  if (!normalized.startsWith("agent:")) {
+    return normalized.startsWith("node-");
+  }
+  const parts = normalized.split(":").filter(Boolean);
+  if (parts.length < 3) {
+    return false;
+  }
+  const rest = parts.slice(2).join(":");
+  return rest.startsWith("node-");
+}
+
+function isInternalSessionOption(
+  key: string,
+  row?: SessionsListResult["sessions"][number],
+): boolean {
+  if (isInternalSessionKey(key)) {
+    return true;
+  }
+  return typeof row?.spawnDepth === "number" && row.spawnDepth > 0;
+}
+
 type SessionOptionEntry = {
   key: string;
   label: string;
@@ -500,6 +532,9 @@ export function resolveSessionOptionGroups(
       continue;
     }
     if (hideCron && row.key !== sessionKey && isCronSessionKey(row.key)) {
+      continue;
+    }
+    if (row.key !== sessionKey && isInternalSessionOption(row.key, row)) {
       continue;
     }
     addOption(row.key);

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -399,6 +399,7 @@ export type SessionCompactionCheckpoint = {
 export type GatewaySessionRow = {
   key: string;
   spawnedBy?: string;
+  spawnDepth?: number;
   kind: "direct" | "group" | "global" | "unknown";
   label?: string;
   displayName?: string;


### PR DESCRIPTION
## Summary
- hide internal subagent, ACP, and node-backed sessions from the chat header session picker
- keep the currently selected internal session visible so active internal runs don't strand the UI
- add picker coverage for hidden internal sessions and the active-session exception

## Why
The webchat session picker was surfacing internal runtime lanes (subagent/Codex/ACP/node-backed sessions) as if they were normal durable chat sessions. This makes the picker noisy very quickly during normal delegated-agent use.

## Review boundary / minimal acceptable fix
This PR is best treated as a **bounded UI-side mitigation**, not the full product fix.

The root issue is a **visibility/classification contract bug**, not just picker clutter:
- gateway enumeration is currently too broad
- internal/runtime rows are not explicitly classified as internal
- the UI picker is therefore downstream of mixed session truth

**Minimal acceptable end-state:**
1. gateway/session source marks subagent/ACP/internal execution sessions as `visibility=internal` (or equivalent explicit internal classification)
2. normal chat/session picker hides `visibility=internal` by default
3. admin/debug Sessions view can still request/show internals explicitly

## What must not ship as the final answer
- manual row pruning as the primary fix
- UI-only filtering presented as sufficient final resolution
- heuristic string-match hiding without source classification
- a fix that removes internal visibility from admin/debug surfaces entirely

## Verification
- direct tsx harness import of `resolveSessionOptionGroups(...)`
  - default labels: `["main"]` when subagent / ACP / node-backed rows are present
  - active internal labels: `["main","Subagent: child task"]` when the selected session is internal
- added focused node tests in `ui/src/ui/app-render.helpers.node.test.ts`

## Notes
This PR can still be valuable as defense-in-depth or an interim mitigation, but the clean product fix remains:
- **gateway classification first**
- **picker default filtering second**

Internal reference:
- `docs/ops/OPENCLAW_SESSION_PICKER_INTERNAL_SESSION_POLLUTION_UPSTREAM_REVIEW_NOTE_2026-04-24.md`
