### PR TITLE
fix(docs): restore nested Memory group in zh-Hans navigation

### DIFF
--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -139,7 +139,8 @@
             "zh-CN/concepts/session-pruning",
             "zh-CN/concepts/session-tool",
             {
-              "group": "Memory",
+            {
+              "group": "记忆",
               "pages": [
                 "zh-CN/concepts/memory",
                 "zh-CN/concepts/memory-builtin",

--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -139,7 +139,6 @@
             "zh-CN/concepts/session-pruning",
             "zh-CN/concepts/session-tool",
             {
-            {
               "group": "记忆",
               "pages": [
                 "zh-CN/concepts/memory",

--- a/docs/.i18n/zh-Hans-navigation.json
+++ b/docs/.i18n/zh-Hans-navigation.json
@@ -138,7 +138,18 @@
             "zh-CN/concepts/session",
             "zh-CN/concepts/session-pruning",
             "zh-CN/concepts/session-tool",
-            "zh-CN/concepts/memory",
+            {
+              "group": "Memory",
+              "pages": [
+                "zh-CN/concepts/memory",
+                "zh-CN/concepts/memory-builtin",
+                "zh-CN/concepts/memory-qmd",
+                "zh-CN/concepts/memory-honcho",
+                "zh-CN/concepts/memory-search",
+                "zh-CN/concepts/active-memory",
+                "zh-CN/concepts/dreaming"
+              ]
+            },
             "zh-CN/concepts/compaction"
           ]
         },


### PR DESCRIPTION
## Summary
This PR is a critical fix to restore the multiple missing Memory sub-pages and apply the correct nested grouping in the Chinese (zh-Hans) navigation, matching the English source of truth.

- **Problem**: Currently, the Chinese sidebar is functionally incomplete. Multiple key advanced features, such as `active-memory`, `memory-qmd`, and `dreaming`, are **entirely missing from the navigation**. Chinese users are unable to access detailed configuration guides for these core OpenClaw functionalities, causing a significant information gap.
- **Why it matters**: This is not just a UI flattening issue; it is a major **feature discoverability failure** for Chinese-speaking users. They are missing out on advanced memory optimization documentation.
- **Solution**: Restructured `docs/.i18n/zh-Hans-navigation.json` to include all 7 Memory-related sub-pages and organized them into a collapsible nested "Memory" folder, ensuring structural and content parity with the primary `docs.json`.

## Change Type
- [x] Bug fix (critical feature discoverability fix)
- [ ] Documentation update

## AI-Assisted Contribution 🤖
- **AI-assisted**: Yes (via Gemini)
- **Degree of testing**: Fully tested in a local Mintlify environment with synchronized `zh-CN` assets from the `openclaw/docs` publish repo.
- **Understanding**: I fully understand that this changes the navigation schema to restore missing paths and restore UI hierarchy. I manually verified JSON syntax.
- **Context**: Used AI to validate the navigation schema, ensure professional documentation standards, and structure the PR report according to the current guidelines.

## Repro + Verification
I verified the changes by running `mintlify dev` locally.

### Before (Missing Pages)
*The Chinese sidebar is incomplete. Key Memory-related sub-pages (like active-memory, memory-qmd, honcho, search, dreaming) are entirely **missing**, making these advanced features undiscoverable.*
<img width="244" height="265" alt="105d2aa2-609d-49da-b154-5549f2780127" src="https://github.com/user-attachments/assets/e42d3201-56e3-41bd-9f30-57d7c034b096" />


### After (Restored & Nested)
*The sidebar is now complete. All 7 Memory sub-pages are **restored** and organized into a clean, professional, collapsible "Memory" folder, matching the English docs UX.*
<img width="310" height="504" alt="d7187290-2f58-4615-a92a-a485dd509711" src="https://github.com/user-attachments/assets/6261378a-3af7-48a4-9e65-b777fc5a3833" />


## Human Verification
- [x] Manually confirmed all 7 Memory paths are now included and valid.
- [x] Verified JSON syntax (2-space indentation, no errors).
- [x] Confirmed the fix restores feature parity for Chinese users.

## Risks and Mitigations
- **Risk**: Future English docs updates might add pages that again become missing in Chinese.
- **Mitigation**: I will monitor future commits to `docs.json` for structural regressions in the zh-Hans locale.