### PR TITLE
fix(codex): isolate app-server OAuth homes

### DIFF
--- a/docs/concepts/oauth.md
+++ b/docs/concepts/oauth.md
@@ -134,6 +134,9 @@ At runtime:
   Codex CLI bootstrap is intentionally narrower: it seeds an empty
   `openai-codex:default` profile, then OpenClaw-owned refreshes keep the local
   profile canonical.
+- the native Codex app-server harness uses a profile-scoped `CODEX_HOME` for
+  the selected `openai-codex:*` profile, then syncs Codex-rotated OAuth tokens
+  back into that OpenClaw profile before later app-server logins or refreshes.
 
 The refresh flow is automatic; you generally don't need to manage tokens manually.
 

--- a/docs/plugins/codex-harness.md
+++ b/docs/plugins/codex-harness.md
@@ -179,15 +179,21 @@ Codex after changing config.
 - Codex app-server `0.125.0` or newer. The bundled plugin manages a compatible
   Codex app-server binary by default, so local `codex` commands on `PATH` do
   not affect normal harness startup.
-- Codex auth available to the app-server process.
+- A usable OpenAI Codex auth profile when running subscription/OAuth-backed
+  Codex models.
 
 The plugin blocks older or unversioned app-server handshakes. That keeps
 OpenClaw on the protocol surface it has been tested against.
 
-For live and Docker smoke tests, auth usually comes from `OPENAI_API_KEY`, plus
-optional Codex CLI files such as `~/.codex/auth.json` and
-`~/.codex/config.toml`. Use the same auth material your local Codex app-server
-uses.
+For OAuth-backed harness runs, OpenClaw starts the stdio app-server with an
+isolated, profile-scoped `CODEX_HOME` and clears ambient OpenAI API-key
+environment variables before spawning Codex. Codex may rotate tokens inside
+that home; OpenClaw syncs the rotated OAuth material back into the selected
+`openai-codex:*` auth profile before later logins and refreshes.
+
+For direct API-key smoke tests, provide auth explicitly through OpenClaw's
+selected auth profile. Do not rely on a process-wide `OPENAI_API_KEY` or
+`~/.codex/auth.json` fallback for native harness turns.
 
 ## Minimal config
 

--- a/extensions/codex/src/app-server/auth-bridge.test.ts
+++ b/extensions/codex/src/app-server/auth-bridge.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
+import { ensureAuthProfileStore, upsertAuthProfile } from "openclaw/plugin-sdk/provider-auth";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyCodexAppServerAuthProfile,
@@ -51,8 +51,56 @@ afterEach(() => {
   providerRuntimeMocks.refreshProviderOAuthCredentialWithPlugin.mockClear();
 });
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 describe("bridgeCodexAppServerStartOptions", () => {
-  it("leaves Codex app-server start options unchanged", async () => {
+  it("uses a stable CODEX_HOME for the selected named OpenAI Codex profile", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const startOptions = {
+      transport: "stdio" as const,
+      command: "codex",
+      args: ["app-server"],
+      headers: { authorization: "Bearer dev-token" },
+      env: { CODEX_HOME: "/tmp/source-codex-home", EXISTING: "1" },
+      clearEnv: ["FOO"],
+    };
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "access-token",
+          refresh: "refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+        },
+      });
+
+      const bridged = await bridgeCodexAppServerStartOptions({
+        startOptions,
+        agentDir,
+        authProfileId: "openai-codex:work",
+      });
+
+      expect(bridged).not.toBe(startOptions);
+      expect(bridged.env?.EXISTING).toBe("1");
+      expect(bridged.env?.CODEX_HOME).toMatch(
+        new RegExp(`^${escapeRegExp(path.join(agentDir, "harness-auth", "codex", "profiles"))}`),
+      );
+      expect(bridged.env?.CODEX_HOME).not.toBe("/tmp/source-codex-home");
+      expect(bridged.clearEnv).toEqual(
+        expect.arrayContaining(["FOO", "OPENAI_API_KEY", "CODEX_API_KEY"]),
+      );
+      await expect(fs.access(bridged.env?.CODEX_HOME ?? "")).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves discovery starts without a selected auth profile unchanged", async () => {
     const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
     const startOptions = {
       transport: "stdio" as const,
@@ -67,12 +115,31 @@ describe("bridgeCodexAppServerStartOptions", () => {
         bridgeCodexAppServerStartOptions({
           startOptions,
           agentDir,
-          authProfileId: "openai-codex:default",
         }),
       ).resolves.toBe(startOptions);
       await expect(fs.access(path.join(agentDir, "harness-auth"))).rejects.toMatchObject({
         code: "ENOENT",
       });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when an explicit OpenAI Codex auth profile is missing", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    try {
+      await expect(
+        bridgeCodexAppServerStartOptions({
+          startOptions: {
+            transport: "stdio" as const,
+            command: "codex",
+            args: ["app-server"],
+            headers: {},
+          },
+          agentDir,
+          authProfileId: "openai-codex:missing",
+        }),
+      ).rejects.toThrow('Codex app-server auth profile "openai-codex:missing" was not found.');
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });
     }
@@ -107,6 +174,71 @@ describe("bridgeCodexAppServerStartOptions", () => {
         accessToken: "access-token",
         chatgptAccountId: "account-123",
         chatgptPlanType: null,
+      });
+    } finally {
+      await fs.rm(agentDir, { recursive: true, force: true });
+    }
+  });
+
+  it("syncs rotated Codex CODEX_HOME OAuth tokens back before app-server login", async () => {
+    const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-app-server-"));
+    const request = vi.fn(async () => ({ type: "chatgptAuthTokens" }));
+    try {
+      upsertAuthProfile({
+        agentDir,
+        profileId: "openai-codex:work",
+        credential: {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "stale-access-token",
+          refresh: "stale-refresh-token",
+          expires: Date.now() + 24 * 60 * 60_000,
+          accountId: "account-123",
+          email: "codex@example.test",
+        },
+      });
+      const bridged = await bridgeCodexAppServerStartOptions({
+        startOptions: {
+          transport: "stdio" as const,
+          command: "codex",
+          args: ["app-server"],
+          headers: {},
+        },
+        agentDir,
+        authProfileId: "openai-codex:work",
+      });
+      const expires = Date.now() + 2 * 60 * 60_000;
+      await fs.writeFile(
+        path.join(bridged.env?.CODEX_HOME ?? "", "auth.json"),
+        JSON.stringify({
+          tokens: {
+            access_token: "rotated-access-token",
+            refresh_token: "rotated-refresh-token",
+            expires_at: expires,
+            account_id: "account-123",
+            id_token: "rotated-id-token",
+          },
+        }),
+      );
+
+      await applyCodexAppServerAuthProfile({
+        client: { request } as never,
+        agentDir,
+        authProfileId: "openai-codex:work",
+      });
+
+      expect(request).toHaveBeenCalledWith("account/login/start", {
+        type: "chatgptAuthTokens",
+        accessToken: "rotated-access-token",
+        chatgptAccountId: "account-123",
+        chatgptPlanType: null,
+      });
+      expect(ensureAuthProfileStore(agentDir).profiles["openai-codex:work"]).toMatchObject({
+        type: "oauth",
+        access: "rotated-access-token",
+        refresh: "rotated-refresh-token",
+        expires,
+        idToken: "rotated-id-token",
       });
     } finally {
       await fs.rm(agentDir, { recursive: true, force: true });

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -1,3 +1,7 @@
+import { Buffer } from "node:buffer";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
 import {
   ensureAuthProfileStore,
   loadAuthProfileStoreForSecretsRuntime,
@@ -5,6 +9,7 @@ import {
   resolveApiKeyForProfile,
   saveAuthProfileStore,
   type AuthProfileCredential,
+  type AuthProfileStore,
   type OAuthCredential,
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { CodexAppServerClient } from "./client.js";
@@ -13,15 +18,38 @@ import type { ChatgptAuthTokensRefreshResponse } from "./protocol-generated/type
 import type { LoginAccountParams } from "./protocol-generated/typescript/v2/LoginAccountParams.js";
 
 const CODEX_APP_SERVER_AUTH_PROVIDER = "openai-codex";
+const CODEX_APP_SERVER_API_KEY_ENV_VARS = [
+  "OPENAI_API_KEY",
+  "OPENAI_API_KEYS",
+  "OPENAI_API_KEY_1",
+  "OPENAI_API_KEY_2",
+  "CODEX_API_KEY",
+  "ACPX_AUTH_OPENAI_API_KEY",
+  "ACPX_AUTH_CODEX_API_KEY",
+];
 
 export async function bridgeCodexAppServerStartOptions(params: {
   startOptions: CodexAppServerStartOptions;
   agentDir: string;
   authProfileId?: string;
 }): Promise<CodexAppServerStartOptions> {
-  void params.agentDir;
-  void params.authProfileId;
-  return params.startOptions;
+  const authProfileId = normalizeAuthProfileId(params.authProfileId);
+  if (!authProfileId) {
+    return params.startOptions;
+  }
+  const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+  getCodexAppServerProfileCredential(store, authProfileId);
+
+  const codexHome = resolveCodexAppServerCodexHome(params.agentDir, authProfileId);
+  await mkdir(codexHome, { recursive: true });
+  return {
+    ...params.startOptions,
+    env: {
+      ...params.startOptions.env,
+      CODEX_HOME: codexHome,
+    },
+    clearEnv: appendUnique(params.startOptions.clearEnv, CODEX_APP_SERVER_API_KEY_ENV_VARS),
+  };
 }
 
 export async function applyCodexAppServerAuthProfile(params: {
@@ -29,6 +57,10 @@ export async function applyCodexAppServerAuthProfile(params: {
   agentDir: string;
   authProfileId?: string;
 }): Promise<void> {
+  await syncCodexAppServerAuthProfileFromCodexHome({
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+  });
   const loginParams = await resolveCodexAppServerAuthProfileLoginParams({
     agentDir: params.agentDir,
     authProfileId: params.authProfileId,
@@ -50,6 +82,10 @@ export async function refreshCodexAppServerAuthTokens(params: {
   agentDir: string;
   authProfileId?: string;
 }): Promise<ChatgptAuthTokensRefreshResponse> {
+  await syncCodexAppServerAuthProfileFromCodexHome({
+    agentDir: params.agentDir,
+    authProfileId: params.authProfileId,
+  });
   const loginParams = await resolveCodexAppServerAuthProfileLoginParamsInternal({
     ...params,
     forceOAuthRefresh: true,
@@ -64,25 +100,30 @@ export async function refreshCodexAppServerAuthTokens(params: {
   };
 }
 
+function normalizeAuthProfileId(authProfileId: string | undefined): string | undefined {
+  return authProfileId?.trim() || undefined;
+}
+
+function resolveCodexAppServerCodexHome(agentDir: string, authProfileId: string): string {
+  const digest = createHash("sha256").update(authProfileId).digest("hex").slice(0, 16);
+  return path.join(agentDir, "harness-auth", "codex", "profiles", digest);
+}
+
+function appendUnique(base: readonly string[] | undefined, additions: readonly string[]): string[] {
+  return [...new Set([...(base ?? []), ...additions])];
+}
+
 async function resolveCodexAppServerAuthProfileLoginParamsInternal(params: {
   agentDir: string;
   authProfileId?: string;
   forceOAuthRefresh?: boolean;
 }): Promise<LoginAccountParams | undefined> {
-  const profileId = params.authProfileId?.trim();
+  const profileId = normalizeAuthProfileId(params.authProfileId);
   if (!profileId) {
     return undefined;
   }
   const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
-  const credential = store.profiles[profileId];
-  if (!credential) {
-    throw new Error(`Codex app-server auth profile "${profileId}" was not found.`);
-  }
-  if (!isCodexAppServerAuthProvider(credential.provider)) {
-    throw new Error(
-      `Codex app-server auth profile "${profileId}" must belong to provider "openai-codex" or a supported alias.`,
-    );
-  }
+  const credential = getCodexAppServerProfileCredential(store, profileId);
   const loginParams = await resolveLoginParamsForCredential(profileId, credential, {
     agentDir: params.agentDir,
     forceOAuthRefresh: params.forceOAuthRefresh === true,
@@ -157,8 +198,222 @@ async function resolveOAuthCredentialForCodexAppServer(
   return resolved?.apiKey ? { ...candidate, access: resolved.apiKey } : candidate;
 }
 
+async function syncCodexAppServerAuthProfileFromCodexHome(params: {
+  agentDir: string;
+  authProfileId?: string;
+}): Promise<void> {
+  const profileId = normalizeAuthProfileId(params.authProfileId);
+  if (!profileId) {
+    return;
+  }
+
+  const codexHome = resolveCodexAppServerCodexHome(params.agentDir, profileId);
+  const codexCredential = await readCodexHomeOAuthCredential(codexHome);
+  if (!codexCredential) {
+    return;
+  }
+
+  const store = loadAuthProfileStoreForSecretsRuntime(params.agentDir);
+  const credential = getCodexAppServerProfileCredential(store, profileId);
+  if (credential.type !== "oauth") {
+    return;
+  }
+
+  const existingAccountId = credential.accountId?.trim();
+  const codexAccountId = codexCredential.accountId?.trim();
+  if (existingAccountId && codexAccountId && existingAccountId !== codexAccountId) {
+    throw new Error(
+      `Codex app-server CODEX_HOME auth for profile "${profileId}" belongs to a different account.`,
+    );
+  }
+
+  const nextCredential: OAuthCredential = {
+    ...credential,
+    access: codexCredential.access,
+    refresh: codexCredential.refresh,
+    expires: codexCredential.expires,
+    accountId: codexCredential.accountId ?? credential.accountId,
+    idToken: codexCredential.idToken ?? credential.idToken,
+  };
+  if (credentialsMatch(credential, nextCredential)) {
+    return;
+  }
+
+  store.profiles[profileId] = nextCredential;
+  saveAuthProfileStore(store, params.agentDir);
+}
+
+function getCodexAppServerProfileCredential(
+  store: AuthProfileStore,
+  profileId: string,
+): AuthProfileCredential {
+  const credential = store.profiles[profileId];
+  if (!credential) {
+    throw new Error(`Codex app-server auth profile "${profileId}" was not found.`);
+  }
+  if (!isCodexAppServerAuthProvider(credential.provider)) {
+    throw new Error(
+      `Codex app-server auth profile "${profileId}" must belong to provider "openai-codex" or a supported alias.`,
+    );
+  }
+  return credential;
+}
+
 function isCodexAppServerAuthProvider(provider: string): boolean {
   return resolveProviderIdForAuth(provider) === CODEX_APP_SERVER_AUTH_PROVIDER;
+}
+
+type CodexHomeOAuthCredential = {
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  idToken?: string;
+};
+
+async function readCodexHomeOAuthCredential(
+  codexHome: string,
+): Promise<CodexHomeOAuthCredential | undefined> {
+  const authPath = path.join(codexHome, "auth.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(authPath, "utf8"));
+  } catch (error) {
+    const code =
+      typeof error === "object" && error !== null && "code" in error
+        ? String((error as { code?: unknown }).code)
+        : "";
+    if (code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const tokens = isRecord(parsed.tokens) ? parsed.tokens : undefined;
+  const access = stringFromCandidates(
+    tokens?.access_token,
+    tokens?.accessToken,
+    parsed.access_token,
+    parsed.accessToken,
+  );
+  const refresh = stringFromCandidates(
+    tokens?.refresh_token,
+    tokens?.refreshToken,
+    parsed.refresh_token,
+    parsed.refreshToken,
+  );
+  if (!access || !refresh) {
+    return undefined;
+  }
+
+  return {
+    access,
+    refresh,
+    expires:
+      numericFromCandidates(
+        tokens?.expires_at,
+        tokens?.expiresAt,
+        parsed.expires_at,
+        parsed.expiresAt,
+      ) ??
+      decodeJwtExpiryMs(access) ??
+      (await resolveCodexHomeAuthFallbackExpiry(authPath, parsed)),
+    accountId: stringFromCandidates(
+      tokens?.account_id,
+      tokens?.accountId,
+      parsed.account_id,
+      parsed.accountId,
+    ),
+    idToken: stringFromCandidates(
+      tokens?.id_token,
+      tokens?.idToken,
+      parsed.id_token,
+      parsed.idToken,
+    ),
+  };
+}
+
+async function resolveCodexHomeAuthFallbackExpiry(
+  authPath: string,
+  parsed: Record<string, unknown>,
+): Promise<number> {
+  const lastRefreshRaw = parsed.last_refresh;
+  const lastRefresh =
+    typeof lastRefreshRaw === "string" || typeof lastRefreshRaw === "number"
+      ? new Date(lastRefreshRaw).getTime()
+      : Number.NaN;
+  if (Number.isFinite(lastRefresh)) {
+    return lastRefresh + 60 * 60_000;
+  }
+  try {
+    const authStat = await stat(authPath);
+    return authStat.mtimeMs + 60 * 60_000;
+  } catch {
+    return Date.now() + 60 * 60_000;
+  }
+}
+
+function credentialsMatch(current: OAuthCredential, next: OAuthCredential): boolean {
+  return (
+    current.type === next.type &&
+    current.access === next.access &&
+    current.refresh === next.refresh &&
+    current.expires === next.expires &&
+    current.accountId === next.accountId &&
+    current.idToken === next.idToken
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringFromCandidates(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value !== "string") {
+      continue;
+    }
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function numericFromCandidates(...values: unknown[]): number | undefined {
+  for (const value of values) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string" && value.trim()) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return undefined;
+}
+
+function decodeJwtExpiryMs(token: string): number | undefined {
+  const [, payload] = token.split(".");
+  if (!payload) {
+    return undefined;
+  }
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as {
+      exp?: unknown;
+    };
+    return typeof parsed.exp === "number" && Number.isFinite(parsed.exp)
+      ? parsed.exp * 1000
+      : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function buildChatgptAuthTokensParams(


### PR DESCRIPTION
## Summary

- Problem: native Codex app-server starts with a selected `openai-codex:*` OAuth profile could still inherit ambient API-key auth when auth handoff failed or drifted.
- Why it matters: that turns an OAuth/subscription-backed Codex run into billable Platform API usage, and stale OpenClaw refresh tokens can later break sub-agent starts after Codex rotates its own auth material.
- What changed: explicit Codex app-server auth profiles now get a stable profile-scoped `CODEX_HOME`, ambient OpenAI API-key env vars are stripped for that start, missing explicit profiles fail before spawn, and Codex-rotated `auth.json` OAuth tokens sync back into the selected OpenClaw profile before later login/refresh calls.
- What did NOT change (scope boundary): unbound app-server discovery starts remain unchanged so model discovery and external smoke-test paths do not get forced into an isolated empty home.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related issue: https://github.com/openclaw/openclaw/issues/70511
- Related profile-drift issues: https://github.com/openclaw/openclaw/issues/59704, https://github.com/openclaw/openclaw/issues/57286, https://github.com/openclaw/openclaw/issues/63385, https://github.com/openclaw/openclaw/issues/63856, https://github.com/openclaw/openclaw/issues/65844
- Related PR lineage: https://github.com/openclaw/openclaw/pull/68284, https://github.com/openclaw/openclaw/pull/69990, https://github.com/openclaw/openclaw/pull/71096
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the app-server auth bridge stopped materializing a Codex home and only applied auth after startup, leaving the process boundary able to see ambient Codex/API-key auth when the selected OpenClaw profile was missing, stale, or not the old `openai-codex:default` profile.
- Missing detection / guardrail: no regression test asserted that explicit named `openai-codex:*` profiles get an isolated Codex home, clear API-key env vars, and fail closed when the explicit profile is absent.
- Contributing context: Codex can rotate OAuth refresh material in its own `CODEX_HOME/auth.json`; OpenClaw's profile store can then become stale unless the harness syncs the rotated auth back.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/auth-bridge.test.ts`
- Scenario the test should lock in: named profiles use stable profile-scoped `CODEX_HOME`, clear API-key env fallback, fail closed when explicit profile is missing, preserve discovery starts, and sync rotated Codex OAuth tokens back before login.
- Why this is the smallest reliable guardrail: the failure was in the app-server auth boundary, before any real Codex model call is needed.
- Existing test that already covers this (if any): previous tests covered app-server login/refresh but not the process auth boundary or CODEX_HOME rotation sync.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OAuth-backed native Codex app-server starts with an explicit selected profile no longer inherit `OPENAI_API_KEY`/Codex API-key environment fallback. If the selected profile is missing or wrong-provider, startup fails before spawning Codex.

## Diagram (if applicable)

```text
Before:
OpenClaw profile -> app-server login only -> Codex process can still see ambient API-key auth

After:
OpenClaw profile -> stable profile CODEX_HOME + API-key env clear -> app-server login -> token rotation syncs back
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: the harness now reads the selected profile's isolated Codex `auth.json` to sync rotated OAuth tokens back into the same OpenClaw profile. It rejects account-id mismatches and clears ambient OpenAI API-key env vars for explicit profile starts.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw worktree
- Model/provider: native Codex app-server / `openai-codex:*` auth profile
- Integration/channel (if any): Codex harness
- Relevant config (redacted): named `openai-codex:*` profile

### Steps

1. Configure a native Codex app-server run with a named `openai-codex:*` OAuth profile.
2. Start app-server through the bridge while ambient OpenAI API-key env vars are present.
3. Let Codex rotate `CODEX_HOME/auth.json`, then request app-server login/refresh again.

### Expected

- The app-server process uses the stable profile-scoped `CODEX_HOME`.
- Ambient API-key env vars are cleared for the explicit profile start.
- Rotated Codex OAuth tokens sync back into the selected OpenClaw profile.
- Missing explicit profiles fail before Codex spawn.

### Actual

- Before this change, a failed/mismapped bridge could leave start options unchanged and let Codex see ambient API-key auth.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial extensions/codex/src/app-server/auth-bridge.test.ts` passed with 12 tests; `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed` passed before the final fast-forward with 29 files / 259 tests in the changed-test lane.
- Edge cases checked: explicit missing profile fails closed; discovery starts without selected profile remain unchanged; Codex-home account-id mismatch rejects; rotated `auth.json` updates the OpenClaw OAuth credential.
- What you did **not** verify: live Codex app-server OAuth against a real ChatGPT account. A final post-fast-forward `pnpm check:changed` rerun was attempted but remained queued behind another worktree's local heavy-check lock, so it was stopped after waiting.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Codex `auth.json` schema changes could stop sync-back.
  - Mitigation: parser accepts current snake_case and camelCase token keys, falls back to JWT expiry, `last_refresh`, or file mtime.
- Risk: unbound discovery starts still see ambient auth.
  - Mitigation: this is intentionally scoped to preserve model discovery; explicit harness profile starts now fail closed instead of inheriting API-key auth.
