### PR TITLE
docs(whatsapp): add 408 disconnect runbook (Fixes #72262)

### DIFF
--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -37,6 +37,7 @@ Healthy baseline:
 | Group messages ignored          | Check `requireMention` + mention patterns in config | Mention the bot or relax mention policy for that group.                                                                          |
 | QR login times out with 408     | Check gateway `HTTPS_PROXY` / `HTTP_PROXY` env      | Set a reachable proxy; use `NO_PROXY` only for bypasses.                                                                         |
 | Random disconnect/relogin loops | `openclaw channels status --probe` + logs           | Recent reconnects are flagged even when currently connected; watch logs, restart the gateway, then relink if flapping continues. |
+| `status=408 Request Time-out`   | Probe, logs, doctor, then gateway status            | Wait for transient reconnect, or back up auth and re-login if the 408 loop persists. |
 
 Full troubleshooting: [WhatsApp troubleshooting](/channels/whatsapp#troubleshooting)
 

--- a/docs/channels/troubleshooting.md
+++ b/docs/channels/troubleshooting.md
@@ -37,7 +37,7 @@ Healthy baseline:
 | Group messages ignored          | Check `requireMention` + mention patterns in config | Mention the bot or relax mention policy for that group.                                                                          |
 | QR login times out with 408     | Check gateway `HTTPS_PROXY` / `HTTP_PROXY` env      | Set a reachable proxy; use `NO_PROXY` only for bypasses.                                                                         |
 | Random disconnect/relogin loops | `openclaw channels status --probe` + logs           | Recent reconnects are flagged even when currently connected; watch logs, restart the gateway, then relink if flapping continues. |
-| `status=408 Request Time-out`   | Probe, logs, doctor, then gateway status            | Wait for transient reconnect, or back up auth and re-login if the 408 loop persists. |
+| `status=408 Request Time-out`   | Probe, logs, doctor, then gateway status            | Wait for transient reconnect, or back up auth and re-login if the 408 loop persists.                                             |
 
 Full troubleshooting: [WhatsApp troubleshooting](/channels/whatsapp#troubleshooting)
 

--- a/docs/channels/whatsapp.md
+++ b/docs/channels/whatsapp.md
@@ -578,6 +578,55 @@ Behavior notes:
 
   </Accordion>
 
+  <Accordion title="Disconnected with status=408 Request Time-out">
+    Symptom: `openclaw channels status --probe` or gateway logs show repeated
+    disconnect/reconnect loops with `error:status=408 Request Time-out Connection was lost`.
+
+    For WhatsApp Web/Baileys, `408` usually means the socket lost connectivity and the
+    reconnect attempt timed out. Common causes are transient network loss, DNS/proxy or
+    firewall routing, stale Baileys auth state, host clock/certificate problems, or a
+    runtime dependency mismatch.
+
+    Run the checks in this order:
+
+    ```bash
+    openclaw channels status --probe
+    openclaw logs --follow
+    openclaw doctor
+    openclaw gateway status
+    ```
+
+    How to decide what to do:
+
+    - If the probe alternates between `running` and `disconnected` but quickly recovers,
+      wait for the built-in reconnect unless messages are being dropped.
+    - If logs repeat `status=408` with auth or logout hints, rebuild auth state for that
+      account.
+    - If logs show DNS, proxy, TLS, or timeout errors across other networked channels,
+      fix host connectivity before re-linking.
+    - If startup also reports missing bundled runtime dependencies, run `openclaw doctor`
+      and restart the gateway after repair.
+
+    A healthy credentials directory for a configured account should contain a current
+    `~/.openclaw/credentials/whatsapp/<accountId>/creds.json` plus the Baileys key files
+    created during login. Before destructive recovery, back up that account directory if
+    you may need to inspect or restore the old auth state.
+
+    Safe recovery path:
+
+    ```bash
+    cp -a ~/.openclaw/credentials/whatsapp/<accountId> \
+      ~/.openclaw/credentials/whatsapp/<accountId>.bak
+    openclaw channels logout --channel whatsapp --account <id>
+    openclaw channels login --channel whatsapp --account <id>
+    ```
+
+    Use the matching account id from `channels.whatsapp.accounts`. For the default
+    account, omit `--account` only when you are sure the default account is the one that is
+    failing.
+
+  </Accordion>
+
   <Accordion title="No active listener when sending">
     Outbound sends fail fast when no active gateway listener exists for the target account.
 


### PR DESCRIPTION
## Summary

### Problem
WhatsApp troubleshooting did not explain the common `status=408 Request Time-out` disconnect loop.

### Why it matters
Operators can see the exact 408 state in `openclaw channels status --probe` and logs, but the docs only had generic reconnect guidance.

### What changed
- Added a WhatsApp 408 troubleshooting accordion with the probe/log/doctor/gateway command ladder.
- Documented wait-vs-relogin guidance, network/proxy checks, runtime-dependency checks, credential health, backup, logout, and login recovery.
- Added a concise 408 row to the channel troubleshooting failure table.

### What did NOT change
No runtime behavior or channel code changed.

## Change Type
Documentation

## Scope
Docs only:
- `docs/channels/whatsapp.md`
- `docs/channels/troubleshooting.md`

## Linked Issue/PR
Closes #72262

## User-visible / Behavior Changes
Users now have a direct runbook for WhatsApp `status=408 Request Time-out` disconnect loops.

## Security Impact
No security-sensitive code changed. The runbook tells users to back up auth state before logout/relogin recovery.

## Repro + Verification

### Environment
- macOS local checkout
- Node v22.12.0
- pnpm 10.33.0

### Steps
1. Read the WhatsApp troubleshooting docs.
2. Check the channel troubleshooting WhatsApp failure table.
3. Run docs lint.

### Expected
The docs include concrete 408 guidance and pass Markdown lint.

### Actual
The new 408 section and table row are present, and Markdown lint passes.

## Evidence
- `pnpm lint:docs` passed.
- `git diff --check` passed.

`pnpm format:docs:check` could not run locally because `oxfmt` is not installed in this environment.

## Human Verification
The diff was reviewed manually against the issue checklist.

## Compatibility / Migration
No migration needed.

## Failure Recovery
Docs-only change. Revert the commit if the runbook needs a different recovery path.

## Risks and Mitigations
Risk: operators may apply logout/relogin too early.
Mitigation: the docs first suggest waiting for transient reconnects and checking logs/network/runtime state before rebuilding auth.
