### PR TITLE
fix: align thinking default label with config

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -139,6 +139,23 @@ describe("gateway session utils", () => {
     );
   });
 
+  test("session defaults honor configured thinking default and per-model override", () => {
+    const defaults = getSessionDefaults({
+      agents: {
+        defaults: {
+          model: { primary: "ollama/gemma4:hermes-e4b" },
+          thinkingDefault: "adaptive",
+          models: {
+            "ollama/gemma4:hermes-e4b": { params: { thinking: "adaptive" } },
+            "ollama/gemma4:26b": { params: { thinking: "off" } },
+          },
+        },
+      },
+    } as OpenClawConfig);
+
+    expect(defaults.thinkingDefault).toBe("adaptive");
+  });
+
   test("classifySessionKey respects chat type + prefixes", () => {
     expect(classifySessionKey("global")).toBe("global");
     expect(classifySessionKey("unknown")).toBe("unknown");
@@ -905,6 +922,36 @@ describe("listSessionsFromStore selected model display", () => {
 
     expect(result.sessions[0]?.modelProvider).toBe("anthropic");
     expect(result.sessions[0]?.model).toBe("claude-opus-4-6");
+  });
+
+  test("uses config-aware thinking default for session rows", () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          model: { primary: "ollama/gemma4:hermes-e4b" },
+          thinkingDefault: "adaptive",
+          models: {
+            "ollama/gemma4:hermes-e4b": { params: { thinking: "adaptive" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = listSessionsFromStore({
+      cfg,
+      storePath: "/tmp/sessions.json",
+      store: {
+        "agent:main:main": {
+          sessionId: "sess-main",
+          updatedAt: Date.now(),
+          modelProvider: "ollama",
+          model: "gemma4:hermes-e4b",
+        } as SessionEntry,
+      },
+      opts: {},
+    });
+
+    expect(result.sessions[0]?.thinkingDefault).toBe("adaptive");
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -17,6 +17,7 @@ import {
   resolveConfiguredModelRef,
   resolveDefaultModelForAgent,
   resolvePersistedSelectedModelRef,
+  resolveThinkingDefault,
 } from "../agents/model-selection.js";
 import {
   countActiveDescendantRuns,
@@ -31,10 +32,7 @@ import {
   RECENT_ENDED_SUBAGENT_CHILD_SESSION_MS,
   shouldKeepSubagentRunChildLink,
 } from "../agents/subagent-run-liveness.js";
-import {
-  listThinkingLevelOptions,
-  resolveThinkingDefaultForModel,
-} from "../auto-reply/thinking.js";
+import { listThinkingLevelOptions } from "../auto-reply/thinking.js";
 import { loadConfig } from "../config/config.js";
 import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -1055,7 +1053,8 @@ export function getSessionDefaults(cfg: OpenClawConfig): GatewaySessionsDefaults
     contextTokens: contextTokens ?? null,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
+    thinkingDefault: resolveThinkingDefault({
+      cfg,
       provider: resolved.provider,
       model: resolved.model,
     }),
@@ -1429,7 +1428,8 @@ export function buildGatewaySessionRow(params: {
     thinkingLevel: entry?.thinkingLevel,
     thinkingLevels,
     thinkingOptions: thinkingLevels.map((level) => level.label),
-    thinkingDefault: resolveThinkingDefaultForModel({
+    thinkingDefault: resolveThinkingDefault({
+      cfg,
       provider: thinkingProvider,
       model: thinkingModel,
     }),


### PR DESCRIPTION
## Summary
Align the Control UI thinking default label with the same config-aware precedence the backend already uses.

## Changes
- switch gateway session/default thinking resolution from the model-only heuristic to `resolveThinkingDefault(...)`
- keep session rows and defaults aligned with configured `agents.defaults.thinkingDefault` and per-model `params.thinking`
- add regression coverage for both session defaults and session rows

## Testing
- `pnpm vitest run src/gateway/session-utils.test.ts`

Fixes openclaw/openclaw#72407