### PR TITLE
fix(nostr): keep setup status off full surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Nostr/setup: keep setup-only status checks on the lightweight surface so Onboard does not import `nostr-tools` while Nostr is unconfigured. Fixes #72182. Thanks @SnowSky1.
 - Gateway/watch: leave `OPENCLAW_TRACE_SYNC_IO` disabled by default in `pnpm gateway:watch:raw` so watch mode avoids noisy Node sync-I/O stack traces unless explicitly requested.
 - Codex app-server: close stdio stdin before force-killing the managed app-server, matching Codex single-client shutdown behavior and avoiding unsettled CLI exits after successful runs.
 - CLI/Codex: dispose registered agent harnesses during short-lived CLI shutdown so successful Codex-backed `agent --local` runs do not leave app-server child processes alive.

--- a/extensions/nostr/src/channel.setup.test.ts
+++ b/extensions/nostr/src/channel.setup.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+import { nostrSetupPlugin } from "./channel.setup.js";
+import { DEFAULT_RELAYS } from "./default-relays.js";
+
+vi.mock("./setup-surface.js", () => {
+  throw new Error("full Nostr setup surface should stay unloaded during setup status checks");
+});
+
+describe("nostr setup-only plugin", () => {
+  function getStatus() {
+    const wizard = nostrSetupPlugin.setupWizard;
+    if (!wizard || !("status" in wizard)) {
+      throw new Error("nostr setup wizard status missing");
+    }
+    return wizard.status;
+  }
+
+  it("resolves setup status without loading the full setup surface", async () => {
+    const status = getStatus();
+
+    expect(await status.resolveConfigured({ cfg: {} })).toBe(false);
+    expect(await status.resolveStatusLines?.({ cfg: {}, configured: false })).toEqual([
+      "Nostr: needs private key",
+      `Relays: ${DEFAULT_RELAYS.length}`,
+    ]);
+  });
+
+  it("reports configured state from lightweight config inspection", async () => {
+    const status = getStatus();
+
+    expect(
+      await status.resolveConfigured({
+        cfg: {
+          channels: {
+            nostr: {
+              privateKey: "0".repeat(64),
+            },
+          },
+        },
+      }),
+    ).toBe(true);
+  });
+});

--- a/extensions/nostr/src/channel.setup.ts
+++ b/extensions/nostr/src/channel.setup.ts
@@ -2,10 +2,10 @@ import { describeAccountSnapshot } from "openclaw/plugin-sdk/account-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { patchTopLevelChannelConfigSection } from "openclaw/plugin-sdk/setup";
 import {
-  createDelegatedSetupWizardProxy,
   createStandardChannelSetupStatus,
   DEFAULT_ACCOUNT_ID,
   type ChannelSetupAdapter,
+  type ChannelSetupWizard,
 } from "openclaw/plugin-sdk/setup-runtime";
 import { buildChannelConfigSchema, type ChannelPlugin } from "./channel-api.js";
 import { NostrConfigSchema } from "./config-schema.js";
@@ -169,31 +169,27 @@ const nostrSetupAdapter: ChannelSetupAdapter = {
   },
 };
 
-const nostrSetupWizard = createDelegatedSetupWizardProxy({
+const nostrSetupWizard: ChannelSetupWizard = {
   channel,
-  loadWizard: async () => (await import("./setup-surface.js")).nostrSetupWizard,
-  status: {
-    ...createStandardChannelSetupStatus({
-      channelLabel: "Nostr",
-      configuredLabel: "configured",
-      unconfiguredLabel: "needs private key",
-      configuredHint: "configured",
-      unconfiguredHint: "needs private key",
-      configuredScore: 1,
-      unconfiguredScore: 0,
-      includeStatusLine: true,
-      resolveConfigured: ({ cfg, accountId }) =>
-        resolveSetupNostrAccount({ cfg, accountId }).configured,
-      resolveExtraStatusLines: ({ cfg }) => {
-        const account = resolveSetupNostrAccount({ cfg });
-        return [`Relays: ${account.relays.length || DEFAULT_RELAYS.length}`];
-      },
-    }),
-  },
+  status: createStandardChannelSetupStatus({
+    channelLabel: "Nostr",
+    configuredLabel: "configured",
+    unconfiguredLabel: "needs private key",
+    configuredHint: "configured",
+    unconfiguredHint: "needs private key",
+    configuredScore: 1,
+    unconfiguredScore: 0,
+    includeStatusLine: true,
+    resolveConfigured: ({ cfg, accountId }) =>
+      resolveSetupNostrAccount({ cfg, accountId }).configured,
+    resolveExtraStatusLines: ({ cfg }) => {
+      const account = resolveSetupNostrAccount({ cfg });
+      return [`Relays: ${account.relays.length || DEFAULT_RELAYS.length}`];
+    },
+  }),
   resolveShouldPromptAccountIds: () => false,
-  delegatePrepare: true,
-  delegateFinalize: true,
-});
+  credentials: [],
+};
 
 export const nostrSetupPlugin: ChannelPlugin<ResolvedNostrSetupAccount> = {
   id: channel,


### PR DESCRIPTION
﻿## Summary
Problem: Opening Onboard / model switching can scan bundled setup surfaces. The Nostr setup-only plugin was using the delegated setup wizard proxy for status resolution, so a status check imported the full `setup-surface.js`. That full surface imports `nostr-key-utils`, which imports `nostr-tools`, so packaged installs without optional Nostr runtime deps could fail even when Nostr was not configured.

What changed:
- Keep Nostr setup status resolution on the lightweight `channel.setup.ts` surface.
- Preserve the existing lightweight setup adapter and account/status behavior.
- Add a regression test that mocks the full `setup-surface.js` to throw, then verifies setup status still resolves without loading it.

Closes #72182

## Change Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [x] Integrations
- [x] UI / DX
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] API / contracts
- [ ] CI/CD / infra

## Root Cause / Regression History
The setup-only Nostr entry point already avoids static `nostr-tools` imports, but `createDelegatedSetupWizardProxy` delegates `status.resolveConfigured` and status detail resolvers to the full wizard. Status/discovery paths can call those resolvers before the user enables Nostr, which pulls in the full setup surface and its Nostr runtime dependency graph.

This keeps the cold setup/status path on the local lightweight resolver instead of delegating to the full wizard for status-only work.

## Regression Test Plan
Coverage level that should have caught this:
- [x] Unit test
- [x] Seam / integration test
- [ ] End-to-end test
- [ ] Existing coverage already sufficient

Target test file: `extensions/nostr/src/channel.setup.test.ts`

Scenario locked in: Nostr setup status resolves when the full `setup-surface.js` would fail to load. The test mocks `./setup-surface.js` to throw, then asserts unconfigured/configured setup status still works from `channel.setup.ts`.

## User-visible / Behavior Changes
Onboard and setup status scans should no longer fail on missing `nostr-tools` when Nostr is unconfigured. Configuring or running the Nostr channel is unchanged.

## Security Impact
New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No

## Repro + Verification
Repro before fix:
1. Use a packaged install where bundled Nostr runtime deps have not been installed.
2. Open Onboard / model switching so setup surfaces are scanned.
3. Nostr status discovery can import the full setup surface and fail with missing `nostr-tools`.

Verification run locally:
- `OPENCLAW_VITEST_INCLUDE_FILE=<temp json for extensions/nostr/**/*.test.ts> node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-messaging.config.ts` — 13 files / 271 tests passed.
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md extensions/nostr/src/channel.setup.ts extensions/nostr/src/channel.setup.test.ts`
- `pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/nostr/src/channel.setup.ts extensions/nostr/src/channel.setup.test.ts`
- `git diff --check`

## Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No

## Failure Recovery
Revert this commit. The change is scoped to Nostr setup-only status discovery and does not modify Nostr runtime send/receive behavior.
## Real behavior proof

- Behavior or issue addressed: Nostr setup status can be evaluated while the channel is unconfigured without entering the credential/full setup path that pulls in the heavier Nostr setup surface.
- Real environment tested: Windows PowerShell local OpenClaw checkout containing this Nostr setup patch, Node v24.13.0, pnpm 10.33.0.
- Exact steps or command run after this patch: Ran a live setup-status smoke through `pnpm exec tsx`, importing `./extensions/nostr/src/channel.setup.ts` and resolving the setup wizard status for both empty and configured Nostr config.
- Evidence after fix: PowerShell terminal output:

```text
openclaw nostr setup status smoke
wizard channel = nostr
credentials length = 0
configured(empty) = false
statusLines(empty) = ["Nostr: needs private key","Relays: 2"]
configured(hex key) = true
```

- Observed result after fix: The setup-only Nostr wizard resolves status for an unconfigured install without requesting credentials, reports the default relay count, and recognizes a configured private key path.
- What was not tested: Full browser onboarding UI and real Nostr relay network I/O; this patch only changes the setup-status surface, not Nostr message transport.
