### PR TITLE
fix(claude-cli): pass system prompt as file path to avoid Windows ENAMETOOLONG (#71600)

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -63,6 +63,12 @@ export function buildAnthropicCliBackend(): CliBackendPlugin {
       sessionMode: "always",
       sessionIdFields: [...CLAUDE_CLI_SESSION_ID_FIELDS],
       systemPromptArg: "--append-system-prompt",
+      // Pass the system prompt as a file path to avoid Windows' ~32,767-char
+      // argv limit causing spawn ENAMETOOLONG when the workspace context
+      // pushes the inline prompt past that bound. Claude Code CLI 2.x
+      // accepts `--append-system-prompt-file <path>` as the file-based
+      // counterpart to `--append-system-prompt`. (#71600)
+      systemPromptFileArg: "--append-system-prompt-file",
       systemPromptMode: "append",
       systemPromptWhen: "first",
       clearEnv: [...CLAUDE_CLI_CLEAR_ENV],

--- a/src/agents/cli-runner.helpers.test.ts
+++ b/src/agents/cli-runner.helpers.test.ts
@@ -144,6 +144,47 @@ describe("buildCliArgs", () => {
     ).toEqual(["-p", "--append-system-prompt", "Stable prefix\nDynamic suffix"]);
   });
 
+  it("passes Claude CLI system prompts via --append-system-prompt-file to avoid Windows argv overflow (#71600)", () => {
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "claude",
+          systemPromptArg: "--append-system-prompt",
+          systemPromptFileArg: "--append-system-prompt-file",
+        },
+        baseArgs: ["-p", "--output-format", "stream-json"],
+        modelId: "claude-sonnet-4-6",
+        systemPrompt: "Stable prefix",
+        systemPromptFilePath: "/tmp/openclaw/system-prompt.md",
+        useResume: false,
+      }),
+    ).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--append-system-prompt-file",
+      "/tmp/openclaw/system-prompt.md",
+    ]);
+  });
+
+  it("falls back to inline systemPromptArg when systemPromptFileArg is set but no file path is provided", () => {
+    // Defensive: writeCliSystemPromptFile failures or upstream code paths that
+    // omit systemPromptFilePath should not leave the system prompt unset.
+    expect(
+      buildCliArgs({
+        backend: {
+          command: "claude",
+          systemPromptArg: "--append-system-prompt",
+          systemPromptFileArg: "--append-system-prompt-file",
+        },
+        baseArgs: ["-p"],
+        modelId: "claude-sonnet-4-6",
+        systemPrompt: "Stable prefix",
+        useResume: false,
+      }),
+    ).toEqual(["-p", "--append-system-prompt", "Stable prefix"]);
+  });
+
   it("passes Codex system prompts via a model instructions file config override", () => {
     expect(
       buildCliArgs({
@@ -453,6 +494,33 @@ describe("writeCliSystemPromptFile", () => {
       await written.cleanup();
     }
     await expect(fs.access(written.filePath ?? "")).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("writes a temp file when systemPromptFileArg is set (Claude CLI #71600 path)", async () => {
+    const written = await writeCliSystemPromptFile({
+      backend: {
+        command: "claude",
+        systemPromptFileArg: "--append-system-prompt-file",
+      },
+      systemPrompt: "Stable prefix",
+    });
+
+    try {
+      expect(written.filePath).toContain("openclaw-cli-system-prompt-");
+      await expect(fs.readFile(written.filePath ?? "", "utf-8")).resolves.toBe("Stable prefix");
+    } finally {
+      await written.cleanup();
+    }
+  });
+
+  it("returns no file path when neither file mechanism is configured", async () => {
+    const written = await writeCliSystemPromptFile({
+      backend: { command: "gemini", systemPromptArg: "--system" },
+      systemPrompt: "Stable prefix",
+    });
+
+    expect(written.filePath).toBeUndefined();
+    await written.cleanup();
   });
 });
 

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -292,7 +292,14 @@ export async function writeCliSystemPromptFile(params: {
   backend: CliBackendConfig;
   systemPrompt: string;
 }): Promise<{ filePath?: string; cleanup: () => Promise<void> }> {
-  if (!params.backend.systemPromptFileConfigKey?.trim()) {
+  // Write a temp file when either path-based mechanism is configured:
+  //   - `systemPromptFileArg` (Claude CLI: `--append-system-prompt-file <path>`)
+  //   - `systemPromptFileConfigKey` (Codex CLI: `-c model_instructions_file="..."`)
+  // Otherwise the backend uses inline `systemPromptArg` and no temp file is needed.
+  if (
+    !params.backend.systemPromptFileArg?.trim() &&
+    !params.backend.systemPromptFileConfigKey?.trim()
+  ) {
     return { cleanup: async () => {} };
   }
   const tempDir = await fs.mkdtemp(
@@ -369,6 +376,18 @@ export function buildCliArgs(params: {
     args.push(params.backend.modelArg, params.modelId);
   }
   if (
+    !params.useResume &&
+    params.systemPrompt &&
+    params.systemPromptFilePath &&
+    params.backend.systemPromptFileArg
+  ) {
+    // File-arg path: e.g. Claude CLI's `--append-system-prompt-file <path>`.
+    // Preferred over inline `systemPromptArg` because passing the prompt as a
+    // file path avoids Windows' ~32,767-character argv limit (#71600). Each
+    // workspace context easily exceeds that — see issue for spawn
+    // ENAMETOOLONG repro at ~41k chars.
+    args.push(params.backend.systemPromptFileArg, params.systemPromptFilePath);
+  } else if (
     !params.useResume &&
     params.systemPrompt &&
     params.systemPromptFilePath &&

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -127,6 +127,16 @@ export type CliBackendConfig = {
   sessionIdFields?: string[];
   /** Flag used to pass system prompt. */
   systemPromptArg?: string;
+  /**
+   * Flag used to pass a system prompt file path directly (e.g.
+   * `--append-system-prompt-file <path>` for Claude CLI). Preferred over
+   * `systemPromptArg` when set, because passing the prompt as a file path
+   * avoids Windows' ~32,767-character command-line argument limit
+   * (`spawn ENAMETOOLONG`) — see #71600. Distinct from
+   * `systemPromptFileConfigKey` which uses a TOML-style config override
+   * (`-c key="path"`).
+   */
+  systemPromptFileArg?: string;
   /** Config override flag used to pass a system prompt file (e.g. -c). */
   systemPromptFileConfigArg?: string;
   /** Config override key used to pass a system prompt file. */


### PR DESCRIPTION
Closes #71600.

## Bug

On Windows, Claude CLI sessions die with `spawn ENAMETOOLONG` whenever the OpenClaw-injected system prompt + workspace context exceeds the ~32,767-character argv limit. Reporter saw this at ~41k chars in a typical workspace — completely deterministic for Windows users with non-trivial workspace context. Linux/macOS don't impose this OS-level limit so the bug is Windows-specific.

Reporter verified hot patch: write the prompt to a temp file and pass `--append-system-prompt-file <path>` instead of `--append-system-prompt`. Resumed 44.7k-prompt sessions immediately.

## Fix

Claude Code CLI 2.x already supports the file-based counterpart `--append-system-prompt-file <path>`. OpenClaw already had a temp-file writer (`writeCliSystemPromptFile`) for the Codex-style TOML-config-override path. This PR generalizes it for Claude's flag-pair shape:

- **`src/config/types.agent-defaults.ts`** — add `systemPromptFileArg` to `CliBackendConfig`. Documented as the file-arg sibling of existing `systemPromptArg` (inline) and `systemPromptFileConfigKey` (TOML).
- **`src/agents/cli-runner/helpers.ts`** —
  - `writeCliSystemPromptFile`: write temp file when EITHER `systemPromptFileArg` OR `systemPromptFileConfigKey` is set.
  - `buildCliArgs`: new branch that prefers the file-arg pair (`flag, path`) over inline arg / TOML override when set + file path present. Falls back to inline `systemPromptArg` if no file path (defense-in-depth so the prompt is never silently dropped on file-write failure).
- **`extensions/anthropic/cli-backend.ts`** — wire `systemPromptFileArg: \"--append-system-prompt-file\"`.

This is also a strict improvement on macOS/Linux: writing the prompt to a file avoids re-encoding the same large string on every spawn and keeps it out of process listings (`ps aux` no longer shows the full prompt). No behavior change for Codex (still uses TOML override), Gemini (still inline), or any backend that doesn't set `systemPromptFileArg`.

## Tests

- new `buildCliArgs` case: `--append-system-prompt-file` flag emitted when configured + file path available.
- new `buildCliArgs` case: falls back to inline arg when file path missing (defense-in-depth).
- new `writeCliSystemPromptFile` case: temp file written when only `systemPromptFileArg` is set (Claude CLI shape).
- new `writeCliSystemPromptFile` case: returns no path when neither file mechanism is configured (Gemini shape).

22 tests pass. Lint clean (`pnpm oxlint` — 0 warnings, 0 errors).

🤖 generated with assistance from Claude Code
Co-authored-by: HCL <chenglunhu@gmail.com>