### PR TITLE
fix(skills): refresh persisted snapshots after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Skills: seed the process-local skills snapshot version at gateway/CLI startup so persisted sessions refresh stale `version: 0` snapshots once after restart, picking up skills added while OpenClaw was offline. Fixes #69715, #55489, #54209, #49059, and #67459.
 - Browser/Playwright: ignore benign already-handled route races during guarded navigation so browser-page tasks no longer fail when Playwright tears down a route mid-flight. (#68708) Thanks @Steady-ai.
 - Telegram: prevent duplicate in-process long pollers for the same bot token and add clearer `getUpdates` conflict diagnostics for external duplicate pollers. Fixes #56230.
 - Browser/Linux: detect Chromium-based installs under `/opt/google`, `/opt/brave.com`, `/usr/lib/chromium`, and `/usr/lib/chromium-browser` before asking users to set `browser.executablePath`. (#48563) Thanks @lupuletic.

--- a/src/agents/skills/refresh-state.test.ts
+++ b/src/agents/skills/refresh-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from "vitest";
+
+describe("skills refresh state", () => {
+  it("seeds a process-local version so persisted restart snapshots refresh once", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-04-25T12:00:00Z"));
+      vi.resetModules();
+      const refreshState = await import("./refresh-state.js");
+
+      const startupVersion = refreshState.getSkillsSnapshotVersion("/tmp/workspace");
+
+      expect(startupVersion).toBe(Date.parse("2026-04-25T12:00:00Z"));
+      expect(refreshState.shouldRefreshSnapshotForVersion(0, startupVersion)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      vi.resetModules();
+    }
+  });
+});

--- a/src/agents/skills/refresh-state.ts
+++ b/src/agents/skills/refresh-state.ts
@@ -6,7 +6,8 @@ export type SkillsChangeEvent = {
 
 const listeners = new Set<(event: SkillsChangeEvent) => void>();
 const workspaceVersions = new Map<string, number>();
-let globalVersion = 0;
+// Process-local: persisted snapshots from an older gateway run should refresh once after restart.
+let globalVersion = Date.now();
 let listenerErrorHandler: ((err: unknown) => void) | undefined;
 
 function bumpVersion(current: number): number {


### PR DESCRIPTION
## Summary

- Seed the process-local skills snapshot version at gateway/CLI startup instead of starting every process at version `0`.
- Force persisted `version: 0` snapshots from older processes to refresh once after restart, covering both gateway reply and CLI `agent` paths.
- Add focused regression coverage plus a changelog entry.

## Fixes

Fixes https://github.com/openclaw/openclaw/issues/69715
Fixes https://github.com/openclaw/openclaw/issues/55489
Fixes https://github.com/openclaw/openclaw/issues/54209
Fixes https://github.com/openclaw/openclaw/issues/49059
Fixes https://github.com/openclaw/openclaw/issues/67459

## Related

Supersedes the same root-cause direction in https://github.com/openclaw/openclaw/pull/69716 while preserving the broader fix in the shared refresh-state layer. That covers the gateway reply path and the CLI `agent` path from one place.

## Validation

- `OPENCLAW_LOCAL_CHECK=0 pnpm test src/agents/skills/refresh-state.test.ts src/agents/skills/refresh.test.ts src/auto-reply/reply/session-updates.test.ts`
- `OPENCLAW_LOCAL_CHECK=0 pnpm check:changed`
