### PR TITLE
feat(gateway): add session sharing via time-limited read-only tokens

### DIFF
--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -161,6 +161,8 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "push.web.unsubscribe",
     "push.web.test",
     "node.pending.enqueue",
+    "sessions.createSharedToken",
+    "sessions.revokeSharedToken",
   ],
   [ADMIN_SCOPE]: [
     "channels.start",

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -269,6 +269,12 @@ import {
   SessionsSendParamsSchema,
   type SessionsUsageParams,
   SessionsUsageParamsSchema,
+  type SessionsCreateSharedTokenParams,
+  SessionsCreateSharedTokenParamsSchema,
+  type SessionsCreateSharedTokenResult,
+  SessionsCreateSharedTokenResultSchema,
+  type SessionsRevokeSharedTokenParams,
+  SessionsRevokeSharedTokenParamsSchema,
   type ShutdownEvent,
   ShutdownEventSchema,
   type SkillsBinsParams,
@@ -456,6 +462,12 @@ export const validateSessionsCompactionRestoreParams = ajv.compile<SessionsCompa
 );
 export const validateSessionsUsageParams =
   ajv.compile<SessionsUsageParams>(SessionsUsageParamsSchema);
+export const validateSessionsCreateSharedTokenParams = ajv.compile<SessionsCreateSharedTokenParams>(
+  SessionsCreateSharedTokenParamsSchema,
+);
+export const validateSessionsRevokeSharedTokenParams = ajv.compile<SessionsRevokeSharedTokenParams>(
+  SessionsRevokeSharedTokenParamsSchema,
+);
 export const validateConfigGetParams = ajv.compile<ConfigGetParams>(ConfigGetParamsSchema);
 export const validateConfigSetParams = ajv.compile<ConfigSetParams>(ConfigSetParamsSchema);
 export const validateConfigApplyParams = ajv.compile<ConfigApplyParams>(ConfigApplyParamsSchema);
@@ -671,6 +683,9 @@ export {
   SessionsDeleteParamsSchema,
   SessionsCompactParamsSchema,
   SessionsUsageParamsSchema,
+  SessionsCreateSharedTokenParamsSchema,
+  SessionsCreateSharedTokenResultSchema,
+  SessionsRevokeSharedTokenParamsSchema,
   ConfigGetParamsSchema,
   ConfigSetParamsSchema,
   ConfigApplyParamsSchema,
@@ -870,6 +885,9 @@ export type {
   SessionsDeleteParams,
   SessionsCompactParams,
   SessionsUsageParams,
+  SessionsCreateSharedTokenParams,
+  SessionsCreateSharedTokenResult,
+  SessionsRevokeSharedTokenParams,
   CronJob,
   CronListParams,
   CronStatusParams,

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -324,3 +324,45 @@ export const SessionsUsageParamsSchema = Type.Object(
   },
   { additionalProperties: false },
 );
+
+export const SessionsCreateSharedTokenParamsSchema = Type.Object(
+  {
+    sessionKey: NonEmptyString,
+    /** TTL in milliseconds. Defaults to 24 hours; max 7 days. */
+    ttlMs: Type.Optional(Type.Integer({ minimum: 1 })),
+  },
+  { additionalProperties: false },
+);
+
+export type SessionsCreateSharedTokenParams = {
+  sessionKey: string;
+  ttlMs?: number;
+};
+
+export const SessionsCreateSharedTokenResultSchema = Type.Object(
+  {
+    ok: Type.Literal(true),
+    token: NonEmptyString,
+    sessionKey: NonEmptyString,
+    expiresAtMs: Type.Integer({ minimum: 0 }),
+  },
+  { additionalProperties: false },
+);
+
+export type SessionsCreateSharedTokenResult = {
+  ok: true;
+  token: string;
+  sessionKey: string;
+  expiresAtMs: number;
+};
+
+export const SessionsRevokeSharedTokenParamsSchema = Type.Object(
+  {
+    token: NonEmptyString,
+  },
+  { additionalProperties: false },
+);
+
+export type SessionsRevokeSharedTokenParams = {
+  token: string;
+};

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -96,6 +96,8 @@ const BASE_METHODS = [
   "sessions.compaction.restore",
   "sessions.create",
   "sessions.send",
+  "sessions.createSharedToken",
+  "sessions.revokeSharedToken",
   "sessions.abort",
   "sessions.patch",
   "sessions.pluginPatch",

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -26,6 +26,7 @@ import { nodeHandlers } from "./server-methods/nodes.js";
 import { pluginHostHookHandlers } from "./server-methods/plugin-host-hooks.js";
 import { pushHandlers } from "./server-methods/push.js";
 import { sendHandlers } from "./server-methods/send.js";
+import { sessionShareTokenHandlers } from "./server-methods/session-share-tokens.js";
 import { sessionsHandlers } from "./server-methods/sessions.js";
 import { skillsHandlers } from "./server-methods/skills.js";
 import { systemHandlers } from "./server-methods/system.js";
@@ -98,6 +99,7 @@ export const coreGatewayHandlers: GatewayRequestHandlers = {
   ...ttsHandlers,
   ...skillsHandlers,
   ...sessionsHandlers,
+  ...sessionShareTokenHandlers,
   ...systemHandlers,
   ...updateHandlers,
   ...nodeHandlers,

--- a/src/gateway/server-methods/session-share-tokens.ts
+++ b/src/gateway/server-methods/session-share-tokens.ts
@@ -1,0 +1,58 @@
+import {
+  createSessionShareToken,
+  revokeSessionShareToken,
+} from "../../infra/session-share-tokens.js";
+import {
+  ErrorCodes,
+  errorShape,
+  validateSessionsCreateSharedTokenParams,
+  validateSessionsRevokeSharedTokenParams,
+} from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+export const sessionShareTokenHandlers: GatewayRequestHandlers = {
+  "sessions.createSharedToken": ({ params, client, respond }) => {
+    if (
+      !assertValidParams(
+        params,
+        validateSessionsCreateSharedTokenParams,
+        "sessions.createSharedToken",
+        respond,
+      )
+    ) {
+      return;
+    }
+    const deviceId = client?.connect?.device?.id ?? "";
+    const entry = createSessionShareToken({
+      sessionKey: params.sessionKey,
+      ttlMs: params.ttlMs,
+      createdByDeviceId: deviceId,
+    });
+    respond(true, {
+      ok: true,
+      token: entry.token,
+      sessionKey: entry.sessionKey,
+      expiresAtMs: entry.expiresAtMs,
+    });
+  },
+
+  "sessions.revokeSharedToken": ({ params, respond }) => {
+    if (
+      !assertValidParams(
+        params,
+        validateSessionsRevokeSharedTokenParams,
+        "sessions.revokeSharedToken",
+        respond,
+      )
+    ) {
+      return;
+    }
+    const revoked = revokeSessionShareToken(params.token);
+    if (!revoked) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "token not found"));
+      return;
+    }
+    respond(true, { ok: true });
+  },
+};

--- a/src/infra/session-share-tokens.test.ts
+++ b/src/infra/session-share-tokens.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clampTtlMs,
   createSessionShareToken,
@@ -99,16 +99,19 @@ describe("session-share-tokens", () => {
     });
 
     it("returns null for expired token", () => {
-      const entry = createSessionShareToken({
-        sessionKey: "my-session",
-        ttlMs: -1, // forces DEFAULT_TTL_MS but we'll manipulate directly
-        createdByDeviceId: "d",
-      });
-      // Manually expire by patching — since store is module-level, use a new
-      // token with a very short TTL and wait (not practical). Instead verify
-      // via revokeSessionShareToken.
-      revokeSessionShareToken(entry.token);
-      expect(resolveSessionShareToken(entry.token)).toBeNull();
+      vi.useFakeTimers();
+      try {
+        const entry = createSessionShareToken({
+          sessionKey: "my-session",
+          ttlMs: 1,
+          createdByDeviceId: "d",
+        });
+        expect(resolveSessionShareToken(entry.token)).not.toBeNull();
+        vi.advanceTimersByTime(2);
+        expect(resolveSessionShareToken(entry.token)).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/infra/session-share-tokens.test.ts
+++ b/src/infra/session-share-tokens.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clampTtlMs,
+  createSessionShareToken,
+  DEFAULT_TTL_MS,
+  initSessionShareTokens,
+  MAX_TTL_MS,
+  pruneExpiredTokens,
+  resolveSessionShareToken,
+  revokeSessionShareToken,
+} from "./session-share-tokens.js";
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "session-share-tokens-test-"));
+}
+
+describe("session-share-tokens", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    initSessionShareTokens({ stateDir: tmpDir });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("clampTtlMs", () => {
+    it("returns DEFAULT_TTL_MS for undefined", () => {
+      expect(clampTtlMs(undefined)).toBe(DEFAULT_TTL_MS);
+    });
+
+    it("returns DEFAULT_TTL_MS for zero", () => {
+      expect(clampTtlMs(0)).toBe(DEFAULT_TTL_MS);
+    });
+
+    it("returns DEFAULT_TTL_MS for negative", () => {
+      expect(clampTtlMs(-1)).toBe(DEFAULT_TTL_MS);
+    });
+
+    it("clamps to MAX_TTL_MS when over limit", () => {
+      expect(clampTtlMs(MAX_TTL_MS + 1)).toBe(MAX_TTL_MS);
+    });
+
+    it("passes through valid TTL", () => {
+      expect(clampTtlMs(60_000)).toBe(60_000);
+    });
+  });
+
+  describe("createSessionShareToken", () => {
+    it("returns a token entry with correct shape", () => {
+      const entry = createSessionShareToken({
+        sessionKey: "agent:default:session:abc",
+        createdByDeviceId: "device-1",
+      });
+      expect(entry.token).toHaveLength(64); // 32 bytes hex
+      expect(entry.sessionKey).toBe("agent:default:session:abc");
+      expect(entry.createdByDeviceId).toBe("device-1");
+      expect(entry.expiresAtMs).toBeGreaterThan(Date.now());
+      expect(entry.createdAtMs).toBeLessThanOrEqual(Date.now());
+    });
+
+    it("generates unique tokens for each call", () => {
+      const a = createSessionShareToken({ sessionKey: "key", createdByDeviceId: "d" });
+      const b = createSessionShareToken({ sessionKey: "key", createdByDeviceId: "d" });
+      expect(a.token).not.toBe(b.token);
+    });
+
+    it("respects custom ttlMs", () => {
+      const ttlMs = 60_000;
+      const before = Date.now();
+      const entry = createSessionShareToken({
+        sessionKey: "key",
+        ttlMs,
+        createdByDeviceId: "d",
+      });
+      const after = Date.now();
+      expect(entry.expiresAtMs).toBeGreaterThanOrEqual(before + ttlMs);
+      expect(entry.expiresAtMs).toBeLessThanOrEqual(after + ttlMs);
+    });
+  });
+
+  describe("resolveSessionShareToken", () => {
+    it("returns sessionKey for a valid token", () => {
+      const entry = createSessionShareToken({
+        sessionKey: "my-session",
+        createdByDeviceId: "d",
+      });
+      const result = resolveSessionShareToken(entry.token);
+      expect(result).toEqual({ sessionKey: "my-session" });
+    });
+
+    it("returns null for unknown token", () => {
+      expect(resolveSessionShareToken("not-a-real-token")).toBeNull();
+    });
+
+    it("returns null for expired token", () => {
+      const entry = createSessionShareToken({
+        sessionKey: "my-session",
+        ttlMs: -1, // forces DEFAULT_TTL_MS but we'll manipulate directly
+        createdByDeviceId: "d",
+      });
+      // Manually expire by patching — since store is module-level, use a new
+      // token with a very short TTL and wait (not practical). Instead verify
+      // via revokeSessionShareToken.
+      revokeSessionShareToken(entry.token);
+      expect(resolveSessionShareToken(entry.token)).toBeNull();
+    });
+  });
+
+  describe("revokeSessionShareToken", () => {
+    it("revokes an existing token", () => {
+      const entry = createSessionShareToken({ sessionKey: "s", createdByDeviceId: "d" });
+      expect(revokeSessionShareToken(entry.token)).toBe(true);
+      expect(resolveSessionShareToken(entry.token)).toBeNull();
+    });
+
+    it("returns false for unknown token", () => {
+      expect(revokeSessionShareToken("nonexistent")).toBe(false);
+    });
+  });
+
+  describe("pruneExpiredTokens", () => {
+    it("returns 0 when no tokens are expired", () => {
+      createSessionShareToken({ sessionKey: "s", createdByDeviceId: "d" });
+      expect(pruneExpiredTokens()).toBe(0);
+    });
+  });
+
+  describe("persistence", () => {
+    it("writes a JSONL file on token creation", () => {
+      createSessionShareToken({ sessionKey: "s", createdByDeviceId: "d" });
+      const filePath = path.join(tmpDir, "session-share-tokens.jsonl");
+      expect(fs.existsSync(filePath)).toBe(true);
+      const content = fs.readFileSync(filePath, "utf8");
+      expect(content.trim()).not.toBe("");
+      const parsed = JSON.parse(content.trim().split("\n")[0]!);
+      expect(parsed.sessionKey).toBe("s");
+    });
+  });
+});

--- a/src/infra/session-share-tokens.test.ts
+++ b/src/infra/session-share-tokens.test.ts
@@ -138,7 +138,7 @@ describe("session-share-tokens", () => {
       expect(fs.existsSync(filePath)).toBe(true);
       const content = fs.readFileSync(filePath, "utf8");
       expect(content.trim()).not.toBe("");
-      const parsed = JSON.parse(content.trim().split("\n")[0]!);
+      const parsed = JSON.parse(content.trim().split("\n")[0] ?? "");
       expect(parsed.sessionKey).toBe("s");
     });
   });

--- a/src/infra/session-share-tokens.ts
+++ b/src/infra/session-share-tokens.ts
@@ -64,15 +64,19 @@ function isValidTokenEntry(entry: unknown): entry is SessionShareToken {
   if (!entry || typeof entry !== "object") {
     return false;
   }
-  const e = entry as Record<string, unknown>;
   return (
-    typeof e.token === "string" &&
-    e.token.length > 0 &&
-    typeof e.sessionKey === "string" &&
-    e.sessionKey.length > 0 &&
-    typeof e.expiresAtMs === "number" &&
-    typeof e.createdAtMs === "number" &&
-    typeof e.createdByDeviceId === "string"
+    "token" in entry &&
+    typeof entry.token === "string" &&
+    entry.token.length > 0 &&
+    "sessionKey" in entry &&
+    typeof entry.sessionKey === "string" &&
+    entry.sessionKey.length > 0 &&
+    "expiresAtMs" in entry &&
+    typeof entry.expiresAtMs === "number" &&
+    "createdAtMs" in entry &&
+    typeof entry.createdAtMs === "number" &&
+    "createdByDeviceId" in entry &&
+    typeof entry.createdByDeviceId === "string"
   );
 }
 

--- a/src/infra/session-share-tokens.ts
+++ b/src/infra/session-share-tokens.ts
@@ -44,7 +44,7 @@ function loadFromDisk(): void {
         continue;
       }
       try {
-        const entry = JSON.parse(trimmed) as unknown;
+        const entry: unknown = JSON.parse(trimmed);
         if (!isValidTokenEntry(entry)) {
           continue;
         }

--- a/src/infra/session-share-tokens.ts
+++ b/src/infra/session-share-tokens.ts
@@ -1,0 +1,174 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { generateSecureHex } from "./secure-random.js";
+
+export type SessionShareToken = {
+  token: string;
+  sessionKey: string;
+  expiresAtMs: number;
+  createdAtMs: number;
+  createdByDeviceId: string;
+};
+
+const SESSION_SHARE_TOKENS_FILE = "session-share-tokens.jsonl";
+
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const TOKEN_BYTES = 32;
+
+// In-memory store keyed by token string.
+const tokenStore = new Map<string, SessionShareToken>();
+
+let persistencePath: string | undefined;
+
+export function initSessionShareTokens(params?: { stateDir?: string }): void {
+  const dir = params?.stateDir ?? resolveStateDir();
+  persistencePath = path.join(dir, SESSION_SHARE_TOKENS_FILE);
+  loadFromDisk();
+}
+
+function loadFromDisk(): void {
+  if (!persistencePath) {
+    return;
+  }
+  try {
+    if (!fs.existsSync(persistencePath)) {
+      return;
+    }
+    const lines = fs.readFileSync(persistencePath, "utf8").split("\n");
+    const nowMs = Date.now();
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        continue;
+      }
+      try {
+        const entry = JSON.parse(trimmed) as unknown;
+        if (!isValidTokenEntry(entry)) {
+          continue;
+        }
+        if (entry.expiresAtMs > nowMs) {
+          tokenStore.set(entry.token, entry);
+        }
+      } catch {
+        // Skip malformed lines.
+      }
+    }
+  } catch {
+    // Best-effort load.
+  }
+}
+
+function isValidTokenEntry(entry: unknown): entry is SessionShareToken {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+  const e = entry as Record<string, unknown>;
+  return (
+    typeof e.token === "string" &&
+    e.token.length > 0 &&
+    typeof e.sessionKey === "string" &&
+    e.sessionKey.length > 0 &&
+    typeof e.expiresAtMs === "number" &&
+    typeof e.createdAtMs === "number" &&
+    typeof e.createdByDeviceId === "string"
+  );
+}
+
+function appendToDisk(entry: SessionShareToken): void {
+  if (!persistencePath) {
+    return;
+  }
+  try {
+    fs.mkdirSync(path.dirname(persistencePath), { recursive: true });
+    fs.appendFileSync(persistencePath, `${JSON.stringify(entry)}\n`, { mode: 0o600 });
+  } catch {
+    // Best-effort persistence.
+  }
+}
+
+function rewriteDisk(): void {
+  if (!persistencePath) {
+    return;
+  }
+  try {
+    const nowMs = Date.now();
+    const lines: string[] = [];
+    for (const entry of tokenStore.values()) {
+      if (entry.expiresAtMs > nowMs) {
+        lines.push(JSON.stringify(entry));
+      }
+    }
+    fs.mkdirSync(path.dirname(persistencePath), { recursive: true });
+    fs.writeFileSync(persistencePath, lines.length > 0 ? `${lines.join("\n")}\n` : "", {
+      mode: 0o600,
+    });
+  } catch {
+    // Best-effort rewrite.
+  }
+}
+
+export function clampTtlMs(ttlMs: number | undefined): number {
+  if (typeof ttlMs !== "number" || !Number.isFinite(ttlMs) || ttlMs <= 0) {
+    return DEFAULT_TTL_MS;
+  }
+  return Math.min(ttlMs, MAX_TTL_MS);
+}
+
+export function createSessionShareToken(params: {
+  sessionKey: string;
+  ttlMs?: number;
+  createdByDeviceId: string;
+}): SessionShareToken {
+  const nowMs = Date.now();
+  const ttl = clampTtlMs(params.ttlMs);
+  const entry: SessionShareToken = {
+    token: generateSecureHex(TOKEN_BYTES),
+    sessionKey: params.sessionKey,
+    expiresAtMs: nowMs + ttl,
+    createdAtMs: nowMs,
+    createdByDeviceId: params.createdByDeviceId,
+  };
+  tokenStore.set(entry.token, entry);
+  appendToDisk(entry);
+  return entry;
+}
+
+export function resolveSessionShareToken(token: string): { sessionKey: string } | null {
+  const entry = tokenStore.get(token);
+  if (!entry) {
+    return null;
+  }
+  if (entry.expiresAtMs <= Date.now()) {
+    tokenStore.delete(token);
+    return null;
+  }
+  return { sessionKey: entry.sessionKey };
+}
+
+export function revokeSessionShareToken(token: string): boolean {
+  const existed = tokenStore.has(token);
+  if (existed) {
+    tokenStore.delete(token);
+    rewriteDisk();
+  }
+  return existed;
+}
+
+export function pruneExpiredTokens(): number {
+  const nowMs = Date.now();
+  let pruned = 0;
+  for (const [token, entry] of tokenStore.entries()) {
+    if (entry.expiresAtMs <= nowMs) {
+      tokenStore.delete(token);
+      pruned++;
+    }
+  }
+  if (pruned > 0) {
+    rewriteDisk();
+  }
+  return pruned;
+}
+
+export { DEFAULT_TTL_MS, MAX_TTL_MS };

--- a/src/infra/session-share-tokens.ts
+++ b/src/infra/session-share-tokens.ts
@@ -25,6 +25,7 @@ let persistencePath: string | undefined;
 export function initSessionShareTokens(params?: { stateDir?: string }): void {
   const dir = params?.stateDir ?? resolveStateDir();
   persistencePath = path.join(dir, SESSION_SHARE_TOKENS_FILE);
+  tokenStore.clear();
   loadFromDisk();
 }
 


### PR DESCRIPTION
## Summary

- Adds `sessions.createSharedToken` (WRITE scope) generating a time-limited, session-scoped read-only token
- Adds `sessions.revokeSharedToken` (WRITE scope) for explicit revocation
- Tokens are random 32-byte hex strings stored in an in-memory map with optional JSONL persistence at `{stateDir}/session-share-tokens.jsonl`
- Default TTL: 24 hours; max: 7 days; expired tokens are pruned automatically
- Auth middleware integration (restricting token holders to READ scope for their bound session) is a follow-up; token store API is ready to be wired in

## Test plan

- [ ] `sessions.createSharedToken` returns a token with correct expiry
- [ ] Token expires after TTL and is rejected
- [ ] `sessions.revokeSharedToken` invalidates token immediately
- [ ] Tokens persist across gateway restarts via JSONL backing
- [ ] `pnpm check:changed` passes

Thanks @ioodu