### PR TITLE
fix(build): copy bundled hook HOOK.md manifests in runtime postbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,7 @@ Docs: https://docs.openclaw.ai
 - Agents/Claude CLI: apply the configured 1M context window override to eligible Claude CLI Opus and Sonnet models when `context1m` is enabled. (#70863) Thanks @bidadh.
 - Models/status: report fresh Claude CLI native auth instead of stale stored `anthropic:claude-cli` profile expiry when local credentials are current. Fixes #71256. (#71332) Thanks @matthiasjanke and @neeravmakwana.
 - CLI backends: compact OpenClaw transcripts after over-budget CLI turns and reseed fresh CLI sessions from the compacted transcript instead of stale external resume state. Fixes #68329. (#71916) Thanks @obviyus.
+- Build/runtime-postbuild: copy bundled hook `HOOK.md` manifests into `dist/bundled/<hook>/` as part of `runRuntimePostBuild` so `pnpm gateway:watch` (which invokes the runtime postbuild but skips the standalone `copy-hook-metadata` step from `BUILD_ALL_PROFILES.gatewayWatch`) ships the manifests its hook discovery scans for. Without this, all bundled internal hooks (e.g. `session-memory`) registered zero handlers in dev. Thanks @jtatum.
 
 ## 2026.4.24
 

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -81,9 +81,37 @@ export function writeStableRootRuntimeAliases(params = {}) {
   }
 }
 
+export function copyBundledHookMetadata(params = {}) {
+  const rootDir = params.rootDir ?? ROOT;
+  const fsImpl = params.fs ?? fs;
+  const warn = params.warn ?? console.warn;
+  const srcRoot = path.join(rootDir, "src", "hooks", "bundled");
+  const distRoot = path.join(rootDir, "dist", "bundled");
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(srcRoot, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const srcMd = path.join(srcRoot, entry.name, "HOOK.md");
+    const destMd = path.join(distRoot, entry.name, "HOOK.md");
+    if (!fsImpl.existsSync(srcMd)) {
+      warn(`[runtime-postbuild] HOOK.md not found, skipping: ${entry.name}`);
+      continue;
+    }
+    fsImpl.mkdirSync(path.dirname(destMd), { recursive: true });
+    fsImpl.copyFileSync(srcMd, destMd);
+  }
+}
+
 export function runRuntimePostBuild(params = {}) {
   copyPluginSdkRootAlias(params);
   copyBundledPluginMetadata(params);
+  copyBundledHookMetadata(params);
   writeOfficialChannelCatalog(params);
   stageBundledPluginRuntimeDeps(params);
   stageBundledPluginRuntime(params);

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
+  copyBundledHookMetadata,
   copyStaticExtensionAssets,
   listStaticExtensionAssetOutputs,
   writeStableRootRuntimeAliases,
@@ -78,5 +79,54 @@ describe("runtime postbuild static assets", () => {
       'export * from "./runtime-tts.runtime-AbCd1234.js";\n',
     );
     await expect(fs.stat(path.join(distDir, "library.js"))).rejects.toThrow();
+  });
+});
+
+describe("copyBundledHookMetadata", () => {
+  it("copies HOOK.md files from src/hooks/bundled/<hook>/ into dist/bundled/<hook>/", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-hooks-");
+    const srcHookDir = path.join(rootDir, "src", "hooks", "bundled", "session-memory");
+    await fs.mkdir(srcHookDir, { recursive: true });
+    await fs.writeFile(
+      path.join(srcHookDir, "HOOK.md"),
+      "---\nname: session-memory\n---\n",
+      "utf8",
+    );
+    // dist/bundled/session-memory/handler.js already exists from a tsdown build;
+    // simulate that so we cover the "alongside-handler" case rather than a clean dest.
+    const distHookDir = path.join(rootDir, "dist", "bundled", "session-memory");
+    await fs.mkdir(distHookDir, { recursive: true });
+    await fs.writeFile(path.join(distHookDir, "handler.js"), "export default () => {};\n", "utf8");
+
+    copyBundledHookMetadata({ rootDir });
+
+    expect(await fs.readFile(path.join(distHookDir, "HOOK.md"), "utf8")).toBe(
+      "---\nname: session-memory\n---\n",
+    );
+    // handler.js untouched
+    expect(await fs.readFile(path.join(distHookDir, "handler.js"), "utf8")).toBe(
+      "export default () => {};\n",
+    );
+  });
+
+  it("warns and skips when a bundled hook directory has no HOOK.md", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-hooks-missing-");
+    const srcHookDir = path.join(rootDir, "src", "hooks", "bundled", "incomplete");
+    await fs.mkdir(srcHookDir, { recursive: true });
+    const warn = vi.fn();
+
+    copyBundledHookMetadata({ rootDir, warn });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[runtime-postbuild] HOOK.md not found, skipping: incomplete",
+    );
+    await expect(
+      fs.stat(path.join(rootDir, "dist", "bundled", "incomplete", "HOOK.md")),
+    ).rejects.toThrow();
+  });
+
+  it("returns silently when src/hooks/bundled does not exist", () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-hooks-empty-");
+    expect(() => copyBundledHookMetadata({ rootDir })).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

`pnpm gateway:watch` does not copy built-in hooks to the `dist/` directory. This makes built-in hooks silently fail when running the dev gateway.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Human Verification (required)

Added a built-in hook to openclaw.json. Validated that it did not load. Applied the fix. The hook now loads.