### PR TITLE
feat(plugin-sdk): extend PluginHookAgentContext with sender and chat context [AI-assisted]

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-1cf7ca2ee1db3bf44682c487c780c6b1c47bbce27e74fb6f455cef445544c84f  plugin-sdk-api-baseline.json
-24b8e3e4773579e5a184dd5f91a5ad2f8e92519b6fe314820a94d7a64bd1141e  plugin-sdk-api-baseline.jsonl
+d4e22eff4436712c937c68f706062d05be51be46ba18fd795d07c92ea2471320  plugin-sdk-api-baseline.json
+3ac170c7f7d61afee79d6761732677a0f899fd878c54daa80516f362280de014  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -276,6 +276,20 @@ as `discord` or `telegram`, while `ctx.channelId` is the conversation target
 identifier when OpenClaw can derive one from the session key or delivery
 metadata.
 
+When sender identity is available, agent hook contexts also include:
+
+- `ctx.senderId` — channel-scoped sender ID (e.g. Feishu `open_id`, Discord
+  user ID). Populated when the run originates from a user message with known
+  sender metadata.
+- `ctx.chatId` — transport-native conversation identifier (e.g. Feishu
+  `chat_id`, Telegram `chat_id`). Populated when the originating channel
+  provides a native conversation ID.
+
+`ctx.senderExternalId` (cross-app ID, e.g. Feishu `union_id`) is declared on
+the type but not currently populated by core; channel plugins can provide it via
+their own hook handlers. All three fields are optional and absent for
+system-originated runs (heartbeat, cron, exec-event).
+
 `agent_end` is an observation hook and runs fire-and-forget after the turn. The
 hook runner applies a 30 second timeout so a wedged plugin or embedding
 endpoint cannot leave the hook promise pending forever. A timeout is logged and

--- a/src/agents/harness/hook-context.ts
+++ b/src/agents/harness/hook-context.ts
@@ -12,6 +12,9 @@ export type AgentHarnessHookContext = {
   messageProvider?: string;
   trigger?: string;
   channelId?: string;
+  senderId?: string;
+  senderExternalId?: string;
+  chatId?: string;
 };
 
 export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHookAgentContext {
@@ -27,5 +30,8 @@ export function buildAgentHookContext(params: AgentHarnessHookContext): PluginHo
     ...(params.messageProvider ? { messageProvider: params.messageProvider } : {}),
     ...(params.trigger ? { trigger: params.trigger } : {}),
     ...(params.channelId ? { channelId: params.channelId } : {}),
+    ...(params.senderId ? { senderId: params.senderId } : {}),
+    ...(params.senderExternalId ? { senderExternalId: params.senderExternalId } : {}),
+    ...(params.chatId ? { chatId: params.chatId } : {}),
   };
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -506,6 +506,8 @@ export async function runEmbeddedPiAgent(
         modelId,
         trigger: params.trigger,
         ...buildAgentHookContextChannelFields(params),
+        ...(params.senderId ? { senderId: params.senderId } : {}),
+        ...(params.currentChannelId ? { chatId: params.currentChannelId } : {}),
       };
       if (params.trigger === "cron" && hookRunner?.hasHooks("before_agent_reply")) {
         const hookResult = await hookRunner.runBeforeAgentReply(

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2965,6 +2965,8 @@ export async function runEmbeddedAttempt(
           modelId: params.model.id,
           trigger: params.trigger,
           ...buildAgentHookContextChannelFields(params),
+          ...(params.senderId ? { senderId: params.senderId } : {}),
+          ...(params.currentChannelId ? { chatId: params.currentChannelId } : {}),
         };
         const promptBuildMessages =
           pruneProcessedHistoryImages(activeSession.messages) ?? activeSession.messages;
@@ -3427,6 +3429,8 @@ export async function runEmbeddedAttempt(
                   workspaceDir: params.workspaceDir,
                   trigger: params.trigger,
                   ...buildAgentHookContextChannelFields(params),
+                  ...(params.senderId ? { senderId: params.senderId } : {}),
+                  ...(params.currentChannelId ? { chatId: params.currentChannelId } : {}),
                 },
               )
               .catch((err) => {
@@ -3885,6 +3889,8 @@ export async function runEmbeddedAttempt(
                 workspaceDir: params.workspaceDir,
                 trigger: params.trigger,
                 ...buildAgentHookContextChannelFields(params),
+                ...(params.senderId ? { senderId: params.senderId } : {}),
+                ...(params.currentChannelId ? { chatId: params.currentChannelId } : {}),
               },
             )
             .catch((err) => {
@@ -3995,6 +4001,8 @@ export async function runEmbeddedAttempt(
               workspaceDir: params.workspaceDir,
               trigger: params.trigger,
               ...buildAgentHookContextChannelFields(params),
+              ...(params.senderId ? { senderId: params.senderId } : {}),
+              ...(params.currentChannelId ? { chatId: params.currentChannelId } : {}),
             },
           )
           .catch((err) => {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -584,6 +584,12 @@ export async function getReplyFromConfig(
           messageProvider: hookMessageProvider,
           trigger: opts?.isHeartbeat ? "heartbeat" : "user",
           channelId: hookMessageProvider,
+          ...(sessionCtx.SenderId ? { senderId: sessionCtx.SenderId } : {}),
+          // NativeChannelId is the transport-native conversation identifier
+          // (Feishu chat_id, Telegram chat_id, Discord channel_id, etc.).
+          ...(sessionCtx.NativeChannelId ? { chatId: sessionCtx.NativeChannelId } : {}),
+          // senderExternalId (cross-app ID, e.g. Feishu union_id) is not available
+          // in MsgContext; channel plugins can populate it via their own hook handlers.
         },
       );
       if (hookResult?.handled) {

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -788,8 +788,14 @@ export async function getReplyFromConfig(
               currentChannelId: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
               messageTo: sessionCtx.OriginatingTo ?? ctx.OriginatingTo ?? ctx.To,
             }),
+            ...(sessionCtx.SenderId ? { senderId: sessionCtx.SenderId } : {}),
+            // NativeChannelId is the transport-native conversation identifier
+            // (Feishu chat_id, Telegram chat_id, Discord channel_id, etc.).
+            ...(sessionCtx.NativeChannelId ? { chatId: sessionCtx.NativeChannelId } : {}),
+            // senderExternalId (cross-app ID, e.g. Feishu union_id) is not available
+            // in MsgContext; channel plugins can populate it via their own hook handlers.
           },
-        ),
+        ),)
       );
       if (hookResult?.handled) {
         return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -795,7 +795,7 @@ export async function getReplyFromConfig(
             // senderExternalId (cross-app ID, e.g. Feishu union_id) is not available
             // in MsgContext; channel plugins can populate it via their own hook handlers.
           },
-        ),)
+        ),
       );
       if (hookResult?.handled) {
         return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -250,10 +250,12 @@ export async function initSessionState(params: {
       ? normalizeOptionalString(ctx.CommandTargetSessionKey)
       : undefined;
   // Sender-scoped session key override: takes priority over thread/conversation
-  // session keys and route-derived keys. Note: lastRoutePolicy is still derived
-  // from the route and controls last-route persistence, which is a separate
-  // concern from the active session key used for this message.
-  const senderSessionKey = normalizeOptionalString(ctx.SenderSessionKey);
+  // session keys and route-derived keys. Guarded by isSystemEvent to prevent
+  // automated system events (heartbeat/cron/exec) from accidentally retargeting
+  // sessions via a stale SenderSessionKey in the context.
+  const senderSessionKey = isSystemEvent
+    ? undefined
+    : normalizeOptionalString(ctx.SenderSessionKey);
   // Native slash/menu commands can arrive on a transport-specific "slash session"
   // while explicitly targeting an existing chat session. Honor that explicit target
   // before any binding lookup so command-side mutations land on the intended session.

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -249,11 +249,18 @@ export async function initSessionState(params: {
     ctx.CommandSource === "native"
       ? normalizeOptionalString(ctx.CommandTargetSessionKey)
       : undefined;
+  // Sender-scoped session key override: takes priority over thread/conversation
+  // session keys and route-derived keys. Note: lastRoutePolicy is still derived
+  // from the route and controls last-route persistence, which is a separate
+  // concern from the active session key used for this message.
+  const senderSessionKey = normalizeOptionalString(ctx.SenderSessionKey);
   // Native slash/menu commands can arrive on a transport-specific "slash session"
   // while explicitly targeting an existing chat session. Honor that explicit target
   // before any binding lookup so command-side mutations land on the intended session.
+  // Priority: commandTargetSessionKey > senderSessionKey > boundConversation > route.
   const targetSessionKey =
     commandTargetSessionKey ??
+    senderSessionKey ??
     resolveBoundConversationSessionKey({
       cfg,
       ctx,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -252,11 +252,18 @@ export async function initSessionState(params: {
     ctx.CommandSource === "native"
       ? normalizeOptionalString(ctx.CommandTargetSessionKey)
       : undefined;
+  // Sender-scoped session key override: takes priority over thread/conversation
+  // session keys and route-derived keys. Note: lastRoutePolicy is still derived
+  // from the route and controls last-route persistence, which is a separate
+  // concern from the active session key used for this message.
+  const senderSessionKey = normalizeOptionalString(ctx.SenderSessionKey);
   // Native slash/menu commands can arrive on a transport-specific "slash session"
   // while explicitly targeting an existing chat session. Honor that explicit target
   // before any binding lookup so command-side mutations land on the intended session.
+  // Priority: commandTargetSessionKey > senderSessionKey > boundConversation > route.
   const targetSessionKey =
     commandTargetSessionKey ??
+    senderSessionKey ??
     resolveBoundConversationSessionKey({
       cfg,
       ctx,

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -253,10 +253,12 @@ export async function initSessionState(params: {
       ? normalizeOptionalString(ctx.CommandTargetSessionKey)
       : undefined;
   // Sender-scoped session key override: takes priority over thread/conversation
-  // session keys and route-derived keys. Note: lastRoutePolicy is still derived
-  // from the route and controls last-route persistence, which is a separate
-  // concern from the active session key used for this message.
-  const senderSessionKey = normalizeOptionalString(ctx.SenderSessionKey);
+  // session keys and route-derived keys. Guarded by isSystemEvent to prevent
+  // automated system events (heartbeat/cron/exec) from accidentally retargeting
+  // sessions via a stale SenderSessionKey in the context.
+  const senderSessionKey = isSystemEvent
+    ? undefined
+    : normalizeOptionalString(ctx.SenderSessionKey);
   // Native slash/menu commands can arrive on a transport-specific "slash session"
   // while explicitly targeting an existing chat session. Honor that explicit target
   // before any binding lookup so command-side mutations land on the intended session.

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -63,6 +63,11 @@ export type MsgContext = {
   To?: string;
   SessionKey?: string;
   /**
+   * Explicit sender-scoped session key override.
+   * Resolution priority: senderSessionKey > threadSessionKey (SessionKey) > route.sessionKey.
+   */
+  SenderSessionKey?: string;
+  /**
    * Session-like key used for runtime policy (sandbox/tool policy) when the
    * conversation key intentionally remains broader, such as a main-session DM.
    */

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -73,6 +73,11 @@ export type MsgContext = {
   To?: string;
   SessionKey?: string;
   /**
+   * Explicit sender-scoped session key override.
+   * Resolution priority: senderSessionKey > threadSessionKey (SessionKey) > route.sessionKey.
+   */
+  SenderSessionKey?: string;
+  /**
    * Session-like key used for runtime policy (sandbox/tool policy) when the
    * conversation key intentionally remains broader, such as a main-session DM.
    */

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -172,6 +172,12 @@ export type PluginHookAgentContext = {
   messageProvider?: string;
   trigger?: string;
   channelId?: string;
+  /** Channel-scoped sender ID (e.g. Feishu open_id, Discord user ID). */
+  senderId?: string;
+  /** Cross-app sender ID (e.g. Feishu union_id, WeCom unionId). */
+  senderExternalId?: string;
+  /** Conversation/chat ID (e.g. Feishu chat_id, Discord channel ID). */
+  chatId?: string;
 };
 
 export type PluginHookBeforeAgentReplyEvent = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -196,6 +196,12 @@ export type PluginHookAgentContext = {
   messageProvider?: string;
   trigger?: string;
   channelId?: string;
+  /** Channel-scoped sender ID (e.g. Feishu open_id, Discord user ID). */
+  senderId?: string;
+  /** Cross-app sender ID (e.g. Feishu union_id, WeCom unionId). */
+  senderExternalId?: string;
+  /** Conversation/chat ID (e.g. Feishu chat_id, Discord channel ID). */
+  chatId?: string;
 };
 
 export type PluginHookBeforeAgentReplyEvent = {


### PR DESCRIPTION
## Summary

- Extend `PluginHookAgentContext` with `senderId`, `senderExternalId`, and `chatId` fields so plugins can access sender/chat context in hook handlers
- Add `SenderSessionKey` to `MsgContext` for session key isolation
- Update session key resolution priority in `session.ts` to support `senderSessionKey`
- Thread new fields through `buildAgentHookContext()` and `get-reply.ts`

## Motivation

Currently `PluginHookAgentContext` has `channelId` but no sender or chat information. This forces channel-specific logic (e.g. Feishu mem0 recall/capture by user, session isolation per sender) into core. Adding these fields enables plugins to implement user-scoped memory, audit logging, multi-tenant token tracking, and sub-agent chat context inheritance without core changes.

## Test plan

- [x] Verify `PluginHookAgentContext` type includes new optional fields
- [x] Run `pnpm test src/agents/harness/hook-context`
- [x] Run `pnpm test src/auto-reply/reply/get-reply`
- [x] Run `pnpm test src/auto-reply/reply/session`

## Attribution

Original author: @lanzhi-lee (lizhan3@xiaomi.com)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)