### PR TITLE
feat(gateway): emit agent.run.status events for run observability

### DIFF
--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -921,6 +921,7 @@ async function agentCommandInternal(
         });
 
         let fallbackAttemptIndex = 0;
+        let toolCallCount = 0;
         const fallbackResult = await runWithModelFallback<AgentAttemptResult>({
           cfg,
           provider,
@@ -973,6 +974,9 @@ async function agentCommandInternal(
                     data: evt.data ?? {},
                   });
                 }
+                if (evt.stream === "tool" && evt.data?.phase === "start") {
+                  toolCallCount += 1;
+                }
                 if (
                   evt.stream === "lifecycle" &&
                   typeof evt.data?.phase === "string" &&
@@ -1015,6 +1019,7 @@ async function agentCommandInternal(
               stopReason,
               ...(agentMeta?.model !== undefined && { model: agentMeta.model }),
               ...(lifecycleUsage !== undefined && { usage: lifecycleUsage }),
+              ...(toolCallCount > 0 && { toolCallCount }),
             },
           });
         }

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -992,6 +992,18 @@ async function agentCommandInternal(
           if (stopReason && stopReason !== "end_turn") {
             console.error(`[agent] run ${runId} ended with stopReason=${stopReason}`);
           }
+          const agentMeta = result.meta.agentMeta;
+          const rawUsage = agentMeta?.usage;
+          const lifecycleUsage =
+            rawUsage !== undefined
+              ? {
+                  inputTokens: rawUsage.input ?? 0,
+                  outputTokens: rawUsage.output ?? 0,
+                  ...(rawUsage.cacheRead !== undefined && {
+                    cacheReadTokens: rawUsage.cacheRead,
+                  }),
+                }
+              : undefined;
           emitAgentEvent({
             runId,
             stream: "lifecycle",
@@ -1001,6 +1013,8 @@ async function agentCommandInternal(
               endedAt: Date.now(),
               aborted: result.meta.aborted ?? false,
               stopReason,
+              ...(agentMeta?.model !== undefined && { model: agentMeta.model }),
+              ...(lifecycleUsage !== undefined && { usage: lifecycleUsage }),
             },
           });
         }

--- a/src/gateway/events.ts
+++ b/src/gateway/events.ts
@@ -5,3 +5,23 @@ export const GATEWAY_EVENT_UPDATE_AVAILABLE = "update.available" as const;
 export type GatewayUpdateAvailableEventPayload = {
   updateAvailable: UpdateAvailable | null;
 };
+
+export const GATEWAY_EVENT_AGENT_RUN_STATUS = "agent.run.status" as const;
+
+export type AgentRunStatusEventStatus = "started" | "completed" | "failed" | "interrupted";
+
+export type GatewayAgentRunStatusEventPayload = {
+  agentId: string;
+  sessionKey: string;
+  status: AgentRunStatusEventStatus;
+  startedAt: number;
+  model?: string;
+  durationMs?: number;
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens?: number;
+  };
+  toolCallCount?: number;
+  exitReason?: string;
+};

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -44,6 +44,7 @@ const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "sessions.changed": [READ_SCOPE],
   "session.message": [READ_SCOPE],
   "session.tool": [READ_SCOPE],
+  "agent.run.status": [READ_SCOPE],
 };
 
 // Events that node-role sessions must receive even when the event's operator

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -4,7 +4,9 @@ import { getRuntimeConfig } from "../config/io.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { detectErrorKind, type ErrorKind } from "../infra/errors.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { setSafeTimeout } from "../utils/timer-delay.js";
+import { GATEWAY_EVENT_AGENT_RUN_STATUS } from "./events.js";
 import {
   normalizeLiveAssistantEventText,
   projectLiveAssistantBufferedText,
@@ -620,6 +622,49 @@ export function createAgentEventHandler({
           { dropIfSlow: true },
         );
       }
+      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : undefined;
+      const endedAt = typeof evt.data?.endedAt === "number" ? evt.data.endedAt : Date.now();
+      const durationMs = startedAt !== undefined ? endedAt - startedAt : undefined;
+      const evtModel = typeof evt.data?.model === "string" ? evt.data.model : undefined;
+      const evtUsageRaw = evt.data?.usage;
+      const evtUsage =
+        evtUsageRaw !== null &&
+        typeof evtUsageRaw === "object" &&
+        typeof (evtUsageRaw as Record<string, unknown>).inputTokens === "number" &&
+        typeof (evtUsageRaw as Record<string, unknown>).outputTokens === "number"
+          ? {
+              inputTokens: (evtUsageRaw as Record<string, unknown>).inputTokens as number,
+              outputTokens: (evtUsageRaw as Record<string, unknown>).outputTokens as number,
+              ...(typeof (evtUsageRaw as Record<string, unknown>).cacheReadTokens === "number" && {
+                cacheReadTokens: (evtUsageRaw as Record<string, unknown>).cacheReadTokens as number,
+              }),
+            }
+          : undefined;
+      const evtToolCallCount =
+        typeof evt.data?.toolCallCount === "number" ? evt.data.toolCallCount : undefined;
+      const evtExitReason =
+        typeof evt.data?.stopReason === "string"
+          ? evt.data.stopReason
+          : typeof evt.data?.error === "string"
+            ? evt.data.error
+            : undefined;
+      const runStatus =
+        lifecyclePhase === "error" ? "failed" : isAborted ? "interrupted" : "completed";
+      broadcast(
+        GATEWAY_EVENT_AGENT_RUN_STATUS,
+        {
+          agentId: resolveAgentIdFromSessionKey(sessionKey),
+          sessionKey,
+          status: runStatus,
+          startedAt: startedAt ?? endedAt,
+          ...(evtModel !== undefined && { model: evtModel }),
+          ...(durationMs !== undefined && { durationMs }),
+          ...(evtUsage !== undefined && { usage: evtUsage }),
+          ...(evtToolCallCount !== undefined && { toolCallCount: evtToolCallCount }),
+          ...(evtExitReason !== undefined && { exitReason: evtExitReason }),
+        },
+        { dropIfSlow: true },
+      );
     }
   };
 
@@ -970,6 +1015,19 @@ export function createAgentEventHandler({
           { dropIfSlow: true },
         );
       }
+      const startedAt = typeof evt.data?.startedAt === "number" ? evt.data.startedAt : evt.ts;
+      const evtModel = typeof evt.data?.model === "string" ? evt.data.model : undefined;
+      broadcast(
+        GATEWAY_EVENT_AGENT_RUN_STATUS,
+        {
+          agentId: resolveAgentIdFromSessionKey(sessionKey),
+          sessionKey,
+          status: "started",
+          startedAt,
+          ...(evtModel !== undefined && { model: evtModel }),
+        },
+        { dropIfSlow: true },
+      );
     }
   };
 }

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -1,5 +1,5 @@
 import { listChannelPlugins } from "../channels/plugins/index.js";
-import { GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
+import { GATEWAY_EVENT_AGENT_RUN_STATUS, GATEWAY_EVENT_UPDATE_AVAILABLE } from "./events.js";
 
 const BASE_METHODS = [
   "health",
@@ -180,4 +180,5 @@ export const GATEWAY_EVENTS = [
   "plugin.approval.requested",
   "plugin.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
+  GATEWAY_EVENT_AGENT_RUN_STATUS,
 ];


### PR DESCRIPTION
## Summary

- Adds `agent.run.status` gateway event emitted at agent run start and completion
- Start payload: `agentId`, `sessionKey`, `model`, `startedAt`
- Completion payload: `status` (completed/failed/interrupted), `durationMs`, token usage (input/output/cache), tool call count, `exitReason`
- Enables the Control UI and external subscribers to observe agent activity in real time without polling
- Uses existing `broadcastGatewayEvent` infrastructure; no new storage or persistence required
- Emission wired in `src/gateway/server-chat.ts` around the agent run dispatch call

## Test plan

- [ ] `agent.run.status` event with `status: "started"` emitted when run begins
- [ ] `agent.run.status` event with `status: "completed"` emitted with correct token counts
- [ ] `status: "failed"` emitted on error with `exitReason`
- [ ] `status: "interrupted"` emitted when run is aborted
- [ ] `pnpm check:changed` passes

Thanks @ioodu