### PR TITLE
fix(pi-embedded): inject body.reasoning when payload has no prior reasoning (#70904)

### DIFF
--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts
@@ -97,6 +97,14 @@ describe("createOpenAIThinkingLevelWrapper", () => {
     expect(payloads[0]?.reasoning).toEqual({ effort: "medium" });
   });
 
+  it("injects reasoning on reasoning-capable model when payload has no prior reasoning (#70904)", () => {
+    const { baseStreamFn, payloads } = createPayloadCapture();
+    const wrapped = createOpenAIThinkingLevelWrapper(baseStreamFn, "high");
+    void wrapped(codexModel, { messages: [] }, {});
+
+    expect(payloads[0]?.reasoning).toEqual({ effort: "high" });
+  });
+
   it("returns underlying streamFn unchanged when thinkingLevel is undefined", () => {
     const { baseStreamFn } = createPayloadCapture();
     const wrapped = createOpenAIThinkingLevelWrapper(baseStreamFn, undefined);

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts
@@ -79,10 +79,23 @@ describe("createOpenAIThinkingLevelWrapper", () => {
     expect(payloads[0]?.reasoning).toEqual({ effort: "low" });
   });
 
-  it("does not add reasoning for non-reasoning models without existing reasoning payload", () => {
+  it("does not add reasoning for proxy-routed models without existing reasoning payload", () => {
+    // Proxy routes fail shouldApplyOpenAIReasoningCompatibility, so the wrapper
+    // must not inject `body.reasoning` even with the #70904 !existingReasoning
+    // branch. Use a baseUrl that routes the request away from default OpenAI
+    // endpoints to exercise the non-compat path.
     const { baseStreamFn, payloads } = createPayloadCapture();
     const wrapped = createOpenAIThinkingLevelWrapper(baseStreamFn, "medium");
-    void wrapped(openaiModel, { messages: [] }, {});
+    void wrapped(
+      {
+        api: "openai-responses",
+        provider: "openai",
+        id: "gpt-5.2",
+        baseUrl: "https://proxy.example.com/v1",
+      } as Model<"openai-responses">,
+      { messages: [] },
+      {},
+    );
 
     expect(payloads[0]?.reasoning).toBeUndefined();
   });

--- a/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/openai-stream-wrappers.ts
@@ -258,6 +258,17 @@ export function createOpenAIThinkingLevelWrapper(
       ) {
         (existingReasoning as Record<string, unknown>).effort =
           mapThinkingLevelToReasoningEffort(thinkingLevel);
+        return;
+      }
+      // pi-ai's Responses/Codex-Responses clients only populate `body.reasoning`
+      // when `options.reasoningEffort` is threaded through, which OpenClaw does
+      // not do for this wrapper. Without this branch, `thinkingLevel` is silently
+      // cosmetic for reasoning-capable models whose payload has no prior
+      // reasoning field. Mirror `normalizeProxyReasoningPayload`'s
+      // `!existingReasoning` case so the configured effort actually reaches the
+      // endpoint. (#70904)
+      if (existingReasoning === undefined || existingReasoning === null) {
+        payloadObj.reasoning = { effort: mapThinkingLevelToReasoningEffort(thinkingLevel) };
       }
     });
   };


### PR DESCRIPTION
## Summary

Closes #70904.

\`createOpenAIThinkingLevelWrapper\` (\`src/agents/pi-embedded-runner/openai-stream-wrappers.ts\`) only reacted to three prior states of \`payloadObj.reasoning\`:
1. \`thinkingLevel === \"off\"\` → delete
2. \`existingReasoning === \"none\"\` → replace with \`{ effort }\`
3. existing \`{ effort }\` object → mutate in place

pi-ai's Responses / Codex-Responses clients only set \`body.reasoning\` when \`options.reasoningEffort\` is threaded through, which OpenClaw does not do for this wrapper. So \`payloadObj.reasoning\` is \`undefined\` in every real run, none of the three branches fires, and \`thinkingDefault\` / \`thinkingLevel\` is **silently cosmetic** for \`openai-codex/gpt-5.x\` and \`openai/gpt-5.x\` — the server-side default applies regardless of user configuration.

The reporter confirmed via A/B runtime instrumentation on 2026.4.22.

## Change

Add the missing \`!existingReasoning\` branch, mirroring \`normalizeProxyReasoningPayload\`'s already-shipped handling in \`proxy-stream-wrappers.ts:43\`. Still gated behind the existing \`shouldApplyOpenAIReasoningCompatibility\` check, so non-reasoning-capable models are untouched.

## Test plan

- Regression test added: \`injects reasoning on reasoning-capable model when payload has no prior reasoning (#70904)\`
- \`pnpm oxlint src/agents/pi-embedded-runner/openai-stream-wrappers.ts src/agents/pi-embedded-runner/openai-stream-wrappers.test.ts\` → 0 warnings, 0 errors
- Manual (per reporter's A/B): with the fix, payload arrives at \`chatgpt.com/backend-api/codex\` as \`body.reasoning = { effort: \"high\" }\` when \`thinkingDefault: \"high\"\`; without the fix, \`body.reasoning\` is absent.