### PR TITLE
feat(bonjour): add instanceName plugin config to override mDNS service name [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Bonjour: add `plugins.entries.bonjour.config.instanceName` to override the mDNS service instance name, so multi-gateway hosts can advertise distinct names instead of relying on the shared machine display name and getting auto-suffixed `(2)` on every restart. Fixes #54467. Thanks @jeffjhunter.
+
 ### Fixes
 
 - Gateway/Bonjour: keep @homebridge/ciao cancellation handlers registered across advertiser restarts so late probing cancellations cannot crash Linux and other mDNS-churned gateways. Thanks @codex.

--- a/docs/gateway/bonjour.md
+++ b/docs/gateway/bonjour.md
@@ -259,6 +259,7 @@ sequences (e.g. spaces become `\032`).
 
 - `openclaw plugins disable bonjour` disables LAN multicast advertising by disabling the bundled plugin.
 - `openclaw plugins enable bonjour` restores the default LAN discovery plugin.
+- `plugins.entries.bonjour.config.instanceName` overrides the mDNS service instance name. By default the service is advertised as `<machine display name> (OpenClaw)`. Set this to a unique value per gateway when running multiple OpenClaw gateways on the same host so each is discoverable on its own name instead of getting auto-suffixed `(2)` by ciao on every restart. The configured value is passed through the same `(OpenClaw)` suffix logic as the default; include `OpenClaw` anywhere in the value to skip the suffix.
 - `OPENCLAW_DISABLE_BONJOUR=1` disables LAN multicast advertising without changing plugin config; accepted truthy values are `1`, `true`, `yes`, and `on` (legacy: `OPENCLAW_DISABLE_BONJOUR`).
 - Docker Compose sets `OPENCLAW_DISABLE_BONJOUR=1` by default for bridge networking; override with `OPENCLAW_DISABLE_BONJOUR=0` only when mDNS multicast is available.
 - `gateway.bind` in `~/.openclaw/openclaw.json` controls the Gateway bind mode.

--- a/extensions/bonjour/index.test.ts
+++ b/extensions/bonjour/index.test.ts
@@ -1,0 +1,81 @@
+import type {
+  OpenClawGatewayDiscoveryAdvertiseContext,
+  OpenClawGatewayDiscoveryService,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { createTestPluginApi } from "../../test/helpers/plugins/plugin-api.js";
+
+const mocks = vi.hoisted(() => ({
+  startGatewayBonjourAdvertiser: vi.fn(),
+  registerUncaughtExceptionHandler: vi.fn(),
+  registerUnhandledRejectionHandler: vi.fn(),
+}));
+
+vi.mock("./src/advertiser.js", () => ({
+  startGatewayBonjourAdvertiser: mocks.startGatewayBonjourAdvertiser,
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime", () => ({
+  registerUncaughtExceptionHandler: mocks.registerUncaughtExceptionHandler,
+  registerUnhandledRejectionHandler: mocks.registerUnhandledRejectionHandler,
+}));
+
+const baseContext: OpenClawGatewayDiscoveryAdvertiseContext = {
+  machineDisplayName: "Mac Mini",
+  gatewayPort: 18789,
+  gatewayTlsEnabled: false,
+  minimal: false,
+};
+
+async function captureAdvertiserOpts(
+  pluginConfig: Record<string, unknown> | undefined,
+  ctx: OpenClawGatewayDiscoveryAdvertiseContext = baseContext,
+): Promise<{ instanceName: unknown }> {
+  mocks.startGatewayBonjourAdvertiser.mockReset();
+  mocks.startGatewayBonjourAdvertiser.mockResolvedValue({ stop: vi.fn() });
+
+  let registered: OpenClawGatewayDiscoveryService | undefined;
+  const api = createTestPluginApi({
+    pluginConfig,
+    registerGatewayDiscoveryService(service) {
+      registered = service;
+    },
+  });
+
+  const { default: plugin } = await import("./index.js");
+  plugin.register(api);
+  if (!registered) {
+    throw new Error("plugin did not register a gateway discovery service");
+  }
+  await registered.advertise(ctx);
+
+  const opts = mocks.startGatewayBonjourAdvertiser.mock.calls[0]?.[0];
+  return { instanceName: opts?.instanceName };
+}
+
+describe("bonjour plugin entry", () => {
+  it("falls back to ctx.machineDisplayName when no instanceName is configured", async () => {
+    const { instanceName } = await captureAdvertiserOpts(undefined);
+    expect(instanceName).toBe("Mac Mini (OpenClaw)");
+  });
+
+  it("falls back to ctx.machineDisplayName when pluginConfig.instanceName is empty/whitespace", async () => {
+    const { instanceName } = await captureAdvertiserOpts({ instanceName: "   " });
+    expect(instanceName).toBe("Mac Mini (OpenClaw)");
+  });
+
+  it("uses pluginConfig.instanceName when provided, applying the (OpenClaw) suffix", async () => {
+    const { instanceName } = await captureAdvertiserOpts({ instanceName: "AI VA PC" });
+    expect(instanceName).toBe("AI VA PC (OpenClaw)");
+  });
+
+  it("does not double-suffix when configured value already mentions OpenClaw", async () => {
+    const { instanceName } = await captureAdvertiserOpts({ instanceName: "Mac Mini (OpenClaw)" });
+    expect(instanceName).toBe("Mac Mini (OpenClaw)");
+  });
+
+  it("ignores non-string instanceName values defensively", async () => {
+    const { instanceName } = await captureAdvertiserOpts({ instanceName: 42 });
+    expect(instanceName).toBe("Mac Mini (OpenClaw)");
+  });
+});

--- a/extensions/bonjour/index.ts
+++ b/extensions/bonjour/index.ts
@@ -5,6 +5,10 @@ import {
 } from "openclaw/plugin-sdk/runtime";
 import { startGatewayBonjourAdvertiser } from "./src/advertiser.js";
 
+type BonjourPluginConfig = {
+  instanceName?: string;
+};
+
 function formatBonjourInstanceName(displayName: string) {
   const trimmed = displayName.trim();
   if (!trimmed) {
@@ -14,6 +18,15 @@ function formatBonjourInstanceName(displayName: string) {
     return trimmed;
   }
   return `${trimmed} (OpenClaw)`;
+}
+
+function resolveInstanceName(
+  pluginConfig: Record<string, unknown> | undefined,
+  machineDisplayName: string,
+): string {
+  const cfg = (pluginConfig ?? {}) as BonjourPluginConfig;
+  const configured = typeof cfg.instanceName === "string" ? cfg.instanceName.trim() : "";
+  return formatBonjourInstanceName(configured || machineDisplayName);
 }
 
 export default definePluginEntry({
@@ -26,7 +39,7 @@ export default definePluginEntry({
       advertise: async (ctx) => {
         const advertiser = await startGatewayBonjourAdvertiser(
           {
-            instanceName: formatBonjourInstanceName(ctx.machineDisplayName),
+            instanceName: resolveInstanceName(api.pluginConfig, ctx.machineDisplayName),
             gatewayPort: ctx.gatewayPort,
             gatewayTlsEnabled: ctx.gatewayTlsEnabled,
             gatewayTlsFingerprintSha256: ctx.gatewayTlsFingerprintSha256,

--- a/extensions/bonjour/openclaw.plugin.json
+++ b/extensions/bonjour/openclaw.plugin.json
@@ -6,6 +6,11 @@
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "properties": {}
+    "properties": {
+      "instanceName": {
+        "type": "string",
+        "description": "Override the mDNS service instance name (defaults to the machine display name, e.g. \"My Mac\" advertises as \"My Mac (OpenClaw)\"). Set this to a unique value per gateway when running multiple OpenClaw gateways on the same host so each can be discovered without ciao auto-suffixing duplicates as \"(2)\". The configured value is passed through the same `(OpenClaw)` suffix logic as the default; include \"OpenClaw\" anywhere in the value to skip the suffix."
+      }
+    }
   }
 }


### PR DESCRIPTION
Closes #54467.

## Summary

Adds a `plugins.entries.bonjour.config.instanceName` plugin config key so each
gateway can advertise a distinct mDNS service instance name, instead of all
gateways on the same host sharing `<machine display name> (OpenClaw)` and
getting auto-suffixed `(2)` by ciao on every restart.

The advertiser already accepted an `opts.instanceName` override
(`extensions/bonjour/src/advertiser.ts:201-205`); only the plugin entry was
missing the config-driven path. Behavior with no config set is unchanged.

## Why this fits the plugin pattern (not `gateway.bonjour.*`)

The original issue suggested `gateway.bonjour.instanceName`, but per the
plugins boundary rules in `src/plugins/CLAUDE.md` ("do not normalize
plugin-owned into core-owned by scattering direct reads of
`plugins.entries.<id>.config` through unrelated core paths"), the right scope
is the bonjour plugin's own `configSchema`. Reads happen in
`extensions/bonjour/index.ts` via `api.pluginConfig`, matching the existing
pattern in `extensions/device-pair/index.ts:299`.

## Behavior

- `plugins.entries.bonjour.config.instanceName` unset → unchanged: uses
  `ctx.machineDisplayName`, suffixed `(OpenClaw)`.
- Set to `"AI VA PC"` → advertises as `AI VA PC (OpenClaw)`.
- Set to `"My Bot (OpenClaw)"` → advertises as `My Bot (OpenClaw)` (no
  double-suffix; existing `formatBonjourInstanceName` regex already handles
  this).
- Set to empty / whitespace → falls back to machine name.
- Non-string value → falls back to machine name (defensive).

## Repro (per #54467)

Two gateway processes on the same host both derive their service instance name
from `getMachineDisplayName()` (`scutil --get ComputerName` on macOS,
`os.hostname()` elsewhere). Without an override, ciao resolves the resulting
collision by suffixing one with `(2)`:

```
+   eth0 IPv4 mac-mini (OpenClaw)         _openclaw-gw._tcp    local
+   eth0 IPv4 mac-mini (OpenClaw) (2)     _openclaw-gw._tcp    local   ← ciao auto-rename
```

The reporter notes this can shift between instances on restart. The plugin's
existing `OPENCLAW_MDNS_HOSTNAME` env var only controls the DNS hostname, not
the service instance name (it's read at `extensions/bonjour/src/advertiser.ts:195`
and only feeds the fallback `${hostname} (OpenClaw)` branch, which is bypassed
because `opts.instanceName` is always non-empty after `formatBonjourInstanceName`).

## After

```jsonc
// gateway A's openclaw.json
{
  "plugins": {
    "entries": {
      "bonjour": {
        "config": { "instanceName": "Mac Mini Primary" }
      }
    }
  }
}

// gateway B's openclaw.json
{
  "plugins": {
    "entries": {
      "bonjour": {
        "config": { "instanceName": "Mac Mini Bot" }
      }
    }
  }
}
```

```
+   eth0 IPv4 Mac Mini Primary (OpenClaw)   _openclaw-gw._tcp    local
+   eth0 IPv4 Mac Mini Bot (OpenClaw)       _openclaw-gw._tcp    local
```

Each gateway is stably discoverable on its own name across restarts.

## Files

- `extensions/bonjour/openclaw.plugin.json` — add `instanceName` to
  `configSchema.properties`.
- `extensions/bonjour/index.ts` — read `api.pluginConfig.instanceName`,
  prefer it over `ctx.machineDisplayName`, route through the existing
  `formatBonjourInstanceName` so suffix semantics match the default.
- `extensions/bonjour/index.test.ts` — new plugin-entry test (5 cases:
  unset, empty/whitespace, configured-without-suffix, configured-with-suffix,
  defensive non-string).
- `docs/gateway/bonjour.md` — document the new config key alongside the
  existing disable/configure entries.
- `CHANGELOG.md` — single-line entry under `## 2026.4.25 (Unreleased)`.

## Tests

- `pnpm test extensions/bonjour` → 32/32 pass (4 files, includes the new 5).
- `pnpm check:changed` → green (typecheck + format + tests for affected lanes).
- `pnpm build` → ok.

## AI-assisted disclosure

This PR was authored with Claude (Anthropic). I came across the bonjour plugin
while debugging an unrelated stability issue on my own installed `2026.4.24`
gateway, found #54467 still open with no PR after a month, and recognized the
fix was a minor wiring change between the plugin entry and the existing
`opts.instanceName` advertiser path. Claude read the source, traced the flow,
mirrored the existing `extensions/device-pair` `pluginConfig` pattern, and
drafted the patch + tests + docs + changelog. I reviewed every line and
verified the new config key produces the expected mDNS advertisement on my
local gateway via `avahi-browse -rt _openclaw-gw._tcp`.

Testing degree: **fully tested** locally (extension test suite green; manual
mDNS verification of the configured-name path).
