### PR TITLE
fix(signal): enable inbound status reactions

### DIFF
--- a/extensions/signal/src/monitor/event-handler.status-reactions.test.ts
+++ b/extensions/signal/src/monitor/event-handler.status-reactions.test.ts
@@ -1,0 +1,222 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dispatchInboundMessageMock, dispatchResult, sendReactionSignalMock, sendTypingMock } =
+  vi.hoisted(() => {
+    const result = { queuedFinal: true };
+    return {
+      dispatchInboundMessageMock: vi.fn(
+        async (params: {
+          ctx: MsgContext;
+          replyOptions?: {
+            onReplyStart?: () => void | Promise<void>;
+            onToolStart?: (payload: { name?: string }) => void | Promise<void>;
+          };
+        }) => {
+          await params.replyOptions?.onReplyStart?.();
+          await params.replyOptions?.onToolStart?.({ name: "read_file" });
+          return { ...result, counts: { tool: result.queuedFinal ? 1 : 0, block: 0, final: 0 } };
+        },
+      ),
+      dispatchResult: result,
+      sendReactionSignalMock: vi.fn().mockResolvedValue({ ok: true }),
+      sendTypingMock: vi.fn().mockResolvedValue(true),
+    };
+  });
+
+vi.mock("../send-reactions.js", () => ({
+  removeReactionSignal: vi.fn(),
+  sendReactionSignal: sendReactionSignalMock,
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendReadReceiptSignal: vi.fn().mockResolvedValue(true),
+  sendTypingSignal: sendTypingMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+  };
+});
+
+const [
+  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+  { createSignalEventHandler },
+] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+
+function createStatusReactionConfig(
+  overrides: {
+    ackReactionScope?: NonNullable<OpenClawConfig["messages"]>["ackReactionScope"];
+    requireMention?: boolean;
+  } = {},
+): OpenClawConfig {
+  return {
+    messages: {
+      ackReaction: "👀",
+      ackReactionScope: overrides.ackReactionScope ?? "all",
+      groupChat: {
+        mentionPatterns: ["@bot"],
+      },
+      inbound: { debounceMs: 0 },
+      statusReactions: {
+        enabled: true,
+        emojis: {
+          done: "✅",
+        },
+        timing: {
+          debounceMs: 60_000,
+          stallSoftMs: 600_000,
+          stallHardMs: 600_000,
+        },
+      },
+    },
+    channels: {
+      signal: {
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        groups: {
+          "*": {
+            requireMention: overrides.requireMention ?? false,
+          },
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("signal status reactions", () => {
+  beforeEach(() => {
+    dispatchResult.queuedFinal = true;
+    dispatchInboundMessageMock.mockClear();
+    sendReactionSignalMock.mockClear();
+    sendTypingMock.mockClear();
+  });
+
+  it("reacts to direct inbound messages with queued and done status", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig(),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        timestamp: 1700000001234,
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalledTimes(2);
+    });
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      1,
+      "+15550002222",
+      1700000001234,
+      "👀",
+      expect.objectContaining({
+        accountId: "default",
+        targetAuthor: "+15550002222",
+      }),
+    );
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      2,
+      "+15550002222",
+      1700000001234,
+      "✅",
+      expect.objectContaining({
+        accountId: "default",
+        targetAuthor: "+15550002222",
+      }),
+    );
+  });
+
+  it("routes group status reactions through groupId and targetAuthor", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig({
+          ackReactionScope: "group-mentions",
+          requireMention: true,
+        }),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550003333",
+        timestamp: 1700000005678,
+        dataMessage: {
+          message: "hello @bot",
+          attachments: [],
+          groupInfo: { groupId: "group-1", groupName: "Test Group" },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalledTimes(2);
+    });
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      1,
+      "",
+      1700000005678,
+      "👀",
+      expect.objectContaining({
+        groupId: "group-1",
+        targetAuthor: "+15550003333",
+      }),
+    );
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      2,
+      "",
+      1700000005678,
+      "✅",
+      expect.objectContaining({
+        groupId: "group-1",
+        targetAuthor: "+15550003333",
+      }),
+    );
+  });
+
+  it("restores the initial reaction instead of done when no final reply is queued", async () => {
+    dispatchResult.queuedFinal = false;
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig(),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550004444",
+        timestamp: 1700000009012,
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalled();
+    });
+    await Promise.resolve();
+    const emojis = sendReactionSignalMock.mock.calls.map((call) => call[2]);
+    expect(emojis).toContain("👀");
+    expect(emojis).not.toContain("✅");
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.status-reactions.test.ts
+++ b/extensions/signal/src/monitor/event-handler.status-reactions.test.ts
@@ -1,0 +1,222 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
+import type { MsgContext } from "openclaw/plugin-sdk/reply-runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { dispatchInboundMessageMock, dispatchResult, sendReactionSignalMock, sendTypingMock } =
+  vi.hoisted(() => {
+    const result = { queuedFinal: true };
+    return {
+      dispatchInboundMessageMock: vi.fn(
+        async (params: {
+          ctx: MsgContext;
+          replyOptions?: {
+            onReplyStart?: () => void | Promise<void>;
+            onToolStart?: (payload: { name?: string }) => void | Promise<void>;
+          };
+        }) => {
+          await params.replyOptions?.onReplyStart?.();
+          await params.replyOptions?.onToolStart?.({ name: "read_file" });
+          return { ...result, counts: { tool: result.queuedFinal ? 1 : 0, block: 0, final: 0 } };
+        },
+      ),
+      dispatchResult: result,
+      sendReactionSignalMock: vi.fn().mockResolvedValue({ ok: true }),
+      sendTypingMock: vi.fn().mockResolvedValue(true),
+    };
+  });
+
+vi.mock("../send-reactions.js", () => ({
+  removeReactionSignal: vi.fn(),
+  sendReactionSignal: sendReactionSignalMock,
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendReadReceiptSignal: vi.fn().mockResolvedValue(true),
+  sendTypingSignal: sendTypingMock,
+}));
+
+vi.mock("openclaw/plugin-sdk/reply-runtime", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/reply-runtime")>(
+    "openclaw/plugin-sdk/reply-runtime",
+  );
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+  };
+});
+
+const [
+  { createBaseSignalEventHandlerDeps, createSignalReceiveEvent },
+  { createSignalEventHandler },
+] = await Promise.all([import("./event-handler.test-harness.js"), import("./event-handler.js")]);
+
+function createStatusReactionConfig(
+  overrides: {
+    ackReactionScope?: NonNullable<OpenClawConfig["messages"]>["ackReactionScope"];
+    requireMention?: boolean;
+  } = {},
+): OpenClawConfig {
+  return {
+    messages: {
+      ackReaction: "👀",
+      ackReactionScope: overrides.ackReactionScope ?? "all",
+      groupChat: {
+        mentionPatterns: ["@bot"],
+      },
+      inbound: { debounceMs: 0 },
+      statusReactions: {
+        enabled: true,
+        emojis: {
+          done: "✅",
+        },
+        timing: {
+          debounceMs: 60_000,
+          stallSoftMs: 600_000,
+          stallHardMs: 600_000,
+        },
+      },
+    },
+    channels: {
+      signal: {
+        dmPolicy: "open",
+        allowFrom: ["*"],
+        groups: {
+          "*": {
+            requireMention: overrides.requireMention ?? false,
+          },
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("signal status reactions", () => {
+  beforeEach(() => {
+    dispatchResult.queuedFinal = true;
+    dispatchInboundMessageMock.mockClear();
+    sendReactionSignalMock.mockClear();
+    sendTypingMock.mockClear();
+  });
+
+  it("reacts to direct inbound messages with queued and done status", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig(),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550002222",
+        timestamp: 1700000001234,
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalledTimes(2);
+    });
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      1,
+      "+15550002222",
+      1700000001234,
+      "👀",
+      expect.objectContaining({
+        accountId: "default",
+        targetAuthor: "+15550002222",
+      }),
+    );
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      2,
+      "+15550002222",
+      1700000001234,
+      "✅",
+      expect.objectContaining({
+        accountId: "default",
+        targetAuthor: "+15550002222",
+      }),
+    );
+  });
+
+  it("routes group status reactions through groupId and targetAuthor", async () => {
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig({
+          ackReactionScope: "group-mentions",
+          requireMention: true,
+        }),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550003333",
+        timestamp: 1700000005678,
+        dataMessage: {
+          message: "hello @bot",
+          attachments: [],
+          groupInfo: { groupId: "group-1", groupName: "Test Group" },
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalledTimes(2);
+    });
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      1,
+      "",
+      1700000005678,
+      "👀",
+      expect.objectContaining({
+        groupId: "group-1",
+        targetAuthor: "+15550003333",
+      }),
+    );
+    expect(sendReactionSignalMock).toHaveBeenNthCalledWith(
+      2,
+      "",
+      1700000005678,
+      "✅",
+      expect.objectContaining({
+        groupId: "group-1",
+        targetAuthor: "+15550003333",
+      }),
+    );
+  });
+
+  it("marks the message done when dispatch succeeds without a final reply", async () => {
+    dispatchResult.queuedFinal = false;
+    const handler = createSignalEventHandler(
+      createBaseSignalEventHandlerDeps({
+        cfg: createStatusReactionConfig(),
+        historyLimit: 0,
+      }),
+    );
+
+    await handler(
+      createSignalReceiveEvent({
+        sourceNumber: "+15550004444",
+        timestamp: 1700000009012,
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    await vi.waitFor(() => {
+      expect(sendReactionSignalMock).toHaveBeenCalled();
+    });
+    await Promise.resolve();
+    const emojis = sendReactionSignalMock.mock.calls.map((call) => call[2]);
+    expect(emojis).toContain("👀");
+    expect(emojis).toContain("✅");
+  });
+});

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -1,5 +1,10 @@
-import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
+import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  createStatusReactionController,
+  logTypingFailure,
+  shouldAckReaction,
+  type StatusReactionController,
+} from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildMentionRegexes,
   createChannelInboundDebouncer,
@@ -25,7 +30,10 @@ import {
   toInternalMessageReceivedContext,
   triggerInternalHook,
 } from "openclaw/plugin-sdk/hook-runtime";
-import { runInboundReplyTurn } from "openclaw/plugin-sdk/inbound-reply-dispatch";
+import {
+  hasVisibleInboundReplyDispatch,
+  runInboundReplyTurn,
+} from "openclaw/plugin-sdk/inbound-reply-dispatch";
 import { kindFromMime } from "openclaw/plugin-sdk/media-runtime";
 import {
   buildPendingHistoryContextFromMap,
@@ -56,6 +64,7 @@ import {
   type SignalSender,
 } from "../identity.js";
 import { normalizeSignalMessagingTarget } from "../normalize.js";
+import { sendReactionSignal } from "../send-reactions.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import type {
@@ -123,6 +132,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    requireMention?: boolean;
+    canDetectMention?: boolean;
+    shouldBypassMention?: boolean;
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
@@ -288,87 +300,189 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       },
     });
 
-    await runInboundReplyTurn({
+    // Status reactions: show emoji on the inbound message as agent progresses
+    const statusReactionsConfig = deps.cfg.messages?.statusReactions;
+    const ackEmoji = resolveAckReaction(deps.cfg, route.agentId, {
       channel: "signal",
-      accountId: route.accountId,
-      raw: entry,
-      adapter: {
-        ingest: () => ({
-          id: entry.messageId ?? `${entry.timestamp ?? Date.now()}`,
-          timestamp: entry.timestamp,
-          rawText: entry.bodyText,
-          raw: entry,
-        }),
-        resolveTurn: () => ({
-          channel: "signal",
-          accountId: route.accountId,
-          routeSessionKey: route.sessionKey,
-          storePath,
-          ctxPayload,
-          recordInboundSession,
-          record: {
-            updateLastRoute: !entry.isGroup
-              ? {
-                  sessionKey: route.mainSessionKey,
-                  channel: "signal",
-                  to: entry.senderRecipient,
-                  accountId: route.accountId,
-                  mainDmOwnerPin: (() => {
-                    const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
-                      dmScope: deps.cfg.session?.dmScope,
-                      allowFrom: deps.allowFrom,
-                      normalizeEntry: normalizeSignalAllowRecipient,
-                    });
-                    if (!pinnedOwner) {
-                      return undefined;
-                    }
-                    return {
-                      ownerRecipient: pinnedOwner,
-                      senderRecipient: entry.senderRecipient,
-                      onSkip: ({ ownerRecipient, senderRecipient }) => {
-                        logVerbose(
-                          `signal: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                        );
-                      },
-                    };
-                  })(),
-                }
-              : undefined,
-            onRecordError: (err) => {
-              logVerbose(`signal: failed updating session meta: ${String(err)}`);
-            },
-          },
-          history: {
-            isGroup: entry.isGroup,
-            historyKey,
-            historyMap: deps.groupHistories,
-            limit: deps.historyLimit,
-          },
-          onPreDispatchFailure: () =>
-            settleReplyDispatcher({
-              dispatcher,
-              onSettled: () => markDispatchIdle(),
-            }),
-          runDispatch: async () => {
+      accountId: deps.accountId,
+    });
+    const canAckReact =
+      Boolean(ackEmoji) &&
+      shouldAckReaction({
+        scope: deps.cfg.messages?.ackReactionScope,
+        isDirect: !entry.isGroup,
+        isGroup: entry.isGroup,
+        isMentionableGroup: entry.isGroup,
+        requireMention: entry.requireMention === true,
+        canDetectMention: entry.canDetectMention === true,
+        effectiveWasMentioned: entry.wasMentioned === true,
+        shouldBypassMention: entry.shouldBypassMention === true,
+      });
+    const statusReactionsEnabled =
+      statusReactionsConfig?.enabled === true && canAckReact && Boolean(entry.timestamp);
+    let statusReactions: StatusReactionController | null = null;
+    if (statusReactionsEnabled && entry.timestamp) {
+      const msgTimestamp = entry.timestamp;
+      const reactionRecipient = entry.isGroup ? "" : (entry.senderRecipient ?? "");
+      const reactionGroupId = entry.isGroup ? (entry.groupId ?? undefined) : undefined;
+      const reactionOpts = {
+        cfg: deps.cfg,
+        baseUrl: deps.baseUrl,
+        account: deps.account,
+        accountId: deps.accountId,
+        targetAuthor: entry.senderRecipient,
+        groupId: reactionGroupId,
+      };
+      statusReactions = createStatusReactionController({
+        enabled: true,
+        adapter: {
+          // Signal auto-replaces reactions (one per user per message).
+          // No explicit removal needed — just send the new emoji.
+          setReaction: async (emoji: string) => {
             try {
-              return await dispatchInboundMessage({
-                ctx: ctxPayload,
-                cfg: deps.cfg,
-                dispatcher,
-                replyOptions: {
-                  ...replyOptions,
-                  disableBlockStreaming:
-                    typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
-                  onModelSelected,
-                },
-              });
-            } finally {
-              markDispatchIdle();
+              await sendReactionSignal(reactionRecipient, msgTimestamp, emoji, reactionOpts);
+            } catch (err) {
+              logVerbose(`signal status-reaction set failed: ${String(err)}`);
             }
           },
-        }),
-      },
-    });
+        },
+        initialEmoji: ackEmoji,
+        emojis: deps.cfg.messages?.statusReactions?.emojis,
+        timing: deps.cfg.messages?.statusReactions?.timing,
+        onError: (err) => {
+          logVerbose(`signal status-reaction error: ${String(err)}`);
+        },
+      });
+      void statusReactions.setQueued();
+      // Start thinking debounce early (before dispatch) so the 700ms
+      // timer has time to fire — matches Telegram's approach.
+      void statusReactions.setThinking();
+    }
+
+    try {
+      const turnResult = await runInboundReplyTurn({
+        channel: "signal",
+        accountId: route.accountId,
+        raw: entry,
+        adapter: {
+          ingest: () => ({
+            id: entry.messageId ?? `${entry.timestamp ?? Date.now()}`,
+            timestamp: entry.timestamp,
+            rawText: entry.bodyText,
+            raw: entry,
+          }),
+          resolveTurn: () => ({
+            channel: "signal",
+            accountId: route.accountId,
+            routeSessionKey: route.sessionKey,
+            storePath,
+            ctxPayload,
+            recordInboundSession,
+            record: {
+              updateLastRoute: !entry.isGroup
+                ? {
+                    sessionKey: route.mainSessionKey,
+                    channel: "signal",
+                    to: entry.senderRecipient,
+                    accountId: route.accountId,
+                    mainDmOwnerPin: (() => {
+                      const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
+                        dmScope: deps.cfg.session?.dmScope,
+                        allowFrom: deps.allowFrom,
+                        normalizeEntry: normalizeSignalAllowRecipient,
+                      });
+                      if (!pinnedOwner) {
+                        return undefined;
+                      }
+                      return {
+                        ownerRecipient: pinnedOwner,
+                        senderRecipient: entry.senderRecipient,
+                        onSkip: ({ ownerRecipient, senderRecipient }) => {
+                          logVerbose(
+                            `signal: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                          );
+                        },
+                      };
+                    })(),
+                  }
+                : undefined,
+              onRecordError: (err) => {
+                logVerbose(`signal: failed updating session meta: ${String(err)}`);
+              },
+            },
+            history: {
+              isGroup: entry.isGroup,
+              historyKey,
+              historyMap: deps.groupHistories,
+              limit: deps.historyLimit,
+            },
+            onPreDispatchFailure: () =>
+              settleReplyDispatcher({
+                dispatcher,
+                onSettled: () => markDispatchIdle(),
+              }),
+            runDispatch: async () => {
+              try {
+                return await dispatchInboundMessage({
+                  ctx: ctxPayload,
+                  cfg: deps.cfg,
+                  dispatcher,
+                  replyOptions: {
+                    ...replyOptions,
+                    disableBlockStreaming:
+                      typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
+                    onModelSelected,
+                    ...(statusReactions
+                      ? {
+                          onReplyStart: async () => {
+                            await replyOptions.onReplyStart?.();
+                            await statusReactions.setThinking();
+                          },
+                          onReasoningStream: async () => {
+                            await statusReactions.setThinking();
+                          },
+                          onToolStart: async (payload: { name?: string }) => {
+                            await statusReactions.setTool(payload.name);
+                          },
+                          onCompactionStart: async () => {
+                            await statusReactions.setCompacting();
+                          },
+                          onCompactionEnd: async () => {
+                            statusReactions.cancelPending();
+                            await statusReactions.setThinking();
+                          },
+                        }
+                      : {}),
+                  },
+                });
+              } finally {
+                markDispatchIdle();
+              }
+            },
+          }),
+        },
+      });
+      if (!turnResult.dispatched) {
+        if (statusReactions) {
+          void statusReactions.restoreInitial();
+        }
+        return;
+      }
+      if (!hasVisibleInboundReplyDispatch(turnResult.dispatchResult)) {
+        if (statusReactions) {
+          void statusReactions.restoreInitial();
+        }
+        return;
+      }
+      if (statusReactions) {
+        void statusReactions.setDone();
+      }
+    } catch (err) {
+      if (statusReactions) {
+        void statusReactions.setError();
+      }
+      throw err;
+    }
   }
 
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
@@ -896,6 +1010,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      requireMention,
+      canDetectMention,
+      shouldBypassMention: mentionDecision.shouldBypassMention,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -1,6 +1,11 @@
 // Signal plugin module implements event handler behavior.
-import { resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
-import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
+import { resolveAckReaction, resolveHumanDelayConfig } from "openclaw/plugin-sdk/agent-runtime";
+import {
+  createStatusReactionController,
+  logTypingFailure,
+  shouldAckReaction,
+  type StatusReactionController,
+} from "openclaw/plugin-sdk/channel-feedback";
 import {
   buildMentionRegexes,
   buildChannelInboundEventContext,
@@ -54,6 +59,7 @@ import {
   type SignalSender,
 } from "../identity.js";
 import { normalizeSignalMessagingTarget } from "../normalize.js";
+import { sendReactionSignal } from "../send-reactions.js";
 import { sendMessageSignal, sendReadReceiptSignal, sendTypingSignal } from "../send.js";
 import { handleSignalDirectMessageAccess, resolveSignalAccessState } from "./access-policy.js";
 import type {
@@ -121,6 +127,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     mediaTypes?: string[];
     commandAuthorized: boolean;
     wasMentioned?: boolean;
+    requireMention?: boolean;
+    canDetectMention?: boolean;
+    shouldBypassMention?: boolean;
     replyToBody?: string;
     replyToSender?: string;
     replyToIsQuote?: boolean;
@@ -322,90 +331,186 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       sessionKey: route.sessionKey,
     });
 
-    await runChannelInboundEvent({
+    // Status reactions: show emoji on the inbound message as agent progresses
+    const statusReactionsConfig = deps.cfg.messages?.statusReactions;
+    const ackEmoji = resolveAckReaction(deps.cfg, route.agentId, {
       channel: "signal",
-      accountId: route.accountId,
-      raw: entry,
-      adapter: {
-        ingest: () => ({
-          id: entry.messageId ?? `${entry.timestamp ?? Date.now()}`,
-          timestamp: entry.timestamp,
-          rawText: entry.bodyText,
-          raw: entry,
-        }),
-        resolveTurn: () => ({
-          channel: "signal",
-          accountId: route.accountId,
-          routeSessionKey: route.sessionKey,
-          storePath,
-          ctxPayload,
-          recordInboundSession,
-          record: {
-            updateLastRoute: !entry.isGroup
-              ? {
-                  sessionKey: inboundLastRouteSessionKey,
-                  channel: "signal",
-                  to: entry.senderRecipient,
-                  accountId: route.accountId,
-                  mainDmOwnerPin: (() => {
-                    if (inboundLastRouteSessionKey !== route.mainSessionKey) {
-                      return undefined;
-                    }
-                    const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
-                      dmScope: deps.cfg.session?.dmScope,
-                      allowFrom: deps.allowFrom,
-                      normalizeEntry: normalizeSignalAllowRecipient,
-                    });
-                    if (!pinnedOwner) {
-                      return undefined;
-                    }
-                    return {
-                      ownerRecipient: pinnedOwner,
-                      senderRecipient: entry.senderRecipient,
-                      onSkip: ({ ownerRecipient, senderRecipient }) => {
-                        logVerbose(
-                          `signal: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                        );
-                      },
-                    };
-                  })(),
-                }
-              : undefined,
-            onRecordError: (err) => {
-              logVerbose(`signal: failed updating session meta: ${String(err)}`);
-            },
-          },
-          history: {
-            isGroup: entry.isGroup,
-            historyKey,
-            historyMap: deps.groupHistories,
-            limit: deps.historyLimit,
-          },
-          onPreDispatchFailure: () =>
-            settleReplyDispatcher({
-              dispatcher,
-              onSettled: () => markDispatchIdle(),
-            }),
-          runDispatch: async () => {
+      accountId: deps.accountId,
+    });
+    const canAckReact =
+      Boolean(ackEmoji) &&
+      shouldAckReaction({
+        scope: deps.cfg.messages?.ackReactionScope,
+        isDirect: !entry.isGroup,
+        isGroup: entry.isGroup,
+        isMentionableGroup: entry.isGroup,
+        requireMention: entry.requireMention === true,
+        canDetectMention: entry.canDetectMention === true,
+        effectiveWasMentioned: entry.wasMentioned === true,
+        shouldBypassMention: entry.shouldBypassMention === true,
+      });
+    const statusReactionsEnabled =
+      statusReactionsConfig?.enabled === true && canAckReact && Boolean(entry.timestamp);
+    let statusReactions: StatusReactionController | null = null;
+    if (statusReactionsEnabled && entry.timestamp) {
+      const msgTimestamp = entry.timestamp;
+      const reactionRecipient = entry.isGroup ? "" : (entry.senderRecipient ?? "");
+      const reactionGroupId = entry.isGroup ? (entry.groupId ?? undefined) : undefined;
+      const reactionOpts = {
+        cfg: deps.cfg,
+        baseUrl: deps.baseUrl,
+        account: deps.account,
+        accountId: deps.accountId,
+        targetAuthor: entry.senderRecipient,
+        groupId: reactionGroupId,
+      };
+      statusReactions = createStatusReactionController({
+        enabled: true,
+        adapter: {
+          // Signal auto-replaces reactions (one per user per message).
+          // No explicit removal needed — just send the new emoji.
+          setReaction: async (emoji: string) => {
             try {
-              return await dispatchInboundMessage({
-                ctx: ctxPayload,
-                cfg: deps.cfg,
-                dispatcher,
-                replyOptions: {
-                  ...replyOptions,
-                  disableBlockStreaming:
-                    typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
-                  onModelSelected,
-                },
-              });
-            } finally {
-              markDispatchIdle();
+              await sendReactionSignal(reactionRecipient, msgTimestamp, emoji, reactionOpts);
+            } catch (err) {
+              logVerbose(`signal status-reaction set failed: ${String(err)}`);
             }
           },
-        }),
-      },
-    });
+        },
+        initialEmoji: ackEmoji,
+        emojis: deps.cfg.messages?.statusReactions?.emojis,
+        timing: deps.cfg.messages?.statusReactions?.timing,
+        onError: (err) => {
+          logVerbose(`signal status-reaction error: ${String(err)}`);
+        },
+      });
+      void statusReactions.setQueued();
+      // Start thinking debounce early (before dispatch) so the 700ms
+      // timer has time to fire — matches Telegram's approach.
+      void statusReactions.setThinking();
+    }
+
+    try {
+      const turnResult = await runChannelInboundEvent({
+        channel: "signal",
+        accountId: route.accountId,
+        raw: entry,
+        adapter: {
+          ingest: () => ({
+            id: entry.messageId ?? `${entry.timestamp ?? Date.now()}`,
+            timestamp: entry.timestamp,
+            rawText: entry.bodyText,
+            raw: entry,
+          }),
+          resolveTurn: () => ({
+            channel: "signal",
+            accountId: route.accountId,
+            routeSessionKey: route.sessionKey,
+            storePath,
+            ctxPayload,
+            recordInboundSession,
+            record: {
+              updateLastRoute: !entry.isGroup
+                ? {
+                    sessionKey: inboundLastRouteSessionKey,
+                    channel: "signal",
+                    to: entry.senderRecipient,
+                    accountId: route.accountId,
+                    mainDmOwnerPin: (() => {
+                      if (inboundLastRouteSessionKey !== route.mainSessionKey) {
+                        return undefined;
+                      }
+                      const pinnedOwner = resolvePinnedMainDmOwnerFromAllowlist({
+                        dmScope: deps.cfg.session?.dmScope,
+                        allowFrom: deps.allowFrom,
+                        normalizeEntry: normalizeSignalAllowRecipient,
+                      });
+                      if (!pinnedOwner) {
+                        return undefined;
+                      }
+                      return {
+                        ownerRecipient: pinnedOwner,
+                        senderRecipient: entry.senderRecipient,
+                        onSkip: ({ ownerRecipient, senderRecipient }) => {
+                          logVerbose(
+                            `signal: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                          );
+                        },
+                      };
+                    })(),
+                  }
+                : undefined,
+              onRecordError: (err) => {
+                logVerbose(`signal: failed updating session meta: ${String(err)}`);
+              },
+            },
+            history: {
+              isGroup: entry.isGroup,
+              historyKey,
+              historyMap: deps.groupHistories,
+              limit: deps.historyLimit,
+            },
+            onPreDispatchFailure: () =>
+              settleReplyDispatcher({
+                dispatcher,
+                onSettled: () => markDispatchIdle(),
+              }),
+            runDispatch: async () => {
+              try {
+                return await dispatchInboundMessage({
+                  ctx: ctxPayload,
+                  cfg: deps.cfg,
+                  dispatcher,
+                  replyOptions: {
+                    ...replyOptions,
+                    disableBlockStreaming:
+                      typeof deps.blockStreaming === "boolean" ? !deps.blockStreaming : undefined,
+                    onModelSelected,
+                    ...(statusReactions
+                      ? {
+                          onReplyStart: async () => {
+                            await replyOptions.onReplyStart?.();
+                            await statusReactions.setThinking();
+                          },
+                          onReasoningStream: async () => {
+                            await statusReactions.setThinking();
+                          },
+                          onToolStart: async (payload: { name?: string }) => {
+                            await statusReactions.setTool(payload.name);
+                          },
+                          onCompactionStart: async () => {
+                            await statusReactions.setCompacting();
+                          },
+                          onCompactionEnd: async () => {
+                            statusReactions.cancelPending();
+                            await statusReactions.setThinking();
+                          },
+                        }
+                      : {}),
+                  },
+                });
+              } finally {
+                markDispatchIdle();
+              }
+            },
+          }),
+        },
+      });
+      if (!turnResult.dispatched) {
+        if (statusReactions) {
+          void statusReactions.restoreInitial();
+        }
+        return;
+      }
+      if (statusReactions) {
+        void statusReactions.setDone();
+      }
+    } catch (err) {
+      if (statusReactions) {
+        void statusReactions.setError();
+      }
+      throw err;
+    }
   }
 
   const { debouncer: inboundDebouncer } = createChannelInboundDebouncer<SignalInboundEntry>({
@@ -933,6 +1038,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       mediaTypes: mediaTypes.length > 0 ? mediaTypes : undefined,
       commandAuthorized,
       wasMentioned: effectiveWasMentioned,
+      requireMention,
+      canDetectMention,
+      shouldBypassMention: mentionDecision.shouldBypassMention,
       replyToBody: visibleQuoteText || undefined,
       replyToSender: visibleQuoteSender,
       replyToIsQuote: visibleQuoteText ? true : undefined,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: Signal has reaction send helpers, but inbound runs never wired `messages.statusReactions.enabled` into the shared status reaction lifecycle.
- Why it matters: Signal users get no queued/thinking/tool/compacting/done/error visual feedback during long-running agent turns even when status reactions are configured.
- What changed: Create a Signal status reaction controller for eligible inbound messages, route lifecycle callbacks through `dispatchInboundMessage`, and send reactions via `sendReactionSignal` for direct and group messages.
- What did NOT change (scope boundary): No config shape changes, no Signal REST/native transport changes, and no agent/tool message-action behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72020
- Related #20393
- Related #65919
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Signal's inbound handler dispatched messages without creating a `StatusReactionController` or passing lifecycle callbacks (`onReplyStart`, `onToolStart`, compaction callbacks, terminal state handling) into `dispatchInboundMessage`.
- Missing detection / guardrail: Signal had send-reaction helper tests, but no inbound regression test for `messages.statusReactions.enabled`.
- Contributing context (if known): Other channels already wire the shared status reaction controller; Signal had the transport primitive but not the inbound lifecycle wiring.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/signal/src/monitor/event-handler.status-reactions.test.ts`
- Scenario the test should lock in: Signal direct and group inbound messages with `messages.statusReactions.enabled` send queued and done reactions through the correct direct recipient or groupId/targetAuthor route.
- Why this is the smallest reliable guardrail: It exercises the Signal inbound handler, dispatch callback wiring, and Signal reaction transport seam without needing a live Signal daemon.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Signal now honors `messages.statusReactions.enabled` for inbound runs by updating reactions on the triggering message during the agent lifecycle.

## Diagram (if applicable)

```text
Before:
Signal inbound -> dispatchInboundMessage -> no status reaction callbacks -> no lifecycle reactions

After:
Signal inbound -> StatusReactionController -> dispatch lifecycle callbacks -> sendReactionSignal -> queued/done status reactions
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux / Ubuntu 24.04
- Runtime/container: Node 22 + pnpm checkout
- Model/provider: N/A for regression test
- Integration/channel (if any): Signal
- Relevant config (redacted):

```json
{
  "messages": {
    "ackReaction": "👀",
    "ackReactionScope": "all",
    "statusReactions": {
      "enabled": true
    }
  },
  "channels": {
    "signal": {
      "dmPolicy": "open",
      "allowFrom": ["*"]
    }
  }
}
```

### Steps

1. Configure Signal with `messages.statusReactions.enabled: true`.
2. Send a Signal DM or allowed Signal group message that triggers an agent run.
3. Observe reactions on the inbound message during processing and completion.

### Expected

- Signal sends lifecycle status reactions such as queued/ack and done (plus intermediate thinking/tool/compacting when those callbacks fire).

### Actual

- Before this fix, Signal sent no automatic lifecycle status reactions because the inbound dispatch path did not wire status reaction callbacks.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Targeted verification:

- `pnpm test extensions/signal/src/monitor/event-handler.status-reactions.test.ts`
- `pnpm lint:extensions`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Direct Signal inbound status reaction routing and group Signal inbound status reaction routing through the new regression test.
- Edge cases checked: Direct recipient uses sender recipient; group reaction uses empty recipient plus `groupId` and `targetAuthor`.
- What you did **not** verify: Live Signal daemon/container end-to-end reaction delivery.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Signal reaction API failures could add noisy logs during long runs.
  - Mitigation: Reaction send failures are caught and logged through existing verbose logging; they do not fail message dispatch.
