### PR TITLE
fix(memory): warn on unverified qmd path conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/QMD: warn with a manual stale collection removal hint when QMD reports a path/pattern conflict but `collection list` lacks verifiable metadata, avoiding unsafe stderr-only rebinds. Refs #71783. (#72297) Thanks @MonkeyLeeT.
 - Docs/Subagents: correct the listed sub-agent bootstrap context files to include `SOUL.md`, `IDENTITY.md`, and `USER.md`. (#79470) Thanks @lastguru-net.
 - Backup: keep live backup archives from copying current agent session transcripts, cron run logs, and delivery queues while preserving workspace lock/temp files and keeping `--json` output parseable when volatile files are skipped. Fixes #72249. (#72251) Thanks @abnershang.
 - OpenAI/Codex: install the Codex runtime plugin from npm during OpenAI onboarding and load it automatically for implicit OpenAI model routes, while preserving manual PI runtime overrides. Fixes #79358.

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1049,7 +1049,7 @@ describe("QmdMemoryManager", () => {
     );
   });
 
-  it("rebinds a path-pattern conflict when qmd add reports the stale collection name", async () => {
+  it("refuses to rebind a stderr-only path-pattern conflict without collection metadata", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1111,10 +1111,10 @@ describe("QmdMemoryManager", () => {
     const { manager } = await createManager({ mode: "full" });
     await manager.close();
 
-    expect(removeCalls).toEqual(["workspace-legacy"]);
-    expect(addCalls).toEqual(["workspace-main", "workspace-main"]);
-    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("rebinding"));
-    expect(logWarnMock).not.toHaveBeenCalledWith(
+    expect(removeCalls).toEqual([]);
+    expect(addCalls).toEqual(["workspace-main"]);
+    expect(logWarnMock).not.toHaveBeenCalledWith(expect.stringContaining("rebinding"));
+    expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("qmd collection add skipped for workspace-main"),
     );
   });

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1049,7 +1049,7 @@ describe("QmdMemoryManager", () => {
     );
   });
 
-  it("refuses to rebind a stderr-only path-pattern conflict without collection metadata", async () => {
+  it("surfaces a manual repair hint for stderr-only path-pattern conflicts", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -1114,6 +1114,14 @@ describe("QmdMemoryManager", () => {
     expect(removeCalls).toEqual([]);
     expect(addCalls).toEqual(["workspace-main"]);
     expect(logWarnMock).not.toHaveBeenCalledWith(expect.stringContaining("rebinding"));
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "qmd reported existing collection workspace-legacy, but list output did not include verifiable path/pattern metadata",
+      ),
+    );
+    expect(logWarnMock).toHaveBeenCalledWith(
+      expect.stringContaining("qmd collection remove workspace-legacy"),
+    );
     expect(logWarnMock).toHaveBeenCalledWith(
       expect.stringContaining("qmd collection add skipped for workspace-main"),
     );

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -1049,6 +1049,76 @@ describe("QmdMemoryManager", () => {
     );
   });
 
+  it("rebinds a path-pattern conflict when qmd add reports the stale collection name", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    let staleCollectionExists = true;
+    const removeCalls: string[] = [];
+    const addCalls: string[] = [];
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "collection" && args[1] === "list") {
+        const child = createMockChild({ autoClose: false });
+        // Older qmd output may expose only names, so path/pattern matching cannot find this.
+        emitAndClose(child, "stdout", JSON.stringify(["workspace-legacy"]));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "remove") {
+        const child = createMockChild({ autoClose: false });
+        const name = args[2] ?? "";
+        removeCalls.push(name);
+        if (name === "workspace-legacy") {
+          staleCollectionExists = false;
+        }
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      if (args[0] === "collection" && args[1] === "add") {
+        const child = createMockChild({ autoClose: false });
+        const name = args[args.indexOf("--name") + 1] ?? "";
+        addCalls.push(name);
+        if (staleCollectionExists && name === "workspace-main") {
+          emitAndClose(
+            child,
+            "stderr",
+            [
+              "A collection already exists for this path and pattern:",
+              "  Name: workspace-legacy (qmd://workspace-legacy/)",
+              "  Pattern: **/*.md",
+              "",
+              "Use 'qmd update' to re-index it, or remove it first with 'qmd collection remove workspace-legacy'",
+            ].join("\n"),
+            1,
+          );
+          return child;
+        }
+        queueMicrotask(() => child.closeWith(0));
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "full" });
+    await manager.close();
+
+    expect(removeCalls).toEqual(["workspace-legacy"]);
+    expect(addCalls).toEqual(["workspace-main", "workspace-main"]);
+    expect(logWarnMock).toHaveBeenCalledWith(expect.stringContaining("rebinding"));
+    expect(logWarnMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("qmd collection add skipped for workspace-main"),
+    );
+  });
+
   it("recreates a managed collection when list fails but add reports the same name exists", async () => {
     await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# canonical root");
     cfg = {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -671,7 +671,23 @@ export class QmdMemoryManager implements MemorySearchManager {
       conflictName = this.findCollectionByPathPattern(collection, existing);
     }
 
-    conflictName ??= this.parseConflictingCollectionNameFromAddError(addErrorMessage);
+    if (!conflictName) {
+      const parsedConflictName = this.parseConflictingCollectionNameFromAddError(addErrorMessage);
+      const parsedDetails = parsedConflictName ? existing.get(parsedConflictName) : undefined;
+      if (
+        parsedConflictName &&
+        parsedDetails?.path &&
+        typeof parsedDetails.pattern === "string" &&
+        this.pathsMatch(parsedDetails.path, collection.path) &&
+        this.patternsMatchForManagedCollection(
+          collection.path,
+          parsedDetails.pattern,
+          collection.pattern,
+        )
+      ) {
+        conflictName = parsedConflictName;
+      }
+    }
 
     if (!conflictName) {
       return false;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -643,6 +643,18 @@ export class QmdMemoryManager implements MemorySearchManager {
     return null;
   }
 
+  private parseConflictingCollectionNameFromAddError(message: string): string | null {
+    if (
+      !normalizeLowercaseStringOrEmpty(message).includes(
+        "a collection already exists for this path and pattern",
+      )
+    ) {
+      return null;
+    }
+    const match = /^\s*Name:\s*([a-z0-9._-]+)\s*\(qmd:\/\/[^)\s]+\/?\)\s*$/im.exec(message);
+    return match?.[1] ?? null;
+  }
+
   private async tryRebindConflictingCollection(params: {
     collection: ManagedCollection;
     existing: Map<string, ListedCollection>;
@@ -658,6 +670,8 @@ export class QmdMemoryManager implements MemorySearchManager {
       }
       conflictName = this.findCollectionByPathPattern(collection, existing);
     }
+
+    conflictName ??= this.parseConflictingCollectionNameFromAddError(addErrorMessage);
 
     if (!conflictName) {
       return false;

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -673,23 +673,11 @@ export class QmdMemoryManager implements MemorySearchManager {
 
     if (!conflictName) {
       const parsedConflictName = this.parseConflictingCollectionNameFromAddError(addErrorMessage);
-      const parsedDetails = parsedConflictName ? existing.get(parsedConflictName) : undefined;
-      if (
-        parsedConflictName &&
-        parsedDetails?.path &&
-        typeof parsedDetails.pattern === "string" &&
-        this.pathsMatch(parsedDetails.path, collection.path) &&
-        this.patternsMatchForManagedCollection(
-          collection.path,
-          parsedDetails.pattern,
-          collection.pattern,
-        )
-      ) {
-        conflictName = parsedConflictName;
+      if (parsedConflictName) {
+        log.warn(
+          `qmd collection add conflict for ${collection.name}: qmd reported existing collection ${parsedConflictName}, but list output did not include verifiable path/pattern metadata; refusing automatic rebind. If ${parsedConflictName} is stale, remove it manually with 'qmd collection remove ${parsedConflictName}'`,
+        );
       }
-    }
-
-    if (!conflictName) {
       return false;
     }
     if (conflictName === collection.name) {


### PR DESCRIPTION
## Summary
- parse QMD path-pattern conflict add errors for the stale collection name
- surface a manual repair hint when QMD list output lacks verifiable path/pattern metadata
- keep automatic rebind limited to structured path/pattern matches
- add regression coverage that stderr-only conflicts do not remove collections
- add changelog attribution for landing

Refs #71783

## Real behavior proof
- Behavior or issue addressed: QMD can reject a managed collection add because another collection already owns the same path/pattern, while `qmd collection list --json` exposes no verifiable path metadata. OpenClaw should warn with a manual repair hint and must not remove/rebind a collection based only on stderr.
- Real environment tested: macOS local OpenClaw checkout rebased on current `main`, real `@tobilu/qmd` 2.1.0 binary, isolated QMD `XDG_CONFIG_HOME` and `XDG_CACHE_HOME`; local QMD source checkout `~/Projects/oss/qmd` at `d58fedf`, package version 2.1.0.
- Exact steps or command run after this patch: created an isolated workspace with `MEMORY.md`, ran real `qmd collection add <workspace> --name workspace-legacy --mask '**/*.md'`, then ran real `qmd collection add <workspace> --name workspace-main --mask '**/*.md'`; inspected `~/Projects/oss/qmd/src/cli/qmd.ts` for the current source contract; ran OpenClaw focused and changed gates.
- Evidence after fix:

```text
$ qmd --version
qmd 2.1.0 (2b422bebcb)

$ XDG_CONFIG_HOME=/tmp/openclaw-qmd-pr72297-proof.i1eAXe/xdg-config \
  XDG_CACHE_HOME=/tmp/openclaw-qmd-pr72297-proof.i1eAXe/xdg-cache \
  qmd collection add /tmp/openclaw-qmd-pr72297-proof.i1eAXe/workspace --name workspace-legacy --mask '**/*.md'
Creating collection 'workspace-legacy'...
Collection: /private/tmp/openclaw-qmd-pr72297-proof.i1eAXe/workspace (**/*.md)
Indexed: 1 new, 0 updated, 0 unchanged, 0 removed
Collection 'workspace-legacy' created successfully

$ XDG_CONFIG_HOME=/tmp/openclaw-qmd-pr72297-proof.i1eAXe/xdg-config \
  XDG_CACHE_HOME=/tmp/openclaw-qmd-pr72297-proof.i1eAXe/xdg-cache \
  qmd collection add /tmp/openclaw-qmd-pr72297-proof.i1eAXe/workspace --name workspace-main --mask '**/*.md'
A collection already exists for this path and pattern:
  Name: workspace-legacy (qmd://workspace-legacy/)
  Pattern: **/*.md

Use 'qmd update' to re-index it, or remove it first with 'qmd collection remove workspace-legacy'
```

- Observed result after fix: QMD's real stderr includes only the conflicting collection name and manual remove text. The local QMD source shows `collection list` prints human output without filesystem path metadata, so OpenClaw's after-fix behavior is the safe one: log the parsed stale-name manual hint and keep automatic removal limited to already-verified path/pattern metadata. Focused OpenClaw proof passed with `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts`; changed gate passed with `OPENCLAW_TESTBOX=0 pnpm check:changed`.
- What was not tested: No destructive automatic rebind was tested against a private real OpenClaw operator memory index; the patch deliberately refuses that path without structured metadata.

## Tests
- `pnpm test extensions/memory-core/src/memory/qmd-manager.test.ts`
- `OPENCLAW_TESTBOX=0 pnpm check:changed`
