### PR TITLE
fix(tui): handle zero history limit

### DIFF
--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -244,6 +244,45 @@ describe("tui session actions", () => {
     expect(btw.clear).toHaveBeenCalled();
   });
 
+  it("skips gateway history loading when history limit is zero", async () => {
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {},
+      sessions: [],
+    });
+    const loadHistory = vi.fn();
+    const chatLog = {
+      addSystem: vi.fn(),
+      clearAll: vi.fn(),
+    } as unknown as import("./components/chat-log.js").ChatLog;
+    const btw = createBtwPresenter();
+    const requestRender = vi.fn();
+    const state = createBaseState();
+
+    const { loadHistory: loadTuiHistory } = createTestSessionActions({
+      client: {
+        listSessions,
+        loadHistory,
+      } as unknown as TuiBackend,
+      chatLog,
+      btw,
+      tui: { requestRender } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: { historyLimit: 0 },
+      state,
+    });
+
+    await loadTuiHistory();
+
+    expect(loadHistory).not.toHaveBeenCalled();
+    expect(chatLog.clearAll).toHaveBeenCalled();
+    expect(btw.clear).toHaveBeenCalled();
+    expect(chatLog.addSystem).toHaveBeenCalledWith("session agent:main:main");
+    expect(state.historyLoaded).toBe(true);
+    expect(requestRender).toHaveBeenCalled();
+  });
+
   it("applies default model info when the current session has no persisted entry yet", async () => {
     const listSessions = vi.fn().mockResolvedValue({
       ts: Date.now(),

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -287,6 +287,15 @@ export function createSessionActions(context: SessionActionContext) {
 
   const loadHistory = async () => {
     try {
+      if (opts.historyLimit === 0) {
+        chatLog.clearAll();
+        btw.clear();
+        chatLog.addSystem(`session ${state.currentSessionKey}`);
+        state.historyLoaded = true;
+        await refreshSessionInfo();
+        tui.requestRender();
+        return;
+      }
       const history = await client.loadHistory({
         sessionKey: state.currentSessionKey,
         limit: opts.historyLimit ?? 200,


### PR DESCRIPTION
## Summary

Fixes `openclaw tui --history-limit 0` so it disables history loading locally instead of sending an invalid `chat.history` request to the gateway.

Before this change, the TUI passed `limit: 0` through to the gateway, which rejected it because history limits must be at least 1.

## Changes

- Treat `historyLimit === 0` as an explicit no-history mode.
- Clear the local chat log and show the session marker without calling gateway history loading.
- Add regression coverage for the zero-history path.

## Testing

- `pnpm vitest run src/tui/tui-session-actions.test.ts`
- `pnpm build`

## Notes

AI-assisted contribution. I reproduced the issue locally with `openclaw tui --history-limit 0` and verified the fix locally.