### PR TITLE
feat: expand thinking level options to include xhigh, adaptive, max

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -20,8 +20,9 @@ title: "Thinking levels"
   - `highest` maps to `high`.
 - Provider notes:
   - Thinking menus and pickers are provider-profile driven. Provider plugins declare the exact level set for the selected model, including labels such as binary `on`.
-  - `adaptive`, `xhigh`, and `max` are only advertised for provider/model profiles that support them. Typed directives for unsupported levels are rejected with that model's valid options.
-  - Existing stored unsupported levels are remapped by provider profile rank. `adaptive` falls back to `medium` on non-adaptive models, while `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
+  - All eight levels (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`, `max`) are available in the dropdown for non-binary providers. When a selected level isn't natively supported by the current model, OpenClaw maps it to the nearest supported level by rank.
+  - Binary thinking providers (e.g., Z.AI) only show `off`/`on` and do not expose `xhigh`, `adaptive`, or `max`.
+  - Existing stored unsupported levels are remapped by provider profile rank. `adaptive` falls back to `high` on non-adaptive models, while `xhigh` and `max` fall back to the largest supported non-off level for the selected model.
   - Anthropic Claude 4.6 models default to `adaptive` when no explicit thinking level is set.
   - Anthropic Claude Opus 4.7 does not default to adaptive thinking. Its API effort default remains provider-owned unless you explicitly set a thinking level.
   - Anthropic Claude Opus 4.7 maps `/think xhigh` to adaptive thinking plus `output_config.effort: "xhigh"`, because `/think` is a thinking directive and `xhigh` is the Opus 4.7 effort setting.

--- a/src/auto-reply/thinking.shared.ts
+++ b/src/auto-reply/thinking.shared.ts
@@ -28,15 +28,24 @@ export type ThinkingCatalogEntry = {
   reasoning?: boolean;
 };
 
-export const BASE_THINKING_LEVELS: ThinkLevel[] = ["off", "minimal", "low", "medium", "high"];
+export const BASE_THINKING_LEVELS: ThinkLevel[] = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "adaptive",
+  "max",
+];
 export const THINKING_LEVEL_RANKS: Record<ThinkLevel, number> = {
   off: 0,
   minimal: 10,
   low: 20,
   medium: 30,
   high: 40,
-  adaptive: 30,
-  xhigh: 60,
+  xhigh: 50,
+  adaptive: 55,
   max: 70,
 };
 const NO_THINKING_LEVELS: ThinkLevel[] = [...BASE_THINKING_LEVELS];

--- a/src/auto-reply/thinking.test.ts
+++ b/src/auto-reply/thinking.test.ts
@@ -122,17 +122,17 @@ describe("listThinkingLevels", () => {
     expect(listThinkingLevels("github-copilot", "gpt-5.4")).toContain("xhigh");
   });
 
-  it("excludes xhigh for non-codex models", () => {
-    expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("xhigh");
+  it("includes xhigh for all non-binary providers", () => {
+    expect(listThinkingLevels(undefined, "gpt-4.1-mini")).toContain("xhigh");
   });
 
-  it("does not include max without provider support", () => {
-    expect(listThinkingLevels("openai", "gpt-5.4")).not.toContain("max");
+  it("includes max for all non-binary providers", () => {
+    expect(listThinkingLevels("openai", "gpt-5.4")).toContain("max");
   });
 
-  it("does not include adaptive without provider support", () => {
-    expect(listThinkingLevels(undefined, "gpt-4.1-mini")).not.toContain("adaptive");
-    expect(listThinkingLevels("openai", "gpt-5.4")).not.toContain("adaptive");
+  it("includes adaptive for all non-binary providers", () => {
+    expect(listThinkingLevels(undefined, "gpt-4.1-mini")).toContain("adaptive");
+    expect(listThinkingLevels("openai", "gpt-5.4")).toContain("adaptive");
   });
 
   it("uses provider thinking profiles for adaptive and max support", () => {
@@ -184,7 +184,7 @@ describe("listThinkingLevels", () => {
     ).toBe("high");
   });
 
-  it("maps unsupported adaptive to medium and unsupported xhigh to high", () => {
+  it("maps unsupported adaptive to high and unsupported xhigh to high", () => {
     providerRuntimeMocks.resolveProviderThinkingProfile.mockReturnValue({
       levels: [{ id: "off" }, { id: "minimal" }, { id: "low" }, { id: "medium" }, { id: "high" }],
     });
@@ -195,7 +195,7 @@ describe("listThinkingLevels", () => {
         model: "gpt-5.4",
         level: "adaptive",
       }),
-    ).toBe("medium");
+    ).toBe("high");
     expect(
       resolveSupportedThinkingLevel({
         provider: "openai",
@@ -211,6 +211,15 @@ describe("listThinkingLevelLabels", () => {
     providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
 
     expect(listThinkingLevelLabels("demo", "demo-model")).toEqual(["off", "on"]);
+  });
+
+  it("excludes xhigh, adaptive, and max for binary thinking providers", () => {
+    providerRuntimeMocks.resolveProviderBinaryThinking.mockReturnValue(true);
+
+    const levels = listThinkingLevels("demo", "demo-model");
+    expect(levels).not.toContain("xhigh");
+    expect(levels).not.toContain("adaptive");
+    expect(levels).not.toContain("max");
   });
 
   it("returns on/off for provider-advertised binary thinking", () => {

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -174,13 +174,21 @@ export function resolveThinkingProfile(params: {
     provider: context.normalizedProvider,
     modelId: context.modelKey || context.modelId,
   };
-  if (
-    resolveProviderXHighThinking({
-      provider: context.normalizedProvider,
-      context: policyContext,
-    }) === true
-  ) {
-    appendProfileLevel(profile, "xhigh");
+  // Append advanced levels for non-binary thinking providers.
+  // Binary providers (off/on) should not expose xhigh/adaptive/max.
+  // For base profiles, these are already in BASE_THINKING_LEVELS.
+  // For plugin profiles, this ensures they're added if supported.
+  if (binaryDecision !== true) {
+    if (
+      resolveProviderXHighThinking({
+        provider: context.normalizedProvider,
+        context: policyContext,
+      }) === true
+    ) {
+      appendProfileLevel(profile, "xhigh");
+    }
+    appendProfileLevel(profile, "adaptive");
+    appendProfileLevel(profile, "max");
   }
   return profile;
 }

--- a/ui/src/ui/thinking.ts
+++ b/ui/src/ui/thinking.ts
@@ -6,7 +6,7 @@ export type ThinkingCatalogEntry = {
   reasoning?: boolean;
 };
 
-const BASE_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
+const BASE_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"] as const;
 
 export function normalizeThinkingProviderId(provider?: string | null): string {
   if (!provider) {

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -65,7 +65,17 @@ export type SessionsProps = {
   onRestoreCheckpoint: (sessionKey: string, checkpointId: string) => void | Promise<void>;
 };
 
-const DEFAULT_THINK_LEVELS = ["off", "minimal", "low", "medium", "high"] as const;
+const DEFAULT_THINK_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh", "adaptive", "max"] as const;
+const THINKING_LEVEL_LABELS: Record<string, string> = {
+  off: "off",
+  minimal: "minimal",
+  low: "low",
+  medium: "medium",
+  high: "high",
+  xhigh: "extra high",
+  adaptive: "adaptive",
+  max: "maximum",
+};
 const VERBOSE_LEVELS = [
   { value: "", label: "inherit" },
   { value: "off", label: "off (explicit)" },
@@ -84,6 +94,15 @@ function normalizeThinkingOptionValue(raw: string): string {
   return normalizeThinkLevel(raw) ?? normalizeLowercaseStringOrEmpty(raw);
 }
 
+function applyThinkingLabel(id: string, fallback: string): string {
+  // Only apply friendly labels when the provider label matches the raw id
+  // (i.e., no custom label was given). Preserve custom provider labels like "on".
+  if (fallback === id) {
+    return THINKING_LEVEL_LABELS[id] ?? fallback;
+  }
+  return fallback;
+}
+
 function resolveThinkLevelOptions(
   row: GatewaySessionRow,
 ): readonly { value: string; label: string }[] {
@@ -97,7 +116,7 @@ function resolveThinkLevelOptions(
     { value: "", label: "inherit" },
     ...options.map((option) => ({
       value: normalizeThinkingOptionValue(option.id),
-      label: option.label,
+      label: applyThinkingLabel(normalizeThinkingOptionValue(option.id), option.label),
     })),
   ];
 }


### PR DESCRIPTION
## Summary

The OpenClaw Control UI thinking level dropdown only shows 5 of 8 supported levels. This PR expands it to show all 8 levels (off, minimal, low, medium, high, xhigh, adaptive, max) with friendly labels for non-binary providers.

## Changes

### Backend (`src/auto-reply/thinking.shared.ts`, `thinking.ts`)
- Expand `BASE_THINKING_LEVELS` from 5 to 8 levels
- Fix adaptive rank collision: 30 → 55 (was same as medium, now between high=40 and xhigh=50)
- Fix xhigh rank: 60 → 50 (now properly ordered)
- Gate all advanced levels (xhigh/adaptive/max) behind `binaryDecision !== true` check
- Binary providers (off/on only) correctly excluded from advanced levels

### Frontend (`ui/src/ui/thinking.ts`, `views/sessions.ts`)
- Expand `DEFAULT_THINK_LEVELS` to match backend
- Add friendly labels: "extra high" for xhigh, "maximum" for max
- Preserve custom provider labels (e.g., binary `on` label for `low`)

### Tests (`thinking.test.ts`)
- Update tests to match new always-visible behavior for non-binary providers
- Add test for binary provider exclusion of xhigh/adaptive/max
- Update fallback mapping test (adaptive now maps to high, not medium)

### Docs (`docs/tools/thinking.md`)
- Update provider notes to reflect new behavior

## Behavior Change

**Before:** xhigh, adaptive, and max only appeared for providers that explicitly declared support.

**After:** All 8 levels appear in the dropdown for non-binary providers. When a selected level isn't natively supported by the current model, OpenClaw maps it to the nearest supported level by rank (graceful degradation already existed).

Binary providers (e.g., Z.AI) continue to show only off/on.

## Testing

- 37/37 tests pass
- Verified binary providers still only show off/on
- Verified custom provider labels (like "on") are preserved
- Verified fallback mapping works correctly with new ranks

## Related

Fixes the GUI limitation where users couldn't access xhigh/adaptive/max from the dropdown even though the backend supported them via `/think:xhigh` etc.