### PR TITLE
fix(skills): clean up partially-copied skill dirs after sync failure

### DIFF
--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -833,6 +833,9 @@ export async function syncSkillsToWorkspace(params: {
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);
         skillsLogger.warn(`Failed to copy ${entry.skill.name} to sandbox: ${message}`);
+        // Remove the partially copied destination so snapshot builders
+        // don't find a broken/incomplete skill directory.
+        await fsp.rm(dest, { recursive: true, force: true }).catch(() => {});
       }
     }
   });


### PR DESCRIPTION
## Summary

Fixes spurious "skipped missing skill file" warnings on every session bootstrap.

## Problem

`syncSkillsToWorkspace` copies skills from the agent's source workspace into the sandbox target workspace. When a copy fails (e.g. the source is a stale `.skill` zip artifact rather than a directory, or the source dir doesn't exist), the catch block logs a warning but leaves the destination in whatever state it reached. Subsequent snapshot builders then find a broken/incomplete skill directory and include it with an invalid `filePath`, causing `collectClaudePluginSkills` to emit a "skipped missing skill file" warning on every session bootstrap.

## Fix

After a failed copy, `await fsp.rm(dest, ...)` removes the partially-written destination. This ensures only successfully-synced skills are visible in the target workspace, so snapshot builders naturally exclude them.

## Root Cause (per Igor's analysis in AI-459)

1. `codex-subagent-worker` has a stale `.skill` zip in the default workspace's `skills/` dir
2. `matt-tasks` has no directory at all in the default workspace
3. `syncSkillsToWorkspace` tries to copy these, fails silently, and the snapshot still references the non-existent target paths
4. The Claude CLI plugin then logs a warn for each missing file per session bootstrap

Closes AI-459