### PR TITLE
fix(telegram): route /new, /reset to control lane to bypass queue

### DIFF
--- a/extensions/telegram/src/sequential-key.test.ts
+++ b/extensions/telegram/src/sequential-key.test.ts
@@ -176,6 +176,25 @@ describe("getTelegramSequentialKey", () => {
       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "please do not do that" }) },
       "telegram:123",
     ],
+    // Session control commands should bypass the queue
+    [
+      { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/new" }) },
+      "telegram:123:control",
+    ],
+    [
+      { message: mockMessage({ chat: mockChat({ id: 456 }), text: "/reset" }) },
+      "telegram:456:control",
+    ],
+    [
+      {
+        me: { username: "openclaw_bot" } as never,
+        message: mockMessage({
+          chat: mockChat({ id: 123 }),
+          text: "/new@openclaw_bot",
+        }),
+      },
+      "telegram:123:control",
+    ],
   ])("resolves key %#", (input, expected) => {
     expect(getTelegramSequentialKey(input)).toBe(expected);
   });

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -27,13 +27,10 @@ export type TelegramSequentialKeyContext = {
   };
 };
 
-function resolveStatusCommandControlLane(params: {
-  rawText?: string;
-  botUsername?: string;
-}): boolean {
-  // Only read-only status commands should bypass the per-topic lane. Commands
-  // like /export-session stay on the normal lane because they materialize
-  // session state to disk and should not interleave with an active turn.
+function resolveControlCommand(
+  params: { rawText?: string; botUsername?: string },
+  predicate: (command: { key: string; category?: string }) => boolean,
+): boolean {
   const normalizedBody = normalizeCommandBody(
     params.rawText?.trim() ?? "",
     params.botUsername ? { botUsername: params.botUsername } : undefined,
@@ -45,7 +42,32 @@ function resolveStatusCommandControlLane(params: {
   const command = listChatCommands().find((entry) =>
     entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
   );
-  return command?.category === "status" && command.key !== "export-session";
+  return command ? predicate(command) : false;
+}
+
+function resolveStatusCommandControlLane(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  // Only read-only status commands should bypass the per-topic lane. Commands
+  // like /export-session stay on the normal lane because they materialize
+  // session state to disk and should not interleave with an active turn.
+  return resolveControlCommand(params, (cmd) =>
+    cmd.category === "status" && cmd.key !== "export-session",
+  );
+}
+
+function resolveSessionControlCommand(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  // Session lifecycle commands (/new, /reset) must bypass the per-topic
+  // sequential queue so they execute immediately even when an agent run is active.
+  // Without this, these commands get queued behind the running turn and never
+  // actually reset the session.
+  return resolveControlCommand(params, (cmd) =>
+    cmd.key === "new" || cmd.key === "reset",
+  );
 }
 
 export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
@@ -72,6 +94,12 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
     return "telegram:control";
   }
   if (resolveStatusCommandControlLane({ rawText, botUsername })) {
+    if (typeof chatId === "number") {
+      return `telegram:${chatId}:control`;
+    }
+    return "telegram:control";
+  }
+  if (resolveSessionControlCommand({ rawText, botUsername })) {
     if (typeof chatId === "number") {
       return `telegram:${chatId}:control`;
     }

--- a/extensions/telegram/src/sequential-key.ts
+++ b/extensions/telegram/src/sequential-key.ts
@@ -61,6 +61,28 @@ export function isTelegramReadOnlyControlLaneText(params: {
   return command?.category === "status" && TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS.has(command.key);
 }
 
+function isTelegramSessionControlCommand(params: {
+  rawText?: string;
+  botUsername?: string;
+}): boolean {
+  // Session lifecycle commands (/new, /reset) must bypass the per-topic
+  // sequential queue so they execute immediately even when an agent run is active.
+  // Without this, these commands get queued behind the running turn and never
+  // actually reset the session.
+  const normalizedBody = normalizeCommandBody(
+    params.rawText?.trim() ?? "",
+    params.botUsername ? { botUsername: params.botUsername } : undefined,
+  );
+  const alias = maybeResolveTextAlias(normalizedBody);
+  if (!alias) {
+    return false;
+  }
+  const command = listChatCommands().find((entry) =>
+    entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
+  );
+  return command?.key === "new" || command?.key === "reset";
+}
+
 function isTelegramTargetedStopCommand(rawText?: string, botUsername?: string): boolean {
   const trimmed = rawText?.trim();
   if (!trimmed) {
@@ -116,6 +138,12 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
   const rawText = msg?.text ?? msg?.caption;
   const botUsername = ctx.me?.username;
   if (isTelegramControlLaneText({ rawText, botUsername })) {
+    if (typeof chatId === "number") {
+      return `telegram:${chatId}:control`;
+    }
+    return "telegram:control";
+  }
+  if (isTelegramSessionControlCommand({ rawText, botUsername })) {
     if (typeof chatId === "number") {
       return `telegram:${chatId}:control`;
     }


### PR DESCRIPTION
## Problem

Session lifecycle commands (`/new`, `/reset`) were getting queued behind active agent runs in the Telegram sequential key system. When a user sent one of these commands while an agent was running, the command would be queued and never execute until the agent finished — defeating the purpose of these interrupt commands.

## Solution

Added `resolveSessionControlCommand()` function to `extensions/telegram/src/sequential-key.ts` that detects session lifecycle commands and routes them to the `:control` lane, bypassing the per-topic sequential queue.

## Changes

- **extensions/telegram/src/sequential-key.ts**: Extracted shared command resolution into `resolveControlCommand()` predicate-based helper, added `resolveSessionControlCommand()` for `/new` and `/reset`
- **extensions/telegram/src/sequential-key.test.ts**: Added test coverage for session control command routing

## Technical Details

The fix follows the same pattern as the existing `resolveStatusCommandControlLane()`:
1. Normalizes the command body using `normalizeCommandBody()`
2. Resolves text aliases using `maybeResolveTextAlias()`
3. Looks up the command in `listChatCommands()`
4. Returns `true` if the command key is `new` or `reset`

When detected, these commands route to `telegram:${chatId}:control` instead of the normal per-topic lane, bypassing the queue and executing immediately.

## Testing

- Added test cases for `/new` and `/reset` routing to control lane
- Includes test for bot-username suffixed command (`/new@bot`)