### PR TITLE
fix(logging): honor OPENCLAW_LOG_MAX_FILE_BYTES env override (#71800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Logging: honor `OPENCLAW_LOG_MAX_FILE_BYTES` env override at logger init so plist / launchd / systemd unit overrides apply even when on-disk `logging.maxFileBytes` has not finished loading by the first log write. Fixes #71800. Thanks @hclsys.
+- Logging: honor `OPENCLAW_LOG_MAX_FILE_BYTES` env override (clamped to 2 GiB) at logger init so plist / launchd / systemd unit overrides apply even when on-disk `logging.maxFileBytes` has not finished loading by the first log write. Fixes #71800. Thanks @hclsys.
 - TTS/WhatsApp: add `/tts latest` read-aloud support with duplicate suppression and `/tts chat on|off|default` session-scoped auto-TTS overrides, completing the on-demand voice-note UX for current-chat replies. Fixes #66032.
 - Plugins/tokenjuice: bump the bundled tokenjuice runtime to 0.6.3. Thanks @vincentkoc.
 - TTS/agents: allow `agents.list[].tts` to override global `messages.tts` for per-agent voices while keeping shared provider credentials and preferences in the existing TTS config surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Logging: honor `OPENCLAW_LOG_MAX_FILE_BYTES` env override at logger init so plist / launchd / systemd unit overrides apply even when on-disk `logging.maxFileBytes` has not finished loading by the first log write. Fixes #71800. Thanks @hclsys.
 - TTS/WhatsApp: add `/tts latest` read-aloud support with duplicate suppression and `/tts chat on|off|default` session-scoped auto-TTS overrides, completing the on-demand voice-note UX for current-chat replies. Fixes #66032.
 - Plugins/tokenjuice: bump the bundled tokenjuice runtime to 0.6.3. Thanks @vincentkoc.
 - TTS/agents: allow `agents.list[].tts` to override global `messages.tts` for per-agent voices while keeping shared provider credentials and preferences in the existing TTS config surface.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Logging: honor `OPENCLAW_LOG_MAX_FILE_BYTES` env override (clamped to 2 GiB) at logger init so plist / launchd / systemd unit overrides apply even when on-disk `logging.maxFileBytes` has not finished loading by the first log write. Fixes #71800. Thanks @hclsys.
+- Logging: honor `OPENCLAW_LOG_MAX_FILE_BYTES` env override (clamped to 1 MiB–2 GiB) at logger init so plist / launchd / systemd unit overrides apply even when on-disk `logging.maxFileBytes` has not finished loading by the first log write. Fixes #71800. Thanks @hclsys.
 - TTS/WhatsApp: add `/tts latest` read-aloud support with duplicate suppression and `/tts chat on|off|default` session-scoped auto-TTS overrides, completing the on-demand voice-note UX for current-chat replies. Fixes #66032.
 - Plugins/tokenjuice: bump the bundled tokenjuice runtime to 0.6.3. Thanks @vincentkoc.
 - TTS/agents: allow `agents.list[].tts` to override global `messages.tts` for per-agent voices while keeping shared provider credentials and preferences in the existing TTS config surface.

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -149,16 +149,20 @@ describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
   });
 
   it("ignores non-numeric / zero / negative / non-finite env values", () => {
-    setLoggerOverride({
-      level: "info",
-      consoleLevel: "warn",
-      consoleStyle: "compact",
-      file: testLogPath,
-      maxFileBytes: defaultMaxFileBytes,
-    });
     for (const bad of ["one-gig", "0", "-1", "Infinity", "NaN"]) {
       process.env.OPENCLAW_LOG_MAX_FILE_BYTES = bad;
-      resetLogger();
+      // setLoggerOverride MUST be inside the loop: resetLogger() clears
+      // overrideSettings, which lets canUseSilentVitestFileLogFastPath
+      // short-circuit resolveSettings() before resolveMaxLogFileBytesFromEnv()
+      // is reached. Without this re-arm the assertions pass vacuously and the
+      // env validator is never exercised. (greptile review on PR #71917)
+      setLoggerOverride({
+        level: "info",
+        consoleLevel: "warn",
+        consoleStyle: "compact",
+        file: testLogPath,
+        maxFileBytes: defaultMaxFileBytes,
+      });
       expect(getResolvedLoggerSettings().maxFileBytes).toBe(defaultMaxFileBytes);
     }
   });
@@ -174,5 +178,32 @@ describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
     process.env.OPENCLAW_LOG_MAX_FILE_BYTES = "1024.7";
 
     expect(getResolvedLoggerSettings().maxFileBytes).toBe(1024);
+  });
+
+  it("clamps env override to 2 GiB to prevent disk-fill DoS via env injection (CWE-400)", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    // 1 TiB attempted; clamps to 2 GiB ceiling.
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = String(1024 * 1024 * 1024 * 1024);
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it("respects env values at or below the 2 GiB cap", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = String(2 * 1024 * 1024 * 1024);
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(2 * 1024 * 1024 * 1024);
   });
 });

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -167,7 +167,7 @@ describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
     }
   });
 
-  it("floors fractional env values", () => {
+  it("floors fractional env values above the 1 MiB minimum", () => {
     setLoggerOverride({
       level: "info",
       consoleLevel: "warn",
@@ -175,9 +175,10 @@ describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
       file: testLogPath,
       maxFileBytes: defaultMaxFileBytes,
     });
-    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = "1024.7";
+    // 100 MiB + 0.7 byte → 100 MiB (Math.floor + above min).
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = String(100 * 1024 * 1024 + 0.7);
 
-    expect(getResolvedLoggerSettings().maxFileBytes).toBe(1024);
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(100 * 1024 * 1024);
   });
 
   it("clamps env override to 2 GiB to prevent disk-fill DoS via env injection (CWE-400)", () => {
@@ -205,5 +206,32 @@ describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
     process.env.OPENCLAW_LOG_MAX_FILE_BYTES = String(2 * 1024 * 1024 * 1024);
 
     expect(getResolvedLoggerSettings().maxFileBytes).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  it("rejects env values below the 1 MiB minimum to prevent audit-log suppression (CWE-15)", () => {
+    for (const tiny of ["1", "10", "1024", String(1024 * 1024 - 1)]) {
+      process.env.OPENCLAW_LOG_MAX_FILE_BYTES = tiny;
+      setLoggerOverride({
+        level: "info",
+        consoleLevel: "warn",
+        consoleStyle: "compact",
+        file: testLogPath,
+        maxFileBytes: defaultMaxFileBytes,
+      });
+      expect(getResolvedLoggerSettings().maxFileBytes).toBe(defaultMaxFileBytes);
+    }
+  });
+
+  it("respects env values at exactly the 1 MiB minimum", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = String(1024 * 1024);
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(1024 * 1024);
   });
 });

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -89,3 +89,90 @@ describe("OPENCLAW_LOG_LEVEL", () => {
     expect(warnings[0]).toContain('Ignoring invalid OPENCLAW_LOG_LEVEL="nope"');
   });
 });
+
+describe("OPENCLAW_LOG_MAX_FILE_BYTES (#71800)", () => {
+  let originalEnv: string | undefined;
+  let testLogPath = "";
+
+  beforeAll(async () => {
+    await logPathTracker.setup();
+  });
+
+  beforeEach(() => {
+    originalEnv = process.env.OPENCLAW_LOG_MAX_FILE_BYTES;
+    testLogPath = logPathTracker.nextPath();
+    delete process.env.OPENCLAW_LOG_MAX_FILE_BYTES;
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.OPENCLAW_LOG_MAX_FILE_BYTES;
+    } else {
+      process.env.OPENCLAW_LOG_MAX_FILE_BYTES = originalEnv;
+    }
+    resetLogger();
+    setLoggerOverride(null);
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await logPathTracker.cleanup();
+    testLogPath = "";
+  });
+
+  it("env override beats config-load race so plist/launchd unit values apply at first log write", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = "1073741824";
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(1073741824);
+  });
+
+  it("ignores empty / whitespace-only env values and falls back to config / default", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = "   ";
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(defaultMaxFileBytes);
+  });
+
+  it("ignores non-numeric / zero / negative / non-finite env values", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    for (const bad of ["one-gig", "0", "-1", "Infinity", "NaN"]) {
+      process.env.OPENCLAW_LOG_MAX_FILE_BYTES = bad;
+      resetLogger();
+      expect(getResolvedLoggerSettings().maxFileBytes).toBe(defaultMaxFileBytes);
+    }
+  });
+
+  it("floors fractional env values", () => {
+    setLoggerOverride({
+      level: "info",
+      consoleLevel: "warn",
+      consoleStyle: "compact",
+      file: testLogPath,
+      maxFileBytes: defaultMaxFileBytes,
+    });
+    process.env.OPENCLAW_LOG_MAX_FILE_BYTES = "1024.7";
+
+    expect(getResolvedLoggerSettings().maxFileBytes).toBe(1024);
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -455,6 +455,12 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   return logger;
 }
 
+// Cap the env override at 2 GiB so a malformed plist / wrapper script env
+// cannot disable the log file size cap entirely (CWE-400 disk-fill DoS).
+// Operators that need an even larger cap should configure
+// `logging.maxFileBytes` in openclaw.json instead.
+const MAX_ENV_LOG_FILE_BYTES = 2 * 1024 * 1024 * 1024;
+
 function resolveMaxLogFileBytesFromEnv(): number | undefined {
   // Env override mirrors OPENCLAW_LOG_LEVEL: read at logger init so plist /
   // launchd / systemd unit overrides apply even when the on-disk config has
@@ -467,7 +473,7 @@ function resolveMaxLogFileBytesFromEnv(): number | undefined {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return undefined;
   }
-  return Math.floor(parsed);
+  return Math.min(Math.floor(parsed), MAX_ENV_LOG_FILE_BYTES);
 }
 
 function resolveMaxLogFileBytes(raw: unknown): number {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -455,7 +455,26 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   return logger;
 }
 
+function resolveMaxLogFileBytesFromEnv(): number | undefined {
+  // Env override mirrors OPENCLAW_LOG_LEVEL: read at logger init so plist /
+  // launchd / systemd unit overrides apply even when the on-disk config has
+  // not finished loading by the first log write. (#71800)
+  const raw = process.env.OPENCLAW_LOG_MAX_FILE_BYTES?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return undefined;
+  }
+  return Math.floor(parsed);
+}
+
 function resolveMaxLogFileBytes(raw: unknown): number {
+  const fromEnv = resolveMaxLogFileBytesFromEnv();
+  if (fromEnv !== undefined) {
+    return fromEnv;
+  }
   if (typeof raw === "number" && Number.isFinite(raw) && raw > 0) {
     return Math.floor(raw);
   }

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -460,6 +460,13 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
 // Operators that need an even larger cap should configure
 // `logging.maxFileBytes` in openclaw.json instead.
 const MAX_ENV_LOG_FILE_BYTES = 2 * 1024 * 1024 * 1024;
+// Floor the env override at 1 MiB so a malformed env (`=1`, `=10`, etc.)
+// cannot suppress all file writes by tripping the size cap on the first
+// log line. Tiny values are rejected and we fall through to the on-disk
+// config / default. The on-disk `logging.maxFileBytes` path is intentionally
+// unbounded — operators that want a small file cap can still set it there.
+// (CWE-15 audit-log suppression, aisle finding on PR #71917)
+const MIN_ENV_LOG_FILE_BYTES = 1 * 1024 * 1024;
 
 function resolveMaxLogFileBytesFromEnv(): number | undefined {
   // Env override mirrors OPENCLAW_LOG_LEVEL: read at logger init so plist /
@@ -473,7 +480,11 @@ function resolveMaxLogFileBytesFromEnv(): number | undefined {
   if (!Number.isFinite(parsed) || parsed <= 0) {
     return undefined;
   }
-  return Math.min(Math.floor(parsed), MAX_ENV_LOG_FILE_BYTES);
+  const floored = Math.floor(parsed);
+  if (floored < MIN_ENV_LOG_FILE_BYTES) {
+    return undefined;
+  }
+  return Math.min(floored, MAX_ENV_LOG_FILE_BYTES);
 }
 
 function resolveMaxLogFileBytes(raw: unknown): number {


### PR DESCRIPTION
## Summary

Fixes #71800.

`logging.maxFileBytes` set in `~/.openclaw/openclaw.json` is silently ignored by the gateway logger when `loadConfig()` hasn't finished resolving by the first log write. The default `DEFAULT_MAX_LOG_FILE_BYTES = 500 MB` continues to apply across plist/launchd reboots even after `openclaw config get logging.maxFileBytes` reports the configured value.

This adds an env-var fast-path mirroring the existing `OPENCLAW_LOG_LEVEL` precedent: `process.env.OPENCLAW_LOG_MAX_FILE_BYTES` is read synchronously at logger init and beats the config-derived value when set. plist / launchd / systemd unit overrides therefore apply on the very first log write, regardless of config-load timing.

The reporter explicitly suggests this path as fix #3 in the issue.

## Why env var, not lazy-init / config-loaded re-read

- The race window is bounded but unpredictable across macOS launchd vs systemd vs Docker entrypoints. Re-reading on a config-loaded event would still leave a window where early errors emit at the wrong cap.
- The logger already does cache invalidation on `settingsChanged()` per call, so the runtime path self-heals — but only if `cfg` is actually populated. In the reporter's repro, the cached miss persisted across **5+ bootout/bootstrap cycles**, indicating the in-process `requireConfig?.(\"../config/config.js\")` path returns `undefined` for the synchronous logger init.
- Env vars are guaranteed-resolved before any module-level read in this codebase (the existing `OPENCLAW_LOG_LEVEL` resolver depends on the same property).

## Validation

| input | result |
|-------|--------|
| `\"1073741824\"`        | override applied |
| `\"1024.7\"`            | floored to `1024` |
| `\"\"` / `\"   \"`         | ignored, falls back to config / default |
| `\"one-gig\"` / `\"0\"` / `\"-1\"` / `\"Infinity\"` / `\"NaN\"` | ignored |

Tests: 4 new cases under `src/logging/logger-env.test.ts \"OPENCLAW_LOG_MAX_FILE_BYTES (#71800)\"`.

## Files

| file | + | − |
|------|---|---|
| `CHANGELOG.md` | 1 | 0 |
| `src/logging/logger.ts` | 19 | 0 |
| `src/logging/logger-env.test.ts` | 87 | 0 |

## Test plan

- [x] `pnpm exec vitest run src/logging/logger-env.test.ts` — 6/6 pass
- [x] `pnpm exec oxfmt --check src/logging/logger.ts src/logging/logger-env.test.ts` — clean
- [x] `pnpm exec oxlint src/logging/logger.ts src/logging/logger-env.test.ts` — 0 warnings/errors
- [ ] CI green