### PR TITLE
fix(exec): drop "Automatic session resume failed" prefix from approval followup (#72143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Gateway/Bonjour: keep @homebridge/ciao cancellation handlers registered across advertiser restarts so late probing cancellations cannot crash Linux and other mDNS-churned gateways. Thanks @codex.
+- Exec/approval-followup: drop the user-facing `Automatic session resume failed, so sending the status directly.` prefix when the async exec follow-up has to fall back to direct delivery. The session-resume failure is now logged internally for ops debugging instead of leaking operator-level state into Telegram/DM surfaces. Fixes #72143. Thanks @hclsys.
 - Plugins/startup: load the default `memory-core` slot during Gateway startup when permitted so active-memory recall can call `memory_search` and `memory_get` without requiring an explicit `plugins.slots.memory` entry, while preserving `plugins.slots.memory: "none"`. Thanks @codex.
 - Plugins/CLI: prefer native require for compiled bundled plugin JavaScript before jiti so read-only config, status, device, and node commands avoid unnecessary transform overhead on slow hosts. Fixes #62842. Thanks @Effet.
 - Plugins/compat: inventory doctor-side deprecation migrations separately from runtime plugin compatibility so release sweeps preserve needed repairs while enforcing dated removal windows. Thanks @vincentkoc.

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -8,7 +8,12 @@ vi.mock("../infra/outbound/message.js", () => ({
   sendMessage: vi.fn(async () => ({ ok: true })),
 }));
 
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
 import { sendMessage } from "../infra/outbound/message.js";
+import { logWarn } from "../logger.js";
 import {
   buildExecApprovalFollowupPrompt,
   sendExecApprovalFollowup,
@@ -194,6 +199,37 @@ describe("exec approval followup", () => {
       expect.objectContaining({
         content: "Command did not run: approval timed out.",
         idempotencyKey: "exec-approval-followup:req-denied-resume-failed",
+      }),
+    );
+  });
+
+  it("sanitizes session resume failure logs to prevent log forging (#72148, CWE-532)", async () => {
+    const multilineError = new Error("session missing\nINJECT: fake log line\rsecond injection");
+    vi.mocked(callGatewayTool).mockRejectedValueOnce(multilineError);
+
+    await sendExecApprovalFollowup({
+      approvalId: "req-log-injection",
+      sessionKey: "agent:main:discord:channel:123",
+      turnSourceChannel: "discord",
+      turnSourceTo: "123",
+      turnSourceAccountId: "default",
+      resultText:
+        "Exec finished (gateway id=req-log-injection, session=sess_x, code 0)\nclean output",
+    });
+
+    expect(logWarn).toHaveBeenCalledTimes(1);
+    const logged = vi.mocked(logWarn).mock.calls[0]?.[0];
+    expect(typeof logged).toBe("string");
+    // Single-line invariant: no newlines or tabs survive into the log line.
+    expect(logged).not.toMatch(/[\r\n\t]/);
+    // Original error content is reduced to a flat single-line form.
+    expect(logged).toContain("session missing INJECT: fake log line second injection");
+    // Diagnostic context still present.
+    expect(logged).toContain("approvalId=req-log-injection");
+    // User-facing message is unchanged from the prefix-free path.
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "clean output",
       }),
     );
   });

--- a/src/agents/bash-tools.exec-approval-followup.test.ts
+++ b/src/agents/bash-tools.exec-approval-followup.test.ts
@@ -146,9 +146,13 @@ describe("exec approval followup", () => {
         "Exec finished (gateway id=req-session-resume-failed, session=sess_1, code 0)\nall good",
     });
 
+    // Reverted to exclude the user-facing "Automatic session resume failed,
+    // so sending the status directly." prefix per #72143 — that string leaked
+    // operator-level state into Telegram/DM surfaces. The session-resume
+    // failure is now logged internally instead.
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: "Automatic session resume failed, so sending the status directly.\n\nall good",
+        content: "all good",
         idempotencyKey: "exec-approval-followup:req-session-resume-failed",
       }),
     );
@@ -185,10 +189,10 @@ describe("exec approval followup", () => {
       resultText: "Exec denied (gateway id=req-denied-resume-failed, approval-timeout): uname -a",
     });
 
+    // Same prefix-removal as above per #72143.
     expect(sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
-        content:
-          "Automatic session resume failed, so sending the status directly.\n\nCommand did not run: approval timed out.",
+        content: "Command did not run: approval timed out.",
         idempotencyKey: "exec-approval-followup:req-denied-resume-failed",
       }),
     );

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -3,6 +3,7 @@ import {
   type ExternalBestEffortDeliveryTarget,
 } from "../infra/outbound/best-effort-delivery.js";
 import { sendMessage } from "../infra/outbound/message.js";
+import { logWarn } from "../logger.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
@@ -116,8 +117,17 @@ function formatDirectExecApprovalFollowupText(
   return sanitizeUserFacingText(parsed.raw, { errorContext: true }).trim() || null;
 }
 
-function buildSessionResumeFallbackPrefix(): string {
-  return "Automatic session resume failed, so sending the status directly.\n\n";
+function logSessionResumeFallback(params: { approvalId: string; sessionError: unknown }): void {
+  // Internal-only diagnostic. Previously this prefix was prepended to the
+  // user-facing message ("Automatic session resume failed, so sending the
+  // status directly.") which leaked operator-level state into Telegram/DM
+  // surfaces and was confusing because the underlying command often
+  // succeeded — only the session handoff failed. The prefix is now dropped
+  // from the user message and the failure is logged for ops debugging
+  // instead. (#72143)
+  logWarn(
+    `exec-approval-followup: session resume failed; falling back to direct delivery (approvalId=${params.approvalId}, error=${formatUnknownError(params.sessionError)})`,
+  );
 }
 
 function canDirectSendDeniedFollowup(sessionError: unknown): boolean {
@@ -173,13 +183,18 @@ async function sendDirectFollowupFallback(params: {
     return false;
   }
 
-  const prefix = params.sessionError ? buildSessionResumeFallbackPrefix() : "";
+  if (params.sessionError) {
+    logSessionResumeFallback({
+      approvalId: params.approvalId,
+      sessionError: params.sessionError,
+    });
+  }
   await sendMessage({
     channel: params.deliveryTarget.channel,
     to: params.deliveryTarget.to ?? "",
     accountId: params.deliveryTarget.accountId,
     threadId: params.deliveryTarget.threadId,
-    content: `${prefix}${directText}`,
+    content: directText,
     agentId: undefined,
     idempotencyKey: `exec-approval-followup:${params.approvalId}`,
   });

--- a/src/agents/bash-tools.exec-approval-followup.ts
+++ b/src/agents/bash-tools.exec-approval-followup.ts
@@ -4,6 +4,7 @@ import {
 } from "../infra/outbound/best-effort-delivery.js";
 import { sendMessage } from "../infra/outbound/message.js";
 import { logWarn } from "../logger.js";
+import { redactSensitiveText } from "../logging/redact.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../sessions/session-key-utils.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { isGatewayMessageChannel, normalizeMessageChannel } from "../utils/message-channel.js";
@@ -117,6 +118,16 @@ function formatDirectExecApprovalFollowupText(
   return sanitizeUserFacingText(parsed.raw, { errorContext: true }).trim() || null;
 }
 
+// Sanitize error text before logging it: redact known secret patterns AND
+// collapse control characters / newlines so the warn line stays single-line
+// (defends against log forging). Caps length so a giant serialized error
+// can't dominate the diagnostic stream. (aisle CWE-532 on PR #72148)
+function sanitizeErrorForLog(value: string): string {
+  return redactSensitiveText(value)
+    .replace(/[\r\n\t]+/g, " ")
+    .slice(0, 2000);
+}
+
 function logSessionResumeFallback(params: { approvalId: string; sessionError: unknown }): void {
   // Internal-only diagnostic. Previously this prefix was prepended to the
   // user-facing message ("Automatic session resume failed, so sending the
@@ -125,8 +136,10 @@ function logSessionResumeFallback(params: { approvalId: string; sessionError: un
   // succeeded — only the session handoff failed. The prefix is now dropped
   // from the user message and the failure is logged for ops debugging
   // instead. (#72143)
+  const safeError = sanitizeErrorForLog(formatUnknownError(params.sessionError));
+  const safeApprovalId = sanitizeErrorForLog(params.approvalId);
   logWarn(
-    `exec-approval-followup: session resume failed; falling back to direct delivery (approvalId=${params.approvalId}, error=${formatUnknownError(params.sessionError)})`,
+    `exec-approval-followup: session resume failed; falling back to direct delivery (approvalId=${safeApprovalId}, error=${safeError})`,
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes #72143.

When an async exec approval follow-up cannot resume the original agent session, the user previously saw:

\`\`\`
Automatic session resume failed, so sending the status directly.

<actual command output>
\`\`\`

This leaks operator-level state into Telegram / DM surfaces and is confusing because the underlying command often succeeded — only the session handoff failed. The reporter tested a local mitigation (\`return \"\";\` from \`buildSessionResumeFallbackPrefix\`) and confirmed it works.

**Fix**: drop the user-facing prefix entirely; log the resume failure as a warn line (with \`approvalId\` + error message) so ops can still debug the handoff issue without it leaking to users.

## Pre-implement audit (skill v6 rules)

| Rule | Status | Notes |
|------|--------|-------|
| Existing-helper check | PASS | \`logWarn\` already imported in adjacent \`bash-tools.exec-host-shared.ts\` / \`bash-tools.exec-runtime.ts\`; reusing same logger pattern |
| Shared-helper-caller check | PASS | \`buildSessionResumeFallbackPrefix\` had exactly one caller in this file; removal is local |
| Broader-fix-rival scan | PASS | No rival PR for #72143 |

## Test plan

- [x] \`pnpm exec vitest run src/agents/bash-tools.exec-approval-followup.test.ts\` — 14/14 pass
- [x] Two existing tests asserting the old prefix updated to assert prefix-free content (their setup paths exercise the resume-failed branch via \`mockRejectedValueOnce\`)
- [x] \`pnpm exec oxfmt --check\` — clean (after auto-format on import order)
- [x] \`pnpm exec oxlint\` — 0 warnings/errors
- [ ] CI green

## Note on retry-with-backoff

The reporter also requested retry-with-backoff before the fallback (their expected-behavior #1). I held that back to keep this diff focused on the user-visible regression — the retry change touches the gateway tool call surface and warrants its own PR with backoff timing + metrics. The prefix removal matches the reporter's tested mitigation and resolves the user-reported bug today.

## Files

| file | + | − |
|------|---|---|
| \`CHANGELOG.md\` | 1 | 0 |
| \`src/agents/bash-tools.exec-approval-followup.ts\` | 17 | 4 |
| \`src/agents/bash-tools.exec-approval-followup.test.ts\` | 9 | 3 |