### PR TITLE
fix(copilot): drop connection-bound replay ids

### DIFF
--- a/extensions/github-copilot/connection-bound-ids.test.ts
+++ b/extensions/github-copilot/connection-bound-ids.test.ts
@@ -5,18 +5,15 @@ import {
 } from "./connection-bound-ids.js";
 
 describe("github-copilot connection-bound response IDs", () => {
-  it("rewrites opaque message response item IDs deterministically", () => {
+  it("drops opaque message response item IDs instead of synthesizing mismatched IDs", () => {
     const originalId = Buffer.from(`message-${"x".repeat(24)}`).toString("base64");
-    const first = [{ id: originalId, type: "message" }];
-    const second = [{ id: originalId, type: "message" }];
+    const input = [{ id: originalId, type: "message" }];
 
-    expect(rewriteCopilotConnectionBoundResponseIds(first)).toBe(true);
-    expect(rewriteCopilotConnectionBoundResponseIds(second)).toBe(true);
-    expect(first[0]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
-    expect(first[0]?.id).toBe(second[0]?.id);
+    expect(rewriteCopilotConnectionBoundResponseIds(input)).toBe(true);
+    expect(input[0]).not.toHaveProperty("id");
   });
 
-  it("uses response item type prefixes and preserves local IDs", () => {
+  it("drops opaque response item IDs and preserves local IDs", () => {
     const functionCallId = Buffer.from(`function-call-${"y".repeat(20)}`).toString("base64");
     const messageId = Buffer.from(`message-${"z".repeat(24)}`).toString("base64");
     const input = [
@@ -31,11 +28,11 @@ describe("github-copilot connection-bound response IDs", () => {
     expect(input[0]?.id).toBe("rs_existing");
     expect(input[1]?.id).toBe("msg_existing");
     expect(input[2]?.id).toBe("fc_existing");
-    expect(input[3]?.id).toMatch(/^fc_[a-f0-9]{16}$/);
-    expect(input[4]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
+    expect(input[3]).not.toHaveProperty("id");
+    expect(input[4]).not.toHaveProperty("id");
   });
 
-  it("preserves reasoning IDs regardless of encrypted_content", () => {
+  it("drops opaque reasoning IDs while preserving encrypted_content", () => {
     const withEncrypted = Buffer.from(`reasoning-${"e".repeat(24)}`).toString("base64");
     const withNull = Buffer.from(`reasoning-${"n".repeat(24)}`).toString("base64");
     const withoutField = Buffer.from(`reasoning-${"a".repeat(24)}`).toString("base64");
@@ -45,10 +42,11 @@ describe("github-copilot connection-bound response IDs", () => {
       { id: withoutField, type: "reasoning" },
     ];
 
-    expect(rewriteCopilotConnectionBoundResponseIds(input)).toBe(false);
-    expect(input[0]?.id).toBe(withEncrypted);
-    expect(input[1]?.id).toBe(withNull);
-    expect(input[2]?.id).toBe(withoutField);
+    expect(rewriteCopilotConnectionBoundResponseIds(input)).toBe(true);
+    expect(input[0]).not.toHaveProperty("id");
+    expect(input[0]?.encrypted_content).toBe("opaque-encrypted-payload");
+    expect(input[1]).not.toHaveProperty("id");
+    expect(input[2]).not.toHaveProperty("id");
   });
 
   it("patches response payload input arrays only", () => {
@@ -56,7 +54,7 @@ describe("github-copilot connection-bound response IDs", () => {
     const payload = { input: [{ id: messageId, type: "message" }] };
 
     expect(rewriteCopilotResponsePayloadConnectionBoundIds(payload)).toBe(true);
-    expect(payload.input[0]?.id).toMatch(/^msg_[a-f0-9]{16}$/);
+    expect(payload.input[0]).not.toHaveProperty("id");
     expect(rewriteCopilotResponsePayloadConnectionBoundIds(undefined)).toBe(false);
     expect(rewriteCopilotResponsePayloadConnectionBoundIds({ input: "text" })).toBe(false);
   });

--- a/extensions/github-copilot/connection-bound-ids.ts
+++ b/extensions/github-copilot/connection-bound-ids.ts
@@ -1,5 +1,3 @@
-import { createHash } from "node:crypto";
-
 // Copilot's OpenAI-compatible `/responses` endpoint can emit replay item IDs
 // that encode upstream connection state. Those IDs are rejected after the
 // connection changes, so normalize them at the provider boundary before send.
@@ -17,12 +15,6 @@ function looksLikeConnectionBoundId(id: string): boolean {
   return Buffer.from(id, "base64").length >= 16;
 }
 
-function deriveReplacementId(type: string | undefined, originalId: string): string {
-  const prefix = type === "function_call" ? "fc" : "msg";
-  const hex = createHash("sha256").update(originalId).digest("hex").slice(0, 16);
-  return `${prefix}_${hex}`;
-}
-
 type InputItem = Record<string, unknown> & { id?: unknown; type?: unknown };
 
 export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolean {
@@ -35,15 +27,13 @@ export function rewriteCopilotConnectionBoundResponseIds(input: unknown): boolea
     if (typeof id !== "string" || id.length === 0) {
       continue;
     }
-    // Reasoning items always reference server-side encrypted state bound to the
-    // original item ID. Rewriting the ID — even when encrypted_content is absent
-    // or null — breaks Copilot's server-side lookup and causes a 400 validation
-    // failure regardless of whether the client included encrypted_content.
-    if (item.type === "reasoning") {
-      continue;
-    }
     if (looksLikeConnectionBoundId(id)) {
-      item.id = deriveReplacementId(typeof item.type === "string" ? item.type : undefined, id);
+      // Copilot accepts replayed connection-bound response items when the id is
+      // omitted and recovers the real id from encrypted_content/server state.
+      // Synthesizing rs_/fc_/msg_ ids with hashes creates values Copilot never
+      // issued, so encrypted_content validation can fail with "item_id did not
+      // match the target item id" on multi-turn tool-call replays.
+      delete item.id;
       rewrote = true;
     }
   }

--- a/src/agents/openai-responses.reasoning-replay.test.ts
+++ b/src/agents/openai-responses.reasoning-replay.test.ts
@@ -46,7 +46,7 @@ const ZERO_USAGE = {
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 } as const;
 
-function buildReasoningPart(id = "rs_test") {
+function buildReasoningPart(id = "rs_test", extra?: Record<string, unknown>) {
   return {
     type: "thinking" as const,
     thinking: "internal",
@@ -54,6 +54,7 @@ function buildReasoningPart(id = "rs_test") {
       type: "reasoning",
       id,
       summary: [],
+      ...extra,
     }),
   };
 }
@@ -172,6 +173,56 @@ describe("openai-responses reasoning replay", () => {
     ) as Record<string, unknown> | undefined;
     expect(functionCall?.call_id).toBe("call_123");
     expect(functionCall?.id).toBe("fc_123");
+  });
+
+  it("preserves encrypted reasoning content when replaying thinking signatures", async () => {
+    const assistantToolOnly = buildAssistantMessage({
+      stopReason: "toolUse",
+      content: [
+        buildReasoningPart("rs_test", {
+          encrypted_content: "opaque-encrypted-content",
+          summary: "brief summary",
+        }),
+        {
+          type: "toolCall",
+          id: "call_123|fc_123",
+          name: "noop",
+          arguments: {},
+        },
+      ],
+    });
+
+    const toolResult: ToolResultMessage = {
+      role: "toolResult",
+      toolCallId: "call_123|fc_123",
+      toolName: "noop",
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+      timestamp: Date.now(),
+    };
+
+    const { input } = await runAbortedOpenAIResponsesStream({
+      messages: [
+        { role: "user", content: "Call noop.", timestamp: Date.now() },
+        assistantToolOnly,
+        toolResult,
+        { role: "user", content: "Now reply with ok.", timestamp: Date.now() },
+      ],
+      tools: [
+        {
+          name: "noop",
+          description: "no-op",
+          parameters: Type.Object({}, { additionalProperties: false }),
+        },
+      ],
+    });
+
+    const reasoning = input.find(
+      (item) =>
+        item && typeof item === "object" && (item as Record<string, unknown>).type === "reasoning",
+    ) as Record<string, unknown> | undefined;
+    expect(reasoning?.encrypted_content).toBe("opaque-encrypted-content");
+    expect(reasoning?.summary).toBe("brief summary");
   });
 
   it("still replays reasoning when paired with an assistant message", async () => {

--- a/src/agents/openai-ws-message-conversion.ts
+++ b/src/agents/openai-ws-message-conversion.ts
@@ -216,8 +216,7 @@ function parseThinkingSignature(value: unknown): ReplayableReasoningItem | null 
     return null;
   }
   try {
-    const signature = toReasoningSignature(JSON.parse(value));
-    return signature ? parseReasoningItem(signature) : null;
+    return parseReasoningItem(JSON.parse(value));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- drop Copilot connection-bound response item ids instead of replacing them with synthetic `msg_` / `fc_` hashes
- apply the same boundary behavior to opaque reasoning ids while preserving `encrypted_content`
- preserve encrypted reasoning content and summary when replaying stored thinking signatures

Fixes #72602

## Testing
- pnpm exec vitest run extensions/github-copilot/connection-bound-ids.test.ts src/agents/openai-responses.reasoning-replay.test.ts src/agents/openai-ws-message-conversion.test.ts
- pnpm exec oxfmt --check extensions/github-copilot/connection-bound-ids.ts extensions/github-copilot/connection-bound-ids.test.ts src/agents/openai-ws-message-conversion.ts src/agents/openai-responses.reasoning-replay.test.ts
- git diff --check
