### PR TITLE
Add managed flow residue resolution

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1474,7 +1474,7 @@ jobs:
             exit 1
           }
 
-          case "${{ matrix.providers }}" in
+          case "$OPENCLAW_LIVE_PROVIDERS" in
             anthropic) require_any Anthropic ANTHROPIC_API_KEY ANTHROPIC_API_KEY_OLD ANTHROPIC_API_TOKEN ;;
             google) require_any Google GEMINI_API_KEY GOOGLE_API_KEY ;;
             minimax) require_any MiniMax MINIMAX_API_KEY ;;
@@ -1485,7 +1485,7 @@ jobs:
             zai) require_any Z.ai ZAI_API_KEY Z_AI_API_KEY ;;
             fireworks) require_any Fireworks FIREWORKS_API_KEY ;;
             *)
-              echo "Unhandled live model provider shard: ${{ matrix.providers }}" >&2
+              echo "Unhandled live model provider shard: $OPENCLAW_LIVE_PROVIDERS" >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/parity-gate.yml
+++ b/.github/workflows/parity-gate.yml
@@ -42,6 +42,12 @@ jobs:
       # followthrough gate that expects a fast post-approval read within a 30s
       # agent.wait timeout.
       QA_PARITY_CONCURRENCY: "1"
+      # The mock provider itself is deterministic, but the parity pack runs a
+      # real gateway, filesystem tools, subagents, config restarts, and two full
+      # provider lanes on a shared CI runner. Keep per-turn waits long enough to
+      # absorb transient event-loop/CPU stalls without weakening the scenario
+      # assertions, which still require the exact tool-derived evidence.
+      OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS: "120000"
       OPENCLAW_CI_OPENAI_MODEL: ${{ vars.OPENCLAW_CI_OPENAI_MODEL || 'openai/gpt-5.5' }}
       OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "180000"
       OPENAI_API_KEY: ""

--- a/extensions/qa-lab/src/live-timeout.test.ts
+++ b/extensions/qa-lab/src/live-timeout.test.ts
@@ -15,6 +15,39 @@ describe("qa live timeout policy", () => {
     ).toBe(30_000);
   });
 
+  it("allows CI to floor mock turn timeouts when the gateway runner is saturated", () => {
+    const previous = process.env.OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS;
+    process.env.OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS = "120000";
+    try {
+      expect(
+        resolveQaLiveTurnTimeoutMs(
+          {
+            providerMode: "mock-openai",
+            primaryModel: "anthropic/claude-opus-4-6",
+            alternateModel: "anthropic/claude-sonnet-4-6",
+          },
+          30_000,
+        ),
+      ).toBe(120_000);
+      expect(
+        resolveQaLiveTurnTimeoutMs(
+          {
+            providerMode: "mock-openai",
+            primaryModel: "anthropic/claude-opus-4-6",
+            alternateModel: "anthropic/claude-sonnet-4-6",
+          },
+          180_000,
+        ),
+      ).toBe(180_000);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS;
+      } else {
+        process.env.OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS = previous;
+      }
+    }
+  });
+
   it("uses the higher gpt-5 live floor for openai heavy turns", () => {
     expect(
       resolveQaLiveTurnTimeoutMs(

--- a/extensions/qa-lab/src/providers/shared/mock-provider-definition.ts
+++ b/extensions/qa-lab/src/providers/shared/mock-provider-definition.ts
@@ -32,7 +32,17 @@ export function createMockQaProviderDefinition(
       transport: "sse",
       openaiWsWarmup: false,
     }),
-    resolveTurnTimeoutMs: ({ fallbackMs }) => fallbackMs,
+    resolveTurnTimeoutMs: ({ fallbackMs }) => {
+      const rawFloorMs = process.env.OPENCLAW_QA_MOCK_TURN_TIMEOUT_FLOOR_MS;
+      if (!rawFloorMs) {
+        return fallbackMs;
+      }
+      const floorMs = Number(rawFloorMs);
+      if (!Number.isFinite(floorMs) || floorMs < 1) {
+        return fallbackMs;
+      }
+      return Math.max(fallbackMs, Math.floor(floorMs));
+    },
     buildGatewayModels: ({ providerBaseUrl }) => ({
       mode: "replace",
       providers: createMockProviderMap(params.mode, providerBaseUrl),

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -365,8 +365,9 @@ export function resolveReplayInvalidFlag(params: {
   attempt: RunLivenessAttempt;
   incompleteTurnText?: string | null;
 }): boolean {
+  const replayMetadata = resolveAttemptReplayMetadata(params.attempt);
   return (
-    !resolveAttemptReplayMetadata(params.attempt).replaySafe ||
+    !replayMetadata.replaySafe ||
     params.attempt.promptErrorSource === "compaction" ||
     params.attempt.timedOutDuringCompaction ||
     Boolean(params.incompleteTurnText)

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,6 +1,11 @@
 import type { Command } from "commander";
 import { exportTrajectoryCommand } from "../../commands/export-trajectory.js";
-import { flowsCancelCommand, flowsListCommand, flowsShowCommand } from "../../commands/flows.js";
+import {
+  flowsCancelCommand,
+  flowsListCommand,
+  flowsResolveResidueCommand,
+  flowsShowCommand,
+} from "../../commands/flows.js";
 import { healthCommand } from "../../commands/health.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
 import { sessionsCommand } from "../../commands/sessions.js";
@@ -317,7 +322,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
     .option("--severity <level>", "Filter by severity (warn, error)")
     .option(
       "--code <name>",
-      "Filter by finding code (stale_queued, stale_running, lost, delivery_failed, missing_cleanup, inconsistent_timestamps, restore_failed, stale_waiting, stale_blocked, cancel_stuck, missing_linked_tasks, blocked_task_missing)",
+      "Filter by finding code (stale_queued, stale_running, lost, delivery_failed, missing_cleanup, inconsistent_timestamps, restore_failed, stale_waiting, stale_blocked, cancel_stuck, missing_linked_tasks, blocked_task_missing, terminal_residue_unresolved)",
     )
     .option("--limit <n>", "Limit displayed findings")
     .action(async (opts, command) => {
@@ -340,6 +345,7 @@ export function registerStatusHealthSessionsCommands(program: Command) {
               | "cancel_stuck"
               | "missing_linked_tasks"
               | "blocked_task_missing"
+              | "terminal_residue_unresolved"
               | undefined,
             limit: parsePositiveIntOrUndefined(opts.limit),
           },
@@ -466,6 +472,30 @@ export function registerStatusHealthSessionsCommands(program: Command) {
         await flowsCancelCommand(
           {
             lookup,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  tasksFlowCmd
+    .command("resolve-residue")
+    .description("Record an owner-approved residue disposition for a managed TaskFlow")
+    .argument("<lookup>", "Flow id or owner key")
+    .requiredOption(
+      "--disposition <name>",
+      "Residue disposition (currently: interpreted_non_blocking)",
+    )
+    .option("--reason <text>", "Human-readable reason")
+    .option("--json", "Output as JSON", false)
+    .action(async (lookup, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await flowsResolveResidueCommand(
+          {
+            lookup,
+            disposition: opts.disposition as string,
+            reason: opts.reason as string | undefined,
+            json: Boolean(opts.json),
           },
           defaultRuntime,
         );

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -108,6 +108,39 @@ function formatFlowListSummary(flows: TaskFlowRecord[]) {
   return `${active} active · ${blocked} blocked · ${cancelRequested} cancel-requested · ${flows.length} total`;
 }
 
+function summarizeWait(flow: TaskFlowRecord): string {
+  if (flow.waitJson == null) {
+    return "waiting";
+  }
+  if (
+    typeof flow.waitJson === "string" ||
+    typeof flow.waitJson === "number" ||
+    typeof flow.waitJson === "boolean"
+  ) {
+    return String(flow.waitJson);
+  }
+  if (Array.isArray(flow.waitJson)) {
+    return `array(${flow.waitJson.length})`;
+  }
+  return Object.keys(flow.waitJson).toSorted().join(", ") || "object";
+}
+
+function summarizeFlowState(flow: TaskFlowRecord): string | null {
+  if (flow.status === "blocked") {
+    if (flow.blockedSummary) {
+      return flow.blockedSummary;
+    }
+    if (flow.blockedTaskId) {
+      return `blocked by ${flow.blockedTaskId}`;
+    }
+    return "blocked";
+  }
+  if (flow.status === "waiting" && flow.waitJson != null) {
+    return summarizeWait(flow);
+  }
+  return null;
+}
+
 function formatResidueResolutionValue(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -176,6 +209,7 @@ export async function flowsShowCommand(
   }
   const tasks = listTasksForFlowId(flow.flowId);
   const taskSummary = getFlowTaskSummary(flow.flowId);
+  const stateSummary = summarizeFlowState(flow);
   const residueResolution = getFlowResidueResolution(flow);
 
   if (opts.json) {
@@ -201,7 +235,7 @@ export async function flowsShowCommand(
     `currentStep: ${safeFlowDisplayText(flow.currentStep)}`,
     `owner: ${safeFlowDisplayText(flow.ownerKey)}`,
     `notify: ${flow.notifyPolicy}`,
-    ...(flow.blockedSummary ? [`state: ${safeFlowDisplayText(flow.blockedSummary)}`] : []),
+    ...(stateSummary ? [`state: ${safeFlowDisplayText(stateSummary)}`] : []),
     ...(residueResolution?.disposition
       ? [
           `residueDisposition: ${safeFlowDisplayText(

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -3,13 +3,18 @@ import { info } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
-import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
+import {
+  cancelFlowById,
+  getFlowTaskSummary,
+  resolveFlowResidueById,
+} from "../tasks/task-executor.js";
 import type { TaskFlowRecord, TaskFlowStatus } from "../tasks/task-flow-registry.types.js";
 import {
   getTaskFlowById,
   listTaskFlowRecords,
   resolveTaskFlowForLookupToken,
 } from "../tasks/task-flow-runtime-internal.js";
+import { getFlowResidueResolution } from "../tasks/task-flow-state-json.js";
 import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import { isRich, theme } from "../terminal/theme.js";
 
@@ -103,37 +108,14 @@ function formatFlowListSummary(flows: TaskFlowRecord[]) {
   return `${active} active · ${blocked} blocked · ${cancelRequested} cancel-requested · ${flows.length} total`;
 }
 
-function summarizeWait(flow: TaskFlowRecord): string {
-  if (flow.waitJson == null) {
+function formatResidueResolutionValue(value: unknown): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value == null) {
     return "n/a";
   }
-  if (
-    typeof flow.waitJson === "string" ||
-    typeof flow.waitJson === "number" ||
-    typeof flow.waitJson === "boolean"
-  ) {
-    return String(flow.waitJson);
-  }
-  if (Array.isArray(flow.waitJson)) {
-    return `array(${flow.waitJson.length})`;
-  }
-  return Object.keys(flow.waitJson).toSorted().join(", ") || "object";
-}
-
-function summarizeFlowState(flow: TaskFlowRecord): string | null {
-  if (flow.status === "blocked") {
-    if (flow.blockedSummary) {
-      return flow.blockedSummary;
-    }
-    if (flow.blockedTaskId) {
-      return `blocked by ${flow.blockedTaskId}`;
-    }
-    return "blocked";
-  }
-  if (flow.status === "waiting" && flow.waitJson != null) {
-    return summarizeWait(flow);
-  }
-  return null;
+  return JSON.stringify(value);
 }
 
 export async function flowsListCommand(
@@ -194,7 +176,7 @@ export async function flowsShowCommand(
   }
   const tasks = listTasksForFlowId(flow.flowId);
   const taskSummary = getFlowTaskSummary(flow.flowId);
-  const stateSummary = summarizeFlowState(flow);
+  const residueResolution = getFlowResidueResolution(flow);
 
   if (opts.json) {
     runtime.log(
@@ -219,7 +201,24 @@ export async function flowsShowCommand(
     `currentStep: ${safeFlowDisplayText(flow.currentStep)}`,
     `owner: ${safeFlowDisplayText(flow.ownerKey)}`,
     `notify: ${flow.notifyPolicy}`,
-    ...(stateSummary ? [`state: ${safeFlowDisplayText(stateSummary)}`] : []),
+    ...(flow.blockedSummary ? [`state: ${safeFlowDisplayText(flow.blockedSummary)}`] : []),
+    ...(residueResolution?.disposition
+      ? [
+          `residueDisposition: ${safeFlowDisplayText(
+            formatResidueResolutionValue(residueResolution.disposition),
+          )}`,
+        ]
+      : []),
+    ...(residueResolution?.reason
+      ? [
+          `residueReason: ${safeFlowDisplayText(
+            formatResidueResolutionValue(residueResolution.reason),
+          )}`,
+        ]
+      : []),
+    ...(typeof residueResolution?.resolvedAt === "number"
+      ? [`residueResolvedAt: ${new Date(residueResolution.resolvedAt).toISOString()}`]
+      : []),
     ...(flow.cancelRequestedAt
       ? [`cancelRequestedAt: ${new Date(flow.cancelRequestedAt).toISOString()}`]
       : []),
@@ -265,4 +264,50 @@ export async function flowsCancelCommand(opts: { lookup: string }, runtime: Runt
   }
   const updated = getTaskFlowById(flow.flowId) ?? result.flow ?? flow;
   runtime.log(`Cancelled ${updated.flowId} (${updated.syncMode}) with status ${updated.status}.`);
+}
+
+export async function flowsResolveResidueCommand(
+  opts: { json?: boolean; lookup: string; disposition: string; reason?: string },
+  runtime: RuntimeEnv,
+) {
+  const flow = resolveTaskFlowForLookupToken(opts.lookup);
+  if (!flow) {
+    runtime.error(`Flow not found: ${opts.lookup}`);
+    runtime.exit(1);
+    return;
+  }
+  const result = resolveFlowResidueById({
+    flowId: flow.flowId,
+    disposition: opts.disposition,
+    reason: opts.reason,
+  });
+  if (!result.found) {
+    runtime.error(result.reason ?? `Flow not found: ${opts.lookup}`);
+    runtime.exit(1);
+    return;
+  }
+  if (!result.applied || !result.flow) {
+    runtime.error(result.reason ?? `Could not resolve residue for TaskFlow: ${opts.lookup}`);
+    runtime.exit(1);
+    return;
+  }
+  if (opts.json) {
+    runtime.log(JSON.stringify({ flow: result.flow, tasks: result.tasks ?? [] }, null, 2));
+    return;
+  }
+  const residueResolution = getFlowResidueResolution(result.flow);
+  runtime.log(`Resolved residue for ${result.flow.flowId} (${result.flow.status}).`);
+  runtime.log(
+    `residueDisposition: ${safeFlowDisplayText(
+      formatResidueResolutionValue(residueResolution?.disposition),
+    )}`,
+  );
+  if (residueResolution?.reason) {
+    runtime.log(
+      `residueReason: ${safeFlowDisplayText(formatResidueResolutionValue(residueResolution.reason))}`,
+    );
+  }
+  if (typeof residueResolution?.resolvedAt === "number") {
+    runtime.log(`residueResolvedAt: ${new Date(residueResolution.resolvedAt).toISOString()}`);
+  }
 }

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -542,7 +542,7 @@ export async function tasksMaintenanceCommand(
 
   runtime.log(
     info(
-      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.recovered} recovered · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.pruned} prune`,
+      `Tasks maintenance (${opts.apply ? "applied" : "preview"}): tasks ${taskMaintenance.reconciled} reconcile · ${taskMaintenance.recovered} recovered · ${taskMaintenance.cleanupStamped} cleanup stamp · ${taskMaintenance.pruned} prune; task-flows ${flowMaintenance.reconciled} reconcile · ${flowMaintenance.invariantStamped} invariant stamp · ${flowMaintenance.pruned} prune`,
     ),
   );
   runtime.log(

--- a/src/plugin-sdk/github-copilot-login.ts
+++ b/src/plugin-sdk/github-copilot-login.ts
@@ -4,7 +4,7 @@ import { loadBundledPluginPublicSurfaceModuleSync } from "./facade-loader.js";
 
 type FacadeModule = {
   githubCopilotLoginCommand: (
-    opts: { profileId?: string; yes?: boolean },
+    opts: { profileId?: string; yes?: boolean; agentDir?: string },
     runtime: RuntimeEnv,
   ) => Promise<void>;
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -1101,6 +1101,7 @@ export type ProviderPluginWizardSetup = {
   modelAllowlist?: {
     allowedKeys?: string[];
     initialSelections?: string[];
+    loadCatalog?: boolean;
     message?: string;
   };
   /**

--- a/src/tasks/task-boundaries.test.ts
+++ b/src/tasks/task-boundaries.test.ts
@@ -29,6 +29,7 @@ const TASK_FLOW_REGISTRY_ALLOWED_IMPORTERS = new Set([
   "tasks/task-flow-registry.audit.ts",
   "tasks/task-flow-registry.maintenance.ts",
   "tasks/task-flow-runtime-internal.ts",
+  "tasks/task-registry.ts",
 ]);
 
 const TASK_REGISTRY_ALLOWED_IMPORTERS = new Set([

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -27,6 +27,7 @@ import {
   deleteTaskFlowRecordById,
   getTaskFlowById,
   requestFlowCancel,
+  resolveManagedFlowResidue,
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
@@ -355,6 +356,14 @@ export function retryBlockedFlowAsRunningTaskRun(
 type CancelFlowResult = {
   found: boolean;
   cancelled: boolean;
+  reason?: string;
+  flow?: TaskFlowRecord;
+  tasks?: TaskRecord[];
+};
+
+type ResidueResolutionResult = {
+  found: boolean;
+  applied: boolean;
   reason?: string;
   flow?: TaskFlowRecord;
   tasks?: TaskRecord[];
@@ -693,4 +702,12 @@ export async function cancelDetachedTaskRunById(params: { cfg: OpenClawConfig; t
     }
   }
   return cancelTaskById(params);
+}
+
+export function resolveFlowResidueById(params: {
+  flowId: string;
+  disposition: string;
+  reason?: string | null;
+}): ResidueResolutionResult {
+  return resolveManagedFlowResidue(params);
 }

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { createRunningTaskRun } from "./task-executor.js";
+import { createQueuedTaskRun, createRunningTaskRun } from "./task-executor.js";
 import { listTaskFlowAuditFindings } from "./task-flow-registry.audit.js";
 import {
   createManagedTaskFlow,
+  finishFlow,
   resetTaskFlowRegistryForTests,
   setFlowWaiting,
 } from "./task-flow-registry.js";
@@ -133,6 +134,44 @@ describe("task-flow-registry audit", () => {
           expect.objectContaining({
             code: "blocked_task_missing",
             flow: expect.objectContaining({ flowId: blocked.flowId }),
+          }),
+        ]),
+      );
+    });
+  });
+
+  it("reports unresolved residue on terminal managed flows with active linked tasks", async () => {
+    await withTaskFlowAuditStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-audit",
+        goal: "Terminal residue",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 100,
+      });
+      createQueuedTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        runId: "queued-residue",
+        task: "Queued child residue",
+      });
+      expect(
+        finishFlow({
+          flowId: flow.flowId,
+          expectedRevision: flow.revision,
+          updatedAt: 200,
+          endedAt: 200,
+        }),
+      ).toMatchObject({ applied: true });
+
+      expect(listTaskFlowAuditFindings({ now: 31 * 60_000 })).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "terminal_residue_unresolved",
+            flow: expect.objectContaining({ flowId: flow.flowId }),
           }),
         ]),
       );

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -1,6 +1,7 @@
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { getFlowResidueResolution } from "./task-flow-state-json.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 export type TaskFlowAuditSeverity = "warn" | "error";
@@ -12,6 +13,7 @@ export type TaskFlowAuditCode =
   | "cancel_stuck"
   | "missing_linked_tasks"
   | "blocked_task_missing"
+  | "terminal_residue_unresolved"
   | "inconsistent_timestamps";
 
 export type TaskFlowAuditFinding = {
@@ -90,6 +92,15 @@ function hasBlockingMetadata(flow: TaskFlowRecord): boolean {
   );
 }
 
+function isTerminalFlow(flow: TaskFlowRecord): boolean {
+  return (
+    flow.status === "succeeded" ||
+    flow.status === "failed" ||
+    flow.status === "cancelled" ||
+    flow.status === "lost"
+  );
+}
+
 function findTimestampInconsistency(flow: TaskFlowRecord): TaskFlowAuditFinding | null {
   if (flow.updatedAt < flow.createdAt) {
     return createFinding({
@@ -131,6 +142,7 @@ export function createEmptyTaskFlowAuditSummary(): TaskFlowAuditSummary {
       cancel_stuck: 0,
       missing_linked_tasks: 0,
       blocked_task_missing: 0,
+      terminal_residue_unresolved: 0,
       inconsistent_timestamps: 0,
     },
   };
@@ -258,6 +270,23 @@ export function listTaskFlowAuditFindings(
           }),
         );
       }
+    }
+
+    if (
+      flow.syncMode === "managed" &&
+      isTerminalFlow(flow) &&
+      activeTasks.length > 0 &&
+      !getFlowResidueResolution(flow)
+    ) {
+      findings.push(
+        createFinding({
+          severity: "warn",
+          code: "terminal_residue_unresolved",
+          flow,
+          ageMs,
+          detail: `terminal managed TaskFlow still has ${activeTasks.length} active linked task(s) without residue disposition`,
+        }),
+      );
     }
 
     const inconsistency = findTimestampInconsistency(flow);

--- a/src/tasks/task-flow-registry.maintenance.test.ts
+++ b/src/tasks/task-flow-registry.maintenance.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import { createRunningTaskRun } from "./task-executor.js";
+import { createQueuedTaskRun, createRunningTaskRun } from "./task-executor.js";
 import {
   createFlowRecord,
   createManagedTaskFlow,
+  finishFlow,
   getTaskFlowById,
   listTaskFlowRecords,
   requestFlowCancel,
@@ -70,11 +71,13 @@ describe("task-flow-registry maintenance", () => {
 
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
+        invariantStamped: 0,
         pruned: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
+        invariantStamped: 0,
         pruned: 0,
       });
       expect(getTaskFlowById(flow.flowId)).toMatchObject({
@@ -100,11 +103,13 @@ describe("task-flow-registry maintenance", () => {
 
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 1,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 1,
       });
       expect(getTaskFlowById(oldFlow.flowId)).toBeUndefined();
@@ -126,11 +131,13 @@ describe("task-flow-registry maintenance", () => {
       expect(getInspectableTaskFlowAuditSummary().byCode.inconsistent_timestamps).toBe(1);
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
+        invariantStamped: 0,
         pruned: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 1,
+        invariantStamped: 0,
         pruned: 0,
       });
       expect(getTaskFlowById(flow.flowId)).toMatchObject({
@@ -181,11 +188,13 @@ describe("task-flow-registry maintenance", () => {
 
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 0,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 0,
       });
       expect(getTaskFlowById(flow.flowId)).toMatchObject({
@@ -194,6 +203,61 @@ describe("task-flow-registry maintenance", () => {
         cancelRequestedAt: 100,
       });
       expect(child.parentFlowId).toBe(flow.flowId);
+    });
+  });
+
+  it("stamps unresolved terminal managed residue without resolving it", async () => {
+    await withTaskFlowMaintenanceStateDir(async () => {
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-flow-maintenance",
+        goal: "Terminal residue",
+        status: "running",
+        createdAt: 1,
+        updatedAt: 100,
+      });
+      createQueuedTaskRun({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        runId: "queued-residue",
+        task: "Queued child residue",
+      });
+      const finished = finishFlow({
+        flowId: flow.flowId,
+        expectedRevision: flow.revision,
+        updatedAt: 200,
+        endedAt: 200,
+      });
+      expect(finished).toMatchObject({ applied: true });
+
+      expect(previewTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        invariantStamped: 1,
+        pruned: 0,
+      });
+
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        invariantStamped: 1,
+        pruned: 0,
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        stateJson: {
+          residueInvariant: {
+            status: "unresolved",
+            activeTaskIds: expect.any(Array),
+            activeTaskStatuses: expect.any(Array),
+            detectedAt: expect.any(Number),
+          },
+        },
+      });
+      expect(await runTaskFlowRegistryMaintenance()).toEqual({
+        reconciled: 0,
+        invariantStamped: 0,
+        pruned: 0,
+      });
     });
   });
 
@@ -234,11 +298,13 @@ describe("task-flow-registry maintenance", () => {
 
       expect(previewTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 25,
       });
 
       expect(await runTaskFlowRegistryMaintenance()).toEqual({
         reconciled: 0,
+        invariantStamped: 0,
         pruned: 25,
       });
 

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -11,11 +11,13 @@ import {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { getFlowResidueResolution, mergeFlowStateJson } from "./task-flow-state-json.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
 export type TaskFlowRegistryMaintenanceSummary = {
   reconciled: number;
+  invariantStamped: number;
   pruned: number;
 };
 
@@ -31,6 +33,12 @@ function isTerminalFlow(flow: TaskFlowRecord): boolean {
 
 function hasActiveLinkedTasks(flowId: string): boolean {
   return listTasksForFlowId(flowId).some(
+    (task) => task.status === "queued" || task.status === "running",
+  );
+}
+
+function listActiveLinkedTasks(flowId: string) {
+  return listTasksForFlowId(flowId).filter(
     (task) => task.status === "queued" || task.status === "running",
   );
 }
@@ -57,6 +65,77 @@ function shouldFinalizeCancelledFlow(flow: TaskFlowRecord): boolean {
     return false;
   }
   return !hasActiveLinkedTasks(flow.flowId);
+}
+
+function shouldStampTerminalResidueInvariant(flow: TaskFlowRecord): boolean {
+  if (flow.syncMode !== "managed" || !isTerminalFlow(flow)) {
+    return false;
+  }
+  if (getFlowResidueResolution(flow)) {
+    return false;
+  }
+  const activeTasks = listActiveLinkedTasks(flow.flowId);
+  if (activeTasks.length === 0) {
+    return false;
+  }
+  const state = flow.stateJson;
+  const invariant =
+    state && typeof state === "object" && !Array.isArray(state) ? state.residueInvariant : null;
+  const activeTaskIds = activeTasks.map((task) => task.taskId).toSorted();
+  if (invariant && typeof invariant === "object" && !Array.isArray(invariant)) {
+    const status = "status" in invariant ? invariant.status : null;
+    const stampedActiveTaskIds = "activeTaskIds" in invariant ? invariant.activeTaskIds : null;
+    if (
+      status === "unresolved" &&
+      Array.isArray(stampedActiveTaskIds) &&
+      stampedActiveTaskIds.every((value) => typeof value === "string") &&
+      stampedActiveTaskIds.toSorted().join("\0") === activeTaskIds.join("\0")
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function stampTerminalResidueInvariant(flow: TaskFlowRecord, now: number): boolean {
+  let current = flow;
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const activeTasks = listActiveLinkedTasks(current.flowId);
+    if (activeTasks.length === 0 || getFlowResidueResolution(current)) {
+      return false;
+    }
+    const stampedAt = Math.max(now, current.updatedAt, current.endedAt ?? now);
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId: current.flowId,
+      expectedRevision: current.revision,
+      patch: {
+        stateJson: mergeFlowStateJson(current.stateJson, {
+          residueInvariant: {
+            status: "unresolved",
+            activeTaskIds: activeTasks.map((task) => task.taskId),
+            activeTaskStatuses: activeTasks.map((task) => ({
+              taskId: task.taskId,
+              status: task.status,
+            })),
+            detectedAt: stampedAt,
+          },
+        }),
+        updatedAt: stampedAt,
+        endedAt: stampedAt,
+      },
+    });
+    if (result.applied) {
+      return true;
+    }
+    if (result.reason === "not_found" || !result.current) {
+      return false;
+    }
+    current = result.current;
+    if (!shouldStampTerminalResidueInvariant(current)) {
+      return false;
+    }
+  }
+  return false;
 }
 
 function finalizeCancelledFlow(flow: TaskFlowRecord, now: number): boolean {
@@ -130,6 +209,7 @@ export function getInspectableTaskFlowAuditSummary(): TaskFlowAuditSummary {
 export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanceSummary {
   const now = Date.now();
   let reconciled = 0;
+  let invariantStamped = 0;
   let pruned = 0;
   for (const flow of listTaskFlowRecords()) {
     if (shouldRepairTerminalMirroredFlowTimestamp(flow)) {
@@ -140,16 +220,21 @@ export function previewTaskFlowRegistryMaintenance(): TaskFlowRegistryMaintenanc
       reconciled += 1;
       continue;
     }
+    if (shouldStampTerminalResidueInvariant(flow)) {
+      invariantStamped += 1;
+      continue;
+    }
     if (shouldPruneFlow(flow, now)) {
       pruned += 1;
     }
   }
-  return { reconciled, pruned };
+  return { reconciled, invariantStamped, pruned };
 }
 
 export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistryMaintenanceSummary> {
   const now = Date.now();
   let reconciled = 0;
+  let invariantStamped = 0;
   let pruned = 0;
   for (const flow of listTaskFlowRecords()) {
     const current = getTaskFlowById(flow.flowId);
@@ -168,9 +253,15 @@ export async function runTaskFlowRegistryMaintenance(): Promise<TaskFlowRegistry
       }
       continue;
     }
+    if (shouldStampTerminalResidueInvariant(current)) {
+      if (stampTerminalResidueInvariant(current, now)) {
+        invariantStamped += 1;
+      }
+      continue;
+    }
     if (shouldPruneFlow(current, now) && deleteTaskFlowRecordById(current.flowId)) {
       pruned += 1;
     }
   }
-  return { reconciled, pruned };
+  return { reconciled, invariantStamped, pruned };
 }

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -398,6 +398,8 @@ describe("task-flow-registry", () => {
         flow: expect.objectContaining({
           flowId: created.flowId,
           revision: 1,
+          updatedAt: 200,
+          endedAt: 200,
           stateJson: {
             residueResolution: {
               disposition: "interpreted_non_blocking",

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -10,6 +10,7 @@ import {
   listTaskFlowRecords,
   requestFlowCancel,
   resetTaskFlowRegistryForTests,
+  resolveManagedFlowResidue,
   resumeFlow,
   setFlowWaiting,
   syncFlowFromTask,
@@ -365,6 +366,47 @@ describe("task-flow-registry", () => {
         status: "waiting",
         currentStep: "wait_for",
         waitJson: { kind: "external_event" },
+      });
+    });
+  });
+
+  it("records owner-approved residue disposition on terminal managed flows", async () => {
+    await withFlowRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskFlowRegistryForTests();
+
+      const created = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/residue-resolution",
+        goal: "Residue resolution",
+        status: "succeeded",
+        createdAt: 1,
+        updatedAt: 100,
+        endedAt: 100,
+      });
+
+      const resolved = resolveManagedFlowResidue({
+        flowId: created.flowId,
+        disposition: "interpreted_non_blocking",
+        reason: "owner approved",
+        updatedAt: 200,
+      });
+
+      expect(resolved).toMatchObject({
+        found: true,
+        applied: true,
+        flow: expect.objectContaining({
+          flowId: created.flowId,
+          revision: 1,
+          stateJson: {
+            residueResolution: {
+              disposition: "interpreted_non_blocking",
+              linkedTaskIds: [],
+              reason: "owner approved",
+              resolvedAt: 200,
+            },
+          },
+        }),
       });
     });
   });

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -672,6 +672,7 @@ export function resolveManagedFlowResidue(params: {
           },
         }),
         updatedAt,
+        endedAt: updatedAt,
       },
     });
     if (result.applied) {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -14,12 +14,25 @@ import type {
   TaskFlowSyncMode,
   JsonValue,
 } from "./task-flow-registry.types.js";
+import { mergeFlowStateJson } from "./task-flow-state-json.js";
+import type { TaskFlowSyncTask } from "./task-flow-sync.types.js";
 import type { TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 
 const log = createSubsystemLogger("tasks/task-flow-registry");
 const flows = new Map<string, TaskFlowRecord>();
 let restoreAttempted = false;
 let restoreFailureMessage: string | null = null;
+let linkedTasksResolver: (flowId: string) => TaskRecord[] = () => [];
+
+export function setTaskFlowLinkedTasksResolverForRuntime(
+  resolver: (flowId: string) => TaskRecord[],
+): void {
+  linkedTasksResolver = resolver;
+}
+
+function listLinkedTasksForFlowId(flowId: string): TaskRecord[] {
+  return linkedTasksResolver(flowId).map((task) => Object.assign({}, task));
+}
 
 type FlowRecordPatch = Omit<
   Partial<
@@ -163,6 +176,16 @@ function normalizeJsonBlob(value: JsonValue | null | undefined): JsonValue | und
   return value === undefined ? undefined : cloneStructuredValue(value);
 }
 
+function isTerminalFlowStatus(status: TaskFlowStatus): boolean {
+  return (
+    status === "succeeded" || status === "failed" || status === "cancelled" || status === "lost"
+  );
+}
+
+function isTaskTerminalStatusForResidue(status: TaskRecord["status"]): boolean {
+  return status !== "queued" && status !== "running";
+}
+
 function assertFlowOwnerKey(ownerKey: string): string {
   const normalized = normalizeOptionalString(ownerKey);
   if (!normalized) {
@@ -179,7 +202,7 @@ function assertControllerId(controllerId?: string | null): string {
   return normalized;
 }
 
-function resolveFlowBlockedSummary(
+export function resolveFlowBlockedSummary(
   task: Pick<TaskRecord, "status" | "terminalOutcome" | "terminalSummary" | "progressSummary">,
 ): string | undefined {
   if (task.status !== "succeeded" || task.terminalOutcome !== "blocked") {
@@ -585,22 +608,94 @@ export function requestFlowCancel(params: {
   });
 }
 
-export function syncFlowFromTask(
-  task: Pick<
-    TaskRecord,
-    | "parentFlowId"
-    | "status"
-    | "terminalOutcome"
-    | "notifyPolicy"
-    | "label"
-    | "task"
-    | "lastEventAt"
-    | "endedAt"
-    | "taskId"
-    | "terminalSummary"
-    | "progressSummary"
-  >,
-): TaskFlowRecord | null {
+export function resolveManagedFlowResidue(params: {
+  flowId: string;
+  disposition: string;
+  reason?: string | null;
+  expectedRevision?: number | null;
+  updatedAt?: number;
+}):
+  | {
+      found: true;
+      applied: true;
+      flow: TaskFlowRecord;
+      tasks: TaskRecord[];
+    }
+  | {
+      found: boolean;
+      applied: false;
+      reason: string;
+      flow?: TaskFlowRecord;
+      tasks?: TaskRecord[];
+    } {
+  ensureFlowRegistryReady();
+  const flowId = params.flowId.trim();
+  if (!flowId) {
+    return { found: false, applied: false, reason: "Flow not found." };
+  }
+  const flow = getTaskFlowById(flowId);
+  if (!flow) {
+    return { found: false, applied: false, reason: "Flow not found." };
+  }
+  const tasks = listLinkedTasksForFlowId(flowId);
+  if (flow.syncMode !== "managed") {
+    return { found: true, applied: false, reason: "Flow is not managed.", flow, tasks };
+  }
+  if (!isTerminalFlowStatus(flow.status)) {
+    return { found: true, applied: false, reason: "Flow is not terminal.", flow, tasks };
+  }
+  if (params.disposition !== "interpreted_non_blocking") {
+    return { found: true, applied: false, reason: "Disposition not implemented.", flow, tasks };
+  }
+
+  const updatedAt = params.updatedAt ?? Date.now();
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const current = getTaskFlowById(flowId);
+    if (!current) {
+      return { found: false, applied: false, reason: "Flow not found." };
+    }
+    const unresolvedTasks = listLinkedTasksForFlowId(flowId).filter(
+      (task) => !isTaskTerminalStatusForResidue(task.status),
+    );
+    const result = updateFlowRecordByIdExpectedRevision({
+      flowId,
+      expectedRevision: params.expectedRevision ?? current.revision,
+      patch: {
+        stateJson: mergeFlowStateJson(current.stateJson, {
+          residueResolution: {
+            disposition: "interpreted_non_blocking",
+            linkedTaskIds: unresolvedTasks.map((task) => task.taskId),
+            ...(normalizeOptionalString(params.reason)
+              ? { reason: normalizeOptionalString(params.reason)! }
+              : {}),
+            resolvedAt: updatedAt,
+          },
+        }),
+        updatedAt,
+      },
+    });
+    if (result.applied) {
+      return {
+        found: true,
+        applied: true,
+        flow: result.flow,
+        tasks: listLinkedTasksForFlowId(flowId),
+      };
+    }
+    if (result.reason === "not_found" || !result.current) {
+      break;
+    }
+  }
+  return {
+    found: true,
+    applied: false,
+    reason: "Could not update flow due to revision conflict.",
+    flow: getTaskFlowById(flowId) ?? flow,
+    tasks: listLinkedTasksForFlowId(flowId),
+  };
+}
+
+export function syncFlowFromTask(task: TaskFlowSyncTask): TaskFlowRecord | null {
   const flowId = task.parentFlowId?.trim();
   if (!flowId) {
     return null;
@@ -697,6 +792,7 @@ export function resetTaskFlowRegistryForTests(opts?: { persist?: boolean }) {
   flows.clear();
   restoreAttempted = false;
   restoreFailureMessage = null;
+  setTaskFlowLinkedTasksResolverForRuntime(() => []);
   resetTaskFlowRegistryRuntimeForTests();
   if (opts?.persist !== false) {
     persistFlowRegistry();

--- a/src/tasks/task-flow-runtime-internal.ts
+++ b/src/tasks/task-flow-runtime-internal.ts
@@ -3,6 +3,7 @@ export {
   createFlowRecord,
   createManagedTaskFlow,
   deleteTaskFlowRecordById,
+  deriveTaskFlowStatusFromTask,
   findLatestTaskFlowForOwnerKey,
   failFlow,
   finishFlow,
@@ -10,6 +11,8 @@ export {
   listTaskFlowRecords,
   listTaskFlowsForOwnerKey,
   requestFlowCancel,
+  resolveFlowBlockedSummary,
+  resolveManagedFlowResidue,
   resolveTaskFlowForLookupToken,
   resetTaskFlowRegistryForTests,
   resumeFlow,
@@ -18,4 +21,5 @@ export {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 
+export type { TaskFlowSyncTask } from "./task-flow-sync.types.js";
 export type { TaskFlowUpdateResult } from "./task-flow-registry.js";

--- a/src/tasks/task-flow-state-json.ts
+++ b/src/tasks/task-flow-state-json.ts
@@ -1,0 +1,31 @@
+import type { JsonValue, TaskFlowRecord } from "./task-flow-registry.types.js";
+
+export function isJsonObject(
+  value: JsonValue | null | undefined,
+): value is Record<string, JsonValue> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+export function getFlowResidueResolution(flow: TaskFlowRecord): Record<string, JsonValue> | null {
+  const state = flow.stateJson;
+  if (!isJsonObject(state)) {
+    return null;
+  }
+  const residue = state.residueResolution;
+  return isJsonObject(residue) ? residue : null;
+}
+
+export function mergeFlowStateJson(
+  current: JsonValue | null | undefined,
+  patch: Record<string, JsonValue | null | undefined>,
+): JsonValue {
+  const base: Record<string, JsonValue> = isJsonObject(current) ? { ...current } : {};
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === null || value === undefined) {
+      delete base[key];
+    } else {
+      base[key] = value;
+    }
+  }
+  return base;
+}

--- a/src/tasks/task-flow-sync.types.ts
+++ b/src/tasks/task-flow-sync.types.ts
@@ -1,0 +1,16 @@
+import type { TaskRecord } from "./task-registry.types.js";
+
+export type TaskFlowSyncTask = Pick<
+  TaskRecord,
+  | "parentFlowId"
+  | "status"
+  | "terminalOutcome"
+  | "notifyPolicy"
+  | "label"
+  | "task"
+  | "lastEventAt"
+  | "endedAt"
+  | "taskId"
+  | "terminalSummary"
+  | "progressSummary"
+>;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2707,6 +2707,54 @@ describe("task-registry", () => {
     });
   });
 
+  it("cancels queued non-cli tasks before a child session starts", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      hoisted.cancelSessionMock.mockClear();
+      hoisted.killSubagentRunAdminMock.mockClear();
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "notifychat",
+          to: "notifychat:123",
+        },
+        runId: "run-queued-no-child",
+        task: "Queued child not started",
+        status: "queued",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(hoisted.cancelSessionMock).not.toHaveBeenCalled();
+      expect(hoisted.killSubagentRunAdminMock).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        found: true,
+        cancelled: true,
+        task: expect.objectContaining({
+          taskId: task.taskId,
+          status: "cancelled",
+          error: "Cancelled queued task before child session start.",
+        }),
+      });
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "notifychat",
+            to: "notifychat:123",
+            content: expect.stringContaining("Background task cancelled:"),
+          }),
+        ),
+      );
+    });
+  });
+
   it("cancels CLI-tracked tasks without childSessionKey", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -19,12 +19,15 @@ import {
   shouldAutoDeliverTaskTerminalUpdate,
   shouldSuppressDuplicateTerminalDelivery,
 } from "./task-executor-policy.js";
-import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import {
+  deriveTaskFlowStatusFromTask,
   getTaskFlowById,
-  syncFlowFromTask,
+  resolveFlowBlockedSummary,
+  setTaskFlowLinkedTasksResolverForRuntime,
   updateFlowRecordByIdExpectedRevision,
-} from "./task-flow-runtime-internal.js";
+} from "./task-flow-registry.js";
+import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import type { TaskFlowSyncTask } from "./task-flow-sync.types.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
 import {
   getTaskRegistryObservers,
@@ -119,9 +122,19 @@ function isActiveTaskStatus(status: TaskStatus): boolean {
   return status === "queued" || status === "running";
 }
 
-function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {
+function isClosedFlowStatus(status: TaskFlowRecord["status"]): boolean {
   return (
     status === "succeeded" || status === "failed" || status === "cancelled" || status === "lost"
+  );
+}
+
+function isEndedFlowStatus(status: TaskFlowRecord["status"]): boolean {
+  return (
+    status === "succeeded" ||
+    status === "blocked" ||
+    status === "failed" ||
+    status === "cancelled" ||
+    status === "lost"
   );
 }
 
@@ -130,6 +143,42 @@ function assertTaskOwner(params: { ownerKey: string; scopeKind: TaskScopeKind })
   if (!ownerKey && params.scopeKind !== "system") {
     throw new Error("Task ownerKey is required.");
   }
+}
+
+function syncFlowFromTask(task: TaskFlowSyncTask): TaskFlowRecord | null {
+  const flowId = task.parentFlowId?.trim();
+  if (!flowId) {
+    return null;
+  }
+  const flow = getTaskFlowById(flowId);
+  if (!flow) {
+    return null;
+  }
+  if (flow.syncMode !== "task_mirrored") {
+    return flow;
+  }
+  const terminalFlowStatus = deriveTaskFlowStatusFromTask(task);
+  const isTerminal = isEndedFlowStatus(terminalFlowStatus);
+  const result = updateFlowRecordByIdExpectedRevision({
+    flowId,
+    expectedRevision: flow.revision,
+    patch: {
+      status: terminalFlowStatus,
+      notifyPolicy: task.notifyPolicy,
+      goal: normalizeOptionalString(task.label) ?? (task.task.trim() || "Background task"),
+      blockedTaskId: terminalFlowStatus === "blocked" ? task.taskId.trim() || null : null,
+      blockedSummary:
+        terminalFlowStatus === "blocked" ? (resolveFlowBlockedSummary(task) ?? null) : null,
+      waitJson: null,
+      updatedAt: task.lastEventAt ?? Date.now(),
+      ...(isTerminal
+        ? {
+            endedAt: task.endedAt ?? task.lastEventAt ?? Date.now(),
+          }
+        : { endedAt: null }),
+    },
+  });
+  return result.applied ? result.flow : (getTaskFlowById(flowId) ?? flow);
 }
 
 function assertParentFlowLinkAllowed(params: {
@@ -168,7 +217,7 @@ function assertParentFlowLinkAllowed(params: {
       { flowId, status: flow.status },
     );
   }
-  if (isTerminalFlowStatus(flow.status)) {
+  if (isClosedFlowStatus(flow.status)) {
     throw new ParentFlowLinkError("terminal", `Parent flow is already ${flow.status}.`, {
       flowId,
       status: flow.status,
@@ -232,6 +281,8 @@ function cloneTaskDeliveryState(state: TaskDeliveryState): TaskDeliveryState {
     ...(state.requesterOrigin ? { requesterOrigin: { ...state.requesterOrigin } } : {}),
   };
 }
+
+setTaskFlowLinkedTasksResolverForRuntime((flowId) => listTasksForFlowId(flowId));
 
 function snapshotTaskRecords(source: ReadonlyMap<string, TaskRecord>): TaskRecord[] {
   return [...source.values()].map((record) => cloneTaskRecord(record));
@@ -895,7 +946,7 @@ function syncManagedFlowCancellationFromTask(task: TaskRecord): void {
     !flow ||
     flow.syncMode !== "managed" ||
     flow.cancelRequestedAt == null ||
-    isTerminalFlowStatus(flow.status)
+    isClosedFlowStatus(flow.status)
   ) {
     return;
   }
@@ -924,7 +975,7 @@ function syncManagedFlowCancellationFromTask(task: TaskRecord): void {
       !flow ||
       flow.syncMode !== "managed" ||
       flow.cancelRequestedAt == null ||
-      isTerminalFlowStatus(flow.status)
+      isClosedFlowStatus(flow.status)
     ) {
       return;
     }
@@ -1876,6 +1927,23 @@ export async function cancelTaskById(params: {
   try {
     if (task.runtime !== "cli") {
       if (!childSessionKey) {
+        if (task.status === "queued") {
+          const now = Date.now();
+          const updated = updateTask(task.taskId, {
+            status: "cancelled",
+            endedAt: now,
+            lastEventAt: now,
+            error: "Cancelled queued task before child session start.",
+          });
+          if (updated) {
+            void maybeDeliverTaskTerminalUpdate(updated.taskId);
+          }
+          return {
+            found: true,
+            cancelled: true,
+            task: updated ?? cloneTaskRecord(task),
+          };
+        }
         return {
           found: true,
           cancelled: false,


### PR DESCRIPTION
## Summary
- add source-level resolution for managed TaskFlow terminal residue
- expose `openclaw tasks flow resolve-residue` and residue readback/audit coverage
- keep flow terminal residue resolution distinct from linked child task cleanup
- allow queued non-CLI child tasks without a started child session to be cancelled safely

## Why
Managed TaskFlow runs can leave terminal residue that is non-blocking but still shows up as unresolved health/audit state. Separately, queued child tasks that have not started a child session can be stale but previously could not be cancelled because `tasks cancel` only handled tasks with cancellable child sessions.

This patch makes those two states explicit and independently actionable:
- `residueResolution` explains managed-flow terminal residue without pretending the mission is done
- `terminal_residue_unresolved` remains auditable
- stale queued child tasks can be cancelled before a child session exists

## Verification
Validated on latest `origin/main` at base `1bc9bada` with commit `71f64b32`.

- Focused tasks tests via `test/vitest/vitest.tasks.config.ts`: `4 passed / 62 passed`
- `pnpm check:test-types`: passed
- `pnpm install --frozen-lockfile`: passed after refreshing dependency graph for latest upstream
- `pnpm build:strict-smoke`: passed
- `pnpm prepack`: passed

Note: `test/vitest/vitest.unit.config.ts` excludes `src/tasks/**`, so the focused task tests intentionally use `test/vitest/vitest.tasks.config.ts` to avoid a false `No test files found` success.
