### PR TITLE
feat(plugins): expose cron lifecycle hook

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -99,6 +99,10 @@ observation-only.
 
 - `subagent_spawning` / `subagent_delivery_target` / `subagent_spawned` / `subagent_ended` — coordinate subagent routing and completion delivery
 
+**Cron**
+
+- `cron_lifecycle` — observe scheduled job start and finish events for both `agentTurn` and `systemEvent` jobs
+
 **Lifecycle**
 
 - `gateway_start` / `gateway_stop` — start or stop plugin-owned services with the Gateway
@@ -263,6 +267,35 @@ resources.
 
 Do not rely on the internal `gateway:startup` hook for plugin-owned runtime
 services.
+
+## Cron lifecycle
+
+Use `cron_lifecycle` when a plugin needs an enforced audit or telemetry trail
+for scheduled work without asking the agent to self-report. The hook fires
+after the cron service emits `started` and `finished` events, before legacy
+completion webhooks and failure notifications run.
+
+The event includes stable job identity and execution fields:
+
+```typescript
+api.on("cron_lifecycle", async (event, ctx) => {
+  await audit.write({
+    jobId: event.jobId,
+    jobName: event.jobName,
+    action: event.action, // "started" | "finished"
+    payloadKind: event.payloadKind, // "agentTurn" | "systemEvent"
+    agentId: event.agentId,
+    status: event.status,
+    durationMs: event.durationMs,
+    error: event.error,
+    storePath: ctx.storePath,
+  });
+});
+```
+
+`started` events include `runAtMs`. `finished` events can also include
+`status`, `durationMs`, `error`, `summary`, delivery status, session
+correlation, model/provider telemetry, and `nextRunAtMs` when available.
 
 ## Upcoming deprecations
 

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -14,6 +14,8 @@ const {
   fetchWithSsrFGuardMock,
   runCronIsolatedAgentTurnMock,
   cleanupBrowserSessionsForLifecycleEndMock,
+  hasHooksMock,
+  runCronLifecycleMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatNowMock: vi.fn(),
@@ -24,6 +26,8 @@ const {
   fetchWithSsrFGuardMock: vi.fn(),
   runCronIsolatedAgentTurnMock: vi.fn(async () => ({ status: "ok" as const, summary: "ok" })),
   cleanupBrowserSessionsForLifecycleEndMock: vi.fn(async () => {}),
+  hasHooksMock: vi.fn(),
+  runCronLifecycleMock: vi.fn(async () => {}),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -77,6 +81,13 @@ vi.mock("../browser-lifecycle-cleanup.js", () => ({
   cleanupBrowserSessionsForLifecycleEnd: cleanupBrowserSessionsForLifecycleEndMock,
 }));
 
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => ({
+    hasHooks: hasHooksMock,
+    runCronLifecycle: runCronLifecycleMock,
+  }),
+}));
+
 import { buildGatewayCronService } from "./server-cron.js";
 
 function createCronConfig(name: string): OpenClawConfig {
@@ -100,6 +111,9 @@ describe("buildGatewayCronService", () => {
     fetchWithSsrFGuardMock.mockClear();
     runCronIsolatedAgentTurnMock.mockClear();
     cleanupBrowserSessionsForLifecycleEndMock.mockClear();
+    hasHooksMock.mockReset();
+    runCronLifecycleMock.mockClear();
+    hasHooksMock.mockReturnValue(false);
   });
 
   it("routes main-target jobs to the scoped session for enqueue + wake", async () => {
@@ -427,6 +441,73 @@ describe("buildGatewayCronService", () => {
             }),
           }),
         }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it.each([
+    {
+      name: "agentTurn",
+      payload: { kind: "agentTurn" as const, message: "run report" },
+      sessionTarget: "isolated" as const,
+    },
+    {
+      name: "systemEvent",
+      payload: { kind: "systemEvent" as const, text: "check inbox" },
+      sessionTarget: "main" as const,
+    },
+  ])("emits cron_lifecycle start and finish hooks for $name jobs", async (jobInput) => {
+    const cfg = createCronConfig(`server-cron-lifecycle-${jobInput.name}`);
+    loadConfigMock.mockReturnValue(cfg);
+    hasHooksMock.mockImplementation((hookName) => hookName === "cron_lifecycle");
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: `${jobInput.name}-lifecycle`,
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: jobInput.sessionTarget,
+        wakeMode: "next-heartbeat",
+        payload: jobInput.payload,
+      });
+
+      await state.cron.run(job.id, "force");
+
+      await vi.waitFor(() => expect(runCronLifecycleMock).toHaveBeenCalledTimes(2));
+      expect(runCronLifecycleMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          jobId: job.id,
+          jobName: `${jobInput.name}-lifecycle`,
+          agentId: "main",
+          action: "started",
+          payloadKind: jobInput.payload.kind,
+          sessionTarget: jobInput.sessionTarget,
+          wakeMode: "next-heartbeat",
+          runAtMs: expect.any(Number),
+        }),
+        { storePath: cfg.cron?.store },
+      );
+      expect(runCronLifecycleMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          jobId: job.id,
+          jobName: `${jobInput.name}-lifecycle`,
+          agentId: "main",
+          action: "finished",
+          payloadKind: jobInput.payload.kind,
+          status: "ok",
+          durationMs: expect.any(Number),
+          nextRunAtMs: expect.any(Number),
+        }),
+        { storePath: cfg.cron?.store },
       );
     } finally {
       state.cron.stop();

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -22,9 +22,10 @@ import {
   resolveCronRunLogPath,
   resolveCronRunLogPruneOptions,
 } from "../cron/run-log.js";
-import { CronService } from "../cron/service.js";
+import { CronService, type CronEvent } from "../cron/service.js";
 import { assertSafeCronSessionTargetId } from "../cron/session-target.js";
 import { resolveCronStorePath } from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
 import { normalizeHttpWebhookUrl } from "../cron/webhook-url.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { runHeartbeatOnce } from "../infra/heartbeat-runner.js";
@@ -34,6 +35,7 @@ import { SsrFBlockedError } from "../infra/net/ssrf.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { getChildLogger } from "../logging.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { normalizeAgentId, toAgentStoreSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -142,6 +144,55 @@ async function postCronWebhook(params: {
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function emitCronLifecycleHook(params: {
+  evt: CronEvent;
+  job?: CronJob;
+  storePath: string;
+  defaultAgentId: string;
+  logger: ReturnType<typeof getChildLogger>;
+}) {
+  if (params.evt.action !== "started" && params.evt.action !== "finished") {
+    return;
+  }
+  const hookRunner = getGlobalHookRunner();
+  if (!hookRunner?.hasHooks("cron_lifecycle")) {
+    return;
+  }
+
+  void hookRunner
+    .runCronLifecycle(
+      {
+        jobId: params.evt.jobId,
+        jobName: params.job?.name,
+        agentId: params.job?.agentId ?? params.defaultAgentId,
+        action: params.evt.action,
+        payloadKind: params.job?.payload.kind,
+        sessionTarget: params.job?.sessionTarget,
+        wakeMode: params.job?.wakeMode,
+        runAtMs: params.evt.runAtMs,
+        durationMs: params.evt.durationMs,
+        status: params.evt.status,
+        error: params.evt.error,
+        summary: params.evt.summary,
+        delivered: params.evt.delivered,
+        deliveryStatus: params.evt.deliveryStatus,
+        deliveryError: params.evt.deliveryError,
+        sessionId: params.evt.sessionId,
+        sessionKey: params.evt.sessionKey,
+        nextRunAtMs: params.evt.nextRunAtMs,
+        model: params.evt.model,
+        provider: params.evt.provider,
+      },
+      { storePath: params.storePath },
+    )
+    .catch((err) => {
+      params.logger.warn(
+        { jobId: params.evt.jobId, err: formatErrorMessage(err) },
+        "cron: lifecycle hook failed",
+      );
+    });
 }
 
 export function buildGatewayCronService(params: {
@@ -416,10 +467,11 @@ export function buildGatewayCronService(params: {
     log: getChildLogger({ module: "cron", storePath }),
     onEvent: (evt) => {
       params.broadcast("cron", evt, { dropIfSlow: true });
+      const job = cron.getJob(evt.jobId);
+      emitCronLifecycleHook({ evt, job, storePath, defaultAgentId, logger: cronLogger });
       if (evt.action === "finished") {
         const webhookToken = normalizeOptionalString(params.cfg.cron?.webhookToken);
         const legacyWebhook = normalizeOptionalString(params.cfg.cron?.webhook);
-        const job = cron.getJob(evt.jobId);
         const legacyNotify = (job as { notify?: unknown } | undefined)?.notify === true;
         const webhookTarget = resolveCronWebhookTarget({
           delivery:

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -82,6 +82,7 @@ export type PluginHookName =
   | "subagent_delivery_target"
   | "subagent_spawned"
   | "subagent_ended"
+  | "cron_lifecycle"
   | "gateway_start"
   | "gateway_stop"
   | "before_dispatch"
@@ -116,6 +117,7 @@ export const PLUGIN_HOOK_NAMES = [
   "subagent_delivery_target",
   "subagent_spawned",
   "subagent_ended",
+  "cron_lifecycle",
   "gateway_start",
   "gateway_stop",
   "before_dispatch",
@@ -557,6 +559,33 @@ export type PluginHookSubagentEndedEvent = {
   error?: string;
 };
 
+export type PluginHookCronLifecycleContext = {
+  storePath?: string;
+};
+
+export type PluginHookCronLifecycleEvent = {
+  jobId: string;
+  jobName?: string;
+  agentId?: string;
+  action: "started" | "finished";
+  payloadKind?: "agentTurn" | "systemEvent";
+  sessionTarget?: string;
+  wakeMode?: string;
+  runAtMs?: number;
+  durationMs?: number;
+  status?: "ok" | "error" | "skipped";
+  error?: string;
+  summary?: string;
+  delivered?: boolean;
+  deliveryStatus?: string;
+  deliveryError?: string;
+  sessionId?: string;
+  sessionKey?: string;
+  nextRunAtMs?: number;
+  model?: string;
+  provider?: string;
+};
+
 export type PluginHookGatewayContext = {
   port?: number;
   config?: OpenClawConfig;
@@ -827,6 +856,10 @@ export type PluginHookHandlerMap = {
   subagent_ended: (
     event: PluginHookSubagentEndedEvent,
     ctx: PluginHookSubagentContext,
+  ) => Promise<void> | void;
+  cron_lifecycle: (
+    event: PluginHookCronLifecycleEvent,
+    ctx: PluginHookCronLifecycleContext,
   ) => Promise<void> | void;
   gateway_start: (
     event: PluginHookGatewayStartEvent,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -61,6 +61,8 @@ import type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentEndedEvent,
   PluginHookSubagentSpawnedEvent,
+  PluginHookCronLifecycleContext,
+  PluginHookCronLifecycleEvent,
   PluginHookToolContext,
   PluginHookToolResultPersistContext,
   PluginHookToolResultPersistEvent,
@@ -126,6 +128,8 @@ export type {
   PluginHookSubagentSpawningResult,
   PluginHookSubagentSpawnedEvent,
   PluginHookSubagentEndedEvent,
+  PluginHookCronLifecycleContext,
+  PluginHookCronLifecycleEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -1116,6 +1120,17 @@ export function createHookRunner(
     return runVoidHook("subagent_ended", event, ctx);
   }
 
+  /**
+   * Run cron_lifecycle hook.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runCronLifecycle(
+    event: PluginHookCronLifecycleEvent,
+    ctx: PluginHookCronLifecycleContext,
+  ): Promise<void> {
+    return runVoidHook("cron_lifecycle", event, ctx);
+  }
+
   // =========================================================================
   // Gateway Hooks
   // =========================================================================
@@ -1232,6 +1247,7 @@ export function createHookRunner(
     runSubagentDeliveryTarget,
     runSubagentSpawned,
     runSubagentEnded,
+    runCronLifecycle,
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,

--- a/src/plugins/wired-hooks-gateway.test.ts
+++ b/src/plugins/wired-hooks-gateway.test.ts
@@ -8,6 +8,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { createHookRunnerWithRegistry } from "./hooks.test-helpers.js";
 import type {
+  PluginHookCronLifecycleContext,
+  PluginHookCronLifecycleEvent,
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
   PluginHookGatewayStopEvent,
@@ -60,5 +62,24 @@ describe("gateway hook runner methods", () => {
 
     expect(runner.hasHooks("gateway_start")).toBe(true);
     expect(runner.hasHooks("gateway_stop")).toBe(false);
+  });
+
+  it("runCronLifecycle invokes registered cron_lifecycle hooks", async () => {
+    const handler = vi.fn();
+    const { runner } = createHookRunnerWithRegistry([{ hookName: "cron_lifecycle", handler }]);
+    const event = {
+      jobId: "job-1",
+      jobName: "Nightly report",
+      agentId: "main",
+      action: "started",
+      payloadKind: "agentTurn",
+      runAtMs: 1770000000000,
+    } satisfies PluginHookCronLifecycleEvent;
+    const ctx = { storePath: "/tmp/openclaw/cron.json" } satisfies PluginHookCronLifecycleContext;
+
+    await runner.runCronLifecycle(event, ctx);
+
+    expect(handler).toHaveBeenCalledWith(event, ctx);
+    expect(runner.hasHooks("cron_lifecycle")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Adds a typed `cron_lifecycle` plugin hook for native cron lifecycle observation.

This replaces the old compliance/webhook-oriented PR shape with the latest maintainer feedback on #8209: expose a generic plugin lifecycle surface instead of adding a one-off `cron.webhooks` config shape.

## What changed

- Adds `cron_lifecycle` to the typed plugin hook catalog.
- Emits `started` and `finished` hook events from gateway cron handling.
- Covers both `agentTurn` and `systemEvent` jobs.
- Includes job identity, agent id, payload kind, session target, timing, status/error, delivery/session correlation, and model/provider telemetry when available.
- Documents the hook in the plugin hook reference.
- Adds focused tests for hook runner wiring and gateway cron start/finish emission.

## Why this shape

Maintainer feedback on #8209 preferred a generic typed cron lifecycle surface, preferably plugin-based, over a core-specific webhook API. This keeps external audit/telemetry integrations in plugins while giving them an enforced gateway-level event stream that does not rely on agent self-reporting.

## Verification

- `pnpm exec vitest run src/plugins/wired-hooks-gateway.test.ts src/gateway/server-cron.test.ts`
- `pnpm exec oxfmt --check src/plugins/hook-types.ts src/plugins/hooks.ts src/gateway/server-cron.ts src/plugins/wired-hooks-gateway.test.ts src/gateway/server-cron.test.ts docs/plugins/hooks.md`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm lint:core`

Closes #8209

Supersedes #8855.
