### PR TITLE
fix(venice): add kimi-k2-6 and qwen-3-6-plus to static catalog (#70827)

### DIFF
--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -113,6 +113,15 @@ export const VENICE_MODEL_CATALOG = [
     privacy: "private",
   },
   {
+    id: "qwen-3-6-plus",
+    name: "Qwen 3.6 Plus",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 65536,
+    privacy: "private",
+  },
+  {
     id: "qwen3-next-80b",
     name: "Qwen3 Next 80B",
     reasoning: false,
@@ -243,6 +252,15 @@ export const VENICE_MODEL_CATALOG = [
   {
     id: "kimi-k2-5",
     name: "Kimi K2.5",
+    reasoning: true,
+    input: ["text", "image"],
+    contextWindow: 256000,
+    maxTokens: 65536,
+    privacy: "private",
+  },
+  {
+    id: "kimi-k2-6",
+    name: "Kimi K2.6",
     reasoning: true,
     input: ["text", "image"],
     contextWindow: 256000,


### PR DESCRIPTION
## Summary

Closes #70827.

Venice's live \`/models\` endpoint advertises \`kimi-k2-6\` and \`qwen-3-6-plus\`, but \`extensions/venice/models.ts\` still stops at \`kimi-k2-5\` / \`qwen3-5-35b-a3b\`. Sessions trying to switch to the newer IDs are rejected before provider dispatch with:

> Model \"venice/kimi-k2-6\" is not allowed

## Change

Two catalog entries added next to their closest siblings, reusing the same context/maxTokens shape as \`kimi-k2-5\` and \`qwen3-5-35b-a3b\`:
- \`kimi-k2-6\` (Kimi K2.6): reasoning, text+image, 256k ctx, 65k max
- \`qwen-3-6-plus\` (Qwen 3.6 Plus): reasoning, text+image, 256k ctx, 65k max

Data-only. The \`discoverVeniceModels\` path already merges any further API-only additions, so follow-on Venice releases don't need catalog edits to be usable — but the allowed-model check that runs before discovery-merge for these specific IDs now passes.

## Test plan

- \`pnpm oxlint extensions/venice/models.ts\` → 0 warnings, 0 errors
- Manual: after update, \`session_status({ model: \"venice/kimi-k2-6\" })\` no longer returns \`Model \"venice/kimi-k2-6\" is not allowed\`.