### PR TITLE
fix(gateway): use -FilePath instead of -LiteralPath in Start-Process [AI-assisted]

### DIFF
--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -44,7 +44,7 @@ describe("resolveConfigOpenCommand", () => {
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        String.raw`Start-Process -LiteralPath 'C:\tmp\o''hai & calc.json'`,
+        String.raw`Start-Process -FilePath 'C:\tmp\o''hai & calc.json'`,
       ],
     });
   });

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -148,7 +148,7 @@ export function resolveConfigOpenCommand(
         "-NoProfile",
         "-NonInteractive",
         "-Command",
-        `Start-Process -LiteralPath '${escapePowerShellSingleQuotedString(configPath)}'`,
+        `Start-Process -FilePath '${escapePowerShellSingleQuotedString(configPath)}'`,
       ],
     };
   }


### PR DESCRIPTION
> 🤖 AI-assisted (Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: On Windows, the "Open Config" action in the dashboard fails with a PowerShell `ParameterBindingException` because `Start-Process` does not support the `-LiteralPath` parameter.
- Why it matters: Windows users cannot open their config file from the dashboard UI.
- What changed: Replaced `-LiteralPath` with `-FilePath` in the `Start-Process` command constructed by `resolveConfigOpenCommand`. The path is still safely escaped via `escapePowerShellSingleQuotedString`.
- What did NOT change (scope boundary): The path escaping logic is untouched. macOS/Linux paths (`open`/`xdg-open`) are untouched.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Gateway server methods (`src/gateway/server-methods/`)

## Linked Issue/PR
- Closes #69933
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `Start-Process` in PowerShell does not have a `-LiteralPath` parameter (unlike `Get-Content`, `Set-Content`, etc.). The correct parameter is `-FilePath`.
- Missing detection / guardrail: The existing test asserted the `-LiteralPath` form, so it passed but did not validate against actual PowerShell behavior.
- Contributing context: `-LiteralPath` is a common PowerShell parameter on content cmdlets, making it an easy mistake to use with `Start-Process`.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/gateway/server-methods/config.test.ts`
- Scenario the test should lock in: `resolveConfigOpenCommand` for `win32` platform produces a command using `-FilePath` (not `-LiteralPath`).
- Why this is the smallest reliable guardrail: Direct assertion on the generated command string.
- Existing test that already covers this: Updated existing test to assert `-FilePath`.

## User-visible / Behavior Changes
"Open Config" now works on Windows.

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- The path escaping via `escapePowerShellSingleQuotedString` is unchanged. `-FilePath` with single-quoted string literal provides the same injection protection as the previous `-LiteralPath` attempt.
