### PR TITLE
fix(exec): accept POSIX `\<newline>` in allowlisted commands; distinct error for unparseable syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec allowlist: accept POSIX `\<newline>` line continuations inside allowlisted shell commands so multi-line `curl` invocations and similar patterns resolve the same as their single-line form, and surface unparseable shell syntax as `exec denied: unsupported shell syntax` (and `SYSTEM_RUN_DENIED: unsupported shell syntax`) instead of the misleading `allowlist miss` signal that led agents to conclude the binary itself was denied.
 - Plugins/onboarding: record local plugin install source metadata without duplicating raw absolute local paths in persisted `plugins.installs`, while preserving linked load-path cleanup. (#70970) Thanks @vincentkoc.
 - Browser/tool: tell agents not to pass per-call `timeoutMs` on existing-session type, evaluate, and other Chrome MCP actions that reject timeout overrides.
 - Codex/GPT-5.4: harden fallback, auth-profile, tool-schema, and replay edge cases across native and embedded runtime paths. (#70743) Thanks @100yenadmin.

--- a/src/agents/bash-tools.exec-host-gateway.test.ts
+++ b/src/agents/bash-tools.exec-host-gateway.test.ts
@@ -280,7 +280,7 @@ describe("processGatewayAllowlist", () => {
   it("keeps denying allowlist misses when durable trust does not match", async () => {
     evaluateShellAllowlistMock.mockReturnValue({
       allowlistMatches: [],
-      analysisOk: false,
+      analysisOk: true,
       allowlistSatisfied: false,
       segments: [{ resolution: null, argv: ["node", "--version"] }],
       segmentAllowlistEntries: [],
@@ -292,6 +292,23 @@ describe("processGatewayAllowlist", () => {
         command: "node --version",
       }),
     ).rejects.toThrow("exec denied: allowlist miss");
+  });
+
+  it("surfaces unparseable shell syntax with a distinct error string", async () => {
+    evaluateShellAllowlistMock.mockReturnValue({
+      allowlistMatches: [],
+      analysisOk: false,
+      allowlistSatisfied: false,
+      segments: [],
+      segmentAllowlistEntries: [],
+    });
+    hasDurableExecApprovalMock.mockReturnValue(false);
+
+    await expect(
+      runGatewayAllowlist({
+        command: "echo 'unterminated",
+      }),
+    ).rejects.toThrow("exec denied: unsupported shell syntax");
   });
 
   it("uses sessionKey for followups when notifySessionKey is absent", async () => {

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -92,6 +92,24 @@ function hasGatewayAllowlistMiss(params: {
   );
 }
 
+function resolveGatewayDeniedReason(params: {
+  hostSecurity: ExecSecurity;
+  analysisOk: boolean;
+  allowlistSatisfied: boolean;
+  durableApprovalSatisfied: boolean;
+}): "unsupported-shell-syntax" | "allowlist-miss" | null {
+  if (!hasGatewayAllowlistMiss(params)) {
+    return null;
+  }
+  return params.analysisOk ? "allowlist-miss" : "unsupported-shell-syntax";
+}
+
+function gatewayDeniedErrorMessage(reason: "unsupported-shell-syntax" | "allowlist-miss"): string {
+  return reason === "unsupported-shell-syntax"
+    ? "exec denied: unsupported shell syntax"
+    : "exec denied: allowlist miss";
+}
+
 export async function processGatewayAllowlist(
   params: ProcessGatewayAllowlistParams,
 ): Promise<ProcessGatewayAllowlistResult> {
@@ -346,16 +364,16 @@ export async function processGatewayAllowlist(
         requiresInlineEvalApproval,
       }));
 
-      if (
-        !approvedByAsk &&
-        hasGatewayAllowlistMiss({
+      if (!approvedByAsk) {
+        const gatewayDeniedReason = resolveGatewayDeniedReason({
           hostSecurity,
           analysisOk,
           allowlistSatisfied,
           durableApprovalSatisfied,
-        })
-      ) {
-        deniedReason = deniedReason ?? "allowlist-miss";
+        });
+        if (gatewayDeniedReason) {
+          deniedReason = deniedReason ?? gatewayDeniedReason;
+        }
       }
 
       if (deniedReason) {
@@ -425,15 +443,14 @@ export async function processGatewayAllowlist(
     };
   }
 
-  if (
-    hasGatewayAllowlistMiss({
-      hostSecurity,
-      analysisOk,
-      allowlistSatisfied,
-      durableApprovalSatisfied,
-    })
-  ) {
-    throw new Error("exec denied: allowlist miss");
+  const gatewayDeniedReason = resolveGatewayDeniedReason({
+    hostSecurity,
+    analysisOk,
+    allowlistSatisfied,
+    durableApprovalSatisfied,
+  });
+  if (gatewayDeniedReason) {
+    throw new Error(gatewayDeniedErrorMessage(gatewayDeniedReason));
   }
 
   recordMatchedAllowlistUse(

--- a/src/agents/exec-approval-result.ts
+++ b/src/agents/exec-approval-result.ts
@@ -82,6 +82,9 @@ export function formatExecDeniedUserMessage(resultText: string): string | null {
   if (metadata.includes("user-denied")) {
     return "Command did not run: approval was denied.";
   }
+  if (metadata.includes("unsupported-shell-syntax")) {
+    return "Command did not run: shell syntax is not supported in allowlist mode.";
+  }
   if (metadata.includes("allowlist-miss")) {
     return "Command did not run: approval is required.";
   }

--- a/src/agents/pi-tools.safe-bins.test.ts
+++ b/src/agents/pi-tools.safe-bins.test.ts
@@ -364,7 +364,7 @@ describe("createOpenClawCodingTools safeBins", () => {
             command: "head -n 1 source.txt > blocked-redirect.txt",
             workdir: tmpDir,
           }),
-        ).rejects.toThrow("exec denied: allowlist miss");
+        ).rejects.toThrow("exec denied: unsupported shell syntax");
         expect(fs.existsSync(path.join(tmpDir, "blocked-redirect.txt"))).toBe(false);
       },
     );

--- a/src/infra/exec-approvals-allowlist.test.ts
+++ b/src/infra/exec-approvals-allowlist.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { joinShellLineContinuations } from "./exec-approvals-analysis.js";
+import { makePathEnv, makeTempDir } from "./exec-approvals-test-helpers.js";
+import { evaluateShellAllowlist } from "./exec-approvals.js";
+
+function makeAllowlistedBinDir(binaries: string[]): { dir: string; paths: Record<string, string> } {
+  const tmp = makeTempDir();
+  const binDir = path.join(tmp, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  const paths: Record<string, string> = {};
+  for (const name of binaries) {
+    const full = path.join(binDir, name);
+    fs.writeFileSync(full, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(full, 0o755);
+    paths[name] = full;
+  }
+  return { dir: binDir, paths };
+}
+
+describe("evaluateShellAllowlist: POSIX line continuations", () => {
+  it("resolves a multi-line allowlisted curl identically to its single-line form", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const { dir, paths } = makeAllowlistedBinDir(["curl"]);
+    const multiLine =
+      'curl -sS \\\n  -H "X-One: a" \\\n  -H "X-Two: b" \\\n  "http://example.invalid/path"';
+    const singleLine = 'curl -sS -H "X-One: a" -H "X-Two: b" "http://example.invalid/path"';
+
+    const multi = evaluateShellAllowlist({
+      command: multiLine,
+      allowlist: [{ pattern: paths.curl }],
+      safeBins: new Set(),
+      env: makePathEnv(dir),
+      cwd: dir,
+    });
+    const single = evaluateShellAllowlist({
+      command: singleLine,
+      allowlist: [{ pattern: paths.curl }],
+      safeBins: new Set(),
+      env: makePathEnv(dir),
+      cwd: dir,
+    });
+
+    expect(multi.analysisOk).toBe(true);
+    expect(multi.allowlistSatisfied).toBe(true);
+    expect(multi.segments[0]?.argv).toEqual(single.segments[0]?.argv);
+  });
+
+  it("accepts CRLF line continuations the same as LF", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const { dir, paths } = makeAllowlistedBinDir(["curl"]);
+    const crlf = 'curl -sS \\\r\n  "http://example.invalid/path"';
+    const result = evaluateShellAllowlist({
+      command: crlf,
+      allowlist: [{ pattern: paths.curl }],
+      safeBins: new Set(),
+      env: makePathEnv(dir),
+      cwd: dir,
+    });
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(true);
+    expect(result.segments[0]?.argv).toEqual(["curl", "-sS", "http://example.invalid/path"]);
+  });
+
+  it("still misses the allowlist when the binary is not listed, without analysis failure", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const { dir, paths } = makeAllowlistedBinDir(["curl", "wget"]);
+    const result = evaluateShellAllowlist({
+      command: 'wget \\\n  "http://example.invalid/"',
+      allowlist: [{ pattern: paths.curl }],
+      safeBins: new Set(),
+      env: makePathEnv(dir),
+      cwd: dir,
+    });
+    expect(result.analysisOk).toBe(true);
+    expect(result.allowlistSatisfied).toBe(false);
+  });
+});
+
+describe("joinShellLineContinuations", () => {
+  it("splices unquoted `\\<LF>` pairs", () => {
+    expect(joinShellLineContinuations("echo one \\\ntwo")).toBe("echo one two");
+  });
+
+  it("splices `\\<CRLF>` pairs", () => {
+    expect(joinShellLineContinuations("echo one \\\r\ntwo")).toBe("echo one two");
+  });
+
+  it("preserves `\\<LF>` inside single quotes", () => {
+    const input = "echo 'a\\\nb'";
+    expect(joinShellLineContinuations(input)).toBe(input);
+  });
+
+  it("splices `\\<LF>` inside double quotes", () => {
+    expect(joinShellLineContinuations('echo "one\\\ntwo"')).toBe('echo "onetwo"');
+  });
+
+  it("preserves `\\<LF>` inside a `#` comment to end of line", () => {
+    const input = "echo hi # literal \\\nnext";
+    expect(joinShellLineContinuations(input)).toBe(input);
+  });
+
+  it("preserves quoted-heredoc bodies verbatim", () => {
+    const input = "cat <<'EOF'\nliteral \\\nstill literal\nEOF\n";
+    expect(joinShellLineContinuations(input)).toBe(input);
+  });
+
+  it("splices inside unquoted heredoc bodies (matches bash)", () => {
+    expect(joinShellLineContinuations("cat <<EOF\nhello \\\nworld\nEOF\n")).toBe(
+      "cat <<EOF\nhello world\nEOF\n",
+    );
+  });
+
+  it("returns the original command for unterminated quotes", () => {
+    const input = "echo 'unterminated \\\n";
+    expect(joinShellLineContinuations(input)).toBe(input);
+  });
+
+  it("is a no-op when the command has no continuation", () => {
+    const input = 'curl -sS "http://example.invalid/"';
+    expect(joinShellLineContinuations(input)).toBe(input);
+  });
+});

--- a/src/infra/exec-approvals-allowlist.test.ts
+++ b/src/infra/exec-approvals-allowlist.test.ts
@@ -118,6 +118,21 @@ describe("joinShellLineContinuations", () => {
     );
   });
 
+  it("recognizes a terminator whose letters are split by a continuation", () => {
+    // bash: the logical line after splicing is `EOF`, so the heredoc terminates.
+    expect(joinShellLineContinuations("cat <<EOF\nbody\nEO\\\nF\ntail\n")).toBe(
+      "cat <<EOF\nbody\nEOF\ntail\n",
+    );
+  });
+
+  it("does not terminate when a continuation joins text into the delimiter line", () => {
+    // bash: the logical line is `foo EOF`, which is NOT the delimiter; keep
+    // consuming the body until a standalone `EOF` arrives.
+    expect(joinShellLineContinuations("cat <<EOF\nfoo \\\nEOF\nEOF\ntail\n")).toBe(
+      "cat <<EOF\nfoo EOF\nEOF\ntail\n",
+    );
+  });
+
   it("returns the original command for unterminated quotes", () => {
     const input = "echo 'unterminated \\\n";
     expect(joinShellLineContinuations(input)).toBe(input);

--- a/src/infra/exec-approvals-allowlist.ts
+++ b/src/infra/exec-approvals-allowlist.ts
@@ -8,6 +8,7 @@ import { isDispatchWrapperExecutable } from "./dispatch-wrapper-resolution.js";
 import {
   analyzeShellCommand,
   isWindowsPlatform,
+  joinShellLineContinuations,
   matchAllowlist,
   resolveExecutionTargetCandidatePath,
   resolveExecutionTargetResolution,
@@ -42,10 +43,6 @@ import {
 import { resolveExecWrapperTrustPlan } from "./exec-wrapper-trust-plan.js";
 import { expandHomePrefix } from "./home-dir.js";
 import { POSIX_INLINE_COMMAND_FLAGS, resolveInlineCommandMatch } from "./shell-inline-command.js";
-
-function hasShellLineContinuation(command: string): boolean {
-  return /\\(?:\r\n|\n|\r)/.test(command);
-}
 
 export function normalizeSafeBins(entries?: readonly string[]): Set<string> {
   if (!Array.isArray(entries)) {
@@ -1092,18 +1089,16 @@ export function evaluateShellAllowlist(
     segmentSatisfiedBy: [],
   });
 
-  // Keep allowlist analysis conservative: line-continuation semantics are shell-dependent
-  // and can rewrite token boundaries at runtime.
-  if (hasShellLineContinuation(params.command)) {
-    return analysisFailure();
-  }
+  // Splice POSIX `\<newline>` line continuations before analysis so multi-line
+  // allowlisted commands resolve identically to their single-line form.
+  const normalizedCommand = joinShellLineContinuations(params.command);
 
   const chainParts = isWindowsPlatform(params.platform)
     ? null
-    : splitCommandChainWithOperators(params.command);
+    : splitCommandChainWithOperators(normalizedCommand);
   if (!chainParts) {
     const analysis = analyzeShellCommand({
-      command: params.command,
+      command: normalizedCommand,
       cwd: params.cwd,
       env: params.env,
       platform: params.platform,

--- a/src/infra/exec-approvals-analysis.ts
+++ b/src/infra/exec-approvals-analysis.ts
@@ -147,13 +147,16 @@ function parseHeredocDelimiter(source: string, start: number): ParsedHeredocDeli
 export function joinShellLineContinuations(command: string): string {
   type HeredocSpec = { delimiter: string; stripTabs: boolean; quoted: boolean };
 
-  let out = "";
+  // Build output via chunked array + `join("")` at the end so concatenation
+  // stays linear for large commands (e.g. big heredoc bodies) rather than
+  // relying on engine-specific optimizations for `+=` concatenation.
+  const out: string[] = [];
+  const heredocLine: string[] = [];
   let inSingle = false;
   let inDouble = false;
   let inComment = false;
   const pendingHeredocs: HeredocSpec[] = [];
   let inHeredocBody = false;
-  let heredocLine = "";
 
   const isContinuation = (i: number): 0 | 2 | 3 => {
     if (command[i] !== "\\") {
@@ -169,6 +172,12 @@ export function joinShellLineContinuations(command: string): string {
     return 0;
   };
 
+  const resetHeredocLine = () => {
+    heredocLine.length = 0;
+  };
+
+  const currentHeredocLine = (): string => heredocLine.join("");
+
   let i = 0;
   while (i < command.length) {
     const ch = command[i];
@@ -179,14 +188,20 @@ export function joinShellLineContinuations(command: string): string {
       if (current && !current.quoted) {
         const skip = isContinuation(i);
         if (skip) {
-          heredocLine = "";
+          // Splice: drop the backslash-newline without resetting the logical
+          // heredoc line. A continued line joins into the next physical line,
+          // so characters accumulated so far still belong to this logical
+          // line — needed to correctly classify `foo \<LF>EOF` (does not
+          // terminate <<EOF, since the logical line is "foo EOF") and
+          // `EO\<LF>F` (does terminate <<EOF, since the logical line is "EOF").
           i += skip;
           continue;
         }
       }
       if (ch === "\n" || ch === "\r") {
         if (current) {
-          const line = current.stripTabs ? heredocLine.replace(/^\t+/, "") : heredocLine;
+          const raw = currentHeredocLine();
+          const line = current.stripTabs ? raw.replace(/^\t+/, "") : raw;
           if (line === current.delimiter) {
             pendingHeredocs.shift();
             if (pendingHeredocs.length === 0) {
@@ -194,18 +209,18 @@ export function joinShellLineContinuations(command: string): string {
             }
           }
         }
-        heredocLine = "";
-        out += ch;
+        resetHeredocLine();
+        out.push(ch);
         if (ch === "\r" && next === "\n") {
-          out += "\n";
+          out.push("\n");
           i += 2;
         } else {
           i += 1;
         }
         continue;
       }
-      heredocLine += ch;
-      out += ch;
+      heredocLine.push(ch);
+      out.push(ch);
       i += 1;
       continue;
     }
@@ -214,7 +229,7 @@ export function joinShellLineContinuations(command: string): string {
       if (ch === "\n" || ch === "\r") {
         inComment = false;
       }
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
@@ -223,7 +238,7 @@ export function joinShellLineContinuations(command: string): string {
       if (ch === "'") {
         inSingle = false;
       }
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
@@ -235,15 +250,14 @@ export function joinShellLineContinuations(command: string): string {
         continue;
       }
       if (ch === "\\" && next !== undefined && DOUBLE_QUOTE_ESCAPES.has(next)) {
-        out += ch;
-        out += next;
+        out.push(ch, next);
         i += 2;
         continue;
       }
       if (ch === '"') {
         inDouble = false;
       }
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
@@ -255,45 +269,44 @@ export function joinShellLineContinuations(command: string): string {
     }
 
     if (ch === "\\" && next !== undefined) {
-      out += ch;
-      out += next;
+      out.push(ch, next);
       i += 2;
       continue;
     }
 
     if (ch === "'") {
       inSingle = true;
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
     if (ch === '"') {
       inDouble = true;
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
 
     if (isShellCommentStart(command, i)) {
       inComment = true;
-      out += ch;
+      out.push(ch);
       i += 1;
       continue;
     }
 
     if (ch === "<" && next === "<") {
-      out += "<<";
+      out.push("<<");
       let scanIndex = i + 2;
       let stripTabs = false;
       if (command[scanIndex] === "-") {
         stripTabs = true;
-        out += "-";
+        out.push("-");
         scanIndex += 1;
       }
       const parsed = parseHeredocDelimiter(command, scanIndex);
       if (parsed) {
         pendingHeredocs.push({ delimiter: parsed.delimiter, stripTabs, quoted: parsed.quoted });
-        out += command.slice(scanIndex, parsed.end);
+        out.push(command.slice(scanIndex, parsed.end));
         i = parsed.end;
       } else {
         i = scanIndex;
@@ -302,28 +315,28 @@ export function joinShellLineContinuations(command: string): string {
     }
 
     if (ch === "\n" || ch === "\r") {
-      out += ch;
+      out.push(ch);
       if (ch === "\r" && next === "\n") {
-        out += "\n";
+        out.push("\n");
         i += 2;
       } else {
         i += 1;
       }
       if (pendingHeredocs.length > 0) {
         inHeredocBody = true;
-        heredocLine = "";
+        resetHeredocLine();
       }
       continue;
     }
 
-    out += ch;
+    out.push(ch);
     i += 1;
   }
 
   if (inSingle || inDouble || (inHeredocBody && pendingHeredocs.length > 0)) {
     return command;
   }
-  return out;
+  return out.join("");
 }
 
 function splitShellPipeline(command: string): { ok: boolean; reason?: string; segments: string[] } {

--- a/src/infra/exec-approvals-analysis.ts
+++ b/src/infra/exec-approvals-analysis.ts
@@ -80,62 +80,257 @@ function isShellCommentStart(source: string, index: number): boolean {
   return Boolean(prev && /\s/.test(prev));
 }
 
+type ParsedHeredocDelimiter = { delimiter: string; end: number; quoted: boolean };
+
+function parseHeredocDelimiter(source: string, start: number): ParsedHeredocDelimiter | null {
+  let i = start;
+  while (i < source.length && (source[i] === " " || source[i] === "\t")) {
+    i += 1;
+  }
+  if (i >= source.length) {
+    return null;
+  }
+
+  const first = source[i];
+  if (first === "'" || first === '"') {
+    const quote = first;
+    i += 1;
+    let delimiter = "";
+    while (i < source.length) {
+      const ch = source[i];
+      if (ch === "\n" || ch === "\r") {
+        return null;
+      }
+      if (quote === '"' && ch === "\\" && i + 1 < source.length) {
+        delimiter += source[i + 1];
+        i += 2;
+        continue;
+      }
+      if (ch === quote) {
+        return { delimiter, end: i + 1, quoted: true };
+      }
+      delimiter += ch;
+      i += 1;
+    }
+    return null;
+  }
+
+  let delimiter = "";
+  while (i < source.length) {
+    const ch = source[i];
+    if (/\s/.test(ch) || ch === "|" || ch === "&" || ch === ";" || ch === "<" || ch === ">") {
+      break;
+    }
+    delimiter += ch;
+    i += 1;
+  }
+  if (!delimiter) {
+    return null;
+  }
+  return { delimiter, end: i, quoted: false };
+}
+
+/**
+ * Splice POSIX `\<newline>` line continuations so downstream tokenization sees
+ * the same tokens the shell would after pre-processing.
+ *
+ * Per POSIX 2.2.1, outside single-quotes a `\` followed by a newline is removed
+ * entirely (the lines are joined). The splicing does NOT happen inside
+ * single-quoted strings, inside quoted-delimiter heredoc bodies (`<<'EOF'`),
+ * or inside `#` comments. Inside double-quotes and unquoted heredoc bodies,
+ * bash does splice `\<newline>` — matched here.
+ *
+ * The helper is a pure text transform: if it cannot confidently classify the
+ * string (e.g., an unterminated quote or heredoc), it returns the input
+ * unchanged so downstream analysis produces the canonical failure result.
+ */
+export function joinShellLineContinuations(command: string): string {
+  type HeredocSpec = { delimiter: string; stripTabs: boolean; quoted: boolean };
+
+  let out = "";
+  let inSingle = false;
+  let inDouble = false;
+  let inComment = false;
+  const pendingHeredocs: HeredocSpec[] = [];
+  let inHeredocBody = false;
+  let heredocLine = "";
+
+  const isContinuation = (i: number): 0 | 2 | 3 => {
+    if (command[i] !== "\\") {
+      return 0;
+    }
+    const a = command[i + 1];
+    if (a === "\n") {
+      return 2;
+    }
+    if (a === "\r" && command[i + 2] === "\n") {
+      return 3;
+    }
+    return 0;
+  };
+
+  let i = 0;
+  while (i < command.length) {
+    const ch = command[i];
+    const next = command[i + 1];
+
+    if (inHeredocBody) {
+      const current = pendingHeredocs[0];
+      if (current && !current.quoted) {
+        const skip = isContinuation(i);
+        if (skip) {
+          heredocLine = "";
+          i += skip;
+          continue;
+        }
+      }
+      if (ch === "\n" || ch === "\r") {
+        if (current) {
+          const line = current.stripTabs ? heredocLine.replace(/^\t+/, "") : heredocLine;
+          if (line === current.delimiter) {
+            pendingHeredocs.shift();
+            if (pendingHeredocs.length === 0) {
+              inHeredocBody = false;
+            }
+          }
+        }
+        heredocLine = "";
+        out += ch;
+        if (ch === "\r" && next === "\n") {
+          out += "\n";
+          i += 2;
+        } else {
+          i += 1;
+        }
+        continue;
+      }
+      heredocLine += ch;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (inComment) {
+      if (ch === "\n" || ch === "\r") {
+        inComment = false;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (inSingle) {
+      if (ch === "'") {
+        inSingle = false;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (inDouble) {
+      const skip = isContinuation(i);
+      if (skip) {
+        i += skip;
+        continue;
+      }
+      if (ch === "\\" && next !== undefined && DOUBLE_QUOTE_ESCAPES.has(next)) {
+        out += ch;
+        out += next;
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = false;
+      }
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    const skip = isContinuation(i);
+    if (skip) {
+      i += skip;
+      continue;
+    }
+
+    if (ch === "\\" && next !== undefined) {
+      out += ch;
+      out += next;
+      i += 2;
+      continue;
+    }
+
+    if (ch === "'") {
+      inSingle = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      inDouble = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (isShellCommentStart(command, i)) {
+      inComment = true;
+      out += ch;
+      i += 1;
+      continue;
+    }
+
+    if (ch === "<" && next === "<") {
+      out += "<<";
+      let scanIndex = i + 2;
+      let stripTabs = false;
+      if (command[scanIndex] === "-") {
+        stripTabs = true;
+        out += "-";
+        scanIndex += 1;
+      }
+      const parsed = parseHeredocDelimiter(command, scanIndex);
+      if (parsed) {
+        pendingHeredocs.push({ delimiter: parsed.delimiter, stripTabs, quoted: parsed.quoted });
+        out += command.slice(scanIndex, parsed.end);
+        i = parsed.end;
+      } else {
+        i = scanIndex;
+      }
+      continue;
+    }
+
+    if (ch === "\n" || ch === "\r") {
+      out += ch;
+      if (ch === "\r" && next === "\n") {
+        out += "\n";
+        i += 2;
+      } else {
+        i += 1;
+      }
+      if (pendingHeredocs.length > 0) {
+        inHeredocBody = true;
+        heredocLine = "";
+      }
+      continue;
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  if (inSingle || inDouble || (inHeredocBody && pendingHeredocs.length > 0)) {
+    return command;
+  }
+  return out;
+}
+
 function splitShellPipeline(command: string): { ok: boolean; reason?: string; segments: string[] } {
   type HeredocSpec = {
     delimiter: string;
     stripTabs: boolean;
     quoted: boolean;
-  };
-
-  const parseHeredocDelimiter = (
-    source: string,
-    start: number,
-  ): { delimiter: string; end: number; quoted: boolean } | null => {
-    let i = start;
-    while (i < source.length && (source[i] === " " || source[i] === "\t")) {
-      i += 1;
-    }
-    if (i >= source.length) {
-      return null;
-    }
-
-    const first = source[i];
-    if (first === "'" || first === '"') {
-      const quote = first;
-      i += 1;
-      let delimiter = "";
-      while (i < source.length) {
-        const ch = source[i];
-        if (ch === "\n" || ch === "\r") {
-          return null;
-        }
-        if (quote === '"' && ch === "\\" && i + 1 < source.length) {
-          delimiter += source[i + 1];
-          i += 2;
-          continue;
-        }
-        if (ch === quote) {
-          return { delimiter, end: i + 1, quoted: true };
-        }
-        delimiter += ch;
-        i += 1;
-      }
-      return null;
-    }
-
-    let delimiter = "";
-    while (i < source.length) {
-      const ch = source[i];
-      if (/\s/.test(ch) || ch === "|" || ch === "&" || ch === ";" || ch === "<" || ch === ">") {
-        break;
-      }
-      delimiter += ch;
-      i += 1;
-    }
-    if (!delimiter) {
-      return null;
-    }
-    return { delimiter, end: i, quoted: false };
   };
 
   const segments: string[] = [];

--- a/src/node-host/exec-policy.test.ts
+++ b/src/node-host/exec-policy.test.ts
@@ -121,10 +121,18 @@ describe("evaluateSystemRunPolicy", () => {
 
   it("denies allowlist misses without approval", () => {
     const denied = expectDeniedDecision(
-      evaluateSystemRunPolicy(buildPolicyParams({ analysisOk: false, allowlistSatisfied: false })),
+      evaluateSystemRunPolicy(buildPolicyParams({ analysisOk: true, allowlistSatisfied: false })),
     );
     expect(denied.eventReason).toBe("allowlist-miss");
     expect(denied.errorMessage).toBe("SYSTEM_RUN_DENIED: allowlist miss");
+  });
+
+  it("surfaces unparseable shell syntax with a distinct reason", () => {
+    const denied = expectDeniedDecision(
+      evaluateSystemRunPolicy(buildPolicyParams({ analysisOk: false, allowlistSatisfied: false })),
+    );
+    expect(denied.eventReason).toBe("unsupported-shell-syntax");
+    expect(denied.errorMessage).toBe("SYSTEM_RUN_DENIED: unsupported shell syntax");
   });
 
   it("keeps POSIX shell wrapper decisions tied to allowlist analysis", () => {

--- a/src/node-host/exec-policy.ts
+++ b/src/node-host/exec-policy.ts
@@ -16,7 +16,11 @@ export type SystemRunPolicyDecision = {
     }
   | {
       allowed: false;
-      eventReason: "security=deny" | "approval-required" | "allowlist-miss";
+      eventReason:
+        | "security=deny"
+        | "approval-required"
+        | "allowlist-miss"
+        | "unsupported-shell-syntax";
       errorMessage: string;
     }
 );
@@ -47,6 +51,10 @@ export function formatSystemRunAllowlistMissMessage(params?: {
     );
   }
   return "SYSTEM_RUN_DENIED: allowlist miss";
+}
+
+export function formatSystemRunUnsupportedShellSyntaxMessage(): string {
+  return "SYSTEM_RUN_DENIED: unsupported shell syntax";
 }
 
 export function evaluateSystemRunPolicy(params: {
@@ -116,6 +124,20 @@ export function evaluateSystemRunPolicy(params: {
     if (params.durableApprovalSatisfied) {
       return {
         allowed: true,
+        analysisOk,
+        allowlistSatisfied,
+        shellWrapperBlocked,
+        windowsShellWrapperBlocked,
+        requiresAsk,
+        approvalDecision: params.approvalDecision,
+        approvedByAsk,
+      };
+    }
+    if (!analysisOk && !shellWrapperBlocked) {
+      return {
+        allowed: false,
+        eventReason: "unsupported-shell-syntax",
+        errorMessage: formatSystemRunUnsupportedShellSyntaxMessage(),
         analysisOk,
         allowlistSatisfied,
         shellWrapperBlocked,

--- a/src/node-host/invoke-system-run.ts
+++ b/src/node-host/invoke-system-run.ts
@@ -66,6 +66,7 @@ type SystemRunDeniedReason =
   | "security=deny"
   | "approval-required"
   | "allowlist-miss"
+  | "unsupported-shell-syntax"
   | "execution-plan-miss"
   | "companion-unavailable"
   | "permission:screenRecording";
@@ -138,6 +139,7 @@ function normalizeDeniedReason(reason: string | null | undefined): SystemRunDeni
     case "security=deny":
     case "approval-required":
     case "allowlist-miss":
+    case "unsupported-shell-syntax":
     case "execution-plan-miss":
     case "companion-unavailable":
     case "permission:screenRecording":


### PR DESCRIPTION
## Summary

- Splice POSIX `\<newline>` line continuations before exec-allowlist analysis so multi-line invocations with an allowlisted leading binary resolve the same as their single-line form (fixes #71153).
- Disambiguate denial signals: when a command cannot be parsed, the gateway throws `exec denied: unsupported shell syntax` and the node host emits `SYSTEM_RUN_DENIED: unsupported shell syntax` with event reason `unsupported-shell-syntax`. `allowlist miss` is reserved for the true case where analysis succeeded but the resolved binary is not on the allowlist.
- New `joinShellLineContinuations` helper walks the command once with the same quote/heredoc/comment state machine used by `splitShellPipeline`, so splicing respects single-quoted strings, quoted-heredoc bodies, and `#` comments. Inside double quotes and unquoted heredoc bodies, `\<newline>` is spliced (matching bash).

## Why the old behavior

`evaluateShellAllowlist()` previously rejected any command containing `\<newline>` before analysis and emitted `allowlist miss`. Agents with allowlisted binaries but multi-line commands therefore concluded their binary was blocked (or the downstream service was down), and escalated incorrectly.

The comment at the old guard noted a concern that line-continuation semantics "can rewrite token boundaries at runtime". POSIX 2.2.1 is unambiguous: outside single-quotes and outside quoted-heredoc bodies, `\<newline>` is *removed* before tokenization. Pre-splicing produces exactly the tokens the shell would see, so the allowlist decision cannot drift between analyzer and runtime — provided the splicing walker respects single-quote and quoted-heredoc exceptions, which it does.

## Key files

- `src/infra/exec-approvals-analysis.ts` — new `joinShellLineContinuations` helper, `parseHeredocDelimiter` lifted to module scope for reuse.
- `src/infra/exec-approvals-allowlist.ts` — drop the early-reject, normalize via `joinShellLineContinuations` before analysis.
- `src/agents/bash-tools.exec-host-gateway.ts` — split error-string path: `unsupported-shell-syntax` vs `allowlist-miss`.
- `src/node-host/exec-policy.ts`, `src/node-host/invoke-system-run.ts`, `src/agents/exec-approval-result.ts` — matching reason/message additions.

## Test plan

- [x] New `src/infra/exec-approvals-allowlist.test.ts`: multi-line allowlisted `curl` with `\<LF>` and `\<CRLF>` resolves identically to single-line; non-allowlisted binary still misses cleanly; direct `joinShellLineContinuations` unit tests cover quote state, comments, heredoc bodies (quoted and unquoted), unterminated quote fallback, and CRLF.
- [x] Extended `src/agents/bash-tools.exec-host-gateway.test.ts`: new assertion that unparseable input throws the distinct `exec denied: unsupported shell syntax` message while the true allowlist-miss case still throws the original string.
- [x] Extended `src/node-host/exec-policy.test.ts`: parallel coverage for `SYSTEM_RUN_DENIED: unsupported shell syntax` with `eventReason: "unsupported-shell-syntax"`.
- [x] `pnpm check:changed` green (typecheck, lint, import cycles, changed-test lanes).
- [x] Targeted regression sweep across `pi-tools.safe-bins`, `exec-approvals-parity`, `exec-approvals-safe-bins`, `exec-approvals-policy`, `invoke-system-run`, `server-node-events`, and `exec-approval-result` suites: all passing.

## Risk notes

- Parity with runtime shell: POSIX line-continuation splicing happens before word-splitting. The walker respects single-quotes, quoted heredocs, and `#` comments, so splicing matches bash semantics.
- Rollback: additive helper + one branch swap in `evaluateShellAllowlist` + one error-string split; small diff.
- No command that previously succeeded changes outcome; only commands previously rejected as "allowlist miss" can now either succeed (multi-line with allowlisted binary) or emit the clearer `unsupported shell syntax` signal.

Fixes #71153.