### PR TITLE
fix(agent): suppress tool-use assistant text

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -386,6 +386,60 @@ describe("qa mock openai server", () => {
     expect(body).not.toContain('"name":"read"');
   });
 
+  it("routes threaded memory prompts even when runtime context is appended as a user item", async () => {
+    const server = await startMockServer();
+    const prompt =
+      "@openclaw Thread memory check: what is the hidden thread codename stored only in memory? Use memory tools first and reply only in this thread.";
+    const runtimeContext = [
+      "OpenClaw runtime context for the immediately preceding user message.",
+      "This context is runtime-generated, not user-authored.",
+      "Conversation info (untrusted metadata):",
+      '```json\n{"chat_id":"thread:qa-room/thread-test","is_group_chat":true}\n```',
+    ].join("\n");
+    const inputWithContext = [makeUserInput(prompt), makeUserInput(runtimeContext)];
+
+    const first = await expectResponsesJson<Record<string, unknown>>(server, {
+      stream: false,
+      model: "gpt-5.5",
+      input: inputWithContext,
+    });
+    expect(JSON.stringify(first)).toContain('"name":"memory_search"');
+    expect(JSON.stringify(first)).toContain("hidden thread codename ORBIT-22");
+
+    const second = await expectResponsesJson<Record<string, unknown>>(server, {
+      stream: false,
+      model: "gpt-5.5",
+      input: [
+        ...inputWithContext,
+        {
+          type: "function_call_output",
+          output: JSON.stringify({ results: [{ path: "MEMORY.md", startLine: 1, endLine: 1 }] }),
+        },
+      ],
+    });
+    expect(JSON.stringify(second)).toContain('"name":"memory_get"');
+    const memoryGetCall = (second.output as Array<{ arguments?: string }>).find(
+      (item) => item.arguments,
+    );
+    expect(JSON.parse(memoryGetCall?.arguments ?? "{}")).toMatchObject({ path: "MEMORY.md" });
+
+    const third = await expectResponsesJson<Record<string, unknown>>(server, {
+      stream: false,
+      model: "gpt-5.5",
+      input: [
+        ...inputWithContext,
+        { type: "function_call_output", output: "Thread-hidden codename: ORBIT-22." },
+      ],
+    });
+    expect(JSON.stringify(third)).toContain("hidden thread codename is ORBIT-22");
+
+    const requests = await fetch(`${server.baseUrl}/debug/requests`);
+    expect(requests.status).toBe(200);
+    const snapshots = (await requests.json()) as Array<{ prompt?: string; allInputText?: string }>;
+    expect(snapshots.at(0)?.prompt).toBe(prompt);
+    expect(snapshots.at(0)?.allInputText).toContain(runtimeContext);
+  });
+
   it("drives repo-contract followthrough as read-read-read-write-then-report", async () => {
     const server = await startQaMockOpenAiServer({
       host: "127.0.0.1",

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -244,6 +244,12 @@ function buildDeterministicEmbedding(text: string, dimensions = 16) {
   return values.map((value) => Number((value / magnitude).toFixed(8)));
 }
 
+function isRuntimeContextInputText(text: string) {
+  return /^OpenClaw runtime (?:context for the immediately preceding user message|event)\./i.test(
+    text.trim(),
+  );
+}
+
 function extractLastUserText(input: ResponsesInputItem[]) {
   for (let index = input.length - 1; index >= 0; index -= 1) {
     const item = input[index];
@@ -251,7 +257,7 @@ function extractLastUserText(input: ResponsesInputItem[]) {
       continue;
     }
     const text = extractInputText(item.content);
-    if (text) {
+    if (text && !isRuntimeContextInputText(text)) {
       return text;
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -463,6 +463,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/diagnostics-prometheus:
+    devDependencies:
+      '@openclaw/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../packages/plugin-sdk
+
   extensions/diffs:
     dependencies:
       '@pierre/diffs':

--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -585,6 +585,48 @@ describe("handleMessageUpdate", () => {
     });
   });
 
+  it("emits final-answer partials even when the aggregate message still contains prior tool use", () => {
+    const onAgentEvent = vi.fn();
+    const ctx = createMessageUpdateContext({
+      onAgentEvent,
+      shouldEmitPartialReplies: false,
+    });
+    const finalPartial = createOpenAiResponsesPartial({
+      text: "Protocol note: ORBIT-22.",
+      id: "item_final",
+      signaturePhase: "final_answer",
+      partialPhase: "final_answer",
+    });
+
+    handleMessageUpdate(ctx, {
+      type: "message_update",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "I'll check memory." },
+          { type: "toolCall", id: "call-1", name: "memory_search", input: {} },
+        ],
+        stopReason: "toolUse",
+      },
+      assistantMessageEvent: {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Protocol note: ORBIT-22.",
+        partial: finalPartial,
+      },
+    } as never);
+
+    expect(onAgentEvent).toHaveBeenCalledTimes(1);
+    expect(onAgentEvent.mock.calls[0]?.[0]).toMatchObject({
+      stream: "assistant",
+      data: {
+        text: "Protocol note: ORBIT-22.",
+        delta: "Protocol note: ORBIT-22.",
+        phase: "final_answer",
+      },
+    });
+  });
+
   it("contains synchronous text_end flush failures", async () => {
     const debug = vi.fn();
     const ctx = createMessageUpdateContext({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -37,7 +37,32 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
-const TOOL_CALL_CONTENT_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+const TOOL_CALL_CONTENT_TYPES = new Set([
+  "toolCall",
+  "toolUse",
+  "functionCall",
+  "tool_call",
+  "tool_use",
+  "function_call",
+]);
+
+function suppressPendingAssistantVisibleOutput(ctx: EmbeddedPiSubscribeContext) {
+  ctx.state.suppressBlockChunks = true;
+  ctx.state.deltaBuffer = "";
+  ctx.state.blockBuffer = "";
+  ctx.blockChunker?.reset();
+  ctx.state.lastStreamedAssistant = undefined;
+  ctx.state.lastStreamedAssistantCleaned = undefined;
+  ctx.state.emittedAssistantUpdate = false;
+  ctx.state.lastBlockReplyText = undefined;
+  ctx.state.pendingAssistantReplyDirectives = undefined;
+  if (ctx.state.assistantTexts.length > ctx.state.assistantTextBaseline) {
+    ctx.state.assistantTexts.splice(ctx.state.assistantTextBaseline);
+    ctx.state.lastAssistantTextMessageIndex = -1;
+    ctx.state.lastAssistantTextNormalized = undefined;
+    ctx.state.lastAssistantTextTrimmed = undefined;
+  }
+}
 
 function hasToolUseContinuation(message: AgentMessage | undefined): boolean {
   if (!message || message.role !== "assistant") {
@@ -436,6 +461,7 @@ export function handleMessageUpdate(
   ctx.noteLastAssistant(msg);
   const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(msg);
   if (suppressVisibleAssistantOutput) {
+    suppressPendingAssistantVisibleOutput(ctx);
     return;
   }
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
@@ -533,6 +559,7 @@ export function handleMessageUpdate(
     ctx.state.lastAssistantStreamItemId = streamItemId;
   }
   if (shouldSuppressAssistantVisibleOutput(partialAssistant)) {
+    suppressPendingAssistantVisibleOutput(ctx);
     return;
   }
   if (isPhasePendingOpenAiResponsesTextItem) {
@@ -689,6 +716,7 @@ export function handleMessageEnd(
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
   ctx.commitAssistantUsage();
   if (suppressVisibleAssistantOutput) {
+    suppressPendingAssistantVisibleOutput(ctx);
     return;
   }
   promoteThinkingTagsToBlocks(assistantMessage);

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -68,8 +68,12 @@ function hasToolUseContinuation(message: AgentMessage | undefined): boolean {
   if (!message || message.role !== "assistant") {
     return false;
   }
-  if ((message as { stopReason?: unknown }).stopReason === "toolUse") {
+  const stopReason = (message as { stopReason?: unknown }).stopReason;
+  if (stopReason === "toolUse") {
     return true;
+  }
+  if (typeof stopReason === "string" && stopReason) {
+    return false;
   }
   const content = (message as { content?: unknown }).content;
   if (!Array.isArray(content)) {
@@ -459,11 +463,6 @@ export function handleMessageUpdate(
   }
 
   ctx.noteLastAssistant(msg);
-  const suppressVisibleAssistantOutput = shouldSuppressAssistantVisibleOutput(msg);
-  if (suppressVisibleAssistantOutput) {
-    suppressPendingAssistantVisibleOutput(ctx);
-    return;
-  }
   const suppressDeterministicApprovalOutput = shouldSuppressDeterministicApprovalOutput(ctx.state);
 
   const assistantEvent = evt.assistantMessageEvent;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -37,8 +37,37 @@ import {
   promoteThinkingTagsToBlocks,
 } from "./pi-embedded-utils.js";
 
+const TOOL_CALL_CONTENT_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
+
+function hasToolUseContinuation(message: AgentMessage | undefined): boolean {
+  if (!message || message.role !== "assistant") {
+    return false;
+  }
+  if ((message as { stopReason?: unknown }).stopReason === "toolUse") {
+    return true;
+  }
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return typeof type === "string" && TOOL_CALL_CONTENT_TYPES.has(type);
+  });
+}
+
 function shouldSuppressAssistantVisibleOutput(message: AgentMessage | undefined): boolean {
-  return resolveAssistantMessagePhase(message) === "commentary";
+  const phase = resolveAssistantMessagePhase(message);
+  if (phase === "commentary") {
+    return true;
+  }
+  if (phase === "final_answer") {
+    return false;
+  }
+  return hasToolUseContinuation(message);
 }
 
 function isTranscriptOnlyOpenClawAssistantMessage(message: AgentMessage | undefined): boolean {
@@ -503,7 +532,7 @@ export function handleMessageUpdate(
     }
     ctx.state.lastAssistantStreamItemId = streamItemId;
   }
-  if (deliveryPhase === "commentary") {
+  if (shouldSuppressAssistantVisibleOutput(partialAssistant)) {
     return;
   }
   if (isPhasePendingOpenAiResponsesTextItem) {

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -98,4 +98,63 @@ describe("subscribeEmbeddedPiSession", () => {
     expect(onPartialReply).not.toHaveBeenCalled();
     expect(subscription.assistantTexts).toEqual([]);
   });
+
+  it.each(["message_end", "text_end"] as const)(
+    "does not flush buffered commentary text before tool execution when phase arrives at text_end (%s)",
+    (blockReplyBreak) => {
+      const onBlockReply = vi.fn();
+      const onPartialReply = vi.fn();
+      const { emit, subscription } = createSubscribedSessionHarness({
+        runId: "run",
+        onBlockReply,
+        onPartialReply,
+        blockReplyBreak,
+      });
+
+      const commentaryMessage = {
+        role: "assistant",
+        content: [{ type: "text", text: "" }],
+      } as AssistantMessage;
+      const text = "I'll check this now.";
+
+      emit({ type: "message_start", message: commentaryMessage });
+      emit({
+        type: "message_update",
+        message: commentaryMessage,
+        assistantMessageEvent: {
+          type: "text_delta",
+          contentIndex: 0,
+          delta: text,
+          partial: commentaryMessage,
+        },
+      });
+      (commentaryMessage.content as Array<Record<string, unknown>>)[0] = {
+        type: "text",
+        text,
+        textSignature: JSON.stringify({ v: 1, id: "msg_sig", phase: "commentary" }),
+      };
+      emit({
+        type: "message_update",
+        message: commentaryMessage,
+        assistantMessageEvent: {
+          type: "text_end",
+          contentIndex: 0,
+          content: text,
+          partial: commentaryMessage,
+        },
+      });
+      emit({ type: "tool_execution_start", toolName: "read", toolCallId: "call-1", args: {} });
+      (commentaryMessage.content as Array<Record<string, unknown>>).push({
+        type: "toolCall",
+        id: "call-1",
+        name: "read",
+        input: { path: "README.md" },
+      });
+      (commentaryMessage as { stopReason?: string }).stopReason = "toolUse";
+      emit({ type: "message_end", message: commentaryMessage });
+
+      expect(onBlockReply).not.toHaveBeenCalled();
+      expect(subscription.assistantTexts).toEqual([]);
+    },
+  );
 });

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -117,6 +117,10 @@ describe("subscribeEmbeddedPiSession", () => {
       } as AssistantMessage;
       const text = "I'll check this now.";
 
+      const commentaryContent = commentaryMessage.content as unknown as Array<
+        Record<string, unknown>
+      >;
+
       emit({ type: "message_start", message: commentaryMessage });
       emit({
         type: "message_update",
@@ -128,7 +132,7 @@ describe("subscribeEmbeddedPiSession", () => {
           partial: commentaryMessage,
         },
       });
-      (commentaryMessage.content as Array<Record<string, unknown>>)[0] = {
+      commentaryContent[0] = {
         type: "text",
         text,
         textSignature: JSON.stringify({ v: 1, id: "msg_sig", phase: "commentary" }),
@@ -144,7 +148,7 @@ describe("subscribeEmbeddedPiSession", () => {
         },
       });
       emit({ type: "tool_execution_start", toolName: "read", toolCallId: "call-1", args: {} });
-      (commentaryMessage.content as Array<Record<string, unknown>>).push({
+      commentaryContent.push({
         type: "toolCall",
         id: "call-1",
         name: "read",

--- a/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
+++ b/src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts
@@ -7,6 +7,38 @@ type AssistantMessageWithPhase = AssistantMessage & {
 };
 
 describe("subscribeEmbeddedPiSession", () => {
+  it("suppresses assistant messages that continue into tool use without phase metadata", () => {
+    const onBlockReply = vi.fn();
+    const onPartialReply = vi.fn();
+    const { emit, subscription } = createSubscribedSessionHarness({
+      runId: "run",
+      onBlockReply,
+      onPartialReply,
+      blockReplyBreak: "message_end",
+    });
+
+    const toolUseMessage = {
+      role: "assistant",
+      content: [
+        { type: "text", text: "I'll check this now." },
+        { type: "toolCall", id: "call-1", name: "read", input: { path: "README.md" } },
+      ],
+      stopReason: "toolUse",
+    } as AssistantMessage;
+
+    emit({ type: "message_start", message: toolUseMessage });
+    emit({
+      type: "message_update",
+      message: toolUseMessage,
+      assistantMessageEvent: { type: "text_delta", delta: "I'll check this now." },
+    });
+    emit({ type: "message_end", message: toolUseMessage });
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(onPartialReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual([]);
+  });
+
   it("suppresses commentary-phase assistant messages before tool use", () => {
     const onBlockReply = vi.fn();
     const onPartialReply = vi.fn();

--- a/src/commands/status-json.test.ts
+++ b/src/commands/status-json.test.ts
@@ -104,15 +104,17 @@ describe("statusJsonCommand", () => {
 
     await statusJsonCommand({ all: true }, runtime);
 
-    expect(mocks.runSecurityAudit).toHaveBeenCalledWith({
-      config: expect.any(Object),
-      sourceConfig: expect.any(Object),
-      deep: false,
-      includeFilesystem: true,
-      includeChannelSecurity: true,
-      loadPluginSecurityCollectors: false,
-      plugins: expect.any(Array),
-    });
+    expect(mocks.runSecurityAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.any(Object),
+        sourceConfig: expect.any(Object),
+        deep: false,
+        includeFilesystem: true,
+        includeChannelSecurity: true,
+        loadPluginSecurityCollectors: false,
+        plugins: expect.any(Array),
+      }),
+    );
     expect(logs).toHaveLength(1);
     expect(JSON.parse(logs[0] ?? "{}")).toHaveProperty("securityAudit.summary.critical", 1);
   });


### PR DESCRIPTION
## Summary

- suppress assistant messages that are tool-use continuations (`stopReason: "toolUse"` or tool-call content) from user-visible assistant output
- keep explicit `final_answer` phase output deliverable
- add regression coverage for unphased tool-use assistant text so it does not emit block/partial replies or final assistant text

Fixes #71588.

## Notes

The Feishu group trigger policy (`groupPolicy=open` / `requireMention=false`) can make this easier to hit because more group messages start agent runs, but it is not the direct root cause. The direct issue is one agent run exposing both intermediate tool-use assistant text and the later final answer as user-visible replies.

## Validation

- `corepack pnpm vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts`
- `corepack pnpm tsgo:core`
- `corepack pnpm exec oxlint --tsconfig tsconfig.oxlint.core.json src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts`
- `corepack pnpm exec oxfmt --check src/agents/pi-embedded-subscribe.handlers.messages.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-commentary-phase-output.test.ts`

Full `corepack pnpm lint:core` currently fails on an unrelated pre-existing `no-array-sort` finding in `src/agents/cli-runner.spawn.test.ts:1029`.
