### PR TITLE
fix(bundle-mcp): coerce stringified object/array params before MCP tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- MCP/bundle: coerce stringified object/array params before MCP tool calls, with JSON Schema array-form type support and prototype-pollution + oversized-payload guards. ([#70882](https://github.com/openclaw/openclaw/pull/70882))
 - Gateway/WebChat: preserve image attachments for text-only primary models by offloading them as media refs instead of dropping them, so configured image tools can still inspect the original file. Fixes #68513, #44276, #51656, #70212.
 - Plugins/Google Meet: hang up delegated Twilio calls on leave, clean up Chrome realtime audio bridges when launch fails, and use a flat provider-safe tool schema.
 - Media understanding: honor explicit image-model configuration before native-vision skips, including `agents.defaults.imageModel`, `tools.media.image.models`, and provider image defaults such as MiniMax VL when the active chat model is text-only. Fixes #47614, #63722, #69171.

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { logWarn } from "../logger.js";
 import { setPluginToolMeta } from "../plugins/tools.js";
@@ -12,6 +13,65 @@ import {
 } from "./pi-bundle-mcp-names.js";
 import type { BundleMcpToolRuntime, SessionMcpRuntime } from "./pi-bundle-mcp-types.js";
 import type { AnyAgentTool } from "./tools/common.js";
+
+/**
+ * Coerce stringified JSON values back to objects/arrays when the inputSchema
+ * declares the property as `type: "object"` or `type: "array"`.  LLMs sometimes
+ * serialize nested parameters as JSON strings (e.g. `"params": "{}"` instead of
+ * `"params": {}`).  Strict MCP servers (Pydantic-backed) reject the string form,
+ * causing "params: must be object" validation errors.
+ *
+ * Fixes https://github.com/openclaw/openclaw/issues/70872
+ */
+function coerceStringifiedObjectProperties(input: unknown, schema: TSchema | undefined): unknown {
+  // Nothing to coerce when input is not a record.
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    return input;
+  }
+
+  const properties: Record<string, TSchema> | undefined =
+    schema && typeof schema === "object" && !Array.isArray(schema)
+      ? ((schema as Record<string, unknown>).properties as Record<string, TSchema> | undefined)
+      : undefined;
+
+  if (!properties) {
+    return input;
+  }
+
+  const record = input as Record<string, unknown>;
+  let mutated = false;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(record)) {
+    const propSchema = properties[key] as Record<string, unknown> | undefined;
+    if (
+      typeof value === "string" &&
+      propSchema &&
+      typeof propSchema.type === "string" &&
+      (propSchema.type === "object" || propSchema.type === "array")
+    ) {
+      try {
+        const parsed = JSON.parse(value);
+        if (
+          (propSchema.type === "object" &&
+            parsed !== null &&
+            typeof parsed === "object" &&
+            !Array.isArray(parsed)) ||
+          (propSchema.type === "array" && Array.isArray(parsed))
+        ) {
+          result[key] = parsed;
+          mutated = true;
+          continue;
+        }
+      } catch {
+        // Not valid JSON — pass through as-is.
+      }
+    }
+    result[key] = value;
+  }
+
+  return mutated ? result : input;
+}
 
 function toAgentToolResult(params: {
   serverName: string;
@@ -104,7 +164,8 @@ export async function materializeBundleMcpToolsForRun(params: {
       description: tool.description || tool.fallbackDescription,
       parameters: tool.inputSchema,
       execute: async (_toolCallId: string, input: unknown) => {
-        const result = await params.runtime.callTool(tool.serverName, tool.toolName, input);
+        const coercedInput = coerceStringifiedObjectProperties(input, tool.inputSchema);
+        const result = await params.runtime.callTool(tool.serverName, tool.toolName, coercedInput);
         return toAgentToolResult({
           serverName: tool.serverName,
           toolName: tool.toolName,

--- a/src/agents/pi-bundle-mcp-materialize.ts
+++ b/src/agents/pi-bundle-mcp-materialize.ts
@@ -40,24 +40,42 @@ function coerceStringifiedObjectProperties(input: unknown, schema: TSchema | und
 
   const record = input as Record<string, unknown>;
   let mutated = false;
-  const result: Record<string, unknown> = {};
+  // Use a null-prototype object to avoid prototype pollution if input keys
+  // include `__proto__`, `constructor`, etc.
+  const result: Record<string, unknown> = Object.create(null) as Record<string, unknown>;
 
   for (const [key, value] of Object.entries(record)) {
+    // Defense-in-depth: skip keys that could be used for prototype pollution
+    // even though Object.create(null) already neutralizes the common vector.
+    if (key === "__proto__" || key === "prototype" || key === "constructor") {
+      continue;
+    }
     const propSchema = properties[key] as Record<string, unknown> | undefined;
+    const schemaTypeAcceptsObject =
+      propSchema &&
+      (typeof propSchema.type === "string"
+        ? propSchema.type === "object" || propSchema.type === "array"
+        : Array.isArray(propSchema.type) &&
+          (propSchema.type.includes("object") || propSchema.type.includes("array")));
     if (
       typeof value === "string" &&
-      propSchema &&
-      typeof propSchema.type === "string" &&
-      (propSchema.type === "object" || propSchema.type === "array")
+      // arbitrary safety bound: skip parsing very large strings to avoid
+      // unbounded JSON.parse work on hostile/oversized payloads.
+      value.length <= 1_048_576 &&
+      schemaTypeAcceptsObject
     ) {
+      const accepts = (t: string): boolean =>
+        typeof propSchema!.type === "string"
+          ? propSchema!.type === t
+          : Array.isArray(propSchema!.type) && (propSchema!.type as unknown[]).includes(t);
       try {
         const parsed = JSON.parse(value);
         if (
-          (propSchema.type === "object" &&
+          (accepts("object") &&
             parsed !== null &&
             typeof parsed === "object" &&
             !Array.isArray(parsed)) ||
-          (propSchema.type === "array" && Array.isArray(parsed))
+          (accepts("array") && Array.isArray(parsed))
         ) {
           result[key] = parsed;
           mutated = true;

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -171,4 +171,116 @@ describe("createBundleMcpToolRuntime", () => {
       "multi__zeta",
     ]);
   });
+
+  it("coerces stringified object params to objects before calling MCP server (issue #70872)", async () => {
+    let capturedInput: unknown;
+    const runtime: SessionMcpRuntime = {
+      sessionId: "session-coerce",
+      workspaceDir: "/tmp",
+      configFingerprint: "fingerprint",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          synology: {
+            serverName: "synology",
+            launchSummary: "synology",
+            toolCount: 1,
+          },
+        },
+        tools: [
+          {
+            serverName: "synology",
+            safeServerName: "synology",
+            toolName: "test_connection",
+            description: "Test connection",
+            inputSchema: {
+              type: "object",
+              properties: {
+                params: { type: "object" },
+                tags: { type: "array" },
+                name: { type: "string" },
+              },
+            },
+            fallbackDescription: "Test connection",
+          },
+        ],
+      }),
+      callTool: async (_serverName, _toolName, input) => {
+        capturedInput = input;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        };
+      },
+      dispose: async () => {},
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const tool = materialized.tools[0];
+
+    // Simulate LLM sending stringified object/array values
+    await tool.execute("call-1", { params: "{}", tags: '["a","b"]', name: "hello" });
+
+    // params should be coerced from string "{}" to object {}
+    // tags should be coerced from string '["a","b"]' to array ["a","b"]
+    // name should remain a string
+    expect(capturedInput).toEqual({ params: {}, tags: ["a", "b"], name: "hello" });
+  });
+
+  it("leaves params unchanged when they are already objects (issue #70872)", async () => {
+    let capturedInput: unknown;
+    const runtime: SessionMcpRuntime = {
+      sessionId: "session-coerce-noop",
+      workspaceDir: "/tmp",
+      configFingerprint: "fingerprint",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          synology: {
+            serverName: "synology",
+            launchSummary: "synology",
+            toolCount: 1,
+          },
+        },
+        tools: [
+          {
+            serverName: "synology",
+            safeServerName: "synology",
+            toolName: "test_connection",
+            description: "Test connection",
+            inputSchema: {
+              type: "object",
+              properties: {
+                params: { type: "object" },
+              },
+            },
+            fallbackDescription: "Test connection",
+          },
+        ],
+      }),
+      callTool: async (_serverName, _toolName, input) => {
+        capturedInput = input;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        };
+      },
+      dispose: async () => {},
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const tool = materialized.tools[0];
+
+    // Already correct object — should pass through unchanged
+    await tool.execute("call-2", { params: { key: "value" } });
+    expect(capturedInput).toEqual({ params: { key: "value" } });
+  });
 });

--- a/src/agents/pi-bundle-mcp-tools.materialize.test.ts
+++ b/src/agents/pi-bundle-mcp-tools.materialize.test.ts
@@ -283,4 +283,183 @@ describe("createBundleMcpToolRuntime", () => {
     await tool.execute("call-2", { params: { key: "value" } });
     expect(capturedInput).toEqual({ params: { key: "value" } });
   });
+
+  it("coerces stringified params when schema declares array-form `type` (issue #70872)", async () => {
+    let capturedInput: unknown;
+    const runtime: SessionMcpRuntime = {
+      sessionId: "session-coerce-array-type",
+      workspaceDir: "/tmp",
+      configFingerprint: "fingerprint",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          synology: {
+            serverName: "synology",
+            launchSummary: "synology",
+            toolCount: 1,
+          },
+        },
+        tools: [
+          {
+            serverName: "synology",
+            safeServerName: "synology",
+            toolName: "test_connection",
+            description: "Test connection",
+            inputSchema: {
+              type: "object",
+              properties: {
+                params: { type: ["object", "null"] },
+                tags: { type: ["array", "null"] },
+              },
+            },
+            fallbackDescription: "Test connection",
+          },
+        ],
+      }),
+      callTool: async (_serverName, _toolName, input) => {
+        capturedInput = input;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        };
+      },
+      dispose: async () => {},
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const tool = materialized.tools[0];
+
+    await tool.execute("call-array-type", { params: "{}", tags: '["a"]' });
+    expect(capturedInput).toEqual({ params: {}, tags: ["a"] });
+  });
+
+  it("does not pollute prototypes when input contains __proto__ key", async () => {
+    let capturedInput: unknown;
+    const runtime: SessionMcpRuntime = {
+      sessionId: "session-coerce-proto",
+      workspaceDir: "/tmp",
+      configFingerprint: "fingerprint",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          synology: {
+            serverName: "synology",
+            launchSummary: "synology",
+            toolCount: 1,
+          },
+        },
+        tools: [
+          {
+            serverName: "synology",
+            safeServerName: "synology",
+            toolName: "test_connection",
+            description: "Test connection",
+            inputSchema: {
+              type: "object",
+              properties: {
+                params: { type: "object" },
+              },
+            },
+            fallbackDescription: "Test connection",
+          },
+        ],
+      }),
+      callTool: async (_serverName, _toolName, input) => {
+        capturedInput = input;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        };
+      },
+      dispose: async () => {},
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const tool = materialized.tools[0];
+
+    // Hostile input shaped to surface `__proto__` as an own enumerable key in
+    // `Object.entries`, which is the path the previous `result = {}` code took
+    // through the `__proto__` setter and which Object.create(null) + key skip
+    // now neutralizes.
+    const hostile: Record<string, unknown> = { params: "{}" };
+    Object.defineProperty(hostile, "__proto__", {
+      value: { polluted: true },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    await tool.execute("call-proto", hostile);
+
+    // Result must not carry the polluted prototype value, and Object.prototype
+    // must remain clean for unrelated objects.
+    expect((capturedInput as Record<string, unknown>).polluted).toBeUndefined();
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("leaves oversized stringified params unchanged (>1MB safety bound)", async () => {
+    let capturedInput: unknown;
+    const runtime: SessionMcpRuntime = {
+      sessionId: "session-coerce-oversize",
+      workspaceDir: "/tmp",
+      configFingerprint: "fingerprint",
+      createdAt: 0,
+      lastUsedAt: 0,
+      markUsed: () => {},
+      getCatalog: async () => ({
+        version: 1,
+        generatedAt: 0,
+        servers: {
+          synology: {
+            serverName: "synology",
+            launchSummary: "synology",
+            toolCount: 1,
+          },
+        },
+        tools: [
+          {
+            serverName: "synology",
+            safeServerName: "synology",
+            toolName: "test_connection",
+            description: "Test connection",
+            inputSchema: {
+              type: "object",
+              properties: {
+                params: { type: "object" },
+              },
+            },
+            fallbackDescription: "Test connection",
+          },
+        ],
+      }),
+      callTool: async (_serverName, _toolName, input) => {
+        capturedInput = input;
+        return {
+          content: [{ type: "text", text: "ok" }],
+          isError: false,
+        };
+      },
+      dispose: async () => {},
+    };
+
+    const materialized = await materializeBundleMcpToolsForRun({ runtime });
+    const tool = materialized.tools[0];
+
+    // Build a syntactically valid JSON object string longer than 1 MiB; if the
+    // size guard didn't apply we'd still get a parsed object, so the assertion
+    // below proves the parse was skipped.
+    const filler = "a".repeat(1_048_577);
+    const oversized = `{"k":"${filler}"}`;
+    expect(oversized.length).toBeGreaterThan(1_048_576);
+
+    await tool.execute("call-oversize", { params: oversized });
+    expect(capturedInput).toEqual({ params: oversized });
+  });
 });


### PR DESCRIPTION
## Summary

LLMs sometimes serialize nested tool parameters as JSON strings (e.g. `"params": "{}"` instead of `"params": {}`). Strict MCP servers with Pydantic validation reject the string form, causing `params: must be object` validation errors.

This adds `coerceStringifiedObjectProperties()` in the MCP tool materialize layer (`pi-bundle-mcp-materialize.ts`) that checks each property's `inputSchema` type and `JSON.parse()`s string values back to objects/arrays when the schema expects them.

## Root Cause

When OpenClaw's native MCP adapter passes tool call arguments to stdio MCP servers, properties declared as `type: "object"` or `type: "array"` in the tool's `inputSchema` may arrive as stringified JSON from the LLM. The MCP server's Pydantic validation rejects `"params": "{}"` when it expects `"params": {}`.

## Fix

- Added `coerceStringifiedObjectProperties()` that iterates over input record entries
- For each property, checks the corresponding `inputSchema` property type
- If the schema expects `object`/`array` and the value is a valid JSON string encoding one, parse it back
- Non-matching values pass through unchanged (safe, no-op for already-correct inputs)

## Testing

- Added 2 new tests to `pi-bundle-mcp-tools.materialize.test.ts`:
  - Verifies stringified `{}` and `[]` are coerced to proper objects/arrays
  - Verifies already-correct object params pass through unchanged
- All 6 tests pass ✅

## Impact

Fixes all MCP servers that use `type: "object"` params with strict validation (Pydantic, Zod, etc.), not just Synology.

Fixes #70872