### PR TITLE
feat(telegram): add chat-type-based reply mode

### DIFF
--- a/extensions/telegram/src/accounts.test.ts
+++ b/extensions/telegram/src/accounts.test.ts
@@ -11,6 +11,7 @@ import {
   resolveTelegramPollActionGateState,
   resolveDefaultTelegramAccountId,
   resolveTelegramAccount,
+  resolveTelegramReplyToModeByChatType,
 } from "./accounts.js";
 
 const { warnMock } = vi.hoisted(() => ({
@@ -122,6 +123,33 @@ describe("resolveTelegramAccount", () => {
     const lines = warnMock.mock.calls.map(([line]) => String(line));
     expect(lines).toContain("listTelegramAccountIds [ 'work' ]");
     expect(lines).toContain("resolve { accountId: 'work', enabled: true, tokenSource: 'config' }");
+  });
+});
+
+describe("resolveTelegramReplyToModeByChatType", () => {
+  it("prefers per-chat settings, then runtime fallback, then account fallback", () => {
+    expect(
+      resolveTelegramReplyToModeByChatType({
+        account: { replyToModeByChatType: { direct: "all" }, replyToMode: "first" },
+        chatType: "direct",
+        fallbackReplyToMode: "off",
+      }),
+    ).toBe("all");
+
+    expect(
+      resolveTelegramReplyToModeByChatType({
+        account: { replyToMode: "first" },
+        chatType: "direct",
+        fallbackReplyToMode: "all",
+      }),
+    ).toBe("all");
+
+    expect(
+      resolveTelegramReplyToModeByChatType({
+        account: { replyToMode: "first" },
+        chatType: "direct",
+      }),
+    ).toBe("first");
   });
 });
 

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -186,21 +186,17 @@ export function listEnabledTelegramAccounts(cfg: OpenClawConfig): ResolvedTelegr
     .filter((account) => account.enabled);
 }
 
-type TelegramReplyToModeByChatTypeCapable = TelegramAccountConfig & {
-  replyToModeByChatType?: {
-    direct?: ReplyToMode;
-    group?: ReplyToMode;
-  };
-};
-
 export function resolveTelegramReplyToModeByChatType(params: {
   account: TelegramAccountConfig;
   chatType: "direct" | "group";
+  fallbackReplyToMode?: ReplyToMode;
 }): ReplyToMode {
-  const account = params.account as TelegramReplyToModeByChatTypeCapable;
-  const perChatType = account.replyToModeByChatType?.[params.chatType];
+  const perChatType = params.account.replyToModeByChatType?.[params.chatType];
   if (perChatType !== undefined) {
     return perChatType;
+  }
+  if (params.fallbackReplyToMode !== undefined) {
+    return params.fallbackReplyToMode;
   }
   if (params.account.replyToMode !== undefined) {
     return params.account.replyToMode;

--- a/extensions/telegram/src/accounts.ts
+++ b/extensions/telegram/src/accounts.ts
@@ -7,6 +7,7 @@ import {
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/account-core";
 import type {
+  ReplyToMode,
   TelegramAccountConfig,
   TelegramActionConfig,
 } from "openclaw/plugin-sdk/config-runtime";
@@ -183,4 +184,26 @@ export function listEnabledTelegramAccounts(cfg: OpenClawConfig): ResolvedTelegr
   return listTelegramAccountIds(cfg)
     .map((accountId) => resolveTelegramAccount({ cfg, accountId }))
     .filter((account) => account.enabled);
+}
+
+type TelegramReplyToModeByChatTypeCapable = TelegramAccountConfig & {
+  replyToModeByChatType?: {
+    direct?: ReplyToMode;
+    group?: ReplyToMode;
+  };
+};
+
+export function resolveTelegramReplyToModeByChatType(params: {
+  account: TelegramAccountConfig;
+  chatType: "direct" | "group";
+}): ReplyToMode {
+  const account = params.account as TelegramReplyToModeByChatTypeCapable;
+  const perChatType = account.replyToModeByChatType?.[params.chatType];
+  if (perChatType !== undefined) {
+    return perChatType;
+  }
+  if (params.account.replyToMode !== undefined) {
+    return params.account.replyToMode;
+  }
+  return params.chatType === "direct" ? "off" : "all";
 }

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -555,6 +555,7 @@ export const dispatchTelegramMessage = async ({
   };
   const deliveryBaseOptions = {
     chatId: String(chatId),
+    currentMessageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
     accountId: route.accountId,
     sessionKeyForInternalHooks: ctxPayload.SessionKey,
     mirrorIsGroup: isGroup,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -117,6 +117,7 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         replyToMode: resolveTelegramReplyToModeByChatType({
           account: telegramCfg,
           chatType: context.isGroup ? "group" : "direct",
+          fallbackReplyToMode: replyToMode,
         }),
         streamMode,
         textLimit,

--- a/extensions/telegram/src/bot-message.ts
+++ b/extensions/telegram/src/bot-message.ts
@@ -2,6 +2,7 @@ import type { ReplyToMode } from "openclaw/plugin-sdk/config-runtime";
 import type { TelegramAccountConfig } from "openclaw/plugin-sdk/config-runtime";
 import { danger, logVerbose, shouldLogVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { resolveTelegramReplyToModeByChatType } from "./accounts.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
 import {
   buildTelegramMessageContext,
@@ -113,7 +114,10 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
         bot,
         cfg,
         runtime,
-        replyToMode,
+        replyToMode: resolveTelegramReplyToModeByChatType({
+          account: telegramCfg,
+          chatType: context.isGroup ? "group" : "direct",
+        }),
         streamMode,
         textLimit,
         telegramCfg,

--- a/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.fixture-test-support.ts
@@ -80,6 +80,30 @@ export function createTelegramPrivateCommandContext(params?: {
   };
 }
 
+export function createTelegramGroupCommandContext(params?: {
+  match?: string;
+  messageId?: number;
+  date?: number;
+  chatId?: number;
+  title?: string;
+  userId?: number;
+  username?: string;
+}) {
+  return {
+    match: params?.match ?? "",
+    message: {
+      message_id: params?.messageId ?? 2,
+      date: params?.date ?? Math.floor(Date.now() / 1000),
+      chat: {
+        id: params?.chatId ?? -1001234567890,
+        type: "supergroup" as const,
+        title: params?.title ?? "OpenClaw",
+      },
+      from: { id: params?.userId ?? 200, username: params?.username ?? "bob" },
+    },
+  };
+}
+
 export function createTelegramTopicCommandContext(params?: {
   match?: string;
   messageId?: number;

--- a/extensions/telegram/src/bot-native-commands.menu-test-support.ts
+++ b/extensions/telegram/src/bot-native-commands.menu-test-support.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { TelegramNativeCommandDeps } from "./bot-native-command-deps.runtime.js";
 import {
   createNativeCommandTestParams as createBaseNativeCommandTestParams,
+  createTelegramGroupCommandContext,
   createTelegramPrivateCommandContext,
   type NativeCommandTestParams as RegisterTelegramNativeCommandsParams,
 } from "./bot-native-commands.fixture-test-support.js";
@@ -129,4 +130,10 @@ export function createPrivateCommandContext(
   params?: Parameters<typeof createTelegramPrivateCommandContext>[0],
 ) {
   return createTelegramPrivateCommandContext(params);
+}
+
+export function createGroupCommandContext(
+  params?: Parameters<typeof createTelegramGroupCommandContext>[0],
+) {
+  return createTelegramGroupCommandContext(params);
 }

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -177,6 +177,24 @@ describe("registerTelegramNativeCommands", () => {
     );
   });
 
+  it("uses per-chat-type reply mode for plugin command delivery in DMs", async () => {
+    const { handler } = registerPlugCommand({
+      cfg: {
+        channels: {
+          telegram: {
+            replyToModeByChatType: { direct: "all", group: "off" },
+          },
+        },
+      } as OpenClawConfig,
+      result: { text: "ok", replyToCurrent: true, replyToId: "1" },
+    });
+
+    await handler(createPrivateCommandContext({ match: "" }));
+
+    expect(deliverReplies).toHaveBeenCalled();
+    expect(deliverReplies.mock.calls.at(-1)?.[0]).toMatchObject({ replyToMode: "all" });
+  });
+
   it("normalizes hyphenated native command names for Telegram registration", async () => {
     const setMyCommands = vi.fn().mockResolvedValue(undefined);
     const command = vi.fn();

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -193,7 +193,9 @@ describe("registerTelegramNativeCommands", () => {
     await handler(createPrivateCommandContext({ match: "" }));
 
     expect(deliverReplies).toHaveBeenCalled();
-    expect(deliverReplies.mock.calls.at(-1)?.[0]).toMatchObject({ replyToMode: "all" });
+    expect(deliverReplies).toHaveBeenLastCalledWith(
+      expect.objectContaining({ replyToMode: "all" }),
+    );
   });
 
   it("normalizes hyphenated native command names for Telegram registration", async () => {

--- a/extensions/telegram/src/bot-native-commands.test.ts
+++ b/extensions/telegram/src/bot-native-commands.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createCommandBot,
   createNativeCommandTestParams,
+  createGroupCommandContext,
   createPrivateCommandContext,
   deliverReplies,
   editMessageTelegram,
@@ -281,6 +282,36 @@ describe("registerTelegramNativeCommands", () => {
     expect(callbackData).toEqual(["tgcmd:/fast status", "tgcmd:/fast on", "tgcmd:/fast off"]);
     expect(parseTelegramNativeCommandCallbackData("tgcmd:/fast status")).toBe("/fast status");
     expect(parseTelegramNativeCommandCallbackData("tgcmd:fast status")).toBeNull();
+  });
+
+  it("uses group replyToModeByChatType for built-in native command menus", async () => {
+    const { bot, commandHandlers, sendMessage } = createCommandBot();
+
+    registerTelegramNativeCommands({
+      ...createNativeCommandTestParams(
+        {
+          channels: {
+            telegram: {
+              replyToModeByChatType: { direct: "off", group: "all" },
+            },
+          },
+        },
+        { accountId: "default", bot },
+      ),
+    });
+
+    const handler = commandHandlers.get("fast");
+    expect(handler).toBeTruthy();
+    await handler?.(createGroupCommandContext({ messageId: 77 }));
+
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.any(String),
+      expect.objectContaining({
+        reply_to_message_id: 77,
+        allow_sending_without_reply: true,
+      }),
+    );
   });
 
   it("passes agent-scoped media roots for plugin command replies with media", async () => {
@@ -600,6 +631,37 @@ describe("registerTelegramNativeCommands", () => {
         from: "telegram:100",
         to: "telegram:100",
         messageThreadId: undefined,
+      }),
+    );
+  });
+
+  it("passes Telegram message ids to plugin commands", async () => {
+    const { handler } = registerPlugCommand();
+
+    await handler({
+      match: "",
+      message: {
+        message_id: 88,
+        date: Math.floor(Date.now() / 1000),
+        chat: {
+          id: -1001234567890,
+          type: "supergroup",
+          title: "Forum Group",
+          is_forum: true,
+        },
+        message_thread_id: 77,
+        reply_to_message: {
+          message_id: 66,
+        },
+        from: { id: 200, username: "bob" },
+      },
+    });
+
+    expect(pluginCommandMocks.executePluginCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageId: "88",
+        replyToMessageId: "66",
+        messageThreadId: 77,
       }),
     );
   });

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -825,6 +825,7 @@ export const registerTelegramNativeCommands = ({
           const effectiveReplyToMode = resolveTelegramReplyToModeByChatType({
             account: runtimeTelegramCfg,
             chatType: isGroup ? "group" : "direct",
+            fallbackReplyToMode: _replyToMode,
           });
           const menuReplyParams =
             effectiveReplyToMode === "off"
@@ -891,6 +892,7 @@ export const registerTelegramNativeCommands = ({
           replyToMode: resolveTelegramReplyToModeByChatType({
             account: runtimeTelegramCfg,
             chatType: isGroup ? "group" : "direct",
+            fallbackReplyToMode: _replyToMode,
           }),
         });
         const conversationLabel = isGroup
@@ -1083,6 +1085,7 @@ export const registerTelegramNativeCommands = ({
           replyToMode: resolveTelegramReplyToModeByChatType({
             account: runtimeTelegramCfg,
             chatType: isGroup ? "group" : "direct",
+            fallbackReplyToMode: _replyToMode,
           }),
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -30,7 +30,7 @@ import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { getChildLogger } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
-import { resolveTelegramAccount } from "./accounts.js";
+import { resolveTelegramAccount, resolveTelegramReplyToModeByChatType } from "./accounts.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { isSenderAllowed, normalizeDmAllowFromWithStore } from "./bot-access.js";
 import type { TelegramBotDeps } from "./bot-deps.js";
@@ -474,7 +474,7 @@ export const registerTelegramNativeCommands = ({
   telegramCfg,
   allowFrom,
   groupAllowFrom,
-  replyToMode,
+  replyToMode: _replyToMode,
   textLimit,
   useAccessGroups,
   nativeEnabled,
@@ -700,6 +700,7 @@ export const registerTelegramNativeCommands = ({
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: TelegramChunkMode;
     linkPreview?: boolean;
+    replyToMode: ReplyToMode;
   }) => ({
     cfg: params.cfg,
     chatId: String(params.chatId),
@@ -712,7 +713,7 @@ export const registerTelegramNativeCommands = ({
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode,
+    replyToMode: params.replyToMode,
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -872,6 +873,10 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          replyToMode: resolveTelegramReplyToModeByChatType({
+            account: runtimeTelegramCfg,
+            chatType: isGroup ? "group" : "direct",
+          }),
         });
         const conversationLabel = isGroup
           ? msg.chat.title
@@ -1059,6 +1064,10 @@ export const registerTelegramNativeCommands = ({
           tableMode,
           chunkMode,
           linkPreview: runtimeTelegramCfg.linkPreview,
+          replyToMode: resolveTelegramReplyToModeByChatType({
+            account: runtimeTelegramCfg,
+            chatType: isGroup ? "group" : "direct",
+          }),
         });
         const from = isGroup ? buildTelegramGroupFrom(chatId, threadSpec.id) : `telegram:${chatId}`;
         const to = `telegram:${chatId}`;

--- a/extensions/telegram/src/bot-native-commands.ts
+++ b/extensions/telegram/src/bot-native-commands.ts
@@ -690,6 +690,7 @@ export const registerTelegramNativeCommands = ({
   const buildCommandDeliveryBaseOptions = (params: {
     cfg: OpenClawConfig;
     chatId: string | number;
+    currentMessageId?: string;
     accountId: string;
     sessionKeyForInternalHooks?: string;
     policySessionKey?: string;
@@ -704,6 +705,7 @@ export const registerTelegramNativeCommands = ({
   }) => ({
     cfg: params.cfg,
     chatId: String(params.chatId),
+    currentMessageId: params.currentMessageId,
     accountId: params.accountId,
     sessionKeyForInternalHooks: params.sessionKeyForInternalHooks,
     policySessionKey: params.policySessionKey,
@@ -820,12 +822,24 @@ export const registerTelegramNativeCommands = ({
             );
           }
           const replyMarkup = buildInlineKeyboard(rows);
+          const effectiveReplyToMode = resolveTelegramReplyToModeByChatType({
+            account: runtimeTelegramCfg,
+            chatType: isGroup ? "group" : "direct",
+          });
+          const menuReplyParams =
+            effectiveReplyToMode === "off"
+              ? {}
+              : {
+                  reply_to_message_id: msg.message_id,
+                  allow_sending_without_reply: true as const,
+                };
           await withTelegramApiErrorLogging({
             operation: "sendMessage",
             runtime,
             fn: () =>
               bot.api.sendMessage(chatId, title, {
                 ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+                ...menuReplyParams,
                 ...threadParams,
               }),
           });
@@ -863,6 +877,7 @@ export const registerTelegramNativeCommands = ({
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: executionCfg,
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: commandSessionKey,
           policySessionKey: commandTargetSessionKey,
@@ -1054,6 +1069,7 @@ export const registerTelegramNativeCommands = ({
         const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
           cfg: runtimeCfg,
           chatId,
+          currentMessageId: String(msg.message_id),
           accountId: route.accountId,
           sessionKeyForInternalHooks: route.sessionKey,
           policySessionKey: route.sessionKey,
@@ -1109,6 +1125,11 @@ export const registerTelegramNativeCommands = ({
           from,
           to,
           accountId,
+          messageId: String(msg.message_id),
+          replyToMessageId:
+            msg.reply_to_message?.message_id == null
+              ? undefined
+              : String(msg.reply_to_message.message_id),
           messageThreadId: threadSpec.id,
         });
 

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -2748,6 +2748,38 @@ describe("createTelegramBot", () => {
       }
     }
   });
+
+  it("keeps runtime replyToMode when per-chat Telegram config is absent", async () => {
+    sendMessageSpy.mockClear();
+    replySpy.mockClear();
+    replySpy.mockResolvedValue({ text: "a".repeat(4500) });
+
+    createTelegramBot({ token: "tok", replyToMode: "first" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+    await handler({
+      message: {
+        chat: { id: 5, type: "private" },
+        text: "hi",
+        date: 1736380800,
+        message_id: 103,
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(sendMessageSpy.mock.calls.length).toBeGreaterThan(1);
+    const replyThreadedCalls = sendMessageSpy.mock.calls.filter(
+      (call) =>
+        (call[2] as { reply_to_message_id?: number } | undefined)?.reply_to_message_id === 103,
+    );
+    const nonThreadedCalls = sendMessageSpy.mock.calls.filter(
+      (call) =>
+        (call[2] as { reply_to_message_id?: number } | undefined)?.reply_to_message_id !== 103,
+    );
+
+    expect(replyThreadedCalls).toHaveLength(1);
+    expect(nonThreadedCalls.length).toBeGreaterThan(0);
+  });
   it("honors routed group activation from session store", async () => {
     const storePath = "/tmp/openclaw-telegram-group-activation.json";
     const routedGroupEntry = {

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -592,6 +592,7 @@ export async function deliverReplies(params: {
   replies: ReplyPayload[];
   cfg?: import("openclaw/plugin-sdk/config-runtime").OpenClawConfig;
   chatId: string;
+  currentMessageId?: string;
   accountId?: string;
   sessionKeyForInternalHooks?: string;
   policySessionKey?: string;
@@ -644,6 +645,7 @@ export async function deliverReplies(params: {
       cfg: params.cfg,
       sessionKey: params.policySessionKey ?? params.sessionKeyForInternalHooks,
       surface: "telegram",
+      currentMessageId: params.currentMessageId,
     }),
   );
   const originalExactSilentCount = candidateReplies.filter(
@@ -681,7 +683,8 @@ export async function deliverReplies(params: {
     const replyToId =
       effectiveReplyToMode === "off" && !explicitReplyOverride
         ? undefined
-        : resolveTelegramReplyId(reply.replyToId);
+        : (resolveTelegramReplyId(reply.replyToId) ??
+          resolveTelegramReplyId(params.currentMessageId));
     if (hasMessageSendingHooks) {
       const hookResult = await hookRunner?.runMessageSending(
         {

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -676,8 +676,12 @@ export async function deliverReplies(params: {
     }
 
     const rawContent = reply.text || "";
+    const explicitReplyOverride = Boolean(reply.replyToTag) || Boolean(reply.replyToCurrent);
+    const effectiveReplyToMode = params.replyToMode;
     const replyToId =
-      params.replyToMode === "off" ? undefined : resolveTelegramReplyId(reply.replyToId);
+      effectiveReplyToMode === "off" && !explicitReplyOverride
+        ? undefined
+        : resolveTelegramReplyId(reply.replyToId);
     if (hasMessageSendingHooks) {
       const hookResult = await hookRunner?.runMessageSending(
         {
@@ -725,7 +729,7 @@ export async function deliverReplies(params: {
           linkPreview: params.linkPreview,
           silent: params.silent,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       } else {
@@ -746,7 +750,7 @@ export async function deliverReplies(params: {
           replyQuoteText: params.replyQuoteText,
           replyMarkup,
           replyToId,
-          replyToMode: params.replyToMode,
+          replyToMode: effectiveReplyToMode,
           progress,
         });
       }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -862,6 +862,28 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it("preserves explicit replyToCurrent override when replyToMode is off", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 19,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "hello", replyToCurrent: true, replyToId: "700" }],
+      chatId: "123",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0][2]).toMatchObject({ reply_to_message_id: 700 });
+  });
+
   it("replyToMode 'first' only applies reply-to to the first text chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -884,6 +884,29 @@ describe("deliverReplies", () => {
     expect(sendMessage.mock.calls[0][2]).toMatchObject({ reply_to_message_id: 700 });
   });
 
+  it("uses currentMessageId for explicit replyToCurrent override when replyToMode is off", async () => {
+    const runtime = createRuntime();
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 19,
+      chat: { id: "123" },
+    });
+    const bot = createBot({ sendMessage });
+
+    await deliverReplies({
+      replies: [{ text: "hello", replyToCurrent: true }],
+      chatId: "123",
+      currentMessageId: "700",
+      token: "tok",
+      runtime,
+      bot,
+      replyToMode: "off",
+      textLimit: 4000,
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0][2]).toMatchObject({ reply_to_message_id: 700 });
+  });
+
   it("replyToMode 'first' only applies reply-to to the first text chunk", async () => {
     const runtime = createRuntime();
     const sendMessage = vi.fn().mockResolvedValue({

--- a/extensions/telegram/src/config-schema.test.ts
+++ b/extensions/telegram/src/config-schema.test.ts
@@ -30,13 +30,14 @@ describe("telegram custom commands schema", () => {
     }
   });
 
-  it("defaults dm/group policy", () => {
+  it("defaults dm/group policy and chat-type reply mode", () => {
     const res = TelegramConfigSchema.safeParse({});
 
     expect(res.success).toBe(true);
     if (res.success) {
       expect(res.data.dmPolicy).toBe("pairing");
       expect(res.data.groupPolicy).toBe("allowlist");
+      expect(res.data.replyToModeByChatType).toEqual({ direct: "off", group: "all" });
     }
   });
 

--- a/src/auto-reply/reply/commands-plugin.ts
+++ b/src/auto-reply/reply/commands-plugin.ts
@@ -48,6 +48,12 @@ export const handlePluginCommand: CommandHandler = async (
     from: command.from,
     to: command.to,
     accountId: params.ctx.AccountId ?? undefined,
+    messageId:
+      normalizeOptionalString(params.ctx.MessageSidFull) ??
+      normalizeOptionalString(params.ctx.MessageSid),
+    replyToMessageId:
+      normalizeOptionalString(params.ctx.ReplyToIdFull) ??
+      normalizeOptionalString(params.ctx.ReplyToId),
     messageThreadId:
       typeof params.ctx.MessageThreadId === "string" ||
       typeof params.ctx.MessageThreadId === "number"

--- a/src/auto-reply/reply/reply-directives.ts
+++ b/src/auto-reply/reply/reply-directives.ts
@@ -17,18 +17,14 @@ export function parseReplyDirectives(
   raw: string,
   options: { currentMessageId?: string; silentToken?: string } = {},
 ): ReplyDirectiveParseResult {
-  const split = splitMediaFromOutput(raw);
-  let text = split.text ?? "";
-
-  const replyParsed = parseInlineDirectives(text, {
+  const replyParsed = parseInlineDirectives(raw, {
     currentMessageId: options.currentMessageId,
     stripAudioTag: false,
     stripReplyTags: true,
   });
 
-  if (replyParsed.hasReplyTag) {
-    text = replyParsed.text;
-  }
+  const split = splitMediaFromOutput(replyParsed.hasReplyTag ? replyParsed.text : raw);
+  let text = split.text ?? "";
 
   const silentToken = options.silentToken ?? SILENT_REPLY_TOKEN;
   const isSilent = isSilentReplyPayloadText(text, silentToken);

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -12672,6 +12672,52 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
             },
           ],
         },
+        replyToModeByChatType: {
+          type: "object",
+          properties: {
+            direct: {
+              anyOf: [
+                {
+                  type: "string",
+                  const: "off",
+                },
+                {
+                  type: "string",
+                  const: "first",
+                },
+                {
+                  type: "string",
+                  const: "all",
+                },
+                {
+                  type: "string",
+                  const: "batched",
+                },
+              ],
+            },
+            group: {
+              anyOf: [
+                {
+                  type: "string",
+                  const: "off",
+                },
+                {
+                  type: "string",
+                  const: "first",
+                },
+                {
+                  type: "string",
+                  const: "all",
+                },
+                {
+                  type: "string",
+                  const: "batched",
+                },
+              ],
+            },
+          },
+          additionalProperties: false,
+        },
         groups: {
           type: "object",
           propertyNames: {
@@ -13712,6 +13758,52 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     const: "batched",
                   },
                 ],
+              },
+              replyToModeByChatType: {
+                type: "object",
+                properties: {
+                  direct: {
+                    anyOf: [
+                      {
+                        type: "string",
+                        const: "off",
+                      },
+                      {
+                        type: "string",
+                        const: "first",
+                      },
+                      {
+                        type: "string",
+                        const: "all",
+                      },
+                      {
+                        type: "string",
+                        const: "batched",
+                      },
+                    ],
+                  },
+                  group: {
+                    anyOf: [
+                      {
+                        type: "string",
+                        const: "off",
+                      },
+                      {
+                        type: "string",
+                        const: "first",
+                      },
+                      {
+                        type: "string",
+                        const: "all",
+                      },
+                      {
+                        type: "string",
+                        const: "batched",
+                      },
+                    ],
+                  },
+                },
+                additionalProperties: false,
               },
               groups: {
                 type: "object",

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -12673,6 +12673,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           ],
         },
         replyToModeByChatType: {
+          default: {
+            direct: "off",
+            group: "all",
+          },
           type: "object",
           properties: {
             direct: {
@@ -13760,6 +13764,10 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 ],
               },
               replyToModeByChatType: {
+                default: {
+                  direct: "off",
+                  group: "all",
+                },
                 type: "object",
                 properties: {
                   direct: {
@@ -14624,7 +14632,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                 ],
               },
             },
-            required: ["dmPolicy", "groupPolicy"],
+            required: ["dmPolicy", "replyToModeByChatType", "groupPolicy"],
             additionalProperties: false,
           },
         },
@@ -14632,7 +14640,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
           type: "string",
         },
       },
-      required: ["dmPolicy", "groupPolicy"],
+      required: ["dmPolicy", "replyToModeByChatType", "groupPolicy"],
       additionalProperties: false,
     },
     uiHints: {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -121,6 +121,8 @@ export type TelegramAccountConfig = {
   tokenFile?: string;
   /** Control reply threading when reply tags are present (off|first|all|batched). */
   replyToMode?: ReplyToMode;
+  /** Override reply threading mode per Telegram chat type. */
+  replyToModeByChatType?: Partial<Record<"direct" | "group", ReplyToMode>>;
   groups?: Record<string, TelegramGroupConfig>;
   /** Per-DM configuration for Telegram DM topics (key is chat ID). */
   direct?: Record<string, TelegramDirectConfig>;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -234,7 +234,10 @@ export const TelegramAccountSchemaBase = z
     botToken: SecretInputSchema.optional().register(sensitive),
     tokenFile: z.string().optional(),
     replyToMode: ReplyToModeSchema.optional(),
-    replyToModeByChatType: TelegramReplyToModeByChatTypeSchema.optional(),
+    replyToModeByChatType: TelegramReplyToModeByChatTypeSchema.default({
+      direct: "off",
+      group: "all",
+    }),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     defaultTo: z.union([z.string(), z.number()]).optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -204,6 +204,13 @@ const validateTelegramCustomCommands = (
   }
 };
 
+const TelegramReplyToModeByChatTypeSchema = z
+  .object({
+    direct: ReplyToModeSchema.optional(),
+    group: ReplyToModeSchema.optional(),
+  })
+  .strict();
+
 export const TelegramAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -227,6 +234,7 @@ export const TelegramAccountSchemaBase = z
     botToken: SecretInputSchema.optional().register(sensitive),
     tokenFile: z.string().optional(),
     replyToMode: ReplyToModeSchema.optional(),
+    replyToModeByChatType: TelegramReplyToModeByChatTypeSchema.optional(),
     groups: z.record(z.string(), TelegramGroupSchema.optional()).optional(),
     allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     defaultTo: z.union([z.string(), z.number()]).optional(),

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -479,6 +479,22 @@ describe("normalizeReplyPayloadsForDelivery", () => {
       },
     ]);
   });
+
+  it("resolves reply_to_current against currentMessageId during outbound planning", () => {
+    const plan = createOutboundPayloadPlan([{ text: "[[reply_to_current]] hello" }], {
+      currentMessageId: "42",
+    });
+
+    expect(plan).toEqual([
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          text: "hello",
+          replyToCurrent: true,
+          replyToId: "42",
+        }),
+      }),
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloadsForJson", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -129,11 +129,14 @@ type PreparedOutboundPayloadPlanEntry = {
 
 function createOutboundPayloadPlanEntry(
   payload: ReplyPayload,
+  options: { currentMessageId?: string } = {},
 ): PreparedOutboundPayloadPlanEntry | null {
   if (shouldSuppressReasoningPayload(payload)) {
     return null;
   }
-  const parsed = parseReplyDirectives(payload.text ?? "");
+  const parsed = parseReplyDirectives(payload.text ?? "", {
+    currentMessageId: options.currentMessageId,
+  });
   const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
   const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
   const mergedMedia = mergeMediaUrls(
@@ -158,7 +161,7 @@ function createOutboundPayloadPlanEntry(
     mediaUrl: resolvedMediaUrl,
     replyToId: payload.replyToId ?? parsed.replyToId,
     replyToTag: payload.replyToTag || parsed.replyToTag,
-    replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
+    replyToCurrent: payload.replyToCurrent ?? parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
   };
   if (!isRenderablePayload(normalizedPayload) && !isSilent) {
@@ -176,7 +179,7 @@ function createOutboundPayloadPlanEntry(
 
 export function createOutboundPayloadPlan(
   payloads: readonly ReplyPayload[],
-  context: OutboundPayloadPlanContext = {},
+  context: OutboundPayloadPlanContext & { currentMessageId?: string } = {},
 ): OutboundPayloadPlan[] {
   // Intentionally scoped to channel-agnostic normalization and projection inputs.
   // Transport concerns (queueing, hooks, retries), channel transforms, and
@@ -191,7 +194,9 @@ export function createOutboundPayloadPlan(
     context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);
   const prepared: PreparedOutboundPayloadPlanEntry[] = [];
   for (const payload of payloads) {
-    const entry = createOutboundPayloadPlanEntry(payload);
+    const entry = createOutboundPayloadPlanEntry(payload, {
+      currentMessageId: context.currentMessageId,
+    });
     if (!entry) {
       continue;
     }

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -686,4 +686,40 @@ describe("registerPluginCommand", () => {
       accountId: "work",
     });
   });
+
+  it("passes message ids through to the plugin command context", async () => {
+    let receivedCtx:
+      | {
+          messageId?: string;
+          replyToMessageId?: string;
+        }
+      | undefined;
+    const handler = async (ctx: { messageId?: string; replyToMessageId?: string }) => {
+      receivedCtx = ctx;
+      return { text: "ok" };
+    };
+
+    const result = await executePluginCommand({
+      command: {
+        name: "messagecheck",
+        description: "Demo command",
+        acceptsArgs: false,
+        handler,
+        pluginId: "demo-plugin",
+      },
+      channel: "telegram",
+      senderId: "U123",
+      isAuthorizedSender: true,
+      commandBody: "/messagecheck",
+      config: {} as never,
+      messageId: "77",
+      replyToMessageId: "55",
+    });
+
+    expect(result).toEqual({ text: "ok" });
+    expect(receivedCtx).toMatchObject({
+      messageId: "77",
+      replyToMessageId: "55",
+    });
+  });
 });

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -184,6 +184,8 @@ export async function executePluginCommand(params: {
   from?: PluginCommandContext["from"];
   to?: PluginCommandContext["to"];
   accountId?: PluginCommandContext["accountId"];
+  messageId?: PluginCommandContext["messageId"];
+  replyToMessageId?: PluginCommandContext["replyToMessageId"];
   messageThreadId?: PluginCommandContext["messageThreadId"];
   threadParentId?: PluginCommandContext["threadParentId"];
 }): Promise<PluginCommandResult> {
@@ -227,6 +229,8 @@ export async function executePluginCommand(params: {
     from: params.from,
     to: params.to,
     accountId: effectiveAccountId,
+    messageId: params.messageId,
+    replyToMessageId: params.replyToMessageId,
     messageThreadId: params.messageThreadId,
     threadParentId: params.threadParentId,
     requestConversationBinding: async (bindingParams) => {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1713,6 +1713,10 @@ export type PluginCommandContext = {
   to?: string;
   /** Account id for multi-account channels */
   accountId?: string;
+  /** Provider message id for the triggering command turn when available. */
+  messageId?: string;
+  /** Provider reply target id for the triggering command turn when available. */
+  replyToMessageId?: string;
   /** Thread/topic id if available */
   messageThreadId?: string | number;
   /** Parent conversation id for thread-capable channels */


### PR DESCRIPTION
## Summary
- add Telegram support for chat-type-based reply mode, similar to the existing Slack option
- wire that mode through native command delivery for direct chats vs groups
- restore `reply_to_current` / `reply_to_id` handling and pass Telegram message ids into plugin command handlers so reply threading works correctly with the new mode

## Testing
- pnpm exec vitest run src/plugins/commands.test.ts
- pnpm exec vitest run src/infra/outbound/payloads.test.ts extensions/telegram/src/bot-native-commands.test.ts extensions/telegram/src/bot/delivery.test.ts
- restarted the gateway on the built current tree and verified the updated behavior manually
