### PR TITLE
Fix heartbeat exec-event delivery source routing

### DIFF
--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -1638,6 +1638,40 @@ describe("sendMessageTelegram", () => {
     }
   });
 
+  it("keeps disable_notification when retrying without message_thread_id", async () => {
+    const chatId = "-100123";
+    const threadErr = new Error("400: Bad Request: message thread not found");
+    const sendMessage = vi
+      .fn()
+      .mockRejectedValueOnce(threadErr)
+      .mockResolvedValueOnce({
+        message_id: 60,
+        chat: { id: chatId },
+      });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    const res = await sendMessageTelegram(chatId, "quiet fallback", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      api,
+      messageThreadId: 271,
+      silent: true,
+    });
+
+    expect(sendMessage).toHaveBeenNthCalledWith(1, chatId, "quiet fallback", {
+      parse_mode: "HTML",
+      message_thread_id: 271,
+      disable_notification: true,
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, chatId, "quiet fallback", {
+      parse_mode: "HTML",
+      disable_notification: true,
+    });
+    expect(res.messageId).toBe("60");
+  });
+
   it("does not retry on non-retriable thread/chat errors", async () => {
     const cases: Array<{
       chatId: string;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -12,7 +12,7 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostInheritedEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { parseAgentSessionKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { scopedExecEventWakeOptions } from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -128,31 +128,6 @@ export const DEFAULT_APPROVAL_TIMEOUT_MS = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
 export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = DEFAULT_APPROVAL_TIMEOUT_MS + 10_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
-const EXEC_EVENT_HEARTBEAT_OVERRIDE = {
-  target: "last",
-  to: undefined,
-  accountId: undefined,
-  isolatedSession: false,
-} as const;
-
-function scopedExecEventWakeOptions(sessionKey: string) {
-  const wakeOptions = { reason: "exec-event", coalesceMs: 0 };
-  if (parseAgentSessionKey(sessionKey)) {
-    return scopedHeartbeatWakeOptions(sessionKey, {
-      ...wakeOptions,
-      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
-    });
-  }
-  if (sessionKey.trim() === "global") {
-    return {
-      ...wakeOptions,
-      sessionKey: "global",
-      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
-    };
-  }
-  return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
-}
-
 export type ExecProcessFailureKind =
   | "shell-command-not-found"
   | "shell-not-executable"

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -143,6 +143,13 @@ function scopedExecEventWakeOptions(sessionKey: string) {
       heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
     });
   }
+  if (sessionKey.trim() === "global") {
+    return {
+      ...wakeOptions,
+      sessionKey: "global",
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    };
+  }
   return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
 }
 

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -12,7 +12,7 @@ import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { isDangerousHostInheritedEnvVarName } from "../infra/host-env-security.js";
 import { findPathKey, mergePathPrepend } from "../infra/path-prepend.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
-import { scopedHeartbeatWakeOptions } from "../routing/session-key.js";
+import { parseAgentSessionKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import type { ProcessSession } from "./bash-process-registry.js";
 import type { ExecToolDetails } from "./bash-tools.exec-types.js";
 import type { BashSandboxConfig } from "./bash-tools.shared.js";
@@ -128,6 +128,23 @@ export const DEFAULT_APPROVAL_TIMEOUT_MS = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
 export const DEFAULT_APPROVAL_REQUEST_TIMEOUT_MS = DEFAULT_APPROVAL_TIMEOUT_MS + 10_000;
 const DEFAULT_APPROVAL_RUNNING_NOTICE_MS = 10_000;
 const APPROVAL_SLUG_LENGTH = 8;
+const EXEC_EVENT_HEARTBEAT_OVERRIDE = {
+  target: "last",
+  to: undefined,
+  accountId: undefined,
+  isolatedSession: false,
+} as const;
+
+function scopedExecEventWakeOptions(sessionKey: string) {
+  const wakeOptions = { reason: "exec-event", coalesceMs: 0 };
+  if (parseAgentSessionKey(sessionKey)) {
+    return scopedHeartbeatWakeOptions(sessionKey, {
+      ...wakeOptions,
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    });
+  }
+  return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
+}
 
 export type ExecProcessFailureKind =
   | "shell-command-not-found"
@@ -344,9 +361,7 @@ function maybeNotifyOnExit(session: ProcessSession, status: "completed" | "faile
     deliveryContext: session.notifyDeliveryContext,
     trusted: false,
   });
-  requestHeartbeatNow(
-    scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event", coalesceMs: 0 }),
-  );
+  requestHeartbeatNow(scopedExecEventWakeOptions(sessionKey));
 }
 
 export function createApprovalSlug(id: string) {
@@ -422,9 +437,7 @@ export function emitExecSystemEvent(
     contextKey: opts.contextKey,
     deliveryContext: opts.deliveryContext,
   });
-  requestHeartbeatNow(
-    scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event", coalesceMs: 0 }),
-  );
+  requestHeartbeatNow(scopedExecEventWakeOptions(sessionKey));
 }
 
 export { renderExecUpdateText } from "./bash-tools.exec-output.js";

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -799,10 +799,11 @@ describe("exec notifyOnExit", () => {
     await expectNotifyOnExitWake(createNotifyOnExitExecTool(), {
       reason: "exec-event",
       sessionKey: DEFAULT_NOTIFY_SESSION_KEY,
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
     });
   });
 
-  it("keeps notifyOnExit heartbeat wake unscoped for non-agent session keys", async () => {
+  it("keeps notifyOnExit heartbeat wake unscoped for the global session key", async () => {
     await expectNotifyOnExitWake(createNotifyOnExitExecTool({ sessionKey: "global" }), {
       reason: "exec-event",
     });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -803,9 +803,11 @@ describe("exec notifyOnExit", () => {
     });
   });
 
-  it("keeps notifyOnExit heartbeat wake unscoped for the global session key", async () => {
+  it("scopes notifyOnExit heartbeat wake to the global session key", async () => {
     await expectNotifyOnExitWake(createNotifyOnExitExecTool({ sessionKey: "global" }), {
       reason: "exec-event",
+      sessionKey: "global",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
     });
   });
 

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -1,5 +1,9 @@
 import type { CronConfig } from "../../config/types.cron.js";
-import type { HeartbeatRunResult, HeartbeatWakeRequest } from "../../infra/heartbeat-wake.js";
+import type {
+  HeartbeatRunResult,
+  HeartbeatWakeOverride,
+  HeartbeatWakeRequest,
+} from "../../infra/heartbeat-wake.js";
 import type {
   CronDeliveryStatus,
   CronDeliveryTrace,
@@ -79,7 +83,7 @@ export type CronServiceDeps = {
     agentId?: string;
     sessionKey?: string;
     /** Optional heartbeat config override (e.g. target: "last" for cron-triggered heartbeats). */
-    heartbeat?: { target?: string };
+    heartbeat?: HeartbeatWakeOverride;
   }) => Promise<HeartbeatRunResult>;
   /**
    * WakeMode=now: max time to wait for runHeartbeatOnce to stop returning

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -316,6 +316,50 @@ describe("buildGatewayCronService", () => {
     }
   });
 
+  it("passes raw forced session keys to immediate heartbeat runs", async () => {
+    const cfg = createCronConfig("server-cron-raw-immediate-heartbeat");
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const cronDeps = (
+        state.cron as unknown as {
+          state?: {
+            deps?: {
+              runHeartbeatOnce?: (opts?: {
+                agentId?: string;
+                sessionKey?: string | null;
+                reason?: string;
+                heartbeat?: { target?: string };
+              }) => Promise<unknown>;
+            };
+          };
+        }
+      ).state?.deps;
+
+      await cronDeps?.runHeartbeatOnce?.({
+        reason: "cron:test",
+        sessionKey: "discord:channel:ops",
+        heartbeat: { target: "last" },
+      });
+
+      expect(runHeartbeatOnceMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: "cron:test",
+          agentId: "main",
+          sessionKey: "discord:channel:ops",
+          heartbeat: { target: "last" },
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
   it("preserves trust downgrades when cron enqueues system events", () => {
     const cfg = createCronConfig("server-cron-untrusted");
     loadConfigMock.mockReturnValue(cfg);

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -658,10 +658,7 @@ describe("buildGatewayCronService", () => {
               ]),
             }),
           }),
-          heartbeat: expect.objectContaining({
-            target: "last",
-            deliveryFormat: "markdown",
-          }),
+          heartbeat: {},
         }),
       );
     } finally {

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -173,15 +173,19 @@ export function buildGatewayCronService(params: {
     return canonical;
   };
 
-  const resolveCronWakeTarget = (opts?: { agentId?: string; sessionKey?: string | null }) => {
+  const resolveCronWakeTarget = (
+    opts?: { agentId?: string; sessionKey?: string | null },
+    resolveOpts?: { preserveRawSessionKey?: boolean },
+  ) => {
+    const requestedSessionKey = opts?.sessionKey?.trim() || undefined;
     const requestedAgentId =
       typeof opts?.agentId === "string" && opts.agentId.trim()
         ? normalizeAgentId(opts.agentId)
         : undefined;
     const derivedAgentId =
       requestedAgentId ??
-      (opts?.sessionKey
-        ? normalizeAgentId(resolveAgentIdFromSessionKey(opts.sessionKey))
+      (requestedSessionKey
+        ? normalizeAgentId(resolveAgentIdFromSessionKey(requestedSessionKey))
         : undefined);
     const runtimeConfigBase = getRuntimeConfig();
     const runtimeConfig =
@@ -190,12 +194,14 @@ export function buildGatewayCronService(params: {
         : runtimeConfigBase;
     const agentId = derivedAgentId || undefined;
     const sessionKey =
-      opts?.sessionKey && agentId
-        ? resolveCronSessionKey({
-            runtimeConfig,
-            agentId,
-            requestedSessionKey: opts.sessionKey,
-          })
+      requestedSessionKey && agentId
+        ? resolveOpts?.preserveRawSessionKey
+          ? requestedSessionKey
+          : resolveCronSessionKey({
+              runtimeConfig,
+              agentId,
+              requestedSessionKey,
+            })
         : undefined;
     return { runtimeConfig, agentId, sessionKey };
   };
@@ -256,7 +262,9 @@ export function buildGatewayCronService(params: {
       });
     },
     runHeartbeatOnce: async (opts) => {
-      const { runtimeConfig, agentId, sessionKey } = resolveCronWakeTarget(opts);
+      const { runtimeConfig, agentId, sessionKey } = resolveCronWakeTarget(opts, {
+        preserveRawSessionKey: true,
+      });
       // Pass cron-supplied heartbeat overrides raw. runHeartbeatOnce centralizes
       // merging with defaults/agent config and target:last routing semantics.
       return await runHeartbeatOnce({

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -257,31 +257,14 @@ export function buildGatewayCronService(params: {
     },
     runHeartbeatOnce: async (opts) => {
       const { runtimeConfig, agentId, sessionKey } = resolveCronWakeTarget(opts);
-      // Merge cron-supplied heartbeat overrides (e.g. target: "last") with the
-      // fully resolved agent heartbeat config so cron-triggered heartbeats
-      // respect agent-specific overrides (agents.list[].heartbeat) before
-      // falling back to agents.defaults.heartbeat.
-      const agentEntry =
-        Array.isArray(runtimeConfig.agents?.list) &&
-        runtimeConfig.agents.list.find(
-          (entry) =>
-            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
-        );
-      const agentHeartbeat =
-        agentEntry && typeof agentEntry === "object" ? agentEntry.heartbeat : undefined;
-      const baseHeartbeat = {
-        ...runtimeConfig.agents?.defaults?.heartbeat,
-        ...agentHeartbeat,
-      };
-      const heartbeatOverride = opts?.heartbeat
-        ? { ...baseHeartbeat, ...opts.heartbeat }
-        : undefined;
+      // Pass cron-supplied heartbeat overrides raw. runHeartbeatOnce centralizes
+      // merging with defaults/agent config and target:last routing semantics.
       return await runHeartbeatOnce({
         cfg: runtimeConfig,
         reason: opts?.reason,
         agentId,
         sessionKey,
-        heartbeat: heartbeatOverride,
+        heartbeat: opts?.heartbeat,
         deps: { ...params.deps, runtime: defaultRuntime },
       });
     },

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -124,8 +124,8 @@ const runtimeMocks = vi.hoisted(() => ({
     }),
   ),
   sanitizeInboundSystemTags: sanitizeInboundSystemTagsMock,
-  scopedHeartbeatWakeOptions: vi.fn((sessionKey?: string, opts?: { reason: string }) => {
-    const wakeOptions = { reason: opts?.reason };
+  scopedHeartbeatWakeOptions: vi.fn((sessionKey?: string, opts?: Record<string, unknown>) => {
+    const wakeOptions = { ...(opts ?? {}) };
     return /^agent:[^:]+:.+$/i.test(sessionKey ?? "")
       ? { ...wakeOptions, sessionKey: sessionKey as string }
       : wakeOptions;
@@ -158,6 +158,12 @@ const updateSessionStoreMock = runtimeMocks.updateSessionStore;
 const loadSessionEntryMock = runtimeMocks.loadSessionEntry;
 const registerApnsRegistrationVi = runtimeMocks.registerApnsRegistration;
 const normalizeChannelIdVi = runtimeMocks.normalizeChannelId;
+const EXEC_EVENT_HEARTBEAT = {
+  target: "last",
+  to: undefined,
+  accountId: undefined,
+  isolatedSession: false,
+};
 
 function buildCtx(): NodeEventContext {
   return {
@@ -216,7 +222,9 @@ describe("node exec events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
+      coalesceMs: 0,
       sessionKey: "agent:main:main",
+      heartbeat: EXEC_EVENT_HEARTBEAT,
     });
   });
 
@@ -236,7 +244,10 @@ describe("node exec events", () => {
       "Exec finished (node=node-2 id=run-2, code 0)\ndone",
       { sessionKey: "node-node-2", contextKey: "exec:run-2", trusted: false },
     );
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      coalesceMs: 0,
+    });
   });
 
   it("dedupes duplicate exec.finished events for the same runId on the same session", async () => {
@@ -293,7 +304,9 @@ describe("node exec events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
+      coalesceMs: 0,
       sessionKey: "agent:main:node-node-2",
+      heartbeat: EXEC_EVENT_HEARTBEAT,
     });
   });
 
@@ -330,7 +343,10 @@ describe("node exec events", () => {
     expect(text.startsWith("Exec finished (node=node-2 id=run-long, code 0)\n")).toBe(true);
     expect(text.endsWith("…")).toBe(true);
     expect(text.length).toBeLessThan(280);
-    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({ reason: "exec-event" });
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      coalesceMs: 0,
+    });
   });
 
   it("enqueues exec.denied events with reason", async () => {
@@ -351,7 +367,9 @@ describe("node exec events", () => {
     );
     expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
       reason: "exec-event",
+      coalesceMs: 0,
       sessionKey: "agent:demo:main",
+      heartbeat: EXEC_EVENT_HEARTBEAT,
     });
   });
 

--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -125,7 +125,7 @@ const runtimeMocks = vi.hoisted(() => ({
   ),
   sanitizeInboundSystemTags: sanitizeInboundSystemTagsMock,
   scopedHeartbeatWakeOptions: vi.fn((sessionKey?: string, opts?: Record<string, unknown>) => {
-    const wakeOptions = { ...(opts ?? {}) };
+    const wakeOptions = { ...opts };
     return /^agent:[^:]+:.+$/i.test(sessionKey ?? "")
       ? { ...wakeOptions, sessionKey: sessionKey as string }
       : wakeOptions;
@@ -306,6 +306,31 @@ describe("node exec events", () => {
       reason: "exec-event",
       coalesceMs: 0,
       sessionKey: "agent:main:node-node-2",
+      heartbeat: EXEC_EVENT_HEARTBEAT,
+    });
+  });
+
+  it("scopes exec heartbeat wake to global and clears delivery overrides", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-2", {
+      event: "exec.finished",
+      payloadJSON: JSON.stringify({
+        sessionKey: "global",
+        runId: "run-global",
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+      }),
+    });
+
+    expect(enqueueSystemEventMock).toHaveBeenCalledWith(
+      "Exec finished (node=node-2 id=run-global, code 0)\ndone",
+      { sessionKey: "global", contextKey: "exec:run-global", trusted: false },
+    );
+    expect(requestHeartbeatNowMock).toHaveBeenCalledWith({
+      reason: "exec-event",
+      coalesceMs: 0,
+      sessionKey: "global",
       heartbeat: EXEC_EVENT_HEARTBEAT,
     });
   });

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,6 +4,7 @@ import { updatePairedDeviceMetadata } from "../infra/device-pairing.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { updatePairedNodeMetadata } from "../infra/node-pairing.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 import {
   NODE_PRESENCE_ALIVE_EVENT,
   normalizeNodePresenceAliveReason,
@@ -50,6 +51,23 @@ const EXEC_FINISHED_RUN_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
 const MAX_RECENT_EXEC_FINISHED_RUNS = 2000;
 const NODE_PRESENCE_PERSIST_MIN_INTERVAL_MS = 60_000;
 const MAX_RECENT_NODE_PRESENCE_KEYS = 1024;
+const EXEC_EVENT_HEARTBEAT_OVERRIDE = {
+  target: "last",
+  to: undefined,
+  accountId: undefined,
+  isolatedSession: false,
+} as const;
+
+function scopedExecEventWakeOptions(sessionKey: string) {
+  const wakeOptions = { reason: "exec-event", coalesceMs: 0 };
+  if (parseAgentSessionKey(sessionKey)) {
+    return scopedHeartbeatWakeOptions(sessionKey, {
+      ...wakeOptions,
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    });
+  }
+  return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
+}
 
 const recentVoiceTranscripts = new Map<string, { fingerprint: string; ts: number }>();
 const recentExecFinishedRuns = new Map<string, number>();
@@ -746,12 +764,9 @@ export const handleNodeEvent = async (
         trusted: false,
       });
       if (queued) {
-        // Scope wakes only for canonical agent sessions. Synthetic node-* fallback
-        // keys should keep legacy unscoped behavior so enabled non-main heartbeat
-        // agents still run when no explicit agent session is provided.
-        requestHeartbeatNow(
-          scopedHeartbeatWakeOptions(sessionKey, { reason: "exec-event", coalesceMs: 0 }),
-        );
+        // Canonical agent/global sessions have stored routing state; synthetic
+        // node-* fallback keys keep legacy heartbeat delivery config.
+        requestHeartbeatNow(scopedExecEventWakeOptions(sessionKey));
       }
       return undefined;
     }

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,7 +4,7 @@ import { updatePairedDeviceMetadata } from "../infra/device-pairing.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { updatePairedNodeMetadata } from "../infra/node-pairing.js";
 import type { PromptImageOrderEntry } from "../media/prompt-image-order.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
+import { scopedExecEventWakeOptions } from "../routing/session-key.js";
 import {
   NODE_PRESENCE_ALIVE_EVENT,
   normalizeNodePresenceAliveReason,
@@ -39,7 +39,6 @@ import {
   resolveSessionAgentId,
   resolveSessionModelRef,
   sanitizeInboundSystemTags,
-  scopedHeartbeatWakeOptions,
   updateSessionStore,
 } from "./server-node-events.runtime.js";
 
@@ -51,31 +50,6 @@ const EXEC_FINISHED_RUN_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
 const MAX_RECENT_EXEC_FINISHED_RUNS = 2000;
 const NODE_PRESENCE_PERSIST_MIN_INTERVAL_MS = 60_000;
 const MAX_RECENT_NODE_PRESENCE_KEYS = 1024;
-const EXEC_EVENT_HEARTBEAT_OVERRIDE = {
-  target: "last",
-  to: undefined,
-  accountId: undefined,
-  isolatedSession: false,
-} as const;
-
-function scopedExecEventWakeOptions(sessionKey: string) {
-  const wakeOptions = { reason: "exec-event", coalesceMs: 0 };
-  if (parseAgentSessionKey(sessionKey)) {
-    return scopedHeartbeatWakeOptions(sessionKey, {
-      ...wakeOptions,
-      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
-    });
-  }
-  if (sessionKey.trim() === "global") {
-    return {
-      ...wakeOptions,
-      sessionKey: "global",
-      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
-    };
-  }
-  return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
-}
-
 const recentVoiceTranscripts = new Map<string, { fingerprint: string; ts: number }>();
 const recentExecFinishedRuns = new Map<string, number>();
 const recentNodePresencePersistAt = new Map<string, number>();

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -66,6 +66,13 @@ function scopedExecEventWakeOptions(sessionKey: string) {
       heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
     });
   }
+  if (sessionKey.trim() === "global") {
+    return {
+      ...wakeOptions,
+      sessionKey: "global",
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    };
+  }
   return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
 }
 

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -614,6 +614,280 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
+  it("keeps plain heartbeat runs on configured heartbeat.session despite a forced topic session", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const directSessionKey = "agent:main:telegram:default:direct:312058326";
+      const topicSessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              session: directSessionKey,
+              target: "telegram",
+              to: "312058326",
+              directPolicy: "allow",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [directSessionKey]: {
+            sessionId: "direct-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:312058326",
+            lastAccountId: "default",
+          },
+          [topicSessionKey]: {
+            sessionId: "topic-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294",
+            lastAccountId: "default",
+            lastThreadId: 47,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "312058326",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "Plain heartbeat" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey: topicSessionKey,
+        reason: "interval",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ SessionKey: directSessionKey }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "312058326",
+        "Plain heartbeat",
+        expect.objectContaining({ accountId: "default" }),
+      );
+    });
+  });
+
+  it("keeps non-event target-last runs on configured heartbeat.session despite a forced topic session", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const directSessionKey = "agent:main:telegram:default:direct:312058326";
+      const topicSessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              session: directSessionKey,
+              target: "telegram",
+              to: "312058326",
+              directPolicy: "allow",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [directSessionKey]: {
+            sessionId: "direct-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:312058326",
+            lastAccountId: "default",
+          },
+          [topicSessionKey]: {
+            sessionId: "topic-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:47",
+            lastAccountId: "default",
+            lastThreadId: 47,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "312058326",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "Plain last heartbeat" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey: topicSessionKey,
+        heartbeat: { target: "last" },
+        reason: "interval",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ SessionKey: directSessionKey }),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  it("keeps wake-triggered event inspection on the forced session even when heartbeat target is pinned", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const directSessionKey = "agent:main:telegram:default:direct:312058326";
+      const topicSessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              session: directSessionKey,
+              target: "telegram",
+              to: "312058326",
+              directPolicy: "allow",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [directSessionKey]: {
+            sessionId: "direct-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:312058326",
+            lastAccountId: "default",
+          },
+          [topicSessionKey]: {
+            sessionId: "topic-sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:47",
+            lastAccountId: "default",
+            lastThreadId: 47,
+          },
+        }),
+      );
+
+      enqueueSystemEvent("Restart continuation", {
+        sessionKey: topicSessionKey,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "Restart ok" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey: topicSessionKey,
+        reason: "wake",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ SessionKey: topicSessionKey }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "312058326",
+        "Restart ok",
+        expect.objectContaining({ accountId: "default" }),
+      );
+    });
+  });
+
+  it("keeps wake-triggered event inspection on raw forced synthetic sessions with queued events", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "none",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "312058326",
+      });
+      enqueueSystemEvent("Exec finished (node=node-2 id=run-2, code 0)\ndone", {
+        sessionKey: "node-node-2",
+        contextKey: "exec:run-2",
+        trusted: false,
+      });
+      const sendTelegram = vi.fn();
+      const getReplySpy = vi.fn().mockResolvedValue({ text: "Synthetic event handled" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey: "node-node-2",
+        reason: "wake",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(getReplySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          SessionKey: "node-node-2",
+          Provider: "exec-event",
+          Body: expect.stringContaining("command completion event was triggered"),
+          ForceSenderIsOwnerFalse: true,
+        }),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
   it("lets exec-event heartbeat overrides bypass a globally pinned heartbeat.to", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {
@@ -760,7 +1034,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
     });
   });
 
-  it("does not inherit pinned routing for bare target-last heartbeat overrides", async () => {
+  it("does not inherit pinned routing when target-last heartbeat overrides explicitly clear route fields", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {
         agents: {
@@ -816,7 +1090,7 @@ describe("Ghost reminder bug (issue #13317)", () => {
         cfg,
         agentId: "main",
         sessionKey,
-        heartbeat: { target: "last" },
+        heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
         reason: "cron:test",
         deps: {
           getReplyFromConfig: getReplySpy,

--- a/src/infra/heartbeat-runner.ghost-reminder.test.ts
+++ b/src/infra/heartbeat-runner.ghost-reminder.test.ts
@@ -550,16 +550,13 @@ describe("Ghost reminder bug (issue #13317)", () => {
       expect(options?.messageThreadId).toBeUndefined();
     });
   });
-  it("keeps exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
+  it("keeps last-target exec-event delivery pinned to the original Telegram topic when session route drifts", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
       const cfg: OpenClawConfig = {
         agents: {
           defaults: {
             workspace: tmpDir,
-            heartbeat: {
-              every: "5m",
-              target: "last",
-            },
+            heartbeat: { every: "5m", target: "last" },
           },
         },
         channels: { telegram: { allowFrom: ["*"] } },
@@ -613,6 +610,494 @@ describe("Ghost reminder bug (issue #13317)", () => {
         "telegram:-1003774691294:topic:47",
         "The review-worker spawn finished successfully.",
         expect.objectContaining({ messageThreadId: 47 }),
+      );
+    });
+  });
+
+  it("lets exec-event heartbeat overrides bypass a globally pinned heartbeat.to", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+              to: "312058326",
+              directPolicy: "allow",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-1003774691294:topic:47",
+        "The review-worker spawn finished successfully.",
+        expect.objectContaining({ messageThreadId: 47 }),
+      );
+    });
+  });
+
+  it("lets exec-event heartbeat overrides bypass a globally pinned heartbeat.accountId", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+              to: "312058326",
+              accountId: "pinned-heartbeat-account",
+              directPolicy: "allow",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastAccountId: "stale-session-account",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          accountId: "requester-account",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-1003774691294:topic:47",
+        "The review-worker spawn finished successfully.",
+        expect.objectContaining({
+          accountId: "requester-account",
+          messageThreadId: 47,
+        }),
+      );
+    });
+  });
+
+  it("does not inherit pinned routing for bare target-last heartbeat overrides", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+              to: "312058326",
+              accountId: "pinned-heartbeat-account",
+              directPolicy: "allow",
+              isolatedSession: true,
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:47",
+            lastAccountId: "session-account",
+            lastThreadId: 47,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "Cron job finished successfully.",
+      });
+      enqueueSystemEvent("Cron job finished", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          accountId: "requester-account",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        heartbeat: { target: "last" },
+        reason: "cron:test",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-1003774691294:topic:47",
+        "Cron job finished successfully.",
+        expect.objectContaining({
+          accountId: "requester-account",
+          messageThreadId: 47,
+        }),
+      );
+    });
+  });
+
+  it("preserves configured heartbeat guards when applying exec-event overrides", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+              to: "312058326",
+              directPolicy: "allow",
+              activeHours: { start: "08:00", end: "09:00", timezone: "UTC" },
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:47",
+            lastThreadId: 47,
+          },
+        }),
+      );
+
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+        reason: "exec-event",
+        deps: {
+          nowMs: () => Date.UTC(2026, 0, 1, 7, 0, 0),
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result).toEqual({ status: "skipped", reason: "quiet-hours" });
+      expect(sendTelegram).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves fixed-channel session routing when an exec event carries cross-channel delivery context", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-1003774691294",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "discord",
+          to: "discord-channel:review",
+          threadId: "discord-thread-1",
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-1003774691294:topic:2175",
+        "The review-worker spawn finished successfully.",
+        expect.not.objectContaining({ messageThreadId: "discord-thread-1" }),
+      );
+    });
+  });
+
+  it("preserves explicit last-target heartbeat.to when an exec event carries turn-scoped delivery context", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "last",
+              to: "telegram:-100999000111:topic:42",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100999000111",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-100999000111:topic:42",
+        "The review-worker spawn finished successfully.",
+        expect.not.objectContaining({ messageThreadId: 47 }),
+      );
+    });
+  });
+
+  it("preserves explicit fixed-channel heartbeat.to when an exec event carries turn-scoped delivery context", async () => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "telegram",
+              to: "telegram:-100999000111:topic:42",
+            },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = "agent:main:telegram:group:-1003774691294:topic:47";
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "telegram",
+            lastTo: "telegram:-1003774691294:topic:2175",
+            lastThreadId: 2175,
+          },
+        }),
+      );
+
+      const sendTelegram = vi.fn().mockResolvedValue({
+        messageId: "m1",
+        chatId: "-100999000111",
+      });
+      const getReplySpy = vi.fn().mockResolvedValue({
+        text: "The review-worker spawn finished successfully.",
+      });
+      enqueueSystemEvent("Exec completed (review-run, code 0)", {
+        sessionKey,
+        trusted: false,
+        deliveryContext: {
+          channel: "telegram",
+          to: "telegram:-1003774691294:topic:47",
+          threadId: 47,
+        },
+      });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        sessionKey,
+        reason: "exec-event",
+        deps: {
+          getReplyFromConfig: getReplySpy,
+          telegram: sendTelegram,
+        },
+      });
+
+      expect(result.status).toBe("ran");
+      expect(sendTelegram).toHaveBeenCalledTimes(1);
+      expect(sendTelegram).toHaveBeenCalledWith(
+        "telegram:-100999000111:topic:42",
+        "The review-worker spawn finished successfully.",
+        expect.not.objectContaining({ messageThreadId: 47 }),
       );
     });
   });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -332,7 +332,7 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
-  it("merges targeted wake heartbeat overrides onto the agent heartbeat config", async () => {
+  it("passes targeted wake heartbeat overrides raw so runOnce can apply target-last semantics", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
@@ -361,12 +361,7 @@ describe("startHeartbeatRunner", () => {
         agentId: "ops",
         reason: "cron:job-123",
         sessionKey: "agent:ops:discord:channel:alerts",
-        heartbeat: {
-          every: "15m",
-          prompt: "Ops prompt",
-          directPolicy: "block",
-          target: "last",
-        },
+        heartbeat: { target: "last" },
       },
     });
 

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -379,6 +379,61 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("does not let a busy targeted wake consume or leak into the next interval", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockImplementation(async ({ reason }) => {
+      if (reason === "exec-event") {
+        return { status: "skipped", reason: "requests-in-flight" } as const;
+      }
+      return { status: "ran", durationMs: 1 } as const;
+    });
+    const intervalMs = 5_000;
+    const runner = startHeartbeatRunner({
+      cfg: heartbeatConfig([{ id: "main", heartbeat: { every: "5s" } }]),
+      runOnce: runSpy,
+      stableSchedulerSeed: TEST_SCHEDULER_SEED,
+    });
+
+    requestHeartbeatNow({
+      reason: "exec-event",
+      agentId: "main",
+      sessionKey: "agent:main:telegram:group:-1003817887412:topic:766",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+      coalesceMs: 0,
+    });
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        agentId: "main",
+        reason: "exec-event",
+        sessionKey: "agent:main:telegram:group:-1003817887412:topic:766",
+        heartbeat: expect.objectContaining({ target: "last", isolatedSession: false }),
+      }),
+    );
+
+    const firstIntervalDueMs = resolveDueFromNow(0, intervalMs, "main");
+    await vi.advanceTimersByTimeAsync(firstIntervalDueMs - Date.now() + 1);
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    const intervalCall = runSpy.mock.calls.find((call) => call[0]?.reason === "interval")?.[0];
+    expect(intervalCall).toEqual(
+      expect.objectContaining({
+        agentId: "main",
+        reason: "interval",
+        heartbeat: expect.objectContaining({ every: "5s" }),
+      }),
+    );
+    expect(intervalCall).not.toHaveProperty("sessionKey");
+    expect(intervalCall?.heartbeat).not.toMatchObject({
+      target: "last",
+      isolatedSession: false,
+    });
+
+    runner.stop();
+  });
+
   it("clamps oversized scheduler delays so heartbeats do not fire in a tight loop (#71414)", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -332,7 +332,7 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
-  it("passes targeted wake heartbeat overrides raw so runOnce can apply target-last semantics", async () => {
+  it("merges targeted wake heartbeat overrides over the target agent heartbeat config", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
@@ -345,6 +345,9 @@ describe("startHeartbeatRunner", () => {
               prompt: "Ops prompt",
               directPolicy: "block",
               target: "discord:channel:ops",
+              to: "configured-ops-destination",
+              accountId: "configured-account",
+              isolatedSession: true,
             },
           },
         ]),
@@ -361,7 +364,15 @@ describe("startHeartbeatRunner", () => {
         agentId: "ops",
         reason: "cron:job-123",
         sessionKey: "agent:ops:discord:channel:alerts",
-        heartbeat: { target: "last" },
+        heartbeat: {
+          every: "15m",
+          prompt: "Ops prompt",
+          directPolicy: "block",
+          target: "last",
+          to: "configured-ops-destination",
+          accountId: "configured-account",
+          isolatedSession: true,
+        },
       },
     });
 

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -240,13 +240,6 @@ function resolveHeartbeatConfig(
   return { ...defaults, ...overrides };
 }
 
-function hasHeartbeatOverrideKey<K extends keyof NonNullable<HeartbeatConfig>>(
-  override: HeartbeatConfig,
-  key: K,
-): boolean {
-  return Object.prototype.hasOwnProperty.call(override, key);
-}
-
 function resolveHeartbeatRunConfig(
   cfg: OpenClawConfig,
   agentId: string,
@@ -256,19 +249,7 @@ function resolveHeartbeatRunConfig(
   if (!override) {
     return resolved;
   }
-  const merged = { ...resolved, ...override };
-  if (override.target === "last") {
-    if (!hasHeartbeatOverrideKey(override, "to")) {
-      merged.to = undefined;
-    }
-    if (!hasHeartbeatOverrideKey(override, "accountId")) {
-      merged.accountId = undefined;
-    }
-    if (!hasHeartbeatOverrideKey(override, "isolatedSession")) {
-      merged.isolatedSession = undefined;
-    }
-  }
-  return merged;
+  return { ...resolved, ...override };
 }
 
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
@@ -627,13 +608,42 @@ async function resolveHeartbeatPreflight(params: {
   reason?: string;
 }): Promise<HeartbeatPreflight> {
   const reasonFlags = resolveHeartbeatReasonFlags(params.reason);
-  const session = resolveHeartbeatSession(
-    params.cfg,
-    params.agentId,
-    params.heartbeat,
-    params.forcedSessionKey,
+  const forcedRawKey = params.forcedSessionKey?.trim() || undefined;
+  const forcedSession = forcedRawKey
+    ? resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat, forcedRawKey)
+    : undefined;
+  const forcedRawEventEntries =
+    forcedRawKey && !isSubagentSessionKey(forcedRawKey) ? peekSystemEventEntries(forcedRawKey) : [];
+  const shouldHonorForcedSessionKey = Boolean(
+    forcedSession &&
+    (reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || reasonFlags.isWakeReason),
   );
-  const pendingEventEntries = peekSystemEventEntries(session.sessionKey);
+  const forcedRawNormalized = normalizeLowercaseStringOrEmpty(forcedRawKey);
+  const shouldUseRawForcedSession = Boolean(
+    shouldHonorForcedSessionKey &&
+    forcedRawKey &&
+    !isSubagentSessionKey(forcedRawKey) &&
+    forcedSession?.sessionKey !== forcedRawKey &&
+    (forcedRawEventEntries.length > 0 ||
+      (reasonFlags.isWakeReason &&
+        !parseAgentSessionKey(forcedRawKey) &&
+        forcedRawNormalized !== "main" &&
+        forcedRawNormalized !== "global")),
+  );
+  const session =
+    shouldHonorForcedSessionKey && forcedSession
+      ? shouldUseRawForcedSession && forcedRawKey
+        ? {
+            ...forcedSession,
+            sessionKey: forcedRawKey,
+            entry: forcedSession.store[forcedRawKey],
+          }
+        : forcedSession
+      : resolveHeartbeatSession(params.cfg, params.agentId, params.heartbeat);
+  const pendingEventEntries =
+    session.sessionKey === forcedRawKey && forcedRawEventEntries.length
+      ? forcedRawEventEntries
+      : peekSystemEventEntries(session.sessionKey);
   const turnSourceDeliveryContext = resolveSystemEventDeliveryContext(pendingEventEntries);
   const hasTaggedCronEvents = pendingEventEntries.some((event) =>
     event.contextKey?.startsWith("cron:"),
@@ -1586,7 +1596,9 @@ export function startHeartbeatRunner(opts: {
           const res = await runOnce({
             cfg: state.cfg,
             agentId: targetAgent.agentId,
-            heartbeat: requestedHeartbeat ?? targetAgent.heartbeat,
+            heartbeat: requestedHeartbeat
+              ? resolveHeartbeatRunConfig(state.cfg, targetAgent.agentId, requestedHeartbeat)
+              : targetAgent.heartbeat,
             reason,
             sessionKey: requestedSessionKey,
             deps: { runtime: state.runtime },

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1607,6 +1607,9 @@ export function startHeartbeatRunner(opts: {
             deps: { runtime: state.runtime },
           });
           if (res.status === "skipped" && isRetryableHeartbeatBusySkipReason(res.reason)) {
+            // Match non-targeted interval handling: a busy lane means this wake has
+            // not actually run yet, so do not consume the agent's regular schedule.
+            // The wake layer will retry the targeted request on its own cooldown.
             retryableBusySkip = true;
             return res;
           }

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -616,7 +616,10 @@ async function resolveHeartbeatPreflight(params: {
     forcedRawKey && !isSubagentSessionKey(forcedRawKey) ? peekSystemEventEntries(forcedRawKey) : [];
   const shouldHonorForcedSessionKey = Boolean(
     forcedSession &&
-    (reasonFlags.isExecEventReason || reasonFlags.isCronEventReason || reasonFlags.isWakeReason),
+    (!params.reason ||
+      reasonFlags.isExecEventReason ||
+      reasonFlags.isCronEventReason ||
+      reasonFlags.isWakeReason),
   );
   const forcedRawNormalized = normalizeLowercaseStringOrEmpty(forcedRawKey);
   const shouldUseRawForcedSession = Boolean(

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -240,6 +240,37 @@ function resolveHeartbeatConfig(
   return { ...defaults, ...overrides };
 }
 
+function hasHeartbeatOverrideKey<K extends keyof NonNullable<HeartbeatConfig>>(
+  override: HeartbeatConfig,
+  key: K,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(override, key);
+}
+
+function resolveHeartbeatRunConfig(
+  cfg: OpenClawConfig,
+  agentId: string,
+  override?: HeartbeatConfig,
+): HeartbeatConfig | undefined {
+  const resolved = resolveHeartbeatConfig(cfg, agentId);
+  if (!override) {
+    return resolved;
+  }
+  const merged = { ...resolved, ...override };
+  if (override.target === "last") {
+    if (!hasHeartbeatOverrideKey(override, "to")) {
+      merged.to = undefined;
+    }
+    if (!hasHeartbeatOverrideKey(override, "accountId")) {
+      merged.accountId = undefined;
+    }
+    if (!hasHeartbeatOverrideKey(override, "isolatedSession")) {
+      merged.isolatedSession = undefined;
+    }
+  }
+  return merged;
+}
+
 function resolveHeartbeatAgents(cfg: OpenClawConfig): HeartbeatAgent[] {
   const list = cfg.agents?.list ?? [];
   if (hasExplicitHeartbeatAgents(cfg)) {
@@ -779,7 +810,7 @@ export async function runHeartbeatOnce(opts: {
   const agentId = normalizeAgentId(
     explicitAgentId || forcedSessionAgentId || resolveDefaultAgentId(cfg),
   );
-  const heartbeat = opts.heartbeat ?? resolveHeartbeatConfig(cfg, agentId);
+  const heartbeat = resolveHeartbeatRunConfig(cfg, agentId, opts.heartbeat);
   if (!areHeartbeatsEnabled()) {
     return { status: "skipped", reason: "disabled" };
   }
@@ -1536,8 +1567,6 @@ export function startHeartbeatRunner(opts: {
     const requestedAgentId = params?.agentId ? normalizeAgentId(params.agentId) : undefined;
     const requestedSessionKey = normalizeOptionalString(params?.sessionKey);
     const requestedHeartbeat = params?.heartbeat;
-    const resolveRequestedHeartbeat = (heartbeat?: HeartbeatConfig) =>
-      requestedHeartbeat ? { ...heartbeat, ...requestedHeartbeat } : heartbeat;
     const isInterval = reason === "interval";
     const startedAt = Date.now();
     const now = startedAt;
@@ -1557,7 +1586,7 @@ export function startHeartbeatRunner(opts: {
           const res = await runOnce({
             cfg: state.cfg,
             agentId: targetAgent.agentId,
-            heartbeat: resolveRequestedHeartbeat(targetAgent.heartbeat),
+            heartbeat: requestedHeartbeat ?? targetAgent.heartbeat,
             reason,
             sessionKey: requestedSessionKey,
             deps: { runtime: state.runtime },

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -71,6 +71,66 @@ describe("heartbeat-wake", () => {
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
+  it("preserves explicit heartbeat route clears when coalescing same-target wakes", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+      coalesceMs: 200,
+    });
+    requestHeartbeatNow({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last" },
+      coalesceMs: 200,
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+    });
+  });
+
+  it("keeps high-priority heartbeat clears when later lower-priority wakes coalesce", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    setHeartbeatWakeHandler(handler);
+
+    requestHeartbeatNow({
+      reason: "wake",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last" },
+      coalesceMs: 200,
+    });
+    requestHeartbeatNow({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+      coalesceMs: 200,
+    });
+    requestHeartbeatNow({
+      reason: "wake",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last", to: "configured-destination", accountId: "configured-account" },
+      coalesceMs: 200,
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({
+      reason: "exec-event",
+      sessionKey: "agent:main:telegram:group:-1003774691294:topic:47",
+      heartbeat: { target: "last", to: undefined, accountId: undefined, isolatedSession: false },
+    });
+  });
+
   it("retries requests-in-flight after the default retry delay", async () => {
     vi.useFakeTimers();
     const handler = vi

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -28,11 +28,18 @@ export function isRetryableHeartbeatBusySkipReason(reason: string): boolean {
   return RETRYABLE_BUSY_SKIP_REASONS.has(reason);
 }
 
+export type HeartbeatWakeOverride = {
+  target?: string;
+  to?: string | undefined;
+  accountId?: string | undefined;
+  isolatedSession?: boolean | undefined;
+};
+
 export type HeartbeatWakeRequest = {
   reason?: string;
   agentId?: string;
   sessionKey?: string;
-  heartbeat?: { target?: string };
+  heartbeat?: HeartbeatWakeOverride;
 };
 
 export type HeartbeatWakeHandler = (opts: HeartbeatWakeRequest) => Promise<HeartbeatRunResult>;
@@ -54,7 +61,7 @@ type PendingWakeReason = {
   requestedAt: number;
   agentId?: string;
   sessionKey?: string;
-  heartbeat?: { target?: string };
+  heartbeat?: HeartbeatWakeOverride;
 };
 
 let handler: HeartbeatWakeHandler | null = null;
@@ -109,7 +116,7 @@ function queuePendingWakeReason(params?: {
   requestedAt?: number;
   agentId?: string;
   sessionKey?: string;
-  heartbeat?: { target?: string };
+  heartbeat?: HeartbeatWakeOverride;
 }) {
   const requestedAt = params?.requestedAt ?? Date.now();
   const normalizedReason = normalizeWakeReason(params?.reason);
@@ -272,7 +279,7 @@ export function requestHeartbeatNow(opts?: {
   coalesceMs?: number;
   agentId?: string;
   sessionKey?: string;
-  heartbeat?: { target?: string };
+  heartbeat?: HeartbeatWakeOverride;
 }) {
   queuePendingWakeReason({
     reason: opts?.reason,

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -111,6 +111,31 @@ function getWakeTargetKey(params: { agentId?: string; sessionKey?: string }) {
   return `${agentId ?? ""}::${sessionKey ?? ""}`;
 }
 
+function hasOwnHeartbeatOverrideKey(
+  heartbeat: HeartbeatWakeOverride | undefined,
+  key: keyof HeartbeatWakeOverride,
+): boolean {
+  return Boolean(heartbeat && Object.prototype.hasOwnProperty.call(heartbeat, key));
+}
+
+function mergeHeartbeatWakeOverrides(
+  previous?: HeartbeatWakeOverride,
+  next?: HeartbeatWakeOverride,
+): HeartbeatWakeOverride | undefined {
+  if (!previous && !next) {
+    return undefined;
+  }
+  const merged: HeartbeatWakeOverride = {};
+  for (const key of ["target", "to", "accountId", "isolatedSession"] as const) {
+    if (hasOwnHeartbeatOverrideKey(next, key)) {
+      merged[key] = next?.[key] as never;
+    } else if (hasOwnHeartbeatOverrideKey(previous, key)) {
+      merged[key] = previous?.[key] as never;
+    }
+  }
+  return merged;
+}
+
 function queuePendingWakeReason(params?: {
   reason?: string;
   requestedAt?: number;
@@ -139,17 +164,22 @@ function queuePendingWakeReason(params?: {
     pendingWakes.set(wakeTargetKey, next);
     return;
   }
-  const merged =
-    (next.heartbeat ?? previous.heartbeat)
-      ? { ...next, heartbeat: next.heartbeat ?? previous.heartbeat }
-      : next;
   if (next.priority > previous.priority) {
-    pendingWakes.set(wakeTargetKey, merged);
+    const heartbeat = mergeHeartbeatWakeOverrides(previous.heartbeat, next.heartbeat);
+    pendingWakes.set(wakeTargetKey, heartbeat ? { ...next, heartbeat } : next);
     return;
   }
   if (next.priority === previous.priority && next.requestedAt >= previous.requestedAt) {
-    pendingWakes.set(wakeTargetKey, merged);
+    const heartbeat = mergeHeartbeatWakeOverrides(previous.heartbeat, next.heartbeat);
+    pendingWakes.set(wakeTargetKey, heartbeat ? { ...next, heartbeat } : next);
+    return;
   }
+  // Lower-priority wakes must not mutate the already queued winner. In particular,
+  // exec-event wakes carry explicit route-clearing overrides that keep completion
+  // notifications pinned to the triggering session instead of configured heartbeat routes.
+  // A later cron/manual/interval wake for the same session is not allowed to reintroduce
+  // those cleared fields before dispatch.
+  pendingWakes.set(wakeTargetKey, previous);
 }
 
 function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -109,10 +109,15 @@ export function resolveHeartbeatDeliveryTarget(params: {
     });
   }
 
-  const resolvedTurnSource =
-    target === "last"
+  const shouldUseTurnSourceRoute = target === "last";
+  const resolvedTurnSource = shouldUseTurnSourceRoute
+    ? params.turnSource
       ? mergeDeliveryContext(params.turnSource, deliveryContextFromSession(entry))
-      : undefined;
+      : deliveryContextFromSession(entry)
+    : undefined;
+
+  const shouldPreferTurnSourceRoute =
+    shouldUseTurnSourceRoute && !heartbeat?.to && Boolean(params.turnSource);
 
   const resolvedTarget = resolveSessionDeliveryTarget({
     entry,
@@ -125,12 +130,11 @@ export function resolveHeartbeatDeliveryTarget(params: {
         : undefined,
     turnSourceTo: resolvedTurnSource?.to,
     turnSourceAccountId: resolvedTurnSource?.accountId,
-    // Only pass threadId from an explicit turn source (e.g., restart sentinel's
-    // delivery context). Do NOT fall back to session-stored threadId here —
-    // heartbeat mode intentionally drops inherited thread IDs to avoid replying
-    // in stale threads (e.g., Slack thread_ts). The sentinel's delivery context
-    // carries the correct topic/thread ID when present.
-    turnSourceThreadId: params.turnSource?.threadId,
+    // Only pass threadId from an explicit turn source when that turn source is
+    // allowed to provide the route. Do NOT let requester-scoped thread IDs
+    // override a fixed heartbeat.to destination.
+    turnSourceThreadId:
+      shouldPreferTurnSourceRoute || !heartbeat?.to ? params.turnSource?.threadId : undefined,
   });
 
   const heartbeatAccountId = heartbeat?.accountId?.trim();

--- a/src/routing/session-key.test.ts
+++ b/src/routing/session-key.test.ts
@@ -10,6 +10,7 @@ import {
   classifySessionKeyShape,
   isValidAgentId,
   parseAgentSessionKey,
+  scopedExecEventWakeOptions,
   toAgentStoreSessionKey,
 } from "./session-key.js";
 
@@ -125,6 +126,40 @@ describe("thread session suffix parsing", () => {
     ).toEqual({
       baseSessionKey: "agent:main:slack:channel:General",
       threadId: "1699999999.0001",
+    });
+  });
+});
+
+describe("scopedExecEventWakeOptions", () => {
+  const heartbeatOverride = {
+    target: "last",
+    to: undefined,
+    accountId: undefined,
+    isolatedSession: false,
+  };
+
+  it("scopes agent session exec-event wakes and clears pinned heartbeat delivery", () => {
+    expect(scopedExecEventWakeOptions("agent:main:telegram:group:123")).toEqual({
+      reason: "exec-event",
+      coalesceMs: 0,
+      sessionKey: "agent:main:telegram:group:123",
+      heartbeat: heartbeatOverride,
+    });
+  });
+
+  it("treats global as a canonical routed exec-event session", () => {
+    expect(scopedExecEventWakeOptions("global")).toEqual({
+      reason: "exec-event",
+      coalesceMs: 0,
+      sessionKey: "global",
+      heartbeat: heartbeatOverride,
+    });
+  });
+
+  it("leaves legacy fallback keys on legacy heartbeat delivery config", () => {
+    expect(scopedExecEventWakeOptions("node-abc")).toEqual({
+      reason: "exec-event",
+      coalesceMs: 0,
     });
   });
 });

--- a/src/routing/session-key.ts
+++ b/src/routing/session-key.ts
@@ -39,6 +39,31 @@ export function scopedHeartbeatWakeOptions<T extends object>(
   return parseAgentSessionKey(sessionKey) ? { ...wakeOptions, sessionKey } : wakeOptions;
 }
 
+const EXEC_EVENT_HEARTBEAT_OVERRIDE = {
+  target: "last",
+  to: undefined,
+  accountId: undefined,
+  isolatedSession: false,
+} as const;
+
+export function scopedExecEventWakeOptions(sessionKey: string) {
+  const wakeOptions = { reason: "exec-event", coalesceMs: 0 };
+  if (parseAgentSessionKey(sessionKey)) {
+    return scopedHeartbeatWakeOptions(sessionKey, {
+      ...wakeOptions,
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    });
+  }
+  if (sessionKey.trim() === "global") {
+    return {
+      ...wakeOptions,
+      sessionKey: "global",
+      heartbeat: EXEC_EVENT_HEARTBEAT_OVERRIDE,
+    };
+  }
+  return scopedHeartbeatWakeOptions(sessionKey, wakeOptions);
+}
+
 export function normalizeMainKey(value: string | undefined | null): string {
   return normalizeLowercaseStringOrEmpty(value) || DEFAULT_MAIN_KEY;
 }


### PR DESCRIPTION
## Summary
- scope exec-event heartbeat wake routing to the originating session/delivery context
- preserve explicit heartbeat session overrides while avoiding interval schedule pollution on busy targeted wakes
- add Telegram regression coverage for retrying topic fallback sends without dropping `disable_notification`

## Local tests
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_WORKERS=1 RAYON_NUM_THREADS=1 TOKIO_WORKER_THREADS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/send.test.ts -t "keeps disable_notification when retrying without message_thread_id"`
  - 1 test passed, 85 skipped
- `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_TEST_WORKERS=1 RAYON_NUM_THREADS=1 TOKIO_WORKER_THREADS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/heartbeat-runner.scheduler.test.ts -t "does not let a busy targeted wake"`
  - 1 test passed, 10 skipped

## Notes
The remaining plain scheduled heartbeat routing edge is tracked separately and should not be mixed with the exec-event fix.