### PR TITLE
docs(codex): document native model lifecycle hooks

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -95,6 +95,7 @@ These run inside the agent loop or gateway pipeline:
 - **`before_agent_start`**: legacy compatibility hook that may run in either phase; prefer the explicit hooks above.
 - **`before_agent_reply`**: runs after inline actions and before the LLM call, letting a plugin claim the turn and return a synthetic reply or silence the turn entirely.
 - **`agent_end`**: inspect the final message list and run metadata after completion.
+- **`llm_input` / `llm_output`**: observe the model input and output shape that the active OpenClaw harness can report.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`before_install`**: inspect built-in scan findings and optionally block skill or plugin installs.
@@ -117,6 +118,9 @@ See [Plugin hooks](/plugins/architecture-internals#provider-runtime-hooks) for t
 Harnesses may adapt these hooks differently. The Codex app-server harness keeps
 OpenClaw plugin hooks as the compatibility contract for documented mirrored
 surfaces, while Codex native hooks remain a separate lower-level Codex mechanism.
+Codex native `PreModelRequest` and `PostModelResponse` hooks, when available,
+are Codex command hooks and do not replace OpenClaw plugin `llm_input` or
+`llm_output`.
 
 ## Streaming + partial replies
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -530,11 +530,17 @@ thread unless Codex exposes that operation through app-server or native hook
 callbacks.
 
 When newer Codex app-server builds expose native compaction and model lifecycle
-hook events, OpenClaw should version-gate that protocol support and map the
-events into the existing OpenClaw hook contract where the semantics are honest.
-Until then, OpenClaw's `before_compaction`, `after_compaction`, `llm_input`, and
-`llm_output` events are adapter-level observations, not byte-for-byte captures
-of Codex's internal request or compaction payloads.
+hook events, OpenClaw version-gates that protocol support and maps events into
+the existing OpenClaw hook contract where the semantics are honest. The
+OpenClaw `before_compaction`, `after_compaction`, `llm_input`, and `llm_output`
+events remain adapter-level observations, not byte-for-byte captures of Codex's
+internal request or compaction payloads.
+
+Codex native `PreModelRequest` and `PostModelResponse` hooks are lower-level
+Codex command hooks. They run inside Codex around native model requests, using
+Codex hook configuration. OpenClaw's plugin `llm_input` and `llm_output` hooks
+remain OpenClaw adapter events for plugin compatibility, and OpenClaw does not
+double-fire them just because native Codex model lifecycle hooks are available.
 
 ## Tools, media, and compaction
 


### PR DESCRIPTION
## Summary

- document Codex native `PreModelRequest` / `PostModelResponse` hooks as Codex-owned command hooks
- clarify that OpenClaw plugin `llm_input` / `llm_output` remain adapter-level compatibility events
- call out that OpenClaw does not double-fire model lifecycle plugin hooks when Codex native hooks are available

## Dependency

- Depends on https://github.com/openai/codex/pull/19182
- Related to https://github.com/openai/codex/pull/19060 because #19182 is expected to stack after or include the compaction hook work

## Validation

- `pnpm format:check -- docs/plugins/codex-harness.md docs/concepts/agent-loop.md`
- `pnpm docs:list`
- `pnpm check:changed`