### PR TITLE
fix(subagent): add 2h staleness gate so orphan runs stop reading as active (#71252)

### DIFF
--- a/src/agents/subagent-list.test.ts
+++ b/src/agents/subagent-list.test.ts
@@ -49,6 +49,7 @@ describe("buildSubagentList", () => {
   });
 
   it("truncates long task text in list lines", () => {
+    const now = Date.now();
     const run = {
       runId: "run-long-task",
       childSessionKey: "agent:main:subagent:long-task",
@@ -56,8 +57,8 @@ describe("buildSubagentList", () => {
       requesterDisplayKey: "main",
       task: "This is a deliberately long task description used to verify that subagent list output keeps the full task text instead of appending ellipsis after a short hard cutoff.",
       cleanup: "keep",
-      createdAt: 1000,
-      startedAt: 1000,
+      createdAt: now,
+      startedAt: now,
     } satisfies SubagentRunRecord;
     addSubagentRunForTests(run);
     const cfg = {
@@ -118,6 +119,7 @@ describe("buildSubagentList", () => {
   });
 
   it("formats io and prompt/cache usage from session entries", async () => {
+    const now = Date.now();
     const run = {
       runId: "run-usage",
       childSessionKey: "agent:main:subagent:usage",
@@ -125,8 +127,8 @@ describe("buildSubagentList", () => {
       requesterDisplayKey: "main",
       task: "do thing",
       cleanup: "keep",
-      createdAt: 1000,
-      startedAt: 1000,
+      createdAt: now,
+      startedAt: now,
     } satisfies SubagentRunRecord;
     addSubagentRunForTests(run);
     const storePath = path.join(testWorkspaceDir, "sessions-subagent-list-usage.json");

--- a/src/agents/subagent-list.test.ts
+++ b/src/agents/subagent-list.test.ts
@@ -179,23 +179,53 @@ describe("isActiveSubagentRun orphan cutoff (#71252)", () => {
     expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(true);
   });
 
+  it("short-circuits fresh runs without calling pendingDescendantCount", () => {
+    const entry = makeEntry({ sessionStartedAt: Date.now() - 60_000 });
+    let calls = 0;
+    const counter = () => {
+      calls += 1;
+      return 0;
+    };
+    expect(isActiveSubagentRun(entry, counter)).toBe(true);
+    expect(calls).toBe(0);
+  });
+
   it("returns false for an orphan run older than the 2h cutoff", () => {
     const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1_000;
     const entry = makeEntry({ sessionStartedAt: threeHoursAgo });
     expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(false);
   });
 
-  it("keeps an old run active when pending descendants remain", () => {
+  it("keeps an old unended run active when pending descendants remain", () => {
     const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1_000;
     const entry = makeEntry({ sessionStartedAt: threeHoursAgo });
     expect(isActiveSubagentRun(entry, () => 1)).toBe(true);
   });
 
-  it("returns false when endedAt is set regardless of age", () => {
+  it("returns false for an ended run with no pending descendants", () => {
     const entry = makeEntry({
       sessionStartedAt: Date.now() - 60_000,
       endedAt: Date.now(),
     });
     expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(false);
+  });
+
+  it("keeps an ended run active while descendants are still settling", () => {
+    const entry = makeEntry({
+      sessionStartedAt: Date.now() - 60_000,
+      endedAt: Date.now(),
+    });
+    expect(isActiveSubagentRun(entry, () => 1)).toBe(true);
+  });
+
+  it("treats createdAt-only entries with no sessionStartedAt/startedAt as orphan after cutoff", () => {
+    const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1_000;
+    const entry = makeEntry({ createdAt: threeHoursAgo });
+    expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(false);
+  });
+
+  it("keeps createdAt-only fresh entries active", () => {
+    const entry = makeEntry({ createdAt: Date.now() - 60_000 });
+    expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(true);
   });
 });

--- a/src/agents/subagent-list.test.ts
+++ b/src/agents/subagent-list.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions/store.js";
-import { buildSubagentList } from "./subagent-list.js";
+import { buildSubagentList, isActiveSubagentRun } from "./subagent-list.js";
 import {
   addSubagentRunForTests,
   resetSubagentRegistryForTests,
@@ -155,5 +155,47 @@ describe("buildSubagentList", () => {
     expect(list.active[0]?.line).toMatch(/tokens 1(\.0)?k \(in 12 \/ out 1(\.0)?k\)/);
     expect(list.active[0]?.line).toContain("prompt/cache 197k");
     expect(list.active[0]?.line).not.toContain("1k io");
+  });
+});
+
+describe("isActiveSubagentRun orphan cutoff (#71252)", () => {
+  const noPendingChildren = () => 0;
+
+  function makeEntry(overrides: Partial<SubagentRunRecord>): SubagentRunRecord {
+    return {
+      runId: "run-1",
+      childSessionKey: "child",
+      requesterSessionKey: "parent",
+      requesterDisplayKey: "parent",
+      task: "t",
+      cleanup: "delete",
+      createdAt: 0,
+      ...overrides,
+    } as SubagentRunRecord;
+  }
+
+  it("returns true for a fresh run that has not ended", () => {
+    const entry = makeEntry({ sessionStartedAt: Date.now() - 60_000 });
+    expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(true);
+  });
+
+  it("returns false for an orphan run older than the 2h cutoff", () => {
+    const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1_000;
+    const entry = makeEntry({ sessionStartedAt: threeHoursAgo });
+    expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(false);
+  });
+
+  it("keeps an old run active when pending descendants remain", () => {
+    const threeHoursAgo = Date.now() - 3 * 60 * 60 * 1_000;
+    const entry = makeEntry({ sessionStartedAt: threeHoursAgo });
+    expect(isActiveSubagentRun(entry, () => 1)).toBe(true);
+  });
+
+  it("returns false when endedAt is set regardless of age", () => {
+    const entry = makeEntry({
+      sessionStartedAt: Date.now() - 60_000,
+      endedAt: Date.now(),
+    });
+    expect(isActiveSubagentRun(entry, noPendingChildren)).toBe(false);
   });
 });

--- a/src/agents/subagent-list.ts
+++ b/src/agents/subagent-list.ts
@@ -129,11 +129,31 @@ export function createPendingDescendantCounter(runsSnapshot?: Map<string, Subage
   };
 }
 
+// Orphan cutoff: subagent runs that started more than ORPHAN_CUTOFF_MS ago and
+// never had endedAt written are treated as dead. Without this gate, any run
+// interrupted by a gateway restart, SIGKILL, or silent tool failure stays in
+// the active list indefinitely — the main agent then reads it through
+// `subagents list` and hallucinates progress narration for work that died
+// hours or days ago. (#71252)
+const SUBAGENT_ORPHAN_CUTOFF_MS = 2 * 60 * 60 * 1_000;
+
 export function isActiveSubagentRun(
   entry: SubagentRunRecord,
   pendingDescendantCount: (sessionKey: string) => number,
 ) {
-  return !entry.endedAt || pendingDescendantCount(entry.childSessionKey) > 0;
+  if (pendingDescendantCount(entry.childSessionKey) > 0) {
+    return true;
+  }
+  if (entry.endedAt) {
+    return false;
+  }
+  const startedAt = getSubagentSessionStartedAt(entry);
+  if (typeof startedAt === "number" && startedAt > 0) {
+    if (Date.now() - startedAt > SUBAGENT_ORPHAN_CUTOFF_MS) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendants?: number }) {

--- a/src/agents/subagent-list.ts
+++ b/src/agents/subagent-list.ts
@@ -141,19 +141,25 @@ export function isActiveSubagentRun(
   entry: SubagentRunRecord,
   pendingDescendantCount: (sessionKey: string) => number,
 ) {
-  if (pendingDescendantCount(entry.childSessionKey) > 0) {
+  // Ended runs only stay "active" while descendants are still settling —
+  // only traverse the descendant graph when we actually need that signal.
+  if (entry.endedAt) {
+    return pendingDescendantCount(entry.childSessionKey) > 0;
+  }
+  // Fresh in-flight runs short-circuit before any descendant lookup so
+  // list/status calls don't pay the traversal cost for the common case.
+  const startedAt = getSubagentSessionStartedAt(entry);
+  if (
+    typeof startedAt !== "number" ||
+    startedAt <= 0 ||
+    Date.now() - startedAt <= SUBAGENT_ORPHAN_CUTOFF_MS
+  ) {
     return true;
   }
-  if (entry.endedAt) {
-    return false;
-  }
-  const startedAt = getSubagentSessionStartedAt(entry);
-  if (typeof startedAt === "number" && startedAt > 0) {
-    if (Date.now() - startedAt > SUBAGENT_ORPHAN_CUTOFF_MS) {
-      return false;
-    }
-  }
-  return true;
+  // Past the cutoff with no endedAt: likely an orphan, but still keep it
+  // active while descendants are pending (an outer run that is waiting on
+  // in-flight children should not collapse).
+  return pendingDescendantCount(entry.childSessionKey) > 0;
 }
 
 function resolveRunStatus(entry: SubagentRunRecord, options?: { pendingDescendants?: number }) {


### PR DESCRIPTION
## Summary

Closes #71252.

\`isActiveSubagentRun()\` classified any entry without \`endedAt\` as active — no staleness fallback. Any run orphaned by gateway restart, SIGKILL, silent cron failure, or deleted cron job stayed in the active list indefinitely. The main agent reads that through \`subagents list\` and **hallucinates progress narration** for work that died hours or days ago. The reporter observed the main agent narrating a 23-minute-44-second research task that never actually ran.

## Change

Add a 2h staleness gate mirroring the reporter's locally-verified patch:

| Prior behavior | Guard | New behavior |
|---|---|---|
| pending descendants > 0 | checked first | active (unchanged) |
| \`endedAt\` set | checked next | not active (unchanged) |
| no \`endedAt\`, \`startedAt\` older than 2h | **new** | not active |
| no \`endedAt\`, started < 2h ago | fallthrough | active (unchanged) |

Reuses \`getSubagentSessionStartedAt\` that already ships in this module — no new resolver logic, no touched call sites (the 3 callers in \`subagent-control.ts\`, \`subagent-list.ts\` itself, and \`tools/subagents-tool.ts\` all benefit equally from the tightened semantics).

## Test plan

Added four unit tests directly against \`isActiveSubagentRun\`:
- fresh run (< 2h, no endedAt) → active
- orphan run (> 2h, no endedAt) → not active (regression guard)
- orphan run with pending descendants → still active (preserves existing behavior)
- endedAt set → not active regardless of age

\`pnpm oxlint src/agents/subagent-list.ts src/agents/subagent-list.test.ts\` → 0 warnings, 0 errors.

## Scope notes

- This is the minimal fix the reporter verified in production. The surrounding class of orphan-generators (#56121 cron lifecycle, #66187 descendant-check inverse, #70421 status-sync, #57920 resolveChildSessionKeys filter) are separate concerns and deliberately out of scope.
- 2h is a conservative default matching the reporter's deployment. A future config knob could expose \`SUBAGENT_ORPHAN_CUTOFF_MS\` but would expand surface area; starting with a single constant.