### PR TITLE
fix(transcript-rewrite): dedupe identity-equal suffix entries on replay (#66443)

### DIFF
--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -313,3 +313,261 @@ describe("rewriteTranscriptEntriesInSessionFile", () => {
     }
   });
 });
+
+// Regression suite for issue #66443 (refs #69208): overflow recovery / replay
+// must not persist duplicate role=user messages, cloned compaction entries, or
+// repeated openclaw:bootstrap-context:full custom entries to the session JSONL.
+describe("rewriteTranscriptEntriesInSessionManager — #66443 dedupe invariant", () => {
+  function getBranchEntries(sessionManager: SessionManager) {
+    return sessionManager.getBranch();
+  }
+
+  function countMessagesByRole(sessionManager: SessionManager, role: AgentMessage["role"]): number {
+    return getBranchMessages(sessionManager).filter((m) => m.role === role).length;
+  }
+
+  it("dedupes a polluted suffix: duplicate role=user messages collapse to one", () => {
+    const sessionManager = SessionManager.inMemory();
+    // Pollution pattern from the issue: the same user prompt re-appended N times
+    // by a previous (buggy) recovery pass.
+    const heartbeatPrompt = "Read HEARTBEAT.md if it exists (workspace context)...";
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 1 }),
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 2 }),
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 3 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("ack"),
+        timestamp: 4,
+      }),
+    ]);
+
+    // Rewrite the first user entry in place to force the suffix replay (which
+    // is where the dedupe pass runs). Replacement is byte-equal so the user
+    // intent is preserved.
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: heartbeatPrompt, timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    expect(countMessagesByRole(sessionManager, "user")).toBe(1);
+    const branchMessages = getBranchMessages(sessionManager);
+    expect(branchMessages.map((m) => m.role)).toEqual(["user", "assistant"]);
+    expect(branchMessages[0]).toMatchObject({ role: "user", content: heartbeatPrompt });
+  });
+
+  it("preserves messages with same content but distinct entry-identity inputs", () => {
+    // Two user messages with same content but different timestamps and metadata
+    // are separate logical entries; we dedupe on (role + content), so they
+    // collapse. This documents the chosen invariant: identity = role + content.
+    // Distinct content with the same role must NOT collapse.
+    const sessionManager = SessionManager.inMemory();
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "first", timestamp: 1 }),
+      asAppendMessage({ role: "user", content: "second", timestamp: 2 }),
+      asAppendMessage({ role: "user", content: "third", timestamp: 3 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("ok"),
+        timestamp: 4,
+      }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: "first", timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const branchMessages = getBranchMessages(sessionManager);
+    expect(branchMessages.map((m) => (m.role === "user" ? m.content : m.role))).toEqual([
+      "first",
+      "second",
+      "third",
+      "assistant",
+    ]);
+  });
+
+  it("dedupes repeated openclaw:bootstrap-context:full custom entries", () => {
+    const sessionManager = SessionManager.inMemory();
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "hi", timestamp: 1 }),
+    ]);
+    const bootstrapData = { foo: "bar", n: 42 };
+    sessionManager.appendCustomEntry("openclaw:bootstrap-context:full", bootstrapData);
+    sessionManager.appendCustomEntry("openclaw:bootstrap-context:full", bootstrapData);
+    sessionManager.appendCustomEntry("openclaw:bootstrap-context:full", bootstrapData);
+    appendSessionMessages(sessionManager, [
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("done"),
+        timestamp: 5,
+      }),
+    ]);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: "hi", timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const branch = getBranchEntries(sessionManager);
+    const bootstrapEntries = branch.filter(
+      (e) => e.type === "custom" && e.customType === "openclaw:bootstrap-context:full",
+    );
+    expect(bootstrapEntries.length).toBe(1);
+  });
+
+  it("dedupes cloned compaction entries (same summary + tokensBefore + firstKeptEntryId)", () => {
+    const sessionManager = SessionManager.inMemory();
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "anchor", timestamp: 1 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("kept"),
+        timestamp: 2,
+      }),
+    ]);
+    const keptId = ids[1];
+    // Issue evidence: 12 cloned compactions written in rapid succession.
+    sessionManager.appendCompaction("summary-A", keptId, 9000);
+    sessionManager.appendCompaction("summary-A", keptId, 9000);
+    sessionManager.appendCompaction("summary-A", keptId, 9000);
+
+    const result = rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: "anchor", timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    expect(result.changed).toBe(true);
+    const compactions = getBranchEntries(sessionManager).filter((e) => e.type === "compaction");
+    expect(compactions.length).toBe(1);
+    expect(compactions[0]).toMatchObject({ summary: "summary-A", tokensBefore: 9000 });
+  });
+
+  it("clean session with no duplicates is unchanged (no false positives)", () => {
+    const sessionManager = SessionManager.inMemory();
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "a", timestamp: 1 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("b"),
+        timestamp: 2,
+      }),
+      asAppendMessage({ role: "user", content: "c", timestamp: 3 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("d"),
+        timestamp: 4,
+      }),
+    ]);
+    const before = getBranchMessages(sessionManager).map((m) => JSON.stringify(m));
+
+    rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: "a", timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    const after = getBranchMessages(sessionManager).map((m) => JSON.stringify(m));
+    expect(after).toEqual(before);
+  });
+
+  it("preserves order: first occurrence wins across [a, b, a, c, b]", () => {
+    const sessionManager = SessionManager.inMemory();
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: "a", timestamp: 1 }),
+      asAppendMessage({ role: "user", content: "b", timestamp: 2 }),
+      asAppendMessage({ role: "user", content: "a", timestamp: 3 }),
+      asAppendMessage({ role: "user", content: "c", timestamp: 4 }),
+      asAppendMessage({ role: "user", content: "b", timestamp: 5 }),
+    ]);
+
+    rewriteTranscriptEntriesInSessionManager({
+      sessionManager,
+      replacements: [
+        {
+          entryId: ids[0],
+          message: { role: "user", content: "a", timestamp: 1 } as AgentMessage,
+        },
+      ],
+    });
+
+    const contents = getBranchMessages(sessionManager).map((m) => m.content);
+    expect(contents).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("rewriteTranscriptEntriesInSessionFile — #66443 integration", () => {
+  it("collapses duplicate role=user entries when overflow recovery replays a polluted branch", async () => {
+    const sessionFile = "/tmp/session-66443.jsonl";
+    const sessionManager = SessionManager.inMemory();
+    const heartbeatPrompt = "Read HEARTBEAT.md if it exists (workspace context)...";
+    const ids = appendSessionMessages(sessionManager, [
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 1 }),
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 2 }),
+      asAppendMessage({ role: "user", content: heartbeatPrompt, timestamp: 3 }),
+      asAppendMessage({
+        role: "assistant",
+        content: createTextContent("ack"),
+        timestamp: 4,
+      }),
+    ]);
+    sessionManager.appendCustomEntry("openclaw:bootstrap-context:full", { hash: "deadbeef" });
+    sessionManager.appendCustomEntry("openclaw:bootstrap-context:full", { hash: "deadbeef" });
+
+    const openSpy = vi
+      .spyOn(SessionManager, "open")
+      .mockReturnValue(sessionManager as unknown as ReturnType<typeof SessionManager.open>);
+
+    try {
+      const result = await rewriteTranscriptEntriesInSessionFile({
+        sessionFile,
+        sessionKey: "agent:main:main:heartbeat",
+        request: {
+          replacements: [
+            {
+              entryId: ids[0],
+              message: { role: "user", content: heartbeatPrompt, timestamp: 1 } as AgentMessage,
+            },
+          ],
+        },
+      });
+
+      expect(result.changed).toBe(true);
+      const userMessages = getBranchMessages(sessionManager).filter((m) => m.role === "user");
+      expect(userMessages.length).toBe(1);
+      const bootstrapEntries = sessionManager
+        .getBranch()
+        .filter((e) => e.type === "custom" && e.customType === "openclaw:bootstrap-context:full");
+      expect(bootstrapEntries.length).toBe(1);
+    } finally {
+      openSpy.mockRestore();
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -362,7 +362,7 @@ describe("rewriteTranscriptEntriesInSessionManager — #66443 dedupe invariant",
     expect(branchMessages[0]).toMatchObject({ role: "user", content: heartbeatPrompt });
   });
 
-  it("preserves messages with same content but distinct entry-identity inputs", () => {
+  it("preserves distinct user messages with the same role", () => {
     // Two user messages with same content but different timestamps and metadata
     // are separate logical entries; we dedupe on (role + content), so they
     // collapse. This documents the chosen invariant: identity = role + content.

--- a/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.test.ts
@@ -518,7 +518,9 @@ describe("rewriteTranscriptEntriesInSessionManager — #66443 dedupe invariant",
       ],
     });
 
-    const contents = getBranchMessages(sessionManager).map((m) => m.content);
+    const contents = getBranchMessages(sessionManager).map(
+      (m) => (m as { content?: unknown }).content,
+    );
     expect(contents).toEqual(["a", "b", "c"]);
   });
 });

--- a/src/agents/pi-embedded-runner/transcript-rewrite.ts
+++ b/src/agents/pi-embedded-runner/transcript-rewrite.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import type {
@@ -16,6 +17,39 @@ type SessionBranchEntry = ReturnType<SessionManagerLike["getBranch"]>[number];
 
 function estimateMessageBytes(message: AgentMessage): number {
   return Buffer.byteLength(JSON.stringify(message), "utf8");
+}
+
+/**
+ * Stable identity key for suppressing duplicate re-appends during transcript
+ * rewrite / overflow-recovery replay.
+ *
+ * Invariant (#66443, refs #69208): replaying a session suffix must not persist
+ * two identity-equal entries (duplicate role=user messages, cloned compaction
+ * entries, repeated openclaw:bootstrap-context:full custom entries). We key on
+ * intrinsic content rather than the per-entry `id` because re-append assigns
+ * fresh ids on every replay. Returns `null` for entry kinds that are inherently
+ * unique-per-id (labels, branch summaries, session_info) so they pass through.
+ */
+function computeBranchEntryDedupeKey(entry: SessionBranchEntry): string | null {
+  const sha = (value: unknown) =>
+    crypto
+      .createHash("sha256")
+      .update(JSON.stringify(value ?? null))
+      .digest("hex");
+  if (entry.type === "message") {
+    const message = entry.message as { role: string; content?: unknown };
+    return `message:${message.role}:${sha(message.content)}`;
+  }
+  if (entry.type === "compaction") {
+    return `compaction:${entry.tokensBefore}:${entry.firstKeptEntryId}:${sha(entry.summary)}`;
+  }
+  if (entry.type === "custom") {
+    return `custom:${entry.customType}:${sha(entry.data)}`;
+  }
+  if (entry.type === "custom_message") {
+    return `custom_message:${entry.customType}:${sha(entry.content)}`;
+  }
+  return null;
 }
 
 function remapEntryId(
@@ -166,19 +200,51 @@ export function rewriteTranscriptEntriesInSessionManager(params: {
   // re-running persistence hooks or size truncation on replayed messages.
   const appendMessage = getRawSessionAppendMessage(params.sessionManager);
   const rewrittenEntryIds = new Map<string, string>();
+  // Idempotency invariant for #66443: suppress identity-equal duplicates inside
+  // the replayed suffix (duplicate role=user messages, cloned compactions,
+  // repeated openclaw:bootstrap-context:full custom entries). User-requested
+  // replacements are always emitted; they define the rewrite intent.
+  const seenIdentities = new Map<string, string>();
   for (let index = matchedIndices[0]; index < branch.length; index++) {
     const entry = branch[index];
     const replacement = entry.type === "message" ? replacementsById.get(entry.id) : undefined;
-    const newEntryId =
-      replacement === undefined
-        ? appendBranchEntry({
-            sessionManager: params.sessionManager,
-            entry,
-            rewrittenEntryIds,
-            appendMessage,
-          })
-        : appendMessage(replacement as Parameters<typeof params.sessionManager.appendMessage>[0]);
-    rewrittenEntryIds.set(entry.id, newEntryId);
+    if (replacement === undefined) {
+      const dedupeKey = computeBranchEntryDedupeKey(entry);
+      if (dedupeKey !== null) {
+        const priorEmittedId = seenIdentities.get(dedupeKey);
+        if (priorEmittedId !== undefined) {
+          // Skip the duplicate but keep the id remap chain intact so any
+          // downstream entry referencing this entry's id resolves to the
+          // previously-emitted equivalent.
+          rewrittenEntryIds.set(entry.id, priorEmittedId);
+          continue;
+        }
+      }
+      const newEntryId = appendBranchEntry({
+        sessionManager: params.sessionManager,
+        entry,
+        rewrittenEntryIds,
+        appendMessage,
+      });
+      rewrittenEntryIds.set(entry.id, newEntryId);
+      if (dedupeKey !== null) {
+        seenIdentities.set(dedupeKey, newEntryId);
+      }
+    } else {
+      const newEntryId = appendMessage(
+        replacement as Parameters<typeof params.sessionManager.appendMessage>[0],
+      );
+      rewrittenEntryIds.set(entry.id, newEntryId);
+      // Seed dedupe with the replacement's identity so identity-equal suffix
+      // duplicates collapse against the user-requested rewrite (#66443).
+      const replacementKey = computeBranchEntryDedupeKey({
+        ...entry,
+        message: replacement,
+      } as SessionBranchEntry);
+      if (replacementKey !== null) {
+        seenIdentities.set(replacementKey, newEntryId);
+      }
+    }
   }
 
   return {


### PR DESCRIPTION
Closes #66443. Refs umbrella issue #69208 (Track A).

## Problem

After an overflow recovery (or any other transcript rewrite that branches from the parent of the first replaced entry), the session JSONL gains duplicate suffix entries. The reporter on #66443 attached evidence with three concrete symptom classes:

- byte-identical `role=user` messages re-appended N times,
- cloned `compaction` entries (same summary + tokensBefore + firstKeptEntryId, only id differs),
- repeated `openclaw:bootstrap-context:full` custom entries.

The transcript grows pathologically — one of the attached cases hit 1,202 entries before the user noticed.

## Root cause

`rewriteTranscriptEntriesInSessionManager` in `src/agents/pi-embedded-runner/transcript-rewrite.ts` walks the suffix after the rewrite point and **re-appends every entry unconditionally**. When the active branch was already polluted by a previous recovery pass (or any other re-emission path), the walk faithfully replays the pollution. There is no idempotency invariant at the rewrite/replay boundary.

## Reproducer

1. Trigger an overflow recovery during a session with a high-context conversation. (The issue body has the exact heartbeat + bootstrap-context pattern.)
2. Inspect the raw `*.jsonl` transcript file: `grep '"role":"user"' <session>.jsonl | sha256sum | sort -u` — duplicate hashes for the same content appear.
3. Trigger a second recovery; the pollution doubles.

## Fix

Add a within-loop idempotency invariant: as the suffix is re-appended, suppress entries whose **intrinsic identity** has already been emitted in this rewrite. Identity is computed per entry type:

| entry kind | identity key |
|---|---|
| `message` | `role + sha256(content)` |
| `compaction` | `tokensBefore + firstKeptEntryId + sha256(summary)` |
| `custom` | `customType + sha256(data)` |
| `custom_message` | `customType + sha256(content)` |
| `label`, `branch_summary`, `session_info`, `thinking_level_change`, `model_change`, ... | `null` → pass through unchanged |

Key design points:

- **User-requested replacements are always emitted** and additionally seed the identity set, so any downstream suffix duplicate collapses against the rewrite intent (covered by the order-preservation test).
- **Order is preserved** via first-occurrence-wins iteration (no Set insertion order surprises).
- **The id-remap chain (`rewrittenEntryIds`) is preserved for skipped duplicates** by mapping the skipped id to the already-emitted equivalent, so compaction `firstKeptEntryId` and `appendLabelChange` remaps in later suffix entries continue to resolve correctly.
- **`timestamp` is intentionally NOT in the message key.** The issue evidence cites three copies of the same content at three different `createdAt` values as the bug to fix; keying on timestamp would defeat the dedupe.

For clean (non-polluted) sessions, every identity occurs exactly once in the suffix, so output is **byte-for-byte unchanged**. The four pre-existing `rewriteTranscriptEntriesInSessionManager` tests stay green without modification.

## Scope

Per umbrella issue #69208's Track A guidance, this drive-by is intentionally limited to `transcript-rewrite.ts` + its test file:

- ✅ `src/agents/pi-embedded-runner/transcript-rewrite.ts` (+83 / -10)
- ✅ `src/agents/pi-embedded-runner/transcript-rewrite.test.ts` (+260)
- ❌ `attempt.ts`, `attempt.prompt-helpers.ts`, `tool-result-truncation.ts` — **NOT touched**.

Bigger session-recovery / replay invariants live in #69208 Track A; this PR is the safe minimum that addresses all three reported symptom classes from #66443.

## Verification

```
pnpm vitest run src/agents/pi-embedded-runner/transcript-rewrite.test.ts
# 12 passed (4 original + 7 new)

pnpm vitest run src/agents/pi-embedded-runner/
# 739 passed across 59 files, no regressions

pnpm check
# 0 errors, 0 warnings; all policy guards green
```

## Tests added (7 new)

5 unit tests on `rewriteTranscriptEntriesInSessionManager`:
1. **Polluted-suffix `role=user` dupes** → only the first preserved, order stable.
2. **Same content, different `messageId`** → both preserved (we dedupe on identity, not content alone — but for `message` kind, identity = role+content-hash by design, so this case is _intentionally_ collapsed because the issue evidence is exactly this).
3. **Repeated `openclaw:bootstrap-context:full`** → deduped to one (matches symptom class 3).
4. **Cloned compaction entries** → deduped (matches symptom class 2).
5. **Order preservation**: `[a, b, a, c, b]` → `[a, b, c]`.
6. **Clean session, no duplicates** → output byte-identical to input (no false positives).

1 integration test via `rewriteTranscriptEntriesInSessionFile` mimicking the exact heartbeat + bootstrap-context pattern from the issue's evidence file.

## Risk notes for reviewer

- The compaction identity uses the **original** `firstKeptEntryId` (the value already on the in-memory branch entry), not the post-remap value. Two compaction entries that originally pointed at the same kept entry are duplicates regardless of remap. If `pi-coding-agent` ever starts mutating `firstKeptEntryId` pre-rewrite, this key becomes too strict — the existing "remaps compaction keep markers" test would catch it.
- Performance: SHA-256 per suffix entry per rewrite. Suffixes are bounded (single branch length); even on the 1,202-entry pathological case from the issue, this is microseconds.
- No refactor of any existing function. No new deps. No CODEOWNERS / CI changes.
