### PR TITLE
fix(agents): harden workspace bootstrap cache identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/bootstrap: include metadata-change time in the guarded workspace file cache identity so equal-size in-place edits with restored `mtime` cannot leave long-lived sessions on stale bootstrap instructions. Related #72406 and #64871. Thanks @aimqwest.
 - macOS Gateway: write launchd services with a state-dir `WorkingDirectory`, use a durable state-dir temp path instead of freezing macOS session `TMPDIR`, create that temp directory before bootstrap, and label abort-shaped launchd exits as `SIGABRT/abort` in status output. Fixes #53679 and #70223; refs #71848. Thanks @dlturock, @stammi922, and @palladius.
 - Exec approvals: accept runtime-owned `source: "allow-always"` and `commandText` allowlist metadata in gateway and node approval-set payloads so Control UI round-trips no longer fail with `unexpected property 'source'`. Fixes #60000; carries forward #60064. Thanks @sd1471123, @sharkqwy, and @luoyanglang.
 - Exec/node: skip approval-plan preparation for full-trust `host=node` runs so interpreter and script commands no longer fail with `SYSTEM_RUN_DENIED: approval cannot safely bind` when effective policy is `security=full` and `ask=off`. Fixes #48457 and duplicate #69251. Thanks @ajtran303, @jaserNo1, @Blakeshannon, @lesliefag, and @AvIsBeastMC.

--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -74,6 +74,41 @@ describe("workspace bootstrap file caching", () => {
     expectAgentsContent(agentsFile2, content2);
   });
 
+  it("invalidates cache when ctime changes with same inode, size, and mtime", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const content1 = "# old-content";
+    const content2 = "# new-content";
+    const filePath = path.join(workspaceDir, DEFAULT_AGENTS_FILENAME);
+
+    expect(content2).toHaveLength(content1.length);
+    await writeWorkspaceFile({
+      dir: workspaceDir,
+      name: DEFAULT_AGENTS_FILENAME,
+      content: content1,
+    });
+    const pinnedTime = new Date(Math.floor(Date.now() / 1_000) * 1_000);
+    await fs.utimes(filePath, pinnedTime, pinnedTime);
+    const originalStat = await fs.stat(filePath);
+
+    const agentsFile1 = await loadAgentsFile(workspaceDir);
+    expectAgentsContent(agentsFile1, content1);
+
+    await fs.writeFile(filePath, content2, "utf-8");
+    await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
+    const updatedStat = await fs.stat(filePath);
+
+    expect(updatedStat.dev).toBe(originalStat.dev);
+    expect(updatedStat.ino).toBe(originalStat.ino);
+    expect(updatedStat.size).toBe(originalStat.size);
+    expect(updatedStat.mtimeMs).toBe(originalStat.mtimeMs);
+    expect(updatedStat.ctimeMs).not.toBe(originalStat.ctimeMs);
+
+    const agentsFile2 = await loadAgentsFile(workspaceDir);
+    expectAgentsContent(agentsFile2, content2);
+  });
+
   it("invalidates cache when inode changes with same mtime", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.bootstrap-cache.test.ts
+++ b/src/agents/workspace.bootstrap-cache.test.ts
@@ -95,6 +95,10 @@ describe("workspace bootstrap file caching", () => {
     const agentsFile1 = await loadAgentsFile(workspaceDir);
     expectAgentsContent(agentsFile1, content1);
 
+    // Let coarse timestamp filesystems tick before the metadata-changing edit.
+    // The regression assertion is the observable reload behavior below, not
+    // direct ctimeMs inequality, which can be flaky on some filesystems.
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
     await fs.writeFile(filePath, content2, "utf-8");
     await fs.utimes(filePath, originalStat.atime, originalStat.mtime);
     const updatedStat = await fs.stat(filePath);
@@ -103,7 +107,6 @@ describe("workspace bootstrap file caching", () => {
     expect(updatedStat.ino).toBe(originalStat.ino);
     expect(updatedStat.size).toBe(originalStat.size);
     expect(updatedStat.mtimeMs).toBe(originalStat.mtimeMs);
-    expect(updatedStat.ctimeMs).not.toBe(originalStat.ctimeMs);
 
     const agentsFile2 = await loadAgentsFile(workspaceDir);
     expectAgentsContent(agentsFile2, content2);

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -41,14 +41,14 @@ const MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES = 2 * 1024 * 1024;
 const workspaceFileCache = new Map<string, { content: string; identity: string }>();
 
 /**
- * Read workspace files via boundary-safe open and cache by inode/dev/size/mtime identity.
+ * Read workspace files via boundary-safe open and cache by inode/dev/size/mtime/ctime identity.
  */
 type WorkspaceGuardedReadResult =
   | { ok: true; content: string }
   | { ok: false; reason: "path" | "validation" | "io"; error?: unknown };
 
 function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): string {
-  return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
+  return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}:${stat.ctimeMs}`;
 }
 
 async function readWorkspaceFileWithGuards(params: {


### PR DESCRIPTION
Objective
Harden the guarded workspace bootstrap file cache identity so an equal-size in-place edit with restored `mtime` cannot keep stale bootstrap instructions cached. This is the narrow cache-identity follow-up to the security tradeoff surfaced on #72406 and preserves the same long-lived-session refresh objective from #64871.

Deploy-source proof
Branch `aimqwest_code/codex0183-workspace-cache-ctime` is based on `openclaw/openclaw` `main` at `9b79eef75091a8444af822229de00727ba9bcf67`. No deployment surface is touched or claimed.

Files changed
- `CHANGELOG.md`
- `src/agents/workspace.ts`
- `src/agents/workspace.bootstrap-cache.test.ts`

Validation
- `pnpm test src/agents/workspace.bootstrap-cache.test.ts` - pass, 8 tests
- `pnpm test src/agents/bootstrap-cache.test.ts src/agents/workspace.bootstrap-cache.test.ts` - pass, 13 tests
- `pnpm exec oxfmt --check --threads=1 src/agents/workspace.ts src/agents/workspace.bootstrap-cache.test.ts` - pass
- `git diff --check` - pass
- `pnpm check:changed` - pass, lanes `core`, `coreTests`, `docs`
- Diff credential-pattern scan - pass, no matches

Evidence files
- `/tmp/codex0183_openclaw_ctime_validation.txt`
- `/tmp/codex0183_pr72406_failed_logs.txt`

Scope statement
OpenClaw workspace bootstrap cache only. No deployment, no production runtime touch, and no AIMQWEST-private workspace content.
