### PR TITLE
fix(tts): honor provider timeoutMs in chat synthesis

### DIFF
--- a/extensions/openai/speech-provider.ts
+++ b/extensions/openai/speech-provider.ts
@@ -34,6 +34,7 @@ type OpenAITtsProviderConfig = {
   baseUrl: string;
   model: string;
   voice: string;
+  timeoutMs?: number;
   speed?: number;
   instructions?: string;
   responseFormat?: OpenAiSpeechResponseFormat;
@@ -112,6 +113,7 @@ function normalizeOpenAIProviderConfig(
     ),
     model: trimToUndefined(raw?.model) ?? "gpt-4o-mini-tts",
     voice: trimToUndefined(raw?.voice) ?? "coral",
+    timeoutMs: asFiniteNumber(raw?.timeoutMs),
     speed: asFiniteNumber(raw?.speed),
     instructions: trimToUndefined(raw?.instructions),
     responseFormat: normalizeOpenAISpeechResponseFormat(raw?.responseFormat),
@@ -125,6 +127,7 @@ function readOpenAIProviderConfig(config: SpeechProviderConfig): OpenAITtsProvid
     baseUrl: trimToUndefined(config.baseUrl) ?? normalized.baseUrl,
     model: trimToUndefined(config.model) ?? normalized.model,
     voice: trimToUndefined(config.voice) ?? normalized.voice,
+    timeoutMs: asFiniteNumber(config.timeoutMs) ?? normalized.timeoutMs,
     speed: asFiniteNumber(config.speed) ?? normalized.speed,
     instructions: trimToUndefined(config.instructions) ?? normalized.instructions,
     responseFormat:

--- a/extensions/speech-core/src/tts.test.ts
+++ b/extensions/speech-core/src/tts.test.ts
@@ -459,6 +459,69 @@ describe("speech-core native voice-note routing", () => {
     );
   });
 
+  it("uses provider-level timeoutMs when no explicit timeout is provided", async () => {
+    await synthesizeSpeech({
+      text: "Use provider timeout.",
+      cfg: {
+        messages: {
+          tts: {
+            enabled: true,
+            provider: "mock",
+            timeoutMs: 30_000,
+            providers: {
+              mock: {
+                timeoutMs: 300_000,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(prepareSynthesisMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 300_000,
+      }),
+    );
+    expect(synthesizeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 300_000,
+      }),
+    );
+  });
+
+  it("prefers explicit timeoutMs over provider-level timeoutMs", async () => {
+    await synthesizeSpeech({
+      text: "Use explicit timeout.",
+      timeoutMs: 10_000,
+      cfg: {
+        messages: {
+          tts: {
+            enabled: true,
+            provider: "mock",
+            timeoutMs: 30_000,
+            providers: {
+              mock: {
+                timeoutMs: 300_000,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(prepareSynthesisMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 10_000,
+      }),
+    );
+    expect(synthesizeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        timeoutMs: 10_000,
+      }),
+    );
+  });
+
   it("skips unbound providers under fail policy while allowing bound fallbacks", async () => {
     installSpeechProviders([
       createMockSpeechProvider("mock", { autoSelectOrder: 1 }),

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -1179,6 +1179,11 @@ export async function synthesizeSpeech(params: {
         logVerbose(`TTS: provider ${provider} skipped (${resolvedProvider.message})`);
         continue;
       }
+      const attemptTimeoutMs = resolveProviderAttemptTimeoutMs({
+        explicitTimeoutMs: timeoutMs,
+        providerConfig: resolvedProvider.providerConfig,
+        defaultTimeoutMs: config.timeoutMs,
+      });
       const prepared = await prepareSpeechSynthesis({
         provider: resolvedProvider.provider,
         text: params.text,
@@ -1188,16 +1193,7 @@ export async function synthesizeSpeech(params: {
         persona: resolvedProvider.synthesisPersona,
         personaProviderConfig: resolvedProvider.personaProviderConfig,
         target,
-        timeoutMs: resolveProviderAttemptTimeoutMs({
-          explicitTimeoutMs: timeoutMs,
-          providerConfig: resolvedProvider.providerConfig,
-          defaultTimeoutMs: config.timeoutMs,
-        }),
-      });
-      const providerTimeoutMs = resolveProviderAttemptTimeoutMs({
-        explicitTimeoutMs: timeoutMs,
-        providerConfig: prepared.providerConfig,
-        defaultTimeoutMs: config.timeoutMs,
+        timeoutMs: attemptTimeoutMs,
       });
       const synthesis = await resolvedProvider.provider.synthesize({
         text: prepared.text,
@@ -1205,7 +1201,7 @@ export async function synthesizeSpeech(params: {
         providerConfig: prepared.providerConfig,
         target,
         providerOverrides: prepared.providerOverrides,
-        timeoutMs: providerTimeoutMs,
+        timeoutMs: attemptTimeoutMs,
       });
       const latencyMs = Date.now() - providerStart;
       attempts.push({

--- a/extensions/speech-core/src/tts.ts
+++ b/extensions/speech-core/src/tts.ts
@@ -854,6 +854,29 @@ function sanitizeTtsErrorForLog(err: unknown): string {
   return redactSensitiveText(raw).replace(/\r/g, "\\r").replace(/\n/g, "\\n").replace(/\t/g, "\\t");
 }
 
+function resolveProviderAttemptTimeoutMs(params: {
+  explicitTimeoutMs?: number;
+  providerConfig: SpeechProviderConfig;
+  defaultTimeoutMs: number;
+}): number {
+  const explicitTimeout =
+    typeof params.explicitTimeoutMs === "number" && Number.isFinite(params.explicitTimeoutMs)
+      ? Math.floor(params.explicitTimeoutMs)
+      : undefined;
+  if (typeof explicitTimeout === "number" && explicitTimeout > 0) {
+    return explicitTimeout;
+  }
+  const providerTimeout =
+    typeof params.providerConfig.timeoutMs === "number" &&
+    Number.isFinite(params.providerConfig.timeoutMs)
+      ? Math.floor(params.providerConfig.timeoutMs)
+      : undefined;
+  if (typeof providerTimeout === "number" && providerTimeout > 0) {
+    return providerTimeout;
+  }
+  return params.defaultTimeoutMs;
+}
+
 function buildTtsFailureResult(
   errors: string[],
   attemptedProviders?: string[],
@@ -1117,7 +1140,10 @@ export async function synthesizeSpeech(params: {
   }
 
   const { config, persona, providers } = setup;
-  const timeoutMs = params.timeoutMs ?? config.timeoutMs;
+  const timeoutMs =
+    typeof params.timeoutMs === "number" && Number.isFinite(params.timeoutMs)
+      ? Math.floor(params.timeoutMs)
+      : undefined;
   const target = resolveTtsSynthesisTarget(params.channel);
 
   const errors: string[] = [];
@@ -1162,7 +1188,16 @@ export async function synthesizeSpeech(params: {
         persona: resolvedProvider.synthesisPersona,
         personaProviderConfig: resolvedProvider.personaProviderConfig,
         target,
-        timeoutMs,
+        timeoutMs: resolveProviderAttemptTimeoutMs({
+          explicitTimeoutMs: timeoutMs,
+          providerConfig: resolvedProvider.providerConfig,
+          defaultTimeoutMs: config.timeoutMs,
+        }),
+      });
+      const providerTimeoutMs = resolveProviderAttemptTimeoutMs({
+        explicitTimeoutMs: timeoutMs,
+        providerConfig: prepared.providerConfig,
+        defaultTimeoutMs: config.timeoutMs,
       });
       const synthesis = await resolvedProvider.provider.synthesize({
         text: prepared.text,
@@ -1170,7 +1205,7 @@ export async function synthesizeSpeech(params: {
         providerConfig: prepared.providerConfig,
         target,
         providerOverrides: prepared.providerOverrides,
-        timeoutMs,
+        timeoutMs: providerTimeoutMs,
       });
       const latencyMs = Date.now() - providerStart;
       attempts.push({


### PR DESCRIPTION
## Problem
For chat/non-telephony TTS, long-running OpenAI-compatible backends (for example local MLX TTS proxies) can be configured with `messages.tts.providers.openai.timeoutMs`, but synthesis still times out around the default ~30s and falls back to the next provider.

In practice this causes:
- `openai` attempt fails with timeout at ~30s
- fallback provider (for example ElevenLabs) is used even though the primary backend would have succeeded with a longer timeout

## Root cause
Two things combined to make provider-level timeout ineffective:

1. The non-telephony synthesis path passed a single timeout derived from global TTS config, so provider-specific timeout values were not applied per attempt.
2. OpenAI speech provider config normalization did not preserve `timeoutMs`, so even if set in config it was dropped before synthesis.

## What this changes
- Preserve `messages.tts.providers.openai.timeoutMs` in OpenAI speech provider config normalization.
- Resolve timeout for each non-telephony provider attempt using precedence:
  - explicit request timeout
  - provider config timeout (`providers.<id>.timeoutMs`)
  - global TTS timeout (`messages.tts.timeoutMs`)
- Apply the resolved per-attempt timeout to both `prepareSynthesis` and `synthesize` calls.

## Why this is safe
- Explicit caller-provided timeout still has highest precedence.
- Global timeout remains fallback behavior when provider timeout is not set.
- Telephony path is unchanged.

## Tests
Added regression coverage in `extensions/speech-core/src/tts.test.ts` for:
- provider timeout used when no explicit timeout is supplied
- explicit timeout overriding provider timeout

## Validation
- [x] `corepack pnpm -s node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-fast.config.ts extensions/speech-core/src/tts.test.ts`
- [x] Manual local validation with long-running MLX/OpenAI-compatible TTS backend (no ~30s fallback timeout)

Made with [Cursor](https://cursor.com)