### PR TITLE
fix(update.run): journal restart continuation so post-update agents can resume their turn (#71178)

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4495,19 +4495,22 @@ public struct UpdateRunParams: Codable, Sendable {
     public let note: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
+    public let continuationmessage: String?
 
     public init(
         sessionkey: String?,
         deliverycontext: [String: AnyCodable]?,
         note: String?,
         restartdelayms: Int?,
-        timeoutms: Int?)
+        timeoutms: Int?,
+        continuationmessage: String?)
     {
         self.sessionkey = sessionkey
         self.deliverycontext = deliverycontext
         self.note = note
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
+        self.continuationmessage = continuationmessage
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4516,6 +4519,7 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+        case continuationmessage = "continuationMessage"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4495,19 +4495,22 @@ public struct UpdateRunParams: Codable, Sendable {
     public let note: String?
     public let restartdelayms: Int?
     public let timeoutms: Int?
+    public let continuationmessage: String?
 
     public init(
         sessionkey: String?,
         deliverycontext: [String: AnyCodable]?,
         note: String?,
         restartdelayms: Int?,
-        timeoutms: Int?)
+        timeoutms: Int?,
+        continuationmessage: String?)
     {
         self.sessionkey = sessionkey
         self.deliverycontext = deliverycontext
         self.note = note
         self.restartdelayms = restartdelayms
         self.timeoutms = timeoutms
+        self.continuationmessage = continuationmessage
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -4516,6 +4519,7 @@ public struct UpdateRunParams: Codable, Sendable {
         case note
         case restartdelayms = "restartDelayMs"
         case timeoutms = "timeoutMs"
+        case continuationmessage = "continuationMessage"
     }
 }
 

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -507,11 +507,15 @@ export function createGatewayTool(opts?: {
           ...gatewayOpts,
           timeoutMs: updateTimeoutMs,
         };
+        // Forward `continuationMessage` so the post-update restart can resume
+        // an agent turn the same way the `restart` action does. (#71178)
+        const continuationMessage = normalizeOptionalString(params.continuationMessage);
         const result = await callGatewayTool("update.run", updateGatewayOpts, {
           sessionKey,
           note,
           restartDelayMs,
           timeoutMs: updateTimeoutMs,
+          ...(continuationMessage ? { continuationMessage } : {}),
         });
         return jsonResult({ ok: true, result });
       }

--- a/src/gateway/protocol/schema/config.ts
+++ b/src/gateway/protocol/schema/config.ts
@@ -60,6 +60,12 @@ export const UpdateRunParamsSchema = Type.Object(
     note: Type.Optional(Type.String()),
     restartDelayMs: Type.Optional(Type.Integer({ minimum: 0 })),
     timeoutMs: Type.Optional(Type.Integer({ minimum: 1 })),
+    // When the caller is an agent that still owes the user a reply, this
+    // message is journaled into the restart-continuation queue so the agent
+    // can resume after the post-update gateway restart and tell the user
+    // what to verify or report. Mirrors `restart` action's continuation
+    // contract. (#71178)
+    continuationMessage: Type.Optional(Type.String()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/restart-request.ts
+++ b/src/gateway/server-methods/restart-request.ts
@@ -42,6 +42,7 @@ export function parseRestartRequestParams(params: unknown): {
   threadId: string | undefined;
   note: string | undefined;
   restartDelayMs: number | undefined;
+  continuationMessage: string | undefined;
 } {
   const sessionKey = normalizeOptionalString((params as { sessionKey?: unknown }).sessionKey);
   const { deliveryContext, threadId } = parseRestartDeliveryContext(params);
@@ -51,5 +52,15 @@ export function parseRestartRequestParams(params: unknown): {
     typeof restartDelayMsRaw === "number" && Number.isFinite(restartDelayMsRaw)
       ? Math.max(0, Math.floor(restartDelayMsRaw))
       : undefined;
-  return { sessionKey, deliveryContext, threadId, note, restartDelayMs };
+  const continuationMessage = normalizeOptionalString(
+    (params as { continuationMessage?: unknown }).continuationMessage,
+  );
+  return {
+    sessionKey,
+    deliveryContext,
+    threadId,
+    note,
+    restartDelayMs,
+    continuationMessage,
+  };
 }

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -167,7 +167,12 @@ describe("update.run sentinel deliveryContext", () => {
       to: "webchat:user-123",
       accountId: "default",
     });
-    expect(capturedPayload!.continuation).toBeUndefined();
+    // With sessionKey present, the post-update restart now journals a default
+    // agentTurn continuation so the agent can resume after boot. (#71178)
+    expect(capturedPayload!.continuation).toEqual({
+      kind: "agentTurn",
+      message: expect.stringContaining("OpenClaw restarted successfully"),
+    });
   });
 
   it("omits deliveryContext when no sessionKey is provided", async () => {
@@ -178,7 +183,8 @@ describe("update.run sentinel deliveryContext", () => {
     expect(capturedPayload).toBeDefined();
     expect(capturedPayload!.deliveryContext).toBeUndefined();
     expect(capturedPayload!.threadId).toBeUndefined();
-    expect(capturedPayload!.continuation).toBeUndefined();
+    // No sessionKey → no agent turn to resume → no continuation. (#71178)
+    expect(capturedPayload!.continuation).toBeNull();
   });
 
   it("includes threadId in sentinel payload for threaded sessions", async () => {
@@ -193,7 +199,22 @@ describe("update.run sentinel deliveryContext", () => {
       accountId: "workspace-1",
     });
     expect(capturedPayload!.threadId).toBe("1234567890.123456");
-    expect(capturedPayload!.continuation).toBeUndefined();
+    expect(capturedPayload!.continuation).toEqual({
+      kind: "agentTurn",
+      message: expect.stringContaining("OpenClaw restarted successfully"),
+    });
+  });
+
+  it("uses an explicit continuationMessage when provided so agents can scope the post-restart resume (#71178)", async () => {
+    capturedPayload = undefined;
+    await invokeUpdateRun({
+      sessionKey: "agent:main:webchat:dm:user-123",
+      continuationMessage: "Verify the new build still passes the user's earlier ask about X",
+    });
+    expect(capturedPayload!.continuation).toEqual({
+      kind: "agentTurn",
+      message: "Verify the new build still passes the user's earlier ask about X",
+    });
   });
 });
 
@@ -242,7 +263,22 @@ describe("update.run restart scheduling", () => {
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
     expect(payload?.ok).toBe(false);
     expect(payload?.restart).toBeNull();
-    expect(capturedPayload?.continuation).toBeUndefined();
+    // No continuation on failed update — without a restart, a continuation
+    // would never run anyway. (#71178)
+    expect(capturedPayload?.continuation).toBeNull();
+  });
+
+  it("does not journal a continuation when the update fails even with sessionKey provided (#71178)", async () => {
+    runGatewayUpdateMock.mockResolvedValueOnce({
+      status: "error",
+      mode: "git",
+      reason: "build-failed",
+      steps: [],
+      durationMs: 100,
+    });
+    capturedPayload = undefined;
+    await invokeUpdateRun({ sessionKey: "agent:main:webchat:dm:user-123" });
+    expect(capturedPayload?.continuation).toBeNull();
   });
 
   it.each([

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -103,6 +103,7 @@ vi.mock("./restart-request.js", () => ({
     sessionKey: params.sessionKey,
     note: params.note,
     restartDelayMs: undefined,
+    continuationMessage: params.continuationMessage,
   }),
 }));
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -3,6 +3,7 @@ import { extractDeliveryInfo } from "../../config/sessions.js";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageVersion } from "../../infra/package-json.js";
 import {
+  buildRestartSuccessContinuation,
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
   writeRestartSentinel,
@@ -41,6 +42,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       threadId: requestedThreadId,
       note,
       restartDelayMs,
+      continuationMessage,
     } = parseRestartRequestParams(params);
     const { deliveryContext: sessionDeliveryContext, threadId: sessionThreadId } =
       extractDeliveryInfo(sessionKey);
@@ -99,6 +101,17 @@ export const updateHandlers: GatewayRequestHandlers = {
       };
     }
 
+    // Mirror the `restart` action's continuation contract: when the caller is
+    // an agent that still owes the user a reply, build a continuation entry
+    // so the post-update gateway boot can resume the agent turn instead of
+    // silently dropping it. Only build a continuation when the update itself
+    // succeeded; on update failure we'll skip the restart (see below) and a
+    // continuation would never run anyway. (#71178)
+    const continuation =
+      result.status === "ok"
+        ? buildRestartSuccessContinuation({ sessionKey, continuationMessage })
+        : null;
+
     const payload: RestartSentinelPayload = {
       kind: "update",
       status: result.status,
@@ -107,6 +120,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       deliveryContext,
       threadId,
       message: note ?? null,
+      continuation,
       doctorHint: formatDoctorNonInteractiveHint(),
       stats: {
         mode: result.mode,


### PR DESCRIPTION
Closes #71178.

## Bug

The `restart` action persists a restart continuation before triggering SIGUSR1, so an agent that still owes the user a reply can resume after the post-restart boot. `update.run` writes a sentinel for the same boot-after-success flow **but did not build a continuation** — so an agent calling \`update.run\` mid-turn loses the user's outstanding reply on every successful in-place update.

steipete called this out with the exact site refs in the issue:

> - \`update.run\` currently writes a sentinel with sessionKey, deliveryContext, threadId, and message, but no continuation: \`src/gateway/server-methods/update.ts:67\`
> - The current update tests explicitly expect that: \`src/gateway/server-methods/update.test.ts:125,151,200\` assert \`continuation\` is undefined.
> - The agent gateway tool exposes \`continuationMessage\` for restart and documents it, but \`action === "update.run"\` only forwards \`sessionKey\`, \`note\`, \`restartDelayMs\`, and \`timeoutMs\`: \`src/agents/tools/gateway-tool.ts:503\`.

## Fix

Mirror the existing \`restart\` action's continuation contract — strict superset, no other behavior change:

- \`src/gateway/protocol/schema/config.ts\` — add \`continuationMessage\` to \`UpdateRunParamsSchema\`.
- \`src/gateway/server-methods/restart-request.ts\` — plumb \`continuationMessage\` through \`parseRestartRequestParams\`.
- \`src/gateway/server-methods/update.ts\` — call \`buildRestartSuccessContinuation({ sessionKey, continuationMessage })\` when \`result.status === \"ok\"\`; on failure leave \`continuation: null\` since we also skip the restart and a journaled continuation would never run.
- \`src/agents/tools/gateway-tool.ts\` — forward \`continuationMessage\` from the \`update.run\` action path the same way the \`restart\` action does.

## Test changes

3 existing assertions that asserted \`continuation === undefined\` now expect a default \`agentTurn\` continuation when \`sessionKey\` is provided (matching \`restart\` behavior). Plus 2 new tests:

- explicit \`continuationMessage\` is honored verbatim
- failed update still produces no continuation even when \`sessionKey\` is provided (we gate on \`result.status === \"ok\"\`)

Lint clean: \`pnpm oxlint\` — 0 warnings, 0 errors.

## Out of scope

Per maintainer comment in the issue, the broader session-delivery queue itself is unchanged. Non-agent callers (no sessionKey) continue to work unchanged — no continuation is journaled.

🤖 generated with assistance from Claude Code
Co-authored-by: HCL <chenglunhu@gmail.com>