### PR TITLE
feat(migrations): add Hermes import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Docs: https://docs.openclaw.ai
 - Control UI: polish the quick settings dashboard grid so common cards align across desktop, tablet, and mobile layouts without wasting horizontal space. Thanks @BunsDev.
 - Matrix/E2EE: add `openclaw matrix encryption setup` to enable Matrix encryption, bootstrap recovery, and print verification status from one setup flow. Thanks @gumadeiras.
 - Agents/compaction: add an opt-in `agents.defaults.compaction.maxActiveTranscriptBytes` preflight trigger that runs normal local compaction when the active JSONL grows too large, requiring transcript rotation so successful compaction moves future turns onto a smaller successor file instead of raw byte-splitting history. Thanks @vincentkoc.
+- CLI/migration: add the fresh-setup `openclaw migrate` importer surface with Hermes detection, planning, redacted reports, onboarding import flags, and memory/config/plugin mapping. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -436,6 +436,14 @@
     "target": "设置"
   },
   {
+    "source": "Migrate",
+    "target": "迁移"
+  },
+  {
+    "source": "CLI reference",
+    "target": "CLI 参考"
+  },
+  {
     "source": "Channel Plugin SDK",
     "target": "渠道插件 SDK"
   },

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -13,22 +13,22 @@ apply across the CLI.
 
 ## Command pages
 
-| Area                 | Commands                                                                                                                                                                                                                                  |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Setup and onboarding | [`crestodian`](/cli/crestodian) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
-| Reset and uninstall  | [`backup`](/cli/backup) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                                                 |
-| Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                                                       |
-| Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions)                                                                                                                                                           |
-| Gateway and logs     | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                                 |
-| Models and inference | [`models`](/cli/models) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`wiki`](/cli/wiki)                                                                                          |
-| Network and nodes    | [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node)                                                                                                                                   |
-| Runtime and sandbox  | [`approvals`](/cli/approvals) · `exec-policy` (see [`approvals`](/cli/approvals)) · [`sandbox`](/cli/sandbox) · [`tui`](/cli/tui) · `chat`/`terminal` (aliases for [`tui --local`](/cli/tui)) · [`browser`](/cli/browser)                 |
-| Automation           | [`cron`](/cli/cron) · [`tasks`](/cli/tasks) · [`hooks`](/cli/hooks) · [`webhooks`](/cli/webhooks)                                                                                                                                         |
-| Discovery and docs   | [`dns`](/cli/dns) · [`docs`](/cli/docs)                                                                                                                                                                                                   |
-| Pairing and channels | [`pairing`](/cli/pairing) · [`qr`](/cli/qr) · [`channels`](/cli/channels)                                                                                                                                                                 |
-| Security and plugins | [`security`](/cli/security) · [`secrets`](/cli/secrets) · [`skills`](/cli/skills) · [`plugins`](/cli/plugins) · [`proxy`](/cli/proxy)                                                                                                     |
-| Legacy aliases       | [`daemon`](/cli/daemon) (gateway service) · [`clawbot`](/cli/clawbot) (namespace)                                                                                                                                                         |
-| Plugins (optional)   | [`voicecall`](/cli/voicecall) (if installed)                                                                                                                                                                                              |
+| Area                 | Commands                                                                                                                                                                                                                                                              |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setup and onboarding | [`crestodian`](/cli/crestodian) · [`setup`](/cli/setup) · [`onboard`](/cli/onboard) · [`migrate`](/cli/migrate) · [`configure`](/cli/configure) · [`config`](/cli/config) · [`completion`](/cli/completion) · [`doctor`](/cli/doctor) · [`dashboard`](/cli/dashboard) |
+| Reset and uninstall  | [`backup`](/cli/backup) · [`reset`](/cli/reset) · [`uninstall`](/cli/uninstall) · [`update`](/cli/update)                                                                                                                                                             |
+| Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                                                                                   |
+| Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions)                                                                                                                                                                                       |
+| Gateway and logs     | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                                                             |
+| Models and inference | [`models`](/cli/models) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`wiki`](/cli/wiki)                                                                                                                      |
+| Network and nodes    | [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node)                                                                                                                                                               |
+| Runtime and sandbox  | [`approvals`](/cli/approvals) · `exec-policy` (see [`approvals`](/cli/approvals)) · [`sandbox`](/cli/sandbox) · [`tui`](/cli/tui) · `chat`/`terminal` (aliases for [`tui --local`](/cli/tui)) · [`browser`](/cli/browser)                                             |
+| Automation           | [`cron`](/cli/cron) · [`tasks`](/cli/tasks) · [`hooks`](/cli/hooks) · [`webhooks`](/cli/webhooks)                                                                                                                                                                     |
+| Discovery and docs   | [`dns`](/cli/dns) · [`docs`](/cli/docs)                                                                                                                                                                                                                               |
+| Pairing and channels | [`pairing`](/cli/pairing) · [`qr`](/cli/qr) · [`channels`](/cli/channels)                                                                                                                                                                                             |
+| Security and plugins | [`security`](/cli/security) · [`secrets`](/cli/secrets) · [`skills`](/cli/skills) · [`plugins`](/cli/plugins) · [`proxy`](/cli/proxy)                                                                                                                                 |
+| Legacy aliases       | [`daemon`](/cli/daemon) (gateway service) · [`clawbot`](/cli/clawbot) (namespace)                                                                                                                                                                                     |
+| Plugins (optional)   | [`voicecall`](/cli/voicecall) (if installed)                                                                                                                                                                                                                          |
 
 ## Global flags
 
@@ -60,6 +60,11 @@ openclaw [--dev] [--profile <name>] <command>
   crestodian
   setup
   onboard
+  migrate
+    detect
+    providers
+    plan
+    apply
   configure
   config
     get

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -1,0 +1,102 @@
+---
+summary: "CLI reference for `openclaw migrate` (import from other agent homes into a fresh setup)"
+read_when:
+  - Importing Hermes into a fresh OpenClaw setup
+  - Previewing migration mappings before onboarding
+title: "Migrate"
+---
+
+# `openclaw migrate`
+
+Detect, plan, and apply imports from other agent homes. The first built-in
+importer supports Hermes.
+
+Imports are fresh-setup only by default. If OpenClaw already has config,
+credentials, sessions, or workspace files, the apply step stops and asks you to
+create a fresh setup first. Backup, overwrite, and merge imports are reserved
+for a future feature-gated path.
+
+## Examples
+
+```bash
+openclaw migrate detect
+openclaw migrate providers
+openclaw migrate plan --from hermes --source ~/.hermes
+openclaw migrate apply --from hermes --source ~/.hermes --yes
+```
+
+Import during onboarding:
+
+```bash
+openclaw onboard --flow import
+openclaw setup --wizard --import-from hermes --import-source ~/.hermes
+```
+
+## Commands
+
+| Command                      | Purpose                                  |
+| ---------------------------- | ---------------------------------------- |
+| `openclaw migrate detect`    | Detect importable agent homes            |
+| `openclaw migrate providers` | List available importers                 |
+| `openclaw migrate plan`      | Build a redacted dry-run plan            |
+| `openclaw migrate apply`     | Apply a plan into a fresh OpenClaw setup |
+
+## Hermes Mapping
+
+The Hermes importer maps:
+
+- identity files: `SOUL.md` into the OpenClaw workspace
+- memory files: `memories/USER.md` and `memories/MEMORY.md` into the workspace
+- skills: `skills/` into `skills/hermes-imports/`
+- model defaults and provider endpoint config into `models` and `agents.defaults`
+- MCP servers into `mcp.servers`
+- skill config into `skills.entries`
+- recognized `.env` keys into OpenClaw `.env` only when `--migrate-secrets` is set
+- external memory providers, cron jobs, sessions, logs, plugin folders, token stores, and auth/session databases into the migration report archive for manual review
+
+External Hermes memory providers are preserved as imported plugin config when
+possible, but OpenClaw keeps the built-in memory plugin active until the matching
+plugin is installed and selected.
+
+## Options
+
+### `plan`
+
+- `--from <provider>`: importer id, currently `hermes`
+- `--source <path>`: source agent home
+- `--target-state <path>`: target OpenClaw state directory
+- `--target-workspace <path>`: target OpenClaw workspace directory
+- `--migrate-secrets`: include opt-in secret migration actions
+- `--json`: print a redacted machine-readable plan
+
+### `apply`
+
+- `--from <provider>`: importer id, currently `hermes`
+- `--source <path>`: source agent home
+- `--target-state <path>`: target OpenClaw state directory
+- `--target-workspace <path>`: target OpenClaw workspace directory
+- `--migrate-secrets`: import recognized secrets into OpenClaw `.env`
+- `--dry-run`: write the plan/report without applying imported state
+- `--yes`: apply without an interactive confirmation
+- `--allow-existing`: feature-gated existing-state import. Requires `OPENCLAW_MIGRATION_EXISTING_IMPORT=1`
+- `--json`: print the apply result as JSON
+
+## Reports
+
+Every plan/apply writes a redacted report under the target state directory:
+
+```text
+migrations/<provider>/<plan-id>/
+```
+
+The report contains:
+
+- `plan.json`: redacted migration plan
+- `report.md`: action summary
+- `archive/`: files copied for manual review when they are not safely auto-loadable
+
+## Related
+
+- [CLI reference](/cli)
+- [Onboarding](/cli/onboard)
+- [Setup](/cli/setup)

--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -36,6 +36,8 @@ openclaw onboard
 openclaw onboard --modern
 openclaw onboard --flow quickstart
 openclaw onboard --flow manual
+openclaw onboard --flow import
+openclaw onboard --import-from hermes --import-source ~/.hermes
 openclaw onboard --skip-bootstrap
 openclaw onboard --mode remote --remote-url wss://gateway-host:18789
 ```
@@ -176,6 +178,7 @@ openclaw onboard --non-interactive \
   <Accordion title="Flow types">
     - `quickstart`: minimal prompts, auto-generates a gateway token.
     - `manual`: full prompts for port, bind, and auth (alias of `advanced`).
+    - `import`: imports from another agent home into a fresh OpenClaw setup.
   </Accordion>
   <Accordion title="Provider prefiltering">
     When an auth choice implies a preferred provider, onboarding prefilters the default-model and allowlist pickers to that provider. For Volcengine and BytePlus, this also matches the coding-plan variants (`volcengine-plan/*`, `byteplus-plan/*`).
@@ -194,6 +197,7 @@ openclaw onboard --non-interactive \
     - Local onboarding DM scope behavior: [CLI setup reference](/start/wizard-cli-reference#outputs-and-internals).
     - Fastest first chat: `openclaw dashboard` (Control UI, no channel setup).
     - Custom provider: connect any OpenAI or Anthropic compatible endpoint, including hosted providers not listed. Use Unknown to auto-detect.
+    - Imports are fresh-setup only by default. Use [Migrate](/cli/migrate) for dry-run plans, reports, and exact Hermes mappings.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/cli/setup.md
+++ b/docs/cli/setup.md
@@ -21,6 +21,7 @@ Related:
 openclaw setup
 openclaw setup --workspace ~/.openclaw/workspace
 openclaw setup --wizard
+openclaw setup --wizard --import-from hermes --import-source ~/.hermes
 openclaw setup --non-interactive --mode remote --remote-url wss://gateway-host:18789 --remote-token <token>
 ```
 
@@ -30,6 +31,9 @@ openclaw setup --non-interactive --mode remote --remote-url wss://gateway-host:1
 - `--wizard`: run onboarding
 - `--non-interactive`: run onboarding without prompts
 - `--mode <local|remote>`: onboarding mode
+- `--import-from <provider>`: import from another agent home during onboarding
+- `--import-source <path>`: source agent home for `--import-from`
+- `--import-migrate-secrets`: import recognized secrets during onboarding import
 - `--remote-url <url>`: remote Gateway WebSocket URL
 - `--remote-token <token>`: remote Gateway token
 
@@ -42,7 +46,8 @@ openclaw setup --wizard
 Notes:
 
 - Plain `openclaw setup` initializes config + workspace without the full onboarding flow.
-- Onboarding auto-runs when any onboarding flags are present (`--wizard`, `--non-interactive`, `--mode`, `--remote-url`, `--remote-token`).
+- Onboarding auto-runs when any onboarding flags are present (`--wizard`, `--non-interactive`, `--mode`, `--remote-url`, `--remote-token`, `--import-from`).
+- Imports are fresh-setup only by default. Use [Migrate](/cli/migrate) to preview mappings before applying.
 
 ## Related
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1545,6 +1545,7 @@
                       "cli/gateway",
                       "cli/health",
                       "cli/logs",
+                      "cli/migrate",
                       "cli/onboard",
                       "cli/reset",
                       "cli/secrets",

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -82,6 +82,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerBackupCommand",
       },
       {
+        commandNames: ["migrate"],
+        loadModule: () => import("./register.migrate.js"),
+        exportName: "registerMigrateCommand",
+      },
+      {
         commandNames: ["doctor", "dashboard", "reset", "uninstall"],
         loadModule: () => import("./register.maintenance.js"),
         exportName: "registerMaintenanceCommands",

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -36,6 +36,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "migrate",
+    description: "Import state from other agent homes into a fresh OpenClaw setup",
+    hasSubcommands: true,
+  },
+  {
     name: "doctor",
     description: "Health checks + quick fixes for the gateway and channels",
     hasSubcommands: false,

--- a/src/cli/program/register.migrate.test.ts
+++ b/src/cli/program/register.migrate.test.ts
@@ -1,0 +1,111 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MigrationDetection } from "../../migrations/types.js";
+import { registerMigrateCommand } from "./register.migrate.js";
+
+const mocks = vi.hoisted(() => ({
+  detectMigrationSources: vi.fn(async (): Promise<MigrationDetection[]> => []),
+  listMigrationProviders: vi.fn(() => [{ id: "hermes", label: "Hermes" }]),
+  buildMigrationPlan: vi.fn(async () => ({
+    id: "plan",
+    providerId: "hermes",
+    label: "Hermes",
+    sourceDir: "/tmp/hermes",
+    targetStateDir: "/tmp/openclaw",
+    targetWorkspaceDir: "/tmp/openclaw/workspace",
+    createdAt: "2026-04-26T00:00:00.000Z",
+    migrateSecrets: false,
+    actions: [],
+    warnings: [],
+  })),
+  applyMigrationPlan: vi.fn(async () => ({
+    planId: "plan",
+    dryRun: true,
+    reportDir: "/tmp/openclaw/migrations/hermes/plan",
+    results: [],
+  })),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../migrations/registry.js", () => ({
+  detectMigrationSources: mocks.detectMigrationSources,
+  listMigrationProviders: mocks.listMigrationProviders,
+}));
+
+vi.mock("../../migrations/plan.js", () => ({
+  buildMigrationPlan: mocks.buildMigrationPlan,
+}));
+
+vi.mock("../../migrations/apply.js", () => ({
+  applyMigrationPlan: mocks.applyMigrationPlan,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("registerMigrateCommand", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerMigrateCommand(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("registers detect", async () => {
+    mocks.detectMigrationSources.mockResolvedValueOnce([
+      {
+        providerId: "hermes",
+        label: "Hermes",
+        sourceDir: "/tmp/hermes",
+        confidence: "high",
+        reasons: ["config.yaml"],
+      },
+    ]);
+
+    await runCli(["migrate", "detect"]);
+
+    expect(mocks.detectMigrationSources).toHaveBeenCalledTimes(1);
+    expect(mocks.runtime.log).toHaveBeenCalledWith(expect.stringContaining("Hermes: /tmp/hermes"));
+  });
+
+  it("builds plans with forwarded options", async () => {
+    await runCli([
+      "migrate",
+      "plan",
+      "--from",
+      "hermes",
+      "--source",
+      "/tmp/hermes",
+      "--target-state",
+      "/tmp/openclaw",
+      "--migrate-secrets",
+    ]);
+
+    expect(mocks.buildMigrationPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: "hermes",
+        sourceDir: "/tmp/hermes",
+        targetStateDir: "/tmp/openclaw",
+        migrateSecrets: true,
+      }),
+    );
+  });
+
+  it("applies plans in dry-run mode", async () => {
+    await runCli(["migrate", "apply", "--from", "hermes", "--dry-run"]);
+
+    expect(mocks.applyMigrationPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dryRun: true,
+      }),
+    );
+  });
+});

--- a/src/cli/program/register.migrate.ts
+++ b/src/cli/program/register.migrate.ts
@@ -1,0 +1,152 @@
+import type { Command } from "commander";
+import { applyMigrationPlan } from "../../migrations/apply.js";
+import { buildMigrationPlan } from "../../migrations/plan.js";
+import { detectMigrationSources, listMigrationProviders } from "../../migrations/registry.js";
+import { formatMigrationPlanText, redactMigrationPlan } from "../../migrations/report.js";
+import type { MigrationProviderId } from "../../migrations/types.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+
+function parseProviderId(value: string | undefined): MigrationProviderId {
+  return (value?.trim() || "hermes") as MigrationProviderId;
+}
+
+export function registerMigrateCommand(program: Command) {
+  const migrate = program
+    .command("migrate")
+    .description("Detect, plan, and apply imports from other agent homes")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/migrate", "docs.openclaw.ai/cli/migrate")}\n`,
+    );
+
+  migrate
+    .command("detect")
+    .description("Detect importable agent homes")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const detections = await detectMigrationSources();
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify(detections, null, 2));
+          return;
+        }
+        if (detections.length === 0) {
+          defaultRuntime.log("No importable agent homes detected.");
+          return;
+        }
+        for (const detection of detections) {
+          defaultRuntime.log(
+            `${detection.label}: ${detection.sourceDir} (${detection.confidence}; ${detection.reasons.join(", ")})`,
+          );
+        }
+      });
+    });
+
+  migrate
+    .command("providers")
+    .description("List available migration importers")
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const providers = listMigrationProviders().map((provider) => ({
+          id: provider.id,
+          label: provider.label,
+        }));
+        defaultRuntime.log(
+          opts.json
+            ? JSON.stringify(providers, null, 2)
+            : providers.map((provider) => `${provider.id}\t${provider.label}`).join("\n"),
+        );
+      });
+    });
+
+  migrate
+    .command("plan")
+    .description("Build a dry-run migration plan")
+    .requiredOption("--from <provider>", "Importer id, e.g. hermes")
+    .option("--source <path>", "Source agent home")
+    .option("--target-state <path>", "Target OpenClaw state dir")
+    .option("--target-workspace <path>", "Target OpenClaw workspace dir")
+    .option("--migrate-secrets", "Include opt-in secret migration actions", false)
+    .option("--json", "Output redacted JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw migrate detect", "Find importable agent homes."],
+          ["openclaw migrate plan --from hermes", "Preview a Hermes import."],
+          [
+            "openclaw migrate plan --from hermes --source ~/.hermes --json",
+            "Print a redacted machine-readable plan.",
+          ],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const plan = await buildMigrationPlan({
+          providerId: parseProviderId(opts.from),
+          sourceDir: opts.source as string | undefined,
+          targetStateDir: opts.targetState as string | undefined,
+          targetWorkspaceDir: opts.targetWorkspace as string | undefined,
+          migrateSecrets: Boolean(opts.migrateSecrets),
+        });
+        defaultRuntime.log(
+          opts.json
+            ? JSON.stringify(redactMigrationPlan(plan), null, 2)
+            : formatMigrationPlanText(plan),
+        );
+      });
+    });
+
+  migrate
+    .command("apply")
+    .description("Apply a migration plan into a fresh OpenClaw setup")
+    .requiredOption("--from <provider>", "Importer id, e.g. hermes")
+    .option("--source <path>", "Source agent home")
+    .option("--target-state <path>", "Target OpenClaw state dir")
+    .option("--target-workspace <path>", "Target OpenClaw workspace dir")
+    .option("--migrate-secrets", "Import recognized secrets into OpenClaw .env", false)
+    .option("--dry-run", "Plan and report without writing imported state", false)
+    .option("--yes", "Apply without an interactive confirmation", false)
+    .option("--allow-existing", "Allow feature-gated import into existing OpenClaw state", false)
+    .option("--json", "Output JSON", false)
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const allowExisting =
+          Boolean(opts.allowExisting) && process.env.OPENCLAW_MIGRATION_EXISTING_IMPORT === "1";
+        const plan = await buildMigrationPlan({
+          providerId: parseProviderId(opts.from),
+          sourceDir: opts.source as string | undefined,
+          targetStateDir: opts.targetState as string | undefined,
+          targetWorkspaceDir: opts.targetWorkspace as string | undefined,
+          migrateSecrets: Boolean(opts.migrateSecrets),
+        });
+        if (!opts.dryRun && !opts.yes && process.stdout.isTTY) {
+          defaultRuntime.error("Refusing to apply without --yes. Re-run with --dry-run or --yes.");
+          defaultRuntime.exit(1);
+          return;
+        }
+        const result = await applyMigrationPlan({
+          plan,
+          dryRun: Boolean(opts.dryRun),
+          yes: Boolean(opts.yes),
+          allowExisting,
+        });
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify(result, null, 2));
+          return;
+        }
+        defaultRuntime.log(
+          [
+            `${opts.dryRun ? "Planned" : "Applied"} ${result.results.length} migration action${result.results.length === 1 ? "" : "s"}.`,
+            `Report: ${result.reportDir}`,
+          ].join("\n"),
+        );
+      });
+    });
+}

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -111,7 +111,7 @@ export function registerOnboardCommand(program: Command) {
       "Acknowledge that agents are powerful and full system access is risky (required for --non-interactive)",
       false,
     )
-    .option("--flow <flow>", "Onboard flow: quickstart|advanced|manual")
+    .option("--flow <flow>", "Onboard flow: quickstart|advanced|manual|import")
     .option("--mode <mode>", "Onboard mode: local|remote")
     .option("--auth-choice <choice>", `Auth: ${AUTH_CHOICE_HELP}`)
     .option(
@@ -168,6 +168,9 @@ export function registerOnboardCommand(program: Command) {
     .option("--skip-health", "Skip health check")
     .option("--skip-ui", "Skip Control UI/TUI prompts")
     .option("--node-manager <name>", "Node manager for skills: npm|pnpm|bun")
+    .option("--import-from <provider>", "Import from another agent home during onboarding")
+    .option("--import-source <path>", "Source agent home for --import-from")
+    .option("--import-migrate-secrets", "Import recognized secrets during onboarding import", false)
     .option("--json", "Output JSON summary", false);
 
   command.action(async (opts, commandRuntime) => {
@@ -195,7 +198,7 @@ export function registerOnboardCommand(program: Command) {
           workspace: opts.workspace as string | undefined,
           nonInteractive: Boolean(opts.nonInteractive),
           acceptRisk: Boolean(opts.acceptRisk),
-          flow: opts.flow as "quickstart" | "advanced" | "manual" | undefined,
+          flow: opts.flow as "quickstart" | "advanced" | "manual" | "import" | undefined,
           mode: opts.mode as "local" | "remote" | undefined,
           authChoice: opts.authChoice as AuthChoice | undefined,
           tokenProvider: opts.tokenProvider as string | undefined,
@@ -235,6 +238,9 @@ export function registerOnboardCommand(program: Command) {
           skipHealth: Boolean(opts.skipHealth),
           skipUi: Boolean(opts.skipUi),
           nodeManager: opts.nodeManager as NodeManagerChoice | undefined,
+          importFrom: opts.importFrom as string | undefined,
+          importSource: opts.importSource as string | undefined,
+          importMigrateSecrets: Boolean(opts.importMigrateSecrets),
           json: Boolean(opts.json),
         },
         defaultRuntime,

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -25,6 +25,9 @@ export function registerSetupCommand(program: Command) {
     .option("--mode <mode>", "Onboard mode: local|remote")
     .option("--remote-url <url>", "Remote Gateway WebSocket URL")
     .option("--remote-token <token>", "Remote Gateway token (optional)")
+    .option("--import-from <provider>", "Import from another agent home during onboarding")
+    .option("--import-source <path>", "Source agent home for --import-from")
+    .option("--import-migrate-secrets", "Import recognized secrets during onboarding import", false)
     .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const hasWizardFlags = hasExplicitOptions(command, [
@@ -33,6 +36,9 @@ export function registerSetupCommand(program: Command) {
           "mode",
           "remoteUrl",
           "remoteToken",
+          "importFrom",
+          "importSource",
+          "importMigrateSecrets",
         ]);
         if (opts.wizard || hasWizardFlags) {
           await setupWizardCommand(
@@ -42,6 +48,9 @@ export function registerSetupCommand(program: Command) {
               mode: opts.mode as "local" | "remote" | undefined,
               remoteUrl: opts.remoteUrl as string | undefined,
               remoteToken: opts.remoteToken as string | undefined,
+              importFrom: opts.importFrom as string | undefined,
+              importSource: opts.importSource as string | undefined,
+              importMigrateSecrets: Boolean(opts.importMigrateSecrets),
             },
             defaultRuntime,
           );

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -35,7 +35,7 @@ type OnboardDynamicProviderOptions = {
 export type OnboardOptions = OnboardDynamicProviderOptions & {
   mode?: OnboardMode;
   /** "manual" is an alias for "advanced". */
-  flow?: "quickstart" | "advanced" | "manual";
+  flow?: "quickstart" | "advanced" | "manual" | "import";
   workspace?: string;
   nonInteractive?: boolean;
   /** Required for non-interactive setup; skips the interactive risk prompt when true. */
@@ -84,4 +84,7 @@ export type OnboardOptions = OnboardDynamicProviderOptions & {
   remoteUrl?: string;
   remoteToken?: string;
   json?: boolean;
+  importFrom?: string;
+  importSource?: string;
+  importMigrateSecrets?: boolean;
 };

--- a/src/migrations/apply.ts
+++ b/src/migrations/apply.ts
@@ -1,0 +1,286 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { writeConfigFile } from "../config/config.js";
+import { resolveConfigPath } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isRecord } from "../utils.js";
+import { mergeConfigPathCreate, setConfigPathCreate } from "./config-merge.js";
+import { inspectExistingOpenClawState } from "./freshness.js";
+import { timestampForPath } from "./path-utils.js";
+import { redactMigrationPlan, writeMigrationReport } from "./report.js";
+import type {
+  MigrationAction,
+  MigrationApplyOptions,
+  MigrationApplyResult,
+  MigrationItemResult,
+} from "./types.js";
+
+async function exists(candidate: string): Promise<boolean> {
+  return fs
+    .access(candidate)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function ensureNoConflict(target: string, mode: "fail" | "skip" | "rename" | "overwrite") {
+  if (!(await exists(target)) || mode === "overwrite") {
+    return target;
+  }
+  if (mode === "skip") {
+    return null;
+  }
+  if (mode === "rename") {
+    const parsed = path.parse(target);
+    for (let index = 1; index < 1000; index += 1) {
+      const candidate = path.join(parsed.dir, `${parsed.name}-${index}${parsed.ext}`);
+      if (!(await exists(candidate))) {
+        return candidate;
+      }
+    }
+  }
+  throw new Error(`Target already exists: ${target}`);
+}
+
+async function copyFileAction(action: Extract<MigrationAction, { kind: "copyFile" }>) {
+  const target = await ensureNoConflict(action.target, action.conflict);
+  if (!target) {
+    return { status: "skipped" as const, target: action.target, details: "target exists" };
+  }
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.copyFile(action.source, target);
+  return { status: "migrated" as const, target };
+}
+
+async function copyTreeAction(action: Extract<MigrationAction, { kind: "copyTree" }>) {
+  const target = await ensureNoConflict(action.target, action.conflict);
+  if (!target) {
+    return { status: "skipped" as const, target: action.target, details: "target exists" };
+  }
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.cp(action.source, target, { recursive: true, force: action.conflict === "overwrite" });
+  return { status: "migrated" as const, target };
+}
+
+async function writeEnvValue(envPath: string, key: string, value: string | undefined) {
+  if (value === undefined) {
+    return;
+  }
+  let existing = "";
+  try {
+    existing = await fs.readFile(envPath, "utf-8");
+  } catch {
+    // New .env.
+  }
+  const lines = existing ? existing.split(/\r?\n/u).filter((line) => line.length > 0) : [];
+  const escaped = JSON.stringify(value);
+  const nextLine = `${key}=${escaped}`;
+  const keyPrefix = `${key}=`;
+  const index = lines.findIndex((line) => line.startsWith(keyPrefix));
+  if (index >= 0) {
+    lines[index] = nextLine;
+  } else {
+    lines.push(nextLine);
+  }
+  await fs.mkdir(path.dirname(envPath), { recursive: true });
+  await fs.writeFile(envPath, `${lines.join("\n")}\n`, { encoding: "utf-8", mode: 0o600 });
+  await fs.chmod(envPath, 0o600).catch(() => undefined);
+}
+
+function enablePlugin(
+  config: OpenClawConfig,
+  action: Extract<MigrationAction, { kind: "enablePlugin" }>,
+) {
+  const record = config as Record<string, unknown>;
+  const plugins = isRecord(record.plugins) ? record.plugins : {};
+  const entries = isRecord(plugins.entries) ? plugins.entries : {};
+  const previous = isRecord(entries[action.pluginId])
+    ? (entries[action.pluginId] as Record<string, unknown>)
+    : {};
+  entries[action.pluginId] = {
+    ...previous,
+    enabled: true,
+    ...(action.config && Object.keys(action.config).length > 0 ? { config: action.config } : {}),
+  };
+  plugins.entries = entries;
+  if (
+    Array.isArray(plugins.allow) &&
+    plugins.allow.length > 0 &&
+    !plugins.allow.includes(action.pluginId)
+  ) {
+    plugins.allow = [...plugins.allow, action.pluginId];
+  }
+  record.plugins = plugins;
+}
+
+function applyConfigAction(config: OpenClawConfig, action: MigrationAction): boolean {
+  if (action.kind === "mergeConfig") {
+    mergeConfigPathCreate(config as Record<string, unknown>, action.path, action.value);
+    return true;
+  }
+  if (action.kind === "writeSecretRef") {
+    setConfigPathCreate(config as Record<string, unknown>, action.targetPath, {
+      source: "env",
+      provider: "default",
+      id: action.envKey,
+    });
+    return true;
+  }
+  if (action.kind === "enablePlugin") {
+    enablePlugin(config, action);
+    return true;
+  }
+  return false;
+}
+
+function resultFor(
+  action: MigrationAction,
+  params: Partial<MigrationItemResult>,
+): MigrationItemResult {
+  return {
+    actionId: action.id,
+    kind: action.kind,
+    category: action.category,
+    status: params.status ?? "planned",
+    reason: action.reason,
+    source: "source" in action ? action.source : undefined,
+    target:
+      params.target ??
+      ("target" in action
+        ? action.target
+        : action.kind === "writeSecretRef"
+          ? action.targetPath.join(".")
+          : undefined),
+    details: params.details,
+  };
+}
+
+export async function applyMigrationPlan(
+  options: MigrationApplyOptions,
+): Promise<MigrationApplyResult> {
+  const env = options.env ?? process.env;
+  const dryRun = options.dryRun === true;
+  const plan = options.plan;
+  const reportDir = path.join(
+    plan.targetStateDir,
+    "migrations",
+    plan.providerId,
+    plan.id || timestampForPath(),
+  );
+
+  if (!dryRun && options.allowExisting !== true) {
+    const existing = await inspectExistingOpenClawState({
+      targetStateDir: plan.targetStateDir,
+      targetWorkspaceDir: plan.targetWorkspaceDir,
+      env,
+    });
+    if (existing.meaningful) {
+      throw new Error(
+        [
+          "This OpenClaw setup already has state. Import into existing setups is disabled.",
+          "Create a fresh setup and import there.",
+          "Existing state:",
+          ...existing.reasons.map((reason) => `- ${reason}`),
+        ].join("\n"),
+      );
+    }
+  }
+
+  const nextConfig: OpenClawConfig = structuredClone(options.baseConfig ?? {});
+  const results: MigrationItemResult[] = [];
+  let configChanged = false;
+  const envPath = path.join(plan.targetStateDir, ".env");
+
+  await fs.mkdir(reportDir, { recursive: true });
+  await fs.writeFile(
+    path.join(reportDir, "plan.json"),
+    `${JSON.stringify(redactMigrationPlan(plan), null, 2)}\n`,
+    "utf-8",
+  );
+
+  for (const action of plan.actions) {
+    if (dryRun) {
+      results.push(resultFor(action, { status: "planned" }));
+      continue;
+    }
+    try {
+      if (action.kind === "copyFile") {
+        const copied = await copyFileAction(action);
+        results.push(resultFor(action, copied));
+        continue;
+      }
+      if (action.kind === "copyTree") {
+        const copied = await copyTreeAction(action);
+        results.push(resultFor(action, copied));
+        continue;
+      }
+      if (action.kind === "writeEnv") {
+        await writeEnvValue(envPath, action.key, action.value);
+        results.push(resultFor(action, { status: "migrated", target: envPath }));
+        continue;
+      }
+      if (action.kind === "archiveOnly") {
+        const target = path.join(reportDir, action.archivePath);
+        const stat = await fs.stat(action.source);
+        if (stat.isDirectory()) {
+          await fs.mkdir(path.dirname(target), { recursive: true });
+          await fs.cp(action.source, target, { recursive: true });
+        } else {
+          await fs.mkdir(path.dirname(target), { recursive: true });
+          await fs.copyFile(action.source, target);
+        }
+        results.push(resultFor(action, { status: "archived", target }));
+        continue;
+      }
+      if (action.kind === "manual") {
+        results.push(resultFor(action, { status: "manual", details: action.recommendation }));
+        continue;
+      }
+      if (applyConfigAction(nextConfig, action)) {
+        configChanged = true;
+        results.push(resultFor(action, { status: "migrated" }));
+        continue;
+      }
+      results.push(resultFor(action, { status: "skipped", details: "unsupported action" }));
+    } catch (error) {
+      results.push(
+        resultFor(action, {
+          status: "error",
+          details: error instanceof Error ? error.message : String(error),
+        }),
+      );
+    }
+  }
+
+  if (!dryRun && configChanged) {
+    await fs.mkdir(plan.targetStateDir, { recursive: true });
+    const configPath = resolveConfigPath(env, plan.targetStateDir);
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    process.env.OPENCLAW_STATE_DIR = previousStateDir ?? plan.targetStateDir;
+    process.env.OPENCLAW_CONFIG_PATH = previousConfigPath ?? configPath;
+    try {
+      await writeConfigFile(nextConfig, { skipRuntimeSnapshotRefresh: true });
+    } finally {
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousConfigPath === undefined) {
+        delete process.env.OPENCLAW_CONFIG_PATH;
+      } else {
+        process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+      }
+    }
+  }
+
+  const result: MigrationApplyResult = {
+    planId: plan.id,
+    dryRun,
+    reportDir,
+    results,
+    nextConfig,
+  };
+  await writeMigrationReport(result);
+  return result;
+}

--- a/src/migrations/config-merge.ts
+++ b/src/migrations/config-merge.ts
@@ -1,0 +1,53 @@
+import { isRecord } from "../utils.js";
+
+export function setConfigPathCreate<T extends Record<string, unknown>>(
+  target: T,
+  pathSegments: string[],
+  value: unknown,
+): T {
+  if (pathSegments.length === 0) {
+    throw new Error("Cannot set empty config path");
+  }
+  let cursor: Record<string, unknown> = target;
+  for (const segment of pathSegments.slice(0, -1)) {
+    const current = cursor[segment];
+    if (!isRecord(current)) {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment] as Record<string, unknown>;
+  }
+  cursor[pathSegments[pathSegments.length - 1]] = value;
+  return target;
+}
+
+export function mergeConfigObjectValue(existing: unknown, next: unknown): unknown {
+  if (!isRecord(existing) || !isRecord(next)) {
+    return structuredClone(next);
+  }
+  const merged: Record<string, unknown> = { ...existing };
+  for (const [key, value] of Object.entries(next)) {
+    merged[key] = mergeConfigObjectValue(merged[key], value);
+  }
+  return merged;
+}
+
+export function mergeConfigPathCreate<T extends Record<string, unknown>>(
+  target: T,
+  pathSegments: string[],
+  value: unknown,
+): T {
+  if (pathSegments.length === 0) {
+    throw new Error("Cannot merge empty config path");
+  }
+  let cursor: Record<string, unknown> = target;
+  for (const segment of pathSegments.slice(0, -1)) {
+    const current = cursor[segment];
+    if (!isRecord(current)) {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment] as Record<string, unknown>;
+  }
+  const key = pathSegments[pathSegments.length - 1];
+  cursor[key] = mergeConfigObjectValue(cursor[key], value);
+  return target;
+}

--- a/src/migrations/freshness.ts
+++ b/src/migrations/freshness.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import JSON5 from "json5";
+import { resolveConfigPath } from "../config/paths.js";
+import { isRecord } from "../utils.js";
+
+const MEANINGFUL_WORKSPACE_ENTRIES = [
+  "AGENTS.md",
+  "SOUL.md",
+  "USER.md",
+  "IDENTITY.md",
+  "MEMORY.md",
+  "skills",
+] as const;
+
+const MEANINGFUL_STATE_ENTRIES = ["credentials", "sessions", "agents"] as const;
+
+async function exists(candidate: string): Promise<boolean> {
+  return fs
+    .access(candidate)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function hasDirectoryEntries(candidate: string): Promise<boolean> {
+  try {
+    const entries = await fs.readdir(candidate);
+    return entries.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function configLooksMeaningful(configPath: string): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(configPath, "utf-8");
+  } catch {
+    return false;
+  }
+  if (!raw.trim()) {
+    return false;
+  }
+  try {
+    const parsed = JSON5.parse(raw);
+    if (!isRecord(parsed)) {
+      return true;
+    }
+    const keys = Object.keys(parsed).filter((key) => key !== "$schema" && key !== "meta");
+    return keys.length > 0;
+  } catch {
+    return true;
+  }
+}
+
+export async function inspectExistingOpenClawState(params: {
+  targetStateDir: string;
+  targetWorkspaceDir: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<{ meaningful: boolean; reasons: string[] }> {
+  const env = params.env ?? process.env;
+  const reasons: string[] = [];
+  const configPath = resolveConfigPath(env, params.targetStateDir);
+  if (await configLooksMeaningful(configPath)) {
+    reasons.push(`config exists: ${configPath}`);
+  }
+  for (const entry of MEANINGFUL_WORKSPACE_ENTRIES) {
+    const candidate = path.join(params.targetWorkspaceDir, entry);
+    if (await exists(candidate)) {
+      reasons.push(`workspace ${entry} exists`);
+    }
+  }
+  for (const entry of MEANINGFUL_STATE_ENTRIES) {
+    const candidate = path.join(params.targetStateDir, entry);
+    if (await hasDirectoryEntries(candidate)) {
+      reasons.push(`state ${entry}/ exists`);
+    }
+  }
+  return { meaningful: reasons.length > 0, reasons };
+}

--- a/src/migrations/path-utils.ts
+++ b/src/migrations/path-utils.ts
@@ -1,0 +1,26 @@
+import os from "node:os";
+import path from "node:path";
+import { resolveHomeRelativePath } from "../infra/home-dir.js";
+
+export function resolveMigrationUserPath(
+  input: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return resolveHomeRelativePath(input, { env, homedir: os.homedir });
+}
+
+export function normalizeMigrationPath(input: string): string {
+  return path.resolve(input);
+}
+
+export function safeRelativeArchivePath(sourceDir: string, sourcePath: string): string {
+  const relative = path.relative(sourceDir, sourcePath);
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return path.basename(sourcePath);
+  }
+  return relative;
+}
+
+export function timestampForPath(date = new Date()): string {
+  return date.toISOString().replaceAll(":", "-");
+}

--- a/src/migrations/plan.ts
+++ b/src/migrations/plan.ts
@@ -1,0 +1,6 @@
+import { getMigrationProvider } from "./registry.js";
+import type { MigrationPlan, MigrationPlanOptions } from "./types.js";
+
+export async function buildMigrationPlan(options: MigrationPlanOptions): Promise<MigrationPlan> {
+  return await getMigrationProvider(options.providerId).plan(options);
+}

--- a/src/migrations/providers/hermes.test.ts
+++ b/src/migrations/providers/hermes.test.ts
@@ -1,0 +1,151 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { applyMigrationPlan } from "../apply.js";
+import { buildMigrationPlan } from "../plan.js";
+import { detectMigrationSources } from "../registry.js";
+
+async function makeHermesHome(): Promise<{
+  root: string;
+  hermes: string;
+  state: string;
+  workspace: string;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hermes-migration-"));
+  const hermes = path.join(root, ".hermes");
+  const state = path.join(root, ".openclaw");
+  const workspace = path.join(state, "workspace");
+  await fs.mkdir(path.join(hermes, "memories"), { recursive: true });
+  await fs.mkdir(path.join(hermes, "skills", "demo-skill"), { recursive: true });
+  await fs.mkdir(path.join(hermes, "cron"), { recursive: true });
+  await fs.writeFile(path.join(hermes, "SOUL.md"), "hermes soul\n");
+  await fs.writeFile(path.join(hermes, "memories", "USER.md"), "hermes user\n");
+  await fs.writeFile(path.join(hermes, "memories", "MEMORY.md"), "hermes memory\n");
+  await fs.writeFile(
+    path.join(hermes, "skills", "demo-skill", "SKILL.md"),
+    "---\nname: demo-skill\ndescription: demo\n---\n",
+  );
+  await fs.writeFile(path.join(hermes, "cron", "jobs.yaml"), "[]\n");
+  await fs.writeFile(
+    path.join(hermes, ".env"),
+    ["OPENAI_API_KEY=sk-test-openai", "BRAVE_API_KEY=brave-test"].join("\n"),
+  );
+  await fs.writeFile(
+    path.join(hermes, "config.yaml"),
+    [
+      "model:",
+      "  default: openai/gpt-5.4",
+      "providers:",
+      "  openai:",
+      "    base_url: https://api.openai.com/v1",
+      "    api_key_env: OPENAI_API_KEY",
+      "    models:",
+      "      - gpt-5.4",
+      "memory:",
+      "  provider: honcho",
+      "  honcho:",
+      "    recall_mode: hybrid",
+      "skills:",
+      "  config:",
+      "    demo-skill:",
+      "      project: docs",
+      "mcp_servers:",
+      "  time:",
+      "    command: npx",
+      "    args: ['-y', 'mcp-server-time']",
+    ].join("\n"),
+  );
+  return { root, hermes, state, workspace };
+}
+
+describe("Hermes migration provider", () => {
+  it("detects Hermes homes from HERMES_HOME", async () => {
+    const fixture = await makeHermesHome();
+    const detections = await detectMigrationSources({ HERMES_HOME: fixture.hermes });
+
+    expect(detections).toEqual([
+      expect.objectContaining({
+        providerId: "hermes",
+        sourceDir: fixture.hermes,
+        confidence: "high",
+      }),
+    ]);
+  });
+
+  it("builds a redacted-safe plan with memory, plugin, provider, skill, mcp, and archive actions", async () => {
+    const fixture = await makeHermesHome();
+    const plan = await buildMigrationPlan({
+      providerId: "hermes",
+      sourceDir: fixture.hermes,
+      targetStateDir: fixture.state,
+      targetWorkspaceDir: fixture.workspace,
+      migrateSecrets: true,
+      env: { HOME: fixture.root },
+    });
+
+    expect(plan.actions.map((action) => action.kind)).toEqual(
+      expect.arrayContaining([
+        "copyFile",
+        "copyTree",
+        "mergeConfig",
+        "writeEnv",
+        "writeSecretRef",
+        "enablePlugin",
+        "archiveOnly",
+      ]),
+    );
+    expect(plan.actions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: "enablePlugin", pluginId: "honcho" }),
+        expect.objectContaining({ kind: "mergeConfig", category: "mcp" }),
+        expect.objectContaining({ kind: "mergeConfig", category: "skills" }),
+      ]),
+    );
+  });
+
+  it("applies into a fresh OpenClaw state and blocks existing state by default", async () => {
+    const fixture = await makeHermesHome();
+    const env = {
+      HOME: fixture.root,
+      OPENCLAW_STATE_DIR: fixture.state,
+      OPENCLAW_CONFIG_PATH: path.join(fixture.state, "openclaw.json"),
+    };
+    const plan = await buildMigrationPlan({
+      providerId: "hermes",
+      sourceDir: fixture.hermes,
+      targetStateDir: fixture.state,
+      targetWorkspaceDir: fixture.workspace,
+      migrateSecrets: true,
+      env,
+    });
+
+    const result = await applyMigrationPlan({ plan, yes: true, env });
+
+    await expect(fs.readFile(path.join(fixture.workspace, "SOUL.md"), "utf-8")).resolves.toBe(
+      "hermes soul\n",
+    );
+    await expect(fs.readFile(path.join(fixture.workspace, "MEMORY.md"), "utf-8")).resolves.toBe(
+      "hermes memory\n",
+    );
+    await expect(
+      fs.readFile(
+        path.join(fixture.workspace, "skills", "hermes-imports", "demo-skill", "SKILL.md"),
+        "utf-8",
+      ),
+    ).resolves.toContain("demo-skill");
+    await expect(fs.readFile(path.join(fixture.state, ".env"), "utf-8")).resolves.toContain(
+      "OPENAI_API_KEY=",
+    );
+    await expect(
+      fs.readFile(path.join(fixture.state, "openclaw.json"), "utf-8"),
+    ).resolves.toContain('"memory"');
+    await expect(
+      fs.readFile(path.join(result.reportDir, "plan.json"), "utf-8"),
+    ).resolves.not.toContain("sk-test-openai");
+
+    await expect(applyMigrationPlan({ plan, yes: true, env })).rejects.toThrow(
+      "Import into existing setups is disabled",
+    );
+  });
+});

--- a/src/migrations/providers/hermes.ts
+++ b/src/migrations/providers/hermes.ts
@@ -1,0 +1,627 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parse as parseDotEnv } from "dotenv";
+import { parse as parseYaml } from "yaml";
+import { resolveStateDir } from "../../config/paths.js";
+import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.models.js";
+import { isRecord } from "../../utils.js";
+import {
+  normalizeMigrationPath,
+  resolveMigrationUserPath,
+  safeRelativeArchivePath,
+  timestampForPath,
+} from "../path-utils.js";
+import type {
+  MigrationAction,
+  MigrationActionInput,
+  MigrationDetection,
+  MigrationPlan,
+  MigrationPlanOptions,
+  MigrationProvider,
+  MigrationSourceSnapshot,
+} from "../types.js";
+
+const HERMES_PROVIDER_ID = "hermes";
+const HERMES_LABEL = "Hermes";
+const CONFIG_FILENAME = "config.yaml";
+const ENV_FILENAME = ".env";
+
+const HERMES_FILE_CANDIDATES = [
+  "SOUL.md",
+  "memories/MEMORY.md",
+  "memories/USER.md",
+  "auth.json",
+  "state.db",
+] as const;
+
+const HERMES_DIRECTORY_CANDIDATES = [
+  "skills",
+  "plugins",
+  "sessions",
+  "logs",
+  "cron",
+  "mcp-tokens",
+] as const;
+
+const COMMON_SECRET_ENV_KEYS = [
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "OPENROUTER_API_KEY",
+  "GOOGLE_API_KEY",
+  "GEMINI_API_KEY",
+  "ELEVENLABS_API_KEY",
+  "BRAVE_API_KEY",
+  "EXA_API_KEY",
+  "TAVILY_API_KEY",
+  "PERPLEXITY_API_KEY",
+  "DISCORD_BOT_TOKEN",
+  "SLACK_BOT_TOKEN",
+  "SLACK_APP_TOKEN",
+  "TELEGRAM_BOT_TOKEN",
+] as const;
+
+type HermesProviderConfig = {
+  id: string;
+  baseUrl?: string;
+  apiKeyEnv?: string;
+  models: string[];
+};
+
+function pathExists(candidate: string): Promise<boolean> {
+  return fs
+    .access(candidate)
+    .then(() => true)
+    .catch(() => false);
+}
+
+async function readTextIfExists(candidate: string): Promise<string | undefined> {
+  try {
+    return await fs.readFile(candidate, "utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((entry): entry is string => typeof entry === "string" && entry.trim() !== "");
+}
+
+function childRecord(
+  root: Record<string, unknown> | undefined,
+  key: string,
+): Record<string, unknown> {
+  const value = root?.[key];
+  return isRecord(value) ? value : {};
+}
+
+function sourceDirFromEnv(env: NodeJS.ProcessEnv = process.env): string[] {
+  const candidates: string[] = [];
+  if (env.HERMES_HOME?.trim()) {
+    candidates.push(resolveMigrationUserPath(env.HERMES_HOME, env));
+  }
+  candidates.push(resolveMigrationUserPath("~/.hermes", env));
+  return [...new Set(candidates.map((candidate) => normalizeMigrationPath(candidate)))];
+}
+
+async function detectHermesProfiles(sourceDir: string): Promise<string[]> {
+  const profilesRootCandidates = [path.join(sourceDir, "profiles"), path.join(sourceDir, "agents")];
+  const profileDirs: string[] = [];
+  for (const profilesRoot of profilesRootCandidates) {
+    let entries: Array<{ name: string; isDirectory: () => boolean }>;
+    try {
+      entries = await fs.readdir(profilesRoot, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const candidate = path.join(profilesRoot, entry.name);
+      if (await pathExists(path.join(candidate, CONFIG_FILENAME))) {
+        profileDirs.push(candidate);
+      }
+    }
+  }
+  return profileDirs;
+}
+
+async function detectHermesSourceDir(sourceDir: string): Promise<MigrationDetection | null> {
+  const reasons: string[] = [];
+  if (await pathExists(path.join(sourceDir, CONFIG_FILENAME))) {
+    reasons.push("config.yaml");
+  }
+  if (await pathExists(path.join(sourceDir, ENV_FILENAME))) {
+    reasons.push(".env");
+  }
+  if (await pathExists(path.join(sourceDir, "SOUL.md"))) {
+    reasons.push("SOUL.md");
+  }
+  if (await pathExists(path.join(sourceDir, "memories"))) {
+    reasons.push("memories/");
+  }
+  if (reasons.length === 0) {
+    return null;
+  }
+  return {
+    providerId: HERMES_PROVIDER_ID,
+    label: HERMES_LABEL,
+    sourceDir,
+    confidence: reasons.includes("config.yaml") ? "high" : "medium",
+    reasons,
+  };
+}
+
+async function inspectHermesSource(sourceDir: string): Promise<MigrationSourceSnapshot> {
+  const configRaw = await readTextIfExists(path.join(sourceDir, CONFIG_FILENAME));
+  const envRaw = await readTextIfExists(path.join(sourceDir, ENV_FILENAME));
+  const files: Record<string, string> = {};
+  const directories: Record<string, string> = {};
+  const warnings: string[] = [];
+  let config: Record<string, unknown> | undefined;
+  if (configRaw) {
+    try {
+      const parsed = parseYaml(configRaw);
+      if (isRecord(parsed)) {
+        config = parsed;
+      } else {
+        warnings.push("Hermes config.yaml did not parse to an object.");
+      }
+    } catch (error) {
+      warnings.push(`Could not parse Hermes config.yaml: ${String(error)}`);
+    }
+  }
+  const env = envRaw ? parseDotEnv(envRaw) : undefined;
+
+  for (const relativePath of HERMES_FILE_CANDIDATES) {
+    const absolutePath = path.join(sourceDir, relativePath);
+    if (await pathExists(absolutePath)) {
+      files[relativePath] = absolutePath;
+    }
+  }
+  for (const relativePath of HERMES_DIRECTORY_CANDIDATES) {
+    const absolutePath = path.join(sourceDir, relativePath);
+    if (await pathExists(absolutePath)) {
+      directories[relativePath] = absolutePath;
+    }
+  }
+
+  return {
+    providerId: HERMES_PROVIDER_ID,
+    sourceDir,
+    label: HERMES_LABEL,
+    config,
+    env,
+    files,
+    directories,
+    warnings,
+  };
+}
+
+function addAction(actions: MigrationAction[], action: MigrationActionInput): void {
+  actions.push({ ...action, id: `${action.category}-${actions.length + 1}` } as MigrationAction);
+}
+
+function inferModelRef(config: Record<string, unknown>): string | undefined {
+  const model = childRecord(config, "model");
+  return (
+    asString(model.provider_model) ??
+    asString(model.default) ??
+    asString(model.name) ??
+    asString(config.default_model) ??
+    asString(config.fallback_model)
+  );
+}
+
+function splitProviderModel(modelRef: string | undefined): { provider?: string; model?: string } {
+  if (!modelRef) {
+    return {};
+  }
+  const slash = modelRef.indexOf("/");
+  if (slash > 0 && slash < modelRef.length - 1) {
+    return { provider: modelRef.slice(0, slash), model: modelRef.slice(slash + 1) };
+  }
+  return { model: modelRef };
+}
+
+function modelDefinition(
+  modelId: string,
+  providerId: string,
+  baseUrl?: string,
+): ModelDefinitionConfig {
+  return {
+    id: modelId,
+    name: modelId,
+    api: baseUrl ? "openai-completions" : "openai-responses",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 8192,
+    baseUrl,
+    metadataSource: "models-add",
+  };
+}
+
+function providerConfig(entry: HermesProviderConfig): ModelProviderConfig {
+  const models = entry.models.length > 0 ? entry.models : [`${entry.id}/default`];
+  return {
+    baseUrl: entry.baseUrl ?? "",
+    apiKey: entry.apiKeyEnv
+      ? { source: "env", provider: "default", id: entry.apiKeyEnv }
+      : undefined,
+    api: "openai-completions",
+    models: models.map((modelId) => modelDefinition(modelId, entry.id, entry.baseUrl)),
+  };
+}
+
+function collectHermesProviders(snapshot: MigrationSourceSnapshot): HermesProviderConfig[] {
+  const config = snapshot.config ?? {};
+  const collected: HermesProviderConfig[] = [];
+  const providers = childRecord(config, "providers");
+  for (const [id, raw] of Object.entries(providers)) {
+    if (!isRecord(raw)) {
+      continue;
+    }
+    const baseUrl =
+      asString(raw.base_url) ?? asString(raw.baseUrl) ?? asString(raw.url) ?? asString(raw.api);
+    const apiKeyEnv =
+      asString(raw.api_key_env) ??
+      asString(raw.apiKeyEnv) ??
+      asString(raw.env) ??
+      `${id.toUpperCase().replaceAll(/[^A-Z0-9]/gu, "_")}_API_KEY`;
+    const modelValues = [
+      ...asStringArray(raw.models),
+      ...Object.keys(childRecord(raw, "models")),
+      asString(raw.model),
+    ].filter((value): value is string => Boolean(value));
+    collected.push({ id, baseUrl, apiKeyEnv, models: [...new Set(modelValues)] });
+  }
+
+  const customProviders = config.custom_providers;
+  if (Array.isArray(customProviders)) {
+    for (const raw of customProviders) {
+      if (!isRecord(raw)) {
+        continue;
+      }
+      const name = asString(raw.name) ?? asString(raw.id);
+      if (!name) {
+        continue;
+      }
+      const baseUrl = asString(raw.base_url) ?? asString(raw.baseUrl) ?? asString(raw.url);
+      const apiKeyEnv = asString(raw.api_key_env) ?? asString(raw.apiKeyEnv);
+      const modelValues = [
+        ...asStringArray(raw.models),
+        ...Object.keys(childRecord(raw, "models")),
+        asString(raw.model),
+      ].filter((value): value is string => Boolean(value));
+      collected.push({ id: name, baseUrl, apiKeyEnv, models: [...new Set(modelValues)] });
+    }
+  }
+
+  const defaultRef = splitProviderModel(inferModelRef(config));
+  if (defaultRef.provider && !collected.some((entry) => entry.id === defaultRef.provider)) {
+    collected.push({
+      id: defaultRef.provider,
+      apiKeyEnv: `${defaultRef.provider.toUpperCase().replaceAll(/[^A-Z0-9]/gu, "_")}_API_KEY`,
+      models: defaultRef.model ? [defaultRef.model] : [],
+    });
+  }
+  return collected;
+}
+
+function mapMcpServers(raw: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(raw)) {
+    return undefined;
+  }
+  const mapped: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(raw)) {
+    if (!isRecord(value)) {
+      continue;
+    }
+    const next: Record<string, unknown> = {};
+    for (const key of [
+      "command",
+      "args",
+      "env",
+      "cwd",
+      "workingDirectory",
+      "url",
+      "transport",
+      "headers",
+      "connectionTimeoutMs",
+    ]) {
+      if (value[key] !== undefined) {
+        next[key] = value[key];
+      }
+    }
+    if (Object.keys(next).length > 0) {
+      mapped[name] = next;
+    }
+  }
+  return Object.keys(mapped).length > 0 ? mapped : undefined;
+}
+
+function mapSkillConfig(snapshot: MigrationSourceSnapshot): Record<string, unknown> | undefined {
+  const skills = childRecord(snapshot.config, "skills");
+  const config = childRecord(skills, "config");
+  const entries: Record<string, unknown> = {};
+  for (const [skillKey, value] of Object.entries(config)) {
+    if (isRecord(value)) {
+      entries[skillKey] = { config: value };
+    }
+  }
+  return Object.keys(entries).length > 0 ? entries : undefined;
+}
+
+function mapMemoryProvider(snapshot: MigrationSourceSnapshot): {
+  pluginId?: string;
+  config?: Record<string, unknown>;
+  manual?: string;
+} {
+  const memory = childRecord(snapshot.config, "memory");
+  const provider = asString(memory.provider);
+  if (!provider) {
+    return {};
+  }
+  if (provider === "honcho") {
+    return { pluginId: "honcho", config: childRecord(memory, "honcho") };
+  }
+  if (provider === "builtin" || provider === "file" || provider === "files") {
+    return {};
+  }
+  return { manual: `Hermes memory provider "${provider}" does not have a known OpenClaw mapping.` };
+}
+
+async function buildHermesPlan(options: MigrationPlanOptions): Promise<MigrationPlan> {
+  const env = options.env ?? process.env;
+  const sourceDir = normalizeMigrationPath(
+    options.sourceDir ?? hermesMigrationProvider.candidateSourceDirs(env)[0] ?? "~/.hermes",
+  );
+  const snapshot = await inspectHermesSource(sourceDir);
+  const targetStateDir = normalizeMigrationPath(options.targetStateDir ?? resolveStateDir(env));
+  const targetWorkspaceDir = normalizeMigrationPath(
+    options.targetWorkspaceDir ?? path.join(targetStateDir, "workspace"),
+  );
+  const migrateSecrets = options.migrateSecrets === true;
+  const createdAt = new Date().toISOString();
+  const reportId = timestampForPath(new Date(createdAt));
+  const actions: MigrationAction[] = [];
+
+  addAction(actions, {
+    kind: "mergeConfig",
+    category: "workspace",
+    path: ["agents", "defaults", "workspace"],
+    value: targetWorkspaceDir,
+    reason: "Set the default OpenClaw workspace for the imported Hermes agent.",
+  });
+
+  const fileMappings: Array<[string, string, "identity" | "memory"]> = [
+    ["SOUL.md", "SOUL.md", "identity"],
+    ["memories/USER.md", "USER.md", "memory"],
+    ["memories/MEMORY.md", "MEMORY.md", "memory"],
+  ];
+  for (const [sourceRelative, targetRelative, category] of fileMappings) {
+    const source = snapshot.files[sourceRelative];
+    if (!source) {
+      continue;
+    }
+    addAction(actions, {
+      kind: "copyFile",
+      category,
+      source,
+      target: path.join(targetWorkspaceDir, targetRelative),
+      conflict: "fail",
+      reason: `Import Hermes ${sourceRelative} into the OpenClaw workspace.`,
+    });
+  }
+
+  const skillsDir = snapshot.directories.skills;
+  if (skillsDir) {
+    addAction(actions, {
+      kind: "copyTree",
+      category: "skills",
+      source: skillsDir,
+      target: path.join(targetWorkspaceDir, "skills", "hermes-imports"),
+      conflict: "fail",
+      reason: "Import Hermes skills into a namespaced OpenClaw workspace skill root.",
+    });
+  }
+
+  addAction(actions, {
+    kind: "mergeConfig",
+    category: "memory",
+    path: ["memory"],
+    value: { backend: "builtin" },
+    reason: "Use OpenClaw built-in file memory for imported Hermes memory files.",
+  });
+  addAction(actions, {
+    kind: "mergeConfig",
+    category: "plugins",
+    path: ["plugins", "slots"],
+    value: { memory: "memory-core" },
+    reason: "Select the default OpenClaw memory plugin for imported file memory.",
+  });
+
+  const memoryProvider = mapMemoryProvider(snapshot);
+  if (memoryProvider.pluginId) {
+    addAction(actions, {
+      kind: "enablePlugin",
+      category: "plugins",
+      pluginId: memoryProvider.pluginId,
+      config: memoryProvider.config,
+      reason: "Map the Hermes external memory provider to an OpenClaw memory plugin.",
+    });
+    addAction(actions, {
+      kind: "manual",
+      category: "memory",
+      source: "config.yaml:memory.provider",
+      reason:
+        "Hermes used an external memory provider. OpenClaw keeps built-in memory active until the matching plugin is installed.",
+      recommendation: `Install or enable the ${memoryProvider.pluginId} memory plugin, then select it for plugins.slots.memory.`,
+    });
+  }
+  if (memoryProvider.manual) {
+    addAction(actions, {
+      kind: "manual",
+      category: "memory",
+      source: "config.yaml:memory.provider",
+      reason: memoryProvider.manual,
+      recommendation: "Install or configure an equivalent OpenClaw memory plugin manually.",
+    });
+  }
+
+  const modelRef = inferModelRef(snapshot.config ?? {});
+  if (modelRef) {
+    addAction(actions, {
+      kind: "mergeConfig",
+      category: "models",
+      path: ["agents", "defaults"],
+      value: { model: modelRef },
+      reason: "Import Hermes default model selection.",
+    });
+  }
+
+  const providers = collectHermesProviders(snapshot);
+  if (providers.length > 0) {
+    const mappedProviders = Object.fromEntries(
+      providers.map((entry) => [entry.id, providerConfig(entry)]),
+    );
+    addAction(actions, {
+      kind: "mergeConfig",
+      category: "models",
+      path: ["models", "providers"],
+      value: mappedProviders,
+      reason: "Import Hermes provider and custom endpoint config.",
+    });
+  }
+
+  if (migrateSecrets && snapshot.env) {
+    for (const key of COMMON_SECRET_ENV_KEYS) {
+      const value = snapshot.env[key];
+      if (!value) {
+        continue;
+      }
+      addAction(actions, {
+        kind: "writeEnv",
+        category: "secrets",
+        key,
+        value,
+        sourceLabel: `${ENV_FILENAME}:${key}`,
+        reason: `Import Hermes ${key} into OpenClaw .env.`,
+      });
+    }
+  } else if (snapshot.env && Object.keys(snapshot.env).length > 0) {
+    addAction(actions, {
+      kind: "manual",
+      category: "secrets",
+      source: path.join(sourceDir, ENV_FILENAME),
+      reason: "Hermes .env exists, but secret migration was not enabled.",
+      recommendation: "Re-run with --migrate-secrets or configure equivalent OpenClaw SecretRefs.",
+    });
+  }
+
+  for (const provider of providers) {
+    if (!provider.apiKeyEnv) {
+      continue;
+    }
+    addAction(actions, {
+      kind: "writeSecretRef",
+      category: "secrets",
+      targetPath: ["models", "providers", provider.id, "apiKey"],
+      envKey: provider.apiKeyEnv,
+      reason: `Use ${provider.apiKeyEnv} as the SecretRef for ${provider.id}.`,
+    });
+  }
+
+  const mcpServers = mapMcpServers(snapshot.config?.mcp_servers ?? snapshot.config?.mcp);
+  if (mcpServers) {
+    addAction(actions, {
+      kind: "mergeConfig",
+      category: "mcp",
+      path: ["mcp", "servers"],
+      value: mcpServers,
+      reason: "Import Hermes MCP server definitions.",
+    });
+  }
+
+  const skillEntries = mapSkillConfig(snapshot);
+  if (skillEntries) {
+    addAction(actions, {
+      kind: "mergeConfig",
+      category: "skills",
+      path: ["skills", "entries"],
+      value: skillEntries,
+      reason: "Import Hermes skill config values.",
+    });
+  }
+
+  for (const relativePath of ["plugins", "sessions", "logs", "cron", "mcp-tokens"] as const) {
+    const source = snapshot.directories[relativePath];
+    if (!source) {
+      continue;
+    }
+    addAction(actions, {
+      kind: "archiveOnly",
+      category: relativePath === "cron" ? "automation" : "archive",
+      source,
+      archivePath: path.join("archive", safeRelativeArchivePath(sourceDir, source)),
+      reason: `Archive Hermes ${relativePath}/ for manual review; it is not safely auto-loadable in OpenClaw v1.`,
+    });
+  }
+  for (const relativePath of ["auth.json", "state.db"] as const) {
+    const source = snapshot.files[relativePath];
+    if (!source) {
+      continue;
+    }
+    addAction(actions, {
+      kind: "archiveOnly",
+      category: "archive",
+      source,
+      archivePath: path.join("archive", safeRelativeArchivePath(sourceDir, source)),
+      reason: `Archive Hermes ${relativePath}; OAuth/session-like state is not migrated automatically.`,
+    });
+  }
+
+  return {
+    id: `hermes-${reportId}`,
+    providerId: HERMES_PROVIDER_ID,
+    label: HERMES_LABEL,
+    sourceDir,
+    targetStateDir,
+    targetWorkspaceDir,
+    createdAt,
+    migrateSecrets,
+    actions,
+    warnings: snapshot.warnings,
+  };
+}
+
+export const hermesMigrationProvider: MigrationProvider = {
+  id: HERMES_PROVIDER_ID,
+  label: HERMES_LABEL,
+  candidateSourceDirs(env = process.env) {
+    return sourceDirFromEnv(env);
+  },
+  async detect(env = process.env) {
+    const baseCandidates = sourceDirFromEnv(env);
+    const profileCandidates = (
+      await Promise.all(baseCandidates.map((candidate) => detectHermesProfiles(candidate)))
+    ).flat();
+    const detections = await Promise.all(
+      [...new Set([...baseCandidates, ...profileCandidates])].map((candidate) =>
+        detectHermesSourceDir(candidate),
+      ),
+    );
+    return detections.filter((entry): entry is MigrationDetection => entry !== null);
+  },
+  inspect: inspectHermesSource,
+  plan: buildHermesPlan,
+};

--- a/src/migrations/redaction.ts
+++ b/src/migrations/redaction.ts
@@ -1,0 +1,31 @@
+const SECRET_KEY_PATTERN =
+  /(api[_-]?key|token|secret|password|credential|cookie|authorization|bearer|refresh)/iu;
+
+const SECRET_VALUE_PATTERNS = [
+  /\bsk-[A-Za-z0-9_-]{12,}\b/gu,
+  /\b[xb]ox[baprs]-[A-Za-z0-9-]{12,}\b/gu,
+  /\bgh[pousr]_[A-Za-z0-9_]{12,}\b/gu,
+  /\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{24,}\b/gu,
+];
+
+export function shouldRedactKey(key: string): boolean {
+  return SECRET_KEY_PATTERN.test(key);
+}
+
+export function redactSecretText(value: string): string {
+  let redacted = value;
+  for (const pattern of SECRET_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, "[redacted]");
+  }
+  return redacted;
+}
+
+export function redactEnvValue(key: string, value: string | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (shouldRedactKey(key)) {
+    return "[redacted]";
+  }
+  return redactSecretText(value);
+}

--- a/src/migrations/registry.ts
+++ b/src/migrations/registry.ts
@@ -1,0 +1,25 @@
+import { hermesMigrationProvider } from "./providers/hermes.js";
+import type { MigrationDetection, MigrationProvider, MigrationProviderId } from "./types.js";
+
+const builtInMigrationProviders: MigrationProvider[] = [hermesMigrationProvider];
+
+export function listMigrationProviders(): MigrationProvider[] {
+  return [...builtInMigrationProviders];
+}
+
+export function getMigrationProvider(providerId: MigrationProviderId): MigrationProvider {
+  const provider = builtInMigrationProviders.find((candidate) => candidate.id === providerId);
+  if (!provider) {
+    throw new Error(`Unknown migration provider: ${providerId}`);
+  }
+  return provider;
+}
+
+export async function detectMigrationSources(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<MigrationDetection[]> {
+  const results = await Promise.all(
+    builtInMigrationProviders.map((provider) => provider.detect(env)),
+  );
+  return results.flat();
+}

--- a/src/migrations/report.ts
+++ b/src/migrations/report.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { redactEnvValue, redactSecretText } from "./redaction.js";
+import type { MigrationAction, MigrationApplyResult, MigrationPlan } from "./types.js";
+
+export function redactMigrationAction(action: MigrationAction): MigrationAction {
+  if (action.kind === "writeEnv") {
+    return {
+      ...action,
+      value: redactEnvValue(action.key, action.value),
+    };
+  }
+  if (action.kind === "mergeConfig") {
+    return JSON.parse(redactSecretText(JSON.stringify(action))) as MigrationAction;
+  }
+  return action;
+}
+
+export function redactMigrationPlan(plan: MigrationPlan): MigrationPlan {
+  return {
+    ...plan,
+    actions: plan.actions.map(redactMigrationAction),
+  };
+}
+
+export function summarizeMigrationPlan(plan: MigrationPlan): Record<string, number> {
+  const summary: Record<string, number> = {};
+  for (const action of plan.actions) {
+    summary[action.category] = (summary[action.category] ?? 0) + 1;
+  }
+  return summary;
+}
+
+export function formatMigrationPlanText(plan: MigrationPlan): string {
+  const summary = summarizeMigrationPlan(plan);
+  const lines = [
+    `${plan.label} migration plan`,
+    `Source: ${plan.sourceDir}`,
+    `Target state: ${plan.targetStateDir}`,
+    `Target workspace: ${plan.targetWorkspaceDir}`,
+    `Actions: ${plan.actions.length}`,
+    "",
+    "Categories:",
+    ...Object.entries(summary).map(([category, count]) => `- ${category}: ${count}`),
+  ];
+  if (plan.warnings.length > 0) {
+    lines.push("", "Warnings:", ...plan.warnings.map((warning) => `- ${warning}`));
+  }
+  return lines.join("\n");
+}
+
+export async function writeMigrationReport(result: MigrationApplyResult): Promise<void> {
+  await fs.mkdir(result.reportDir, { recursive: true });
+  const lines = [
+    `# Migration Report`,
+    "",
+    `Plan: ${result.planId}`,
+    `Dry run: ${result.dryRun ? "yes" : "no"}`,
+    "",
+    "| Status | Kind | Category | Reason |",
+    "| --- | --- | --- | --- |",
+    ...result.results.map(
+      (entry) =>
+        `| ${entry.status} | ${entry.kind} | ${entry.category} | ${entry.reason.replaceAll("|", "\\|")} |`,
+    ),
+    "",
+  ];
+  await fs.writeFile(path.join(result.reportDir, "report.md"), lines.join("\n"), "utf-8");
+}

--- a/src/migrations/types.ts
+++ b/src/migrations/types.ts
@@ -1,0 +1,163 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+
+export type MigrationProviderId = "hermes" | (string & {});
+
+export type MigrationStatus =
+  | "planned"
+  | "migrated"
+  | "skipped"
+  | "archived"
+  | "manual"
+  | "conflict"
+  | "error";
+
+export type MigrationConflictMode = "fail" | "skip" | "rename" | "overwrite";
+
+export type MigrationCategory =
+  | "identity"
+  | "workspace"
+  | "memory"
+  | "models"
+  | "secrets"
+  | "skills"
+  | "plugins"
+  | "mcp"
+  | "channels"
+  | "automation"
+  | "archive"
+  | "manual";
+
+export type MigrationDetection = {
+  providerId: MigrationProviderId;
+  label: string;
+  sourceDir: string;
+  confidence: "high" | "medium" | "low";
+  reasons: string[];
+};
+
+export type MigrationSourceSnapshot = {
+  providerId: MigrationProviderId;
+  sourceDir: string;
+  label: string;
+  config?: Record<string, unknown>;
+  env?: Record<string, string>;
+  files: Record<string, string>;
+  directories: Record<string, string>;
+  warnings: string[];
+};
+
+export type MigrationActionBase = {
+  id: string;
+  category: MigrationCategory;
+  reason: string;
+};
+
+export type MigrationAction =
+  | (MigrationActionBase & {
+      kind: "copyFile";
+      source: string;
+      target: string;
+      conflict: MigrationConflictMode;
+    })
+  | (MigrationActionBase & {
+      kind: "copyTree";
+      source: string;
+      target: string;
+      conflict: MigrationConflictMode;
+    })
+  | (MigrationActionBase & {
+      kind: "mergeConfig";
+      path: string[];
+      value: unknown;
+    })
+  | (MigrationActionBase & {
+      kind: "writeEnv";
+      key: string;
+      value?: string;
+      sourceLabel: string;
+    })
+  | (MigrationActionBase & {
+      kind: "writeSecretRef";
+      targetPath: string[];
+      envKey: string;
+    })
+  | (MigrationActionBase & {
+      kind: "enablePlugin";
+      pluginId: string;
+      config?: Record<string, unknown>;
+    })
+  | (MigrationActionBase & {
+      kind: "archiveOnly";
+      source: string;
+      archivePath: string;
+    })
+  | (MigrationActionBase & {
+      kind: "manual";
+      source?: string;
+      recommendation?: string;
+    });
+
+export type MigrationActionInput = MigrationAction extends infer Action
+  ? Action extends MigrationAction
+    ? Omit<Action, "id">
+    : never
+  : never;
+
+export type MigrationPlan = {
+  id: string;
+  providerId: MigrationProviderId;
+  label: string;
+  sourceDir: string;
+  targetStateDir: string;
+  targetWorkspaceDir: string;
+  createdAt: string;
+  migrateSecrets: boolean;
+  actions: MigrationAction[];
+  warnings: string[];
+};
+
+export type MigrationPlanOptions = {
+  providerId: MigrationProviderId;
+  sourceDir?: string;
+  targetStateDir?: string;
+  targetWorkspaceDir?: string;
+  migrateSecrets?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type MigrationApplyOptions = {
+  plan: MigrationPlan;
+  dryRun?: boolean;
+  yes?: boolean;
+  allowExisting?: boolean;
+  env?: NodeJS.ProcessEnv;
+  baseConfig?: OpenClawConfig;
+};
+
+export type MigrationItemResult = {
+  actionId: string;
+  kind: MigrationAction["kind"];
+  category: MigrationCategory;
+  status: MigrationStatus;
+  reason: string;
+  source?: string;
+  target?: string;
+  details?: string;
+};
+
+export type MigrationApplyResult = {
+  planId: string;
+  dryRun: boolean;
+  reportDir: string;
+  results: MigrationItemResult[];
+  nextConfig?: OpenClawConfig;
+};
+
+export type MigrationProvider = {
+  id: MigrationProviderId;
+  label: string;
+  candidateSourceDirs: (env?: NodeJS.ProcessEnv) => string[];
+  detect: (env?: NodeJS.ProcessEnv) => Promise<MigrationDetection[]>;
+  inspect: (sourceDir: string) => Promise<MigrationSourceSnapshot>;
+  plan: (options: MigrationPlanOptions) => Promise<MigrationPlan>;
+};

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -12,6 +12,7 @@ import { createConfigIO, resolveGatewayPort, writeConfigFile } from "../config/c
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import type { MigrationProviderId } from "../migrations/types.js";
 import {
   buildPluginCompatibilitySnapshotNotices,
   formatPluginCompatibilityNotice,
@@ -27,6 +28,8 @@ import {
   SECURITY_NOTE_TITLE,
 } from "./setup.security-note.js";
 import type { QuickstartGatewayDefaults, WizardFlow } from "./setup.types.js";
+
+type SetupFlowChoice = WizardFlow | "import";
 
 type AuthChoiceModule = typeof import("../commands/auth-choice.js");
 type ConfigLoggingModule = typeof import("../config/logging.js");
@@ -170,6 +173,85 @@ async function requireRiskAcknowledgement(params: {
   }
 }
 
+async function runSetupMigrationImport(params: {
+  opts: OnboardOptions;
+  baseConfig: OpenClawConfig;
+  prompter: WizardPrompter;
+  runtime: RuntimeEnv;
+}) {
+  const [
+    { applyMigrationPlan },
+    { buildMigrationPlan },
+    { detectMigrationSources },
+    { formatMigrationPlanText },
+  ] = await Promise.all([
+    import("../migrations/apply.js"),
+    import("../migrations/plan.js"),
+    import("../migrations/registry.js"),
+    import("../migrations/report.js"),
+  ]);
+  const onboardHelpers = await import("../commands/onboard-helpers.js");
+  const detections = await detectMigrationSources();
+  const providerId =
+    params.opts.importFrom ??
+    ((await params.prompter.select({
+      message: "Import source",
+      options: detections.length
+        ? detections.map((detection) => ({
+            value: detection.providerId,
+            label: detection.label,
+            hint: detection.sourceDir,
+          }))
+        : [
+            {
+              value: "hermes",
+              label: "Hermes",
+              hint: "No detected home; enter a source path next.",
+            },
+          ],
+      initialValue: detections[0]?.providerId ?? "hermes",
+    })) as string);
+  const sourceDir =
+    params.opts.importSource ??
+    detections.find((detection) => detection.providerId === providerId)?.sourceDir ??
+    (await params.prompter.text({
+      message: "Source agent home",
+      initialValue: "~/.hermes",
+    }));
+  const workspaceInput =
+    params.opts.workspace ??
+    params.baseConfig.agents?.defaults?.workspace ??
+    onboardHelpers.DEFAULT_WORKSPACE;
+  const targetWorkspaceDir = resolveUserPath(workspaceInput);
+  const plan = await buildMigrationPlan({
+    providerId: providerId as MigrationProviderId,
+    sourceDir,
+    targetWorkspaceDir,
+    migrateSecrets: params.opts.importMigrateSecrets === true,
+  });
+  await params.prompter.note(formatMigrationPlanText(plan), "Import preview");
+  const confirmed =
+    params.opts.nonInteractive === true
+      ? true
+      : await params.prompter.confirm({
+          message: "Apply this import into a fresh OpenClaw setup?",
+          initialValue: false,
+        });
+  if (!confirmed) {
+    throw new WizardCancelledError("import cancelled");
+  }
+  const result = await applyMigrationPlan({
+    plan,
+    yes: true,
+    allowExisting: false,
+    baseConfig: params.baseConfig,
+  });
+  await params.prompter.note(`Report: ${result.reportDir}`, "Import complete");
+  await params.prompter.outro(
+    "Import complete. Run openclaw configure when you want to tune channels, search, or gateway details.",
+  );
+}
+
 export async function runSetupWizard(
   opts: OnboardOptions,
   runtime: RuntimeEnv = defaultRuntime,
@@ -234,23 +316,27 @@ export async function runSetupWizard(
   if (
     normalizedExplicitFlow &&
     normalizedExplicitFlow !== "quickstart" &&
-    normalizedExplicitFlow !== "advanced"
+    normalizedExplicitFlow !== "advanced" &&
+    normalizedExplicitFlow !== "import"
   ) {
-    runtime.error("Invalid --flow (use quickstart, manual, or advanced).");
+    runtime.error("Invalid --flow (use quickstart, manual, advanced, or import).");
     runtime.exit(1);
     return;
   }
-  const explicitFlow: WizardFlow | undefined =
-    normalizedExplicitFlow === "quickstart" || normalizedExplicitFlow === "advanced"
+  const explicitFlow: SetupFlowChoice | undefined =
+    normalizedExplicitFlow === "quickstart" ||
+    normalizedExplicitFlow === "advanced" ||
+    normalizedExplicitFlow === "import"
       ? normalizedExplicitFlow
       : undefined;
-  let flow: WizardFlow =
+  let flow: SetupFlowChoice =
     explicitFlow ??
     (await prompter.select({
       message: "Setup mode",
       options: [
         { value: "quickstart", label: "QuickStart", hint: quickstartHint },
         { value: "advanced", label: "Manual", hint: manualHint },
+        { value: "import", label: "Import from another agent", hint: "Fresh setup only" },
       ],
       initialValue: "quickstart",
     }));
@@ -299,6 +385,12 @@ export async function runSetupWizard(
       baseConfig = {};
     }
   }
+
+  if (opts.importFrom || flow === "import") {
+    await runSetupMigrationImport({ opts, baseConfig, prompter, runtime });
+    return;
+  }
+  const wizardFlow = flow;
 
   const quickstartGateway: QuickstartGatewayDefaults = (() => {
     const hasExisting =
@@ -351,7 +443,7 @@ export async function runSetupWizard(
     };
   })();
 
-  if (flow === "quickstart") {
+  if (wizardFlow === "quickstart") {
     const formatBind = (value: "loopback" | "lan" | "auto" | "custom" | "tailnet") => {
       if (value === "loopback") {
         return "Loopback (127.0.0.1)";
@@ -482,7 +574,7 @@ export async function runSetupWizard(
 
   const mode =
     opts.mode ??
-    (flow === "quickstart"
+    (wizardFlow === "quickstart"
       ? "local"
       : ((await prompter.select({
           message: "What do you want to set up?",
@@ -525,7 +617,7 @@ export async function runSetupWizard(
 
   const workspaceInput =
     opts.workspace ??
-    (flow === "quickstart"
+    (wizardFlow === "quickstart"
       ? (baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE)
       : await prompter.text({
           message: "Workspace directory",
@@ -669,7 +761,7 @@ export async function runSetupWizard(
 
   const { configureGatewayForSetup } = await import("./setup.gateway-config.js");
   const gateway = await configureGatewayForSetup({
-    flow,
+    flow: wizardFlow,
     baseConfig,
     nextConfig,
     localPort,


### PR DESCRIPTION
## Summary
- add a generic migration framework and fresh-setup guard
- add the built-in Hermes importer with memory/config/plugin/MCP/skill mappings
- add `openclaw migrate` and onboarding import flags
- document migration imports and i18n labels

## Tests
- `OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm test:serial src/migrations/providers/hermes.test.ts src/cli/program/register.migrate.test.ts`
- `pnpm check:docs`

## Notes
- Full `pnpm check:changed` previously passed typecheck/lint/import-cycle/security guards and most selected tests after `pnpm build`, but an existing gateway multi-instance e2e timed out waiting for a telegram-shaped final chat event. The focused migration and docs gates are green on the rebased branch.