### PR TITLE
fix(agents): scope provider discovery from configured models

### DIFF
--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -1,3 +1,8 @@
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
+import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -7,7 +12,10 @@ import {
   resolvePluginDiscoveryProviders,
   runProviderCatalog,
 } from "../plugins/provider-discovery.js";
-import { resolveOwningPluginIdsForProvider } from "../plugins/providers.js";
+import {
+  resolveOwningPluginIdsForModelRefs,
+  resolveOwningPluginIdsForProvider,
+} from "../plugins/providers.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
 import {
   isNonSecretApiKeyMarker,
@@ -71,6 +79,7 @@ function resolveProviderDiscoveryFilter(params: {
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
   resolveOwners?: (provider: string) => readonly string[] | undefined;
+  resolveModelOwners?: (models: readonly string[]) => readonly string[];
 }): string[] | undefined {
   const { config, workspaceDir, env } = params;
   const testRaw = env.OPENCLAW_TEST_ONLY_PROVIDER_PLUGIN_IDS?.trim();
@@ -84,7 +93,14 @@ function resolveProviderDiscoveryFilter(params: {
   const live =
     env.OPENCLAW_LIVE_TEST === "1" || env.OPENCLAW_LIVE_GATEWAY === "1" || env.LIVE === "1";
   if (!live) {
-    return undefined;
+    const configured = resolveConfiguredProviderDiscoveryPluginIds({
+      config,
+      workspaceDir,
+      env,
+      resolveOwners: params.resolveOwners,
+      resolveModelOwners: params.resolveModelOwners,
+    });
+    return configured.length > 0 ? configured : undefined;
   }
   const rawValues = [
     env.OPENCLAW_LIVE_PROVIDERS?.trim(),
@@ -124,11 +140,102 @@ function resolveProviderDiscoveryFilter(params: {
     : undefined;
 }
 
+function collectAgentModelRefs(model: AgentModelConfig | undefined, refs: Set<string>): void {
+  const primary = resolveAgentModelPrimaryValue(model)?.trim();
+  if (primary) {
+    refs.add(primary);
+  }
+  for (const fallback of resolveAgentModelFallbackValues(model)) {
+    const trimmed = fallback.trim();
+    if (trimmed) {
+      refs.add(trimmed);
+    }
+  }
+}
+
+function collectConfiguredModelRefs(config: OpenClawConfig | undefined): string[] {
+  const refs = new Set<string>();
+  const defaults = config?.agents?.defaults;
+  if (defaults) {
+    collectAgentModelRefs(defaults.model, refs);
+    collectAgentModelRefs(defaults.imageModel, refs);
+    collectAgentModelRefs(defaults.imageGenerationModel, refs);
+    collectAgentModelRefs(defaults.videoGenerationModel, refs);
+    collectAgentModelRefs(defaults.musicGenerationModel, refs);
+    collectAgentModelRefs(defaults.pdfModel, refs);
+    collectAgentModelRefs(defaults.subagents?.model, refs);
+    for (const key of Object.keys(defaults.models ?? {})) {
+      const trimmed = key.trim();
+      if (trimmed) {
+        refs.add(trimmed);
+      }
+    }
+  }
+  for (const agent of config?.agents?.list ?? []) {
+    collectAgentModelRefs(agent.model, refs);
+    collectAgentModelRefs(agent.subagents?.model, refs);
+  }
+  return [...refs].toSorted((left, right) => left.localeCompare(right));
+}
+
+function resolveConfiguredProviderDiscoveryPluginIds(params: {
+  config?: OpenClawConfig;
+  workspaceDir?: string;
+  env: NodeJS.ProcessEnv;
+  resolveOwners?: (provider: string) => readonly string[] | undefined;
+  resolveModelOwners?: (models: readonly string[]) => readonly string[];
+}): string[] {
+  const modelRefs = collectConfiguredModelRefs(params.config);
+  const providerIds = new Set(Object.keys(params.config?.models?.providers ?? {}));
+  for (const modelRef of modelRefs) {
+    const slash = modelRef.indexOf("/");
+    if (slash > 0) {
+      const provider = modelRef.slice(0, slash).trim();
+      if (provider) {
+        providerIds.add(provider);
+      }
+    }
+  }
+
+  const pluginIds = new Set<string>();
+  for (const providerId of providerIds) {
+    const owners =
+      params.resolveOwners?.(providerId) ??
+      resolveOwningPluginIdsForProvider({
+        provider: providerId,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      }) ??
+      [];
+    for (const owner of owners) {
+      pluginIds.add(owner);
+    }
+  }
+
+  if (modelRefs.length > 0) {
+    const modelOwners =
+      params.resolveModelOwners?.(modelRefs) ??
+      resolveOwningPluginIdsForModelRefs({
+        models: modelRefs,
+        config: params.config,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
+      });
+    for (const owner of modelOwners) {
+      pluginIds.add(owner);
+    }
+  }
+
+  return [...pluginIds].toSorted((left, right) => left.localeCompare(right));
+}
+
 export function resolveProviderDiscoveryFilterForTest(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env: NodeJS.ProcessEnv;
   resolveOwners?: (provider: string) => readonly string[] | undefined;
+  resolveModelOwners?: (models: readonly string[]) => readonly string[];
 }): string[] | undefined {
   return resolveProviderDiscoveryFilter(params);
 }

--- a/src/agents/models-config.providers.live-filter.test.ts
+++ b/src/agents/models-config.providers.live-filter.test.ts
@@ -9,10 +9,43 @@ function liveFilterEnv(overrides: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 }
 
 function resolveOwners(provider: string): readonly string[] | undefined {
+  if (provider === "openai-codex") {
+    return ["openai"];
+  }
   return provider === "claude-cli" ? ["anthropic"] : undefined;
 }
 
 describe("resolveProviderDiscoveryFilterForTest", () => {
+  it("scopes non-live discovery to configured model provider owners", () => {
+    expect(
+      resolveProviderDiscoveryFilterForTest({
+        config: {
+          agents: {
+            defaults: {
+              model: { primary: "openai-codex/gpt-5.4" },
+              models: {
+                "openai-codex/gpt-5.4": {},
+              },
+            },
+          },
+        },
+        env: liveFilterEnv({}),
+        resolveOwners,
+      }),
+    ).toEqual(["openai"]);
+  });
+
+  it("preserves broad non-live discovery when no model/provider hints are configured", () => {
+    expect(
+      resolveProviderDiscoveryFilterForTest({
+        config: {},
+        env: liveFilterEnv({}),
+        resolveOwners,
+        resolveModelOwners: () => [],
+      }),
+    ).toBeUndefined();
+  });
+
   it("maps live provider backend ids to owning plugin ids", () => {
     expect(
       resolveProviderDiscoveryFilterForTest({


### PR DESCRIPTION
## Summary

Reduces unnecessary provider/plugin discovery work by scoping non-live provider discovery to the plugins implied by configured models and providers.

While profiling slow OpenClaw startup, the hot path was broad plugin manifest/provider discovery even when the active config only referenced a specific model provider. This change narrows discovery when config contains model/provider hints, while preserving broad discovery when no hints exist.

## Changes

- Collect configured model references from agent defaults, fallbacks, subagent models, and named model entries.
- Resolve owning plugin ids from configured providers and model refs.
- Use that plugin-id filter for non-live provider discovery when hints are present.
- Preserve broad non-live discovery when no model/provider hints are configured.
- Add regression coverage for both scoped and broad fallback behavior.

## Testing

- `pnpm vitest run src/agents/models-config.providers.live-filter.test.ts`
- `pnpm build`

## Notes

AI-assisted contribution. I profiled the local CPU hotspot, verified it came from provider/plugin discovery, and tested the scoped discovery behavior locally.