### PR TITLE
fix(agents): sanitize tool-call json previews

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.test.ts
@@ -536,6 +536,35 @@ describe("handleMessageUpdate", () => {
     expect(ctx.state.blockBuffer).toBe("");
   });
 
+  it("withholds bare tool_calls JSON from partial replies before preview delivery", () => {
+    const onPartialReply = vi.fn();
+    const ctx = createMessageUpdateContext({ onPartialReply });
+
+    handleMessageUpdate(
+      ctx,
+      createTextUpdateEvent({
+        type: "text_delta",
+        text: 'Aku submit issue-nya sekarang.\n{"tool_calls":[{"function":{"arguments":"{}","name":"process"}',
+      }),
+    );
+
+    expect(onPartialReply).toHaveBeenCalledTimes(1);
+    expect(onPartialReply.mock.calls[0]?.[0]).toMatchObject({
+      text: "Aku submit issue-nya sekarang.",
+      delta: "Aku submit issue-nya sekarang.",
+    });
+
+    handleMessageUpdate(
+      ctx,
+      createTextUpdateEvent({
+        type: "text_delta",
+        text: ',"id":"call_1","type":"function"}]}',
+      }),
+    );
+
+    expect(onPartialReply).toHaveBeenCalledTimes(1);
+  });
+
   it("suppresses commentary partials even when they contain visible text", () => {
     const onAgentEvent = vi.fn();
     const ctx = createMessageUpdateContext({

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -16,6 +16,7 @@ import {
   type AssistantPhase,
 } from "../shared/chat-message-content.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
+import { sanitizeStreamingBareToolCallJsonText } from "../shared/text/assistant-visible-text.js";
 import {
   isMessagingToolDuplicateNormalized,
   normalizeTextForComparison,
@@ -554,7 +555,9 @@ export function handleMessageUpdate(
       recordPendingAssistantReplyDirectives(ctx.state, parsedStreamDirectives);
     }
     const parsedFull = parseReplyDirectives(splitTrailingDirective(next).text);
-    const cleanedText = parsedFull.text;
+    const cleanedText = sanitizeStreamingBareToolCallJsonText(parsedFull.text, {
+      final: evtType === "text_end",
+    });
     const { mediaUrls, hasMedia } = resolveSendableOutboundReplyParts(parsedStreamDirectives ?? {});
     const hasAudio = Boolean(parsedStreamDirectives?.audioAsVoice);
     const previousCleaned = ctx.state.lastStreamedAssistantCleaned ?? "";

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -515,12 +515,27 @@ describe("stripDowngradedToolCallText", () => {
     expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
   });
 
-  it("strips incomplete bare tool_calls JSON fragments to the end of the chunk", () => {
-    expect(
-      stripDowngradedToolCallText(
-        'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}',
-      ),
-    ).toBe("Before");
+  it("preserves incomplete bare tool_calls JSON fragments", () => {
+    const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("preserves no-op bare JSON scans without trimming history whitespace", () => {
+    const input = '  {"type":"function","description":"example"}  ';
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+    expect(sanitizeAssistantVisibleTextWithProfile(input, "history")).toBe(input);
+  });
+
+  it("requires strict OpenAI-style tool call entries before stripping", () => {
+    const input = [
+      "Before",
+      '{"tool_calls":[{"id":"123","function":{"name":"report","arguments":"{}"}}]}',
+      "After",
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
   });
 
   it("preserves bare tool_calls JSON inside fenced and inline code examples", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
+  sanitizeStreamingBareToolCallJsonText,
   stripAssistantInternalScaffolding,
   stripDowngradedToolCallText,
 } from "./assistant-visible-text.js";
@@ -515,10 +516,10 @@ describe("stripDowngradedToolCallText", () => {
     expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
   });
 
-  it("preserves incomplete bare tool_calls JSON fragments", () => {
+  it("strips incomplete bare tool_calls JSON fragments as defense in depth", () => {
     const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
 
-    expect(stripDowngradedToolCallText(input)).toBe(input);
+    expect(stripDowngradedToolCallText(input)).toBe("Before");
   });
 
   it("preserves no-op bare JSON scans without trimming history whitespace", () => {
@@ -550,6 +551,36 @@ describe("stripDowngradedToolCallText", () => {
     ].join("\n");
 
     expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+
+  it("preserves inline tool_calls-shaped JSON that is not a standalone payload", () => {
+    const input =
+      'Example: {"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}';
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
+  });
+});
+
+describe("sanitizeStreamingBareToolCallJsonText", () => {
+  it("withholds incomplete standalone JSON during partial preview streaming", () => {
+    const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
+
+    expect(sanitizeStreamingBareToolCallJsonText(input)).toBe("Before");
+  });
+
+  it("drops complete standalone tool_calls JSON during partial preview streaming", () => {
+    const input = [
+      "Before",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}',
+    ].join("\n");
+
+    expect(sanitizeStreamingBareToolCallJsonText(input)).toBe("Before");
+  });
+
+  it("releases ordinary standalone JSON once it is complete", () => {
+    const input = ["Before", '{"tool":"not a tool call","value":1}'].join("\n");
+
+    expect(sanitizeStreamingBareToolCallJsonText(input)).toBe(input);
   });
 });
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -568,6 +568,20 @@ describe("stripDowngradedToolCallText", () => {
 
     expect(stripDowngradedToolCallText(input)).toBe(input);
   });
+
+  it("preserves unvalidated JSON candidates before stripping a later real tool call", () => {
+    const ordinaryJsonLines = Array.from(
+      { length: 51 },
+      (_, index) => `{"tool_calls":"example-${index}","type":"function"}`,
+    );
+    const toolCallJson =
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}';
+    const input = [...ordinaryJsonLines, toolCallJson].join("\n");
+    const expected = ordinaryJsonLines.join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(expected);
+    expect(sanitizeStreamingBareToolCallJsonText(input)).toBe(expected);
+  });
 });
 
 describe("sanitizeStreamingBareToolCallJsonText", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -3,6 +3,7 @@ import {
   sanitizeAssistantVisibleText,
   sanitizeAssistantVisibleTextWithProfile,
   stripAssistantInternalScaffolding,
+  stripDowngradedToolCallText,
 } from "./assistant-visible-text.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
 
@@ -501,6 +502,39 @@ describe("sanitizeAssistantVisibleText", () => {
     ].join("\n");
 
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+});
+
+describe("stripDowngradedToolCallText", () => {
+  it("strips bare OpenAI-style tool_calls JSON while preserving the visible lead-in", () => {
+    const input = [
+      "Aku submit issue-nya sekarang.",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}',
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
+  });
+
+  it("strips incomplete bare tool_calls JSON fragments to the end of the chunk", () => {
+    expect(
+      stripDowngradedToolCallText(
+        'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}',
+      ),
+    ).toBe("Before");
+  });
+
+  it("preserves bare tool_calls JSON inside fenced and inline code examples", () => {
+    const input = [
+      "Example:",
+      "",
+      "```json",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"id":"call_1","type":"function"}]}',
+      "```",
+      "",
+      'Inline `{"tool_calls":[{"function":{"name":"process"}}]}` stays visible.',
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe(input);
   });
 });
 

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -516,6 +516,15 @@ describe("stripDowngradedToolCallText", () => {
     expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
   });
 
+  it("strips bare function_call-style tool_calls JSON", () => {
+    const input = [
+      "Aku submit issue-nya sekarang.",
+      '{"tool_calls":[{"function":{"arguments":"{}","name":"process"},"type":"function_call"}]}',
+    ].join("\n");
+
+    expect(stripDowngradedToolCallText(input)).toBe("Aku submit issue-nya sekarang.");
+  });
+
   it("strips incomplete bare tool_calls JSON fragments as defense in depth", () => {
     const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
 
@@ -562,10 +571,20 @@ describe("stripDowngradedToolCallText", () => {
 });
 
 describe("sanitizeStreamingBareToolCallJsonText", () => {
+  it("preserves trailing whitespace when no JSON was sanitized", () => {
+    expect(sanitizeStreamingBareToolCallJsonText("Hello\n\n")).toBe("Hello\n\n");
+  });
+
   it("withholds incomplete standalone JSON during partial preview streaming", () => {
     const input = 'Before\n{"tool_calls":[{"function":{"name":"process","arguments":"{}"}';
 
     expect(sanitizeStreamingBareToolCallJsonText(input)).toBe("Before");
+  });
+
+  it("does not withhold incomplete ordinary JSON without a tool-call marker", () => {
+    const input = 'Prose\n{"ordinary":"value"\nMore prose';
+
+    expect(sanitizeStreamingBareToolCallJsonText(input)).toBe(input);
   });
 
   it("drops complete standalone tool_calls JSON during partial preview streaming", () => {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -131,8 +131,9 @@ function isToolCallObject(value: unknown): boolean {
     return false;
   }
   const functionValue = value.function;
+  const type = value.type;
   return (
-    value.type === "function" &&
+    (type === "function" || type === "function_call") &&
     isRecord(functionValue) &&
     typeof functionValue.name === "string" &&
     (typeof functionValue.arguments === "string" || isRecord(functionValue.arguments))
@@ -216,11 +217,27 @@ function isStandaloneJsonCandidateStart(input: string, index: number): boolean {
   return (ch === "{" || ch === "[") && hasOnlyLineWhitespaceBefore(input, index);
 }
 
+function findNextLineStart(input: string, start: number): number {
+  const nextNewline = input.indexOf("\n", start);
+  const nextCarriage = input.indexOf("\r", start);
+  if (nextNewline === -1 && nextCarriage === -1) {
+    return input.length;
+  }
+  if (nextNewline === -1) {
+    return input[nextCarriage + 1] === "\n" ? nextCarriage + 2 : nextCarriage + 1;
+  }
+  if (nextCarriage === -1 || nextNewline < nextCarriage) {
+    return nextNewline + 1;
+  }
+  return input[nextCarriage + 1] === "\n" ? nextCarriage + 2 : nextCarriage + 1;
+}
+
 function stripBareToolCallJsonPayloads(
   input: string,
   options?: BareToolCallJsonSanitizeOptions,
 ): { text: string; changed: boolean } {
-  if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input) && !options?.withholdIncomplete) {
+  const mayHaveBareToolCallJson = BARE_TOOL_CALL_JSON_QUICK_RE.test(input);
+  if (!mayHaveBareToolCallJson || (!input.includes("{") && !input.includes("["))) {
     return { text: input, changed: false };
   }
 
@@ -228,27 +245,25 @@ function stripBareToolCallJsonPayloads(
   let result = "";
   let cursor = 0;
   let changed = false;
-  let candidates = 0;
-  for (let index = 0; index < input.length; index += 1) {
-    if (
-      index < cursor ||
-      !isStandaloneJsonCandidateStart(input, index) ||
-      isInsideCode(index, codeRegions)
-    ) {
-      continue;
+  let parseAttempts = 0;
+  let lineStart = 0;
+  while (lineStart < input.length) {
+    let index = lineStart;
+    while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+      index += 1;
     }
 
-    candidates += 1;
-    if (candidates > MAX_BARE_TOOL_CALL_JSON_CANDIDATES) {
-      break;
+    if (!isStandaloneJsonCandidateStart(input, index) || isInsideCode(index, codeRegions)) {
+      lineStart = findNextLineStart(input, lineStart);
+      continue;
     }
 
     const end = consumeJsonish(input, index);
     if (end === null) {
       const tail = input.slice(index);
+      const looksLikeToolCall = BARE_TOOL_CALL_JSON_QUICK_RE.test(tail);
       const shouldStripTail =
-        options?.withholdIncomplete ||
-        (options?.stripIncompleteToolCalls && BARE_TOOL_CALL_JSON_QUICK_RE.test(tail));
+        looksLikeToolCall && (options?.withholdIncomplete || options?.stripIncompleteToolCalls);
       if (!shouldStripTail) {
         break;
       }
@@ -259,30 +274,35 @@ function stripBareToolCallJsonPayloads(
     }
 
     if (!hasOnlyLineWhitespaceAfter(input, end)) {
-      index = Math.max(index, end - 1);
+      lineStart = findNextLineStart(input, end);
       continue;
     }
 
     const rawLength = end - index;
     if (rawLength > MAX_BARE_TOOL_CALL_JSON_PAYLOAD_CHARS) {
-      index = Math.max(index, end - 1);
+      lineStart = findNextLineStart(input, end);
       continue;
     }
 
     const raw = input.slice(index, end);
     if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
-      index = Math.max(index, end - 1);
+      lineStart = findNextLineStart(input, end);
       continue;
     }
 
     let shouldStrip = false;
-    try {
-      shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
-    } catch {
-      shouldStrip = false;
+    parseAttempts += 1;
+    if (parseAttempts > MAX_BARE_TOOL_CALL_JSON_CANDIDATES) {
+      shouldStrip = true;
+    } else {
+      try {
+        shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
+      } catch {
+        shouldStrip = false;
+      }
     }
     if (!shouldStrip) {
-      index = Math.max(index, end - 1);
+      lineStart = findNextLineStart(input, end);
       continue;
     }
 
@@ -290,7 +310,7 @@ function stripBareToolCallJsonPayloads(
     const stripEnd = skipOneRedundantNewline(input, end, result);
     cursor = stripEnd;
     changed = true;
-    index = Math.max(index, cursor - 1);
+    lineStart = cursor;
   }
   if (!changed) {
     return { text: input, changed: false };
@@ -303,10 +323,11 @@ export function sanitizeStreamingBareToolCallJsonText(
   text: string,
   options?: { final?: boolean },
 ): string {
-  return stripBareToolCallJsonPayloads(text, {
+  const result = stripBareToolCallJsonPayloads(text, {
     stripIncompleteToolCalls: options?.final,
     withholdIncomplete: !options?.final,
-  }).text.trimEnd();
+  });
+  return result.changed ? result.text.trimEnd() : result.text;
 }
 
 function endsInsideQuotedString(text: string, start: number, end: number): boolean {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -427,29 +427,18 @@ export function stripDowngradedToolCallText(text: string): string {
       return false;
     }
     const functionValue = value.function;
-    if (
-      isRecord(functionValue) &&
-      (value.type === "function" || typeof value.id === "string") &&
-      (typeof functionValue.name === "string" ||
-        typeof functionValue.arguments === "string" ||
-        isRecord(functionValue.arguments))
-    ) {
-      return true;
-    }
     return (
-      value.type === "function_call" &&
-      typeof value.name === "string" &&
-      (typeof value.arguments === "string" || isRecord(value.arguments) || "call_id" in value)
+      value.type === "function" &&
+      isRecord(functionValue) &&
+      typeof functionValue.name === "string" &&
+      (typeof functionValue.arguments === "string" || isRecord(functionValue.arguments))
     );
   };
 
   const hasToolCallsArray = (value: unknown): boolean =>
-    Array.isArray(value) && value.some((item) => isToolCallObject(item));
+    Array.isArray(value) && value.length > 0 && value.every((item) => isToolCallObject(item));
 
   const isBareToolCallJsonPayload = (value: unknown): boolean => {
-    if (hasToolCallsArray(value) || isToolCallObject(value)) {
-      return true;
-    }
     if (!isRecord(value)) {
       return false;
     }
@@ -473,9 +462,6 @@ export function stripDowngradedToolCallText(text: string): string {
     return false;
   };
 
-  const looksLikeBareToolCallJsonFragment = (value: string): boolean =>
-    /^\s*\{[\s\S]*"tool_calls"\s*:\s*\[/i.test(value);
-
   const skipOneRedundantNewline = (input: string, start: number, result: string): number => {
     let index = start;
     while (index < input.length && (input[index] === " " || input[index] === "\t")) {
@@ -495,14 +481,27 @@ export function stripDowngradedToolCallText(text: string): string {
     return index;
   };
 
-  const stripBareToolCallJsonPayloads = (input: string): string => {
+  const findNextLineBreak = (input: string, start: number): number => {
+    const nextNewline = input.indexOf("\n", start);
+    const nextCarriage = input.indexOf("\r", start);
+    if (nextNewline === -1) {
+      return nextCarriage;
+    }
+    if (nextCarriage === -1) {
+      return nextNewline;
+    }
+    return Math.min(nextNewline, nextCarriage);
+  };
+
+  const stripBareToolCallJsonPayloads = (input: string): { text: string; changed: boolean } => {
     if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input)) {
-      return input;
+      return { text: input, changed: false };
     }
 
     const codeRegions = findCodeRegions(input);
     let result = "";
     let cursor = 0;
+    let changed = false;
     for (let index = 0; index < input.length; index += 1) {
       const ch = input[index];
       if ((ch !== "{" && ch !== "[") || index < cursor || isInsideCode(index, codeRegions)) {
@@ -511,7 +510,6 @@ export function stripDowngradedToolCallText(text: string): string {
 
       const end = consumeJsonish(input, index);
       let shouldStrip = false;
-      let stripEnd = end ?? input.length;
       if (end !== null) {
         const raw = input.slice(index, end);
         if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
@@ -528,7 +526,12 @@ export function stripDowngradedToolCallText(text: string): string {
           continue;
         }
       } else {
-        shouldStrip = looksLikeBareToolCallJsonFragment(input.slice(index));
+        const nextLineBreak = findNextLineBreak(input, index + 1);
+        if (nextLineBreak === -1) {
+          break;
+        }
+        index = nextLineBreak;
+        continue;
       }
 
       if (!shouldStrip) {
@@ -536,12 +539,16 @@ export function stripDowngradedToolCallText(text: string): string {
       }
 
       result += input.slice(cursor, index);
-      stripEnd = skipOneRedundantNewline(input, stripEnd, result);
+      const stripEnd = skipOneRedundantNewline(input, end, result);
       cursor = stripEnd;
+      changed = true;
       index = Math.max(index, cursor - 1);
     }
+    if (!changed) {
+      return { text: input, changed: false };
+    }
     result += input.slice(cursor);
-    return result;
+    return { text: result, changed: true };
   };
 
   const stripToolCalls = (input: string): string => {
@@ -599,7 +606,8 @@ export function stripDowngradedToolCallText(text: string): string {
     return result;
   };
 
-  let cleaned = stripBareToolCallJsonPayloads(text);
+  const bareToolCallJsonResult = stripBareToolCallJsonPayloads(text);
+  let cleaned = bareToolCallJsonResult.text;
 
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
   cleaned = stripToolCalls(cleaned);
@@ -610,7 +618,7 @@ export function stripDowngradedToolCallText(text: string): string {
   // Remove [Historical context: ...] markers (self-contained within brackets).
   cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
 
-  return cleaned.trim();
+  return cleaned === text && !bareToolCallJsonResult.changed ? text : cleaned.trim();
 }
 
 function stripRelevantMemoriesTags(text: string): string {

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -30,7 +30,6 @@ const TOOL_CALL_JSON_PAYLOAD_START_RE =
 const TOOL_CALL_XML_PAYLOAD_START_RE =
   /^\s*(?:\r?\n\s*)?<(?:function|invoke|parameters?|arguments?)\b/i;
 const BARE_TOOL_CALL_JSON_QUICK_RE = /"tool_calls"\s*:|"type"\s*:\s*"function(?:_call)?"/i;
-const MAX_BARE_TOOL_CALL_JSON_CANDIDATES = 50;
 const MAX_BARE_TOOL_CALL_JSON_PAYLOAD_CHARS = 50_000;
 
 type ToolCallPayloadKind = "json" | "xml" | null;
@@ -245,7 +244,6 @@ function stripBareToolCallJsonPayloads(
   let result = "";
   let cursor = 0;
   let changed = false;
-  let parseAttempts = 0;
   let lineStart = 0;
   while (lineStart < input.length) {
     let index = lineStart;
@@ -291,15 +289,10 @@ function stripBareToolCallJsonPayloads(
     }
 
     let shouldStrip = false;
-    parseAttempts += 1;
-    if (parseAttempts > MAX_BARE_TOOL_CALL_JSON_CANDIDATES) {
-      shouldStrip = true;
-    } else {
-      try {
-        shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
-      } catch {
-        shouldStrip = false;
-      }
+    try {
+      shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
+    } catch {
+      shouldStrip = false;
     }
     if (!shouldStrip) {
       lineStart = findNextLineStart(input, end);

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -29,6 +29,7 @@ const TOOL_CALL_JSON_PAYLOAD_START_RE =
   /^(?:\s+[A-Za-z_:][-A-Za-z0-9_:.]*\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))*\s*(?:\r?\n\s*)?[[{]/;
 const TOOL_CALL_XML_PAYLOAD_START_RE =
   /^\s*(?:\r?\n\s*)?<(?:function|invoke|parameters?|arguments?)\b/i;
+const BARE_TOOL_CALL_JSON_QUICK_RE = /"tool_calls"\s*:|"type"\s*:\s*"function(?:_call)?"/i;
 
 type ToolCallPayloadKind = "json" | "xml" | null;
 
@@ -329,7 +330,10 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+  const hasDowngradedMarkers =
+    /\[Tool (?:Call|Result)/i.test(text) || /\[Historical context/i.test(text);
+  const mayHaveBareToolCallJson = BARE_TOOL_CALL_JSON_QUICK_RE.test(text);
+  if (!hasDowngradedMarkers && !mayHaveBareToolCallJson) {
     return text;
   }
 
@@ -415,6 +419,131 @@ export function stripDowngradedToolCallText(text: string): string {
     return end;
   };
 
+  const isRecord = (value: unknown): value is Record<string, unknown> =>
+    Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+  const isToolCallObject = (value: unknown): boolean => {
+    if (!isRecord(value)) {
+      return false;
+    }
+    const functionValue = value.function;
+    if (
+      isRecord(functionValue) &&
+      (value.type === "function" || typeof value.id === "string") &&
+      (typeof functionValue.name === "string" ||
+        typeof functionValue.arguments === "string" ||
+        isRecord(functionValue.arguments))
+    ) {
+      return true;
+    }
+    return (
+      value.type === "function_call" &&
+      typeof value.name === "string" &&
+      (typeof value.arguments === "string" || isRecord(value.arguments) || "call_id" in value)
+    );
+  };
+
+  const hasToolCallsArray = (value: unknown): boolean =>
+    Array.isArray(value) && value.some((item) => isToolCallObject(item));
+
+  const isBareToolCallJsonPayload = (value: unknown): boolean => {
+    if (hasToolCallsArray(value) || isToolCallObject(value)) {
+      return true;
+    }
+    if (!isRecord(value)) {
+      return false;
+    }
+    if (hasToolCallsArray(value.tool_calls)) {
+      return true;
+    }
+    if (isRecord(value.message) && hasToolCallsArray(value.message.tool_calls)) {
+      return true;
+    }
+    if (Array.isArray(value.choices)) {
+      return value.choices.some((choice) => {
+        if (!isRecord(choice)) {
+          return false;
+        }
+        return (
+          (isRecord(choice.message) && hasToolCallsArray(choice.message.tool_calls)) ||
+          (isRecord(choice.delta) && hasToolCallsArray(choice.delta.tool_calls))
+        );
+      });
+    }
+    return false;
+  };
+
+  const looksLikeBareToolCallJsonFragment = (value: string): boolean =>
+    /^\s*\{[\s\S]*"tool_calls"\s*:\s*\[/i.test(value);
+
+  const skipOneRedundantNewline = (input: string, start: number, result: string): number => {
+    let index = start;
+    while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+      index += 1;
+    }
+    if (
+      (input[index] === "\n" || input[index] === "\r") &&
+      (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
+    ) {
+      if (input[index] === "\r") {
+        index += 1;
+      }
+      if (input[index] === "\n") {
+        index += 1;
+      }
+    }
+    return index;
+  };
+
+  const stripBareToolCallJsonPayloads = (input: string): string => {
+    if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input)) {
+      return input;
+    }
+
+    const codeRegions = findCodeRegions(input);
+    let result = "";
+    let cursor = 0;
+    for (let index = 0; index < input.length; index += 1) {
+      const ch = input[index];
+      if ((ch !== "{" && ch !== "[") || index < cursor || isInsideCode(index, codeRegions)) {
+        continue;
+      }
+
+      const end = consumeJsonish(input, index);
+      let shouldStrip = false;
+      let stripEnd = end ?? input.length;
+      if (end !== null) {
+        const raw = input.slice(index, end);
+        if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
+          index = Math.max(index, end - 1);
+          continue;
+        }
+        try {
+          shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
+        } catch {
+          shouldStrip = false;
+        }
+        if (!shouldStrip) {
+          index = Math.max(index, end - 1);
+          continue;
+        }
+      } else {
+        shouldStrip = looksLikeBareToolCallJsonFragment(input.slice(index));
+      }
+
+      if (!shouldStrip) {
+        continue;
+      }
+
+      result += input.slice(cursor, index);
+      stripEnd = skipOneRedundantNewline(input, stripEnd, result);
+      cursor = stripEnd;
+      index = Math.max(index, cursor - 1);
+    }
+    result += input.slice(cursor);
+    return result;
+  };
+
   const stripToolCalls = (input: string): string => {
     const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
     let result = "";
@@ -470,8 +599,10 @@ export function stripDowngradedToolCallText(text: string): string {
     return result;
   };
 
+  let cleaned = stripBareToolCallJsonPayloads(text);
+
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
-  let cleaned = stripToolCalls(text);
+  cleaned = stripToolCalls(cleaned);
 
   // Remove [Tool Result for ID ...] blocks and their content.
   cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -30,8 +30,284 @@ const TOOL_CALL_JSON_PAYLOAD_START_RE =
 const TOOL_CALL_XML_PAYLOAD_START_RE =
   /^\s*(?:\r?\n\s*)?<(?:function|invoke|parameters?|arguments?)\b/i;
 const BARE_TOOL_CALL_JSON_QUICK_RE = /"tool_calls"\s*:|"type"\s*:\s*"function(?:_call)?"/i;
+const MAX_BARE_TOOL_CALL_JSON_CANDIDATES = 50;
+const MAX_BARE_TOOL_CALL_JSON_PAYLOAD_CHARS = 50_000;
 
 type ToolCallPayloadKind = "json" | "xml" | null;
+
+type BareToolCallJsonSanitizeOptions = {
+  stripIncompleteToolCalls?: boolean;
+  withholdIncomplete?: boolean;
+};
+
+function consumeJsonish(
+  input: string,
+  start: number,
+  options?: { allowLeadingNewlines?: boolean },
+): number | null {
+  const { allowLeadingNewlines = false } = options ?? {};
+  let index = start;
+  while (index < input.length) {
+    const ch = input[index];
+    if (ch === " " || ch === "\t") {
+      index += 1;
+      continue;
+    }
+    if (allowLeadingNewlines && (ch === "\n" || ch === "\r")) {
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  if (index >= input.length) {
+    return null;
+  }
+
+  const startChar = input[index];
+  if (startChar === "{" || startChar === "[") {
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    for (let idx = index; idx < input.length; idx += 1) {
+      const ch = input[idx];
+      if (inString) {
+        if (escape) {
+          escape = false;
+        } else if (ch === "\\") {
+          escape = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+      if (ch === "{" || ch === "[") {
+        depth += 1;
+      } else if (ch === "}" || ch === "]") {
+        depth -= 1;
+        if (depth === 0) {
+          return idx + 1;
+        }
+      }
+    }
+    return null;
+  }
+
+  if (startChar === '"') {
+    let escape = false;
+    for (let idx = index + 1; idx < input.length; idx += 1) {
+      const ch = input[idx];
+      if (escape) {
+        escape = false;
+        continue;
+      }
+      if (ch === "\\") {
+        escape = true;
+        continue;
+      }
+      if (ch === '"') {
+        return idx + 1;
+      }
+    }
+    return null;
+  }
+
+  let end = index;
+  while (end < input.length && input[end] !== "\n" && input[end] !== "\r") {
+    end += 1;
+  }
+  return end;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isToolCallObject(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  const functionValue = value.function;
+  return (
+    value.type === "function" &&
+    isRecord(functionValue) &&
+    typeof functionValue.name === "string" &&
+    (typeof functionValue.arguments === "string" || isRecord(functionValue.arguments))
+  );
+}
+
+function hasToolCallsArray(value: unknown): boolean {
+  return Array.isArray(value) && value.length > 0 && value.every((item) => isToolCallObject(item));
+}
+
+function isBareToolCallJsonPayload(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (hasToolCallsArray(value.tool_calls)) {
+    return true;
+  }
+  if (isRecord(value.message) && hasToolCallsArray(value.message.tool_calls)) {
+    return true;
+  }
+  if (Array.isArray(value.choices)) {
+    return value.choices.some((choice) => {
+      if (!isRecord(choice)) {
+        return false;
+      }
+      return (
+        (isRecord(choice.message) && hasToolCallsArray(choice.message.tool_calls)) ||
+        (isRecord(choice.delta) && hasToolCallsArray(choice.delta.tool_calls))
+      );
+    });
+  }
+  return false;
+}
+
+function skipOneRedundantNewline(input: string, start: number, result: string): number {
+  let index = start;
+  while (index < input.length && (input[index] === " " || input[index] === "\t")) {
+    index += 1;
+  }
+  if (
+    (input[index] === "\n" || input[index] === "\r") &&
+    (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
+  ) {
+    if (input[index] === "\r") {
+      index += 1;
+    }
+    if (input[index] === "\n") {
+      index += 1;
+    }
+  }
+  return index;
+}
+
+function hasOnlyLineWhitespaceBefore(input: string, index: number): boolean {
+  const lineStart =
+    Math.max(input.lastIndexOf("\n", index - 1), input.lastIndexOf("\r", index - 1)) + 1;
+  for (let idx = lineStart; idx < index; idx += 1) {
+    const ch = input[idx];
+    if (ch !== " " && ch !== "\t") {
+      return false;
+    }
+  }
+  return true;
+}
+
+function hasOnlyLineWhitespaceAfter(input: string, index: number): boolean {
+  for (let idx = index; idx < input.length; idx += 1) {
+    const ch = input[idx];
+    if (ch === "\n" || ch === "\r") {
+      return true;
+    }
+    if (ch !== " " && ch !== "\t") {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isStandaloneJsonCandidateStart(input: string, index: number): boolean {
+  const ch = input[index];
+  return (ch === "{" || ch === "[") && hasOnlyLineWhitespaceBefore(input, index);
+}
+
+function stripBareToolCallJsonPayloads(
+  input: string,
+  options?: BareToolCallJsonSanitizeOptions,
+): { text: string; changed: boolean } {
+  if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input) && !options?.withholdIncomplete) {
+    return { text: input, changed: false };
+  }
+
+  const codeRegions = findCodeRegions(input);
+  let result = "";
+  let cursor = 0;
+  let changed = false;
+  let candidates = 0;
+  for (let index = 0; index < input.length; index += 1) {
+    if (
+      index < cursor ||
+      !isStandaloneJsonCandidateStart(input, index) ||
+      isInsideCode(index, codeRegions)
+    ) {
+      continue;
+    }
+
+    candidates += 1;
+    if (candidates > MAX_BARE_TOOL_CALL_JSON_CANDIDATES) {
+      break;
+    }
+
+    const end = consumeJsonish(input, index);
+    if (end === null) {
+      const tail = input.slice(index);
+      const shouldStripTail =
+        options?.withholdIncomplete ||
+        (options?.stripIncompleteToolCalls && BARE_TOOL_CALL_JSON_QUICK_RE.test(tail));
+      if (!shouldStripTail) {
+        break;
+      }
+      result += input.slice(cursor, index);
+      cursor = input.length;
+      changed = true;
+      break;
+    }
+
+    if (!hasOnlyLineWhitespaceAfter(input, end)) {
+      index = Math.max(index, end - 1);
+      continue;
+    }
+
+    const rawLength = end - index;
+    if (rawLength > MAX_BARE_TOOL_CALL_JSON_PAYLOAD_CHARS) {
+      index = Math.max(index, end - 1);
+      continue;
+    }
+
+    const raw = input.slice(index, end);
+    if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
+      index = Math.max(index, end - 1);
+      continue;
+    }
+
+    let shouldStrip = false;
+    try {
+      shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
+    } catch {
+      shouldStrip = false;
+    }
+    if (!shouldStrip) {
+      index = Math.max(index, end - 1);
+      continue;
+    }
+
+    result += input.slice(cursor, index);
+    const stripEnd = skipOneRedundantNewline(input, end, result);
+    cursor = stripEnd;
+    changed = true;
+    index = Math.max(index, cursor - 1);
+  }
+  if (!changed) {
+    return { text: input, changed: false };
+  }
+  result += input.slice(cursor);
+  return { text: result, changed: true };
+}
+
+export function sanitizeStreamingBareToolCallJsonText(
+  text: string,
+  options?: { final?: boolean },
+): string {
+  return stripBareToolCallJsonPayloads(text, {
+    stripIncompleteToolCalls: options?.final,
+    withholdIncomplete: !options?.final,
+  }).text.trimEnd();
+}
 
 function endsInsideQuotedString(text: string, start: number, end: number): boolean {
   let quoteChar: "'" | '"' | null = null;
@@ -337,220 +613,6 @@ export function stripDowngradedToolCallText(text: string): string {
     return text;
   }
 
-  const consumeJsonish = (
-    input: string,
-    start: number,
-    options?: { allowLeadingNewlines?: boolean },
-  ): number | null => {
-    const { allowLeadingNewlines = false } = options ?? {};
-    let index = start;
-    while (index < input.length) {
-      const ch = input[index];
-      if (ch === " " || ch === "\t") {
-        index += 1;
-        continue;
-      }
-      if (allowLeadingNewlines && (ch === "\n" || ch === "\r")) {
-        index += 1;
-        continue;
-      }
-      break;
-    }
-    if (index >= input.length) {
-      return null;
-    }
-
-    const startChar = input[index];
-    if (startChar === "{" || startChar === "[") {
-      let depth = 0;
-      let inString = false;
-      let escape = false;
-      for (let idx = index; idx < input.length; idx += 1) {
-        const ch = input[idx];
-        if (inString) {
-          if (escape) {
-            escape = false;
-          } else if (ch === "\\") {
-            escape = true;
-          } else if (ch === '"') {
-            inString = false;
-          }
-          continue;
-        }
-        if (ch === '"') {
-          inString = true;
-          continue;
-        }
-        if (ch === "{" || ch === "[") {
-          depth += 1;
-        } else if (ch === "}" || ch === "]") {
-          depth -= 1;
-          if (depth === 0) {
-            return idx + 1;
-          }
-        }
-      }
-      return null;
-    }
-
-    if (startChar === '"') {
-      let escape = false;
-      for (let idx = index + 1; idx < input.length; idx += 1) {
-        const ch = input[idx];
-        if (escape) {
-          escape = false;
-          continue;
-        }
-        if (ch === "\\") {
-          escape = true;
-          continue;
-        }
-        if (ch === '"') {
-          return idx + 1;
-        }
-      }
-      return null;
-    }
-
-    let end = index;
-    while (end < input.length && input[end] !== "\n" && input[end] !== "\r") {
-      end += 1;
-    }
-    return end;
-  };
-
-  const isRecord = (value: unknown): value is Record<string, unknown> =>
-    Boolean(value) && typeof value === "object" && !Array.isArray(value);
-
-  const isToolCallObject = (value: unknown): boolean => {
-    if (!isRecord(value)) {
-      return false;
-    }
-    const functionValue = value.function;
-    return (
-      value.type === "function" &&
-      isRecord(functionValue) &&
-      typeof functionValue.name === "string" &&
-      (typeof functionValue.arguments === "string" || isRecord(functionValue.arguments))
-    );
-  };
-
-  const hasToolCallsArray = (value: unknown): boolean =>
-    Array.isArray(value) && value.length > 0 && value.every((item) => isToolCallObject(item));
-
-  const isBareToolCallJsonPayload = (value: unknown): boolean => {
-    if (!isRecord(value)) {
-      return false;
-    }
-    if (hasToolCallsArray(value.tool_calls)) {
-      return true;
-    }
-    if (isRecord(value.message) && hasToolCallsArray(value.message.tool_calls)) {
-      return true;
-    }
-    if (Array.isArray(value.choices)) {
-      return value.choices.some((choice) => {
-        if (!isRecord(choice)) {
-          return false;
-        }
-        return (
-          (isRecord(choice.message) && hasToolCallsArray(choice.message.tool_calls)) ||
-          (isRecord(choice.delta) && hasToolCallsArray(choice.delta.tool_calls))
-        );
-      });
-    }
-    return false;
-  };
-
-  const skipOneRedundantNewline = (input: string, start: number, result: string): number => {
-    let index = start;
-    while (index < input.length && (input[index] === " " || input[index] === "\t")) {
-      index += 1;
-    }
-    if (
-      (input[index] === "\n" || input[index] === "\r") &&
-      (result.endsWith("\n") || result.endsWith("\r") || result.length === 0)
-    ) {
-      if (input[index] === "\r") {
-        index += 1;
-      }
-      if (input[index] === "\n") {
-        index += 1;
-      }
-    }
-    return index;
-  };
-
-  const findNextLineBreak = (input: string, start: number): number => {
-    const nextNewline = input.indexOf("\n", start);
-    const nextCarriage = input.indexOf("\r", start);
-    if (nextNewline === -1) {
-      return nextCarriage;
-    }
-    if (nextCarriage === -1) {
-      return nextNewline;
-    }
-    return Math.min(nextNewline, nextCarriage);
-  };
-
-  const stripBareToolCallJsonPayloads = (input: string): { text: string; changed: boolean } => {
-    if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(input)) {
-      return { text: input, changed: false };
-    }
-
-    const codeRegions = findCodeRegions(input);
-    let result = "";
-    let cursor = 0;
-    let changed = false;
-    for (let index = 0; index < input.length; index += 1) {
-      const ch = input[index];
-      if ((ch !== "{" && ch !== "[") || index < cursor || isInsideCode(index, codeRegions)) {
-        continue;
-      }
-
-      const end = consumeJsonish(input, index);
-      let shouldStrip = false;
-      if (end !== null) {
-        const raw = input.slice(index, end);
-        if (!BARE_TOOL_CALL_JSON_QUICK_RE.test(raw)) {
-          index = Math.max(index, end - 1);
-          continue;
-        }
-        try {
-          shouldStrip = isBareToolCallJsonPayload(JSON.parse(raw));
-        } catch {
-          shouldStrip = false;
-        }
-        if (!shouldStrip) {
-          index = Math.max(index, end - 1);
-          continue;
-        }
-      } else {
-        const nextLineBreak = findNextLineBreak(input, index + 1);
-        if (nextLineBreak === -1) {
-          break;
-        }
-        index = nextLineBreak;
-        continue;
-      }
-
-      if (!shouldStrip) {
-        continue;
-      }
-
-      result += input.slice(cursor, index);
-      const stripEnd = skipOneRedundantNewline(input, end, result);
-      cursor = stripEnd;
-      changed = true;
-      index = Math.max(index, cursor - 1);
-    }
-    if (!changed) {
-      return { text: input, changed: false };
-    }
-    result += input.slice(cursor);
-    return { text: result, changed: true };
-  };
-
   const stripToolCalls = (input: string): string => {
     const toolCallRe = /\[Tool Call:[^\]]*\]/gi;
     let result = "";
@@ -606,7 +668,9 @@ export function stripDowngradedToolCallText(text: string): string {
     return result;
   };
 
-  const bareToolCallJsonResult = stripBareToolCallJsonPayloads(text);
+  const bareToolCallJsonResult = stripBareToolCallJsonPayloads(text, {
+    stripIncompleteToolCalls: true,
+  });
   let cleaned = bareToolCallJsonResult.text;
 
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.


### PR DESCRIPTION
## Summary

New attempt after closed #71954. That PR only hardened final/visible-text cleanup; this version adds the missing streaming-preview guard called out in the maintainer review.

- Problem: #70797 can leak raw `{"tool_calls":[...]}` text into Telegram direct preview streaming before final delivery cleanup runs.
- Why it matters: preview streaming can expose internal tool-call arguments to the user while the reply is still being generated.
- What changed: sanitize partial-preview text in `src/agents/pi-embedded-subscribe.handlers.messages.ts` before `onPartialReply`, withhold incomplete standalone JSON during preview streaming, drop complete OpenAI-style `tool_calls` payloads, and release complete ordinary JSON.
- What did NOT change (scope boundary): this does not recover execution after a provider has already downgraded a structured tool call into plain assistant text; it prevents that payload from reaching user-visible preview/final text. Tool-call execution recovery remains provider/runtime-boundary follow-up work if maintainers want that behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #70797
- Related #71954
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Telegram direct preview streaming builds partial assistant preview text in `src/agents/pi-embedded-subscribe.handlers.messages.ts` and calls `onPartialReply` before the final assistant-visible-text sanitizer can run.
- Missing detection / guardrail: there was no streaming-aware sanitizer/accumulator in the partial reply path, and the previous final sanitizer approach preserved incomplete JSON fragments.
- Contributing context (if known): the reported repro involves background `exec` followed by `process poll`, where a provider/runtime path can downgrade structured tool-call JSON into assistant text.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/agents/pi-embedded-subscribe.handlers.messages.test.ts`
  - `src/shared/text/assistant-visible-text.test.ts`
- Scenario the test should lock in: partial preview delivery with a visible lead-in plus incomplete `tool_calls` JSON emits only the lead-in and does not emit the completed raw payload later.
- Why this is the smallest reliable guardrail: it exercises the exact `handleMessageUpdate` path that builds `onPartialReply` data without requiring live Telegram transport.
- Existing test that already covers this (if any): existing visible-text sanitizer tests covered final cleanup shapes, but not the partial-preview path.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Telegram/preview streaming should no longer show standalone OpenAI-style `tool_calls` JSON payloads. Incomplete standalone JSON tails may be withheld from preview until complete; complete ordinary JSON is released.

## Diagram (if applicable)

```text
Before:
model text_delta -> partial preview text -> onPartialReply -> Telegram preview can show raw tool_calls JSON

After:
model text_delta -> partial preview sanitizer -> onPartialReply -> Telegram preview shows only safe visible text
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A. This reduces exposure of internal tool-call arguments in user-visible previews.

## Repro + Verification

### Environment

- OS: macOS local dev
- Runtime/container: local Node/pnpm repo checks
- Model/provider: reported with `tinyrouter/cx/gpt-5.4`; local verification uses deterministic stream-update tests
- Integration/channel (if any): Telegram direct preview streaming path
- Relevant config (redacted): `channels.telegram.streaming.mode="partial"` per issue context

### Steps

1. Simulate an assistant `text_delta` containing visible prose followed by an incomplete standalone `{"tool_calls":[...]}` JSON payload.
2. Let `handleMessageUpdate` build the assistant partial reply data.
3. Complete the same JSON payload in a later `text_delta`.

### Expected

- The partial reply callback receives the visible prose only.
- The raw `tool_calls` JSON is withheld while incomplete and dropped when complete.
- Complete ordinary standalone JSON is released once it proves not to be a tool-call payload.

### Actual

- Before this change, the partial preview path used unsanitized `cleanedText`, so the raw payload could be passed to `onPartialReply`.
- After this change, the new regression covers the partial preview path and the raw payload is not emitted.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-subscribe.handlers.messages.test.ts src/agents/pi-embedded-utils.test.ts`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm check:changed`
- Edge cases checked: incomplete `tool_calls` fragments, complete standalone `tool_calls` JSON, strict OpenAI-style tool-call entries, inline/fenced JSON examples, complete ordinary standalone JSON, no-op history whitespace.
- What you did **not** verify: live Telegram/tinyrouter reproduction and execution recovery for downgraded text tool calls.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No review conversations exist on this new PR yet. This PR explicitly addresses the maintainer close reason from #71954.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Preview streaming may temporarily withhold incomplete ordinary standalone JSON tails.
  - Mitigation: the sanitizer releases complete ordinary JSON, preserves inline/fenced code examples, and only applies this withholding to partial-preview text before final delivery.
