### PR TITLE
fix(gateway): dedupe WebChat sends before attachment parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- WebChat/Control UI: claim `chat.send` idempotency keys before attachment preprocessing so duplicate sends with the same message id stay on the in-flight path instead of starting a second agent response. Fixes #72536. Thanks @AngryC888.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.
 - Matrix/E2EE: stabilize recovery and broken-device QA flows while avoiding Matrix device-cleanup sync races that could leave shutdown-time crypto work running. Thanks @gumadeiras.

--- a/src/gateway/server-methods/agent.test.ts
+++ b/src/gateway/server-methods/agent.test.ts
@@ -12,6 +12,7 @@ import {
   resetTaskRegistryForTests,
 } from "../../tasks/task-registry.js";
 import { withTempDir } from "../../test-helpers/temp-dir.js";
+import { waitForTerminalGatewayDedupe } from "./agent-wait-dedupe.js";
 import { agentHandlers } from "./agent.js";
 import { chatHandlers } from "./chat.js";
 import { expectSubagentFollowupReactivation } from "./subagent-followup.test-helpers.js";
@@ -2402,6 +2403,57 @@ describe("gateway agent handler chat.abort integration", () => {
     await waitForAssertion(() => {
       expect(context.chatAbortControllers.has(runId)).toBe(false);
     });
+  });
+
+  it("agent.wait ignores stale agent snapshots while chat.send is preclaimed", async () => {
+    const context = makeContext();
+    const runId = "idem-wait-preclaimed-chat";
+    context.dedupe.set(`agent:${runId}`, {
+      ts: 100,
+      ok: true,
+      payload: { runId, status: "ok", startedAt: 1, endedAt: 2 },
+    });
+    context.dedupe.set(`chat:${runId}`, {
+      ts: 200,
+      ok: true,
+      payload: { runId, status: "in_flight" },
+    });
+    const respond = vi.fn();
+
+    await agentHandlers["agent.wait"]({
+      params: { runId, timeoutMs: 0 },
+      respond: respond as never,
+      context,
+      req: { type: "req", id: "agent-wait-preclaimed", method: "agent.wait" },
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { runId, status: "timeout" });
+  });
+
+  it("dedupe wait ignores stale agent snapshots while chat.send is preclaimed", async () => {
+    const dedupe = new Map();
+    const runId = "idem-dedupe-preclaimed-chat";
+    dedupe.set(`agent:${runId}`, {
+      ts: 100,
+      ok: true,
+      payload: { runId, status: "ok", startedAt: 1, endedAt: 2 },
+    });
+    dedupe.set(`chat:${runId}`, {
+      ts: 200,
+      ok: true,
+      payload: { runId, status: "in_flight" },
+    });
+
+    await expect(
+      waitForTerminalGatewayDedupe({
+        dedupe,
+        runId,
+        timeoutMs: 0,
+        ignoreAgentTerminalSnapshot: true,
+      }),
+    ).resolves.toBeNull();
   });
 
   it("removes the chatAbortControllers entry after the run errors", async () => {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -92,6 +92,7 @@ import {
   validateAgentParams,
   validateAgentWaitParams,
 } from "../protocol/index.js";
+import type { DedupeEntry } from "../server-shared.js";
 import { performGatewaySessionReset } from "../session-reset-service.js";
 import { reactivateCompletedSubagentSession } from "../session-subagent-reactivation.js";
 import {
@@ -129,6 +130,14 @@ function resolveAllowModelOverrideFromClient(
 
 function resolveCanResetSessionFromClient(client: GatewayRequestHandlerOptions["client"]): boolean {
   return resolveSenderIsOwnerFromClient(client);
+}
+
+function isActiveChatDedupeEntry(entry: DedupeEntry | undefined): boolean {
+  if (!entry?.ok || !entry.payload || typeof entry.payload !== "object") {
+    return false;
+  }
+  const status = (entry.payload as { status?: unknown }).status;
+  return status === "accepted" || status === "started" || status === "in_flight";
 }
 
 async function runSessionResetFromAgent(params: {
@@ -1288,7 +1297,10 @@ export const agentHandlers: GatewayRequestHandlers = {
     // chat.send specifically — not an agent-kind entry registered by the
     // `agent` RPC for its own abort surface.
     const activeChatEntry = context.chatAbortControllers.get(runId);
-    const hasActiveChatRun = activeChatEntry !== undefined && activeChatEntry.kind !== "agent";
+    const hasRegisteredActiveChatRun =
+      activeChatEntry !== undefined && activeChatEntry.kind !== "agent";
+    const hasPreclaimedActiveChatRun = isActiveChatDedupeEntry(context.dedupe.get(`chat:${runId}`));
+    const hasActiveChatRun = hasRegisteredActiveChatRun || hasPreclaimedActiveChatRun;
 
     const cachedGatewaySnapshot = readTerminalSnapshotFromGatewayDedupe({
       dedupe: context.dedupe,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1787,7 +1787,8 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    const cached = context.dedupe.get(`chat:${clientRunId}`);
+    const chatDedupeKey = `chat:${clientRunId}`;
+    const cached = context.dedupe.get(chatDedupeKey);
     if (cached) {
       respond(cached.ok, cached.payload, cached.error, {
         cached: true,
@@ -1806,20 +1807,30 @@ export const chatHandlers: GatewayRequestHandlers = {
     const explicitOriginTargetsPlugin = explicitOriginTargetsPluginBinding(
       explicitOriginResult.value,
     );
+    const inFlightPayload = { runId: clientRunId, status: "in_flight" as const };
+    setGatewayDedupeEntry({
+      dedupe: context.dedupe,
+      key: chatDedupeKey,
+      entry: {
+        ts: now,
+        ok: true,
+        payload: inFlightPayload,
+      },
+    });
     if (normalizedAttachments.length > 0) {
-      const modelRef = resolveSessionModelRef(cfg, entry, agentId);
-      const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
-        loadGatewayModelCatalog: context.loadGatewayModelCatalog,
-        provider: modelRef.provider,
-        model: modelRef.model,
-      });
-      // Bound plugin sessions own the real recipient model, so keep image
-      // attachments even when the parent OpenClaw session model is text-only.
-      const supportsImages =
-        supportsSessionModelImages ||
-        explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
-        explicitOriginTargetsPlugin;
       try {
+        const modelRef = resolveSessionModelRef(cfg, entry, agentId);
+        const supportsSessionModelImages = await resolveGatewayModelSupportsImages({
+          loadGatewayModelCatalog: context.loadGatewayModelCatalog,
+          provider: modelRef.provider,
+          model: modelRef.model,
+        });
+        // Bound plugin sessions own the real recipient model, so keep image
+        // attachments even when the parent OpenClaw session model is text-only.
+        const supportsImages =
+          supportsSessionModelImages ||
+          explicitOriginTargetsAcpSession(explicitOriginResult.value) ||
+          explicitOriginTargetsPlugin;
         const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
           maxBytes: 5_000_000,
           log: context.logGateway,
@@ -1830,14 +1841,20 @@ export const chatHandlers: GatewayRequestHandlers = {
         imageOrder = parsed.imageOrder;
         offloadedRefs = parsed.offloadedRefs;
       } catch (err) {
-        respond(
-          false,
-          undefined,
-          errorShape(
-            err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
-            String(err),
-          ),
+        const error = errorShape(
+          err instanceof MediaOffloadError ? ErrorCodes.UNAVAILABLE : ErrorCodes.INVALID_REQUEST,
+          String(err),
         );
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: chatDedupeKey,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            error,
+          },
+        });
+        respond(false, undefined, error);
         return;
       }
     }
@@ -1855,6 +1872,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         kind: "chat-send",
       });
       if (!activeRunAbort.registered) {
+        context.dedupe.delete(chatDedupeKey);
         respond(true, { runId: clientRunId, status: "in_flight" as const }, undefined, {
           cached: true,
           runId: clientRunId,
@@ -2314,7 +2332,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           }
           setGatewayDedupeEntry({
             dedupe: context.dedupe,
-            key: `chat:${clientRunId}`,
+            key: chatDedupeKey,
             entry: {
               ts: Date.now(),
               ok: true,
@@ -2336,7 +2354,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
           setGatewayDedupeEntry({
             dedupe: context.dedupe,
-            key: `chat:${clientRunId}`,
+            key: chatDedupeKey,
             entry: {
               ts: Date.now(),
               ok: false,
@@ -2370,7 +2388,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       };
       setGatewayDedupeEntry({
         dedupe: context.dedupe,
-        key: `chat:${clientRunId}`,
+        key: chatDedupeKey,
         entry: {
           ts: Date.now(),
           ok: false,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -220,11 +220,17 @@ describe("gateway server chat", () => {
         expect(context.loadGatewayModelCatalog).toHaveBeenCalledTimes(1);
       }, FAST_WAIT_OPTS);
 
+      expect(context.dedupe.get("chat:idem-attachment-race")?.payload).toEqual({
+        runId: "idem-attachment-race",
+        status: "in_flight",
+      });
+      expect(context.chatAbortControllers.has("idem-attachment-race")).toBe(false);
+
       await callSend("duplicate");
       expect(responses).toContainEqual({
         id: "duplicate",
         ok: true,
-        payload: { runId: "idem-attachment-race", status: "started" },
+        payload: { runId: "idem-attachment-race", status: "in_flight" },
         error: undefined,
       });
 
@@ -241,7 +247,7 @@ describe("gateway server chat", () => {
       expect(responses).toContainEqual({
         id: "first",
         ok: true,
-        payload: { runId: "idem-attachment-race", status: "in_flight" },
+        payload: { runId: "idem-attachment-race", status: "started" },
         error: undefined,
       });
       expect(dispatchInboundMessageMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary

- Problem: WebChat / Control UI duplicate `chat.send` calls with the same message id could race before active run registration when attachment/model preprocessing awaited.
- Why it matters: the duplicate could dispatch a second agent response, causing duplicate replies and doubled token use.
- What changed: `chat.send` now claims the `chat:<idempotencyKey>` dedupe entry as `in_flight` before attachment preprocessing, overwrites it on terminal success/error, and keeps `agent.wait` from treating stale same-runId agent snapshots as terminal while that preclaim is active.
- What did NOT change (scope boundary): no UI event handling, WebSocket reconnect logic, channel routing, model/provider behavior, or external delivery semantics changed.

AI-assisted: yes. I used Codex to implement and review the change, and I understand the code path and tests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72536
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `chat.send` only wrote the idempotency dedupe entry after terminal completion/failure, and the active run abort/controller entry was registered after async attachment/model capability preprocessing. A repeated WebChat send with the same idempotency key could enter that await window before the active run existed.
- Missing detection / guardrail: the existing race test did not assert that the dedupe state was claimed before attachment preprocessing or that stale same-runId agent snapshots were ignored during that preclaimed in-flight state.
- Contributing context (if known): duplicate WebChat messages use the same message id / idempotency key, so backend idempotency is the narrow guardrail even if the duplicate originates from reconnect/retry behavior.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/gateway/server.chat.gateway-server-chat-b.test.ts`
  - `src/gateway/server-methods/agent.test.ts`
- Scenario the test should lock in: while the first `chat.send` is waiting on attachment/model preprocessing, the gateway has already cached `{status:"in_flight"}`, a duplicate send with the same idempotency key returns `in_flight`, only one dispatch/run is created, and `agent.wait` does not resolve from stale same-runId agent terminal snapshots during the preclaimed chat state.
- Why this is the smallest reliable guardrail: it exercises the gateway handler seam at the exact await boundary that previously allowed the race, without requiring a browser/WebSocket reconnect reproduction.
- Existing test that already covers this (if any): the attachment race test existed but now asserts the earlier dedupe claim and single dispatch behavior.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Duplicate WebChat / Control UI sends with the same message id now stay on the in-flight path instead of starting a second agent response.

## Diagram (if applicable)

```text
Before:
[first chat.send] -> [attachment/model preprocessing await]
[duplicate chat.send] -> [no dedupe/no active run yet] -> [second dispatch possible]

After:
[first chat.send] -> [chat:<id> in_flight claim] -> [attachment/model preprocessing await]
[duplicate chat.send] -> [cached in_flight] -> [single dispatch]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Darwin
- Runtime/container: local Node/pnpm checkout
- Model/provider: mocked gateway test provider
- Integration/channel (if any): WebChat / Control UI `chat.send`
- Relevant config (redacted): local test session with `test-provider` / `vision-model`

### Steps

1. Start a `chat.send` with an image attachment and idempotency key `idem-attachment-race`.
2. Hold the first request while model catalog / attachment preprocessing is awaiting.
3. Send a duplicate `chat.send` with the same idempotency key before abort-controller registration.
4. Release preprocessing and let the first request dispatch.

### Expected

- The duplicate request returns `{ runId, status: "in_flight" }`.
- The original request returns `{ runId, status: "started" }`.
- Only one `dispatchInboundMessage` and one `addChatRun` occur.
- `agent.wait` ignores stale `agent:<runId>` terminal snapshots while the preclaimed `chat:<runId>` entry is in flight.

### Actual

- Matches expected after this patch.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run locally:

```text
pnpm test src/gateway/server-methods/agent.test.ts src/gateway/server.chat.gateway-server-chat-b.test.ts -- --reporter=verbose
✓ src/gateway/server.chat.gateway-server-chat-b.test.ts > gateway server chat > chat.send returns in_flight when duplicate attachment send wins parsing race
✓ src/gateway/server-methods/agent.test.ts > gateway agent handler chat.abort integration > agent.wait ignores stale agent snapshots while chat.send is preclaimed
✓ src/gateway/server-methods/agent.test.ts > gateway agent handler chat.abort integration > dedupe wait ignores stale agent snapshots while chat.send is preclaimed
Test Files 2 passed
Tests 72 passed
```

Additional local checks:

```text
pnpm check:changed
pnpm build
pnpm check
pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/gateway/server-methods/chat.ts src/gateway/server.chat.gateway-server-chat-b.test.ts
codex review --base upstream/main
```

`pnpm test` was also attempted. It currently fails on unrelated existing broad-suite issues outside this patch, including missing generated/public plugin artifacts and strict SSRF/network fixture expectations in provider/browser/media extension tests. The targeted gateway tests above and `pnpm check:changed` pass for this touched surface.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: source path from `chat.send` validation through idempotency claim, attachment preprocessing, abort-controller registration, terminal dedupe overwrite, duplicate response, and `agent.wait` stale-snapshot handling.
- Edge cases checked: attachment preprocessing failure overwrites the provisional dedupe entry with an error; successful completion overwrites with `ok`; concurrent duplicate before controller registration returns `in_flight`; preclaimed chat dedupe prevents stale same-runId agent terminal snapshots from preempting waits.
- What you did **not** verify: no manual browser/WebChat UI reproduction and no live model/provider run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: a provisional in-flight dedupe entry could make `agent.wait` prefer the active chat path before the abort controller exists.
  - Mitigation: `agent.wait` now treats non-terminal `chat:<runId>` dedupe entries as active chat sends and ignores stale same-runId agent snapshots in that window.
- Risk: attachment/model preprocessing can fail after the provisional dedupe claim.
  - Mitigation: preprocessing failures overwrite the provisional dedupe entry with the shaped error, and terminal dispatch success/failure still overwrites the same dedupe key.
