### PR TITLE
fix(config): add actionable hints to version-mismatch warning on downgrade

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -928,7 +928,12 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
   }
   if (shouldWarnOnTouchedVersion(VERSION, touched)) {
     logger.warn(
-      `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
+      [
+        `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
+        "Some config keys or value formats may be incompatible with this version.",
+        'Run "openclaw doctor --fix" to strip unrecognized keys automatically.',
+        "Keys whose value format changed between versions (e.g. channels.*.streaming) may require manual correction after stripping.",
+      ].join(" "),
     );
   }
 }


### PR DESCRIPTION
## Problem

When a user downgrades from a newer OpenClaw version (e.g. 2026.4.24 → 2026.3.2), `openclaw.json` may contain keys and value formats written by the newer binary that are invalid in the older schema. The gateway currently emits:

> Config was last written by a newer OpenClaw (2026.4.24); current version is 2026.3.2.

...but gives no guidance on what to do next. Users are left with cryptic `Invalid config` errors and a non-functional Discord channel (see #72527).

## Fix

Extend `warnIfConfigFromFuture` to include actionable follow-up hints:

1. **Run `openclaw doctor --fix`** — this already calls `stripUnknownConfigKeys` which removes keys the current Zod schema doesn't recognise (e.g. `agents.defaults.imageGenerationModel` added in 2026.4.x).
2. **Note about value-format changes** — some known keys had their value format changed between versions (e.g. `channels.discord.streaming` migrated from a plain string to an object in 2026.4.x). These cannot be auto-stripped and require manual correction; the warning now says so explicitly.

## Before / After

**Before:**
```
Config was last written by a newer OpenClaw (2026.4.24); current version is 2026.3.2.
```

**After:**
```
Config was last written by a newer OpenClaw (2026.4.24); current version is 2026.3.2. Some config keys or value formats may be incompatible with this version. Run "openclaw doctor --fix" to strip unrecognized keys automatically. Keys whose value format changed between versions (e.g. channels.*.streaming) may require manual correction after stripping.
```

## Related

- Closes #72527
- The Windows ESM Discord crash that triggered real-world downgrade traffic: #71749 (fixed in 2026.4.25-beta.4)

## Testing

Existing `warnIfConfigFromFuture` call sites are covered by integration tests in `io.ts`. No behaviour change for the happy path (same-version or forward configs). The warning is only emitted when `shouldWarnOnTouchedVersion` returns `true`.