### PR TITLE
fix(mcp): auto-reinitialize streamable-http session on -32000 Server not initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory-host SDK: use trusted env-proxy mode for remote embedding and batch HTTP calls only when Undici will proxy that target, preserving SSRF DNS pinning for `ALL_PROXY`-only and `NO_PROXY` bypass cases. Fixes #52162. (#71506) Thanks @DhtIsCoding.
+- MCP: reinitialize lost streamable-http sessions in place, refresh SDK tool metadata after reconnect, and keep failed reconnect attempts retryable. (#71545) Thanks @Vianne-droid.
 - Gateway/dashboard: render Control UI and WebSocket links with `https://`/`wss://` when `gateway.tls.enabled=true`, including `openclaw gateway status`. Fixes #71494. (#71499) Thanks @deepkilo.
 - Agents/OpenAI-compatible: default proxy/local completions tool requests to `tool_choice: "auto"` when tools are present, so providers enter native tool-calling mode instead of replying with plain-text tool directives. (#71472) Thanks @Speed-maker.
 - OpenAI image generation: use `gpt-5.5` for the Codex OAuth responses transport instead of the retired `gpt-5.4` model, fixing 500s from ChatGPT Codex image generation. Fixes #71513. Thanks @baolongl.

--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -1,8 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBundleMcpJsonSchemaValidator } from "./pi-bundle-mcp-runtime.js";
-import { cleanupBundleMcpHarness } from "./pi-bundle-mcp-test-harness.js";
+import {
+  cleanupBundleMcpHarness,
+  startStreamableHttpProbeServer,
+} from "./pi-bundle-mcp-test-harness.js";
 import {
   __testing,
+  createSessionMcpRuntime,
   getOrCreateSessionMcpRuntime,
   materializeBundleMcpToolsForRun,
   retireSessionMcpRuntime,
@@ -93,6 +97,137 @@ describe("session MCP runtime", () => {
       errorMessage: undefined,
     });
     expect(validator({ url: 42 }).valid).toBe(false);
+  });
+
+  it("reinitializes lost streamable-http sessions and refreshes SDK tool metadata", async () => {
+    const server = await startStreamableHttpProbeServer();
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-streamable-http-reconnect",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            streamableProbe: {
+              transport: "streamable-http",
+              url: `http://127.0.0.1:${server.port}/mcp`,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      await expect(runtime.getCatalog()).resolves.toMatchObject({
+        servers: { streamableProbe: { toolCount: 1 } },
+      });
+      expect(server.getListToolsRequestCount()).toBe(1);
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).resolves.toEqual(
+        expect.objectContaining({
+          structuredContent: { value: "generation:1" },
+        }),
+      );
+
+      await server.resetSession();
+
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).resolves.toEqual(
+        expect.objectContaining({
+          structuredContent: { value: "generation:2" },
+        }),
+      );
+      expect(server.getListToolsRequestCount()).toBe(2);
+    } finally {
+      await runtime.dispose();
+      await server.close();
+    }
+  });
+
+  it("keeps streamable-http sessions recoverable when a reconnect attempt fails", async () => {
+    const server = await startStreamableHttpProbeServer();
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-streamable-http-reconnect-retry",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            streamableProbe: {
+              transport: "streamable-http",
+              url: `http://127.0.0.1:${server.port}/mcp`,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      await runtime.getCatalog();
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).resolves.toEqual(
+        expect.objectContaining({
+          structuredContent: { value: "generation:1" },
+        }),
+      );
+
+      await server.resetSession();
+      server.failNextInitialize();
+
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).rejects.toThrow(
+        /Server not initialized/u,
+      );
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).resolves.toEqual(
+        expect.objectContaining({
+          structuredContent: { value: "generation:2" },
+        }),
+      );
+    } finally {
+      await runtime.dispose();
+      await server.close();
+    }
+  });
+
+  it("shares one streamable-http reconnect across concurrent lost-session calls", async () => {
+    const server = await startStreamableHttpProbeServer();
+    const runtime = createSessionMcpRuntime({
+      sessionId: "session-streamable-http-reconnect-concurrent",
+      workspaceDir: "/workspace",
+      cfg: {
+        mcp: {
+          servers: {
+            streamableProbe: {
+              transport: "streamable-http",
+              url: `http://127.0.0.1:${server.port}/mcp`,
+            },
+          },
+        },
+      },
+    });
+
+    try {
+      await runtime.getCatalog();
+      await expect(runtime.callTool("streamableProbe", "structured_probe", {})).resolves.toEqual(
+        expect.objectContaining({
+          structuredContent: { value: "generation:1" },
+        }),
+      );
+
+      await server.resetSession();
+
+      await expect(
+        Promise.all([
+          runtime.callTool("streamableProbe", "structured_probe", {}),
+          runtime.callTool("streamableProbe", "structured_probe", {}),
+        ]),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          structuredContent: { value: "generation:2" },
+        }),
+        expect.objectContaining({
+          structuredContent: { value: "generation:2" },
+        }),
+      ]);
+      expect(server.getListToolsRequestCount()).toBe(2);
+    } finally {
+      await runtime.dispose();
+      await server.close();
+    }
   });
 
   it("keeps colliding sanitized tool definitions stable across catalog order changes", async () => {

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -351,14 +351,77 @@ export function createSessionMcpRuntime(params: {
     async callTool(serverName, toolName, input) {
       failIfDisposed();
       await getCatalog();
-      const session = sessions.get(serverName);
-      if (!session) {
-        throw new Error(`bundle-mcp server "${serverName}" is not connected`);
+      const args = isMcpConfigRecord(input) ? input : {};
+      const attemptCallTool = async () => {
+        const session = sessions.get(serverName);
+        if (!session) {
+          throw new Error(`bundle-mcp server "${serverName}" is not connected`);
+        }
+        return (await session.client.callTool({
+          name: toolName,
+          arguments: args,
+        })) as CallToolResult;
+      };
+      // Streamable-HTTP servers can lose their session (idle reap, redeploy,
+      // network blip). The MCP SDK client does not auto-reinitialize, so we
+      // detect the well-known JSON-RPC -32000 / "Server not initialized" error
+      // and transparently rebuild the connection once before retrying.
+      // SSE and stdio transports are unaffected.
+      const isStreamableSessionLost = (error: unknown): boolean => {
+        const session = sessions.get(serverName);
+        if (!session || session.transportType !== "streamable-http") return false;
+        const msg = String((error as Error)?.message ?? error ?? "");
+        return (
+          msg.includes("Server not initialized") ||
+          msg.includes("Session not found") ||
+          msg.includes("Mcp-Session-Id header is required") ||
+          /HTTP\s*4(?:00|04)/i.test(msg)
+        );
+      };
+      const reconnectStreamableSession = async (): Promise<boolean> => {
+        const current = sessions.get(serverName);
+        if (!current) return false;
+        const rawServer = loaded.mcpServers[serverName];
+        if (!rawServer) return false;
+        await disposeSession(current).catch(() => {});
+        sessions.delete(serverName);
+        const resolved = resolveMcpTransport(serverName, rawServer);
+        if (!resolved) return false;
+        const client = new Client(
+          { name: "openclaw-bundle-mcp", version: "0.0.0" },
+          {},
+        );
+        const nextSession = {
+          serverName,
+          client,
+          transport: resolved.transport,
+          transportType: resolved.transportType,
+          detachStderr: resolved.detachStderr,
+        };
+        sessions.set(serverName, nextSession);
+        try {
+          await connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs);
+          return true;
+        } catch (connectError) {
+          logWarn(
+            `bundle-mcp: reconnect failed for "${serverName}": ${redactErrorUrls(connectError)}`,
+          );
+          await disposeSession(nextSession).catch(() => {});
+          sessions.delete(serverName);
+          return false;
+        }
+      };
+      try {
+        return await attemptCallTool();
+      } catch (error) {
+        if (!isStreamableSessionLost(error)) throw error;
+        logWarn(
+          `bundle-mcp: streamable-http session lost for "${serverName}" (${redactErrorUrls(error)}); reinitializing and retrying once.`,
+        );
+        const reconnected = await reconnectStreamableSession();
+        if (!reconnected) throw error;
+        return await attemptCallTool();
       }
-      return (await session.client.callTool({
-        name: toolName,
-        arguments: isMcpConfigRecord(input) ? input : {},
-      })) as CallToolResult;
     },
     async dispose() {
       if (disposed) {

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -47,6 +47,7 @@ const SESSION_MCP_RUNTIME_MANAGER_KEY = Symbol.for("openclaw.sessionMcpRuntimeMa
 const DRAFT_2020_12_SCHEMA = "https://json-schema.org/draft/2020-12/schema";
 const DEFAULT_SESSION_MCP_RUNTIME_IDLE_TTL_MS = 10 * 60 * 1000;
 const SESSION_MCP_RUNTIME_SWEEP_INTERVAL_MS = 60 * 1000;
+const BUNDLE_MCP_CLIENT_INFO = { name: "openclaw-bundle-mcp", version: "0.0.0" };
 
 type Ajv2020Like = {
   compile: (schema: JsonSchemaType) => ValidateFunction;
@@ -139,6 +140,39 @@ async function disposeSession(session: BundleMcpSession) {
   await session.client.close().catch(() => {});
 }
 
+function createBundleMcpClient(): Client {
+  return new Client(BUNDLE_MCP_CLIENT_INFO, {
+    jsonSchemaValidator: createBundleMcpJsonSchemaValidator(),
+  });
+}
+
+function createBundleMcpSession(params: {
+  serverName: string;
+  client: Client;
+  resolved: NonNullable<ReturnType<typeof resolveMcpTransport>>;
+}): BundleMcpSession {
+  return {
+    serverName: params.serverName,
+    client: params.client,
+    transport: params.resolved.transport,
+    transportType: params.resolved.transportType,
+    detachStderr: params.resolved.detachStderr,
+  };
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : typeof error === "string" ? error : "";
+}
+
+function isStreamableHttpSessionLostError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return (
+    message.includes("Server not initialized") ||
+    message.includes("Session not found") ||
+    message.includes("Mcp-Session-Id header is required")
+  );
+}
+
 function createCatalogFingerprint(servers: Record<string, unknown>): string {
   return crypto.createHash("sha1").update(JSON.stringify(servers)).digest("hex");
 }
@@ -196,6 +230,7 @@ export function createSessionMcpRuntime(params: {
   let catalog: McpToolCatalog | null = null;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   const sessions = new Map<string, BundleMcpSession>();
+  const reconnectInFlight = new Map<string, Promise<boolean>>();
   const failIfDisposed = () => {
     if (disposed) {
       throw createDisposedError(params.sessionId);
@@ -238,22 +273,8 @@ export function createSessionMcpRuntime(params: {
             );
           }
 
-          const client = new Client(
-            {
-              name: "openclaw-bundle-mcp",
-              version: "0.0.0",
-            },
-            {
-              jsonSchemaValidator: createBundleMcpJsonSchemaValidator(),
-            },
-          );
-          const session: BundleMcpSession = {
-            serverName,
-            client,
-            transport: resolved.transport,
-            transportType: resolved.transportType,
-            detachStderr: resolved.detachStderr,
-          };
+          const client = createBundleMcpClient();
+          const session = createBundleMcpSession({ serverName, client, resolved });
           sessions.set(serverName, session);
 
           try {
@@ -352,11 +373,13 @@ export function createSessionMcpRuntime(params: {
       failIfDisposed();
       await getCatalog();
       const args = isMcpConfigRecord(input) ? input : {};
+      let attemptedSession: BundleMcpSession | undefined;
       const attemptCallTool = async () => {
         const session = sessions.get(serverName);
         if (!session) {
           throw new Error(`bundle-mcp server "${serverName}" is not connected`);
         }
+        attemptedSession = session;
         return (await session.client.callTool({
           name: toolName,
           arguments: args,
@@ -367,59 +390,76 @@ export function createSessionMcpRuntime(params: {
       // detect the well-known JSON-RPC -32000 / "Server not initialized" error
       // and transparently rebuild the connection once before retrying.
       // SSE and stdio transports are unaffected.
-      const isStreamableSessionLost = (error: unknown): boolean => {
-        const session = sessions.get(serverName);
-        if (!session || session.transportType !== "streamable-http") return false;
-        const msg = String((error as Error)?.message ?? error ?? "");
+      const isStreamableSessionLost = (
+        error: unknown,
+        session: BundleMcpSession | undefined,
+      ): session is BundleMcpSession => {
         return (
-          msg.includes("Server not initialized") ||
-          msg.includes("Session not found") ||
-          msg.includes("Mcp-Session-Id header is required") ||
-          /HTTP\s*4(?:00|04)/i.test(msg)
+          session?.transportType === "streamable-http" && isStreamableHttpSessionLostError(error)
         );
       };
-      const reconnectStreamableSession = async (): Promise<boolean> => {
-        const current = sessions.get(serverName);
-        if (!current) return false;
-        const rawServer = loaded.mcpServers[serverName];
-        if (!rawServer) return false;
-        await disposeSession(current).catch(() => {});
-        sessions.delete(serverName);
-        const resolved = resolveMcpTransport(serverName, rawServer);
-        if (!resolved) return false;
-        const client = new Client(
-          { name: "openclaw-bundle-mcp", version: "0.0.0" },
-          {},
-        );
-        const nextSession = {
-          serverName,
-          client,
-          transport: resolved.transport,
-          transportType: resolved.transportType,
-          detachStderr: resolved.detachStderr,
-        };
-        sessions.set(serverName, nextSession);
-        try {
-          await connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs);
-          return true;
-        } catch (connectError) {
-          logWarn(
-            `bundle-mcp: reconnect failed for "${serverName}": ${redactErrorUrls(connectError)}`,
-          );
-          await disposeSession(nextSession).catch(() => {});
-          sessions.delete(serverName);
-          return false;
+      const reconnectStreamableSession = async (failedSession: BundleMcpSession) => {
+        const existing = reconnectInFlight.get(serverName);
+        if (existing) {
+          return await existing;
         }
+        const reconnect = (async (): Promise<boolean> => {
+          if (sessions.get(serverName) !== failedSession) {
+            return true;
+          }
+          const rawServer = loaded.mcpServers[serverName];
+          if (!rawServer) {
+            return false;
+          }
+          const resolved = resolveMcpTransport(serverName, rawServer);
+          if (!resolved) {
+            return false;
+          }
+          const client = createBundleMcpClient();
+          const nextSession = createBundleMcpSession({ serverName, client, resolved });
+          try {
+            await connectWithTimeout(client, resolved.transport, resolved.connectionTimeoutMs);
+            await listAllTools(client);
+            if (disposed) {
+              await disposeSession(nextSession).catch(() => {});
+              return false;
+            }
+            if (sessions.get(serverName) !== failedSession) {
+              await disposeSession(nextSession).catch(() => {});
+              return true;
+            }
+            sessions.set(serverName, nextSession);
+            await disposeSession(failedSession).catch(() => {});
+            return true;
+          } catch (connectError) {
+            logWarn(
+              `bundle-mcp: reconnect failed for "${serverName}": ${redactErrorUrls(connectError)}`,
+            );
+            await disposeSession(nextSession).catch(() => {});
+            return false;
+          }
+        })().finally(() => {
+          if (reconnectInFlight.get(serverName) === reconnect) {
+            reconnectInFlight.delete(serverName);
+          }
+        });
+        reconnectInFlight.set(serverName, reconnect);
+        return await reconnect;
       };
       try {
         return await attemptCallTool();
       } catch (error) {
-        if (!isStreamableSessionLost(error)) throw error;
+        const failedSession = attemptedSession;
+        if (!isStreamableSessionLost(error, failedSession)) {
+          throw error;
+        }
         logWarn(
           `bundle-mcp: streamable-http session lost for "${serverName}" (${redactErrorUrls(error)}); reinitializing and retrying once.`,
         );
-        const reconnected = await reconnectStreamableSession();
-        if (!reconnected) throw error;
+        const reconnected = await reconnectStreamableSession(failedSession);
+        if (!reconnected) {
+          throw error;
+        }
         return await attemptCallTool();
       }
     },
@@ -430,6 +470,7 @@ export function createSessionMcpRuntime(params: {
       disposed = true;
       catalog = null;
       catalogInFlight = undefined;
+      reconnectInFlight.clear();
       const sessionsToClose = Array.from(sessions.values());
       sessions.clear();
       await Promise.allSettled(sessionsToClose.map((session) => disposeSession(session)));

--- a/src/agents/pi-bundle-mcp-test-harness.ts
+++ b/src/agents/pi-bundle-mcp-test-harness.ts
@@ -1,8 +1,10 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
+import * as z from "zod/v3";
 import {
   writeBundleProbeMcpServer,
   writeClaudeBundle,
@@ -12,6 +14,8 @@ import {
 const require = createRequire(import.meta.url);
 const SDK_SERVER_MCP_PATH = require.resolve("@modelcontextprotocol/sdk/server/mcp.js");
 const SDK_SERVER_SSE_PATH = require.resolve("@modelcontextprotocol/sdk/server/sse.js");
+const SDK_SERVER_STREAMABLE_HTTP_PATH =
+  require.resolve("@modelcontextprotocol/sdk/server/streamableHttp.js");
 
 const tempDirs: string[] = [];
 
@@ -86,6 +90,120 @@ export async function startSseProbeServer(
       await new Promise<void>((resolve, reject) =>
         httpServer.close((error) => (error ? reject(error) : resolve())),
       );
+    },
+  };
+}
+
+export async function startStreamableHttpProbeServer(): Promise<{
+  close: () => Promise<void>;
+  failNextInitialize: () => void;
+  getListToolsRequestCount: () => number;
+  port: number;
+  resetSession: () => Promise<void>;
+}> {
+  const { McpServer } = (await import(
+    SDK_SERVER_MCP_PATH
+  )) as typeof import("@modelcontextprotocol/sdk/server/mcp.js");
+  const { StreamableHTTPServerTransport } = (await import(
+    SDK_SERVER_STREAMABLE_HTTP_PATH
+  )) as typeof import("@modelcontextprotocol/sdk/server/streamableHttp.js");
+
+  let generation = 0;
+  let listToolsRequestCount = 0;
+  let failInitializeCount = 0;
+  let active: {
+    transport: InstanceType<typeof StreamableHTTPServerTransport>;
+  };
+
+  const createActiveTransport = async () => {
+    generation += 1;
+    const mcpServer = new McpServer({ name: "streamable-probe", version: "1.0.0" });
+    mcpServer.registerTool(
+      "structured_probe",
+      {
+        description: "Streamable HTTP probe",
+        outputSchema: { value: z.string() },
+      },
+      async () => ({
+        content: [{ type: "text", text: `generation:${generation}` }],
+        structuredContent: { value: `generation:${generation}` },
+      }),
+    );
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: randomUUID,
+    });
+    await mcpServer.connect(transport);
+    return { transport };
+  };
+
+  active = await createActiveTransport();
+
+  const readParsedBody = async (req: http.IncomingMessage): Promise<unknown> => {
+    if (req.method !== "POST") {
+      return undefined;
+    }
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+    if (chunks.length === 0) {
+      return undefined;
+    }
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+  };
+
+  const includesMethod = (parsedBody: unknown, method: string): boolean => {
+    const messages = Array.isArray(parsedBody) ? parsedBody : [parsedBody];
+    return messages.some(
+      (message) =>
+        message &&
+        typeof message === "object" &&
+        (message as { method?: unknown }).method === method,
+    );
+  };
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.url !== "/mcp") {
+      res.writeHead(404).end();
+      return;
+    }
+    try {
+      const parsedBody = await readParsedBody(req);
+      if (includesMethod(parsedBody, "tools/list")) {
+        listToolsRequestCount += 1;
+      }
+      if (includesMethod(parsedBody, "initialize") && failInitializeCount > 0) {
+        failInitializeCount -= 1;
+        res.writeHead(503).end("initialize temporarily unavailable");
+        return;
+      }
+      await active.transport.handleRequest(req, res, parsedBody);
+    } catch (error) {
+      res.writeHead(500).end(String(error));
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, "127.0.0.1", resolve);
+  });
+  const address = httpServer.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+
+  return {
+    close: async () => {
+      await active.transport.close().catch(() => {});
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+    failNextInitialize: () => {
+      failInitializeCount += 1;
+    },
+    getListToolsRequestCount: () => listToolsRequestCount,
+    port,
+    resetSession: async () => {
+      await active.transport.close().catch(() => {});
+      active = await createActiveTransport();
     },
   };
 }


### PR DESCRIPTION
## Problem

Streamable-HTTP MCP servers maintain stateful sessions via `Mcp-Session-Id`. Sessions can be lost due to server redeploys, container restarts, idle TTL expiry, or network blips. The MCP SDK client does not auto-reinitialize — subsequent `callTool` calls fail permanently with:

```
Streamable HTTP error: Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request: Server not initialized"},"id":null}
```

The only workaround today is a full gateway restart (`openclaw gateway restart`), which interrupts the active session.

## Fix

Wrap `callTool` in `createSessionMcpRuntime` with transparent reconnect-and-retry logic:

1. On any `callTool` error, detect if it looks like a lost streamable-http session (`-32000 / Server not initialized`, `Session not found`, HTTP 400/404).
2. If so: dispose dead client+transport → build fresh via existing `resolveMcpTransport` → reconnect via `connectWithTimeout` → retry the original call once.
3. If reconnect itself fails, re-throw the original error unchanged.
4. SSE and stdio transports are completely unaffected (guard checks `session.transportType === "streamable-http"`).

## Repro

1. Configure a stateful streamable-http MCP server (e.g. any server using `sessionIdGenerator: () => randomUUID()`)
2. Call any tool successfully
3. Restart/redeploy the MCP server (drops sessions)
4. Call any tool again → **before:** `Server not initialized`, gateway restart required; **after:** transparent reconnect, call succeeds

## Notes

- No changes to SSE or stdio paths
- The retry is exactly once — if the server is genuinely down, the reconnect fails and the original error propagates normally
- Tested against a live Railway-hosted VianneFlow MCP server (stateful streamable-http)