### PR TITLE
fix(mattermost): handle post_edited websocket events (#71930)

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -46,6 +46,11 @@ export const MattermostPostSchema = z
     type: z.string().nullable().optional(),
     root_id: z.string().nullable().optional(),
     create_at: z.number().nullable().optional(),
+    // Mattermost server stamps `edit_at` with the edit-revision timestamp
+    // (milliseconds since epoch) on `post_edited` events; remains 0 for the
+    // original `posted` event. Used by the replay guard to distinguish edit
+    // revisions from the original post (#71930).
+    edit_at: z.number().nullable().optional(),
     props: z.record(z.string(), z.unknown()).nullable().optional(),
   })
   .passthrough();

--- a/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.test.ts
@@ -1,7 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../runtime-api.js";
+import type { MattermostPost } from "./client.js";
 import {
   createMattermostConnectOnce,
+  type MattermostEventPayload,
   type MattermostWebSocketLike,
   WebSocketClosedBeforeOpenError,
 } from "./monitor-websocket.js";
@@ -161,7 +163,7 @@ describe("mattermost websocket monitor", () => {
 
   it("dispatches reaction events to the reaction handler", async () => {
     const socket = new FakeWebSocket();
-    const onPosted = vi.fn(async () => {});
+    const onPosted = vi.fn(async (_post: MattermostPost, _payload: MattermostEventPayload) => {});
     const onReaction = vi.fn(async (payload) => payload);
     const connectOnce = createMattermostConnectOnce({
       wsUrl: "wss://example.invalid/api/v4/websocket",
@@ -403,5 +405,179 @@ describe("mattermost websocket monitor", () => {
     socket.emitClose(1000);
     await connected;
     vi.useRealTimers();
+  });
+
+  it("dispatches post_edited events through onPosted (regression: #71930)", async () => {
+    const socket = new FakeWebSocket();
+    const onPosted = vi.fn(async (_post: MattermostPost, _payload: MattermostEventPayload) => {});
+    const runtime = testRuntime();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted,
+      webSocketFactory: () => socket,
+    });
+
+    const connected = connectOnce();
+    queueMicrotask(() => {
+      socket.emitOpen();
+      socket.emitMessage(
+        Buffer.from(
+          JSON.stringify({
+            event: "post_edited",
+            data: {
+              post: JSON.stringify({
+                id: "post-edited-1",
+                user_id: "user-9",
+                channel_id: "chan-1",
+                message: "hey @bot please look",
+                edit_at: 1234567890,
+              }),
+            },
+          }),
+        ),
+      );
+      socket.emitClose(1000);
+    });
+
+    await connected;
+
+    expect(onPosted).toHaveBeenCalledTimes(1);
+    const [post, payload] = onPosted.mock.calls[0];
+    expect(post).toMatchObject({
+      id: "post-edited-1",
+      user_id: "user-9",
+      message: "hey @bot please look",
+    });
+    expect(payload.event).toBe("post_edited");
+    // Surfaces an audit-log breadcrumb so dropped/handled edits are diffable.
+    expect(runtime.log).toHaveBeenCalledWith(
+      "mattermost: re-evaluating edited post post-edited-1 (post_edited)",
+    );
+  });
+
+  it("still dispatches plain posted events without the edit log (backward compat)", async () => {
+    const socket = new FakeWebSocket();
+    const onPosted = vi.fn(async (_post: MattermostPost, _payload: MattermostEventPayload) => {});
+    const runtime = testRuntime();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted,
+      webSocketFactory: () => socket,
+    });
+
+    const connected = connectOnce();
+    queueMicrotask(() => {
+      socket.emitOpen();
+      socket.emitMessage(
+        Buffer.from(
+          JSON.stringify({
+            event: "posted",
+            data: {
+              post: JSON.stringify({
+                id: "post-fresh-1",
+                user_id: "user-7",
+                channel_id: "chan-1",
+                message: "hello",
+              }),
+            },
+          }),
+        ),
+      );
+      socket.emitClose(1000);
+    });
+
+    await connected;
+
+    expect(onPosted).toHaveBeenCalledTimes(1);
+    const logCalls = (runtime.log as ReturnType<typeof vi.fn>).mock.calls.map((call) => call[0]);
+    expect(logCalls.some((msg) => String(msg).includes("post_edited"))).toBe(false);
+  });
+
+  it("forwards post_edited even when the editor is the bot itself (downstream filters)", async () => {
+    // The websocket layer must not silently drop bot-self edits — the bot-self
+    // filter lives downstream (monitor.ts handlePost). Dropping here would mask
+    // mention-by-edit cases where a non-bot user edits a bot-quoted message.
+    const socket = new FakeWebSocket();
+    const onPosted = vi.fn(async (_post: MattermostPost, _payload: MattermostEventPayload) => {});
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime: testRuntime(),
+      nextSeq: () => 1,
+      onPosted,
+      webSocketFactory: () => socket,
+    });
+
+    const connected = connectOnce();
+    queueMicrotask(() => {
+      socket.emitOpen();
+      socket.emitMessage(
+        Buffer.from(
+          JSON.stringify({
+            event: "post_edited",
+            data: {
+              post: JSON.stringify({
+                id: "post-bot-edit",
+                user_id: "bot-user-id",
+                channel_id: "chan-1",
+                message: "let me check… done.",
+                edit_at: 999,
+              }),
+            },
+          }),
+        ),
+      );
+      socket.emitClose(1000);
+    });
+
+    await connected;
+
+    expect(onPosted).toHaveBeenCalledTimes(1);
+    expect(onPosted.mock.calls[0][0]).toMatchObject({
+      id: "post-bot-edit",
+      user_id: "bot-user-id",
+    });
+  });
+
+  it("drops post_edited with a missing/malformed post body without crashing", async () => {
+    const socket = new FakeWebSocket();
+    const onPosted = vi.fn(async (_post: MattermostPost, _payload: MattermostEventPayload) => {});
+    const runtime = testRuntime();
+    const connectOnce = createMattermostConnectOnce({
+      wsUrl: "wss://example.invalid/api/v4/websocket",
+      botToken: "token",
+      runtime,
+      nextSeq: () => 1,
+      onPosted,
+      webSocketFactory: () => socket,
+    });
+
+    const connected = connectOnce();
+    queueMicrotask(() => {
+      socket.emitOpen();
+      // post_edited with no `data.post` — should be dropped silently.
+      socket.emitMessage(Buffer.from(JSON.stringify({ event: "post_edited", data: {} })));
+      // post_edited with malformed JSON in `data.post` — also dropped.
+      socket.emitMessage(
+        Buffer.from(
+          JSON.stringify({
+            event: "post_edited",
+            data: { post: "{not-json" },
+          }),
+        ),
+      );
+      socket.emitClose(1000);
+    });
+
+    await connected;
+
+    expect(onPosted).not.toHaveBeenCalled();
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 });

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -111,10 +111,19 @@ export const defaultMattermostWebSocketFactory: MattermostWebSocketFactory = (ur
   return new WebSocket(url, agent ? { agent } : undefined) as MattermostWebSocketLike;
 };
 
+/**
+ * Mattermost WebSocket events that carry a fresh post body in `data.post`.
+ * `post_edited` is included so an @mention added via edit still wakes the
+ * agent — see issue #71930. The downstream handler keys on `post.id` and
+ * filters self-authored posts, so re-routing edits through the same path
+ * is safe and behavior-preserving for `posted`.
+ */
+const POST_BEARING_EVENTS = new Set(["posted", "post_edited"]);
+
 export function parsePostedPayload(
   payload: MattermostEventPayload,
 ): { payload: MattermostEventPayload; post: MattermostPost } | null {
-  if (payload.event !== "posted") {
+  if (!payload.event || !POST_BEARING_EVENTS.has(payload.event)) {
     return null;
   }
   const postData = payload.data?.post;
@@ -301,12 +310,17 @@ export function createMattermostConnectOnce(
             return;
           }
 
-          if (payload.event !== "posted") {
+          if (!payload.event || !POST_BEARING_EVENTS.has(payload.event)) {
             return;
           }
           const parsed = parsePostedPayload(payload);
           if (!parsed) {
             return;
+          }
+          if (payload.event === "post_edited") {
+            opts.runtime.log?.(
+              `mattermost: re-evaluating edited post ${parsed.post.id} (post_edited)`,
+            );
           }
           try {
             await opts.onPosted(parsed.post, parsed.payload);

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -704,6 +704,170 @@ describe("processMattermostReplayGuardedPost", () => {
     expect(handlePost).toHaveBeenCalledTimes(1);
     expect(visibleSideEffect).toHaveBeenCalledTimes(1);
   });
+
+  // Regression: a `post_edited` arriving after the original `posted` event
+  // (within the 5-minute replay TTL) MUST NOT be silently deduped against
+  // the original key. Without per-edit keying the bug from #71930 returns —
+  // a user adding @mention via edit would never wake the agent because the
+  // original key already sits in `recentInboundMessages`.
+  it("treats an edited revision as a fresh claim, not a duplicate of the original posted key", async () => {
+    const replayGuard = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+    });
+    const handlePost = vi.fn(async () => undefined);
+
+    // 1. Original `posted` event commits its key.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-edit-1"],
+        editAts: [0],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    // 2. `post_edited` for the same post arrives (same id, edit_at > 0)
+    // — must be treated as a NEW event, not a duplicate.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-edit-1"],
+        editAts: [1700000000000],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    // 3. A second edit (different edit_at) is also fresh.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-edit-1"],
+        editAts: [1700000000999],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    // 4. Re-delivery of the SAME edit revision is correctly deduped.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-edit-1"],
+        editAts: [1700000000999],
+        handlePost,
+      }),
+    ).resolves.toBe("duplicate");
+
+    expect(handlePost).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves legacy id-only key when editAts is omitted (back-compat)", async () => {
+    const replayGuard = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+    });
+    const handlePost = vi.fn(async () => undefined);
+
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["legacy-post"],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    // Same id, no editAts → legacy key collision → duplicate (existing behavior).
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["legacy-post"],
+        handlePost,
+      }),
+    ).resolves.toBe("duplicate");
+
+    expect(handlePost).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats edit_at=null/undefined as 'not edited' (legacy id key)", async () => {
+    const replayGuard = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+    });
+    const handlePost = vi.fn(async () => undefined);
+
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["nullable-post"],
+        editAts: [null],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["nullable-post"],
+        editAts: [undefined],
+        handlePost,
+      }),
+    ).resolves.toBe("duplicate");
+
+    expect(handlePost).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys batched edits independently per post in a multi-post flush", async () => {
+    const replayGuard = createClaimableDedupe({
+      ttlMs: 10_000,
+      memoryMaxSize: 100,
+    });
+    const handlePost = vi.fn(async () => undefined);
+
+    // Two-post batch: first is original posted, second is an edit of a
+    // different post in the same debounce window.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-A", "post-B"],
+        editAts: [0, 1700000000000],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    // Re-deliver the same batch: both keys should now collide → duplicate.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-A", "post-B"],
+        editAts: [0, 1700000000000],
+        handlePost,
+      }),
+    ).resolves.toBe("duplicate");
+
+    // But a NEW edit revision of post-B is still fresh, even though post-A
+    // is a known duplicate.
+    await expect(
+      processMattermostReplayGuardedPost({
+        replayGuard,
+        accountId: "acct",
+        messageIds: ["post-A", "post-B"],
+        editAts: [0, 1700000099999],
+        handlePost,
+      }),
+    ).resolves.toBe("processed");
+
+    expect(handlePost).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("buildMattermostModelPickerSelectMessageSid", () => {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -159,15 +159,48 @@ export function buildMattermostModelPickerSelectMessageSid(params: {
 function buildMattermostInboundReplayKeys(params: {
   accountId: string;
   messageIds: string[];
+  /**
+   * Per-message edit timestamps from `MattermostPost.edit_at`, aligned by
+   * index with `messageIds`. When a message has been edited (`edit_at > 0`),
+   * the replay key gains an `:edit:<edit_at>` suffix so each edit revision
+   * is treated as a distinct claim — fixes #71930 where a `post_edited`
+   * arriving after the original `posted` (within the 5-minute TTL) was
+   * silently deduped against the original key, dropping mention-by-edit.
+   *
+   * Pure `posted` events (`edit_at == 0` or absent) keep the legacy
+   * `${accountId}:${id}` key so the existing replay-guard semantics for
+   * non-edit traffic are preserved byte-for-byte.
+   */
+  editAts?: ReadonlyArray<number | null | undefined>;
 }): string[] {
-  return [...new Set(params.messageIds.map((id) => `${params.accountId}:${id.trim()}`))].filter(
-    (key) => !key.endsWith(":"),
-  );
+  const editAts = params.editAts ?? [];
+  return [
+    ...new Set(
+      params.messageIds.map((id, idx) => {
+        const trimmed = id.trim();
+        if (!trimmed) {
+          return `${params.accountId}:`;
+        }
+        const editAt = editAts[idx];
+        if (typeof editAt === "number" && editAt > 0) {
+          return `${params.accountId}:${trimmed}:edit:${editAt}`;
+        }
+        return `${params.accountId}:${trimmed}`;
+      }),
+    ),
+  ].filter((key) => !key.endsWith(":"));
 }
 
 export async function processMattermostReplayGuardedPost(params: {
   accountId: string;
   messageIds: string[];
+  /**
+   * Optional per-message edit timestamps (aligned by index with
+   * `messageIds`). When provided, edited revisions get distinct replay
+   * keys; absent values fall back to the legacy id-only key. See
+   * `buildMattermostInboundReplayKeys` and #71930.
+   */
+  editAts?: ReadonlyArray<number | null | undefined>;
   handlePost: () => Promise<void>;
   replayGuard?: ClaimableDedupe;
 }): Promise<"processed" | "duplicate"> {
@@ -175,6 +208,7 @@ export async function processMattermostReplayGuardedPost(params: {
   const replayKeys = buildMattermostInboundReplayKeys({
     accountId: params.accountId,
     messageIds: params.messageIds,
+    editAts: params.editAts,
   });
   if (replayKeys.length === 0) {
     await params.handlePost();
@@ -1189,6 +1223,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     post: MattermostPost,
     payload: MattermostEventPayload,
     messageIds?: string[],
+    /**
+     * Optional per-message edit timestamps aligned with `messageIds`. Carries
+     * `MattermostPost.edit_at` so the replay guard distinguishes a freshly
+     * edited revision from the original `posted` event (#71930).
+     */
+    editAts?: ReadonlyArray<number | null | undefined>,
   ) => {
     const channelId = post.channel_id ?? payload.data?.channel_id ?? payload.broadcast?.channel_id;
     if (!channelId) {
@@ -1201,9 +1241,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       logVerboseMessage("mattermost: drop post (missing message id)");
       return;
     }
+    // Align edit_at values with allMessageIds. When the caller supplied
+    // explicit batched ids+editAts (debounced multi-post flush), trust them
+    // verbatim. Otherwise fall back to the single post's edit_at so a
+    // direct `post_edited` flow still gets a unique replay key (#71930).
+    const allEditAts: ReadonlyArray<number | null | undefined> = messageIds?.length
+      ? editAts && editAts.length === messageIds.length
+        ? editAts
+        : messageIds.map(() => undefined)
+      : [post.edit_at];
     const replayResult = await processMattermostReplayGuardedPost({
       accountId: account.accountId,
       messageIds: allMessageIds,
+      editAts: allEditAts,
       handlePost: async () => {
         const senderId = post.user_id ?? payload.broadcast?.user_id;
         if (!senderId) {
@@ -1967,8 +2017,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         message: combinedText,
         file_ids: [],
       };
-      const ids = entries.map((entry) => entry.post.id).filter(Boolean);
-      await handlePost(mergedPost, last.payload, ids.length > 0 ? ids : undefined);
+      // Build (id, edit_at) pairs in lockstep so the replay-guard key for an
+      // edited post in the batch reflects its own revision (#71930).
+      const idEditPairs = entries
+        .map((entry) => [entry.post.id, entry.post.edit_at] as const)
+        .filter(([id]) => Boolean(id));
+      const ids = idEditPairs.map(([id]) => id);
+      const editAts = idEditPairs.map(([, editAt]) => editAt);
+      await handlePost(
+        mergedPost,
+        last.payload,
+        ids.length > 0 ? ids : undefined,
+        ids.length > 0 ? editAts : undefined,
+      );
     },
     onError: (err) => {
       runtime.error?.(`mattermost debounce flush failed: ${String(err)}`);


### PR DESCRIPTION
Closes #71930.

## Problem

In a Mattermost channel where the bot is already running, **adding an @mention by editing an existing message** never wakes the agent. The mention is simply ignored.

## Root cause

The Mattermost WebSocket dispatcher at `extensions/mattermost/src/mattermost/monitor-websocket.ts` filters events by literal string match on `event === "posted"`:

```ts
if (data.event === "posted") {
  // ... parse data.post, dispatch to onPosted
}
// any other event silently dropped
```

`post_edited` carries the **full updated post body** in `data.post` (same shape as `posted` — verified against the Mattermost server WebSocket event schema), but it never reaches the dispatcher branch. The agent has no way to learn that the message it ignored a moment ago now contains an @mention directed at it.

## Reproducer

1. Configure OpenClaw on Mattermost with a bot user `@openclawbot` in some channel.
2. From a different account, post a message **without** mention: `hello world`.
3. Edit that message to add the mention: `hello world @openclawbot`.
4. Observe: bot does not react. Logs show `posted` events but no trace of the edit.

## Fix

Route `post_edited` through the same `parsePostedPayload` → `onPosted` path as `posted`. Mattermost's `post_edited` payload carries the full updated post body in `data.post` (same shape as `posted`), so no new parsing is required.

Implementation:

```ts
// New seam: events that carry data.post and should be re-evaluated.
const POST_BEARING_EVENTS = new Set(["posted", "post_edited"]);

if (POST_BEARING_EVENTS.has(data.event)) {
  if (data.event === "post_edited") {
    log.debug(`mattermost: re-evaluating edited post ${postId} (post_edited)`);
  }
  // ... existing parse + dispatch path, unchanged
}
```

A debug log breadcrumb is emitted on the edit path so dropped vs. handled edits are diffable in logs (satisfies the issue's "at minimum, emit a warning log" ask).

### Why not filter bot-self edits at the WS layer?

The bot-self loop concern (an assistant editing its own past replies) is **already mitigated downstream**:

- `extensions/mattermost/src/mattermost/monitor.ts:1201` drops events where `senderId === botUserId`.
- The post debouncer keys on `post.id`, so an edit of an in-flight post replaces rather than double-fires.

The WebSocket layer is the wrong seam for that filter. The right move here is to **stop dropping the event**.

## Verification

```
pnpm vitest run extensions/mattermost/src/mattermost/monitor-websocket.test.ts
# 12 passed (8 original + 4 new)

pnpm vitest run extensions/mattermost
# 363 passed across 37 mattermost test files, no regressions

pnpm check
# 0 errors, 0 warnings; all policy guards green
```

## Tests added (4 new)

1. **`post_edited` dispatch** — event with full post body in `data.post` reaches `onPosted`; debug log `re-evaluating edited post ...` is emitted (regression for #71930).
2. **`posted` backward-compat** — still dispatches; no edit-log breadcrumb emitted on the non-edit path.
3. **Bot-self `post_edited`** — still forwarded at the WebSocket layer; downstream `monitor.ts` is responsible for filtering.
4. **Malformed `post_edited` (missing `data.post`)** — silently dropped, no crash, no error log.

## Risk notes

- `parsePostedPayload`'s name now slightly understates what it handles (it accepts both `posted` and `post_edited`). Did NOT rename to avoid cascading API churn (it's a public export). The `POST_BEARING_EVENTS` Set + comment block above documents the intent.
- `post_deleted` is **NOT** added — it carries a different payload shape (`post_id` only, no full body) and is out of scope for this PR.
- Diff: +18 lines in `monitor-websocket.ts`, +178 lines in tests.