### PR TITLE
feat: implemented configurable label templates for spawned agent sess…

### DIFF
--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -224,8 +224,8 @@ export function createSessionsSpawnTool(
           if (!tmpl) return "";
           const taskPreview = task.slice(0, 40).replace(/[\r\n]+/g, " ").trim();
           return tmpl
-            .replace("{agentId}", requestedAgentId ?? "")
-            .replace("{taskPreview}", taskPreview);
+            .replaceAll("{agentId}", requestedAgentId ?? "")
+            .replaceAll("{taskPreview}", taskPreview);
         })();
       const resumeSessionId = readStringParam(params, "resumeSessionId");
       const modelOverride = readStringParam(params, "model");

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -210,9 +210,23 @@ export function createSessionsSpawnTool(
         );
       }
       const task = readStringParam(params, "task", { required: true });
-      const label = readStringParam(params, "label") ?? "";
+      const explicitLabel = readStringParam(params, "label");
       const runtime = params.runtime === "acp" ? "acp" : "subagent";
       const requestedAgentId = readStringParam(params, "agentId");
+      const label =
+        explicitLabel ??
+        (() => {
+          const cfg = opts?.config;
+          const perAgent = requestedAgentId
+            ? cfg?.agents?.list?.find((a) => a.id === requestedAgentId)?.subagents?.labelTemplate
+            : undefined;
+          const tmpl = perAgent ?? cfg?.agents?.defaults?.subagents?.labelTemplate;
+          if (!tmpl) return "";
+          const taskPreview = task.slice(0, 40).replace(/[\r\n]+/g, " ").trim();
+          return tmpl
+            .replace("{agentId}", requestedAgentId ?? "")
+            .replace("{taskPreview}", taskPreview);
+        })();
       const resumeSessionId = readStringParam(params, "resumeSessionId");
       const modelOverride = readStringParam(params, "model");
       const thinkingOverrideRaw = readStringParam(params, "thinking");

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -412,6 +412,8 @@ export type AgentDefaultsConfig = {
     announceTimeoutMs?: number;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). Default: false. */
     requireAgentId?: boolean;
+    /** Template for auto-generating a session label when sessions_spawn omits label. Tokens: {agentId}, {taskPreview}. Explicit label always takes precedence. */
+    labelTemplate?: string;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -117,6 +117,8 @@ export type AgentConfig = {
     model?: AgentModelConfig;
     /** Require explicit agentId in sessions_spawn (no default same-as-caller). */
     requireAgentId?: boolean;
+    /** Template for auto-generating a session label when sessions_spawn omits label. Tokens: {agentId}, {taskPreview}. Overrides agents.defaults.subagents.labelTemplate. */
+    labelTemplate?: string;
   };
   /** Optional per-agent embedded Pi overrides. */
   embeddedPi?: {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -282,6 +282,7 @@ export const AgentDefaultsSchema = z
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
         requireAgentId: z.boolean().optional(),
+        labelTemplate: z.string().max(200).optional(),
       })
       .strict()
       .optional(),

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -861,6 +861,7 @@ export const AgentEntrySchema = z
           .optional(),
         thinking: z.string().optional(),
         requireAgentId: z.boolean().optional(),
+        labelTemplate: z.string().max(200).optional(),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
Summary                                                                                                                                                                                                      
         
  - Problem: sessions_spawn accepted a plain label param with no convention or auto-prefix mechanism; in multi-agent pipelines (Manager / Extractor / Scorer / Reporter), the sessions list shows raw          
  user-supplied labels with no way to filter or identify which agent spawned a session.                                                                                                                        
  - Why it matters: Operators running multi-agent workflows must manually prefix every sessions_spawn call — fragile, discipline-dependent, and breaks when callers omit it.
  - What changed: Added a labelTemplate config field (string with {agentId} and {taskPreview} tokens) to both agents.defaults.subagents and per-agent agents.list[].subagents. When sessions_spawn is called   
  without an explicit label, the template fires as fallback. Per-agent config overrides defaults. Explicit label always wins.                                                                                  
  - What did NOT change: No change to spawn behavior, session lifecycle, registry, ACP path, or any existing config keys. Fully additive and backwards-compatible.
  
  Change Type                                               
                                                                                                                                                                                                                                                               
  - Feature
  
   Linked Issue/PR
                                                                                                                                                                                                               
  - Closes #72074                                           
  - This PR fixes a bug or regression

  Root Cause (if applicable)

  N/A — feature addition, not a bug.                                                                                                                                                                           
   
  - Root cause: N/A                                                                                                                                                                                            
  - Missing detection / guardrail: N/A                      
  - Contributing context: N/A                                                                                                                                                                                  
   
  Regression Test Plan (if applicable)                                                                                                                                                                         
                                                            
  N/A — no existing behavior changed.

  - Coverage level that should have caught this: N/A
  - Target test or file: N/A
  - If no new test is added, why not: Pure additive config + fallback path. No existing code path altered; template only fires when label is absent and labelTemplate is configured.                           
                                                                                                                                                                                                               
  User-visible / Behavior Changes                                                                                                                                                                              
                                                                                                                                                                                                               
  New optional config field labelTemplate in agents.defaults.subagents and agents.list[].subagents. No change when field is absent (default behavior unchanged).                                               
   
  Example config:
  ```                                                                                                                                                                                              
  {                                                         
    "agents": {
      "defaults": {
        "subagents": { "labelTemplate": "{agentId}-{taskPreview}" }                                                                                                                                            
      }                                                            
    }                                                                                                                                                                                                          
  }       
```                                                  
   
  Tokens: {agentId} = target agent id, {taskPreview} = first 40 chars of task (newlines stripped).
                                                                                                                                                                                                               
  Diagram
                                                                                                                                                                                                               
  Before:                                                   
  ```sessions_spawn(task, label?) -> label || ""  (no template)```
                                                                                                                                                                                                               
  After:
 ``` 
 sessions_spawn(task, label?) -> explicitLabel                                                                                                                                                                
                               ?? perAgentTemplate(agentId, task)
                               ?? defaultsTemplate(agentId, task)                                                                                                                                              
                               ?? ""
  ```
                                                                                                                                                                                                               
  Security Impact                                           

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No                                                                                                                                                                 
  - Data access scope changed? No
                                                                                                                                                                                                               
  Repro + Verification                                      

  Environment

  - OS: macOS 25.0.0                                                                                                                                                                                           
  - Runtime: Node 22+
  - Relevant config: agents.defaults.subagents.labelTemplate: "{agentId}-{taskPreview}"                                                                                                                        
                                                                                                                                                                                                               
  Steps
                                                                                                                                                                                                               
  1. Set agents.defaults.subagents.labelTemplate to "{agentId}-{taskPreview}" in config.                                                                                                                       
  2. Invoke sessions_spawn with agentId: "scorer", task: "Score all candidates", no label.
  3. Check sessions list.                                                                                                                                                                                      
                                                            
  Expected                                                                                                                                                                                                     
                                                            
  - Session label: scorer-Score all candidates                                                                                                                                                                 
   
  Actual                                                                                                                                                                                                       
                                                            
  - Before fix: label is empty string.                                                                                                                                                                         
   
  Evidence                                                                                                                                                                                                     
                                                            
  - Failing test/log before + passing after
  - Trace/log snippets
  - Screenshot/recording
  - Perf numbers (if relevant)

  Code-reviewed manually; no runtime environment available for live verification (Node 18 on dev machine, repo requires Node 22+).                                                                             
   
  Human Verification                                                                                                                                                                                           
                                                            
  - Verified scenarios: config type additions, zod schema additions (both defaults + per-agent), template substitution logic, explicit label precedence, per-agent-over-defaults precedence.                   
  - Edge cases checked: no labelTemplate configured (returns ""), no agentId provided (token replaced with ""), task longer than 40 chars (truncated), task with newlines (stripped).
  - What I did not verify: live runtime spawn with actual session list inspection.                                                                                                                             
                                                                                                                                                                                                               
  Review Conversations                                                                                                                                                                                         
                                                                                                                                                                                                               
  - I replied to or resolved every bot review conversation I addressed in this PR.
  - I left unresolved only the conversations that still need reviewer or maintainer judgment.

  Compatibility / Migration

  - Backward compatible? Yes                                                                                                                                                                                   
  - Config/env changes? Yes — new optional fields added, no existing fields changed
  - Migration needed? No                                                                                                                                                                                       
                                                            
  Risks and Mitigations                                                                                                                                                                                        
                                                            
  - Risk: Template with no tokens (e.g. "fixed-label") stamps every session with the same label.                                                                                                               
    - Mitigation: Acceptable — user-configured, documented behavior. Could add a lint warning later.
  - Risk: opts?.config is snapshotted at tool-construction time, not call time.                                                                                                                                
    - Mitigation: Consistent with all other opts?.config usage in the same function; not a regression. 