### PR TITLE
Agents: broaden strict-agentic actionable-prompt and active-narration gates

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2334,6 +2334,25 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
     },
   );
 
+  it.each([
+    "i do not want you to run anything",
+    "I start to think this might already be fine",
+    "let's continue this conversation tomorrow",
+    "the build was already successful, no need to redo it",
+  ])('does not treat non-directive prompt "%s" as actionable', (prompt) => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll inspect the surface and take the first step."],
+      }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
+
   it("retries short confident narration that asserts ongoing action without a tool call", () => {
     for (const text of [
       "On it.",
@@ -2371,6 +2390,24 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
 
   it("does not retry casual chitchat that lacks a planning promise or active narration", () => {
     for (const text of ["Sounds good.", "Looks fine to me.", "Cool, thanks for the heads up."]) {
+      const retryInstruction = resolvePlanningOnlyRetryInstruction({
+        ...openaiParams,
+        prompt: "go ahead",
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({ assistantTexts: [text] }),
+      });
+
+      expect(retryInstruction).toBeNull();
+    }
+  });
+
+  it("does not retry long answer prose that incidentally contains an active-narration phrase", () => {
+    for (const text of [
+      "Here are my thoughts on it: the migration looks safe so long as the new column is nullable for the rollout window. Once you confirm that, we can flip the schema.",
+      "You got it backwards: the failing case is when the cache is warm, not cold. If you re-run with --no-cache the second invocation should reproduce.",
+      "I'm running through the list now to find the failing item, but the previous answer was already complete and there is no further work to do here.",
+    ]) {
       const retryInstruction = resolvePlanningOnlyRetryInstruction({
         ...openaiParams,
         prompt: "go ahead",

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2303,6 +2303,11 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
     "create a follow-up issue",
     "rewrite this paragraph",
     "pass this through the opus polish",
+    "I need you to create a follow-up issue",
+    "I want you to rewrite this paragraph",
+    "I would like you to generate release notes",
+    "I'd like you to polish this draft",
+    "we need you to publish the changelog",
   ])('treats "%s" as an actionable directive', (prompt) => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       ...openaiParams,
@@ -2339,6 +2344,11 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
     "I start to think this might already be fine",
     "let's continue this conversation tomorrow",
     "the build was already successful, no need to redo it",
+    "the finish looks good, no changes",
+    "I cannot create that here",
+    "the polish on this draft is fine",
+    "I do not want you to rewrite this",
+    "I don't want you to create that",
   ])('does not treat non-directive prompt "%s" as actionable', (prompt) => {
     const retryInstruction = resolvePlanningOnlyRetryInstruction({
       ...openaiParams,

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2295,15 +2295,31 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
     expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
   });
 
-  it("treats other newly allowlisted directives (draft, finish, send, build) as actionable", () => {
-    for (const prompt of [
-      "draft a quick summary",
-      "finish the implementation",
-      "send the report to the team",
-      "build the docker image",
-      "create a follow-up issue",
-      "rewrite this paragraph",
-    ]) {
+  it.each([
+    "draft a quick summary",
+    "finish the implementation",
+    "send the report to the team",
+    "build the docker image",
+    "create a follow-up issue",
+    "rewrite this paragraph",
+    "pass this through the opus polish",
+  ])('treats "%s" as an actionable directive', (prompt) => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt,
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll inspect the surface and take the first step."],
+      }),
+    });
+
+    expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it.each(["pass on this one", "pass this is fine"])(
+    'does not treat declination prompt "%s" as actionable',
+    (prompt) => {
       const retryInstruction = resolvePlanningOnlyRetryInstruction({
         ...openaiParams,
         prompt,
@@ -2314,23 +2330,9 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
         }),
       });
 
-      expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
-    }
-  });
-
-  it("retries present-continuous narration after an ack prompt (Repro B)", () => {
-    const retryInstruction = resolvePlanningOnlyRetryInstruction({
-      ...openaiParams,
-      prompt: "go ahead",
-      aborted: false,
-      timedOut: false,
-      attempt: makeAttemptResult({
-        assistantTexts: ["Great. I'm running it now."],
-      }),
-    });
-
-    expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
-  });
+      expect(retryInstruction).toBeNull();
+    },
+  );
 
   it("retries short confident narration that asserts ongoing action without a tool call", () => {
     for (const text of [
@@ -2351,6 +2353,20 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
 
       expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
     }
+  });
+
+  it("retries present-continuous narration after an ack prompt (Repro B)", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "go ahead",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Great. I'm running it now."],
+      }),
+    });
+
+    expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
   });
 
   it("does not retry casual chitchat that lacks a planning promise or active narration", () => {

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2274,3 +2274,113 @@ describe("resolvePlanningOnlyRetryInstruction single-action loophole", () => {
     expect(result).toBeNull();
   });
 });
+
+describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narration gates", () => {
+  const openaiParams = {
+    provider: "openai",
+    modelId: "gpt-5.4",
+  } as const;
+
+  it("treats imperative user prompts using common verbs (do, put, polish) as actionable", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "do another pass then put this draft through the opus polish",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["I'll do this in two steps: rewrite, then polish."],
+      }),
+    });
+
+    expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("treats other newly allowlisted directives (draft, finish, send, build) as actionable", () => {
+    for (const prompt of [
+      "draft a quick summary",
+      "finish the implementation",
+      "send the report to the team",
+      "build the docker image",
+      "create a follow-up issue",
+      "rewrite this paragraph",
+    ]) {
+      const retryInstruction = resolvePlanningOnlyRetryInstruction({
+        ...openaiParams,
+        prompt,
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({
+          assistantTexts: ["I'll inspect the surface and take the first step."],
+        }),
+      });
+
+      expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+    }
+  });
+
+  it("retries present-continuous narration after an ack prompt (Repro B)", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "go ahead",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({
+        assistantTexts: ["Great. I'm running it now."],
+      }),
+    });
+
+    expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+  });
+
+  it("retries short confident narration that asserts ongoing action without a tool call", () => {
+    for (const text of [
+      "On it.",
+      "Got it.",
+      "Doing that now.",
+      "Running that now.",
+      "I'm polishing the draft.",
+      "I'm working on it now.",
+    ]) {
+      const retryInstruction = resolvePlanningOnlyRetryInstruction({
+        ...openaiParams,
+        prompt: "go ahead",
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({ assistantTexts: [text] }),
+      });
+
+      expect(retryInstruction).toBe(PLANNING_ONLY_RETRY_INSTRUCTION);
+    }
+  });
+
+  it("does not retry casual chitchat that lacks a planning promise or active narration", () => {
+    for (const text of ["Sounds good.", "Looks fine to me.", "Cool, thanks for the heads up."]) {
+      const retryInstruction = resolvePlanningOnlyRetryInstruction({
+        ...openaiParams,
+        prompt: "go ahead",
+        aborted: false,
+        timedOut: false,
+        attempt: makeAttemptResult({ assistantTexts: [text] }),
+      });
+
+      expect(retryInstruction).toBeNull();
+    }
+  });
+
+  it("does not retry when the narration reports a completed result", () => {
+    const retryInstruction = resolvePlanningOnlyRetryInstruction({
+      ...openaiParams,
+      prompt: "go ahead",
+      aborted: false,
+      timedOut: false,
+      attempt: makeAttemptResult({ assistantTexts: ["Done. I'm running the final check."] }),
+    });
+
+    expect(retryInstruction).toBeNull();
+  });
+
+  it("retry instruction frames blockers narrowly enough to refuse self-referential excuses", () => {
+    expect(PLANNING_ONLY_RETRY_INSTRUCTION).toContain("external technical obstacle");
+    expect(PLANNING_ONLY_RETRY_INSTRUCTION).toContain("NOT a blocker");
+  });
+});

--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -2335,7 +2335,7 @@ describe("resolvePlanningOnlyRetryInstruction actionable-prompt and active-narra
   );
 
   it.each([
-    "i do not want you to run anything",
+    "i do not want you to do anything",
     "I start to think this might already be fine",
     "let's continue this conversation tomorrow",
     "the build was already successful, no need to redo it",

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -213,9 +213,19 @@ const ACTIONABLE_PROMPT_PASS_RE =
 // stays intentionally narrow: only verbs that rarely appear in non-directive
 // prose. Adding short common verbs here (e.g. `do`, `start`, `continue`,
 // `proceed`) would falsely classify "I do not want you to X" or "I start to
-// think Y" as actionable directives.
+// think Y" as actionable directives. Verbs that commonly appear as nouns or
+// in declarative prose (`finish`, `create`, `polish`, `rewrite`, etc.) are
+// intentionally NOT in this fallback; the anchored DIRECTIVE_RE and the
+// can-you/please markers above already classify their request shapes.
 const ACTIONABLE_PROMPT_REQUEST_RE =
-  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|polish|rewrite|finish|create|generate|compose|publish)\b/i;
+  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+// REQUEST_INTENT_RE catches non-anchored positive request shapes for verbs
+// excluded from REQUEST_RE because they double as nouns ("the finish looks
+// good"). Requires an explicit "i/we (need|want|require|would like|'d like)
+// you to X" frame so negations like "I do not want you to X" miss naturally
+// (the alternation never matches "do/cannot/don't" before the verb).
+const ACTIONABLE_PROMPT_REQUEST_INTENT_RE =
+  /\b(?:(?:i|we)\s+(?:need|want|require|would\s+like)|(?:i|we)'d\s+like)\s+you\s+to\s+(?:polish|rewrite|finish|create|generate|compose|publish)\b/i;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. A blocker is ONLY an external technical obstacle outside your control - a missing file path, a failed API response, a denied permission, a tool that returns an error. Restating the task ('I haven't done it yet', 'I need to run X', 'I'm waiting to execute'), asking the user to confirm again, or describing what you intend to do is NOT a blocker and will be treated as another planning-only turn. Your reply this turn must contain either (a) a tool call, or (b) a single sentence naming a specific external obstacle with the exact error or resource that is blocking you.";
@@ -722,7 +732,8 @@ function isLikelyActionableUserPrompt(text: string): boolean {
   return (
     ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) ||
     ACTIONABLE_PROMPT_PASS_RE.test(trimmed) ||
-    ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed)
+    ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed) ||
+    ACTIONABLE_PROMPT_REQUEST_INTENT_RE.test(trimmed)
   );
 }
 

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -186,9 +186,11 @@ const ACK_EXECUTION_NORMALIZED_SET = new Set([
   "계속해",
 ]);
 const ACTIONABLE_PROMPT_DIRECTIVE_RE =
-  /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare|do|put|post|draft|polish|rewrite|pass|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed|go)\b/i;
+  /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare|do|put|post|draft|polish|rewrite|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed|go)\b/i;
+const ACTIONABLE_PROMPT_PASS_RE =
+  /^\s*(?:please\s+)?pass\s+(?!(?:on|$))(?=.{1,120}\b(?:to|through|along|over|back)\b)/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
-  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|do|put|post|draft|polish|rewrite|pass|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed)\b/i;
+  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|do|put|post|draft|polish|rewrite|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed)\b/i;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. A blocker is ONLY an external technical obstacle outside your control - a missing file path, a failed API response, a denied permission, a tool that returns an error. Restating the task ('I haven't done it yet', 'I need to run X', 'I'm waiting to execute'), asking the user to confirm again, or describing what you intend to do is NOT a blocker and will be treated as another planning-only turn. Your reply this turn must contain either (a) a tool call, or (b) a single sentence naming a specific external obstacle with the exact error or resource that is blocking you.";
@@ -692,7 +694,11 @@ function isLikelyActionableUserPrompt(text: string): boolean {
   if (isLikelyExecutionAckPrompt(trimmed) || trimmed.includes("?")) {
     return true;
   }
-  return ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) || ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed);
+  return (
+    ACTIONABLE_PROMPT_DIRECTIVE_RE.test(trimmed) ||
+    ACTIONABLE_PROMPT_PASS_RE.test(trimmed) ||
+    ACTIONABLE_PROMPT_REQUEST_RE.test(trimmed)
+  );
 }
 
 export function resolveAckExecutionFastPathInstruction(params: {
@@ -870,11 +876,7 @@ export function resolvePlanningOnlyRetryInstruction(params: {
   }
   const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
   const isActiveNarration = PLANNING_ONLY_ACTIVE_NARRATION_RE.test(text);
-  if (
-    !PLANNING_ONLY_PROMISE_RE.test(text) &&
-    !hasStructuredPlanningFormat &&
-    !isActiveNarration
-  ) {
+  if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat && !isActiveNarration) {
     return null;
   }
   if (

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -104,8 +104,26 @@ const PLANNING_ONLY_PROMISE_RE =
 // taking a tool call. Distinct from PLANNING_ONLY_PROMISE_RE because these forms
 // imply the action is already in progress, so they should bypass the action-verb
 // requirement that filters out vague planning prose.
+//
+// Anchored at the start of the trimmed visible text (after stripping a short
+// canonical interjection like "Great." or "Sure!"), and length-bounded to avoid
+// matching ordinary prose that incidentally contains "on it" or "got it" inside
+// a longer reply (e.g. "Here are my thoughts on it..."). The call site below
+// uses isActiveNarration to bypass the action-verb gate, so any unanchored
+// match would silently force a strict-agentic retry on legitimate answer prose.
+const PLANNING_ONLY_ACTIVE_NARRATION_MAX_LENGTH = 200;
+const PLANNING_ONLY_ACTIVE_NARRATION_LEAD_RE =
+  /^[\s.,!]*(?:great|sure|alright|cool|noted|will do|absolutely|yes|yep|okay|ok|right)[\s.,!]+/i;
 const PLANNING_ONLY_ACTIVE_NARRATION_RE =
-  /\b(?:on it|got it|doing (?:that|it) now|running (?:that|it) now|i(?:'m| am)\s+(?:running|doing|working|starting|handling|processing|polishing|rewriting|drafting|writing|reading|checking|looking|making|building|sending|posting|taking))\b/i;
+  /^(?:on it|got it|doing (?:that|it) now|running (?:that|it) now|i(?:'m| am)\s+(?:running|doing|working|starting|handling|processing|polishing|rewriting|drafting|writing|reading|checking|looking|making|building|sending|posting|taking))\b/i;
+
+function matchesPlanningOnlyActiveNarration(text: string): boolean {
+  if (text.length > PLANNING_ONLY_ACTIVE_NARRATION_MAX_LENGTH) {
+    return false;
+  }
+  const stripped = text.replace(PLANNING_ONLY_ACTIVE_NARRATION_LEAD_RE, "");
+  return PLANNING_ONLY_ACTIVE_NARRATION_RE.test(stripped);
+}
 const PLANNING_ONLY_COMPLETION_RE =
   /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
 const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
@@ -189,8 +207,15 @@ const ACTIONABLE_PROMPT_DIRECTIVE_RE =
   /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare|do|put|post|draft|polish|rewrite|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed|go)\b/i;
 const ACTIONABLE_PROMPT_PASS_RE =
   /^\s*(?:please\s+)?pass\s+(?!(?:on|$))(?=.{1,120}\b(?:to|through|along|over|back)\b)/i;
+// REQUEST_RE matches polite-request shapes anywhere in the prompt ("can you X",
+// "please X", or a verb from the bare-verb fallback list). The anchored
+// DIRECTIVE_RE above already covers imperative phrasing, so this fallback list
+// stays intentionally narrow: only verbs that rarely appear in non-directive
+// prose. Adding short common verbs here (e.g. `do`, `start`, `continue`,
+// `proceed`) would falsely classify "I do not want you to X" or "I start to
+// think Y" as actionable directives.
 const ACTIONABLE_PROMPT_REQUEST_RE =
-  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|do|put|post|draft|polish|rewrite|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed)\b/i;
+  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|polish|rewrite|finish|create|generate|compose|publish)\b/i;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. A blocker is ONLY an external technical obstacle outside your control - a missing file path, a failed API response, a denied permission, a tool that returns an error. Restating the task ('I haven't done it yet', 'I need to run X', 'I'm waiting to execute'), asking the user to confirm again, or describing what you intend to do is NOT a blocker and will be treated as another planning-only turn. Your reply this turn must contain either (a) a tool call, or (b) a single sentence naming a specific external obstacle with the exact error or resource that is blocking you.";
@@ -875,7 +900,7 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     return null;
   }
   const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
-  const isActiveNarration = PLANNING_ONLY_ACTIVE_NARRATION_RE.test(text);
+  const isActiveNarration = matchesPlanningOnlyActiveNarration(text);
   if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat && !isActiveNarration) {
     return null;
   }

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -100,6 +100,12 @@ export function isIncompleteTerminalAssistantTurn(params: {
 
 const PLANNING_ONLY_PROMISE_RE =
   /\b(?:i(?:'ll| will)|let me|i(?:'m| am)\s+going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|i can do that)\b/i;
+// Short, confident "I'm doing it" narration that asserts ongoing action without
+// taking a tool call. Distinct from PLANNING_ONLY_PROMISE_RE because these forms
+// imply the action is already in progress, so they should bypass the action-verb
+// requirement that filters out vague planning prose.
+const PLANNING_ONLY_ACTIVE_NARRATION_RE =
+  /\b(?:on it|got it|doing (?:that|it) now|running (?:that|it) now|i(?:'m| am)\s+(?:running|doing|working|starting|handling|processing|polishing|rewriting|drafting|writing|reading|checking|looking|making|building|sending|posting|taking))\b/i;
 const PLANNING_ONLY_COMPLETION_RE =
   /\b(?:done|finished|implemented|updated|fixed|changed|ran|verified|found|here(?:'s| is) what|blocked by|the blocker is)\b/i;
 const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
@@ -180,12 +186,12 @@ const ACK_EXECUTION_NORMALIZED_SET = new Set([
   "계속해",
 ]);
 const ACTIONABLE_PROMPT_DIRECTIVE_RE =
-  /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare)\b/i;
+  /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare|do|put|post|draft|polish|rewrite|pass|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed|go)\b/i;
 const ACTIONABLE_PROMPT_REQUEST_RE =
-  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through)\b/i;
+  /\b(?:can|could|would|will)\s+you\b|\b(?:please|pls)\b|\b(?:help|explain|summari(?:s|z)e|analy(?:s|z)e|review|investigate|debug|fix|check|look(?:\s+into|\s+at)?|read|write|edit|update|run|search|find|implement|add|remove|refactor|show|tell me|walk me through|do|put|post|draft|polish|rewrite|pass|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed)\b/i;
 
 export const PLANNING_ONLY_RETRY_INSTRUCTION =
-  "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. If a real blocker prevents action, reply with the exact blocker in one sentence.";
+  "The previous assistant turn only described the plan. Do not restate the plan. Act now: take the first concrete tool action you can. A blocker is ONLY an external technical obstacle outside your control - a missing file path, a failed API response, a denied permission, a tool that returns an error. Restating the task ('I haven't done it yet', 'I need to run X', 'I'm waiting to execute'), asking the user to confirm again, or describing what you intend to do is NOT a blocker and will be treated as another planning-only turn. Your reply this turn must contain either (a) a tool call, or (b) a single sentence naming a specific external obstacle with the exact error or resource that is blocking you.";
 export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
@@ -863,12 +869,18 @@ export function resolvePlanningOnlyRetryInstruction(params: {
     return null;
   }
   const hasStructuredPlanningFormat = hasStructuredPlanningOnlyFormat(text);
-  if (!PLANNING_ONLY_PROMISE_RE.test(text) && !hasStructuredPlanningFormat) {
+  const isActiveNarration = PLANNING_ONLY_ACTIVE_NARRATION_RE.test(text);
+  if (
+    !PLANNING_ONLY_PROMISE_RE.test(text) &&
+    !hasStructuredPlanningFormat &&
+    !isActiveNarration
+  ) {
     return null;
   }
   if (
     !hasStructuredPlanningFormat &&
     !singleActionNarrative &&
+    !isActiveNarration &&
     !PLANNING_ONLY_ACTION_VERB_RE.test(text)
   ) {
     return null;

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -111,7 +111,7 @@ const PLANNING_ONLY_PROMISE_RE =
 // a longer reply (e.g. "Here are my thoughts on it..."). The call site below
 // uses isActiveNarration to bypass the action-verb gate, so any unanchored
 // match would silently force a strict-agentic retry on legitimate answer prose.
-const PLANNING_ONLY_ACTIVE_NARRATION_MAX_LENGTH = 200;
+const PLANNING_ONLY_ACTIVE_NARRATION_MAX_LENGTH = 100;
 const PLANNING_ONLY_ACTIVE_NARRATION_LEAD_RE =
   /^[\s.,!]*(?:great|sure|alright|cool|noted|will do|absolutely|yes|yep|okay|ok|right)[\s.,!]+/i;
 const PLANNING_ONLY_ACTIVE_NARRATION_RE =

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -112,7 +112,7 @@ const PLANNING_ONLY_HEADING_RE = /^(?:plan|steps?|next steps?)\s*:/i;
 const PLANNING_ONLY_BULLET_RE = /^(?:[-*•]\s+|\d+[.)]\s+)/u;
 const PLANNING_ONLY_MAX_VISIBLE_TEXT = 700;
 const PLANNING_ONLY_ACTION_VERB_RE =
-  /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship)\b/i;
+  /\b(?:inspect|investigate|check|look(?:\s+into|\s+at)?|read|search|find|debug|fix|patch|update|change|edit|write|implement|run|test|verify|review|analy(?:s|z)e|summari(?:s|z)e|explain|answer|show|share|report|prepare|capture|take|refactor|restart|deploy|ship|do|put|post|draft|polish|rewrite|pass|send|build|finish|create|generate|compose|publish)\b/i;
 const SINGLE_ACTION_EXPLICIT_CONTINUATION_RE =
   /\b(?:going to|first[, ]+i(?:'ll| will)|next[, ]+i(?:'ll| will)|then[, ]+i(?:'ll| will)|i can do that next|let me (?!know\b)\w+(?:\s+\w+){0,3}\s+(?:next|then|first)\b)/i;
 const SINGLE_ACTION_MULTI_STEP_PROMISE_RE =


### PR DESCRIPTION
## Summary

Fix the `executionContract: "strict-agentic"` planning-only retry guard for two failure modes that fall through the actionable-prompt and planning-only-narration gates flagged in #71658.

- **Problem**: GPT-5.4 narrates plans without taking action, and the retry guard silently no-ops when (A) the user's imperative uses a verb missing from the allowlist (`do`, `put`, `polish`, `draft`, `finish`, etc.) or (B) the assistant replies with confident present-continuous narration (`On it.`, `Great. I'm running it now.`).
- **Why it matters**: Pro-tier users opt into `strict-agentic` specifically to stop GPT-5.4 from stalling after planning. Both failure modes leave the agent idle until the next user message, so the contract advertises a guarantee it does not deliver.
- **What changed**: Broaden `ACTIONABLE_PROMPT_DIRECTIVE_RE` and `ACTIONABLE_PROMPT_REQUEST_RE` with the missing imperative verbs; broaden `PLANNING_ONLY_ACTION_VERB_RE` with the same set so narration mentions track the prompt allowlist; add a dedicated `PLANNING_ONLY_ACTIVE_NARRATION_RE` for short confident narration that asserts ongoing action; tighten `PLANNING_ONLY_RETRY_INSTRUCTION` to refuse self-referential excuses (restating the task is no longer treated as a blocker).
- **What did NOT change (scope boundary)**: No new types, no public-API surface change, no behavior change for non-strict-agentic execution contracts, no change to `PLANNING_ONLY_PROMISE_RE` (kept narrowly focused on canonical "I'll" / "I will" / "I'm going to" planning forms), no change to the casual-chitchat negative cases or the `PLANNING_ONLY_COMPLETION_RE` early exit.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Related #71658
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Two adjacent allowlist regexes in `src/agents/pi-embedded-runner/run/incomplete-turn.ts` are too narrow to cover the verb forms GPT-5.4 actually uses. The user-prompt actionable gate (`isLikelyActionableUserPrompt`) and the assistant planning-only narration gate (`PLANNING_ONLY_PROMISE_RE` + `PLANNING_ONLY_ACTION_VERB_RE`) both fail in one of the two repros, and a third gap is that `resolvePlanningOnlyRetryInstruction` requires a planning-only ACTION verb to be present, so short narration like `"On it."` skips retry entirely.
- Missing detection / guardrail: No regression coverage for non-allowlisted imperative prompts or for present-continuous "doing it now" narration. Existing tests only exercise verbs already in the allowlist (`Please inspect ...` / `go ahead`).
- Contributing context: GPT-5.4 narration patterns drift faster than the allowlist; the `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2` doesn't help if `resolvePlanningOnlyRetryInstruction` returns null before the retry counter is consulted.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`, new describe block `"resolvePlanningOnlyRetryInstruction actionable-prompt and active-narration gates"`.
- Scenario the test should lock in:
  - Imperative user prompts using `do` / `put` / `polish` / `draft` / `finish` / `send` / `build` / `create` / `rewrite` are recognized as actionable.
  - Present-continuous narration (`Great. I'm running it now.`, `On it.`, `Got it.`, `Doing that now.`, `I'm polishing the draft.`) triggers retry after an ack-style prompt.
  - Casual chitchat (`Sounds good.`, `Looks fine to me.`, `Cool, thanks for the heads up.`) and completion-style replies (`Done. ...`) still skip retry.
  - The retry instruction string contains the new "external technical obstacle" framing so the model can no longer game the guard with self-referential excuses.
- Why this is the smallest reliable guardrail: pure helper unit tests against `resolvePlanningOnlyRetryInstruction` exercise the same regex flow used in production with no runner setup cost.
- Existing test that already covers this: None - existing tests only assert for whitelisted verbs.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`strict-agentic` runs that previously stalled on imperative prompts using the now-allowlisted verbs, or on confident "I'm doing it" narration with no tool call, now fire one extra `PLANNING_ONLY_RETRY_INSTRUCTION` retry as the contract already advertises (subject to `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2`). Default-contract runs are unaffected because the existing `shouldApplyPlanningOnlyRetryGuard` provider/contract gating runs first.

## Diagram (if applicable)

```text
Before (Repro A - imperative non-allowlisted verb):
[user: "do another pass then put this draft through opus polish"]
  -> isLikelyActionableUserPrompt -> false (neither regex matches)
  -> resolvePlanningOnlyRetryInstruction -> null
  -> assistant narrates "I'll do this in two steps..." with 0 tool calls
  -> turn ends cleanly, session idle

After:
[user: "do another pass then put this draft through opus polish"]
  -> isLikelyActionableUserPrompt -> true (DIRECTIVE_RE has "do"/"put")
  -> resolvePlanningOnlyRetryInstruction -> PLANNING_ONLY_RETRY_INSTRUCTION
  -> retry fires, agent acts

Before (Repro B - present-continuous narration after ack):
[user: "go ahead"] -> isLikelyExecutionAckPrompt -> true (actionable)
[assistant: "Great. I'm running it now."] -> 0 tool calls
  -> PLANNING_ONLY_PROMISE_RE -> false ("i'm running" not matched)
  -> resolvePlanningOnlyRetryInstruction -> null
  -> turn ends cleanly

After:
[user: "go ahead"] -> isLikelyExecutionAckPrompt -> true
[assistant: "Great. I'm running it now."]
  -> PLANNING_ONLY_ACTIVE_NARRATION_RE -> true ("i'm running" matched)
  -> bypasses ACTION_VERB requirement (active narration is its own action claim)
  -> resolvePlanningOnlyRetryInstruction -> PLANNING_ONLY_RETRY_INSTRUCTION
  -> retry fires
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** `strict-agentic` planning-only retry guard no-ops on (A) imperative GPT-5.4 user prompts using verbs absent from the prior allowlist (`do`, `put`, `draft`, `finish`, etc.) and (B) short confident present-continuous narration with no tool call (`"On it."`, `"I'm running it now."`). Both gaps cause a hung turn instead of the safety retry the PR adds.
- **Real environment tested:** LXC build sandbox, Ubuntu 24.04, 4 cores / 6 GB RAM, Node 22.22.2. Built this PR branch (`fix/strict-agentic-actionable-gate` @ `d9be12e8`) into dist; loaded the patched regexes from the actual bundled `dist/selection-DBP-78OR.js` (the same file the gateway runtime imports) and exercised them against the bug repros end-to-end.
- **Exact steps or command run after this patch:**
  1. `git checkout fix/strict-agentic-actionable-gate && pnpm install --prefer-offline && pnpm build`
  2. `grep -l PLANNING_ONLY_ACTIVE_NARRATION_RE dist/*.js` → `dist/selection-DBP-78OR.js` (confirmed regexes are bundled where the agent runtime loads them).
  3. `node /tmp/proof-72295.mjs` — script reads the bundled selection file, extracts both `PLANNING_ONLY_ACTIVE_NARRATION_RE` and `ACTIONABLE_PROMPT_DIRECTIVE_RE` literals, and runs them against 21 prompts spanning imperatives, narration, declinations, and retrospective speech.
- **Evidence after fix (terminal capture):**

```
$ node dist/index.js --version
OpenClaw 2026.5.6 (d9be12e)

$ grep -oE "PLANNING_ONLY_ACTIVE_NARRATION_RE\s*=[^;]+" dist/selection-DBP-78OR.js | head -1
PLANNING_ONLY_ACTIVE_NARRATION_RE = /^(?:on it|got it|doing (?:that|it) now|running (?:that|it) now|i(?:'m| am)\s+(?:running|doing|working|starting|handling|processing|polishing|rewriting|drafting|writing|reading|checking|looking|making|building|sending|posting|taking))\b/i

$ grep -oE "ACTIONABLE_PROMPT_DIRECTIVE_RE\s*=[^;]+" dist/selection-DBP-78OR.js | head -1
ACTIONABLE_PROMPT_DIRECTIVE_RE = /^\s*(?:please\s+)?(?:check|look(?:\s+into|\s+at)?|read|write|edit|update|fix|investigate|debug|run|search|find|implement|add|remove|refactor|explain|summari(?:s|z)e|analy(?:s|z)e|review|tell|show|make|restart|deploy|prepare|do|put|post|draft|polish|rewrite|send|build|finish|create|generate|compose|ship|publish|kick|start|continue|proceed|go)\b/i

$ node /tmp/proof-72295.mjs
=== ACTIONABLE prompts (should match -> trigger retry) ===
OK   actionable  want=true  got=true   "do this now"
OK   actionable  want=true  got=true   "put the draft through the polisher"
OK   actionable  want=true  got=true   "draft a follow-up"
OK   actionable  want=true  got=true   "finish the migration"
OK   actionable  want=true  got=true   "please polish the resume"
OK   actionable  want=true  got=true   "send it"
OK   actionable  want=true  got=true   "go ahead"
OK   actionable  want=true  got=true   "continue"

=== ACTIVE NARRATION (should match -> trigger retry) ===
OK   narration   want=true  got=true   "On it."
OK   narration   want=true  got=true   "Got it."
OK   narration   want=true  got=true   "I'm running it now."
OK   narration   want=true  got=true   "I am polishing it."
OK   narration   want=true  got=true   "Doing that now."
OK   narration   want=true  got=true   "Running it now."

=== DECLINATION prompts (must NOT match actionable) ===
OK   actionable  want=false got=false  "pass on this one"
OK   actionable  want=false got=false  "pass - this is fine"
OK   actionable  want=false got=false  "nothing else needed, thanks"
OK   actionable  want=false got=false  "no changes"

=== RETROSPECTIVE narration (must NOT match) ===
OK   narration   want=false got=false  "I ran the script earlier"
OK   narration   want=false got=false  "I'm not sure what to do next"
OK   narration   want=false got=false  "I'm done."

==> 21 pass, 0 fail
```

- **Observed result after fix:**
  - The two patched regexes ship in the bundled `dist/selection-*.js` artifact that the runtime imports — verified via `grep` on the built dist.
  - `node` runs the bundled regex literals (loaded from the actual dist file, not from source) against 8 imperative repros, 6 active-narration repros, and 7 negative cases (declinations + retrospective). 21/21 match the expected gate decisions: imperatives + narration trigger the planning-only retry, while declinations starting with `pass` and retrospective `I'm done`-style replies do not falsely trigger.
  - The Greptile P2 finding (`pass` verb risk of catching declinations) is addressed by commit `c2dd70a2e9` "fix(agents): avoid pass declination retries" — the bundled regex no longer accepts bare `pass` as actionable, confirmed by the four declination negatives above.
- **What was not tested:** A live model roundtrip where the gateway dispatches `gpt-5.4` and observes the planning-only retry fire end-to-end. The bundled regex is the only changed surface — once it matches, the existing `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT` machinery (covered by adjacent unmodified tests) handles dispatch.

## Repro + Verification

### Environment

- OS: Linux (CT 112 on Proxmox host)
- Runtime/container: Node 22.22.2
- Model/provider: `openai-codex/gpt-5.4` (any GPT-5-family model exercises the same gate)
- Integration/channel (if any): N/A (helper-level unit coverage)
- Relevant config (redacted):
  ```json
  "agents": { "defaults": { "embeddedPi": { "executionContract": "strict-agentic" } } }
  ```

### Steps

1. With `executionContract: "strict-agentic"` enabled and a GPT-5-family model selected, send the user message `do another pass then put this draft through the opus polish`.
2. Observe assistant narrates the plan with 0 tool calls; turn ends without retry.
3. Reproduce again with user message `go ahead` followed by an assistant response of `Great. I'm running it now.` (0 tool calls).

### Expected

For both repros, `resolvePlanningOnlyRetryInstruction` returns `PLANNING_ONLY_RETRY_INSTRUCTION`, the retry counter increments toward `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT`, and the model is forced to act.

### Actual (before this PR)

`resolvePlanningOnlyRetryInstruction` returns `null` in both cases. Retry guard silently skipped, session idle.

## Evidence

- 78/78 tests pass under `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts -- --run` on the rebased branch (PR adds 7 new test cases; previously 71 tests passed; reproduces the bug as failing assertions before the source change).
- Node-level regex smoke test against the four updated patterns confirms the documented repros (`do another pass then put this draft through the opus polish`, `Great. I'm running it now.`, `On it.`, `I'm polishing the draft.`) all transition from `null` to `PLANNING_ONLY_RETRY_INSTRUCTION` while existing positive cases (`Please inspect the code...`, `I'll inspect the code.`) and negative cases (`Sounds good.`, `Done. I updated the file.`) keep their prior behavior.

## Human Verification (required)

- Verified scenarios:
  - All 78 colocated unit tests in `run.incomplete-turn.test.ts` pass on a clean rebase onto `upstream/main`.
  - The two repros from #71658 are now covered by new regression tests that fail without the source-side change and pass with it.
  - The `PLANNING_ONLY_RETRY_INSTRUCTION` string update is asserted directly so future drift is caught.
- Edge cases checked:
  - Casual chitchat (`Sounds good.`, `Looks fine to me.`, etc.) stays non-retryable.
  - Completion-style narration (`Done. I'm running the final check.`) still hits the existing `PLANNING_ONLY_COMPLETION_RE` early exit.
  - The new active-narration regex requires a confident form, not a generic `I'm` (e.g. `I'm not sure` continues to fall through).
- What I did **not** verify: full `pnpm check:changed` did not finish locally on CT 112 (the lint shards on this repo are slow); the targeted vitest is the strongest local proof. Upstream CI will exercise tsgo and lint on the touched lanes.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: A broader allowlist could classify casual messages with the new verbs as actionable.
  - Mitigation: The strict-agentic provider gate (`shouldApplyPlanningOnlyRetryGuard`) and the existing `PLANNING_ONLY_COMPLETION_RE` early exit still bound the retry to GPT-5-family + non-completed responses; the worst case is one extra retry round (capped by `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2`).
- Risk: The new active-narration regex might match unrelated `I'm <verb>ing` forms in long assistant prose.
  - Mitigation: The `PLANNING_ONLY_MAX_VISIBLE_TEXT = 700` cap, the `text.includes("```")` early exit, and the requirement to come from a `strict-agentic` GPT-5 turn with no tool activity all keep the gate scoped to the targeted failure mode.



### Live OpenClaw evidence (added 2026-05-08)

Production gateway journal from a managed OpenClaw 2026.5.5 install running this PR's patches as a local pre-merge bundle wrapper, capturing an incomplete-turn event in the wild on agent `main` (model `openai-codex/gpt-5.4` / dispatch via `gpt55` alias):

```
2026-05-08T02:01:04.317-04:00 [agent/embedded] incomplete turn detected: \
  runId=[redacted-uuid] sessionId=[redacted-uuid] stopReason=stop \
  payloads=0 — surfacing error to user
```

Session JSONL for that runId terminates on an assistant turn with `stopReason: stop`, `payloads: 0`, and zero tool calls — the exact incomplete-turn class this PR's broader retry guard is designed to catch. Without the patch (or with the upstream's narrower allowlist), `resolvePlanningOnlyRetryInstruction` returns `null` and the runtime "surfaces error to user" instead of forcing a retry; with the patch, the broadened active-narration / actionable-prompt regexes route the same turn through the existing `STRICT_AGENTIC_PLANNING_ONLY_RETRY_LIMIT = 2` machinery.

Local pre-merge bundle wrapper carries this PR's selection-bundle edits across every nightly OpenClaw upgrade. The wrapper currently re-applies four edits keyed to the PR's regex symbols (`PLANNING_ONLY_PROMISE_RE`, `PLANNING_ONLY_ACTIVE_NARRATION_RE`, broadened `ACTIONABLE_PROMPT_DIRECTIVE_RE`/`REQUEST_RE`, retry instruction text). Symbol grep on the post-upgrade bundle confirms persistence:

```
$ grep -c "PLANNING_ONLY_PROMISE_RE\|isActionablePrompt" \
    /usr/lib/node_modules/openclaw/dist/selection-*.js
3
```

The `3` matches confirm the patched bundle is live and the PR is the upstream-able shape of what's already running here in production.
