### PR TITLE
fix(github-copilot): also skip function_call items in connection-bound-id rewriter (#72602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/GitHub Copilot: also skip `function_call` items in `rewriteCopilotConnectionBoundResponseIds` so Copilot's server-side `encrypted_content` lookup keeps working. Synthesising `fc_<sha256>` IDs on replay was breaking every multi-turn tool-call session with `400 item_id did not match`, mirroring the `rs_<sha256>` reasoning-item bug fixed in #71684. Fixes #72602.
 - Plugins/install: stage bundled plugin runtime dependencies before Gateway startup and drain update restarts while preserving per-plugin isolation when pre-stage scan or install fails. Thanks @codex.
 - CLI/startup: read generated startup metadata from the bundled `dist` layout before falling back to live help rendering, so root/browser help and channel-option bootstrap stay on the fast path. Thanks @vincentkoc.
 - CLI/help: treat positional `help` invocations like `openclaw channels help` as help paths for startup gating, avoiding model/auth warmup while preserving positional arguments such as `openclaw docs help`. Thanks @gumadeiras.

--- a/extensions/github-copilot/connection-bound-ids.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.test.ts
@@ -31,8 +31,21 @@ describe("github-copilot connection-bound response IDs", () => {
     expect(input[0]?.id).toBe("rs_existing");
     expect(input[1]?.id).toBe("msg_existing");
     expect(input[2]?.id).toBe("fc_existing");
-    expect(input[3]?.id).toMatch(/^fc_[a-f0-9]{16}$/);
+    expect(input[3]?.id).toBe(functionCallId);
     expect(input[4]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
+  });
+
+  it("preserves function_call IDs regardless of encrypted_content (#72602)", () => {
+    const withEncrypted = Buffer.from(`function-call-${"f".repeat(20)}`).toString("base64");
+    const withoutField = Buffer.from(`function-call-${"g".repeat(20)}`).toString("base64");
+    const input = [
+      { id: withEncrypted, type: "function_call", encrypted_content: "opaque-encrypted-payload" },
+      { id: withoutField, type: "function_call" },
+    ];
+
+    expect(rewriteCopilotConnectionBoundResponseIds(input)).toBe(false);
+    expect(input[0]?.id).toBe(withEncrypted);
+    expect(input[1]?.id).toBe(withoutField);
   });
 
   it("preserves reasoning IDs regardless of encrypted_content", () => {

--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -35,11 +35,14 @@ export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolea
     if (typeof id !== "string" || id.length === 0) {
       continue;
     }
-    // Reasoning items always reference server-side encrypted state bound to the
-    // original item ID. Rewriting the ID — even when encrypted_content is absent
-    // or null — breaks Copilot's server-side lookup and causes a 400 validation
-    // failure regardless of whether the client included encrypted_content.
-    if (item.type === "reasoning") {
+    // Reasoning AND function_call items reference server-side state bound to
+    // the original item ID. Copilot validates the replayed ID against the
+    // encrypted blob and rejects any rewrite, even when encrypted_content is
+    // absent or null. Curl evidence in #72602 confirms `fc_<hash>` 400s the
+    // same way `rs_<hash>` did before #71684 — sending the original opaque ID
+    // (or omitting it) succeeds, the synthesised ID does not. Skip both types
+    // unconditionally so Copilot's server-side lookup keeps working.
+    if (item.type === "reasoning" || item.type === "function_call") {
       continue;
     }
     if (looksLikeConnectionBoundId(id)) {


### PR DESCRIPTION
Fixes #72602.

## Summary

PR #71684 stopped rewriting \`reasoning\` item IDs in
\`rewriteCopilotConnectionBoundResponseIds\` because Copilot's
\`/responses\` endpoint validates the replayed ID against
\`encrypted_content\` server-side and rejects any synthesised
\`rs_<sha256>\` value with
\`400 \"item_id did not match the target item id\"\`.

The same bug class survives for \`function_call\` items: every
multi-turn tool-call session against a GitHub Copilot Responses model
fails on the second turn with the same 400 because OpenClaw is sending
a freshly synthesised
\`fc_<sha256(originalId).hex().slice(0,16)>\` instead of the opaque
base64 ID Copilot recovers from \`encrypted_content\`.

## Reporter evidence

Issue #72602 includes standalone curl variants against
\`api.individual.githubcopilot.com/responses\` that confirm Copilot's
acceptance rules:

| reasoning.id | function_call.id | result |
|---|---|---|
| original base64 | original base64 | **200 OK** |
| _omitted_ | original base64 | **200 OK** |
| _omitted_ | _omitted_ | **200 OK** |
| **OpenClaw \`rs_<hash>\`** | **OpenClaw \`fc_<hash>\`** | **400** |

The reporter also reproduces the exact failure ID via:

\`\`\`python
>>> \"rs_\" + hashlib.sha256(b\"<original base64>\").hexdigest()[:16]
'rs_951f665be3b6e210'  # bit-for-bit match for the 400's quoted ID
\`\`\`

## Fix

Extend the existing \`if (item.type === \"reasoning\") continue;\` guard
in \`extensions/github-copilot/connection-bound-ids.ts\` to also cover
\`function_call\` items. Both item types reference server-side state
bound to the original ID, so leaving the original opaque base64 ID in
place lets Copilot's lookup keep working.

## Tests

Updated existing test that previously expected \`fc_[a-f0-9]{16}\` for
function_call items. Added a new test \"preserves function_call IDs
regardless of encrypted_content\" mirroring the existing reasoning-item
test from #71684.

\`\`\`
Test Files  2 passed (connection-bound-ids.test.ts: 5, stream.test.ts: 6)
     Tests  11 passed (11)
\`\`\`