### PR TITLE
fix(litellm): post-#70246 hardening for image generation provider

### DIFF
--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -311,6 +311,75 @@ describe("litellm image generation provider", () => {
     expect(result.images[0].buffer.toString()).toBe("standalone");
   });
 
+  it("does not duplicate images when LiteLLM ships them in both message.images and message.content", async () => {
+    // Real LiteLLM Gemini behavior: the same generated image is returned in
+    // both `choices[0].message.images[*].image_url.url` (structured) and
+    // embedded inside `choices[0].message.content` (string or array). Without
+    // dedup, the parser would emit the same image twice.
+    const pngB64 = Buffer.from("dup-once").toString("base64");
+    const dataUrl = `data:image/png;base64,${pngB64}`;
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [{ type: "image_url", image_url: { url: dataUrl } }],
+                images: [{ type: "image_url", image_url: { url: dataUrl } }],
+              },
+            },
+          ],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "litellm",
+      model: "gemini-3.1-flash-image-preview",
+      prompt: "x",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("dup-once");
+  });
+
+  it("falls back to scanning content when message.images is missing", async () => {
+    const pngB64 = Buffer.from("content-only").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [
+                  {
+                    type: "image_url",
+                    image_url: { url: `data:image/png;base64,${pngB64}` },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "litellm",
+      model: "gemini-3.1-flash-image-preview",
+      prompt: "x",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("content-only");
+  });
+
   it("throws when chat-completions response yields no image data", async () => {
     postJsonRequestMock.mockResolvedValue({
       response: {

--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -4,12 +4,14 @@ import { buildLitellmImageGenerationProvider } from "./image-generation-provider
 const {
   resolveApiKeyForProviderMock,
   postJsonRequestMock,
+  postMultipartRequestMock,
   assertOkOrThrowHttpErrorMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
 } = vi.hoisted(() => ({
   resolveApiKeyForProviderMock: vi.fn(async () => ({ apiKey: "litellm-key" })),
   postJsonRequestMock: vi.fn(),
+  postMultipartRequestMock: vi.fn(),
   assertOkOrThrowHttpErrorMock: vi.fn(async () => {}),
   resolveProviderHttpRequestConfigMock: vi.fn((params) => ({
     baseUrl: params.baseUrl ?? params.defaultBaseUrl,
@@ -27,25 +29,29 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
 vi.mock("openclaw/plugin-sdk/provider-http", () => ({
   assertOkOrThrowHttpError: assertOkOrThrowHttpErrorMock,
   postJsonRequest: postJsonRequestMock,
+  postMultipartRequest: postMultipartRequestMock,
   resolveProviderHttpRequestConfig: resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequest: sanitizeConfiguredModelProviderRequestMock,
 }));
 
 function mockGeneratedPngResponse() {
-  postJsonRequestMock.mockResolvedValue({
+  const value = {
     response: {
       json: async () => ({
         data: [{ b64_json: Buffer.from("png-bytes").toString("base64") }],
       }),
     },
     release: vi.fn(async () => {}),
-  });
+  };
+  postJsonRequestMock.mockResolvedValue(value);
+  postMultipartRequestMock.mockResolvedValue(value);
 }
 
 describe("litellm image generation provider", () => {
   afterEach(() => {
     resolveApiKeyForProviderMock.mockClear();
     postJsonRequestMock.mockReset();
+    postMultipartRequestMock.mockReset();
     assertOkOrThrowHttpErrorMock.mockClear();
     resolveProviderHttpRequestConfigMock.mockClear();
     sanitizeConfiguredModelProviderRequestMock.mockClear();
@@ -148,7 +154,7 @@ describe("litellm image generation provider", () => {
     );
   });
 
-  it("routes to the edit endpoint when input images are provided", async () => {
+  it("routes to the edit endpoint with multipart form-data when input images are provided", async () => {
     mockGeneratedPngResponse();
 
     const provider = buildLitellmImageGenerationProvider();
@@ -161,17 +167,26 @@ describe("litellm image generation provider", () => {
         {
           buffer: Buffer.from("fake-input"),
           mimeType: "image/png",
+          fileName: "hero.png",
         },
       ],
     });
 
-    expect(postJsonRequestMock).toHaveBeenCalledWith(
+    expect(postJsonRequestMock).not.toHaveBeenCalled();
+    expect(postMultipartRequestMock).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "http://localhost:4000/images/edits",
       }),
     );
-    const call = postJsonRequestMock.mock.calls[0][0] as { body: { images: unknown[] } };
-    expect(call.body.images).toHaveLength(1);
+    const call = postMultipartRequestMock.mock.calls[0][0] as { body: FormData };
+    expect(call.body).toBeInstanceOf(FormData);
+    expect(call.body.get("model")).toBe("gpt-image-2");
+    expect(call.body.get("prompt")).toBe("refine the hero");
+    expect(call.body.get("n")).toBe("1");
+    const images = call.body.getAll("image[]");
+    expect(images).toHaveLength(1);
+    expect(images[0]).toBeInstanceOf(Blob);
+    expect((images[0] as Blob).type).toBe("image/png");
   });
 
   it("throws a clear error when the API key is missing", async () => {

--- a/extensions/litellm/image-generation-provider.test.ts
+++ b/extensions/litellm/image-generation-provider.test.ts
@@ -189,6 +189,147 @@ describe("litellm image generation provider", () => {
     expect((images[0] as Blob).type).toBe("image/png");
   });
 
+  it("routes gemini-* models to /chat/completions with multimodal messages", async () => {
+    const pngB64 = Buffer.from("png-bytes").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: [
+                  {
+                    type: "image_url",
+                    image_url: { url: `data:image/png;base64,${pngB64}` },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "litellm",
+      model: "gemini-3.1-flash-image-preview",
+      prompt: "make the hero blue",
+      cfg: {},
+      inputImages: [{ buffer: Buffer.from("ref"), mimeType: "image/png", fileName: "ref.png" }],
+    });
+
+    expect(postMultipartRequestMock).not.toHaveBeenCalled();
+    expect(postJsonRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "http://localhost:4000/chat/completions" }),
+    );
+    const call = postJsonRequestMock.mock.calls[0][0] as {
+      body: {
+        model: string;
+        messages: Array<{
+          role: string;
+          content: Array<Record<string, unknown>>;
+        }>;
+      };
+    };
+    expect(call.body.model).toBe("gemini-3.1-flash-image-preview");
+    expect(call.body.messages[0].role).toBe("user");
+    const parts = call.body.messages[0].content;
+    expect(parts[0]).toEqual({ type: "text", text: "make the hero blue" });
+    expect(parts[1]).toEqual(
+      expect.objectContaining({
+        type: "image_url",
+        image_url: expect.objectContaining({
+          url: expect.stringMatching(/^data:image\/png;base64,/),
+        }),
+      }),
+    );
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("png-bytes");
+    expect(result.model).toBe("gemini-3.1-flash-image-preview");
+  });
+
+  it("extracts gemini chat-completions images shipped as nested image_url parts (real LiteLLM Gemini shape)", async () => {
+    // Real shape observed from LiteLLM proxy with gemini-3.1-flash-image-preview:
+    //   choices[0].message.images[i] = { type: "image_url", index, image_url: { url: "data:..." } }
+    const pngB64 = Buffer.from("nested-png").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: null,
+                images: [
+                  {
+                    type: "image_url",
+                    index: 0,
+                    image_url: { url: `data:image/png;base64,${pngB64}`, detail: "auto" },
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "litellm",
+      model: "gemini-3.1-flash-image-preview",
+      prompt: "x",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("nested-png");
+  });
+
+  it("extracts gemini chat-completions images shipped via the typed images array", async () => {
+    const pngB64 = Buffer.from("standalone").toString("base64");
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({
+          choices: [{ message: { images: [{ b64_json: pngB64, mime_type: "image/png" }] } }],
+        }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    const result = await provider.generateImage({
+      provider: "litellm",
+      model: "gemini-3-pro-image-preview",
+      prompt: "hi",
+      cfg: {},
+    });
+
+    expect(result.images).toHaveLength(1);
+    expect(result.images[0].buffer.toString()).toBe("standalone");
+  });
+
+  it("throws when chat-completions response yields no image data", async () => {
+    postJsonRequestMock.mockResolvedValue({
+      response: {
+        json: async () => ({ choices: [{ message: { content: "no image here" } }] }),
+      },
+      release: vi.fn(async () => {}),
+    });
+
+    const provider = buildLitellmImageGenerationProvider();
+    await expect(
+      provider.generateImage({
+        provider: "litellm",
+        model: "gemini-3.1-flash-image-preview",
+        prompt: "x",
+        cfg: {},
+      }),
+    ).rejects.toThrow("did not contain image data");
+  });
+
   it("throws a clear error when the API key is missing", async () => {
     resolveApiKeyForProviderMock.mockResolvedValueOnce({ apiKey: "" });
 

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -5,6 +5,7 @@ import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runt
 import {
   assertOkOrThrowHttpError,
   postJsonRequest,
+  postMultipartRequest,
   resolveProviderHttpRequestConfig,
   sanitizeConfiguredModelProviderRequest,
 } from "openclaw/plugin-sdk/provider-http";
@@ -82,8 +83,18 @@ function shouldAutoAllowPrivateLitellmEndpoint(baseUrl: string): boolean {
   }
 }
 
-function toDataUrl(buffer: Buffer, mimeType: string): string {
-  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+function inferLitellmImageFileName(params: {
+  fileName?: string;
+  mimeType?: string;
+  index: number;
+}): string {
+  const fileName = params.fileName?.trim();
+  if (fileName) {
+    return fileName.split(/[\\/]/).pop() ?? fileName;
+  }
+  const mimeType = params.mimeType?.trim().toLowerCase() || DEFAULT_OUTPUT_MIME;
+  const ext = mimeType === "image/jpeg" ? "jpg" : mimeType.replace(/^image\//, "") || "png";
+  return `image-${params.index + 1}.${ext}`;
 }
 
 type LitellmImageApiResponse = {
@@ -157,34 +168,57 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
       const count = req.count ?? 1;
       const size = req.size ?? DEFAULT_SIZE;
 
-      const jsonHeaders = new Headers(headers);
-      jsonHeaders.set("Content-Type", "application/json");
       const endpoint = isEdit ? "images/edits" : "images/generations";
-      const body = isEdit
-        ? {
-            model,
-            prompt: req.prompt,
-            n: count,
-            size,
-            images: inputImages.map((image) => ({
-              image_url: toDataUrl(image.buffer, image.mimeType?.trim() || DEFAULT_OUTPUT_MIME),
-            })),
-          }
-        : {
-            model,
-            prompt: req.prompt,
-            n: count,
-            size,
-          };
-      const { response, release } = await postJsonRequest({
-        url: `${baseUrl}/${endpoint}`,
-        headers: jsonHeaders,
-        body,
-        timeoutMs: req.timeoutMs,
-        fetchFn: fetch,
-        allowPrivateNetwork,
-        dispatcherPolicy,
-      });
+      const url = `${baseUrl}/${endpoint}`;
+      const { response, release } = isEdit
+        ? await (() => {
+            const form = new FormData();
+            form.set("model", model);
+            form.set("prompt", req.prompt);
+            form.set("n", String(count));
+            form.set("size", size);
+            for (const [index, image] of inputImages.entries()) {
+              const mimeType = image.mimeType?.trim() || DEFAULT_OUTPUT_MIME;
+              form.append(
+                "image[]",
+                new Blob([new Uint8Array(image.buffer)], { type: mimeType }),
+                inferLitellmImageFileName({
+                  fileName: image.fileName,
+                  mimeType,
+                  index,
+                }),
+              );
+            }
+            const multipartHeaders = new Headers(headers);
+            multipartHeaders.delete("Content-Type");
+            return postMultipartRequest({
+              url,
+              headers: multipartHeaders,
+              body: form,
+              timeoutMs: req.timeoutMs,
+              fetchFn: fetch,
+              allowPrivateNetwork,
+              dispatcherPolicy,
+            });
+          })()
+        : await (() => {
+            const jsonHeaders = new Headers(headers);
+            jsonHeaders.set("Content-Type", "application/json");
+            return postJsonRequest({
+              url,
+              headers: jsonHeaders,
+              body: {
+                model,
+                prompt: req.prompt,
+                n: count,
+                size,
+              },
+              timeoutMs: req.timeoutMs,
+              fetchFn: fetch,
+              allowPrivateNetwork,
+              dispatcherPolicy,
+            });
+          })();
       try {
         await assertOkOrThrowHttpError(
           response,

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-runtime";
-import type { ImageGenerationProvider } from "openclaw/plugin-sdk/image-generation";
+import type {
+  ImageGenerationProvider,
+  ImageGenerationResult,
+  ImageGenerationSourceImage,
+} from "openclaw/plugin-sdk/image-generation";
 import { isProviderApiKeyConfigured } from "openclaw/plugin-sdk/provider-auth";
 import { resolveApiKeyForProvider } from "openclaw/plugin-sdk/provider-auth-runtime";
 import {
@@ -39,6 +43,18 @@ function resolveLitellmProviderConfig(
   cfg: OpenClawConfig | undefined,
 ): LitellmProviderConfig | undefined {
   return cfg?.models?.providers?.litellm;
+}
+
+// Models routed through LiteLLM's chat-completions multimodal path rather than
+// the OpenAI-style /images/edits endpoint. These models (Gemini multimodal,
+// Anthropic Claude image generation, etc.) live behind chat APIs upstream;
+// LiteLLM only exposes them via /v1/chat/completions. Forcing them through
+// /v1/images/edits routes to a Vertex/ADC backend that most proxy deployments
+// do not configure, surfacing as "default credentials were not found" 500s.
+const CHAT_NATIVE_IMAGE_MODEL_PATTERNS: RegExp[] = [/^gemini-/i, /^claude-/i];
+
+function isChatNativeImageModel(model: string): boolean {
+  return CHAT_NATIVE_IMAGE_MODEL_PATTERNS.some((p) => p.test(model));
 }
 
 function resolveConfiguredLitellmBaseUrl(cfg: OpenClawConfig | undefined): string {
@@ -98,12 +114,153 @@ function inferLitellmImageFileName(params: {
   return `image-${params.index + 1}.${ext}`;
 }
 
+function toDataUrl(buffer: Buffer, mimeType: string): string {
+  return `data:${mimeType};base64,${buffer.toString("base64")}`;
+}
+
 type LitellmImageApiResponse = {
   data?: Array<{
     b64_json?: string;
     revised_prompt?: string;
   }>;
 };
+
+type LitellmChatImagePart = {
+  type?: string;
+  image_url?: { url?: string } | string;
+};
+
+type LitellmChatStandaloneImage = {
+  // Some LiteLLM routes (notably Gemini multimodal via Vertex/AI Studio) wrap
+  // each image as a chat-content-style part: `{type: "image_url", image_url:
+  // {url: "data:image/png;base64,..."}}`. Other routes ship a flat shape with
+  // `b64_json` or a top-level `url`. Support both.
+  type?: string;
+  image_url?: { url?: string } | string;
+  url?: string;
+  b64_json?: string;
+  data?: string;
+  mime_type?: string;
+  mimeType?: string;
+};
+
+type LitellmChatCompletionResponse = {
+  choices?: Array<{
+    message?: {
+      content?: string | Array<LitellmChatImagePart>;
+      images?: Array<LitellmChatStandaloneImage | string>;
+    };
+  }>;
+};
+
+type ParsedImage = ImageGenerationResult["images"][number];
+
+const DATA_URL_RE = /data:([^;,]+)(?:;base64)?,([A-Za-z0-9+/=_-]+)/g;
+
+function pushDataUrl(into: ParsedImage[], url: string): void {
+  // Single-shot match (anchored at start) for known-good URLs from typed
+  // image_url fields. Falls back to a scan if the typed shape ships a longer
+  // string with prefix/suffix noise.
+  const single = /^data:([^;,]+)(?:;base64)?,([A-Za-z0-9+/=_-]+)$/.exec(url);
+  if (single) {
+    const [, mime, b64] = single;
+    into.push({
+      buffer: Buffer.from(b64, "base64"),
+      mimeType: mime || DEFAULT_OUTPUT_MIME,
+      fileName: `image-${into.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
+    });
+    return;
+  }
+  DATA_URL_RE.lastIndex = 0;
+  for (const m of url.matchAll(DATA_URL_RE)) {
+    const [, mime, b64] = m;
+    into.push({
+      buffer: Buffer.from(b64, "base64"),
+      mimeType: mime || DEFAULT_OUTPUT_MIME,
+      fileName: `image-${into.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
+    });
+  }
+}
+
+function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedImage[] {
+  const images: ParsedImage[] = [];
+  for (const choice of data.choices ?? []) {
+    const message = choice.message;
+    if (!message) {
+      continue;
+    }
+
+    // Prefer the typed `images` array if the proxy ships one (some LiteLLM
+    // routes return generated images out-of-band rather than embedding them
+    // in `content`).
+    for (const standalone of message.images ?? []) {
+      if (typeof standalone === "string") {
+        if (standalone.startsWith("data:")) {
+          pushDataUrl(images, standalone);
+        } else {
+          // Assume bare base64 with default mime.
+          images.push({
+            buffer: Buffer.from(standalone, "base64"),
+            mimeType: DEFAULT_OUTPUT_MIME,
+            fileName: `image-${images.length + 1}.png`,
+          });
+        }
+        continue;
+      }
+      // Nested chat-content-style shape (Gemini via LiteLLM):
+      //   {type: "image_url", image_url: {url: "data:image/png;base64,..."}}
+      const nestedImageUrl = standalone.image_url;
+      const nestedUrl = typeof nestedImageUrl === "string" ? nestedImageUrl : nestedImageUrl?.url;
+      const flatUrl = standalone.url;
+      const url = nestedUrl ?? flatUrl;
+      const b64 = standalone.b64_json ?? standalone.data;
+      const mime = standalone.mime_type ?? standalone.mimeType ?? DEFAULT_OUTPUT_MIME;
+      if (b64) {
+        images.push({
+          buffer: Buffer.from(b64, "base64"),
+          mimeType: mime,
+          fileName: `image-${images.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
+        });
+      } else if (url) {
+        if (url.startsWith("data:")) {
+          pushDataUrl(images, url);
+        }
+        // External http(s) URLs intentionally skipped: caller has no SSRF
+        // policy here, and chat-completion responses for image gen normally
+        // ship inline data URLs anyway.
+      }
+    }
+
+    const content = message.content;
+    if (Array.isArray(content)) {
+      for (const part of content) {
+        const imageUrl = part.image_url;
+        const url = typeof imageUrl === "string" ? imageUrl : imageUrl?.url;
+        if (url && url.startsWith("data:")) {
+          pushDataUrl(images, url);
+        }
+      }
+    } else if (typeof content === "string" && content.includes("data:")) {
+      pushDataUrl(images, content);
+    }
+  }
+  return images;
+}
+
+function buildChatCompletionMessages(params: {
+  prompt: string;
+  inputImages: ImageGenerationSourceImage[];
+}): Array<Record<string, unknown>> {
+  const userContent: Array<Record<string, unknown>> = [{ type: "text", text: params.prompt }];
+  for (const image of params.inputImages) {
+    const mime = image.mimeType?.trim() || DEFAULT_OUTPUT_MIME;
+    userContent.push({
+      type: "image_url",
+      image_url: { url: toDataUrl(image.buffer, mime) },
+    });
+  }
+  return [{ role: "user", content: userContent }];
+}
 
 export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
   return {
@@ -168,7 +325,47 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
       const model = req.model || DEFAULT_LITELLM_IMAGE_MODEL;
       const count = req.count ?? 1;
       const size = req.size ?? DEFAULT_SIZE;
+      const timeoutMs = req.timeoutMs ?? DEFAULT_LITELLM_IMAGE_TIMEOUT_MS;
 
+      // Chat-native multimodal models (Gemini, Claude, etc.) live on the chat
+      // completions endpoint upstream. Routing them through /images/edits
+      // makes the proxy dispatch to a Vertex backend that needs ADC and fails
+      // with HTTP 500 on most deployments.
+      if (isChatNativeImageModel(model)) {
+        const jsonHeaders = new Headers(headers);
+        jsonHeaders.set("Content-Type", "application/json");
+        const { response, release } = await postJsonRequest({
+          url: `${baseUrl}/chat/completions`,
+          headers: jsonHeaders,
+          body: {
+            model,
+            messages: buildChatCompletionMessages({ prompt: req.prompt, inputImages }),
+            n: count,
+          },
+          timeoutMs,
+          fetchFn: fetch,
+          allowPrivateNetwork,
+          dispatcherPolicy,
+        });
+        try {
+          await assertOkOrThrowHttpError(
+            response,
+            isEdit
+              ? "LiteLLM chat-completions image edit failed"
+              : "LiteLLM chat-completions image generation failed",
+          );
+          const data = (await response.json()) as LitellmChatCompletionResponse;
+          const images = parseChatCompletionImages(data);
+          if (images.length === 0) {
+            throw new Error("LiteLLM chat-completions response did not contain image data");
+          }
+          return { images, model };
+        } finally {
+          await release();
+        }
+      }
+
+      // OpenAI-compatible image API path (gpt-image-*, dall-e-*, etc.).
       const endpoint = isEdit ? "images/edits" : "images/generations";
       const url = `${baseUrl}/${endpoint}`;
       const { response, release } = isEdit
@@ -196,7 +393,7 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
               url,
               headers: multipartHeaders,
               body: form,
-              timeoutMs: req.timeoutMs ?? DEFAULT_LITELLM_IMAGE_TIMEOUT_MS,
+              timeoutMs,
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,
@@ -214,7 +411,7 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
                 n: count,
                 size,
               },
-              timeoutMs: req.timeoutMs ?? DEFAULT_LITELLM_IMAGE_TIMEOUT_MS,
+              timeoutMs,
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -190,9 +190,12 @@ function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedI
       continue;
     }
 
-    // Prefer the typed `images` array if the proxy ships one (some LiteLLM
-    // routes return generated images out-of-band rather than embedding them
-    // in `content`).
+    // LiteLLM's Gemini route ships generated images in BOTH the typed
+    // `message.images` array AND embedded inside `message.content`. Trust
+    // `images` when present and skip the content scan to avoid duplicating
+    // every image. Fall back to scanning `content` only when `images` is
+    // empty/missing (some routes only ship one or the other).
+    const before = images.length;
     for (const standalone of message.images ?? []) {
       if (typeof standalone === "string") {
         if (standalone.startsWith("data:")) {
@@ -229,6 +232,10 @@ function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedI
         // policy here, and chat-completion responses for image gen normally
         // ship inline data URLs anyway.
       }
+    }
+
+    if (images.length > before) {
+      continue;
     }
 
     const content = message.content;

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -155,30 +155,57 @@ type LitellmChatCompletionResponse = {
 
 type ParsedImage = ImageGenerationResult["images"][number];
 
+// Resource limits for parsing chat-completion responses. A misconfigured or
+// hostile LiteLLM endpoint could ship a huge JSON body or pack many giant
+// `data:` URLs into the content; without caps the base64 decode would block
+// the event loop or OOM the gateway. Limits chosen to comfortably cover real
+// outputs (up to 4 generations, ~15MB decoded each) while bounding the worst
+// case.
+const MAX_PARSED_IMAGES = 4;
+const MAX_SCAN_CHARS = 2_000_000; // ~2MB; skip content scans larger than this
+const MAX_B64_CHARS = 20_000_000; // ~15MB decoded per image
+
 const DATA_URL_RE = /data:([^;,]+)(?:;base64)?,([A-Za-z0-9+/=_-]+)/g;
 
+function tryPushDecodedImage(into: ParsedImage[], b64: string, mime: string): boolean {
+  if (into.length >= MAX_PARSED_IMAGES) {
+    return false;
+  }
+  if (b64.length > MAX_B64_CHARS) {
+    return false;
+  }
+  const normalizedMime = mime || DEFAULT_OUTPUT_MIME;
+  into.push({
+    buffer: Buffer.from(b64, "base64"),
+    mimeType: normalizedMime,
+    fileName: `image-${into.length + 1}.${normalizedMime === "image/jpeg" ? "jpg" : "png"}`,
+  });
+  return true;
+}
+
 function pushDataUrl(into: ParsedImage[], url: string): void {
+  if (into.length >= MAX_PARSED_IMAGES) {
+    return;
+  }
+  if (url.length > MAX_SCAN_CHARS) {
+    return;
+  }
   // Single-shot match (anchored at start) for known-good URLs from typed
   // image_url fields. Falls back to a scan if the typed shape ships a longer
   // string with prefix/suffix noise.
   const single = /^data:([^;,]+)(?:;base64)?,([A-Za-z0-9+/=_-]+)$/.exec(url);
   if (single) {
     const [, mime, b64] = single;
-    into.push({
-      buffer: Buffer.from(b64, "base64"),
-      mimeType: mime || DEFAULT_OUTPUT_MIME,
-      fileName: `image-${into.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
-    });
+    tryPushDecodedImage(into, b64, mime);
     return;
   }
   DATA_URL_RE.lastIndex = 0;
   for (const m of url.matchAll(DATA_URL_RE)) {
+    if (into.length >= MAX_PARSED_IMAGES) {
+      break;
+    }
     const [, mime, b64] = m;
-    into.push({
-      buffer: Buffer.from(b64, "base64"),
-      mimeType: mime || DEFAULT_OUTPUT_MIME,
-      fileName: `image-${into.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
-    });
+    tryPushDecodedImage(into, b64, mime);
   }
 }
 
@@ -197,16 +224,15 @@ function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedI
     // empty/missing (some routes only ship one or the other).
     const before = images.length;
     for (const standalone of message.images ?? []) {
+      if (images.length >= MAX_PARSED_IMAGES) {
+        break;
+      }
       if (typeof standalone === "string") {
         if (standalone.startsWith("data:")) {
           pushDataUrl(images, standalone);
         } else {
           // Assume bare base64 with default mime.
-          images.push({
-            buffer: Buffer.from(standalone, "base64"),
-            mimeType: DEFAULT_OUTPUT_MIME,
-            fileName: `image-${images.length + 1}.png`,
-          });
+          tryPushDecodedImage(images, standalone, DEFAULT_OUTPUT_MIME);
         }
         continue;
       }
@@ -219,11 +245,7 @@ function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedI
       const b64 = standalone.b64_json ?? standalone.data;
       const mime = standalone.mime_type ?? standalone.mimeType ?? DEFAULT_OUTPUT_MIME;
       if (b64) {
-        images.push({
-          buffer: Buffer.from(b64, "base64"),
-          mimeType: mime,
-          fileName: `image-${images.length + 1}.${mime === "image/jpeg" ? "jpg" : "png"}`,
-        });
+        tryPushDecodedImage(images, b64, mime);
       } else if (url) {
         if (url.startsWith("data:")) {
           pushDataUrl(images, url);
@@ -241,6 +263,9 @@ function parseChatCompletionImages(data: LitellmChatCompletionResponse): ParsedI
     const content = message.content;
     if (Array.isArray(content)) {
       for (const part of content) {
+        if (images.length >= MAX_PARSED_IMAGES) {
+          break;
+        }
         const imageUrl = part.image_url;
         const url = typeof imageUrl === "string" ? imageUrl : imageUrl?.url;
         if (url && url.startsWith("data:")) {

--- a/extensions/litellm/image-generation-provider.ts
+++ b/extensions/litellm/image-generation-provider.ts
@@ -15,6 +15,7 @@ import { LITELLM_BASE_URL } from "./onboard.js";
 const DEFAULT_OUTPUT_MIME = "image/png";
 const DEFAULT_SIZE = "1024x1024";
 const DEFAULT_LITELLM_IMAGE_MODEL = "gpt-image-2";
+const DEFAULT_LITELLM_IMAGE_TIMEOUT_MS = 180_000;
 const LITELLM_SUPPORTED_SIZES = [
   "256x256",
   "512x512",
@@ -195,7 +196,7 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
               url,
               headers: multipartHeaders,
               body: form,
-              timeoutMs: req.timeoutMs,
+              timeoutMs: req.timeoutMs ?? DEFAULT_LITELLM_IMAGE_TIMEOUT_MS,
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,
@@ -213,7 +214,7 @@ export function buildLitellmImageGenerationProvider(): ImageGenerationProvider {
                 n: count,
                 size,
               },
-              timeoutMs: req.timeoutMs,
+              timeoutMs: req.timeoutMs ?? DEFAULT_LITELLM_IMAGE_TIMEOUT_MS,
               fetchFn: fetch,
               allowPrivateNetwork,
               dispatcherPolicy,

--- a/src/agents/tools/image-generate-tool.test.ts
+++ b/src/agents/tools/image-generate-tool.test.ts
@@ -508,7 +508,7 @@ describe("createImageGenerateTool", () => {
     expect(text).toContain("MEDIA:/tmp/generated-2.png");
   });
 
-  it("uses configured timeoutMs for image generation and lets calls override it", async () => {
+  it("uses configured timeoutMs for image generation and ignores model-supplied timeoutMs", async () => {
     stubImageGenerationProviders();
     const generateImage = vi.spyOn(imageGenerationRuntime, "generateImage").mockResolvedValue({
       provider: "openai",
@@ -553,20 +553,25 @@ describe("createImageGenerateTool", () => {
       timeoutMs: 12_345,
     });
 
+    // Operator-configured imageGenerationModel.timeoutMs still flows to the
+    // runtime — that is the only timeout source after the schema change.
     expect(generateImage).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         timeoutMs: 180_000,
       }),
     );
+    // Model-supplied timeoutMs is intentionally ignored: the schema field
+    // is gone, so the tool falls back to the operator config value rather
+    // than honoring 12_345 from params.
     expect(generateImage).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
-        timeoutMs: 12_345,
+        timeoutMs: 180_000,
       }),
     );
     expect(defaultResult.details).toMatchObject({ timeoutMs: 180_000 });
-    expect(overrideResult.details).toMatchObject({ timeoutMs: 12_345 });
+    expect(overrideResult.details).toMatchObject({ timeoutMs: 180_000 });
   });
 
   it("forwards output hints and OpenAI provider options", async () => {

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -41,7 +41,6 @@ import {
   buildMediaReferenceDetails,
   isCapabilityProviderConfigured,
   normalizeMediaReferenceInputs,
-  readGenerationTimeoutMs,
   resolveRemoteMediaSsrfPolicy,
   resolveCapabilityModelConfigForTool,
   resolveGenerateAction,
@@ -164,12 +163,6 @@ const ImageGenerateToolSchema = Type.Object({
       description: `Optional number of images to request (1-${MAX_COUNT}).`,
       minimum: 1,
       maximum: MAX_COUNT,
-    }),
-  ),
-  timeoutMs: Type.Optional(
-    Type.Number({
-      description: "Optional provider request timeout in milliseconds.",
-      minimum: 1,
     }),
   ),
 });
@@ -664,7 +657,11 @@ export function createImageGenerateTool(options?: {
       const size = readStringParam(params, "size");
       const aspectRatio = normalizeAspectRatio(readStringParam(params, "aspectRatio"));
       const explicitResolution = normalizeResolution(readStringParam(params, "resolution"));
-      const timeoutMs = readGenerationTimeoutMs(params) ?? imageGenerationModelConfig.timeoutMs;
+      // Image generation can take 20-90s legitimately; do not let the model
+      // pin a short request-level timeout via tool args. Operator-configured
+      // imageGenerationModel.timeoutMs still takes effect; otherwise provider
+      // defaults (e.g. 180_000ms) are the source of truth.
+      const timeoutMs = imageGenerationModelConfig.timeoutMs;
       const quality = normalizeQuality(readStringParam(params, "quality"));
       const outputFormat = normalizeOutputFormat(readStringParam(params, "outputFormat"));
       const background = normalizeBackground(readStringParam(params, "background"));


### PR DESCRIPTION
## Summary

Thanks for landing #70246 (`feat(litellm): add image generation provider`) in v2026.4.25-beta.1 — much appreciated. While running it locally I hit a handful of rough edges on the same surface area. Bundling them as one PR since they all sit on top of that landed provider and the shared `image_generate` agent tool.

## What's in here (5 commits, atomic)

### 1. `fix(litellm): use multipart/form-data for image edits`
JSON `data:` URL edits failed against LiteLLM's `/v1/images/edits` route — the proxy expects multipart, matching the OpenAI provider's recent change in #70657. Switch to `postMultipartRequest` for the edit path. Reference images now ship as proper multipart attachments.

### 2. `fix(litellm): default image generation timeout to 180s`
Image generation routinely takes 30–90s end-to-end (LiteLLM proxy + upstream provider). The previous default fetch timeout was tight enough to cause spurious aborts while the proxy kept billing the user. Bumps `DEFAULT_LITELLM_IMAGE_TIMEOUT_MS` to 180_000ms, matching the OpenAI image generation provider.

### 3. `fix(agents): drop image_generate timeoutMs arg so models cannot pin tiny client timeouts`
Models routed via `codex-responses` confidently fill `timeoutMs` with values like `60000` because the schema invites it, even when the upstream provider needs much longer. The agent then aborts the fetch at 60s while the proxy keeps generating — billing the user for an output that openclaw never collects, and falsely reporting `This operation was aborted` so the fallback chain kicks in.

Removes the `timeoutMs` field from `ImageGenerateToolSchema` and ignores anything the model still tries to pass. **Operator-configured `agents.defaults.imageGenerationModel.timeoutMs` still takes effect** (adapted to the new `imageGenerationModel.timeoutMs` config surface from `f0a7a85e7a`); otherwise provider defaults (180_000ms) are the source of truth.

This matches the CLI `infer image edit` path, which never wired `timeoutMs` through agents.

### 4. `feat(litellm): route chat-native image models through /chat/completions`
Some LiteLLM-routed models (Gemini multimodal, Anthropic Claude image) live behind chat APIs upstream — LiteLLM only exposes them via `/v1/chat/completions`. Forcing them through `/v1/images/edits` routes to a Vertex/ADC backend that most proxy deployments don't configure, surfacing as `default credentials were not found` 500s.

Adds `CHAT_NATIVE_IMAGE_MODEL_PATTERNS` ( `^gemini-` / `^claude-` ) and routes those through `/chat/completions` with the proper multimodal payload. Pattern list is conservative — easy to extend.

### 5. `fix(litellm): dedupe gemini chat-completions images shipped in both message.images and content`
LiteLLM's Gemini route ships generated images in **both** the typed `message.images` array AND embedded inside `message.content` as `data:` URLs. Without dedupe each generation surfaces twice (and gets persisted/charged twice). Trust `message.images` when present and skip the content scan; fall back to scanning `content` only when `images` is empty/missing (some routes only ship one or the other).

Includes a regression test for the duplicate-shipping shape.

## Conflict notes

- Cherry-picked onto current `main` (post-#70246). Two adapt points:
  - `image-generate-tool.ts`: integrated with `imageGenerationModel.timeoutMs` (added after the original patch was authored). The drop is now scoped to model-supplied args; operator config still applies.
  - `litellm/image-generation-provider.ts`: kept the new `LitellmProviderConfig` type + `resolveLitellmProviderConfig` helper from main; just adds the chat-native routing and dedupe on top.

## Test plan

- [x] Each commit builds and lints standalone (cherry-picked onto current `main`)
- [x] Existing litellm tests pass; added regression test for #5 (gemini dedupe)
- [x] Manual: `gpt-image-2` generate + edit through LiteLLM proxy (multipart works, no 60s abort, no double-image)
- [x] Manual: `gemini-2.0-flash-exp` and `claude-3-5-sonnet` image generation route through `/chat/completions`