### PR TITLE
[codex] fix: trim final text chunk

### DIFF
--- a/extensions/matrix/runtime-api.test.ts
+++ b/extensions/matrix/runtime-api.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { chunkTextForOutbound } from "./runtime-api.js";
+
+describe("Matrix runtime API chunkTextForOutbound", () => {
+  it("preserves short text and empty input behavior", () => {
+    expect(chunkTextForOutbound("", 10)).toEqual([""]);
+    expect(chunkTextForOutbound("hello ", 10)).toEqual(["hello "]);
+  });
+
+  it("trims trailing whitespace from the final over-limit chunk", () => {
+    expect(chunkTextForOutbound("alpha beta ", 8)).toEqual(["alpha", "beta"]);
+  });
+});

--- a/extensions/matrix/runtime-api.ts
+++ b/extensions/matrix/runtime-api.ts
@@ -38,17 +38,27 @@ export type {
 export { formatZonedTimestamp } from "openclaw/plugin-sdk/matrix-runtime-shared";
 
 export function chunkTextForOutbound(text: string, limit: number): string[] {
+  if (!text) {
+    return [text];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
   const chunks: string[] = [];
   let remaining = text;
   while (remaining.length > limit) {
     const window = remaining.slice(0, limit);
     const splitAt = Math.max(window.lastIndexOf("\n"), window.lastIndexOf(" "));
     const breakAt = splitAt > 0 ? splitAt : limit;
-    chunks.push(remaining.slice(0, breakAt).trimEnd());
+    const chunk = remaining.slice(0, breakAt).trimEnd();
+    if (chunk.length > 0) {
+      chunks.push(chunk);
+    }
     remaining = remaining.slice(breakAt).trimStart();
   }
-  if (remaining.length > 0 || text.length === 0) {
-    chunks.push(remaining);
+  const finalChunk = remaining.trimEnd();
+  if (finalChunk.length > 0) {
+    chunks.push(finalChunk);
   }
   return chunks;
 }

--- a/src/markdown/ir.chunking.test.ts
+++ b/src/markdown/ir.chunking.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { chunkMarkdownIR, markdownToIR } from "./ir.js";
+
+describe("chunkMarkdownIR", () => {
+  it("preserves styled trailing whitespace in the final chunk", () => {
+    const ir = markdownToIR("```\n123456789\n```");
+
+    expect(ir.text).toBe("123456789\n");
+
+    const chunks = chunkMarkdownIR(ir, 7);
+
+    expect(chunks.map((chunk) => chunk.text)).toEqual(["1234567", "89\n"]);
+    expect(chunks.at(-1)?.styles).toEqual([{ start: 0, end: 3, style: "code_block" }]);
+  });
+});

--- a/src/markdown/ir.ts
+++ b/src/markdown/ir.ts
@@ -901,6 +901,22 @@ function sliceLinkSpans(spans: MarkdownLinkSpan[], start: number, end: number): 
   return sliced;
 }
 
+function expandFinalChunkEndForTrailingStyles(
+  spans: MarkdownStyleSpan[],
+  start: number,
+  end: number,
+  maxLength: number,
+): number {
+  let expandedEnd = end;
+  for (const span of spans) {
+    if (span.end <= expandedEnd || span.start > expandedEnd || span.end <= start) {
+      continue;
+    }
+    expandedEnd = Math.min(maxLength, span.end);
+  }
+  return expandedEnd;
+}
+
 export function sliceMarkdownIR(ir: MarkdownIR, start: number, end: number): MarkdownIR {
   return {
     text: ir.text.slice(start, end),
@@ -997,9 +1013,14 @@ export function chunkMarkdownIR(ir: MarkdownIR, limit: number): MarkdownIR[] {
       }
     }
     const start = cursor;
-    const end = Math.min(ir.text.length, start + chunk.length);
+    const rawEnd = Math.min(ir.text.length, start + chunk.length);
+    const end =
+      index === chunks.length - 1
+        ? expandFinalChunkEndForTrailingStyles(ir.styles, start, rawEnd, ir.text.length)
+        : rawEnd;
+    const text = end === rawEnd ? chunk : ir.text.slice(start, end);
     results.push({
-      text: chunk,
+      text,
       styles: sliceStyleSpans(ir.styles, start, end),
       links: sliceLinkSpans(ir.links, start, end),
     });

--- a/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
+++ b/src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts
@@ -97,7 +97,7 @@ const RUNTIME_API_EXPORT_GUARDS: Record<string, readonly string[]> = {
     'export { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";',
     'export type { ChannelDirectoryEntry, ChannelMessageActionContext, OpenClawConfig, PluginRuntime, RuntimeLogger, RuntimeEnv, WizardPrompter } from "openclaw/plugin-sdk/matrix-runtime-shared";',
     'export { formatZonedTimestamp } from "openclaw/plugin-sdk/matrix-runtime-shared";',
-    'export function chunkTextForOutbound(text: string, limit: number): string[] { const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; chunks.push(remaining.slice(0, breakAt).trimEnd()); remaining = remaining.slice(breakAt).trimStart(); } if (remaining.length > 0 || text.length === 0) { chunks.push(remaining); } return chunks; }',
+    'export function chunkTextForOutbound(text: string, limit: number): string[] { if (!text) { return [text]; } if (limit <= 0 || text.length <= limit) { return [text]; } const chunks: string[] = []; let remaining = text; while (remaining.length > limit) { const window = remaining.slice(0, limit); const splitAt = Math.max(window.lastIndexOf("\\n"), window.lastIndexOf(" ")); const breakAt = splitAt > 0 ? splitAt : limit; const chunk = remaining.slice(0, breakAt).trimEnd(); if (chunk.length > 0) { chunks.push(chunk); } remaining = remaining.slice(breakAt).trimStart(); } const finalChunk = remaining.trimEnd(); if (finalChunk.length > 0) { chunks.push(finalChunk); } return chunks; }',
   ],
   [bundledPluginFile({
     rootDir: ROOT_DIR,

--- a/src/shared/text-chunking.test.ts
+++ b/src/shared/text-chunking.test.ts
@@ -37,4 +37,14 @@ describe("shared/text-chunking", () => {
       "def",
     ]);
   });
+
+  it("trims trailing whitespace from the final chunk", () => {
+    expect(
+      chunkTextByBreakResolver("  ! ", 2, (window) => window.lastIndexOf(" ") || window.length),
+    ).toEqual(["!"]);
+    expect(chunkTextByBreakResolver("a b ", 2, (window) => window.lastIndexOf(" "))).toEqual([
+      "a",
+      "b",
+    ]);
+  });
 });

--- a/src/shared/text-chunking.ts
+++ b/src/shared/text-chunking.ts
@@ -27,8 +27,9 @@ export function chunkTextByBreakResolver(
     const nextStart = Math.min(remaining.length, breakIdx + (brokeOnSeparator ? 1 : 0));
     remaining = remaining.slice(nextStart).trimStart();
   }
-  if (remaining.length) {
-    chunks.push(remaining);
+  const finalChunk = remaining.trimEnd();
+  if (finalChunk.length > 0) {
+    chunks.push(finalChunk);
   }
   return chunks;
 }


### PR DESCRIPTION
## Summary

- Problem: `chunkTextByBreakResolver` trimmed intermediate chunks but returned the final residual chunk as-is, so over-limit text ending in whitespace could send a trailing-space final chunk.
- Why it matters: outbound plugin/API chunking should not leak separator whitespace into the last delivered message chunk.
- What changed: trim and skip the final residual chunk in the shared resolver, add regression tests, preserve styled trailing whitespace needed by Markdown code-block IR chunking, and align Matrix's lightweight runtime API copy plus guardrail.
- What did NOT change (scope boundary): short/under-limit text still returns as-is; no channel defaults, config, network behavior, or delivery APIs changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #64036
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the shared chunking loop trims emitted chunks while it is still splitting, but the final `remaining` tail bypassed that normalization.
- Missing detection / guardrail: tests covered intermediate chunk trimming but not an over-limit final residual chunk with trailing whitespace.
- Contributing context (if known): Matrix's lightweight runtime API carries a small inline chunker for import-laziness, so it needed the same normalization and guardrail update.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/shared/text-chunking.test.ts`, `src/markdown/ir.chunking.test.ts`, `extensions/matrix/runtime-api.test.ts`, `src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`.
- Scenario the test should lock in: over-limit final chunks are `trimEnd()` normalized, while Markdown code-block final newlines that belong to a style span are preserved.
- Why this is the smallest reliable guardrail: the bug is isolated to chunk helper output, plus one Markdown IR edge where trailing whitespace is semantically required for rendering.
- Existing test that already covers this (if any): existing tests covered earlier chunks and hard breaks, but not this final-tail case.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Over-limit outbound text chunks no longer include trailing whitespace in the final emitted chunk. Markdown fenced code blocks still preserve the final newline needed for correct rendering.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v22.22.0, pnpm 10.33.0
- Model/provider: N/A
- Integration/channel (if any): shared outbound chunking helpers; Matrix lightweight runtime API
- Relevant config (redacted): N/A

### Steps

1. Chunk an over-limit string whose residual final chunk ends in whitespace, for example `a b ` with limit `2`.
2. Chunk a fenced Markdown code block through Markdown IR with a limit that leaves the final styled newline in the last chunk.
3. Import Matrix's lightweight `runtime-api.ts` chunker and chunk `alpha beta ` with limit `8`.

### Expected

- Final non-Markdown residual chunks are emitted without trailing whitespace.
- Markdown code-block final newline remains attached to the code-block style span.
- Matrix runtime API chunking matches the normalized final chunk behavior.

### Actual

- Before: the shared final residual chunk and Matrix inline helper could keep trailing whitespace.
- After: final residual chunks are trimmed, with Markdown code-block trailing newline preserved when semantically styled.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `pnpm test src/shared/text-chunking.test.ts src/plugin-sdk/text-chunking.test.ts src/markdown/ir.chunking.test.ts extensions/matrix/runtime-api.test.ts`
- `pnpm test src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/shared/text-chunking.ts src/shared/text-chunking.test.ts src/plugin-sdk/text-chunking.ts src/plugin-sdk/text-chunking.test.ts src/markdown/ir.ts src/markdown/ir.chunking.test.ts extensions/matrix/runtime-api.ts extensions/matrix/runtime-api.test.ts src/plugins/contracts/plugin-sdk-runtime-api-guardrails.test.ts`
- `pnpm check:changed`
- `codex review -c model="gpt-5.4" --base origin/main` found no discrete correctness regression in the final diff. Note: its internal read-only sandbox could not create `.git/openclaw-local-checks/heavy-check.lock` when it tried to rerun tests, so the listed test/check commands above were run in the normal workspace.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: reproduced the final-tail whitespace case via unit tests, checked plugin SDK coverage through the shared helper, and checked Matrix's lightweight runtime API copy.
- Edge cases checked: short/under-limit Matrix text remains unchanged; empty Matrix input still returns the historical `['']`; Markdown code-block final newline remains preserved in the final IR chunk.
- What you did **not** verify: live channel delivery against a real Matrix/Telegram/Slack/QQBot account.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No GitHub bot review conversations exist yet. AI-assisted: yes, with human review and local validation. lobster-biscuit

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: shared chunking behavior affects multiple outbound integrations.
  - Mitigation: targeted shared tests, Matrix runtime API tests, Markdown IR code-block regression coverage, contract guardrail update, `pnpm check:changed`, and `codex review` on the final diff.
