### PR TITLE
fix(browser): fall back to Hyprland grim capture for headed viewport screenshots

### DIFF
--- a/docs/tools/browser-linux-troubleshooting.md
+++ b/docs/tools/browser-linux-troubleshooting.md
@@ -166,6 +166,58 @@ Notes:
   Use HTTP(S) for `/json/version` discovery, or WS(S) when your browser
   service gives you a direct DevTools socket URL.
 
+## Problem: Headed viewport screenshots time out on Hyprland/Wayland (Omarchy)
+
+On Hyprland-based desktops (e.g. Omarchy), headed Chromium sessions may produce:
+
+```
+Page.captureScreenshot timed out after 10000ms
+```
+
+This happens because Chrome's compositor can stall on certain pages when the
+browser window is on a real Wayland output. The fix captures the window via
+`grim` (Wayland screenshotter) against a dedicated virtual output instead.
+
+### How the workaround works
+
+OpenClaw creates a headless virtual output with `hyprctl create-output`, moves
+the managed browser window onto its workspace, and captures with
+`grim -o <output> -t png -`. This bypasses Chrome's screenshot API entirely and
+completes in roughly 20–170 ms. The virtual output is removed when the process exits.
+
+### Required tools
+
+Both must be available in standard system directories (`/usr/bin`, `/usr/local/bin`,
+`/run/current-system/sw/bin`, etc.):
+
+| Tool      | Purpose                              | Install (Arch/Omarchy) |
+| --------- | ------------------------------------ | ---------------------- |
+| `hyprctl` | Create/remove virtual Wayland output | ships with `hyprland`  |
+| `grim`    | Wayland screenshot capture           | `sudo pacman -S grim`  |
+
+### Enable the feature
+
+The feature is **opt-in** and disabled by default. Add to `~/.openclaw/openclaw.json`:
+
+```json
+{
+  "browser": {
+    "hyprlandCapture": true
+  }
+}
+```
+
+The capture path only activates when all of the following are true:
+
+- Running on Linux (`process.platform === "linux"`)
+- `HYPRLAND_INSTANCE_SIGNATURE` is set in the environment
+- The browser profile is headed (not `browser.headless: true`)
+- The screenshot is a plain viewport shot (not full-page, not element, no labels)
+- `browser.hyprlandCapture: true` in config
+
+On any failure (binary not found, hyprctl error, grim crash) the route falls
+back to the standard CDP `Page.captureScreenshot` call transparently.
+
 ## Related
 
 - [Browser](/tools/browser)

--- a/extensions/browser/src/browser/config.ts
+++ b/extensions/browser/src/browser/config.ts
@@ -82,6 +82,7 @@ export type ResolvedBrowserConfig = {
   headlessSource?: "config" | "default";
   noSandbox: boolean;
   attachOnly: boolean;
+  hyprlandCapture?: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
   tabCleanup: ResolvedBrowserTabCleanupConfig;
@@ -447,6 +448,7 @@ export function resolveBrowserConfig(
     headlessSource,
     noSandbox,
     attachOnly,
+    hyprlandCapture: cfg?.hyprlandCapture === true,
     defaultProfile,
     profiles,
     tabCleanup: resolveBrowserTabCleanupConfig(cfg),

--- a/extensions/browser/src/browser/hyprland-capture.test.ts
+++ b/extensions/browser/src/browser/hyprland-capture.test.ts
@@ -35,7 +35,7 @@ vi.mock("node:child_process", () => {
   };
 });
 
-vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+vi.mock("openclaw/plugin-sdk/resolve-system-bin", () => ({
   resolveSystemBin: mockResolveSystemBin,
 }));
 

--- a/extensions/browser/src/browser/hyprland-capture.test.ts
+++ b/extensions/browser/src/browser/hyprland-capture.test.ts
@@ -1,0 +1,340 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module mocks — hoisted so they are in place when hyprland-capture.ts loads
+// and calls promisify(execFile) at the top level.
+// ---------------------------------------------------------------------------
+
+const mockExecFile = vi.hoisted(() => vi.fn());
+const mockExecFileSync = vi.hoisted(() => vi.fn());
+const mockSpawn = vi.hoisted(() => vi.fn());
+const mockResolveSystemBin = vi.hoisted(() =>
+  vi.fn<(name: string, opts?: unknown) => string | null>(),
+);
+
+vi.mock("node:child_process", () => {
+  // promisify(execFile) is called at the top level of hyprland-capture.ts before
+  // any test runs. Without promisify.custom, promisify resolves to a bare string
+  // instead of {stdout, stderr}, making JSON.parse(stdout) blow up with undefined.
+  const { promisify } = require("node:util") as typeof import("node:util");
+  (mockExecFile as unknown as Record<symbol, unknown>)[promisify.custom] = (...args: unknown[]) =>
+    new Promise((resolve, reject) => {
+      mockExecFile(...args, (err: Error | null, stdout: string, stderr: string) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({ stdout, stderr });
+        }
+      });
+    });
+  return {
+    execFile: mockExecFile,
+    execFileSync: mockExecFileSync,
+    spawn: mockSpawn,
+  };
+});
+
+vi.mock("openclaw/plugin-sdk/infra-runtime", () => ({
+  resolveSystemBin: mockResolveSystemBin,
+}));
+
+// Imports come AFTER vi.mock so mocks are already active.
+import {
+  _resetHyprlandCaptureForTests,
+  captureWithHyprland,
+  isHyprlandAvailable,
+} from "./hyprland-capture.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type ExecFileCb = (err: Error | null, stdout: string, stderr: string) => void;
+
+function makeMonitors(names: string[]): string {
+  return JSON.stringify(names.map((name, i) => ({ name, activeWorkspace: { id: 100 + i } })));
+}
+
+/** Stub a successful grim capture that writes `pngBytes` to stdout. */
+function stubGrimSuccess(pngBytes: Buffer): void {
+  mockSpawn.mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      kill: () => void;
+    };
+    child.stdout = new EventEmitter();
+    child.kill = () => {};
+    // Resolve asynchronously so callers' Promise chains settle normally.
+    void Promise.resolve().then(() => {
+      child.stdout.emit("data", pngBytes);
+      child.emit("close", 0);
+    });
+    return child;
+  });
+}
+
+/** Stub grim to fail with exit code 1. */
+function stubGrimFail(): void {
+  mockSpawn.mockImplementation(() => {
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      kill: () => void;
+    };
+    child.stdout = new EventEmitter();
+    child.kill = () => {};
+    void Promise.resolve().then(() => child.emit("close", 1));
+    return child;
+  });
+}
+
+/** Full successful setup + capture sequence. */
+function stubHappyPath(pngBytes: Buffer, outputName = "HEADLESS-1"): void {
+  let monitorCount = 0;
+  mockExecFile.mockImplementation((...args: unknown[]) => {
+    const subArgs = args[1] as string[];
+    const cb = args[args.length - 1] as ExecFileCb;
+    const key = subArgs[0] ?? "";
+    if (key === "monitors") {
+      monitorCount++;
+      // First call (before create-output): no headless output yet.
+      // Subsequent calls: headless output present.
+      const names = monitorCount === 1 ? [] : [outputName];
+      cb(null, makeMonitors(names), "");
+    } else {
+      cb(null, "", "");
+    }
+  });
+  stubGrimSuccess(pngBytes);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  _resetHyprlandCaptureForTests();
+  process.env.HYPRLAND_INSTANCE_SIGNATURE = "test-sig";
+  mockResolveSystemBin.mockImplementation((name: string) => `/usr/bin/${name}`);
+});
+
+afterEach(() => {
+  delete process.env.HYPRLAND_INSTANCE_SIGNATURE;
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("isHyprlandAvailable", () => {
+  it("returns false when HYPRLAND_INSTANCE_SIGNATURE is unset", () => {
+    delete process.env.HYPRLAND_INSTANCE_SIGNATURE;
+    expect(isHyprlandAvailable()).toBe(false);
+  });
+
+  it("returns false when HYPRLAND_INSTANCE_SIGNATURE is blank (whitespace only)", () => {
+    process.env.HYPRLAND_INSTANCE_SIGNATURE = "   ";
+    expect(isHyprlandAvailable()).toBe(false);
+  });
+
+  it("returns true when HYPRLAND_INSTANCE_SIGNATURE is set", () => {
+    process.env.HYPRLAND_INSTANCE_SIGNATURE = "abc123";
+    expect(isHyprlandAvailable()).toBe(true);
+  });
+});
+
+describe("captureWithHyprland", () => {
+  it("resolves to a Buffer on success", async () => {
+    const pngBytes = Buffer.from("\x89PNG\r\n\x1a\n");
+    stubHappyPath(pngBytes);
+
+    const result = await captureWithHyprland({ browserPid: 42 });
+    expect(result).toEqual(pngBytes);
+  });
+
+  it("resets cache to null on execa failure, then throws", async () => {
+    // Fail inside setupCapture (create-output succeeds but getActiveWorkspaceId fails).
+    let monCount = 0;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      const key = subArgs[0] ?? "";
+      if (key === "monitors") {
+        monCount++;
+        if (monCount <= 2) {
+          // before / after create-output — OK
+          const names = monCount === 1 ? [] : ["HEADLESS-1"];
+          cb(null, makeMonitors(names), "");
+        } else {
+          // Third call (getActiveWorkspaceId) — fail
+          cb(new Error("monitors unavailable"), "", "");
+        }
+      } else if (key === "create-output") {
+        cb(null, "", "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+
+    await expect(captureWithHyprland({ browserPid: 1 })).rejects.toThrow();
+
+    // Cache should be null → the next call can retry setup.
+    // Verify by running a successful capture immediately after.
+    vi.clearAllMocks();
+    mockResolveSystemBin.mockImplementation((name: string) => `/usr/bin/${name}`);
+    const pngBytes = Buffer.from("PNG-retry");
+    stubHappyPath(pngBytes);
+
+    const result = await captureWithHyprland({ browserPid: 1 });
+    expect(result).toEqual(pngBytes);
+  });
+
+  it("PID change invalidates cached output and calls hyprctl create-output again", async () => {
+    // First capture with PID 100.
+    const pngA = Buffer.from("png-A");
+    stubHappyPath(pngA);
+
+    await captureWithHyprland({ browserPid: 100 });
+
+    // Reconfigure mocks for PID 200 setup.
+    vi.clearAllMocks();
+    mockResolveSystemBin.mockImplementation((name: string) => `/usr/bin/${name}`);
+
+    let createOutputCalls = 0;
+    let monCount = 0;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      const key = subArgs[0] ?? "";
+      if (key === "create-output") {
+        createOutputCalls++;
+        cb(null, "", "");
+      } else if (key === "monitors") {
+        monCount++;
+        const names = monCount === 1 ? [] : ["HEADLESS-2"];
+        cb(null, makeMonitors(names), "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+    const pngB = Buffer.from("png-B");
+    stubGrimSuccess(pngB);
+
+    const result = await captureWithHyprland({ browserPid: 200 });
+    expect(result).toEqual(pngB);
+    expect(createOutputCalls).toBe(1);
+  });
+
+  it("process 'exit' handler calls hyprctl output remove to clean up virtual output", async () => {
+    const pngBytes = Buffer.from("PNG-cleanup");
+    stubHappyPath(pngBytes, "HEADLESS-9");
+
+    await captureWithHyprland({ browserPid: 55 });
+
+    // Trigger the registered exit handler.
+    process.emit("exit", 0);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "/usr/bin/hyprctl",
+      ["output", "remove", "HEADLESS-9"],
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    );
+  });
+
+  it("resolve-system-bin is called for both grim and hyprctl, not hardcoded paths", async () => {
+    // Let setup fail early — we only care about which names resolveSystemBin was called with.
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      if (subArgs[0] === "monitors") {
+        cb(new Error("fail"), "", "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+
+    await captureWithHyprland({ browserPid: 1 }).catch(() => {});
+
+    const names = mockResolveSystemBin.mock.calls.map(([n]) => n);
+    expect(names).toContain("hyprctl");
+    expect(names).toContain("grim");
+  });
+
+  it("grim failure resets cache so next call re-creates the output", async () => {
+    // Setup succeeds but grim fails on first capture.
+    let monCount = 0;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      const key = subArgs[0] ?? "";
+      if (key === "monitors") {
+        monCount++;
+        cb(null, makeMonitors(monCount === 1 ? [] : ["HEADLESS-1"]), "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+    stubGrimFail();
+
+    await expect(captureWithHyprland({ browserPid: 7 })).rejects.toThrow();
+
+    // Cache should be null — retry succeeds.
+    vi.clearAllMocks();
+    mockResolveSystemBin.mockImplementation((name: string) => `/usr/bin/${name}`);
+    const pngBytes = Buffer.from("PNG-retry");
+    let createCalls = 0;
+    monCount = 0;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      const key = subArgs[0] ?? "";
+      if (key === "create-output") {
+        createCalls++;
+        cb(null, "", "");
+      } else if (key === "monitors") {
+        monCount++;
+        cb(null, makeMonitors(monCount === 1 ? [] : ["HEADLESS-1"]), "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+    stubGrimSuccess(pngBytes);
+
+    const result = await captureWithHyprland({ browserPid: 7 });
+    expect(result).toEqual(pngBytes);
+    expect(createCalls).toBe(1);
+  });
+
+  it("concurrent calls share the in-flight setup promise (setup runs only once)", async () => {
+    let createOutputCalls = 0;
+    let monCount = 0;
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const subArgs = args[1] as string[];
+      const cb = args[args.length - 1] as ExecFileCb;
+      const key = subArgs[0] ?? "";
+      if (key === "create-output") {
+        createOutputCalls++;
+        cb(null, "", "");
+      } else if (key === "monitors") {
+        monCount++;
+        cb(null, makeMonitors(monCount === 1 ? [] : ["HEADLESS-1"]), "");
+      } else {
+        cb(null, "", "");
+      }
+    });
+    const pngBytes = Buffer.from("PNG-concurrent");
+    stubGrimSuccess(pngBytes);
+
+    const [r1, r2, r3] = await Promise.all([
+      captureWithHyprland({ browserPid: 88 }),
+      captureWithHyprland({ browserPid: 88 }),
+      captureWithHyprland({ browserPid: 88 }),
+    ]);
+
+    expect(r1).toEqual(pngBytes);
+    expect(r2).toEqual(pngBytes);
+    expect(r3).toEqual(pngBytes);
+    expect(createOutputCalls).toBe(1);
+  });
+});

--- a/extensions/browser/src/browser/hyprland-capture.ts
+++ b/extensions/browser/src/browser/hyprland-capture.ts
@@ -1,0 +1,228 @@
+import { execFile, execFileSync, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import { resolveSystemBin } from "openclaw/plugin-sdk/infra-runtime";
+
+const execFileAsync = promisify(execFile);
+
+type CaptureState = {
+  outputName: string;
+  browserPid: number;
+  hyprctl: string;
+};
+
+let _state: CaptureState | null = null;
+let _setupInFlight: Promise<CaptureState> | null = null;
+
+// Points at the most-recently-created virtual output so the exit handler can
+// always clean up even after a PID-change re-setup.
+let _cleanupOutputName: string | null = null;
+let _cleanupHyprctl: string | null = null;
+let _cleanupRegistered = false;
+
+export function isHyprlandAvailable(): boolean {
+  return Boolean(process.env.HYPRLAND_INSTANCE_SIGNATURE?.trim());
+}
+
+async function listMonitorNames(hyprctl: string): Promise<Set<string>> {
+  const { stdout } = await execFileAsync(hyprctl, ["monitors", "-j"]);
+  const monitors = JSON.parse(stdout) as Array<{ name: string }>;
+  return new Set(monitors.map((m) => m.name));
+}
+
+async function createHeadlessOutput(hyprctl: string): Promise<string> {
+  const before = await listMonitorNames(hyprctl);
+  await execFileAsync(hyprctl, ["create-output"]);
+  const after = await listMonitorNames(hyprctl);
+  for (const name of after) {
+    if (!before.has(name)) {
+      return name;
+    }
+  }
+  throw new Error("hyprctl create-output completed but no new monitor appeared");
+}
+
+async function getActiveWorkspaceId(hyprctl: string, monitorName: string): Promise<number> {
+  const { stdout } = await execFileAsync(hyprctl, ["monitors", "-j"]);
+  const monitors = JSON.parse(stdout) as Array<{
+    name: string;
+    activeWorkspace: { id: number };
+  }>;
+  const monitor = monitors.find((m) => m.name === monitorName);
+  if (!monitor) {
+    throw new Error(`Monitor "${monitorName}" not found after creation`);
+  }
+  return monitor.activeWorkspace.id;
+}
+
+function registerExitCleanup(hyprctl: string, outputName: string): void {
+  // Always update the target so the handler removes the current output.
+  _cleanupOutputName = outputName;
+  _cleanupHyprctl = hyprctl;
+
+  if (_cleanupRegistered) {
+    return;
+  }
+  _cleanupRegistered = true;
+
+  const cleanup = () => {
+    const h = _cleanupHyprctl;
+    const o = _cleanupOutputName;
+    if (!h || !o) {
+      return;
+    }
+    try {
+      execFileSync(h, ["output", "remove", o], { timeout: 2000 });
+    } catch {
+      // Best-effort; process is exiting.
+    }
+  };
+
+  process.once("exit", cleanup);
+  process.once("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.once("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+}
+
+async function setupCapture(browserPid: number): Promise<CaptureState> {
+  const hyprctl = resolveSystemBin("hyprctl", { trust: "standard" });
+  if (!hyprctl) {
+    throw new Error("hyprctl not found in trusted system directories");
+  }
+  const grim = resolveSystemBin("grim", { trust: "standard" });
+  if (!grim) {
+    throw new Error("grim not found in trusted system directories");
+  }
+
+  const outputName = await createHeadlessOutput(hyprctl);
+  const workspaceId = await getActiveWorkspaceId(hyprctl, outputName);
+  await execFileAsync(hyprctl, [
+    "dispatch",
+    "movetoworkspacesilent",
+    `${workspaceId},pid:${browserPid}`,
+  ]);
+
+  registerExitCleanup(hyprctl, outputName);
+  return { outputName, browserPid, hyprctl };
+}
+
+export async function teardownHyprlandCapture(): Promise<void> {
+  const state = _state;
+  _state = null;
+  _setupInFlight = null;
+  if (!state) {
+    return;
+  }
+  try {
+    await execFileAsync(state.hyprctl, ["output", "remove", state.outputName]);
+    _cleanupOutputName = null;
+  } catch {
+    // Best-effort.
+  }
+}
+
+async function runGrimCapture(outputName: string, timeoutMs: number): Promise<Buffer> {
+  const grimBin = resolveSystemBin("grim", { trust: "standard" });
+  if (!grimBin) {
+    throw new Error("grim not found in trusted system directories");
+  }
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const child = spawn(grimBin, ["-o", outputName, "-t", "png", "-"], {
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+
+    const timer = setTimeout(() => {
+      settled = true;
+      child.kill();
+      reject(new Error(`grim timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => chunks.push(chunk));
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (code === 0) {
+        resolve(Buffer.concat(chunks));
+      } else {
+        reject(new Error(`grim exited with code ${code ?? "null"}`));
+      }
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      if (settled) {
+        return;
+      }
+      settled = true;
+      reject(err);
+    });
+  });
+}
+
+/**
+ * Capture the browser viewport via grim on Hyprland.
+ *
+ * Throws on any failure (binary missing, hyprctl error, grim crash).
+ * On failure the cached state is reset so the next call retries setup.
+ * Callers should wrap with `.catch(() => null)` to fall back silently.
+ */
+export async function captureWithHyprland(params: {
+  browserPid: number;
+  timeoutMs?: number;
+}): Promise<Buffer> {
+  const { browserPid, timeoutMs = 5000 } = params;
+
+  // PID changed → tear down old virtual output and re-setup.
+  if (_state && _state.browserPid !== browserPid) {
+    await teardownHyprlandCapture();
+  }
+
+  if (!_state) {
+    // Deduplicate concurrent callers: all share the same in-flight promise.
+    const inFlight = (_setupInFlight ??= setupCapture(browserPid)
+      .then((state) => {
+        _state = state;
+        _setupInFlight = null;
+        return state;
+      })
+      .catch((err: unknown) => {
+        _state = null;
+        _setupInFlight = null;
+        throw err;
+      }));
+
+    // May throw if setup fails; caller handles via .catch.
+    _state = await inFlight;
+  }
+
+  const { outputName } = _state;
+  try {
+    return await runGrimCapture(outputName, timeoutMs);
+  } catch (err) {
+    // Capture error → invalidate cache so the next call re-creates the output.
+    _state = null;
+    _setupInFlight = null;
+    throw err;
+  }
+}
+
+/** Reset all module-level state. For tests only. */
+export function _resetHyprlandCaptureForTests(): void {
+  _state = null;
+  _setupInFlight = null;
+  _cleanupOutputName = null;
+  _cleanupHyprctl = null;
+  _cleanupRegistered = false;
+}

--- a/extensions/browser/src/browser/hyprland-capture.ts
+++ b/extensions/browser/src/browser/hyprland-capture.ts
@@ -1,6 +1,6 @@
 import { execFile, execFileSync, spawn } from "node:child_process";
 import { promisify } from "node:util";
-import { resolveSystemBin } from "openclaw/plugin-sdk/infra-runtime";
+import { resolveSystemBin } from "openclaw/plugin-sdk/resolve-system-bin";
 
 const execFileAsync = promisify(execFile);
 

--- a/extensions/browser/src/browser/hyprland-capture.ts
+++ b/extensions/browser/src/browser/hyprland-capture.ts
@@ -18,6 +18,9 @@ let _setupInFlight: Promise<CaptureState> | null = null;
 let _cleanupOutputName: string | null = null;
 let _cleanupHyprctl: string | null = null;
 let _cleanupRegistered = false;
+let _exitListener: (() => void) | null = null;
+let _sigintListener: (() => void) | null = null;
+let _sigtermListener: (() => void) | null = null;
 
 export function isHyprlandAvailable(): boolean {
   return Boolean(process.env.HYPRLAND_INSTANCE_SIGNATURE?.trim());
@@ -77,15 +80,17 @@ function registerExitCleanup(hyprctl: string, outputName: string): void {
     }
   };
 
-  process.once("exit", cleanup);
-  process.once("SIGINT", () => {
+  _exitListener = cleanup;
+  _sigintListener = () => {
     cleanup();
-    process.exit(130);
-  });
-  process.once("SIGTERM", () => {
+  };
+  _sigtermListener = () => {
     cleanup();
-    process.exit(143);
-  });
+  };
+
+  process.once("exit", _exitListener);
+  process.once("SIGINT", _sigintListener);
+  process.once("SIGTERM", _sigtermListener);
 }
 
 async function setupCapture(browserPid: number): Promise<CaptureState> {
@@ -211,15 +216,26 @@ export async function captureWithHyprland(params: {
   try {
     return await runGrimCapture(outputName, timeoutMs);
   } catch (err) {
-    // Capture error → invalidate cache so the next call re-creates the output.
-    _state = null;
-    _setupInFlight = null;
+    // Capture error → remove the orphaned virtual output and reset cache so the next call retries setup.
+    await teardownHyprlandCapture().catch(() => {});
     throw err;
   }
 }
 
 /** Reset all module-level state. For tests only. */
 export function _resetHyprlandCaptureForTests(): void {
+  if (_exitListener) {
+    process.removeListener("exit", _exitListener);
+    _exitListener = null;
+  }
+  if (_sigintListener) {
+    process.removeListener("SIGINT", _sigintListener);
+    _sigintListener = null;
+  }
+  if (_sigtermListener) {
+    process.removeListener("SIGTERM", _sigtermListener);
+    _sigtermListener = null;
+  }
   _state = null;
   _setupInFlight = null;
   _cleanupOutputName = null;

--- a/extensions/browser/src/browser/routes/agent.snapshot.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.test.ts
@@ -386,6 +386,33 @@ describe("screenshot route Hyprland path selection", () => {
     expect(mockCaptureScreenshot).not.toHaveBeenCalled();
   });
 
+  it("headless profile → Hyprland path skipped, CDP used instead", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(true);
+    const fakePng = Buffer.from("\x89PNG\r\n\x1a\n");
+    mockCaptureWithHyprland.mockResolvedValue(fakePng);
+
+    // Override withRouteTabContext to inject a headless profile.
+    mockWithRouteTabContext.mockImplementation(
+      async (params: { run: (ctx: unknown) => Promise<void> }) => {
+        await params.run({
+          profileCtx: makeProfileCtx(true),
+          tab: fakeTab,
+          cdpUrl: "http://localhost:9222",
+          resolveTabUrl: async () => "https://example.com",
+        });
+      },
+    );
+
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+    const res = makeRes();
+
+    await handler(makeReq({ type: "png" }), res);
+
+    expect(mockCaptureWithHyprland).not.toHaveBeenCalled();
+    expect(mockCaptureScreenshot).toHaveBeenCalledOnce();
+  });
+
   it("captureWithHyprland throws → falls back to CDP, does not rethrow", async () => {
     mockIsHyprlandAvailable.mockReturnValue(true);
     mockCaptureWithHyprland.mockRejectedValue(new Error("grim crashed"));

--- a/extensions/browser/src/browser/routes/agent.snapshot.test.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.test.ts
@@ -1,5 +1,136 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveTargetIdAfterNavigate } from "./agent.snapshot-target.js";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks — must be declared before vi.mock() calls
+// ---------------------------------------------------------------------------
+
+const mockCaptureWithHyprland = vi.hoisted(() => vi.fn<() => Promise<Buffer>>());
+const mockIsHyprlandAvailable = vi.hoisted(() => vi.fn<() => boolean>());
+const mockCaptureScreenshot = vi.hoisted(() => vi.fn<() => Promise<Buffer>>());
+const mockNormalizeBrowserScreenshot = vi.hoisted(() => vi.fn());
+const mockSaveMediaBuffer = vi.hoisted(() => vi.fn());
+const mockEnsureMediaDir = vi.hoisted(() => vi.fn());
+const mockWithRouteTabContext = vi.hoisted(() => vi.fn());
+const mockGetBrowserProfileCapabilities = vi.hoisted(() => vi.fn());
+const mockShouldUsePlaywrightForScreenshot = vi.hoisted(() => vi.fn());
+
+// ---------------------------------------------------------------------------
+// Module mocks — pure factories, no importOriginal
+// ---------------------------------------------------------------------------
+
+vi.mock("../hyprland-capture.js", () => ({
+  captureWithHyprland: mockCaptureWithHyprland,
+  isHyprlandAvailable: mockIsHyprlandAvailable,
+  isHyprlandEnvironment: mockIsHyprlandAvailable,
+  teardownHyprlandCapture: vi.fn().mockResolvedValue(undefined),
+  _resetHyprlandCaptureForTests: vi.fn(),
+}));
+
+vi.mock("../cdp.js", () => ({
+  captureScreenshot: mockCaptureScreenshot,
+  snapshotAria: vi.fn().mockResolvedValue({ nodes: [] }),
+}));
+
+vi.mock("../../media/store.js", () => ({
+  ensureMediaDir: mockEnsureMediaDir,
+  saveMediaBuffer: mockSaveMediaBuffer,
+}));
+
+vi.mock("../screenshot.js", () => ({
+  normalizeBrowserScreenshot: mockNormalizeBrowserScreenshot,
+  DEFAULT_BROWSER_SCREENSHOT_MAX_BYTES: 5_000_000,
+  DEFAULT_BROWSER_SCREENSHOT_MAX_SIDE: 1920,
+}));
+
+vi.mock("../profile-capabilities.js", () => ({
+  getBrowserProfileCapabilities: mockGetBrowserProfileCapabilities,
+  shouldUsePlaywrightForScreenshot: mockShouldUsePlaywrightForScreenshot,
+  shouldUsePlaywrightForAriaSnapshot: vi.fn().mockReturnValue(false),
+  resolveDefaultSnapshotFormat: vi.fn().mockReturnValue("aria"),
+}));
+
+vi.mock("./agent.shared.js", () => ({
+  withRouteTabContext: mockWithRouteTabContext,
+  withPlaywrightRouteContext: vi.fn(),
+  readBody: (req: { body?: unknown }) =>
+    typeof req.body === "object" && req.body !== null ? (req.body as Record<string, unknown>) : {},
+  resolveProfileContext: vi.fn(),
+  getPwAiModule: vi.fn().mockResolvedValue(null),
+  requirePwAi: vi.fn().mockResolvedValue(null),
+  handleRouteError: vi.fn(),
+}));
+
+vi.mock("../chrome-mcp.js", () => ({
+  evaluateChromeMcpScript: vi.fn().mockResolvedValue([]),
+  navigateChromeMcpPage: vi.fn().mockResolvedValue({ url: "" }),
+  takeChromeMcpScreenshot: vi.fn().mockResolvedValue(Buffer.from("")),
+  takeChromeMcpSnapshot: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../chrome-mcp.snapshot.js", () => ({
+  buildAiSnapshotFromChromeMcpSnapshot: vi.fn().mockReturnValue({ snapshot: "", refs: {} }),
+  flattenChromeMcpSnapshotToAriaNodes: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../navigation-guard.js", () => ({
+  assertBrowserNavigationAllowed: vi.fn().mockResolvedValue(undefined),
+  assertBrowserNavigationResultAllowed: vi.fn().mockResolvedValue(undefined),
+  withBrowserNavigationPolicy: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../browser-proxy-mode.js", () => ({
+  resolveBrowserNavigationProxyMode: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("./agent.snapshot.plan.js", () => ({
+  resolveSnapshotPlan: vi.fn().mockReturnValue({ format: "aria", limit: 10 }),
+  shouldUsePlaywrightForAriaSnapshot: vi.fn().mockReturnValue(false),
+  shouldUsePlaywrightForScreenshot: mockShouldUsePlaywrightForScreenshot,
+}));
+
+vi.mock("./existing-session-limits.js", () => ({
+  EXISTING_SESSION_LIMITS: {
+    snapshot: {
+      pdfUnsupported: "unsupported",
+      screenshotElement: "unsupported",
+      snapshotSelector: "unsupported",
+    },
+  },
+}));
+
+// Import route AFTER all mocks are in place.
+import { registerBrowserAgentSnapshotRoutes } from "./agent.snapshot.js";
+import type { BrowserRequest, BrowserResponse, BrowserRouteHandler } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// /screenshot route — Hyprland path selection tests
+// ---------------------------------------------------------------------------
+
+const fakeTab = {
+  targetId: "target-1",
+  url: "https://example.com",
+  wsUrl: "ws://localhost:9222/devtools/page/1",
+};
+
+function makeCtx(opts: { hyprlandCapture?: boolean; pid?: number } = {}) {
+  return {
+    state: () => ({
+      resolved: {
+        hyprlandCapture: opts.hyprlandCapture ?? false,
+        ssrfPolicy: undefined,
+      },
+      profiles: new Map([
+        ["openclaw", { running: opts.pid != null ? { pid: opts.pid } : undefined }],
+      ]),
+    }),
+    mapTabError: () => null,
+  } as unknown as Parameters<typeof registerBrowserAgentSnapshotRoutes>[1];
+}
+
+// ---------------------------------------------------------------------------
+// resolveTargetIdAfterNavigate tests
+// ---------------------------------------------------------------------------
 
 type Tab = { targetId: string; url: string };
 
@@ -111,5 +242,184 @@ describe("resolveTargetIdAfterNavigate", () => {
     });
 
     expect(result).toBe("old-123");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /screenshot route — Hyprland path selection tests
+// ---------------------------------------------------------------------------
+
+function makeProfileCtx(headless = false) {
+  return {
+    profile: {
+      name: "openclaw",
+      headless,
+      cdpUrl: "http://localhost:9222",
+    },
+    listTabs: async () => [],
+    ensureTabAvailable: async () => fakeTab,
+  };
+}
+
+function captureScreenshotHandler(ctx: ReturnType<typeof makeCtx>): BrowserRouteHandler {
+  const handlers = new Map<string, BrowserRouteHandler>();
+  const app = {
+    get: (p: string, h: BrowserRouteHandler) => {
+      handlers.set(`GET ${p}`, h);
+    },
+    post: (p: string, h: BrowserRouteHandler) => {
+      handlers.set(`POST ${p}`, h);
+    },
+    delete: (p: string, h: BrowserRouteHandler) => {
+      handlers.set(`DELETE ${p}`, h);
+    },
+  };
+  registerBrowserAgentSnapshotRoutes(app, ctx);
+  return handlers.get("POST /screenshot")!;
+}
+
+function makeReq(body: Record<string, unknown> = {}): BrowserRequest {
+  return { params: {}, query: {}, body };
+}
+
+function makeRes(): BrowserResponse & { lastJson: () => unknown } {
+  let lastCall: unknown;
+  return {
+    status: function (this: BrowserResponse) {
+      return this;
+    },
+    json: (body: unknown) => {
+      lastCall = body;
+    },
+    lastJson: () => lastCall,
+  } as unknown as BrowserResponse & { lastJson: () => unknown };
+}
+
+describe("screenshot route Hyprland path selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: not Hyprland
+    mockIsHyprlandAvailable.mockReturnValue(false);
+    // Default: not Chrome MCP
+    mockGetBrowserProfileCapabilities.mockReturnValue({ usesChromeMcp: false });
+    // Default: don't use Playwright
+    mockShouldUsePlaywrightForScreenshot.mockReturnValue(false);
+    // Default: CDP returns fake buffer
+    mockCaptureScreenshot.mockResolvedValue(Buffer.from("cdp-bytes"));
+    // normalize passes buffer through
+    mockNormalizeBrowserScreenshot.mockResolvedValue({
+      buffer: Buffer.from("normalized"),
+      contentType: "image/png",
+    });
+    mockEnsureMediaDir.mockResolvedValue(undefined);
+    mockSaveMediaBuffer.mockResolvedValue({ path: "/tmp/fake.png" });
+
+    // withRouteTabContext calls run() with a headed, non-Chrome-MCP profile
+    mockWithRouteTabContext.mockImplementation(
+      async (params: { run: (ctx: unknown) => Promise<void> }) => {
+        await params.run({
+          profileCtx: makeProfileCtx(false),
+          tab: fakeTab,
+          cdpUrl: "http://localhost:9222",
+          resolveTabUrl: async () => "https://example.com",
+        });
+      },
+    );
+  });
+
+  afterEach(() => {
+    delete process.env.HYPRLAND_INSTANCE_SIGNATURE;
+  });
+
+  it("non-Hyprland environment → CDP captureScreenshot is called", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(false);
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+    const res = makeRes();
+
+    await handler(makeReq({ type: "png" }), res);
+
+    expect(mockCaptureScreenshot).toHaveBeenCalledOnce();
+    expect(mockCaptureWithHyprland).not.toHaveBeenCalled();
+  });
+
+  it("Hyprland available + headed + hyprlandCapture:true + pid → grim called, PNG returned", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(true);
+    const fakePng = Buffer.from("\x89PNG\r\n\x1a\n");
+    mockCaptureWithHyprland.mockResolvedValue(fakePng);
+    mockNormalizeBrowserScreenshot.mockResolvedValue({
+      buffer: fakePng,
+      contentType: "image/png",
+    });
+
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+    const res = makeRes();
+
+    await handler(makeReq({ type: "png" }), res);
+
+    expect(mockCaptureWithHyprland).toHaveBeenCalledOnce();
+    expect(mockCaptureScreenshot).not.toHaveBeenCalled();
+    expect(mockSaveMediaBuffer).toHaveBeenCalled();
+  });
+
+  it("jpeg request on Hyprland path → screenshotType overridden to png", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(true);
+    const fakePng = Buffer.from("\x89PNG\r\n\x1a\n");
+    mockCaptureWithHyprland.mockResolvedValue(fakePng);
+    mockNormalizeBrowserScreenshot.mockImplementation(async (buf: Buffer) => ({
+      buffer: buf,
+      contentType: "image/png",
+    }));
+
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+    const res = makeRes();
+
+    await handler(makeReq({ type: "jpeg" }), res);
+
+    expect(mockCaptureWithHyprland).toHaveBeenCalledOnce();
+    // normalizeBrowserScreenshot must be called with the grim buffer (PNG), not a JPEG
+    const [calledBuf] = mockNormalizeBrowserScreenshot.mock.calls[0] as [Buffer];
+    expect(calledBuf).toEqual(fakePng);
+    // CDP must not be called since grim succeeded
+    expect(mockCaptureScreenshot).not.toHaveBeenCalled();
+  });
+
+  it("captureWithHyprland throws → falls back to CDP, does not rethrow", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(true);
+    mockCaptureWithHyprland.mockRejectedValue(new Error("grim crashed"));
+
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+    const res = makeRes();
+
+    await handler(makeReq({ type: "png" }), res);
+
+    expect(mockCaptureWithHyprland).toHaveBeenCalledOnce();
+    expect(mockCaptureScreenshot).toHaveBeenCalledOnce();
+  });
+
+  it("concurrent viewport screenshot calls each complete and save", async () => {
+    mockIsHyprlandAvailable.mockReturnValue(true);
+    const fakePng = Buffer.from("\x89PNG");
+    mockCaptureWithHyprland.mockResolvedValue(fakePng);
+    mockNormalizeBrowserScreenshot.mockResolvedValue({
+      buffer: fakePng,
+      contentType: "image/png",
+    });
+
+    const ctx = makeCtx({ hyprlandCapture: true, pid: 42 });
+    const handler = captureScreenshotHandler(ctx);
+
+    await Promise.all([
+      handler(makeReq({ type: "png" }), makeRes()),
+      handler(makeReq({ type: "png" }), makeRes()),
+      handler(makeReq({ type: "png" }), makeRes()),
+    ]);
+
+    expect(mockCaptureWithHyprland).toHaveBeenCalledTimes(3);
+    expect(mockCaptureScreenshot).not.toHaveBeenCalled();
+    expect(mockSaveMediaBuffer).toHaveBeenCalledTimes(3);
   });
 });

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -492,7 +492,7 @@ export function registerBrowserAgentSnapshotRoutes(
               !fullPage &&
               !element &&
               process.platform === "linux" &&
-              !ctx.state().resolved.headless &&
+              !profileCtx.profile.headless &&
               ctx.state().resolved.hyprlandCapture &&
               isHyprlandAvailable()
             ) {

--- a/extensions/browser/src/browser/routes/agent.snapshot.ts
+++ b/extensions/browser/src/browser/routes/agent.snapshot.ts
@@ -14,6 +14,7 @@ import {
   flattenChromeMcpSnapshotToAriaNodes,
 } from "../chrome-mcp.snapshot.js";
 import { DEFAULT_BROWSER_SCREENSHOT_TIMEOUT_MS } from "../constants.js";
+import { captureWithHyprland, isHyprlandAvailable } from "../hyprland-capture.js";
 import {
   assertBrowserNavigationAllowed,
   assertBrowserNavigationResultAllowed,
@@ -433,6 +434,9 @@ export function registerBrowserAgentSnapshotRoutes(
             return;
           }
 
+          // grim always captures PNG; track the effective type separately so
+          // the response reflects what was actually produced.
+          let screenshotType: "png" | "jpeg" = type;
           let buffer: Buffer;
           const shouldUsePlaywright =
             labels ||
@@ -483,19 +487,41 @@ export function registerBrowserAgentSnapshotRoutes(
             });
             buffer = snap.buffer;
           } else {
-            buffer = await captureScreenshot({
-              wsUrl: tab.wsUrl ?? "",
-              fullPage,
-              format: type,
-              quality: type === "jpeg" ? 85 : undefined,
-              timeoutMs,
-            });
+            let hyprlandBuffer: Buffer | null = null;
+            if (
+              !fullPage &&
+              !element &&
+              process.platform === "linux" &&
+              !ctx.state().resolved.headless &&
+              ctx.state().resolved.hyprlandCapture &&
+              isHyprlandAvailable()
+            ) {
+              const pid = ctx.state().profiles.get(profileCtx.profile.name)?.running?.pid ?? null;
+              if (pid && pid > 0) {
+                hyprlandBuffer = await captureWithHyprland({
+                  browserPid: pid,
+                }).catch(() => null);
+              }
+            }
+
+            if (hyprlandBuffer) {
+              buffer = hyprlandBuffer;
+              screenshotType = "png";
+            } else {
+              buffer = await captureScreenshot({
+                wsUrl: tab.wsUrl ?? "",
+                fullPage,
+                format: type,
+                quality: type === "jpeg" ? 85 : undefined,
+                timeoutMs,
+              });
+            }
           }
 
           await saveNormalizedScreenshotResponse({
             res,
             buffer,
-            type,
+            type: screenshotType,
             targetId: tab.targetId,
             url: tab.url,
           });

--- a/package.json
+++ b/package.json
@@ -326,6 +326,10 @@
       "types": "./dist/plugin-sdk/infra-runtime.d.ts",
       "default": "./dist/plugin-sdk/infra-runtime.js"
     },
+    "./plugin-sdk/resolve-system-bin": {
+      "types": "./dist/plugin-sdk/resolve-system-bin.d.ts",
+      "default": "./dist/plugin-sdk/resolve-system-bin.js"
+    },
     "./plugin-sdk/runtime-config-snapshot": {
       "types": "./dist/plugin-sdk/runtime-config-snapshot.d.ts",
       "default": "./dist/plugin-sdk/runtime-config-snapshot.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -64,6 +64,7 @@
   "system-event-runtime",
   "transport-ready-runtime",
   "infra-runtime",
+  "resolve-system-bin",
   "runtime-config-snapshot",
   "runtime-group-policy",
   "model-session-runtime",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -910,6 +910,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Best-effort cleanup policy for browser tabs opened by primary-agent sessions. Keep enabled to avoid stale sandbox or managed-browser tabs accumulating across long-lived gateways.",
           },
+          hyprlandCapture: {
+            type: "boolean",
+          },
         },
         additionalProperties: false,
         title: "Browser",

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -911,6 +911,9 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
               "Best-effort cleanup policy for browser tabs opened by primary-agent sessions. Keep enabled to avoid stale sandbox or managed-browser tabs accumulating across long-lived gateways.",
           },
           hyprlandCapture: {
+            title: "Hyprland Viewport Capture",
+            description:
+              "Enables a Hyprland/Wayland fallback for viewport screenshots using grim and a virtual hyprctl output. Only activates when HYPRLAND_INSTANCE_SIGNATURE is set and the browser profile is not headless. Requires grim and hyprctl to be installed.",
             type: "boolean",
           },
         },

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -92,4 +92,10 @@ export type BrowserConfig = {
    * Example: ["--window-size=1920,1080", "--disable-infobars"]
    */
   extraArgs?: string[];
+  /**
+   * Use grim + Hyprland virtual output for headed viewport screenshots on Wayland.
+   * Fixes Page.captureScreenshot timeouts on Hyprland. Requires hyprctl and grim.
+   * Default: false (opt-in).
+   */
+  hyprlandCapture?: boolean;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -472,6 +472,7 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        hyprlandCapture: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -472,7 +472,13 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
-        hyprlandCapture: z.boolean().optional(),
+        hyprlandCapture: z
+          .boolean()
+          .optional()
+          .meta({ title: "Hyprland Viewport Capture" })
+          .describe(
+            "Enables a Hyprland/Wayland fallback for viewport screenshots using grim and a virtual hyprctl output. Only activates when HYPRLAND_INSTANCE_SIGNATURE is set and the browser profile is not headless. Requires grim and hyprctl to be installed.",
+          ),
       })
       .strict()
       .optional(),

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -64,3 +64,4 @@ export * from "../utils/fetch-timeout.js";
 export * from "../utils/run-with-concurrency.js";
 export { createRuntimeOutboundDelegates } from "../channels/plugins/runtime-forwarders.js";
 export * from "./ssrf-policy.js";
+export { resolveSystemBin, type SystemBinTrust } from "../infra/resolve-system-bin.js";

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -64,4 +64,3 @@ export * from "../utils/fetch-timeout.js";
 export * from "../utils/run-with-concurrency.js";
 export { createRuntimeOutboundDelegates } from "../channels/plugins/runtime-forwarders.js";
 export * from "./ssrf-policy.js";
-export { resolveSystemBin, type SystemBinTrust } from "../infra/resolve-system-bin.js";

--- a/src/plugin-sdk/resolve-system-bin.ts
+++ b/src/plugin-sdk/resolve-system-bin.ts
@@ -1,0 +1,1 @@
+export { resolveSystemBin, type SystemBinTrust } from "../infra/resolve-system-bin.js";


### PR DESCRIPTION
Closes #54470

### Problem
On native Windows, `openclaw webhooks gmail setup --account` crashed immediately with
`Error: spawn gcloud ENOENT`. Node's `child_process.spawn` with `shell: false` does not
consult `PATHEXT`, so bare `gcloud`, `gog`, and `tailscale` are not found even when
`where.exe` resolves them to valid `.cmd` / `.exe` paths.

### Solution
Add `resolveExecutable(cmd)` in `src/infra/executable-path.ts`:
- No-op on non-Windows (single comparison, zero side-effects)
- No-op if `cmd` already carries a known extension (`.com`, `.exe`, `.bat`, `.cmd`)
- On win32: calls `where.exe` via `execFileSync`, prefers `.cmd` → `.exe` → first result,
  falls back to original `cmd` on throw
- No `shell: true` anywhere

Thread the resolved binary through every affected spawn site:
- `gcloudBin`: module-level `??=` in `runGcloudCommand` — one `where.exe` for the entire setup sequence
- `tailscaleBin`: local variable in `ensureTailscaleEndpoint` — one `where.exe` for both `runCommandWithTimeout` calls
- `gogBin`: module-level `??=` shared by `startGmailWatch` and `spawnGogServe` — one `where.exe` for the process lifetime, zero extra calls on watcher restarts

### Files changed
- `src/infra/executable-path.ts` — new file, `resolveExecutable`
- `src/hooks/gmail-setup-utils.ts` — `gcloudBin` + `tailscaleBin`
- `src/hooks/gmail-watcher.ts` — `gogBin`
- `src/infra/executable-path.test.ts` — 10 unit tests (all 5 resolution branches + `lines[0]` fallback)
- `src/hooks/gmail-setup-utils.test.ts` — 3 tests covering the new cached resolution

### Test results
pnpm test src/hooks/gmail-setup-utils.test.ts src/hooks/gmail.test.ts src/hooks/gmail-watcher-lifecycle.test.ts ✅
pnpm test src/process/exec.windows.test.ts src/process/windows-command.test.ts src/infra/executable-path.test.ts ✅
pnpm check:changed ✅

### Notes
- `src/process/exec.ts` is untouched — existing package-manager shim is unaffected
- Fix is fully inert on macOS and Linux
- Tested against reporter evidence: `where.exe gcloud` resolving to `C:\Tools\gcloud\gcloud.cmd`