### PR TITLE
fix(feishu): strip only leading bot self-mention so multi-bot groups respond

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -272,15 +272,27 @@ export function normalizeMentions(
   }
   const escaped = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const escapeName = (value: string) => value.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  // Strip ONLY the bot's own mention when it appears as the leading
+  // addressing prefix (optional whitespace before it, whitespace or end after).
+  // This preserves the #35994 slash-command UX (`@Bot /help` → `/help`)
+  // while keeping the bot's own <at> tag visible to the LLM whenever the
+  // mention appears mid-sentence — fixing the multi-bot NO_REPLY regression
+  // in #72504 where `Hey @BotA @BotB` would have BotA's own tag stripped,
+  // causing it to conclude it was not addressed.
   let result = text;
+  if (botStripId) {
+    const selfLeading = mentions.find(
+      (m) => m.id.open_id === botStripId && new RegExp(`^\\s*${escaped(m.key)}(\\s|$)`).test(text),
+    );
+    if (selfLeading) {
+      result = result.replace(new RegExp(`^\\s*${escaped(selfLeading.key)}\\s*`), "");
+    }
+  }
   for (const mention of mentions) {
     const mentionId = mention.id.open_id;
-    const replacement =
-      botStripId && mentionId === botStripId
-        ? ""
-        : mentionId
-          ? `<at user_id="${mentionId}">${escapeName(mention.name)}</at>`
-          : `@${mention.name}`;
+    const replacement = mentionId
+      ? `<at user_id="${mentionId}">${escapeName(mention.name)}</at>`
+      : `@${mention.name}`;
     result = result.replace(new RegExp(escaped(mention.key), "g"), () => replacement).trim();
   }
   return result;

--- a/extensions/feishu/src/bot.stripBotMention.test.ts
+++ b/extensions/feishu/src/bot.stripBotMention.test.ts
@@ -123,4 +123,38 @@ describe("normalizeMentions (via parseFeishuMessageEvent)", () => {
     );
     expect(ctx.content).toBe('<at user_id="ou_x">&lt;script&gt;</at> test');
   });
+
+  it("preserves bot self-mention when it appears mid-sentence (#72504 multi-bot groups)", () => {
+    // User @-mentions BotA and BotB together in a group. Each bot must see
+    // its own <at> tag so the LLM doesn't conclude it was unaddressed and
+    // return NO_REPLY. Only the leading addressing prefix gets stripped.
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "Hey @_bot_a @_bot_b please coordinate",
+        [
+          { key: "@_bot_a", name: "BotA", id: { open_id: "ou_bot" } },
+          { key: "@_bot_b", name: "BotB", id: { open_id: "ou_bot_b" } },
+        ],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe(
+      'Hey <at user_id="ou_bot">BotA</at> <at user_id="ou_bot_b">BotB</at> please coordinate',
+    );
+  });
+
+  it("strips leading bot mention but keeps inline self-mention (#72504)", () => {
+    // Same bot mentioned twice: leading prefix is addressing (strip),
+    // mid-sentence is semantic (keep, so LLM sees who was named).
+    const ctx = parseFeishuMessageEvent(
+      makeEvent(
+        "@_bot_1 ask @_bot_1 to summarize",
+        [{ key: "@_bot_1", name: "Bot", id: { open_id: "ou_bot" } }],
+        "group",
+      ),
+      BOT_OPEN_ID,
+    );
+    expect(ctx.content).toBe('ask <at user_id="ou_bot">Bot</at> to summarize');
+  });
 });


### PR DESCRIPTION
Fixes #72504. Refs #35994.

## Problem

In Feishu group chats where a user @-mentions multiple bots together — e.g. `@BotA @BotB please coordinate` — every bot returns `NO_REPLY`. Root cause is `normalizeMentions()` in `extensions/feishu/src/bot-content.ts`: it strips EVERY occurrence of the receiving bot's own `<at>` tag from the message body. After stripping, each bot only sees its peer's `<at>` tag, so its LLM concludes it was not addressed.

## Fix

Narrow the strip to ONLY the leading addressing prefix (optional whitespace → bot's mention key → whitespace or end-of-text). This preserves the #35994 slash-command UX (`@Bot /help` → `/help`) while keeping mid-sentence self-mentions visible to the LLM so multi-bot routing decisions stay correct.

The bot-mentioned detection itself (`checkBotMentioned` in bot-content.ts) is unchanged and continues to read `event.message.mentions[]` directly — so this fix only affects what the LLM sees as the prompt body, not whether the bot is woken up.

## Tests

All 11 existing `bot.stripBotMention.test.ts` cases pass unchanged (every leading-prefix scenario continues to strip identically). Two new tests cover the regression:

1. Mid-sentence self-mention in a multi-bot group is preserved (`Hey @BotA @BotB ...`).
2. Leading prefix is stripped while a separate inline self-mention in the same message is kept (`@Bot1 ask @Bot1 to summarize` → `ask <at>Bot</at> to summarize`).

Full file: 13/13 pass. `pnpm tsgo:test` clean.

## Diff

+53 / -6 across 2 production files + 1 test file (62 lines incl. CHANGELOG entry).