### PR TITLE
fix(agents): keep added workspaces peer-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/CLI: keep `agents add` workspace defaults peer-level as `workspace-<agentId>` when the main setup workspace is `workspace`, avoiding nested agent workspaces under the main agent. Fixes #71889. Thanks @pushpendrachauhan.
 - Diagnostics/OTEL: treat normal early model stream cleanup as a completed model call instead of exporting a misleading `StreamAbandoned` error span. Thanks @vincentkoc.
 - Gateway/pairing: stop corrupt or unreadable device/node pairing stores from being treated as empty state, preserving `paired.json` for repair instead of overwriting approved pairings. Fixes #71873. Thanks @iret77.
 - ACP: keep `/acp` management commands, plus local `/status` and `/unfocus`, on the Gateway path inside ACP-bound threads so they are not consumed as ACP prompt text. Fixes #66298. Thanks @kindomLee.

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -58,6 +58,8 @@ reach other host locations unless sandboxing is enabled. See
 - Agent dir: `~/.openclaw/agents/<agentId>/agent` (or `agents.list[].agentDir`)
 - Sessions: `~/.openclaw/agents/<agentId>/sessions`
 
+Keep additional agent workspaces peer-level (`workspace-<agentId>`), not nested under `workspace/`. Recursive operations that intentionally target the main workspace, such as cleanup, search, or memory scans, can also traverse any agent workspace placed inside it.
+
 ### Single-agent mode (default)
 
 If you do nothing, OpenClaw runs a single agent:

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -53,6 +53,15 @@ function stripNullBytes(s: string): string {
   return s.replaceAll("\0", "");
 }
 
+function isManagedMainWorkspaceDir(workspaceDir: string, env: NodeJS.ProcessEnv): boolean {
+  const resolved = path.resolve(workspaceDir);
+  const stateDir = path.resolve(stripNullBytes(resolveStateDir(env)));
+  const name = path.basename(resolved);
+  return (
+    path.dirname(resolved) === stateDir && (name === "workspace" || name.startsWith("workspace-"))
+  );
+}
+
 export function listAgentEntries(cfg: OpenClawConfig): AgentEntry[] {
   const list = cfg.agents?.list;
   if (!Array.isArray(list)) {
@@ -171,7 +180,7 @@ export function resolveAgentWorkspaceDir(
   }
   if (fallback) {
     const resolvedFallback = stripNullBytes(resolveUserPath(fallback, env));
-    if (path.resolve(resolvedFallback) !== path.resolve(resolveDefaultAgentWorkspaceDir(env))) {
+    if (!isManagedMainWorkspaceDir(resolvedFallback, env)) {
       return stripNullBytes(path.join(resolvedFallback, id));
     }
   }

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -170,7 +170,10 @@ export function resolveAgentWorkspaceDir(
     return stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
   }
   if (fallback) {
-    return stripNullBytes(path.join(resolveUserPath(fallback, env), id));
+    const resolvedFallback = stripNullBytes(resolveUserPath(fallback, env));
+    if (path.resolve(resolvedFallback) !== path.resolve(resolveDefaultAgentWorkspaceDir(env))) {
+      return stripNullBytes(path.join(resolvedFallback, id));
+    }
   }
   const stateDir = resolveStateDir(env);
   return stripNullBytes(path.join(stateDir, `workspace-${id}`));

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import type {
@@ -53,13 +54,23 @@ function stripNullBytes(s: string): string {
   return s.replaceAll("\0", "");
 }
 
+function canonicalizePathForComparison(input: string): string {
+  const resolved = path.resolve(stripNullBytes(input));
+  try {
+    const realpath = fs.realpathSync.native(resolved);
+    return process.platform === "win32" ? realpath.toLowerCase() : realpath;
+  } catch {
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  }
+}
+
 function isManagedMainWorkspaceDir(workspaceDir: string, env: NodeJS.ProcessEnv): boolean {
-  const resolved = path.resolve(workspaceDir);
-  const stateDir = stripNullBytes(resolveStateDir(env));
-  const defaultWorkspaceDir = stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
+  const resolved = canonicalizePathForComparison(workspaceDir);
+  const stateDir = resolveStateDir(env);
+  const defaultWorkspaceDir = resolveDefaultAgentWorkspaceDir(env);
   return (
-    resolved === path.resolve(stateDir, "workspace") ||
-    resolved === path.resolve(defaultWorkspaceDir)
+    resolved === canonicalizePathForComparison(path.join(stateDir, "workspace")) ||
+    resolved === canonicalizePathForComparison(defaultWorkspaceDir)
   );
 }
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -55,10 +55,11 @@ function stripNullBytes(s: string): string {
 
 function isManagedMainWorkspaceDir(workspaceDir: string, env: NodeJS.ProcessEnv): boolean {
   const resolved = path.resolve(workspaceDir);
-  const stateDir = path.resolve(stripNullBytes(resolveStateDir(env)));
-  const name = path.basename(resolved);
+  const stateDir = stripNullBytes(resolveStateDir(env));
+  const defaultWorkspaceDir = stripNullBytes(resolveDefaultAgentWorkspaceDir(env));
   return (
-    path.dirname(resolved) === stateDir && (name === "workspace" || name.startsWith("workspace-"))
+    resolved === path.resolve(stateDir, "workspace") ||
+    resolved === path.resolve(defaultWorkspaceDir)
   );
 }
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -493,6 +493,20 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.resolve("/shared-ws/main"));
   });
 
+  it("non-default agent preserves in-state custom shared workspace bases", () => {
+    const stateDir = path.join(path.sep, "tmp", "test-state");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: path.join(stateDir, "workspace-shared") },
+        list: [{ id: "main" }, { id: "work", default: true, workspace: "/work-ws" }],
+      },
+    };
+
+    const workspace = resolveAgentWorkspaceDir(cfg, "main");
+    expect(workspace).toBe(path.join(stateDir, "workspace-shared", "main"));
+  });
+
   it("non-default agent does not nest under the default main workspace", () => {
     const home = path.join(path.sep, "tmp", "test-home");
     const stateDir = path.join(home, ".openclaw");

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -493,6 +493,22 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.resolve("/shared-ws/main"));
   });
 
+  it("non-default agent does not nest under the default main workspace", () => {
+    const home = path.join(path.sep, "tmp", "test-home");
+    const stateDir = path.join(home, ".openclaw");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: path.join(stateDir, "workspace") },
+        list: [{ id: "main", default: true }, { id: "work" }],
+      },
+    };
+
+    const workspace = resolveAgentWorkspaceDir(cfg, "work");
+    expect(workspace).toBe(path.join(stateDir, "workspace-work"));
+  });
+
   it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -523,6 +523,32 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.join(stateDir, "workspace-work"));
   });
 
+  it("non-default agent does not nest through a symlink to the main workspace", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-agent-scope-symlink-"));
+    try {
+      const stateDir = path.join(rootDir, ".openclaw");
+      const mainWorkspace = path.join(stateDir, "workspace");
+      const workspaceLink = path.join(rootDir, "workspace-link");
+      fs.mkdirSync(mainWorkspace, { recursive: true });
+      fs.symlinkSync(mainWorkspace, workspaceLink);
+      vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: workspaceLink },
+          list: [{ id: "main", default: true }, { id: "work" }],
+        },
+      };
+
+      const workspace = resolveAgentWorkspaceDir(cfg, "work");
+      expect(workspace).toBe(path.join(stateDir, "workspace-work"));
+    } finally {
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("non-default agent does not nest after changing OPENCLAW_PROFILE", () => {
     const home = path.join(path.sep, "tmp", "test-home");
     const stateDir = path.join(home, ".openclaw");

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -509,6 +509,41 @@ describe("resolveAgentConfig", () => {
     expect(workspace).toBe(path.join(stateDir, "workspace-work"));
   });
 
+  it("non-default agent does not nest after changing OPENCLAW_PROFILE", () => {
+    const home = path.join(path.sep, "tmp", "test-home");
+    const stateDir = path.join(home, ".openclaw");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_STATE_DIR", "");
+    vi.stubEnv("OPENCLAW_PROFILE", "dev");
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: path.join(stateDir, "workspace") },
+        list: [{ id: "main", default: true }, { id: "work" }],
+      },
+    };
+
+    const workspace = resolveAgentWorkspaceDir(cfg, "work");
+    expect(workspace).toBe(path.join(stateDir, "workspace-work"));
+  });
+
+  it("keeps explicit nested agent workspace configs unchanged", () => {
+    const stateDir = path.join(path.sep, "tmp", "test-state");
+    const nestedWorkspace = path.join(stateDir, "workspace", "work");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: { workspace: path.join(stateDir, "workspace") },
+        list: [
+          { id: "main", default: true },
+          { id: "work", workspace: nestedWorkspace },
+        ],
+      },
+    };
+
+    const workspace = resolveAgentWorkspaceDir(cfg, "work");
+    expect(workspace).toBe(nestedWorkspace);
+  });
+
   it("default agent without per-agent workspace uses agents.defaults.workspace directly", () => {
     const cfg: OpenClawConfig = {
       agents: {


### PR DESCRIPTION
## Summary
- Fix `agents add` workspace defaults so setup's main `workspace` directory is treated as the main agent workspace, not a shared base for new agents.
- Preserve custom shared workspace bases, where non-default agents still resolve under the configured base.
- Add regression coverage and a changelog entry for #71889.

## Root Cause
`openclaw setup` stores the main workspace in `agents.defaults.workspace`. The `agents add` wizard asks `resolveAgentWorkspaceDir()` for the new agent's default, and the resolver appended non-default agent ids to any `agents.defaults.workspace`, including the setup-created main workspace. That produced nested paths like `workspace/testbug` instead of the documented peer-level `workspace-testbug`.

## Why This Fix Is Safe
The resolver now only treats `agents.defaults.workspace` as a shared base when it differs from the normal main-agent workspace default. Explicit per-agent `workspace` values still win, default-agent resolution is unchanged, and intentionally custom bases such as `/shared-ws/<agentId>` keep the existing behavior.

## Security / Runtime Controls
This changes the runtime workspace path resolver used by the CLI and Gateway paths; it does not rely on prompt text. Workspace sandboxing, fs-safe policy, workspace-only controls, and agent config authorization behavior are unchanged.

## Self-Review
- Test helper defaults match production defaults: the regression uses `resolveAgentWorkspaceDir()` with `OPENCLAW_HOME` to model setup's default main workspace.
- Config defaults, schema help, and generated artifacts are unchanged; only the fallback interpretation changed.
- Security posture is unchanged because this affects path selection, not sandbox policy or permission checks.

## Tests
- `pnpm test src/agents/agent-scope.test.ts`
- `pnpm test src/agents/agent-scope.test.ts src/commands/agents.add.test.ts src/infra/changelog-unreleased.test.ts`
- `pnpm check:changed` (failed in expanded agents test lane with Vitest worker OOM after 349/350 files passed; typecheck, lint, import-cycle, and guards passed)
- `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`

## Notes
- AI-assisted: yes.

Made with [Cursor](https://cursor.com)