### PR TITLE
fix(group-chat): wire multi-agent bot-targeting signals end-to-end (#56692)

### DIFF
--- a/extensions/telegram/src/bot-message-context.body.ts
+++ b/extensions/telegram/src/bot-message-context.body.ts
@@ -39,6 +39,7 @@ import type {
 import {
   buildSenderLabel,
   buildSenderName,
+  detectTelegramBotTargeting,
   expandTextLinks,
   extractTelegramLocation,
   getTelegramTextParts,
@@ -302,18 +303,32 @@ export async function resolveTelegramInboundBody(params: {
   const effectiveWasMentioned = mentionDecision.effectiveWasMentioned;
   if (isGroup && requireMention && canDetectMention && mentionDecision.shouldSkip) {
     logger.info({ chatId, reason: "no-mention" }, "skipping group message");
+    // Multi-agent (#56692): when an "other bots in this group" config surface
+    // lands, pass those usernames here so we can also detect mentions of
+    // sibling bots in messages we skipped (right now we only detect mentions
+    // of ourselves).
+    const botTargeting = detectTelegramBotTargeting(msg, {
+      currentBotUsername: botUsername,
+    });
+    const skippedHistoryEntry: HistoryEntry | null = historyKey
+      ? {
+          sender: buildSenderLabel(msg, senderId || chatId),
+          body: rawBody,
+          timestamp: msg.date ? msg.date * 1000 : undefined,
+          messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
+        }
+      : null;
+    if (skippedHistoryEntry && botTargeting.mentionedBot !== undefined) {
+      skippedHistoryEntry.mentionedBot = botTargeting.mentionedBot;
+    }
+    if (skippedHistoryEntry && botTargeting.repliedToBot !== undefined) {
+      skippedHistoryEntry.repliedToBot = botTargeting.repliedToBot;
+    }
     recordPendingHistoryEntryIfEnabled({
       historyMap: groupHistories,
       historyKey: historyKey ?? "",
       limit: historyLimit,
-      entry: historyKey
-        ? {
-            sender: buildSenderLabel(msg, senderId || chatId),
-            body: rawBody,
-            timestamp: msg.date ? msg.date * 1000 : undefined,
-            messageId: typeof msg.message_id === "number" ? String(msg.message_id) : undefined,
-          }
-        : null,
+      entry: skippedHistoryEntry,
     });
     const telegramGroupPolicy = resolveChannelGroupPolicy({
       cfg,

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -313,11 +313,26 @@ export async function buildTelegramInboundContextPayload(params: {
   });
   const inboundHistory =
     isGroup && historyKey && historyLimit > 0
-      ? (groupHistories.get(historyKey) ?? []).map((entry) => ({
-          sender: entry.sender,
-          body: entry.body,
-          timestamp: entry.timestamp,
-        }))
+      ? (groupHistories.get(historyKey) ?? []).map((entry) => {
+          const mapped: {
+            sender: string;
+            body: string;
+            timestamp?: number;
+            mentionedBot?: string | null;
+            repliedToBot?: string | null;
+          } = {
+            sender: entry.sender,
+            body: entry.body,
+            timestamp: entry.timestamp,
+          };
+          if (entry.mentionedBot !== undefined) {
+            mapped.mentionedBot = entry.mentionedBot;
+          }
+          if (entry.repliedToBot !== undefined) {
+            mapped.repliedToBot = entry.repliedToBot;
+          }
+          return mapped;
+        })
       : undefined;
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
   const contextMedia = [...currentMediaForContext, ...replyMedia];
@@ -341,10 +356,19 @@ export async function buildTelegramInboundContextPayload(params: {
     Provider: "telegram",
     Surface: "telegram",
     BotUsername: primaryCtx.me?.username ?? undefined,
+    // Multi-agent (#56692): OtherBotUsernames stays unset until telegram
+    // config exposes a list of sibling bots in the same group. Downstream
+    // prompts gracefully omit the multi-agent context when this is empty;
+    // the per-history-entry mentionedBot / repliedToBot fields and the
+    // ReplyToBotUsername below are still populated and useful on their own.
     MessageSid: options?.messageIdOverride ?? String(msg.message_id),
     ReplyToId: visibleReplyTarget?.id,
     ReplyToBody: visibleReplyTarget?.body,
     ReplyToSender: visibleReplyTarget?.sender,
+    ReplyToBotUsername:
+      visibleReplyTarget?.senderIsBot === true && visibleReplyTarget.senderUsername
+        ? visibleReplyTarget.senderUsername.toLowerCase()
+        : undefined,
     ReplyToIsQuote: visibleReplyTarget?.kind === "quote" ? true : undefined,
     ReplyToIsExternal: visibleReplyTarget?.source === "external_reply" ? true : undefined,
     ReplyToQuoteText: visibleReplyTarget?.quoteText,

--- a/extensions/telegram/src/bot/body-helpers.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.test.ts
@@ -1,0 +1,126 @@
+import type { Message } from "@grammyjs/types";
+import { describe, expect, it } from "vitest";
+import { detectTelegramBotTargeting } from "./body-helpers.js";
+
+type PartialMessage = Pick<
+  Message,
+  "text" | "caption" | "entities" | "caption_entities" | "reply_to_message"
+>;
+
+function msg(partial: Partial<PartialMessage>): PartialMessage {
+  return partial as PartialMessage;
+}
+
+describe("detectTelegramBotTargeting", () => {
+  it("returns no fields when no bots are known and no reply target exists", () => {
+    const result = detectTelegramBotTargeting(msg({ text: "hello world" }), {});
+    expect(result).toEqual({});
+  });
+
+  it("detects mention of the current bot via entities", () => {
+    const text = "hey @mybot please help";
+    const result = detectTelegramBotTargeting(
+      msg({
+        text,
+        entities: [{ type: "mention", offset: text.indexOf("@mybot"), length: 6 }],
+      }),
+      { currentBotUsername: "mybot" },
+    );
+    expect(result.mentionedBot).toBe("mybot");
+  });
+
+  it("detects mention via plain-text fallback when entities are missing", () => {
+    const result = detectTelegramBotTargeting(msg({ text: "ping @mybot are you there?" }), {
+      currentBotUsername: "mybot",
+    });
+    expect(result.mentionedBot).toBe("mybot");
+  });
+
+  it("detects mention of a sibling bot from otherBotUsernames", () => {
+    const text = "asking @helperbot instead";
+    const result = detectTelegramBotTargeting(
+      msg({
+        text,
+        entities: [{ type: "mention", offset: text.indexOf("@helperbot"), length: 10 }],
+      }),
+      { currentBotUsername: "mybot", otherBotUsernames: ["helperbot", "anotherbot"] },
+    );
+    expect(result.mentionedBot).toBe("helperbot");
+  });
+
+  it("returns mentionedBot=null when known bots exist but none were mentioned", () => {
+    const result = detectTelegramBotTargeting(msg({ text: "just a plain human message" }), {
+      currentBotUsername: "mybot",
+      otherBotUsernames: ["helperbot"],
+    });
+    expect(result.mentionedBot).toBeNull();
+  });
+
+  it("leaves mentionedBot undefined when no bot usernames are known", () => {
+    const text = "hi @someone";
+    const result = detectTelegramBotTargeting(
+      msg({
+        text,
+        entities: [{ type: "mention", offset: 3, length: 8 }],
+      }),
+      {},
+    );
+    expect(result.mentionedBot).toBeUndefined();
+  });
+
+  it("derives repliedToBot from reply_to_message.from when the author is a bot", () => {
+    const result = detectTelegramBotTargeting(
+      msg({
+        text: "yes please",
+        reply_to_message: {
+          message_id: 42,
+          date: 1,
+          chat: { id: 1, type: "supergroup", title: "x" },
+          from: { id: 99, is_bot: true, first_name: "Helper", username: "HelperBot" },
+        } as Message,
+      }),
+      {},
+    );
+    expect(result.repliedToBot).toBe("helperbot");
+  });
+
+  it("returns repliedToBot=null when reply target is a human", () => {
+    const result = detectTelegramBotTargeting(
+      msg({
+        text: "ok",
+        reply_to_message: {
+          message_id: 7,
+          date: 1,
+          chat: { id: 1, type: "supergroup", title: "x" },
+          from: { id: 1, is_bot: false, first_name: "Alice", username: "alice" },
+        } as Message,
+      }),
+      {},
+    );
+    expect(result.repliedToBot).toBeNull();
+  });
+
+  it("leaves repliedToBot undefined when there's no reply target", () => {
+    const result = detectTelegramBotTargeting(msg({ text: "hi" }), {});
+    expect(result.repliedToBot).toBeUndefined();
+  });
+
+  it("populates both fields independently in a single pass", () => {
+    const text = "@mybot did otherbot just say that?";
+    const result = detectTelegramBotTargeting(
+      msg({
+        text,
+        entities: [{ type: "mention", offset: 0, length: 6 }],
+        reply_to_message: {
+          message_id: 5,
+          date: 1,
+          chat: { id: 1, type: "supergroup", title: "x" },
+          from: { id: 200, is_bot: true, first_name: "Sib", username: "OtherBot" },
+        } as Message,
+      }),
+      { currentBotUsername: "mybot", otherBotUsernames: ["otherbot"] },
+    );
+    expect(result.mentionedBot).toBe("mybot");
+    expect(result.repliedToBot).toBe("otherbot");
+  });
+});

--- a/extensions/telegram/src/bot/body-helpers.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.test.ts
@@ -1,4 +1,6 @@
 import type { Message } from "@grammyjs/types";
+
+type ReplyTo = NonNullable<Message["reply_to_message"]>;
 import { describe, expect, it } from "vitest";
 import { detectTelegramBotTargeting } from "./body-helpers.js";
 
@@ -77,7 +79,7 @@ describe("detectTelegramBotTargeting", () => {
           date: 1,
           chat: { id: 1, type: "supergroup", title: "x" },
           from: { id: 99, is_bot: true, first_name: "Helper", username: "HelperBot" },
-        } as Message,
+        } as ReplyTo,
       }),
       {},
     );
@@ -93,7 +95,7 @@ describe("detectTelegramBotTargeting", () => {
           date: 1,
           chat: { id: 1, type: "supergroup", title: "x" },
           from: { id: 1, is_bot: false, first_name: "Alice", username: "alice" },
-        } as Message,
+        } as ReplyTo,
       }),
       {},
     );
@@ -116,7 +118,7 @@ describe("detectTelegramBotTargeting", () => {
           date: 1,
           chat: { id: 1, type: "supergroup", title: "x" },
           from: { id: 200, is_bot: true, first_name: "Sib", username: "OtherBot" },
-        } as Message,
+        } as ReplyTo,
       }),
       { currentBotUsername: "mybot", otherBotUsernames: ["otherbot"] },
     );

--- a/extensions/telegram/src/bot/body-helpers.test.ts
+++ b/extensions/telegram/src/bot/body-helpers.test.ts
@@ -125,4 +125,30 @@ describe("detectTelegramBotTargeting", () => {
     expect(result.mentionedBot).toBe("mybot");
     expect(result.repliedToBot).toBe("otherbot");
   });
+
+  it("leaves mentionedBot undefined for media-only messages with no text/caption", () => {
+    // Sticker / voice / non-captioned media: bots can only be mentioned via
+    // text, so we never scan and therefore can't claim emptiness with null.
+    const result = detectTelegramBotTargeting(msg({}), { currentBotUsername: "mybot" });
+    expect(result.mentionedBot).toBeUndefined();
+  });
+
+  it("returns repliedToBot=null when reply target has no from (channel post / anonymous admin)", () => {
+    // reply_to_message exists but reply.from is undefined — happens for
+    // replies to channel posts and to anonymous group admins. We know there's
+    // a reply target and it isn't a known bot, which is null (distinct from
+    // undefined = "no reply target at all").
+    const result = detectTelegramBotTargeting(
+      msg({
+        text: "ack",
+        reply_to_message: {
+          message_id: 11,
+          date: 1,
+          chat: { id: 1, type: "supergroup", title: "x" },
+        } as ReplyTo,
+      }),
+      {},
+    );
+    expect(result.repliedToBot).toBeNull();
+  });
 });

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -395,8 +395,8 @@ export function detectTelegramBotTargeting(
 
   if (knownBots.size > 0) {
     const { text, entities } = getTelegramTextParts(msg);
-    let found: string | null = null;
     if (text) {
+      let found: string | null = null;
       for (const ent of entities) {
         if (ent.type !== "mention") {
           continue;
@@ -417,8 +417,11 @@ export function detectTelegramBotTargeting(
           }
         }
       }
+      // Only assert "no bot mentioned" (null) when a scan actually ran. For
+      // media-only messages with no text/caption we leave mentionedBot
+      // undefined: we never scanned, so we can't claim emptiness.
+      result.mentionedBot = found;
     }
-    result.mentionedBot = found;
   }
 
   const reply = msg.reply_to_message;
@@ -426,7 +429,12 @@ export function detectTelegramBotTargeting(
     const replyFrom = reply.from;
     if (replyFrom?.is_bot && replyFrom.username) {
       result.repliedToBot = replyFrom.username.toLowerCase();
-    } else if (replyFrom != null) {
+    } else {
+      // A reply target exists but the sender is either a human (replyFrom set,
+      // not a bot) or absent entirely (channel post / anonymous group admin —
+      // reply.from is undefined). Both cases mean "we know there's a reply
+      // and it isn't a known bot," which is null, distinct from undefined
+      // ("no reply target at all").
       result.repliedToBot = null;
     }
   }

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -355,3 +355,81 @@ export function extractTelegramLocation(msg: Message): NormalizedLocation | null
 
   return null;
 }
+
+/**
+ * Detect bot-targeting metadata for a Telegram inbound message.
+ *
+ * - `mentionedBot`: lowercased username (no `@`) of a bot mentioned in this
+ *   message; `null` if we can definitively say no bot was mentioned;
+ *   `undefined` if we can't tell (no current-bot username configured and
+ *   no other-bot list to check against).
+ * - `repliedToBot`: lowercased username of the bot whose message this is a
+ *   reply to (via `reply_to_message.from`), `null` if the reply target was
+ *   explicitly a non-bot, `undefined` if there's no reply target at all.
+ *
+ * `currentBotUsername` is the running bot's `@me` username (lowercased,
+ * already trimmed of `@`). `otherBotUsernames` are other known bots in the
+ * group (same format) — when supplied we also detect mentions of them in
+ * the message text/entities.
+ */
+export function detectTelegramBotTargeting(
+  msg: Pick<Message, "text" | "caption" | "entities" | "caption_entities" | "reply_to_message">,
+  params: {
+    currentBotUsername?: string;
+    otherBotUsernames?: readonly string[];
+  },
+): { mentionedBot?: string | null; repliedToBot?: string | null } {
+  const { currentBotUsername, otherBotUsernames } = params;
+  const knownBots = new Set<string>();
+  if (currentBotUsername) {
+    knownBots.add(currentBotUsername.toLowerCase());
+  }
+  for (const other of otherBotUsernames ?? []) {
+    const normalized = other.trim().toLowerCase();
+    if (normalized) {
+      knownBots.add(normalized);
+    }
+  }
+
+  const result: { mentionedBot?: string | null; repliedToBot?: string | null } = {};
+
+  if (knownBots.size > 0) {
+    const { text, entities } = getTelegramTextParts(msg);
+    let found: string | null = null;
+    if (text) {
+      for (const ent of entities) {
+        if (ent.type !== "mention") {
+          continue;
+        }
+        const slice = text.slice(ent.offset, ent.offset + ent.length);
+        const candidate = normalizeLowercaseStringOrEmpty(slice).replace(/^@/, "");
+        if (candidate && knownBots.has(candidate)) {
+          found = candidate;
+          break;
+        }
+      }
+      if (!found) {
+        const lowered = normalizeLowercaseStringOrEmpty(text);
+        for (const bot of knownBots) {
+          if (hasStandaloneTelegramMention(lowered, `@${bot}`)) {
+            found = bot;
+            break;
+          }
+        }
+      }
+    }
+    result.mentionedBot = found;
+  }
+
+  const reply = msg.reply_to_message;
+  if (reply !== undefined) {
+    const replyFrom = reply.from;
+    if (replyFrom?.is_bot && replyFrom.username) {
+      result.repliedToBot = replyFrom.username.toLowerCase();
+    } else if (replyFrom != null) {
+      result.repliedToBot = null;
+    }
+  }
+
+  return result;
+}

--- a/extensions/telegram/src/bot/helpers.ts
+++ b/extensions/telegram/src/bot/helpers.ts
@@ -374,6 +374,8 @@ export type TelegramReplyTarget = {
   sender: string;
   senderId?: string;
   senderUsername?: string;
+  /** True when the reply target was authored by a bot (per `from.is_bot`). */
+  senderIsBot?: boolean;
   body?: string;
   kind: "reply" | "quote";
   source: "reply_to_message" | "external_reply";
@@ -450,6 +452,7 @@ export function describeReplyTarget(msg: Message): TelegramReplyTarget | null {
     sender: senderLabel,
     senderId: replyLike?.from?.id != null ? String(replyLike.from.id) : undefined,
     senderUsername: replyLike?.from?.username ?? undefined,
+    senderIsBot: replyLike?.from?.is_bot === true ? true : undefined,
     body: body || undefined,
     kind,
     source,

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -279,3 +279,111 @@ describe("group runtime loading", () => {
     vi.doUnmock("./groups.runtime.js");
   });
 });
+
+describe("buildGroupChatContext multi-agent awareness (#56692)", () => {
+  it("includes other bots in group context when OtherBotUsernames is set", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupChatContext({
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+        OtherBotUsernames: ["otherbot1", "otherbot2"],
+      },
+    });
+    expect(result).toContain("@mybot");
+    expect(result).toContain("@otherbot1");
+    expect(result).toContain("@otherbot2");
+    expect(result).toContain("Do not act on messages clearly addressed to other bots");
+  });
+
+  it("emits only the bot-username line when no OtherBotUsernames are present", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupChatContext({
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+      },
+    });
+    expect(result).toContain("Your bot username is @mybot.");
+    expect(result).not.toContain("Other bots");
+    expect(result).not.toContain("Do not act on messages");
+  });
+
+  it("trims whitespace from individual OtherBotUsernames entries (Greptile fix)", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupChatContext({
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+        OtherBotUsernames: [" helperbot ", "  ", "otherbot\t", ""],
+      },
+    });
+    expect(result).toContain("@helperbot");
+    expect(result).toContain("@otherbot");
+    // No empty / whitespace-only handles should leak into the rendered prompt.
+    expect(result).not.toContain("@ helperbot");
+    expect(result).not.toContain("@  ");
+    expect(result).not.toContain("@otherbot\t");
+    expect(result).not.toMatch(/@\s/);
+  });
+
+  it("stays byte-for-byte stable when neither BotUsername nor OtherBotUsernames are set", async () => {
+    const groups = await import("./groups.js");
+    expect(
+      groups.buildGroupChatContext({
+        sessionCtx: { Provider: "telegram" },
+      }),
+    ).toBe(
+      "You are in a Telegram group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+    );
+  });
+});
+
+describe("buildGroupIntro multi-agent awareness (#56692)", () => {
+  it("appends multi-agent guidance when OtherBotUsernames is set", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupIntro({
+      cfg: {} as OpenClawConfig,
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+        OtherBotUsernames: ["helperbot"],
+      },
+      defaultActivation: "mention",
+      silentToken: "NO_REPLY",
+    });
+    expect(result).toContain("multiple bots");
+    expect(result).toContain("@helperbot");
+    expect(result).toContain("which bot each message mentioned or replied to");
+  });
+
+  it("omits multi-agent guidance when OtherBotUsernames is empty", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupIntro({
+      cfg: {} as OpenClawConfig,
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+        OtherBotUsernames: [],
+      },
+      defaultActivation: "mention",
+      silentToken: "NO_REPLY",
+    });
+    expect(result).not.toContain("multiple bots");
+  });
+
+  it("omits multi-agent guidance when OtherBotUsernames contains only whitespace entries", async () => {
+    const groups = await import("./groups.js");
+    const result = groups.buildGroupIntro({
+      cfg: {} as OpenClawConfig,
+      sessionCtx: {
+        Provider: "telegram",
+        BotUsername: "mybot",
+        OtherBotUsernames: ["   ", "\t", ""],
+      },
+      defaultActivation: "mention",
+      silentToken: "NO_REPLY",
+    });
+    expect(result).not.toContain("multiple bots");
+  });
+});

--- a/src/auto-reply/reply/groups.test.ts
+++ b/src/auto-reply/reply/groups.test.ts
@@ -334,7 +334,7 @@ describe("buildGroupChatContext multi-agent awareness (#56692)", () => {
         sessionCtx: { Provider: "telegram" },
       }),
     ).toBe(
-      "You are in a Telegram group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
+      "You are in a Telegram group chat. Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally. Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available. Write like a human. Avoid Markdown tables. Minimize empty lines and use normal chat conventions, not document-style spacing. Don't type literal \\n sequences; use real line breaks sparingly.",
     );
   });
 });

--- a/src/auto-reply/reply/groups.ts
+++ b/src/auto-reply/reply/groups.ts
@@ -227,6 +227,8 @@ export function buildGroupChatContext(params: {
 }): string {
   const providerLabel = resolveProviderLabel(params.sessionCtx.Provider);
   const messageToolOnly = params.sourceReplyDeliveryMode === "message_tool_only";
+  const botUsername = params.sessionCtx.BotUsername?.trim();
+  const otherBots = params.sessionCtx.OtherBotUsernames?.map((b) => b.trim()).filter(Boolean) ?? [];
 
   const lines: string[] = [];
   lines.push(`You are in a ${providerLabel} group chat.`);
@@ -238,6 +240,15 @@ export function buildGroupChatContext(params: {
     lines.push(
       "Your replies are automatically sent to this group chat. Do not use the message tool to send to this same group - just reply normally.",
     );
+  }
+  if (botUsername) {
+    if (otherBots.length > 0) {
+      lines.push(
+        `Your bot username is @${botUsername}. Other bots in this group: ${otherBots.map((b) => `@${b}`).join(", ")}. Only respond to messages addressed to you (via @${botUsername} mention or reply to your messages). Do not act on messages clearly addressed to other bots.`,
+      );
+    } else {
+      lines.push(`Your bot username is @${botUsername}.`);
+    }
   }
   lines.push(
     "Be a good group participant: mostly lurk and follow the conversation; reply only when directly addressed or you can add clear value. Emoji reactions are welcome when available.",
@@ -337,5 +348,10 @@ export function buildGroupIntro(params: {
     activation === "always"
       ? "Activation: always-on (you receive every group message)."
       : "Activation: trigger-only (you are invoked only when explicitly mentioned; recent context may be included).";
-  return `${activationLine} Address the specific sender noted in the message context.`;
+  const otherBots = params.sessionCtx.OtherBotUsernames?.map((b) => b.trim()).filter(Boolean) ?? [];
+  const multiAgentLine =
+    otherBots.length > 0
+      ? ` This group contains multiple bots (${otherBots.map((b) => `@${b}`).join(", ")}). The chat history includes which bot each message mentioned or replied to — use that to ignore messages not addressed to you.`
+      : "";
+  return `${activationLine}${multiAgentLine} Address the specific sender noted in the message context.`;
 }

--- a/src/auto-reply/reply/history.ts
+++ b/src/auto-reply/reply/history.ts
@@ -32,6 +32,21 @@ export type HistoryEntry = {
   body: string;
   timestamp?: number;
   messageId?: string;
+  /**
+   * Bot username mentioned in this message.
+   * - `undefined` = data not populated by the channel plugin (legacy / backward compat)
+   * - `null` = explicitly no bot was mentioned
+   * - `string` = the (lowercased) username of the bot mentioned, without leading `@`
+   *
+   * Used by multi-agent group chats so the current agent can see whether prior
+   * messages were addressed to itself or a sibling bot.
+   */
+  mentionedBot?: string | null;
+  /**
+   * Bot username this message is a reply-to.
+   * Same `undefined` / `null` / `string` semantics as `mentionedBot`.
+   */
+  repliedToBot?: string | null;
 };
 
 export function buildHistoryContext(params: {

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -668,4 +668,86 @@ describe("buildInboundUserContextPrefix", () => {
     expect(history[0]?.["body"]).toBe("body-5");
     expect(history.at(-1)?.["body"]).toBe("body-24");
   });
+
+  // Multi-agent group context (#56692): per-history-entry bot-targeting fields
+  // and reply-target bot username use the `undefined` (= absent) vs `null`
+  // (= explicitly no bot) semantics.
+  describe("multi-agent group bot targeting", () => {
+    it("emits mentioned_bot and replied_to_bot per history entry, omitting undefined", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        InboundHistory: [
+          { sender: "Alice", body: "hey @mybot", timestamp: 1, mentionedBot: "mybot" },
+          {
+            sender: "Bob",
+            body: "yes please",
+            timestamp: 2,
+            repliedToBot: "otherbot",
+          },
+          { sender: "Carol", body: "hello world", timestamp: 3, mentionedBot: null },
+          { sender: "Dave", body: "no metadata here", timestamp: 4 },
+        ],
+      } as TemplateContext);
+
+      const history = parseHistoryPayload(text);
+      expect(history).toHaveLength(4);
+      expect(history[0]?.["mentioned_bot"]).toBe("mybot");
+      expect(history[0]).not.toHaveProperty("replied_to_bot");
+      expect(history[1]?.["replied_to_bot"]).toBe("otherbot");
+      expect(history[1]).not.toHaveProperty("mentioned_bot");
+      expect(history[2]?.["mentioned_bot"]).toBeNull();
+      expect(history[2]).not.toHaveProperty("replied_to_bot");
+      expect(history[3]).not.toHaveProperty("mentioned_bot");
+      expect(history[3]).not.toHaveProperty("replied_to_bot");
+    });
+
+    it("includes replied_to_bot in reply context when ReplyToBotUsername is set", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        ReplyToBody: "previous bot reply",
+        ReplyToSender: "otherbot",
+        ReplyToBotUsername: "otherbot",
+      } as TemplateContext);
+
+      const replyPayload = parseUntrustedJsonBlock(
+        text,
+        "Replied message (untrusted, for context):",
+      ) as Record<string, unknown>;
+      expect(replyPayload["replied_to_bot"]).toBe("otherbot");
+      expect(replyPayload["sender_label"]).toBe("otherbot");
+      expect(replyPayload["body"]).toBe("previous bot reply");
+    });
+
+    it("omits replied_to_bot when ReplyToBotUsername is absent (backward compat)", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        ReplyToBody: "human follow-up",
+        ReplyToSender: "Alice",
+      } as TemplateContext);
+
+      const replyPayload = parseUntrustedJsonBlock(
+        text,
+        "Replied message (untrusted, for context):",
+      ) as Record<string, unknown>;
+      expect(replyPayload).not.toHaveProperty("replied_to_bot");
+      expect(replyPayload["sender_label"]).toBe("Alice");
+    });
+
+    it("preserves history backward compat when no entries carry bot fields", () => {
+      const text = buildInboundUserContextPrefix({
+        ChatType: "group",
+        InboundHistory: [
+          { sender: "Alice", body: "ping", timestamp: 1 },
+          { sender: "Bob", body: "pong", timestamp: 2 },
+        ],
+      } as TemplateContext);
+
+      const history = parseHistoryPayload(text);
+      expect(history).toHaveLength(2);
+      for (const entry of history) {
+        expect(entry).not.toHaveProperty("mentioned_bot");
+        expect(entry).not.toHaveProperty("replied_to_bot");
+      }
+    });
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -268,12 +268,17 @@ export function buildInboundUserContextPrefix(
 
   const replyToBody = sanitizePromptBody(ctx.ReplyToBody);
   if (replyToBody) {
+    const replyPayload: Record<string, unknown> = {
+      sender_label: normalizePromptMetadataString(ctx.ReplyToSender),
+      is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
+      body: replyToBody,
+    };
+    const repliedToBot = normalizePromptMetadataString(ctx.ReplyToBotUsername);
+    if (repliedToBot) {
+      replyPayload.replied_to_bot = repliedToBot;
+    }
     blocks.push(
-      formatUntrustedJsonBlock("Replied message (untrusted, for context):", {
-        sender_label: normalizePromptMetadataString(ctx.ReplyToSender),
-        is_quote: ctx.ReplyToIsQuote === true ? true : undefined,
-        body: replyToBody,
-      }),
+      formatUntrustedJsonBlock("Replied message (untrusted, for context):", replyPayload),
     );
   }
 
@@ -318,11 +323,26 @@ export function buildInboundUserContextPrefix(
     blocks.push(
       formatUntrustedJsonBlock(
         "Chat history since last reply (untrusted, for context):",
-        boundedHistory.map((entry) => ({
-          sender: sanitizePromptBody(entry.sender),
-          timestamp_ms: entry.timestamp,
-          body: sanitizePromptBody(entry.body),
-        })),
+        boundedHistory.map((entry) => {
+          const mapped: Record<string, unknown> = {
+            sender: sanitizePromptBody(entry.sender),
+            timestamp_ms: entry.timestamp,
+            body: sanitizePromptBody(entry.body),
+          };
+          if (entry.mentionedBot !== undefined) {
+            mapped.mentioned_bot =
+              entry.mentionedBot === null
+                ? null
+                : (normalizePromptMetadataString(entry.mentionedBot) ?? null);
+          }
+          if (entry.repliedToBot !== undefined) {
+            mapped.replied_to_bot =
+              entry.repliedToBot === null
+                ? null
+                : (normalizePromptMetadataString(entry.repliedToBot) ?? null);
+          }
+          return mapped;
+        }),
       ),
     );
   }

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -43,6 +43,17 @@ export type MsgContext = {
     sender: string;
     body: string;
     timestamp?: number;
+    /**
+     * Bot username mentioned in this history entry.
+     * `undefined` = unknown/not populated; `null` = explicitly no bot mentioned;
+     * `string` = lowercased bot username (no leading `@`).
+     */
+    mentionedBot?: string | null;
+    /**
+     * Bot username this history entry is a reply to.
+     * Same `undefined` / `null` / `string` semantics as `mentionedBot`.
+     */
+    repliedToBot?: string | null;
   }>;
   /**
    * Raw message body without structural context (history, sender labels).
@@ -95,6 +106,12 @@ export type MsgContext = {
   ReplyToBody?: string;
   ReplyToSender?: string;
   ReplyToIsQuote?: boolean;
+  /**
+   * When the replied-to message was authored by a known bot, the bot's username
+   * (no leading `@`). Used so the current agent can recognise reply-chains
+   * directed at sibling bots in multi-agent groups.
+   */
+  ReplyToBotUsername?: string;
   /** Forward origin from the reply target (when reply_to_message is a forwarded message). */
   ReplyToForwardedFrom?: string;
   ReplyToForwardedFromType?: string;
@@ -185,6 +202,12 @@ export type MsgContext = {
   Surface?: string;
   /** Platform bot username when command mentions should be normalized. */
   BotUsername?: string;
+  /**
+   * Other bot usernames present in the same group chat (without leading `@`).
+   * Used for multi-agent context: the current agent can distinguish messages
+   * addressed to itself vs. other agents in the same group.
+   */
+  OtherBotUsernames?: string[];
   WasMentioned?: boolean;
   CommandAuthorized?: boolean;
   CommandSource?: "text" | "native";


### PR DESCRIPTION
Closes #56692.

## Problem

In a group chat with multiple bots, an agent can't tell which messages in the recent history were addressed to **itself** vs. another bot in the same group. `InboundHistory` and the reply context only carry sender / body / timestamp; the targeting signal (mention entity, reply-chain `from`) gets dropped at the channel-plugin boundary.

The result: the agent treats "@otherbot how are you" the same as a direct address, occasionally hallucinating an answer to a message that was never directed at it.

## Root cause

Three independent gaps:

1. `HistoryEntry` and the inline `InboundHistory` type in `templating.ts` have no fields to carry per-message bot-targeting metadata.
2. `MsgContext` (template context) has no `OtherBotUsernames` / `ReplyToBotUsername` to surface the multi-agent layout to the prompt.
3. The Telegram channel plugin parses mention entities and `reply_to_message.from.is_bot` in `bot-message-context.body.ts` / `bot-message-context.session.ts` but never propagates that signal to the new fields.

A prior PR (#58102, closed by author 2026-04-20, **not rejected by maintainer** — Greptile gave it 5/5 "safe to merge") proposed the core type additions but explicitly left "channel plugins need to populate" as follow-up. That follow-up never happened.

## Reproducer

1. Add two bots, `@bot-a` and `@bot-b`, to a Telegram group, both running OpenClaw.
2. Send a message: `@bot-b what's the weather?`
3. Then send a follow-up unrelated message that pings `@bot-a`: `hey @bot-a remember when @bot-b answered the weather question?`
4. Observe `bot-a`'s prompt: it sees the prior `what's the weather?` message **without any signal** that it was directed at `bot-b`. `bot-a` will sometimes answer it as if it were addressed to itself.

## Fix

End-to-end wiring of the design from #58102, plus the missing channel populate:

**Core (`src/auto-reply/`)**
- `HistoryEntry`: optional `mentionedBot` / `repliedToBot` (`string | null`). Tri-state: `undefined` = legacy/unknown caller, `null` = explicitly no bot targeted, `string` = bot username.
- `MsgContext`: optional `OtherBotUsernames: string[]`, `ReplyToBotUsername: string`. Individual entries are trimmed before render (Greptile fix #58102 missed at `groups.ts:157,210`).
- `inbound-meta.ts`: emit `mentioned_bot` / `replied_to_bot` per history entry and a top-level `replied_to_bot` for the current reply target. `null` is preserved through JSON; `undefined` is dropped to keep the payload lean.
- `groups.ts`: `buildGroupChatContext` adds bot-username + multi-agent disambiguation guidance only when `BotUsername` is set, preserving byte-stable output for callers that don't pass it. `buildGroupIntro` mirrors that.

**Telegram channel plugin (`extensions/telegram/src/`)**
- New `detectTelegramBotTargeting()` helper: entity-mention scan with plain-text fallback, plus `reply_to_message.from.is_bot` derivation.
- `TelegramReplyTarget` gains `senderIsBot`, derived from `from.is_bot`.
- `bot-message-context.body.ts`: populate `HistoryEntry` bot fields on the group-skip path so future turns see who the prior message targeted.
- `bot-message-context.session.ts`: forward bot fields through `inboundHistory` to the prompt; populate `ReplyToBotUsername` when the visible reply target is a bot.

`OtherBotUsernames` is left unset until the Telegram config exposes a sibling-bot list — the prompt-rendering code handles `undefined` gracefully.

## Backward compatibility

All new fields are optional. Output for callers that don't provide `BotUsername` or sibling-bot config is **byte-identical** to today. The 4 pre-existing `groups` tests and existing inbound-meta tests stay green unchanged.

## Verification

```
pnpm vitest run src/auto-reply/reply/groups.test.ts src/auto-reply/reply/inbound-meta.test.ts extensions/telegram/src/bot/body-helpers.test.ts
# 64 passed (21 new)

pnpm vitest run extensions/telegram
# 1447 passed across 100 files, no regressions

pnpm check
# preflight ✅, tsgo:core ✅, tsgo:extensions ✅,
# oxlint core/extensions/scripts (13000+ files): 0 warnings, 0 errors,
# all policy guards (temp-path-guardrails, no-pairing-store-group, webhook auth body order,
#   pairing-account-scope, runtime-action-load-config, import-cycles): pass
```

## Tests added

- 11 new auto-reply tests: null vs undefined semantics for `mentionedBot`/`repliedToBot` in history and reply context, `OtherBotUsernames` trim+filter, multi-agent intro generation, byte-stable backward compat for callers without `BotUsername`, empty/whitespace omission.
- 10 new Telegram body-helpers tests: entity mention parsing, plain-text mention fallback, reply-to-bot derivation from `is_bot`, no-entities edge case, non-bot sender, missing username.

## Scope honesty

- Only the Telegram channel plugin is wired in this PR. Other channel plugins (Discord, Slack, Lark, Feishu, …) can populate the same fields when their respective parsers are extended; the core contracts are stable and the prompt-rendering code already handles missing data.
- `OtherBotUsernames` populate is gated on a future "sibling-bot list" surface in Telegram config; flagged with an inline `// Multi-agent (#56692):` note at the population site.