### PR TITLE
fix(hooks): write allowedSessionKeyPrefixes from gmail wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Hooks/Gmail: make `openclaw webhooks gmail setup` write
+  `hooks.allowedSessionKeyPrefixes: ["hook:"]` alongside the gmail preset so the
+  emitted config passes the gateway hooks validator on next start. Without
+  this, the wizard succeeded but the gateway then refused to load the config
+  because the gmail preset uses a templated mapping `sessionKey`
+  (`hook:gmail:{{messages[0].id}}`), which requires
+  `allowedSessionKeyPrefixes` to be set. Thanks @semmlerino.
 - QQ Bot: make `qqbot_remind` schedule, list, and remove Gateway cron jobs
   directly for owner-authorized senders instead of returning `cronParams` and
   relying on a follow-up generic `cron` tool call. Fixes #70865. (#70937)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/chat: keep optimistic messages and in-progress response text
+  visible when refreshing chat history while a reply is still streaming, and
+  avoid losing a final reply that lands during the refresh. Thanks @gabri.
 - Hooks/Gmail: make `openclaw webhooks gmail setup` write
   `hooks.allowedSessionKeyPrefixes: ["hook:"]` alongside the gmail preset so the
   emitted config passes the gateway hooks validator on next start. Without

--- a/src/gateway/hooks.test.ts
+++ b/src/gateway/hooks.test.ts
@@ -434,6 +434,23 @@ describe("gateway hooks helpers", () => {
     ).not.toThrow();
   });
 
+  test("resolveHooksConfig accepts the gmail wizard's emitted config (preset + hook: prefix)", () => {
+    expect(() =>
+      resolveHooksConfig({
+        hooks: {
+          enabled: true,
+          token: "secret",
+          presets: ["gmail"],
+          allowedSessionKeyPrefixes: ["hook:"],
+          gmail: {
+            account: "user@example.com",
+            topic: "projects/demo/topics/gog-gmail-watch",
+          },
+        },
+      } as OpenClawConfig),
+    ).not.toThrow();
+  });
+
   test("resolveHooksConfig allows a static catch-all mapping to shadow a later templated mapping", () => {
     expect(() =>
       resolveHooksConfig({

--- a/src/hooks/gmail-ops.ts
+++ b/src/hooks/gmail-ops.ts
@@ -38,6 +38,7 @@ import {
   type GmailHookOverrides,
   type GmailHookRuntimeConfig,
   generateHookToken,
+  mergeAllowedSessionKeyPrefixes,
   mergeHookPresets,
   normalizeHooksPath,
   normalizeServePath,
@@ -206,6 +207,10 @@ export async function runGmailSetup(opts: GmailSetupOptions) {
       path: hooksPath,
       token: hookToken,
       presets: mergeHookPresets(baseConfig.hooks?.presets, "gmail"),
+      allowedSessionKeyPrefixes: mergeAllowedSessionKeyPrefixes(
+        baseConfig.hooks?.allowedSessionKeyPrefixes,
+        "hook:",
+      ),
       gmail: {
         ...baseConfig.hooks?.gmail,
         account: opts.account,

--- a/src/hooks/gmail.test.ts
+++ b/src/hooks/gmail.test.ts
@@ -4,6 +4,7 @@ import {
   buildDefaultHookUrl,
   buildGogWatchServeLogArgs,
   buildTopicPath,
+  mergeAllowedSessionKeyPrefixes,
   parseTopicPath,
   resolveGmailHookRuntimeConfig,
 } from "./gmail.js";
@@ -155,5 +156,23 @@ describe("gmail hook config", () => {
       tailscale: { mode: "funnel", target },
     });
     expectResolvedPaths(result, { servePath: "/custom", publicPath: "/custom", target });
+  });
+});
+
+describe("mergeAllowedSessionKeyPrefixes", () => {
+  it("seeds the list when none is configured", () => {
+    expect(mergeAllowedSessionKeyPrefixes(undefined, "hook:")).toEqual(["hook:"]);
+  });
+
+  it("preserves existing prefixes and adds the new one", () => {
+    expect(mergeAllowedSessionKeyPrefixes(["agent:"], "hook:")).toEqual(["agent:", "hook:"]);
+  });
+
+  it("dedupes when the prefix is already present", () => {
+    expect(mergeAllowedSessionKeyPrefixes(["hook:"], "hook:")).toEqual(["hook:"]);
+  });
+
+  it("trims and ignores empty entries", () => {
+    expect(mergeAllowedSessionKeyPrefixes([" agent: ", ""], "hook:")).toEqual(["agent:", "hook:"]);
   });
 });

--- a/src/hooks/gmail.ts
+++ b/src/hooks/gmail.ts
@@ -69,6 +69,19 @@ export function mergeHookPresets(existing: string[] | undefined, preset: string)
   return Array.from(next);
 }
 
+// The gmail preset uses templated mapping sessionKeys (`hook:gmail:{{...}}`),
+// which the gateway validator only accepts when allowedSessionKeyPrefixes is
+// set and includes "hook:". Adding "hook:" here keeps wizard-written configs
+// loadable without forcing the user to edit openclaw.json by hand.
+export function mergeAllowedSessionKeyPrefixes(
+  existing: string[] | undefined,
+  prefix: string,
+): string[] {
+  const next = new Set((existing ?? []).map((item) => item.trim()).filter(Boolean));
+  next.add(prefix);
+  return Array.from(next);
+}
+
 export function normalizeHooksPath(raw?: string): string {
   const base = raw?.trim() || DEFAULT_HOOKS_PATH;
   if (base === "/") {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -818,6 +818,74 @@ describe("loadChatHistory", () => {
     expect(state.chatStream).toBeNull();
   });
 
+  it("keeps a final reply that arrives while history reload is in flight", async () => {
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      timestamp: 10,
+    };
+    const historyUser = {
+      role: "user",
+      content: [{ type: "text", text: "latest ask" }],
+      __openclaw: { seq: 1 },
+    };
+    const finalAssistant = {
+      role: "assistant",
+      content: [{ type: "text", text: "latest answer" }],
+      timestamp: 11,
+    };
+    const historyRequest = createDeferred<{ messages: Array<unknown> }>();
+    const request = vi.fn().mockReturnValue(historyRequest.promise);
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [optimisticUser],
+      chatRunId: "run-1",
+      chatStream: "latest answer",
+      chatStreamStartedAt: 10,
+    });
+
+    const load = loadChatHistory(state);
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    handleChatEvent(state, {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: finalAssistant,
+    });
+    historyRequest.resolve({ messages: [historyUser] });
+    await load;
+
+    expect(state.chatMessages).toEqual([historyUser, finalAssistant]);
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
+  it("keeps the optimistic user message and stream when refreshing an active empty session", async () => {
+    const optimisticUser = {
+      role: "user",
+      content: [{ type: "text", text: "first ask" }],
+      timestamp: 10,
+    };
+    const request = vi.fn().mockResolvedValue({ messages: [] });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [optimisticUser],
+      chatRunId: "run-1",
+      chatStream: "partial answer",
+      chatStreamStartedAt: 10,
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toEqual([optimisticUser]);
+    expect(state.chatRunId).toBe("run-1");
+    expect(state.chatStream).toBe("partial answer");
+    expect(state.chatStreamStartedAt).toBe(10);
+  });
+
   it("does not duplicate optimistic tail messages after history catches up", async () => {
     const optimisticUser = {
       role: "user",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -267,8 +267,9 @@ function messageDisplaySignature(message: unknown): string | null {
 function preserveOptimisticTailMessages(
   historyMessages: unknown[],
   previousMessages: unknown[],
+  options?: { preserveUnanchoredTail?: boolean },
 ): unknown[] {
-  if (historyMessages.length === 0 || previousMessages.length === 0) {
+  if (previousMessages.length === 0) {
     return historyMessages;
   }
   const historySignatures = new Set(
@@ -285,20 +286,55 @@ function preserveOptimisticTailMessages(
     }
   }
   if (sharedPreviousIndex < 0) {
+    if (options?.preserveUnanchoredTail) {
+      const optimisticTail = collectLocalOptimisticSuffix(previousMessages, historySignatures);
+      return optimisticTail.length > 0 ? [...historyMessages, ...optimisticTail] : historyMessages;
+    }
     return historyMessages;
   }
+
+  const optimisticTail = collectLocalOptimisticTail(
+    previousMessages.slice(sharedPreviousIndex + 1),
+    historySignatures,
+  );
+  return optimisticTail.length > 0 ? [...historyMessages, ...optimisticTail] : historyMessages;
+}
+
+function collectLocalOptimisticTail(
+  messages: unknown[],
+  historySignatures: ReadonlySet<string>,
+): unknown[] {
   const optimisticTail: unknown[] = [];
-  for (const message of previousMessages.slice(sharedPreviousIndex + 1)) {
+  for (const message of messages) {
     if (!isLocallyOptimisticHistoryMessage(message) || shouldHideHistoryMessage(message)) {
-      return historyMessages;
+      return [];
     }
     const signature = messageDisplaySignature(message);
     if (!signature || historySignatures.has(signature)) {
-      return historyMessages;
+      return [];
     }
     optimisticTail.push(message);
   }
-  return optimisticTail.length > 0 ? [...historyMessages, ...optimisticTail] : historyMessages;
+  return optimisticTail;
+}
+
+function collectLocalOptimisticSuffix(
+  messages: unknown[],
+  historySignatures: ReadonlySet<string>,
+): unknown[] {
+  const optimisticTail: unknown[] = [];
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (!isLocallyOptimisticHistoryMessage(message) || shouldHideHistoryMessage(message)) {
+      break;
+    }
+    const signature = messageDisplaySignature(message);
+    if (!signature || historySignatures.has(signature)) {
+      break;
+    }
+    optimisticTail.unshift(message);
+  }
+  return optimisticTail;
 }
 
 function isRetryableStartupUnavailable(err: unknown, method: string): err is GatewayRequestError {
@@ -368,8 +404,10 @@ export async function loadChatHistory(state: ChatState) {
   }
   const sessionKey = state.sessionKey;
   const requestVersion = beginChatHistoryRequest(state);
+  const hadActiveRunAtStart = Boolean(
+    state.chatRunId || state.chatStreamStartedAt !== null || state.chatSending,
+  );
   const startedAt = Date.now();
-  const previousMessages = state.chatMessages;
   state.chatLoading = true;
   state.lastError = null;
   try {
@@ -405,13 +443,20 @@ export async function loadChatHistory(state: ChatState) {
     }
     const messages = Array.isArray(res.messages) ? res.messages : [];
     const visibleMessages = messages.filter((message) => !shouldHideHistoryMessage(message));
-    state.chatMessages = preserveOptimisticTailMessages(visibleMessages, previousMessages);
+    const hasActiveRunAtApply = Boolean(
+      state.chatRunId || state.chatStreamStartedAt !== null || state.chatSending,
+    );
+    state.chatMessages = preserveOptimisticTailMessages(visibleMessages, state.chatMessages, {
+      preserveUnanchoredTail: hadActiveRunAtStart || hasActiveRunAtApply,
+    });
     state.chatThinkingLevel = res.thinkingLevel ?? null;
-    // Clear all streaming state — history includes tool results and text
-    // inline, so keeping streaming artifacts would cause duplicates.
-    maybeResetToolStream(state);
-    state.chatStream = null;
-    state.chatStreamStartedAt = null;
+    if (!hasActiveRunAtApply) {
+      // Clear all streaming state after terminal reloads. During an active run,
+      // history may lag behind live events, so keep the in-progress stream/tool UI.
+      maybeResetToolStream(state);
+      state.chatStream = null;
+      state.chatStreamStartedAt = null;
+    }
   } catch (err) {
     if (!shouldApplyChatHistoryResult(state, requestVersion, sessionKey)) {
       return;


### PR DESCRIPTION
## Summary

`openclaw webhooks gmail setup` produces a config that the gateway then refuses to load on the next start. The wizard writes `presets: ["gmail"]` but never writes `hooks.allowedSessionKeyPrefixes`, and the gmail preset uses a templated mapping `sessionKey` (`hook:gmail:{{messages[0].id}}`), which the gateway hooks validator only accepts when `allowedSessionKeyPrefixes` is configured (see `src/gateway/hooks.ts` around the `templated mapping sessionKey` check). End user has to hand-edit `openclaw.json` to add `"allowedSessionKeyPrefixes": ["hook:"]` to recover.

This change makes the wizard write `allowedSessionKeyPrefixes: ["hook:"]` alongside the gmail preset, preserving anything the user already had.

## Reproduction (before this fix)

```
openclaw webhooks gmail setup
# wizard succeeds, writes hooks.presets = ["gmail"], gmail block populated
openclaw gateway restart
# gateway throws: hooks mapping sessionKey "hook:gmail:..." is templated but allowedSessionKeyPrefixes is not set
```

## Changes

- `src/hooks/gmail.ts` — add `mergeAllowedSessionKeyPrefixes` (Set-based dedup, parallels existing `mergeHookPresets`)
- `src/hooks/gmail-ops.ts` — `runGmailSetup` writes `hooks.allowedSessionKeyPrefixes` when it writes the gmail preset
- `src/hooks/gmail.test.ts` — unit coverage for the merge helper (seeds, dedupes, trims, preserves)
- `src/gateway/hooks.test.ts` — integration test asserting the wizard's emitted shape (preset + `hook:` prefix) passes `resolveHooksConfig`
- `CHANGELOG.md` — Fixes entry under `2026.4.25 (Unreleased)`

## Test plan

- [x] `pnpm check:changed` smart gate green (typecheck, tests, import-cycles, webhook/auth guards)
- [x] `pnpm test src/hooks/gmail.test.ts` — 13 passed (4 new tests for `mergeAllowedSessionKeyPrefixes`)
- [x] `pnpm test src/gateway/hooks.test.ts` — 26 passed (1 new test asserting the wizard-output shape passes the runtime validator)
- [ ] Live end-to-end (`openclaw webhooks gmail setup` → `openclaw gateway restart`) not executed in this branch; the original failure was reproduced by reading `src/gateway/hooks.ts`'s `templated mapping sessionKey` validator + `src/gateway/hooks-mapping.ts`'s gmail preset, and the new gateway test pins the exact wizard-output shape against that validator.
