### PR TITLE
docs(taskflow): remove duplicated word in summary

### DIFF
--- a/docs/automation/taskflow.md
+++ b/docs/automation/taskflow.md
@@ -1,5 +1,5 @@
 ---
-summary: "Task Flow flow orchestration layer above background tasks"
+summary: "Task Flow orchestration layer above background tasks"
 read_when:
   - You want to understand how Task Flow relates to background tasks
   - You encounter Task Flow or openclaw tasks flow in release notes or docs


### PR DESCRIPTION
## Summary
Fixes a duplicated word in the Task Flow doc frontmatter summary:

- from: `Task Flow flow orchestration layer above background tasks`
- to:   `Task Flow orchestration layer above background tasks`

## Why
Tiny docs-quality fix for cleaner phrasing and search snippets.