### PR TITLE
ci: use release approval for npm Telegram E2E

### DIFF
--- a/.github/workflows/npm-telegram-beta-e2e.yml
+++ b/.github/workflows/npm-telegram-beta-e2e.yml
@@ -34,8 +34,8 @@ env:
   PNPM_VERSION: "10.33.0"
 
 jobs:
-  authorize_actor:
-    name: Authorize workflow actor
+  validate_dispatch_ref:
+    name: Validate dispatch ref
     runs-on: blacksmith-8vcpu-ubuntu-2404
     steps:
       - name: Require main workflow ref
@@ -48,28 +48,20 @@ jobs:
             exit 1
           fi
 
-      - name: Require release manager team membership
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const { owner } = context.repo;
-            const teamSlug = "openclaw-release-managers";
-            const members = await github.paginate(github.rest.teams.listMembersInOrg, {
-              org: owner,
-              team_slug: teamSlug,
-              per_page: 100,
-            });
-            const memberLogins = new Set(members.map((member) => member.login));
-            core.info(`${teamSlug} members loaded: ${memberLogins.size}`);
-            if (!memberLogins.has(context.actor)) {
-              core.setFailed(
-                `Workflow requires active ${teamSlug} membership. Actor "${context.actor}" is not a member of ${owner}/${teamSlug}.`,
-              );
-            }
+  approve_release_manager:
+    name: Approve release manager run
+    needs: validate_dispatch_ref
+    runs-on: ubuntu-latest
+    environment: npm-release
+    steps:
+      - name: Approve npm Telegram beta E2E
+        env:
+          PACKAGE_SPEC: ${{ inputs.package_spec }}
+        run: echo "Approved npm Telegram beta E2E for ${PACKAGE_SPEC}"
 
   run_npm_telegram_beta_e2e:
     name: Run published npm Telegram E2E
-    needs: authorize_actor
+    needs: approve_release_manager
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 60
     environment: qa-live-shared

--- a/test/scripts/npm-telegram-live.test.ts
+++ b/test/scripts/npm-telegram-live.test.ts
@@ -41,14 +41,15 @@ describe("npm Telegram live Docker E2E", () => {
     expect(script).toContain('credential_role="ci"');
   });
 
-  it("limits the manual npm beta workflow to release managers", () => {
+  it("requires release manager environment approval for the manual npm beta workflow", () => {
     const workflow = readFileSync(WORKFLOW_PATH, "utf8");
 
-    expect(workflow).toContain('const teamSlug = "openclaw-release-managers";');
-    expect(workflow).toContain("github.rest.teams.listMembersInOrg");
-    expect(workflow).toContain("memberLogins.has(context.actor)");
+    expect(workflow).toContain("approve_release_manager:");
+    expect(workflow).toContain("environment: npm-release");
+    expect(workflow).toContain("needs: approve_release_manager");
     expect(workflow).not.toContain('new Set(["admin", "write"])');
     expect(workflow).not.toContain("data.role_name");
+    expect(workflow).not.toContain("github.rest.teams.listMembersInOrg");
     expect(workflow).not.toContain("getMembershipForUserInOrg");
   });
 


### PR DESCRIPTION
Fixes the manual npm Telegram beta E2E authorization failure.

Changes:
- replace org team membership API lookup with the existing `npm-release` environment approval gate
- keep the main-branch dispatch guard
- update the workflow guard test

Validation:
- `pnpm test test/scripts/npm-telegram-live.test.ts`
- `bash -n scripts/e2e/npm-telegram-live-docker.sh`
- `pnpm check:changed`