### PR TITLE
fix(status): preserve target session context window

### DIFF
--- a/src/agents/agent-scope-config.ts
+++ b/src/agents/agent-scope-config.ts
@@ -27,6 +27,7 @@ export type ResolvedAgentConfig = {
   humanDelay?: AgentEntry["humanDelay"];
   tts?: AgentEntry["tts"];
   contextLimits?: AgentContextLimitsConfig;
+  contextTokens?: AgentEntry["contextTokens"];
   heartbeat?: AgentEntry["heartbeat"];
   identity?: AgentEntry["identity"];
   groupChat?: AgentEntry["groupChat"];
@@ -129,6 +130,7 @@ export function resolveAgentConfig(
       typeof entry.contextLimits === "object" && entry.contextLimits
         ? { ...agentDefaults?.contextLimits, ...entry.contextLimits }
         : agentDefaults?.contextLimits,
+    contextTokens: entry.contextTokens,
     heartbeat: entry.heartbeat,
     identity: entry.identity,
     groupChat: entry.groupChat,

--- a/src/agents/agent-scope.test.ts
+++ b/src/agents/agent-scope.test.ts
@@ -87,6 +87,24 @@ describe("resolveAgentConfig", () => {
     expect(resolveAgentConfig(cfg, "main")?.verboseDefault).toBe("on");
   });
 
+  it("preserves per-agent contextTokens", () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          contextTokens: 272_000,
+        },
+        list: [
+          {
+            id: "main",
+            contextTokens: 500_000,
+          },
+        ],
+      },
+    };
+
+    expect(resolveAgentConfig(cfg, "main")?.contextTokens).toBe(500_000);
+  });
+
   it("merges contextLimits from defaults with per-agent overrides", () => {
     const cfg: OpenClawConfig = {
       agents: {

--- a/src/auto-reply/reply/commands-info.test.ts
+++ b/src/auto-reply/reply/commands-info.test.ts
@@ -268,6 +268,34 @@ describe("info command handlers", () => {
     );
   });
 
+  it("uses the target session context window when routing /status", async () => {
+    const params = buildInfoParams("/status", {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig);
+    params.contextTokens = 272000;
+    params.sessionStore = {
+      [params.sessionKey]: {
+        sessionId: "target-session",
+        updatedAt: Date.now(),
+        contextTokens: 500000,
+      },
+    };
+
+    const statusResult = await handleStatusCommand(params, true);
+
+    expect(statusResult?.shouldContinue).toBe(false);
+    expect(vi.mocked(buildStatusReply)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionEntry: expect.objectContaining({
+          sessionId: "target-session",
+          contextTokens: 500000,
+        }),
+        contextTokens: 500000,
+      }),
+    );
+  });
+
   it("forwards resolved fast mode to /status", async () => {
     const params = buildInfoParams("/status", {
       commands: { text: true },

--- a/src/auto-reply/reply/commands-info.ts
+++ b/src/auto-reply/reply/commands-info.ts
@@ -202,7 +202,7 @@ export const handleStatusCommand: CommandHandler = async (params, allowTextComma
     storePath: params.storePath,
     provider: params.provider,
     model: params.model,
-    contextTokens: params.contextTokens,
+    contextTokens: targetSessionEntry?.contextTokens ?? params.contextTokens,
     resolvedThinkLevel: params.resolvedThinkLevel,
     resolvedFastMode: params.resolvedFastMode,
     resolvedVerboseLevel: params.resolvedVerboseLevel,


### PR DESCRIPTION
## Summary
- preserve per-agent `contextTokens` when resolving agent config
- prefer the target session entry's persisted context window when building `/status`
- add regression coverage for both code paths

## Tests
- `node scripts/test-projects.mjs src/agents/agent-scope.test.ts src/auto-reply/reply/commands-info.test.ts`
- `corepack pnpm tsgo:core:test`
- `corepack pnpm exec oxlint src/agents/agent-scope-config.ts src/agents/agent-scope.test.ts src/auto-reply/reply/commands-info.ts src/auto-reply/reply/commands-info.test.ts`
