### PR TITLE
fix(agents/wizard): pre-fill peer-level workspace path on agents add for documented default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,7 @@ Docs: https://docs.openclaw.ai
 - Agents/sessions: stop session write-lock timeouts from entering model failover, so local lock contention surfaces directly instead of cascading across providers. (#68700) Thanks @MonkeyLeeT.
 - Auto-reply: run inbound reply delivery through `message_sending` hooks so plugins can transform or cancel generated replies before they are sent. (#70118) Thanks @jzakirov.
 - CI/release-checks: pass workflow inputs and matrix values through step environment variables instead of embedding them directly into `run:` shell commands, reducing template-injection surface in the cross-OS release-check workflow. (#66884) Thanks @alexlomt.
+- Agents wizard: pre-fill `agents add <id>` with a peer-level `~/.openclaw/workspace-<id>` path matching `docs/concepts/multi-agent.md` instead of nesting the new agent under `~/.openclaw/workspace/<id>`, avoiding silent skill leakage and `rm -rf` data-loss footguns when accepting the default. Fixes #71889. Thanks @pushpendrachauhan.
 
 ## 2026.4.23
 

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -187,3 +187,28 @@ export function resolveAgentDir(
   const root = resolveStateDir(env);
   return path.join(root, "agents", id, "agent");
 }
+
+/**
+ * Suggest a peer-level workspace path for a NEW agent, used as the wizard's
+ * `Workspace directory` initial value. Matches the documented `~/.openclaw/
+ * workspace-<agentId>` convention from docs/concepts/multi-agent.md and avoids
+ * the nested `<main>/<agentId>` footgun where main's recursive workspace
+ * operations leak into other agents' folders (#71889).
+ *
+ * Existing per-agent overrides and runtime resolution via
+ * `resolveAgentWorkspaceDir` are intentionally unchanged.
+ */
+export function suggestPeerAgentWorkspaceDir(
+  cfg: OpenClawConfig,
+  agentId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const id = normalizeAgentId(agentId);
+  const fallback = cfg.agents?.defaults?.workspace?.trim();
+  const baseWorkspace = fallback
+    ? resolveUserPath(fallback, env)
+    : resolveDefaultAgentWorkspaceDir(env);
+  const dir = path.dirname(baseWorkspace);
+  const base = path.basename(baseWorkspace);
+  return stripNullBytes(path.join(dir, `${base}-${id}`));
+}

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -188,24 +188,24 @@ export function resolveAgentDir(
   return path.join(root, "agents", id, "agent");
 }
 
-const WORKSPACE_DIR_BASENAME_RE = /^workspace(?:-[\w.-]+)?$/;
-
 /**
  * Suggest a default workspace path for a NEW agent, used as the wizard's
  * `Workspace directory` initial value.
  *
- * When the configured base looks like a concrete workspace directory (basename
- * `workspace` or `workspace-<suffix>`, matching the documented default and the
- * `OPENCLAW_PROFILE` form), apply the documented peer-level pattern from
- * docs/concepts/multi-agent.md (`~/.openclaw/workspace-<agentId>`) so the
- * recursive-leak / `rm -rf workspace` footgun from #71889 is avoided.
+ * Only overrides the runtime-resolved default in the narrow post-setup
+ * scenario where `agents.defaults.workspace` exactly matches the documented
+ * `~/.openclaw/workspace[-<profile>]` location (the value `setup.ts` writes on
+ * first run). In that case the suggestion follows the documented peer-level
+ * pattern from docs/concepts/multi-agent.md (`~/.openclaw/workspace-<agentId>`)
+ * to avoid the recursive-leak / `rm -rf workspace` footgun from #71889.
  *
- * When the base is a shared parent directory (basename does not look like a
- * workspace), preserve the historic nested layout `<base>/<id>` from #59789 so
- * operators who configured a shared agent root keep that contract.
+ * For every other shape, including unset `defaults.workspace`, custom shared
+ * roots, and `OPENCLAW_STATE_DIR`-isolated multi-gateway setups, defers to
+ * `resolveAgentWorkspaceDir` so the contracts from #59789 (shared-base nesting)
+ * and per-instance state-dir isolation are preserved.
  *
- * Existing per-agent overrides and runtime resolution via
- * `resolveAgentWorkspaceDir` are intentionally unchanged.
+ * Existing per-agent overrides and runtime resolution itself are intentionally
+ * unchanged.
  */
 export function suggestPeerAgentWorkspaceDir(
   cfg: OpenClawConfig,
@@ -213,13 +213,17 @@ export function suggestPeerAgentWorkspaceDir(
   env: NodeJS.ProcessEnv = process.env,
 ): string {
   const id = normalizeAgentId(agentId);
+  const runtimeDefault = resolveAgentWorkspaceDir(cfg, id, env);
   const fallback = cfg.agents?.defaults?.workspace?.trim();
-  const baseWorkspace = fallback
-    ? resolveUserPath(fallback, env)
-    : resolveDefaultAgentWorkspaceDir(env);
-  const base = path.basename(baseWorkspace);
-  if (WORKSPACE_DIR_BASENAME_RE.test(base)) {
-    return stripNullBytes(path.join(path.dirname(baseWorkspace), `${base}-${id}`));
+  if (!fallback) {
+    return runtimeDefault;
   }
-  return stripNullBytes(path.join(baseWorkspace, id));
+  const fallbackResolved = path.resolve(resolveUserPath(fallback, env));
+  const documentedDefault = path.resolve(resolveDefaultAgentWorkspaceDir(env));
+  if (fallbackResolved !== documentedDefault) {
+    return runtimeDefault;
+  }
+  return stripNullBytes(
+    path.join(path.dirname(fallbackResolved), `${path.basename(fallbackResolved)}-${id}`),
+  );
 }

--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -188,12 +188,21 @@ export function resolveAgentDir(
   return path.join(root, "agents", id, "agent");
 }
 
+const WORKSPACE_DIR_BASENAME_RE = /^workspace(?:-[\w.-]+)?$/;
+
 /**
- * Suggest a peer-level workspace path for a NEW agent, used as the wizard's
- * `Workspace directory` initial value. Matches the documented `~/.openclaw/
- * workspace-<agentId>` convention from docs/concepts/multi-agent.md and avoids
- * the nested `<main>/<agentId>` footgun where main's recursive workspace
- * operations leak into other agents' folders (#71889).
+ * Suggest a default workspace path for a NEW agent, used as the wizard's
+ * `Workspace directory` initial value.
+ *
+ * When the configured base looks like a concrete workspace directory (basename
+ * `workspace` or `workspace-<suffix>`, matching the documented default and the
+ * `OPENCLAW_PROFILE` form), apply the documented peer-level pattern from
+ * docs/concepts/multi-agent.md (`~/.openclaw/workspace-<agentId>`) so the
+ * recursive-leak / `rm -rf workspace` footgun from #71889 is avoided.
+ *
+ * When the base is a shared parent directory (basename does not look like a
+ * workspace), preserve the historic nested layout `<base>/<id>` from #59789 so
+ * operators who configured a shared agent root keep that contract.
  *
  * Existing per-agent overrides and runtime resolution via
  * `resolveAgentWorkspaceDir` are intentionally unchanged.
@@ -208,7 +217,9 @@ export function suggestPeerAgentWorkspaceDir(
   const baseWorkspace = fallback
     ? resolveUserPath(fallback, env)
     : resolveDefaultAgentWorkspaceDir(env);
-  const dir = path.dirname(baseWorkspace);
   const base = path.basename(baseWorkspace);
-  return stripNullBytes(path.join(dir, `${base}-${id}`));
+  if (WORKSPACE_DIR_BASENAME_RE.test(base)) {
+    return stripNullBytes(path.join(path.dirname(baseWorkspace), `${base}-${id}`));
+  }
+  return stripNullBytes(path.join(baseWorkspace, id));
 }

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -518,27 +518,32 @@ describe("resolveAgentConfig", () => {
 });
 
 describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
-  it("returns peer-level path next to defaults.workspace when basename looks like a workspace", () => {
-    const cfg: OpenClawConfig = {
-      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace" } },
-    };
-    const suggested = suggestPeerAgentWorkspaceDir(cfg, "testbug");
-    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-testbug"));
-  });
-
-  it("applies peer suffix to OPENCLAW_PROFILE workspace-<profile> bases", () => {
-    const cfg: OpenClawConfig = {
-      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace-prod" } },
-    };
-    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
-    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-prod-ops"));
-  });
-
-  it("derives peer-level path from the default workspace location when no fallback", () => {
+  it("returns peer-level path when defaults.workspace matches the documented default", () => {
     const home = path.join(path.sep, "srv", "openclaw-home");
     vi.stubEnv("OPENCLAW_HOME", home);
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: path.join(home, ".openclaw", "workspace") } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "testbug");
+    expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-testbug"));
+  });
+
+  it("applies peer suffix to OPENCLAW_PROFILE workspace-<profile> defaults", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    vi.stubEnv("OPENCLAW_PROFILE", "prod");
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: path.join(home, ".openclaw", "workspace-prod") } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
+    expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-prod-ops"));
+  });
+
+  it("defers to runtime stateDir resolution when defaults.workspace is unset", () => {
+    const stateDir = path.join(path.sep, "var", "openclaw-prod");
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
     const suggested = suggestPeerAgentWorkspaceDir({}, "alex");
-    expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-alex"));
+    expect(suggested).toBe(path.join(stateDir, "workspace-alex"));
   });
 
   it("preserves the historic shared-base nested layout from #59789", () => {
@@ -549,12 +554,30 @@ describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
     expect(suggested).toBe(path.resolve("/srv/agents/ops"));
   });
 
-  it("normalizes agent ids before suffixing", () => {
+  it("preserves nesting for shared roots whose basename happens to be `workspace`", () => {
     const cfg: OpenClawConfig = {
-      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace" } },
+      agents: { defaults: { workspace: "/srv/workspace" } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
+    expect(suggested).toBe(path.resolve("/srv/workspace/ops"));
+  });
+
+  it("preserves nesting for shared roots whose basename happens to be `workspace-prod`", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: "/srv/workspace-prod" } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
+    expect(suggested).toBe(path.resolve("/srv/workspace-prod/ops"));
+  });
+
+  it("normalizes agent ids before suffixing", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: path.join(home, ".openclaw", "workspace") } },
     };
     const suggested = suggestPeerAgentWorkspaceDir(cfg, "Test Bug");
-    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-test-bug"));
+    expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-test-bug"));
   });
 });
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -18,6 +18,7 @@ import {
   resolveAgentWorkspaceDir,
   resolveAgentIdByWorkspacePath,
   resolveAgentIdsByWorkspacePath,
+  suggestPeerAgentWorkspaceDir,
 } from "./agent-scope.js";
 
 afterEach(() => {
@@ -513,6 +514,39 @@ describe("resolveAgentConfig", () => {
     };
     const workspace = resolveAgentWorkspaceDir(cfg, "main");
     expect(workspace).toBe(path.join(stateDir, "workspace-main"));
+  });
+});
+
+describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
+  it("returns peer-level path next to defaults.workspace when configured", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace" } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "testbug");
+    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-testbug"));
+  });
+
+  it("derives peer-level path from the default workspace location when no fallback", () => {
+    const home = path.join(path.sep, "srv", "openclaw-home");
+    vi.stubEnv("OPENCLAW_HOME", home);
+    const suggested = suggestPeerAgentWorkspaceDir({}, "alex");
+    expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-alex"));
+  });
+
+  it("treats a custom shared base as the peer root rather than nesting under it", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: "/shared-ws" }, list: [{ id: "main" }] },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
+    expect(suggested).toBe(path.resolve("/shared-ws-ops"));
+  });
+
+  it("normalizes agent ids before suffixing", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace" } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "Test Bug");
+    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-test-bug"));
   });
 });
 

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -518,12 +518,20 @@ describe("resolveAgentConfig", () => {
 });
 
 describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
-  it("returns peer-level path next to defaults.workspace when configured", () => {
+  it("returns peer-level path next to defaults.workspace when basename looks like a workspace", () => {
     const cfg: OpenClawConfig = {
       agents: { defaults: { workspace: "/Users/me/.openclaw/workspace" } },
     };
     const suggested = suggestPeerAgentWorkspaceDir(cfg, "testbug");
     expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-testbug"));
+  });
+
+  it("applies peer suffix to OPENCLAW_PROFILE workspace-<profile> bases", () => {
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { workspace: "/Users/me/.openclaw/workspace-prod" } },
+    };
+    const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
+    expect(suggested).toBe(path.join("/Users/me/.openclaw", "workspace-prod-ops"));
   });
 
   it("derives peer-level path from the default workspace location when no fallback", () => {
@@ -533,12 +541,12 @@ describe("suggestPeerAgentWorkspaceDir (#71889)", () => {
     expect(suggested).toBe(path.join(path.resolve(home), ".openclaw", "workspace-alex"));
   });
 
-  it("treats a custom shared base as the peer root rather than nesting under it", () => {
+  it("preserves the historic shared-base nested layout from #59789", () => {
     const cfg: OpenClawConfig = {
-      agents: { defaults: { workspace: "/shared-ws" }, list: [{ id: "main" }] },
+      agents: { defaults: { workspace: "/srv/agents" }, list: [{ id: "main" }] },
     };
     const suggested = suggestPeerAgentWorkspaceDir(cfg, "ops");
-    expect(suggested).toBe(path.resolve("/shared-ws-ops"));
+    expect(suggested).toBe(path.resolve("/srv/agents/ops"));
   });
 
   it("normalizes agent ids before suffixing", () => {

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -34,6 +34,7 @@ export {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
+  suggestPeerAgentWorkspaceDir,
   type ResolvedAgentConfig,
 } from "./agent-scope-config.js";
 

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -75,4 +75,72 @@ describe("agents add command", () => {
     expect(runtime.exit).toHaveBeenCalledWith(1);
     expect(writeConfigFileMock).not.toHaveBeenCalled();
   });
+
+  it("uses peer-level workspace as initialValue for a brand-new agent (#71889)", async () => {
+    const cfg = {
+      agents: {
+        defaults: { workspace: "/Users/me/.openclaw/workspace" },
+        list: [{ id: "main", default: true }],
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      parsed: cfg,
+      config: cfg,
+    });
+
+    const text = vi.fn().mockRejectedValue(new WizardCancelledError());
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      note: vi.fn(),
+      text: vi.fn().mockResolvedValueOnce("freshbug").mockImplementation(text),
+      confirm: vi.fn().mockResolvedValue(false),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Workspace directory",
+        initialValue: "/Users/me/.openclaw/workspace-freshbug",
+      }),
+    );
+  });
+
+  it("preserves the existing workspace as initialValue when updating an existing agent (#71889 follow-up)", async () => {
+    const cfg = {
+      agents: {
+        defaults: { workspace: "/Users/me/.openclaw/workspace" },
+        list: [
+          { id: "main", default: true },
+          { id: "agent-007", workspace: "/Users/me/code/agent-007-ws" },
+        ],
+      },
+    };
+    readConfigFileSnapshotMock.mockResolvedValue({
+      ...baseConfigSnapshot,
+      parsed: cfg,
+      config: cfg,
+    });
+
+    const text = vi.fn().mockRejectedValue(new WizardCancelledError());
+    wizardMocks.createClackPrompter.mockReturnValue({
+      intro: vi.fn(),
+      note: vi.fn(),
+      text: vi.fn().mockResolvedValueOnce("agent-007").mockImplementation(text),
+      // First confirm = "Agent already exists. Update it?" → yes
+      confirm: vi.fn().mockResolvedValue(true),
+      outro: vi.fn(),
+    });
+
+    await agentsAddCommand({}, runtime);
+
+    expect(text).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Workspace directory",
+        initialValue: "/Users/me/code/agent-007-ws",
+      }),
+    );
+  });
 });

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -2,8 +2,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   resolveAgentDir,
-  resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
+  suggestPeerAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { resolveAuthStorePath } from "../agents/auth-profiles/paths.js";
@@ -224,7 +224,7 @@ export async function agentsAddCommand(
       }
     }
 
-    const workspaceDefault = resolveAgentWorkspaceDir(cfg, agentId);
+    const workspaceDefault = suggestPeerAgentWorkspaceDir(cfg, agentId);
     const workspaceInput = await prompter.text({
       message: "Workspace directory",
       initialValue: workspaceDefault,

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import {
   resolveAgentDir,
+  resolveAgentWorkspaceDir,
   resolveDefaultAgentId,
   suggestPeerAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
@@ -224,7 +225,12 @@ export async function agentsAddCommand(
       }
     }
 
-    const workspaceDefault = suggestPeerAgentWorkspaceDir(cfg, agentId);
+    // Brand-new agents get the documented peer-level suggestion (#71889);
+    // updating an existing agent must preserve its current workspace so a
+    // pressed-Enter on this prompt does not silently relocate the agent.
+    const workspaceDefault = existingAgent
+      ? resolveAgentWorkspaceDir(cfg, agentId)
+      : suggestPeerAgentWorkspaceDir(cfg, agentId);
     const workspaceInput = await prompter.text({
       message: "Workspace directory",
       initialValue: workspaceDefault,


### PR DESCRIPTION
Fixes #71889.

## Root cause

`openclaw setup` writes `agents.defaults.workspace = ~/.openclaw/workspace` on first run. When the operator later runs `openclaw agents add <id>`, the wizard's "Workspace directory" prompt seeds `initialValue` from `resolveAgentWorkspaceDir(cfg, agentId)`. For non-default agents that path resolves to `path.join(defaults.workspace, id)` (set by #59789) — i.e. `~/.openclaw/workspace/<id>`, **nested under the main agent's tree**, not the peer-level `~/.openclaw/workspace-<id>` documented in [`docs/concepts/multi-agent.md:57,67`](https://github.com/openclaw/openclaw/blob/main/docs/concepts/multi-agent.md#L57).

If the operator hits Enter, the nested layout becomes the persisted reality:

- Skill discovery walking `~/.openclaw/workspace/skills/` traverses `<other-agent>/skills/` along with main's, leaking cross-agent skills under OpenClaw's "soft sandbox" model.
- `rm -rf ~/.openclaw/workspace` to reset main wipes every nested agent's workspace, memory, and skills.
- Recursive memory/grep/glob inside main's workspace silently treats other agents' private files as main's.

## Fix

`src/agents/agent-scope-config.ts` — add `suggestPeerAgentWorkspaceDir(cfg, id, env)`. The helper only overrides runtime resolution in the **narrow post-setup scenario** where `agents.defaults.workspace` exactly matches `resolveDefaultAgentWorkspaceDir(env)` (the value the setup wizard wrote). In that case it returns the documented peer-level form `~/.openclaw/workspace-<id>`. Every other shape — unset `defaults.workspace`, custom shared roots like `/srv/agents`, `/srv/workspace`, `/srv/workspace-prod`, and `OPENCLAW_STATE_DIR`-isolated multi-gateway setups — defers to `resolveAgentWorkspaceDir` so the contracts from #59789 (shared-base nesting) and per-instance state-dir isolation stay intact.

`src/commands/agents.commands.add.ts` — the wizard uses the new helper as `initialValue` only for **brand-new** agents. When `openclaw agents add <existing-id>` is used to update an existing agent, the prompt still seeds from `resolveAgentWorkspaceDir(cfg, agentId)` so a pressed-Enter on a routine auth/binding update does not silently relocate the agent.

Runtime resolution via `resolveAgentWorkspaceDir` is intentionally unchanged. Existing per-agent `workspace` overrides take precedence, and the #59789 nested layout is preserved for everyone who explicitly configured it.

## Verification

- `node` standalone trace through 8 representative configs (default install, OPENCLAW_PROFILE, OPENCLAW_STATE_DIR isolation, /srv/agents shared root, /srv/workspace and /srv/workspace-prod ambiguous bases, /shared-ws #59789, id normalization) — all behave as expected.
- Added 6 unit tests in `agent-scope.test.ts` covering each scenario above and 2 wizard tests in `agents.add.test.ts` covering both new-agent prefill and existing-agent update paths.
- `oxfmt --check` and `npx oxlint` clean on changed files.
- `pnpm tsgo:core` produces the same set of pre-existing unrelated errors as `c070509b7f` (verified by stashing and re-running on clean main).
- 4 review iterations with `codex review --base origin/main` against this diff. Final pass: "I did not identify any blocking correctness issues in the diff."

## Test plan

- [x] Unit tests added for the new helper covering all 6 documented config shapes.
- [x] Wizard tests for both new-agent and existing-agent update paths.
- [x] Codex review clean.
- [ ] Manual `pnpm openclaw agents add testbug` on a fresh `~/.openclaw` to confirm the prompt prefill matches expectations.
- [ ] Manual `pnpm openclaw agents add <existing-id>` on a config with a customized agent workspace to confirm the prefill preserves it.