### PR TITLE
fix(channels): remove stale --deep guidance

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -33,6 +33,9 @@ openclaw channels logs --channel all
 - `channels resolve`: `<entries...>`, `--channel <name>`, `--account <id>`, `--kind <auto|user|group>`, `--json`
 - `channels logs`: `--channel <name|all>`, `--lines <n>`, `--json`
 
+For broader gateway health probes, use the top-level `openclaw status --deep`.
+`channels status` itself only supports `--probe`, `--timeout`, and `--json`.
+
 `channels status --probe` is the live path: on a reachable gateway it runs per-account
 `probeAccount` and optional `auditAccount` checks, so output can include transport
 state plus probe results such as `works`, `probe failed`, `audit ok`, or `audit failed`.
@@ -93,7 +96,7 @@ Notes:
 
 ## Troubleshooting
 
-- Run `openclaw status --deep` for a broad probe.
+- Run the top-level `openclaw status --deep` for a broad gateway probe.
 - Use `openclaw doctor` for guided fixes.
 - `openclaw channels list` prints `Claude: HTTP 403 ... user:profile` → usage snapshot needs the `user:profile` scope. Use `--no-usage`, or provide a claude.ai session key (`CLAUDE_WEB_SESSION_KEY` / `CLAUDE_WEB_COOKIE`), or re-auth via Claude CLI.
 - `openclaw channels status` falls back to config-only summaries when the gateway is unreachable. If a supported channel credential is configured via SecretRef but unavailable in the current command path, it reports that account as configured with degraded notes instead of showing it as not configured.

--- a/src/cli/channels-cli.ts
+++ b/src/cli/channels-cli.ts
@@ -96,7 +96,9 @@ export function registerChannelsCli(program: Command) {
 
   channels
     .command("status")
-    .description("Show gateway channel status (use status --deep for local)")
+    .description(
+      "Show gateway channel status (--probe runs live checks; use top-level openclaw status --deep for broader gateway health)",
+    )
     .option("--probe", "Probe channel credentials", false)
     .option("--timeout <ms>", "Timeout in ms", "10000")
     .option("--json", "Output JSON", false)

--- a/src/commands/channels.config-only-status-output.test.ts
+++ b/src/commands/channels.config-only-status-output.test.ts
@@ -181,6 +181,9 @@ describe("config-only channels status output", () => {
     expect(joined).toContain("TokenOnly primary");
     expect(joined).toContain("configured, secret unavailable in this command path");
     expect(joined).toContain("token:config (unavailable)");
+    expect(joined).toContain("openclaw status --deep");
+    expect(joined).toContain("broader gateway health probes");
+    expect(joined).not.toContain("channels status --deep");
   });
 
   it("prefers resolved config snapshots when command-local secret resolution succeeds", async () => {

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -18,7 +18,6 @@ import { collectChannelStatusIssues } from "../../infra/channels-status-issues.j
 import { formatTimeAgo } from "../../infra/format-time/format-relative.ts";
 import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
-import { formatDocsLink } from "../../terminal/links.js";
 import { theme } from "../../terminal/theme.js";
 import {
   type ChatChannel,
@@ -205,7 +204,7 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
     lines.push("");
   }
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: run ${formatCliCommand("openclaw status --deep")} for broader gateway health probes (top-level status; requires a reachable gateway).`,
   );
   return lines;
 }
@@ -272,7 +271,7 @@ export async function formatConfigChannelsStatusLines(
 
   lines.push("");
   lines.push(
-    `Tip: ${formatDocsLink("/cli#status", "status --deep")} adds gateway health probes to status output (requires a reachable gateway).`,
+    `Tip: run ${formatCliCommand("openclaw status --deep")} for broader gateway health probes (top-level status; requires a reachable gateway).`,
   );
   return lines;
 }


### PR DESCRIPTION
## Summary
- remove stale `--deep` guidance from `channels status` help and runtime tips
- clarify that broader gateway health probes live on top-level `openclaw status --deep`
- add a regression test covering the config-only status footer

## Why
`openclaw channels status` does not accept `--deep`, but some help and status text could still read as though that flag belonged to the subcommand.

Closes #69341.

## Verification
- `node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/channels.config-only-status-output.test.ts src/commands/channels.status.command-flow.test.ts`