### PR TITLE
fix(build): exclude *.test-helpers.ts from plugin-sdk dts emit

### DIFF
--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -17,5 +17,5 @@
     "src/video-generation/types.ts",
     "src/types/**/*.d.ts"
   ],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test-helpers.ts"]
 }

--- a/tsconfig.plugin-sdk.dts.json
+++ b/tsconfig.plugin-sdk.dts.json
@@ -18,5 +18,5 @@
     "src/video-generation/types.ts",
     "src/types/**/*.d.ts"
   ],
-  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test-helpers.ts"]
 }


### PR DESCRIPTION
## Problem

`pnpm build` fails with TS2883 in the `build:plugin-sdk:dts` step:

```
error TS2883: The inferred type of 'makeQaRuntimeSurface' cannot be named
without a reference to 'Procedure' from
'@vitest/expect/node_modules/@vitest/spy'. This is likely not portable.
A type annotation is necessary.
```

Repro on a clean build (with `rm -rf dist/plugin-sdk/.tsbuildinfo` to defeat the incremental cache).

## Cause

`tsconfig.plugin-sdk.dts.json` excludes `src/**/*.test.ts` from the declaration build but **not** `src/**/*.test-helpers.ts`. The recently-added `src/plugin-sdk/qa-runtime.test-helpers.ts` (commit 905d2d8062, `test: share qa runtime fixtures`) returns an object built from `vi.fn()` calls whose inferred type references `@vitest/spy`'s `Procedure`, which is not in a path TS can portably emit in declarations.

Test helpers shaped as `*.test-helpers.ts` are vitest fixtures and have no business being part of the public plugin-sdk type surface.

## Fix

Add `"src/**/*.test-helpers.ts"` to the exclude list in `tsconfig.plugin-sdk.dts.json`. Mirrors the existing `*.test.ts` exclude.

## Note on naming

This pattern only matches files with a dot before `test-helpers` (`*.test-helpers.ts`). Files like `src/plugin-sdk/test-helpers.ts` and `src/plugin-sdk/browser-facade-test-helpers.ts` remain part of the emitted surface, which is correct — those are intentionally exported test utilities for plugin authors. Only the `qa-runtime.test-helpers.ts`-style files are excluded, which matches the established naming convention for "this is a shared fixture for tests in this directory" vs. "this is a public test API."

## Verification

```bash
rm -rf dist/plugin-sdk/.tsbuildinfo
pnpm build:plugin-sdk:dts   # passes cleanly
pnpm build                  # full build passes
```
