### PR TITLE
feat(gateway): persist tool approval decisions to audit log

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -106,6 +106,7 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "sessions.usage",
     "sessions.usage.timeseries",
     "sessions.usage.logs",
+    "exec.approval.auditLog",
     "cron.list",
     "cron.status",
     "cron.runs",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -151,6 +151,8 @@ import {
   ExecApprovalRequestParamsSchema,
   type ExecApprovalResolveParams,
   ExecApprovalResolveParamsSchema,
+  type ExecApprovalAuditLogParams,
+  ExecApprovalAuditLogParamsSchema,
   type PluginApprovalRequestParams,
   PluginApprovalRequestParamsSchema,
   type PluginApprovalResolveParams,
@@ -553,6 +555,9 @@ export const validateExecApprovalRequestParams = ajv.compile<ExecApprovalRequest
 export const validateExecApprovalResolveParams = ajv.compile<ExecApprovalResolveParams>(
   ExecApprovalResolveParamsSchema,
 );
+export const validateExecApprovalAuditLogParams = ajv.compile<ExecApprovalAuditLogParams>(
+  ExecApprovalAuditLogParamsSchema,
+);
 export const validatePluginApprovalRequestParams = ajv.compile<PluginApprovalRequestParams>(
   PluginApprovalRequestParamsSchema,
 );
@@ -749,6 +754,7 @@ export {
   ExecApprovalGetParamsSchema,
   ExecApprovalRequestParamsSchema,
   ExecApprovalResolveParamsSchema,
+  ExecApprovalAuditLogParamsSchema,
   ChatHistoryParamsSchema,
   ChatSendParamsSchema,
   ChatInjectParamsSchema,
@@ -885,6 +891,7 @@ export type {
   ExecApprovalGetParams,
   ExecApprovalRequestParams,
   ExecApprovalResolveParams,
+  ExecApprovalAuditLogParams,
   LogsTailParams,
   LogsTailResult,
   PollParams,

--- a/src/gateway/protocol/schema/exec-approvals.ts
+++ b/src/gateway/protocol/schema/exec-approvals.ts
@@ -152,3 +152,18 @@ export const ExecApprovalResolveParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+export const ExecApprovalAuditLogParamsSchema = Type.Object(
+  {
+    since: Type.Optional(Type.Integer({ minimum: 0 })),
+    limit: Type.Optional(Type.Integer({ minimum: 1 })),
+    agentId: Type.Optional(Type.String()),
+  },
+  { additionalProperties: false },
+);
+
+export type ExecApprovalAuditLogParams = {
+  since?: number;
+  limit?: number;
+  agentId?: string;
+};

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -41,6 +41,7 @@ const BASE_METHODS = [
   "exec.approval.request",
   "exec.approval.waitDecision",
   "exec.approval.resolve",
+  "exec.approval.auditLog",
   "plugin.approval.list",
   "plugin.approval.request",
   "plugin.approval.waitDecision",

--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,3 +1,4 @@
+import { appendApprovalAuditEntry, readApprovalAuditLog } from "../../infra/exec-approval-audit.js";
 import {
   resolveExecApprovalCommandDisplay,
   sanitizeExecApprovalDisplayText,
@@ -22,6 +23,7 @@ import {
   ErrorCodes,
   errorShape,
   formatValidationErrors,
+  validateExecApprovalAuditLogParams,
   validateExecApprovalGetParams,
   validateExecApprovalRequestParams,
   validateExecApprovalResolveParams,
@@ -47,9 +49,15 @@ type ExecApprovalIosPushDelivery = {
   handleExpired?: (request: ExecApprovalRequest) => Promise<void>;
 };
 
+type AppendAuditEntry = typeof appendApprovalAuditEntry;
+
 export function createExecApprovalHandlers(
   manager: ExecApprovalManager,
-  opts?: { forwarder?: ExecApprovalForwarder; iosPushDelivery?: ExecApprovalIosPushDelivery },
+  opts?: {
+    forwarder?: ExecApprovalForwarder;
+    iosPushDelivery?: ExecApprovalIosPushDelivery;
+    appendAuditEntry?: AppendAuditEntry;
+  },
 ): GatewayRequestHandlers {
   return {
     "exec.approval.get": async ({ params, respond }) => {
@@ -378,15 +386,62 @@ export function createExecApprovalHandlers(
           }) satisfies ExecApprovalResolved,
         forwardResolved: (resolvedEvent) => opts?.forwarder?.handleResolved(resolvedEvent),
         forwardResolvedErrorLabel: "exec approvals: forward resolve failed",
-        extraResolvedHandlers: opts?.iosPushDelivery?.handleResolved
-          ? [
-              {
-                run: (resolvedEvent) => opts.iosPushDelivery!.handleResolved!(resolvedEvent),
-                errorLabel: "exec approvals: iOS push resolve failed",
-              },
-            ]
-          : undefined,
+        extraResolvedHandlers: [
+          ...(opts?.iosPushDelivery?.handleResolved
+            ? [
+                {
+                  run: (resolvedEvent: ExecApprovalResolved) =>
+                    opts.iosPushDelivery!.handleResolved!(resolvedEvent),
+                  errorLabel: "exec approvals: iOS push resolve failed",
+                },
+              ]
+            : []),
+          {
+            run: (resolvedEvent: ExecApprovalResolved) => {
+              const auditDecision: "approved" | "denied" =
+                resolvedEvent.decision === "deny" ? "denied" : "approved";
+              const doAppend = opts?.appendAuditEntry ?? appendApprovalAuditEntry;
+              doAppend({
+                ts: resolvedEvent.ts,
+                approvalId: resolvedEvent.id,
+                command: resolvedEvent.request?.command ?? "",
+                decision: auditDecision,
+                resolvedBy: {
+                  deviceId: client?.connect?.device?.id ?? null,
+                  clientId: client?.connect?.client?.id ?? null,
+                  connId: client?.connId ?? null,
+                },
+                agentId: resolvedEvent.request?.agentId ?? null,
+                sessionKey: resolvedEvent.request?.sessionKey ?? null,
+                args: resolvedEvent.request?.commandArgv,
+              });
+            },
+            errorLabel: "exec approvals: audit log write failed",
+          },
+        ],
       });
+    },
+    "exec.approval.auditLog": async ({ params, respond }) => {
+      if (!validateExecApprovalAuditLogParams(params)) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `invalid exec.approval.auditLog params: ${formatValidationErrors(
+              validateExecApprovalAuditLogParams.errors,
+            )}`,
+          ),
+        );
+        return;
+      }
+      const p = params as { since?: number; limit?: number; agentId?: string };
+      const entries = readApprovalAuditLog({
+        since: p.since,
+        limit: p.limit,
+        agentId: p.agentId,
+      });
+      respond(true, { entries }, undefined);
     },
   };
 }

--- a/src/infra/exec-approval-audit.ts
+++ b/src/infra/exec-approval-audit.ts
@@ -33,7 +33,16 @@ export function resolveApprovalAuditLogPath(
 }
 
 function redactSecretArgs(args: unknown): unknown {
-  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+  if (Array.isArray(args)) {
+    return args.map((item) =>
+      typeof item === "string" && /^[A-Z_]+=/.test(item)
+        ? item.replace(/^([^=]+=)(.*)$/, (_, key, val) =>
+            SECRET_KEY_PATTERNS.test(key) ? `${key}[REDACTED]` : `${key}${val}`,
+          )
+        : item,
+    );
+  }
+  if (args === null || typeof args !== "object") {
     return args;
   }
   const result: Record<string, unknown> = {};

--- a/src/infra/exec-approval-audit.ts
+++ b/src/infra/exec-approval-audit.ts
@@ -1,0 +1,110 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+
+const APPROVAL_AUDIT_LOG_FILENAME = "approvals.jsonl";
+
+// Keys whose values should be redacted when logging args.
+const SECRET_KEY_PATTERNS = /key|token|password|secret|credential|auth|apikey/i;
+
+export type ApprovalAuditResolvedBy = {
+  deviceId?: string | null;
+  clientId?: string | null;
+  connId?: string | null;
+};
+
+export type ApprovalAuditEntry = {
+  ts: number;
+  approvalId: string;
+  command: string;
+  decision: "approved" | "denied";
+  resolvedBy: ApprovalAuditResolvedBy;
+  agentId?: string | null;
+  sessionKey?: string | null;
+  args?: unknown;
+};
+
+export function resolveApprovalAuditLogPath(
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = () => os.homedir(),
+): string {
+  return path.join(resolveStateDir(env, homedir), "audit", APPROVAL_AUDIT_LOG_FILENAME);
+}
+
+function redactSecretArgs(args: unknown): unknown {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) {
+    return args;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
+    result[key] = SECRET_KEY_PATTERNS.test(key) ? "[REDACTED]" : value;
+  }
+  return result;
+}
+
+export function appendApprovalAuditEntry(
+  entry: ApprovalAuditEntry,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = () => os.homedir(),
+): void {
+  try {
+    const auditPath = resolveApprovalAuditLogPath(env, homedir);
+    const redacted: ApprovalAuditEntry = {
+      ...entry,
+      args: entry.args !== undefined ? redactSecretArgs(entry.args) : undefined,
+    };
+    fs.mkdirSync(path.dirname(auditPath), { recursive: true, mode: 0o700 });
+    fs.appendFileSync(auditPath, `${JSON.stringify(redacted)}\n`, {
+      encoding: "utf-8",
+      mode: 0o600,
+    });
+  } catch {
+    // best-effort
+  }
+}
+
+export type ReadApprovalAuditLogOpts = {
+  since?: number;
+  limit?: number;
+  agentId?: string;
+};
+
+export function readApprovalAuditLog(
+  opts: ReadApprovalAuditLogOpts = {},
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = () => os.homedir(),
+): ApprovalAuditEntry[] {
+  const auditPath = resolveApprovalAuditLogPath(env, homedir);
+  let raw: string;
+  try {
+    raw = fs.readFileSync(auditPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+
+  const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+  const entries: ApprovalAuditEntry[] = [];
+  for (const line of lines) {
+    try {
+      const entry = JSON.parse(line) as ApprovalAuditEntry;
+      if (opts.since !== undefined && entry.ts < opts.since) {
+        continue;
+      }
+      if (opts.agentId !== undefined && entry.agentId !== opts.agentId) {
+        continue;
+      }
+      entries.push(entry);
+    } catch {
+      // skip malformed lines
+    }
+  }
+
+  if (opts.limit !== undefined && opts.limit > 0 && entries.length > opts.limit) {
+    return entries.slice(entries.length - opts.limit);
+  }
+  return entries;
+}


### PR DESCRIPTION
## Summary

- Tool approval decisions (approved/denied) are now persisted to `{stateDir}/audit/approvals.jsonl` as append-only JSONL
- Each entry captures: timestamp, approval ID, command text, decision, resolver identity (deviceId/clientId/connId), agentId, sessionKey
- Adds `exec.approval.auditLog` gateway method (READ scope) for querying the log with optional `since`, `limit`, and `agentId` filters
- Follows the existing audit log pattern from `src/config/io.audit.ts`
- In-memory approval tracking behavior unchanged; audit log is additive
- Sensitive argument values (keys matching key/token/password/secret/credential/auth/apikey) are redacted in persisted entries

## Test plan

- [ ] Approving a tool call writes an entry to `approvals.jsonl`
- [ ] Denying a tool call writes an entry with `decision: "denied"`
- [ ] `exec.approval.auditLog` returns persisted entries across gateway restarts
- [ ] `agentId`, `since`, and `limit` filters work correctly
- [ ] `pnpm check:changed` passes

Thanks @ioodu