### PR TITLE
CI: add AGENTS.md size guard to check-additional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1364,6 +1364,7 @@
     "ios:version:sync": "node --import tsx scripts/ios-sync-versioning.ts --write",
     "lint": "node scripts/run-oxlint-shards.mjs",
     "lint:agent:ingress-owner": "node scripts/check-ingress-agent-owner-context.mjs",
+    "lint:agents-md:size": "node --import tsx scripts/check-agents-md.ts",
     "lint:all": "node scripts/run-oxlint.mjs",
     "lint:apps": "pnpm lint:swift",
     "lint:auth:no-pairing-store-group": "node scripts/check-no-pairing-store-group-auth.mjs",

--- a/scripts/check-agents-md.ts
+++ b/scripts/check-agents-md.ts
@@ -1,0 +1,147 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+// Line-count ceiling for every tracked `AGENTS.md` in the repo. Enforces the
+// progressive-disclosure invariant: rules colocate with the surface they
+// govern, and no single guide is allowed to grow back into a monolith.
+//
+// The target is 150. Exemptions below are tombstoned — remove once the
+// corresponding migration lands.
+export const DEFAULT_MAX_LINES = 150;
+
+// Paths (repo-root relative, forward slash) that are intentionally allowed to
+// exceed the cap today. Each entry MUST name the reason and the PR/condition
+// under which it can be removed.
+export const KNOWN_EXEMPTIONS: ReadonlyArray<{ path: string; reason: string }> = [
+  {
+    path: "AGENTS.md",
+    // Remove once the root-CLAUDE.md slim-down PR (the "task -> guide" router
+    // split) lands. Tracking: council verdict 2026-04-24.
+    reason:
+      "Root AGENTS.md is scheduled for extraction into docs/contributing/*. Exemption must be removed once that restructure lands.",
+  },
+  {
+    path: "docs/reference/templates/AGENTS.md",
+    // Templates document exemplar content (copy-paste starter material). They
+    // are not live contributor rules and never should be.
+    reason: "Template file — documents exemplar content, not live rules.",
+  },
+] as const;
+
+function writeStdoutLine(message: string): void {
+  process.stdout.write(`${message}\n`);
+}
+
+type ParsedArgs = {
+  maxLines: number;
+};
+
+function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+  let maxLines = DEFAULT_MAX_LINES;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+    if (arg === "--max") {
+      const next = argv[index + 1];
+      if (!next || Number.isNaN(Number(next))) {
+        throw new Error("Missing/invalid --max value");
+      }
+      maxLines = Number(next);
+      index++;
+      continue;
+    }
+  }
+
+  return { maxLines };
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function gitLsAgentsFiles(cwd?: string): string[] {
+  const stdout = execFileSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "*AGENTS.md"],
+    { encoding: "utf8", cwd },
+  );
+  return stdout
+    .split("\n")
+    .map((line) => normalizePath(line.trim()))
+    .filter(Boolean)
+    .filter((filePath) => path.basename(filePath) === "AGENTS.md");
+}
+
+export function isExempt(
+  relativePath: string,
+  exemptions: ReadonlyArray<{ path: string }> = KNOWN_EXEMPTIONS,
+): boolean {
+  const normalized = normalizePath(relativePath);
+  return exemptions.some((entry) => entry.path === normalized);
+}
+
+export type Offender = {
+  filePath: string;
+  lines: number;
+};
+
+export async function findOversizedAgentsFiles(
+  filePaths: ReadonlyArray<string>,
+  maxLines: number,
+  exemptions: ReadonlyArray<{ path: string }> = KNOWN_EXEMPTIONS,
+  readFileImpl: (p: string) => Promise<string> = (p) => readFile(p, "utf8"),
+): Promise<Offender[]> {
+  const results = await Promise.all(
+    filePaths
+      .filter((filePath) => !isExempt(filePath, exemptions))
+      .map(async (filePath) => {
+        const content = await readFileImpl(filePath);
+        // Count physical lines. Keeps the rule predictable across editors.
+        const lines = content.split("\n").length;
+        return { filePath, lines };
+      }),
+  );
+
+  return results.filter((result) => result.lines > maxLines).toSorted((a, b) => b.lines - a.lines);
+}
+
+async function main(): Promise<void> {
+  // Makes `... | head` safe.
+  process.stdout.on("error", (error: NodeJS.ErrnoException) => {
+    if (error.code === "EPIPE") {
+      process.exit(0);
+    }
+    throw error;
+  });
+
+  const { maxLines } = parseArgs(process.argv.slice(2));
+  const tracked = gitLsAgentsFiles().filter((filePath) => existsSync(filePath));
+
+  const offenders = await findOversizedAgentsFiles(tracked, maxLines);
+
+  if (!offenders.length) {
+    return;
+  }
+
+  writeStdoutLine(`AGENTS.md files exceeding ${maxLines} lines:`);
+  for (const offender of offenders) {
+    writeStdoutLine(`${offender.lines}\t${offender.filePath}`);
+  }
+  writeStdoutLine("");
+  writeStdoutLine("Extract rules into the scoped guide they govern, or into docs/contributing/*.");
+  writeStdoutLine(
+    "If a file genuinely must exceed the cap, add it to KNOWN_EXEMPTIONS in scripts/check-agents-md.ts with a tombstoned reason.",
+  );
+
+  process.exitCode = 1;
+}
+
+// Only run main when executed directly (keeps tests clean).
+const invokedDirectly =
+  typeof process.argv[1] === "string" &&
+  normalizePath(process.argv[1]).endsWith("scripts/check-agents-md.ts");
+if (invokedDirectly) {
+  await main();
+}

--- a/scripts/run-additional-boundary-checks.mjs
+++ b/scripts/run-additional-boundary-checks.mjs
@@ -52,6 +52,7 @@ export const BOUNDARY_CHECKS = [
     ["run", "lint:extensions:no-relative-outside-package"],
   ],
   ["lint:ui:no-raw-window-open", "pnpm", ["lint:ui:no-raw-window-open"]],
+  ["lint:agents-md:size", "pnpm", ["run", "lint:agents-md:size"]],
 ].map(([label, command, args]) => ({ label, command, args }));
 
 export function resolveConcurrency(value, fallback = 4) {

--- a/test/scripts/check-agents-md.test.ts
+++ b/test/scripts/check-agents-md.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MAX_LINES,
+  findOversizedAgentsFiles,
+  isExempt,
+  KNOWN_EXEMPTIONS,
+} from "../../scripts/check-agents-md.ts";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+function writeAgentsFile(root: string, relPath: string, lineCount: number): string {
+  const fullPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  // `lineCount` physical lines = that many `\n`-separated chunks.
+  const content = Array.from({ length: lineCount }, (_, i) => `line ${i + 1}`).join("\n");
+  fs.writeFileSync(fullPath, content);
+  return fullPath;
+}
+
+describe("check-agents-md", () => {
+  it("flags AGENTS.md files over the cap", async () => {
+    const root = createTempDir("openclaw-agents-md-");
+    writeAgentsFile(root, "src/foo/AGENTS.md", 200);
+
+    const offenders = await findOversizedAgentsFiles(["src/foo/AGENTS.md"], 150, [], (p) =>
+      Promise.resolve(fs.readFileSync(path.join(root, p), "utf8")),
+    );
+
+    expect(offenders).toEqual([{ filePath: "src/foo/AGENTS.md", lines: 200 }]);
+  });
+
+  it("passes files at or below the cap", async () => {
+    const root = createTempDir("openclaw-agents-md-");
+    writeAgentsFile(root, "src/small/AGENTS.md", 100);
+    writeAgentsFile(root, "src/exact/AGENTS.md", 150);
+
+    const offenders = await findOversizedAgentsFiles(
+      ["src/small/AGENTS.md", "src/exact/AGENTS.md"],
+      150,
+      [],
+      (p) => Promise.resolve(fs.readFileSync(path.join(root, p), "utf8")),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("skips files on the exemption allowlist", async () => {
+    const root = createTempDir("openclaw-agents-md-");
+    writeAgentsFile(root, "AGENTS.md", 400);
+
+    const offenders = await findOversizedAgentsFiles(
+      ["AGENTS.md"],
+      150,
+      [{ path: "AGENTS.md" }],
+      (p) => Promise.resolve(fs.readFileSync(path.join(root, p), "utf8")),
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("sorts offenders by size descending", async () => {
+    const root = createTempDir("openclaw-agents-md-");
+    writeAgentsFile(root, "src/a/AGENTS.md", 160);
+    writeAgentsFile(root, "src/b/AGENTS.md", 300);
+    writeAgentsFile(root, "src/c/AGENTS.md", 200);
+
+    const offenders = await findOversizedAgentsFiles(
+      ["src/a/AGENTS.md", "src/b/AGENTS.md", "src/c/AGENTS.md"],
+      150,
+      [],
+      (p) => Promise.resolve(fs.readFileSync(path.join(root, p), "utf8")),
+    );
+
+    expect(offenders.map((o) => o.filePath)).toEqual([
+      "src/b/AGENTS.md",
+      "src/c/AGENTS.md",
+      "src/a/AGENTS.md",
+    ]);
+  });
+
+  it("normalizes Windows-style path separators when matching exemptions", () => {
+    expect(isExempt("AGENTS.md", [{ path: "AGENTS.md" }])).toBe(true);
+    expect(
+      isExempt("docs\\reference\\templates\\AGENTS.md", [
+        { path: "docs/reference/templates/AGENTS.md" },
+      ]),
+    ).toBe(true);
+    expect(isExempt("extensions/AGENTS.md", [{ path: "AGENTS.md" }])).toBe(false);
+  });
+
+  it("exposes a default line cap of 150", () => {
+    expect(DEFAULT_MAX_LINES).toBe(150);
+  });
+
+  it("documents every exemption with a reason", () => {
+    for (const entry of KNOWN_EXEMPTIONS) {
+      expect(entry.reason.length).toBeGreaterThan(20);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/check-agents-md.ts` — caps every tracked `AGENTS.md` at 150 lines to stop any single guide from regrowing into a monolith.
- Wires into the sharded `check-additional` layout via `BOUNDARY_CHECKS` in `scripts/run-additional-boundary-checks.mjs`; adds matching `pnpm run lint:agents-md:size` script.
- Tombstoned exemptions (must be removed when each condition fires):
  - `AGENTS.md` (root, 318 lines) — exempt until the planned root slim-down PR extracts operational content to `docs/contributing/*`.
  - `docs/reference/templates/AGENTS.md` — permanent exemption (template exemplar content, not live rules).

## Why now

Context: the root `AGENTS.md` has grown to 318 lines / ~42 KB and mixes ~12 unrelated domains (architecture boundaries, build/test, coding style, testing perf guardrails, platform tips, multi-agent safety…). Before any restructure lands, this guard establishes the floor so the new per-surface guides can't quietly regrow. Mechanical invariant > aspirational hygiene.

## Design notes

- Line-count only in PR1. A follow-up will add a duplicate-rule-sentence guard once the root extraction lands — running it today would fire on current-state near-duplicates across root and scoped guides.
- Exemptions carry a `reason:` field and are enforced by the test suite (`documents every exemption with a reason`).
- Uses the same shape as `scripts/check-ts-max-loc.ts` (git-ls-files + line count + descending offenders output).

## Test plan

- [x] `pnpm test test/scripts/check-agents-md.test.ts` — 7/7 pass
- [x] `pnpm run lint:agents-md:size` — exit 0 on current `origin/main`
- [x] Manual: introduced a fake 200-line `AGENTS.md` and verified the guard reports it sorted-by-size-descending and sets exit 1
- [x] Manual: confirmed exempt paths bypass the cap (root + templates)

Design verified against a 5-advisor Council session with peer review (transcript available on request).