### PR TITLE
fix(discord): humanize thread and failure delivery

### DIFF
--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -96,7 +96,11 @@ describe("discord config schema", () => {
           requireMention: false,
           users: ["steipete"],
           channels: {
-            general: { enabled: true, autoThread: true },
+            general: {
+              enabled: true,
+              autoThread: true,
+              autoThreadGate: { minChars: 24, taskMinChars: 6, longTaskChars: 96 },
+            },
           },
         },
       },
@@ -111,6 +115,11 @@ describe("discord config schema", () => {
     expect(cfg.guilds?.["123"]?.slug).toBe("friends-of-openclaw");
     expect(cfg.guilds?.["123"]?.channels?.general?.enabled).toBe(true);
     expect(cfg.guilds?.["123"]?.channels?.general?.autoThread).toBe(true);
+    expect(cfg.guilds?.["123"]?.channels?.general?.autoThreadGate).toEqual({
+      minChars: 24,
+      taskMinChars: 6,
+      longTaskChars: 96,
+    });
   });
 
   it("accepts voice model override field", () => {

--- a/extensions/discord/src/monitor/allow-list.ts
+++ b/extensions/discord/src/monitor/allow-list.ts
@@ -23,6 +23,14 @@ export type DiscordAllowListMatch = AllowlistMatch<"wildcard" | "id" | "name" | 
 
 const DISCORD_OWNER_ALLOWLIST_PREFIXES = ["discord:", "user:", "pk:"];
 
+type DiscordAutoThreadGateConfig =
+  | false
+  | {
+      minChars?: number;
+      taskMinChars?: number;
+      longTaskChars?: number;
+    };
+
 type DiscordChannelOverrideConfig = {
   requireMention?: boolean;
   ignoreOtherMentions?: boolean;
@@ -33,6 +41,7 @@ type DiscordChannelOverrideConfig = {
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
+  autoThreadGate?: DiscordAutoThreadGateConfig;
   autoThreadName?: "message" | "generated";
   autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
 };
@@ -406,6 +415,7 @@ function resolveDiscordChannelConfigEntry(
     systemPrompt: entry.systemPrompt,
     includeThreadStarter: entry.includeThreadStarter,
     autoThread: entry.autoThread,
+    autoThreadGate: entry.autoThreadGate,
     autoThreadName: entry.autoThreadName,
     autoArchiveDuration: entry.autoArchiveDuration,
   };

--- a/extensions/discord/src/monitor/monitor.threading-utils.test.ts
+++ b/extensions/discord/src/monitor/monitor.threading-utils.test.ts
@@ -442,6 +442,7 @@ describe("maybeCreateDiscordAutoThread", () => {
       isGuildMessage: true,
       channelConfig: {
         autoThread: true,
+        autoThreadGate: false,
       } as unknown as DiscordChannelConfigResolved,
       threadChannel: null,
       baseText: "hello",
@@ -500,7 +501,7 @@ describe("resolveDiscordAutoThreadReplyPlan", () => {
       isGuildMessage: true,
       channelConfig:
         overrides?.channelConfig ??
-        ({ autoThread: true } as unknown as DiscordChannelConfigResolved),
+        ({ autoThread: true, autoThreadGate: false } as unknown as DiscordChannelConfigResolved),
       threadChannel: overrides?.threadChannel ?? null,
       baseText: "hello",
       combinedBody: "hello",

--- a/extensions/discord/src/monitor/threading.auto-thread.test.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.test.ts
@@ -36,8 +36,8 @@ function createBaseParams(
     isGuildMessage: true,
     channelConfig: { allowed: true, autoThread: true },
     channelType: ChannelType.GuildText,
-    baseText: "test",
-    combinedBody: "test",
+    baseText: "fix test issue",
+    combinedBody: "fix test issue",
     cfg: EMPTY_DISCORD_TEST_CONFIG,
     ...overrides,
   };
@@ -313,6 +313,67 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
     expect(result).toBe("thread1");
     await flushAsyncWork();
     expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("skips casual short pings", async () => {
+    const result = await maybeCreateDiscordAutoThread(
+      createBaseParams({
+        baseText: "yo",
+        combinedBody: "yo",
+      }),
+    );
+    expect(result).toBeUndefined();
+    expect(postMock).not.toHaveBeenCalled();
+  });
+
+  it("threads links and task-like requests", async () => {
+    postMock.mockResolvedValueOnce({ id: "link-thread" });
+    await expect(
+      maybeCreateDiscordAutoThread(
+        createBaseParams({
+          baseText: "https://example.com/report",
+          combinedBody: "https://example.com/report",
+        }),
+      ),
+    ).resolves.toBe("link-thread");
+
+    postMock.mockResolvedValueOnce({ id: "task-thread" });
+    await expect(
+      maybeCreateDiscordAutoThread(
+        createBaseParams({
+          baseText: "fix this",
+          combinedBody: "fix this",
+        }),
+      ),
+    ).resolves.toBe("task-thread");
+  });
+
+  it("allows legacy always-thread behavior when autoThreadGate is false", async () => {
+    postMock.mockResolvedValueOnce({ id: "thread1" });
+    const result = await maybeCreateDiscordAutoThread(
+      createBaseParams({
+        baseText: "yo",
+        combinedBody: "yo",
+        channelConfig: { allowed: true, autoThread: true, autoThreadGate: false },
+      }),
+    );
+    expect(result).toBe("thread1");
+  });
+
+  it("honors custom autoThreadGate thresholds", async () => {
+    const result = await maybeCreateDiscordAutoThread(
+      createBaseParams({
+        baseText: "fix it",
+        combinedBody: "fix it",
+        channelConfig: {
+          allowed: true,
+          autoThread: true,
+          autoThreadGate: { taskMinChars: 20 },
+        },
+      }),
+    );
+    expect(result).toBeUndefined();
+    expect(postMock).not.toHaveBeenCalled();
   });
 
   it("skips thread creation when autoThread is false", async () => {

--- a/extensions/discord/src/monitor/threading.ts
+++ b/extensions/discord/src/monitor/threading.ts
@@ -83,6 +83,97 @@ type DiscordThreadStarterRestMessage = {
 };
 type DiscordMessageEvent = Parameters<MessageCreateListener["handle"]>[0];
 
+const DISCORD_AUTO_THREAD_MIN_CHARS = 30;
+const DISCORD_AUTO_THREAD_STRONG_TASK_MIN_CHARS = 8;
+const DISCORD_AUTO_THREAD_LONG_TASK_CHARS = 80;
+const DISCORD_CASUAL_THREAD_BLOCKLIST =
+  /^(yo|hi|hey|hello|sup|ok|okay|thanks|thank you|cool|nice|bet|gm|gn|ping|test|testing|status|status\?|update\?|done\?|all good\?|you there\?|quick check)$/i;
+const DISCORD_TASK_INTENT_RE =
+  /\b(fix|run|check|review|merge|audit|implement|build|create|update|debug|investigate|verify|clean|summarize|find|search|look up|schedule|remind|send|post|email|open|test|ship|continue|proceed|deploy|restart|triage|compare|explain|help)\b/i;
+const DISCORD_URL_RE = /https?:\/\/|discord\.com\/channels\//i;
+
+type DiscordAutoThreadGateResolved = Exclude<
+  NonNullable<DiscordChannelConfigResolved["autoThreadGate"]>,
+  false
+>;
+
+function hasDiscordThreadWorthyAttachment(message: MaybeCreateDiscordAutoThreadParams["message"]) {
+  const withAttachments = message as {
+    attachments?: unknown;
+    embeds?: unknown[];
+    message_snapshots?: unknown[];
+  };
+  const attachments = withAttachments.attachments;
+  if (Array.isArray(attachments)) {
+    return attachments.length > 0;
+  }
+  if (attachments && typeof (attachments as { size?: unknown }).size === "number") {
+    return ((attachments as { size: number }).size ?? 0) > 0;
+  }
+  if (Array.isArray(withAttachments.embeds) && withAttachments.embeds.length > 0) {
+    return true;
+  }
+  if (
+    Array.isArray(withAttachments.message_snapshots) &&
+    withAttachments.message_snapshots.length > 0
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function normalizeDiscordAutoThreadGateConfig(
+  channelConfig?: DiscordChannelConfigResolved | null,
+): DiscordAutoThreadGateResolved {
+  const gate = channelConfig?.autoThreadGate;
+  return gate && typeof gate === "object" && !Array.isArray(gate) ? gate : {};
+}
+
+export function shouldCreateDiscordAutoThreadForMessage(
+  params: MaybeCreateDiscordAutoThreadParams,
+) {
+  if (params.channelConfig?.autoThreadGate === false) {
+    return true;
+  }
+  const gate = normalizeDiscordAutoThreadGateConfig(params.channelConfig);
+  const rawText = (params.baseText || params.combinedBody || "")
+    .replace(/<@!?\d+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (hasDiscordThreadWorthyAttachment(params.message)) {
+    return true;
+  }
+  if (DISCORD_URL_RE.test(rawText)) {
+    return true;
+  }
+  const lower = rawText.toLowerCase();
+  if (!lower) {
+    return false;
+  }
+  if (DISCORD_CASUAL_THREAD_BLOCKLIST.test(lower)) {
+    return false;
+  }
+  const minChars = Math.max(1, Math.floor(gate.minChars ?? DISCORD_AUTO_THREAD_MIN_CHARS));
+  const taskMinChars = Math.max(
+    1,
+    Math.floor(gate.taskMinChars ?? DISCORD_AUTO_THREAD_STRONG_TASK_MIN_CHARS),
+  );
+  const longTaskChars = Math.max(
+    minChars,
+    Math.floor(gate.longTaskChars ?? DISCORD_AUTO_THREAD_LONG_TASK_CHARS),
+  );
+  if (rawText.length >= longTaskChars) {
+    return true;
+  }
+  if (rawText.length >= taskMinChars && DISCORD_TASK_INTENT_RE.test(rawText)) {
+    return true;
+  }
+  if (rawText.length < minChars) {
+    return false;
+  }
+  return rawText.endsWith("?") || DISCORD_TASK_INTENT_RE.test(rawText);
+}
+
 // Cache entry with timestamp for TTL-based eviction
 type DiscordThreadStarterCacheEntry = {
   value: DiscordThreadStarter;
@@ -517,6 +608,9 @@ export async function maybeCreateDiscordAutoThread(
     params.channelType === ChannelType.GuildVoice ||
     params.channelType === ChannelType.GuildStageVoice
   ) {
+    return undefined;
+  }
+  if (!shouldCreateDiscordAutoThreadForMessage(params)) {
     return undefined;
   }
 

--- a/extensions/discord/src/send.sends-basic-channel-messages.test.ts
+++ b/extensions/discord/src/send.sends-basic-channel-messages.test.ts
@@ -95,6 +95,10 @@ describe("sendMessageDiscord", () => {
     });
   }
 
+  function expectNoReplyReference(body: { message_reference?: unknown } | undefined) {
+    expect(body).not.toHaveProperty("message_reference");
+  }
+
   async function sendChunkedReplyAndCollectBodies(params: { text: string; mediaUrl?: string }) {
     const { rest, postMock } = makeDiscordRest();
     postMock.mockResolvedValue({ id: "msg1", channel_id: "789" });
@@ -503,21 +507,21 @@ describe("sendMessageDiscord", () => {
     });
   });
 
-  it("preserves reply reference across all text chunks", async () => {
+  it("includes reply reference only on the first text chunk", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2001),
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expectNoReplyReference(secondBody);
   });
 
-  it("preserves reply reference for follow-up text chunks after media caption split", async () => {
+  it("includes reply reference only on the media caption when caption text splits", async () => {
     const { firstBody, secondBody } = await sendChunkedReplyAndCollectBodies({
       text: "a".repeat(2500),
       mediaUrl: "file:///tmp/photo.jpg",
     });
     expectReplyReference(firstBody, "orig-123");
-    expectReplyReference(secondBody, "orig-123");
+    expectNoReplyReference(secondBody);
   });
 });
 

--- a/extensions/discord/src/send.shared.test.ts
+++ b/extensions/discord/src/send.shared.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildDiscordTextChunks, sanitizeDiscordDeliveryText } from "./send.shared.js";
+
+describe("sanitizeDiscordDeliveryText", () => {
+  it("strips memory citation blocks and internal announcement scaffolding", () => {
+    const input = [
+      "Discord announcement to send:",
+      "Done.",
+      "<oai-mem-citation>",
+      "<citation_entries>",
+      "memory/foo.md:1-2|note=[internal]",
+      "</citation_entries>",
+      "</oai-mem-citation>",
+    ].join("\n");
+
+    expect(sanitizeDiscordDeliveryText(input)).toBe("Done.");
+  });
+
+  it("rewrites cron failures into impact-first copy", () => {
+    expect(
+      sanitizeDiscordDeliveryText('Cron job "Weekly Audit" failed: cron: job execution timed out'),
+    ).toBe(
+      [
+        "Weekly Audit missed",
+        "",
+        "Impact",
+        "- This scheduled job did not complete.",
+        "",
+        "What happened",
+        "- The job ran too long and timed out before it finished.",
+        "",
+        "Next",
+        "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+      ].join("\n"),
+    );
+  });
+});
+
+describe("buildDiscordTextChunks", () => {
+  it("coalesces title-only first chunks with the first useful section", () => {
+    expect(
+      buildDiscordTextChunks("Morning Briefing\n\nOverview\n- One", {
+        maxLinesPerMessage: 1,
+        chunkMode: "newline",
+      }),
+    ).toEqual(["Morning Briefing\n\nOverview", "- One"]);
+  });
+
+  it("returns no chunks when sanitization removes all text", () => {
+    expect(buildDiscordTextChunks("<oai-mem-citation>\nsecret\n</oai-mem-citation>")).toEqual([]);
+  });
+});

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -257,6 +257,127 @@ export async function resolveDiscordChannelType(
 // Discord message flag for silent/suppress notifications
 export const SUPPRESS_NOTIFICATIONS_FLAG = 1 << 12;
 
+const INTERNAL_DISCORD_LINE_PATTERNS = [
+  /^\s*Discord announcement to send:?\s*$/i,
+  /^\s*I read the prompt\.?\s*$/i,
+  /^\s*Followed instructions exactly\.?\s*$/i,
+  /^\s*Here is the Discord announcement:?\s*$/i,
+];
+
+function humanizeDiscordFailureDetail(detail: string | undefined) {
+  const value = (detail ?? "").trim();
+  if (!value) {
+    return "The failure did not include a useful error message.";
+  }
+  if (/job execution timed out/i.test(value)) {
+    return "The job ran too long and timed out before it finished.";
+  }
+  if (/approval-timeout/i.test(value)) {
+    return "The gateway waited for an approval response and timed out.";
+  }
+  if (/all models failed|FallbackSummaryError/i.test(value)) {
+    return "The model step failed across the configured fallbacks.";
+  }
+  if (/network|econnreset|econnrefused|fetch failed|socket/i.test(value)) {
+    return "A network call failed before the job could finish.";
+  }
+  return value.slice(0, 220);
+}
+
+function rewriteDiscordFailureHeadline(text: string) {
+  const trimmed = text.trim();
+  const cronMatch = trimmed.match(/^Cron job\s+"([^"]+)"\s+failed:\s*([\s\S]+)$/i);
+  if (cronMatch) {
+    return [
+      `${cronMatch[1]} missed`,
+      "",
+      "Impact",
+      "- This scheduled job did not complete.",
+      "",
+      "What happened",
+      `- ${humanizeDiscordFailureDetail(cronMatch[2])}`,
+      "",
+      "Next",
+      "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+    ].join("\n");
+  }
+  const execDeniedMatch = trimmed.match(/^Exec denied\s*\(([^)]*)\):\s*([\s\S]+)$/i);
+  if (execDeniedMatch) {
+    return [
+      "Command did not run",
+      "",
+      "Impact",
+      "- No command output was produced.",
+      "",
+      "What happened",
+      `- ${humanizeDiscordFailureDetail(execDeniedMatch[1])}`,
+      "",
+      "Next",
+      "- I kept the raw command in logs; fix approval routing or run it manually if needed.",
+    ].join("\n");
+  }
+  if (/^FallbackSummaryError:/i.test(trimmed) || /^All models failed/i.test(trimmed)) {
+    return [
+      "Model step failed",
+      "",
+      "Impact",
+      "- The requested work did not finish because every configured model attempt failed.",
+      "",
+      "What happened",
+      `- ${humanizeDiscordFailureDetail(trimmed)}`,
+      "",
+      "Next",
+      "- I kept the raw provider details in logs; retry after the provider/network issue clears.",
+    ].join("\n");
+  }
+  return text;
+}
+
+export function sanitizeDiscordDeliveryText(text: string) {
+  let cleaned = String(text ?? "");
+  cleaned = cleaned.replace(/<oai-mem-citation>[\s\S]*?<\/oai-mem-citation>/gi, "");
+  cleaned = rewriteDiscordFailureHeadline(cleaned);
+  const lines = cleaned
+    .split(/\r?\n/)
+    .filter((line) => !INTERNAL_DISCORD_LINE_PATTERNS.some((pattern) => pattern.test(line)));
+  return lines
+    .join("\n")
+    .replace(/\n{4,}/g, "\n\n\n")
+    .trim();
+}
+
+function isTitleOnlyDiscordChunk(chunk: string) {
+  const value = chunk.trim();
+  if (!value || value.includes("\n")) {
+    return false;
+  }
+  if (value.length > 90) {
+    return false;
+  }
+  if (/[:.!?]$/.test(value)) {
+    return false;
+  }
+  if (/^[-*`>]/.test(value)) {
+    return false;
+  }
+  return /[A-Za-z]/.test(value);
+}
+
+function coalesceTitleOnlyDiscordChunk(
+  chunks: string[],
+  opts: { maxLinesPerMessage?: number; maxChars?: number } = {},
+) {
+  if (chunks.length < 2 || !isTitleOnlyDiscordChunk(chunks[0] ?? "")) {
+    return chunks;
+  }
+  const merged = `${(chunks[0] ?? "").trim()}\n\n${(chunks[1] ?? "").trimStart()}`;
+  const maxChars = opts.maxChars ?? DISCORD_TEXT_LIMIT;
+  if (merged.length > maxChars) {
+    return chunks;
+  }
+  return [merged, ...chunks.slice(2)];
+}
+
 export function buildDiscordTextChunks(
   text: string,
   opts: { maxLinesPerMessage?: number; chunkMode?: ChunkMode; maxChars?: number } = {},
@@ -264,12 +385,19 @@ export function buildDiscordTextChunks(
   if (!text) {
     return [];
   }
-  const chunks = chunkDiscordTextWithMode(text, {
-    maxChars: opts.maxChars ?? DISCORD_TEXT_LIMIT,
-    maxLines: opts.maxLinesPerMessage,
-    chunkMode: opts.chunkMode,
-  });
-  return resolveTextChunksWithFallback(text, chunks);
+  const sanitized = sanitizeDiscordDeliveryText(text);
+  if (!sanitized) {
+    return [];
+  }
+  const chunks = resolveTextChunksWithFallback(
+    sanitized,
+    chunkDiscordTextWithMode(sanitized, {
+      maxChars: opts.maxChars ?? DISCORD_TEXT_LIMIT,
+      maxLines: opts.maxLinesPerMessage,
+      chunkMode: opts.chunkMode,
+    }),
+  );
+  return coalesceTitleOnlyDiscordChunk(chunks, opts);
 }
 
 function hasV2Components(components?: TopLevelComponents[]): boolean {

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -517,7 +517,7 @@ async function sendDiscordText(
     });
     const body = stripUndefinedFields({
       ...serializePayload(payload),
-      ...(messageReference ? { message_reference: messageReference } : {}),
+      ...(messageReference && isFirst ? { message_reference: messageReference } : {}),
     });
     return (await request(
       () =>
@@ -616,7 +616,7 @@ async function sendDiscordMedia(
       rest,
       channelId,
       chunk,
-      replyTo,
+      undefined,
       request,
       maxLinesPerMessage,
       undefined,

--- a/extensions/discord/src/send.shared.ts
+++ b/extensions/discord/src/send.shared.ts
@@ -333,17 +333,18 @@ function rewriteDiscordFailureHeadline(text: string) {
   return text;
 }
 
-export function sanitizeDiscordDeliveryText(text: string) {
-  let cleaned = String(text ?? "");
+export function sanitizeDiscordDeliveryText(
+  text: string,
+  opts: { preserveOuterWhitespace?: boolean } = {},
+) {
+  let cleaned = text;
   cleaned = cleaned.replace(/<oai-mem-citation>[\s\S]*?<\/oai-mem-citation>/gi, "");
   cleaned = rewriteDiscordFailureHeadline(cleaned);
   const lines = cleaned
     .split(/\r?\n/)
     .filter((line) => !INTERNAL_DISCORD_LINE_PATTERNS.some((pattern) => pattern.test(line)));
-  return lines
-    .join("\n")
-    .replace(/\n{4,}/g, "\n\n\n")
-    .trim();
+  const normalized = lines.join("\n").replace(/\n{4,}/g, "\n\n\n");
+  return opts.preserveOuterWhitespace ? normalized : normalized.trim();
 }
 
 function isTitleOnlyDiscordChunk(chunk: string) {
@@ -380,13 +381,20 @@ function coalesceTitleOnlyDiscordChunk(
 
 export function buildDiscordTextChunks(
   text: string,
-  opts: { maxLinesPerMessage?: number; chunkMode?: ChunkMode; maxChars?: number } = {},
+  opts: {
+    maxLinesPerMessage?: number;
+    chunkMode?: ChunkMode;
+    maxChars?: number;
+    preserveOuterWhitespace?: boolean;
+  } = {},
 ): string[] {
   if (!text) {
     return [];
   }
-  const sanitized = sanitizeDiscordDeliveryText(text);
-  if (!sanitized) {
+  const sanitized = sanitizeDiscordDeliveryText(text, {
+    preserveOuterWhitespace: opts.preserveOuterWhitespace,
+  });
+  if (!sanitized.trim()) {
     return [];
   }
   const chunks = resolveTextChunksWithFallback(
@@ -561,7 +569,12 @@ async function sendDiscordMedia(
     (media.contentType ? `upload${extensionForMime(media.contentType) ?? ""}` : "") ||
     "upload";
   const chunks = text
-    ? buildDiscordTextChunks(text, { maxLinesPerMessage, chunkMode, maxChars })
+    ? buildDiscordTextChunks(text, {
+        maxLinesPerMessage,
+        chunkMode,
+        maxChars,
+        preserveOuterWhitespace: true,
+      })
     : [];
   const caption = chunks[0] ?? "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -226,6 +226,20 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(input)).toBe("Done. Clean answer only.");
   });
 
+  it("strips oai memory citation blocks from user-facing text", () => {
+    const input = [
+      "Done.",
+      "",
+      "<oai-mem-citation>",
+      "<citation_entries>",
+      "memory/foo.md:1-2|note=[internal]",
+      "</citation_entries>",
+      "</oai-mem-citation>",
+    ].join("\n");
+
+    expect(sanitizeUserFacingText(input)).toBe("Done.");
+  });
+
   it("strips copied inbound metadata blocks from user-facing assistant text", () => {
     const input = [
       "Conversation info (untrusted metadata):",

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -11,6 +11,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "../../shared/string-coerce.js";
+import { stripOaiMemoryCitationBlocks } from "../../shared/text/assistant-visible-text.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
 import { stripInternalRuntimeContext } from "../internal-runtime-context.js";
 import { stableStringify } from "../stable-stringify.js";
@@ -366,7 +367,9 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     return raw;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw)));
+  const stripped = stripInboundMetadata(
+    stripInternalRuntimeContext(stripOaiMemoryCitationBlocks(stripFinalTagsFromText(raw))),
+  );
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -1285,6 +1285,35 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                     autoThread: {
                       type: "boolean",
                     },
+                    autoThreadGate: {
+                      anyOf: [
+                        {
+                          type: "boolean",
+                          const: false,
+                        },
+                        {
+                          type: "object",
+                          properties: {
+                            minChars: {
+                              type: "integer",
+                              exclusiveMinimum: 0,
+                              maximum: 9007199254740991,
+                            },
+                            taskMinChars: {
+                              type: "integer",
+                              exclusiveMinimum: 0,
+                              maximum: 9007199254740991,
+                            },
+                            longTaskChars: {
+                              type: "integer",
+                              exclusiveMinimum: 0,
+                              maximum: 9007199254740991,
+                            },
+                          },
+                          additionalProperties: false,
+                        },
+                      ],
+                    },
                     autoThreadName: {
                       type: "string",
                       enum: ["message", "generated"],
@@ -2639,6 +2668,35 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
                           },
                           autoThread: {
                             type: "boolean",
+                          },
+                          autoThreadGate: {
+                            anyOf: [
+                              {
+                                type: "boolean",
+                                const: false,
+                              },
+                              {
+                                type: "object",
+                                properties: {
+                                  minChars: {
+                                    type: "integer",
+                                    exclusiveMinimum: 0,
+                                    maximum: 9007199254740991,
+                                  },
+                                  taskMinChars: {
+                                    type: "integer",
+                                    exclusiveMinimum: 0,
+                                    maximum: 9007199254740991,
+                                  },
+                                  longTaskChars: {
+                                    type: "integer",
+                                    exclusiveMinimum: 0,
+                                    maximum: 9007199254740991,
+                                  },
+                                },
+                                additionalProperties: false,
+                              },
+                            ],
                           },
                           autoThreadName: {
                             type: "string",

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -36,6 +36,17 @@ export type DiscordDmConfig = {
   groupChannels?: string[];
 };
 
+export type DiscordAutoThreadGateConfig =
+  | false
+  | {
+      /** Minimum message length before question/intent-based auto-threading can create a thread. */
+      minChars?: number;
+      /** Minimum length for strong task-intent messages to create a thread. */
+      taskMinChars?: number;
+      /** Length at which auto-threading creates a thread without requiring task intent. */
+      longTaskChars?: number;
+    };
+
 export type DiscordGuildChannelConfig = {
   requireMention?: boolean;
   /**
@@ -60,6 +71,8 @@ export type DiscordGuildChannelConfig = {
   includeThreadStarter?: boolean;
   /** If true, automatically create a thread for each new message in this channel. */
   autoThread?: boolean;
+  /** Gate auto-threading to task-like messages. Set false to keep legacy always-thread behavior. */
+  autoThreadGate?: DiscordAutoThreadGateConfig;
   /** Archive duration (minutes) for auto-created threads. Valid values: 60, 1440, 4320, 10080. */
   autoArchiveDuration?: "60" | "1440" | "4320" | "10080" | 60 | 1440 | 4320 | 10080;
   /** Naming strategy for auto-created threads. "message" uses message text; "generated" renames with an LLM title. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -445,6 +445,17 @@ export const DiscordThreadSchema = z
   })
   .strict();
 
+const DiscordAutoThreadGateSchema = z.union([
+  z.literal(false),
+  z
+    .object({
+      minChars: z.number().int().positive().optional(),
+      taskMinChars: z.number().int().positive().optional(),
+      longTaskChars: z.number().int().positive().optional(),
+    })
+    .strict(),
+]);
+
 export const DiscordGuildChannelSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -458,6 +469,7 @@ export const DiscordGuildChannelSchema = z
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
+    autoThreadGate: DiscordAutoThreadGateSchema.optional(),
     /** Naming strategy for auto-created threads. "message" uses message text; "generated" creates an LLM title after thread creation. */
     autoThreadName: z.enum(["message", "generated"]).optional(),
     /** Archive duration for auto-created threads in minutes. Discord supports 60, 1440 (1 day), 4320 (3 days), 10080 (1 week). Default: 60. */

--- a/src/cron/service.failure-alert.test.ts
+++ b/src/cron/service.failure-alert.test.ts
@@ -97,7 +97,7 @@ describe("CronService failure alerts", () => {
         job: expect.objectContaining({ id: job.id }),
         channel: "telegram",
         to: "19098680",
-        text: expect.stringContaining('Cron job "daily report" failed 2 times'),
+        text: expect.stringContaining("daily report is failing"),
       }),
     );
 
@@ -109,7 +109,7 @@ describe("CronService failure alerts", () => {
     expect(sendCronFailureAlert).toHaveBeenCalledTimes(2);
     expect(sendCronFailureAlert).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        text: expect.stringContaining('Cron job "daily report" failed 4 times'),
+        text: expect.stringContaining("This scheduled job has failed 4 times in a row."),
       }),
     );
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -369,13 +369,29 @@ function emitFailureAlert(
   },
 ) {
   const safeJobName = params.job.name || params.job.id;
-  const truncatedError = (params.error?.trim() || "unknown reason").slice(0, 200);
-  const statusVerb = params.status === "skipped" ? "skipped" : "failed";
-  const detailLabel = params.status === "skipped" ? "Skip reason" : "Last error";
-  const text = [
-    `Cron job "${safeJobName}" ${statusVerb} ${params.consecutiveErrors} times`,
-    `${detailLabel}: ${truncatedError}`,
-  ].join("\n");
+  const truncatedError = (
+    params.error?.trim() || (params.status === "skipped" ? "unknown reason" : "unknown error")
+  ).slice(0, 200);
+  const failureCountLabel =
+    params.consecutiveErrors === 1 ? "1 time" : `${params.consecutiveErrors} times`;
+  const text =
+    params.status === "skipped"
+      ? [
+          `Cron job "${safeJobName}" skipped ${params.consecutiveErrors} times`,
+          `Skip reason: ${truncatedError}`,
+        ].join("\n")
+      : [
+          `${safeJobName} is failing`,
+          "",
+          "Impact",
+          `- This scheduled job has failed ${failureCountLabel} in a row.`,
+          "",
+          "What happened",
+          `- ${truncatedError}`,
+          "",
+          "Next",
+          "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+        ].join("\n");
 
   if (state.deps.sendCronFailureAlert) {
     void state.deps

--- a/src/gateway/server-cron-notifications.ts
+++ b/src/gateway/server-cron-notifications.ts
@@ -125,6 +125,21 @@ async function postCronWebhook(params: {
   }
 }
 
+function formatCronFailureMessage(jobName: string, error?: string) {
+  return [
+    `${jobName} missed`,
+    "",
+    "Impact",
+    "- This scheduled job did not complete.",
+    "",
+    "What happened",
+    `- ${error ?? "unknown error"}`,
+    "",
+    "Next",
+    "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+  ].join("\n");
+}
+
 export async function sendGatewayCronFailureAlert(params: {
   deps: CliDeps;
   logger: CronLogger;
@@ -275,7 +290,7 @@ function dispatchCronFailureDestinationNotifications(params: {
     return;
   }
 
-  const failureMessage = `Cron job "${params.job.name}" failed: ${params.evt.error ?? "unknown error"}`;
+  const failureMessage = formatCronFailureMessage(params.job.name, params.evt.error);
   const failureDest = resolveFailureDestination(params.job, params.globalFailureDestination);
   const deliverySessionKey = resolveCronDeliverySessionKey(params.job);
 
@@ -330,7 +345,7 @@ function dispatchCronFailureDestinationNotifications(params: {
           accountId: failureDest.accountId,
           sessionKey: deliverySessionKey,
         },
-        `⚠️ ${failureMessage}`,
+        failureMessage,
       );
     }
     return;
@@ -353,6 +368,6 @@ function dispatchCronFailureDestinationNotifications(params: {
       accountId: primaryPlan.accountId,
       sessionKey: deliverySessionKey,
     },
-    `⚠️ ${failureMessage}`,
+    failureMessage,
   );
 }

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1239,7 +1239,18 @@ describe("gateway server cron", () => {
       expect(failureDestCall.url).toBe("https://example.invalid/failure-destination");
       const failureDestBody = failureDestCall.body;
       expect(failureDestBody.message).toBe(
-        'Cron job "failure destination webhook" failed: unknown error',
+        [
+          "failure destination webhook missed",
+          "",
+          "Impact",
+          "- This scheduled job did not complete.",
+          "",
+          "What happened",
+          "- unknown error",
+          "",
+          "Next",
+          "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+        ].join("\n"),
       );
 
       fetchWithSsrFGuardMock.mockClear();
@@ -1335,7 +1346,18 @@ describe("gateway server cron", () => {
           accountId: undefined,
           sessionKey: "agent:main:telegram:direct:123:thread:99",
         },
-        '⚠️ Cron job "primary delivery fallback" failed: unknown error',
+        [
+          "primary delivery fallback missed",
+          "",
+          "Impact",
+          "- This scheduled job did not complete.",
+          "",
+          "What happened",
+          "- unknown error",
+          "",
+          "Next",
+          "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+        ].join("\n"),
       );
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -1417,7 +1417,18 @@ describe("gateway server cron", () => {
           accountId: undefined,
           sessionKey: "agent:avery:feishu:direct:ou_founder",
         },
-        '⚠️ Cron job "session target failure fallback" failed: unknown error',
+        [
+          "session target failure fallback missed",
+          "",
+          "Impact",
+          "- This scheduled job did not complete.",
+          "",
+          "What happened",
+          "- unknown error",
+          "",
+          "Next",
+          "- I kept the raw failure details in logs; inspect or rerun the job when you are ready.",
+        ].join("\n"),
       );
     } finally {
       await cleanupCronTestRun({ ws, server, prevSkipCron });

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -518,6 +518,28 @@ describe("sanitizeAssistantVisibleText", () => {
     expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
   });
 
+  it("strips oai memory citation blocks on the canonical user-visible path", () => {
+    const input = [
+      "Visible answer",
+      "",
+      "<oai-mem-citation>",
+      "<citation_entries>",
+      "memory/foo.md:1-2|note=[internal]",
+      "</citation_entries>",
+      "</oai-mem-citation>",
+    ].join("\n");
+
+    expect(sanitizeAssistantVisibleText(input)).toBe("Visible answer");
+  });
+
+  it("preserves oai memory citation tags inside fenced code blocks", () => {
+    const input = ["```xml", "<oai-mem-citation>", "example", "</oai-mem-citation>", "```"].join(
+      "\n",
+    );
+
+    expect(sanitizeAssistantVisibleText(input)).toBe(input);
+  });
+
   it("strips relevant-memories blocks on the canonical user-visible path", () => {
     const input = [
       "<relevant-memories>",

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -10,6 +10,8 @@ import {
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
+const OAI_MEM_CITATION_TAG_RE = /<\s*(\/?)\s*oai-mem-citation\b[^<>]*>/gi;
+const OAI_MEM_CITATION_TAG_QUICK_RE = /<\s*\/?\s*oai-mem-citation\b/i;
 
 /**
  * Strip XML-style tool call tags that models sometimes emit as plain text.
@@ -483,41 +485,56 @@ export function stripDowngradedToolCallText(text: string): string {
   return cleaned.trim();
 }
 
-function stripRelevantMemoriesTags(text: string): string {
-  if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
+function stripXmlTagBlockOutsideCode(text: string, quickRe: RegExp, tagRe: RegExp): string {
+  if (!text || !quickRe.test(text)) {
     return text;
   }
-  MEMORY_TAG_RE.lastIndex = 0;
+  tagRe.lastIndex = 0;
 
   const codeRegions = findCodeRegions(text);
   let result = "";
   let lastIndex = 0;
-  let inMemoryBlock = false;
+  let inBlock = false;
 
-  for (const match of text.matchAll(MEMORY_TAG_RE)) {
+  for (const match of text.matchAll(tagRe)) {
     const idx = match.index ?? 0;
     if (isInsideCode(idx, codeRegions)) {
       continue;
     }
 
     const isClose = match[1] === "/";
-    if (!inMemoryBlock) {
+    if (!inBlock) {
       result += text.slice(lastIndex, idx);
       if (!isClose) {
-        inMemoryBlock = true;
+        inBlock = true;
       }
     } else if (isClose) {
-      inMemoryBlock = false;
+      inBlock = false;
     }
 
     lastIndex = idx + match[0].length;
   }
 
-  if (!inMemoryBlock) {
+  if (!inBlock) {
     result += text.slice(lastIndex);
   }
 
   return result;
+}
+
+function stripRelevantMemoriesTags(text: string): string {
+  return stripXmlTagBlockOutsideCode(text, MEMORY_TAG_QUICK_RE, MEMORY_TAG_RE);
+}
+
+export function stripOaiMemoryCitationBlocks(text: string): string {
+  if (!text || !OAI_MEM_CITATION_TAG_QUICK_RE.test(text)) {
+    return text;
+  }
+  return stripXmlTagBlockOutsideCode(
+    text,
+    OAI_MEM_CITATION_TAG_QUICK_RE,
+    OAI_MEM_CITATION_TAG_RE,
+  ).trimEnd();
 }
 
 export type AssistantVisibleTextSanitizerProfile = "delivery" | "history" | "internal-scaffolding";
@@ -586,6 +603,7 @@ function applyAssistantVisibleTextStagePipeline(
     }
     cleaned = stripModelSpecialTokens(cleaned);
     cleaned = stripRelevantMemoriesTags(cleaned);
+    cleaned = stripOaiMemoryCitationBlocks(cleaned);
     cleaned = stripToolCallXmlTags(cleaned);
     cleaned = stripPlainTextToolCallBlocks(cleaned);
     if (!options.preserveDowngradedToolText) {


### PR DESCRIPTION
## Summary
- add a config-backed Discord `autoThreadGate` so short casual pings do not create threads while links, attachments, longer asks, and task-like messages still do
- sanitize outbound Discord text by stripping memory-citation/internal scaffold blocks, coalescing title-only first chunks, and rewriting cron/exec/model failures into impact-first copy
- make cron failure alerts and failure-destination announcements use the same user-first structure

## Verification
- `pnpm install`
- `pnpm config:channels:gen`
- `pnpm config:channels:check`
- `pnpm exec oxfmt --check --threads=1 extensions/discord/src/send.shared.ts extensions/discord/src/send.shared.test.ts extensions/discord/src/monitor/threading.ts extensions/discord/src/monitor/threading.auto-thread.test.ts extensions/discord/src/monitor/allow-list.ts extensions/discord/src/config-schema.test.ts src/config/types.discord.ts src/config/zod-schema.providers-core.ts src/config/bundled-channel-config-metadata.generated.ts src/gateway/server-cron.ts src/gateway/server.cron.test.ts src/cron/service/timer.ts src/cron/service.failure-alert.test.ts src/shared/text/assistant-visible-text.ts src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/send.shared.test.ts extensions/discord/src/monitor/threading.auto-thread.test.ts extensions/discord/src/config-schema.test.ts`
- `pnpm exec vitest run src/shared/text/assistant-visible-text.test.ts src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts src/cron/service.failure-alert.test.ts`
- `pnpm exec vitest run src/gateway/server.cron.test.ts`
- `pnpm tsgo:core`
- `pnpm tsgo:extensions`
