### PR TITLE
docs(contextPruning): document softTrimRatio and hardClearRatio valid range (0.0–1.0)

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -617,6 +617,7 @@ Notes:
 
 - Image blocks are never trimmed/cleared.
 - Ratios are character-based (approximate), not exact token counts.
+- `softTrimRatio` and `hardClearRatio` each accept values in the range 0.0–1.0 (inclusive); values outside this range are rejected by config validation.
 - If fewer than `keepLastAssistants` assistant messages exist, pruning is skipped.
 
 </Accordion>


### PR DESCRIPTION
## Summary

- Problem: `softTrimRatio` and `hardClearRatio` under `agents.defaults.contextPruning` are validated to the range 0.0–1.0 by the Zod schema (`src/config/zod-schema.agent-defaults.ts` lines 128–129), but the configuration reference gave no indication of this constraint.
- Why it matters: A user setting `softTrimRatio: 1.5` expecting custom behavior gets a config validation error with no hint from the docs about the valid range.
- What changed: Added one bullet to the contextPruning accordion in `docs/gateway/config-agents.md` documenting the 0.0–1.0 accepted range for both fields.
- What did NOT change: No code touched. No behavior changed. Scope boundary is documentation only.

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening

## Linked Issue/PR

Retargets #72280 — fix moved to correct file `docs/gateway/config-agents.md` as suggested by @clawsweeper.

## Test plan

Docs-only change; no code touched.
Verified bounds against `src/config/zod-schema.agent-defaults.ts` lines 128–129.