### PR TITLE
fix(auto-reply): surface progress for long reply runs

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -22,6 +22,7 @@ import {
   freezeDiagnosticTraceContext,
 } from "../../infra/diagnostic-trace-context.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
+import { getLogger } from "../../logging.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import {
@@ -1113,6 +1114,18 @@ export async function runReplyAgent(params: {
       });
       await opts?.onBlockReply?.(payload);
     },
+    onError: (error) => {
+      getLogger().warn(
+        {
+          error,
+          replyRunKey: replyOperation.key,
+          sessionKey: replySessionKey,
+          sessionId: followupRun.run.sessionId,
+          phase: replyOperation.phase,
+        },
+        "reply run progress notice delivery failed",
+      );
+    },
   });
 
   let runFollowupTurn = queuedRunFollowupTurn;
@@ -1287,6 +1300,17 @@ export async function runReplyAgent(params: {
     }
 
     const payloadArray = runResult.payloads ?? [];
+    const buildEmptyFinalPayload = () =>
+      buildEmptyFinalReplyPayload({
+        isHeartbeat,
+        silentExpected: followupRun.run.silentExpected,
+        hasVisibleBlockReply:
+          (directlySentBlockKeys?.size ?? 0) > 0 || blockReplyPipeline?.didStream() === true,
+        hasMessagingToolSend:
+          (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+          (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
+          (runResult.messagingToolSentTargets?.length ?? 0) > 0,
+      });
 
     if (blockReplyPipeline) {
       await blockReplyPipeline.flush({ force: true });
@@ -1381,20 +1405,7 @@ export async function runReplyAgent(params: {
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
     if (payloadArray.length === 0) {
-      return finalizeWithFollowup(
-        buildEmptyFinalReplyPayload({
-          isHeartbeat,
-          silentExpected: followupRun.run.silentExpected,
-          hasVisibleBlockReply:
-            (directlySentBlockKeys?.size ?? 0) > 0 || blockReplyPipeline?.didStream() === true,
-          hasMessagingToolSend:
-            (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
-            (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
-            (runResult.messagingToolSentTargets?.length ?? 0) > 0,
-        }),
-        queueKey,
-        runFollowupTurn,
-      );
+      return finalizeWithFollowup(buildEmptyFinalPayload(), queueKey, runFollowupTurn);
     }
 
     const payloadResult = await buildReplyPayloads({
@@ -1787,7 +1798,11 @@ export async function runReplyAgent(params: {
     }
 
     return finalizeWithFollowup(
-      finalPayloads.length === 1 ? finalPayloads[0] : finalPayloads,
+      finalPayloads.length === 0
+        ? buildEmptyFinalPayload()
+        : finalPayloads.length === 1
+          ? finalPayloads[0]
+          : finalPayloads,
       queueKey,
       runFollowupTurn,
     );

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -58,6 +58,7 @@ import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-l
 import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import { buildEmptyFinalReplyPayload } from "./empty-final-reply.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -75,6 +76,11 @@ import {
   replyRunRegistry,
   type ReplyOperation,
 } from "./reply-run-registry.js";
+import {
+  buildReplyRunProgressPayload,
+  createReplyRunProgressWatchdog,
+  type ReplyRunProgressWatchdog,
+} from "./reply-run-watchdog.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
@@ -109,6 +115,42 @@ function formatRawTraceBlock(title: string, value: string | undefined): string {
 
 function escapeTraceFence(value: string): string {
   return value.replace(/^~~~/gm, "\\~~~");
+}
+
+function wrapReplyOptionsWithVisibleActivity(
+  opts: GetReplyOptions | undefined,
+  markVisibleActivity: () => void,
+): GetReplyOptions | undefined {
+  if (!opts) {
+    return undefined;
+  }
+  return {
+    ...opts,
+    onPartialReply: opts.onPartialReply
+      ? async (payload) => {
+          markVisibleActivity();
+          await opts.onPartialReply?.(payload);
+        }
+      : undefined,
+    onBlockReplyQueued: opts.onBlockReplyQueued
+      ? async (payload, context) => {
+          markVisibleActivity();
+          await opts.onBlockReplyQueued?.(payload, context);
+        }
+      : undefined,
+    onBlockReply: opts.onBlockReply
+      ? async (payload, context) => {
+          markVisibleActivity();
+          await opts.onBlockReply?.(payload, context);
+        }
+      : undefined,
+    onToolResult: opts.onToolResult
+      ? async (payload) => {
+          markVisibleActivity();
+          await opts.onToolResult?.(payload);
+        }
+      : undefined,
+  };
 }
 
 function hasTraceUsageFields(
@@ -907,8 +949,12 @@ export async function runReplyAgent(params: {
     resolvedVerboseLevel,
   });
 
+  let progressWatchdog: ReplyRunProgressWatchdog | undefined;
+  const markProgressVisibleActivity = () => progressWatchdog?.markVisibleActivity();
+  const runOpts = wrapReplyOptionsWithVisibleActivity(opts, markProgressVisibleActivity);
+
   const pendingToolTasks = new Set<Promise<void>>();
-  const blockReplyTimeoutMs = opts?.blockReplyTimeoutMs ?? BLOCK_REPLY_SEND_TIMEOUT_MS;
+  const blockReplyTimeoutMs = runOpts?.blockReplyTimeoutMs ?? BLOCK_REPLY_SEND_TIMEOUT_MS;
   const touchActiveSessionEntry = async () => {
     if (!activeSessionEntry || !activeSessionStore || !sessionKey) {
       return;
@@ -1014,7 +1060,7 @@ export async function runReplyAgent(params: {
     requesterSenderE164: followupRun.run.senderE164,
   });
   const blockReplyCoalescing =
-    blockStreamingEnabled && opts?.onBlockReply
+    blockStreamingEnabled && runOpts?.onBlockReply
       ? resolveEffectiveBlockStreamingConfig({
           cfg,
           provider: sessionCtx.Provider,
@@ -1023,15 +1069,16 @@ export async function runReplyAgent(params: {
         }).coalescing
       : undefined;
   const blockReplyPipeline =
-    blockStreamingEnabled && opts?.onBlockReply
+    blockStreamingEnabled && runOpts?.onBlockReply
       ? createBlockReplyPipeline({
-          onBlockReply: opts.onBlockReply,
+          onBlockReply: runOpts.onBlockReply,
           timeoutMs: blockReplyTimeoutMs,
           coalescing: blockReplyCoalescing,
           buffer: createAudioAsVoiceBuffer({ isAudioPayload }),
         })
       : null;
 
+  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
   const replySessionKey = sessionKey ?? followupRun.run.sessionKey;
   let replyOperation: ReplyOperation;
   try {
@@ -1052,6 +1099,22 @@ export async function runReplyAgent(params: {
     }
     throw error;
   }
+  progressWatchdog = createReplyRunProgressWatchdog({
+    enabled:
+      !isHeartbeat &&
+      followupRun.run.silentExpected !== true &&
+      typeof opts?.onBlockReply === "function",
+    getPhase: () => replyOperation.phase,
+    sendNotice: async (notice) => {
+      const payload = applyReplyToMode({
+        ...buildReplyRunProgressPayload(notice),
+        replyToId: currentMessageId,
+        replyToCurrent: true,
+      });
+      await opts?.onBlockReply?.(payload);
+    },
+  });
+
   let runFollowupTurn = queuedRunFollowupTurn;
   const prePreflightCompactionCount = activeSessionEntry?.compactionCount ?? 0;
   let preflightCompactionApplied = false;
@@ -1081,7 +1144,7 @@ export async function runReplyAgent(params: {
       followupRun,
       promptForEstimate: followupRun.prompt,
       sessionCtx,
-      opts,
+      opts: runOpts,
       defaultModel,
       agentCfgContextTokens,
       resolvedVerboseLevel,
@@ -1161,7 +1224,7 @@ export async function runReplyAgent(params: {
       sessionCtx,
       replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
       replyOperation,
-      opts,
+      opts: runOpts,
       typingSignals,
       blockReplyPipeline,
       blockStreamingEnabled,
@@ -1318,10 +1381,22 @@ export async function runReplyAgent(params: {
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
     if (payloadArray.length === 0) {
-      return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+      return finalizeWithFollowup(
+        buildEmptyFinalReplyPayload({
+          isHeartbeat,
+          silentExpected: followupRun.run.silentExpected,
+          hasVisibleBlockReply:
+            (directlySentBlockKeys?.size ?? 0) > 0 || blockReplyPipeline?.didStream() === true,
+          hasMessagingToolSend:
+            (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+            (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0 ||
+            (runResult.messagingToolSentTargets?.length ?? 0) > 0,
+        }),
+        queueKey,
+        runFollowupTurn,
+      );
     }
 
-    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
     const payloadResult = await buildReplyPayloads({
       payloads: payloadArray,
       isHeartbeat,
@@ -1752,6 +1827,7 @@ export async function runReplyAgent(params: {
     finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     throw error;
   } finally {
+    progressWatchdog?.stop();
     replyOperation.complete();
     blockReplyPipeline?.stop();
     typing.markRunComplete();

--- a/src/auto-reply/reply/empty-final-reply.test.ts
+++ b/src/auto-reply/reply/empty-final-reply.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { EMPTY_FINAL_REPLY_TEXT, buildEmptyFinalReplyPayload } from "./empty-final-reply.js";
+
+describe("empty final reply fallback", () => {
+  it("builds a deterministic error payload for user runs that produce no visible output", () => {
+    expect(
+      buildEmptyFinalReplyPayload({
+        isHeartbeat: false,
+      }),
+    ).toEqual({ text: EMPTY_FINAL_REPLY_TEXT, isError: true });
+  });
+
+  it("suppresses the fallback when another visible path already handled the run", () => {
+    expect(buildEmptyFinalReplyPayload({ isHeartbeat: true })).toBeUndefined();
+    expect(
+      buildEmptyFinalReplyPayload({ isHeartbeat: false, silentExpected: true }),
+    ).toBeUndefined();
+    expect(
+      buildEmptyFinalReplyPayload({
+        isHeartbeat: false,
+        hasVisibleBlockReply: true,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildEmptyFinalReplyPayload({
+        isHeartbeat: false,
+        hasMessagingToolSend: true,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/src/auto-reply/reply/empty-final-reply.ts
+++ b/src/auto-reply/reply/empty-final-reply.ts
@@ -1,0 +1,25 @@
+import type { ReplyPayload } from "../reply-payload.js";
+
+export const EMPTY_FINAL_REPLY_TEXT =
+  "⚠️ The run finished without a visible reply. Please retry, or check the session logs if this repeats.";
+
+type BuildEmptyFinalReplyPayloadParams = {
+  isHeartbeat: boolean;
+  silentExpected?: boolean;
+  hasVisibleBlockReply?: boolean;
+  hasMessagingToolSend?: boolean;
+};
+
+export function buildEmptyFinalReplyPayload(
+  params: BuildEmptyFinalReplyPayloadParams,
+): ReplyPayload | undefined {
+  if (
+    params.isHeartbeat ||
+    params.silentExpected === true ||
+    params.hasVisibleBlockReply === true ||
+    params.hasMessagingToolSend === true
+  ) {
+    return undefined;
+  }
+  return { text: EMPTY_FINAL_REPLY_TEXT, isError: true };
+}

--- a/src/auto-reply/reply/reply-run-watchdog.test.ts
+++ b/src/auto-reply/reply/reply-run-watchdog.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ReplyOperationPhase } from "./reply-run-registry.js";
+import {
+  buildReplyRunProgressNoticeText,
+  createReplyRunProgressWatchdog,
+} from "./reply-run-watchdog.js";
+
+describe("reply run progress watchdog", () => {
+  it("emits a deterministic progress notice after the first quiet interval", async () => {
+    vi.useFakeTimers();
+    try {
+      let phase: ReplyOperationPhase = "running";
+      const notices: string[] = [];
+      createReplyRunProgressWatchdog({
+        enabled: true,
+        firstNoticeMs: 1_000,
+        repeatNoticeMs: 1_000,
+        getPhase: () => phase,
+        sendNotice: (notice) => {
+          notices.push(buildReplyRunProgressNoticeText(notice));
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(notices).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(notices).toEqual([
+        "Still working — current phase: running (1m elapsed). I’ll send the final reply when it’s ready.",
+      ]);
+
+      phase = "memory_flushing";
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(notices.at(-1)).toBe(
+        "Still working — current phase: memory flushing (1m elapsed). I’ll send the final reply when it’s ready.",
+      );
+      expect(notices).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets the quiet interval when visible activity is marked", async () => {
+    vi.useFakeTimers();
+    try {
+      const notices: string[] = [];
+      const watchdog = createReplyRunProgressWatchdog({
+        enabled: true,
+        firstNoticeMs: 1_000,
+        repeatNoticeMs: 1_000,
+        getPhase: () => "running",
+        sendNotice: (notice) => {
+          notices.push(buildReplyRunProgressNoticeText(notice));
+        },
+      });
+
+      await vi.advanceTimersByTimeAsync(900);
+      watchdog.markVisibleActivity();
+      await vi.advanceTimersByTimeAsync(999);
+      expect(notices).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(notices).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not emit after the run reaches a terminal phase", async () => {
+    vi.useFakeTimers();
+    try {
+      let phase: ReplyOperationPhase = "running";
+      const notices: string[] = [];
+      createReplyRunProgressWatchdog({
+        enabled: true,
+        firstNoticeMs: 1_000,
+        repeatNoticeMs: 1_000,
+        getPhase: () => phase,
+        sendNotice: () => {
+          notices.push("notice");
+        },
+      });
+
+      phase = "completed";
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(notices).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/auto-reply/reply/reply-run-watchdog.test.ts
+++ b/src/auto-reply/reply/reply-run-watchdog.test.ts
@@ -88,4 +88,41 @@ describe("reply run progress watchdog", () => {
       vi.useRealTimers();
     }
   });
+
+  it("keeps first-notice cadence until a notice is delivered", async () => {
+    vi.useFakeTimers();
+    try {
+      const notices: string[] = [];
+      const errors: unknown[] = [];
+      let attempts = 0;
+      createReplyRunProgressWatchdog({
+        enabled: true,
+        firstNoticeMs: 1_000,
+        repeatNoticeMs: 5_000,
+        getPhase: () => "running",
+        sendNotice: (notice) => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error("transport unavailable");
+          }
+          notices.push(buildReplyRunProgressNoticeText(notice));
+        },
+        onError: (error) => errors.push(error),
+      });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(attempts).toBe(1);
+      expect(errors).toHaveLength(1);
+      expect(notices).toEqual([]);
+
+      await vi.advanceTimersByTimeAsync(999);
+      expect(attempts).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(attempts).toBe(2);
+      expect(notices).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/auto-reply/reply/reply-run-watchdog.ts
+++ b/src/auto-reply/reply/reply-run-watchdog.ts
@@ -123,9 +123,10 @@ export function createReplyRunProgressWatchdog(
       noticeCount += 1;
     } catch (error) {
       params.onError?.(error);
-      // Do not spin on failing transports; retry on the normal repeat cadence.
+      // Do not spin on failing transports. Keep the first-notice cadence until
+      // a notice is actually delivered so custom first/repeat intervals do not
+      // drift after transport failures.
       lastVisibleActivityAt = now();
-      noticeCount += 1;
     } finally {
       sending = false;
       schedule();

--- a/src/auto-reply/reply/reply-run-watchdog.ts
+++ b/src/auto-reply/reply/reply-run-watchdog.ts
@@ -1,0 +1,152 @@
+import type { ReplyPayload } from "../reply-payload.js";
+import type { ReplyOperationPhase } from "./reply-run-registry.js";
+
+export const DEFAULT_REPLY_RUN_PROGRESS_FIRST_NOTICE_MS = 5 * 60 * 1000;
+export const DEFAULT_REPLY_RUN_PROGRESS_REPEAT_MS = 5 * 60 * 1000;
+
+export type ReplyRunProgressWatchdogPhase = Exclude<
+  ReplyOperationPhase,
+  "completed" | "failed" | "aborted"
+>;
+
+export type ReplyRunProgressNotice = {
+  phase: ReplyRunProgressWatchdogPhase;
+  elapsedMs: number;
+};
+
+export type ReplyRunProgressWatchdog = {
+  markVisibleActivity(): void;
+  stop(): void;
+};
+
+type TimerHandle = NodeJS.Timeout;
+
+type ReplyRunProgressWatchdogParams = {
+  enabled: boolean;
+  firstNoticeMs?: number;
+  repeatNoticeMs?: number;
+  now?: () => number;
+  setTimer?: (callback: () => void, delayMs: number) => TimerHandle;
+  clearTimer?: (timer: TimerHandle) => void;
+  getPhase: () => ReplyOperationPhase;
+  sendNotice: (notice: ReplyRunProgressNotice) => Promise<void> | void;
+  onError?: (error: unknown) => void;
+};
+
+function normalizeDelayMs(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.max(1_000, Math.floor(value));
+}
+
+function isTerminalPhase(phase: ReplyOperationPhase): phase is "completed" | "failed" | "aborted" {
+  return phase === "completed" || phase === "failed" || phase === "aborted";
+}
+
+function formatPhaseLabel(phase: ReplyRunProgressWatchdogPhase): string {
+  return phase.replaceAll("_", " ");
+}
+
+export function buildReplyRunProgressNoticeText(notice: ReplyRunProgressNotice): string {
+  const elapsedMinutes = Math.max(1, Math.round(notice.elapsedMs / 60_000));
+  return `Still working — current phase: ${formatPhaseLabel(notice.phase)} (${elapsedMinutes}m elapsed). I’ll send the final reply when it’s ready.`;
+}
+
+export function buildReplyRunProgressPayload(notice: ReplyRunProgressNotice): ReplyPayload {
+  return { text: buildReplyRunProgressNoticeText(notice) };
+}
+
+export function createReplyRunProgressWatchdog(
+  params: ReplyRunProgressWatchdogParams,
+): ReplyRunProgressWatchdog {
+  const now = params.now ?? Date.now;
+  const setTimer = params.setTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+  const clearTimer = params.clearTimer ?? ((timer) => clearTimeout(timer));
+  const firstNoticeMs = normalizeDelayMs(
+    params.firstNoticeMs,
+    DEFAULT_REPLY_RUN_PROGRESS_FIRST_NOTICE_MS,
+  );
+  const repeatNoticeMs = normalizeDelayMs(
+    params.repeatNoticeMs,
+    DEFAULT_REPLY_RUN_PROGRESS_REPEAT_MS,
+  );
+  const startedAt = now();
+  let lastVisibleActivityAt = startedAt;
+  let noticeCount = 0;
+  let active = params.enabled;
+  let timer: TimerHandle | undefined;
+  let sending = false;
+
+  const clearCurrentTimer = () => {
+    if (timer) {
+      clearTimer(timer);
+      timer = undefined;
+    }
+  };
+
+  const schedule = () => {
+    clearCurrentTimer();
+    if (!active) {
+      return;
+    }
+    const delayMs = noticeCount === 0 ? firstNoticeMs : repeatNoticeMs;
+    const dueAt = lastVisibleActivityAt + delayMs;
+    timer = setTimer(
+      () => {
+        void tick();
+      },
+      Math.max(1_000, dueAt - now()),
+    );
+  };
+
+  const tick = async () => {
+    if (!active || sending) {
+      return;
+    }
+    const phase = params.getPhase();
+    if (isTerminalPhase(phase)) {
+      active = false;
+      clearCurrentTimer();
+      return;
+    }
+    const currentTime = now();
+    const delayMs = noticeCount === 0 ? firstNoticeMs : repeatNoticeMs;
+    if (currentTime - lastVisibleActivityAt < delayMs) {
+      schedule();
+      return;
+    }
+    sending = true;
+    try {
+      await params.sendNotice({ phase, elapsedMs: currentTime - startedAt });
+      lastVisibleActivityAt = now();
+      noticeCount += 1;
+    } catch (error) {
+      params.onError?.(error);
+      // Do not spin on failing transports; retry on the normal repeat cadence.
+      lastVisibleActivityAt = now();
+      noticeCount += 1;
+    } finally {
+      sending = false;
+      schedule();
+    }
+  };
+
+  if (active) {
+    schedule();
+  }
+
+  return {
+    markVisibleActivity() {
+      if (!active) {
+        return;
+      }
+      lastVisibleActivityAt = now();
+      schedule();
+    },
+    stop() {
+      active = false;
+      clearCurrentTimer();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add a deterministic reply-run progress watchdog for long user-triggered runs
- reset the watchdog whenever a visible reply/progress callback fires
- add an empty-final fallback so user-triggered runs that complete without visible output surface a clear error instead of going silent

## Why

Today stuck-session diagnostics can detect long processing runs, but they are log-only. If a user-triggered reply run keeps working, stalls, or completes with no final payload, the user can see silence even though the gateway has state about the active run. This patch makes that failure mode visible without relying on model-generated filler.

## Behavior

- Non-heartbeat, non-silent reply runs with an outbound block-reply route send a deterministic progress notice after 5 minutes of no visible activity, then at most every 5 minutes thereafter.
- Any visible partial/block/tool-result callback resets the quiet timer.
- Terminal reply-run phases stop the watchdog.
- If a user-triggered run completes with no final payload and no other explicit visible delivery path handled it, OpenClaw returns a deterministic error payload.

## Validation

- `pnpm check:changed`
- `node scripts/test-projects.mjs src/auto-reply/reply/reply-run-watchdog.test.ts src/auto-reply/reply/empty-final-reply.test.ts`
- `pnpm build`

Note: I also ran `pnpm test:changed`; it hit an unrelated existing `src/cli/gateway-cli/run.option-collisions.test.ts` assertion (`__exit__:78` vs `__exit__:1`). The changed-area checks and focused tests above pass.
