### PR TITLE
fix(ui): reuse chat session active window

### DIFF
--- a/ui/src/ui/app-chat.test.ts
+++ b/ui/src/ui/app-chat.test.ts
@@ -15,6 +15,7 @@ vi.mock("./app-last-active-session.ts", () => ({
 let handleSendChat: typeof import("./app-chat.ts").handleSendChat;
 let steerQueuedChatMessage: typeof import("./app-chat.ts").steerQueuedChatMessage;
 let handleAbortChat: typeof import("./app-chat.ts").handleAbortChat;
+let refreshChat: typeof import("./app-chat.ts").refreshChat;
 let refreshChatAvatar: typeof import("./app-chat.ts").refreshChatAvatar;
 let clearPendingQueueItemsForRun: typeof import("./app-chat.ts").clearPendingQueueItemsForRun;
 
@@ -23,6 +24,7 @@ async function loadChatHelpers(): Promise<void> {
     handleSendChat,
     steerQueuedChatMessage,
     handleAbortChat,
+    refreshChat,
     refreshChatAvatar,
     clearPendingQueueItemsForRun,
   } = await import("./app-chat.ts"));
@@ -388,6 +390,59 @@ describe("refreshChatAvatar", () => {
       "/avatar/ops",
       expect.objectContaining({ method: "GET" }),
     );
+  });
+});
+
+describe("refreshChat", () => {
+  beforeAll(async () => {
+    await loadChatHelpers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads the session list through the shared active-session window", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({}),
+      }) as unknown as typeof fetch,
+    );
+    const request = vi.fn(async (method: string, params?: unknown) => {
+      if (method === "chat.history") {
+        return { messages: [], thinkingLevel: null };
+      }
+      if (method === "sessions.list") {
+        return {
+          ts: 0,
+          path: "",
+          count: 0,
+          defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
+          sessions: [],
+          params,
+        };
+      }
+      if (method === "models.list") {
+        return { models: [] };
+      }
+      if (method === "commands.list") {
+        return { commands: [] };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const host = makeHost({
+      client: { request } as unknown as ChatHost["client"],
+    });
+
+    await refreshChat(host);
+
+    expect(request).toHaveBeenCalledWith("sessions.list", {
+      activeMinutes: 120,
+      includeGlobal: true,
+      includeUnknown: true,
+    });
   });
 });
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -514,7 +514,7 @@ export async function refreshChat(host: ChatHost, opts?: { scheduleScroll?: bool
   await Promise.all([
     loadChatHistory(host as unknown as ChatState),
     loadSessions(host as unknown as SessionsState, {
-      activeMinutes: 0,
+      activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
       limit: 0,
       includeGlobal: true,
       includeUnknown: true,

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -15,6 +15,7 @@ const {
 }));
 
 vi.mock("./app-chat.ts", () => ({
+  CHAT_SESSIONS_ACTIVE_MINUTES: 10,
   refreshChat: refreshChatMock,
   refreshChatAvatar: refreshChatAvatarMock,
 }));
@@ -548,7 +549,7 @@ describe("switchChatSession", () => {
     });
     expect(loadChatHistoryMock).toHaveBeenCalledWith(state);
     expect(loadSessionsMock).toHaveBeenCalledWith(state, {
-      activeMinutes: 0,
+      activeMinutes: 10,
       limit: 0,
       includeGlobal: true,
       includeUnknown: true,

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -1,6 +1,6 @@
 import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
-import { refreshChat, refreshChatAvatar } from "./app-chat.ts";
+import { CHAT_SESSIONS_ACTIVE_MINUTES, refreshChat, refreshChatAvatar } from "./app-chat.ts";
 import { syncUrlWithSessionKey } from "./app-settings.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import {
@@ -547,7 +547,7 @@ export function switchChatSession(state: AppViewState, nextSessionKey: string) {
 
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
-    activeMinutes: 0,
+    activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
     limit: 0,
     includeGlobal: true,
     includeUnknown: true,

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -1,5 +1,6 @@
 import { html } from "lit";
 import { repeat } from "lit/directives/repeat.js";
+import { CHAT_SESSIONS_ACTIVE_MINUTES } from "../app-chat.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import { createChatModelOverride } from "../chat-model-ref.ts";
 import {
@@ -73,7 +74,7 @@ export function renderChatSessionSelect(
 
 async function refreshSessionOptions(state: AppViewState) {
   await loadSessions(state as unknown as Parameters<typeof loadSessions>[0], {
-    activeMinutes: 0,
+    activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES,
     limit: 0,
     includeGlobal: true,
     includeUnknown: true,


### PR DESCRIPTION
## Summary

- Problem: several Control UI chat session refresh paths still hardcoded `activeMinutes: 0` even though `CHAT_SESSIONS_ACTIVE_MINUTES` already exists.
- Why it matters: the initial chat load, session switch refresh, and chat header session controls could drift and bypass the same active-session window.
- What changed: all current Control UI chat-session list callsites now pass `activeMinutes: CHAT_SESSIONS_ACTIVE_MINUTES`.
- What did NOT change (scope boundary): this does not change the constant value, product default, session API behavior, Dreaming filters, cron filtering, docs, or config/schema.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared `CHAT_SESSIONS_ACTIVE_MINUTES` constant existed, but newer/adjacent session refresh callsites kept local `activeMinutes: 0` literals.
- Missing detection / guardrail: tests did not assert the active-session window for initial chat refresh or session-switch refresh.
- Contributing context (if known): session refresh logic exists in multiple UI modules (`app-chat`, `app-render.helpers`, and `chat/session-controls`).

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `ui/src/ui/app-chat.test.ts`, `ui/src/ui/app-render.helpers.node.test.ts`
- Scenario the test should lock in: initial chat refresh and session-switch refresh both use the shared active-session window instead of a hardcoded zero-minute window.
- Why this is the smallest reliable guardrail: these are deterministic UI controller/helper paths and do not need a live gateway or browser session.
- Existing test that already covers this (if any): session switching already covered reload behavior, but expected the old `activeMinutes: 0` literal.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

The chat session dropdown refresh paths now consistently use the existing active-session window. No visible text, config, or default-value change.

## Diagram (if applicable)

```text
Before:
[chat/session refresh] -> [some callsites activeMinutes: 0]

After:
[chat/session refresh] -> [all current callsites use CHAT_SESSIONS_ACTIVE_MINUTES]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.18.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): Control UI
- Relevant config (redacted): N/A

### Steps

1. Inspect Control UI chat-session refresh callsites for `activeMinutes: 0`.
2. Change them to use the existing `CHAT_SESSIONS_ACTIVE_MINUTES` constant.
3. Run targeted UI tests and the changed-file verification gate.

### Expected

- No current Control UI chat-session refresh callsite hardcodes `activeMinutes: 0`.
- Existing active-session constant remains unchanged.
- UI tests and changed-file checks pass.

### Actual

- Matches expected behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Verified locally:

```bash
pnpm test ui/src/ui/app-chat.test.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/views/chat.test.ts ui/src/ui/app-gateway.sessions.node.test.ts
pnpm check:changed --base upstream/main --head HEAD
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: initial chat refresh uses the shared active-session window; session switching uses the shared active-session window; current `app-chat`, `app-render.helpers`, and `chat/session-controls` callsites no longer contain `activeMinutes: 0`.
- Edge cases checked: the constant value remains `120`; `limit: 0` / `includeGlobal` / `includeUnknown` options are unchanged; Dreaming/session filtering is untouched.
- What you did **not** verify: manual browser interaction against a live gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: reviewers may consider the existing active-session window a product behavior choice.
  - Mitigation: this PR does not change the value or default; it only makes existing callsites use the already-defined constant consistently.
