### PR TITLE
fix: refuse local tsgo under host pressure

### DIFF
--- a/extensions/bonjour/src/ciao.ts
+++ b/extensions/bonjour/src/ciao.ts
@@ -56,7 +56,10 @@ export function classifyCiaoProcessError(reason: unknown): CiaoProcessErrorClass
   return null;
 }
 
-/** Backward-compatible alias for unhandled-rejection classification. */
+/**
+ * Backward-compatible alias for unhandled-rejection classification.
+ * @deprecated Use classifyCiaoProcessError instead.
+ */
 export const classifyCiaoUnhandledRejection = classifyCiaoProcessError;
 
 /** Return whether a ciao unhandled rejection is known and ignorable. */

--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -13,6 +13,7 @@ import {
 import { createRequire } from "node:module";
 import os from "node:os";
 import path, { dirname, join, resolve } from "node:path";
+import { getLocalNativeTypecheckRefusalError } from "./lib/local-heavy-check-runtime.mjs";
 import { parsePositiveInt } from "./lib/numeric-options.mjs";
 import {
   forwardSignalToVitestProcessGroup,
@@ -851,6 +852,17 @@ async function runCanaryCheck(extensionIds) {
 export async function main(argv = process.argv.slice(2)) {
   const startedAt = Date.now();
   const mode = parseMode(argv);
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: argv,
+    env: process.env,
+    shouldRunHeavyCheck: mode === "all" || mode === "compile",
+    toolName: "extension package boundary tsgo",
+  });
+  if (nativeTypecheckRefusalError) {
+    process.stderr.write(`${nativeTypecheckRefusalError}\n`);
+    process.exitCode = 1;
+    return;
+  }
   const optInExtensionIds = collectOptInExtensionIds();
   const canaryExtensionIds = collectCanaryExtensionIds(optInExtensionIds);
   const cleanupExtensionIds = optInExtensionIds;

--- a/scripts/check-extension-package-tsc-boundary.mjs
+++ b/scripts/check-extension-package-tsc-boundary.mjs
@@ -13,6 +13,7 @@ import {
 import { createRequire } from "node:module";
 import os from "node:os";
 import path, { dirname, join, resolve } from "node:path";
+import { getLocalNativeTypecheckRefusalError } from "./lib/local-heavy-check-runtime.mjs";
 
 const require = createRequire(import.meta.url);
 const repoRoot = resolve(import.meta.dirname, "..");
@@ -771,6 +772,17 @@ async function runCanaryCheck(extensionIds) {
 export async function main(argv = process.argv.slice(2)) {
   const startedAt = Date.now();
   const mode = parseMode(argv);
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: argv,
+    env: process.env,
+    shouldRunHeavyCheck: mode === "all" || mode === "compile",
+    toolName: "extension package boundary tsgo",
+  });
+  if (nativeTypecheckRefusalError) {
+    process.stderr.write(`${nativeTypecheckRefusalError}\n`);
+    process.exitCode = 1;
+    return;
+  }
   const optInExtensionIds = collectOptInExtensionIds();
   const canaryExtensionIds = collectCanaryExtensionIds(optInExtensionIds);
   const cleanupExtensionIds = optInExtensionIds;

--- a/scripts/check-tsgo-core-boundary.mjs
+++ b/scripts/check-tsgo-core-boundary.mjs
@@ -3,6 +3,10 @@
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
+import {
+  applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
+} from "./lib/local-heavy-check-runtime.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const tsgoPath = path.join(repoRoot, "node_modules", ".bin", "tsgo");
@@ -14,6 +18,17 @@ const coreGraphs = [
   { name: "core-test-non-agents", config: "test/tsconfig/tsconfig.core.test.non-agents.json" },
 ];
 
+const coreBoundaryRefusalError = getLocalNativeTypecheckRefusalError({
+  args: ["--listFilesOnly", ...coreGraphs.map((graph) => graph.config)],
+  env: process.env,
+  shouldRunHeavyCheck: true,
+  toolName: "core boundary tsgo",
+});
+if (coreBoundaryRefusalError) {
+  console.error(coreBoundaryRefusalError);
+  process.exit(1);
+}
+
 function normalizeFilePath(filePath) {
   const normalized = filePath.trim().replaceAll("\\", "/");
   const normalizedRoot = repoRoot.replaceAll("\\", "/");
@@ -24,12 +39,17 @@ function normalizeFilePath(filePath) {
 }
 
 function listGraphFiles(graph) {
+  const policy = applyLocalTsgoPolicy(
+    ["-p", graph.config, "--pretty", "false", "--listFilesOnly"],
+    process.env,
+  );
   const tsgo = createManagedCommandInvocation({
-    args: ["-p", graph.config, "--pretty", "false", "--listFilesOnly"],
+    args: policy.args,
     bin: tsgoPath,
   });
   const result = spawnSync(tsgo.command, tsgo.args, {
     cwd: repoRoot,
+    env: policy.env,
     encoding: "utf8",
     maxBuffer: 256 * 1024 * 1024,
     shell: tsgo.shell,

--- a/scripts/check-tsgo-core-boundary.mjs
+++ b/scripts/check-tsgo-core-boundary.mjs
@@ -2,6 +2,10 @@
 
 import { spawnSync } from "node:child_process";
 import path from "node:path";
+import {
+  applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
+} from "./lib/local-heavy-check-runtime.mjs";
 
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const tsgoPath = path.join(repoRoot, "node_modules", ".bin", "tsgo");
@@ -13,6 +17,17 @@ const coreGraphs = [
   { name: "core-test-non-agents", config: "test/tsconfig/tsconfig.core.test.non-agents.json" },
 ];
 
+const coreBoundaryRefusalError = getLocalNativeTypecheckRefusalError({
+  args: ["--listFilesOnly", ...coreGraphs.map((graph) => graph.config)],
+  env: process.env,
+  shouldRunHeavyCheck: true,
+  toolName: "core boundary tsgo",
+});
+if (coreBoundaryRefusalError) {
+  console.error(coreBoundaryRefusalError);
+  process.exit(1);
+}
+
 function normalizeFilePath(filePath) {
   const normalized = filePath.trim().replaceAll("\\", "/");
   const normalizedRoot = repoRoot.replaceAll("\\", "/");
@@ -23,8 +38,13 @@ function normalizeFilePath(filePath) {
 }
 
 function listGraphFiles(graph) {
-  const result = spawnSync(tsgoPath, ["-p", graph.config, "--pretty", "false", "--listFilesOnly"], {
+  const { args, env } = applyLocalTsgoPolicy(
+    ["-p", graph.config, "--pretty", "false", "--listFilesOnly"],
+    process.env,
+  );
+  const result = spawnSync(tsgoPath, args, {
     cwd: repoRoot,
+    env,
     encoding: "utf8",
     maxBuffer: 256 * 1024 * 1024,
     shell: process.platform === "win32",

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -13,6 +13,10 @@ const DEFAULT_LOCK_PROGRESS_MS = 15 * 1000;
 const DEFAULT_STALE_LOCK_MS = 30 * 1000;
 const DEFAULT_FAST_LOCAL_CHECK_MIN_MEMORY_BYTES = 48 * GIB;
 const DEFAULT_FAST_LOCAL_CHECK_MIN_CPUS = 12;
+const DEFAULT_MIN_AVAILABLE_MEMORY_BYTES = 1536 * 1024 ** 2;
+const DEFAULT_MIN_TMP_AVAILABLE_BYTES = 1024 * 1024 ** 2;
+const DEFAULT_MAX_TMP_USED_PERCENT = 80;
+const DEFAULT_LOCAL_HEAVY_CHECK_TMP_SUBDIR = path.join(".artifacts", "tmp", "local-heavy-checks");
 const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 
 export function isLocalCheckEnabled(env) {
@@ -161,7 +165,89 @@ export function shouldAcquireLocalHeavyCheckLockForTsgo(args, env = process.env)
   );
 }
 
-function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
+export function resolveLocalHeavyCheckTmpDir({ cwd = process.cwd(), env = process.env } = {}) {
+  return path.resolve(
+    cwd,
+    env.OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR || DEFAULT_LOCAL_HEAVY_CHECK_TMP_SUBDIR,
+  );
+}
+
+export function prepareLocalHeavyCheckEnvironment({ cwd = process.cwd(), env = process.env } = {}) {
+  const nextEnv = { ...env };
+  if (!isLocalCheckEnabled(nextEnv)) {
+    return nextEnv;
+  }
+
+  const tmpDir = resolveLocalHeavyCheckTmpDir({ cwd, env: nextEnv });
+  fs.mkdirSync(tmpDir, { recursive: true });
+  nextEnv.TMPDIR = tmpDir;
+  nextEnv.TEMP = tmpDir;
+  nextEnv.TMP = tmpDir;
+  return nextEnv;
+}
+
+export function getLocalHeavyCheckPressureError({
+  cwd = process.cwd(),
+  env = process.env,
+  hostPressure,
+} = {}) {
+  if (!isLocalCheckEnabled(env) || env.OPENCLAW_HEAVY_CHECK_FORCE === "1") {
+    return null;
+  }
+
+  const pressure = hostPressure ?? readHostPressure(cwd, env);
+  const reasons = [];
+  const minMemAvailableBytes = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES,
+    DEFAULT_MIN_AVAILABLE_MEMORY_BYTES,
+  );
+  const minTmpAvailableBytes = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MIN_TMP_AVAILABLE_BYTES,
+    DEFAULT_MIN_TMP_AVAILABLE_BYTES,
+  );
+  const maxTmpUsedPercent = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MAX_TMP_USED_PERCENT,
+    DEFAULT_MAX_TMP_USED_PERCENT,
+  );
+
+  if (
+    typeof pressure.memAvailableBytes === "number" &&
+    pressure.memAvailableBytes < minMemAvailableBytes
+  ) {
+    reasons.push(
+      `MemAvailable ${formatBytes(pressure.memAvailableBytes)} is below ${formatBytes(
+        minMemAvailableBytes,
+      )}`,
+    );
+  }
+  if (
+    typeof pressure.tmpAvailableBytes === "number" &&
+    pressure.tmpAvailableBytes < minTmpAvailableBytes
+  ) {
+    reasons.push(
+      `temp directory available ${formatBytes(pressure.tmpAvailableBytes)} is below ${formatBytes(
+        minTmpAvailableBytes,
+      )}`,
+    );
+  }
+  if (typeof pressure.tmpUsedPercent === "number" && pressure.tmpUsedPercent >= maxTmpUsedPercent) {
+    reasons.push(
+      `temp directory is ${pressure.tmpUsedPercent}% used (limit ${maxTmpUsedPercent}%)`,
+    );
+  }
+
+  if (reasons.length === 0) {
+    return null;
+  }
+
+  return [
+    "Refusing to start a local heavy check because this host is already under pressure:",
+    ...reasons.map((reason) => `- ${reason}`),
+    "Wait for pressure to clear, free temp space, or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 if you really mean it.",
+  ].join("\n");
+}
+
+export function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
   if (!isLocalCheckEnabled(env)) {
     return false;
   }
@@ -335,6 +421,63 @@ function resolveHostResources(hostResources) {
     logicalCpuCount:
       typeof os.availableParallelism === "function" ? os.availableParallelism() : os.cpus().length,
   };
+}
+
+function readHostPressure(cwd, env) {
+  return {
+    memAvailableBytes: readMemAvailableBytes(),
+    ...readTmpPressure(cwd, resolveLocalHeavyCheckTmpDir({ cwd, env })),
+  };
+}
+
+function readMemAvailableBytes() {
+  try {
+    const meminfo = fs.readFileSync("/proc/meminfo", "utf8");
+    const match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(meminfo);
+    return match ? Number.parseInt(match[1], 10) * 1024 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTmpPressure(cwd, tmpDir) {
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  } catch {
+    return {};
+  }
+
+  const result = spawnSync("df", ["-Pk", tmpDir], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0 || !result.stdout) {
+    return {};
+  }
+
+  const [, dataLine] = result.stdout.trim().split(/\n/);
+  const columns = dataLine?.trim().split(/\s+/) ?? [];
+  const availableKib = Number.parseInt(columns[3] ?? "", 10);
+  const usedPercent = Number.parseInt((columns[4] ?? "").replace(/%$/, ""), 10);
+  return {
+    tmpAvailableBytes: Number.isFinite(availableKib) ? availableKib * 1024 : undefined,
+    tmpUsedPercent: Number.isFinite(usedPercent) ? usedPercent : undefined,
+  };
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return "unknown";
+  }
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
 }
 
 function readPositiveInt(rawValue, fallback) {

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -276,11 +276,15 @@ export function getLocalNativeTypecheckRefusalError({
     return null;
   }
 
+  if (env.OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK !== "1") {
+    return null;
+  }
+
   return [
     `Refusing to start ${toolName} on this local host.`,
-    "Native type-aware checks can exhaust constrained developer/agent machines; run them in GitHub CI, Blacksmith/Testbox, or another remote worker instead.",
+    "Native type-aware checks can exhaust constrained developer/agent machines; this opt-in guard keeps them on GitHub CI, Blacksmith/Testbox, or another remote worker instead.",
     `Arguments: ${args.length > 0 ? args.join(" ") : "<default project run>"}`,
-    "If you really mean to run this locally, rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 or OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1.",
+    "If you really mean to run this locally, unset OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 or OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1.",
   ].join("\n");
 }
 

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -254,6 +254,36 @@ export function getLocalHeavyCheckPressureError({
   ].join("\n");
 }
 
+export function getLocalNativeTypecheckRefusalError({
+  args = [],
+  env = process.env,
+  shouldRunHeavyCheck = true,
+  toolName = "native type-aware check",
+} = {}) {
+  if (
+    !shouldRunHeavyCheck ||
+    !isLocalCheckEnabled(env) ||
+    isCiLikeEnv(env) ||
+    env.OPENCLAW_HEAVY_CHECK_FORCE === "1" ||
+    env.OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK === "1" ||
+    env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
+    env.OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD === "1"
+  ) {
+    return null;
+  }
+
+  if (readLocalCheckMode(env, "throttled") === "full") {
+    return null;
+  }
+
+  return [
+    `Refusing to start ${toolName} on this local host.`,
+    "Native type-aware checks can exhaust constrained developer/agent machines; run them in GitHub CI, Blacksmith/Testbox, or another remote worker instead.",
+    `Arguments: ${args.length > 0 ? args.join(" ") : "<default project run>"}`,
+    "If you really mean to run this locally, rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 or OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1.",
+  ].join("\n");
+}
+
 export function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
   if (!isLocalCheckEnabled(env)) {
     return false;

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -13,6 +13,10 @@ const DEFAULT_LOCK_PROGRESS_MS = 15 * 1000;
 const DEFAULT_STALE_LOCK_MS = 30 * 1000;
 const DEFAULT_FAST_LOCAL_CHECK_MIN_MEMORY_BYTES = 48 * GIB;
 const DEFAULT_FAST_LOCAL_CHECK_MIN_CPUS = 12;
+const DEFAULT_MIN_AVAILABLE_MEMORY_BYTES = 1536 * 1024 ** 2;
+const DEFAULT_MIN_TMP_AVAILABLE_BYTES = 1024 * 1024 ** 2;
+const DEFAULT_MAX_TMP_USED_PERCENT = 80;
+const DEFAULT_LOCAL_HEAVY_CHECK_TMP_SUBDIR = path.join(".artifacts", "tmp", "local-heavy-checks");
 const SLEEP_BUFFER = new Int32Array(new SharedArrayBuffer(4));
 
 export function isLocalCheckEnabled(env) {
@@ -168,7 +172,89 @@ export function shouldAcquireLocalHeavyCheckLockForTsgo(args, env = process.env)
   );
 }
 
-function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
+export function resolveLocalHeavyCheckTmpDir({ cwd = process.cwd(), env = process.env } = {}) {
+  return path.resolve(
+    cwd,
+    env.OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR || DEFAULT_LOCAL_HEAVY_CHECK_TMP_SUBDIR,
+  );
+}
+
+export function prepareLocalHeavyCheckEnvironment({ cwd = process.cwd(), env = process.env } = {}) {
+  const nextEnv = { ...env };
+  if (!isLocalCheckEnabled(nextEnv)) {
+    return nextEnv;
+  }
+
+  const tmpDir = resolveLocalHeavyCheckTmpDir({ cwd, env: nextEnv });
+  fs.mkdirSync(tmpDir, { recursive: true });
+  nextEnv.TMPDIR = tmpDir;
+  nextEnv.TEMP = tmpDir;
+  nextEnv.TMP = tmpDir;
+  return nextEnv;
+}
+
+export function getLocalHeavyCheckPressureError({
+  cwd = process.cwd(),
+  env = process.env,
+  hostPressure,
+} = {}) {
+  if (!isLocalCheckEnabled(env) || env.OPENCLAW_HEAVY_CHECK_FORCE === "1") {
+    return null;
+  }
+
+  const pressure = hostPressure ?? readHostPressure(cwd, env);
+  const reasons = [];
+  const minMemAvailableBytes = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES,
+    DEFAULT_MIN_AVAILABLE_MEMORY_BYTES,
+  );
+  const minTmpAvailableBytes = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MIN_TMP_AVAILABLE_BYTES,
+    DEFAULT_MIN_TMP_AVAILABLE_BYTES,
+  );
+  const maxTmpUsedPercent = readPositiveInt(
+    env.OPENCLAW_HEAVY_CHECK_MAX_TMP_USED_PERCENT,
+    DEFAULT_MAX_TMP_USED_PERCENT,
+  );
+
+  if (
+    typeof pressure.memAvailableBytes === "number" &&
+    pressure.memAvailableBytes < minMemAvailableBytes
+  ) {
+    reasons.push(
+      `MemAvailable ${formatBytes(pressure.memAvailableBytes)} is below ${formatBytes(
+        minMemAvailableBytes,
+      )}`,
+    );
+  }
+  if (
+    typeof pressure.tmpAvailableBytes === "number" &&
+    pressure.tmpAvailableBytes < minTmpAvailableBytes
+  ) {
+    reasons.push(
+      `temp directory available ${formatBytes(pressure.tmpAvailableBytes)} is below ${formatBytes(
+        minTmpAvailableBytes,
+      )}`,
+    );
+  }
+  if (typeof pressure.tmpUsedPercent === "number" && pressure.tmpUsedPercent >= maxTmpUsedPercent) {
+    reasons.push(
+      `temp directory is ${pressure.tmpUsedPercent}% used (limit ${maxTmpUsedPercent}%)`,
+    );
+  }
+
+  if (reasons.length === 0) {
+    return null;
+  }
+
+  return [
+    "Refusing to start a local heavy check because this host is already under pressure:",
+    ...reasons.map((reason) => `- ${reason}`),
+    "Wait for pressure to clear, free temp space, or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 if you really mean it.",
+  ].join("\n");
+}
+
+export function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
   if (!isLocalCheckEnabled(env)) {
     return false;
   }
@@ -381,7 +467,64 @@ function resolveHostResources(hostResources) {
   };
 }
 
-function readPositiveInt(rawValue, fallback, label) {
+function readHostPressure(cwd, env) {
+  return {
+    memAvailableBytes: readMemAvailableBytes(),
+    ...readTmpPressure(cwd, resolveLocalHeavyCheckTmpDir({ cwd, env })),
+  };
+}
+
+function readMemAvailableBytes() {
+  try {
+    const meminfo = fs.readFileSync("/proc/meminfo", "utf8");
+    const match = /^MemAvailable:\s+(\d+)\s+kB$/m.exec(meminfo);
+    return match ? Number.parseInt(match[1], 10) * 1024 : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readTmpPressure(cwd, tmpDir) {
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  } catch {
+    return {};
+  }
+
+  const result = spawnSync("df", ["-Pk", tmpDir], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status !== 0 || !result.stdout) {
+    return {};
+  }
+
+  const [, dataLine] = result.stdout.trim().split(/\n/);
+  const columns = dataLine?.trim().split(/\s+/) ?? [];
+  const availableKib = Number.parseInt(columns[3] ?? "", 10);
+  const usedPercent = Number.parseInt((columns[4] ?? "").replace(/%$/, ""), 10);
+  return {
+    tmpAvailableBytes: Number.isFinite(availableKib) ? availableKib * 1024 : undefined,
+    tmpUsedPercent: Number.isFinite(usedPercent) ? usedPercent : undefined,
+  };
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) {
+    return "unknown";
+  }
+  const units = ["B", "KiB", "MiB", "GiB", "TiB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  return `${value.toFixed(value >= 10 || unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function readPositiveInt(rawValue, fallback, label = "value") {
   const text = rawValue?.trim();
   if (!text) {
     return fallback;

--- a/scripts/lib/local-heavy-check-runtime.mjs
+++ b/scripts/lib/local-heavy-check-runtime.mjs
@@ -247,6 +247,36 @@ export function getLocalHeavyCheckPressureError({
   ].join("\n");
 }
 
+export function getLocalNativeTypecheckRefusalError({
+  args = [],
+  env = process.env,
+  shouldRunHeavyCheck = true,
+  toolName = "native type-aware check",
+} = {}) {
+  if (
+    !shouldRunHeavyCheck ||
+    !isLocalCheckEnabled(env) ||
+    isCiLikeEnv(env) ||
+    env.OPENCLAW_HEAVY_CHECK_FORCE === "1" ||
+    env.OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK === "1" ||
+    env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
+    env.OPENCLAW_TEST_HEAVY_CHECK_LOCK_HELD === "1"
+  ) {
+    return null;
+  }
+
+  if (readLocalCheckMode(env, "throttled") === "full") {
+    return null;
+  }
+
+  return [
+    `Refusing to start ${toolName} on this local host.`,
+    "Native type-aware checks can exhaust constrained developer/agent machines; run them in GitHub CI, Blacksmith/Testbox, or another remote worker instead.",
+    `Arguments: ${args.length > 0 ? args.join(" ") : "<default project run>"}`,
+    "If you really mean to run this locally, rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 or OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1.",
+  ].join("\n");
+}
+
 export function shouldThrottleLocalHeavyChecks(env, hostResources, defaultMode = "throttled") {
   if (!isLocalCheckEnabled(env)) {
     return false;

--- a/scripts/lib/run-extension-oxlint.mjs
+++ b/scripts/lib/run-extension-oxlint.mjs
@@ -5,15 +5,51 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
+  getLocalNativeTypecheckRefusalError,
 } from "./local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation } from "./managed-child-process.mjs";
 
 export function runExtensionOxlint(params) {
   const repoRoot = process.cwd();
   const oxlintPath = path.resolve("node_modules", ".bin", "oxlint");
+  const extensionFiles = params.roots.flatMap((root) =>
+    collectTypeScriptFiles(path.resolve(repoRoot, root)),
+  );
+
+  if (extensionFiles.length === 0) {
+    console.log(params.emptyMessage);
+    if (params.allowEmpty === true) {
+      return;
+    }
+    process.exit(1);
+  }
+
+  const previewArgs = [
+    "-c",
+    "<extension-oxlint-config>",
+    ...process.argv.slice(2),
+    ...extensionFiles,
+  ];
+  const { args: previewFinalArgs, env: previewEnv } = applyLocalOxlintPolicy(
+    previewArgs,
+    process.env,
+  );
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: previewFinalArgs,
+    env: previewEnv,
+    shouldRunHeavyCheck: true,
+    toolName: params.toolName,
+  });
+
+  if (nativeTypecheckRefusalError) {
+    console.error(nativeTypecheckRefusalError);
+    process.exitCode = 1;
+    return;
+  }
+
   const releaseLock = acquireLocalHeavyCheckLockSync({
     cwd: repoRoot,
-    env: process.env,
+    env: previewEnv,
     toolName: params.toolName,
     lockName: params.lockName,
   });
@@ -23,23 +59,10 @@ export function runExtensionOxlint(params) {
 
   try {
     prepareExtensionPackageBoundaryArtifacts(repoRoot);
-
-    const extensionFiles = params.roots.flatMap((root) =>
-      collectTypeScriptFiles(path.resolve(repoRoot, root)),
-    );
-
-    if (extensionFiles.length === 0) {
-      console.log(params.emptyMessage);
-      if (params.allowEmpty === true) {
-        return;
-      }
-      process.exit(1);
-    }
-
     writeTempOxlintConfig(repoRoot, tempConfigPath);
 
     const baseArgs = ["-c", tempConfigPath, ...process.argv.slice(2), ...extensionFiles];
-    const { args: finalArgs, env } = applyLocalOxlintPolicy(baseArgs, process.env);
+    const { args: finalArgs, env } = applyLocalOxlintPolicy(baseArgs, previewEnv);
     const oxlint = createManagedCommandInvocation({
       args: finalArgs,
       bin: oxlintPath,

--- a/scripts/profile-tsgo.mjs
+++ b/scripts/profile-tsgo.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
@@ -130,7 +131,18 @@ function removeIfFreshMode(filePath, reuse) {
 
 function runTsgo(label, args, params = {}) {
   const { args: finalArgs, env } = applyLocalTsgoPolicy(args, process.env);
-  const releaseLock = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env)
+  const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: finalArgs,
+    env,
+    shouldRunHeavyCheck,
+    toolName: "tsgo profile",
+  });
+  if (nativeTypecheckRefusalError) {
+    throw new Error(nativeTypecheckRefusalError);
+  }
+
+  const releaseLock = shouldRunHeavyCheck
     ? acquireLocalHeavyCheckLockSync({
         cwd: repoRoot,
         env,

--- a/scripts/profile-tsgo.mjs
+++ b/scripts/profile-tsgo.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
 
@@ -129,7 +130,18 @@ function removeIfFreshMode(filePath, reuse) {
 
 function runTsgo(label, args, params = {}) {
   const { args: finalArgs, env } = applyLocalTsgoPolicy(args, process.env);
-  const releaseLock = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env)
+  const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: finalArgs,
+    env,
+    shouldRunHeavyCheck,
+    toolName: "tsgo profile",
+  });
+  if (nativeTypecheckRefusalError) {
+    throw new Error(nativeTypecheckRefusalError);
+  }
+
+  const releaseLock = shouldRunHeavyCheck
     ? acquireLocalHeavyCheckLockSync({
         cwd: repoRoot,
         env,

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -4,9 +4,12 @@ import os from "node:os";
 import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
+  getLocalNativeTypecheckRefusalError,
+  prepareLocalHeavyCheckEnvironment,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForOxlint,
 } from "./lib/local-heavy-check-runtime.mjs";
+import { shouldPrepareExtensionPackageBoundaryArtifacts } from "./run-oxlint.mjs";
 
 const DEFAULT_WINDOWS_EXTENSION_CHUNK_SIZE = 8;
 const DEFAULT_SHARD_HEARTBEAT_MS = 30_000;
@@ -202,26 +205,67 @@ function listSourceRootTargetGroups({ cwd, readDir }) {
 export async function main(extraArgs = process.argv.slice(2), runtimeEnv = process.env) {
   const runner = path.resolve("scripts", "run-oxlint.mjs");
   const shardArgs = parseShardRunnerArgs(extraArgs);
-  const env = resolveLocalHeavyCheckEnv(runtimeEnv);
-  const hasMetadataOnlyFlag = shardArgs.oxlintArgs.some((arg) =>
-    ["--help", "-h", "--version", "-V", "--rules", "--print-config", "--init"].includes(arg),
-  );
-  const shouldAcquireParentLock =
-    !hasMetadataOnlyFlag ||
-    shouldAcquireLocalHeavyCheckLockForOxlint(shardArgs.oxlintArgs, {
-      cwd: process.cwd(),
-      env,
+
+  const baseEnv = resolveLocalHeavyCheckEnv(runtimeEnv);
+
+  if (!shouldPrepareExtensionPackageBoundaryArtifacts(shardArgs.oxlintArgs)) {
+    const result = spawnSync(process.execPath, [runner, ...shardArgs.oxlintArgs], {
+      stdio: "inherit",
+      env: baseEnv,
     });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    process.exitCode = result.status ?? 1;
+    return;
+  }
+
+  const shouldAcquireParentLock = shouldAcquireLocalHeavyCheckLockForOxlint(shardArgs.oxlintArgs, {
+    cwd: process.cwd(),
+    env: baseEnv,
+  });
+  if (!shouldAcquireParentLock) {
+    const result = spawnSync(process.execPath, [runner, ...shardArgs.oxlintArgs], {
+      stdio: "inherit",
+      env: baseEnv,
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    process.exitCode = result.status ?? 1;
+    return;
+  }
+
+  const policyEnv = resolveLocalHeavyCheckEnv(baseEnv);
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: shardArgs.oxlintArgs,
+    env: policyEnv,
+    shouldRunHeavyCheck: shouldAcquireParentLock,
+    toolName: "sharded type-aware oxlint",
+  });
+
+  if (nativeTypecheckRefusalError) {
+    console.error(nativeTypecheckRefusalError);
+    process.exitCode = 1;
+    return;
+  }
+
+  const env = prepareLocalHeavyCheckEnvironment({
+    cwd: process.cwd(),
+    env: baseEnv,
+  });
   const releaseLock =
-    env.OPENCLAW_OXLINT_SKIP_LOCK === "1"
+    env.OPENCLAW_OXLINT_SKIP_LOCK === "1" || !shouldAcquireParentLock
       ? () => {}
-      : shouldAcquireParentLock
-        ? acquireLocalHeavyCheckLockSync({
-            cwd: process.cwd(),
-            env,
-            toolName: "oxlint shards",
-          })
-        : () => {};
+      : acquireLocalHeavyCheckLockSync({
+          cwd: process.cwd(),
+          env,
+          toolName: "oxlint shards",
+        });
 
   const shards = createOxlintShards({
     cwd: process.cwd(),

--- a/scripts/run-oxlint-shards.mjs
+++ b/scripts/run-oxlint-shards.mjs
@@ -1,25 +1,14 @@
 import { spawn, spawnSync } from "node:child_process";
 import path from "node:path";
+import {
+  acquireLocalHeavyCheckLockSync,
+  getLocalNativeTypecheckRefusalError,
+  prepareLocalHeavyCheckEnvironment,
+  resolveLocalHeavyCheckEnv,
+} from "./lib/local-heavy-check-runtime.mjs";
 
 const extraArgs = process.argv.slice(2);
 const runner = path.resolve("scripts", "run-oxlint.mjs");
-
-const prepareResult = spawnSync(
-  process.execPath,
-  [path.resolve("scripts", "prepare-extension-package-boundary-artifacts.mjs")],
-  {
-    stdio: "inherit",
-    env: process.env,
-  },
-);
-
-if (prepareResult.error) {
-  throw prepareResult.error;
-}
-if ((prepareResult.status ?? 1) !== 0) {
-  process.exit(prepareResult.status ?? 1);
-}
-
 const shards = [
   {
     name: "core",
@@ -34,27 +23,69 @@ const shards = [
     args: ["--tsconfig", "config/tsconfig/oxlint.scripts.json", "scripts"],
   },
 ];
+const env = prepareLocalHeavyCheckEnvironment({
+  cwd: process.cwd(),
+  env: resolveLocalHeavyCheckEnv(process.env),
+});
+const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+  args: extraArgs,
+  env,
+  shouldRunHeavyCheck: true,
+  toolName: "sharded type-aware oxlint",
+});
 
-const runSerial = process.env.OPENCLAW_OXLINT_SHARDS_SERIAL === "1";
-const results = runSerial
-  ? await runShardsSerial(shards)
-  : await Promise.all(shards.map((shard) => runShard(shard)));
-process.exitCode = results.find((status) => status !== 0) ?? 0;
+if (nativeTypecheckRefusalError) {
+  console.error(nativeTypecheckRefusalError);
+  process.exitCode = 1;
+} else {
+  const releaseLock = acquireLocalHeavyCheckLockSync({
+    cwd: process.cwd(),
+    env,
+    toolName: "oxlint-shards",
+  });
 
-async function runShardsSerial(entries) {
+  try {
+    const prepareResult = spawnSync(
+      process.execPath,
+      [path.resolve("scripts", "prepare-extension-package-boundary-artifacts.mjs")],
+      {
+        stdio: "inherit",
+        env,
+      },
+    );
+
+    if (prepareResult.error) {
+      throw prepareResult.error;
+    }
+    if ((prepareResult.status ?? 1) !== 0) {
+      process.exitCode = prepareResult.status ?? 1;
+    } else {
+      const runSerial = env.OPENCLAW_OXLINT_SHARDS_SERIAL === "1";
+      const results = runSerial
+        ? await runShardsSerial(shards, env)
+        : await Promise.all(shards.map((shard) => runShard(shard, env)));
+      process.exitCode = results.find((status) => status !== 0) ?? 0;
+    }
+  } finally {
+    releaseLock();
+  }
+}
+
+async function runShardsSerial(entries, parentEnv) {
   const results = [];
   for (const shard of entries) {
-    results.push(await runShard(shard));
+    results.push(await runShard(shard, parentEnv));
   }
   return results;
 }
 
-async function runShard(shard) {
+async function runShard(shard, parentEnv) {
   console.error(`[oxlint:${shard.name}] starting`);
   const child = spawn(process.execPath, [runner, ...shard.args, ...extraArgs], {
     stdio: "inherit",
     env: {
-      ...process.env,
+      ...parentEnv,
+      OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK: "1",
       OPENCLAW_OXLINT_SKIP_LOCK: "1",
       OPENCLAW_OXLINT_SKIP_PREPARE: "1",
     },

--- a/scripts/run-oxlint.mjs
+++ b/scripts/run-oxlint.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
+  getLocalNativeTypecheckRefusalError,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForOxlint,
 } from "./lib/local-heavy-check-runtime.mjs";
@@ -43,6 +44,10 @@ const OXLINT_VALUE_FLAGS = new Set([
 
 export function shouldPrepareExtensionPackageBoundaryArtifacts(args) {
   return !args.some((arg) => OXLINT_PREPARE_SKIP_FLAGS.has(arg));
+}
+
+export function shouldRunNativeTypeAwareOxlint(args) {
+  return args.includes("--type-aware") && shouldPrepareExtensionPackageBoundaryArtifacts(args);
 }
 
 export function filterSparseMissingOxlintTargets(
@@ -220,21 +225,32 @@ export async function main(argv = process.argv.slice(2), runtimeEnv = process.en
     return;
   }
 
+  const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForOxlint(finalArgs, {
+    cwd: process.cwd(),
+    env,
+  });
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: finalArgs,
+    env,
+    shouldRunHeavyCheck: shouldRunHeavyCheck || shouldRunNativeTypeAwareOxlint(finalArgs),
+    toolName: "type-aware oxlint",
+  });
   const releaseLock =
-    env.OPENCLAW_OXLINT_SKIP_LOCK === "1"
+    env.OPENCLAW_OXLINT_SKIP_LOCK === "1" || nativeTypecheckRefusalError || !shouldRunHeavyCheck
       ? () => {}
-      : shouldAcquireLocalHeavyCheckLockForOxlint(finalArgs, {
-            cwd: process.cwd(),
-            env,
-          })
-        ? acquireLocalHeavyCheckLockSync({
-            cwd: process.cwd(),
-            env,
-            toolName: "oxlint",
-          })
-        : () => {};
+      : acquireLocalHeavyCheckLockSync({
+          cwd: process.cwd(),
+          env,
+          toolName: "oxlint",
+        });
 
   try {
+    if (nativeTypecheckRefusalError) {
+      console.error(nativeTypecheckRefusalError);
+      process.exitCode = 1;
+      return;
+    }
+
     if (
       env.OPENCLAW_OXLINT_SKIP_PREPARE !== "1" &&
       shouldPrepareExtensionPackageBoundaryArtifacts(finalArgs)

--- a/scripts/run-oxlint.mjs
+++ b/scripts/run-oxlint.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
+  getLocalNativeTypecheckRefusalError,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForOxlint,
 } from "./lib/local-heavy-check-runtime.mjs";
@@ -40,6 +41,10 @@ const OXLINT_VALUE_FLAGS = new Set([
 
 export function shouldPrepareExtensionPackageBoundaryArtifacts(args) {
   return !args.some((arg) => OXLINT_PREPARE_SKIP_FLAGS.has(arg));
+}
+
+export function shouldRunNativeTypeAwareOxlint(args) {
+  return args.includes("--type-aware") && shouldPrepareExtensionPackageBoundaryArtifacts(args);
 }
 
 export function filterSparseMissingOxlintTargets(
@@ -207,21 +212,32 @@ export async function main(argv = process.argv.slice(2), runtimeEnv = process.en
     return;
   }
 
+  const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForOxlint(finalArgs, {
+    cwd: process.cwd(),
+    env,
+  });
+  const nativeTypecheckRefusalError = getLocalNativeTypecheckRefusalError({
+    args: finalArgs,
+    env,
+    shouldRunHeavyCheck: shouldRunHeavyCheck || shouldRunNativeTypeAwareOxlint(finalArgs),
+    toolName: "type-aware oxlint",
+  });
   const releaseLock =
-    env.OPENCLAW_OXLINT_SKIP_LOCK === "1"
+    env.OPENCLAW_OXLINT_SKIP_LOCK === "1" || nativeTypecheckRefusalError || !shouldRunHeavyCheck
       ? () => {}
-      : shouldAcquireLocalHeavyCheckLockForOxlint(finalArgs, {
-            cwd: process.cwd(),
-            env,
-          })
-        ? acquireLocalHeavyCheckLockSync({
-            cwd: process.cwd(),
-            env,
-            toolName: "oxlint",
-          })
-        : () => {};
+      : acquireLocalHeavyCheckLockSync({
+          cwd: process.cwd(),
+          env,
+          toolName: "oxlint",
+        });
 
   try {
+    if (nativeTypecheckRefusalError) {
+      console.error(nativeTypecheckRefusalError);
+      process.exitCode = 1;
+      return;
+    }
+
     if (
       env.OPENCLAW_OXLINT_SKIP_PREPARE !== "1" &&
       shouldPrepareExtensionPackageBoundaryArtifacts(finalArgs)

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -28,21 +28,18 @@ if (tsBuildInfoFile) {
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
 const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
-const pressureGuardError =
-  sparseGuardError || !shouldRunHeavyCheck
-    ? null
-    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 const releaseLock =
-  sparseGuardError ||
-  pressureGuardError ||
-  env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
-  !shouldRunHeavyCheck
+  sparseGuardError || env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" || !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
         env,
         toolName: "tsgo",
       });
+const pressureGuardError =
+  sparseGuardError || !shouldRunHeavyCheck
+    ? null
+    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 
 try {
   if (sparseGuardError) {

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -5,6 +5,8 @@ import { readFlagValue } from "./lib/arg-utils.mjs";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
+  getLocalHeavyCheckPressureError,
+  prepareLocalHeavyCheckEnvironment,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
@@ -13,10 +15,11 @@ import {
   shouldSkipSparseTsgoGuardError,
 } from "./lib/tsgo-sparse-guard.mjs";
 
-const { args: finalArgs, env } = applyLocalTsgoPolicy(
+const { args: finalArgs, env: policyEnv } = applyLocalTsgoPolicy(
   process.argv.slice(2),
   resolveLocalHeavyCheckEnv(process.env),
 );
+const env = prepareLocalHeavyCheckEnvironment({ cwd: process.cwd(), env: policyEnv });
 
 const tsgoPath = path.resolve("node_modules", ".bin", "tsgo");
 const tsBuildInfoFile = readFlagValue(finalArgs, "--tsBuildInfoFile");
@@ -24,10 +27,16 @@ if (tsBuildInfoFile) {
   fs.mkdirSync(path.dirname(path.resolve(tsBuildInfoFile)), { recursive: true });
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
+const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+const pressureGuardError =
+  sparseGuardError || !shouldRunHeavyCheck
+    ? null
+    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 const releaseLock =
   sparseGuardError ||
+  pressureGuardError ||
   env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
-  !shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env)
+  !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
@@ -44,6 +53,9 @@ try {
     } else {
       process.exitCode = 1;
     }
+  } else if (pressureGuardError) {
+    console.error(pressureGuardError);
+    process.exitCode = 1;
   } else {
     const result = spawnSync(tsgoPath, finalArgs, {
       stdio: "inherit",

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -29,21 +29,18 @@ if (tsBuildInfoFile) {
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
 const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
-const pressureGuardError =
-  sparseGuardError || !shouldRunHeavyCheck
-    ? null
-    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 const releaseLock =
-  sparseGuardError ||
-  pressureGuardError ||
-  env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
-  !shouldRunHeavyCheck
+  sparseGuardError || env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" || !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
         env,
         toolName: "tsgo",
       });
+const pressureGuardError =
+  sparseGuardError || !shouldRunHeavyCheck
+    ? null
+    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 
 try {
   if (sparseGuardError) {

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -21,55 +21,61 @@ const { args: finalArgs, env: policyEnv } = applyLocalTsgoPolicy(
   process.argv.slice(2),
   resolveLocalHeavyCheckEnv(process.env),
 );
-const env = prepareLocalHeavyCheckEnvironment({ cwd: process.cwd(), env: policyEnv });
 
 const tsgoPath = path.resolve("node_modules", ".bin", "tsgo");
 const tsBuildInfoFile = readFlagValue(finalArgs, "--tsBuildInfoFile");
-if (tsBuildInfoFile) {
-  fs.mkdirSync(path.dirname(path.resolve(tsBuildInfoFile)), { recursive: true });
-}
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
-const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, policyEnv);
 const nativeTypecheckRefusalError = sparseGuardError
   ? null
   : getLocalNativeTypecheckRefusalError({
       args: finalArgs,
-      env,
+      env: policyEnv,
       shouldRunHeavyCheck,
       toolName: "tsgo",
     });
 const releaseLock =
+  policyEnv.OPENCLAW_TSGO_SKIP_LOCK === "1" ||
   sparseGuardError ||
   nativeTypecheckRefusalError ||
-  env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
+  policyEnv.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
   !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
-        env,
+        env: policyEnv,
         toolName: "tsgo",
       });
-const pressureGuardError =
-  sparseGuardError || nativeTypecheckRefusalError || !shouldRunHeavyCheck
-    ? null
-    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 
 try {
+  const pressureGuardError =
+    sparseGuardError || nativeTypecheckRefusalError || !shouldRunHeavyCheck
+      ? null
+      : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env: policyEnv });
+
   if (sparseGuardError) {
     console.error(sparseGuardError);
-    if (shouldSkipSparseTsgoGuardError(env)) {
+    if (shouldSkipSparseTsgoGuardError(policyEnv)) {
       console.error("[tsgo] skipping sparse-missing project because OPENCLAW_TSGO_SPARSE_SKIP=1");
       process.exitCode = 0;
     } else {
       process.exitCode = 1;
     }
-  } else if (pressureGuardError) {
-    console.error(pressureGuardError);
-    process.exitCode = 1;
   } else if (nativeTypecheckRefusalError) {
     console.error(nativeTypecheckRefusalError);
     process.exitCode = 1;
+  } else if (pressureGuardError) {
+    console.error(pressureGuardError);
+    process.exitCode = 1;
   } else {
+    const env = shouldRunHeavyCheck
+      ? prepareLocalHeavyCheckEnvironment({ cwd: process.cwd(), env: policyEnv })
+      : policyEnv;
+
+    if (tsBuildInfoFile) {
+      fs.mkdirSync(path.dirname(path.resolve(tsBuildInfoFile)), { recursive: true });
+    }
+
     const tsgo = createManagedCommandInvocation({
       args: finalArgs,
       bin: tsgoPath,

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -5,6 +5,8 @@ import { readFlagValue } from "./lib/arg-utils.mjs";
 import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
+  getLocalHeavyCheckPressureError,
+  prepareLocalHeavyCheckEnvironment,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForTsgo,
 } from "./lib/local-heavy-check-runtime.mjs";
@@ -14,10 +16,11 @@ import {
 } from "./lib/tsgo-sparse-guard.mjs";
 import { createManagedCommandInvocation } from "./lib/managed-child-process.mjs";
 
-const { args: finalArgs, env } = applyLocalTsgoPolicy(
+const { args: finalArgs, env: policyEnv } = applyLocalTsgoPolicy(
   process.argv.slice(2),
   resolveLocalHeavyCheckEnv(process.env),
 );
+const env = prepareLocalHeavyCheckEnvironment({ cwd: process.cwd(), env: policyEnv });
 
 const tsgoPath = path.resolve("node_modules", ".bin", "tsgo");
 const tsBuildInfoFile = readFlagValue(finalArgs, "--tsBuildInfoFile");
@@ -25,10 +28,16 @@ if (tsBuildInfoFile) {
   fs.mkdirSync(path.dirname(path.resolve(tsBuildInfoFile)), { recursive: true });
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
+const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+const pressureGuardError =
+  sparseGuardError || !shouldRunHeavyCheck
+    ? null
+    : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 const releaseLock =
   sparseGuardError ||
+  pressureGuardError ||
   env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
-  !shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env)
+  !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
@@ -45,6 +54,9 @@ try {
     } else {
       process.exitCode = 1;
     }
+  } else if (pressureGuardError) {
+    console.error(pressureGuardError);
+    process.exitCode = 1;
   } else {
     const tsgo = createManagedCommandInvocation({
       args: finalArgs,

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -6,6 +6,7 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
   getLocalHeavyCheckPressureError,
+  getLocalNativeTypecheckRefusalError,
   prepareLocalHeavyCheckEnvironment,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForTsgo,
@@ -29,8 +30,19 @@ if (tsBuildInfoFile) {
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
 const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+const nativeTypecheckRefusalError = sparseGuardError
+  ? null
+  : getLocalNativeTypecheckRefusalError({
+      args: finalArgs,
+      env,
+      shouldRunHeavyCheck,
+      toolName: "tsgo",
+    });
 const releaseLock =
-  sparseGuardError || env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" || !shouldRunHeavyCheck
+  sparseGuardError ||
+  nativeTypecheckRefusalError ||
+  env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
+  !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
@@ -38,7 +50,7 @@ const releaseLock =
         toolName: "tsgo",
       });
 const pressureGuardError =
-  sparseGuardError || !shouldRunHeavyCheck
+  sparseGuardError || nativeTypecheckRefusalError || !shouldRunHeavyCheck
     ? null
     : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 
@@ -53,6 +65,9 @@ try {
     }
   } else if (pressureGuardError) {
     console.error(pressureGuardError);
+    process.exitCode = 1;
+  } else if (nativeTypecheckRefusalError) {
+    console.error(nativeTypecheckRefusalError);
     process.exitCode = 1;
   } else {
     const tsgo = createManagedCommandInvocation({

--- a/scripts/run-tsgo.mjs
+++ b/scripts/run-tsgo.mjs
@@ -6,6 +6,7 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalTsgoPolicy,
   getLocalHeavyCheckPressureError,
+  getLocalNativeTypecheckRefusalError,
   prepareLocalHeavyCheckEnvironment,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForTsgo,
@@ -28,8 +29,19 @@ if (tsBuildInfoFile) {
 }
 const sparseGuardError = getSparseTsgoGuardError(finalArgs, { cwd: process.cwd() });
 const shouldRunHeavyCheck = shouldAcquireLocalHeavyCheckLockForTsgo(finalArgs, env);
+const nativeTypecheckRefusalError = sparseGuardError
+  ? null
+  : getLocalNativeTypecheckRefusalError({
+      args: finalArgs,
+      env,
+      shouldRunHeavyCheck,
+      toolName: "tsgo",
+    });
 const releaseLock =
-  sparseGuardError || env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" || !shouldRunHeavyCheck
+  sparseGuardError ||
+  nativeTypecheckRefusalError ||
+  env.OPENCLAW_TSGO_HEAVY_CHECK_LOCK_HELD === "1" ||
+  !shouldRunHeavyCheck
     ? () => {}
     : acquireLocalHeavyCheckLockSync({
         cwd: process.cwd(),
@@ -37,7 +49,7 @@ const releaseLock =
         toolName: "tsgo",
       });
 const pressureGuardError =
-  sparseGuardError || !shouldRunHeavyCheck
+  sparseGuardError || nativeTypecheckRefusalError || !shouldRunHeavyCheck
     ? null
     : getLocalHeavyCheckPressureError({ cwd: process.cwd(), env });
 
@@ -52,6 +64,9 @@ try {
     }
   } else if (pressureGuardError) {
     console.error(pressureGuardError);
+    process.exitCode = 1;
+  } else if (nativeTypecheckRefusalError) {
+    console.error(nativeTypecheckRefusalError);
     process.exitCode = 1;
   } else {
     const result = spawnSync(tsgoPath, finalArgs, {

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -141,7 +141,10 @@ export function buildCliAgentSystemPrompt(params: {
   });
 }
 
-/** Back-compat alias for the CLI system prompt builder. */
+/**
+ * Back-compat alias for the CLI system prompt builder.
+ * @deprecated Use buildCliAgentSystemPrompt instead.
+ */
 export const buildSystemPrompt = buildCliAgentSystemPrompt;
 
 /** Applies backend model aliases to a requested CLI model id. */

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import type { OpenClawConfig } from "../config/config.js";
 import { loggingState } from "../logging/state.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { agentCliCommand, agentViaGatewayTesting } from "./agent-via-gateway.js";
+import { __testing as agentViaGatewayTesting, agentCliCommand } from "./agent-via-gateway.js";
 import type { agentCommand as AgentCommand } from "./agent.js";
 
 const loadConfig = vi.hoisted(() => vi.fn());

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -146,7 +146,7 @@ function loadReplyPayloadModule() {
   return replyPayloadModulePromise;
 }
 
-export const agentViaGatewayTesting = {
+const testing = {
   resetLazyImportsForTests(): void {
     embeddedAgentCommandPromise = undefined;
     agentSessionModulePromise = undefined;
@@ -163,6 +163,8 @@ export const agentViaGatewayTesting = {
     gatewayAbortRetryDelaysMsForTests = delays;
   },
 };
+
+export { testing as __testing };
 
 function protectJsonStdout(opts: Pick<AgentCliOpts, "json">): void {
   if (opts.json === true) {

--- a/src/cron/isolated-agent.run-timeout-override.test.ts
+++ b/src/cron/isolated-agent.run-timeout-override.test.ts
@@ -20,7 +20,7 @@ describe("resolveCronRunTimeoutOverrideMs", () => {
     expect(resolveCronRunTimeoutOverrideMs(Number.MAX_SAFE_INTEGER)).toBe(MAX_TIMER_TIMEOUT_MS);
   });
 
-  it("omits the signal when the cron payload has no positive numeric timeout", () => {
+  it("ignores missing, invalid, or non-positive timeout values", () => {
     expect(resolveCronRunTimeoutOverrideMs(undefined)).toBeUndefined();
     expect(resolveCronRunTimeoutOverrideMs(0)).toBeUndefined();
     expect(resolveCronRunTimeoutOverrideMs(-1)).toBeUndefined();

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -90,7 +90,6 @@ import {
   resolveThinkingDefault,
   setSessionRuntimeModel,
 } from "./run.runtime.js";
-import { resolveCronRunTimeoutOverrideMs } from "./run-timeout.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -90,6 +90,7 @@ import {
   resolveThinkingDefault,
   setSessionRuntimeModel,
 } from "./run.runtime.js";
+import { resolveCronRunTimeoutOverrideMs } from "./run-timeout.js";
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { resolveCronAgentSessionKey } from "./session-key.js";
 import { resolveCronSession } from "./session.js";

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -214,7 +214,7 @@ describe("production lint suppressions", () => {
         "src/plugin-sdk/test-helpers/public-surface-loader.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugin-sdk/test-helpers/subagent-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/hooks.ts|typescript/no-unnecessary-type-parameters|1",
-        "src/plugins/host-hook-runtime.ts|typescript/no-unnecessary-type-parameters|2",
+        "src/plugins/host-hook-runtime.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hook-state.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/host-hooks.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/lazy-service-module.ts|typescript/no-unnecessary-type-parameters|1",

--- a/test/scripts/local-heavy-check-pressure.test.ts
+++ b/test/scripts/local-heavy-check-pressure.test.ts
@@ -1,0 +1,53 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { spawnSyncMock } = vi.hoisted(() => ({
+  spawnSyncMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importActual) => ({
+  ...(await importActual<typeof import("node:child_process")>()),
+  spawnSync: spawnSyncMock,
+}));
+
+const { getLocalHeavyCheckPressureError } =
+  await import("../../scripts/lib/local-heavy-check-runtime.mjs");
+
+const { createTempDir } = createScriptTestHarness();
+
+describe("local heavy-check pressure guard", () => {
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+  });
+
+  it("checks pressure on the effective heavy-check temp directory", () => {
+    const cwd = createTempDir("openclaw-heavy-check-pressure-");
+    const tempDir = path.join(cwd, ".heavy-check-tmp");
+
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: [
+        "Filesystem 1024-blocks Used Available Capacity Mounted on",
+        "/dev/fake 1024000 921600 102400 90% /fake-heavy-tmp",
+      ].join("\n"),
+    });
+
+    expect(
+      getLocalHeavyCheckPressureError({
+        cwd,
+        env: {
+          OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tempDir,
+          OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES: "1",
+          OPENCLAW_HEAVY_CHECK_MIN_TMP_AVAILABLE_BYTES: `${1024 * 1024 ** 2}`,
+        },
+      }),
+    ).toContain("temp directory available 100 MiB is below 1.0 GiB");
+
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      "df",
+      ["-Pk", tempDir],
+      expect.objectContaining({ cwd }),
+    );
+  });
+});

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -233,10 +233,21 @@ describe("local-heavy-check-runtime", () => {
     ).toBe(true);
   });
 
-  it("refuses local native type-aware checks by default", () => {
+  it("keeps local native type-aware checks compatible by default", () => {
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        args: ["--extendedDiagnostics"],
+        env: makeEnv(),
+        shouldRunHeavyCheck: true,
+        toolName: "tsgo",
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses local native type-aware checks when the strict refusal guard is enabled", () => {
     const error = getLocalNativeTypecheckRefusalError({
       args: ["--extendedDiagnostics"],
-      env: makeEnv(),
+      env: makeEnv({ OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK: "1" }),
       shouldRunHeavyCheck: true,
       toolName: "tsgo",
     });

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -33,6 +33,9 @@ function makeEnv(overrides: Record<string, string | undefined> = {}) {
   if (!Object.hasOwn(overrides, "OPENCLAW_LOCAL_CHECK_MODE")) {
     delete env.OPENCLAW_LOCAL_CHECK_MODE;
   }
+  if (!Object.hasOwn(overrides, "CI")) {
+    delete env.CI;
+  }
   return env;
 }
 

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -36,6 +36,9 @@ function makeEnv(overrides: Record<string, string | undefined> = {}) {
   if (!Object.hasOwn(overrides, "CI")) {
     delete env.CI;
   }
+  if (!Object.hasOwn(overrides, "GITHUB_ACTIONS")) {
+    delete env.GITHUB_ACTIONS;
+  }
   return env;
 }
 

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -6,6 +6,7 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
   applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForOxlint,
   shouldAcquireLocalHeavyCheckLockForTsgo,
@@ -224,6 +225,55 @@ describe("local-heavy-check-runtime", () => {
         makeEnv({ OPENCLAW_TSGO_FORCE_LOCK: "1" }),
       ),
     ).toBe(true);
+  });
+
+  it("refuses local native type-aware checks by default", () => {
+    const error = getLocalNativeTypecheckRefusalError({
+      args: ["--extendedDiagnostics"],
+      env: makeEnv(),
+      shouldRunHeavyCheck: true,
+      toolName: "tsgo",
+    });
+
+    expect(error).toContain("Refusing to start tsgo on this local host");
+    expect(error).toContain("GitHub CI");
+  });
+
+  it("allows local native type-aware checks in CI, full mode, or explicit break-glass mode", () => {
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ CI: "true" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_LOCAL_CHECK_MODE: "full" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_HEAVY_CHECK_FORCE: "1" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK: "1" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not refuse metadata-only native tool commands", () => {
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        args: ["--help"],
+        env: makeEnv(),
+        shouldRunHeavyCheck: false,
+      }),
+    ).toBeNull();
   });
 
   it("serializes local oxlint runs onto one thread on constrained hosts", () => {

--- a/test/scripts/local-heavy-check-runtime.test.ts
+++ b/test/scripts/local-heavy-check-runtime.test.ts
@@ -5,6 +5,7 @@ import {
   acquireLocalHeavyCheckLockSync,
   applyLocalOxlintPolicy,
   applyLocalTsgoPolicy,
+  getLocalNativeTypecheckRefusalError,
   resolveLocalHeavyCheckEnv,
   shouldAcquireLocalHeavyCheckLockForOxlint,
   shouldAcquireLocalHeavyCheckLockForTsgo,
@@ -223,6 +224,55 @@ describe("local-heavy-check-runtime", () => {
         makeEnv({ OPENCLAW_TSGO_FORCE_LOCK: "1" }),
       ),
     ).toBe(true);
+  });
+
+  it("refuses local native type-aware checks by default", () => {
+    const error = getLocalNativeTypecheckRefusalError({
+      args: ["--extendedDiagnostics"],
+      env: makeEnv(),
+      shouldRunHeavyCheck: true,
+      toolName: "tsgo",
+    });
+
+    expect(error).toContain("Refusing to start tsgo on this local host");
+    expect(error).toContain("GitHub CI");
+  });
+
+  it("allows local native type-aware checks in CI, full mode, or explicit break-glass mode", () => {
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ CI: "true" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_LOCAL_CHECK_MODE: "full" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_HEAVY_CHECK_FORCE: "1" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        env: makeEnv({ OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK: "1" }),
+        shouldRunHeavyCheck: true,
+      }),
+    ).toBeNull();
+  });
+
+  it("does not refuse metadata-only native tool commands", () => {
+    expect(
+      getLocalNativeTypecheckRefusalError({
+        args: ["--help"],
+        env: makeEnv(),
+        shouldRunHeavyCheck: false,
+      }),
+    ).toBeNull();
   });
 
   it("serializes local oxlint runs onto one thread on constrained hosts", () => {

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import fs, { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path, { join } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
@@ -22,6 +22,9 @@ import {
   shouldPrepareExtensionPackageBoundaryArtifacts,
   shouldRunNativeTypeAwareOxlint,
 } from "../../scripts/run-oxlint.mjs";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
 
 describe("run-oxlint", () => {
   it("prepares extension package boundary artifacts for normal lint runs", () => {
@@ -609,5 +612,26 @@ describe("run-oxlint", () => {
       skippedTargets: [],
       skippedConfigs: [],
     });
+  });
+
+  it("does not create local heavy-check temp directories when sharded oxlint is refused", () => {
+    const tmpDir = path.join(createTempDir("openclaw-run-oxlint-refused-"), "heavy-tmp");
+    const result = spawnSync(process.execPath, ["scripts/run-oxlint-shards.mjs"], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "Refusing to start sharded type-aware oxlint on this local host",
+    );
+    expect(fs.existsSync(tmpDir)).toBe(false);
   });
 });

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   filterSparseMissingOxlintTargets,
   shouldPrepareExtensionPackageBoundaryArtifacts,
+  shouldRunNativeTypeAwareOxlint,
 } from "../../scripts/run-oxlint.mjs";
 
 describe("run-oxlint", () => {
@@ -27,6 +28,12 @@ describe("run-oxlint", () => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts([])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["src/index.ts"])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--type-aware"])).toBe(true);
+  });
+
+  it("treats type-aware oxlint as native type-aware work even with explicit file targets", () => {
+    expect(shouldRunNativeTypeAwareOxlint(["--type-aware", "--", "src/index.ts"])).toBe(true);
+    expect(shouldRunNativeTypeAwareOxlint(["src/index.ts"])).toBe(false);
+    expect(shouldRunNativeTypeAwareOxlint(["--help", "--type-aware"])).toBe(false);
   });
 
   it("skips artifact preparation for metadata-only oxlint commands", () => {

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -654,4 +654,30 @@ describe("run-oxlint", () => {
     expect(result.stderr).not.toContain("Refusing to start sharded type-aware oxlint");
     expect(fs.existsSync(tmpDir)).toBe(false);
   });
+
+  it("delegates explicit file-target sharded oxlint requests before heavy setup", () => {
+    const fixtureDir = createTempDir("openclaw-run-oxlint-file-target-");
+    const fixtureFile = path.join(fixtureDir, "target.ts");
+    const tmpDir = path.join(fixtureDir, "heavy-tmp");
+    fs.writeFileSync(fixtureFile, "export const ok = 1;\n");
+
+    const result = spawnSync(process.execPath, ["scripts/run-oxlint-shards.mjs", fixtureFile], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).not.toContain("prepare-extension-package-boundary-artifacts");
+    expect(result.stderr).not.toContain("[oxlint:core] starting");
+    expect(result.stderr).toContain("Refusing to start type-aware oxlint");
+    expect(result.stderr).not.toContain("Refusing to start sharded type-aware oxlint");
+    expect(fs.existsSync(tmpDir)).toBe(false);
+  });
 });

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -635,6 +635,24 @@ describe("run-oxlint", () => {
     expect(fs.existsSync(tmpDir)).toBe(false);
   });
 
+  it("refuses bundled extension oxlint when strict native refusal is enabled", () => {
+    const result = spawnSync(process.execPath, ["scripts/run-bundled-extension-oxlint.mjs"], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK: "1",
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to start oxlint-bundled-extensions");
+    expect(result.stderr).not.toContain("prepare-extension-package-boundary-artifacts");
+  });
+
   it("delegates sharded metadata-only commands before heavy setup", () => {
     const tmpDir = path.join(createTempDir("openclaw-run-oxlint-metadata-"), "heavy-tmp");
     const result = spawnSync(process.execPath, ["scripts/run-oxlint-shards.mjs", "--help"], {

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -546,14 +546,13 @@ describe("run-oxlint", () => {
 
   it("rejects invalid Windows oxlint extension chunk size overrides", () => {
     expect(resolveWindowsExtensionChunkSize({})).toBe(8);
-    expect(
-      () => resolveWindowsExtensionChunkSize({ OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE: "0" }),
+    expect(() =>
+      resolveWindowsExtensionChunkSize({ OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE: "0" }),
     ).toThrow("OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE must be a positive integer; got: 0");
-    expect(
-      () =>
-        resolveWindowsExtensionChunkSize({
-          OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE: "8 chunks",
-        }),
+    expect(() =>
+      resolveWindowsExtensionChunkSize({
+        OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE: "8 chunks",
+      }),
     ).toThrow(
       "OPENCLAW_OXLINT_WINDOWS_EXTENSION_CHUNK_SIZE must be a positive integer; got: 8 chunks",
     );
@@ -624,6 +623,7 @@ describe("run-oxlint", () => {
         CI: "",
         GITHUB_ACTIONS: "",
         OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK: "1",
         OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
       },
     });
@@ -669,6 +669,7 @@ describe("run-oxlint", () => {
         CI: "",
         GITHUB_ACTIONS: "",
         OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK: "1",
         OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
       },
     });

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -634,4 +634,24 @@ describe("run-oxlint", () => {
     );
     expect(fs.existsSync(tmpDir)).toBe(false);
   });
+
+  it("delegates sharded metadata-only commands before heavy setup", () => {
+    const tmpDir = path.join(createTempDir("openclaw-run-oxlint-metadata-"), "heavy-tmp");
+    const result = spawnSync(process.execPath, ["scripts/run-oxlint-shards.mjs", "--help"], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
+      },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain("prepare-extension-package-boundary-artifacts");
+    expect(result.stderr).not.toContain("Refusing to start sharded type-aware oxlint");
+    expect(fs.existsSync(tmpDir)).toBe(false);
+  });
 });

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   filterSparseMissingOxlintTargets,
   shouldPrepareExtensionPackageBoundaryArtifacts,
+  shouldRunNativeTypeAwareOxlint,
 } from "../../scripts/run-oxlint.mjs";
 
 describe("run-oxlint", () => {
@@ -10,6 +11,12 @@ describe("run-oxlint", () => {
     expect(shouldPrepareExtensionPackageBoundaryArtifacts([])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["src/index.ts"])).toBe(true);
     expect(shouldPrepareExtensionPackageBoundaryArtifacts(["--type-aware"])).toBe(true);
+  });
+
+  it("treats type-aware oxlint as native type-aware work even with explicit file targets", () => {
+    expect(shouldRunNativeTypeAwareOxlint(["--type-aware", "--", "src/index.ts"])).toBe(true);
+    expect(shouldRunNativeTypeAwareOxlint(["src/index.ts"])).toBe(false);
+    expect(shouldRunNativeTypeAwareOxlint(["--help", "--type-aware"])).toBe(false);
   });
 
   it("skips artifact preparation for metadata-only oxlint commands", () => {

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -213,5 +214,77 @@ describe("run-tsgo pressure guard", () => {
     expect(env.TEMP).toBe(expectedTmp);
     expect(env.TMP).toBe(expectedTmp);
     expect(fs.existsSync(expectedTmp)).toBe(true);
+  });
+
+  it("samples pressure after a queued heavy-check lock is acquired", async () => {
+    const cwd = createTempDir("openclaw-run-tsgo-queued-pressure-");
+    const gitDir = path.join(cwd, ".git");
+    const lockDir = path.join(gitDir, "openclaw-local-checks", "heavy-check.lock");
+    const fakeTsgo = path.join(
+      cwd,
+      "node_modules",
+      ".bin",
+      process.platform === "win32" ? "tsgo.cmd" : "tsgo",
+    );
+    const ranMarker = path.join(cwd, "tsgo-ran");
+
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, tool: "existing-check", cwd })}\n`,
+      "utf8",
+    );
+    fs.mkdirSync(path.dirname(fakeTsgo), { recursive: true });
+    fs.writeFileSync(
+      fakeTsgo,
+      process.platform === "win32"
+        ? `@echo off\r\ntype nul > "${ranMarker}"\r\n`
+        : `#!/usr/bin/env sh\ntouch "${ranMarker}"\n`,
+      "utf8",
+    );
+    fs.chmodSync(fakeTsgo, 0o755);
+
+    const child = spawn(process.execPath, [path.join(process.cwd(), "scripts", "run-tsgo.mjs")], {
+      cwd,
+      env: {
+        ...process.env,
+        OPENCLAW_LOCAL_CHECK: "1",
+        OPENCLAW_LOCAL_CHECK_MODE: "full",
+        OPENCLAW_HEAVY_CHECK_LOCK_POLL_MS: "10",
+        OPENCLAW_HEAVY_CHECK_LOCK_PROGRESS_MS: "50",
+        OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS: "5000",
+        OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES: `${Number.MAX_SAFE_INTEGER}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (stderr.includes("queued behind the local heavy-check lock")) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+      }
+    });
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`run-tsgo did not exit after queued lock release. stderr:\n${stderr}`));
+      }, 10_000);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+
+    expect(stderr).toContain("queued behind the local heavy-check lock");
+    expect(stderr).toContain("Refusing to start a local heavy check");
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(ranMarker)).toBe(false);
   });
 });

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  getLocalHeavyCheckPressureError,
+  prepareLocalHeavyCheckEnvironment,
+} from "../../scripts/lib/local-heavy-check-runtime.mjs";
+import {
   createSparseTsgoSkipEnv,
   getSparseTsgoGuardError,
   shouldSkipSparseTsgoGuardError,
@@ -151,5 +155,63 @@ describe("run-tsgo sparse guard", () => {
       PATH: "/usr/bin",
       OPENCLAW_TSGO_SPARSE_SKIP: "1",
     });
+  });
+});
+
+describe("run-tsgo pressure guard", () => {
+  it("allows heavy checks when memory and temp space have headroom", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: {},
+        hostPressure: {
+          memAvailableBytes: 4 * 1024 ** 3,
+          tmpAvailableBytes: 2 * 1024 ** 3,
+          tmpUsedPercent: 25,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses heavy checks when temp space or memory is already pressured", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: {},
+        hostPressure: {
+          memAvailableBytes: 512 * 1024 ** 2,
+          tmpAvailableBytes: 256 * 1024 ** 2,
+          tmpUsedPercent: 91,
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      "Refusing to start a local heavy check because this host is already under pressure:
+      - MemAvailable 512 MiB is below 1.5 GiB
+      - temp directory available 256 MiB is below 1.0 GiB
+      - temp directory is 91% used (limit 80%)
+      Wait for pressure to clear, free temp space, or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 if you really mean it."
+    `);
+  });
+
+  it("lets explicit force bypass pressure refusal", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: { OPENCLAW_HEAVY_CHECK_FORCE: "1" },
+        hostPressure: {
+          memAvailableBytes: 1,
+          tmpAvailableBytes: 1,
+          tmpUsedPercent: 99,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("routes local heavy-check temp files into the worktree artifact directory", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-");
+    const env = prepareLocalHeavyCheckEnvironment({ cwd, env: {} });
+    const expectedTmp = path.join(cwd, ".artifacts", "tmp", "local-heavy-checks");
+
+    expect(env.TMPDIR).toBe(expectedTmp);
+    expect(env.TEMP).toBe(expectedTmp);
+    expect(env.TMP).toBe(expectedTmp);
+    expect(fs.existsSync(expectedTmp)).toBe(true);
   });
 });

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -208,6 +208,25 @@ describe("run-tsgo pressure guard", () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it("does not create local heavy-check temp directories when local tsgo is refused", () => {
+    const tmpDir = path.join(createTempDir("openclaw-run-tsgo-refused-"), "heavy-tmp");
+    const result = spawnSync(process.execPath, ["scripts/run-tsgo.mjs", "--extendedDiagnostics"], {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "",
+        GITHUB_ACTIONS: "",
+        OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
+      },
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Refusing to start tsgo on this local host");
+    expect(fs.existsSync(tmpDir)).toBe(false);
   });
 
   it("routes local heavy-check temp files into the worktree artifact directory", () => {

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -220,6 +220,7 @@ describe("run-tsgo pressure guard", () => {
         CI: "",
         GITHUB_ACTIONS: "",
         OPENCLAW_LOCAL_CHECK_MODE: "",
+        OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK: "1",
         OPENCLAW_LOCAL_HEAVY_CHECK_TMPDIR: tmpDir,
       },
     });

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -218,5 +219,77 @@ describe("run-tsgo pressure guard", () => {
     expect(env.TEMP).toBe(expectedTmp);
     expect(env.TMP).toBe(expectedTmp);
     expect(fs.existsSync(expectedTmp)).toBe(true);
+  });
+
+  it("samples pressure after a queued heavy-check lock is acquired", async () => {
+    const cwd = createTempDir("openclaw-run-tsgo-queued-pressure-");
+    const gitDir = path.join(cwd, ".git");
+    const lockDir = path.join(gitDir, "openclaw-local-checks", "heavy-check.lock");
+    const fakeTsgo = path.join(
+      cwd,
+      "node_modules",
+      ".bin",
+      process.platform === "win32" ? "tsgo.cmd" : "tsgo",
+    );
+    const ranMarker = path.join(cwd, "tsgo-ran");
+
+    fs.mkdirSync(lockDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lockDir, "owner.json"),
+      `${JSON.stringify({ pid: process.pid, tool: "existing-check", cwd })}\n`,
+      "utf8",
+    );
+    fs.mkdirSync(path.dirname(fakeTsgo), { recursive: true });
+    fs.writeFileSync(
+      fakeTsgo,
+      process.platform === "win32"
+        ? `@echo off\r\ntype nul > "${ranMarker}"\r\n`
+        : `#!/usr/bin/env sh\ntouch "${ranMarker}"\n`,
+      "utf8",
+    );
+    fs.chmodSync(fakeTsgo, 0o755);
+
+    const child = spawn(process.execPath, [path.join(process.cwd(), "scripts", "run-tsgo.mjs")], {
+      cwd,
+      env: {
+        ...process.env,
+        OPENCLAW_LOCAL_CHECK: "1",
+        OPENCLAW_LOCAL_CHECK_MODE: "full",
+        OPENCLAW_HEAVY_CHECK_LOCK_POLL_MS: "10",
+        OPENCLAW_HEAVY_CHECK_LOCK_PROGRESS_MS: "50",
+        OPENCLAW_HEAVY_CHECK_LOCK_TIMEOUT_MS: "5000",
+        OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES: `${Number.MAX_SAFE_INTEGER}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+      if (stderr.includes("queued behind the local heavy-check lock")) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+      }
+    });
+
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`run-tsgo did not exit after queued lock release. stderr:\n${stderr}`));
+      }, 10_000);
+      child.on("error", (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+      child.on("exit", (code) => {
+        clearTimeout(timeout);
+        resolve(code);
+      });
+    });
+
+    expect(stderr).toContain("queued behind the local heavy-check lock");
+    expect(stderr).toContain("Refusing to start a local heavy check");
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(ranMarker)).toBe(false);
   });
 });

--- a/test/scripts/run-tsgo.test.ts
+++ b/test/scripts/run-tsgo.test.ts
@@ -2,6 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  getLocalHeavyCheckPressureError,
+  prepareLocalHeavyCheckEnvironment,
+} from "../../scripts/lib/local-heavy-check-runtime.mjs";
+import {
   createSparseTsgoSkipEnv,
   getSparseTsgoGuardError,
   shouldSkipSparseTsgoGuardError,
@@ -156,5 +160,63 @@ describe("run-tsgo sparse guard", () => {
       PATH: "/usr/bin",
       OPENCLAW_TSGO_SPARSE_SKIP: "1",
     });
+  });
+});
+
+describe("run-tsgo pressure guard", () => {
+  it("allows heavy checks when memory and temp space have headroom", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: {},
+        hostPressure: {
+          memAvailableBytes: 4 * 1024 ** 3,
+          tmpAvailableBytes: 2 * 1024 ** 3,
+          tmpUsedPercent: 25,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses heavy checks when temp space or memory is already pressured", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: {},
+        hostPressure: {
+          memAvailableBytes: 512 * 1024 ** 2,
+          tmpAvailableBytes: 256 * 1024 ** 2,
+          tmpUsedPercent: 91,
+        },
+      }),
+    ).toMatchInlineSnapshot(`
+      "Refusing to start a local heavy check because this host is already under pressure:
+      - MemAvailable 512 MiB is below 1.5 GiB
+      - temp directory available 256 MiB is below 1.0 GiB
+      - temp directory is 91% used (limit 80%)
+      Wait for pressure to clear, free temp space, or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 if you really mean it."
+    `);
+  });
+
+  it("lets explicit force bypass pressure refusal", () => {
+    expect(
+      getLocalHeavyCheckPressureError({
+        env: { OPENCLAW_HEAVY_CHECK_FORCE: "1" },
+        hostPressure: {
+          memAvailableBytes: 1,
+          tmpAvailableBytes: 1,
+          tmpUsedPercent: 99,
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("routes local heavy-check temp files into the worktree artifact directory", () => {
+    const cwd = createTempDir("openclaw-run-tsgo-");
+    const env = prepareLocalHeavyCheckEnvironment({ cwd, env: {} });
+    const expectedTmp = path.join(cwd, ".artifacts", "tmp", "local-heavy-checks");
+
+    expect(env.TMPDIR).toBe(expectedTmp);
+    expect(env.TEMP).toBe(expectedTmp);
+    expect(env.TMP).toBe(expectedTmp);
+    expect(fs.existsSync(expectedTmp)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- keep local native type-aware checks compatible by default
- retain the host-pressure refusal guard for local heavy checks when memory or temp headroom is too low
- make the broader native type-aware refusal an explicit opt-in guard via `OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK=1`
- keep CI/GitHub Actions unblocked so broad native checks run online instead of on constrained hosts
- preserve explicit break-glass overrides for local runs
- keep effective heavy-check temp-dir routing from the earlier patch

## Why
A constrained Raspberry Pi/agent host repeatedly became unstable when native type-aware checks (`tsgo`/`tsgolint` via type-aware oxlint) ran locally. The safe repo-wide default still needs to preserve existing developer workflows, so this PR now separates the two policies:

- pressure-based refusal remains automatic when the local host is already unsafe
- fail-closed native type-aware refusal is available only when an operator opts into it

That addresses the constrained-host use case without silently breaking normal local `pnpm tsgo:*`, `pnpm lint`, or direct wrapper workflows.

## Behavior
Automatic local pressure checks still refuse heavy checks when headroom is too low:

- `OPENCLAW_HEAVY_CHECK_MIN_MEM_AVAILABLE_BYTES` defaults to `1.5 GiB`
- `OPENCLAW_HEAVY_CHECK_MIN_TMP_AVAILABLE_BYTES` defaults to `1 GiB`
- `OPENCLAW_HEAVY_CHECK_MAX_TMP_USED_PERCENT` defaults to `80`

The stricter native type-aware refusal only applies when `OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK=1` is set and local heavy-check policy is active:

- `scripts/run-tsgo.mjs`
- `scripts/run-oxlint.mjs` when it runs type-aware oxlint, including explicit file-target runs
- `scripts/run-oxlint-shards.mjs` before artifact prep or child shard spawning
- `scripts/check-extension-package-tsc-boundary.mjs`
- `scripts/check-tsgo-core-boundary.mjs`
- `scripts/profile-tsgo.mjs`

Bypasses / allowed cases:

- default local native type-aware checks remain runnable for compatibility
- GitHub Actions / CI are not blocked
- metadata-only commands are not blocked
- `OPENCLAW_LOCAL_CHECK_MODE=full` allows the local run
- `OPENCLAW_HEAVY_CHECK_FORCE=1` allows the local run
- `OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1` allows the local run
- child processes already covered by a parent heavy-check lock can continue without self-deadlock

## GitHub CI note
GitHub CI means broad validation runs online on GitHub/runner machines after pushing the branch, not on the local Raspberry Pi. The PR gets pass/fail status from those remote runners.

## Test Plan
Current head: `5351871501dbf710b5d9742104e3640058865d82`

Local checks intentionally stayed narrow. Broad lint/test/type-aware gates are left to GitHub CI.

## Real behavior proof

- **Behavior or issue addressed:** Local OpenClaw heavy-check wrappers keep automatic pressure refusal for unsafe constrained hosts, strict native/type-aware refusal remains opt-in, and the same opt-in refusal now reaches the shared extension oxlint wrapper path instead of letting bundled extension oxlint bypass it.
- **Real environment tested:** Raspberry Pi OpenClaw checkout on branch `fix/local-tsgo-pressure-guard`, current head `2b9475b1373bb99dd8adae381a88c2f363b44414`. Broad lint/build/typecheck remain delegated to GitHub CI/remote runners.
- **Exact steps or command run after this patch:**

```bash
node --check scripts/lib/local-heavy-check-runtime.mjs
node --check scripts/lib/run-extension-oxlint.mjs
env -u CI -u GITHUB_ACTIONS OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK=1 node scripts/run-bundled-extension-oxlint.mjs
node scripts/test-projects.mjs test/scripts/run-oxlint.test.ts test/scripts/local-heavy-check-runtime.test.ts test/scripts/run-tsgo.test.ts
```

- **Evidence after fix:**

```text
### syntax checks
exit=0

### strict refusal reaches bundled extension oxlint wrapper before artifact prep
Refusing to start oxlint-bundled-extensions on this local host.
Native type-aware checks can exhaust constrained developer/agent machines; this opt-in guard keeps them on GitHub CI, Blacksmith/Testbox, or another remote worker instead.
If you really mean to run this locally, unset OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK or rerun with OPENCLAW_HEAVY_CHECK_FORCE=1 or OPENCLAW_ALLOW_LOCAL_NATIVE_TYPECHECK=1.
exit=1

### targeted wrapper tests
Test Files  3 passed (3)
Tests  76 passed (76)
[test] passed 1 Vitest shard
```

- **Observed result after fix:** Default local strict native refusal is still not active unless `OPENCLAW_REFUSE_LOCAL_NATIVE_TYPECHECK=1` is set; opt-in strict refusal exits before bundled extension oxlint artifact prep/spawn; pressure/native wrapper regression tests pass.
- **What was not tested:** Broad CI, full lint, full build, and full typecheck were intentionally not run locally on the Raspberry Pi. Full validation is delegated to GitHub CI/remote runners.
