### PR TITLE
fix: remove outdated "(Telegram only)" from reasoning stream ack [AI-assisted]

### DIFF
--- a/src/auto-reply/reply/directive-handling.impl.ts
+++ b/src/auto-reply/reply/directive-handling.impl.ts
@@ -533,7 +533,7 @@ export async function handleDirectiveOnly(
       directives.reasoningLevel === "off"
         ? formatDirectiveAck("Reasoning visibility disabled.")
         : directives.reasoningLevel === "stream"
-          ? formatDirectiveAck("Reasoning stream enabled (Telegram only).")
+          ? formatDirectiveAck("Reasoning stream enabled.")
           : formatDirectiveAck("Reasoning visibility enabled."),
     );
   }

--- a/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
+++ b/src/auto-reply/reply/directive-handling.mixed-inline.test.ts
@@ -192,6 +192,54 @@ describe("mixed inline directives", () => {
     expect(sessionEntry.reasoningLevel).toBe("off");
   });
 
+  it("emits reasoning stream ack without channel-specific qualifier", async () => {
+    const directives = parseInlineDirectives("please reply\n/reasoning stream");
+    const cfg = createConfig();
+    const sessionEntry = createSessionEntry({ reasoningLevel: "off" });
+    const sessionStore = { "agent:main:discord:user": sessionEntry };
+
+    const fastLane = await applyInlineDirectivesFastLane({
+      directives,
+      commandAuthorized: true,
+      senderIsOwner: false,
+      ctx: { Surface: "discord" } as never,
+      cfg,
+      agentId: "main",
+      isGroup: false,
+      sessionEntry,
+      sessionStore,
+      sessionKey: "agent:main:discord:user",
+      storePath: undefined,
+      elevatedEnabled: false,
+      elevatedAllowed: false,
+      elevatedFailures: [],
+      messageProviderKey: "discord",
+      defaultProvider: "openrouter",
+      defaultModel: "x-ai/grok-4.1-fast",
+      aliasIndex: { byAlias: new Map(), byKey: new Map() },
+      allowedModelKeys: new Set(),
+      allowedModelCatalog: [],
+      resetModelOverride: false,
+      provider: "openrouter",
+      model: "x-ai/grok-4.1-fast",
+      initialModelLabel: "openrouter/x-ai/grok-4.1-fast",
+      formatModelSwitchEvent: (label) => label,
+      agentCfg: cfg.agents?.defaults,
+      modelState: {
+        resolveDefaultThinkingLevel: async () => "off",
+        allowedModelKeys: new Set(),
+        allowedModelCatalog: [],
+        resetModelOverride: false,
+      },
+    });
+
+    expect(fastLane.directiveAck).toEqual({
+      text: "⚙️ Reasoning stream enabled.",
+    });
+
+    expect(sessionEntry.reasoningLevel).toBe("stream");
+  });
+
   it("does not persist trace directives for unauthorized mixed messages", async () => {
     const directives = parseInlineDirectives("please reply\n/trace raw");
     const cfg = createConfig();


### PR DESCRIPTION
## Summary

- Remove the `(Telegram only)` qualifier from the reasoning stream directive ack message
- The reasoning stream feature works on all channels (including Feishu/Lark), so the channel-specific qualifier was misleading
- Add a test verifying the stream ack message has no channel qualifier

When a user sends `/reasoning stream` on any channel, the bot previously replied with "Reasoning stream enabled (Telegram only)." — suggesting the feature was Telegram-exclusive even though it works fine on Feishu/Lark and other channels. This is a simple string fix to remove the outdated qualifier.

## Test plan

- [x] `pnpm test src/auto-reply/reply/directive-handling.mixed-inline.test.ts` — 4/4 pass
- [x] Verify `/reasoning stream` on Feishu/Lark shows "Reasoning stream enabled." without "(Telegram only)"
- [ ] Verify `/reasoning stream` on Telegram still works as before
- [x] Verify `/reasoning on` and `/reasoning off` ack messages are unchanged

Fixes #68305

🤖 Generated with [Claude Code](https://claude.com/claude-code)