### PR TITLE
fix: /allowlist --store bypasses channel configWrites policy

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -538,6 +538,76 @@ describe("handleAllowlistCommand", () => {
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 
+  it("blocks store-targeted allowlist edits when channel configWrites is false", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          allowFrom: ["123"],
+          configWrites: false,
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store 789", cfg);
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.configWrites=true");
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks store-targeted allowlist edits when account configWrites is false", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          configWrites: true,
+          accounts: {
+            work: { configWrites: false, allowFrom: ["123"] },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store --account work 789", cfg, {
+      AccountId: "work",
+    });
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.work.configWrites=true");
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("allows store-targeted allowlist edits when configWrites is true", async () => {
+    addChannelAllowFromStoreEntryMock.mockResolvedValueOnce({
+      changed: true,
+      allowFrom: ["789"],
+    });
+
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          allowFrom: ["123"],
+          configWrites: true,
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store 789", cfg);
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("DM allowlist added in pairing store");
+    expect(addChannelAllowFromStoreEntryMock).toHaveBeenCalledWith({
+      channel: "telegram",
+      entry: "789",
+      accountId: "default",
+    });
+  });
+
   it("removes default-account entries from scoped and legacy pairing stores", async () => {
     removeChannelAllowFromStoreEntryMock
       .mockResolvedValueOnce({

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -553,7 +553,7 @@ describe("handleAllowlistCommand", () => {
     const result = await handleAllowlistCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply?.text).toContain("channels.telegram.configWrites=true");
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.default.configWrites=true");
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -37,10 +37,12 @@ vi.mock("../../config/config.js", () => ({
     transform: (
       currentConfig: OpenClawConfig,
       context: { snapshot: ConfigSnapshotMock; previousHash: string | null; attempt: number },
-    ) => Promise<{ nextConfig: OpenClawConfig; result?: unknown }> | {
-      nextConfig: OpenClawConfig;
-      result?: unknown;
-    };
+    ) =>
+      | Promise<{ nextConfig: OpenClawConfig; result?: unknown }>
+      | {
+          nextConfig: OpenClawConfig;
+          result?: unknown;
+        };
   }) => {
     const snapshot = (await readConfigFileSnapshotMock()) as ConfigSnapshotMock;
     const previousHash = snapshot.hash ?? null;
@@ -586,6 +588,31 @@ describe("handleAllowlistCommand", () => {
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 
+  it("blocks cross-channel config edits when the command origin disables writes", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: { allowFrom: ["123"], configWrites: false },
+        discord: { allowFrom: ["456"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    readConfigFileSnapshotMock.mockResolvedValueOnce({
+      valid: true,
+      parsed: structuredClone(cfg),
+    });
+    const params = buildAllowlistParams("/allowlist add dm --channel discord --config 789", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+    });
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.default.configWrites=true");
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
   it("blocks store-targeted allowlist edits when channel configWrites is false", async () => {
     const cfg = {
       commands: { text: true, config: true },
@@ -625,6 +652,26 @@ describe("handleAllowlistCommand", () => {
 
     expect(result?.shouldContinue).toBe(false);
     expect(result?.reply?.text).toContain("channels.telegram.accounts.work.configWrites=true");
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks cross-channel store edits when the command origin disables writes", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: { allowFrom: ["123"], configWrites: false },
+        discord: { allowFrom: ["456"], configWrites: true },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --channel discord --store 789", cfg, {
+      Provider: "telegram",
+      Surface: "telegram",
+    });
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.default.configWrites=true");
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -601,7 +601,7 @@ describe("handleAllowlistCommand", () => {
     const result = await handleAllowlistCommand(params, true);
 
     expect(result?.shouldContinue).toBe(false);
-    expect(result?.reply?.text).toContain("channels.telegram.configWrites=true");
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.default.configWrites=true");
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 

--- a/src/auto-reply/reply/commands-allowlist.test.ts
+++ b/src/auto-reply/reply/commands-allowlist.test.ts
@@ -586,6 +586,76 @@ describe("handleAllowlistCommand", () => {
     expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
   });
 
+  it("blocks store-targeted allowlist edits when channel configWrites is false", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          allowFrom: ["123"],
+          configWrites: false,
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store 789", cfg);
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.configWrites=true");
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks store-targeted allowlist edits when account configWrites is false", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          configWrites: true,
+          accounts: {
+            work: { configWrites: false, allowFrom: ["123"] },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store --account work 789", cfg, {
+      AccountId: "work",
+    });
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("channels.telegram.accounts.work.configWrites=true");
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("allows store-targeted allowlist edits when configWrites is true", async () => {
+    addChannelAllowFromStoreEntryMock.mockResolvedValueOnce({
+      changed: true,
+      allowFrom: ["789"],
+    });
+
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: {
+        telegram: {
+          allowFrom: ["123"],
+          configWrites: true,
+        },
+      },
+    } as OpenClawConfig;
+    const params = buildAllowlistParams("/allowlist add dm --store 789", cfg);
+    params.command.senderIsOwner = true;
+    const result = await handleAllowlistCommand(params, true);
+
+    expect(result?.shouldContinue).toBe(false);
+    expect(result?.reply?.text).toContain("DM allowlist added in pairing store");
+    expect(addChannelAllowFromStoreEntryMock).toHaveBeenCalledWith({
+      channel: "telegram",
+      entry: "789",
+      accountId: "default",
+    });
+  });
+
   it("removes default-account entries from scoped and legacy pairing stores", async () => {
     removeChannelAllowFromStoreEntryMock
       .mockResolvedValueOnce({

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -1,3 +1,4 @@
+import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { normalizeChannelId } from "../../channels/registry.js";
@@ -26,7 +27,6 @@ import {
 } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
-import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 
 type AllowlistScope = "dm" | "group" | "all";
 type AllowlistAction = "list" | "add" | "remove";

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -26,6 +26,7 @@ import {
 } from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
+import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 
 type AllowlistScope = "dm" | "group" | "all";
 type AllowlistAction = "list" | "add" | "remove";
@@ -554,6 +555,21 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     return {
       shouldContinue: false,
       reply: { text: "⚠️ This channel does not support allowlist storage." },
+    };
+  }
+
+  const storeDeniedText = resolveConfigWriteDeniedText({
+    cfg: params.cfg,
+    channel: params.command.channel,
+    channelId,
+    accountId,
+    gatewayClientScopes: params.ctx.GatewayClientScopes,
+    target: resolveExplicitConfigWriteTarget({ channelId, accountId }),
+  });
+  if (storeDeniedText) {
+    return {
+      shouldContinue: false,
+      reply: { text: storeDeniedText },
     };
   }
 

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -15,6 +15,7 @@ import {
   normalizeOptionalString,
 } from "../../shared/string-coerce.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
+import { resolveChannelAccountId, resolveCommandSurfaceChannel } from "./channel-context.js";
 import {
   rejectNonOwnerCommand,
   rejectUnauthorizedCommand,
@@ -308,6 +309,13 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     parsedAccount: parsed.account,
     ctxAccountId: params.ctx.AccountId,
   });
+  const originChannelId =
+    params.command.channelId ?? normalizeChannelId(resolveCommandSurfaceChannel(params));
+  const originAccountId = resolveChannelAccountId({
+    cfg: params.cfg,
+    ctx: params.ctx,
+    command: params.command,
+  });
   const plugin = getChannelPlugin(channelId);
 
   if (parsed.action === "list") {
@@ -491,10 +499,11 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     const deniedText = resolveConfigWriteDeniedText({
       cfg: params.cfg,
       channel: params.command.channel,
-      channelId,
-      accountId,
+      originChannelId,
+      originAccountId,
       gatewayClientScopes: params.ctx.GatewayClientScopes,
       target: editResult.writeTarget,
+      fallbackChannelId: channelId,
     });
     if (deniedText) {
       return {
@@ -566,10 +575,11 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   const storeDeniedText = resolveConfigWriteDeniedText({
     cfg: params.cfg,
     channel: params.command.channel,
-    channelId,
-    accountId,
+    originChannelId,
+    originAccountId,
     gatewayClientScopes: params.ctx.GatewayClientScopes,
     target: resolveExplicitConfigWriteTarget({ channelId, accountId }),
+    fallbackChannelId: channelId,
   });
   if (storeDeniedText) {
     return {

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -1,3 +1,4 @@
+import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import { normalizeChannelId } from "../../channels/registry.js";
@@ -23,7 +24,6 @@ import {
 import type { CommandHandler } from "./commands-types.js";
 import { applyAllowlistConfigMutation, AutoReplyConfigMutationError } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
-import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 
 type AllowlistScope = "dm" | "group" | "all";
 type AllowlistAction = "list" | "add" | "remove";

--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -23,6 +23,7 @@ import {
 import type { CommandHandler } from "./commands-types.js";
 import { applyAllowlistConfigMutation, AutoReplyConfigMutationError } from "./config-mutations.js";
 import { resolveConfigWriteDeniedText } from "./config-write-authorization.js";
+import { resolveExplicitConfigWriteTarget } from "../../channels/plugins/config-writes.js";
 
 type AllowlistScope = "dm" | "group" | "all";
 type AllowlistAction = "list" | "add" | "remove";
@@ -559,6 +560,21 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
     return {
       shouldContinue: false,
       reply: { text: "⚠️ This channel does not support allowlist storage." },
+    };
+  }
+
+  const storeDeniedText = resolveConfigWriteDeniedText({
+    cfg: params.cfg,
+    channel: params.command.channel,
+    channelId,
+    accountId,
+    gatewayClientScopes: params.ctx.GatewayClientScopes,
+    target: resolveExplicitConfigWriteTarget({ channelId, accountId }),
+  });
+  if (storeDeniedText) {
+    return {
+      shouldContinue: false,
+      reply: { text: storeDeniedText },
     };
   }
 

--- a/src/auto-reply/reply/commands-config.ts
+++ b/src/auto-reply/reply/commands-config.ts
@@ -81,8 +81,8 @@ export const handleConfigCommand: CommandHandler = async (params, allowTextComma
     const deniedText = resolveConfigWriteDeniedText({
       cfg: params.cfg,
       channel: params.command.channel,
-      channelId,
-      accountId: resolveChannelAccountId({
+      originChannelId: channelId,
+      originAccountId: resolveChannelAccountId({
         cfg: params.cfg,
         ctx: params.ctx,
         command: params.command,

--- a/src/auto-reply/reply/config-write-authorization.ts
+++ b/src/auto-reply/reply/config-write-authorization.ts
@@ -9,14 +9,15 @@ import type { OpenClawConfig } from "../../config/types.openclaw.js";
 export function resolveConfigWriteDeniedText(params: {
   cfg: OpenClawConfig;
   channel?: string | null;
-  channelId: ChannelId | null;
-  accountId?: string;
+  originChannelId: ChannelId | null;
+  originAccountId?: string;
   gatewayClientScopes?: string[];
   target: Parameters<typeof authorizeConfigWrite>[0]["target"];
+  fallbackChannelId?: ChannelId | null;
 }): string | null {
   const writeAuth = authorizeConfigWrite({
     cfg: params.cfg,
-    origin: { channelId: params.channelId, accountId: params.accountId },
+    origin: { channelId: params.originChannelId, accountId: params.originAccountId },
     target: params.target,
     allowBypass: canBypassConfigWritePolicy({
       channel: params.channel ?? "",
@@ -28,6 +29,6 @@ export function resolveConfigWriteDeniedText(params: {
   }
   return formatConfigWriteDeniedMessage({
     result: writeAuth,
-    fallbackChannelId: params.channelId,
+    fallbackChannelId: params.fallbackChannelId ?? params.originChannelId,
   });
 }


### PR DESCRIPTION
## Summary

- Problem: An authorized sender on a channel where `configWrites=false` can invoke `/allowlist add|remove --store <id>` to add or remove entries from the persistent pairing allowlist store, defeating the operator's intent to block channel-initiated access-control writes. Because pairing-store entries are merged into the effective DM `allowFrom` list at authorization time, this bypass grants or revokes DM access for future senders without the operator's consent.
- Why it matters: Configure a pairing-capable channel (e.g.
- What changed: Configure a pairing-capable channel (e.g.
- What did NOT change (scope boundary): No unrelated defaults, migrations, or compatibility behavior were intentionally changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72360
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Configure a pairing-capable channel (e.g.
- Missing detection / guardrail: No narrower detection note was recorded in the issue bundle.
- Contributing context (if known): See the linked issue analysis and changed files below.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this: Validation command `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`
- Target test or file: Not explicitly recorded in the issue bundle.
- Scenario the test should lock in: An authorized sender on a channel where `configWrites=false` can invoke `/allowlist add|remove --store <id>` to add or remove entries from the persistent pairing allowlist store, defeating the operator's intent to block channel-initiated access-control writes. Because pairing-store entries are merged into the effective DM `allowFrom` list at authorization time, this bypass grants or revokes DM access for future senders without the operator's consent.
- Why this is the smallest reliable guardrail: It validates the failing behavior on the touched path without expanding scope.
- Existing test that already covers this (if any): Unknown.
- If no new test is added, why not: The staged bundle did not record a narrower regression target.

## User-visible / Behavior Changes

- None beyond resolving the linked issue's broken behavior.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): Yes
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): Yes
- Data access scope changed? (`Yes/No`): Yes
- If any `Yes`, explain risk + mitigation: Configure a pairing-capable channel (e.g.. Mitigation: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test` reported `passed`.

## Repro + Verification

### Environment

- OS: N/A
- Runtime/container: N/A
- Model/provider: opencode/glm-5.1
- Integration/channel (if any): N/A
- Relevant config (redacted): AI-assisted=yes

### Steps

1. Reproduce the linked issue using the recorded issue bundle.
2. Apply the fix from this branch.
3. Run `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test`.

### Expected

- An authorized sender on a channel where `configWrites=false` can invoke `/allowlist add|remove --store <id>` to add or remove entries from the persistent pairing allowlist store, defeating the operator's intent to block channel-initiated access-control writes. Because pairing-store entries are merged into the effective DM `allowFrom` list at authorization time, this bypass grants or revokes DM access for future senders without the operator's consent.
- Validation passes for the touched behavior.

### Actual

- Validation status: passed

## Evidence

- Validation evidence: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test` reported `passed`.
- CVSS v3.1: 7.6 (High)
- CVSS v4.0: 7.2 (High)
- Changed files:
- `src/auto-reply/reply/commands-allowlist.test.ts` (+70/-0)
- `src/auto-reply/reply/commands-allowlist.ts` (+16/-0)

## Human Verification (required)

- Verified scenarios: An authorized sender on a channel where `configWrites=false` can invoke `/allowlist add|remove --store <id>` to add or remove entries from the persistent pairing allowlist store, defeating the operator's intent to block channel-initiated access-control writes. Because pairing-store entries are merged into the effective DM `allowFrom` list at authorization time, this bypass grants or revokes DM access for future senders without the operator's consent.
- Edge cases checked: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test` completed with status `passed`.
- What you did **not** verify: Interactive/manual scenarios not captured in the staged issue bundle.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Regression in the touched behavior while closing the linked issue.
  - Mitigation: `pnpm exec oxlint src/ && pnpm build && pnpm check && pnpm test` reported `passed` and the changed-file scope stayed limited to the recorded diff.
