### PR TITLE
Fix stale no-progress loop blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
   untrusted text in agent context while preserving raw transcript mention
   detection. Closes #33360. Thanks @smartchainark.
 - Control UI/Quick Settings: persist the assistant avatar override to browser local storage (mirroring the user avatar) so uploaded image data URLs no longer fail config validation with "Too big: expected string to have <=200 characters". Also lift the gateway-side `ui.assistant.avatar` length cap to match the user avatar size budget for non-UI clients writing the field directly. Thanks @BunsDev.
+- Agents/tool-loop: scope no-progress loop detection to the current repeated tool-call tail, so an agent can retry a polling tool after doing other work without being blocked by stale identical results. Thanks @LyazS.
 - Browser/CDP: make readiness diagnostics use the same discovery-first fallback as reachability for bare `ws://` Browserless and Browserbase CDP URLs. Fixes #69532.
 - ACP/OpenCode: update the bundled acpx runtime to 0.6.0 and cover the OpenCode ACP bind path in Docker live tests.
 - Browser/existing-session: support per-profile Chrome MCP command/args, map `cdpUrl` to `--browserUrl` or `--wsEndpoint`, and avoid combining endpoint flags with `--userDataDir`. Fixes #47879, #48037, and #62706. Thanks @puneet1409, @zhehao, and @madkow1001.

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -446,6 +446,31 @@ describe("tool-loop-detection", () => {
       expect(loopResult.stuck).toBe(false);
     });
 
+    it("does not block known polling after another tool breaks the no-progress tail", () => {
+      const state = createState();
+      const { params, result } = createNoProgressPollFixture("sess-tail");
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "process",
+        toolParams: params,
+        result,
+        count: CRITICAL_THRESHOLD,
+      });
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: "read",
+        toolParams: { path: "/status.txt" },
+        result: {
+          content: [{ type: "text", text: "checked another signal" }],
+          details: { ok: true },
+        },
+        count: WARNING_THRESHOLD,
+      });
+
+      const loopResult = detectToolCallLoop(state, "process", params, enabledLoopDetectionConfig);
+      expect(loopResult.stuck).toBe(false);
+    });
+
     it("blocks any tool with global no-progress breaker at 30", () => {
       const fixture = createReadNoProgressFixture();
       const loopResult = detectLoopAfterRepeatedCalls({
@@ -459,6 +484,37 @@ describe("tool-loop-detection", () => {
         expect(loopResult.level).toBe("critical");
         expect(loopResult.detector).toBe("global_circuit_breaker");
         expect(loopResult.message).toContain("global circuit breaker");
+      }
+    });
+
+    it("keeps global no-progress breaker scoped to the current repeated tail", () => {
+      const state = createState();
+      const fixture = createReadNoProgressFixture();
+      recordRepeatedSuccessfulCalls({
+        state,
+        toolName: fixture.toolName,
+        toolParams: fixture.params,
+        result: fixture.result,
+        count: GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+      });
+      recordSuccessfulCall(
+        state,
+        "list",
+        { dir: "/workspace" },
+        { content: [{ type: "text", text: "workspace files" }], details: { ok: true } },
+        0,
+      );
+
+      const loopResult = detectToolCallLoop(
+        state,
+        fixture.toolName,
+        fixture.params,
+        enabledLoopDetectionConfig,
+      );
+      expect(loopResult.stuck).toBe(true);
+      if (loopResult.stuck) {
+        expect(loopResult.level).toBe("warning");
+        expect(loopResult.detector).toBe("generic_repeat");
       }
     });
 

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -296,10 +296,10 @@ function getNoProgressStreak(
   for (let i = history.length - 1; i >= 0; i -= 1) {
     const record = history[i];
     if (!record || record.toolName !== toolName || record.argsHash !== argsHash) {
-      continue;
+      break;
     }
     if (typeof record.resultHash !== "string" || !record.resultHash) {
-      continue;
+      break;
     }
     if (!latestResultHash) {
       latestResultHash = record.resultHash;


### PR DESCRIPTION
## Summary

- Problem: no-progress loop detection scanned the whole recent history for matching tool name/args/result, so stale polling attempts could block a later retry even after the agent used other tools.
- Why it matters: a tool can legitimately start returning useful data after the agent waits or performs other work; stale identical results should not make that later retry look stuck.
- What changed: `getNoProgressStreak` now stops at the first non-matching or missing-result record, matching the current-tail semantics used by other repeat detectors.
- What did NOT change (scope boundary): unknown-tool repeat detection and generic repeat warning behavior keep their existing thresholds and policy.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `getNoProgressStreak` used `continue` for records with a different tool name/args or missing result hash, so it counted non-contiguous stale matches from earlier in the history.
- Missing detection / guardrail: tests covered repeated no-progress calls but did not cover interleaving another tool between old polling attempts and a later retry.
- Contributing context (if known): unknown-tool repeat detection already used contiguous-tail semantics, which made this helper inconsistent with the surrounding loop detection model.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/tool-loop-detection.test.ts`
- Scenario the test should lock in: `process` polling repeats hit the critical threshold, another tool call breaks the tail, and a later `process` retry is not blocked by stale no-progress results.
- Why this is the smallest reliable guardrail: the bug is in the pure loop-detection helper and can be isolated with synthetic history records.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Agents can retry a previously no-progress polling tool after doing other work without being blocked by stale identical results from earlier in the turn history.

## Diagram (if applicable)

```text
Before:
A(no progress) x threshold -> B -> retry A -> blocked by stale A history

After:
A(no progress) x threshold -> B -> retry A -> allowed because B breaks the tail
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Record repeated successful calls for tool A with identical args/results up to the no-progress threshold.
2. Record another successful tool B call.
3. Ask loop detection whether a new tool A call with the same args should be blocked.

### Expected

- The intervening tool B call breaks the no-progress tail, so the later tool A retry is allowed.

### Actual

- Before this change, stale tool A history could still count toward the no-progress threshold and block the retry.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/agents/tool-loop-detection.test.ts`
  - `pnpm lint:core`
  - `git diff --check`
- Edge cases checked: global no-progress circuit breaker also stays scoped to the current repeated tail.
- What you did **not** verify: full `pnpm check`; `pnpm check:changed` reached conflict markers, core typecheck, and core test typecheck successfully, then `lint:core` waited on the same local heavy-check lock held by `check:changed`. I stopped that stuck run and reran `pnpm lint:core` directly.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Allowing retries after an intervening tool call could make a truly stuck polling loop run longer.
  - Mitigation: repeated no-progress calls are still blocked when they remain contiguous, and the generic repeat warning/circuit breaker still applies to the current tail.