### PR TITLE
fix(cron): warn on main heartbeat handoff ghost runs

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -6115,6 +6115,7 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let runatms: Int?
     public let durationms: Int?
     public let nextrunatms: Int?
+    public let warnings: [String]?
     public let model: String?
     public let provider: String?
     public let usage: [String: AnyCodable]?
@@ -6139,6 +6140,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         runatms: Int?,
         durationms: Int?,
         nextrunatms: Int?,
+        warnings: [String]? = nil,
         model: String?,
         provider: String?,
         usage: [String: AnyCodable]?,
@@ -6162,6 +6164,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.runatms = runatms
         self.durationms = durationms
         self.nextrunatms = nextrunatms
+        self.warnings = warnings
         self.model = model
         self.provider = provider
         self.usage = usage
@@ -6187,6 +6190,7 @@ public struct CronRunLogEntry: Codable, Sendable {
         case runatms = "runAtMs"
         case durationms = "durationMs"
         case nextrunatms = "nextRunAtMs"
+        case warnings
         case model
         case provider
         case usage

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -226,6 +226,16 @@ Retention and pruning are controlled in config:
 - `cron.sessionRetention` (default `24h`) prunes completed isolated run sessions.
 - `cron.runLog.keepLines` prunes retained SQLite run-history rows per job. `cron.runLog.maxBytes` remains accepted for compatibility with older file-backed run logs.
 
+## Ghost-run warnings
+
+For main-session `systemEvent` jobs that use `wakeMode: "next-heartbeat"`, cron may finish quickly after handing work to the next heartbeat. OpenClaw annotates very fast successful handoffs with `possible-main-next-heartbeat-ghost-run` in the run log so operators know the scheduler accepted the handoff but did not prove agent processing completed in that cron run.
+
+- `cron.ghostRunWarningThresholdMs` controls the fast-run threshold in milliseconds.
+- Default: `50`.
+- Set `cron.ghostRunWarningThresholdMs: 0` to disable this warning.
+- Increase the threshold if your environment has slower handoff bookkeeping and you still want these runs flagged.
+- Check `openclaw cron runs --id <job-id>` or the job's run-log JSONL for the `warnings` array when investigating this warning.
+
 ## Migrating older jobs
 
 <Note>

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1288,6 +1288,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
     webhook: "https://example.invalid/legacy", // deprecated fallback for stored notify:true jobs
     webhookToken: "replace-with-dedicated-token", // optional bearer token for outbound webhook auth
     sessionRetention: "24h", // duration string or false
+    ghostRunWarningThresholdMs: 50, // set 0 to disable fast handoff warnings
     runLog: {
       maxBytes: "2mb", // default 2_000_000 bytes
       keepLines: 2000, // default 2000
@@ -1297,6 +1298,7 @@ Current builds no longer include the TCP bridge. Nodes connect over the Gateway 
 ```
 
 - `sessionRetention`: how long to keep completed isolated cron run sessions before pruning from `sessions.json`. Also controls cleanup of archived deleted cron transcripts. Default: `24h`; set `false` to disable.
+- `ghostRunWarningThresholdMs`: threshold in milliseconds for annotating very fast successful main-session `systemEvent` jobs using `wakeMode: "next-heartbeat"` with `possible-main-next-heartbeat-ghost-run` in the run-log `warnings` array. Default: `50`; set `0` to disable.
 - `runLog.maxBytes`: accepted for compatibility with older file-backed cron run logs. Default: `2_000_000` bytes.
 - `runLog.keepLines`: newest SQLite run-history rows retained per job. Default: `2000`.
 - `webhookToken`: bearer token used for cron webhook POST delivery (`delivery.mode = "webhook"`), if omitted no auth header is sent.

--- a/extensions/matrix/src/matrix/monitor/auto-join.ts
+++ b/extensions/matrix/src/matrix/monitor/auto-join.ts
@@ -69,8 +69,7 @@ export function registerMatrixAutoJoin(params: {
       });
   };
 
-  // Handle invites directly so both "always" and "allowlist" modes share the same path.
-  client.on("room.invite", (roomId: string, _inviteEvent: unknown) => {
+  const handleRoomInvite = (roomId: string, _inviteEvent: unknown) => {
     runInviteTask(roomId, async () => {
       if (autoJoin === "allowlist") {
         const allowedAliasRoomIds = await resolveAllowedAliasRoomIds();
@@ -92,5 +91,8 @@ export function registerMatrixAutoJoin(params: {
         runtime.error?.(`matrix: failed to join room ${roomId}: ${String(err)}`);
       }
     });
-  });
+  };
+
+  // Handle invites directly so both "always" and "allowlist" modes share the same path.
+  client.on("room.invite", handleRoomInvite);
 }

--- a/extensions/matrix/src/matrix/monitor/events.ts
+++ b/extensions/matrix/src/matrix/monitor/events.ts
@@ -272,7 +272,7 @@ export function registerMatrixMonitorEvents(params: {
     );
   });
 
-  client.on("room.failed_decryption", (roomId: string, event: MatrixRawEvent, error: Error) => {
+  const handleFailedDecryption = (roomId: string, event: MatrixRawEvent, error: Error) => {
     void runMonitorTask(
       `failed decryption handler room=${roomId} id=${event.event_id ?? "unknown"}`,
       async () => {
@@ -328,7 +328,8 @@ export function registerMatrixMonitorEvents(params: {
         );
       },
     );
-  });
+  };
+  client.on("room.failed_decryption", handleFailedDecryption);
 
   client.on("verification.summary", (summary) => {
     void runMonitorTask("verification summary handler", async () => {

--- a/packages/gateway-protocol/src/schema/cron.ts
+++ b/packages/gateway-protocol/src/schema/cron.ts
@@ -559,6 +559,7 @@ export const CronRunLogEntrySchema = Type.Object(
     runAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
     durationMs: Type.Optional(Type.Integer({ minimum: 0 })),
     nextRunAtMs: Type.Optional(Type.Integer({ minimum: 0 })),
+    warnings: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
     model: Type.Optional(Type.String()),
     provider: Type.Optional(Type.String()),
     usage: Type.Optional(

--- a/scripts/protocol-gen-swift.ts
+++ b/scripts/protocol-gen-swift.ts
@@ -77,7 +77,7 @@ const DEFAULTED_OPTIONAL_INIT_PARAM_ENTRIES: readonly [string, readonly string[]
   ["ChatInjectParams", ["agentId"]],
   ["ChatSendParams", ["agentId"]],
   ["MessageActionParams", ["inboundTurnKind"]],
-  ["CronRunLogEntry", ["errorReason", "failureNotificationDelivery"]],
+  ["CronRunLogEntry", ["errorReason", "failureNotificationDelivery", "warnings"]],
   ["ExecApprovalRequestParams", ["requireDeliveryRoute", "suppressDelivery"]],
   ["AgentSummary", ["thinkingLevels", "thinkingOptions", "thinkingDefault"]],
   ["ModelChoice", ["available"]],

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1710,6 +1710,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Bearer token attached to cron webhook POST deliveries when webhook mode is used. Prefer secret/env substitution and rotate this token regularly if shared webhook endpoints are internet-reachable.",
   "cron.sessionRetention":
     "Controls how long completed cron run sessions are kept before pruning (`24h`, `7d`, `1h30m`, or `false` to disable pruning; default: `24h`). Use shorter retention to reduce storage growth on high-frequency schedules.",
+  "cron.ghostRunWarningThresholdMs":
+    'Warns when a main-session `systemEvent` cron job using `wakeMode="next-heartbeat"` finishes as `ok` faster than this threshold, because that usually means cron only handed work to the next heartbeat and did not confirm agent processing. Set `0` to disable; default: `50`.',
   "cron.runLog":
     "Pruning controls for per-job cron run history. Run history is stored in SQLite; maxBytes remains accepted for older file-backed run logs.",
   "cron.runLog.maxBytes":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -861,6 +861,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "cron.webhook": "Cron Legacy Webhook (Deprecated)",
   "cron.webhookToken": "Cron Webhook Bearer Token",
   "cron.sessionRetention": "Cron Session Retention",
+  "cron.ghostRunWarningThresholdMs": "Cron Ghost Run Warning Threshold (ms)",
   "cron.runLog": "Cron Run Log Pruning",
   "cron.runLog.maxBytes": "Cron Run Log Max Bytes",
   "cron.runLog.keepLines": "Cron Run Log Keep Lines",

--- a/src/config/types.cron.ts
+++ b/src/config/types.cron.ts
@@ -51,6 +51,11 @@ export type CronConfig = {
    */
   sessionRetention?: string | false;
   /**
+   * Warn when a main-session systemEvent next-heartbeat handoff finishes faster than this.
+   * Set to 0 to disable the warning. Default: 50ms.
+   */
+  ghostRunWarningThresholdMs?: number;
+  /**
    * Run-history pruning controls. History is stored in SQLite; maxBytes is
    * retained for compatibility with older file-backed run logs.
    * Defaults: `maxBytes=2_000_000`, `keepLines=2000`.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -836,6 +836,7 @@ export const OpenClawSchema = z
         webhook: HttpUrlSchema.optional(),
         webhookToken: SecretInputSchema.optional().register(sensitive),
         sessionRetention: z.union([z.string(), z.literal(false)]).optional(),
+        ghostRunWarningThresholdMs: z.number().int().nonnegative().optional(),
         runLog: z
           .object({
             maxBytes: z.union([z.string(), z.number()]).optional(),

--- a/src/cron/cron-protocol-conformance.test.ts
+++ b/src/cron/cron-protocol-conformance.test.ts
@@ -126,4 +126,9 @@ describe("cron protocol conformance", () => {
     expect(errorReason).toBeDefined();
     expect(extractConstUnionValues(errorReason ?? {})).toEqual(expectedReasons);
   });
+
+  it("cron run-log schema declares warning annotations", () => {
+    const properties = (CronRunLogEntrySchema as SchemaLike).properties ?? {};
+    expect(properties.warnings).toBeDefined();
+  });
 });

--- a/src/cron/run-log-types.ts
+++ b/src/cron/run-log-types.ts
@@ -30,4 +30,5 @@ export type CronRunLogEntry = {
   runAtMs?: number;
   durationMs?: number;
   nextRunAtMs?: number;
+  warnings?: string[];
 } & CronRunTelemetry;

--- a/src/cron/run-log.ts
+++ b/src/cron/run-log.ts
@@ -379,6 +379,7 @@ export async function readCronRunLogEntriesPage(
         entry.delivery?.intended?.channel ?? "",
         entry.delivery?.resolved?.channel ?? "",
         ...(entry.delivery?.messageToolSentTo ?? []).map((target) => target.channel),
+        ...(entry.warnings ?? []),
       ].join(" ");
     },
   });

--- a/src/cron/run-log/entry-codec.ts
+++ b/src/cron/run-log/entry-codec.ts
@@ -143,5 +143,13 @@ export function parseCronRunLogEntryObject(
   if (typeof entryObj.sessionKey === "string" && entryObj.sessionKey.trim().length > 0) {
     entry.sessionKey = entryObj.sessionKey;
   }
+  if (Array.isArray(entryObj.warnings)) {
+    const warnings = entryObj.warnings.filter(
+      (warning): warning is string => typeof warning === "string" && warning.trim().length > 0,
+    );
+    if (warnings.length > 0) {
+      entry.warnings = warnings;
+    }
+  }
   return entry;
 }

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -19,6 +19,10 @@ const {
   runCronChangedMock,
   abortAndDrainEmbeddedAgentRunMock,
   retireSessionMcpRuntimeMock,
+  loggerDebugMock,
+  loggerInfoMock,
+  loggerWarnMock,
+  loggerErrorMock,
 } = vi.hoisted(() => ({
   enqueueSystemEventMock: vi.fn(),
   requestHeartbeatMock: vi.fn(),
@@ -40,6 +44,10 @@ const {
     forceCleared: false,
   })),
   retireSessionMcpRuntimeMock: vi.fn(async () => true),
+  loggerDebugMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
 }));
 
 function enqueueSystemEvent(...args: unknown[]) {
@@ -112,6 +120,29 @@ vi.mock("../agents/agent-bundle-mcp-tools.js", () => ({
   retireSessionMcpRuntime: retireSessionMcpRuntimeMock,
 }));
 
+vi.mock("../logging.js", () => {
+  const subsystemLogger = {
+    debug: loggerDebugMock,
+    info: loggerInfoMock,
+    warn: loggerWarnMock,
+    error: loggerErrorMock,
+    isEnabled: vi.fn(() => true),
+  };
+  return {
+    createSubsystemLogger: vi.fn(() => ({
+      ...subsystemLogger,
+      child: vi.fn(() => subsystemLogger),
+    })),
+    getChildLogger: vi.fn(() => ({
+      debug: loggerDebugMock,
+      info: loggerInfoMock,
+      warn: loggerWarnMock,
+      error: loggerErrorMock,
+    })),
+  };
+});
+
+import { readCronRunLogEntries } from "../cron/run-log.js";
 import { buildGatewayCronService } from "./server-cron.js";
 
 function createCronConfig(name: string): OpenClawConfig {
@@ -218,6 +249,10 @@ describe("buildGatewayCronService", () => {
       hasHooks: (hookName: string) => hookName === "cron_changed",
       runCronChanged: runCronChangedMock,
     });
+    loggerDebugMock.mockClear();
+    loggerInfoMock.mockClear();
+    loggerWarnMock.mockClear();
+    loggerErrorMock.mockClear();
   });
 
   it("emits cron_changed hooks with computed next run state", async () => {
@@ -558,6 +593,98 @@ describe("buildGatewayCronService", () => {
         to: undefined,
         accountId: undefined,
       });
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("warns and annotates fast main next-heartbeat systemEvent handoffs", async () => {
+    const cfg = createCronConfig("server-cron-ghost-warning");
+    cfg.cron = {
+      ...cfg.cron,
+      ghostRunWarningThresholdMs: 60_000,
+    };
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "main-next-heartbeat-handoff",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: "hello" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: job.id,
+          jobName: "main-next-heartbeat-handoff",
+          durationMs: expect.any(Number),
+          thresholdMs: 60_000,
+          wakeMode: "next-heartbeat",
+          sessionTarget: "main",
+          payloadKind: "systemEvent",
+        }),
+        "cron: possible ghost run; next-heartbeat systemEvent finished before confirmed agent processing",
+      );
+
+      const entries = await readCronRunLogEntries({
+        storePath: state.storePath,
+        jobId: job.id,
+        limit: 10,
+      });
+      expect(entries).toContainEqual(
+        expect.objectContaining({
+          jobId: job.id,
+          status: "ok",
+          warnings: ["possible-main-next-heartbeat-ghost-run"],
+        }),
+      );
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("does not warn for fast wakeMode now main systemEvent runs", async () => {
+    const cfg = createCronConfig("server-cron-ghost-warning-now");
+    cfg.cron = {
+      ...cfg.cron,
+      ghostRunWarningThresholdMs: 60_000,
+    };
+    loadConfigMock.mockReturnValue(cfg);
+
+    const state = buildGatewayCronService({
+      cfg,
+      deps: {} as CliDeps,
+      broadcast: () => {},
+    });
+    try {
+      const job = await state.cron.add({
+        name: "main-now",
+        enabled: true,
+        schedule: { kind: "at", at: new Date(1).toISOString() },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "hello" },
+      });
+
+      await state.cron.run(job.id, "force");
+
+      expect(loggerWarnMock).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: job.id,
+          payloadKind: "systemEvent",
+        }),
+        "cron: possible ghost run; next-heartbeat systemEvent finished before confirmed agent processing",
+      );
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -20,7 +20,7 @@ import { resolveCronDeliveryPlan, sendCronAnnouncePayloadStrict } from "../cron/
 import { runCronIsolatedAgentTurn } from "../cron/isolated-agent.js";
 import { appendCronRunLog, resolveCronRunLogPruneOptions } from "../cron/run-log.js";
 import type { CronServiceContract } from "../cron/service-contract.js";
-import { CronService } from "../cron/service.js";
+import { CronService, type CronEvent } from "../cron/service.js";
 import {
   resolveCronDeliverySessionKey,
   resolveCronSessionTargetSessionKey,
@@ -51,6 +51,11 @@ import {
   dispatchGatewayCronFinishedNotifications,
   sendGatewayCronFailureAlert,
 } from "./server-cron-notifications.js";
+
+const DEFAULT_GHOST_RUN_WARNING_THRESHOLD_MS = 50;
+const POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN = "possible-main-next-heartbeat-ghost-run";
+const POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN_MESSAGE =
+  "cron: possible ghost run; next-heartbeat systemEvent finished before confirmed agent processing";
 
 export type GatewayCronState = {
   cron: CronServiceContract;
@@ -119,6 +124,43 @@ function toPluginCronJob(job: CronJob): PluginHookGatewayCronJob {
     },
     createdAtMs: job.createdAtMs,
     updatedAtMs: job.updatedAtMs,
+  };
+}
+
+function resolveGhostRunWarningThresholdMs(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return DEFAULT_GHOST_RUN_WARNING_THRESHOLD_MS;
+  }
+  return Math.floor(value);
+}
+
+function getMainNextHeartbeatGhostRunWarning(params: {
+  evt: CronEvent;
+  job: CronJob | undefined;
+  thresholdMs: number;
+}):
+  | {
+      code: typeof POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN;
+      message: typeof POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN_MESSAGE;
+    }
+  | undefined {
+  const { evt, job, thresholdMs } = params;
+  if (thresholdMs <= 0 || !job || evt.action !== "finished" || evt.status !== "ok") {
+    return undefined;
+  }
+  if (
+    job.sessionTarget !== "main" ||
+    job.wakeMode !== "next-heartbeat" ||
+    job.payload.kind !== "systemEvent"
+  ) {
+    return undefined;
+  }
+  if (typeof evt.durationMs !== "number" || evt.durationMs >= thresholdMs) {
+    return undefined;
+  }
+  return {
+    code: POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN,
+    message: POSSIBLE_MAIN_NEXT_HEARTBEAT_GHOST_RUN_MESSAGE,
   };
 }
 
@@ -292,6 +334,9 @@ export function buildGatewayCronService(params: {
       agentId: agentId ?? defaultAgentId,
     });
   const sessionStorePath = resolveSessionStorePath(defaultAgentId);
+  const ghostRunWarningThresholdMs = resolveGhostRunWarningThresholdMs(
+    params.cfg.cron?.ghostRunWarningThresholdMs,
+  );
 
   const runCronChangedHook = (evt: PluginHookCronChangedEvent) => {
     const hookRunner = getGlobalHookRunner();
@@ -573,6 +618,25 @@ export function buildGatewayCronService(params: {
       runCronChangedHook(hookEvt);
       if (evt.action === "finished") {
         const job = evt.job ?? cron.getJob(evt.jobId);
+        const ghostRunWarning = getMainNextHeartbeatGhostRunWarning({
+          evt,
+          job,
+          thresholdMs: ghostRunWarningThresholdMs,
+        });
+        if (ghostRunWarning) {
+          cronLogger.warn(
+            {
+              jobId: evt.jobId,
+              jobName: job?.name,
+              durationMs: evt.durationMs,
+              thresholdMs: ghostRunWarningThresholdMs,
+              sessionTarget: job?.sessionTarget,
+              wakeMode: job?.wakeMode,
+              payloadKind: job?.payload.kind,
+            },
+            ghostRunWarning.message,
+          );
+        }
         dispatchGatewayCronFinishedNotifications({
           evt,
           job,
@@ -607,6 +671,7 @@ export function buildGatewayCronService(params: {
             model: evt.model,
             provider: evt.provider,
             usage: evt.usage,
+            warnings: ghostRunWarning ? [ghostRunWarning.code] : undefined,
           },
           opts: { keepLines: runLogPrune.keepLines },
         }).catch((err: unknown) => {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -645,6 +645,7 @@ export type CronRunLogEntry = {
   delivered?: boolean;
   deliveryStatus?: CronDeliveryStatus;
   deliveryError?: string;
+  warnings?: string[];
   sessionId?: string;
   sessionKey?: string;
   runAtMs?: number;

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -534,6 +534,31 @@ describe("cron view", () => {
     expect(container.querySelector(".cron-run-entry__body strong")?.textContent).toBe("markdown");
   });
 
+  it("renders cron run log warnings in history rows", () => {
+    const container = document.createElement("div");
+    render(
+      renderCron(
+        createProps({
+          runs: [
+            {
+              ts: 2,
+              jobId: "job-warning",
+              status: "ok",
+              summary: "handoff complete",
+              warnings: ["possible-main-next-heartbeat-ghost-run"],
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const warningChip = Array.from(container.querySelectorAll(".cron-run-entry .chip-warn")).find(
+      (chip) => chip.textContent?.includes("possible-main-next-heartbeat-ghost-run"),
+    );
+    expect(warningChip?.textContent?.trim()).toBe("possible-main-next-heartbeat-ghost-run");
+  });
+
   it("treats empty run summaries as absent when an error exists", () => {
     const container = document.createElement("div");
     render(

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1878,6 +1878,7 @@ function renderRun(
       : usage && typeof usage.input_tokens === "number" && typeof usage.output_tokens === "number"
         ? `${usage.input_tokens} in / ${usage.output_tokens} out`
         : null;
+  const warnings = (entry.warnings ?? []).filter((warning) => warning.trim().length > 0);
   const bodySource = entry.summary || entry.error || t("cron.runEntry.noSummary");
   const showErrorInMeta = Boolean(entry.error) && Boolean(entry.summary);
   return html`
@@ -1893,6 +1894,7 @@ function renderRun(
             ${entry.model ? html`<span class="chip">${entry.model}</span>` : nothing}
             ${entry.provider ? html`<span class="chip">${entry.provider}</span>` : nothing}
             ${usageSummary ? html`<span class="chip">${usageSummary}</span>` : nothing}
+            ${warnings.map((warning) => html`<span class="chip chip-warn">${warning}</span>`)}
           </div>
         </div>
         <div class="list-meta cron-run-entry__meta">


### PR DESCRIPTION
Fixes #63106.

## Summary

- Add a scoped warning for fast successful main-session `systemEvent` cron jobs using `wakeMode="next-heartbeat"`.
- Persist the `possible-main-next-heartbeat-ghost-run` annotation in cron run logs.
- Carry and render cron run-log warnings in the Control UI run history.
- Add `cron.ghostRunWarningThresholdMs` config with schema/help metadata and public docs.
- Keep `CronRunLogEntry.warnings` source-compatible in generated Swift by defaulting the optional initializer parameter to `nil`.
- Keep release-note context in the PR body only; this branch does not edit `CHANGELOG.md`.

## Real behavior proof

Behavior or issue addressed: Verified that a fast successful main-session `systemEvent` cron handoff using `wakeMode: "next-heartbeat"` writes the `possible-main-next-heartbeat-ghost-run` warning into the cron run log, that Control UI run history can render that warning from `CronRunLogEntry.warnings`, and that existing Swift call sites can construct `CronRunLogEntry` without passing the new optional `warnings` label.

Real environment tested: Local macOS checkout on current PR head `5238f67159`, rebased on current `upstream/main` `4a206db106`, using the real `buildGatewayCronService`, real cron run-log reader, Control UI cron run-history renderer, protocol generators, and Swift compiler typecheck. The cron proof used an isolated temporary `OPENCLAW_HOME` and did not touch the real user cron store.

Exact steps or command run after this patch: Rebased onto current `upstream/main`, regenerated gateway protocol artifacts, ran focused cron/gateway and Control UI tests, checked formatting/whitespace, verified generated protocol output stability, and typechecked a Swift compatibility snippet that constructs `CronRunLogEntry` without `warnings`.

Evidence after fix: Current-head focused test output:

```console
$ node scripts/test-projects.mjs src/gateway/server-cron.test.ts src/cron/cron-protocol-conformance.test.ts ui/src/ui/views/cron.test.ts --reporter verbose

 RUN  v4.1.7 /Users/antonio/projects/openclaw_worktrees/pr72677_clean

 Test Files  3 passed (3)
      Tests  42 passed (42)
   Start at  18:42:27
   Duration  16.44s
```

```console
$ ./node_modules/.bin/oxfmt --check scripts/protocol-gen-swift.ts src/gateway/server-cron.ts src/gateway/server-cron.test.ts src/cron/run-log.ts src/cron/cron-protocol-conformance.test.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts
Checking formatting...

All matched files use the correct format.
Finished in 250ms on 7 files using 12 threads.
```

Current-head isolated run-log proof shape, redacted from the real gateway cron service/run-log path:

```json
{
  "home": "/tmp/openclaw-ghost-proof.redacted",
  "jobId": "redacted-job-id",
  "logPath": "/tmp/openclaw-ghost-proof.redacted/runs/redacted-job-id.jsonl",
  "latest": {
    "action": "finished",
    "status": "ok",
    "summary": "proof handoff",
    "runId": "cron:redacted-job-id:redacted-start-ms",
    "durationMs": 7,
    "deliveryStatus": "not-requested",
    "warnings": [
      "possible-main-next-heartbeat-ghost-run"
    ]
  }
}
```

Swift compatibility proof:

```console
$ swiftc -typecheck \
  apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift \
  apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift \
  /private/tmp/openclaw-pr72677-swift-compat.swift
(no output)
```

The compatibility snippet constructs `CronRunLogEntry(...)` without a `warnings:` argument, matching existing Swift call sites.

Protocol generation stability:

```console
$ node --import tsx scripts/protocol-gen.ts
wrote /Users/antonio/projects/openclaw_worktrees/pr72677_clean/dist/protocol.schema.json

$ node --import tsx scripts/protocol-gen-swift.ts
wrote /Users/antonio/projects/openclaw_worktrees/pr72677_clean/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift

$ git diff --exit-code -- dist/protocol.schema.json apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
(no output)
```

Format and whitespace checks:

```console
$ git diff --check upstream/main...HEAD
(no output)
```

Observed result after fix: The forced main-session `next-heartbeat` handoff completed successfully, the persisted run-log entry contains `warnings: ["possible-main-next-heartbeat-ghost-run"]`, Control UI run history renders that warning as a warning chip, regenerated Swift now emits `warnings: [String]? = nil`, and an old-style Swift initializer call without `warnings:` typechecks.

What was not tested: I did not dispatch a real scheduled agent turn from the user's production cron store; the warning proof used an isolated temporary OpenClaw home with the real gateway cron service and run-log modules so it would not affect real scheduled jobs. Full `swift test --package-path apps/shared/OpenClawKit` could not run on this machine because the active developer directory is Command Line Tools only and SwiftPM rejects the package platform declarations `.iOS(.v18)` / `.macOS(.v15)` before compiling sources; the targeted Swift compiler proof above covers the specific initializer compatibility blocker.

## Tests

- [x] `node scripts/test-projects.mjs src/gateway/server-cron.test.ts src/cron/cron-protocol-conformance.test.ts ui/src/ui/views/cron.test.ts --reporter verbose`
- [x] `./node_modules/.bin/oxfmt --check scripts/protocol-gen-swift.ts src/gateway/server-cron.ts src/gateway/server-cron.test.ts src/cron/run-log.ts src/cron/cron-protocol-conformance.test.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
- [x] `git diff --check upstream/main...HEAD`
- [x] `node --import tsx scripts/protocol-gen.ts`
- [x] `node --import tsx scripts/protocol-gen-swift.ts`
- [x] `git diff --exit-code -- dist/protocol.schema.json apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift`
- [x] `swiftc -typecheck apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift /private/tmp/openclaw-pr72677-swift-compat.swift`

