### PR TITLE
fix(gateway): guard maxLines compact against active session runs

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -385,7 +385,7 @@ function hasTrackedActiveSessionRun(params: {
   requestedKey: string;
   canonicalKey: string;
 }): boolean {
-  for (const active of params.context.chatAbortControllers.values()) {
+  for (const active of (params.context.chatAbortControllers ?? new Map()).values()) {
     if (active.sessionKey === params.canonicalKey || active.sessionKey === params.requestedKey) {
       return true;
     }

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -1757,6 +1757,20 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
 
+    const interruptResult = await interruptSessionRunIfActive({
+      req,
+      context,
+      client,
+      isWebchatConnect,
+      requestedKey: key,
+      canonicalKey: target.canonicalKey,
+      sessionId,
+    });
+    if (interruptResult.error) {
+      respond(false, undefined, interruptResult.error);
+      return;
+    }
+
     const raw = fs.readFileSync(filePath, "utf-8");
     const lines = raw.split(/\r?\n/).filter((l) => Boolean(normalizeOptionalString(l)));
     if (lines.length <= maxLines) {

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1628,6 +1628,45 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.compact with maxLines rejects when an embedded run is active and does not stop", async () => {
+    const { dir, storePath } = await createSessionStoreDir();
+    const transcriptPath = path.join(dir, "sess-main.jsonl");
+    const lines = Array.from({ length: 10 }, (_, i) =>
+      JSON.stringify({ role: i % 2 === 0 ? "user" : "assistant", content: `msg ${i}` }),
+    ).join("\n");
+    await fs.writeFile(transcriptPath, `${lines}\n`, "utf-8");
+    await fs.writeFile(
+      storePath,
+      JSON.stringify({
+        "agent:main:main": { sessionId: "sess-main", updatedAt: Date.now() },
+      }),
+      "utf-8",
+    );
+
+    embeddedRunMock.activeIds.add("sess-main");
+    embeddedRunMock.waitResults.set("sess-main", false);
+
+    try {
+      const result = await directSessionReq("sessions.compact", {
+        key: "main",
+        maxLines: 3,
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error?.code).toBe("UNAVAILABLE");
+
+      const afterLines = (await fs.readFile(transcriptPath, "utf-8"))
+        .split(/\r?\n/)
+        .filter((l) => l.trim().length > 0);
+      expect(afterLines).toHaveLength(10);
+      const files = await fs.readdir(dir);
+      expect(files.some((f) => f.startsWith("sess-main.jsonl.bak."))).toBe(false);
+    } finally {
+      embeddedRunMock.activeIds.delete("sess-main");
+      embeddedRunMock.waitResults.delete("sess-main");
+    }
+  });
+
   test("sessions.patch preserves nested model ids under provider overrides", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gw-sessions-nested-"));
     const storePath = path.join(dir, "sessions.json");


### PR DESCRIPTION
## Summary

- `sessions.compact` with `maxLines` skips the `interruptSessionRunIfActive` guard that the AI compaction path uses
- When an agent run is active, `archiveFileOnDisk` renames the live transcript to `.bak`; the active runner continues writing to the renamed file while `writeFileSync` creates a new truncated file at the original path — all post-compact agent output is silently lost
- The fix inserts the same `interruptSessionRunIfActive` guard used by the AI compaction path, mirroring the pattern also used by `sessions.compaction.restore`

## Fix

Add `interruptSessionRunIfActive` call to the `maxLines` branch of `sessions.compact` before the transcript file is read and overwritten.

## Test plan

- [ ] `sessions.compact` with `maxLines` during an active run now aborts the run first (same behavior as AI compaction)
- [ ] `sessions.compact` with `maxLines` when no run is active works unchanged
- [ ] `pnpm check:changed` passes

Thanks @ioodu