### PR TITLE
fix(tasks): serialize structured task values for sqlite

### DIFF
--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -90,6 +90,10 @@ function parseJsonValue<T>(raw: string | null): T | undefined {
   }
 }
 
+function serializeTaskValue(value: TaskRecord["task"]): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
 function rowToTaskRecord(row: TaskRegistryRow): TaskRecord {
   const startedAt = normalizeNumber(row.started_at);
   const endedAt = normalizeNumber(row.ended_at);
@@ -152,7 +156,7 @@ function bindTaskRecordBase(record: TaskRecord) {
     agent_id: record.agentId ?? null,
     run_id: record.runId ?? null,
     label: record.label ?? null,
-    task: record.task,
+    task: serializeTaskValue(record.task),
     status: record.status,
     delivery_status: record.deliveryStatus,
     notify_policy: record.notifyPolicy,

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -17,6 +17,7 @@ import {
   configureTaskRegistryRuntime,
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
+import { upsertTaskRegistryRecordToSqlite } from "./task-registry.store.sqlite.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 function createStoredTask(): TaskRecord {
@@ -82,6 +83,41 @@ describe("task-registry store runtime", () => {
     };
     expect(latestSnapshot.tasks.size).toBe(2);
     expect(latestSnapshot.tasks.get("task-restored")?.task).toBe("Restored task");
+  });
+
+  it("stringifies structured task values before binding them to sqlite", () => {
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), "openclaw-task-store-object-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const structuredTask = { kind: "plan", steps: ["scan", "fix"] };
+    const record = {
+      taskId: "task-object",
+      runtime: "acp",
+      requesterSessionKey: "agent:main:main",
+      ownerKey: "agent:main:main",
+      scopeKind: "session",
+      childSessionKey: "agent:main:subagent:object",
+      runId: "run-object",
+      task: structuredTask as never,
+      status: "running",
+      deliveryStatus: "pending",
+      notifyPolicy: "done_only",
+      createdAt: 123,
+    } as TaskRecord;
+
+    expect(() => upsertTaskRegistryRecordToSqlite(record)).not.toThrow();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(resolveTaskRegistrySqlitePath(process.env));
+    const row = db.prepare("SELECT task FROM task_runs WHERE task_id = ?").get(record.taskId) as
+      | { task?: string }
+      | undefined;
+
+    expect(row?.task).toBe(JSON.stringify(structuredTask));
+
+    db.close();
+    resetTaskRegistryForTests({ persist: false });
+    rmSync(stateDir, { recursive: true, force: true });
   });
 
   it("emits incremental observer events for restore, mutation, and delete", () => {


### PR DESCRIPTION
## Summary

- serialize structured `TaskRecord.task` values before binding them into sqlite
- preserve existing string task values unchanged
- add regression coverage that object task payloads are stored as JSON strings instead of throwing during sqlite binding

## Root cause

The sqlite task registry store binds `record.task` directly into the `task_runs.task` column. Most task values are strings, but structured task payloads can appear from agent/runtime paths. Passing a non-string object directly to sqlite binding can throw or persist incorrectly. The store should normalize the value before binding.

## Verification

- `pnpm exec oxfmt --write --threads=1 src/tasks/task-registry.store.sqlite.ts src/tasks/task-registry.store.test.ts`
- `git diff --check`
- `node scripts/test-projects.mjs src/tasks/task-registry.store.test.ts`
  - `src/tasks/task-registry.store.test.ts`: 11 passed
- `pnpm tsgo`
- `pnpm lint`
  - 0 warnings / 0 errors
