### PR TITLE
Refresh configured agent models.json caches during startup warmup

### DIFF
--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -154,6 +154,9 @@ vi.mock("../agents/agent-paths.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  listAgentIds: vi.fn(() => ["default"]),
+  resolveAgentDir: vi.fn(() => "/tmp/openclaw-state/agents/default/agent"),
+  resolveAgentEffectiveModelPrimary: vi.fn(() => undefined),
   resolveAgentWorkspaceDir: vi.fn(() => "/tmp/openclaw-workspace"),
   resolveDefaultAgentId: vi.fn(() => "default"),
 }));
@@ -166,6 +169,7 @@ vi.mock("../agents/defaults.js", () => ({
 vi.mock("../agents/model-selection.js", () => ({
   isCliProvider: hoisted.isCliProvider,
   resolveConfiguredModelRef: hoisted.resolveConfiguredModelRef,
+  resolveDefaultModelForAgent: hoisted.resolveConfiguredModelRef,
 }));
 
 vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -126,6 +126,69 @@ async function hasGatewayStartupInternalHookListeners(): Promise<boolean> {
   return hasInternalHookListeners("gateway", "startup");
 }
 
+async function refreshConfiguredAgentModelsJsonOnStartup(params: {
+  cfg: OpenClawConfig;
+  workspaceDir?: string;
+  log: { warn: (msg: string) => void };
+}): Promise<void> {
+  const [
+    { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir },
+    { resolveOpenClawAgentDir },
+    { DEFAULT_MODEL, DEFAULT_PROVIDER },
+    { isCliProvider, resolveConfiguredModelRef, resolveDefaultModelForAgent },
+    { ensureOpenClawModelsJson },
+  ] = await Promise.all([
+    import("../agents/agent-scope.js"),
+    import("../agents/agent-paths.js"),
+    import("../agents/defaults.js"),
+    import("../agents/model-selection.js"),
+    import("../agents/models-config.js"),
+  ]);
+  const agentIds = listAgentIds(params.cfg);
+  const configuredProviders = new Set<string>();
+  const defaultRef = resolveConfiguredModelRef({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+    defaultModel: DEFAULT_MODEL,
+  });
+  configuredProviders.add(defaultRef.provider);
+  for (const agentId of agentIds) {
+    configuredProviders.add(resolveDefaultModelForAgent({ cfg: params.cfg, agentId }).provider);
+  }
+  const providerDiscoveryProviderIds = [...configuredProviders].filter(
+    (provider) => !isCliProvider(provider, params.cfg),
+  );
+  const providerDiscoveryOptions =
+    providerDiscoveryProviderIds.length > 0
+      ? {
+          providerDiscoveryProviderIds,
+          providerDiscoveryTimeoutMs: STARTUP_PROVIDER_DISCOVERY_TIMEOUT_MS,
+          providerDiscoveryEntriesOnly: true,
+        }
+      : {};
+  const defaultAgentDir = resolveOpenClawAgentDir();
+  const agentDirs = new Map<string, { workspaceDir?: string }>();
+  agentDirs.set(defaultAgentDir, { workspaceDir: params.workspaceDir });
+  for (const agentId of agentIds) {
+    const agentDir = resolveAgentDir(params.cfg, agentId);
+    if (!agentDirs.has(agentDir)) {
+      agentDirs.set(agentDir, { workspaceDir: resolveAgentWorkspaceDir(params.cfg, agentId) });
+    }
+  }
+  await Promise.all(
+    [...agentDirs.entries()].map(async ([agentDir, entry]) => {
+      try {
+        await ensureOpenClawModelsJson(params.cfg, agentDir, {
+          ...(entry.workspaceDir ? { workspaceDir: entry.workspaceDir } : {}),
+          ...providerDiscoveryOptions,
+        });
+      } catch (err) {
+        params.log.warn(`startup models.json refresh failed for ${agentDir}: ${String(err)}`);
+      }
+    }),
+  );
+}
+
 async function waitForAcpRuntimeBackendReady(params: {
   backendId?: string;
   timeoutMs?: number;
@@ -398,6 +461,11 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {
+        await refreshConfiguredAgentModelsJsonOnStartup({
+          cfg: params.cfg,
+          workspaceDir: params.defaultWorkspaceDir,
+          log: params.log,
+        });
         schedulePrimaryModelPrewarm(
           {
             cfg: params.cfg,
@@ -720,6 +788,7 @@ export async function startGatewayPostAttachRuntime(
 }
 
 export const __testing = {
+  refreshConfiguredAgentModelsJsonOnStartup,
   prewarmConfiguredPrimaryModel,
   prewarmConfiguredPrimaryModelWithTimeout,
   resolveGatewayMemoryStartupPolicy,

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -135,12 +135,14 @@ async function refreshConfiguredAgentModelsJsonOnStartup(params: {
     { listAgentIds, resolveAgentDir, resolveAgentWorkspaceDir },
     { resolveOpenClawAgentDir },
     { DEFAULT_MODEL, DEFAULT_PROVIDER },
+    { DEFAULT_AGENT_ID },
     { isCliProvider, resolveConfiguredModelRef, resolveDefaultModelForAgent },
     { ensureOpenClawModelsJson },
   ] = await Promise.all([
     import("../agents/agent-scope.js"),
     import("../agents/agent-paths.js"),
     import("../agents/defaults.js"),
+    import("../routing/session-key.js"),
     import("../agents/model-selection.js"),
     import("../agents/models-config.js"),
   ]);
@@ -170,6 +172,9 @@ async function refreshConfiguredAgentModelsJsonOnStartup(params: {
   const agentDirs = new Map<string, { workspaceDir?: string }>();
   agentDirs.set(defaultAgentDir, { workspaceDir: params.workspaceDir });
   for (const agentId of agentIds) {
+    if (agentId === DEFAULT_AGENT_ID && !params.cfg.agents?.list?.length) {
+      continue;
+    }
     const agentDir = resolveAgentDir(params.cfg, agentId);
     if (!agentDirs.has(agentDir)) {
       agentDirs.set(agentDir, { workspaceDir: resolveAgentWorkspaceDir(params.cfg, agentId) });

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -17,9 +17,11 @@ vi.mock("../agents/agent-paths.js", () => ({
 
 vi.mock("../agents/agent-scope.js", () => ({
   listAgentIds: (cfg: any) =>
-    Array.isArray(cfg?.agents?.list) ? cfg.agents.list.map((entry: any) => entry.id) : ["default"],
+    Array.isArray(cfg?.agents?.list) && cfg.agents.list.length > 0
+      ? cfg.agents.list.map((entry: any) => entry.id)
+      : ["main"],
   resolveAgentDir: (_cfg: unknown, agentId: unknown) =>
-    agentId === "default" ? "/tmp/agent" : `/tmp/${String(agentId)}/agent`,
+    agentId === "main" ? "/tmp/main/agent" : `/tmp/${String(agentId)}/agent`,
   resolveAgentEffectiveModelPrimary: (cfg: any, agentId: string) =>
     cfg?.agents?.list?.find((entry: any) => entry?.id === agentId)?.model?.primary ??
     cfg?.agents?.list?.find((entry: any) => entry?.id === agentId)?.model,
@@ -190,6 +192,34 @@ describe("gateway startup primary model warmup", () => {
       }),
     );
     expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledTimes(3);
+    expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("does not refresh the synthetic main agent separately when no agents are configured", async () => {
+    const cfg = {} as OpenClawConfig;
+
+    await refreshConfiguredAgentModelsJsonOnStartup({
+      cfg,
+      workspaceDir: "/tmp/default-workspace",
+      log: { warn: vi.fn() },
+    });
+
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledOnce();
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/default-workspace",
+        providerDiscoveryProviderIds: ["openai"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).not.toHaveBeenCalledWith(
+      cfg,
+      "/tmp/main/agent",
+      expect.anything(),
+    );
     expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
   });
 

--- a/src/gateway/server-startup.test.ts
+++ b/src/gateway/server-startup.test.ts
@@ -16,7 +16,15 @@ vi.mock("../agents/agent-paths.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
-  resolveAgentWorkspaceDir: () => "/tmp/workspace",
+  listAgentIds: (cfg: any) =>
+    Array.isArray(cfg?.agents?.list) ? cfg.agents.list.map((entry: any) => entry.id) : ["default"],
+  resolveAgentDir: (_cfg: unknown, agentId: unknown) =>
+    agentId === "default" ? "/tmp/agent" : `/tmp/${String(agentId)}/agent`,
+  resolveAgentEffectiveModelPrimary: (cfg: any, agentId: string) =>
+    cfg?.agents?.list?.find((entry: any) => entry?.id === agentId)?.model?.primary ??
+    cfg?.agents?.list?.find((entry: any) => entry?.id === agentId)?.model,
+  resolveAgentWorkspaceDir: (_cfg: unknown, agentId: unknown) =>
+    `/tmp/${String(agentId)}-workspace`,
   resolveDefaultAgentId: () => "default",
 }));
 
@@ -36,13 +44,18 @@ vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
   resolveEmbeddedAgentRuntime: () => resolveEmbeddedAgentRuntimeMock(),
 }));
 
+let refreshConfiguredAgentModelsJsonOnStartup: typeof import("./server-startup.js").__testing.refreshConfiguredAgentModelsJsonOnStartup;
 let prewarmConfiguredPrimaryModel: typeof import("./server-startup.js").__testing.prewarmConfiguredPrimaryModel;
 let shouldSkipStartupModelPrewarm: typeof import("./server-startup.js").__testing.shouldSkipStartupModelPrewarm;
 
 describe("gateway startup primary model warmup", () => {
   beforeAll(async () => {
     ({
-      __testing: { prewarmConfiguredPrimaryModel, shouldSkipStartupModelPrewarm },
+      __testing: {
+        refreshConfiguredAgentModelsJsonOnStartup,
+        prewarmConfiguredPrimaryModel,
+        shouldSkipStartupModelPrewarm,
+      },
     } = await import("./server-startup.js"));
   });
 
@@ -73,12 +86,110 @@ describe("gateway startup primary model warmup", () => {
       cfg,
       "/tmp/agent",
       expect.objectContaining({
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: "/tmp/default-workspace",
         providerDiscoveryProviderIds: ["openai-codex"],
         providerDiscoveryTimeoutMs: 5000,
         providerDiscoveryEntriesOnly: true,
       }),
     );
+    expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes configured non-default agent dirs during startup", async () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai-codex/gpt-5.4",
+          },
+        },
+        list: [{ id: "zed" }, { id: "kim" }],
+      },
+    } as OpenClawConfig;
+
+    await refreshConfiguredAgentModelsJsonOnStartup({
+      cfg,
+      workspaceDir: "/tmp/default-workspace",
+      log: { warn: vi.fn() },
+    });
+
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/default-workspace",
+        providerDiscoveryProviderIds: ["openai-codex"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/zed/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/zed-workspace",
+        providerDiscoveryProviderIds: ["openai-codex"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/kim/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/kim-workspace",
+        providerDiscoveryProviderIds: ["openai-codex"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("refreshes configured custom agent dirs even without a default primary model", async () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "zed" }, { id: "kim" }],
+      },
+    } as OpenClawConfig;
+
+    await refreshConfiguredAgentModelsJsonOnStartup({
+      cfg,
+      workspaceDir: "/tmp/default-workspace",
+      log: { warn: vi.fn() },
+    });
+
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/default-workspace",
+        providerDiscoveryProviderIds: ["openai"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/zed/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/zed-workspace",
+        providerDiscoveryProviderIds: ["openai"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledWith(
+      cfg,
+      "/tmp/kim/agent",
+      expect.objectContaining({
+        workspaceDir: "/tmp/kim-workspace",
+        providerDiscoveryProviderIds: ["openai"],
+        providerDiscoveryTimeoutMs: 5000,
+        providerDiscoveryEntriesOnly: true,
+      }),
+    );
+    expect(ensureOpenClawModelsJsonMock).toHaveBeenCalledTimes(3);
     expect(piModelModuleLoadedMock).not.toHaveBeenCalled();
   });
 
@@ -170,7 +281,7 @@ describe("gateway startup primary model warmup", () => {
       cfg,
       "/tmp/agent",
       expect.objectContaining({
-        workspaceDir: "/tmp/workspace",
+        workspaceDir: "/tmp/default-workspace",
         providerDiscoveryProviderIds: ["openai-codex"],
         providerDiscoveryTimeoutMs: 5000,
         providerDiscoveryEntriesOnly: true,


### PR DESCRIPTION
Fixes #71192

## Summary
- refresh `models.json` for the default agent dir and every configured agent dir during startup
- keep primary-model prewarm separate and non-blocking on top of current `main`
- limit startup provider discovery to configured model providers and entries-only metadata to avoid broad plugin runtime loads
- add regression coverage for `main`/`zed`/`kim`, including custom agents with no default primary model

## Why
We reproduced a stale-cache case where source config was correct, but non-default agent `models.json` files stayed stale across restart until `ensureOpenClawModelsJson(cfg, <agentDir>)` was invoked directly for those agents.

The important review point was that cache refresh must not live behind `prewarmConfiguredPrimaryModel()` early returns. This version uses an independent startup refresh helper, so configured agent dirs refresh even when there is no `agents.defaults.model.primary`.

## Performance note
This rebase preserves the adjacent startup-prewarm improvements on `main`: the refresh passes `providerDiscoveryEntriesOnly: true`, a 5s discovery timeout, workspace context, and a narrowed provider list derived from the default/configured agent models. Primary model prewarm remains separately scheduled and non-blocking.

## Validation
- `pnpm exec oxfmt --check src/gateway/server-startup-post-attach.ts src/gateway/server-startup.test.ts`
- `pnpm -C /Users/debbie/openclaw-source test src/gateway/server-startup.test.ts`
- `git diff --check origin/main...HEAD`
