### PR TITLE
fix(cron): allow webhook isolated runs to reuse sessionKey sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/webhooks: let isolated `/hooks/agent` runs reuse approved stable `sessionKey` sessions instead of always forcing a fresh isolated session. Fixes #70894. Thanks @dannylin108.
 - Codex/media understanding: support `codex/*` image models through bounded Codex app-server image turns, while keeping `openai-codex/*` on the OpenAI Codex OAuth route and validating app-server responses against generated protocol contracts. Fixes #70201.
 - Providers/OpenAI Codex: synthesize the `openai-codex/gpt-5.5` OAuth model row when Codex catalog discovery omits it, so cron and subagent runs do not fail with `Unknown model` while the account is authenticated.
 - Models/CLI: keep `openclaw models list` read-only while still showing eligible configured-provider rows, so listing models no longer rewrites per-agent `models.json`. (#70847) Thanks @shakkernerd.

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -128,6 +128,23 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
     });
   });
 
+  it("reuses webhook hook sessions when sessionTarget is isolated", async () => {
+    await runSkillFilterCase({
+      sessionKey: "hook:webhook:stable-thread",
+      job: makeSkillJob({
+        payload: {
+          kind: "agentTurn",
+          message: "test",
+          externalContentSource: "webhook",
+        },
+      }),
+    });
+    expect(resolveCronSessionMock).toHaveBeenCalledOnce();
+    expect(resolveCronSessionMock.mock.calls[0]?.[0]).toMatchObject({
+      forceNew: false,
+    });
+  });
+
   it("reuses cached snapshot when version and normalized skillFilter are unchanged", async () => {
     resolveAgentSkillsFilterMock.mockReturnValue([" weather ", "meme-factory", "weather"]);
     resolveCronSessionMock.mockReturnValue({

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -467,6 +467,8 @@ async function prepareCronRunContext(params: {
     input.job.payload.kind === "agentTurn" ? input.job.payload.externalContentSource : undefined;
   const hookExternalContentSource =
     payloadHookExternalContentSource ?? resolveHookExternalContentSource(baseSessionKey);
+  const forceNewSession =
+    input.job.sessionTarget === "isolated" && hookExternalContentSource === undefined;
 
   const workspaceDirRaw = resolveAgentWorkspaceDir(input.cfg, agentId);
   const agentDir = resolveAgentDir(input.cfg, agentId);
@@ -483,7 +485,7 @@ async function prepareCronRunContext(params: {
     sessionKey: agentSessionKey,
     agentId,
     nowMs: now,
-    forceNew: input.job.sessionTarget === "isolated",
+    forceNew: forceNewSession,
   });
   const runSessionId = cronSession.sessionEntry.sessionId;
   if (!cronSession.sessionEntry.sessionFile?.trim()) {


### PR DESCRIPTION
### Motivation
- Isolated cron runs always forced a fresh session which discarded context even for `/hooks/agent` webhook calls that intentionally provide stable `sessionKey` values or `externalContentSource`; this caused unwanted session rollovers and lost history.

### Description
- Compute `forceNewSession` in `src/cron/isolated-agent/run.ts` and only force a fresh session when `sessionTarget === "isolated"` and the run is not hook/webhook-sourced, preserving hook sessions when `externalContentSource` or `hook:*` session keys are present.
- Update `src/cron/isolated-agent/run.skill-filter.test.ts` to add a regression test that verifies webhook-sourced isolated runs pass `forceNew: false` to `resolveCronSession` while keeping the existing isolated-cron behavior.
- Modified files: `src/cron/isolated-agent/run.ts`, `src/cron/isolated-agent/run.skill-filter.test.ts`.

### Testing
- Ran the targeted tests with `pnpm test src/cron/isolated-agent/run.skill-filter.test.ts src/cron/isolated-agent/session.test.ts` and the suite passed.
- Test output: 2 test files ran, 27 tests passed (all green).

Fixes #70894
