### PR TITLE
feat(plugin-sdk): add service lifecycle test harness

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-fd941e0485a92ebb8256cf2256330b58c2d5bd94189f4a05d7394353ef7bed88  plugin-sdk-api-baseline.json
-11ef8362518a0d9f221dc1958b25db46956d1916f278b53e52199bf6c2cbc65b  plugin-sdk-api-baseline.jsonl
+da4f9f857c6535eacb10c992fd3f1fedd991e3da3ca6207d5625f0589d710209  plugin-sdk-api-baseline.json
+683b689ea61bcb938e23fe2ef96033913f6e1bf6db71b96e0f52f75ec92ce1ed  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-testing.md
+++ b/docs/plugins/sdk-testing.md
@@ -25,6 +25,7 @@ The testing subpath exports a narrow set of helpers for plugin authors:
 
 ```typescript
 import {
+  createPluginServiceLifecycleTestHarness,
   installCommonResolveTargetErrorCases,
   shouldAckReaction,
   removeAckReactionAfterReply,
@@ -33,11 +34,12 @@ import {
 
 ### Available exports
 
-| Export                                 | Purpose                                                |
-| -------------------------------------- | ------------------------------------------------------ |
-| `installCommonResolveTargetErrorCases` | Shared test cases for target resolution error handling |
-| `shouldAckReaction`                    | Check whether a channel should add an ack reaction     |
-| `removeAckReactionAfterReply`          | Remove ack reaction after reply delivery               |
+| Export                                    | Purpose                                                      |
+| ----------------------------------------- | ------------------------------------------------------------ |
+| `installCommonResolveTargetErrorCases`    | Shared test cases for target resolution error handling       |
+| `shouldAckReaction`                       | Check whether a channel should add an ack reaction           |
+| `removeAckReactionAfterReply`             | Remove ack reaction after reply delivery                     |
+| `createPluginServiceLifecycleTestHarness` | Finite test harness for registered plugin services and hooks |
 
 ### Types
 
@@ -53,6 +55,36 @@ import type {
   MockFn,
 } from "openclaw/plugin-sdk/testing";
 ```
+
+## Testing service lifecycle
+
+Use `createPluginServiceLifecycleTestHarness` for finite tests that need to
+start and stop a registered plugin service without launching the Gateway:
+
+```typescript
+import { createPluginServiceLifecycleTestHarness } from "openclaw/plugin-sdk/testing";
+
+const harness = await createPluginServiceLifecycleTestHarness();
+
+harness.registerService({
+  id: "my-service",
+  async start(ctx) {
+    await writeMyState(ctx.stateDir);
+  },
+  stop() {
+    // release test resources
+  },
+});
+
+await harness.startServices();
+await harness.runGatewayStart({ port: 0 });
+await harness.stopServices();
+await harness.cleanup();
+```
+
+The harness creates a temporary `stateDir` when one is not provided and exposes
+`runGatewayStart(...)` / `runGatewayStop(...)` for generic hook interaction
+tests. It is intended for finite tests only, not production service management.
 
 ## Testing target resolution
 

--- a/src/plugin-sdk/service-lifecycle-test-harness.test.ts
+++ b/src/plugin-sdk/service-lifecycle-test-harness.test.ts
@@ -1,0 +1,137 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginServiceContext } from "./plugin-entry.js";
+import { createPluginServiceLifecycleTestHarness } from "./testing.js";
+
+const harnesses: Array<{ cleanup: () => Promise<void> }> = [];
+
+afterEach(async () => {
+  const current = harnesses.splice(0);
+  await Promise.all(current.map((harness) => harness.cleanup()));
+});
+
+describe("plugin service lifecycle test harness", () => {
+  it("starts and stops a registered service with a usable state directory", async () => {
+    const harness = await createPluginServiceLifecycleTestHarness();
+    harnesses.push(harness);
+    const starts: string[] = [];
+    const stops: string[] = [];
+
+    harness.registerService({
+      id: "state-dir-probe",
+      async start(ctx) {
+        starts.push(ctx.stateDir);
+        await fs.writeFile(path.join(ctx.stateDir, "service-probe.txt"), "ok", "utf8");
+      },
+      stop(ctx) {
+        stops.push(ctx.stateDir);
+      },
+    });
+
+    await harness.startServices();
+    await harness.stopServices();
+
+    expect(starts).toEqual([harness.stateDir]);
+    expect(stops).toEqual([harness.stateDir]);
+    await expect(
+      fs.readFile(path.join(harness.stateDir, "service-probe.txt"), "utf8"),
+    ).resolves.toBe("ok");
+  });
+
+  it("throws on empty or duplicate service ids", async () => {
+    const harness = await createPluginServiceLifecycleTestHarness();
+    harnesses.push(harness);
+
+    expect(() =>
+      harness.registerService({
+        id: "   ",
+        start() {},
+      }),
+    ).toThrow("registerService: service.id must not be empty");
+
+    harness.registerService({
+      id: "duplicate-service",
+      start() {},
+    });
+
+    expect(() =>
+      harness.registerService({
+        id: "duplicate-service",
+        start() {},
+      }),
+    ).toThrow('registerService: a service with id "duplicate-service" is already registered');
+  });
+
+  it("runs a registered hook that can write a generic whitelist record through service state", async () => {
+    const harness = await createPluginServiceLifecycleTestHarness();
+    harnesses.push(harness);
+    let serviceContext: OpenClawPluginServiceContext | undefined;
+
+    harness.registerService({
+      id: "generic-record-service",
+      start(ctx) {
+        serviceContext = ctx;
+      },
+      stop() {
+        serviceContext = undefined;
+      },
+    });
+    harness.registerHook("gateway_start", async () => {
+      if (!serviceContext) {
+        throw new Error("service context unavailable");
+      }
+      const dir = path.join(serviceContext.stateDir, "generic-whitelist");
+      await fs.mkdir(dir, { recursive: true });
+      await fs.writeFile(path.join(dir, "record.json"), JSON.stringify({ allowed: true }), "utf8");
+    });
+
+    await harness.startServices();
+    await harness.runGatewayStart({ port: 1234 });
+
+    await expect(
+      fs.readFile(path.join(harness.stateDir, "generic-whitelist", "record.json"), "utf8"),
+    ).resolves.toBe(JSON.stringify({ allowed: true }));
+
+    await harness.stopServices();
+    expect(serviceContext).toBeUndefined();
+  });
+
+  it("keeps hook write failure non-fatal while services remain stoppable", async () => {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const harness = await createPluginServiceLifecycleTestHarness({ logger });
+    harnesses.push(harness);
+    const stops: string[] = [];
+    let serviceContext: OpenClawPluginServiceContext | undefined;
+
+    harness.registerService({
+      id: "write-failure-service",
+      start(ctx) {
+        serviceContext = ctx;
+      },
+      stop(ctx) {
+        stops.push(ctx.stateDir);
+      },
+    });
+    harness.registerHook("gateway_start", async () => {
+      if (!serviceContext) {
+        throw new Error("service context unavailable");
+      }
+      const filePath = path.join(serviceContext.stateDir, "generic-whitelist");
+      await fs.writeFile(filePath, "not a directory", "utf8");
+      await fs.mkdir(path.join(filePath, "records"), { recursive: true });
+    });
+
+    await harness.startServices();
+    await expect(harness.runGatewayStart()).resolves.toBeUndefined();
+    await harness.stopServices();
+
+    expect(stops).toEqual([harness.stateDir]);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/plugin-sdk/testing.ts
+++ b/src/plugin-sdk/testing.ts
@@ -32,6 +32,11 @@ export {
 } from "../plugins/runtime.js";
 export { capturePluginRegistration } from "../plugins/captured-registration.js";
 export { resolveProviderPluginChoice } from "../plugins/provider-auth-choice.runtime.js";
+export {
+  createPluginServiceLifecycleTestHarness,
+  type PluginServiceLifecycleTestHarness,
+  type PluginServiceLifecycleTestHarnessOptions,
+} from "../plugins/service-lifecycle-test-harness.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { RuntimeEnv } from "../runtime.js";
 export type { MockFn } from "../test-utils/vitest-mock-fn.js";

--- a/src/plugins/service-lifecycle-test-harness.ts
+++ b/src/plugins/service-lifecycle-test-harness.ts
@@ -1,0 +1,201 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createHookRunner } from "./hooks.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistry } from "./registry-types.js";
+import { startPluginServices, type PluginServicesHandle } from "./services.js";
+import type {
+  OpenClawPluginService,
+  PluginHookGatewayContext,
+  PluginHookGatewayStartEvent,
+  PluginHookGatewayStopEvent,
+  PluginHookName,
+  PluginHookRegistration,
+  PluginLogger,
+} from "./types.js";
+
+export type PluginServiceLifecycleTestHarnessOptions = {
+  pluginId?: string;
+  pluginName?: string;
+  config?: OpenClawConfig;
+  stateDir?: string;
+  workspaceDir?: string;
+  logger?: PluginLogger;
+};
+
+export type PluginServiceLifecycleTestHarness = {
+  registry: PluginRegistry;
+  stateDir: string;
+  workspaceDir?: string;
+  registerService: (service: OpenClawPluginService) => void;
+  registerHook: <K extends PluginHookName>(
+    hookName: K,
+    handler: PluginHookRegistration<K>["handler"],
+    hookOptions?: { priority?: number },
+  ) => void;
+  startServices: () => Promise<PluginServicesHandle>;
+  stopServices: () => Promise<void>;
+  runGatewayStart: (
+    event?: Partial<PluginHookGatewayStartEvent>,
+    context?: Partial<PluginHookGatewayContext>,
+  ) => Promise<void>;
+  runGatewayStop: (
+    event?: PluginHookGatewayStopEvent,
+    context?: Partial<PluginHookGatewayContext>,
+  ) => Promise<void>;
+  cleanup: () => Promise<void>;
+};
+
+function createNoopPluginLogger(): PluginLogger {
+  return {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+function addTestPluginRecord(params: {
+  registry: PluginRegistry;
+  pluginId: string;
+  pluginName: string;
+  source: string;
+  rootDir: string;
+}): void {
+  params.registry.plugins.push({
+    id: params.pluginId,
+    name: params.pluginName,
+    source: params.source,
+    rootDir: params.rootDir,
+    origin: "workspace",
+    enabled: true,
+    status: "loaded",
+    toolNames: [],
+    hookNames: [],
+    channelIds: [],
+    cliBackendIds: [],
+    providerIds: [],
+    speechProviderIds: [],
+    realtimeTranscriptionProviderIds: [],
+    realtimeVoiceProviderIds: [],
+    mediaUnderstandingProviderIds: [],
+    imageGenerationProviderIds: [],
+    videoGenerationProviderIds: [],
+    musicGenerationProviderIds: [],
+    webFetchProviderIds: [],
+    webSearchProviderIds: [],
+    memoryEmbeddingProviderIds: [],
+    agentHarnessIds: [],
+    gatewayMethods: [],
+    cliCommands: [],
+    services: [],
+    gatewayDiscoveryServiceIds: [],
+    commands: [],
+    httpRoutes: 0,
+    hookCount: 0,
+    configSchema: false,
+  });
+}
+
+export async function createPluginServiceLifecycleTestHarness(
+  options: PluginServiceLifecycleTestHarnessOptions = {},
+): Promise<PluginServiceLifecycleTestHarness> {
+  const createdStateDir = options.stateDir
+    ? undefined
+    : await mkdtemp(path.join(tmpdir(), "openclaw-plugin-service-"));
+  const stateDir = options.stateDir ?? createdStateDir!;
+  const registry = createEmptyPluginRegistry();
+  const pluginId = options.pluginId ?? "test-plugin";
+  const pluginName = options.pluginName ?? "Test Plugin";
+  const source = "plugin-service-lifecycle-test-harness";
+  const rootDir = stateDir;
+  const config = options.config ?? ({} as OpenClawConfig);
+  let servicesHandle: PluginServicesHandle | undefined;
+
+  addTestPluginRecord({ registry, pluginId, pluginName, source, rootDir });
+  const pluginRecord = registry.plugins[0];
+
+  const registerService = (service: OpenClawPluginService): void => {
+    const id = service.id.trim();
+    if (!id) {
+      throw new Error("registerService: service.id must not be empty");
+    }
+    if (registry.services.some((entry) => entry.service.id === id)) {
+      throw new Error(`registerService: a service with id "${id}" is already registered`);
+    }
+    pluginRecord.services.push(id);
+    registry.services.push({
+      pluginId,
+      pluginName,
+      service,
+      source,
+      origin: "workspace",
+      rootDir,
+    });
+  };
+
+  const registerHook = <K extends PluginHookName>(
+    hookName: K,
+    handler: PluginHookRegistration<K>["handler"],
+    hookOptions?: { priority?: number },
+  ): void => {
+    pluginRecord.hookNames.push(hookName);
+    pluginRecord.hookCount += 1;
+    registry.typedHooks.push({
+      pluginId,
+      hookName,
+      handler,
+      priority: hookOptions?.priority ?? 0,
+      source,
+    });
+  };
+
+  const stopServices = async (): Promise<void> => {
+    const handle = servicesHandle;
+    servicesHandle = undefined;
+    await handle?.stop();
+  };
+
+  const getHookRunner = () =>
+    createHookRunner(registry, { logger: options.logger ?? createNoopPluginLogger() });
+
+  return {
+    registry,
+    stateDir,
+    ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+    registerService,
+    registerHook,
+    startServices: async () => {
+      await stopServices();
+      servicesHandle = await startPluginServices({
+        registry,
+        config,
+        workspaceDir: options.workspaceDir,
+        stateDir,
+      });
+      return servicesHandle;
+    },
+    stopServices,
+    runGatewayStart: async (event, context) => {
+      await getHookRunner().runGatewayStart(
+        { port: event?.port ?? 0 },
+        { config, workspaceDir: options.workspaceDir, ...context },
+      );
+    },
+    runGatewayStop: async (event, context) => {
+      await getHookRunner().runGatewayStop(event ?? {}, {
+        config,
+        workspaceDir: options.workspaceDir,
+        ...context,
+      });
+    },
+    cleanup: async () => {
+      await stopServices();
+      if (createdStateDir) {
+        await rm(createdStateDir, { recursive: true, force: true });
+      }
+    },
+  };
+}

--- a/src/plugins/services.ts
+++ b/src/plugins/services.ts
@@ -22,6 +22,7 @@ function createPluginLogger(): PluginLogger {
 function createServiceContext(params: {
   config: OpenClawConfig;
   workspaceDir?: string;
+  stateDir?: string;
   service?: PluginServiceRegistration;
 }): OpenClawPluginServiceContext {
   const grantsInternalDiagnostics =
@@ -33,7 +34,7 @@ function createServiceContext(params: {
   return {
     config: params.config,
     workspaceDir: params.workspaceDir,
-    stateDir: STATE_DIR,
+    stateDir: params.stateDir ?? STATE_DIR,
     logger: createPluginLogger(),
     ...(grantsInternalDiagnostics
       ? {
@@ -54,6 +55,7 @@ export async function startPluginServices(params: {
   registry: PluginRegistry;
   config: OpenClawConfig;
   workspaceDir?: string;
+  stateDir?: string;
 }): Promise<PluginServicesHandle> {
   const running: Array<{
     id: string;
@@ -64,6 +66,7 @@ export async function startPluginServices(params: {
     const serviceContext = createServiceContext({
       config: params.config,
       workspaceDir: params.workspaceDir,
+      stateDir: params.stateDir,
       service: entry,
     });
     try {


### PR DESCRIPTION
## Summary

Adds a generic plugin-SDK service lifecycle test harness for finite plugin service/hook tests.

This gives plugin authors a supported test helper for exercising registered plugin services with a usable `stateDir`, optional `workspaceDir`, finite service start/stop, and generic gateway start/stop hook interaction without launching the full Gateway.

## What changed

- Add `createPluginServiceLifecycleTestHarness` under the plugin testing SDK surface.
- Allow plugin service startup to receive an optional caller-provided `stateDir`.
- Add finite lifecycle/hook tests covering:
  - service start/stop with usable `stateDir`
  - generic hook/service interaction writing a whitelist test record under `stateDir`
  - non-fatal hook write failure while services remain stoppable
- Document the new testing helper in `docs/plugins/sdk-testing.md`.
- Refresh plugin SDK API baseline hashes.

## Scope boundaries

This PR is intentionally generic and plugin-SDK focused.

It does **not** add:

- artifact-gated workflow policy
- workflow closure semantics in core
- project-specific artifact/report checks
- notification behavior
- production daemon/service-management behavior
- repair/rerun/corrective-action behavior
- Telegram extension changes

## Validation

Ran successfully after rebasing on current `origin/main`:

```bash
pnpm test -- src/plugin-sdk/service-lifecycle-test-harness.test.ts
pnpm plugin-sdk:api:check
pnpm plugin-sdk:check-exports
pnpm test -- extensions/telegram/src/bot.create-telegram-bot.test.ts
```

Results:

- plugin service lifecycle harness test: 3 passed
- plugin SDK API check: passed
- plugin SDK export check: passed
- Telegram targeted test: 66 passed

## Notes

The branch is based on current upstream `main` and contains one commit over `origin/main`:

```text
67ba6d1a2b feat(plugin-sdk): add service lifecycle test harness
```

No Telegram files are changed in this PR.
