### PR TITLE
fix(control-ui): keep chat UI mounted across transient reconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI webchat: keep the chat UI mounted across transient WebSocket reconnects (tab refocus, gateway restart, network blips) instead of flashing the full credentials gate every cycle. Track a sticky per-tab `hasEverConnected` flag set on the first successful hello; reset it on explicit auth/pairing failures and on server-initiated revocation closes (code `4001` reasons `gateway auth changed`/`device removed`/`session revoked`) so the gate still appears for genuine re-auth even when no structured error payload is forwarded. Fixes #72500. Thanks @brandco.
 - fix(infra): block workspace state-directory env override [AI]. (#75940) Thanks @pgondhi987.
 - MCP/OpenAI: normalize parameter-free tool schemas whose top-level object `properties` is missing, null, or invalid before sending tools to OpenAI, so MCP tools without params stay usable. Fixes #75362. Thanks @tolkonepiu and @SymbolStar.
 - TTS: honor explicit short `[[tts:text]]...[[/tts:text]]` blocks while keeping untagged short auto-TTS suppressed, so tagged voice replies are synthesized instead of being dropped as empty voice-only payloads. Fixes #73758. Thanks @yfge.

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -141,6 +141,7 @@ function createHost(): TestGatewayHost {
     clientInstanceId: "instance-test",
     client: null,
     connected: false,
+    hasEverConnected: false,
     hello: null,
     lastError: null,
     lastErrorCode: null,
@@ -422,6 +423,68 @@ describe("connectGateway", () => {
     secondClient.emitClose({ code: 1005 });
     expect(host.lastError).toBe("disconnected (1005): no reason");
     expect(host.lastErrorCode).toBeNull();
+  });
+
+  it("sets hasEverConnected sticky flag on first hello and keeps it across transient closes", () => {
+    const host = createHost();
+    expect(host.hasEverConnected).toBe(false);
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    expect(client).toBeDefined();
+
+    client.emitHello();
+    expect(host.connected).toBe(true);
+    expect(host.hasEverConnected).toBe(true);
+
+    // Tab focus / network blip / 1012 service restart should NOT reset the
+    // sticky flag — the renderer keeps the chat UI mounted across these.
+    client.emitClose({ code: 1006 });
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(true);
+
+    // Reconnect cycle restores connected without ever flipping the gate.
+    connectGateway(host);
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(true);
+    const reconnect = gatewayClientInstances[1];
+    reconnect.emitHello();
+    expect(host.connected).toBe(true);
+    expect(host.hasEverConnected).toBe(true);
+  });
+
+  it("clears hasEverConnected on explicit auth-failure close codes", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    client.emitHello();
+    expect(host.hasEverConnected).toBe(true);
+
+    client.emitClose({
+      code: 4001,
+      reason: "unauthorized",
+      error: { code: "AUTH_TOKEN_MISMATCH", message: "bad token" },
+    });
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(false);
+    expect(host.lastErrorCode).toBe("AUTH_TOKEN_MISMATCH");
+  });
+
+  it("clears hasEverConnected on PAIRING_REQUIRED close", () => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    client.emitHello();
+    expect(host.hasEverConnected).toBe(true);
+
+    client.emitClose({
+      code: 4003,
+      reason: "pairing required",
+      error: { code: "PAIRING_REQUIRED", message: "pair first" },
+    });
+    expect(host.hasEverConnected).toBe(false);
   });
 
   it("preserves pending approval requests across reconnect", () => {

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -509,6 +509,77 @@ describe("connectGateway", () => {
     expect(host.hasEverConnected).toBe(true);
   });
 
+  it.each([
+    "gateway auth changed",
+    "gateway auth rotated",
+    "gateway auth revoked",
+    "shared auth changed",
+    "device removed",
+    "device revoked",
+    "session revoked",
+    "pairing revoked",
+  ])(
+    "clears hasEverConnected on code:4001 revocation reason %j with no error payload",
+    (reason) => {
+      // Server-initiated shared-auth rotation, device removal, and session
+      // revocation closes use code 4001 + reason text. The browser client
+      // forwards only `code` + `reason` for post-hello closes (`error` is
+      // populated only from the pending connect error), so without
+      // classifying the code/reason directly the sticky chat UI would
+      // survive explicit revocation. Codex review on #72522.
+      const host = createHost();
+
+      connectGateway(host);
+      const client = gatewayClientInstances[0];
+      client.emitHello();
+      expect(host.hasEverConnected).toBe(true);
+
+      client.emitClose({ code: 4001, reason, error: undefined });
+      expect(host.connected).toBe(false);
+      expect(host.hasEverConnected).toBe(false);
+    },
+  );
+
+  it("keeps hasEverConnected on code:4001 with non-revocation reason and no error payload", () => {
+    // Defensive: only the explicit revocation reason allowlist should drop
+    // the sticky flag. A generic 4001 close (e.g. policy violation that is
+    // not actually a credential rotation) must not be misclassified.
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    client.emitHello();
+    expect(host.hasEverConnected).toBe(true);
+
+    client.emitClose({
+      code: 4001,
+      reason: "policy violation",
+      error: undefined,
+    });
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(true);
+  });
+
+  it("keeps hasEverConnected on non-4001 close even if reason mentions revocation", () => {
+    // Defensive: the reason allowlist only matters when paired with the
+    // canonical 4001 revocation code. A 1006 transient close that happens
+    // to embed the substring must stay sticky.
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    client.emitHello();
+    expect(host.hasEverConnected).toBe(true);
+
+    client.emitClose({
+      code: 1006,
+      reason: "transient: device removed retry",
+      error: undefined,
+    });
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(true);
+  });
+
   it("preserves pending approval requests across reconnect", () => {
     const host = createHost();
     host.execApprovalQueue = [

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -487,6 +487,28 @@ describe("connectGateway", () => {
     expect(host.hasEverConnected).toBe(false);
   });
 
+  it.each([
+    "AUTH_RATE_LIMITED",
+    "AUTH_TAILSCALE_WHOIS_FAILED",
+    "AUTH_TAILSCALE_PROXY_MISSING",
+    "AUTH_TAILSCALE_IDENTITY_MISSING",
+  ])("keeps hasEverConnected on transient infra code %s", (code) => {
+    const host = createHost();
+
+    connectGateway(host);
+    const client = gatewayClientInstances[0];
+    client.emitHello();
+    expect(host.hasEverConnected).toBe(true);
+
+    client.emitClose({
+      code: 1006,
+      reason: "transient",
+      error: { code, message: "transient" },
+    });
+    expect(host.connected).toBe(false);
+    expect(host.hasEverConnected).toBe(true);
+  });
+
   it("preserves pending approval requests across reconnect", () => {
     const host = createHost();
     host.execApprovalQueue = [

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -71,26 +71,49 @@ function isGenericBrowserFetchFailure(message: string): boolean {
 }
 
 /**
+ * Detail codes that represent a genuine credential/identity failure where the
+ * user must re-authenticate. Transient infra codes like `AUTH_RATE_LIMITED`
+ * or the `AUTH_TAILSCALE_*` family are deliberately excluded — those map to
+ * server-side conditions the user can't fix by re-entering credentials, and
+ * treating them as auth failures would re-flash the credentials gate on a
+ * brief WhoIs blip (the exact regression this PR prevents).
+ */
+const AUTH_FAILURE_DETAIL_CODES: ReadonlySet<string> = new Set([
+  ConnectErrorDetailCodes.AUTH_REQUIRED,
+  ConnectErrorDetailCodes.AUTH_UNAUTHORIZED,
+  ConnectErrorDetailCodes.AUTH_TOKEN_MISSING,
+  ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_TOKEN_NOT_CONFIGURED,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_MISSING,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_PASSWORD_NOT_CONFIGURED,
+  ConnectErrorDetailCodes.AUTH_BOOTSTRAP_TOKEN_INVALID,
+  ConnectErrorDetailCodes.AUTH_DEVICE_TOKEN_MISMATCH,
+  ConnectErrorDetailCodes.AUTH_TAILSCALE_IDENTITY_MISMATCH,
+  ConnectErrorDetailCodes.DEVICE_AUTH_INVALID,
+  ConnectErrorDetailCodes.DEVICE_AUTH_DEVICE_ID_MISMATCH,
+  ConnectErrorDetailCodes.DEVICE_AUTH_SIGNATURE_EXPIRED,
+  ConnectErrorDetailCodes.DEVICE_AUTH_NONCE_REQUIRED,
+  ConnectErrorDetailCodes.DEVICE_AUTH_NONCE_MISMATCH,
+  ConnectErrorDetailCodes.DEVICE_AUTH_SIGNATURE_INVALID,
+  ConnectErrorDetailCodes.DEVICE_AUTH_PUBLIC_KEY_INVALID,
+  ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED,
+  ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED,
+  ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED,
+  ConnectErrorDetailCodes.PAIRING_REQUIRED,
+]);
+
+/**
  * Returns true when a gateway close detail code indicates an explicit
  * auth/identity failure that should force the credentials gate to reappear.
- * Pure transport disconnects (network blip, server restart, tab focus) do
- * NOT match here — those keep the sticky `hasEverConnected` flag set so the
+ * Pure transport disconnects (network blip, server restart, tab focus) and
+ * transient infra codes (`AUTH_RATE_LIMITED`, `AUTH_TAILSCALE_WHOIS_FAILED`,
+ * `AUTH_TAILSCALE_PROXY_MISSING`, `AUTH_TAILSCALE_IDENTITY_MISSING`) do NOT
+ * match here — those keep the sticky `hasEverConnected` flag set so the
  * renderer can hold the chat UI mounted across reconnects.
  */
 export function isAuthFailureDetailCode(code: string): boolean {
-  if (!code) {
-    return false;
-  }
-  if (code === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
-    return true;
-  }
-  return (
-    code.startsWith("AUTH_") ||
-    code.startsWith("DEVICE_AUTH_") ||
-    code === ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED ||
-    code === ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED ||
-    code === ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED
-  );
+  return !!code && AUTH_FAILURE_DETAIL_CODES.has(code);
 }
 
 type GatewayHost = {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -104,6 +104,46 @@ const AUTH_FAILURE_DETAIL_CODES: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Reason substrings on `code: 4001` close frames that indicate explicit
+ * server-initiated auth/identity revocation, even when the WebSocket close
+ * carries no structured error payload (e.g. shared-auth rotation closes
+ * shared-auth sockets with reason `gateway auth changed`, device removal
+ * closes with reason `device removed`, and session revocation closes use
+ * `session revoked` / `gateway auth revoked`). The browser client only
+ * forwards `code` + `reason` for these post-hello closes (`error` is set only
+ * for the pending connect error), so the sticky `hasEverConnected` reset has
+ * to look at the close code/reason directly.
+ *
+ * Match on lowercased substrings so reason text variants stay covered
+ * without forcing the gateway to ship structured detail codes for closes
+ * that already use `4001` + reason as the canonical revocation signal.
+ */
+const AUTH_REVOCATION_CLOSE_CODE = 4001;
+const AUTH_REVOCATION_REASON_SUBSTRINGS = [
+  "gateway auth changed",
+  "gateway auth rotated",
+  "gateway auth revoked",
+  "shared auth changed",
+  "shared auth rotated",
+  "shared auth revoked",
+  "device removed",
+  "device revoked",
+  "session revoked",
+  "pairing revoked",
+];
+
+export function isAuthRevocationClose(close: { code?: number; reason?: string }): boolean {
+  if (close.code !== AUTH_REVOCATION_CLOSE_CODE) {
+    return false;
+  }
+  const reason = (close.reason ?? "").toLowerCase();
+  if (!reason) {
+    return false;
+  }
+  return AUTH_REVOCATION_REASON_SUBSTRINGS.some((needle) => reason.includes(needle));
+}
+
+/**
  * Returns true when a gateway close detail code indicates an explicit
  * auth/identity failure that should force the credentials gate to reappear.
  * Pure transport disconnects (network blip, server restart, tab focus) and
@@ -534,8 +574,19 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
         (typeof error?.code === "string" ? error.code : null);
       // If the close looks like an explicit auth/identity failure, drop the
       // sticky hasEverConnected flag so the renderer falls back to the full
-      // credentials gate instead of holding the stale chat UI in place.
+      // credentials gate instead of holding the stale chat UI in place. This
+      // covers two distinct shapes:
+      //   1. Structured error payloads on the connect path (lastErrorCode set
+      //      from resolveGatewayErrorDetailCode) — the original allowlist.
+      //   2. Server-initiated `code: 4001` closes where the browser client
+      //      forwards only `code` + `reason` (no structured error). Shared-auth
+      //      rotation, device removal, and session revocation all use this
+      //      shape, so cached Control UI content would otherwise survive
+      //      explicit revocation until the next reconnect outcome (P2 codex
+      //      finding on #72522).
       if (host.lastErrorCode && isAuthFailureDetailCode(host.lastErrorCode)) {
+        host.hasEverConnected = false;
+      } else if (isAuthRevocationClose({ code, reason })) {
         host.hasEverConnected = false;
       }
       if (code !== 1012) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -70,12 +70,36 @@ function isGenericBrowserFetchFailure(message: string): boolean {
   return /^(?:typeerror:\s*)?(?:fetch failed|failed to fetch)$/i.test(message.trim());
 }
 
+/**
+ * Returns true when a gateway close detail code indicates an explicit
+ * auth/identity failure that should force the credentials gate to reappear.
+ * Pure transport disconnects (network blip, server restart, tab focus) do
+ * NOT match here — those keep the sticky `hasEverConnected` flag set so the
+ * renderer can hold the chat UI mounted across reconnects.
+ */
+export function isAuthFailureDetailCode(code: string): boolean {
+  if (!code) {
+    return false;
+  }
+  if (code === ConnectErrorDetailCodes.PAIRING_REQUIRED) {
+    return true;
+  }
+  return (
+    code.startsWith("AUTH_") ||
+    code.startsWith("DEVICE_AUTH_") ||
+    code === ConnectErrorDetailCodes.DEVICE_IDENTITY_REQUIRED ||
+    code === ConnectErrorDetailCodes.CONTROL_UI_ORIGIN_NOT_ALLOWED ||
+    code === ConnectErrorDetailCodes.CONTROL_UI_DEVICE_IDENTITY_REQUIRED
+  );
+}
+
 type GatewayHost = {
   settings: UiSettings;
   password: string;
   clientInstanceId: string;
   client: GatewayBrowserClient | null;
   connected: boolean;
+  hasEverConnected: boolean;
   hello: GatewayHelloOk | null;
   lastError: string | null;
   lastErrorCode: string | null;
@@ -425,6 +449,7 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       }
       shutdownHost.pendingShutdownMessage = null;
       host.connected = true;
+      host.hasEverConnected = true;
       host.lastError = null;
       host.lastErrorCode = null;
       host.hello = hello;
@@ -484,6 +509,12 @@ export function connectGateway(host: GatewayHost, options?: ConnectGatewayOption
       host.lastErrorCode =
         resolveGatewayErrorDetailCode(error) ??
         (typeof error?.code === "string" ? error.code : null);
+      // If the close looks like an explicit auth/identity failure, drop the
+      // sticky hasEverConnected flag so the renderer falls back to the full
+      // credentials gate instead of holding the stale chat UI in place.
+      if (host.lastErrorCode && isAuthFailureDetailCode(host.lastErrorCode)) {
+        host.hasEverConnected = false;
+      }
       if (code !== 1012) {
         if (error?.message) {
           host.lastError =

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -631,7 +631,14 @@ export function renderApp(state: AppViewState) {
 
   // Gate: require successful gateway connection before showing the dashboard.
   // The gateway URL confirmation overlay is always rendered so URL-param flows still work.
-  if (!state.connected) {
+  //
+  // hasEverConnected lets us keep the chat UI mounted across transient WebSocket
+  // reconnects (e.g. tab refocus, gateway restart) instead of flashing the full
+  // credentials gate every time `connected` briefly toggles to false. The gate
+  // still appears on the very first connect and on explicit auth failures (those
+  // reset hasEverConnected in app-gateway's onClose handler).
+  // See https://github.com/openclaw/openclaw/issues/72500.
+  if (!state.connected && !state.hasEverConnected) {
     return html` ${renderLoginGate(state)} ${renderGatewayUrlConfirmation(state)} `;
   }
 

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -58,6 +58,12 @@ export type AppViewState = {
   onboarding: boolean;
   basePath: string;
   connected: boolean;
+  /**
+   * Sticky flag set on the first successful hello handshake in this tab. Lets
+   * the renderer keep showing the chat UI during transient reconnects instead
+   * of flashing the credentials gate. Cleared on explicit auth failures.
+   */
+  hasEverConnected: boolean;
   theme: ThemeName;
   themeMode: ThemeMode;
   themeResolved: ResolvedTheme;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -158,6 +158,12 @@ export class OpenClawApp extends LitElement {
   @state() tab: Tab = "chat";
   @state() onboarding = resolveOnboardingMode();
   @state() connected = false;
+  // Tracks whether this tab has ever successfully completed a hello handshake.
+  // Used to keep the chat UI mounted across transient WebSocket reconnects (e.g. tab
+  // refocus, gateway restart) instead of flashing the credentials gate. Reset to
+  // false on explicit auth failures so the gate reappears when re-auth is required.
+  // See https://github.com/openclaw/openclaw/issues/72500.
+  @state() hasEverConnected = false;
   @state() theme: ThemeName = this.settings.theme ?? "claw";
   @state() themeMode: ThemeMode = this.settings.themeMode ?? "system";
   @state() themeResolved: ResolvedTheme = "dark";


### PR DESCRIPTION
Fixes #72500.

## Problem

Webchat flashes the full credentials gate every time the browser tab loses and regains focus. On slower hardware (Pi-class) the flash lasts long enough that it looks like a forced logout. Same flash happens on any transient WebSocket close — gateway restart, network blip, brief sleep.

Root cause is exactly what @brandco diagnosed:

1. `app-render.ts` renders `renderLoginGate(state)` unconditionally on `!state.connected`.
2. `app-gateway.ts` flips `connected = false` immediately on every WebSocket close, including expected transient closes when the tab backgrounds.
3. There is no distinction between *"never authenticated"* and *"temporarily disconnected from a known-good session."*

## Fix

Add a sticky `hasEverConnected` flag on the gateway host (and on `AppViewState` / the Lit element). It latches to `true` on the first successful hello handshake. The renderer now only shows the credentials gate when the user has both never connected AND is currently disconnected:

```ts
if (!state.connected && !state.hasEverConnected) {
  return html` ${renderLoginGate(state)} ${renderGatewayUrlConfirmation(state)} `;
}
```

For genuine re-auth (token rotated, password changed, pairing revoked) the flag is cleared in the `onClose` handler when the close detail code matches an auth/pairing failure. New helper `isAuthFailureDetailCode()` catches `AUTH_*`, `DEVICE_AUTH_*`, `PAIRING_REQUIRED`, `DEVICE_IDENTITY_REQUIRED`, and the `CONTROL_UI_*` identity errors from `connect-error-details.ts`.

Plain transport closes (1006, 1012 service restart, network blips) keep the flag set, so the chat UI stays mounted. The existing sidebar `renderSidebarConnectionStatus` already surfaces the offline state via the status dot, satisfying the "non-blocking reconnecting indicator" expectation in the issue without adding a new banner.

## Tests

```
pnpm test ui/src/ui/
# 661 passed (661)
```

Three new tests in `app-gateway.node.test.ts`:

- Sticky flag survives transient `1006` closes and reconnect cycles.
- `AUTH_TOKEN_MISMATCH` close clears the flag → gate reappears.
- `PAIRING_REQUIRED` close clears the flag.

## Diff

5 files, +115/-1.

| File | Change |
|---|---|
| `ui/src/ui/app-gateway.ts` | Add `hasEverConnected` to `GatewayHost`; set in `onHello`; conditionally clear in `onClose`; new `isAuthFailureDetailCode` helper. |
| `ui/src/ui/app-render.ts` | Gate condition now `!connected && !hasEverConnected`. |
| `ui/src/ui/app-view-state.ts` | Add `hasEverConnected` to view state. |
| `ui/src/ui/app.ts` | Add `@state() hasEverConnected = false` to the Lit element. |
| `ui/src/ui/app-gateway.node.test.ts` | Initialize flag + 3 new tests. |

## Out of scope

The issue also suggested a 1–2s debounce on the `connected = false` transition. That's not needed here — the sticky flag already absorbs the transition without any timing dependency, which is more robust on Pi-class hardware where reconnect latency varies wildly.

cc @brandco — would appreciate confirmation this fixes the flash on your Pi 5 setup.
