### PR TITLE
fix(agents): close ACP runtime handle on spawn dispatch failure

### DIFF
--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1410,6 +1410,7 @@ export async function spawnAcpDirect(
       sessionKey,
       shouldDeleteSession: true,
       deleteTranscript: true,
+      runtimeCloseHandle: initializedRuntime,
     });
     return createAcpSpawnFailure({
       status: "error",


### PR DESCRIPTION
## Summary

- `acp-spawn.ts` has two catch blocks guarding the spawn flow; the second (dispatch failure, after runtime is already initialized) omits `runtimeCloseHandle` from `cleanupFailedAcpSpawn`, leaking the backend connection on every failed dispatch
- The first catch block (session/runtime init failure at ~line 1251) correctly passes `runtimeCloseHandle: initializedRuntime`
- `cleanupFailedAcpSpawn` in `src/acp/control-plane/spawn.ts` only calls `runtime.close()` when the handle is provided — without it, the connection is never closed

## Fix

Add `runtimeCloseHandle: initializedRuntime` to the second catch block at `src/agents/acp-spawn.ts`, mirroring the pattern already used in the first catch block.

## Test plan

- [ ] ACP spawn where dispatch call fails no longer leaks runtime handle
- [ ] First catch block (init failure) behavior unchanged
- [ ] `pnpm check:changed` passes

Thanks @ioodu