### PR TITLE
fix(infra): use updateSessionStore in heartbeat to prevent TOCTOU race

### DIFF
--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -938,28 +938,28 @@ export async function runHeartbeatOnce(opts: {
       return;
     }
 
-    const store = loadSessionStore(storePath);
-    const current = store[sessionKey];
-    // Initialize stub entry on first run when current doesn't exist
-    const base = current ?? {
-      // Generate valid sessionId - derive from sessionKey without colons
-      sessionId: sessionKey.replace(/:/g, "_"),
-      updatedAt: startedAt,
-      createdAt: startedAt,
-      messageCount: 0,
-      lastMessageAt: startedAt,
-      heartbeatTaskState: {},
-    };
-    const taskState = { ...base.heartbeatTaskState };
+    await updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey];
+      // Initialize stub entry on first run when current doesn't exist
+      const base = current ?? {
+        // Generate valid sessionId - derive from sessionKey without colons
+        sessionId: sessionKey.replace(/:/g, "_"),
+        updatedAt: startedAt,
+        createdAt: startedAt,
+        messageCount: 0,
+        lastMessageAt: startedAt,
+        heartbeatTaskState: {},
+      };
+      const taskState = { ...base.heartbeatTaskState };
 
-    for (const task of preflight.tasks) {
-      if (isTaskDue(taskState[task.name], task.interval, startedAt)) {
-        taskState[task.name] = startedAt;
+      for (const task of preflight.tasks!) {
+        if (isTaskDue(taskState[task.name], task.interval, startedAt)) {
+          taskState[task.name] = startedAt;
+        }
       }
-    }
 
-    store[sessionKey] = { ...base, heartbeatTaskState: taskState };
-    await saveSessionStore(storePath, store);
+      store[sessionKey] = { ...base, heartbeatTaskState: taskState };
+    });
   };
 
   const consumeInspectedSystemEvents = () => {
@@ -1271,16 +1271,16 @@ export async function runHeartbeatOnce(opts: {
 
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {
-      const store = loadSessionStore(storePath);
-      const current = store[sessionKey];
-      if (current) {
-        store[sessionKey] = {
-          ...current,
-          lastHeartbeatText: normalized.text,
-          lastHeartbeatSentAt: startedAt,
-        };
-        await saveSessionStore(storePath, store);
-      }
+      await updateSessionStore(storePath, (store) => {
+        const current = store[sessionKey];
+        if (current) {
+          store[sessionKey] = {
+            ...current,
+            lastHeartbeatText: normalized.text,
+            lastHeartbeatSentAt: startedAt,
+          };
+        }
+      });
     }
 
     emitHeartbeatEvent({


### PR DESCRIPTION
## Summary

- `updateTaskTimestamps` in `heartbeat-runner.ts` loads the session store outside any lock, mutates it, then saves — creating a TOCTOU window spanning the entire LLM call duration
- Concurrent inbound message handlers (`recordSessionMetaFromInbound`, `updateLastRoute`) use `updateSessionStore` (re-reads inside lock) and can have their `messageCount`/`updatedAt`/`lastMessageAt` updates silently overwritten by the stale heartbeat snapshot
- The sibling function `restoreHeartbeatUpdatedAt` was already fixed to use `updateSessionStore`; `updateTaskTimestamps` and the `lastHeartbeatText` save block were not
- `src/config/sessions/store.ts:427` documents the invariant: "Always re-read inside the lock to avoid clobbering concurrent writers"

## Fix

Replace `loadSessionStore` + `saveSessionStore` with `updateSessionStore` in `updateTaskTimestamps` and the `lastHeartbeatText`/`lastHeartbeatSentAt` save block.

## Test plan

- [ ] Heartbeat task state updates no longer overwrite concurrent session metadata changes
- [ ] `restoreHeartbeatUpdatedAt` behavior unchanged
- [ ] `pnpm check:changed` passes

Thanks @ioodu