### PR TITLE
fix: show daily log dreaming entries by dailyCount

### DIFF
--- a/ui/src/ui/views/dreaming.test.ts
+++ b/ui/src/ui/views/dreaming.test.ts
@@ -522,6 +522,60 @@ describe("dreaming view", () => {
     setDreamSubTab("scene");
   });
 
+  it("labels daily-only and grounded-only waiting entries as daily log origins", () => {
+    setDreamSubTab("advanced");
+    setDreamAdvancedWaitingSort("recent");
+    const shortTermEntries = [
+      {
+        key: "memory:daily-only",
+        path: "memory/2026-04-05.md",
+        startLine: 1,
+        endLine: 1,
+        snippet: "Daily-only replay",
+        recallCount: 0,
+        dailyCount: 2,
+        groundedCount: 0,
+        totalSignalCount: 2,
+        lightHits: 0,
+        remHits: 0,
+        phaseHitCount: 0,
+        lastRecalledAt: "2026-04-06T12:00:00.000Z",
+      },
+      {
+        key: "memory:grounded-only",
+        path: "memory/2026-04-04.md",
+        startLine: 1,
+        endLine: 1,
+        snippet: "Grounded-only replay",
+        recallCount: 0,
+        dailyCount: 0,
+        groundedCount: 3,
+        totalSignalCount: 3,
+        lightHits: 0,
+        remHits: 1,
+        phaseHitCount: 1,
+        lastRecalledAt: "2026-04-04T12:00:00.000Z",
+      },
+    ];
+
+    const container = renderInto(
+      buildProps({
+        shortTermEntries,
+        promotedEntries: [],
+      }),
+    );
+
+    const badges = [...container.querySelectorAll(".dreams-advanced__badge")].map((node) =>
+      node.textContent?.trim(),
+    );
+    expect(badges.filter((badge) => badge === "replayed").length).toBeGreaterThanOrEqual(2);
+    expect(container.querySelector(".dreams-advanced__summary")?.textContent).toContain(
+      "1 from daily log",
+    );
+    setDreamAdvancedWaitingSort("recent");
+    setDreamSubTab("scene");
+  });
+
   it("sorts waiting entries by strongest support without swapping datasets", () => {
     setDreamSubTab("advanced");
     const shortTermEntries = [
@@ -547,8 +601,8 @@ describe("dreaming view", () => {
         endLine: 1,
         snippet: "Older but strongly supported",
         recallCount: 5,
-        dailyCount: 4,
-        groundedCount: 0,
+        dailyCount: 0,
+        groundedCount: 4,
         totalSignalCount: 9,
         lightHits: 2,
         remHits: 1,

--- a/ui/src/ui/views/dreaming.ts
+++ b/ui/src/ui/views/dreaming.ts
@@ -680,11 +680,12 @@ function sortWaitingEntries(entries: DreamingEntry[], sort: AdvancedWaitingSort)
 
 function describeWaitingEntryOrigin(entry: DreamingEntry): string {
   const hasGroundedReplay = entry.groundedCount > 0;
-  const hasLiveSupport = entry.recallCount > 0 || entry.dailyCount > 0;
+  const hasDailyLog = entry.dailyCount > 0;
+  const hasLiveSupport = entry.recallCount > 0 || hasDailyLog;
   if (hasGroundedReplay && hasLiveSupport) {
     return t("dreaming.advanced.originMixed");
   }
-  if (hasGroundedReplay) {
+  if (hasDailyLog || hasGroundedReplay) {
     return t("dreaming.advanced.originDailyLog");
   }
   return t("dreaming.advanced.originLive");
@@ -746,11 +747,11 @@ function renderAdvancedEntryList(params: {
 }
 
 function renderAdvancedSection(props: DreamingProps) {
-  const groundedEntries = props.shortTermEntries.filter((entry) => entry.groundedCount > 0);
+  const dailyEntries = props.shortTermEntries.filter((entry) => entry.dailyCount > 0);
   const waitingEntries = sortWaitingEntries(props.shortTermEntries, _advancedWaitingSort);
   const description = t("dreaming.advanced.description");
   const summary = [
-    `${groundedEntries.length} ${t("dreaming.advanced.summaryFromDailyLog")}`,
+    `${dailyEntries.length} ${t("dreaming.advanced.summaryFromDailyLog")}`,
     `${props.shortTermCount} ${t("dreaming.advanced.summaryWaiting")}`,
     `${props.promotedCount} ${t("dreaming.advanced.summaryPromotedToday")}`,
   ].join(" · ");
@@ -837,7 +838,7 @@ function renderAdvancedSection(props: DreamingProps) {
           titleKey: "dreaming.advanced.stagedTitle",
           descriptionKey: "dreaming.advanced.stagedDescription",
           emptyKey: "dreaming.advanced.emptyGrounded",
-          entries: groundedEntries,
+          entries: dailyEntries,
           controls: html`
             <button
               class="btn btn--subtle btn--sm"
@@ -849,11 +850,11 @@ function renderAdvancedSection(props: DreamingProps) {
           `,
           badge: () => t("dreaming.advanced.originDailyLog"),
           meta: (entry) => [
+            entry.dailyCount > 0 ? `${entry.dailyCount} daily` : "",
+            entry.recallCount > 0 ? `${entry.recallCount} recall` : "",
             entry.groundedCount > 0
               ? `${entry.groundedCount} ${t("dreaming.stats.grounded").toLowerCase()}`
               : "",
-            entry.recallCount > 0 ? `${entry.recallCount} recall` : "",
-            entry.dailyCount > 0 ? `${entry.dailyCount} daily` : "",
           ],
         })}
         ${renderAdvancedEntryList({


### PR DESCRIPTION
## Summary

Fixes the remaining Daily Log Review mapping from #68904.

PR #68942 updates the waiting-entry badge/origin label to use `dailyCount`, but the Advanced tab summary and staged "From Daily Log" section still used `groundedCount`-derived entries. That means a store with many `dailyCount > 0` entries and no grounded replay entries still renders the Daily Log section as empty/misleading.

This PR updates the Advanced tab to:

- use `dailyCount > 0` for the "From Daily Log" summary count
- render the "From Daily Log" staged section from daily-log-backed entries
- keep grounded replay information visible in the entry metadata when present
- keep the waiting-entry origin badge aligned with `dailyCount > 0`

## Test plan

- `pnpm format:check -- ui/src/ui/views/dreaming.ts ui/src/ui/views/dreaming.test.ts`
- `pnpm tsgo:test:ui`
- `pnpm --filter openclaw-control-ui exec vitest run --config vitest.config.ts src/ui/views/dreaming.test.ts`

Note: I also tried `pnpm --dir ui test`; unrelated style tests failed because they resolve paths as `ui/ui/src/...` when run from `ui/`. The targeted dreaming view test passes.
