### PR TITLE
fix(tui): skip eager context warmup during startup

### DIFF
--- a/src/agents/context.lookup.test.ts
+++ b/src/agents/context.lookup.test.ts
@@ -219,6 +219,7 @@ describe("lookupContextTokens", () => {
       false,
     );
     expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "status", "--json"])).toBe(false);
+    expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "tui"])).toBe(false);
     expect(shouldEagerWarmContextWindowCache(["node", "openclaw", "sessions", "--json"])).toBe(
       false,
     );

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -160,6 +160,7 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "secrets",
   "sessions",
   "status",
+  "tui",
   "update",
   "webhooks",
 ]);


### PR DESCRIPTION
## Summary

  Fixes slow TUI startup/input lag by skipping eager context-window
  warmup for `openclaw tui`.

  Before this change, TUI startup could trigger model/provider
  discovery before the gateway handshake. On my system this caused
  visible startup/input delay due to plugin manifest discovery.

  ## Changes

  - Add `tui` to `SKIP_EAGER_WARMUP_PRIMARY_COMMANDS`.
  - Add regression coverage for
  `shouldEagerWarmContextWindowCache(["node", "openclaw", "tui"])`.

  ## Testing

  - `pnpm vitest run src/agents/context.lookup.test.ts`
  - `pnpm build`

  ## Notes

  AI-assisted contribution. I reproduced the lag locally, profiled the
  TUI startup path, and verified the fix locally.