### PR TITLE
fix(gateway): prefer physical LAN addresses before bridge interfaces

### DIFF
--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -242,7 +242,8 @@ function pickMatchingIPv4(predicate: (address: string) => boolean): string | nul
 
 const preferredLanInterfaceNames = ["en0", "eth0"];
 const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
-const deprioritizedLanInterfaceNamePattern = /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr)/i;
+const deprioritizedLanInterfaceNamePattern =
+  /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr|flannel|cali|weave|cilium)/i;
 
 function pickPreferredLanIPv4(candidates: IPv4Candidate[]): string | null {
   for (const name of preferredLanInterfaceNames) {

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -245,7 +246,47 @@ const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
 const deprioritizedLanInterfaceNamePattern =
   /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr|flannel|cali|weave|cilium)/i;
 
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function readLinuxDefaultRouteInterfaceNames(): string[] {
+  let routeTable: string;
+  try {
+    routeTable = readFileSync("/proc/net/route", "utf8");
+  } catch {
+    return [];
+  }
+
+  const routes: Array<{ name: string; metric: number }> = [];
+  for (const line of routeTable.split(/\r?\n/).slice(1)) {
+    const [name, destination, , flagsRaw, , , metricRaw, mask] = line.trim().split(/\s+/);
+    if (!name || destination !== "00000000" || mask !== "00000000") {
+      continue;
+    }
+    const flags = Number.parseInt(flagsRaw ?? "", 16);
+    if (!Number.isFinite(flags) || (flags & 0x1) === 0) {
+      continue;
+    }
+    const metric = Number.parseInt(metricRaw ?? "0", 10);
+    routes.push({ name, metric: Number.isFinite(metric) ? metric : 0 });
+  }
+
+  routes.sort((a, b) => a.metric - b.metric);
+  return uniqueStrings(routes.map((route) => route.name));
+}
+
 function pickPreferredLanIPv4(candidates: IPv4Candidate[]): string | null {
+  const preferredByRoute = uniqueStrings(readLinuxDefaultRouteInterfaceNames())
+    .map((name) => candidates.find((entry) => entry.name === name))
+    .filter((entry) => entry !== undefined);
+  const nonDeprioritizedRoute = preferredByRoute.find(
+    (entry) => !deprioritizedLanInterfaceNamePattern.test(entry.name),
+  );
+  if (nonDeprioritizedRoute) {
+    return nonDeprioritizedRoute.address;
+  }
+
   for (const name of preferredLanInterfaceNames) {
     const preferred = candidates.find((entry) => entry.name === name);
     if (preferred) {
@@ -258,7 +299,13 @@ function pickPreferredLanIPv4(candidates: IPv4Candidate[]): string | null {
   const preferredByName = nonDeprioritized.find((entry) =>
     preferredLanInterfaceNamePattern.test(entry.name),
   );
-  return preferredByName?.address ?? nonDeprioritized[0]?.address ?? candidates[0]?.address ?? null;
+  return (
+    preferredByName?.address ??
+    nonDeprioritized[0]?.address ??
+    preferredByRoute[0]?.address ??
+    candidates[0]?.address ??
+    null
+  );
 }
 
 function pickLanIPv4(): string | null {

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -208,9 +208,12 @@ function isTailnetIPv4(address: string): boolean {
   return a === 100 && b >= 64 && b <= 127;
 }
 
-function pickMatchingIPv4(predicate: (address: string) => boolean): string | null {
+type IPv4Candidate = { name: string; address: string };
+
+function listMatchingIPv4(predicate: (address: string) => boolean): IPv4Candidate[] {
   const nets = os.networkInterfaces();
-  for (const entries of Object.values(nets)) {
+  const candidates: IPv4Candidate[] = [];
+  for (const [name, entries] of Object.entries(nets)) {
     if (!entries) {
       continue;
     }
@@ -226,15 +229,39 @@ function pickMatchingIPv4(predicate: (address: string) => boolean): string | nul
         continue;
       }
       if (predicate(address)) {
-        return address;
+        candidates.push({ name, address });
       }
     }
   }
-  return null;
+  return candidates;
+}
+
+function pickMatchingIPv4(predicate: (address: string) => boolean): string | null {
+  return listMatchingIPv4(predicate)[0]?.address ?? null;
+}
+
+const preferredLanInterfaceNames = ["en0", "eth0"];
+const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
+const deprioritizedLanInterfaceNamePattern = /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr)/i;
+
+function pickPreferredLanIPv4(candidates: IPv4Candidate[]): string | null {
+  for (const name of preferredLanInterfaceNames) {
+    const preferred = candidates.find((entry) => entry.name === name);
+    if (preferred) {
+      return preferred.address;
+    }
+  }
+  const nonDeprioritized = candidates.filter(
+    (entry) => !deprioritizedLanInterfaceNamePattern.test(entry.name),
+  );
+  const preferredByName = nonDeprioritized.find((entry) =>
+    preferredLanInterfaceNamePattern.test(entry.name),
+  );
+  return preferredByName?.address ?? nonDeprioritized[0]?.address ?? candidates[0]?.address ?? null;
 }
 
 function pickLanIPv4(): string | null {
-  return pickMatchingIPv4(isPrivateIPv4);
+  return pickPreferredLanIPv4(listMatchingIPv4(isPrivateIPv4));
 }
 
 function pickTailnetIPv4(): string | null {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -367,6 +367,16 @@ describe("pickPrimaryLanIPv4", () => {
       expected: "172.17.0.1",
     },
     {
+      name: "deprioritizes Kubernetes CNI overlays before other candidates",
+      interfaces: makeNetworkInterfacesSnapshot({
+        lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        "flannel.1": [{ address: "10.244.0.1", family: "IPv4" }],
+        cali123456789: [{ address: "10.244.1.1", family: "IPv4" }],
+        wg0: [{ address: "192.168.178.209", family: "IPv4" }],
+      }),
+      expected: "192.168.178.209",
+    },
+    {
       name: "no non-internal interface",
       interfaces: makeNetworkInterfacesSnapshot({
         lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -12,6 +12,7 @@ import {
   isSecureWebSocketUrl,
   isTrustedProxyAddress,
   pickPrimaryLanIPv4,
+  pickPrimaryLanIPv4FromSnapshot,
   resolveClientIp,
   resolveGatewayBindHost,
   resolveGatewayListenHosts,
@@ -390,6 +391,32 @@ describe("pickPrimaryLanIPv4", () => {
       expect(pickPrimaryLanIPv4()).toBe(expected);
     },
   );
+
+  it("prefers the default-route interface before physical name heuristics", () => {
+    const interfaces = makeNetworkInterfacesSnapshot({
+      lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      enp14s0: [{ address: "192.168.1.193", family: "IPv4" }],
+      wgdh: [{ address: "192.168.178.209", family: "IPv4" }],
+    });
+
+    expect(pickPrimaryLanIPv4FromSnapshot(interfaces, { preferredInterfaceNames: ["wgdh"] })).toBe(
+      "192.168.178.209",
+    );
+  });
+
+  it("deprioritizes a default-route bridge before physical LAN candidates", () => {
+    const interfaces = makeNetworkInterfacesSnapshot({
+      lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+      "br-c87a82b2afb7": [{ address: "172.18.0.1", family: "IPv4" }],
+      wlp13s0: [{ address: "192.168.1.193", family: "IPv4" }],
+    });
+
+    expect(
+      pickPrimaryLanIPv4FromSnapshot(interfaces, {
+        preferredInterfaceNames: ["br-c87a82b2afb7"],
+      }),
+    ).toBe("192.168.1.193");
+  });
 
   it("throws when interface discovery throws", () => {
     vi.spyOn(os, "networkInterfaces").mockImplementation(() => {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -350,6 +350,23 @@ describe("pickPrimaryLanIPv4", () => {
       expected: "172.16.0.99",
     },
     {
+      name: "prefers physical LAN interfaces before Docker bridges",
+      interfaces: makeNetworkInterfacesSnapshot({
+        lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        "br-c87a82b2afb7": [{ address: "172.18.0.1", family: "IPv4" }],
+        wlp13s0: [{ address: "192.168.1.193", family: "IPv4" }],
+      }),
+      expected: "192.168.1.193",
+    },
+    {
+      name: "still falls back to Docker bridges when they are the only candidate",
+      interfaces: makeNetworkInterfacesSnapshot({
+        lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+        docker0: [{ address: "172.17.0.1", family: "IPv4" }],
+      }),
+      expected: "172.17.0.1",
+    },
+    {
       name: "no non-internal interface",
       interfaces: makeNetworkInterfacesSnapshot({
         lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
@@ -357,7 +374,7 @@ describe("pickPrimaryLanIPv4", () => {
       expected: undefined,
     },
   ] as const)(
-    "prefers en0, then eth0, then any non-internal IPv4: $name",
+    "prefers physical LAN candidates before virtual bridge fallback: $name",
     ({ interfaces, expected }) => {
       vi.spyOn(os, "networkInterfaces").mockReturnValue(interfaces);
       expect(pickPrimaryLanIPv4()).toBe(expected);

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -22,6 +22,36 @@ const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
 const deprioritizedLanInterfaceNamePattern =
   /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr|flannel|cali|weave|cilium)/i;
 
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
+}
+
+function readLinuxDefaultRouteInterfaceNames(): string[] {
+  let routeTable: string;
+  try {
+    routeTable = fs.readFileSync("/proc/net/route", "utf8");
+  } catch {
+    return [];
+  }
+
+  const routes: Array<{ name: string; metric: number }> = [];
+  for (const line of routeTable.split(/\r?\n/).slice(1)) {
+    const [name, destination, , flagsRaw, , , metricRaw, mask] = line.trim().split(/\s+/);
+    if (!name || destination !== "00000000" || mask !== "00000000") {
+      continue;
+    }
+    const flags = Number.parseInt(flagsRaw ?? "", 16);
+    if (!Number.isFinite(flags) || (flags & 0x1) === 0) {
+      continue;
+    }
+    const metric = Number.parseInt(metricRaw ?? "0", 10);
+    routes.push({ name, metric: Number.isFinite(metric) ? metric : 0 });
+  }
+
+  routes.sort((a, b) => a.metric - b.metric);
+  return uniqueStrings(routes.map((route) => route.name));
+}
+
 function isDeprioritizedLanInterfaceName(name: string): boolean {
   return deprioritizedLanInterfaceNamePattern.test(name);
 }
@@ -32,12 +62,24 @@ function isPreferredLanInterfaceName(name: string): boolean {
 
 export function pickPrimaryLanIPv4FromSnapshot(
   snapshot: NetworkInterfacesSnapshot | undefined,
-  params: { matches?: (address: string) => boolean } = {},
+  params: { matches?: (address: string) => boolean; preferredInterfaceNames?: string[] } = {},
 ): string | undefined {
   const matches = params.matches ?? (() => true);
   const addresses = listExternalInterfaceAddresses(snapshot, "IPv4").filter((entry) =>
     matches(entry.address),
   );
+
+  const preferredByRoute = uniqueStrings(
+    params.preferredInterfaceNames ?? readLinuxDefaultRouteInterfaceNames(),
+  )
+    .map((name) => addresses.find((entry) => entry.name === name))
+    .filter((entry) => entry !== undefined);
+  const nonDeprioritizedRoute = preferredByRoute.find(
+    (entry) => !isDeprioritizedLanInterfaceName(entry.name),
+  );
+  if (nonDeprioritizedRoute) {
+    return nonDeprioritizedRoute.address;
+  }
 
   for (const name of preferredLanInterfaceNames) {
     const preferred = addresses.find((entry) => entry.name === name);
@@ -50,7 +92,12 @@ export function pickPrimaryLanIPv4FromSnapshot(
     (entry) => !isDeprioritizedLanInterfaceName(entry.name),
   );
   const preferredByName = nonDeprioritized.find((entry) => isPreferredLanInterfaceName(entry.name));
-  return preferredByName?.address ?? nonDeprioritized[0]?.address ?? addresses[0]?.address;
+  return (
+    preferredByName?.address ??
+    nonDeprioritized[0]?.address ??
+    preferredByRoute[0]?.address ??
+    addresses[0]?.address
+  );
 }
 
 /**

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -19,7 +19,8 @@ import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 const preferredLanInterfaceNames = ["en0", "eth0"];
 const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
-const deprioritizedLanInterfaceNamePattern = /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr)/i;
+const deprioritizedLanInterfaceNamePattern =
+  /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr|flannel|cali|weave|cilium)/i;
 
 function isDeprioritizedLanInterfaceName(name: string): boolean {
   return deprioritizedLanInterfaceNamePattern.test(name);

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -3,8 +3,9 @@ import type { IncomingMessage } from "node:http";
 import net from "node:net";
 import type { GatewayBindMode } from "../config/types.gateway.js";
 import {
-  pickMatchingExternalInterfaceAddress,
+  listExternalInterfaceAddresses,
   readNetworkInterfaces,
+  type NetworkInterfacesSnapshot,
 } from "../infra/network-interfaces.js";
 import { pickPrimaryTailnetIPv4, pickPrimaryTailnetIPv6 } from "../infra/tailnet.js";
 import {
@@ -16,15 +17,48 @@ import {
 } from "../shared/net/ip.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
+const preferredLanInterfaceNames = ["en0", "eth0"];
+const preferredLanInterfaceNamePattern = /^(?:en|eth|wl|wlan|wi-?fi|ethernet)/i;
+const deprioritizedLanInterfaceNamePattern = /^(?:docker\d*|br-|veth|cni|podman|virbr|lxc|lxdbr)/i;
+
+function isDeprioritizedLanInterfaceName(name: string): boolean {
+  return deprioritizedLanInterfaceNamePattern.test(name);
+}
+
+function isPreferredLanInterfaceName(name: string): boolean {
+  return preferredLanInterfaceNamePattern.test(name);
+}
+
+export function pickPrimaryLanIPv4FromSnapshot(
+  snapshot: NetworkInterfacesSnapshot | undefined,
+  params: { matches?: (address: string) => boolean } = {},
+): string | undefined {
+  const matches = params.matches ?? (() => true);
+  const addresses = listExternalInterfaceAddresses(snapshot, "IPv4").filter((entry) =>
+    matches(entry.address),
+  );
+
+  for (const name of preferredLanInterfaceNames) {
+    const preferred = addresses.find((entry) => entry.name === name);
+    if (preferred) {
+      return preferred.address;
+    }
+  }
+
+  const nonDeprioritized = addresses.filter(
+    (entry) => !isDeprioritizedLanInterfaceName(entry.name),
+  );
+  const preferredByName = nonDeprioritized.find((entry) => isPreferredLanInterfaceName(entry.name));
+  return preferredByName?.address ?? nonDeprioritized[0]?.address ?? addresses[0]?.address;
+}
+
 /**
  * Pick the primary non-internal IPv4 address (LAN IP).
- * Prefers common interface names (en0, eth0) then falls back to any external IPv4.
+ * Prefers physical/default-looking LAN interfaces and only falls back to
+ * Docker/bridge-style interfaces when they are the only available candidate.
  */
 export function pickPrimaryLanIPv4(): string | undefined {
-  return pickMatchingExternalInterfaceAddress(readNetworkInterfaces(), {
-    family: "IPv4",
-    preferredNames: ["en0", "eth0"],
-  });
+  return pickPrimaryLanIPv4FromSnapshot(readNetworkInterfaces());
 }
 
 export function normalizeHostHeader(hostHeader?: string): string {

--- a/src/pairing/setup-code.test.ts
+++ b/src/pairing/setup-code.test.ts
@@ -505,6 +505,46 @@ describe("pairing setup code", () => {
     });
   });
 
+  it("prefers physical LAN interfaces before Docker bridge candidates", async () => {
+    await expectResolvedSetupSuccessCase({
+      config: {
+        gateway: {
+          bind: "lan",
+          auth: { mode: "password", password: "secret" },
+        },
+      } satisfies ResolveSetupConfig,
+      options: {
+        networkInterfaces: () => ({
+          "br-c87a82b2afb7": [
+            {
+              address: "172.18.0.1",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.0.0",
+              mac: "00:00:00:00:00:00",
+              cidr: "172.18.0.1/16",
+            },
+          ],
+          wlp13s0: [
+            {
+              address: "192.168.1.193",
+              family: "IPv4",
+              internal: false,
+              netmask: "255.255.252.0",
+              mac: "00:00:00:00:00:00",
+              cidr: "192.168.1.193/22",
+            },
+          ],
+        }),
+      } satisfies ResolveSetupOptions,
+      expected: {
+        authLabel: "password",
+        url: "ws://192.168.1.193:18789",
+        urlSource: "gateway.bind=lan",
+      },
+    });
+  });
+
   it.each([
     {
       name: "errors when gateway is loopback only",

--- a/src/pairing/setup-code.ts
+++ b/src/pairing/setup-code.ts
@@ -4,7 +4,11 @@ import type { OpenClawConfig } from "../config/types.js";
 import { normalizeSecretInputString, resolveSecretInputRef } from "../config/types.secrets.js";
 import { materializeGatewayAuthSecretRefs } from "../gateway/auth-config-utils.js";
 import { assertExplicitGatewayAuthModeWhenBothConfigured } from "../gateway/auth-mode-policy.js";
-import { isLoopbackHost, isSecureWebSocketUrl } from "../gateway/net.js";
+import {
+  isLoopbackHost,
+  isSecureWebSocketUrl,
+  pickPrimaryLanIPv4FromSnapshot,
+} from "../gateway/net.js";
 import { issueDeviceBootstrapToken } from "../infra/device-bootstrap.js";
 import {
   pickMatchingExternalInterfaceAddress,
@@ -195,7 +199,11 @@ function pickIPv4Matching(
 function pickLanIPv4(
   networkInterfaces: () => ReturnType<typeof os.networkInterfaces>,
 ): string | null {
-  return pickIPv4Matching(networkInterfaces, isPrivateIPv4);
+  return (
+    pickPrimaryLanIPv4FromSnapshot(safeNetworkInterfaces(networkInterfaces), {
+      matches: isPrivateIPv4,
+    }) ?? null
+  );
 }
 
 function pickTailnetIPv4(


### PR DESCRIPTION
## Summary

Fixes #71493.

`gateway.bind=lan` address selection now prefers physical/default-looking LAN interfaces before Docker/bridge/container-style interfaces when advertising automatic LAN URLs.

The change intentionally does **not** hard-ban Docker/bridge/veth/cni/virbr/podman-style interfaces. They are only de-prioritized for automatic selection and remain usable when explicitly configured, or when they are the only candidate.

## Details

- Adds a shared LAN IPv4 picker that prefers:
  - exact common physical names (`en0`, `eth0`)
  - physical/default-looking names (`en*`, `eth*`, `wl*`, `wlan*`, etc.)
  - other non-deprioritized interfaces
  - Docker/bridge-style interfaces as final fallback
- Uses the same selection behavior for pairing setup code LAN URL resolution.
- Mirrors the behavior in the bundled `device-pair` plugin path so plugin-issued pairing codes do not drift from core QR behavior.

## Validation

- `corepack pnpm test src/gateway/net.test.ts src/pairing/setup-code.test.ts`
- `corepack pnpm test extensions/device-pair/index.test.ts`
- `corepack pnpm test src/gateway/server.node-pairing-auto-approve.test.ts`
