### PR TITLE
fix(mattermost): keep status read-only for SecretRef tokens

### DIFF
--- a/extensions/mattermost/src/channel-actions-setup-status.contract.test.ts
+++ b/extensions/mattermost/src/channel-actions-setup-status.contract.test.ts
@@ -1,5 +1,5 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
   installChannelActionsContractSuite,
   installChannelSetupContractSuite,
@@ -118,5 +118,42 @@ describe("mattermost status contract", () => {
         },
       },
     ],
+  });
+
+  it("inspects SecretRef botToken status without resolving the secret", async () => {
+    const cfg = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          botToken: {
+            source: "exec",
+            provider: "keychain",
+            id: "openclaw/mattermost-bottoken",
+          },
+          baseUrl: "https://chat.example.com",
+        },
+      },
+    } as OpenClawConfig;
+
+    const account = mattermostPlugin.config.inspectAccount?.(cfg, "default");
+    expect(account).toMatchObject({
+      accountId: "default",
+      configured: true,
+      botTokenSource: "config",
+      botTokenStatus: "configured_unavailable",
+      baseUrl: "https://chat.example.com",
+    });
+
+    const snapshot = await mattermostPlugin.status!.buildAccountSnapshot!({
+      account: account as never,
+      cfg,
+    });
+    expect(snapshot).toMatchObject({
+      accountId: "default",
+      configured: true,
+      botTokenSource: "config",
+      botTokenStatus: "configured_unavailable",
+      baseUrl: "https://chat.example.com",
+    });
   });
 });

--- a/extensions/mattermost/src/channel-config-shared.ts
+++ b/extensions/mattermost/src/channel-config-shared.ts
@@ -10,6 +10,7 @@ import {
   resolveMattermostGatewayAuthBypassPaths,
 } from "./gateway-auth-bypass.js";
 import {
+  inspectMattermostAccount,
   listMattermostAccountIds,
   resolveDefaultMattermostAccountId,
   resolveMattermostAccount,
@@ -56,6 +57,7 @@ export const mattermostConfigAdapter = createScopedChannelConfigAdapter<Resolved
   sectionKey: "mattermost",
   listAccountIds: listMattermostAccountIds,
   resolveAccount: adaptScopedAccountAccessor(resolveMattermostAccount),
+  inspectAccount: adaptScopedAccountAccessor(inspectMattermostAccount),
   defaultAccountId: resolveDefaultMattermostAccountId,
   clearBaseFields: ["botToken", "baseUrl", "name"],
   resolveAllowFrom: (account) => account.config.allowFrom,
@@ -67,7 +69,7 @@ export const mattermostConfigAdapter = createScopedChannelConfigAdapter<Resolved
 });
 
 export function isMattermostConfigured(account: ResolvedMattermostAccount): boolean {
-  return Boolean(account.botToken && account.baseUrl);
+  return account.configured ?? Boolean(account.botToken && account.baseUrl);
 }
 
 export function describeMattermostAccount(account: ResolvedMattermostAccount) {

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -364,9 +364,10 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
         accountId: account.accountId,
         name: account.name,
         enabled: account.enabled,
-        configured: Boolean(account.botToken && account.baseUrl),
+        configured: account.configured ?? Boolean(account.botToken && account.baseUrl),
         extra: {
           botTokenSource: account.botTokenSource,
+          botTokenStatus: account.botTokenStatus,
           baseUrl: account.baseUrl,
           connected: runtime?.connected ?? false,
           lastConnectedAt: runtime?.lastConnectedAt ?? null,

--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../runtime-api.js";
 import {
+  inspectMattermostAccount,
   resolveDefaultMattermostAccountId,
   resolveMattermostAccount,
   resolveMattermostReplyToMode,
@@ -133,6 +134,37 @@ describe("resolveMattermostReplyToMode", () => {
     expect(account.config.commands).toEqual({
       native: true,
       callbackPath: "/hooks/work",
+    });
+  });
+
+  it("inspects unresolved SecretRef bot tokens without dereferencing them", () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        mattermost: {
+          enabled: true,
+          baseUrl: "https://chat.example.com",
+          botToken: {
+            source: "exec",
+            provider: "keychain",
+            id: "openclaw/mattermost-bottoken",
+          },
+        },
+      },
+    };
+
+    expect(() => resolveMattermostAccount({ cfg, accountId: "default" })).toThrow(
+      /unresolved SecretRef/,
+    );
+
+    expect(inspectMattermostAccount({ cfg, accountId: "default" })).toMatchObject({
+      accountId: "default",
+      enabled: true,
+      configured: true,
+      botToken: undefined,
+      baseUrl: "https://chat.example.com",
+      botTokenSource: "config",
+      botTokenStatus: "configured_unavailable",
+      baseUrlSource: "config",
     });
   });
 });

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -184,17 +184,17 @@ export function inspectMattermostAccount(params: {
   const botToken = tokenInspection.botToken ?? envToken;
   const botTokenSource: MattermostTokenSource = tokenInspection.botToken
     ? "config"
-    : tokenInspection.botTokenStatus === "configured_unavailable"
-      ? "config"
-      : envToken
-        ? "env"
+    : envToken
+      ? "env"
+      : tokenInspection.botTokenStatus === "configured_unavailable"
+        ? "config"
         : "none";
   const botTokenStatus: MattermostCredentialStatus = tokenInspection.botToken
     ? "available"
-    : tokenInspection.botTokenStatus === "configured_unavailable"
-      ? "configured_unavailable"
-      : envToken
-        ? "available"
+    : envToken
+      ? "available"
+      : tokenInspection.botTokenStatus === "configured_unavailable"
+        ? "configured_unavailable"
         : "missing";
   const baseUrl = normalizeMattermostBaseUrl(configUrl || envUrl);
   const baseUrlSource: MattermostBaseUrlSource = configUrl ? "config" : envUrl ? "env" : "none";

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -7,7 +7,11 @@ import {
   resolveChannelStreamingChunkMode,
 } from "openclaw/plugin-sdk/channel-streaming";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
-import { normalizeResolvedSecretInputString, normalizeSecretInputString } from "../secret-input.js";
+import {
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "../secret-input.js";
 import type {
   MattermostAccountConfig,
   MattermostChatMode,
@@ -19,15 +23,18 @@ import type { OpenClawConfig } from "./runtime-api.js";
 
 export type MattermostTokenSource = "env" | "config" | "none";
 export type MattermostBaseUrlSource = "env" | "config" | "none";
+export type MattermostCredentialStatus = "available" | "configured_unavailable" | "missing";
 
 export type ResolvedMattermostAccount = {
   accountId: string;
   enabled: boolean;
+  configured?: boolean;
   name?: string;
   botToken?: string;
   baseUrl?: string;
   botTokenSource: MattermostTokenSource;
   baseUrlSource: MattermostBaseUrlSource;
+  botTokenStatus?: MattermostCredentialStatus;
   config: MattermostAccountConfig;
   chatmode?: MattermostChatMode;
   oncharPrefixes?: string[];
@@ -76,6 +83,31 @@ function resolveMattermostRequireMention(config: MattermostAccountConfig): boole
   return config.requireMention;
 }
 
+function inspectMattermostBotToken(value: unknown): {
+  botToken?: string;
+  botTokenSource: Exclude<MattermostTokenSource, "env">;
+  botTokenStatus: MattermostCredentialStatus;
+} {
+  const botToken = normalizeSecretInputString(value);
+  if (botToken) {
+    return {
+      botToken,
+      botTokenSource: "config",
+      botTokenStatus: "available",
+    };
+  }
+  if (hasConfiguredSecretInput(value)) {
+    return {
+      botTokenSource: "config",
+      botTokenStatus: "configured_unavailable",
+    };
+  }
+  return {
+    botTokenSource: "none",
+    botTokenStatus: "missing",
+  };
+}
+
 export function resolveMattermostAccount(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
@@ -114,6 +146,70 @@ export function resolveMattermostAccount(params: {
     baseUrl,
     botTokenSource,
     baseUrlSource,
+    config: merged,
+    chatmode: merged.chatmode,
+    oncharPrefixes: merged.oncharPrefixes,
+    requireMention,
+    textChunkLimit: merged.textChunkLimit,
+    chunkMode: resolveChannelStreamingChunkMode(merged) ?? merged.chunkMode,
+    blockStreaming: resolveChannelStreamingBlockEnabled(merged) ?? merged.blockStreaming,
+    blockStreamingCoalesce:
+      resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
+  };
+}
+
+export function inspectMattermostAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+  envBotToken?: string | null;
+  envUrl?: string | null;
+}): ResolvedMattermostAccount {
+  const accountId = normalizeAccountId(
+    params.accountId ?? resolveDefaultMattermostAccountId(params.cfg),
+  );
+  const baseEnabled = params.cfg.channels?.mattermost?.enabled !== false;
+  const merged = mergeMattermostAccountConfig(params.cfg, accountId);
+  const accountEnabled = merged.enabled !== false;
+  const enabled = baseEnabled && accountEnabled;
+  const tokenInspection = inspectMattermostBotToken(merged.botToken);
+
+  const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
+  const envToken = allowEnv
+    ? normalizeSecretInputString(params.envBotToken ?? process.env.MATTERMOST_BOT_TOKEN)
+    : undefined;
+  const envUrl = allowEnv
+    ? normalizeSecretInputString(params.envUrl ?? process.env.MATTERMOST_URL)
+    : undefined;
+  const configUrl = merged.baseUrl?.trim();
+  const botToken = tokenInspection.botToken ?? envToken;
+  const botTokenSource: MattermostTokenSource = tokenInspection.botToken
+    ? "config"
+    : tokenInspection.botTokenStatus === "configured_unavailable"
+      ? "config"
+      : envToken
+        ? "env"
+        : "none";
+  const botTokenStatus: MattermostCredentialStatus = tokenInspection.botToken
+    ? "available"
+    : tokenInspection.botTokenStatus === "configured_unavailable"
+      ? "configured_unavailable"
+      : envToken
+        ? "available"
+        : "missing";
+  const baseUrl = normalizeMattermostBaseUrl(configUrl || envUrl);
+  const baseUrlSource: MattermostBaseUrlSource = configUrl ? "config" : envUrl ? "env" : "none";
+  const requireMention = resolveMattermostRequireMention(merged);
+
+  return {
+    accountId,
+    enabled,
+    configured: botTokenStatus !== "missing" && Boolean(baseUrl),
+    name: normalizeOptionalString(merged.name),
+    botToken,
+    baseUrl,
+    botTokenSource,
+    baseUrlSource,
+    botTokenStatus,
     config: merged,
     chatmode: merged.chatmode,
     oncharPrefixes: merged.oncharPrefixes,


### PR DESCRIPTION
## Summary

- Problem: `openclaw status` text mode crashed when Mattermost `botToken` used an unresolved `exec:keychain` SecretRef.
- Why it matters: Mattermost could be healthy at runtime, but read-only diagnostics failed before printing the channel table.
- What changed: Added a Mattermost read-only account inspector that reports configured-but-unavailable credential metadata without dereferencing the secret, and taught status snapshots to preserve that state.
- What did NOT change (scope boundary): Runtime Mattermost token resolution remains strict; this only changes read-only inspection/status behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70942
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Mattermost had strict runtime account resolution but no read-only `inspectAccount` path. Status rendering fell back to `resolveAccount`, which throws on unresolved SecretRefs.
- Missing detection / guardrail: No Mattermost regression test covered read-only status inspection with an unresolved SecretRef credential.
- Contributing context (if known): Telegram, Discord, and Slack already had read-only inspectors; Mattermost was missing the equivalent path.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/mattermost/src/mattermost/accounts.test.ts`
  - `extensions/mattermost/src/channel-actions-setup-status.contract.test.ts`
- Scenario the test should lock in: unresolved Mattermost SecretRef bot tokens are reported as configured/unavailable in read-only inspection without throwing.
- Why this is the smallest reliable guardrail: It tests the plugin resolver and the status snapshot contract directly without requiring a live Mattermost server.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw status` no longer crashes for Mattermost accounts whose bot token is configured as an unresolved SecretRef. It reports degraded credential availability instead.

## Diagram (if applicable)

```text
Before:
openclaw status -> Mattermost resolveAccount -> unresolved SecretRef throw -> CLI crash

After:
openclaw status -> Mattermost inspectAccount -> configured_unavailable metadata -> status table renders
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: Read-only status now detects configured SecretRefs without resolving them. It does not expose token values, and runtime resolution remains strict.

## Repro + Verification

### Environment

- OS: macOS local checkout
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Mattermost
- Relevant config (redacted): `channels.mattermost.botToken` as `exec:keychain` SecretRef plus `baseUrl`

### Steps

1. Configure Mattermost with `botToken` as an unresolved SecretRef.
2. Run `openclaw status`.
3. Inspect the Mattermost status row.

### Expected

- Status renders and reports Mattermost as configured with unavailable credentials.

### Actual

- Fixed by this PR. Before the fix, status crashed with an unresolved SecretRef error.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation:

- `pnpm test extensions/mattermost/src/mattermost/accounts.test.ts extensions/mattermost/src/channel-actions-setup-status.contract.test.ts`
- `pnpm check:changed`

## Human Verification (required)

- Verified scenarios:
  - Mattermost account inspection preserves unresolved SecretRef state without dereferencing the secret.
  - Mattermost status snapshots include `botTokenStatus: configured_unavailable`.
  - Changed-lane validation passed.
- Edge cases checked:
  - Runtime `resolveMattermostAccount` still throws on unresolved SecretRefs.
  - Read-only inspection treats SecretRef + baseUrl as configured but unavailable.
- What you did **not** verify:
  - A live Mattermost server connection.
  - A real `exec:keychain` secret provider returning a token.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A.

## Risks and Mitigations

- Risk: Status may treat a configured-but-unavailable SecretRef as configured even when the command cannot read it.
  - Mitigation: The row is marked with unavailable credential metadata, and runtime token use still requires successful strict resolution.