### PR TITLE
fix(heartbeat): suppress final ok payloads

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
+import { HEARTBEAT_TOKEN } from "../tokens.js";
 import { buildReplyPayloads } from "./agent-runner-payloads.js";
 
 const baseParams = {
@@ -24,6 +25,52 @@ async function expectSameTargetRepliesSuppressed(params: { provider: string; to:
 
   expect(replyPayloads).toHaveLength(0);
 }
+
+describe("buildReplyPayloads heartbeat token sanitation", () => {
+  it("suppresses OK-only final payloads for heartbeat runs", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [{ text: HEARTBEAT_TOKEN }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("continues suppressing OK-only final payloads for non-heartbeat runs", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: HEARTBEAT_TOKEN }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("preserves real alert text for heartbeat runs", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [{ text: "SARS eFiling letter notification needs attention." }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("SARS eFiling letter notification needs attention.");
+  });
+
+  it("preserves media-bearing heartbeat payloads after stripping OK-only text", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [{ text: HEARTBEAT_TOKEN, mediaUrl: "file:///tmp/heartbeat.png" }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({
+      text: undefined,
+      mediaUrl: "file:///tmp/heartbeat.png",
+    });
+  });
+});
 
 describe("buildReplyPayloads media filter integration", () => {
   it("strips media URL from payload when in messagingToolSentMediaUrls", async () => {

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -65,10 +65,21 @@ describe("buildReplyPayloads heartbeat token sanitation", () => {
     });
 
     expect(replyPayloads).toHaveLength(1);
-    expect(replyPayloads[0]).toMatchObject({
-      text: undefined,
-      mediaUrl: "file:///tmp/heartbeat.png",
+    expect(replyPayloads[0]?.text).toBeUndefined();
+    expect(replyPayloads[0]?.mediaUrl).toBe("file:///tmp/heartbeat.png");
+  });
+
+  it("does not expand Bun socket error formatting to heartbeat runs", async () => {
+    const text = "TypeError: fetch failed: socket connection was closed unexpectedly";
+
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      isHeartbeat: true,
+      payloads: [{ text, isError: true }],
     });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe(text);
   });
 });
 

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -113,7 +113,7 @@ export async function buildReplyPayloads(params: {
   const sanitizedPayloads = params.payloads.flatMap((payload) => {
     let text = payload.text;
 
-    if (payload.isError && text && isBunFetchSocketError(text)) {
+    if (!params.isHeartbeat && payload.isError && text && isBunFetchSocketError(text)) {
       text = formatBunFetchSocketError(text);
     }
 

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -110,29 +110,27 @@ export async function buildReplyPayloads(params: {
   normalizeMediaPaths?: (payload: ReplyPayload) => Promise<ReplyPayload>;
 }): Promise<{ replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean }> {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
-  const sanitizedPayloads = params.isHeartbeat
-    ? params.payloads
-    : params.payloads.flatMap((payload) => {
-        let text = payload.text;
+  const sanitizedPayloads = params.payloads.flatMap((payload) => {
+    let text = payload.text;
 
-        if (payload.isError && text && isBunFetchSocketError(text)) {
-          text = formatBunFetchSocketError(text);
-        }
+    if (payload.isError && text && isBunFetchSocketError(text)) {
+      text = formatBunFetchSocketError(text);
+    }
 
-        if (!text || !text.includes("HEARTBEAT_OK")) {
-          return [{ ...payload, text }];
-        }
-        const stripped = stripHeartbeatToken(text, { mode: "message" });
-        if (stripped.didStrip && !didLogHeartbeatStrip) {
-          didLogHeartbeatStrip = true;
-          logVerbose("Stripped stray HEARTBEAT_OK token from reply");
-        }
-        const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
-        if (stripped.shouldSkip && !hasMedia) {
-          return [];
-        }
-        return [{ ...payload, text: stripped.text }];
-      });
+    if (!text || !text.includes("HEARTBEAT_OK")) {
+      return [{ ...payload, text }];
+    }
+    const stripped = stripHeartbeatToken(text, { mode: "message" });
+    if (stripped.didStrip && !didLogHeartbeatStrip) {
+      didLogHeartbeatStrip = true;
+      logVerbose("Stripped stray HEARTBEAT_OK token from reply");
+    }
+    const hasMedia = resolveSendableOutboundReplyParts(payload).hasMedia;
+    if (stripped.shouldSkip && !hasMedia) {
+      return [];
+    }
+    return [{ ...payload, text: stripped.text }];
+  });
 
   const replyTaggedPayloads = (
     await Promise.all(


### PR DESCRIPTION
## Summary

- Problem: OK-only heartbeat final replies can leak into channel sessions because heartbeat payloads bypass final reply token stripping.
- Why it matters: routine internal heartbeat acknowledgments like `HEARTBEAT_OK` can appear as unsolicited Telegram/WhatsApp/chat messages.
- What changed: final heartbeat payloads now run through the same `HEARTBEAT_OK` sanitation path as non-heartbeat final replies.
- What did NOT change (scope boundary): heartbeat scheduling, alert delivery, async exec completion handling, and channel-specific routing were not changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72217
- Related #71860
- Related #69492
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `buildReplyPayloads` returned raw `params.payloads` whenever `params.isHeartbeat` was true, so heartbeat final payloads skipped the existing `stripHeartbeatToken` sanitation branch.
- Missing detection / guardrail: there was no payload-layer regression asserting that an exact `HEARTBEAT_OK` heartbeat final reply is dropped before channel delivery.
- Contributing context (if known): docs already describe default OK-ack suppression; this path did not match that contract.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/agent-runner-payloads.test.ts`
- Scenario the test should lock in: `isHeartbeat: true` plus exact `HEARTBEAT_OK` produces no final reply payloads; real heartbeat alert text remains deliverable; media-bearing payloads keep media after token stripping.
- Why this is the smallest reliable guardrail: the bug is the final payload sanitation branch in `buildReplyPayloads`, so the focused payload test exercises the failing conditional directly without channel-specific fixtures.
- Existing test that already covers this (if any): none for `isHeartbeat: true` final payload sanitation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OK-only heartbeat acknowledgments should no longer appear as visible channel messages by default. Real heartbeat alert content should still be delivered.

## Diagram (if applicable)

```text
Before:
heartbeat final payload -> isHeartbeat bypass -> HEARTBEAT_OK can remain visible

After:
heartbeat final payload -> shared token sanitation -> OK-only payload dropped, alerts continue
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout on current `origin/main`
- Model/provider: not provider-specific
- Integration/channel (if any): final reply payload path used before channel delivery
- Relevant config (redacted): default heartbeat OK visibility behavior documented in `docs/gateway/heartbeat.md`

### Steps

1. Call `buildReplyPayloads` with `isHeartbeat: true` and `payloads: [{ text: "HEARTBEAT_OK" }]`.
2. Before this PR, observe the final reply payload remains deliverable.
3. After this PR, observe no final reply payload is returned.

### Expected

- OK-only heartbeat final replies are suppressed before channel delivery.
- Real alert text from heartbeat runs is preserved.

### Actual

- Before this PR, OK-only heartbeat final replies bypassed token stripping when `isHeartbeat` was true.
- After this PR, they use the shared token sanitation path and are dropped when text-only.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Failing-before evidence from the new regression test:

```text
FAIL src/auto-reply/reply/agent-runner-payloads.test.ts > buildReplyPayloads heartbeat token sanitation > suppresses OK-only final payloads for heartbeat runs
AssertionError: expected [ { text: 'HEARTBEAT_OK', ... } ] to have a length of +0 but got 1
```

Passing-after evidence:

```text
node scripts/test-projects.mjs src/auto-reply/reply/agent-runner-payloads.test.ts
Test Files  1 passed (1)
Tests  27 passed (27)
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: exact heartbeat OK final payload is suppressed; non-heartbeat OK suppression still works; heartbeat alert text is preserved; media-bearing heartbeat payload keeps media after OK text stripping.
- Edge cases checked: media-bearing payload with OK-only text, existing media dedupe tests, existing silent-turn tests, existing block-streaming final payload tests.
- What you did **not** verify: live Telegram/WhatsApp delivery against a real account in this PR branch.

Additional local checks:

```text
pnpm check:changed
# passed: conflict marker check, core typecheck, core test typecheck, core lint, import-cycle check, auth/webhook guards, focused test

pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-payloads.test.ts
# passed

git diff --check
# passed
```

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.


## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Real heartbeat alert content could be over-suppressed.
  - Mitigation: Added a regression test showing alert text without the OK token is preserved for heartbeat runs.
- Risk: Media payloads could be dropped when OK text is stripped.
  - Mitigation: Added a regression test showing media remains renderable after OK text stripping.

