### PR TITLE
fix(memory-core): skip orphan archival when session store is empty

### DIFF
--- a/extensions/memory-core/src/dreaming-narrative.ts
+++ b/extensions/memory-core/src/dreaming-narrative.ts
@@ -743,6 +743,14 @@ async function scrubDreamingNarrativeArtifacts(logger: Logger): Promise<void> {
       continue;
     }
 
+    // Guard: if store is empty, skip cleanup to avoid false orphan archival
+    if (Object.keys(store).length === 0) {
+      logger.warn(
+        `[memory-core] dreaming cleanup: session store is empty for agent ${agentEntry.name}; skipping cleanup for this agent.`,
+      );
+      continue;
+    }
+
     const referencedSessionFiles = new Set<string>();
     let needsStoreUpdate = false;
     for (const [key, entry] of Object.entries(store)) {
@@ -935,3 +943,4 @@ export async function generateAndAppendDreamNarrative(params: {
     });
   }
 }
+


### PR DESCRIPTION
## Summary

When `loadSessionStore()` fails silently and returns an empty object `{}`, the orphan cleanup in `scrubDreamingNarrativeArtifacts()` would archive ALL transcripts belonging to that agent as false orphans.

This bug caused 261 active sessions to be mistakenly archived in a real-world scenario.

## Fix

Added a guard that skips orphan archival for an agent when its session store is empty (`Object.keys(store).length === 0`). Instead of proceeding with a false empty reference set, the cleanup now logs a warning and skips that agent.

```typescript
// Guard: if store is empty, skip cleanup to avoid false orphan archival
if (Object.keys(store).length === 0) {
  logger.warn(
    `[memory-core] dreaming cleanup: session store is empty for agent ${agentEntry.name}; skipping cleanup for this agent.`,
  );
  continue;
}
```

## Root Cause

The original code catches store load failures and `continue`s, but leaves `referencedSessionFiles` as an empty Set. All transcript files then appear unreferenced and get archived after the 5-minute threshold.

## Testing

The fix adds a defensive check at the point where an empty store would otherwise cause silent data loss.

---
Reported by: lemon890918-png
Source: self-investigation and root cause analysis
