### PR TITLE
fix: restore explicit requester depth lookup without cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -841,6 +841,7 @@ Docs: https://docs.openclaw.ai
 - Exec approvals: omit generated command highlights for non-POSIX Windows and shell-wrapper approval commands until those command languages have native highlighting support. (#80566) Thanks @jesse-merhi.
 - Telegram: keep verbose tool progress and result drafts separate from the final assistant answer so tool output no longer blends into the final Telegram message. (#80294) Thanks @jalehman.
 - Plugin SDK/Windows: enable the native require fast path for root `openclaw/plugin-sdk` dist aliases instead of forcing Jiti transforms. (#80878) Thanks @medns.
+- Agents/subagents: read persisted explicit requester session depth from the default session store when no config is supplied, so announce delivery keeps those requester sessions on the internal path instead of misrouting them as external. (#70888)
 - Agents/compaction: keep the recent tail after manual `/compact` when Pi returns an empty or no-op compaction summary, preventing blank checkpoints from replacing the live context.
 - Native commands: handle slash commands before workspace and agent-reply bootstrap so Telegram `/status` and other command-only native replies do not wait behind full agent turn setup.
 - Telegram/groups: include the recent local chat window and nearby reply-target window as generic inbound context so stale reply ancestry does not overshadow the live group conversation.

--- a/src/agents/subagent-announce-delivery.test.ts
+++ b/src/agents/subagent-announce-delivery.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __testing as sessionBindingServiceTesting,
@@ -11,6 +14,7 @@ import type {
 import {
   __testing,
   deliverSubagentAnnouncement,
+  isInternalAnnounceRequesterSession,
   resolveSubagentCompletionOrigin,
 } from "./subagent-announce-delivery.js";
 import {
@@ -20,9 +24,21 @@ import {
 } from "./subagent-announce-delivery.runtime.js";
 import { resolveAnnounceOrigin } from "./subagent-announce-origin.js";
 
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
 afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
   sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
   __testing.setDepsForTest();
+  vi.unstubAllEnvs();
 });
 
 const slackThreadOrigin = {
@@ -303,6 +319,44 @@ async function deliverSlackChannelAnnouncement(params: {
     sourceTool: params.sourceTool,
   });
 }
+
+describe("isInternalAnnounceRequesterSession", () => {
+  it("treats explicit requester sessions with persisted spawnDepth as internal", () => {
+    const stateDir = createTempDir("openclaw-explicit-requester-session-state-");
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const key = "agent:main:explicit:new-skills-zoom-panel-20260423a:acct:default";
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          [key]: {
+            sessionId: "new-skills-zoom-panel-20260423a",
+            spawnDepth: 1,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    expect(isInternalAnnounceRequesterSession(key)).toBe(true);
+  });
+
+  it("treats explicit requester sessions without persisted metadata as external", () => {
+    const stateDir = createTempDir("openclaw-explicit-requester-session-empty-state-");
+    const key = "agent:main:explicit:new-skills-zoom-panel-20260423a:acct:default";
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    expect(isInternalAnnounceRequesterSession(key)).toBe(false);
+  });
+
+  it("still treats cron requester sessions as internal", () => {
+    expect(isInternalAnnounceRequesterSession("agent:main:cron:nightly-sync")).toBe(true);
+  });
+});
 
 describe("resolveAnnounceOrigin threaded route targets", () => {
   it("preserves stored thread ids when requester origin omits one for the same chat", () => {

--- a/src/agents/subagent-depth.test.ts
+++ b/src/agents/subagent-depth.test.ts
@@ -1,9 +1,24 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { resolveAgentTimeoutMs, resolveAgentTimeoutSeconds } from "./timeout.js";
+
+const tempDirs: string[] = [];
+
+function createTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  vi.unstubAllEnvs();
+});
 
 describe("getSubagentDepthFromSessionStore", () => {
   it("uses spawnDepth from the session store when available", () => {
@@ -45,7 +60,7 @@ describe("getSubagentDepthFromSessionStore", () => {
   });
 
   it("resolves prefixed store keys when caller key omits the agent prefix", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-subagent-depth-"));
+    const tmpDir = createTempDir("openclaw-subagent-depth-");
     const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
     const prefixedKey = "agent:main:subagent:flat";
     const storePath = storeTemplate.replaceAll("{agentId}", "main");
@@ -77,7 +92,7 @@ describe("getSubagentDepthFromSessionStore", () => {
   });
 
   it("accepts JSON5 syntax in the on-disk depth store for backward compatibility", () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-subagent-depth-json5-"));
+    const tmpDir = createTempDir("openclaw-subagent-depth-json5-");
     const storeTemplate = path.join(tmpDir, "sessions-{agentId}.json");
     const storePath = storeTemplate.replaceAll("{agentId}", "main");
     fs.writeFileSync(
@@ -111,6 +126,72 @@ describe("getSubagentDepthFromSessionStore", () => {
       },
     });
     expect(depth).toBe(1);
+  });
+
+  it("falls back to session-key segment counting when the default store file is absent", () => {
+    const stateDir = createTempDir("openclaw-subagent-depth-missing-default-store-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const depth = getSubagentDepthFromSessionStore("agent:main:subagent:orphan");
+
+    expect(depth).toBe(1);
+  });
+
+  it("uses the default on-disk session store for explicit agent keys when cfg is omitted", () => {
+    const stateDir = createTempDir("openclaw-subagent-depth-default-state-");
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const key = "agent:main:explicit:new-skills-zoom-panel-20260423a:acct:default";
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          [key]: {
+            sessionId: "new-skills-zoom-panel-20260423a",
+            spawnDepth: 1,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const depth = getSubagentDepthFromSessionStore(key);
+
+    expect(depth).toBe(1);
+  });
+
+  it("derives spawnedBy ancestry from the default on-disk session store when cfg is omitted", () => {
+    const stateDir = createTempDir("openclaw-subagent-depth-default-ancestry-");
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const parentKey = "agent:main:subagent:panel-parent";
+    const key = "agent:main:explicit:new-skills-zoom-panel-20260423a:acct:default";
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify(
+        {
+          [parentKey]: {
+            sessionId: "panel-parent",
+            spawnedBy: "agent:main:main",
+          },
+          [key]: {
+            sessionId: "new-skills-zoom-panel-20260423a",
+            spawnedBy: parentKey,
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+
+    const depth = getSubagentDepthFromSessionStore(key);
+
+    expect(depth).toBe(2);
   });
 });
 

--- a/src/agents/subagent-depth.ts
+++ b/src/agents/subagent-depth.ts
@@ -90,16 +90,12 @@ function resolveEntryForSessionKey(params: {
     return findEntryBySessionId(params.store, params.sessionKey);
   }
 
-  if (!params.cfg) {
-    return undefined;
-  }
-
   for (const key of candidates) {
     const parsed = parseAgentSessionKey(key);
     if (!parsed?.agentId) {
       continue;
     }
-    const storePath = resolveStorePath(params.cfg.session?.store, { agentId: parsed.agentId });
+    const storePath = resolveStorePath(params.cfg?.session?.store, { agentId: parsed.agentId });
     let store = params.cache.get(storePath);
     if (!store) {
       store = readSessionStore(storePath);


### PR DESCRIPTION
Title: fix: restore explicit requester depth lookup without cfg

## Summary

- Problem: persisted `agent:main:explicit:...:acct:default` requester sessions could resolve to depth `0` when `getSubagentDepthFromSessionStore()` was called without `cfg`.
- Why it matters: no-`cfg` announce paths could misclassify those persisted explicit requester sessions as external and attempt delivery without a valid `channel` in multi-channel setups.
- What changed: `resolveEntryForSessionKey()` now preserves the default on-disk session-store lookup when `cfg` is omitted, and regression tests lock in the explicit acct-suffixed session-key shape plus related no-`cfg` fallback behavior.
- Scope boundary: session depth resolution only; no routing or delivery logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `resolveEntryForSessionKey()` returned early when `cfg` was omitted, so persisted explicit requester sessions never reached the default on-disk store lookup and fell back to `:subagent:` segment counting. Explicit requester keys do not include that segment, so the depth resolved to `0` even when the store had persisted metadata.
- Missing detection / guardrail: there was no regression test for explicit acct-suffixed requester keys on a no-`cfg` path.
- Contributing context (if known): the first known manifestation was announce delivery, but the same root cause also affected other no-`cfg` announce call sites that rely on persisted requester depth.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/subagent-depth.test.ts`
  - `src/agents/subagent-announce-delivery.test.ts`
- Scenario the test should lock in:
  - persisted explicit requester depth resolves from on-disk metadata without `cfg`
  - stored `spawnedBy` ancestry still resolves without `cfg`
  - the no-`cfg` path falls back cleanly when the default store file is absent
  - persisted explicit requester sessions classify as internal
  - non-persisted explicit requester sessions stay external
  - cron requester sessions still classify as internal
- Why this is the smallest reliable guardrail: the bug happens before any real channel delivery; the smallest stable check is persisted-session depth resolution plus the internal-requester classification gate.
- Existing test that already covers this (if any): none for this explicit no-`cfg` path.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Persisted explicit child sessions now stay on the internal announce path instead of being misrouted as external deliveries when the session store already records their depth metadata.

## Diagram (if applicable)

```text
Before:
[persisted explicit requester] -> [no-cfg depth lookup] -> [store read skipped] -> [depth 0] -> [treated as external]

After:
[persisted explicit requester] -> [no-cfg depth lookup] -> [default store read] -> [stored depth/ancestry] -> [treated as internal]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (arm64)
- Runtime/container: source clone + isolated Docker `stage-mock`
- Model/provider: N/A
- Integration/channel (if any): announce-delivery logic for multi-channel environments
- Relevant config (redacted): persisted session-store entry for the explicit requester key; multi-channel setup reproducing the original missing-channel failure

### Steps

1. Persist `agent:main:explicit:new-skills-zoom-panel-20260423a:acct:default` in the session store.
2. Exercise `getSubagentDepthFromSessionStore(sessionKey)` from a no-`cfg` path.
3. Check whether the requester resolves from stored metadata or falls back to segment counting.

### Expected

- The persisted explicit requester resolves from the on-disk store and stays on the internal announce path.

### Actual

- Before the fix, the lookup skipped the store and fell back to depth `0`.
- After the fix, the same persisted key resolves from stored metadata and is classified as internal.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence used for this PR:
- targeted tests: `corepack pnpm test -- src/agents/subagent-depth.test.ts src/agents/subagent-announce-delivery.test.ts` → `2 test files passed / 36 tests passed`
- isolated `stage-mock` proof: the same persisted explicit key returned depth `0` in the current image and depth `1` in the patched image under the same clean-baseline setup

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted regression tests pass on the clean PR branch
  - isolated `stage-mock` reproduction shows the current image misresolves the persisted explicit key to depth `0`
  - isolated `stage-mock` patched image resolves the same persisted explicit key to stored depth again
- Edge cases checked:
  - exact acct-suffixed explicit requester key shape
  - no-`cfg` store lookup via direct `spawnDepth`
  - no-`cfg` store lookup via `spawnedBy` ancestry
  - clean fallback when the default store file is absent
  - non-persisted explicit requester keys remain external
  - cron requester sessions remain internal
  - no prod install/package path touched during validation
- What you did **not** verify:
  - a full live Discord/Telegram end-to-end after the code change in `stage-real`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: restoring the default store lookup when `cfg` is omitted also affects other no-`cfg` callers.
  - Mitigation: that is the intended behavior; regression tests now cover direct stored depth, stored ancestry, missing-store fallback, and the announce classification gate for the failing explicit-session shape.
- Risk: reviewers may overread the change as a generic routing fix.
  - Mitigation: the PR body and tests explicitly scope it to persisted explicit requester depth resolution, not routing policy.

## Real behavior proof

- **Behavior or issue addressed**: Explicit requester session keys such as `agent:main:explicit:...:acct:default` should still use persisted session-store metadata when classifying announcement requesters and resolving subagent depth. Omitting `cfg` must not skip the default `OPENCLAW_STATE_DIR/agents/<agent>/sessions/sessions.json` lookup.
- **Real environment tested**: Isolated OpenClaw source checkout at PR head `df8eb9d570df` on Linux with Node 22, using disposable temp state directories. No live Gateway, production config, production session store, or runtime service was modified.
- **Exact steps or command run after this patch**: Created a disposable `agents/main/sessions/sessions.json` containing explicit requester entries with persisted `spawnDepth` and `spawnedBy` metadata, ran `corepack pnpm exec tsx review/explicit-requester-depth-proof-20260508/proof-explicit-requester-depth.ts`, then ran the targeted agents regression tests with `OPENCLAW_VITEST_MAX_WORKERS=2 corepack pnpm test src/agents/subagent-depth.test.ts src/agents/subagent-announce-delivery.test.ts`.
- **Evidence after fix**: Copied terminal output from the isolated proof run:

  ```text
  explicit requester depth proof
  stateDir=$TMPDIR/openclaw-explicit-requester-proof-* (disposable)
  storeShape=agents/main/sessions/sessions.json
  explicit_spawnDepth=1
  explicit_ancestry_depth=2
  explicit_requester_is_internal=true
  missing_explicit_requester_is_internal=false
  verdict=PASS
  ```

  Targeted regression output from the same PR head:

  ```text
  src/agents/subagent-depth.test.ts (12 tests) passed
  src/agents/subagent-announce-delivery.test.ts (33 tests) passed
  Test Files: 2 passed (2)
  Tests: 45 passed (45)
  ```

- **Observed result after fix**: The default on-disk session store lookup returned depth `1` from persisted `spawnDepth`, derived depth `2` from `spawnedBy` ancestry, classified the persisted explicit requester as internal, kept a missing explicit requester external, and the targeted regression suite passed.
- **What was not tested**: No live Gateway restart, production announcement delivery, real Discord/Slack send, or production session-store migration was exercised; the proof intentionally stayed in an isolated source checkout with disposable state.
