### PR TITLE
refactor(whatsapp): centralize account policy

### DIFF
--- a/extensions/whatsapp/src/account-policy.test.ts
+++ b/extensions/whatsapp/src/account-policy.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveWhatsAppAccountPolicy,
+  resolveWhatsAppDirectTargetAuthorization,
+} from "./account-policy.js";
+
+describe("resolveWhatsAppAccountPolicy", () => {
+  it("prefers explicit accountId over configured defaultAccount", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            defaultAccount: "work",
+            accounts: {
+              personal: { allowFrom: ["+15550000001"] },
+              work: { allowFrom: ["+15550000002"] },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+      accountId: "personal",
+    });
+
+    expect(policy.accountId).toBe("personal");
+    expect(policy.configuredAllowFrom).toEqual(["+15550000001"]);
+  });
+
+  it("uses configured defaultAccount when accountId is omitted", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            defaultAccount: "work",
+            accounts: {
+              work: { allowFrom: ["+15550000002"] },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+    });
+
+    expect(policy.accountId).toBe("work");
+    expect(policy.configuredAllowFrom).toEqual(["+15550000002"]);
+  });
+
+  it("falls back to the default account when no preferred account is configured", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {},
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+    });
+
+    expect(policy.accountId).toBe("default");
+  });
+
+  it("inherits shared defaults from accounts.default for named accounts", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                dmPolicy: "allowlist",
+                allowFrom: [" +15550001111 "],
+                groupPolicy: "open",
+                groupAllowFrom: [" +15550002222 "],
+              },
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(policy.dmPolicy).toBe("allowlist");
+    expect(policy.groupPolicy).toBe("open");
+    expect(policy.configuredAllowFrom).toEqual(["+15550001111"]);
+    expect(policy.groupAllowFrom).toEqual(["+15550002222"]);
+  });
+
+  it("does not inherit default-only authDir or selfChatMode for named accounts", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            accounts: {
+              default: {
+                authDir: "/tmp/default-auth",
+                selfChatMode: true,
+              },
+              work: {},
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+      accountId: "work",
+      selfE164: "+15550009999",
+    });
+
+    expect(policy.account.authDir).toMatch(/whatsapp[/\\]work$/);
+    expect(policy.account.selfChatMode).toBeUndefined();
+    expect(policy.isSelfChat).toBe(false);
+  });
+
+  it("falls back groupAllowFrom to allowFrom when unset", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: [" +15550001111 ", "+15550002222"],
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+    });
+
+    expect(policy.configuredAllowFrom).toEqual(["+15550001111", "+15550002222"]);
+    expect(policy.groupAllowFrom).toEqual(["+15550001111", "+15550002222"]);
+  });
+
+  it("keeps self-chat classification inputs aligned with allowFrom and selfE164", () => {
+    const policy = resolveWhatsAppAccountPolicy({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15550009999"],
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccountPolicy>[0]["cfg"],
+      selfE164: "+15550009999",
+    });
+
+    expect(policy.dmAllowFrom).toEqual(["+15550009999"]);
+    expect(policy.isSamePhone("+15550009999")).toBe(true);
+    expect(policy.isDmSenderAllowed(policy.dmAllowFrom, "+15550009999")).toBe(true);
+    expect(policy.isSelfChat).toBe(true);
+  });
+});
+
+describe("resolveWhatsAppDirectTargetAuthorization", () => {
+  it("allows wildcard direct targets", () => {
+    const authorized = resolveWhatsAppDirectTargetAuthorization({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["*"],
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppDirectTargetAuthorization>[0]["cfg"],
+      to: "+15550007777",
+    });
+
+    expect(authorized.accountId).toBe("default");
+    expect(authorized.resolution).toEqual({ ok: true, to: "+15550007777" });
+  });
+
+  it("allows direct targets when allowFrom is empty", () => {
+    const authorized = resolveWhatsAppDirectTargetAuthorization({
+      cfg: {
+        channels: {
+          whatsapp: {},
+        },
+      } as Parameters<typeof resolveWhatsAppDirectTargetAuthorization>[0]["cfg"],
+      to: "+15550007777",
+    });
+
+    expect(authorized.resolution).toEqual({ ok: true, to: "+15550007777" });
+  });
+
+  it("blocks non-allowlisted direct targets", () => {
+    const authorized = resolveWhatsAppDirectTargetAuthorization({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15550001111"],
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppDirectTargetAuthorization>[0]["cfg"],
+      to: "+15550007777",
+    });
+
+    expect(authorized.resolution.ok).toBe(false);
+  });
+
+  it("always allows group JIDs", () => {
+    const authorized = resolveWhatsAppDirectTargetAuthorization({
+      cfg: {
+        channels: {
+          whatsapp: {
+            allowFrom: ["+15550001111"],
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppDirectTargetAuthorization>[0]["cfg"],
+      to: "12345@g.us",
+    });
+
+    expect(authorized.resolution).toEqual({ ok: true, to: "12345@g.us" });
+  });
+});

--- a/extensions/whatsapp/src/account-policy.ts
+++ b/extensions/whatsapp/src/account-policy.ts
@@ -1,0 +1,119 @@
+import {
+  resolveDefaultGroupPolicy,
+  type DmPolicy,
+  type GroupPolicy,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import { resolveEffectiveAllowFromLists } from "openclaw/plugin-sdk/security-runtime";
+import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
+import {
+  resolveWhatsAppOutboundTarget,
+  type WhatsAppOutboundTargetResolution,
+} from "./resolve-outbound-target.js";
+import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
+import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
+
+export type ResolvedWhatsAppAccountPolicy = {
+  account: ResolvedWhatsAppAccount;
+  accountId: string;
+  dmPolicy: DmPolicy;
+  groupPolicy: GroupPolicy;
+  configuredAllowFrom: string[];
+  dmAllowFrom: string[];
+  groupAllowFrom: string[];
+  isSelfChat: boolean;
+  providerMissingFallbackApplied: boolean;
+  shouldReadStorePairingApprovals: boolean;
+  isSamePhone: (value?: string | null) => boolean;
+  isDmSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
+  isGroupSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
+};
+
+function normalizeConfiguredAllowEntries(entries?: Array<string | number> | null): string[] {
+  return (entries ?? []).map((entry) => String(entry).trim()).filter(Boolean);
+}
+
+function isNormalizedSenderAllowed(allowEntries: string[], sender?: string | null): boolean {
+  if (allowEntries.includes("*")) {
+    return true;
+  }
+  const normalizedSender = normalizeE164(sender ?? "");
+  if (!normalizedSender) {
+    return false;
+  }
+  const normalizedEntrySet = new Set(
+    allowEntries
+      .map((entry) => normalizeE164(entry))
+      .filter((entry): entry is string => Boolean(entry)),
+  );
+  return normalizedEntrySet.has(normalizedSender);
+}
+
+export function resolveWhatsAppAccountPolicy(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  selfE164?: string | null;
+}): ResolvedWhatsAppAccountPolicy {
+  const account = resolveWhatsAppAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  const configuredAllowFrom = normalizeConfiguredAllowEntries(account.allowFrom);
+  const dmPolicy = account.dmPolicy ?? "pairing";
+  const dmAllowFrom =
+    configuredAllowFrom.length > 0 ? configuredAllowFrom : params.selfE164 ? [params.selfE164] : [];
+  const configuredGroupAllowFrom = normalizeConfiguredAllowEntries(account.groupAllowFrom);
+  const { effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
+    allowFrom: configuredAllowFrom,
+    groupAllowFrom: configuredGroupAllowFrom,
+  });
+  const defaultGroupPolicy = resolveDefaultGroupPolicy(params.cfg);
+  const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({
+    providerConfigPresent: params.cfg.channels?.whatsapp !== undefined,
+    groupPolicy: account.groupPolicy,
+    defaultGroupPolicy,
+  });
+  const isSamePhone = (value?: string | null) =>
+    typeof value === "string" && typeof params.selfE164 === "string" && value === params.selfE164;
+  return {
+    account,
+    accountId: account.accountId,
+    dmPolicy,
+    groupPolicy,
+    configuredAllowFrom,
+    dmAllowFrom,
+    groupAllowFrom: effectiveGroupAllowFrom,
+    isSelfChat: account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom),
+    providerMissingFallbackApplied,
+    shouldReadStorePairingApprovals: dmPolicy !== "allowlist",
+    isSamePhone,
+    isDmSenderAllowed: (allowEntries, sender) =>
+      isSamePhone(sender) || isNormalizedSenderAllowed(allowEntries, sender),
+    isGroupSenderAllowed: (allowEntries, sender) => isNormalizedSenderAllowed(allowEntries, sender),
+  };
+}
+
+export function resolveWhatsAppDirectTargetAuthorization(params: {
+  cfg: OpenClawConfig;
+  to: string;
+  accountId?: string | null;
+  mode?: string | null;
+}): {
+  account: ResolvedWhatsAppAccount;
+  accountId: string;
+  resolution: WhatsAppOutboundTargetResolution;
+} {
+  const policy = resolveWhatsAppAccountPolicy({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
+  return {
+    account: policy.account,
+    accountId: policy.accountId,
+    resolution: resolveWhatsAppOutboundTarget({
+      to: params.to,
+      allowFrom: policy.configuredAllowFrom,
+      mode: params.mode ?? "implicit",
+    }),
+  };
+}

--- a/extensions/whatsapp/src/action-runtime-target-auth.ts
+++ b/extensions/whatsapp/src/action-runtime-target-auth.ts
@@ -1,7 +1,6 @@
 import { ToolAuthorizationError } from "openclaw/plugin-sdk/channel-actions";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { resolveWhatsAppAccount } from "./accounts.js";
-import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
+import { resolveWhatsAppDirectTargetAuthorization } from "./account-policy.js";
 
 export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   cfg: OpenClawConfig;
@@ -9,19 +8,16 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   accountId?: string;
   actionLabel: string;
 }): { to: string; accountId: string } {
-  const account = resolveWhatsAppAccount({
+  const authorized = resolveWhatsAppDirectTargetAuthorization({
     cfg: params.cfg,
-    accountId: params.accountId,
-  });
-  const resolution = resolveWhatsAppOutboundTarget({
     to: params.chatJid,
-    allowFrom: account.allowFrom ?? [],
+    accountId: params.accountId,
     mode: "implicit",
   });
-  if (!resolution.ok) {
+  if (!authorized.resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${authorized.accountId}".`,
     );
   }
-  return { to: resolution.to, accountId: account.accountId };
+  return { to: authorized.resolution.to, accountId: authorized.accountId };
 }

--- a/extensions/whatsapp/src/action-runtime.test.ts
+++ b/extensions/whatsapp/src/action-runtime.test.ts
@@ -327,4 +327,40 @@ describe("handleWhatsAppAction", () => {
       }),
     );
   });
+
+  it("uses configured defaultAccount for action authorization when accountId is omitted", async () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          defaultAccount: "work",
+          actions: { reactions: true },
+          allowFrom: ["999@s.whatsapp.net"],
+          accounts: {
+            work: {
+              allowFrom: ["123@s.whatsapp.net"],
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    await handleWhatsAppAction(
+      {
+        action: "react",
+        chatJid: "123@s.whatsapp.net",
+        messageId: "msg1",
+        emoji: "✅",
+      },
+      cfg,
+    );
+
+    expect(sendReactionWhatsApp).toHaveBeenLastCalledWith(
+      "+123",
+      "msg1",
+      "✅",
+      expect.objectContaining({
+        accountId: "work",
+      }),
+    );
+  });
 });

--- a/extensions/whatsapp/src/heartbeat-recipients.ts
+++ b/extensions/whatsapp/src/heartbeat-recipients.ts
@@ -1,6 +1,5 @@
-import { resolveDefaultWhatsAppAccountId, resolveWhatsAppAccount } from "./accounts.js";
+import { resolveWhatsAppAccountPolicy } from "./account-policy.js";
 import {
-  DEFAULT_ACCOUNT_ID,
   loadSessionStore,
   normalizeChannelId,
   normalizeE164,
@@ -56,17 +55,17 @@ export function resolveWhatsAppHeartbeatRecipients(
   }
 
   const sessionRecipients = getSessionRecipients(cfg);
-  const resolvedAccountId =
-    opts.accountId?.trim() || resolveDefaultWhatsAppAccountId(cfg) || DEFAULT_ACCOUNT_ID;
-  const configuredAllowFrom = (
-    resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId }).allowFrom ?? []
-  )
+  const policy = resolveWhatsAppAccountPolicy({
+    cfg,
+    accountId: opts.accountId,
+  });
+  const configuredAllowFrom = policy.configuredAllowFrom
     .filter((value) => value !== "*")
     .map(normalizeE164);
   const storeAllowFrom = readChannelAllowFromStoreSync(
     "whatsapp",
     process.env,
-    resolvedAccountId,
+    policy.accountId,
   ).map(normalizeE164);
 
   const unique = (list: string[]) => [...new Set(list.filter(Boolean))];

--- a/extensions/whatsapp/src/inbound-policy.ts
+++ b/extensions/whatsapp/src/inbound-policy.ts
@@ -1,37 +1,25 @@
 import {
   resolveChannelGroupPolicy,
   resolveChannelGroupRequireMention,
-  resolveDefaultGroupPolicy,
   resolveGroupSessionKey,
   type ChannelGroupPolicy,
-  type DmPolicy,
   type GroupPolicy,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/config-runtime";
 import {
   readStoreAllowFromForDmPolicy,
-  resolveEffectiveAllowFromLists,
   resolveDmGroupAccessWithCommandGate,
 } from "openclaw/plugin-sdk/security-runtime";
-import { resolveWhatsAppAccount, type ResolvedWhatsAppAccount } from "./accounts.js";
+import {
+  resolveWhatsAppAccountPolicy,
+  type ResolvedWhatsAppAccountPolicy,
+} from "./account-policy.js";
+import type { ResolvedWhatsAppAccount } from "./accounts.js";
 import { getSelfIdentity, getSenderIdentity } from "./identity.js";
 import type { WebInboundMessage } from "./inbound/types.js";
-import { resolveWhatsAppRuntimeGroupPolicy } from "./runtime-group-policy.js";
-import { isSelfChatMode, normalizeE164 } from "./text-runtime.js";
+import { normalizeE164 } from "./text-runtime.js";
 
-export type ResolvedWhatsAppInboundPolicy = {
-  account: ResolvedWhatsAppAccount;
-  dmPolicy: DmPolicy;
-  groupPolicy: GroupPolicy;
-  configuredAllowFrom: string[];
-  dmAllowFrom: string[];
-  groupAllowFrom: string[];
-  isSelfChat: boolean;
-  providerMissingFallbackApplied: boolean;
-  shouldReadStorePairingApprovals: boolean;
-  isSamePhone: (value?: string | null) => boolean;
-  isDmSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
-  isGroupSenderAllowed: (allowEntries: string[], sender?: string | null) => boolean;
+export type ResolvedWhatsAppInboundPolicy = ResolvedWhatsAppAccountPolicy & {
   resolveConversationGroupPolicy: (conversationId: string) => ChannelGroupPolicy;
   resolveConversationRequireMention: (conversationId: string) => boolean;
 };
@@ -44,22 +32,6 @@ function resolveGroupConversationId(conversationId: string): string {
       Provider: "whatsapp",
     })?.id ?? conversationId
   );
-}
-
-function isNormalizedSenderAllowed(allowEntries: string[], sender?: string | null): boolean {
-  if (allowEntries.includes("*")) {
-    return true;
-  }
-  const normalizedSender = normalizeE164(sender ?? "");
-  if (!normalizedSender) {
-    return false;
-  }
-  const normalizedEntrySet = new Set(
-    allowEntries
-      .map((entry) => normalizeE164(entry))
-      .filter((entry): entry is string => Boolean(entry)),
-  );
-  return normalizedEntrySet.has(normalizedSender);
 }
 
 function buildResolvedWhatsAppGroupConfig(params: {
@@ -81,54 +53,23 @@ export function resolveWhatsAppInboundPolicy(params: {
   accountId?: string | null;
   selfE164?: string | null;
 }): ResolvedWhatsAppInboundPolicy {
-  const account = resolveWhatsAppAccount({
+  const policy = resolveWhatsAppAccountPolicy({
     cfg: params.cfg,
     accountId: params.accountId,
-  });
-  const configuredAllowFrom = account.allowFrom ?? [];
-  const dmPolicy = account.dmPolicy ?? "pairing";
-  const dmAllowFrom =
-    configuredAllowFrom.length > 0 ? configuredAllowFrom : params.selfE164 ? [params.selfE164] : [];
-  const groupAllowFrom =
-    account.groupAllowFrom ??
-    (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined) ??
-    [];
-  const { effectiveGroupAllowFrom } = resolveEffectiveAllowFromLists({
-    allowFrom: configuredAllowFrom,
-    groupAllowFrom,
-  });
-  const defaultGroupPolicy = resolveDefaultGroupPolicy(params.cfg);
-  const { groupPolicy, providerMissingFallbackApplied } = resolveWhatsAppRuntimeGroupPolicy({
-    providerConfigPresent: params.cfg.channels?.whatsapp !== undefined,
-    groupPolicy: account.groupPolicy,
-    defaultGroupPolicy,
+    selfE164: params.selfE164,
   });
   const resolvedGroupCfg = buildResolvedWhatsAppGroupConfig({
-    groupPolicy,
-    groups: account.groups,
+    groupPolicy: policy.groupPolicy,
+    groups: policy.account.groups,
   });
-  const isSamePhone = (value?: string | null) =>
-    typeof value === "string" && typeof params.selfE164 === "string" && value === params.selfE164;
   return {
-    account,
-    dmPolicy,
-    groupPolicy,
-    configuredAllowFrom,
-    dmAllowFrom,
-    groupAllowFrom,
-    isSelfChat: account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom),
-    providerMissingFallbackApplied,
-    shouldReadStorePairingApprovals: dmPolicy !== "allowlist",
-    isSamePhone,
-    isDmSenderAllowed: (allowEntries, sender) =>
-      isSamePhone(sender) || isNormalizedSenderAllowed(allowEntries, sender),
-    isGroupSenderAllowed: (allowEntries, sender) => isNormalizedSenderAllowed(allowEntries, sender),
+    ...policy,
     resolveConversationGroupPolicy: (conversationId) =>
       resolveChannelGroupPolicy({
         cfg: resolvedGroupCfg,
         channel: "whatsapp",
         groupId: resolveGroupConversationId(conversationId),
-        hasGroupAllowFrom: effectiveGroupAllowFrom.length > 0,
+        hasGroupAllowFrom: policy.groupAllowFrom.length > 0,
       }),
     resolveConversationRequireMention: (conversationId) =>
       resolveChannelGroupRequireMention({
@@ -171,7 +112,7 @@ export async function resolveWhatsAppCommandAuthorized(params: {
       ? []
       : await readStoreAllowFromForDmPolicy({
           provider: "whatsapp",
-          accountId: policy.account.accountId,
+          accountId: policy.accountId,
           dmPolicy: policy.dmPolicy,
           shouldRead: policy.shouldReadStorePairingApprovals,
         });

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -8,11 +8,8 @@ import {
 } from "openclaw/plugin-sdk/markdown-table-runtime";
 import { normalizePollInput, type PollInput } from "openclaw/plugin-sdk/poll-runtime";
 import { createSubsystemLogger, getChildLogger } from "openclaw/plugin-sdk/runtime-env";
-import {
-  resolveDefaultWhatsAppAccountId,
-  resolveWhatsAppAccount,
-  resolveWhatsAppMediaMaxBytes,
-} from "./accounts.js";
+import { resolveWhatsAppAccountPolicy } from "./account-policy.js";
+import { resolveWhatsAppMediaMaxBytes } from "./accounts.js";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
 import type { ActiveWebListener, ActiveWebSendOptions } from "./inbound/types.js";
 import {
@@ -25,31 +22,22 @@ import { markdownToWhatsApp, toWhatsappJid } from "./text-runtime.js";
 
 const outboundLog = createSubsystemLogger("gateway/channels/whatsapp").child("outbound");
 
-function resolveOutboundWhatsAppAccountId(params: {
-  cfg: OpenClawConfig;
-  accountId?: string;
-}): string | undefined {
-  const explicitAccountId = params.accountId?.trim();
-  if (explicitAccountId) {
-    return explicitAccountId;
-  }
-  return resolveDefaultWhatsAppAccountId(params.cfg);
-}
-
 function requireOutboundActiveWebListener(params: { cfg: OpenClawConfig; accountId?: string }): {
-  accountId: string;
+  policy: ReturnType<typeof resolveWhatsAppAccountPolicy>;
   listener: ActiveWebListener;
 } {
-  const accountId = resolveOutboundWhatsAppAccountId(params);
-  const resolvedAccountId = accountId ?? resolveDefaultWhatsAppAccountId(params.cfg);
+  const policy = resolveWhatsAppAccountPolicy({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
   const listener =
-    getRegisteredWhatsAppConnectionController(resolvedAccountId)?.getActiveListener() ?? null;
+    getRegisteredWhatsAppConnectionController(policy.accountId)?.getActiveListener() ?? null;
   if (!listener) {
     throw new Error(
-      `No active WhatsApp Web listener (account: ${resolvedAccountId}). Start the gateway, then link WhatsApp with: ${formatCliCommand(`openclaw channels login --channel whatsapp --account ${resolvedAccountId}`)}.`,
+      `No active WhatsApp Web listener (account: ${policy.accountId}). Start the gateway, then link WhatsApp with: ${formatCliCommand(`openclaw channels login --channel whatsapp --account ${policy.accountId}`)}.`,
     );
   }
-  return { accountId: resolvedAccountId, listener };
+  return { policy, listener };
 }
 
 export async function sendMessageWhatsApp(
@@ -88,18 +76,16 @@ export async function sendMessageWhatsApp(
   const correlationId = generateSecureUuid();
   const startedAt = Date.now();
   const cfg = requireRuntimeConfig(options.cfg, "WhatsApp send");
-  const { listener: active, accountId: resolvedAccountId } = requireOutboundActiveWebListener({
+  const { listener: active, policy } = requireOutboundActiveWebListener({
     cfg,
     accountId: options.accountId,
   });
-  const account = resolveWhatsAppAccount({
-    cfg,
-    accountId: resolvedAccountId ?? options.accountId,
-  });
+  const account = policy.account;
+  const resolvedAccountId = policy.accountId;
   const tableMode = resolveMarkdownTableMode({
     cfg,
     channel: "whatsapp",
-    accountId: resolvedAccountId ?? options.accountId,
+    accountId: resolvedAccountId,
   });
   text = convertMarkdownTables(text ?? "", tableMode);
   text = markdownToWhatsApp(text);


### PR DESCRIPTION
## Summary
- add a canonical WhatsApp-local account policy seam in `extensions/whatsapp/src/account-policy.ts`
- migrate inbound policy, send, heartbeat recipient resolution, and action target auth to consume that seam instead of re-deriving multi-account policy locally
- add focused account-policy coverage and keep the existing WhatsApp consumer tests pinned to preserved behavior

## Preserved behavior
- `defaultAccount` selection and omitted-account fallback behavior
- `accounts.default` inheritance rules, including non-inheritance of default-only `authDir` and `selfChatMode`
- direct-chat outbound authorization and group-JID handling
- same-phone / self-chat handling
- pairing-store read behavior in allowlist vs pairing modes
- heartbeat recipient selection semantics
- action authorization account resolution

## Tests
- `pnpm test extensions/whatsapp/src/account-policy.test.ts`
- `pnpm test extensions/whatsapp/src/inbound/access-control.test.ts`
- `pnpm test extensions/whatsapp/src/heartbeat-recipients.test.ts`
- `pnpm test extensions/whatsapp/src/action-runtime.test.ts`
- `pnpm test extensions/whatsapp/src/send.test.ts`
- `pnpm test extensions/whatsapp/src/accounts.test.ts`
- `pnpm check:changed`

## Notes
- keeps the PR focused on the WhatsApp plugin and directly related tests
- future changes to account selection, allowlists, DM/group defaults, and direct-target auth should now be mostly isolated to the new seam