### PR TITLE
fix gateway restart outside systemd

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -52,6 +52,7 @@ const probeGateway = vi.fn<
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
+const resolveDaemonProbeAuth = vi.hoisted(() => vi.fn(async () => ({ auth: undefined })));
 
 vi.mock("../../config/config.js", () => ({
   loadConfig: () => loadConfig(),
@@ -86,6 +87,10 @@ vi.mock("../../daemon/service.js", () => ({
 vi.mock("./launchd-recovery.js", () => ({
   recoverInstalledLaunchAgent: (args: { result: "started" | "restarted" }) =>
     recoverInstalledLaunchAgent(args),
+}));
+
+vi.mock("./status.gather.js", () => ({
+  resolveDaemonProbeAuth: (params: unknown) => resolveDaemonProbeAuth(params),
 }));
 
 vi.mock("./restart-health.js", () => ({
@@ -159,6 +164,7 @@ describe("runDaemonRestart health checks", () => {
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
     recoverInstalledLaunchAgent.mockReset();
+    resolveDaemonProbeAuth.mockReset();
 
     service.readCommand.mockResolvedValue({
       programArguments: ["openclaw", "gateway", "--port", "18789"],
@@ -200,6 +206,7 @@ describe("runDaemonRestart health checks", () => {
     isRestartEnabled.mockReturnValue(true);
     signalVerifiedGatewayPidSync.mockImplementation(() => {});
     formatGatewayPidList.mockImplementation((pids) => pids.join(", "));
+    resolveDaemonProbeAuth.mockResolvedValue({ auth: undefined });
   });
 
   afterEach(() => {
@@ -368,6 +375,21 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("passes resolved probe auth into unmanaged restart health checks", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    resolveDaemonProbeAuth.mockResolvedValue({ auth: { token: "resolved-token" } });
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 18789,
+        auth: { token: "resolved-token" },
+      }),
+    );
   });
 
   it("prefers unmanaged restart over launchd repair when a gateway listener is present", async () => {

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -392,6 +392,17 @@ describe("runDaemonRestart health checks", () => {
     );
   });
 
+  it("reuses one config/probe-auth lookup across unmanaged restart checks", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    resolveDaemonProbeAuth.mockResolvedValue({ auth: { token: "resolved-token" } });
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(resolveDaemonProbeAuth).toHaveBeenCalledTimes(1);
+  });
+
   it("prefers unmanaged restart over launchd repair when a gateway listener is present", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -53,6 +53,9 @@ const callGatewayCli = vi.fn();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.hoisted(() => vi.fn(() => ({})));
 const recoverInstalledLaunchAgent = vi.hoisted(() => vi.fn());
+const resolveGatewayProbeAuthSafeWithSecretInputs = vi.hoisted(() =>
+  vi.fn(async () => ({ auth: undefined })),
+);
 const repairLoadedGatewayServiceForStart = vi.hoisted(() => vi.fn());
 const findInstalledSystemdGatewayScope = vi.hoisted(() =>
   vi.fn<() => Promise<{ scope: "user" | "system"; unitName: string; unitPath: string } | null>>(
@@ -131,6 +134,11 @@ vi.mock("../../daemon/systemd.js", () => ({
 vi.mock("./launchd-recovery.js", () => ({
   recoverInstalledLaunchAgent: (args: { result: "started" | "restarted" }) =>
     recoverInstalledLaunchAgent(args),
+}));
+
+vi.mock("../../gateway/probe-auth.js", () => ({
+  resolveGatewayProbeAuthSafeWithSecretInputs: (params: unknown) =>
+    resolveGatewayProbeAuthSafeWithSecretInputs(params),
 }));
 
 vi.mock("./start-repair.js", () => ({
@@ -214,6 +222,7 @@ describe("runDaemonRestart health checks", () => {
     isRestartEnabled.mockReset();
     loadConfig.mockReset();
     recoverInstalledLaunchAgent.mockReset();
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockReset();
     repairLoadedGatewayServiceForStart.mockReset();
 
     service.readCommand.mockResolvedValue({
@@ -553,6 +562,36 @@ describe("runDaemonRestart health checks", () => {
     expect(waitForGatewayHealthyRestart).not.toHaveBeenCalled();
     expect(terminateStaleGatewayPids).not.toHaveBeenCalled();
     expect(service.restart).not.toHaveBeenCalled();
+  });
+
+  it("passes resolved probe auth into unmanaged restart health checks", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockResolvedValue({
+      auth: { token: "resolved-token" },
+    });
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(waitForGatewayHealthyListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        port: 18789,
+        auth: { token: "resolved-token" },
+      }),
+    );
+  });
+
+  it("reuses one config/probe-auth lookup across unmanaged restart checks", async () => {
+    findVerifiedGatewayListenerPidsOnPortSync.mockReturnValue([4200]);
+    resolveGatewayProbeAuthSafeWithSecretInputs.mockResolvedValue({
+      auth: { token: "resolved-token" },
+    });
+    mockUnmanagedRestart({ runPostRestartCheck: true });
+
+    await runDaemonRestart({ json: true });
+
+    expect(loadConfig).toHaveBeenCalledTimes(1);
+    expect(resolveGatewayProbeAuthSafeWithSecretInputs).toHaveBeenCalledTimes(1);
   });
 
   it("prefers launchd repair over unmanaged restart when an installed LaunchAgent is unloaded", async () => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -79,19 +79,33 @@ function resolveGatewayPortFallback(): Promise<number> {
     .catch(() => resolveGatewayPort(undefined, process.env));
 }
 
-async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void> {
+async function resolveGatewayRestartConfigContext(): Promise<{
+  cfg: Awaited<ReturnType<typeof readBestEffortConfig>> | undefined;
+  probeAuth?: Awaited<ReturnType<typeof resolveDaemonProbeAuth>>;
+}> {
   const cfg = await readBestEffortConfig().catch(() => undefined);
+  return {
+    cfg,
+    probeAuth: cfg
+      ? await resolveDaemonProbeAuth({
+          cfg,
+          env: process.env,
+        }).catch(() => undefined)
+      : undefined,
+  };
+}
+
+async function assertUnmanagedGatewayRestartEnabled(params: {
+  port: number;
+  cfg?: Awaited<ReturnType<typeof readBestEffortConfig>>;
+  probeAuth?: Awaited<ReturnType<typeof resolveDaemonProbeAuth>>;
+}): Promise<void> {
+  const cfg = params.cfg;
   const tlsEnabled = !!cfg?.gateway?.tls?.enabled;
   const scheme = tlsEnabled ? "wss" : "ws";
-  const probeAuth = cfg
-    ? await resolveDaemonProbeAuth({
-        cfg,
-        env: process.env,
-      }).catch(() => undefined)
-    : undefined;
   const probe = await probeGateway({
-    url: `${scheme}://127.0.0.1:${port}`,
-    auth: probeAuth?.auth ?? {
+    url: `${scheme}://127.0.0.1:${params.port}`,
+    auth: params.probeAuth?.auth ?? {
       token: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN),
       password: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD),
     },
@@ -128,8 +142,14 @@ async function stopGatewayWithoutServiceManager(port: number) {
   };
 }
 
-async function restartGatewayWithoutServiceManager(port: number) {
-  await assertUnmanagedGatewayRestartEnabled(port);
+async function restartGatewayWithoutServiceManager(
+  port: number,
+  context?: {
+    cfg?: Awaited<ReturnType<typeof readBestEffortConfig>>;
+    probeAuth?: Awaited<ReturnType<typeof resolveDaemonProbeAuth>>;
+  },
+) {
+  await assertUnmanagedGatewayRestartEnabled({ port, ...context });
   const pids = resolveVerifiedGatewayListenerPids(port);
   if (pids.length === 0) {
     return null;
@@ -197,13 +217,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
-  const cfg = await readBestEffortConfig().catch(() => undefined);
-  const restartProbeAuth = cfg
-    ? await resolveDaemonProbeAuth({
-        cfg,
-        env: process.env,
-      }).catch(() => undefined)
-    : undefined;
+  const restartContext = await resolveGatewayRestartConfigContext();
   const restartHealthAttempts = postRestartHealthAttempts();
   const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
@@ -215,7 +229,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     opts,
     checkTokenDrift: true,
     onNotLoaded: async () => {
-      const handled = await restartGatewayWithoutServiceManager(restartPort);
+      const handled = await restartGatewayWithoutServiceManager(restartPort, restartContext);
       if (handled) {
         restartedWithoutServiceManager = true;
         return handled;
@@ -228,7 +242,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           port: restartPort,
           attempts: restartHealthAttempts,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
-          auth: restartProbeAuth?.auth,
+          auth: restartContext.probeAuth?.auth,
         });
         if (health.healthy) {
           return undefined;

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -29,6 +29,7 @@ import {
   waitForGatewayHealthyRestart,
 } from "./restart-health.js";
 import { parsePortFromArgs, renderGatewayServiceStartHints } from "./shared.js";
+import { resolveDaemonProbeAuth } from "./status.gather.js";
 import type { DaemonLifecycleOptions } from "./types.js";
 
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
@@ -82,9 +83,15 @@ async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void>
   const cfg = await readBestEffortConfig().catch(() => undefined);
   const tlsEnabled = !!cfg?.gateway?.tls?.enabled;
   const scheme = tlsEnabled ? "wss" : "ws";
+  const probeAuth = cfg
+    ? await resolveDaemonProbeAuth({
+        cfg,
+        env: process.env,
+      }).catch(() => undefined)
+    : undefined;
   const probe = await probeGateway({
     url: `${scheme}://127.0.0.1:${port}`,
-    auth: {
+    auth: probeAuth?.auth ?? {
       token: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN),
       password: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD),
     },
@@ -190,6 +197,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
+  const cfg = await readBestEffortConfig().catch(() => undefined);
+  const restartProbeAuth = cfg
+    ? await resolveDaemonProbeAuth({
+        cfg,
+        env: process.env,
+      }).catch(() => undefined)
+    : undefined;
   const restartHealthAttempts = postRestartHealthAttempts();
   const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
@@ -214,6 +228,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           port: restartPort,
           attempts: restartHealthAttempts,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          auth: restartProbeAuth?.auth,
         });
         if (health.healthy) {
           return undefined;

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -18,16 +18,17 @@ import {
 import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
 import { type GatewayRestartIntent, writeGatewayRestartIntentSync } from "../../infra/restart.js";
 import { defaultRuntime } from "../../runtime.js";
+import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { formatCliCommand } from "../command-format.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { recoverInstalledLaunchAgent } from "./launchd-recovery.js";
-import { createNullWriter } from "./response.js";
 import {
   runServiceRestart,
   runServiceStart,
   runServiceStop,
   runServiceUninstall,
 } from "./lifecycle-core.js";
+import { createNullWriter } from "./response.js";
 import {
   DEFAULT_RESTART_HEALTH_ATTEMPTS,
   DEFAULT_RESTART_HEALTH_DELAY_MS,
@@ -45,6 +46,18 @@ import type { DaemonLifecycleOptions } from "./types.js";
 const POST_RESTART_HEALTH_ATTEMPTS = DEFAULT_RESTART_HEALTH_ATTEMPTS;
 const POST_RESTART_HEALTH_DELAY_MS = DEFAULT_RESTART_HEALTH_DELAY_MS;
 const WINDOWS_POST_RESTART_HEALTH_TIMEOUT_MS = 180_000;
+const gatewayProbeAuthModuleLoader = createLazyImportLoader(
+  () => import("../../gateway/probe-auth.js"),
+);
+
+type GatewayProbeAuthResolution = {
+  auth: { token?: string; password?: string };
+  warning?: string;
+};
+
+function loadGatewayProbeAuthModule() {
+  return gatewayProbeAuthModuleLoader.load();
+}
 
 function postRestartHealthAttempts(): number {
   return process.platform === "win32"
@@ -89,13 +102,38 @@ function resolveGatewayPortFallback(): Promise<number> {
     .catch(() => resolveGatewayPort(undefined, process.env));
 }
 
-async function assertUnmanagedGatewayRestartEnabled(port: number): Promise<void> {
+async function resolveGatewayRestartConfigContext(): Promise<{
+  cfg: Awaited<ReturnType<typeof readBestEffortConfig>> | undefined;
+  probeAuth?: GatewayProbeAuthResolution;
+}> {
   const cfg = await readBestEffortConfig().catch(() => undefined);
+  return {
+    cfg,
+    probeAuth: cfg
+      ? await loadGatewayProbeAuthModule()
+          .then(({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
+            resolveGatewayProbeAuthSafeWithSecretInputs({
+              cfg,
+              mode: "local",
+              env: process.env,
+            }),
+          )
+          .catch(() => undefined)
+      : undefined,
+  };
+}
+
+async function assertUnmanagedGatewayRestartEnabled(params: {
+  port: number;
+  cfg?: Awaited<ReturnType<typeof readBestEffortConfig>>;
+  probeAuth?: GatewayProbeAuthResolution;
+}): Promise<void> {
+  const cfg = params.cfg;
   const tlsEnabled = Boolean(cfg?.gateway?.tls?.enabled);
   const scheme = tlsEnabled ? "wss" : "ws";
   const probe = await probeGateway({
-    url: `${scheme}://127.0.0.1:${port}`,
-    auth: {
+    url: `${scheme}://127.0.0.1:${params.port}`,
+    auth: params.probeAuth?.auth ?? {
       token: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN),
       password: normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD),
     },
@@ -230,12 +268,16 @@ async function requestSafeGatewayRestart(opts: DaemonLifecycleOptions): Promise<
 async function restartGatewayWithoutServiceManager(
   port: number,
   restartIntent?: GatewayRestartIntent,
+  context?: {
+    cfg?: Awaited<ReturnType<typeof readBestEffortConfig>>;
+    probeAuth?: GatewayProbeAuthResolution;
+  },
 ) {
   const managed = await handleSystemScopeSystemdGateway("restart");
   if (managed) {
     return managed;
   }
-  await assertUnmanagedGatewayRestartEnabled(port);
+  await assertUnmanagedGatewayRestartEnabled({ port, ...context });
   const pids = resolveVerifiedGatewayListenerPids(port);
   if (pids.length === 0) {
     return null;
@@ -325,6 +367,10 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
     resolveGatewayPortFallback(),
   );
+  let restartContextPromise:
+    | Promise<Awaited<ReturnType<typeof resolveGatewayRestartConfigContext>>>
+    | undefined;
+  const getRestartContext = () => (restartContextPromise ??= resolveGatewayRestartConfigContext());
   const restartHealthAttempts = postRestartHealthAttempts();
   const restartWaitMs = restartHealthAttempts * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
@@ -345,7 +391,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
           return recovered;
         }
       }
-      const handled = await restartGatewayWithoutServiceManager(restartPort, restartIntent);
+      const handled = await restartGatewayWithoutServiceManager(
+        restartPort,
+        restartIntent,
+        await getRestartContext(),
+      );
       if (handled) {
         restartedWithoutServiceManager = true;
         return handled;
@@ -354,10 +404,12 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
     },
     postRestartCheck: async ({ warnings, fail, stdout }) => {
       if (restartedWithoutServiceManager) {
+        const restartContext = await getRestartContext();
         const health = await waitForGatewayHealthyListener({
           port: restartPort,
           attempts: restartHealthAttempts,
           delayMs: POST_RESTART_HEALTH_DELAY_MS,
+          auth: restartContext.probeAuth?.auth,
         });
         if (health.healthy) {
           return undefined;

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -109,6 +109,26 @@ async function waitForStoppedFreeGatewayRestart() {
   });
 }
 
+async function waitForGatewayHealthyListenerWithAuth(params: {
+  auth?: { token?: string; password?: string };
+  probeResult: Awaited<ReturnType<typeof probeGateway>>;
+}) {
+  inspectPortUsage.mockResolvedValue({
+    port: 18789,
+    status: "busy",
+    listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+    hints: [],
+  });
+  probeGateway.mockResolvedValue(params.probeResult);
+  const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+  return waitForGatewayHealthyListener({
+    port: 18789,
+    attempts: 1,
+    delayMs: 1,
+    auth: params.auth,
+  });
+}
+
 describe("inspectGatewayRestart", () => {
   beforeEach(() => {
     inspectPortUsage.mockReset();
@@ -248,6 +268,24 @@ describe("inspectGatewayRestart", () => {
     });
 
     expect(snapshot.healthy).toBe(true);
+  });
+
+  it("forwards explicit auth into listener health probes", async () => {
+    const snapshot = await waitForGatewayHealthyListenerWithAuth({
+      auth: { token: "resolved-token" },
+      probeResult: {
+        ok: false,
+        close: { code: 1008, reason: "auth required" },
+      },
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        auth: { token: "resolved-token", password: undefined },
+      }),
+    );
   });
 
   it("requires the expected gateway version when provided", async () => {

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -133,6 +133,26 @@ async function waitForStoppedFreeGatewayRestart() {
   });
 }
 
+async function waitForGatewayHealthyListenerWithAuth(params: {
+  auth?: { token?: string; password?: string };
+  probeResult: Awaited<ReturnType<typeof probeGateway>>;
+}) {
+  inspectPortUsage.mockResolvedValue({
+    port: 18789,
+    status: "busy",
+    listeners: [{ pid: 8000, commandLine: "openclaw-gateway" }],
+    hints: [],
+  });
+  probeGateway.mockResolvedValue(params.probeResult);
+  const { waitForGatewayHealthyListener } = await import("./restart-health.js");
+  return waitForGatewayHealthyListener({
+    port: 18789,
+    attempts: 1,
+    delayMs: 1,
+    auth: params.auth,
+  });
+}
+
 describe("inspectGatewayRestart", () => {
   beforeEach(() => {
     inspectPortUsage.mockReset();
@@ -325,6 +345,24 @@ describe("inspectGatewayRestart", () => {
       expect(snapshot.healthy).toBe(false);
     },
   );
+
+  it("forwards explicit auth into listener health probes", async () => {
+    const snapshot = await waitForGatewayHealthyListenerWithAuth({
+      auth: { token: "resolved-token" },
+      probeResult: {
+        ok: false,
+        close: { code: 1008, reason: "auth required" },
+      },
+    });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "ws://127.0.0.1:18789",
+        auth: { token: "resolved-token", password: undefined },
+      }),
+    );
+  });
 
   it("requires the expected gateway version when provided", async () => {
     probeGateway.mockResolvedValue({

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -164,9 +164,12 @@ function applyActivatedPluginErrors(snapshot: GatewayRestartSnapshot): GatewayRe
 async function confirmGatewayReachable(params: {
   port: number;
   includeHealthDetails?: boolean;
+  auth?: { token?: string; password?: string };
 }): Promise<GatewayReachability> {
-  const token = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_TOKEN);
-  const password = normalizeOptionalString(process.env.OPENCLAW_GATEWAY_PASSWORD);
+  const token = normalizeOptionalString(params.auth?.token ?? process.env.OPENCLAW_GATEWAY_TOKEN);
+  const password = normalizeOptionalString(
+    params.auth?.password ?? process.env.OPENCLAW_GATEWAY_PASSWORD,
+  );
   const probe = await probeGateway({
     url: `ws://127.0.0.1:${params.port}`,
     auth: token || password ? { token, password } : undefined,
@@ -180,7 +183,10 @@ async function confirmGatewayReachable(params: {
   };
 }
 
-async function inspectGatewayPortHealth(port: number): Promise<GatewayPortHealthSnapshot> {
+async function inspectGatewayPortHealth(
+  port: number,
+  auth?: { token?: string; password?: string },
+): Promise<GatewayPortHealthSnapshot> {
   let portUsage: PortUsage;
   try {
     portUsage = await inspectPortUsage(port);
@@ -197,7 +203,7 @@ async function inspectGatewayPortHealth(port: number): Promise<GatewayPortHealth
   let healthy = false;
   if (portUsage.status === "busy") {
     try {
-      healthy = (await confirmGatewayReachable({ port })).reachable;
+      healthy = (await confirmGatewayReachable({ port, auth })).reachable;
     } catch {
       // best-effort probe
     }
@@ -446,18 +452,19 @@ export async function waitForGatewayHealthyListener(params: {
   port: number;
   attempts?: number;
   delayMs?: number;
+  auth?: { token?: string; password?: string };
 }): Promise<GatewayPortHealthSnapshot> {
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
 
-  let snapshot = await inspectGatewayPortHealth(params.port);
+  let snapshot = await inspectGatewayPortHealth(params.port, params.auth);
 
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     if (snapshot.healthy) {
       return snapshot;
     }
     await sleep(delayMs);
-    snapshot = await inspectGatewayPortHealth(params.port);
+    snapshot = await inspectGatewayPortHealth(params.port, params.auth);
   }
 
   return snapshot;

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -289,6 +289,7 @@ async function resolveGatewayRestartProbeAuth(
 async function inspectGatewayPortHealth(params: {
   port: number;
   auth?: GatewayRestartProbeAuth;
+  env?: NodeJS.ProcessEnv;
 }): Promise<GatewayPortHealthSnapshot> {
   let portUsage: PortUsage;
   try {
@@ -310,7 +311,7 @@ async function inspectGatewayPortHealth(params: {
         await confirmGatewayReachable({
           port: params.port,
           auth: params.auth,
-          env: process.env,
+          env: params.env,
         })
       ).reachable;
     } catch {
@@ -583,11 +584,13 @@ export async function waitForGatewayHealthyListener(params: {
   port: number;
   attempts?: number;
   delayMs?: number;
+  auth?: GatewayRestartProbeAuth;
 }): Promise<GatewayPortHealthSnapshot> {
   const attempts = params.attempts ?? DEFAULT_RESTART_HEALTH_ATTEMPTS;
   const delayMs = params.delayMs ?? DEFAULT_RESTART_HEALTH_DELAY_MS;
 
-  const probeAuth = await resolveGatewayRestartProbeAuth(undefined).catch(() => undefined);
+  const probeAuth =
+    params.auth ?? (await resolveGatewayRestartProbeAuth(undefined).catch(() => undefined));
   let snapshot = await inspectGatewayPortHealth({
     port: params.port,
     auth: probeAuth,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -87,6 +87,27 @@ function loadGatewayProbeAuthModule() {
   return gatewayProbeAuthModulePromise;
 }
 
+export async function resolveDaemonProbeAuth(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  explicitAuth?: { token?: string; password?: string };
+}): Promise<{ auth?: { token?: string; password?: string }; warning?: string }> {
+  const probeMode = params.cfg.gateway?.mode === "remote" ? "remote" : "local";
+  const probeAuthResolution = await loadGatewayProbeAuthModule().then(
+    ({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
+      resolveGatewayProbeAuthSafeWithSecretInputs({
+        cfg: params.cfg,
+        mode: probeMode,
+        env: params.env,
+        explicitAuth: params.explicitAuth,
+      }),
+  );
+  return {
+    auth: probeAuthResolution.auth,
+    warning: probeAuthResolution.warning,
+  };
+}
+
 function loadDaemonInspectModule() {
   daemonInspectModulePromise ??= import("../../daemon/inspect.js");
   return daemonInspectModulePromise;
@@ -414,19 +435,14 @@ export async function gatherDaemonStatus(
   let daemonProbeAuth: { token?: string; password?: string } | undefined;
   let rpcAuthWarning: string | undefined;
   if (opts.probe) {
-    const probeMode = daemonCfg.gateway?.mode === "remote" ? "remote" : "local";
-    const probeAuthResolution = await loadGatewayProbeAuthModule().then(
-      ({ resolveGatewayProbeAuthSafeWithSecretInputs }) =>
-        resolveGatewayProbeAuthSafeWithSecretInputs({
-          cfg: daemonCfg,
-          mode: probeMode,
-          env: mergedDaemonEnv as NodeJS.ProcessEnv,
-          explicitAuth: {
-            token: opts.rpc.token,
-            password: opts.rpc.password,
-          },
-        }),
-    );
+    const probeAuthResolution = await resolveDaemonProbeAuth({
+      cfg: daemonCfg,
+      env: mergedDaemonEnv as NodeJS.ProcessEnv,
+      explicitAuth: {
+        token: opts.rpc.token,
+        password: opts.rpc.password,
+      },
+    });
     daemonProbeAuth = probeAuthResolution.auth;
     rpcAuthWarning = probeAuthResolution.warning;
   }

--- a/src/infra/gateway-process-argv.test.ts
+++ b/src/infra/gateway-process-argv.test.ts
@@ -64,6 +64,12 @@ describe("isGatewayArgv", () => {
         allowGatewayBinary: true,
       }),
     ).toBe(true);
+    expect(isGatewayArgv(["openclaw-gateway"])).toBe(false);
+    expect(
+      isGatewayArgv(["openclaw-gateway"], {
+        allowGatewayBinary: true,
+      }),
+    ).toBe(true);
   });
 
   it("rejects unknown gateway argv even when the token is present", () => {

--- a/src/infra/gateway-process-argv.ts
+++ b/src/infra/gateway-process-argv.ts
@@ -64,5 +64,5 @@ export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: bool
     return true;
   }
 
-  return exe.endsWith("/openclaw") || exe === "openclaw" || isGatewayBinary;
+  return exe.endsWith("/openclaw") || exe === "openclaw";
 }

--- a/src/infra/gateway-process-argv.ts
+++ b/src/infra/gateway-process-argv.ts
@@ -39,6 +39,15 @@ export function parseWindowsCmdline(raw: string): string[] {
 
 export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: boolean }): boolean {
   const normalized = args.map(normalizeProcArg);
+  const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
+  const isGatewayBinary =
+    opts?.allowGatewayBinary === true &&
+    (exe.endsWith("/openclaw-gateway") || exe === "openclaw-gateway");
+
+  if (isGatewayBinary) {
+    return true;
+  }
+
   if (!normalized.includes("gateway")) {
     return false;
   }
@@ -55,10 +64,5 @@ export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: bool
     return true;
   }
 
-  const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
-  return (
-    exe.endsWith("/openclaw") ||
-    exe === "openclaw" ||
-    (opts?.allowGatewayBinary === true && exe.endsWith("/openclaw-gateway"))
-  );
+  return exe.endsWith("/openclaw") || exe === "openclaw" || isGatewayBinary;
 }

--- a/src/infra/gateway-process-argv.ts
+++ b/src/infra/gateway-process-argv.ts
@@ -37,6 +37,15 @@ export function parseWindowsCmdline(raw: string): string[] {
 
 export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: boolean }): boolean {
   const normalized = args.map(normalizeProcArg);
+  const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
+  const isGatewayBinary =
+    opts?.allowGatewayBinary === true &&
+    (exe.endsWith("/openclaw-gateway") || exe === "openclaw-gateway");
+
+  if (isGatewayBinary) {
+    return true;
+  }
+
   if (!normalized.includes("gateway")) {
     return false;
   }
@@ -53,10 +62,5 @@ export function isGatewayArgv(args: string[], opts?: { allowGatewayBinary?: bool
     return true;
   }
 
-  const exe = (normalized[0] ?? "").replace(/\.(bat|cmd|exe)$/i, "");
-  return (
-    exe.endsWith("/openclaw") ||
-    exe === "openclaw" ||
-    (opts?.allowGatewayBinary === true && exe.endsWith("/openclaw-gateway"))
-  );
+  return exe.endsWith("/openclaw") || exe === "openclaw";
 }

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -157,6 +157,21 @@ describe("gateway-processes", () => {
     );
   });
 
+  it("accepts bare openclaw-gateway process titles when gateway binary verification is enabled", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("openclaw-gateway\0");
+    parseProcCmdlineMock.mockReturnValue(["openclaw-gateway"]);
+    isGatewayArgvMock.mockReturnValue(true);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    signalVerifiedGatewayPidSync(700, "SIGUSR1");
+
+    expect(isGatewayArgvMock).toHaveBeenCalledWith(["openclaw-gateway"], {
+      allowGatewayBinary: true,
+    });
+    expect(killSpy).toHaveBeenCalledWith(700, "SIGUSR1");
+  });
+
   it("dedupes and filters verified gateway listener pids on unix and windows", () => {
     setPlatform("linux");
     findGatewayPidsOnPortSyncMock.mockReturnValue([process.pid, 200, 200, 300, -1]);

--- a/src/infra/gateway-processes.test.ts
+++ b/src/infra/gateway-processes.test.ts
@@ -147,6 +147,21 @@ describe("gateway-processes", () => {
     );
   });
 
+  it("accepts bare openclaw-gateway process titles when gateway binary verification is enabled", () => {
+    setPlatform("linux");
+    readFileSyncMock.mockReturnValue("openclaw-gateway\0");
+    parseProcCmdlineMock.mockReturnValue(["openclaw-gateway"]);
+    isGatewayArgvMock.mockReturnValue(true);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    signalVerifiedGatewayPidSync(700, "SIGUSR1");
+
+    expect(isGatewayArgvMock).toHaveBeenCalledWith(["openclaw-gateway"], {
+      allowGatewayBinary: true,
+    });
+    expect(killSpy).toHaveBeenCalledWith(700, "SIGUSR1");
+  });
+
   it("dedupes and filters verified gateway listener pids on unix and windows", () => {
     setPlatform("linux");
     findGatewayPidsOnPortSyncMock.mockReturnValue([process.pid, 200, 200, 300, -1]);

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -32,6 +32,8 @@ const mockReadWindowsProcessArgsResult = vi.hoisted(() =>
 // from the same baseline; tests that need to simulate deeper ancestor chains
 // override it via `mockImplementation` / `mockImplementationOnce`.
 const mockReadFileSync = vi.hoisted(() => vi.fn());
+const mockReadDirSync = vi.hoisted(() => vi.fn());
+const mockReadLinkSync = vi.hoisted(() => vi.fn());
 
 vi.mock("node:fs", async () => {
   const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
@@ -46,6 +48,10 @@ vi.mock("node:fs", async () => {
       // reads); the cast is a precise retype, not `any`.
       readFileSync: ((path: unknown, encoding?: unknown) =>
         mockReadFileSync(path, encoding)) as typeof actual.readFileSync,
+      readdirSync: ((path: unknown, options?: unknown) =>
+        mockReadDirSync(path, options)) as typeof actual.readdirSync,
+      readlinkSync: ((path: unknown, options?: unknown) =>
+        mockReadLinkSync(path, options)) as typeof actual.readlinkSync,
     }),
   );
 });
@@ -167,9 +173,21 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
     mockReadWindowsProcessArgs.mockReset();
     mockReadWindowsProcessArgsResult.mockReset();
     mockReadFileSync.mockReset();
+    mockReadDirSync.mockReset();
+    mockReadLinkSync.mockReset();
     mockReadFileSync.mockImplementation(() => {
       // Default: simulate /proc unavailable. Walks that reach this mock
       // degrade silently and return whatever set they collected so far.
+      const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+      error.code = "ENOENT";
+      throw error;
+    });
+    mockReadDirSync.mockImplementation(() => {
+      const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+      error.code = "ENOENT";
+      throw error;
+    });
+    mockReadLinkSync.mockImplementation(() => {
       const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
       error.code = "ENOENT";
       throw error;
@@ -229,6 +247,92 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       expect(mockRestartWarn).toHaveBeenCalledWith(
         expect.stringContaining("lsof failed during initial stale-pid scan"),
       );
+    });
+
+    it("prefers native /proc socket discovery before lsof on linux", () => {
+      const stalePid = process.pid + 777;
+      mockReadFileSync.mockImplementation((path: unknown) => {
+        if (path === "/proc/net/tcp") {
+          return [
+            "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+            "   0: 00000000:4965 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 12345 1 0000000000000000 100 0 0 10 0",
+          ].join("\n");
+        }
+        if (path === "/proc/net/tcp6") {
+          return "";
+        }
+        if (path === `/proc/${stalePid}/cmdline`) {
+          return "openclaw-gateway\0";
+        }
+        const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+        error.code = "ENOENT";
+        throw error;
+      });
+      mockReadDirSync.mockImplementation((path: unknown) => {
+        if (path === "/proc") {
+          return [String(stalePid)];
+        }
+        if (path === `/proc/${stalePid}/fd`) {
+          return ["21"];
+        }
+        const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+        error.code = "ENOENT";
+        throw error;
+      });
+      mockReadLinkSync.mockImplementation((path: unknown) => {
+        if (path === `/proc/${stalePid}/fd/21`) {
+          return "socket:[12345]";
+        }
+        const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+        error.code = "ENOENT";
+        throw error;
+      });
+
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([stalePid]);
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+    });
+
+    it("falls back to ss when lsof is unavailable and /proc cannot inspect listener owners", () => {
+      const stalePid = process.pid + 778;
+      mockReadFileSync.mockImplementation((path: unknown) => {
+        if (path === "/proc/net/tcp") {
+          return [
+            "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode",
+            "   0: 00000000:4965 00000000:0000 0A 00000000:00000000 00:00000000 00000000 1000 0 22345 1 0000000000000000 100 0 0 10 0",
+          ].join("\n");
+        }
+        if (path === "/proc/net/tcp6") {
+          return "";
+        }
+        if (path === `/proc/${stalePid}/cmdline`) {
+          return "openclaw-gateway\0";
+        }
+        const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+        error.code = "ENOENT";
+        throw error;
+      });
+      mockReadDirSync.mockImplementation((path: unknown) => {
+        if (path === "/proc") {
+          return [String(stalePid)];
+        }
+        const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+        error.code = "ENOENT";
+        throw error;
+      });
+      mockSpawnSync.mockImplementation((command: string) => {
+        if (command === "lsof") {
+          return createErrnoResult("ENOENT", "lsof missing");
+        }
+        if (command === "ss") {
+          return createLsofResult({
+            status: 0,
+            stdout: `LISTEN 0 511 0.0.0.0:18789 0.0.0.0:* users:(("openclaw-gateway",pid=${stalePid},fd=22))`,
+          });
+        }
+        return createLsofResult({ status: 1 });
+      });
+
+      expect(findGatewayPidsOnPortSync(18789)).toEqual([stalePid]);
     });
 
     it("parses openclaw-gateway pids and excludes the current process", () => {
@@ -735,43 +839,48 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       const events: string[] = [];
       events.push("initial-find");
       installInitialBusyPoll(stalePid, (call) => {
-        // Permanent ENOENT — lsof is not installed
-        events.push(`enoent-poll-${call}`);
-        return createErrnoResult("ENOENT", "lsof not found");
+        events.push(`poll-${call}`);
+        if (call % 2 === 0) {
+          return createErrnoResult("ENOENT", "lsof not found");
+        }
+        return createErrnoResult("ENOENT", "ss not found");
       });
 
       vi.spyOn(process, "kill").mockReturnValue(true);
       expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
 
       // Must bail after first ENOENT poll — no point retrying a missing binary
-      const enoentPolls = events.filter((e) => e.startsWith("enoent-poll"));
-      expect(enoentPolls.length).toBe(1);
+      const polls = events.filter((e) => e.startsWith("poll-"));
+      expect(polls.length).toBe(2);
     });
 
     it("bails immediately when lsof is permanently unavailable (EPERM) — SELinux/AppArmor", () => {
       // EPERM occurs when lsof exists but a MAC policy (SELinux/AppArmor) blocks
       // execution. Like ENOENT/EACCES, this is permanent — retrying is pointless.
       const stalePid = process.pid + 305;
-      const getCallCount = installInitialBusyPoll(stalePid, () =>
-        createErrnoResult("EPERM", "lsof eperm"),
+      const getCallCount = installInitialBusyPoll(stalePid, (call) =>
+        call % 2 === 0
+          ? createErrnoResult("EPERM", "lsof eperm")
+          : createErrnoResult("EPERM", "ss eperm"),
       );
       vi.spyOn(process, "kill").mockReturnValue(true);
       expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
-      // Must bail after exactly 1 EPERM poll — same as ENOENT/EACCES
-      expect(getCallCount()).toBe(2); // 1 initial find + 1 EPERM poll
+      // Initial stale-pid scan uses lsof then ss; first poll does same and then bails.
+      expect(getCallCount()).toBe(3);
     });
 
     it("bails immediately when lsof is permanently unavailable (EACCES) — same as ENOENT", () => {
       // EACCES and EPERM are also permanent conditions — lsof exists but the
       // process has no permission to run it. No point retrying.
       const stalePid = process.pid + 302;
-      const getCallCount = installInitialBusyPoll(stalePid, () =>
-        createErrnoResult("EACCES", "lsof permission denied"),
+      const getCallCount = installInitialBusyPoll(stalePid, (call) =>
+        call % 2 === 0
+          ? createErrnoResult("EACCES", "lsof permission denied")
+          : createErrnoResult("EACCES", "ss permission denied"),
       );
       vi.spyOn(process, "kill").mockReturnValue(true);
       expect(() => cleanStaleGatewayProcessesSync()).not.toThrow();
-      // Should have bailed after exactly 1 poll call (the EACCES one)
-      expect(getCallCount()).toBe(2); // 1 initial find + 1 EACCES poll
+      expect(getCallCount()).toBe(3);
     });
 
     it("proceeds with warning when polling budget is exhausted — fake clock, no real 2s wait", () => {

--- a/src/infra/restart-stale-pids.test.ts
+++ b/src/infra/restart-stale-pids.test.ts
@@ -672,20 +672,46 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       const stalePid = process.pid + 501;
       const events: string[] = [];
       events.push("initial-find");
+      let lsofCalls = 0;
+      let ssCalls = 0;
       installInitialBusyPoll(stalePid, (call) => {
         if (call === 2) {
-          // Permission/runtime error — status 2, should NOT be treated as free
+          // Permission/runtime error — status 2, should NOT be treated as free.
+          // `pollPortOnce` now falls through to `ss`, so keep `ss` inconclusive too.
           events.push("error-poll");
           return createLsofResult({ status: 2, stderr: "lsof: permission denied" });
         }
-        // Eventually port is free
         events.push("free-poll");
+        return createLsofResult({ status: 1 });
+      });
+      mockSpawnSync.mockImplementation((command: unknown) => {
+        if (command === "ss") {
+          ssCalls += 1;
+          if (ssCalls === 1) {
+            events.push("ss-transient");
+            return createLsofResult({ status: 2, stderr: "ss: permission denied" });
+          }
+          return createLsofResult({ status: 1 });
+        }
+        if (command === "lsof") {
+          lsofCalls += 1;
+          if (lsofCalls === 1) {
+            return createOpenClawBusyResult(stalePid);
+          }
+          if (lsofCalls === 2) {
+            events.push("error-poll");
+            return createLsofResult({ status: 2, stderr: "lsof: permission denied" });
+          }
+          events.push("free-poll");
+          return createLsofResult({ status: 1 });
+        }
         return createLsofResult({ status: 1 });
       });
       vi.spyOn(process, "kill").mockReturnValue(true);
       cleanStaleGatewayProcessesSync();
 
       // Must have continued polling after the status-2 error, not exited early
+      expect(events).toContain("ss-transient");
       expect(events).toContain("free-poll");
     });
 
@@ -964,14 +990,29 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
       const stalePid = process.pid + 301;
       const events: string[] = [];
       events.push("initial-find");
-      installInitialBusyPoll(stalePid, (call) => {
-        if (call === 2) {
-          // Transient: spawnSync timeout (no ENOENT code)
-          events.push("transient-error");
-          return createLsofResult({ error: new Error("timeout"), status: null });
+      let lsofCalls = 0;
+      let ssCalls = 0;
+      mockSpawnSync.mockImplementation((command: unknown) => {
+        if (command === "ss") {
+          ssCalls += 1;
+          if (ssCalls === 1) {
+            events.push("ss-transient");
+            return createLsofResult({ error: new Error("ss timeout"), status: null });
+          }
+          return createLsofResult({ status: 1 });
         }
-        // Port free on the next poll
-        events.push("port-free");
+        if (command === "lsof") {
+          lsofCalls += 1;
+          if (lsofCalls === 1) {
+            return createOpenClawBusyResult(stalePid);
+          }
+          if (lsofCalls === 2) {
+            events.push("transient-error");
+            return createLsofResult({ error: new Error("timeout"), status: null });
+          }
+          events.push("port-free");
+          return createLsofResult({ status: 1 });
+        }
         return createLsofResult({ status: 1 });
       });
 
@@ -980,6 +1021,7 @@ describe.skipIf(isWindows)("restart-stale-pids", () => {
 
       // Must have kept polling after the transient error and reached port-free
       expect(events).toContain("transient-error");
+      expect(events).toContain("ss-transient");
       expect(events).toContain("port-free");
     });
 

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -1,10 +1,10 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, readlinkSync } from "node:fs";
 import path from "node:path";
 import { resolveGatewayPort } from "../config/paths.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { isGatewayArgv } from "./gateway-process-argv.js";
+import { isGatewayArgv, parseProcCmdline } from "./gateway-process-argv.js";
 import { resolveLsofCommandSync } from "./ports-lsof.js";
 import {
   readWindowsListeningPidsOnPortSync,
@@ -164,6 +164,185 @@ function getSelfAndAncestorPidsSync(): Set<number> {
   return pids;
 }
 
+function parseLinuxListeningSocketInodes(stdout: string, port: number): Set<string> {
+  const inodes = new Set<string>();
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("sl")) {
+      continue;
+    }
+    const parts = line.split(/\s+/);
+    const localAddress = parts[1];
+    const state = parts[3];
+    const inode = parts[9];
+    if (!localAddress || !state || !inode || state.toUpperCase() !== "0A") {
+      continue;
+    }
+    const sep = localAddress.lastIndexOf(":");
+    if (sep < 0) {
+      continue;
+    }
+    const parsedPort = Number.parseInt(localAddress.slice(sep + 1), 16);
+    if (parsedPort === port) {
+      inodes.add(inode);
+    }
+  }
+  return inodes;
+}
+
+function readLinuxListeningSocketInodesSync(port: number): Set<string> | null {
+  let readAny = false;
+  const inodes = new Set<string>();
+  for (const pathname of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    try {
+      const content = readFileSync(pathname, "utf8");
+      readAny = true;
+      for (const inode of parseLinuxListeningSocketInodes(content, port)) {
+        inodes.add(inode);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return readAny ? inodes : null;
+}
+
+function readLinuxProcessArgsSync(pid: number): string[] | null {
+  try {
+    return parseProcCmdline(readFileSync(`/proc/${pid}/cmdline`, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function findGatewayPidsViaLinuxProcSync(
+  port: number,
+): { pids: number[]; definitive: boolean } | null {
+  if (process.platform !== "linux") {
+    return null;
+  }
+  const inodes = readLinuxListeningSocketInodesSync(port);
+  if (inodes == null) {
+    return null;
+  }
+  if (inodes.size === 0) {
+    return { pids: [], definitive: true };
+  }
+
+  let procEntries: string[];
+  try {
+    procEntries = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+
+  const excluded = getSelfAndAncestorPidsSync();
+  const candidatePids = new Set<number>();
+  for (const entry of procEntries) {
+    const pid = Number.parseInt(entry, 10);
+    if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
+      continue;
+    }
+
+    let fds: string[];
+    try {
+      fds = readdirSync(`/proc/${pid}/fd`);
+    } catch {
+      continue;
+    }
+
+    for (const fd of fds) {
+      try {
+        const target = readlinkSync(`/proc/${pid}/fd/${fd}`);
+        const match = target.match(/^socket:\[(\d+)\]$/);
+        if (match?.[1] && inodes.has(match[1])) {
+          candidatePids.add(pid);
+          break;
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  if (candidatePids.size === 0) {
+    return { pids: [], definitive: false };
+  }
+
+  const verified: number[] = [];
+  for (const pid of candidatePids) {
+    const args = readLinuxProcessArgsSync(pid);
+    if (args != null && isGatewayArgv(args, { allowGatewayBinary: true })) {
+      verified.push(pid);
+    }
+  }
+  return { pids: [...new Set(verified)], definitive: verified.length > 0 };
+}
+
+function parsePidsFromSsOutput(stdout: string, port: number): number[] {
+  const excluded = getSelfAndAncestorPidsSync();
+  const pids = new Set<number>();
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.includes("LISTEN") || !line.includes(`:${port}`)) {
+      continue;
+    }
+    const command = normalizeLowercaseStringOrEmpty(line.match(/users:\(\("([^"]+)"/)?.[1] ?? "");
+    const pidMatches = line.matchAll(/pid=(\d+)/g);
+    for (const match of pidMatches) {
+      const pid = Number.parseInt(match[1] ?? "", 10);
+      if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
+        continue;
+      }
+      const args = readLinuxProcessArgsSync(pid);
+      if (args != null) {
+        if (isGatewayArgv(args, { allowGatewayBinary: true })) {
+          pids.add(pid);
+        }
+        continue;
+      }
+      if (command.includes("openclaw")) {
+        pids.add(pid);
+      }
+    }
+  }
+  return [...pids];
+}
+
+function findGatewayPidsViaSsSync(port: number, spawnTimeoutMs: number): number[] | null {
+  const res = spawnSync("ss", ["-H", "-ltnp", `sport = :${port}`], {
+    encoding: "utf8",
+    timeout: spawnTimeoutMs,
+  });
+  if (res.error) {
+    return null;
+  }
+  const stderr = res.stderr?.trim() ?? "";
+  const stdout = res.stdout?.trim() ?? "";
+  if (res.status === 0 || (res.status === 1 && !stderr && !stdout)) {
+    return stdout ? parsePidsFromSsOutput(res.stdout, port) : [];
+  }
+  return null;
+}
+
+function pollPortOnceViaSs(port: number): PollResult {
+  const ss = spawnSync("ss", ["-H", "-ltn", `sport = :${port}`], {
+    encoding: "utf8",
+    timeout: POLL_SPAWN_TIMEOUT_MS,
+  });
+  if (ss.error) {
+    const code = (ss.error as NodeJS.ErrnoException).code;
+    const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
+    return { free: null, permanent };
+  }
+  const stderr = ss.stderr?.trim() ?? "";
+  const stdout = ss.stdout?.trim() ?? "";
+  if (ss.status === 0 || (ss.status === 1 && !stderr && !stdout)) {
+    return stdout ? { free: false } : { free: true };
+  }
+  return { free: null, permanent: false };
+}
+
 /**
  * Parse openclaw gateway PIDs from lsof -Fpc stdout, excluding the current
  * process and its ancestors (see `getSelfAndAncestorPidsSync` for the full
@@ -272,7 +451,22 @@ export function findGatewayPidsOnPortSync(
     // command-line verification to find only openclaw gateway processes.
     return findVerifiedWindowsGatewayPidsOnPortSync(port);
   }
-  const lsof = resolveLsofCommandSync();
+  const procResult = findGatewayPidsViaLinuxProcSync(port);
+  if (procResult && (procResult.definitive || procResult.pids.length > 0)) {
+    return procResult.pids;
+  }
+
+  let lsof: string;
+  try {
+    lsof = resolveLsofCommandSync();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    restartLog.warn(
+      `lsof resolution failed during initial stale-pid scan for port ${port}: ${detail}`,
+    );
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
+  }
+
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
     encoding: "utf8",
     timeout: spawnTimeoutMs,
@@ -286,37 +480,38 @@ export function findGatewayPidsOnPortSync(
           ? res.error.message
           : "unknown error";
     restartLog.warn(`lsof failed during initial stale-pid scan for port ${port}: ${detail}`);
-    return [];
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
   }
   if (res.status === 1) {
-    return [];
+    const pids = res.stdout ? parsePidsFromLsofOutput(res.stdout) : [];
+    return pids.length > 0 ? pids : [];
   }
   if (res.status !== 0) {
     restartLog.warn(
       `lsof exited with status ${res.status} during initial stale-pid scan for port ${port}; skipping stale pid check`,
     );
-    return [];
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
   }
   return parsePidsFromLsofOutput(res.stdout);
 }
 
 /**
- * Attempt a single lsof poll for the given port.
+ * Attempt a single Linux/Unix port poll for the given port.
  *
  * Returns a discriminated union with four possible states:
  *
  *   { free: true }                      — port confirmed free
  *   { free: false }                     — port confirmed busy
  *   { free: null; permanent: false }    — transient error, keep retrying
- *   { free: null; permanent: true }     — lsof unavailable (ENOENT / EACCES),
+ *   { free: null; permanent: true }     — listener backends unavailable (ENOENT / EACCES),
  *                                         no point retrying
  *
  * Separating transient from permanent errors is critical so that:
- *  1. A slow/timed-out lsof call (transient) does not abort the polling loop —
+ *  1. A slow/timed-out listener probe (transient) does not abort polling —
  *     the caller retries until the wall-clock budget expires.
  *  2. Non-zero lsof exits from runtime/permission failures (status > 1) are
  *     not misclassified as "port free" — they are inconclusive and retried.
- *  3. A missing lsof binary (permanent) short-circuits cleanly rather than
+ *  3. Missing lsof/ss backends short-circuit cleanly rather than
  *     spinning the full budget pointlessly.
  */
 type PollResult = { free: true } | { free: false } | { free: null; permanent: boolean };
@@ -324,6 +519,10 @@ type PollResult = { free: true } | { free: false } | { free: null; permanent: bo
 function pollPortOnce(port: number): PollResult {
   if (process.platform === "win32") {
     return pollPortOnceWindows(port);
+  }
+  const procInodes = readLinuxListeningSocketInodesSync(port);
+  if (procInodes != null) {
+    return procInodes.size === 0 ? { free: true } : { free: false };
   }
   try {
     const lsof = resolveLsofCommandSync();
@@ -334,9 +533,7 @@ function pollPortOnce(port: number): PollResult {
     if (res.error) {
       // Spawn-level failure. ENOENT / EACCES means lsof is permanently
       // unavailable on this system; other errors (e.g. timeout) are transient.
-      const code = (res.error as NodeJS.ErrnoException).code;
-      const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
-      return { free: null, permanent };
+      return pollPortOnceViaSs(port);
     }
     if (res.status === 1) {
       // lsof canonical "no matching processes" exit — port is genuinely free.
@@ -353,14 +550,14 @@ function pollPortOnce(port: number): PollResult {
       // status > 1: runtime/permission/flag error. Cannot confirm port state —
       // treat as a transient failure and keep polling rather than falsely
       // reporting the port as free (which would recreate the EADDRINUSE race).
-      return { free: null, permanent: false };
+      return pollPortOnceViaSs(port);
     }
     // status === 0: lsof found listeners. Parse pids from the stdout we
     // already hold — no second lsof spawn, no new failure surface.
     const pids = parsePidsFromLsofOutput(res.stdout);
     return pids.length === 0 ? { free: true } : { free: false };
   } catch {
-    return { free: null, permanent: false };
+    return pollPortOnceViaSs(port);
   }
 }
 

--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync, readlinkSync } from "node:fs";
 import path from "node:path";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { uniqueValues } from "@openclaw/normalization-core/string-normalization";
@@ -186,6 +186,185 @@ export function getSelfAndAncestorPidsSync(spawnTimeoutMs = SPAWN_TIMEOUT_MS): S
   return pids;
 }
 
+function parseLinuxListeningSocketInodes(stdout: string, port: number): Set<string> {
+  const inodes = new Set<string>();
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("sl")) {
+      continue;
+    }
+    const parts = line.split(/\s+/);
+    const localAddress = parts[1];
+    const state = parts[3];
+    const inode = parts[9];
+    if (!localAddress || !state || !inode || state.toUpperCase() !== "0A") {
+      continue;
+    }
+    const sep = localAddress.lastIndexOf(":");
+    if (sep < 0) {
+      continue;
+    }
+    const parsedPort = Number.parseInt(localAddress.slice(sep + 1), 16);
+    if (parsedPort === port) {
+      inodes.add(inode);
+    }
+  }
+  return inodes;
+}
+
+function readLinuxListeningSocketInodesSync(port: number): Set<string> | null {
+  let readAny = false;
+  const inodes = new Set<string>();
+  for (const pathname of ["/proc/net/tcp", "/proc/net/tcp6"]) {
+    try {
+      const content = readFileSync(pathname, "utf8");
+      readAny = true;
+      for (const inode of parseLinuxListeningSocketInodes(content, port)) {
+        inodes.add(inode);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return readAny ? inodes : null;
+}
+
+function readLinuxProcessArgsSync(pid: number): string[] | null {
+  try {
+    return parseProcCmdline(readFileSync(`/proc/${pid}/cmdline`, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function findGatewayPidsViaLinuxProcSync(
+  port: number,
+): { pids: number[]; definitive: boolean } | null {
+  if (process.platform !== "linux") {
+    return null;
+  }
+  const inodes = readLinuxListeningSocketInodesSync(port);
+  if (inodes == null) {
+    return null;
+  }
+  if (inodes.size === 0) {
+    return { pids: [], definitive: true };
+  }
+
+  let procEntries: string[];
+  try {
+    procEntries = readdirSync("/proc");
+  } catch {
+    return null;
+  }
+
+  const excluded = getSelfAndAncestorPidsSync();
+  const candidatePids = new Set<number>();
+  for (const entry of procEntries) {
+    const pid = Number.parseInt(entry, 10);
+    if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
+      continue;
+    }
+
+    let fds: string[];
+    try {
+      fds = readdirSync(`/proc/${pid}/fd`);
+    } catch {
+      continue;
+    }
+
+    for (const fd of fds) {
+      try {
+        const target = readlinkSync(`/proc/${pid}/fd/${fd}`);
+        const match = target.match(/^socket:\[(\d+)\]$/);
+        if (match?.[1] && inodes.has(match[1])) {
+          candidatePids.add(pid);
+          break;
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  if (candidatePids.size === 0) {
+    return { pids: [], definitive: false };
+  }
+
+  const verified: number[] = [];
+  for (const pid of candidatePids) {
+    const args = readLinuxProcessArgsSync(pid);
+    if (args != null && isGatewayArgv(args, { allowGatewayBinary: true })) {
+      verified.push(pid);
+    }
+  }
+  return { pids: [...new Set(verified)], definitive: verified.length > 0 };
+}
+
+function parsePidsFromSsOutput(stdout: string, port: number): number[] {
+  const excluded = getSelfAndAncestorPidsSync();
+  const pids = new Set<number>();
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || !line.includes("LISTEN") || !line.includes(`:${port}`)) {
+      continue;
+    }
+    const command = normalizeLowercaseStringOrEmpty(line.match(/users:\(\("([^"]+)"/)?.[1] ?? "");
+    const pidMatches = line.matchAll(/pid=(\d+)/g);
+    for (const match of pidMatches) {
+      const pid = Number.parseInt(match[1] ?? "", 10);
+      if (!Number.isFinite(pid) || pid <= 0 || excluded.has(pid)) {
+        continue;
+      }
+      const args = readLinuxProcessArgsSync(pid);
+      if (args != null) {
+        if (isGatewayArgv(args, { allowGatewayBinary: true })) {
+          pids.add(pid);
+        }
+        continue;
+      }
+      if (command.includes("openclaw")) {
+        pids.add(pid);
+      }
+    }
+  }
+  return [...pids];
+}
+
+function findGatewayPidsViaSsSync(port: number, spawnTimeoutMs: number): number[] | null {
+  const res = spawnSync("ss", ["-H", "-ltnp", `sport = :${port}`], {
+    encoding: "utf8",
+    timeout: spawnTimeoutMs,
+  });
+  if (res.error) {
+    return null;
+  }
+  const stderr = res.stderr?.trim() ?? "";
+  const stdout = res.stdout?.trim() ?? "";
+  if (res.status === 0 || (res.status === 1 && !stderr && !stdout)) {
+    return stdout ? parsePidsFromSsOutput(res.stdout, port) : [];
+  }
+  return null;
+}
+
+function pollPortOnceViaSs(port: number): PollResult {
+  const ss = spawnSync("ss", ["-H", "-ltn", `sport = :${port}`], {
+    encoding: "utf8",
+    timeout: POLL_SPAWN_TIMEOUT_MS,
+  });
+  if (ss.error) {
+    const code = (ss.error as NodeJS.ErrnoException).code;
+    const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
+    return { free: null, permanent };
+  }
+  const stderr = ss.stderr?.trim() ?? "";
+  const stdout = ss.stdout?.trim() ?? "";
+  if (ss.status === 0 || (ss.status === 1 && !stderr && !stdout)) {
+    return stdout ? { free: false } : { free: true };
+  }
+  return { free: null, permanent: false };
+}
+
 /**
  * Parse raw PIDs from lsof -Fpc stdout, excluding the current
  * process and its ancestors (see `getSelfAndAncestorPidsSync` for the full
@@ -342,7 +521,20 @@ export function findGatewayPidsOnPortSync(
     // command-line verification to find only openclaw gateway processes.
     return findVerifiedWindowsGatewayPidsOnPortSync(port);
   }
-  const lsof = resolveLsofCommandSync();
+  const procResult = findGatewayPidsViaLinuxProcSync(port);
+  if (procResult && (procResult.definitive || procResult.pids.length > 0)) {
+    return procResult.pids;
+  }
+  let lsof: string;
+  try {
+    lsof = resolveLsofCommandSync();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    restartLog.warn(
+      `lsof resolution failed during initial stale-pid scan for port ${port}: ${detail}`,
+    );
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
+  }
   const res = spawnSync(lsof, ["-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-Fpc"], {
     encoding: "utf8",
     timeout: spawnTimeoutMs,
@@ -356,37 +548,38 @@ export function findGatewayPidsOnPortSync(
           ? res.error.message
           : "unknown error";
     restartLog.warn(`lsof failed during initial stale-pid scan for port ${port}: ${detail}`);
-    return [];
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
   }
   if (res.status === 1) {
-    return [];
+    const pids = res.stdout ? parsePidsFromLsofOutput(res.stdout, spawnTimeoutMs) : [];
+    return pids.length > 0 ? pids : [];
   }
   if (res.status !== 0) {
     restartLog.warn(
       `lsof exited with status ${res.status} during initial stale-pid scan for port ${port}; skipping stale pid check`,
     );
-    return [];
+    return findGatewayPidsViaSsSync(port, spawnTimeoutMs) ?? [];
   }
   return parsePidsFromLsofOutput(res.stdout, spawnTimeoutMs);
 }
 
 /**
- * Attempt a single lsof poll for the given port.
+ * Attempt a single Linux/Unix port poll for the given port.
  *
  * Returns a discriminated union with four possible states:
  *
  *   { free: true }                      — port confirmed free
  *   { free: false }                     — port confirmed busy
  *   { free: null; permanent: false }    — transient error, keep retrying
- *   { free: null; permanent: true }     — lsof unavailable (ENOENT / EACCES),
+ *   { free: null; permanent: true }     — listener backends unavailable (ENOENT / EACCES),
  *                                         no point retrying
  *
  * Separating transient from permanent errors is critical so that:
- *  1. A slow/timed-out lsof call (transient) does not abort the polling loop —
+ *  1. A slow/timed-out listener probe (transient) does not abort polling —
  *     the caller retries until the wall-clock budget expires.
  *  2. Non-zero lsof exits from runtime/permission failures (status > 1) are
  *     not misclassified as "port free" — they are inconclusive and retried.
- *  3. A missing lsof binary (permanent) short-circuits cleanly rather than
+ *  3. Missing lsof/ss backends short-circuit cleanly rather than
  *     spinning the full budget pointlessly.
  */
 type PollResult = { free: true } | { free: false } | { free: null; permanent: boolean };
@@ -394,6 +587,10 @@ type PollResult = { free: true } | { free: false } | { free: null; permanent: bo
 function pollPortOnce(port: number): PollResult {
   if (process.platform === "win32") {
     return pollPortOnceWindows(port);
+  }
+  const procInodes = readLinuxListeningSocketInodesSync(port);
+  if (procInodes != null) {
+    return procInodes.size === 0 ? { free: true } : { free: false };
   }
   try {
     const lsof = resolveLsofCommandSync();
@@ -404,9 +601,7 @@ function pollPortOnce(port: number): PollResult {
     if (res.error) {
       // Spawn-level failure. ENOENT / EACCES means lsof is permanently
       // unavailable on this system; other errors (e.g. timeout) are transient.
-      const code = (res.error as NodeJS.ErrnoException).code;
-      const permanent = code === "ENOENT" || code === "EACCES" || code === "EPERM";
-      return { free: null, permanent };
+      return pollPortOnceViaSs(port);
     }
     if (res.status === 1) {
       // lsof canonical "no matching processes" exit — port is genuinely free.
@@ -423,14 +618,14 @@ function pollPortOnce(port: number): PollResult {
       // status > 1: runtime/permission/flag error. Cannot confirm port state —
       // treat as a transient failure and keep polling rather than falsely
       // reporting the port as free (which would recreate the EADDRINUSE race).
-      return { free: null, permanent: false };
+      return pollPortOnceViaSs(port);
     }
     // status === 0: lsof found listeners. Parse pids from the stdout we
     // already hold — no second lsof spawn, no new failure surface.
     const pids = parsePidsFromLsofOutput(res.stdout, POLL_SPAWN_TIMEOUT_MS);
     return pids.length === 0 ? { free: true } : { free: false };
   } catch {
-    return { free: null, permanent: false };
+    return pollPortOnceViaSs(port);
   }
 }
 

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -4,11 +4,29 @@ import { captureFullEnv } from "../test-utils/env.js";
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 const resolveLsofCommandSyncMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn());
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+const readDirSyncMock = vi.hoisted(() => vi.fn());
+const readLinkSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeChildProcessSpawnSync } =
     await import("../../test/helpers/node-builtin-mocks.js");
   return mockNodeChildProcessSpawnSync(spawnSyncMock);
+});
+
+vi.mock("node:fs", async () => {
+  const { mockNodeBuiltinModule } = await import("../../test/helpers/node-builtin-mocks.js");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:fs")>("node:fs"),
+    (actual) => ({
+      readFileSync: ((path: unknown, encoding?: unknown) =>
+        readFileSyncMock(path, encoding)) as typeof actual.readFileSync,
+      readdirSync: ((path: unknown, options?: unknown) =>
+        readDirSyncMock(path, options)) as typeof actual.readdirSync,
+      readlinkSync: ((path: unknown, options?: unknown) =>
+        readLinkSyncMock(path, options)) as typeof actual.readlinkSync,
+    }),
+  );
 });
 
 vi.mock("./ports-lsof.js", () => ({
@@ -42,10 +60,28 @@ beforeEach(() => {
   spawnSyncMock.mockReset();
   resolveLsofCommandSyncMock.mockReset();
   resolveGatewayPortMock.mockReset();
+  readFileSyncMock.mockReset();
+  readDirSyncMock.mockReset();
+  readLinkSyncMock.mockReset();
 
   currentTimeMs = 0;
   resolveLsofCommandSyncMock.mockReturnValue("/usr/sbin/lsof");
   resolveGatewayPortMock.mockReturnValue(18789);
+  readFileSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
+  readDirSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
+  readLinkSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
   __testing.setSleepSyncOverride((ms) => {
     currentTimeMs += ms;
   });

--- a/src/infra/restart.test.ts
+++ b/src/infra/restart.test.ts
@@ -11,6 +11,9 @@ const execFileMock = vi.hoisted(() =>
 );
 const resolveLsofCommandSyncMock = vi.hoisted(() => vi.fn());
 const resolveGatewayPortMock = vi.hoisted(() => vi.fn());
+const readFileSyncMock = vi.hoisted(() => vi.fn());
+const readDirSyncMock = vi.hoisted(() => vi.fn());
+const readLinkSyncMock = vi.hoisted(() => vi.fn());
 
 vi.mock("node:child_process", async () => {
   const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
@@ -20,6 +23,21 @@ vi.mock("node:child_process", async () => {
       execFile: execFileMock,
       spawnSync: (...args: unknown[]) => spawnSyncMock(...args),
     } as Partial<typeof import("node:child_process")>,
+  );
+});
+
+vi.mock("node:fs", async () => {
+  const { mockNodeBuiltinModule } = await import("openclaw/plugin-sdk/test-node-mocks");
+  return mockNodeBuiltinModule(
+    () => vi.importActual<typeof import("node:fs")>("node:fs"),
+    (actual) => ({
+      readFileSync: ((path: unknown, encoding?: unknown) =>
+        readFileSyncMock(path, encoding)) as typeof actual.readFileSync,
+      readdirSync: ((path: unknown, options?: unknown) =>
+        readDirSyncMock(path, options)) as typeof actual.readdirSync,
+      readlinkSync: ((path: unknown, options?: unknown) =>
+        readLinkSyncMock(path, options)) as typeof actual.readlinkSync,
+    }),
   );
 });
 
@@ -45,10 +63,28 @@ beforeEach(() => {
   spawnSyncMock.mockReset();
   resolveLsofCommandSyncMock.mockReset();
   resolveGatewayPortMock.mockReset();
+  readFileSyncMock.mockReset();
+  readDirSyncMock.mockReset();
+  readLinkSyncMock.mockReset();
 
   currentTimeMs = 0;
   resolveLsofCommandSyncMock.mockReturnValue("/usr/sbin/lsof");
   resolveGatewayPortMock.mockReturnValue(18789);
+  readFileSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
+  readDirSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
+  readLinkSyncMock.mockImplementation(() => {
+    const error: NodeJS.ErrnoException = new Error("ENOENT: test default");
+    error.code = "ENOENT";
+    throw error;
+  });
   testing.setSleepSyncOverride((ms) => {
     currentTimeMs += ms;
   });


### PR DESCRIPTION
Closes #72223

## Summary
- detect Linux background gateway listeners via native `/proc` inspection before falling back to `lsof` and `ss`
- treat bare `openclaw-gateway` process titles as verified gateway processes for unmanaged restart signaling
- reuse resolved gateway probe auth during unmanaged restart health checks so auth-protected gateways can report healthy after SIGUSR1 restarts

## Testing
- pnpm test src/cli/daemon-cli/lifecycle.test.ts src/cli/daemon-cli/restart-health.test.ts
- pnpm test src/infra/gateway-process-argv.test.ts src/infra/gateway-processes.test.ts src/infra/restart-stale-pids.test.ts src/infra/restart.test.ts
- pnpm build
- verified locally in a non-systemd container: `node openclaw.mjs gateway restart --json` now returns `result: "restarted"` while the gateway is running in the background
