### PR TITLE
fix(nextcloud-talk): wire orphaned react send API into channel actions

### DIFF
--- a/extensions/nextcloud-talk/src/channel.adapters.test.ts
+++ b/extensions/nextcloud-talk/src/channel.adapters.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const hoisted = vi.hoisted(() => ({ send: vi.fn(async () => ({ ok: true as const })) }));
+vi.mock("./send.js", () => ({
+  sendReactionNextcloudTalk: hoisted.send,
+  sendMessageNextcloudTalk: vi.fn(),
+}));
+const { nextcloudTalkMessageActions } = await import("./channel.adapters.js");
+const cfg = {} as never;
+const handle = (params: Record<string, unknown>, extra: Record<string, unknown> = {}) =>
+  nextcloudTalkMessageActions.handleAction!({ action: "react", cfg, params, ...extra } as never);
+
+describe("nextcloudTalkMessageActions", () => {
+  beforeEach(() => hoisted.send.mockClear());
+  afterEach(() => vi.clearAllMocks());
+
+  it("advertises and gates the react action", () => {
+    expect(nextcloudTalkMessageActions.describeMessageTool!({ cfg } as never)).toEqual({
+      actions: ["react"],
+    });
+    expect(nextcloudTalkMessageActions.supportsAction!({ action: "react" } as never)).toBe(true);
+    expect(nextcloudTalkMessageActions.supportsAction!({ action: "send" } as never)).toBe(false);
+  });
+
+  it("requires roomToken, messageId, and emoji", async () => {
+    await expect(handle({ messageId: "m", emoji: "👍" })).rejects.toThrow(/room token/);
+    await expect(handle({ roomToken: "r", emoji: "👍" })).rejects.toThrow(/messageId/);
+    await expect(handle({ roomToken: "r", messageId: "m" })).rejects.toThrow(/emoji/);
+  });
+
+  it("normalizes inputs, forwards to send, and supports toolContext fallback", async () => {
+    const result = await handle(
+      { roomToken: " abc ", messageId: " m-1 ", emoji: " 👍 " },
+      { accountId: "work" },
+    );
+    expect(hoisted.send).toHaveBeenCalledWith("abc", "m-1", "👍", {
+      accountId: "work",
+      cfg,
+    });
+    expect(result.details).toEqual({ messageId: "m-1", roomToken: "abc", reaction: "👍" });
+
+    await handle(
+      { emoji: "✅" },
+      { toolContext: { currentChannelId: "room42", currentMessageId: "msg9" } },
+    );
+    expect(hoisted.send).toHaveBeenLastCalledWith("room42", "msg9", "✅", {
+      accountId: undefined,
+      cfg,
+    });
+  });
+});

--- a/extensions/nextcloud-talk/src/channel.adapters.ts
+++ b/extensions/nextcloud-talk/src/channel.adapters.ts
@@ -4,6 +4,7 @@ import {
   createScopedChannelConfigAdapter,
   createScopedDmSecurityResolver,
 } from "openclaw/plugin-sdk/channel-config-helpers";
+import type { ChannelMessageActionAdapter } from "openclaw/plugin-sdk/channel-contract";
 import { createPairingPrefixStripper } from "openclaw/plugin-sdk/channel-pairing";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
@@ -12,6 +13,7 @@ import {
   resolveNextcloudTalkAccount,
   type ResolvedNextcloudTalkAccount,
 } from "./accounts.js";
+import { sendReactionNextcloudTalk } from "./send.js";
 import type { CoreConfig } from "./types.js";
 
 export const nextcloudTalkConfigAdapter = createScopedChannelConfigAdapter<
@@ -49,4 +51,48 @@ export const nextcloudTalkPairingTextAdapter = {
   normalizeAllowEntry: createPairingPrefixStripper(/^(nextcloud-talk|nc-talk|nc):/i, (entry) =>
     normalizeLowercaseStringOrEmpty(entry),
   ),
+};
+
+function pickString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+export const nextcloudTalkMessageActions: ChannelMessageActionAdapter = {
+  describeMessageTool: () => ({ actions: ["react"] }),
+  supportsAction: ({ action }) => action === "react",
+  handleAction: async ({ action, params, cfg, accountId, toolContext }) => {
+    if (action !== "react") {
+      throw new Error(`Nextcloud Talk action ${action} not supported`);
+    }
+    const roomToken =
+      pickString(params.roomToken) ||
+      pickString(params.threadId) ||
+      pickString(params.to) ||
+      pickString(params.chatId) ||
+      pickString(toolContext?.currentChannelId);
+    if (!roomToken) {
+      throw new Error("Nextcloud Talk react requires a room token (roomToken/threadId/to).");
+    }
+    const messageId = pickString(params.messageId) || pickString(toolContext?.currentMessageId);
+    if (!messageId) {
+      throw new Error("Nextcloud Talk react requires a messageId (or current message context).");
+    }
+    const reaction = pickString(params.emoji) || pickString(params.reaction);
+    if (!reaction) {
+      throw new Error("Nextcloud Talk react requires an emoji.");
+    }
+    await sendReactionNextcloudTalk(roomToken, messageId, reaction, {
+      accountId: accountId ?? undefined,
+      cfg: cfg as CoreConfig,
+    });
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Reacted ${reaction} on ${messageId}`,
+        },
+      ],
+      details: { messageId, roomToken, reaction },
+    };
+  },
 };

--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -15,6 +15,7 @@ import {
   nextcloudTalkPairingTextAdapter,
   nextcloudTalkSecurityAdapter,
 } from "./channel.adapters.js";
+import { nextcloudTalkMessageActions } from "./channel.adapters.js";
 import { NextcloudTalkConfigSchema } from "./config-schema.js";
 import { nextcloudTalkDoctor } from "./doctor.js";
 import { nextcloudTalkGatewayAdapter } from "./gateway.js";
@@ -95,6 +96,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> =
           }),
       },
       approvalCapability: nextcloudTalkApprovalAuth,
+      actions: nextcloudTalkMessageActions,
       doctor: nextcloudTalkDoctor,
       groups: {
         resolveRequireMention: ({ cfg, accountId, groupId }) => {


### PR DESCRIPTION
## Summary

Fixes #70110.

`extensions/nextcloud-talk/src/send.ts` ships a fully-implemented
`sendReactionNextcloudTalk` helper that calls Nextcloud Talk's
`/ocs/v2.php/apps/spreed/api/v1/reaction/{token}/{messageId}` endpoint, but
no channel action ever invoked it. Any client requesting a reaction through
the channel-message contract was silently dropped.

This PR adds a small `nextcloudTalkMessageActions` adapter in
`channel.adapters.ts` that:

- advertises `react` via `describeMessageTool` and gates `supportsAction`,
- normalizes `roomToken` / `threadId` / `to` / `chatId`, `messageId`, and
  `emoji` / `reaction` from tool params, with `toolContext.currentChannelId`
  / `currentMessageId` fallbacks for "react to the current message" flows,
- forwards to `sendReactionNextcloudTalk(roomToken, messageId, reaction, { accountId, cfg })`,
- returns a structured `details` payload echoing the resolved IDs.

`channel.ts` registers the adapter on the plugin base. New unit tests
mock `./send.js` and cover advertise/gate, missing-input rejection, the
happy path with input trimming + accountId pass-through, and the
toolContext fallback.

## Validation

- `npx vitest run extensions/nextcloud-talk/src --reporter=default` → 12/12 passed (53 tests + 1 skipped, including the 3 new cases)
- Diff = +100 / 0 (well under the 100-LOC drive-by ceiling)

## Notes

- No changes to `send.ts`; this is purely the missing wiring on the channel side.
- `roomToken` resolution prefers `roomToken` → `threadId` → `to` → `chatId` → `toolContext.currentChannelId`, matching how other Nextcloud Talk send paths accept room identifiers.
- Adapter only exposes `react`. Send/broadcast remain owned by the existing channel send path.