### PR TITLE
fix(models/auth): accept sk-ant-api03 API keys in paste-token (#72121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Bonjour: keep @homebridge/ciao cancellation handlers registered across advertiser restarts so late probing cancellations cannot crash Linux and other mDNS-churned gateways. Thanks @codex.
+- Models/auth: accept standard `sk-ant-api03-…` Anthropic API keys via `openclaw models auth paste-token --provider anthropic` in addition to the existing `sk-ant-oat01-…` setup-token prefix. The validation error now lists both supported prefixes instead of only mentioning the OAuth one. Fixes #72121. Thanks @hclsys.
 - Plugins/startup: load the default `memory-core` slot during Gateway startup when permitted so active-memory recall can call `memory_search` and `memory_get` without requiring an explicit `plugins.slots.memory` entry, while preserving `plugins.slots.memory: "none"`. Thanks @codex.
 - Plugins/CLI: prefer native require for compiled bundled plugin JavaScript before jiti so read-only config, status, device, and node commands avoid unnecessary transform overhead on slow hosts. Fixes #62842. Thanks @Effet.
 - Plugins/compat: inventory doctor-side deprecation migrations separately from runtime plugin compatibility so release sweeps preserve needed repairs while enforcing dated removal windows. Thanks @vincentkoc.

--- a/src/plugins/provider-auth-token.test.ts
+++ b/src/plugins/provider-auth-token.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  ANTHROPIC_API_KEY_PREFIX,
+  ANTHROPIC_SETUP_TOKEN_MIN_LENGTH,
+  ANTHROPIC_SETUP_TOKEN_PREFIX,
+  ANTHROPIC_TOKEN_PREFIXES,
+  buildTokenProfileId,
+  DEFAULT_TOKEN_PROFILE_NAME,
+  normalizeTokenProfileName,
+  validateAnthropicSetupToken,
+} from "./provider-auth-token.js";
+
+describe("validateAnthropicSetupToken", () => {
+  it("accepts a full sk-ant-oat01- setup token", () => {
+    const token = `${ANTHROPIC_SETUP_TOKEN_PREFIX}${"a".repeat(80)}`;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("accepts a full sk-ant-api03- API key (#72121)", () => {
+    const token = `${ANTHROPIC_API_KEY_PREFIX}${"a".repeat(80)}`;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("returns 'Required' for empty input", () => {
+    expect(validateAnthropicSetupToken("")).toBe("Required");
+    expect(validateAnthropicSetupToken("   ")).toBe("Required");
+  });
+
+  it("rejects tokens with neither known prefix and lists both in the error", () => {
+    const result = validateAnthropicSetupToken("sk-other-foobar");
+    expect(result).toBe(
+      `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX} or ${ANTHROPIC_API_KEY_PREFIX}`,
+    );
+  });
+
+  it("rejects setup-token-prefixed but too-short input with the setup-token hint", () => {
+    expect(validateAnthropicSetupToken(`${ANTHROPIC_SETUP_TOKEN_PREFIX}short`)).toBe(
+      "Token looks too short; paste the full setup-token",
+    );
+  });
+
+  it("rejects api-key-prefixed but too-short input with the API-key hint (#72121)", () => {
+    expect(validateAnthropicSetupToken(`${ANTHROPIC_API_KEY_PREFIX}short`)).toBe(
+      "Token looks too short; paste the full API key",
+    );
+  });
+
+  it("trims surrounding whitespace before validating", () => {
+    const token = `   ${ANTHROPIC_API_KEY_PREFIX}${"a".repeat(80)}   `;
+    expect(validateAnthropicSetupToken(token)).toBeUndefined();
+  });
+
+  it("ANTHROPIC_TOKEN_PREFIXES enumerates both supported prefixes", () => {
+    expect(ANTHROPIC_TOKEN_PREFIXES).toEqual([
+      ANTHROPIC_SETUP_TOKEN_PREFIX,
+      ANTHROPIC_API_KEY_PREFIX,
+    ]);
+  });
+
+  it("respects the shared minimum length boundary for both prefixes", () => {
+    const oatTokenAtBoundary = `${ANTHROPIC_SETUP_TOKEN_PREFIX}${"a".repeat(
+      ANTHROPIC_SETUP_TOKEN_MIN_LENGTH - ANTHROPIC_SETUP_TOKEN_PREFIX.length,
+    )}`;
+    const apiTokenAtBoundary = `${ANTHROPIC_API_KEY_PREFIX}${"a".repeat(
+      ANTHROPIC_SETUP_TOKEN_MIN_LENGTH - ANTHROPIC_API_KEY_PREFIX.length,
+    )}`;
+    expect(validateAnthropicSetupToken(oatTokenAtBoundary)).toBeUndefined();
+    expect(validateAnthropicSetupToken(apiTokenAtBoundary)).toBeUndefined();
+  });
+});
+
+describe("normalizeTokenProfileName", () => {
+  it("returns the default profile name when input is empty", () => {
+    expect(normalizeTokenProfileName("")).toBe(DEFAULT_TOKEN_PROFILE_NAME);
+    expect(normalizeTokenProfileName("   ")).toBe(DEFAULT_TOKEN_PROFILE_NAME);
+  });
+
+  it("slugifies arbitrary input", () => {
+    expect(normalizeTokenProfileName("My Profile!")).toBe("my-profile");
+  });
+});
+
+describe("buildTokenProfileId", () => {
+  it("composes provider and normalized name", () => {
+    expect(buildTokenProfileId({ provider: "anthropic", name: "Default" })).toBe(
+      "anthropic:default",
+    );
+  });
+});

--- a/src/plugins/provider-auth-token.ts
+++ b/src/plugins/provider-auth-token.ts
@@ -2,7 +2,17 @@ import { normalizeProviderId } from "../agents/provider-id.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 export const ANTHROPIC_SETUP_TOKEN_PREFIX = "sk-ant-oat01-";
+// Standard long-lived Anthropic API key prefix. Both prefixes are valid
+// `paste-token` inputs for the `anthropic` provider — sk-ant-oat01- for
+// OAuth setup tokens, sk-ant-api03- for direct API keys. Without this the
+// CLI rejects valid API keys with "Expected token starting with
+// sk-ant-oat01-". (#72121)
+export const ANTHROPIC_API_KEY_PREFIX = "sk-ant-api03-";
 export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 80;
+export const ANTHROPIC_TOKEN_PREFIXES = [
+  ANTHROPIC_SETUP_TOKEN_PREFIX,
+  ANTHROPIC_API_KEY_PREFIX,
+] as const;
 export const DEFAULT_TOKEN_PROFILE_NAME = "default";
 
 export function normalizeTokenProfileName(raw: string): string {
@@ -28,11 +38,14 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
+  const matchedPrefix = ANTHROPIC_TOKEN_PREFIXES.find((prefix) => trimmed.startsWith(prefix));
+  if (!matchedPrefix) {
+    return `Expected token starting with ${ANTHROPIC_TOKEN_PREFIXES.join(" or ")}`;
   }
   if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
-    return "Token looks too short; paste the full setup-token";
+    return matchedPrefix === ANTHROPIC_SETUP_TOKEN_PREFIX
+      ? "Token looks too short; paste the full setup-token"
+      : "Token looks too short; paste the full API key";
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Fixes #72121.

\`openclaw models auth paste-token --provider anthropic\` rejects valid Anthropic API keys with the standard \`sk-ant-api03-\` prefix and prints:

\`\`\`
Expected token starting with sk-ant-oat01-
\`\`\`

Both \`sk-ant-oat01-\` (OAuth setup tokens) and \`sk-ant-api03-\` (standard API keys) are documented Anthropic credential families. The CLI should accept both via paste-token.

**Fix**: \`validateAnthropicSetupToken\` now accepts either prefix via the new \`ANTHROPIC_TOKEN_PREFIXES\` array. The validation error lists both prefixes. The too-short error is tailored per matched prefix family for accuracy.

## Pre-implement audit (skill v6 rules)

| Rule | Status | Notes |
|------|--------|-------|
| Existing-helper check | PASS | Extending the existing \`validateAnthropicSetupToken\` validator and reusing \`ANTHROPIC_SETUP_TOKEN_MIN_LENGTH\`; no parallel validator introduced |
| Shared-helper-caller check | PASS | One external call site at \`src/commands/models/auth.ts:406\`; contract widened additively (sk-ant-oat01- input still accepted) |
| Broader-fix-rival scan | PASS | No rival PR for #72121 |

## Test plan

- [x] 12 new tests in \`src/plugins/provider-auth-token.test.ts\` covering:
  - Both prefix families pass full-length validation
  - Empty / whitespace-only input → \"Required\"
  - Unknown prefix → error mentions both supported prefixes
  - Too-short input → tailored \"setup-token\" vs \"API key\" hint
  - Leading/trailing whitespace trimmed before validation
  - \`ANTHROPIC_TOKEN_PREFIXES\` enumerates both prefixes in order
  - Boundary at \`ANTHROPIC_SETUP_TOKEN_MIN_LENGTH\` accepts both
- [x] \`pnpm exec vitest run src/plugins/provider-auth-token.test.ts\` — 12/12 pass
- [x] \`pnpm exec vitest run src/commands/auth-choice.test.ts src/commands/models/auth.test.ts\` — 26/26 pass (no regression in callers)
- [x] \`pnpm exec oxfmt --check\` — clean
- [x] \`pnpm exec oxlint\` — 0 warnings/errors
- [ ] CI green

## Files

| file | + | − |
|------|---|---|
| \`CHANGELOG.md\` | 1 | 0 |
| \`src/plugins/provider-auth-token.ts\` | 19 | 3 |
| \`src/plugins/provider-auth-token.test.ts\` | 86 | 0 (new) |