### PR TITLE
[codex] fix: allow trusted .openclaw symlink

### DIFF
--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -560,11 +560,15 @@ enum ExecApprovalsStore {
     }
 
     private static func validateStateFilePath() throws {
-        try ExecApprovalsSocketPathGuard.validateApprovalsFilePath(for: self.fileURL().path)
+        try ExecApprovalsSocketPathGuard.validateApprovalsFilePath(
+            for: self.fileURL().path,
+            allowingSymlinksIn: OpenClawPaths.stateDirURL)
     }
 
     private static func hardenStateFilePath() throws {
-        try ExecApprovalsSocketPathGuard.hardenApprovalsFilePath(for: self.fileURL().path)
+        try ExecApprovalsSocketPathGuard.hardenApprovalsFilePath(
+            for: self.fileURL().path,
+            allowingSymlinksIn: OpenClawPaths.stateDirURL)
     }
 
     private static func logUnsafeStatePath(_ error: Error) {

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -342,18 +342,14 @@ enum ExecApprovalsStore {
         }
     }
 
-    static func saveFile(_ file: ExecApprovalsFile) {
-        do {
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            let data = try encoder.encode(file)
-            let url = self.fileURL()
-            try self.hardenStateFilePath()
-            try data.write(to: url, options: [.atomic])
-            try? FileManager().setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-        } catch {
-            self.logger.error("exec approvals save failed: \(error.localizedDescription, privacy: .public)")
-        }
+    static func saveFile(_ file: ExecApprovalsFile) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(file)
+        let url = self.fileURL()
+        try self.hardenStateFilePath()
+        try data.write(to: url, options: [.atomic])
+        try? FileManager().setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
     static func ensureFile() -> ExecApprovalsFile {
@@ -380,7 +376,12 @@ enum ExecApprovalsStore {
         }
         if file.agents == nil { file.agents = [:] }
         if !existed || loadedHash != self.hashFile(file) {
-            self.saveFile(file)
+            do {
+                try self.saveFile(file)
+            } catch {
+                self.logger.error("exec approvals save failed: \(error.localizedDescription, privacy: .public)")
+                return self.emptyFile()
+            }
         }
         return file
     }
@@ -552,7 +553,11 @@ enum ExecApprovalsStore {
     private static func updateFile(_ mutate: (inout ExecApprovalsFile) -> Void) {
         var file = self.ensureFile()
         mutate(&file)
-        self.saveFile(file)
+        do {
+            try self.saveFile(file)
+        } catch {
+            self.logger.error("exec approvals save failed: \(error.localizedDescription, privacy: .public)")
+        }
     }
 
     private static func emptyFile() -> ExecApprovalsFile {

--- a/apps/macos/Sources/OpenClaw/ExecApprovals.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovals.swift
@@ -226,7 +226,6 @@ enum ExecApprovalsStore {
     private static let defaultAsk: ExecAsk = .onMiss
     private static let defaultAskFallback: ExecSecurity = .deny
     private static let defaultAutoAllowSkills = false
-    private static let secureStateDirPermissions = 0o700
 
     static func fileURL() -> URL {
         OpenClawPaths.stateDirURL.appendingPathComponent("exec-approvals.json")
@@ -271,12 +270,22 @@ enum ExecApprovalsStore {
 
     static func readSnapshot() -> ExecApprovalsSnapshot {
         let url = self.fileURL()
+        do {
+            try self.validateStateFilePath()
+        } catch {
+            self.logUnsafeStatePath(error)
+            return ExecApprovalsSnapshot(
+                path: url.path,
+                exists: false,
+                hash: self.hashRaw(nil),
+                file: self.emptyFile())
+        }
         guard FileManager().fileExists(atPath: url.path) else {
             return ExecApprovalsSnapshot(
                 path: url.path,
                 exists: false,
                 hash: self.hashRaw(nil),
-                file: ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:]))
+                file: self.emptyFile())
         }
         let raw = try? String(contentsOf: url, encoding: .utf8)
         let data = raw.flatMap { $0.data(using: .utf8) }
@@ -284,7 +293,7 @@ enum ExecApprovalsStore {
             if let data, let file = try? JSONDecoder().decode(ExecApprovalsFile.self, from: data), file.version == 1 {
                 return file
             }
-            return ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+            return self.emptyFile()
         }()
         return ExecApprovalsSnapshot(
             path: url.path,
@@ -311,19 +320,25 @@ enum ExecApprovalsStore {
 
     static func loadFile() -> ExecApprovalsFile {
         let url = self.fileURL()
+        do {
+            try self.validateStateFilePath()
+        } catch {
+            self.logUnsafeStatePath(error)
+            return self.emptyFile()
+        }
         guard FileManager().fileExists(atPath: url.path) else {
-            return ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+            return self.emptyFile()
         }
         do {
             let data = try Data(contentsOf: url)
             let decoded = try JSONDecoder().decode(ExecApprovalsFile.self, from: data)
             if decoded.version != 1 {
-                return ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+                return self.emptyFile()
             }
             return decoded
         } catch {
             self.logger.warning("exec approvals load failed: \(error.localizedDescription, privacy: .public)")
-            return ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+            return self.emptyFile()
         }
     }
 
@@ -333,10 +348,7 @@ enum ExecApprovalsStore {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             let data = try encoder.encode(file)
             let url = self.fileURL()
-            self.ensureSecureStateDirectory()
-            try FileManager().createDirectory(
-                at: url.deletingLastPathComponent(),
-                withIntermediateDirectories: true)
+            try self.hardenStateFilePath()
             try data.write(to: url, options: [.atomic])
             try? FileManager().setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
         } catch {
@@ -345,8 +357,13 @@ enum ExecApprovalsStore {
     }
 
     static func ensureFile() -> ExecApprovalsFile {
-        self.ensureSecureStateDirectory()
         let url = self.fileURL()
+        do {
+            try self.hardenStateFilePath()
+        } catch {
+            self.logUnsafeStatePath(error)
+            return self.emptyFile()
+        }
         let existed = FileManager().fileExists(atPath: url.path)
         let loaded = self.loadFile()
         let loadedHash = self.hashFile(loaded)
@@ -538,20 +555,21 @@ enum ExecApprovalsStore {
         self.saveFile(file)
     }
 
-    private static func ensureSecureStateDirectory() {
-        let url = OpenClawPaths.stateDirURL
-        do {
-            try FileManager().createDirectory(at: url, withIntermediateDirectories: true)
-            try FileManager().setAttributes(
-                [.posixPermissions: self.secureStateDirPermissions],
-                ofItemAtPath: url.path)
-        } catch {
-            let message =
-                "exec approvals state dir permission hardening failed: \(error.localizedDescription)"
-            self.logger
-                .warning(
-                    "\(message, privacy: .public)")
-        }
+    private static func emptyFile() -> ExecApprovalsFile {
+        ExecApprovalsFile(version: 1, socket: nil, defaults: nil, agents: [:])
+    }
+
+    private static func validateStateFilePath() throws {
+        try ExecApprovalsSocketPathGuard.validateApprovalsFilePath(for: self.fileURL().path)
+    }
+
+    private static func hardenStateFilePath() throws {
+        try ExecApprovalsSocketPathGuard.hardenApprovalsFilePath(for: self.fileURL().path)
+    }
+
+    private static func logUnsafeStatePath(_ error: Error) {
+        self.logger.warning(
+            "exec approvals state path hardening failed: \(error.localizedDescription, privacy: .public)")
     }
 
     private static func generateToken() -> String {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -649,6 +649,7 @@ enum ExecApprovalsSocketPathGuard {
 
     private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {
         let parentPath = parentURL.path
+        try self.validateParentSymlinkLocation(for: parentURL)
         var status = stat()
         if stat(parentPath, &status) != 0 {
             throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
@@ -686,6 +687,29 @@ enum ExecApprovalsSocketPathGuard {
         }
         try self.validateResolvedAncestorChain(for: targetURL, reportedPath: parentPath)
         return targetURL
+    }
+
+    private static func validateParentSymlinkLocation(for parentURL: URL) throws {
+        let parentPath = parentURL.path
+        var linkStatus = stat()
+        if lstat(parentPath, &linkStatus) != 0 {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "symlink lstat failed (errno \(errno))")
+        }
+        guard linkStatus.st_uid == getuid() else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "symlink is not owned by the current user")
+        }
+
+        let locationURL = parentURL.deletingLastPathComponent().standardizedFileURL
+        try self.validateNoAdditionalSymlinkTargetHops(
+            in: locationURL.path,
+            reportedPath: parentPath)
+        try self.validateResolvedAncestorChain(
+            for: locationURL.resolvingSymlinksInPath(),
+            reportedPath: parentPath)
     }
 
     private static func symlinkDestinationPath(for parentURL: URL) throws -> String {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -678,6 +678,7 @@ enum ExecApprovalsSocketPathGuard {
 
         var rawURL = URL(fileURLWithPath: components[0], isDirectory: true)
         var hardenedURL = rawURL
+        var acceptedStateSymlink = false
 
         for component in components.dropFirst() {
             rawURL.appendPathComponent(component, isDirectory: true)
@@ -686,6 +687,12 @@ enum ExecApprovalsSocketPathGuard {
             case .missing, .directory:
                 hardenedURL = nextHardenedURL
             case .symlink:
+                guard component == ".openclaw" && !acceptedStateSymlink else {
+                    throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
+                        path: rawURL.path,
+                        kind: .symlink)
+                }
+                acceptedStateSymlink = true
                 hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
             case let kind:
                 throw ExecApprovalsSocketPathGuardError.parentPathInvalid(

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -560,6 +560,7 @@ enum ExecApprovalsSocketPathKind: Equatable {
 
 enum ExecApprovalsSocketPathGuardError: LocalizedError {
     case lstatFailed(path: String, code: Int32)
+    case approvalsFilePathInvalid(path: String, kind: ExecApprovalsSocketPathKind)
     case parentPathInvalid(path: String, kind: ExecApprovalsSocketPathKind)
     case parentSymlinkTargetInvalid(path: String, message: String)
     case socketPathInvalid(path: String, kind: ExecApprovalsSocketPathKind)
@@ -571,6 +572,8 @@ enum ExecApprovalsSocketPathGuardError: LocalizedError {
         switch self {
         case let .lstatFailed(path, code):
             "lstat failed for \(path) (errno \(code))"
+        case let .approvalsFilePathInvalid(path, kind):
+            "exec approvals file path invalid (\(kind)) at \(path)"
         case let .parentPathInvalid(path, kind):
             "socket parent path invalid (\(kind)) at \(path)"
         case let .parentSymlinkTargetInvalid(path, message):
@@ -593,6 +596,11 @@ enum ExecApprovalsSocketPathGuard {
     private static let posixGroupOrOtherWrite = mode_t(0o022)
     private static let posixSticky = mode_t(0o1000)
 
+    private struct TrustedParentDirectory {
+        let url: URL
+        let hardenFromURL: URL?
+    }
+
     static func pathKind(at path: String) throws -> ExecApprovalsSocketPathKind {
         var status = stat()
         let result = lstat(path, &status)
@@ -612,25 +620,60 @@ enum ExecApprovalsSocketPathGuard {
 
     static func hardenParentDirectory(for socketPath: String) throws {
         let parentURL = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
-        let hardenedParentURL = try self.trustedParentDirectoryURL(for: parentURL)
-        try self.createHardenedDirectoryPath(hardenedParentURL)
+        let trustedParent = try self.trustedParentDirectory(for: parentURL)
+        try self.createHardenedDirectoryPath(
+            trustedParent.url,
+            hardenFrom: trustedParent.hardenFromURL)
     }
 
-    private static func createHardenedDirectoryPath(_ directoryURL: URL) throws {
+    static func validateApprovalsFilePath(for filePath: String) throws {
+        let parentURL = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        _ = try self.trustedParentDirectory(for: parentURL)
+        try self.validateApprovalsFileDestination(at: filePath)
+    }
+
+    static func hardenApprovalsFilePath(for filePath: String) throws {
+        let parentURL = URL(fileURLWithPath: filePath).deletingLastPathComponent()
+        let trustedParent = try self.trustedParentDirectory(for: parentURL)
+        try self.createHardenedDirectoryPath(
+            trustedParent.url,
+            hardenFrom: trustedParent.hardenFromURL)
+        try self.validateApprovalsFileDestination(at: filePath)
+    }
+
+    private static func validateApprovalsFileDestination(at filePath: String) throws {
+        let kind = try self.pathKind(at: filePath)
+        switch kind {
+        case .missing, .other:
+            return
+        case .directory, .socket, .symlink:
+            throw ExecApprovalsSocketPathGuardError.approvalsFilePathInvalid(
+                path: filePath,
+                kind: kind)
+        }
+    }
+
+    private static func createHardenedDirectoryPath(
+        _ directoryURL: URL,
+        hardenFrom hardenFromURL: URL?
+    ) throws {
         let standardizedURL = directoryURL.standardizedFileURL
         let components = standardizedURL.pathComponents
         guard !components.isEmpty else {
             return
         }
 
+        let hardenFromPath = (hardenFromURL ?? standardizedURL).standardizedFileURL.path
         var currentURL = URL(fileURLWithPath: components[0], isDirectory: true)
         for component in components.dropFirst() {
             currentURL.appendPathComponent(component, isDirectory: true)
+            let shouldHarden = currentURL.path == hardenFromPath
+                || currentURL.path.hasPrefix("\(hardenFromPath)/")
             switch try self.pathKind(at: currentURL.path) {
             case .missing:
                 try self.createHardenedDirectory(currentURL)
             case .directory:
-                if currentURL.path == standardizedURL.path {
+                if shouldHarden {
                     try self.setHardenedDirectoryPermissions(currentURL)
                 }
             case let kind:
@@ -669,15 +712,16 @@ enum ExecApprovalsSocketPathGuard {
         }
     }
 
-    private static func trustedParentDirectoryURL(for parentURL: URL) throws -> URL {
+    private static func trustedParentDirectory(for parentURL: URL) throws -> TrustedParentDirectory {
         let standardizedURL = parentURL.standardizedFileURL
         let components = standardizedURL.pathComponents
         guard !components.isEmpty else {
-            return standardizedURL
+            return TrustedParentDirectory(url: standardizedURL, hardenFromURL: nil)
         }
 
         var rawURL = URL(fileURLWithPath: components[0], isDirectory: true)
         var hardenedURL = rawURL
+        var hardenFromURL: URL?
         var acceptedStateSymlink = false
 
         for component in components.dropFirst() {
@@ -686,6 +730,9 @@ enum ExecApprovalsSocketPathGuard {
             switch try self.pathKind(at: rawURL.path) {
             case .missing, .directory:
                 hardenedURL = nextHardenedURL
+                if component == ".openclaw", hardenFromURL == nil {
+                    hardenFromURL = hardenedURL
+                }
             case .symlink:
                 guard component == ".openclaw" && !acceptedStateSymlink else {
                     throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
@@ -694,6 +741,7 @@ enum ExecApprovalsSocketPathGuard {
                 }
                 acceptedStateSymlink = true
                 hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
+                hardenFromURL = hardenedURL
             case let kind:
                 throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
                     path: rawURL.path,
@@ -701,7 +749,7 @@ enum ExecApprovalsSocketPathGuard {
             }
         }
 
-        return hardenedURL
+        return TrustedParentDirectory(url: hardenedURL, hardenFromURL: hardenFromURL)
     }
 
     private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -756,6 +756,9 @@ enum ExecApprovalsSocketPathGuard {
                 let isConfiguredStateSymlink = self.isStateDirectoryPrefix(
                     rawURL.path,
                     stateDirURL: stateDirURL)
+                let isStateBoundary = self.isStateDirectoryBoundary(
+                    rawURL.path,
+                    stateDirURL: stateDirURL)
                 let isDefaultStateSymlink = stateDirURL == nil
                     && component == ".openclaw"
                     && !acceptedDefaultStateSymlink
@@ -767,9 +770,16 @@ enum ExecApprovalsSocketPathGuard {
                 if isDefaultStateSymlink {
                     acceptedDefaultStateSymlink = true
                 }
-                hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
+                if !isStateBoundary,
+                   !isDefaultStateSymlink,
+                   try self.isTrustedSystemSymlink(at: rawURL.path)
+                {
+                    hardenedURL = try self.trustedSystemParentSymlinkTarget(for: rawURL)
+                } else {
+                    hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
+                }
                 if hardenFromURL == nil,
-                   self.isStateDirectoryBoundary(rawURL.path, stateDirURL: stateDirURL)
+                   isStateBoundary
                     || (stateDirURL == nil && component == ".openclaw")
                 {
                     hardenFromURL = hardenedURL
@@ -798,6 +808,22 @@ enum ExecApprovalsSocketPathGuard {
         }
         let candidatePath = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
         return stateDirPath == candidatePath
+    }
+
+    private static func trustedSystemParentSymlinkTarget(for parentURL: URL) throws -> URL {
+        let parentPath = parentURL.path
+        try self.validateStableSymlinkHopLocation(at: parentPath, reportedPath: parentPath)
+        let targetURL = parentURL.resolvingSymlinksInPath()
+        switch try self.pathKind(at: targetURL.path) {
+        case .directory:
+            break
+        case let kind:
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "resolved system symlink target kind is \(kind)")
+        }
+        try self.validateResolvedAncestorChain(for: targetURL, reportedPath: parentPath)
+        return targetURL
     }
 
     private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -726,11 +726,24 @@ enum ExecApprovalsSocketPathGuard {
         for path in ancestors.reversed() {
             let kind = try self.pathKind(at: path)
             if kind == .symlink {
+                if try self.isTrustedSystemSymlink(at: path) {
+                    continue
+                }
                 throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
                     path: reportedPath,
                     message: "target resolves through another symlink at \(path)")
             }
         }
+    }
+
+    private static func isTrustedSystemSymlink(at path: String) throws -> Bool {
+        var status = stat()
+        if lstat(path, &status) != 0 {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: path,
+                message: "symlink lstat failed (errno \(errno))")
+        }
+        return status.st_uid == 0
     }
 
     private static func validateResolvedAncestorChain(for targetURL: URL, reportedPath: String)

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -618,23 +618,36 @@ enum ExecApprovalsSocketPathGuard {
         return .other
     }
 
-    static func hardenParentDirectory(for socketPath: String) throws {
+    static func hardenParentDirectory(
+        for socketPath: String,
+        allowingSymlinksIn stateDirURL: URL? = nil
+    ) throws {
         let parentURL = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
-        let trustedParent = try self.trustedParentDirectory(for: parentURL)
+        let trustedParent = try self.trustedParentDirectory(
+            for: parentURL,
+            allowingSymlinksIn: stateDirURL)
         try self.createHardenedDirectoryPath(
             trustedParent.url,
             hardenFrom: trustedParent.hardenFromURL)
     }
 
-    static func validateApprovalsFilePath(for filePath: String) throws {
+    static func validateApprovalsFilePath(
+        for filePath: String,
+        allowingSymlinksIn stateDirURL: URL? = nil
+    ) throws {
         let parentURL = URL(fileURLWithPath: filePath).deletingLastPathComponent()
-        _ = try self.trustedParentDirectory(for: parentURL)
+        _ = try self.trustedParentDirectory(for: parentURL, allowingSymlinksIn: stateDirURL)
         try self.validateApprovalsFileDestination(at: filePath)
     }
 
-    static func hardenApprovalsFilePath(for filePath: String) throws {
+    static func hardenApprovalsFilePath(
+        for filePath: String,
+        allowingSymlinksIn stateDirURL: URL? = nil
+    ) throws {
         let parentURL = URL(fileURLWithPath: filePath).deletingLastPathComponent()
-        let trustedParent = try self.trustedParentDirectory(for: parentURL)
+        let trustedParent = try self.trustedParentDirectory(
+            for: parentURL,
+            allowingSymlinksIn: stateDirURL)
         try self.createHardenedDirectoryPath(
             trustedParent.url,
             hardenFrom: trustedParent.hardenFromURL)
@@ -712,7 +725,10 @@ enum ExecApprovalsSocketPathGuard {
         }
     }
 
-    private static func trustedParentDirectory(for parentURL: URL) throws -> TrustedParentDirectory {
+    private static func trustedParentDirectory(
+        for parentURL: URL,
+        allowingSymlinksIn stateDirURL: URL?
+    ) throws -> TrustedParentDirectory {
         let standardizedURL = parentURL.standardizedFileURL
         let components = standardizedURL.pathComponents
         guard !components.isEmpty else {
@@ -722,7 +738,7 @@ enum ExecApprovalsSocketPathGuard {
         var rawURL = URL(fileURLWithPath: components[0], isDirectory: true)
         var hardenedURL = rawURL
         var hardenFromURL: URL?
-        var acceptedStateSymlink = false
+        var acceptedDefaultStateSymlink = false
 
         for component in components.dropFirst() {
             rawURL.appendPathComponent(component, isDirectory: true)
@@ -730,18 +746,34 @@ enum ExecApprovalsSocketPathGuard {
             switch try self.pathKind(at: rawURL.path) {
             case .missing, .directory:
                 hardenedURL = nextHardenedURL
-                if component == ".openclaw", hardenFromURL == nil {
+                if hardenFromURL == nil,
+                   self.isStateDirectoryBoundary(rawURL.path, stateDirURL: stateDirURL)
+                    || (stateDirURL == nil && component == ".openclaw")
+                {
                     hardenFromURL = hardenedURL
                 }
             case .symlink:
-                guard component == ".openclaw" && !acceptedStateSymlink else {
+                let isConfiguredStateSymlink = self.isStateDirectoryPrefix(
+                    rawURL.path,
+                    stateDirURL: stateDirURL)
+                let isDefaultStateSymlink = stateDirURL == nil
+                    && component == ".openclaw"
+                    && !acceptedDefaultStateSymlink
+                guard isConfiguredStateSymlink || isDefaultStateSymlink else {
                     throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
                         path: rawURL.path,
                         kind: .symlink)
                 }
-                acceptedStateSymlink = true
+                if isDefaultStateSymlink {
+                    acceptedDefaultStateSymlink = true
+                }
                 hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
-                hardenFromURL = hardenedURL
+                if hardenFromURL == nil,
+                   self.isStateDirectoryBoundary(rawURL.path, stateDirURL: stateDirURL)
+                    || (stateDirURL == nil && component == ".openclaw")
+                {
+                    hardenFromURL = hardenedURL
+                }
             case let kind:
                 throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
                     path: rawURL.path,
@@ -750,6 +782,22 @@ enum ExecApprovalsSocketPathGuard {
         }
 
         return TrustedParentDirectory(url: hardenedURL, hardenFromURL: hardenFromURL)
+    }
+
+    private static func isStateDirectoryPrefix(_ path: String, stateDirURL: URL?) -> Bool {
+        guard let stateDirPath = stateDirURL?.standardizedFileURL.path else {
+            return false
+        }
+        let candidatePath = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+        return stateDirPath == candidatePath || stateDirPath.hasPrefix("\(candidatePath)/")
+    }
+
+    private static func isStateDirectoryBoundary(_ path: String, stateDirURL: URL?) -> Bool {
+        guard let stateDirPath = stateDirURL?.standardizedFileURL.path else {
+            return false
+        }
+        let candidatePath = URL(fileURLWithPath: path, isDirectory: true).standardizedFileURL.path
+        return stateDirPath == candidatePath
     }
 
     private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {
@@ -1038,7 +1086,9 @@ private final class ExecApprovalsSocketServer: @unchecked Sendable {
             return -1
         }
         do {
-            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: self.socketPath)
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(
+                for: self.socketPath,
+                allowingSymlinksIn: OpenClawPaths.stateDirURL)
             try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
         } catch {
             self.logger

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -589,6 +589,9 @@ enum ExecApprovalsSocketPathGuardError: LocalizedError {
 
 enum ExecApprovalsSocketPathGuard {
     static let parentDirectoryPermissions = 0o700
+    private static let posixOwnerWrite = mode_t(0o200)
+    private static let posixGroupOrOtherWrite = mode_t(0o022)
+    private static let posixSticky = mode_t(0o1000)
 
     static func pathKind(at path: String) throws -> ExecApprovalsSocketPathKind {
         var status = stat()
@@ -677,7 +680,65 @@ enum ExecApprovalsSocketPathGuard {
                 path: parentPath,
                 message: "resolved target kind is \(kind)")
         }
+        try self.validateResolvedAncestorChain(for: targetURL, reportedPath: parentPath)
         return targetURL
+    }
+
+    private static func validateResolvedAncestorChain(for targetURL: URL, reportedPath: String)
+        throws
+    {
+        let currentUID = getuid()
+        var ancestors: [URL] = []
+        var current = targetURL.standardizedFileURL
+
+        while true {
+            ancestors.append(current)
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+
+        for url in ancestors.reversed() {
+            try self.validateStableResolvedAncestor(
+                at: url.path,
+                reportedPath: reportedPath,
+                currentUID: currentUID)
+        }
+    }
+
+    private static func validateStableResolvedAncestor(
+        at path: String,
+        reportedPath: String,
+        currentUID: uid_t
+    ) throws {
+        var status = stat()
+        if lstat(path, &status) != 0 {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: reportedPath,
+                message: "ancestor lstat failed at \(path) (errno \(errno))")
+        }
+        let fileType = status.st_mode & mode_t(S_IFMT)
+        guard fileType == mode_t(S_IFDIR) else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: reportedPath,
+                message: "ancestor is not a directory at \(path)")
+        }
+        guard status.st_uid == currentUID || status.st_uid == 0
+            || (status.st_mode & self.posixOwnerWrite) == 0
+        else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: reportedPath,
+                message: "ancestor is owner-writable by an untrusted user at \(path)")
+        }
+        guard (status.st_mode & self.posixGroupOrOtherWrite) == 0
+            || (status.st_mode & self.posixSticky) != 0
+        else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: reportedPath,
+                message: "ancestor is group/other-writable at \(path)")
+        }
     }
 
     static func removeExistingSocket(at socketPath: String) throws {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -751,6 +751,7 @@ enum ExecApprovalsSocketPathGuard {
             let kind = try self.pathKind(at: path)
             if kind == .symlink {
                 if try self.isTrustedSystemSymlink(at: path) {
+                    try self.validateStableSymlinkHopLocation(at: path, reportedPath: reportedPath)
                     continue
                 }
                 throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
@@ -768,6 +769,15 @@ enum ExecApprovalsSocketPathGuard {
                 message: "symlink lstat failed (errno \(errno))")
         }
         return status.st_uid == 0
+    }
+
+    private static func validateStableSymlinkHopLocation(at path: String, reportedPath: String)
+        throws
+    {
+        let parentURL = URL(fileURLWithPath: path)
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+        try self.validateResolvedAncestorChain(for: parentURL, reportedPath: reportedPath)
     }
 
     private static func validateResolvedAncestorChain(for targetURL: URL, reportedPath: String)

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -613,22 +613,58 @@ enum ExecApprovalsSocketPathGuard {
     static func hardenParentDirectory(for socketPath: String) throws {
         let parentURL = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
         let hardenedParentURL = try self.trustedParentDirectoryURL(for: parentURL)
+        try self.createHardenedDirectoryPath(hardenedParentURL)
+    }
 
-        do {
-            try FileManager().createDirectory(at: hardenedParentURL, withIntermediateDirectories: true)
-        } catch {
-            throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
-                path: hardenedParentURL.path,
-                message: error.localizedDescription)
+    private static func createHardenedDirectoryPath(_ directoryURL: URL) throws {
+        let standardizedURL = directoryURL.standardizedFileURL
+        let components = standardizedURL.pathComponents
+        guard !components.isEmpty else {
+            return
         }
 
+        var currentURL = URL(fileURLWithPath: components[0], isDirectory: true)
+        for component in components.dropFirst() {
+            currentURL.appendPathComponent(component, isDirectory: true)
+            switch try self.pathKind(at: currentURL.path) {
+            case .missing:
+                try self.createHardenedDirectory(currentURL)
+            case .directory:
+                if currentURL.path == standardizedURL.path {
+                    try self.setHardenedDirectoryPermissions(currentURL)
+                }
+            case let kind:
+                throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
+                    path: currentURL.path,
+                    kind: kind)
+            }
+        }
+    }
+
+    private static func createHardenedDirectory(_ directoryURL: URL) throws {
+        do {
+            try FileManager().createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: false,
+                attributes: [.posixPermissions: self.parentDirectoryPermissions])
+        } catch {
+            if (try? self.pathKind(at: directoryURL.path)) != .directory {
+                throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
+                    path: directoryURL.path,
+                    message: error.localizedDescription)
+            }
+        }
+        try self.setHardenedDirectoryPermissions(directoryURL)
+    }
+
+    private static func setHardenedDirectoryPermissions(_ directoryURL: URL) throws {
         do {
             try FileManager().setAttributes(
                 [.posixPermissions: self.parentDirectoryPermissions],
-                ofItemAtPath: hardenedParentURL.path)
+                ofItemAtPath: directoryURL.path)
         } catch {
             throw ExecApprovalsSocketPathGuardError.setParentDirectoryPermissionsFailed(
-                path: hardenedParentURL.path,
+                path: directoryURL.path,
                 message: error.localizedDescription)
         }
     }

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -612,28 +612,14 @@ enum ExecApprovalsSocketPathGuard {
 
     static func hardenParentDirectory(for socketPath: String) throws {
         let parentURL = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
-        let parentPath = parentURL.path
-        let hardenedParentURL: URL
+        let hardenedParentURL = try self.trustedParentDirectoryURL(for: parentURL)
 
-        switch try self.pathKind(at: parentPath) {
-        case .missing:
-            hardenedParentURL = parentURL
-        case .directory:
-            hardenedParentURL = parentURL
-        case .symlink:
-            hardenedParentURL = try self.trustedParentSymlinkTarget(for: parentURL)
-        case let kind:
-            throw ExecApprovalsSocketPathGuardError.parentPathInvalid(path: parentPath, kind: kind)
-        }
-
-        if hardenedParentURL.path == parentPath {
-            do {
-                try FileManager().createDirectory(at: parentURL, withIntermediateDirectories: true)
-            } catch {
-                throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
-                    path: parentPath,
-                    message: error.localizedDescription)
-            }
+        do {
+            try FileManager().createDirectory(at: hardenedParentURL, withIntermediateDirectories: true)
+        } catch {
+            throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
+                path: hardenedParentURL.path,
+                message: error.localizedDescription)
         }
 
         do {
@@ -645,6 +631,34 @@ enum ExecApprovalsSocketPathGuard {
                 path: hardenedParentURL.path,
                 message: error.localizedDescription)
         }
+    }
+
+    private static func trustedParentDirectoryURL(for parentURL: URL) throws -> URL {
+        let standardizedURL = parentURL.standardizedFileURL
+        let components = standardizedURL.pathComponents
+        guard !components.isEmpty else {
+            return standardizedURL
+        }
+
+        var rawURL = URL(fileURLWithPath: components[0], isDirectory: true)
+        var hardenedURL = rawURL
+
+        for component in components.dropFirst() {
+            rawURL.appendPathComponent(component, isDirectory: true)
+            let nextHardenedURL = hardenedURL.appendingPathComponent(component, isDirectory: true)
+            switch try self.pathKind(at: rawURL.path) {
+            case .missing, .directory:
+                hardenedURL = nextHardenedURL
+            case .symlink:
+                hardenedURL = try self.trustedParentSymlinkTarget(for: rawURL)
+            case let kind:
+                throw ExecApprovalsSocketPathGuardError.parentPathInvalid(
+                    path: rawURL.path,
+                    kind: kind)
+            }
+        }
+
+        return hardenedURL
     }
 
     private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -561,6 +561,7 @@ enum ExecApprovalsSocketPathKind: Equatable {
 enum ExecApprovalsSocketPathGuardError: LocalizedError {
     case lstatFailed(path: String, code: Int32)
     case parentPathInvalid(path: String, kind: ExecApprovalsSocketPathKind)
+    case parentSymlinkTargetInvalid(path: String, message: String)
     case socketPathInvalid(path: String, kind: ExecApprovalsSocketPathKind)
     case unlinkFailed(path: String, code: Int32)
     case createParentDirectoryFailed(path: String, message: String)
@@ -572,6 +573,8 @@ enum ExecApprovalsSocketPathGuardError: LocalizedError {
             "lstat failed for \(path) (errno \(code))"
         case let .parentPathInvalid(path, kind):
             "socket parent path invalid (\(kind)) at \(path)"
+        case let .parentSymlinkTargetInvalid(path, message):
+            "socket parent symlink target invalid at \(path): \(message)"
         case let .socketPathInvalid(path, kind):
             "socket path invalid (\(kind)) at \(path)"
         case let .unlinkFailed(path, code):
@@ -607,31 +610,74 @@ enum ExecApprovalsSocketPathGuard {
     static func hardenParentDirectory(for socketPath: String) throws {
         let parentURL = URL(fileURLWithPath: socketPath).deletingLastPathComponent()
         let parentPath = parentURL.path
+        let hardenedParentURL: URL
 
         switch try self.pathKind(at: parentPath) {
-        case .missing, .directory:
-            break
+        case .missing:
+            hardenedParentURL = parentURL
+        case .directory:
+            hardenedParentURL = parentURL
+        case .symlink:
+            hardenedParentURL = try self.trustedParentSymlinkTarget(for: parentURL)
         case let kind:
             throw ExecApprovalsSocketPathGuardError.parentPathInvalid(path: parentPath, kind: kind)
         }
 
-        do {
-            try FileManager().createDirectory(at: parentURL, withIntermediateDirectories: true)
-        } catch {
-            throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
-                path: parentPath,
-                message: error.localizedDescription)
+        if hardenedParentURL.path == parentPath {
+            do {
+                try FileManager().createDirectory(at: parentURL, withIntermediateDirectories: true)
+            } catch {
+                throw ExecApprovalsSocketPathGuardError.createParentDirectoryFailed(
+                    path: parentPath,
+                    message: error.localizedDescription)
+            }
         }
 
         do {
             try FileManager().setAttributes(
                 [.posixPermissions: self.parentDirectoryPermissions],
-                ofItemAtPath: parentPath)
+                ofItemAtPath: hardenedParentURL.path)
         } catch {
             throw ExecApprovalsSocketPathGuardError.setParentDirectoryPermissionsFailed(
-                path: parentPath,
+                path: hardenedParentURL.path,
                 message: error.localizedDescription)
         }
+    }
+
+    private static func trustedParentSymlinkTarget(for parentURL: URL) throws -> URL {
+        let parentPath = parentURL.path
+        var status = stat()
+        if stat(parentPath, &status) != 0 {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "stat failed (errno \(errno))")
+        }
+        let fileType = status.st_mode & mode_t(S_IFMT)
+        guard fileType == mode_t(S_IFDIR) else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "target is not a directory")
+        }
+        guard status.st_uid == getuid() else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "target is not owned by the current user")
+        }
+        guard (status.st_mode & mode_t(0o022)) == 0 else {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "target is group/other-writable")
+        }
+        let targetURL = parentURL.resolvingSymlinksInPath()
+        switch try self.pathKind(at: targetURL.path) {
+        case .directory:
+            break
+        case let kind:
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "resolved target kind is \(kind)")
+        }
+        return targetURL
     }
 
     static func removeExistingSocket(at socketPath: String) throws {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift
@@ -671,6 +671,10 @@ enum ExecApprovalsSocketPathGuard {
                 path: parentPath,
                 message: "target is group/other-writable")
         }
+        let destinationPath = try self.symlinkDestinationPath(for: parentURL)
+        try self.validateNoAdditionalSymlinkTargetHops(
+            in: destinationPath,
+            reportedPath: parentPath)
         let targetURL = parentURL.resolvingSymlinksInPath()
         switch try self.pathKind(at: targetURL.path) {
         case .directory:
@@ -682,6 +686,51 @@ enum ExecApprovalsSocketPathGuard {
         }
         try self.validateResolvedAncestorChain(for: targetURL, reportedPath: parentPath)
         return targetURL
+    }
+
+    private static func symlinkDestinationPath(for parentURL: URL) throws -> String {
+        let parentPath = parentURL.path
+        do {
+            let destination = try FileManager().destinationOfSymbolicLink(atPath: parentPath)
+            if destination.hasPrefix("/") {
+                return URL(fileURLWithPath: destination).standardizedFileURL.path
+            }
+            return parentURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(destination)
+                .standardizedFileURL
+                .path
+        } catch {
+            throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                path: parentPath,
+                message: "readlink failed: \(error.localizedDescription)")
+        }
+    }
+
+    private static func validateNoAdditionalSymlinkTargetHops(
+        in targetPath: String,
+        reportedPath: String
+    ) throws {
+        var ancestors: [String] = []
+        var current = URL(fileURLWithPath: targetPath).standardizedFileURL
+
+        while true {
+            ancestors.append(current.path)
+            let parent = current.deletingLastPathComponent()
+            if parent.path == current.path {
+                break
+            }
+            current = parent
+        }
+
+        for path in ancestors.reversed() {
+            let kind = try self.pathKind(at: path)
+            if kind == .symlink {
+                throw ExecApprovalsSocketPathGuardError.parentSymlinkTargetInvalid(
+                    path: reportedPath,
+                    message: "target resolves through another symlink at \(path)")
+            }
+        }
     }
 
     private static func validateResolvedAncestorChain(for targetURL: URL, reportedPath: String)

--- a/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift
@@ -775,7 +775,7 @@ actor MacNodeRuntime {
             : current.socket?.token?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         normalized.socket = ExecApprovalsSocketConfig(path: resolvedPath, token: resolvedToken)
 
-        ExecApprovalsStore.saveFile(normalized)
+        try ExecApprovalsStore.saveFile(normalized)
         let nextSnapshot = ExecApprovalsStore.readSnapshot()
         let redacted = ExecApprovalsSnapshot(
             path: nextSnapshot.path,

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -46,6 +46,31 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory accepts nested socket below secure symlink parent`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("run", isDirectory: true)
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+
+        let nestedTarget = target.appendingPathComponent("run", isDirectory: true)
+        #expect(FileManager().fileExists(atPath: nestedTarget.path))
+        let attrs = try FileManager().attributesOfItem(atPath: nestedTarget.path)
+        let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+        #expect(permissions & 0o777 == 0o700)
+    }
+
+    @Test
     func `harden parent directory accepts secure symlink parent under system tmp path`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
@@ -91,6 +116,36 @@ struct ExecApprovalsSocketPathGuardTests {
         do {
             try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
             Issue.record("Expected writable symlink parent target rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentSymlinkTargetInvalid(path, message):
+                #expect(path == linkedState.path)
+                #expect(message.contains("group/other-writable"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
+    func `harden parent directory rejects nested socket below writable symlink parent target`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("run", isDirectory: true)
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected nested writable symlink parent target rejection")
         } catch let error as ExecApprovalsSocketPathGuardError {
             switch error {
             case let .parentSymlinkTargetInvalid(path, message):

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -104,6 +104,40 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory rejects deeper symlink below state directory`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let release = target.appendingPathComponent("release-123", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        let current = target.appendingPathComponent("current", isDirectory: true)
+        try FileManager().createDirectory(at: release, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: release.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+        try FileManager().createSymbolicLink(at: current, withDestinationURL: release)
+
+        let socketPath = linkedState
+            .appendingPathComponent("current", isDirectory: true)
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected deeper symlink rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentPathInvalid(path, kind):
+                #expect(path == linkedState.appendingPathComponent("current", isDirectory: true).path)
+                #expect(kind == .symlink)
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
     func `harden parent directory accepts secure symlink parent under system tmp path`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -104,6 +104,36 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory secures existing nested directories below state directory`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let run = target.appendingPathComponent("run", isDirectory: true)
+        let cache = run.appendingPathComponent("cache", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: cache, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: run.path)
+        try FileManager().setAttributes([.posixPermissions: 0o755], ofItemAtPath: cache.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("run", isDirectory: true)
+            .appendingPathComponent("cache", isDirectory: true)
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+
+        for directory in [target, run, cache] {
+            let attrs = try FileManager().attributesOfItem(atPath: directory.path)
+            let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+            #expect(permissions & 0o777 == 0o700)
+        }
+    }
+
+    @Test
     func `harden parent directory rejects deeper symlink below state directory`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct ExecApprovalsSocketPathGuardTests {
     @Test
     func `harden parent directory creates directory with0700 permissions`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let socketPath = root
@@ -25,7 +25,7 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `harden parent directory accepts secure symlink parent`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let target = root.appendingPathComponent("state-target", isDirectory: true)
@@ -47,7 +47,7 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `harden parent directory rejects writable symlink parent target`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let target = root.appendingPathComponent("state-target", isDirectory: true)
@@ -75,8 +75,39 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory rejects symlink target through another symlink`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let intermediate = root.appendingPathComponent("current-state", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: intermediate, withDestinationURL: target)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: intermediate)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected symlink target hop rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentSymlinkTargetInvalid(path, message):
+                #expect(path == linkedState.path)
+                #expect(message.contains("resolves through another symlink"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
     func `harden parent directory rejects symlink target below writable ancestor`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let sharedParent = root.appendingPathComponent("shared-parent", isDirectory: true)
@@ -107,7 +138,7 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `remove existing socket rejects symlink path`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         try FileManager().createDirectory(at: root, withIntermediateDirectories: true)
@@ -133,7 +164,7 @@ struct ExecApprovalsSocketPathGuardTests {
 
     @Test
     func `remove existing socket rejects regular file path`() throws {
-        let root = FileManager().temporaryDirectory
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         try FileManager().createDirectory(at: root, withIntermediateDirectories: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -71,6 +71,39 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory secures every created nested directory`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("run", isDirectory: true)
+            .appendingPathComponent("cache", isDirectory: true)
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        let previousUmask = umask(0)
+        defer { umask(previousUmask) }
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+
+        for directory in [
+            target.appendingPathComponent("run", isDirectory: true),
+            target.appendingPathComponent("run", isDirectory: true)
+                .appendingPathComponent("cache", isDirectory: true),
+        ] {
+            #expect(FileManager().fileExists(atPath: directory.path))
+            let attrs = try FileManager().attributesOfItem(atPath: directory.path)
+            let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+            #expect(permissions & 0o777 == 0o700)
+        }
+    }
+
+    @Test
     func `harden parent directory accepts secure symlink parent under system tmp path`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -165,6 +165,38 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory rejects symlink parent in writable location`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let sharedParent = root.appendingPathComponent("shared-link-parent", isDirectory: true)
+        let linkedState = sharedParent.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createDirectory(at: sharedParent, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: sharedParent.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected symlink parent location rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentSymlinkTargetInvalid(path, message):
+                #expect(path == linkedState.path)
+                #expect(message.contains("ancestor is group/other-writable"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
     func `remove existing socket rejects symlink path`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -75,6 +75,37 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory rejects symlink target below writable ancestor`() throws {
+        let root = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let sharedParent = root.appendingPathComponent("shared-parent", isDirectory: true)
+        let target = sharedParent.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: sharedParent.path)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected symlink target ancestor rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentSymlinkTargetInvalid(path, message):
+                #expect(path == linkedState.path)
+                #expect(message.contains("ancestor is group/other-writable"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
     func `remove existing socket rejects symlink path`() throws {
         let root = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -46,6 +46,34 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory accepts secure symlink parent under system tmp path`() throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        let rawTargetRoot = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("openclaw-socket-target-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager().removeItem(at: root)
+            try? FileManager().removeItem(at: rawTargetRoot)
+        }
+        let target = rawTargetRoot.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+
+        let attrs = try FileManager().attributesOfItem(atPath: target.path)
+        let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+        #expect(permissions & 0o777 == 0o700)
+    }
+
+    @Test
     func `harden parent directory rejects writable symlink parent target`() throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift
@@ -24,6 +24,57 @@ struct ExecApprovalsSocketPathGuardTests {
     }
 
     @Test
+    func `harden parent directory accepts secure symlink parent`() throws {
+        let root = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+
+        let attrs = try FileManager().attributesOfItem(atPath: target.path)
+        let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+        #expect(permissions & 0o777 == 0o700)
+    }
+
+    @Test
+    func `harden parent directory rejects writable symlink parent target`() throws {
+        let root = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        let socketPath = linkedState
+            .appendingPathComponent("exec-approvals.sock", isDirectory: false)
+            .path
+
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: socketPath)
+            Issue.record("Expected writable symlink parent target rejection")
+        } catch let error as ExecApprovalsSocketPathGuardError {
+            switch error {
+            case let .parentSymlinkTargetInvalid(path, message):
+                #expect(path == linkedState.path)
+                #expect(message.contains("group/other-writable"))
+            default:
+                Issue.record("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    @Test
     func `remove existing socket rejects symlink path`() throws {
         let root = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-socket-guard-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -78,6 +78,50 @@ struct ExecApprovalsStoreRefactorTests {
         }
     }
 
+    @Test
+    func `ensure file accepts trusted symlinked state directory`() async throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": linkedState.path]) {
+            _ = ExecApprovalsStore.ensureFile()
+
+            let approvalsURL = target.appendingPathComponent("exec-approvals.json")
+            #expect(FileManager().fileExists(atPath: approvalsURL.path))
+            let attrs = try FileManager().attributesOfItem(atPath: target.path)
+            let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+            #expect(permissions & 0o777 == 0o700)
+        }
+    }
+
+    @Test
+    func `ensure file refuses unsafe symlinked state directory`() async throws {
+        let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: root) }
+        let target = root.appendingPathComponent("state-target", isDirectory: true)
+        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
+        try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: target.path)
+        try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
+
+        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": linkedState.path]) {
+            let file = ExecApprovalsStore.ensureFile()
+            let snapshot = ExecApprovalsStore.readSnapshot()
+
+            #expect(file.agents?.isEmpty ?? true)
+            #expect(snapshot.exists == false)
+            #expect(!FileManager().fileExists(
+                atPath: target.appendingPathComponent("exec-approvals.json").path))
+        }
+    }
+
     private static func fileIdentity(at url: URL) throws -> Int {
         let attributes = try FileManager().attributesOfItem(atPath: url.path)
         guard let identifier = (attributes[.systemFileNumber] as? NSNumber)?.intValue else {

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -101,6 +101,23 @@ struct ExecApprovalsStoreRefactorTests {
     }
 
     @Test
+    func `ensure file accepts state directory below system tmp symlink`() async throws {
+        let stateDir = URL(fileURLWithPath: "/tmp", isDirectory: true)
+            .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager().removeItem(at: stateDir) }
+
+        try await TestIsolation.withEnvValues(["OPENCLAW_STATE_DIR": stateDir.path]) {
+            _ = ExecApprovalsStore.ensureFile()
+
+            let approvalsURL = stateDir.appendingPathComponent("exec-approvals.json")
+            #expect(FileManager().fileExists(atPath: approvalsURL.path))
+            let attrs = try FileManager().attributesOfItem(atPath: stateDir.path)
+            let permissions = (attrs[.posixPermissions] as? NSNumber)?.intValue ?? -1
+            #expect(permissions & 0o777 == 0o700)
+        }
+    }
+
+    @Test
     func `ensure file refuses unsafe symlinked state directory`() async throws {
         let root = FileManager().temporaryDirectory.resolvingSymlinksInPath()
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)

--- a/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift
@@ -84,7 +84,7 @@ struct ExecApprovalsStoreRefactorTests {
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let target = root.appendingPathComponent("state-target", isDirectory: true)
-        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        let linkedState = root.appendingPathComponent("state-link", isDirectory: true)
         try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
         try FileManager().setAttributes([.posixPermissions: 0o700], ofItemAtPath: target.path)
         try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)
@@ -106,7 +106,7 @@ struct ExecApprovalsStoreRefactorTests {
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager().removeItem(at: root) }
         let target = root.appendingPathComponent("state-target", isDirectory: true)
-        let linkedState = root.appendingPathComponent(".openclaw", isDirectory: true)
+        let linkedState = root.appendingPathComponent("state-link", isDirectory: true)
         try FileManager().createDirectory(at: target, withIntermediateDirectories: true)
         try FileManager().setAttributes([.posixPermissions: 0o777], ofItemAtPath: target.path)
         try FileManager().createSymbolicLink(at: linkedState, withDestinationURL: target)

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -183,6 +183,9 @@ Targeting notes:
 - `--agent` defaults to `"*"`, which applies to all agents.
 - The node host must advertise `system.execApprovals.get/set` (macOS app or headless node host).
 - Approvals files are stored per host at `~/.openclaw/exec-approvals.json`.
+- The first-level `~/.openclaw` directory may be a symlink to a current-user-owned,
+  non-group/other-writable directory. Deeper symlinks and a symlinked
+  `exec-approvals.json` destination are refused.
 
 ## Related
 

--- a/docs/cli/approvals.md
+++ b/docs/cli/approvals.md
@@ -184,8 +184,8 @@ Targeting notes:
 - The node host must advertise `system.execApprovals.get/set` (macOS app or headless node host).
 - Approvals files are stored per host at `~/.openclaw/exec-approvals.json`.
 - The first-level `~/.openclaw` directory may be a symlink to a current-user-owned,
-  non-group/other-writable directory. Deeper symlinks and a symlinked
-  `exec-approvals.json` destination are refused.
+  non-group/other-writable directory with a stable resolved ancestor chain. Deeper
+  symlinks and a symlinked `exec-approvals.json` destination are refused.
 
 ## Related
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -16,6 +16,7 @@ type ExecApprovalsModule = typeof import("./exec-approvals.js");
 let addAllowlistEntry: ExecApprovalsModule["addAllowlistEntry"];
 let addDurableCommandApproval: ExecApprovalsModule["addDurableCommandApproval"];
 let ensureExecApprovals: ExecApprovalsModule["ensureExecApprovals"];
+let loadExecApprovals: ExecApprovalsModule["loadExecApprovals"];
 let mergeExecApprovalsSocketDefaults: ExecApprovalsModule["mergeExecApprovalsSocketDefaults"];
 let normalizeExecApprovals: ExecApprovalsModule["normalizeExecApprovals"];
 let persistAllowAlwaysPatterns: ExecApprovalsModule["persistAllowAlwaysPatterns"];
@@ -35,6 +36,7 @@ beforeAll(async () => {
     addAllowlistEntry,
     addDurableCommandApproval,
     ensureExecApprovals,
+    loadExecApprovals,
     mergeExecApprovalsSocketDefaults,
     normalizeExecApprovals,
     persistAllowAlwaysPatterns,
@@ -183,7 +185,7 @@ describe("exec approvals store helpers", () => {
 
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
-    ).toThrow(/Refusing to write exec approvals via symlink/);
+    ).toThrow(/Refusing to use exec approvals via symlink/);
     expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 
@@ -230,6 +232,12 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink target/);
+      expect(() => loadExecApprovals()).toThrow(
+        /group\/other-writable exec approvals \.openclaw symlink target/,
+      );
+      expect(() => readExecApprovalsSnapshot()).toThrow(
+        /group\/other-writable exec approvals \.openclaw symlink target/,
+      );
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -242,6 +250,8 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/ENOENT|no such file or directory/i);
+    expect(() => loadExecApprovals()).toThrow(/ENOENT|no such file or directory/i);
+    expect(() => readExecApprovalsSnapshot()).toThrow(/ENOENT|no such file or directory/i);
     expect(fs.existsSync(path.join(missingTarget, "exec-approvals.json"))).toBe(false);
   });
 
@@ -256,7 +266,9 @@ describe("exec approvals store helpers", () => {
 
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
-    ).toThrow(/Refusing to write exec approvals via symlink/);
+    ).toThrow(/Refusing to use exec approvals via symlink/);
+    expect(() => loadExecApprovals()).toThrow(/Refusing to use exec approvals via symlink/);
+    expect(() => readExecApprovalsSnapshot()).toThrow(/Refusing to use exec approvals via symlink/);
     expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -246,6 +246,25 @@ describe("exec approvals store helpers", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "refuses a first-level .openclaw symlink target below a writable ancestor",
+    () => {
+      const dir = createHomeDir();
+      const sharedParent = path.join(dir, "shared-parent");
+      const linkedStateTarget = path.join(sharedParent, "state-target");
+      fs.mkdirSync(linkedStateTarget, { recursive: true, mode: 0o700 });
+      fs.chmodSync(sharedParent, 0o777);
+      fs.chmodSync(linkedStateTarget, 0o700);
+      fs.symlinkSync(linkedStateTarget, path.join(dir, ".openclaw"), "dir");
+
+      expect(() =>
+        saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+      ).toThrow(/group\/other-writable exec approvals \.openclaw symlink ancestor/);
+      expectBestEffortEmptyApprovalsRead();
+      expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
+    },
+  );
+
   it("refuses a dangling first-level .openclaw symlink", () => {
     const dir = createHomeDir();
     const missingTarget = path.join(dir, "missing-state-target");

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -67,7 +67,7 @@ afterEach(() => {
 });
 
 function createHomeDir(): string {
-  const dir = makeTempDir();
+  const dir = fs.realpathSync(makeTempDir());
   tempDirs.push(dir);
   process.env.OPENCLAW_HOME = dir;
   return dir;
@@ -200,7 +200,7 @@ describe("exec approvals store helpers", () => {
   });
 
   it("accepts a symlinked OPENCLAW_HOME as the trusted approvals root", () => {
-    const realHome = makeTempDir();
+    const realHome = fs.realpathSync(makeTempDir());
     const linkedHome = `${realHome}-link`;
     tempDirs.push(realHome, linkedHome);
     fs.symlinkSync(realHome, linkedHome, "dir");
@@ -214,7 +214,7 @@ describe("exec approvals store helpers", () => {
   });
 
   it("accepts a trusted first-level .openclaw symlink", () => {
-    const realHome = makeTempDir();
+    const realHome = fs.realpathSync(makeTempDir());
     const linkedHome = `${realHome}-link`;
     const linkedStateTarget = path.join(realHome, "state-target");
     tempDirs.push(realHome, linkedHome);
@@ -266,6 +266,25 @@ describe("exec approvals store helpers", () => {
       expectUnsafeApprovalsReadFailsClosed(
         /group\/other-writable exec approvals \.openclaw symlink ancestor/,
       );
+      expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "refuses a first-level .openclaw symlink target that resolves through another symlink",
+    () => {
+      const dir = createHomeDir();
+      const linkedStateTarget = path.join(dir, "state-target");
+      const intermediateLink = path.join(dir, "current-state");
+      fs.mkdirSync(linkedStateTarget, { recursive: true, mode: 0o700 });
+      fs.chmodSync(linkedStateTarget, 0o700);
+      fs.symlinkSync(linkedStateTarget, intermediateLink, "dir");
+      fs.symlinkSync(intermediateLink, path.join(dir, ".openclaw"), "dir");
+
+      expect(() =>
+        saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+      ).toThrow(/resolves through another symlink/);
+      expectUnsafeApprovalsReadFailsClosed(/resolves through another symlink/);
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -24,6 +24,7 @@ let readExecApprovalsSnapshot: ExecApprovalsModule["readExecApprovalsSnapshot"];
 let recordAllowlistMatchesUse: ExecApprovalsModule["recordAllowlistMatchesUse"];
 let recordAllowlistUse: ExecApprovalsModule["recordAllowlistUse"];
 let requestExecApprovalViaSocket: ExecApprovalsModule["requestExecApprovalViaSocket"];
+let resolveExecApprovals: ExecApprovalsModule["resolveExecApprovals"];
 let resolveExecApprovalsPath: ExecApprovalsModule["resolveExecApprovalsPath"];
 let resolveExecApprovalsSocketPath: ExecApprovalsModule["resolveExecApprovalsSocketPath"];
 let saveExecApprovals: ExecApprovalsModule["saveExecApprovals"];
@@ -44,6 +45,7 @@ beforeAll(async () => {
     recordAllowlistMatchesUse,
     recordAllowlistUse,
     requestExecApprovalViaSocket,
+    resolveExecApprovals,
     resolveExecApprovalsPath,
     resolveExecApprovalsSocketPath,
     saveExecApprovals,
@@ -88,6 +90,12 @@ function expectUnsafeApprovalsReadFailsClosed(pattern: RegExp) {
     agents: {},
   });
   expect(loadExecApprovals()).toEqual(closed);
+  expect(ensureExecApprovals()).toEqual(closed);
+  expect(resolveExecApprovals("main").agent).toMatchObject({
+    security: "deny",
+    ask: "always",
+    askFallback: "deny",
+  });
   expect(() => readExecApprovalsSnapshot()).toThrow(pattern);
 }
 
@@ -229,6 +237,25 @@ describe("exec approvals store helpers", () => {
       '"security": "full"',
     );
   });
+
+  it.runIf(process.platform !== "win32")(
+    "accepts a trusted first-level .openclaw symlink target under a system tmp path",
+    () => {
+      const dir = createHomeDir();
+      const rawTargetRoot = fs.mkdtempSync(path.join("/tmp", "openclaw-approvals-target-"));
+      tempDirs.push(rawTargetRoot);
+      const linkedStateTarget = path.join(rawTargetRoot, "state-target");
+      fs.mkdirSync(linkedStateTarget, { recursive: true, mode: 0o700 });
+      fs.chmodSync(linkedStateTarget, 0o700);
+      fs.symlinkSync(linkedStateTarget, path.join(dir, ".openclaw"), "dir");
+
+      saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} });
+
+      expect(
+        fs.readFileSync(path.join(linkedStateTarget, "exec-approvals.json"), "utf8"),
+      ).toContain('"security": "full"');
+    },
+  );
 
   it.runIf(process.platform !== "win32")(
     "refuses a group-writable first-level .openclaw symlink target",

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -81,6 +81,15 @@ function readApprovalsFile(homeDir: string): ExecApprovalsFile {
   return JSON.parse(fs.readFileSync(approvalsFilePath(homeDir), "utf8")) as ExecApprovalsFile;
 }
 
+function expectBestEffortEmptyApprovalsRead() {
+  const empty = normalizeExecApprovals({ version: 1, agents: {} });
+  expect(loadExecApprovals()).toEqual(empty);
+  const snapshot = readExecApprovalsSnapshot();
+  expect(snapshot.exists).toBe(false);
+  expect(snapshot.raw).toBeNull();
+  expect(snapshot.file).toEqual(empty);
+}
+
 describe("exec approvals store helpers", () => {
   it("expands home-prefixed default file and socket paths", () => {
     const dir = createHomeDir();
@@ -232,12 +241,7 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink target/);
-      expect(() => loadExecApprovals()).toThrow(
-        /group\/other-writable exec approvals \.openclaw symlink target/,
-      );
-      expect(() => readExecApprovalsSnapshot()).toThrow(
-        /group\/other-writable exec approvals \.openclaw symlink target/,
-      );
+      expectBestEffortEmptyApprovalsRead();
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -250,8 +254,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/ENOENT|no such file or directory/i);
-    expect(() => loadExecApprovals()).toThrow(/ENOENT|no such file or directory/i);
-    expect(() => readExecApprovalsSnapshot()).toThrow(/ENOENT|no such file or directory/i);
+    expectBestEffortEmptyApprovalsRead();
     expect(fs.existsSync(path.join(missingTarget, "exec-approvals.json"))).toBe(false);
   });
 
@@ -267,8 +270,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/Refusing to use exec approvals via symlink/);
-    expect(() => loadExecApprovals()).toThrow(/Refusing to use exec approvals via symlink/);
-    expect(() => readExecApprovalsSnapshot()).toThrow(/Refusing to use exec approvals via symlink/);
+    expectBestEffortEmptyApprovalsRead();
     expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -221,7 +221,7 @@ describe("exec approvals store helpers", () => {
     ).toContain('"security": "full"');
   });
 
-  it("accepts a trusted first-level .openclaw symlink", () => {
+  it.runIf(process.platform !== "win32")("accepts a trusted first-level .openclaw symlink", () => {
     const realHome = fs.realpathSync(makeTempDir());
     const linkedHome = `${realHome}-link`;
     const linkedStateTarget = path.join(realHome, "state-target");

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -81,13 +81,14 @@ function readApprovalsFile(homeDir: string): ExecApprovalsFile {
   return JSON.parse(fs.readFileSync(approvalsFilePath(homeDir), "utf8")) as ExecApprovalsFile;
 }
 
-function expectBestEffortEmptyApprovalsRead() {
-  const empty = normalizeExecApprovals({ version: 1, agents: {} });
-  expect(loadExecApprovals()).toEqual(empty);
-  const snapshot = readExecApprovalsSnapshot();
-  expect(snapshot.exists).toBe(false);
-  expect(snapshot.raw).toBeNull();
-  expect(snapshot.file).toEqual(empty);
+function expectUnsafeApprovalsReadFailsClosed(pattern: RegExp) {
+  const closed = normalizeExecApprovals({
+    version: 1,
+    defaults: { security: "deny", ask: "always", askFallback: "deny" },
+    agents: {},
+  });
+  expect(loadExecApprovals()).toEqual(closed);
+  expect(() => readExecApprovalsSnapshot()).toThrow(pattern);
 }
 
 describe("exec approvals store helpers", () => {
@@ -241,7 +242,9 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink target/);
-      expectBestEffortEmptyApprovalsRead();
+      expectUnsafeApprovalsReadFailsClosed(
+        /group\/other-writable exec approvals \.openclaw symlink target/,
+      );
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -260,7 +263,9 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink ancestor/);
-      expectBestEffortEmptyApprovalsRead();
+      expectUnsafeApprovalsReadFailsClosed(
+        /group\/other-writable exec approvals \.openclaw symlink ancestor/,
+      );
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -273,7 +278,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/ENOENT|no such file or directory/i);
-    expectBestEffortEmptyApprovalsRead();
+    expectUnsafeApprovalsReadFailsClosed(/ENOENT|no such file or directory/i);
     expect(fs.existsSync(path.join(missingTarget, "exec-approvals.json"))).toBe(false);
   });
 
@@ -289,7 +294,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/Refusing to use exec approvals via symlink/);
-    expectBestEffortEmptyApprovalsRead();
+    expectUnsafeApprovalsReadFailsClosed(/Refusing to use exec approvals via symlink/);
     expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -201,7 +201,7 @@ describe("exec approvals store helpers", () => {
     ).toContain('"security": "full"');
   });
 
-  it("refuses to traverse symlinked approvals components below a symlinked home", () => {
+  it("accepts a trusted first-level .openclaw symlink", () => {
     const realHome = makeTempDir();
     const linkedHome = `${realHome}-link`;
     const linkedStateTarget = path.join(realHome, "state-target");
@@ -211,10 +211,53 @@ describe("exec approvals store helpers", () => {
     fs.symlinkSync(linkedStateTarget, path.join(realHome, ".openclaw"), "dir");
     process.env.OPENCLAW_HOME = linkedHome;
 
+    saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} });
+
+    expect(fs.readFileSync(path.join(linkedStateTarget, "exec-approvals.json"), "utf8")).toContain(
+      '"security": "full"',
+    );
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "refuses a group-writable first-level .openclaw symlink target",
+    () => {
+      const dir = createHomeDir();
+      const linkedStateTarget = path.join(dir, "state-target");
+      fs.mkdirSync(linkedStateTarget, { recursive: true, mode: 0o777 });
+      fs.chmodSync(linkedStateTarget, 0o777);
+      fs.symlinkSync(linkedStateTarget, path.join(dir, ".openclaw"), "dir");
+
+      expect(() =>
+        saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+      ).toThrow(/group\/other-writable exec approvals \.openclaw symlink target/);
+      expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
+    },
+  );
+
+  it("refuses a dangling first-level .openclaw symlink", () => {
+    const dir = createHomeDir();
+    const missingTarget = path.join(dir, "missing-state-target");
+    fs.symlinkSync(missingTarget, path.join(dir, ".openclaw"), "dir");
+
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
-    ).toThrow(/Refusing to traverse symlink in exec approvals path/);
-    expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
+    ).toThrow(/ENOENT|no such file or directory/i);
+    expect(fs.existsSync(path.join(missingTarget, "exec-approvals.json"))).toBe(false);
+  });
+
+  it("still refuses to write approvals through a symlink destination inside .openclaw", () => {
+    const dir = createHomeDir();
+    const linkedStateTarget = path.join(dir, "state-target");
+    const targetPath = path.join(dir, "elsewhere.json");
+    fs.mkdirSync(linkedStateTarget, { recursive: true });
+    fs.writeFileSync(targetPath, '{"sentinel":true}\n', "utf8");
+    fs.symlinkSync(linkedStateTarget, path.join(dir, ".openclaw"), "dir");
+    fs.symlinkSync(targetPath, path.join(linkedStateTarget, "exec-approvals.json"));
+
+    expect(() =>
+      saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+    ).toThrow(/Refusing to write exec approvals via symlink/);
+    expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 
   it("adds trimmed allowlist entries once and persists generated ids", () => {

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -83,7 +83,7 @@ function readApprovalsFile(homeDir: string): ExecApprovalsFile {
   return JSON.parse(fs.readFileSync(approvalsFilePath(homeDir), "utf8")) as ExecApprovalsFile;
 }
 
-function expectUnsafeApprovalsReadFailsClosed(pattern: RegExp) {
+function expectUnsafeApprovalsReadFailsClosed() {
   const closed = normalizeExecApprovals({
     version: 1,
     defaults: { security: "deny", ask: "always", askFallback: "deny" },
@@ -96,7 +96,11 @@ function expectUnsafeApprovalsReadFailsClosed(pattern: RegExp) {
     ask: "always",
     askFallback: "deny",
   });
-  expect(() => readExecApprovalsSnapshot()).toThrow(pattern);
+  expect(readExecApprovalsSnapshot()).toMatchObject({
+    exists: false,
+    raw: null,
+    file: closed,
+  });
 }
 
 describe("exec approvals store helpers", () => {
@@ -269,9 +273,7 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink target/);
-      expectUnsafeApprovalsReadFailsClosed(
-        /group\/other-writable exec approvals \.openclaw symlink target/,
-      );
+      expectUnsafeApprovalsReadFailsClosed();
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -290,9 +292,7 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/group\/other-writable exec approvals \.openclaw symlink ancestor/);
-      expectUnsafeApprovalsReadFailsClosed(
-        /group\/other-writable exec approvals \.openclaw symlink ancestor/,
-      );
+      expectUnsafeApprovalsReadFailsClosed();
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -311,7 +311,7 @@ describe("exec approvals store helpers", () => {
       expect(() =>
         saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
       ).toThrow(/resolves through another symlink/);
-      expectUnsafeApprovalsReadFailsClosed(/resolves through another symlink/);
+      expectUnsafeApprovalsReadFailsClosed();
       expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
     },
   );
@@ -324,7 +324,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/ENOENT|no such file or directory/i);
-    expectUnsafeApprovalsReadFailsClosed(/ENOENT|no such file or directory/i);
+    expectUnsafeApprovalsReadFailsClosed();
     expect(fs.existsSync(path.join(missingTarget, "exec-approvals.json"))).toBe(false);
   });
 
@@ -340,7 +340,7 @@ describe("exec approvals store helpers", () => {
     expect(() =>
       saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
     ).toThrow(/Refusing to use exec approvals via symlink/);
-    expectUnsafeApprovalsReadFailsClosed(/Refusing to use exec approvals via symlink/);
+    expectUnsafeApprovalsReadFailsClosed();
     expect(fs.readFileSync(targetPath, "utf8")).toBe('{"sentinel":true}\n');
   });
 

--- a/src/infra/exec-approvals-store.test.ts
+++ b/src/infra/exec-approvals-store.test.ts
@@ -298,6 +298,26 @@ describe("exec approvals store helpers", () => {
   );
 
   it.runIf(process.platform !== "win32")(
+    "refuses a first-level .openclaw symlink in a writable location",
+    () => {
+      const dir = createHomeDir();
+      const targetRoot = fs.realpathSync(makeTempDir());
+      tempDirs.push(targetRoot);
+      const linkedStateTarget = path.join(targetRoot, "state-target");
+      fs.mkdirSync(linkedStateTarget, { recursive: true, mode: 0o700 });
+      fs.chmodSync(linkedStateTarget, 0o700);
+      fs.chmodSync(dir, 0o777);
+      fs.symlinkSync(linkedStateTarget, path.join(dir, ".openclaw"), "dir");
+
+      expect(() =>
+        saveExecApprovals({ version: 1, defaults: { security: "full" }, agents: {} }),
+      ).toThrow(/group\/other-writable exec approvals \.openclaw symlink ancestor/);
+      expectUnsafeApprovalsReadFailsClosed();
+      expect(fs.existsSync(path.join(linkedStateTarget, "exec-approvals.json"))).toBe(false);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "refuses a first-level .openclaw symlink target that resolves through another symlink",
     () => {
       const dir = createHomeDir();

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -187,6 +187,26 @@ function hashExecApprovalsRaw(raw: string | null): string {
     .digest("hex");
 }
 
+function emptyExecApprovalsFile(): ExecApprovalsFile {
+  return normalizeExecApprovals({ version: 1, agents: {} });
+}
+
+function emptyExecApprovalsSnapshot(filePath: string): ExecApprovalsSnapshot {
+  return {
+    path: filePath,
+    exists: false,
+    raw: null,
+    file: emptyExecApprovalsFile(),
+    hash: hashExecApprovalsRaw(null),
+  };
+}
+
+function isBestEffortReadPathError(err: unknown): boolean {
+  return (
+    err instanceof UnsafeExecApprovalsPathError || (err as NodeJS.ErrnoException).code === "ENOENT"
+  );
+}
+
 export function resolveExecApprovalsPath(): string {
   return expandHomePrefix(DEFAULT_FILE);
 }
@@ -478,16 +498,16 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
-  assertSafeExecApprovalsFilePath(filePath);
+  try {
+    assertSafeExecApprovalsFilePath(filePath);
+  } catch (err) {
+    if (isBestEffortReadPathError(err)) {
+      return emptyExecApprovalsSnapshot(filePath);
+    }
+    throw err;
+  }
   if (!fs.existsSync(filePath)) {
-    const file = normalizeExecApprovals({ version: 1, agents: {} });
-    return {
-      path: filePath,
-      exists: false,
-      raw: null,
-      file,
-      hash: hashExecApprovalsRaw(null),
-    };
+    return emptyExecApprovalsSnapshot(filePath);
   }
   const raw = fs.readFileSync(filePath, "utf8");
   let parsed: ExecApprovalsFile | null = null;
@@ -496,10 +516,7 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   } catch {
     parsed = null;
   }
-  const file =
-    parsed?.version === 1
-      ? normalizeExecApprovals(parsed)
-      : normalizeExecApprovals({ version: 1, agents: {} });
+  const file = parsed?.version === 1 ? normalizeExecApprovals(parsed) : emptyExecApprovalsFile();
   return {
     path: filePath,
     exists: true,
@@ -511,19 +528,19 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
 
 export function loadExecApprovals(): ExecApprovalsFile {
   const filePath = resolveExecApprovalsPath();
-  assertSafeExecApprovalsFilePath(filePath);
   try {
+    assertSafeExecApprovalsFilePath(filePath);
     if (!fs.existsSync(filePath)) {
-      return normalizeExecApprovals({ version: 1, agents: {} });
+      return emptyExecApprovalsFile();
     }
     const raw = fs.readFileSync(filePath, "utf8");
     const parsed = JSON.parse(raw) as ExecApprovalsFile;
     if (parsed?.version !== 1) {
-      return normalizeExecApprovals({ version: 1, agents: {} });
+      return emptyExecApprovalsFile();
     }
     return normalizeExecApprovals(parsed);
   } catch {
-    return normalizeExecApprovals({ version: 1, agents: {} });
+    return emptyExecApprovalsFile();
   }
 }
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -173,6 +173,13 @@ const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
 
+class UnsafeExecApprovalsPathError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsafeExecApprovalsPathError";
+  }
+}
+
 function hashExecApprovalsRaw(raw: string | null): string {
   return crypto
     .createHash("sha256")
@@ -229,16 +236,25 @@ function mergeLegacyAgent(
 
 function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
-  assertNoSymlinkPathComponents(dir, resolveRequiredHomeDir());
+  assertSafeExecApprovalsDirectoryPath(dir);
   fs.mkdirSync(dir, { recursive: true });
+  assertSafeExecApprovalsDirectoryPath(dir);
   const dirStat = fs.statSync(dir);
   if (!dirStat.isDirectory()) {
-    throw new Error(`Refusing to use unsafe exec approvals directory: ${dir}`);
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use unsafe exec approvals directory: ${dir}`,
+    );
   }
   return dir;
 }
 
-function assertNoSymlinkPathComponents(targetPath: string, trustedRoot: string): void {
+function assertSafeExecApprovalsFilePath(filePath: string): void {
+  assertSafeExecApprovalsDirectoryPath(path.dirname(filePath));
+  assertSafeExecApprovalsDestination(filePath);
+}
+
+function assertSafeExecApprovalsDirectoryPath(targetPath: string): void {
+  const trustedRoot = resolveRequiredHomeDir();
   const resolvedTarget = path.resolve(targetPath);
   const resolvedRoot = path.resolve(trustedRoot);
   if (resolvedTarget !== resolvedRoot && !resolvedTarget.startsWith(`${resolvedRoot}${path.sep}`)) {
@@ -261,7 +277,9 @@ function assertNoSymlinkPathComponents(targetPath: string, trustedRoot: string):
     }
     if (stat.isSymbolicLink()) {
       if (index !== 0 || segment !== ".openclaw") {
-        throw new Error(`Refusing to traverse symlink in exec approvals path: ${current}`);
+        throw new UnsafeExecApprovalsPathError(
+          `Refusing to traverse symlink in exec approvals path: ${current}`,
+        );
       }
       current = resolveTrustedOpenClawSymlink(current);
     }
@@ -272,17 +290,19 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
   const realPath = fs.realpathSync(linkPath);
   const targetStat = fs.statSync(realPath);
   if (!targetStat.isDirectory()) {
-    throw new Error(`Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`);
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`,
+    );
   }
   if (process.platform !== "win32") {
     const getuid = process.getuid;
     if (typeof getuid === "function" && targetStat.uid !== getuid.call(process)) {
-      throw new Error(
+      throw new UnsafeExecApprovalsPathError(
         `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
       );
     }
     if ((targetStat.mode & 0o022) !== 0) {
-      throw new Error(
+      throw new UnsafeExecApprovalsPathError(
         `Refusing to use group/other-writable exec approvals .openclaw symlink target: ${linkPath}`,
       );
     }
@@ -294,7 +314,9 @@ function assertSafeExecApprovalsDestination(filePath: string): void {
   try {
     const stat = fs.lstatSync(filePath);
     if (stat.isSymbolicLink()) {
-      throw new Error(`Refusing to write exec approvals via symlink: ${filePath}`);
+      throw new UnsafeExecApprovalsPathError(
+        `Refusing to use exec approvals via symlink: ${filePath}`,
+      );
     }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -456,6 +478,7 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
+  assertSafeExecApprovalsFilePath(filePath);
   if (!fs.existsSync(filePath)) {
     const file = normalizeExecApprovals({ version: 1, agents: {} });
     return {
@@ -488,6 +511,7 @@ export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
 
 export function loadExecApprovals(): ExecApprovalsFile {
   const filePath = resolveExecApprovalsPath();
+  assertSafeExecApprovalsFilePath(filePath);
   try {
     if (!fs.existsSync(filePath)) {
       return normalizeExecApprovals({ version: 1, agents: {} });

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -366,11 +366,18 @@ function assertNoAdditionalOpenClawSymlinkTargetHops(targetPath: string, linkPat
     current = path.join(current, segment);
     const stat = fs.lstatSync(current);
     if (stat.isSymbolicLink()) {
+      if (isTrustedSystemSymlink(stat)) {
+        continue;
+      }
       throw new UnsafeExecApprovalsPathError(
         `Refusing to use exec approvals .openclaw symlink target that resolves through another symlink: ${current} (${linkPath})`,
       );
     }
   }
+}
+
+function isTrustedSystemSymlink(stat: fs.Stats): boolean {
+  return process.platform !== "win32" && stat.uid === 0;
 }
 
 function assertStableResolvedOpenClawSymlinkTarget(
@@ -667,19 +674,26 @@ export function restoreExecApprovalsSnapshot(snapshot: ExecApprovalsSnapshot): v
 }
 
 export function ensureExecApprovals(): ExecApprovalsFile {
-  const loaded = loadExecApprovals();
-  const next = normalizeExecApprovals(loaded);
-  const socketPath = next.socket?.path?.trim();
-  const token = next.socket?.token?.trim();
-  const updated: ExecApprovalsFile = {
-    ...next,
-    socket: {
-      path: socketPath && socketPath.length > 0 ? socketPath : resolveExecApprovalsSocketPath(),
-      token: token && token.length > 0 ? token : generateToken(),
-    },
-  };
-  saveExecApprovals(updated);
-  return updated;
+  try {
+    const loaded = loadExecApprovals();
+    const next = normalizeExecApprovals(loaded);
+    const socketPath = next.socket?.path?.trim();
+    const token = next.socket?.token?.trim();
+    const updated: ExecApprovalsFile = {
+      ...next,
+      socket: {
+        path: socketPath && socketPath.length > 0 ? socketPath : resolveExecApprovalsSocketPath(),
+        token: token && token.length > 0 ? token : generateToken(),
+      },
+    };
+    saveExecApprovals(updated);
+    return updated;
+  } catch (err) {
+    if (isUnsafeOrMissingApprovalsPathError(err)) {
+      return closedExecApprovalsFile();
+    }
+    throw err;
+  }
 }
 
 function isExecSecurity(value: unknown): value is ExecSecurity {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -322,6 +322,8 @@ function assertSafeExecApprovalsDirectoryPath(targetPath: string): void {
 }
 
 function resolveTrustedOpenClawSymlink(linkPath: string): string {
+  const targetPath = resolveOpenClawSymlinkDestinationPath(linkPath);
+  assertNoAdditionalOpenClawSymlinkTargetHops(targetPath, linkPath);
   const realPath = fs.realpathSync(linkPath);
   const targetStat = fs.statSync(realPath);
   if (!targetStat.isDirectory()) {
@@ -348,6 +350,27 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
     assertStableResolvedOpenClawSymlinkTarget(realPath, linkPath, currentUid);
   }
   return realPath;
+}
+
+function resolveOpenClawSymlinkDestinationPath(linkPath: string): string {
+  const destination = fs.readlinkSync(linkPath);
+  return path.resolve(path.dirname(linkPath), destination);
+}
+
+function assertNoAdditionalOpenClawSymlinkTargetHops(targetPath: string, linkPath: string): void {
+  const root = path.parse(targetPath).root;
+  let current = root;
+  const relative = path.relative(root, targetPath);
+  const segments = relative && relative !== "." ? relative.split(path.sep).filter(Boolean) : [];
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink()) {
+      throw new UnsafeExecApprovalsPathError(
+        `Refusing to use exec approvals .openclaw symlink target that resolves through another symlink: ${current} (${linkPath})`,
+      );
+    }
+  }
 }
 
 function assertStableResolvedOpenClawSymlinkTarget(

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -216,6 +216,16 @@ function emptyExecApprovalsSnapshot(filePath: string): ExecApprovalsSnapshot {
   };
 }
 
+function closedExecApprovalsSnapshot(filePath: string): ExecApprovalsSnapshot {
+  return {
+    path: filePath,
+    exists: false,
+    raw: null,
+    file: closedExecApprovalsFile(),
+    hash: hashExecApprovalsRaw(null),
+  };
+}
+
 function isUnsafeOrMissingApprovalsPathError(err: unknown): boolean {
   return (
     err instanceof UnsafeExecApprovalsPathError || (err as NodeJS.ErrnoException).code === "ENOENT"
@@ -596,25 +606,32 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
-  assertSafeExecApprovalsFilePath(filePath);
-  if (!fs.existsSync(filePath)) {
-    return emptyExecApprovalsSnapshot(filePath);
-  }
-  const raw = fs.readFileSync(filePath, "utf8");
-  let parsed: ExecApprovalsFile | null = null;
   try {
-    parsed = JSON.parse(raw) as ExecApprovalsFile;
-  } catch {
-    parsed = null;
+    assertSafeExecApprovalsFilePath(filePath);
+    if (!fs.existsSync(filePath)) {
+      return emptyExecApprovalsSnapshot(filePath);
+    }
+    const raw = fs.readFileSync(filePath, "utf8");
+    let parsed: ExecApprovalsFile | null = null;
+    try {
+      parsed = JSON.parse(raw) as ExecApprovalsFile;
+    } catch {
+      parsed = null;
+    }
+    const file = parsed?.version === 1 ? normalizeExecApprovals(parsed) : emptyExecApprovalsFile();
+    return {
+      path: filePath,
+      exists: true,
+      raw,
+      file,
+      hash: hashExecApprovalsRaw(raw),
+    };
+  } catch (err) {
+    if (isUnsafeOrMissingApprovalsPathError(err)) {
+      return closedExecApprovalsSnapshot(filePath);
+    }
+    throw err;
   }
-  const file = parsed?.version === 1 ? normalizeExecApprovals(parsed) : emptyExecApprovalsFile();
-  return {
-    path: filePath,
-    exists: true,
-    raw,
-    file,
-    hash: hashExecApprovalsRaw(raw),
-  };
 }
 
 export function loadExecApprovals(): ExecApprovalsFile {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -231,8 +231,8 @@ function ensureDir(filePath: string) {
   const dir = path.dirname(filePath);
   assertNoSymlinkPathComponents(dir, resolveRequiredHomeDir());
   fs.mkdirSync(dir, { recursive: true });
-  const dirStat = fs.lstatSync(dir);
-  if (!dirStat.isDirectory() || dirStat.isSymbolicLink()) {
+  const dirStat = fs.statSync(dir);
+  if (!dirStat.isDirectory()) {
     throw new Error(`Refusing to use unsafe exec approvals directory: ${dir}`);
   }
   return dir;
@@ -248,19 +248,46 @@ function assertNoSymlinkPathComponents(targetPath: string, trustedRoot: string):
   const relative = path.relative(resolvedRoot, resolvedTarget);
   const segments = relative && relative !== "." ? relative.split(path.sep) : [];
   let current = resolvedRoot;
-  for (const segment of segments) {
+  for (const [index, segment] of segments.entries()) {
     current = path.join(current, segment);
+    let stat: fs.Stats;
     try {
-      const stat = fs.lstatSync(current);
-      if (stat.isSymbolicLink()) {
-        throw new Error(`Refusing to traverse symlink in exec approvals path: ${current}`);
-      }
+      stat = fs.lstatSync(current);
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
         throw err;
       }
+      continue;
+    }
+    if (stat.isSymbolicLink()) {
+      if (index !== 0 || segment !== ".openclaw") {
+        throw new Error(`Refusing to traverse symlink in exec approvals path: ${current}`);
+      }
+      current = resolveTrustedOpenClawSymlink(current);
     }
   }
+}
+
+function resolveTrustedOpenClawSymlink(linkPath: string): string {
+  const realPath = fs.realpathSync(linkPath);
+  const targetStat = fs.statSync(realPath);
+  if (!targetStat.isDirectory()) {
+    throw new Error(`Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`);
+  }
+  if (process.platform !== "win32") {
+    const getuid = process.getuid;
+    if (typeof getuid === "function" && targetStat.uid !== getuid.call(process)) {
+      throw new Error(
+        `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
+      );
+    }
+    if ((targetStat.mode & 0o022) !== 0) {
+      throw new Error(
+        `Refusing to use group/other-writable exec approvals .openclaw symlink target: ${linkPath}`,
+      );
+    }
+  }
+  return realPath;
 }
 
 function assertSafeExecApprovalsDestination(filePath: string): void {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -333,14 +333,6 @@ function assertSafeExecApprovalsDirectoryPath(targetPath: string): void {
 
 function resolveTrustedOpenClawSymlink(linkPath: string): string {
   const targetPath = resolveOpenClawSymlinkDestinationPath(linkPath);
-  assertNoAdditionalOpenClawSymlinkTargetHops(targetPath, linkPath);
-  const realPath = fs.realpathSync(linkPath);
-  const targetStat = fs.statSync(realPath);
-  if (!targetStat.isDirectory()) {
-    throw new UnsafeExecApprovalsPathError(
-      `Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`,
-    );
-  }
   if (process.platform === "win32") {
     throw new UnsafeExecApprovalsPathError(
       `Refusing to use exec approvals .openclaw symlink target on Windows without ACL validation: ${linkPath}`,
@@ -348,9 +340,19 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
   }
   const getuid = process.getuid;
   if (typeof getuid !== "function") {
-    return realPath;
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink target without ownership validation: ${linkPath}`,
+    );
   }
   const currentUid = getuid.call(process);
+  assertNoAdditionalOpenClawSymlinkTargetHops(targetPath, linkPath, currentUid);
+  const realPath = fs.realpathSync(linkPath);
+  const targetStat = fs.statSync(realPath);
+  if (!targetStat.isDirectory()) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`,
+    );
+  }
   if (targetStat.uid !== currentUid) {
     throw new UnsafeExecApprovalsPathError(
       `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
@@ -370,7 +372,11 @@ function resolveOpenClawSymlinkDestinationPath(linkPath: string): string {
   return path.resolve(path.dirname(linkPath), destination);
 }
 
-function assertNoAdditionalOpenClawSymlinkTargetHops(targetPath: string, linkPath: string): void {
+function assertNoAdditionalOpenClawSymlinkTargetHops(
+  targetPath: string,
+  linkPath: string,
+  currentUid: number,
+): void {
   const root = path.parse(targetPath).root;
   let current = root;
   const relative = path.relative(root, targetPath);
@@ -380,6 +386,7 @@ function assertNoAdditionalOpenClawSymlinkTargetHops(targetPath: string, linkPat
     const stat = fs.lstatSync(current);
     if (stat.isSymbolicLink()) {
       if (isTrustedSystemSymlink(stat)) {
+        assertStableOpenClawSymlinkHopLocation(current, linkPath, currentUid);
         continue;
       }
       throw new UnsafeExecApprovalsPathError(
@@ -391,6 +398,15 @@ function assertNoAdditionalOpenClawSymlinkTargetHops(targetPath: string, linkPat
 
 function isTrustedSystemSymlink(stat: fs.Stats): boolean {
   return process.platform !== "win32" && stat.uid === 0;
+}
+
+function assertStableOpenClawSymlinkHopLocation(
+  hopPath: string,
+  linkPath: string,
+  currentUid: number,
+): void {
+  const parentRealPath = fs.realpathSync(path.dirname(hopPath));
+  assertStableResolvedOpenClawSymlinkTarget(parentRealPath, linkPath, currentUid);
 }
 
 function assertStableResolvedOpenClawSymlinkTarget(

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -345,6 +345,7 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
     );
   }
   const currentUid = getuid.call(process);
+  assertStableOpenClawSymlinkLocation(linkPath, currentUid);
   assertNoAdditionalOpenClawSymlinkTargetHops(targetPath, linkPath, currentUid);
   const realPath = fs.realpathSync(linkPath);
   const targetStat = fs.statSync(realPath);
@@ -370,6 +371,17 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
 function resolveOpenClawSymlinkDestinationPath(linkPath: string): string {
   const destination = fs.readlinkSync(linkPath);
   return path.resolve(path.dirname(linkPath), destination);
+}
+
+function assertStableOpenClawSymlinkLocation(linkPath: string, currentUid: number): void {
+  const linkStat = fs.lstatSync(linkPath);
+  if (linkStat.uid !== currentUid) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink not owned by current user: ${linkPath}`,
+    );
+  }
+  const parentRealPath = fs.realpathSync(path.dirname(linkPath));
+  assertStableResolvedOpenClawSymlinkTarget(parentRealPath, linkPath, currentUid);
 }
 
 function assertNoAdditionalOpenClawSymlinkTargetHops(

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -172,6 +172,9 @@ export const DEFAULT_EXEC_APPROVAL_ASK_FALLBACK: ExecSecurity = "full";
 const DEFAULT_AUTO_ALLOW_SKILLS = false;
 const DEFAULT_SOCKET = "~/.openclaw/exec-approvals.sock";
 const DEFAULT_FILE = "~/.openclaw/exec-approvals.json";
+const POSIX_OWNER_WRITE = 0o200;
+const POSIX_GROUP_OR_OTHER_WRITE = 0o022;
+const POSIX_STICKY = 0o1000;
 
 class UnsafeExecApprovalsPathError extends Error {
   constructor(message: string) {
@@ -316,18 +319,68 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
   }
   if (process.platform !== "win32") {
     const getuid = process.getuid;
-    if (typeof getuid === "function" && targetStat.uid !== getuid.call(process)) {
+    if (typeof getuid !== "function") {
+      return realPath;
+    }
+    const currentUid = getuid.call(process);
+    if (targetStat.uid !== currentUid) {
       throw new UnsafeExecApprovalsPathError(
         `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
       );
     }
-    if ((targetStat.mode & 0o022) !== 0) {
+    if ((targetStat.mode & POSIX_GROUP_OR_OTHER_WRITE) !== 0) {
       throw new UnsafeExecApprovalsPathError(
         `Refusing to use group/other-writable exec approvals .openclaw symlink target: ${linkPath}`,
       );
     }
+    assertStableResolvedOpenClawSymlinkTarget(realPath, linkPath, currentUid);
   }
   return realPath;
+}
+
+function assertStableResolvedOpenClawSymlinkTarget(
+  realPath: string,
+  linkPath: string,
+  currentUid: number,
+): void {
+  const root = path.parse(realPath).root;
+  let current = root;
+  assertStableResolvedOpenClawDirectory(current, linkPath, currentUid);
+
+  const relative = path.relative(root, realPath);
+  const segments = relative && relative !== "." ? relative.split(path.sep).filter(Boolean) : [];
+  for (const segment of segments) {
+    current = path.join(current, segment);
+    assertStableResolvedOpenClawDirectory(current, linkPath, currentUid);
+  }
+}
+
+function assertStableResolvedOpenClawDirectory(
+  dirPath: string,
+  linkPath: string,
+  currentUid: number,
+): void {
+  const stat = fs.lstatSync(dirPath);
+  if (!stat.isDirectory()) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink ancestor that is not a directory: ${dirPath} (${linkPath})`,
+    );
+  }
+  if (stat.isSymbolicLink()) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink ancestor that resolves through another symlink: ${dirPath} (${linkPath})`,
+    );
+  }
+  if (stat.uid !== currentUid && stat.uid !== 0 && (stat.mode & POSIX_OWNER_WRITE) !== 0) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use owner-writable exec approvals .openclaw symlink ancestor not owned by current user: ${dirPath} (${linkPath})`,
+    );
+  }
+  if ((stat.mode & POSIX_GROUP_OR_OTHER_WRITE) !== 0 && (stat.mode & POSIX_STICKY) === 0) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use group/other-writable exec approvals .openclaw symlink ancestor: ${dirPath} (${linkPath})`,
+    );
+  }
 }
 
 function assertSafeExecApprovalsDestination(filePath: string): void {

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -331,24 +331,27 @@ function resolveTrustedOpenClawSymlink(linkPath: string): string {
       `Refusing to use unsafe exec approvals .openclaw symlink target: ${linkPath}`,
     );
   }
-  if (process.platform !== "win32") {
-    const getuid = process.getuid;
-    if (typeof getuid !== "function") {
-      return realPath;
-    }
-    const currentUid = getuid.call(process);
-    if (targetStat.uid !== currentUid) {
-      throw new UnsafeExecApprovalsPathError(
-        `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
-      );
-    }
-    if ((targetStat.mode & POSIX_GROUP_OR_OTHER_WRITE) !== 0) {
-      throw new UnsafeExecApprovalsPathError(
-        `Refusing to use group/other-writable exec approvals .openclaw symlink target: ${linkPath}`,
-      );
-    }
-    assertStableResolvedOpenClawSymlinkTarget(realPath, linkPath, currentUid);
+  if (process.platform === "win32") {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink target on Windows without ACL validation: ${linkPath}`,
+    );
   }
+  const getuid = process.getuid;
+  if (typeof getuid !== "function") {
+    return realPath;
+  }
+  const currentUid = getuid.call(process);
+  if (targetStat.uid !== currentUid) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use exec approvals .openclaw symlink target not owned by current user: ${linkPath}`,
+    );
+  }
+  if ((targetStat.mode & POSIX_GROUP_OR_OTHER_WRITE) !== 0) {
+    throw new UnsafeExecApprovalsPathError(
+      `Refusing to use group/other-writable exec approvals .openclaw symlink target: ${linkPath}`,
+    );
+  }
+  assertStableResolvedOpenClawSymlinkTarget(realPath, linkPath, currentUid);
   return realPath;
 }
 

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -194,6 +194,18 @@ function emptyExecApprovalsFile(): ExecApprovalsFile {
   return normalizeExecApprovals({ version: 1, agents: {} });
 }
 
+function closedExecApprovalsFile(): ExecApprovalsFile {
+  return normalizeExecApprovals({
+    version: 1,
+    defaults: {
+      security: "deny",
+      ask: "always",
+      askFallback: "deny",
+    },
+    agents: {},
+  });
+}
+
 function emptyExecApprovalsSnapshot(filePath: string): ExecApprovalsSnapshot {
   return {
     path: filePath,
@@ -204,7 +216,7 @@ function emptyExecApprovalsSnapshot(filePath: string): ExecApprovalsSnapshot {
   };
 }
 
-function isBestEffortReadPathError(err: unknown): boolean {
+function isUnsafeOrMissingApprovalsPathError(err: unknown): boolean {
   return (
     err instanceof UnsafeExecApprovalsPathError || (err as NodeJS.ErrnoException).code === "ENOENT"
   );
@@ -551,14 +563,7 @@ function generateToken(): string {
 
 export function readExecApprovalsSnapshot(): ExecApprovalsSnapshot {
   const filePath = resolveExecApprovalsPath();
-  try {
-    assertSafeExecApprovalsFilePath(filePath);
-  } catch (err) {
-    if (isBestEffortReadPathError(err)) {
-      return emptyExecApprovalsSnapshot(filePath);
-    }
-    throw err;
-  }
+  assertSafeExecApprovalsFilePath(filePath);
   if (!fs.existsSync(filePath)) {
     return emptyExecApprovalsSnapshot(filePath);
   }
@@ -592,8 +597,10 @@ export function loadExecApprovals(): ExecApprovalsFile {
       return emptyExecApprovalsFile();
     }
     return normalizeExecApprovals(parsed);
-  } catch {
-    return emptyExecApprovalsFile();
+  } catch (err) {
+    return isUnsafeOrMissingApprovalsPathError(err)
+      ? closedExecApprovalsFile()
+      : emptyExecApprovalsFile();
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #72572.

This restores support for dotfile-managed `~/.openclaw` directories while keeping exec approval paths hardened on both the Node and macOS node-host paths.

- allow trusted first-level `~/.openclaw` symlinks on POSIX after validating link ownership, link location, target ownership, target permissions, and stable resolved ancestors
- keep Windows `.openclaw` symlink targets blocked until ACL validation exists
- keep rejecting user-controlled chained symlink targets, deeper symlink traversal, and symlinked `exec-approvals.json` destinations
- fail closed for unsafe approvals reads in runtime policy paths while keeping snapshot/control-plane reads usable
- apply equivalent state-dir, JSON store, and socket-parent hardening on macOS, including symlinked `OPENCLAW_STATE_DIR` overrides and system `/tmp`/`/var` symlink roots
- document the supported symlink shape in approvals CLI docs

## Validation

- `pnpm docs:list`
- `pnpm exec oxfmt --check --threads=1 src/infra/exec-approvals.ts src/infra/exec-approvals-store.test.ts`
- `pnpm test src/infra/exec-approvals-store.test.ts`
- `swiftc -parse apps/macos/Sources/OpenClaw/ExecApprovals.swift apps/macos/Sources/OpenClaw/ExecApprovalsSocket.swift apps/macos/Sources/OpenClaw/NodeMode/MacNodeRuntime.swift apps/macos/Tests/OpenClawIPCTests/ExecApprovalsSocketPathGuardTests.swift apps/macos/Tests/OpenClawIPCTests/ExecApprovalsStoreRefactorTests.swift`
- `git diff --check`
- `pnpm check:changed` (core lanes passed; apps lane stopped because `swiftlint` is not installed locally)
- `swift test --filter ExecApprovalsSocketPathGuardTests` attempted; SwiftPM hung while downloading/building Sparkle artifact locally
- `codex review -c model="gpt-5.4" --base origin/main`

AI-assisted: yes
lobster-biscuit
