### PR TITLE
fix(/v1/responses): drop the extra phantom assistant turn on client-tool calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/responses: terminate the Pi agent loop immediately on client-tool handoff so the placeholder stub does not feed back into another model turn that would narrate it alongside the real function_call. Also tightens the SSE event sequence for streamed function_call output items to follow the OpenAI Responses-API streaming convention more closely (`output_item.added` with empty placeholder, `function_call_arguments.delta` and `.done`, `output_item.done` with the populated args), so client parsers that read args only from the dedicated streaming events receive them instead of an empty `{}`.
 - Plugins/onboarding: record local plugin install source metadata without duplicating raw absolute local paths in persisted `plugins.installs`, while preserving linked load-path cleanup. (#70970) Thanks @vincentkoc.
 - Browser/tool: tell agents not to pass per-call `timeoutMs` on existing-session type, evaluate, and other Chrome MCP actions that reject timeout overrides.
 - Codex/GPT-5.4: harden fallback, auth-profile, tool-schema, and replay edge cases across native and embedded runtime paths. (#70743) Thanks @100yenadmin.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3287,4 +3287,124 @@ describe("openai transport stream", () => {
       __testing.processOpenAICompletionsStream(mockStream(), output, model, stream),
     ).rejects.toThrow("Exceeded tool-call argument buffer limit");
   });
+
+  // Regression: a conformant Responses-API upstream may deliver the full
+  // function-call arguments only via `response.function_call_arguments.done`,
+  // with no intermediate `.delta` events and an empty `arguments` field on
+  // `output_item.done`'s item. Prior to the fix, `processResponsesStream`
+  // ignored the `.done` event entirely, so `partialJson` stayed empty and
+  // the emitted `toolcall_end` carried `{}` as its arguments — losing every
+  // client-tool call's parameters whenever the upstream chose this shape.
+  //
+  // This test reproduces that exact shape: the stream only emits
+  // output_item.added -> function_call_arguments.done -> output_item.done
+  // (with an empty arguments field on the item). The toolcall_end event
+  // must carry the real parsed arguments.
+  it("captures function_call arguments from response.function_call_arguments.done when no deltas are emitted", async () => {
+    const model = {
+      id: "foo-llm",
+      name: "Foo LLM",
+      api: "openai-responses",
+      provider: "acme",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 400_000,
+      maxTokens: 32_000,
+    } satisfies Model<"openai-responses">;
+
+    const output: Parameters<typeof __testing.processResponsesStream>[1] = {
+      role: "assistant",
+      content: [],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+        totalTokens: 0,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+      },
+      stopReason: "stop",
+      timestamp: Date.now(),
+    } as Parameters<typeof __testing.processResponsesStream>[1];
+
+    const collected: unknown[] = [];
+    const stream = {
+      push(event: unknown) {
+        collected.push(event);
+      },
+    };
+
+    const sseEvents: Array<Record<string, unknown>> = [
+      // 1. The function_call item is announced with empty arguments.
+      {
+        type: "response.output_item.added",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_abc123",
+          call_id: "call_xyz789",
+          name: "probe",
+          arguments: "",
+        },
+      },
+      // 2. The full arguments arrive ONLY via the .done event — no intermediate
+      //    deltas. This is a valid degenerate case of a conformant Responses-API
+      //    stream that the parser must handle.
+      {
+        type: "response.function_call_arguments.done",
+        output_index: 0,
+        item_id: "fc_abc123",
+        arguments: '{"foo":"bar","n":7}',
+      },
+      // 3. output_item.done arrives with an empty arguments field on the item —
+      //    this is deliberately the worst case: the parser cannot rely on the
+      //    item.arguments fallback. The .done event above is the only carrier.
+      {
+        type: "response.output_item.done",
+        output_index: 0,
+        item: {
+          type: "function_call",
+          id: "fc_abc123",
+          call_id: "call_xyz789",
+          name: "probe",
+          arguments: "",
+        },
+      },
+      {
+        type: "response.completed",
+        response: {
+          status: "completed",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+            total_tokens: 120,
+            input_tokens_details: { cached_tokens: 0 },
+          },
+        },
+      },
+    ];
+
+    async function* sseStream(): AsyncGenerator {
+      for (const event of sseEvents) {
+        yield event;
+      }
+    }
+
+    await __testing.processResponsesStream(sseStream(), output, stream, model);
+
+    const toolcallEnd = collected.find(
+      (event) =>
+        typeof event === "object" &&
+        event !== null &&
+        (event as { type?: unknown }).type === "toolcall_end",
+    ) as { toolCall?: { arguments?: unknown; name?: unknown } } | undefined;
+
+    expect(toolcallEnd).toBeDefined();
+    expect(toolcallEnd?.toolCall?.name).toBe("probe");
+    expect(toolcallEnd?.toolCall?.arguments).toEqual({ foo: "bar", n: 7 });
+  });
 });

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -3311,6 +3311,7 @@ describe("openai transport stream", () => {
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: 400_000,
       maxTokens: 32_000,
+      baseUrl: "https://api.example.com/v1",
     } satisfies Model<"openai-responses">;
 
     const output: Parameters<typeof __testing.processResponsesStream>[1] = {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -476,6 +476,37 @@ async function processResponsesStream(
           partial: output,
         });
       }
+    } else if (type === "response.function_call_arguments.done") {
+      // The Responses-API convention is that the dedicated
+      // function_call_arguments.{delta,done} events are the canonical source
+      // of streamed function-call arguments — `output_item.done`'s
+      // `item.arguments` is a finalization snapshot, not a reliable carrier
+      // when no deltas were emitted. A conformant upstream may legitimately
+      // deliver the full arguments JSON only via this event with no
+      // intermediate deltas. Assigning `event.arguments` to `partialJson`
+      // here guarantees the subsequent `output_item.done` branch finds the
+      // real args on `currentBlock.partialJson` instead of falling back to
+      // the "{}" default.
+      if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
+        const previousPartialJson = stringifyJsonLike(currentBlock.partialJson);
+        const finalArguments = stringifyJsonLike(event.arguments);
+        currentBlock.partialJson = finalArguments;
+        currentBlock.arguments = parseStreamingJson(finalArguments);
+        // If deltas didn't carry the tail, emit the delta between what we
+        // already streamed and the authoritative final args so downstream
+        // consumers see a coherent sequence.
+        if (finalArguments.startsWith(previousPartialJson)) {
+          const delta = finalArguments.slice(previousPartialJson.length);
+          if (delta.length > 0) {
+            stream.push({
+              type: "toolcall_delta",
+              contentIndex: blockIndex(),
+              delta,
+              partial: output,
+            });
+          }
+        }
+      }
     } else if (type === "response.output_item.done") {
       const item = event.item as Record<string, unknown>;
       if (item.type === "reasoning" && currentBlock?.type === "thinking") {
@@ -1819,4 +1850,5 @@ function mapStopReason(reason: string | null) {
 export const __testing = {
   buildOpenAICompletionsClientConfig,
   processOpenAICompletionsStream,
+  processResponsesStream,
 };

--- a/src/agents/pi-tool-definition-adapter.test.ts
+++ b/src/agents/pi-tool-definition-adapter.test.ts
@@ -183,6 +183,31 @@ describe("toClientToolDefinitions – param coercion", () => {
     );
     expect(calledWith).toEqual({ action: "search", params: { q: "test", page: 1 } });
   });
+
+  // Regression: when Pi invokes the wrapped client-tool definition's execute()
+  // callback during the model loop, the adapter must return `terminate: true`
+  // on the stub result so Pi stops its agent loop right after this batch
+  // (`shouldTerminateToolBatch` in pi-ai's agent-loop.ts). Without it, Pi
+  // would feed the placeholder stub back as a normal tool result and run
+  // another model turn — the model would then narrate the stub (e.g. "I see
+  // status: pending...") alongside the real function_call we hand back to the
+  // /v1/responses caller, producing a ghost turn the caller never asked for.
+  // See the full architecture rationale in pi-tool-definition-adapter.ts at
+  // the `terminate: true` site.
+  it("returns terminate=true on the execute result so Pi aborts the loop after handoff", async () => {
+    const [def] = toClientToolDefinitions([makeClientTool("search")], () => undefined);
+    if (!def) {
+      throw new Error("missing client tool definition");
+    }
+    const result = await def.execute(
+      "call-terminate-1",
+      { query: "hello" },
+      undefined,
+      undefined,
+      extensionContext,
+    );
+    expect(result.terminate).toBe(true);
+  });
 });
 
 describe("client tool name conflict checks", () => {

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -338,12 +338,39 @@ export function toClientToolDefinitions(
         if (onClientToolCall) {
           onClientToolCall(func.name, paramsRecord);
         }
-        // Return a pending result - the client will execute this tool
-        return jsonResult({
-          status: "pending",
-          tool: func.name,
-          message: "Tool execution delegated to client",
-        });
+        // Why `terminate: true`:
+        //
+        // For `/v1/responses`, a client-tool call is inherently a handoff —
+        // the real execution happens on the client, in a *different* HTTP
+        // request from this one. The model's next input for this tool is the
+        // `function_call_output` the client sends in its follow-up request;
+        // it is not, and cannot be, produced inside this session.
+        //
+        // If we returned this stub as a normal tool result, Pi's loop would
+        // treat the tool as completed and run another model turn with the
+        // stub JSON in the thread. The model would then narrate the stub
+        // (e.g. "I see status: pending…") and that narration would ship to
+        // the client alongside the actual function_call, polluting the
+        // conversation with a ghost turn the client never asked for.
+        //
+        // `terminate: true` is Pi's native signal for "stop the loop after
+        // this batch"; see `shouldTerminateToolBatch` in pi-ai's
+        // `packages/agent/src/agent-loop.ts`. The outer runner then observes
+        // `clientToolCallDetected` and surfaces the real function_call via
+        // `pendingToolCalls`, which is what the client is meant to receive.
+        //
+        // The stub payload is preserved for any downstream observer
+        // (session replay, debug logs) that wants to know a handoff
+        // happened at this point — the loop just won't run another model
+        // turn over it.
+        return {
+          ...jsonResult({
+            status: "pending",
+            tool: func.name,
+            message: "Tool execution delegated to client",
+          }),
+          terminate: true,
+        };
       },
     } satisfies ToolDefinition;
   });

--- a/src/gateway/open-responses.schema.ts
+++ b/src/gateway/open-responses.schema.ts
@@ -361,6 +361,20 @@ export const OutputTextDoneEventSchema = z.object({
   text: z.string(),
 });
 
+export const FunctionCallArgumentsDeltaEventSchema = z.object({
+  type: z.literal("response.function_call_arguments.delta"),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  delta: z.string(),
+});
+
+export const FunctionCallArgumentsDoneEventSchema = z.object({
+  type: z.literal("response.function_call_arguments.done"),
+  item_id: z.string(),
+  output_index: z.number().int().nonnegative(),
+  arguments: z.string(),
+});
+
 export type StreamingEvent =
   | z.infer<typeof ResponseCreatedEventSchema>
   | z.infer<typeof ResponseInProgressEventSchema>
@@ -371,4 +385,6 @@ export type StreamingEvent =
   | z.infer<typeof ContentPartAddedEventSchema>
   | z.infer<typeof ContentPartDoneEventSchema>
   | z.infer<typeof OutputTextDeltaEventSchema>
-  | z.infer<typeof OutputTextDoneEventSchema>;
+  | z.infer<typeof OutputTextDoneEventSchema>
+  | z.infer<typeof FunctionCallArgumentsDeltaEventSchema>
+  | z.infer<typeof FunctionCallArgumentsDoneEventSchema>;

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -936,6 +936,213 @@ describe("OpenResponses HTTP API (e2e)", () => {
     expect(events.some((event) => event.data === "[DONE]")).toBe(true);
   });
 
+  // Regression: the canonical OpenAI Responses API streaming sequence for a
+  // function_call delivers arguments via dedicated events:
+  //   response.output_item.added                  (function_call item announced)
+  //   response.function_call_arguments.delta      (args string chunk(s))
+  //   response.function_call_arguments.done       (consolidated full args)
+  //   response.output_item.done                   (function_call item finalized)
+  //
+  // OpenClaw previously only emitted .added and .done with arguments stuffed
+  // into the item field. Spec-strict client parsers (including IntelligenceKit's
+  // own custom parser) ignore item.arguments on .added and rely on
+  // function_call_arguments.delta + .done to fill their args buffer — so they
+  // observed arguments == "{}" for every client-tool call.
+  //
+  // This test pins the canonical four-event sequence so we don't regress.
+  it("emits function_call_arguments.delta + .done between output_item events for streamed tool calls", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    const fullArgs = '{"alpha":42,"beta":"hello","gamma":[1,2,3]}';
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "ack" }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [
+          {
+            id: "call_canonical_1",
+            name: "probe",
+            arguments: fullArgs,
+          },
+        ],
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "x",
+      tools: WEATHER_TOOL,
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+    const eventTypes = events.map((event) => event.event).filter(Boolean);
+
+    // Find the indices of the four function-call related events so we can also
+    // assert ordering, not just presence.
+    const fcAddedIdx = eventTypes.findIndex((t) => t === "response.output_item.added");
+    const fcArgsDeltaIdx = eventTypes.findIndex(
+      (t) => t === "response.function_call_arguments.delta",
+    );
+    const fcArgsDoneIdx = eventTypes.findIndex(
+      (t) => t === "response.function_call_arguments.done",
+    );
+    // output_item.done fires twice in this scenario (once for the assistant
+    // message, once for the function_call). We want the function_call one,
+    // which is the LAST output_item.done before completion.
+    const fcDoneIdx = eventTypes.lastIndexOf("response.output_item.done");
+
+    // All four must be present.
+    expect(
+      fcAddedIdx,
+      "missing response.output_item.added for function_call",
+    ).toBeGreaterThanOrEqual(0);
+    expect(fcArgsDeltaIdx, "missing response.function_call_arguments.delta").toBeGreaterThanOrEqual(
+      0,
+    );
+    expect(fcArgsDoneIdx, "missing response.function_call_arguments.done").toBeGreaterThanOrEqual(
+      0,
+    );
+    expect(fcDoneIdx, "missing response.output_item.done for function_call").toBeGreaterThanOrEqual(
+      0,
+    );
+
+    // Order must be added < delta < done(args) < done(item).
+    expect(fcArgsDeltaIdx).toBeGreaterThan(fcAddedIdx);
+    expect(fcArgsDoneIdx).toBeGreaterThan(fcArgsDeltaIdx);
+    expect(fcDoneIdx).toBeGreaterThan(fcArgsDoneIdx);
+
+    // The delta event must carry the full args string in `delta` (we don't
+    // chunk artificially — by emission time we already have the whole string).
+    const deltaEvent = events[fcArgsDeltaIdx];
+    const deltaPayload = JSON.parse(deltaEvent?.data ?? "{}") as {
+      type?: string;
+      delta?: string;
+      item_id?: string;
+    };
+    expect(deltaPayload.type).toBe("response.function_call_arguments.delta");
+    expect(deltaPayload.delta).toBe(fullArgs);
+    expect(typeof deltaPayload.item_id).toBe("string");
+
+    // The done event must carry the consolidated args string in `arguments`.
+    const doneEvent = events[fcArgsDoneIdx];
+    const donePayload = JSON.parse(doneEvent?.data ?? "{}") as {
+      type?: string;
+      arguments?: string;
+      item_id?: string;
+    };
+    expect(donePayload.type).toBe("response.function_call_arguments.done");
+    expect(donePayload.arguments).toBe(fullArgs);
+    // The item_id on the args events must match the function_call item_id so
+    // accumulators on the client can correlate the chunks back to the item.
+    expect(donePayload.item_id).toBe(deltaPayload.item_id);
+  });
+
+  // Regression: at output_item.added time the function_call args have not yet
+  // streamed, so item.arguments must be the empty string. Real OpenAI does
+  // this; the dedicated function_call_arguments.{delta,done} events that follow
+  // carry the actual payload. If we ship the full args on .added AND repeat
+  // them on .delta, parsers that seed from item.arguments and then append on
+  // .delta (e.g. pi-ai) end up with a transiently doubled raw buffer. Today
+  // that's invisible because partial-json stops at the first complete value
+  // and pi-ai's synthetic-delta guard only fires for prefix-extensions — but
+  // it's "works by accident." Match the spec.
+  it("emits empty item.arguments on output_item.added for streamed function_calls", async () => {
+    const port = enabledPort;
+    agentCommand.mockClear();
+    const fullArgs = '{"alpha":42,"beta":"hello","gamma":[1,2,3]}';
+    agentCommand.mockResolvedValueOnce({
+      payloads: [{ text: "ack" }],
+      meta: {
+        stopReason: "tool_calls",
+        pendingToolCalls: [
+          {
+            id: "call_added_empty_args",
+            name: "probe",
+            arguments: fullArgs,
+          },
+        ],
+      },
+    } as never);
+
+    const res = await postResponses(port, {
+      stream: true,
+      model: "openclaw",
+      input: "x",
+      tools: WEATHER_TOOL,
+    });
+
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const events = parseSseEvents(text);
+
+    // Find every output_item.added event and locate the one whose item is the
+    // function_call. (There's also one for the assistant message earlier.)
+    const addedFunctionCallEvent = events.find((event) => {
+      if (event.event !== "response.output_item.added") {
+        return false;
+      }
+      try {
+        const parsed = JSON.parse(event.data ?? "{}") as {
+          item?: { type?: string };
+        };
+        return parsed.item?.type === "function_call";
+      } catch {
+        return false;
+      }
+    });
+    expect(addedFunctionCallEvent, "missing output_item.added for function_call").toBeDefined();
+
+    const addedPayload = JSON.parse(addedFunctionCallEvent!.data ?? "{}") as {
+      item?: { type?: string; arguments?: string };
+    };
+    expect(addedPayload.item?.type).toBe("function_call");
+    // The arguments field must be empty on .added — args arrive via the
+    // dedicated function_call_arguments.{delta,done} events that follow.
+    expect(addedPayload.item?.arguments).toBe("");
+
+    // And the corresponding output_item.done MUST carry the populated args
+    // (the item is "completed" at that point — args belong on the item).
+    const doneFunctionCallEvent = events.toReversed().find((event) => {
+      if (event.event !== "response.output_item.done") {
+        return false;
+      }
+      try {
+        const parsed = JSON.parse(event.data ?? "{}") as {
+          item?: { type?: string };
+        };
+        return parsed.item?.type === "function_call";
+      } catch {
+        return false;
+      }
+    });
+    expect(doneFunctionCallEvent, "missing output_item.done for function_call").toBeDefined();
+    const donePayloadItem = JSON.parse(doneFunctionCallEvent!.data ?? "{}") as {
+      item?: { type?: string; arguments?: string };
+    };
+    expect(donePayloadItem.item?.arguments).toBe(fullArgs);
+
+    // Regression: the response.completed event embeds the final response
+    // snapshot. Its `output` array's function_call entry must carry the
+    // populated args, not the empty placeholder used on output_item.added.
+    // (Without this assertion, a snapshot-reading consumer would see args
+    // == "" for every streamed client-tool call.)
+    const completedEvent = events.find((event) => event.event === "response.completed");
+    expect(completedEvent, "missing response.completed").toBeDefined();
+    const completedPayload = JSON.parse(completedEvent!.data ?? "{}") as {
+      response?: {
+        output?: Array<{ type?: string; arguments?: string }>;
+      };
+    };
+    const snapshotFunctionCall = completedPayload.response?.output?.find(
+      (item) => item.type === "function_call",
+    );
+    expect(snapshotFunctionCall, "missing function_call in response.completed snapshot").toBeDefined();
+    expect(snapshotFunctionCall?.arguments).toBe(fullArgs);
+  });
+
   it("reuses the prior session when previous_response_id is provided", async () => {
     const port = enabledPort;
     agentCommand.mockClear();

--- a/src/gateway/openresponses-http.test.ts
+++ b/src/gateway/openresponses-http.test.ts
@@ -981,18 +981,33 @@ describe("OpenResponses HTTP API (e2e)", () => {
     const eventTypes = events.map((event) => event.event).filter(Boolean);
 
     // Find the indices of the four function-call related events so we can also
-    // assert ordering, not just presence.
-    const fcAddedIdx = eventTypes.findIndex((t) => t === "response.output_item.added");
+    // assert ordering, not just presence. output_item.{added,done} also fire
+    // for the assistant text item that precedes the function_call, so we
+    // can't just match on the event type — we have to look at the embedded
+    // item.type to find the function_call's bookend events specifically.
+    const isFunctionCallItemEvent = (event: { event?: string; data?: string }, eventType: string) => {
+      if (event.event !== eventType) {
+        return false;
+      }
+      try {
+        const parsed = JSON.parse(event.data ?? "{}") as { item?: { type?: string } };
+        return parsed.item?.type === "function_call";
+      } catch {
+        return false;
+      }
+    };
+    const fcAddedIdx = events.findIndex((event) =>
+      isFunctionCallItemEvent(event, "response.output_item.added"),
+    );
+    const fcDoneIdx = events.findIndex((event) =>
+      isFunctionCallItemEvent(event, "response.output_item.done"),
+    );
     const fcArgsDeltaIdx = eventTypes.findIndex(
       (t) => t === "response.function_call_arguments.delta",
     );
     const fcArgsDoneIdx = eventTypes.findIndex(
       (t) => t === "response.function_call_arguments.done",
     );
-    // output_item.done fires twice in this scenario (once for the assistant
-    // message, once for the function_call). We want the function_call one,
-    // which is the LAST output_item.done before completion.
-    const fcDoneIdx = eventTypes.lastIndexOf("response.output_item.done");
 
     // All four must be present.
     expect(

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -1037,16 +1037,51 @@ export async function handleOpenResponsesHttpRequest(
         });
 
         const functionCallItemId = `call_${randomUUID()}`;
+        // Match the convention common to streaming APIs (and used by the
+        // OpenAI Responses API): the announce event carries an in-progress
+        // item with an empty payload placeholder; the dedicated delta/done
+        // events that follow fill the payload; the done-event item finalizes
+        // it. Some parsers specifically expect this — IntelligenceKit's
+        // parser, for instance, treats item.arguments on .added as a
+        // placeholder and only fills its args buffer from the dedicated
+        // delta/done events. Shipping the full args on .added would also
+        // cause accumulators that seed from item.arguments and then append
+        // each delta to double them.
         const functionCallItem = createFunctionCallOutputItem({
           id: functionCallItemId,
           callId: functionCall.id,
           name: functionCall.name,
-          arguments: functionCall.arguments,
+          arguments: "",
         });
         writeSseEvent(res, {
           type: "response.output_item.added",
           output_index: 1,
           item: functionCallItem,
+        });
+        // Emit the dedicated function-call argument streaming events between
+        // .added and .done. Conformant client parsers (including
+        // IntelligenceKit's) ignore item.arguments on output_item events for
+        // streamed function_calls and rely exclusively on the
+        // response.function_call_arguments.{delta,done} events to fill their
+        // args buffer. Without these, every streamed client-tool call lands on
+        // the wire with arguments == "{}".
+        //
+        // We don't have per-token granularity here — by the time
+        // pendingToolCalls is built, the model has already finalized the args
+        // string. Emitting one delta carrying the full string is honest about
+        // the data shape; clients accumulate the same way regardless of chunk
+        // count. A subsequent .done event consolidates and signals end-of-args.
+        writeSseEvent(res, {
+          type: "response.function_call_arguments.delta",
+          item_id: functionCallItemId,
+          output_index: 1,
+          delta: functionCall.arguments,
+        });
+        writeSseEvent(res, {
+          type: "response.function_call_arguments.done",
+          item_id: functionCallItemId,
+          output_index: 1,
+          arguments: functionCall.arguments,
         });
         const completedFunctionCallItem = createFunctionCallOutputItem({
           id: functionCallItemId,
@@ -1065,7 +1100,7 @@ export async function handleOpenResponsesHttpRequest(
           id: responseId,
           model,
           status: "incomplete",
-          output: [completedItem, functionCallItem],
+          output: [completedItem, completedFunctionCallItem],
           usage,
         });
         closed = true;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** Two issues affected `/v1/responses` client-tool calls (tools the API caller passes in `tools: [...]` for the agent to delegate back to them):
  - **Bug:** every client-tool call shipped an extra phantom assistant turn alongside the real `function_call`. **Symptom:** the model first denies it can run the tool, then seconds later in the same SSE response claims it did — a self-contradictory mini-transcript every caller saw, regardless of how their parser was built.
  - **Separately, some clients didn't see the args at all.** The gateway delivered them by populating `item.arguments` on the `output_item.added` / `output_item.done` events, instead of using the dedicated `response.function_call_arguments.delta` / `.done` events that the Responses-API streaming convention reserves for incremental function-call arguments. Clients whose parsers follow that convention strictly — only reading args from those dedicated events — saw `arguments == "{}"` for every call, because the dedicated events simply weren't being emitted. More permissive clients (e.g. OpenAI's Node SDK, which also reads `item.arguments` directly) recovered the args from the bundled-in shape and worked anyway.
  Two unrelated root causes combined to produce these symptoms. (1) The Pi-side adapter for client-tool definitions returned a placeholder stub from its `execute()` callback without `terminate: true`, so Pi treated the stub as a normal tool result and ran *another* model turn before the runner observed the handoff — that extra turn is what leaked into the stream as the contradictory phantom narration. (2) The `/v1/responses` SSE emitter never emitted the dedicated `response.function_call_arguments.delta` / `.done` events.
- **Why it matters:** Together, the two issues meant `/v1/responses` couldn't be relied on for client-tool calls — every caller (lenient or strict) saw the conversation contaminated by the contradictory phantom narration, and on top of that, strict clients lost the args entirely.
- **What changed:** The Pi adapter for client-tool definitions now returns `terminate: true` on its handoff stub, so Pi stops the agent loop after this batch and the placeholder stub does not produce another model turn. Piggybacked on top of that, the gateway's SSE event sequence for streamed function_call output items is tightened to follow the Responses-API streaming convention more closely (`output_item.added` with empty placeholder → `function_call_arguments.delta` → `function_call_arguments.done` → `output_item.done` with populated args), and the upstream Responses-stream parser also gains a handler for `response.function_call_arguments.done` to cover the case where an upstream delivers the full args only via `.done`.
- **What did NOT change (scope boundary):** No changes to the non-streaming JSON response path. No changes to non-`/v1/responses` endpoints. No changes to authentication, secrets handling, command/tool execution surface, or data access scope. No changes to `DefaultConfigurationExtension.threadTransformers` seeding or to any plugin contract.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause:** Two independent root causes in two layers.
  1. The Pi adapter at `src/agents/pi-tool-definition-adapter.ts` returned a placeholder stub for client-tool calls without setting Pi's `terminate: true` flag, so Pi treated the stub as a normal tool result and ran an extra model turn before the outer runner observed `clientToolCallDetected`. That extra turn is what produced the contradictory phantom narration in the SSE stream.
  2. The `/v1/responses` SSE emitter at `src/gateway/openresponses-http.ts` shipped streamed function-call args by populating `item.arguments` on the `output_item.added` / `output_item.done` events instead of using the dedicated `response.function_call_arguments.delta` / `.done` events. The Responses-API streaming convention reserves those dedicated events for incremental args; some client parsers (those that read args only from those events) saw nothing because they weren't emitted.
- **Missing detection / guardrail:** No regression test asserted that the adapter's `execute()` callback returned `terminate: true`, and no regression test pinned the four-event SSE sequence for streamed function_calls. Both are now covered.
- **Contributing context (if known):** The Responses-API streaming convention pairs the bookend `output_item.{added,done}` events with dedicated `function_call_arguments.{delta,done}` events that carry the streamed args; `openresponses-http.ts` had only ever emitted the bookends. The OpenAI Node SDK and pi-ai both seed their args buffer from `output_item.added.item.arguments` and then append each `delta`, so they recovered the args from the bundled-in shape; parsers that read args only from the dedicated events did not.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- **Target test or file:**
  - `src/agents/pi-tool-definition-adapter.test.ts` — pins the `terminate: true` flag on the handoff stub returned by the wrapped client-tool `execute()` callback.
  - `src/gateway/openresponses-http.test.ts` — pins the SSE event sequence for streamed function_call output items.
  - `src/agents/openai-transport-stream.test.ts` — pins the `.done`-only-args recovery branch in the upstream Responses-stream parser.
- **Scenario the test should lock in:** The Pi adapter's `execute()` callback returns `terminate: true` so the agent loop stops after the handoff; the `/v1/responses` SSE stream for a streamed `function_call` carries the dedicated `function_call_arguments.{delta,done}` events between the `output_item.added` and `output_item.done` bookends; and `processResponsesStream` recovers args from `function_call_arguments.done` when no intermediate deltas were emitted.
- **Why this is the smallest reliable guardrail:** All three are unit-level seams over the exact code paths involved (the adapter's execute callback, the SSE emitter, and the upstream stream parser). They are deterministic, fast, and survive refactoring of internal helpers.
- **Existing test that already covers this (if any):** None.
- **If no new test is added, why not:** N/A — three new tests added.

## User-visible / Behavior Changes

External clients consuming `/v1/responses` for client-tool calls will no longer see the conversation contaminated by a self-contradictory phantom assistant turn (where the model first claimed it could not run the tool, then seconds later claimed it did). On top of that, clients whose parsers read streamed args only from the dedicated `function_call_arguments.{delta,done}` events will now receive the parsed function-call arguments through those events instead of an empty `{}`. No CLI/UI/default-config changes.

## Diagram (if applicable)

**Pi agent loop (the main fix):**

```text
Before:
  model emits function_call(tool=client_tool, args={...})
  Pi → wrapped execute(args) → returns { status:"pending", ... }   (no terminate flag)
  Pi treats stub as normal tool result → runs ANOTHER model turn
  model now has the stub in context → narrates "can't run that tool"
                                          → seconds later → "actually did run it"
  loop finally returns → runner observes clientToolCallDetected
  → both the real function_call AND the contradictory narration go on the wire

After:
  model emits function_call(tool=client_tool, args={...})
  Pi → wrapped execute(args) → returns { status:"pending", ..., terminate: true }
  Pi sees terminate=true → STOPS the loop after this batch
  runner observes clientToolCallDetected → surfaces the real function_call via pendingToolCalls
  → only the real function_call goes on the wire, no narration
```

**`/v1/responses` SSE event sequence (the piggybacked wire-shape improvement):**

```text
Before:
client POST /v1/responses (stream=true, tools=[client_tool])
  -> SSE: output_item.added       (item.arguments = "<full args>")
  -> SSE: output_item.done        (item.arguments = "<full args>")
  -> client parser sees arguments == "{}"   (only if it ignores item.arguments)

After:
client POST /v1/responses (stream=true, tools=[client_tool])
  -> SSE: output_item.added                  (item.arguments = "")
  -> SSE: function_call_arguments.delta      (full args string)
  -> SSE: function_call_arguments.done       (full args string)
  -> SSE: output_item.done                   (item.arguments populated)
  -> all parsers see parsed args             ← correct
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` — same client-tool handoff contract, just delivered through a more usual SSE event sequence.
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A.

## Repro + Verification

### Environment

- OS: any (issue is platform-agnostic)
- Runtime/container: OpenClaw self-hosted gateway via the standard docker-compose deployment
- Model/provider: provider-agnostic — reproduces with any model that triggers a client-tool call
- Integration/channel (if any): `/v1/responses` HTTP endpoint, client-tool definition handed off to the API caller
- Relevant config (redacted): gateway with `/v1/responses` enabled and at least one agent configured

### Steps

1. Run the OpenClaw gateway with at least one agent that exposes the `/v1/responses` endpoint.
2. From any external HTTP client (curl or any OpenAI-Responses-compatible client), POST to `/v1/responses` with `stream: true` and a `tools: [...]` array including a client-tool definition.
3. Cause the model to call that client tool with non-trivial arguments.
4. Observe the conversation transcript and the parsed function-call arguments on the client side.

### Expected

- No extra assistant-text turn narrating the placeholder stub appears alongside the real `function_call`. The transcript is exactly what the caller asked for: the model emits the tool call and the agent loop yields control back for the client to handle it.
- The client receives the parsed function-call arguments matching what the model produced (delivered through the dedicated `function_call_arguments.{delta,done}` SSE events for parsers that read from those, or via `item.arguments` on the bookend events for parsers that read from there).

### Actual

- Matches Expected with this PR. Without it: a self-contradictory assistant narration appears alongside the real `function_call` (the model first declares it cannot run the tool, then a few seconds later claims it did), and clients that read args only from the dedicated streaming events see `arguments == "{}"`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — three regression tests added in this PR, RED before each respective fix, GREEN after (`openresponses-http.test.ts`, `pi-tool-definition-adapter.test.ts`, `openai-transport-stream.test.ts`).
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What I personally verified (not just CI), and how:

- **Verified scenarios:**
  - Ran the OpenClaw gateway locally and drove a real `/v1/responses` request from a local client that triggered a client-tool call. The client tool received its parsed arguments correctly, and the conversation contained no phantom narration of the placeholder stub alongside the real `function_call`.
- **Edge cases checked:** N/A — the regression tests pin the wire-shape invariants for any args payload, and the scenario above exercises the real handoff loop.
- **What I did not verify:** nothing scope-relevant beyond the above.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — additive on the wire (the dedicated `function_call_arguments.{delta,done}` events are new; `item.arguments` on `output_item.done` still carries the populated args; only `output_item.added`'s `item.arguments` field changes from `<full args>` to `""`).
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- **Risk:** A client that read `item.arguments` from `output_item.added` as its sole source (and ignored both the dedicated args events and `output_item.done`'s `item.arguments`) will now read `""`.
  - **Mitigation:** This is an uncommon parser pattern — neither the OpenAI Node SDK nor pi-ai work that way; both also consume the dedicated streaming events and `output_item.done.item.arguments`. The populated args remain available via both of those alternative sources for any client that follows either pattern.

---

## AI-assisted PR

- [x] Mark as AI-assisted in the PR title or description
- [x] Note the degree of testing: **fully tested** (three RED/GREEN regression tests added in this PR; CONTRIBUTING.md gates `pnpm build && pnpm check && pnpm test` run on a Linux box matching CI conditions; touched files clean for `pnpm lint` and `pnpm format:check`).
- Session logs: developed iteratively with Claude Opus 4.7 via Claude Code in the OpenClaw repo.
- [x] I understand what the code does — see the per-file commit body for the rationale at each touch point.
