### PR TITLE
Gateway: allow cron.enabled and compaction mode config paths

### DIFF
--- a/src/agents/tools/gateway-tool-guard-coverage.test.ts
+++ b/src/agents/tools/gateway-tool-guard-coverage.test.ts
@@ -62,9 +62,11 @@ describe("gateway config mutation guard coverage", () => {
       expect.arrayContaining([
         "agents.defaults.systemPromptOverride",
         "agents.defaults.model",
+        "agents.defaults.compaction.mode",
         "agents.list[].id",
         "agents.list[].model",
         "channels.*.requireMention",
+        "cron.enabled",
       ]),
     );
   });
@@ -506,6 +508,17 @@ describe("gateway config mutation guard coverage", () => {
           },
         },
       },
+    );
+  });
+
+  it("allows cron.enabled toggles via config.patch", () => {
+    expectAllowed({ cron: { enabled: true } }, { cron: { enabled: false } });
+  });
+
+  it("allows agents.defaults.compaction.mode edits via config.patch", () => {
+    expectAllowed(
+      { agents: { defaults: { compaction: { mode: "default" } } } },
+      { agents: { defaults: { compaction: { mode: "safeguard" } } } },
     );
   });
 });

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -36,6 +36,7 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   "agents.defaults.thinkingDefault",
   "agents.defaults.reasoningDefault",
   "agents.defaults.fastModeDefault",
+  "agents.defaults.compaction.mode",
   "agents.list[].id",
   "agents.list[].systemPromptOverride",
   "agents.list[].model",
@@ -51,6 +52,8 @@ const ALLOWED_GATEWAY_CONFIG_PATHS = [
   "channels.*.*.*.requireMention",
   "channels.*.*.*.*.requireMention",
   "channels.*.*.*.*.*.requireMention",
+  // Runtime toggles that are safe for owner-triggered agent automation.
+  "cron.enabled",
 ] as const;
 
 /** @internal Exposed for regression tests only; do not import from runtime code. */


### PR DESCRIPTION
﻿## Summary
- Add `cron.enabled` to the gateway tool config mutation allowlist so owner automation can toggle cron through `config.patch`.
- Add `agents.defaults.compaction.mode` to the same allowlist so compaction mode can be updated via API-driven gateway edits.
- Extend guard coverage tests to assert both allowlist entries and add explicit positive patch cases.

## Test plan
- [x] `pnpm test src/agents/tools/gateway-tool-guard-coverage.test.ts`
