### PR TITLE
feat(agents): add session working-context capsule (MVP for #67511)

### DIFF
--- a/src/agents/session-working-context.test.ts
+++ b/src/agents/session-working-context.test.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearWorkingContext,
+  normalizeWorkingContext,
+  readWorkingContext,
+  resolveWorkingContextPath,
+  SESSION_WORKING_CONTEXT_VERSION,
+  writeWorkingContext,
+} from "./session-working-context.js";
+
+const tempDirs: string[] = [];
+
+async function createTempSessionPath() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-working-context-"));
+  tempDirs.push(dir);
+  return { dir, file: path.join(dir, "session.jsonl") };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("resolveWorkingContextPath", () => {
+  it("places the capsule next to the session file with a .context.json suffix", () => {
+    const resolved = resolveWorkingContextPath("/var/data/openclaw/sessions/abc.jsonl");
+    expect(resolved).toBe("/var/data/openclaw/sessions/abc.context.json");
+  });
+
+  it("handles session files without a .jsonl extension", () => {
+    const resolved = resolveWorkingContextPath("/tmp/session");
+    expect(resolved).toBe("/tmp/session.context.json");
+  });
+
+  it("throws when given an empty path", () => {
+    expect(() => resolveWorkingContextPath("")).toThrow(/sessionFile/);
+  });
+});
+
+describe("normalizeWorkingContext", () => {
+  it("drops unknown fields and invalid types", () => {
+    const normalized = normalizeWorkingContext({
+      cwd: "/work/repo",
+      branch: 42, // wrong type
+      tempClones: ["/tmp/a", 17, "/tmp/b"],
+      sandboxed: "yes", // wrong type
+      bogus: "ignored",
+    });
+    expect(normalized).toEqual({
+      cwd: "/work/repo",
+      tempClones: ["/tmp/a", "/tmp/b"],
+    });
+  });
+
+  it("returns an empty object for non-object input", () => {
+    expect(normalizeWorkingContext(null)).toEqual({});
+    expect(normalizeWorkingContext("oops")).toEqual({});
+    expect(normalizeWorkingContext([1, 2])).toEqual({});
+  });
+
+  it("preserves boolean false for sandboxed", () => {
+    const normalized = normalizeWorkingContext({ sandboxed: false });
+    expect(normalized).toEqual({ sandboxed: false });
+  });
+});
+
+describe("writeWorkingContext / readWorkingContext", () => {
+  it("round-trips a typical working-context capsule", async () => {
+    const { file } = await createTempSessionPath();
+    const capsulePath = await writeWorkingContext(file, {
+      cwd: "/work/openclaw",
+      activeRepoRoot: "/work/openclaw",
+      branch: "feat/context-persistence",
+      tempClones: ["/tmp/pr-conflict-clone"],
+      lastPushRemote: "origin",
+      lastPushBranch: "feat/context-persistence",
+      sandboxed: false,
+      notes: "resumed after /compact",
+    });
+
+    expect(capsulePath.endsWith("session.context.json")).toBe(true);
+
+    const loaded = await readWorkingContext(file);
+    expect(loaded).toMatchObject({
+      cwd: "/work/openclaw",
+      activeRepoRoot: "/work/openclaw",
+      branch: "feat/context-persistence",
+      tempClones: ["/tmp/pr-conflict-clone"],
+      lastPushRemote: "origin",
+      lastPushBranch: "feat/context-persistence",
+      sandboxed: false,
+      notes: "resumed after /compact",
+    });
+    expect(typeof loaded?.updatedAt).toBe("string");
+  });
+
+  it("returns null when no capsule exists", async () => {
+    const { file } = await createTempSessionPath();
+    expect(await readWorkingContext(file)).toBeNull();
+  });
+
+  it("returns null for malformed JSON capsules", async () => {
+    const { file } = await createTempSessionPath();
+    const capsulePath = resolveWorkingContextPath(file);
+    await fs.writeFile(capsulePath, "{not json", "utf-8");
+    expect(await readWorkingContext(file)).toBeNull();
+  });
+
+  it("returns null when the envelope is missing a version", async () => {
+    const { file } = await createTempSessionPath();
+    const capsulePath = resolveWorkingContextPath(file);
+    await fs.writeFile(capsulePath, JSON.stringify({ context: { cwd: "/x" } }), "utf-8");
+    expect(await readWorkingContext(file)).toBeNull();
+  });
+
+  it("ignores unknown future fields forward-compatibly", async () => {
+    const { file } = await createTempSessionPath();
+    const capsulePath = resolveWorkingContextPath(file);
+    await fs.writeFile(
+      capsulePath,
+      JSON.stringify({
+        version: SESSION_WORKING_CONTEXT_VERSION + 1,
+        context: { cwd: "/x", futureField: { shape: "unknown" } },
+      }),
+      "utf-8",
+    );
+    const loaded = await readWorkingContext(file);
+    expect(loaded).toMatchObject({ cwd: "/x" });
+  });
+
+  it("stamps updatedAt using the provided clock", async () => {
+    const { file } = await createTempSessionPath();
+    const fixed = new Date("2026-04-24T16:00:00.000Z");
+    await writeWorkingContext(file, { cwd: "/x" }, { now: () => fixed });
+    const loaded = await readWorkingContext(file);
+    expect(loaded?.updatedAt).toBe(fixed.toISOString());
+  });
+
+  it("creates the session directory if it does not yet exist", async () => {
+    const { dir } = await createTempSessionPath();
+    const nestedSessionFile = path.join(dir, "nested", "sessions", "s1.jsonl");
+    await writeWorkingContext(nestedSessionFile, { cwd: "/x" });
+    const loaded = await readWorkingContext(nestedSessionFile);
+    expect(loaded?.cwd).toBe("/x");
+  });
+
+  it("overwrites the capsule on subsequent writes", async () => {
+    const { file } = await createTempSessionPath();
+    await writeWorkingContext(file, { cwd: "/first", branch: "main" });
+    await writeWorkingContext(file, { cwd: "/second" });
+    const loaded = await readWorkingContext(file);
+    expect(loaded?.cwd).toBe("/second");
+    expect(loaded?.branch).toBeUndefined();
+  });
+});
+
+describe("clearWorkingContext", () => {
+  it("removes an existing capsule and returns true", async () => {
+    const { file } = await createTempSessionPath();
+    await writeWorkingContext(file, { cwd: "/x" });
+    expect(await clearWorkingContext(file)).toBe(true);
+    expect(await readWorkingContext(file)).toBeNull();
+  });
+
+  it("returns false when there is nothing to remove", async () => {
+    const { file } = await createTempSessionPath();
+    expect(await clearWorkingContext(file)).toBe(false);
+  });
+});

--- a/src/agents/session-working-context.ts
+++ b/src/agents/session-working-context.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Small, structured per-session "working context" capsule.
+ *
+ * The JSONL transcript preserves *semantic* continuity (what was said and
+ * decided). It does not cleanly preserve *engineering* working state — which
+ * repo the agent was operating in, which branch, any temp clones in play,
+ * etc. After `/compact` or `/new`, that state is easy to lose even when the
+ * summary is fine.
+ *
+ * This module provides a minimal, stable file format for persisting that
+ * working context next to the session file. It is intentionally small,
+ * append-free, best-effort, and independent of runtime/engine wiring so it
+ * can be adopted incrementally (see #67511 for the broader proposal).
+ */
+
+export type SessionWorkingContext = {
+  /** Runtime cwd the agent last observed. */
+  cwd?: string;
+  /** Repository root the agent is actively modifying, if any. */
+  activeRepoRoot?: string;
+  /** Git branch checked out in the active repo, if known. */
+  branch?: string;
+  /** Temporary clones the session is currently using. */
+  tempClones?: string[];
+  /** Remote most recently pushed to. */
+  lastPushRemote?: string;
+  /** Branch most recently pushed. */
+  lastPushBranch?: string;
+  /** Whether the session is running inside a sandbox. */
+  sandboxed?: boolean;
+  /** ISO timestamp of the last update. Set by the writer; ignored on input. */
+  updatedAt?: string;
+  /** Free-form notes the agent may persist (short; not a transcript). */
+  notes?: string;
+};
+
+/** Current on-disk schema version. Bump when the persisted shape changes. */
+export const SESSION_WORKING_CONTEXT_VERSION = 1 as const;
+
+type PersistedEnvelope = {
+  version: number;
+  context: SessionWorkingContext;
+};
+
+/**
+ * Resolve the path of the working-context capsule for a given session file.
+ *
+ * Given `/path/to/session.jsonl`, returns `/path/to/session.context.json`.
+ * The capsule sits next to the transcript so it is naturally scoped to the
+ * session and cleaned up with it.
+ */
+export function resolveWorkingContextPath(sessionFile: string): string {
+  const trimmed = sessionFile.trim();
+  if (!trimmed) {
+    throw new Error("resolveWorkingContextPath: sessionFile is required");
+  }
+  const dir = path.dirname(trimmed);
+  const base = path.basename(trimmed);
+  const stem = base.endsWith(".jsonl") ? base.slice(0, -".jsonl".length) : base;
+  return path.join(dir, `${stem}.context.json`);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function coerceString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function coerceStringArray(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const out = value.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Normalize a raw record into a {@link SessionWorkingContext}, discarding
+ * unknown fields and values of the wrong type. Returns an empty object if
+ * nothing usable is present.
+ */
+export function normalizeWorkingContext(raw: unknown): SessionWorkingContext {
+  if (!isPlainObject(raw)) {
+    return {};
+  }
+  const out: SessionWorkingContext = {};
+  const cwd = coerceString(raw.cwd);
+  if (cwd) out.cwd = cwd;
+  const activeRepoRoot = coerceString(raw.activeRepoRoot);
+  if (activeRepoRoot) out.activeRepoRoot = activeRepoRoot;
+  const branch = coerceString(raw.branch);
+  if (branch) out.branch = branch;
+  const tempClones = coerceStringArray(raw.tempClones);
+  if (tempClones) out.tempClones = tempClones;
+  const lastPushRemote = coerceString(raw.lastPushRemote);
+  if (lastPushRemote) out.lastPushRemote = lastPushRemote;
+  const lastPushBranch = coerceString(raw.lastPushBranch);
+  if (lastPushBranch) out.lastPushBranch = lastPushBranch;
+  if (typeof raw.sandboxed === "boolean") out.sandboxed = raw.sandboxed;
+  const updatedAt = coerceString(raw.updatedAt);
+  if (updatedAt) out.updatedAt = updatedAt;
+  const notes = coerceString(raw.notes);
+  if (notes) out.notes = notes;
+  return out;
+}
+
+/**
+ * Read and parse the working-context capsule for a session.
+ *
+ * Returns `null` when the capsule does not exist or is unreadable/invalid.
+ * Missing capsules are not errors — older sessions simply have no capsule.
+ */
+export async function readWorkingContext(
+  sessionFile: string,
+): Promise<SessionWorkingContext | null> {
+  const capsulePath = resolveWorkingContextPath(sessionFile);
+  let raw: string;
+  try {
+    raw = await fs.readFile(capsulePath, "utf-8");
+  } catch (err) {
+    const code = (err as { code?: string } | undefined)?.code;
+    if (code === "ENOENT") {
+      return null;
+    }
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) {
+    return null;
+  }
+  const envelope = parsed as Partial<PersistedEnvelope>;
+  if (typeof envelope.version !== "number" || envelope.version <= 0) {
+    return null;
+  }
+  if (envelope.version > SESSION_WORKING_CONTEXT_VERSION) {
+    // Forward-compatible: read what we understand; ignore what we don't.
+  }
+  return normalizeWorkingContext(envelope.context);
+}
+
+/**
+ * Persist the working-context capsule for a session.
+ *
+ * Writes atomically via temp + rename. The directory is created if needed.
+ * `updatedAt` is stamped automatically; callers should not pass one.
+ */
+export async function writeWorkingContext(
+  sessionFile: string,
+  context: SessionWorkingContext,
+  opts: { now?: () => Date } = {},
+): Promise<string> {
+  const capsulePath = resolveWorkingContextPath(sessionFile);
+  await fs.mkdir(path.dirname(capsulePath), { recursive: true });
+  const now = (opts.now ?? (() => new Date()))().toISOString();
+  const normalized = normalizeWorkingContext({ ...context });
+  normalized.updatedAt = now;
+  const envelope: PersistedEnvelope = {
+    version: SESSION_WORKING_CONTEXT_VERSION,
+    context: normalized,
+  };
+  const tmpPath = `${capsulePath}.tmp-${process.pid}-${Date.now()}`;
+  const serialized = `${JSON.stringify(envelope, null, 2)}\n`;
+  try {
+    await fs.writeFile(tmpPath, serialized, "utf-8");
+    await fs.rename(tmpPath, capsulePath);
+  } catch (err) {
+    try {
+      await fs.unlink(tmpPath);
+    } catch {
+      // best-effort cleanup
+    }
+    throw err;
+  }
+  return capsulePath;
+}
+
+/**
+ * Remove the working-context capsule for a session, if one exists.
+ * Returns `true` when a capsule was removed, `false` otherwise.
+ */
+export async function clearWorkingContext(sessionFile: string): Promise<boolean> {
+  const capsulePath = resolveWorkingContextPath(sessionFile);
+  try {
+    await fs.unlink(capsulePath);
+    return true;
+  } catch (err) {
+    const code = (err as { code?: string } | undefined)?.code;
+    if (code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a small, self-contained module for persisting a per-session "working context" capsule alongside the session transcript.

This is the minimal MVP piece of #67511: the persistence primitive itself, with no runtime wiring yet. Landing the storage shape first lets `/status`, compaction, and spawn paths opt in incrementally in follow-up PRs without the shape being debated at the same time as the integration.

## Why

The JSONL transcript preserves semantic continuity — what was said and decided — but not engineering working state: active repo root, current cwd, branch, temp clones, last push target, sandbox status. After `/compact` or `/new`, this state is easy to lose even when the summary survives, which is the pain point described in #67511.

## What

New file `src/agents/session-working-context.ts`:

- `resolveWorkingContextPath(sessionFile)` → `<session>.context.json` next to the transcript, so the capsule is naturally scoped to and cleaned up with the session.
- `readWorkingContext(sessionFile)` — returns `null` on missing or malformed capsules; never throws on bad input, so older sessions just look like "no capsule".
- `writeWorkingContext(sessionFile, context)` — atomic temp + rename, `updatedAt` stamped automatically, clock is injectable for tests.
- `clearWorkingContext(sessionFile)` — for cleanup flows.
- `normalizeWorkingContext(raw)` — strips unknown/ill-typed fields so a forward-rolled capsule (e.g. from a newer build) reads back as the subset we understand.
- Envelope carries an explicit `version` field; reads accept higher versions and just ignore fields they don't know about.

Fields in the capsule today (all optional):

```ts
type SessionWorkingContext = {
  cwd?: string;
  activeRepoRoot?: string;
  branch?: string;
  tempClones?: string[];
  lastPushRemote?: string;
  lastPushBranch?: string;
  sandboxed?: boolean;
  updatedAt?: string;
  notes?: string;
};
```

## What this PR deliberately does not do

- No changes to the session manager, transcript writer, `/status`, compaction, or subagent spawn paths.
- No new config surface, no new docs pages, no migrations.
- No attempt to auto-populate the capsule from `exec`/git tools — that belongs in a follow-up once the shape lands.

The intent is to keep this PR reviewable as a pure utility module and have the behavioral integration land as separate, smaller PRs.

## Tests

`src/agents/session-working-context.test.ts` covers:

- Path resolution (with and without `.jsonl` suffix, empty-path error).
- `normalizeWorkingContext` drops unknown fields and wrong-type values, preserves `sandboxed: false`, tolerates non-object input.
- Round-trip write/read of a typical capsule.
- `readWorkingContext` returns `null` for missing / malformed / unversioned capsules.
- Forward-compatible read of a capsule with a higher `version`.
- Injected clock stamps `updatedAt`.
- Writer creates missing session directories.
- Overwrite semantics (second write replaces the first).
- `clearWorkingContext` returns `true`/`false` correctly.

## Related

- #67511 — Persist per-session working context across compact/new flows (this PR implements the MVP persistence primitive from the proposal)

## Notes for reviewers

- Kept the file inside `src/agents/` next to `session-file-repair.ts` / `session-write-lock.ts` since those are the closest existing neighbours in both shape and scope.
- Chose a sibling `.context.json` file rather than extending the JSONL header to avoid touching transcript parsing and to keep the capsule trivially rewritable without a session-write-lock round trip. Happy to move it behind the existing lock / inside the transcript if you'd prefer.
- Opening as draft because I'd like a steer on (a) whether the field set above is the right starting shape and (b) where you'd prefer the first integration point to live (`/status`, compaction pre-hook, or subagent spawn).
