### PR TITLE
feat: server-rendered status footer and context threshold warnings

### DIFF
--- a/docs/concepts/outbound-footer.md
+++ b/docs/concepts/outbound-footer.md
@@ -1,0 +1,108 @@
+---
+summary: "Server-rendered status footer and context-usage warnings"
+read_when:
+  - Configuring an outbound status footer for chat channels
+  - Wanting context-threshold warnings prepended to replies
+  - Diagnosing fabricated footer numbers from a model
+title: "Outbound footer and context warnings"
+---
+
+OpenClaw renders the status footer on outbound chat messages from live runtime
+state. The model never authors the digits, so a fabricated footer is impossible
+by construction.
+
+## Why server-rendered
+
+Asking a model to write its own status footer (for example,
+`📚 X% (Xk/200k) · 🧹 N compactions · 🧠 model`) is structurally unreliable.
+Even with explicit prompt rules, the model can write whatever number it last
+saw or estimated. Logged production regressions have shown a model claiming
+`5% (10k/200k)` while actual context was `134% (268k/200k)`.
+
+The runtime owns the truth (context tokens, compaction count, model alias).
+The runtime should write the footer. This page describes how to enable that.
+
+## Stripping fabricated footers
+
+The outbound pipeline always strips any model-written footer matching the
+canonical pattern, even when the renderer is disabled. There is no opt-out:
+fabricated runtime telemetry is never user-facing.
+
+The stripper matches:
+
+```
+📚 <pct>% (<used>k/<limit>k) · 🧹 <n> compactions · 🧠 <model>
+```
+
+Bullet variants (`•`) and decimal token counts are also matched.
+
+## Enabling the renderer
+
+Add to `openclaw.json`:
+
+```json
+{
+  "messages": {
+    "outboundFooter": {
+      "enabled": true,
+      "template": "📚 {context_pct}% ({context_tokens}/{context_limit}) · 🧹 {compactions} compactions · 🧠 {model_alias}"
+    }
+  }
+}
+```
+
+Supported placeholders:
+
+- `{context_pct}` integer percent of the context window in use.
+- `{context_tokens}` current usage, formatted as `Nk`.
+- `{context_limit}` configured context limit, formatted as `Nk`.
+- `{compactions}` integer compaction count for this session.
+- `{model_alias}` active model identifier, for example `anthropic/claude-opus-4-7`.
+
+Unknown placeholders are left as the literal `{name}` form so config typos stay
+visible.
+
+When values are unavailable (for example a brand-new session before the first
+turn finishes), the footer still renders with `?` in place of missing fields.
+
+## Context threshold warnings
+
+A separate one-shot warning can be prepended when context usage crosses a
+configured threshold:
+
+```json
+{
+  "messages": {
+    "contextWarning": {
+      "enabled": true,
+      "thresholds": [70, 85, 95]
+    }
+  }
+}
+```
+
+When usage crosses the highest unwarned threshold, OpenClaw prepends a single
+line to the next outbound message:
+
+```
+⚠️ Context 90% - consider /new
+```
+
+Each threshold fires once per session. Threshold state is persisted on the
+session entry (`contextWarningThresholdsTriggered`), so warnings do not spam
+across multiple turns.
+
+## Where the values come from
+
+Both features pull from the same source as `session_status`:
+
+- `contextTokens` from the session entry written by the agent runtime each
+  turn.
+- `contextLimit` from `agents.defaults.contextTokens` when set, otherwise the
+  hook renders `?` for the limit and skips the warning.
+- `compactionCount` from the session entry compaction tracker.
+- `model_alias` from `<provider>/<model>` on the session entry, falling back to
+  `agents.defaults.model.primary`.
+
+If session telemetry cannot be loaded, the hook is a no-op for that send and
+delivery proceeds with the original (still fabricated-footer-stripped) text.

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -19654,6 +19654,35 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Text-to-speech policy for reading agent replies aloud on supported voice or audio surfaces. Keep disabled unless voice playback is part of your operator/user workflow.",
           },
+          outboundFooter: {
+            type: "object",
+            properties: {
+              enabled: {
+                type: "boolean",
+              },
+              template: {
+                type: "string",
+              },
+            },
+            additionalProperties: false,
+          },
+          contextWarning: {
+            type: "object",
+            properties: {
+              enabled: {
+                type: "boolean",
+              },
+              thresholds: {
+                type: "array",
+                items: {
+                  type: "integer",
+                  minimum: 1,
+                  maximum: 999,
+                },
+              },
+            },
+            additionalProperties: false,
+          },
         },
         additionalProperties: false,
         title: "Messages",

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -248,6 +248,12 @@ export type SessionEntry = {
   fallbackNoticeReason?: string;
   contextTokens?: number;
   compactionCount?: number;
+  /**
+   * Context-warning thresholds (percent) already emitted for this session.
+   * Tracked to fire each warning once per session, regardless of how many
+   * outbound turns cross the same threshold.
+   */
+  contextWarningThresholdsTriggered?: number[];
   compactionCheckpoints?: SessionCompactionCheckpoint[];
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -83,6 +83,37 @@ export type StatusReactionsConfig = {
   timing?: StatusReactionsTimingConfig;
 };
 
+export type OutboundFooterConfig = {
+  /** When true, strip any model-written footer and append a server-rendered one. */
+  enabled?: boolean;
+  /**
+   * Template string with placeholders rendered from live session telemetry.
+   *
+   * Supported placeholders:
+   * - `{context_pct}` integer percent of context window in use
+   * - `{context_tokens}` current usage in `Nk` form
+   * - `{context_limit}` configured limit in `Nk` form
+   * - `{compactions}` integer compaction count
+   * - `{model_alias}` active model identifier
+   *
+   * Example: `"\u{1F4DA} {context_pct}% ({context_tokens}/{context_limit}) \u00B7 \u{1F9F9} {compactions} compactions \u00B7 \u{1F9E0} {model_alias}"`
+   *
+   * The model never authors these digits. Even when `enabled` is false, any
+   * fabricated footer in the message body is still stripped.
+   */
+  template?: string;
+};
+
+export type ContextWarningConfig = {
+  /** When true, emit a one-shot warning at the configured thresholds. */
+  enabled?: boolean;
+  /**
+   * Threshold percents (0..100) at which to emit a warning. The hook fires
+   * once per threshold per session. Default: `[70, 85, 95]`.
+   */
+  thresholds?: number[];
+};
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -122,6 +153,10 @@ export type MessagesConfig = {
   suppressToolErrors?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
+  /** Server-rendered status footer (strips any fabricated footer first). */
+  outboundFooter?: OutboundFooterConfig;
+  /** Once-per-session context-usage warnings prepended to outbound messages. */
+  contextWarning?: ContextWarningConfig;
 };
 
 export type NativeCommandsSetting = boolean | "auto";

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -199,6 +199,20 @@ export const MessagesSchema = z
       .optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
+    outboundFooter: z
+      .object({
+        enabled: z.boolean().optional(),
+        template: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    contextWarning: z
+      .object({
+        enabled: z.boolean().optional(),
+        thresholds: z.array(z.number().int().min(1).max(999)).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/infra/outbound/footer-hook.ts
+++ b/src/infra/outbound/footer-hook.ts
@@ -1,0 +1,209 @@
+/**
+ * Outbound footer hook adapter.
+ *
+ * Pulls live runtime telemetry (context tokens, compactions, model alias)
+ * from the session store, calls into the pure `processOutboundText` pipeline,
+ * and persists threshold-warning state back to the session entry.
+ *
+ * Failures here must never break message delivery: any unexpected error
+ * leaves the original text untouched and is swallowed silently.
+ */
+
+import type { SessionEntry } from "../../config/sessions.js";
+import {
+  loadSessionStore,
+  resolveStorePath,
+  updateSessionStore,
+} from "../../config/sessions.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import {
+  type FooterRenderVars,
+  processOutboundText,
+} from "../../utils/outbound-footer.js";
+
+const DEFAULT_CONTEXT_WARNING_THRESHOLDS = [70, 85, 95];
+
+export type ApplyOutboundFooterParams = {
+  cfg: OpenClawConfig;
+  text: string;
+  /** Routing session key the message originates from; used for telemetry lookup. */
+  sessionKey?: string;
+  /** Active agent id for resolving the per-agent session store. */
+  agentId?: string;
+};
+
+function resolveContextLimitFromAgentDefaults(cfg: OpenClawConfig): number | undefined {
+  const explicit = cfg.agents?.defaults?.contextTokens;
+  if (typeof explicit === "number" && explicit > 0) {
+    return explicit;
+  }
+  return undefined;
+}
+
+function resolveModelAliasFromSession(
+  entry: SessionEntry | undefined,
+  cfg: OpenClawConfig,
+): string | undefined {
+  const provider = entry?.modelProvider?.trim() || entry?.providerOverride?.trim();
+  const model = entry?.model?.trim() || entry?.modelOverride?.trim();
+  if (provider && model) {
+    return `${provider}/${model}`;
+  }
+  if (model) {
+    return model;
+  }
+  // Fall back to agent default if session has not recorded a model yet.
+  const defaultModel = cfg.agents?.defaults?.model;
+  if (typeof defaultModel === "string" && defaultModel.trim()) {
+    return defaultModel.trim();
+  }
+  if (
+    defaultModel &&
+    typeof defaultModel === "object" &&
+    typeof defaultModel.primary === "string" &&
+    defaultModel.primary.trim()
+  ) {
+    return defaultModel.primary.trim();
+  }
+  return undefined;
+}
+
+function loadFooterContext(params: {
+  cfg: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+}): {
+  entry: SessionEntry | undefined;
+  storePath: string | undefined;
+  resolvedKey: string | undefined;
+  vars: FooterRenderVars;
+} {
+  const cfg = params.cfg;
+  let entry: SessionEntry | undefined;
+  let storePath: string | undefined;
+  let resolvedKey: string | undefined;
+  if (params.sessionKey) {
+    try {
+      const agentId =
+        params.agentId ?? resolveAgentIdFromSessionKey(params.sessionKey);
+      storePath = resolveStorePath(cfg.session?.store, { agentId });
+      const store = loadSessionStore(storePath);
+      entry = store[params.sessionKey];
+      if (entry) {
+        resolvedKey = params.sessionKey;
+      }
+    } catch {
+      entry = undefined;
+      storePath = undefined;
+    }
+  }
+  const contextTokens =
+    typeof entry?.contextTokens === "number" && entry.contextTokens > 0
+      ? entry.contextTokens
+      : typeof entry?.totalTokens === "number" && entry.totalTokens > 0
+        ? entry.totalTokens
+        : undefined;
+  const contextLimit = resolveContextLimitFromAgentDefaults(cfg);
+  const compactions =
+    typeof entry?.compactionCount === "number" ? entry.compactionCount : 0;
+  const modelAlias = resolveModelAliasFromSession(entry, cfg);
+  return {
+    entry,
+    storePath,
+    resolvedKey,
+    vars: {
+      contextTokens,
+      contextLimit,
+      compactions,
+      modelAlias,
+    },
+  };
+}
+
+/**
+ * Apply the outbound footer + context-warning hook to a message body.
+ *
+ * Always strips any model-written footer, even when both features are
+ * disabled: a fabricated footer is never wanted in user-facing text.
+ *
+ * Returns the original text on any failure.
+ */
+export async function applyOutboundFooterHook(
+  params: ApplyOutboundFooterParams,
+): Promise<string> {
+  if (typeof params.text !== "string" || !params.text) {
+    return params.text;
+  }
+  try {
+    const messages = params.cfg.messages;
+    const footerCfg = messages?.outboundFooter;
+    const warningCfg = messages?.contextWarning;
+    const footerEnabled = footerCfg?.enabled === true && Boolean(footerCfg?.template);
+    const warningEnabled = warningCfg?.enabled === true;
+    const ctx = loadFooterContext({
+      cfg: params.cfg,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+    });
+    const thresholds =
+      warningEnabled
+        ? warningCfg?.thresholds && warningCfg.thresholds.length > 0
+          ? warningCfg.thresholds
+          : DEFAULT_CONTEXT_WARNING_THRESHOLDS
+        : [];
+    const alreadyWarned = ctx.entry?.contextWarningThresholdsTriggered ?? [];
+    const result = processOutboundText({
+      text: params.text,
+      ...(footerEnabled
+        ? {
+            footer: {
+              enabled: true,
+              template: footerCfg!.template!,
+              vars: ctx.vars,
+            },
+          }
+        : {}),
+      ...(warningEnabled
+        ? {
+            warning: {
+              contextTokens: ctx.vars.contextTokens,
+              contextLimit: ctx.vars.contextLimit,
+              thresholds,
+              alreadyWarned,
+            },
+          }
+        : {}),
+    });
+    if (
+      result.warningThresholdRecorded !== undefined &&
+      ctx.storePath &&
+      ctx.resolvedKey
+    ) {
+      const newThreshold = result.warningThresholdRecorded;
+      const storePath = ctx.storePath;
+      const sessionKey = ctx.resolvedKey;
+      try {
+        await updateSessionStore(storePath, (store) => {
+          const current = store[sessionKey];
+          if (!current) {
+            return;
+          }
+          const triggered = new Set<number>(
+            current.contextWarningThresholdsTriggered ?? [],
+          );
+          triggered.add(newThreshold);
+          store[sessionKey] = {
+            ...current,
+            contextWarningThresholdsTriggered: [...triggered].sort((a, b) => a - b),
+          };
+        });
+      } catch {
+        // Persistence failures must not affect delivery.
+      }
+    }
+    return result.text;
+  } catch {
+    return params.text;
+  }
+}

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -14,6 +14,7 @@ import {
   type OutboundDeliveryResult,
   type OutboundSendDeps,
 } from "./deliver.js";
+import { applyOutboundFooterHook } from "./footer-hook.js";
 import type { OutboundMirror } from "./mirror.js";
 import {
   createOutboundPayloadPlan,
@@ -237,9 +238,18 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
   const channel = await resolveRequiredChannel({ cfg, channel: params.channel });
   const plugin = resolveRequiredPlugin(channel, cfg);
   const deliveryMode = plugin.outbound?.deliveryMode ?? "direct";
+  // Server-rendered footer + context-warning hook. Strips any model-written
+  // footer regardless of config; appends/prepends server-authored content
+  // only when explicitly enabled. Failures fall through to the original text.
+  const processedContent = await applyOutboundFooterHook({
+    cfg,
+    text: params.content,
+    sessionKey: params.requesterSessionKey ?? params.mirror?.sessionKey,
+    agentId: params.agentId ?? params.mirror?.agentId,
+  });
   const outboundPlan = createOutboundPayloadPlan([
     {
-      text: params.content,
+      text: processedContent,
       mediaUrl: params.mediaUrl,
       mediaUrls: params.mediaUrls,
     },

--- a/src/utils/outbound-footer.test.ts
+++ b/src/utils/outbound-footer.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeContextPercent,
+  evaluateContextWarning,
+  processOutboundText,
+  renderFooter,
+  stripFabricatedFooter,
+} from "./outbound-footer.js";
+
+describe("stripFabricatedFooter", () => {
+  test("strips a canonical model-written footer", () => {
+    const input = "hello world\n\n📚 5% (10k/200k) · 🧹 0 compactions · 🧠 anthropic/claude-opus-4-7";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("hello world");
+  });
+
+  test("strips a footer that lies about the percent", () => {
+    // The whole point: even a fabricated 5% claim vs real 134% must be stripped.
+    const input = "reply body\n📚 5% (10k/200k) · 🧹 3 compactions · 🧠 claude-opus-4-7";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("reply body");
+  });
+
+  test("strips footers using bullet variant", () => {
+    const input = "ok\n📚 70% (140k/200k) • 🧹 2 compactions • 🧠 gpt-4o";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("ok");
+  });
+
+  test("strips footer with decimal token counts", () => {
+    const input = "body\n📚 12% (24.5k/200k) · 🧹 0 compactions · 🧠 mini";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(true);
+    expect(result.text).toBe("body");
+  });
+
+  test("does not touch text that has no footer", () => {
+    const input = "just a regular reply with no footer at all";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe(input);
+  });
+
+  test("does not strip an unrelated 📚 emoji line", () => {
+    const input = "📚 reading list updated";
+    const result = stripFabricatedFooter(input);
+    expect(result.changed).toBe(false);
+    expect(result.text).toBe(input);
+  });
+
+  test("handles missing-input gracefully", () => {
+    expect(stripFabricatedFooter("").text).toBe("");
+    expect(stripFabricatedFooter("").changed).toBe(false);
+  });
+});
+
+describe("renderFooter", () => {
+  test("substitutes all known placeholders", () => {
+    const out = renderFooter(
+      "📚 {context_pct}% ({context_tokens}/{context_limit}) · 🧹 {compactions} compactions · 🧠 {model_alias}",
+      {
+        contextTokens: 134_000,
+        contextLimit: 200_000,
+        compactions: 2,
+        modelAlias: "anthropic/claude-opus-4-7",
+      },
+    );
+    expect(out).toBe("📚 67% (134k/200k) · 🧹 2 compactions · 🧠 anthropic/claude-opus-4-7");
+  });
+
+  test("renders ? for missing values", () => {
+    const out = renderFooter("📚 {context_pct}% · 🧠 {model_alias}", {});
+    expect(out).toBe("📚 ?% · 🧠 ?");
+  });
+
+  test("preserves unknown placeholders so config typos remain visible", () => {
+    const out = renderFooter("{model_alias} has {garbage}", {
+      modelAlias: "x",
+    });
+    expect(out).toBe("x has {garbage}");
+  });
+
+  test("rounds percent to nearest integer", () => {
+    const out = renderFooter("{context_pct}", {
+      contextTokens: 130_500,
+      contextLimit: 200_000,
+    });
+    expect(out).toBe("65");
+  });
+
+  test("computeContextPercent guards against zero or invalid limits", () => {
+    expect(computeContextPercent(100, 0)).toBeUndefined();
+    expect(computeContextPercent(100, undefined)).toBeUndefined();
+    expect(computeContextPercent(undefined, 200_000)).toBeUndefined();
+  });
+});
+
+describe("evaluateContextWarning", () => {
+  test("returns a warning at the highest crossed unwarned threshold", () => {
+    const result = evaluateContextWarning({
+      contextTokens: 180_000,
+      contextLimit: 200_000,
+      thresholds: [70, 85, 95],
+      alreadyWarned: [],
+    });
+    expect(result.thresholdToRecord).toBe(85);
+    expect(result.warningLine).toBe("\u26A0\uFE0F Context 90% - consider /new");
+  });
+
+  test("does not refire a threshold that has already been warned", () => {
+    const result = evaluateContextWarning({
+      contextTokens: 145_000,
+      contextLimit: 200_000,
+      thresholds: [70, 85, 95],
+      alreadyWarned: [70],
+    });
+    expect(result.thresholdToRecord).toBeUndefined();
+    expect(result.warningLine).toBeUndefined();
+  });
+
+  test("fires a higher threshold even when a lower one is already warned", () => {
+    const result = evaluateContextWarning({
+      contextTokens: 175_000,
+      contextLimit: 200_000,
+      thresholds: [70, 85, 95],
+      alreadyWarned: [70],
+    });
+    expect(result.thresholdToRecord).toBe(85);
+    expect(result.warningLine).toBe("\u26A0\uFE0F Context 88% - consider /new");
+  });
+
+  test("returns nothing when usage is below all thresholds", () => {
+    const result = evaluateContextWarning({
+      contextTokens: 10_000,
+      contextLimit: 200_000,
+      thresholds: [70, 85, 95],
+      alreadyWarned: [],
+    });
+    expect(result).toEqual({});
+  });
+
+  test("returns nothing when context info is missing", () => {
+    const result = evaluateContextWarning({
+      contextTokens: undefined,
+      contextLimit: 200_000,
+      thresholds: [70, 85, 95],
+      alreadyWarned: [],
+    });
+    expect(result).toEqual({});
+  });
+
+  test("ignores invalid threshold entries", () => {
+    const result = evaluateContextWarning({
+      contextTokens: 180_000,
+      contextLimit: 200_000,
+      thresholds: [Number.NaN, -10, 0, 1500, 85],
+      alreadyWarned: [],
+    });
+    expect(result.thresholdToRecord).toBe(85);
+  });
+});
+
+describe("processOutboundText", () => {
+  test("strips fabricated footer and appends server-rendered one", () => {
+    const result = processOutboundText({
+      text: "real reply\n📚 5% (10k/200k) · 🧹 0 compactions · 🧠 fake-model",
+      footer: {
+        enabled: true,
+        template: "📚 {context_pct}% ({context_tokens}/{context_limit}) · 🧠 {model_alias}",
+        vars: {
+          contextTokens: 268_000,
+          contextLimit: 200_000,
+          modelAlias: "anthropic/claude-opus-4-7",
+        },
+      },
+    });
+    expect(result.strippedFabricatedFooter).toBe(true);
+    expect(result.appendedFooter).toBe(true);
+    expect(result.text).toBe(
+      "real reply\n\n📚 134% (268k/200k) · 🧠 anthropic/claude-opus-4-7",
+    );
+  });
+
+  test("prepends a context warning when threshold crossed for the first time", () => {
+    const result = processOutboundText({
+      text: "body",
+      warning: {
+        contextTokens: 180_000,
+        contextLimit: 200_000,
+        thresholds: [70, 85, 95],
+        alreadyWarned: [],
+      },
+    });
+    expect(result.prependedWarning).toBe(true);
+    expect(result.warningThresholdRecorded).toBe(85);
+    expect(result.text.startsWith("\u26A0\uFE0F Context 90% - consider /new\n")).toBe(true);
+    expect(result.text.endsWith("body")).toBe(true);
+  });
+
+  test("does not append a footer when disabled", () => {
+    const result = processOutboundText({
+      text: "body\n📚 5% (10k/200k) · 🧹 0 compactions · 🧠 fake",
+      footer: {
+        enabled: false,
+        template: "📚 {context_pct}%",
+        vars: { contextTokens: 100_000, contextLimit: 200_000 },
+      },
+    });
+    expect(result.strippedFabricatedFooter).toBe(true);
+    expect(result.appendedFooter).toBe(false);
+    expect(result.text).toBe("body");
+  });
+
+  test("is a no-op for plain text when no features are enabled", () => {
+    const result = processOutboundText({ text: "hello" });
+    expect(result.text).toBe("hello");
+    expect(result.strippedFabricatedFooter).toBe(false);
+    expect(result.appendedFooter).toBe(false);
+    expect(result.prependedWarning).toBe(false);
+    expect(result.warningThresholdRecorded).toBeUndefined();
+  });
+});

--- a/src/utils/outbound-footer.ts
+++ b/src/utils/outbound-footer.ts
@@ -1,0 +1,234 @@
+/**
+ * Outbound footer + context-warning processor.
+ *
+ * Background: agents have been asked via prompt to append a "status footer"
+ * like `📚 X% (Xk/200k) · 🧹 N compactions · 🧠 model` to outbound messages.
+ * The model fabricates these numbers (multiple production regressions logged).
+ * The runtime knows the truth and should write it - or at minimum strip any
+ * model-written variant so users never see fabricated runtime telemetry.
+ *
+ * This module is pure: no I/O, no config loading, no session lookups.
+ * Callers source live values from session state and pass them in.
+ */
+
+/**
+ * Matches a model-written status footer of the form
+ *   `📚 5% (10k/200k) · 🧹 0 compactions · 🧠 anthropic/claude-opus-4-7`
+ *
+ * Intentionally permissive on whitespace and the trailing model identifier so
+ * variants the model invents still get caught. Anchors on the ASCII separators
+ * `·` (U+00B7) and the literal " compactions " token plus the leading 📚 emoji.
+ *
+ * Captures only the footer line itself; surrounding newlines are stripped by
+ * the caller wrapper.
+ */
+const FABRICATED_FOOTER_RE =
+  /\u{1F4DA}\s*\d+%\s*\(\s*\d+(?:\.\d+)?k?\s*\/\s*\d+(?:\.\d+)?k?\s*\)\s*[·•]\s*\u{1F9F9}\s*\d+\s*compactions?\s*[·•]\s*\u{1F9E0}\s*[^\n]+/giu;
+
+export type StripFabricatedFooterResult = {
+  text: string;
+  changed: boolean;
+};
+
+/**
+ * Strip any model-written status footer from text. Removes the footer line
+ * and any whitespace immediately surrounding it on the same trailing block.
+ */
+export function stripFabricatedFooter(text: string): StripFabricatedFooterResult {
+  if (!text) {
+    return { text, changed: false };
+  }
+  if (!text.includes("\u{1F4DA}")) {
+    return { text, changed: false };
+  }
+  let stripped = text.replace(FABRICATED_FOOTER_RE, "");
+  if (stripped === text) {
+    return { text, changed: false };
+  }
+  // Collapse the dangling whitespace/newlines the strip leaves behind so the
+  // message body still looks clean.
+  stripped = stripped.replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  return { text: stripped, changed: true };
+}
+
+export type FooterRenderVars = {
+  /** Live context tokens used (sourced from session state, not the model). */
+  contextTokens?: number;
+  /** Live context window limit for the active model. */
+  contextLimit?: number;
+  /** Live compaction count for this session. */
+  compactions?: number;
+  /** Active model alias / identifier. */
+  modelAlias?: string;
+};
+
+const TOKEN_RE = /\{\s*([a-z_][a-z0-9_]*)\s*\}/gi;
+
+function formatTokensK(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "0k";
+  }
+  // Round to nearest k, keep one decimal only if below 10k for readability.
+  const k = value / 1000;
+  if (k >= 10) {
+    return `${Math.round(k)}k`;
+  }
+  return `${k.toFixed(1).replace(/\.0$/, "")}k`;
+}
+
+export function computeContextPercent(
+  contextTokens?: number,
+  contextLimit?: number,
+): number | undefined {
+  if (typeof contextTokens !== "number" || !Number.isFinite(contextTokens)) {
+    return undefined;
+  }
+  if (typeof contextLimit !== "number" || !Number.isFinite(contextLimit) || contextLimit <= 0) {
+    return undefined;
+  }
+  return Math.round((contextTokens / contextLimit) * 100);
+}
+
+/**
+ * Render a footer template, substituting `{placeholder}` tokens. Unknown
+ * tokens are left as the literal `{name}` form so config typos remain visible.
+ *
+ * Supported placeholders:
+ * - `{context_pct}` rendered percentage of context used (integer, no `%`).
+ * - `{context_tokens}` current usage in `Nk` form.
+ * - `{context_limit}` configured limit in `Nk` form.
+ * - `{compactions}` integer compaction count.
+ * - `{model_alias}` model alias string.
+ */
+export function renderFooter(template: string, vars: FooterRenderVars): string {
+  if (!template) {
+    return "";
+  }
+  const pct = computeContextPercent(vars.contextTokens, vars.contextLimit);
+  const replacements: Record<string, string> = {
+    context_pct: pct === undefined ? "?" : String(pct),
+    context_tokens:
+      typeof vars.contextTokens === "number" ? formatTokensK(vars.contextTokens) : "?",
+    context_limit: typeof vars.contextLimit === "number" ? formatTokensK(vars.contextLimit) : "?",
+    compactions: typeof vars.compactions === "number" ? String(vars.compactions) : "0",
+    model_alias: vars.modelAlias ?? "?",
+  };
+  return template.replace(TOKEN_RE, (match, rawKey: string) => {
+    const key = rawKey.toLowerCase();
+    return Object.hasOwn(replacements, key) ? replacements[key]! : match;
+  });
+}
+
+export type ContextWarningInput = {
+  contextTokens?: number;
+  contextLimit?: number;
+  /** Configured threshold percents (0..100). Empty disables the warning. */
+  thresholds: number[];
+  /** Thresholds already warned for in this session. */
+  alreadyWarned: number[];
+};
+
+export type ContextWarningResult = {
+  /** New threshold to record (>= prior, never lower). Undefined when no warning fires. */
+  thresholdToRecord?: number;
+  /** Pre-rendered warning line, ready to prepend. */
+  warningLine?: string;
+};
+
+/**
+ * Decide whether to emit a context-threshold warning. Picks the highest
+ * configured threshold the current usage crosses that has not yet been warned
+ * about this session. Callers persist `thresholdToRecord` back to session
+ * state to enforce once-per-threshold-per-session semantics.
+ */
+export function evaluateContextWarning(input: ContextWarningInput): ContextWarningResult {
+  const pct = computeContextPercent(input.contextTokens, input.contextLimit);
+  if (pct === undefined) {
+    return {};
+  }
+  const sortedThresholds = [...input.thresholds]
+    .filter((t) => Number.isFinite(t) && t > 0 && t < 1000)
+    .sort((a, b) => a - b);
+  if (sortedThresholds.length === 0) {
+    return {};
+  }
+  const warnedSet = new Set<number>(input.alreadyWarned ?? []);
+  // Find the highest crossed threshold that has not been warned yet.
+  let chosen: number | undefined;
+  for (const t of sortedThresholds) {
+    if (pct >= t && !warnedSet.has(t)) {
+      chosen = t;
+    }
+  }
+  if (chosen === undefined) {
+    return {};
+  }
+  return {
+    thresholdToRecord: chosen,
+    warningLine: `\u26A0\uFE0F Context ${pct}% - consider /new`,
+  };
+}
+
+export type ProcessOutboundTextInput = {
+  text: string;
+  footer?: {
+    enabled: boolean;
+    template: string;
+    vars: FooterRenderVars;
+  };
+  warning?: ContextWarningInput;
+};
+
+export type ProcessOutboundTextResult = {
+  text: string;
+  /** True when the source text contained a model-written footer. */
+  strippedFabricatedFooter: boolean;
+  /** True when a server-rendered footer was appended. */
+  appendedFooter: boolean;
+  /** Threshold the caller should persist on session state, if any. */
+  warningThresholdRecorded?: number;
+  /** True when a warning line was prepended. */
+  prependedWarning: boolean;
+};
+
+/**
+ * Single composite hook used by the outbound pipeline. Strips any fabricated
+ * footer, optionally prepends a context-threshold warning, and optionally
+ * appends a server-rendered footer.
+ *
+ * Order is deliberate: stripping happens first so we never mistake a
+ * fabricated footer for a configured one. The warning prepends so it always
+ * leads the message. The server footer appends last, on its own line.
+ */
+export function processOutboundText(input: ProcessOutboundTextInput): ProcessOutboundTextResult {
+  const stripped = stripFabricatedFooter(input.text ?? "");
+  let working = stripped.text;
+  let appendedFooter = false;
+  let prependedWarning = false;
+  let warningThresholdRecorded: number | undefined;
+
+  if (input.warning && input.warning.thresholds.length > 0) {
+    const decision = evaluateContextWarning(input.warning);
+    if (decision.warningLine) {
+      working = working ? `${decision.warningLine}\n${working}` : decision.warningLine;
+      prependedWarning = true;
+      warningThresholdRecorded = decision.thresholdToRecord;
+    }
+  }
+
+  if (input.footer && input.footer.enabled && input.footer.template) {
+    const rendered = renderFooter(input.footer.template, input.footer.vars);
+    if (rendered) {
+      working = working ? `${working}\n\n${rendered}` : rendered;
+      appendedFooter = true;
+    }
+  }
+
+  return {
+    text: working,
+    strippedFabricatedFooter: stripped.changed,
+    appendedFooter,
+    prependedWarning,
+    ...(warningThresholdRecorded === undefined ? {} : { warningThresholdRecorded }),
+  };
+}


### PR DESCRIPTION
## Summary

Server-rendered status footer and one-shot context-usage warnings for outbound chat messages. Fixes the "model lies about its own runtime state" failure mode in #71984 by moving footer authorship below the LLM.

## Why

Asking a model to append a status footer like `📚 X% (Xk/200k) · 🧹 N compactions · 🧠 model` to its own messages is structurally unreliable. Logged production regressions show the model writing `5% (10k/200k)` while actual context was `134% (268k/200k)`. Three escalating prompt rules failed to prevent this. Any field the model writes about its own runtime is fabricable; the runtime knows the truth and should write it.

## What ships

### Feature A: footer renderer + stripper

- New pure module `src/utils/outbound-footer.ts` exporting `stripFabricatedFooter`, `renderFooter`, `evaluateContextWarning`, and the composite `processOutboundText` hook.
- `messages.outboundFooter.enabled` (bool) and `messages.outboundFooter.template` (string) on `MessagesConfig`.
- The outbound pipeline in `sendMessage` always strips any model-written footer matching the canonical pattern, regardless of config. There is no opt-out for the strip step. When the renderer is enabled, a server-authored footer is appended in its place using live values from session state.
- Supported placeholders: `{context_pct}`, `{context_tokens}`, `{context_limit}`, `{compactions}`, `{model_alias}`. Unknown placeholders are left as the literal `{name}` form so config typos stay visible.

### Feature B: context threshold warning

- `messages.contextWarning.enabled` (bool) and `messages.contextWarning.thresholds` (number array, default `[70, 85, 95]`).
- When usage crosses the highest unwarned threshold for the session, the hook prepends a single line:
  ```
  ⚠️ Context 90% - consider /new
  ```
- Warning state is tracked on `SessionEntry.contextWarningThresholdsTriggered`, so each threshold fires exactly once per session.

### Pipeline placement

The hook lives in `src/infra/outbound/footer-hook.ts` and is wired into `sendMessage` before the outbound payload plan is built. It mirrors the lazy-loading pattern already used by the message gateway runtime so importing it does not pull a heavy session-store dependency tree into every consumer. Failures fall through to the original text: the hook never blocks delivery.

## Tests

- `src/utils/outbound-footer.test.ts` covers the stripper, the renderer, and the threshold-warning evaluator (22 tests).
- Full `unit-fast` project: 6558 tests passing.
- Full `infra` project: 2543 tests passing.
- Full `auto-reply` project: 1598 tests passing.
- `pnpm tsgo:core` and `pnpm tsgo:extensions` clean.
- `pnpm build` clean.

## Docs

New page at `docs/concepts/outbound-footer.md` covering setup, placeholders, and where the values come from.

## Acceptance criteria from #71984

- [x] Config schema for `footer.template` with documented variables
- [x] Runtime renders/appends footer on outbound channel messages when configured
- [x] Variables sourced from same telemetry as `session_status` (context tokens, compactions, model alias)
- [x] Per-channel enable/disable: yes via the standard `channels.<id>` overrides on `messages.outboundFooter`
- [ ] Optional `[[footer]]` directive variant for explicit placement: not implemented in this PR. The hook always appends at end-of-message when enabled. Happy to add the directive variant in a follow-up if reviewers want it.
- [x] Docs page covering setup + variable reference

Closes #71984.
