### PR TITLE
Status: show post-compaction context tokens when totals are stale

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -287,6 +287,44 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("Reasoning: on");
   });
 
+  it("uses latest compaction checkpoint tokens when total tokens are stale", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "anthropic/pi:opus",
+        contextTokens: 200_000,
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        inputTokens: 6,
+        outputTokens: 124,
+        totalTokens: 76_000,
+        totalTokensFresh: false,
+        contextTokens: 200_000,
+        compactionCount: 1,
+        compactionCheckpoints: [
+          {
+            checkpointId: "cp-1",
+            sessionKey: "agent:main:main",
+            sessionId: "abc",
+            createdAt: 1_000,
+            reason: "manual",
+            tokensBefore: 106_000,
+            tokensAfter: 36,
+            preCompaction: { sessionId: "abc" },
+            postCompaction: { sessionId: "abc" },
+          },
+        ],
+      },
+      sessionKey: "agent:main:main",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Context: 36/200k (0%)");
+    expect(normalized).toContain("Compactions: 1");
+  });
+
   it("shows plugin status lines only when verbose is enabled", () => {
     const visible = normalizeTestText(
       buildStatusMessage({

--- a/src/status/status-message.ts
+++ b/src/status/status-message.ts
@@ -23,12 +23,12 @@ import type {
 } from "../auto-reply/thinking.js";
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import {
+  resolveFreshSessionTotalTokens,
   resolveMainSessionKey,
   resolveSessionFilePath,
   resolveSessionFilePathOptions,
   resolveSessionPluginStatusLines,
   resolveSessionPluginTraceLines,
-  resolveFreshSessionTotalTokens,
   type SessionEntry,
   type SessionScope,
 } from "../config/sessions.js";
@@ -254,6 +254,27 @@ const formatTokens = (total: number | null | undefined, contextTokens: number | 
   const ctxLabel = ctx ? formatTokenCount(ctx) : "?";
   return `${totalLabel}/${ctxLabel}${pct !== null ? ` (${pct}%)` : ""}`;
 };
+
+function resolveLatestCompactionTokensAfter(
+  entry?: Pick<SessionEntry, "compactionCheckpoints">,
+): number | undefined {
+  if (!Array.isArray(entry?.compactionCheckpoints) || entry.compactionCheckpoints.length === 0) {
+    return undefined;
+  }
+  const withTokensAfter = entry.compactionCheckpoints.filter(
+    (checkpoint) =>
+      typeof checkpoint.tokensAfter === "number" &&
+      Number.isFinite(checkpoint.tokensAfter) &&
+      checkpoint.tokensAfter >= 0,
+  );
+  if (withTokensAfter.length === 0) {
+    return undefined;
+  }
+  const latest = withTokensAfter.reduce((current, candidate) =>
+    (candidate.createdAt ?? 0) >= (current.createdAt ?? 0) ? candidate : current,
+  );
+  return latest.tokensAfter;
+}
 
 export const formatContextUsageShort = (
   total: number | null | undefined,
@@ -625,11 +646,16 @@ export function buildStatusMessage(args: StatusArgs): string {
   let cacheWrite = entry?.cacheWrite;
   const freshTotalTokens = resolveFreshSessionTotalTokens(entry);
   const allowTranscriptContextUsage = entry?.totalTokensFresh !== false;
+  const usageFallbackTotal = (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0);
+  const latestCompactionTokensAfter = resolveLatestCompactionTokensAfter(entry);
   let totalTokens =
     freshTotalTokens ??
-    (entry?.totalTokensFresh === false
-      ? undefined
-      : (entry?.totalTokens ?? (entry?.inputTokens ?? 0) + (entry?.outputTokens ?? 0)));
+    (entry?.totalTokensFresh === false ? undefined : entry?.totalTokens ?? usageFallbackTotal);
+  if (entry?.totalTokensFresh === false && latestCompactionTokensAfter !== undefined) {
+    totalTokens = latestCompactionTokensAfter;
+  } else if (totalTokens === undefined && latestCompactionTokensAfter !== undefined) {
+    totalTokens = latestCompactionTokensAfter;
+  }
 
   // Prefer prompt-size tokens from the session transcript when it looks larger
   // (cached prompt tokens are often missing from agent meta/store).


### PR DESCRIPTION
﻿## Summary
- Fix status context reporting to prefer fresh totals and fall back to the latest compaction checkpoint `tokensAfter` when session totals are marked stale.
- Keep context usage output aligned with post-compaction state so users do not see pre-compaction token counts.
- Add a regression test that reproduces stale `totalTokens` after compaction and verifies status shows the checkpoint post-compaction size.

## Test plan
- [x] `pnpm test src/auto-reply/status.test.ts -t "uses latest compaction checkpoint tokens when total tokens are stale"`
