### PR TITLE
fix(signal): await daemon shutdown on restart

### DIFF
--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -81,7 +81,7 @@ describe("spawnSignalDaemon stop", () => {
     vi.useFakeTimers();
     const fake = createFakeDaemonChild();
     spawnMock.mockReturnValue(fake.child);
-    const { spawnSignalDaemon } = await import("./daemon.js");
+    const { SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS, spawnSignalDaemon } = await import("./daemon.js");
 
     const handle = spawnSignalDaemon({
       cliPath: "signal-cli",
@@ -90,7 +90,7 @@ describe("spawnSignalDaemon stop", () => {
     });
 
     const stopPromise = handle.stop();
-    await vi.advanceTimersByTimeAsync(1_501);
+    await vi.advanceTimersByTimeAsync(SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS + 1);
 
     expect(fake.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
     expect(fake.kill).toHaveBeenNthCalledWith(2, "SIGKILL");

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,0 +1,126 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+function createFakeDaemonChild() {
+  const child = new EventEmitter() as EventEmitter & ChildProcessWithoutNullStreams;
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  let killed = false;
+  const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>((signal) => {
+    if (signal) {
+      killed = true;
+    }
+    return true;
+  });
+
+  Object.defineProperty(child, "killed", {
+    get: () => killed,
+    configurable: true,
+  });
+  Object.defineProperty(child, "pid", {
+    value: 4321,
+    configurable: true,
+  });
+
+  child.stdout = stdout as ChildProcessWithoutNullStreams["stdout"];
+  child.stderr = stderr as ChildProcessWithoutNullStreams["stderr"];
+  child.stdin = null as unknown as ChildProcessWithoutNullStreams["stdin"];
+  child.kill = kill as ChildProcessWithoutNullStreams["kill"];
+
+  return { child, kill };
+}
+
+describe("spawnSignalDaemon stop", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for exit after SIGTERM before resolving stop", async () => {
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    let resolved = false;
+    const stopPromise = handle.stop().then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+
+    expect(fake.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(resolved).toBe(false);
+
+    fake.child.emit("exit", 0, null);
+    fake.child.emit("close", 0, null);
+    await stopPromise;
+
+    expect(resolved).toBe(true);
+  });
+
+  it("falls back to SIGKILL if the daemon does not exit in time", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const stopPromise = handle.stop();
+    await vi.advanceTimersByTimeAsync(1_501);
+
+    expect(fake.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(fake.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+
+    fake.child.emit("exit", null, "SIGKILL");
+    fake.child.emit("close", null, "SIGKILL");
+    await stopPromise;
+  });
+
+  it("reuses the same in-flight stop promise across repeated stop calls", async () => {
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+
+    expect(firstStop).toBe(secondStop);
+    expect(fake.kill).toHaveBeenCalledTimes(1);
+    expect(fake.kill).toHaveBeenCalledWith("SIGTERM");
+
+    fake.child.emit("exit", 0, null);
+    fake.child.emit("close", 0, null);
+    await firstStop;
+    await secondStop;
+  });
+});

--- a/extensions/signal/src/daemon.test.ts
+++ b/extensions/signal/src/daemon.test.ts
@@ -1,8 +1,49 @@
 // Signal tests cover daemon plugin behavior.
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { testApi } from "./daemon.js";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+function createFakeDaemonChild() {
+  const child = new EventEmitter() as EventEmitter & ChildProcessWithoutNullStreams;
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  let killed = false;
+  const kill = vi.fn<(signal?: NodeJS.Signals) => boolean>((signal) => {
+    if (signal) {
+      killed = true;
+    }
+    return true;
+  });
+
+  Object.defineProperty(child, "killed", {
+    get: () => killed,
+    configurable: true,
+  });
+  Object.defineProperty(child, "pid", {
+    value: 4321,
+    configurable: true,
+  });
+
+  child.stdout = stdout as ChildProcessWithoutNullStreams["stdout"];
+  child.stderr = stderr as ChildProcessWithoutNullStreams["stderr"];
+  child.stdin = null as unknown as ChildProcessWithoutNullStreams["stdin"];
+  child.kill = kill as ChildProcessWithoutNullStreams["kill"];
+
+  return { child, kill };
+}
 
 describe("signal daemon args", () => {
   it("expands home-relative configPath before passing it to signal-cli", () => {
@@ -44,5 +85,89 @@ describe("signal daemon log classification", () => {
   it("still surfaces signal-cli failures as errors", () => {
     expect(testApi.classifySignalCliLogLine("ERROR DaemonCommand - startup failed")).toBe("error");
     expect(testApi.classifySignalCliLogLine("SEVERE Manager - database exception")).toBe("error");
+  });
+});
+
+describe("spawnSignalDaemon stop", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("waits for exit after SIGTERM before resolving stop", async () => {
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    let resolved = false;
+    const stopPromise = handle.stop().then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+
+    expect(fake.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(resolved).toBe(false);
+
+    fake.child.emit("exit", 0, null);
+    fake.child.emit("close", 0, null);
+    await stopPromise;
+
+    expect(resolved).toBe(true);
+  });
+
+  it("falls back to SIGKILL if the daemon does not exit in time", async () => {
+    vi.useFakeTimers();
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS, spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const stopPromise = handle.stop();
+    await vi.advanceTimersByTimeAsync(SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS + 1);
+
+    expect(fake.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(fake.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+
+    fake.child.emit("exit", null, "SIGKILL");
+    fake.child.emit("close", null, "SIGKILL");
+    await stopPromise;
+  });
+
+  it("reuses the same in-flight stop promise across repeated stop calls", async () => {
+    const fake = createFakeDaemonChild();
+    spawnMock.mockReturnValue(fake.child);
+    const { spawnSignalDaemon } = await import("./daemon.js");
+
+    const handle = spawnSignalDaemon({
+      cliPath: "signal-cli",
+      httpHost: "127.0.0.1",
+      httpPort: 8080,
+    });
+
+    const firstStop = handle.stop();
+    const secondStop = handle.stop();
+
+    expect(firstStop).toBe(secondStop);
+    expect(fake.kill).toHaveBeenCalledTimes(1);
+    expect(fake.kill).toHaveBeenCalledWith("SIGTERM");
+
+    fake.child.emit("exit", 0, null);
+    fake.child.emit("close", 0, null);
+    await firstStop;
+    await secondStop;
   });
 });

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -20,6 +20,8 @@ export type SignalDaemonHandle = {
   isExited: () => boolean;
 };
 
+export const SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS = 1500;
+
 export type SignalDaemonExitEvent = {
   source: "process" | "spawn-error";
   code: number | null;
@@ -158,7 +160,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
           } finally {
             void exitedPromise.finally(() => resolve());
           }
-        }, 1500);
+        }, SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS);
         void exitedPromise.finally(() => {
           clearTimeout(timeout);
           resolve();

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -15,7 +15,7 @@ type SignalDaemonOpts = {
 
 export type SignalDaemonHandle = {
   pid?: number;
-  stop: () => void;
+  stop: () => Promise<void>;
   exited: Promise<SignalDaemonExitEvent>;
   isExited: () => boolean;
 };
@@ -97,6 +97,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
   const error = opts.runtime?.error ?? (() => {});
   let exited = false;
   let settledExit = false;
+  let stopPromise: Promise<void> | null = null;
   let resolveExit!: (value: SignalDaemonExitEvent) => void;
   const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
     resolveExit = resolve;
@@ -139,9 +140,31 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     exited: exitedPromise,
     isExited: () => exited,
     stop: () => {
-      if (!child.killed && !exited) {
+      if (exited) {
+        return Promise.resolve();
+      }
+      if (stopPromise) {
+        return stopPromise;
+      }
+      if (!child.killed) {
         child.kill("SIGTERM");
       }
+      stopPromise = new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          try {
+            if (!exited) {
+              child.kill("SIGKILL");
+            }
+          } finally {
+            void exitedPromise.finally(() => resolve());
+          }
+        }, 1500);
+        void exitedPromise.finally(() => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      return stopPromise;
     },
   };
 }

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -19,7 +19,7 @@ type SignalDaemonOpts = {
 
 export type SignalDaemonHandle = {
   pid?: number;
-  stop: () => void;
+  stop: () => Promise<void>;
   exited: Promise<SignalDaemonExitEvent>;
   isExited: () => boolean;
 };
@@ -123,6 +123,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
   const error = opts.runtime?.error ?? (() => {});
   let exited = false;
   let settledExit = false;
+  let stopPromise: Promise<void> | null = null;
   let resolveExit!: (value: SignalDaemonExitEvent) => void;
   const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
     resolveExit = resolve;
@@ -165,9 +166,31 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
     exited: exitedPromise,
     isExited: () => exited,
     stop: () => {
-      if (!child.killed && !exited) {
+      if (exited) {
+        return Promise.resolve();
+      }
+      if (stopPromise) {
+        return stopPromise;
+      }
+      if (!child.killed) {
         child.kill("SIGTERM");
       }
+      stopPromise = new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => {
+          try {
+            if (!exited) {
+              child.kill("SIGKILL");
+            }
+          } finally {
+            void exitedPromise.finally(() => resolve());
+          }
+        }, 1500);
+        void exitedPromise.finally(() => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      return stopPromise;
     },
   };
 }

--- a/extensions/signal/src/daemon.ts
+++ b/extensions/signal/src/daemon.ts
@@ -24,6 +24,8 @@ export type SignalDaemonHandle = {
   isExited: () => boolean;
 };
 
+export const SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS = 1500;
+
 export type SignalDaemonExitEvent = {
   source: "process" | "spawn-error";
   code: number | null;
@@ -184,7 +186,7 @@ export function spawnSignalDaemon(opts: SignalDaemonOpts): SignalDaemonHandle {
           } finally {
             void exitedPromise.finally(() => resolve());
           }
-        }, 1500);
+        }, SIGNAL_DAEMON_STOP_KILL_TIMEOUT_MS);
         void exitedPromise.finally(() => {
           clearTimeout(timeout);
           resolve();

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -161,7 +161,7 @@ describe("monitorSignalProvider autostart", () => {
     const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
       resolveExit = resolve;
     });
-    const stop = vi.fn(() => {
+    const stop = vi.fn(async () => {
       if (exited) {
         return;
       }
@@ -170,6 +170,7 @@ describe("monitorSignalProvider autostart", () => {
         throw new Error("Expected signal daemon exit resolver to be initialized");
       }
       resolveExit({ source: "process", code: null, signal: "SIGTERM" });
+      await exitedPromise;
     });
     spawnSignalDaemonMock.mockReturnValueOnce(
       createMockSignalDaemonHandle({
@@ -190,5 +191,44 @@ describe("monitorSignalProvider autostart", () => {
         abortSignal: abortController.signal,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("awaits daemon stop before resolving aborted monitor shutdown", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig();
+    const abortController = new AbortController();
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    const stop = vi.fn(() => stopPromise);
+
+    spawnSignalDaemonMock.mockReturnValueOnce(
+      createMockSignalDaemonHandle({
+        stop,
+      }),
+    );
+    streamMock.mockImplementationOnce(async () => {
+      abortController.abort(new Error("stop"));
+    });
+
+    let settled = false;
+    const monitorPromise = runMonitorWithMocks({
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      runtime,
+      abortSignal: abortController.signal,
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    resolveStop();
+    await monitorPromise;
+    expect(settled).toBe(true);
   });
 });

--- a/extensions/signal/src/monitor.tool-result.autostart.test.ts
+++ b/extensions/signal/src/monitor.tool-result.autostart.test.ts
@@ -214,7 +214,7 @@ describe("monitorSignalProvider autostart", () => {
     const exitedPromise = new Promise<SignalDaemonExitEvent>((resolve) => {
       resolveExit = resolve;
     });
-    const stop = vi.fn(() => {
+    const stop = vi.fn(async () => {
       if (exited) {
         return;
       }
@@ -223,6 +223,7 @@ describe("monitorSignalProvider autostart", () => {
         throw new Error("Expected signal daemon exit resolver to be initialized");
       }
       resolveExit({ source: "process", code: null, signal: "SIGTERM" });
+      await exitedPromise;
     });
     spawnSignalDaemonMock.mockReturnValueOnce(
       createMockSignalDaemonHandle({
@@ -243,6 +244,45 @@ describe("monitorSignalProvider autostart", () => {
         abortSignal: abortController.signal,
       }),
     ).resolves.toBeUndefined();
+  });
+
+  it("awaits daemon stop before resolving aborted monitor shutdown", async () => {
+    const runtime = createMonitorRuntime();
+    setSignalAutoStartConfig();
+    const abortController = new AbortController();
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((resolve) => {
+      resolveStop = resolve;
+    });
+    const stop = vi.fn(() => stopPromise);
+
+    spawnSignalDaemonMock.mockReturnValueOnce(
+      createMockSignalDaemonHandle({
+        stop,
+      }),
+    );
+    streamMock.mockImplementationOnce(async () => {
+      abortController.abort(new Error("stop"));
+    });
+
+    let settled = false;
+    const monitorPromise = runMonitorWithMocks({
+      autoStart: true,
+      baseUrl: SIGNAL_BASE_URL,
+      runtime,
+      abortSignal: abortController.signal,
+    }).then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    resolveStop();
+    await monitorPromise;
+    expect(settled).toBe(true);
   });
 });
 

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -90,7 +90,7 @@ export function createMockSignalDaemonHandle(
   const exited = overrides.exited ?? new Promise<SignalDaemonExitEvent>(() => {});
   const isExited = overrides.isExited ?? (() => false);
   return {
-    stop: stop as unknown as () => void,
+    stop: stop as unknown as () => Promise<void>,
     exited,
     isExited,
   };

--- a/extensions/signal/src/monitor.tool-result.test-harness.ts
+++ b/extensions/signal/src/monitor.tool-result.test-harness.ts
@@ -86,7 +86,7 @@ export function createMockSignalDaemonHandle(
   const exited = overrides.exited ?? new Promise<SignalDaemonExitEvent>(() => {});
   const isExited = overrides.isExited ?? (() => false);
   return {
-    stop: stop as unknown as () => void,
+    stop: stop as unknown as () => Promise<void>,
     exited,
     isExited,
   };

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -119,9 +119,9 @@ function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   let daemonExitError: Error | undefined;
   const daemonAbortController = new AbortController();
   const mergedAbort = mergeAbortSignals(params.abortSignal, daemonAbortController.signal);
-  const stop = () => {
+  const stop = async () => {
     daemonStopRequested = true;
-    daemonHandle?.stop();
+    await daemonHandle?.stop();
   };
   const attach = (handle: SignalDaemonHandle) => {
     daemonHandle = handle;
@@ -449,7 +449,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    daemonLifecycle.stop();
+    void daemonLifecycle.stop();
   };
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
@@ -526,6 +526,6 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   } finally {
     daemonLifecycle.dispose();
     opts.abortSignal?.removeEventListener("abort", onAbort);
-    daemonLifecycle.stop();
+    await daemonLifecycle.stop();
   }
 }

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -449,7 +449,9 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    void daemonLifecycle.stop();
+    void daemonLifecycle.stop().catch((err) => {
+      runtime.error?.(`daemon stop error on abort: ${String(err)}`);
+    });
   };
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -488,7 +488,9 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    void daemonLifecycle.stop();
+    void daemonLifecycle.stop().catch((err) => {
+      runtime.error?.(`daemon stop error on abort: ${String(err)}`);
+    });
   };
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -144,9 +144,9 @@ function createSignalDaemonLifecycle(params: { abortSignal?: AbortSignal }) {
   let daemonExitError: Error | undefined;
   const daemonAbortController = new AbortController();
   const mergedAbort = mergeAbortSignals(params.abortSignal, daemonAbortController.signal);
-  const stop = () => {
+  const stop = async () => {
     daemonStopRequested = true;
-    daemonHandle?.stop();
+    await daemonHandle?.stop();
   };
   const attach = (handle: SignalDaemonHandle) => {
     daemonHandle = handle;
@@ -488,7 +488,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    daemonLifecycle.stop();
+    void daemonLifecycle.stop();
   };
   opts.abortSignal?.addEventListener("abort", onAbort, { once: true });
 
@@ -584,6 +584,6 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
     await monitorTaskRunner.waitForIdle();
     daemonLifecycle.dispose();
     opts.abortSignal?.removeEventListener("abort", onAbort);
-    daemonLifecycle.stop();
+    await daemonLifecycle.stop();
   }
 }

--- a/extensions/signal/src/monitor.ts
+++ b/extensions/signal/src/monitor.ts
@@ -488,7 +488,7 @@ export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promi
   }
 
   const onAbort = () => {
-    void daemonLifecycle.stop().catch((err) => {
+    void daemonLifecycle.stop().catch((err: unknown) => {
       runtime.error?.(`daemon stop error on abort: ${String(err)}`);
     });
   };


### PR DESCRIPTION
## Summary
- make Signal daemon shutdown asynchronous and await process exit
- fall back to SIGKILL if signal-cli does not exit after SIGTERM
- add regression coverage for daemon stop semantics and aborted monitor shutdown

## Testing
- corepack pnpm exec vitest run extensions/signal/src/daemon.test.ts extensions/signal/src/monitor.tool-result.autostart.test.ts
- corepack pnpm exec vitest run extensions/signal/src

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Signal auto-start monitor shutdown/restart must wait for the spawned daemon process to exit instead of returning while the daemon is still alive, preventing orphaned `signal-cli daemon` processes across abort/restart paths.
- Real environment tested: macOS 14.8.5 arm64 on a local OpenClaw checkout, Node v22.22.2, PR head `3fa74e98e72de378366b4dc5d48cae5f6dd21249`. The machine does not have a linked Signal account or `signal-cli` installed, so this proof used the real OpenClaw Signal monitor/daemon lifecycle code with a local signal-cli-compatible child process that exposes `/api/v1/check` and `/api/v1/events`; no external Signal messages were sent.
- Exact steps or command run after this patch:

```bash
cd /Users/zhoukailian/Desktop/mySelf/openclaw/.worktrees/fix-signal-daemon-stop-race
node --import tsx /tmp/openclaw-signal-lifecycle-proof.mjs | tee /tmp/openclaw-signal-lifecycle-proof.out
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```json
{
  "repoHead": "3fa74e98e72de378366b4dc5d48cae5f6dd21249",
  "baseMain": "e0225380a7454a85db1038e495d18a28b5d918ed",
  "port": 20031,
  "pid": 34488,
  "aliveBeforeAbort": true,
  "monitorResolved": true,
  "resolveWaitMs": 659,
  "aliveAfterMonitorResolved": false,
  "elapsedMs": 867,
  "events": "START pid=34488 args=[\"daemon\",\"--http\",\"127.0.0.1:20031\",\"--no-receive-stdout\",\"--receive-mode\",\"manual\"]\nSIGTERM pid=34488 at=1778304230573\nEXIT_AFTER_SIGTERM pid=34488 at=1778304231225",
  "runtimeLogs": [
    {
      "level": "log",
      "t": 200,
      "msg": "signal-cli: signal-cli shim READY pid=34488 http=127.0.0.1:20031"
    },
    {
      "level": "error",
      "t": 867,
      "msg": "signal daemon exited (source=process code=0 signal=null)"
    }
  ]
}
```

- Observed result after fix: The Signal monitor started the daemon child process, verified it was alive before abort, sent SIGTERM on abort, waited about 659ms for the child to finish its shutdown, then resolved only after the process exited. `aliveAfterMonitorResolved: false` confirms there was no leftover daemon process after `monitorSignalProvider` returned.
- What was not tested: A live linked Signal account, real `signal-cli` network traffic, actual inbound/outbound Signal message delivery, or the macOS LaunchAgent restart path. This proof is scoped to the changed OpenClaw daemon lifecycle behavior and avoids sending external Signal messages from the test machine.
- Before evidence (optional but encouraged): The regression tests added in this PR demonstrate the previous behavior: on unpatched main, `stop()` returned `undefined` instead of a promise and there was no SIGKILL escalation. The live proof above verifies the patched after-fix runtime behavior on this machine.

## Root Cause

- Root cause: Signal daemon shutdown was fire-and-forget. `stop()` only sent SIGTERM and returned immediately, so monitor abort/restart could continue while the old daemon process was still shutting down.
- Missing detection / guardrail: There was no regression coverage asserting that daemon stop returns a promise, waits for process exit, is idempotent across overlapping callers, and escalates to SIGKILL when SIGTERM does not finish.
- Contributing context (if known): `signal-cli` daemon shutdown can be slow enough that immediate restart paths race with the previous process still owning resources.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `extensions/signal/src/daemon.test.ts`
  - `extensions/signal/src/monitor.tool-result.autostart.test.ts`
- Scenario the test should lock in: `stop()` waits for daemon exit after SIGTERM, escalates to SIGKILL after the timeout, reuses an in-flight stop promise, and `monitorSignalProvider` awaits daemon stop before resolving aborted shutdown.
- Why this is the smallest reliable guardrail: It exercises the Signal daemon lifecycle seam directly without requiring a live Signal account or sending external messages.
- Existing test that already covers this (if any): None before this PR.

## User-visible / Behavior Changes

Signal auto-start restart/shutdown should leave fewer orphaned daemon processes. Shutdown may now wait briefly for `signal-cli daemon` to exit; if it does not exit after SIGTERM, OpenClaw escalates to SIGKILL after the configured timeout.

Closes #22676
