### PR TITLE
fix(feishu): emit sent hooks for normal replies

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1174,6 +1174,9 @@ export async function handleFeishuMessage(params: {
             accountId: account.accountId,
             identity,
             messageCreateTimeMs,
+            sessionKeyForInternalHooks: agentSessionKey,
+            mirrorIsGroup: isGroup,
+            mirrorGroupId: isGroup ? ctx.chatId : undefined,
           });
 
           log(
@@ -1283,6 +1286,9 @@ export async function handleFeishuMessage(params: {
         accountId: account.accountId,
         identity,
         messageCreateTimeMs,
+        sessionKeyForInternalHooks: route.sessionKey,
+        mirrorIsGroup: isGroup,
+        mirrorGroupId: isGroup ? ctx.chatId : undefined,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -5,6 +5,7 @@ type StreamingSessionStub = {
   start: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  getMessageId: ReturnType<typeof vi.fn>;
   isActive: ReturnType<typeof vi.fn>;
 };
 
@@ -19,6 +20,9 @@ const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const createReplyDispatcherWithTypingMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
+const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
+const runMessageSentMock = vi.hoisted(() => vi.fn(async () => {}));
+const triggerInternalHookMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted((): StreamingSessionStub[] => []);
 
 function mergeStreamingText(
@@ -65,6 +69,55 @@ vi.mock("./typing.js", () => ({
   addTypingIndicator: addTypingIndicatorMock,
   removeTypingIndicator: removeTypingIndicatorMock,
 }));
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getGlobalHookRunner: getGlobalHookRunnerMock,
+}));
+vi.mock("openclaw/plugin-sdk/hook-runtime", () => ({
+  buildCanonicalSentMessageHookContext: (params: Record<string, unknown>) => ({
+    ...params,
+    conversationId: params.conversationId ?? params.to,
+  }),
+  createInternalHookEvent: (
+    type: string,
+    action: string,
+    sessionKey: string,
+    context: Record<string, unknown>,
+  ) => ({
+    type,
+    action,
+    sessionKey,
+    context,
+  }),
+  fireAndForgetHook: (task: Promise<unknown>) => {
+    void task;
+  },
+  toInternalMessageSentContext: (canonical: Record<string, unknown>) => ({
+    to: canonical.to,
+    content: canonical.content,
+    success: canonical.success,
+    error: canonical.error,
+    channelId: canonical.channelId,
+    accountId: canonical.accountId,
+    conversationId: canonical.conversationId,
+    messageId: canonical.messageId,
+    isGroup: canonical.isGroup,
+    groupId: canonical.groupId,
+  }),
+  toPluginMessageContext: (canonical: Record<string, unknown>) => ({
+    channelId: canonical.channelId,
+    accountId: canonical.accountId,
+    conversationId: canonical.conversationId,
+    messageId: canonical.messageId,
+  }),
+  toPluginMessageSentEvent: (canonical: Record<string, unknown>) => ({
+    to: canonical.to,
+    content: canonical.content,
+    success: canonical.success,
+    error: canonical.error,
+    messageId: canonical.messageId,
+  }),
+  triggerInternalHook: triggerInternalHookMock,
+}));
 vi.mock("./streaming-card.js", () => {
   return {
     mergeStreamingText,
@@ -77,6 +130,7 @@ vi.mock("./streaming-card.js", () => {
       close = vi.fn(async () => {
         this.active = false;
       });
+      getMessageId = vi.fn(() => "om_stream");
       isActive = vi.fn(() => this.active);
 
       constructor() {
@@ -98,8 +152,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     vi.clearAllMocks();
     clearFeishuStreamingStartBackoffForTests();
     streamingInstances.length = 0;
-    sendMediaFeishuMock.mockResolvedValue(undefined);
-    sendStructuredCardFeishuMock.mockResolvedValue(undefined);
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn(() => false),
+      runMessageSent: runMessageSentMock,
+    });
+    triggerInternalHookMock.mockResolvedValue(undefined);
+    runMessageSentMock.mockResolvedValue(undefined);
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_text", chatId: "oc_chat" });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media", chatId: "oc_chat" });
+    sendStructuredCardFeishuMock.mockResolvedValue({ messageId: "om_card", chatId: "oc_chat" });
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",
@@ -178,6 +239,13 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       result,
       options: createReplyDispatcherWithTypingMock.mock.calls.at(-1)?.[0],
     };
+  }
+
+  function enableMessageSentHooks() {
+    getGlobalHookRunnerMock.mockReturnValue({
+      hasHooks: vi.fn((name: string) => name === "message_sent"),
+      runMessageSent: runMessageSentMock,
+    });
   }
 
   it("skips typing indicator when account typingIndicator is disabled", async () => {
@@ -269,6 +337,76 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
+  it("emits message_sent and internal message:sent for normal text replies", async () => {
+    enableMessageSentHooks();
+    const { options } = createDispatcherHarness({
+      accountId: "main",
+      sessionKeyForInternalHooks: "agent:main:feishu:oc_chat",
+      mirrorIsGroup: true,
+      mirrorGroupId: "oc_chat",
+    });
+
+    await options.deliver({ text: "plain text" }, { kind: "final" });
+
+    expect(runMessageSentMock).toHaveBeenCalledTimes(1);
+    expect(runMessageSentMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        content: "plain text",
+        success: true,
+        messageId: "om_text",
+      }),
+      expect.objectContaining({
+        channelId: "feishu",
+        accountId: "main",
+        conversationId: "oc_chat",
+        messageId: "om_text",
+      }),
+    );
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "sent",
+        sessionKey: "agent:main:feishu:oc_chat",
+        context: expect.objectContaining({
+          to: "oc_chat",
+          content: "plain text",
+          success: true,
+          channelId: "feishu",
+          accountId: "main",
+          conversationId: "oc_chat",
+          messageId: "om_text",
+          isGroup: true,
+          groupId: "oc_chat",
+        }),
+      }),
+    );
+  });
+
+  it("emits message:sent with failure details when Feishu delivery fails", async () => {
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("Feishu send failed"));
+    const { options } = createDispatcherHarness({
+      sessionKeyForInternalHooks: "agent:main:feishu:oc_chat",
+    });
+
+    await expect(options.deliver({ text: "plain text" }, { kind: "final" })).rejects.toThrow(
+      "Feishu send failed",
+    );
+
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "agent:main:feishu:oc_chat",
+        context: expect.objectContaining({
+          content: "plain text",
+          success: false,
+          error: "Feishu send failed",
+        }),
+      }),
+    );
+  });
+
   it("suppresses internal block payload delivery", async () => {
     const { options } = createDispatcherHarness();
     await options.deliver({ text: "internal reasoning chunk" }, { kind: "block" });
@@ -314,6 +452,73 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
+  });
+
+  it("emits internal message:sent after streaming card replies close", async () => {
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      sessionKeyForInternalHooks: "agent:main:feishu:oc_chat",
+    });
+
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+    expect(triggerInternalHookMock).not.toHaveBeenCalled();
+
+    await options.onIdle?.();
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "sent",
+        sessionKey: "agent:main:feishu:oc_chat",
+        context: expect.objectContaining({
+          to: "oc_chat",
+          content: "```ts\nconst x = 1\n```",
+          success: true,
+          channelId: "feishu",
+          messageId: "om_stream",
+        }),
+      }),
+    );
+  });
+
+  it("emits streaming success instead of failure when media send fails after streaming text", async () => {
+    sendMediaFeishuMock.mockRejectedValueOnce(new Error("media failed"));
+    const { options } = createDispatcherHarness({
+      runtime: createRuntimeLogger(),
+      sessionKeyForInternalHooks: "agent:main:feishu:oc_chat",
+    });
+
+    await expect(
+      options.deliver(
+        { text: "```ts\nconst x = 1\n```", mediaUrl: "https://example.com/a.png" },
+        { kind: "final" },
+      ),
+    ).rejects.toThrow("media failed");
+
+    expect(streamingInstances).toHaveLength(1);
+    expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledTimes(1);
+    expect(triggerInternalHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "message",
+        action: "sent",
+        sessionKey: "agent:main:feishu:oc_chat",
+        context: expect.objectContaining({
+          content: "```ts\nconst x = 1\n```",
+          success: true,
+          messageId: "om_stream",
+        }),
+      }),
+    );
+    expect(triggerInternalHookMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        context: expect.objectContaining({
+          success: false,
+        }),
+      }),
+    );
   });
 
   it("closes streaming with block text when final reply is missing", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -1,9 +1,18 @@
 import { logTypingFailure } from "openclaw/plugin-sdk/channel-feedback";
 import { createChannelReplyPipeline } from "openclaw/plugin-sdk/channel-reply-pipeline";
 import {
+  buildCanonicalSentMessageHookContext,
+  createInternalHookEvent,
+  fireAndForgetHook,
+  toInternalMessageSentContext,
+  toPluginMessageContext,
+  toPluginMessageSentEvent,
+  triggerInternalHook,
+} from "openclaw/plugin-sdk/hook-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
+import {
   resolveSendableOutboundReplyParts,
   resolveTextChunksWithFallback,
-  sendMediaWithLeadingCaption,
 } from "openclaw/plugin-sdk/reply-payload";
 import { stripReasoningTagsFromText } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
@@ -120,7 +129,78 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Session key for internal message:sent hooks on normal Feishu replies. */
+  sessionKeyForInternalHooks?: string;
+  mirrorIsGroup?: boolean;
+  mirrorGroupId?: string;
 };
+
+function formatHookError(error: unknown): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function emitFeishuMessageSentHooks(params: {
+  hookRunner: ReturnType<typeof getGlobalHookRunner>;
+  hasMessageSentHooks: boolean;
+  runtime: RuntimeEnv;
+  chatId: string;
+  accountId?: string;
+  sessionKeyForInternalHooks?: string;
+  mirrorIsGroup?: boolean;
+  mirrorGroupId?: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: string;
+}): void {
+  const canEmitInternalHook = Boolean(params.sessionKeyForInternalHooks);
+  if (!params.hasMessageSentHooks && !canEmitInternalHook) {
+    return;
+  }
+  const canonical = buildCanonicalSentMessageHookContext({
+    to: params.chatId,
+    content: params.content,
+    success: params.success,
+    error: params.error,
+    channelId: "feishu",
+    accountId: params.accountId,
+    conversationId: params.chatId,
+    messageId: params.messageId,
+    isGroup: params.mirrorIsGroup,
+    groupId: params.mirrorGroupId,
+  });
+  const logHookFailure = (message: string) => {
+    params.runtime.log?.(message);
+  };
+  if (params.hasMessageSentHooks) {
+    fireAndForgetHook(
+      params.hookRunner!.runMessageSent(
+        toPluginMessageSentEvent(canonical),
+        toPluginMessageContext(canonical),
+      ),
+      "feishu: message_sent plugin hook failed",
+      logHookFailure,
+    );
+  }
+  if (!canEmitInternalHook) {
+    return;
+  }
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent(
+        "message",
+        "sent",
+        params.sessionKeyForInternalHooks!,
+        toInternalMessageSentContext(canonical),
+      ),
+    ),
+    "feishu: message:sent internal hook failed",
+    logHookFailure,
+  );
+}
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
   const core = getFeishuRuntime();
@@ -136,12 +216,34 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     mentionTargets,
     accountId,
     identity,
+    sessionKeyForInternalHooks,
+    mirrorIsGroup,
+    mirrorGroupId,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
+  const hookRunner = getGlobalHookRunner();
+  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
+  const emitMessageSent = (event: {
+    content: string;
+    success: boolean;
+    error?: string;
+    messageId?: string;
+  }) =>
+    emitFeishuMessageSentHooks({
+      hookRunner,
+      hasMessageSentHooks,
+      runtime: params.runtime,
+      chatId,
+      accountId,
+      sessionKeyForInternalHooks,
+      mirrorIsGroup,
+      mirrorGroupId,
+      ...event,
+    });
 
   let typingState: TypingIndicatorState | null = null;
   const { typingCallbacks } = createChannelReplyPipeline({
@@ -225,6 +327,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let statusLine = "";
   let snapshotBaseText = "";
   let lastSnapshotTextLength = 0;
+  let streamingSentHookEmitted = false;
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
@@ -359,7 +462,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     })();
   };
 
-  const closeStreaming = async () => {
+  const closeStreaming = async (options?: { emitMessageSent?: boolean }) => {
     try {
       if (streamingStartPromise) {
         await streamingStartPromise;
@@ -372,12 +475,21 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           text = buildMentionedCardContent(mentionTargets, text);
         }
         const finalNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+        const messageId = streaming.getMessageId();
         await streaming.close(text, { note: finalNote });
         // Track the raw streamed text so the duplicate-final check in deliver()
         // can skip the redundant text delivery that arrives after onIdle closes
         // the streaming card.
         if (streamText) {
           deliveredFinalTexts.add(streamText);
+        }
+        if (options?.emitMessageSent && streamText && !streamingSentHookEmitted) {
+          streamingSentHookEmitted = true;
+          emitMessageSent({
+            content: streamText,
+            success: true,
+            messageId,
+          });
         }
       }
     } finally {
@@ -390,6 +502,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       statusLine = "";
       snapshotBaseText = "";
       lastSnapshotTextLength = 0;
+      streamingSentHookEmitted = false;
     }
   };
 
@@ -406,8 +519,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     text: string;
     useCard: boolean;
     infoKind?: string;
-    sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<void>;
-  }) => {
+    sendChunk: (params: { chunk: string; isFirst: boolean }) => Promise<{ messageId?: string }>;
+  }): Promise<{ messageId?: string } | undefined> => {
     const chunkSource = params.useCard
       ? params.text
       : core.channel.text.convertMarkdownTables(params.text, tableMode);
@@ -415,8 +528,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       chunkSource,
       core.channel.text.chunkTextWithMode(chunkSource, textChunkLimit, chunkMode),
     );
+    let lastResult: { messageId?: string } | undefined;
     for (const [index, chunk] of chunks.entries()) {
-      await params.sendChunk({
+      lastResult = await params.sendChunk({
         chunk,
         isFirst: index === 0,
       });
@@ -424,24 +538,25 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     if (params.infoKind === "final") {
       deliveredFinalTexts.add(params.text);
     }
+    return lastResult;
   };
 
-  const sendMediaReplies = async (payload: ReplyPayload) => {
-    await sendMediaWithLeadingCaption({
-      mediaUrls: resolveSendableOutboundReplyParts(payload).mediaUrls,
-      caption: "",
-      send: async ({ mediaUrl }) => {
-        await sendMediaFeishu({
-          cfg,
-          to: chatId,
-          mediaUrl,
-          replyToMessageId: sendReplyToMessageId,
-          replyInThread: effectiveReplyInThread,
-          accountId,
-          ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
-        });
-      },
-    });
+  const sendMediaReplies = async (
+    payload: ReplyPayload,
+  ): Promise<{ messageId?: string } | undefined> => {
+    let lastResult: { messageId?: string } | undefined;
+    for (const mediaUrl of resolveSendableOutboundReplyParts(payload).mediaUrls) {
+      lastResult = await sendMediaFeishu({
+        cfg,
+        to: chatId,
+        mediaUrl,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        accountId,
+        ...(payload.audioAsVoice === true ? { audioAsVoice: true } : {}),
+      });
+    }
+    return lastResult;
   };
 
   const { dispatcher, replyOptions, markDispatchIdle } =
@@ -464,95 +579,130 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         const skipTextForDuplicateFinal =
           info?.kind === "final" && hasText && deliveredFinalTexts.has(text);
         const shouldDeliverText = hasText && !skipTextForDuplicateFinal;
+        let delivered = false;
+        let messageId: string | undefined;
+        let skipFailureHook = false;
 
-        if (!shouldDeliverText && !hasMedia) {
-          return;
-        }
-
-        if (shouldDeliverText) {
-          const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
-
-          if (info?.kind === "block") {
-            // Drop internal block chunks unless we can safely consume them as
-            // streaming-card fallback content.
-            if (!(streamingEnabled && useCard)) {
-              return;
-            }
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
-            }
-          }
-
-          if (info?.kind === "final" && streamingEnabled && useCard) {
-            startStreaming();
-            if (streamingStartPromise) {
-              await streamingStartPromise;
-            }
-          }
-
-          if (streaming?.isActive()) {
-            if (info?.kind === "block") {
-              // Some runtimes emit block payloads without onPartial/final callbacks.
-              // Mirror block text into streamText so onIdle close still sends content.
-              queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
-            }
-            if (info?.kind === "final") {
-              streamText = text;
-              snapshotBaseText = "";
-              lastSnapshotTextLength = text.length;
-              flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
-            }
-            // Send media even when streaming handled the text
-            if (hasMedia) {
-              await sendMediaReplies(payload);
-            }
+        try {
+          if (!shouldDeliverText && !hasMedia) {
             return;
           }
 
-          if (useCard) {
-            const cardHeader = resolveCardHeader(agentId, identity);
-            const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
-            await sendChunkedTextReply({
-              text,
-              useCard: true,
-              infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
-                await sendStructuredCardFeishu({
-                  cfg,
-                  to: chatId,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  mentions: isFirst ? mentionTargets : undefined,
-                  accountId,
-                  header: cardHeader,
-                  note: cardNote,
-                });
-              },
-            });
-          } else {
-            await sendChunkedTextReply({
-              text,
-              useCard: false,
-              infoKind: info?.kind,
-              sendChunk: async ({ chunk, isFirst }) => {
-                await sendMessageFeishu({
-                  cfg,
-                  to: chatId,
-                  text: chunk,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  mentions: isFirst ? mentionTargets : undefined,
-                  accountId,
-                });
-              },
+          if (shouldDeliverText) {
+            const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+
+            if (info?.kind === "block") {
+              // Drop internal block chunks unless we can safely consume them as
+              // streaming-card fallback content.
+              if (!(streamingEnabled && useCard)) {
+                return;
+              }
+              startStreaming();
+              if (streamingStartPromise) {
+                await streamingStartPromise;
+              }
+            }
+
+            if (info?.kind === "final" && streamingEnabled && useCard) {
+              startStreaming();
+              if (streamingStartPromise) {
+                await streamingStartPromise;
+              }
+            }
+
+            if (streaming?.isActive()) {
+              if (info?.kind === "block") {
+                // Some runtimes emit block payloads without onPartial/final callbacks.
+                // Mirror block text into streamText so onIdle close still sends content.
+                queueStreamingUpdate(text, { mode: "delta", dedupeWithLastPartial: true });
+              }
+              if (info?.kind === "final") {
+                streamText = text;
+                snapshotBaseText = "";
+                lastSnapshotTextLength = text.length;
+                flushStreamingCardUpdate(buildCombinedStreamText(reasoningText, streamText));
+              }
+              // Send media even when streaming handled the text. The final
+              // message:sent emission happens when the streaming card closes.
+              if (hasMedia) {
+                try {
+                  await sendMediaReplies(payload);
+                } catch (error) {
+                  if (streamText && !streamingSentHookEmitted) {
+                    await closeStreaming({ emitMessageSent: true });
+                    skipFailureHook = true;
+                  }
+                  throw error;
+                }
+              }
+              return;
+            }
+
+            if (useCard) {
+              const cardHeader = resolveCardHeader(agentId, identity);
+              const cardNote = resolveCardNote(agentId, identity, prefixContext.prefixContext);
+              const result = await sendChunkedTextReply({
+                text,
+                useCard: true,
+                infoKind: info?.kind,
+                sendChunk: async ({ chunk, isFirst }) =>
+                  await sendStructuredCardFeishu({
+                    cfg,
+                    to: chatId,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    mentions: isFirst ? mentionTargets : undefined,
+                    accountId,
+                    header: cardHeader,
+                    note: cardNote,
+                  }),
+              });
+              messageId = result?.messageId;
+              delivered = true;
+            } else {
+              const result = await sendChunkedTextReply({
+                text,
+                useCard: false,
+                infoKind: info?.kind,
+                sendChunk: async ({ chunk, isFirst }) =>
+                  await sendMessageFeishu({
+                    cfg,
+                    to: chatId,
+                    text: chunk,
+                    replyToMessageId: sendReplyToMessageId,
+                    replyInThread: effectiveReplyInThread,
+                    mentions: isFirst ? mentionTargets : undefined,
+                    accountId,
+                  }),
+              });
+              messageId = result?.messageId;
+              delivered = true;
+            }
+          }
+
+          if (hasMedia) {
+            const result = await sendMediaReplies(payload);
+            messageId = result?.messageId ?? messageId;
+            delivered = true;
+          }
+
+          if (delivered) {
+            emitMessageSent({
+              content: text,
+              success: true,
+              messageId,
             });
           }
-        }
-
-        if (hasMedia) {
-          await sendMediaReplies(payload);
+        } catch (error) {
+          if (!skipFailureHook) {
+            emitMessageSent({
+              content: text,
+              success: false,
+              error: formatHookError(error),
+            });
+          }
+          throw error;
         }
       },
       onError: async (error, info) => {
@@ -563,7 +713,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         typingCallbacks?.onIdle?.();
       },
       onIdle: async () => {
-        await closeStreaming();
+        await closeStreaming({ emitMessageSent: true });
         typingCallbacks?.onIdle?.();
       },
       onCleanup: () => {

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -428,6 +428,10 @@ export class FeishuStreamingSession {
       .catch((e) => this.log?.(`Note update failed: ${String(e)}`));
   }
 
+  getMessageId(): string | undefined {
+    return this.state?.messageId;
+  }
+
   async close(finalText?: string, options?: { note?: string }): Promise<void> {
     if (!this.state || this.closed) {
       return;


### PR DESCRIPTION
## Problem
Feishu normal conversation replies are sent by `createFeishuReplyDispatcher`. Scripts listening for internal `message:sent` do not fire after those replies, so Feishu workflows that depend on successful outbound messages miss normal bot responses.

## Root cause
Feishu normal conversation replies bypass the shared outbound delivery path in `src/infra/outbound/deliver.ts`, where canonical sent-message hook emission already happens. The custom Feishu dispatcher sent text, card, media, and streaming-card replies directly without mirroring successful or failed delivery into sent hooks.

## Complete fix boundary
- Emit canonical plugin `message_sent` and internal `message:sent` from the Feishu normal reply dispatcher when hooks or a routed session key are available.
- Cover the visible normal-reply send branches in that dispatcher: plain text, structured/chunked card text, media-only/media-after-text, streaming card finalization, and delivery failures.
- Include the finalized streaming-card `messageId` in sent hooks, and avoid emitting a false failure for the delivered streaming text when only companion media delivery fails.
- Pass routed session key and group mirror metadata from both Feishu conversation entry paths: active broadcast fanout and normal routed agent dispatch.

## What intentionally did not change
- Core outbound delivery was not changed; other channels already use the generic sent-hook path or have separate surfaces.
- Feishu Drive/comment reply flows were not changed because #72125 reports normal Feishu bot conversation replies, and comment replies are a different inbound/outbound surface.
- Internal block chunks remain suppressed unless the streaming-card fallback consumes them, preserving the existing dispatcher behavior.

## Tests run
- `pnpm test extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot.broadcast.test.ts extensions/feishu/src/monitor.bot-menu.test.ts extensions/feishu/src/monitor.card-action.test.ts extensions/feishu/src/monitor.reply-once.lifecycle.test.ts extensions/feishu/src/monitor.broadcast.reply-once.lifecycle.test.ts`
- `pnpm tsgo:extensions`
- `pnpm tsgo:test:extensions`
- `pnpm lint --threads=8`
- `pnpm exec oxfmt --check extensions/feishu/src/reply-dispatcher.ts extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/bot.ts extensions/feishu/src/streaming-card.ts`
- `pnpm check:changed`
- `git diff --check -- . ':!node_modules'`

## Linked issue
Fixes #72125