### PR TITLE
feat(plugin-sdk): add resolve_exec_env hook for channel-specific env injection [AI-assisted]

### DIFF
--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -122,6 +122,7 @@ observation-only.
 - `after_tool_call` - observe tool results, errors, and duration
 - **`tool_result_persist`** - rewrite the assistant message produced from a tool result
 - **`before_message_write`** - inspect or block an in-progress message write (rare)
+- `resolve_exec_env` - contribute channel-specific environment variables to exec tool invocations
 
 **Messages and delivery**
 
@@ -229,6 +230,28 @@ not prompt content:
   persistence cap. Hooks should still keep returned `details` small and avoid
   placing prompt-relevant text only in `details`; put model-visible tool output
   in `content`.
+
+### Exec environment injection
+
+`resolve_exec_env` lets plugins contribute channel-specific environment
+variables to exec tool invocations. The hook fires after the host environment
+is sanitized and receives:
+
+- `event.sessionKey`, `event.toolName`, `event.host` (`"gateway"`,
+  `"sandbox"`, or `"node"`)
+- `ctx.agentId`, `ctx.sessionKey`, `ctx.messageProvider`, `ctx.channelId`
+
+Return a `Record<string, string>` of environment variables to merge. Multiple
+plugins can contribute; later plugins override earlier ones for the same key.
+
+Hook output is filtered through the host env security policy: keys matching
+`isDangerousHostEnvVarName` or `isDangerousHostEnvOverrideVarName` (e.g.
+`LD_PRELOAD`, `BASH_ENV`, `NODE_OPTIONS`, proxy/TLS overrides) are silently
+dropped. `PATH` overrides are intentionally allowed so plugins can prepend
+custom tool directories.
+
+For `host=node` executions, filtered hook env is forwarded to the node
+execution payload alongside the original request env.
 
 ## Prompt and model hooks
 

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -16,6 +16,7 @@ import {
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
 import { logInfo } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -1603,6 +1604,27 @@ export function createExecTool(
         );
       } else {
         applyPathPrepend(env, defaultPathPrepend);
+      }
+
+      // Let plugins contribute channel-specific env vars. Plugins are responsible
+      // for the values they inject — do not return secrets, tokens, or credentials
+      // unless the exec context explicitly requires them.
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("resolve_exec_env")) {
+        const pluginEnv = await hookRunner.runResolveExecEnv(
+          {
+            sessionKey: defaults?.sessionKey,
+            toolName: "exec",
+            host,
+          },
+          {
+            agentId,
+            sessionKey: defaults?.sessionKey,
+            messageProvider: defaults?.messageProvider,
+            channelId: defaults?.currentChannelId,
+          },
+        );
+        Object.assign(env, pluginEnv);
       }
 
       if (host === "node") {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -15,6 +15,7 @@ import {
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import {
   isDangerousHostEnvOverrideVarName,
+  isDangerousHostEnvVarName,
   sanitizeHostExecEnvWithDiagnostics,
 } from "../infra/host-env-security.js";
 import {
@@ -1526,9 +1527,10 @@ export function createExecTool(
       }
 
       // Let plugins contribute channel-specific env vars. Filter out keys that
-      // the host env security policy marks as dangerous overrides (e.g. LD_PRELOAD,
-      // proxy/TLS pivots) so plugin hooks cannot silently bypass the sanitizer.
-      // PATH overrides are intentionally allowed — plugins may prepend custom tool dirs.
+      // the host env security policy marks as dangerous (LD_*, BASH_ENV,
+      // NODE_OPTIONS, proxy/TLS pivots, and blocked-everywhere keys) so plugin
+      // hooks cannot silently bypass the sanitizer. PATH overrides are
+      // intentionally allowed — plugins may prepend custom tool dirs.
       let pluginEnv: Record<string, string> | undefined;
       const hookRunner = getGlobalHookRunner();
       if (hookRunner?.hasHooks("resolve_exec_env")) {
@@ -1547,7 +1549,7 @@ export function createExecTool(
         );
         pluginEnv = {};
         for (const [key, value] of Object.entries(rawPluginEnv)) {
-          if (!isDangerousHostEnvOverrideVarName(key)) {
+          if (!isDangerousHostEnvVarName(key) && !isDangerousHostEnvOverrideVarName(key)) {
             pluginEnv[key] = value;
           }
         }

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -13,7 +13,10 @@ import {
   requireValidExecTarget,
 } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
-import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
+import {
+  isDangerousHostEnvOverrideVarName,
+  sanitizeHostExecEnvWithDiagnostics,
+} from "../infra/host-env-security.js";
 import {
   getShellPathFromLoginShell,
   resolveShellEnvFallbackTimeoutMs,
@@ -1522,12 +1525,14 @@ export function createExecTool(
         applyPathPrepend(env, defaultPathPrepend);
       }
 
-      // Let plugins contribute channel-specific env vars. Plugins are responsible
-      // for the values they inject — do not return secrets, tokens, or credentials
-      // unless the exec context explicitly requires them.
+      // Let plugins contribute channel-specific env vars. Filter out keys that
+      // the host env security policy marks as dangerous overrides (e.g. LD_PRELOAD,
+      // proxy/TLS pivots) so plugin hooks cannot silently bypass the sanitizer.
+      // PATH overrides are intentionally allowed — plugins may prepend custom tool dirs.
+      let pluginEnv: Record<string, string> | undefined;
       const hookRunner = getGlobalHookRunner();
       if (hookRunner?.hasHooks("resolve_exec_env")) {
-        const pluginEnv = await hookRunner.runResolveExecEnv(
+        const rawPluginEnv = await hookRunner.runResolveExecEnv(
           {
             sessionKey: defaults?.sessionKey,
             toolName: "exec",
@@ -1540,6 +1545,12 @@ export function createExecTool(
             channelId: defaults?.currentChannelId,
           },
         );
+        pluginEnv = {};
+        for (const [key, value] of Object.entries(rawPluginEnv)) {
+          if (!isDangerousHostEnvOverrideVarName(key)) {
+            pluginEnv[key] = value;
+          }
+        }
         Object.assign(env, pluginEnv);
       }
 
@@ -1548,7 +1559,7 @@ export function createExecTool(
           command: params.command,
           workdir,
           env,
-          requestedEnv: params.env,
+          requestedEnv: { ...params.env, ...pluginEnv },
           requestedNode: params.node?.trim(),
           boundNode: defaults?.node?.trim(),
           sessionKey: defaults?.sessionKey,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -19,6 +19,7 @@ import {
   resolveShellEnvFallbackTimeoutMs,
 } from "../infra/shell-env.js";
 import { logInfo } from "../logger.js";
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { parseAgentSessionKey, resolveAgentIdFromSessionKey } from "../routing/session-key.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import {
@@ -1519,6 +1520,27 @@ export function createExecTool(
         );
       } else {
         applyPathPrepend(env, defaultPathPrepend);
+      }
+
+      // Let plugins contribute channel-specific env vars. Plugins are responsible
+      // for the values they inject — do not return secrets, tokens, or credentials
+      // unless the exec context explicitly requires them.
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("resolve_exec_env")) {
+        const pluginEnv = await hookRunner.runResolveExecEnv(
+          {
+            sessionKey: defaults?.sessionKey,
+            toolName: "exec",
+            host,
+          },
+          {
+            agentId,
+            sessionKey: defaults?.sessionKey,
+            messageProvider: defaults?.messageProvider,
+            channelId: defaults?.currentChannelId,
+          },
+        );
+        Object.assign(env, pluginEnv);
       }
 
       if (host === "node") {

--- a/src/plugins/hook-resolve-exec-env.test.ts
+++ b/src/plugins/hook-resolve-exec-env.test.ts
@@ -77,4 +77,18 @@ describe("resolve_exec_env hook", () => {
     const result = await runner.runResolveExecEnv({ sessionKey: "test", toolName: "exec" }, {});
     expect(result).toEqual({ ASYNC_KEY: "value" });
   });
+
+  it("isolates handler errors — other plugins still contribute env vars", async () => {
+    const throwingHandler = vi.fn().mockRejectedValue(new Error("plugin crash"));
+    const goodHandler = vi.fn().mockResolvedValue({ GOOD_KEY: "ok" });
+    const runner = createHookRunner(
+      createTestRegistry([
+        { pluginId: "crasher", hookName: "resolve_exec_env", handler: throwingHandler },
+        { pluginId: "good-plugin", hookName: "resolve_exec_env", handler: goodHandler },
+      ]),
+      { catchErrors: true },
+    );
+    const result = await runner.runResolveExecEnv({ sessionKey: "test", toolName: "exec" }, {});
+    expect(result).toEqual({ GOOD_KEY: "ok" });
+  });
 });

--- a/src/plugins/hook-resolve-exec-env.test.ts
+++ b/src/plugins/hook-resolve-exec-env.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from "vitest";
+import type { GlobalHookRunnerRegistry } from "./hook-registry.types.js";
+import { createHookRunner } from "./hooks.js";
+
+function createTestRegistry(
+  hooks: Array<{
+    pluginId: string;
+    hookName: string;
+    handler: (event: unknown, ctx: unknown) => unknown;
+  }>,
+) {
+  return {
+    hooks,
+    typedHooks: hooks.map((h) => ({
+      pluginId: h.pluginId,
+      hookName: h.hookName as any,
+      handler: h.handler,
+      priority: 0,
+      source: "test",
+    })),
+    channelPlugins: [],
+    providerPlugins: [],
+    getPluginConfig: () => undefined,
+  } as unknown as GlobalHookRunnerRegistry;
+}
+
+describe("resolve_exec_env hook", () => {
+  it("returns empty object when no hooks registered", async () => {
+    const runner = createHookRunner(createTestRegistry([]), { catchErrors: true });
+    const result = await runner.runResolveExecEnv(
+      { sessionKey: "test", toolName: "exec", host: "gateway" },
+      { sessionKey: "test" },
+    );
+    expect(result).toEqual({});
+  });
+
+  it("merges env vars from a single plugin", async () => {
+    const handler = vi.fn().mockResolvedValue({ FEISHU_APP_ID: "cli_123", FEISHU_USER_ID: "u456" });
+    const runner = createHookRunner(
+      createTestRegistry([{ pluginId: "feishu", hookName: "resolve_exec_env", handler }]),
+      { catchErrors: true },
+    );
+    const result = await runner.runResolveExecEnv(
+      { sessionKey: "test", toolName: "exec", host: "gateway" },
+      { sessionKey: "test" },
+    );
+    expect(result).toEqual({ FEISHU_APP_ID: "cli_123", FEISHU_USER_ID: "u456" });
+    expect(handler).toHaveBeenCalledWith(
+      { sessionKey: "test", toolName: "exec", host: "gateway" },
+      { sessionKey: "test" },
+    );
+  });
+
+  it("merges env vars from multiple plugins, later overrides earlier", async () => {
+    const handler1 = vi.fn().mockResolvedValue({ A: "1", B: "2" });
+    const handler2 = vi.fn().mockResolvedValue({ B: "3", C: "4" });
+    const runner = createHookRunner(
+      createTestRegistry([
+        { pluginId: "plugin-a", hookName: "resolve_exec_env", handler: handler1 },
+        { pluginId: "plugin-b", hookName: "resolve_exec_env", handler: handler2 },
+      ]),
+      { catchErrors: true },
+    );
+    const result = await runner.runResolveExecEnv({ sessionKey: "test", toolName: "exec" }, {});
+    expect(result).toEqual({ A: "1", B: "3", C: "4" });
+  });
+
+  it("handles async handlers", async () => {
+    const handler = vi.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+      return { ASYNC_KEY: "value" };
+    });
+    const runner = createHookRunner(
+      createTestRegistry([{ pluginId: "async-plugin", hookName: "resolve_exec_env", handler }]),
+      { catchErrors: true },
+    );
+    const result = await runner.runResolveExecEnv({ sessionKey: "test", toolName: "exec" }, {});
+    expect(result).toEqual({ ASYNC_KEY: "value" });
+  });
+});

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -720,6 +720,8 @@ export type PluginHookResolveExecEnvEvent = {
   host?: "gateway" | "sandbox" | "node";
 };
 
+export type PluginHookResolveExecEnvContext = PluginHookAgentContext;
+
 export type PluginHookHandlerMap = {
   before_model_resolve: (
     event: PluginHookBeforeModelResolveEvent,
@@ -854,7 +856,7 @@ export type PluginHookHandlerMap = {
   ) => Promise<PluginHookBeforeInstallResult | void> | PluginHookBeforeInstallResult | void;
   resolve_exec_env: (
     event: PluginHookResolveExecEnvEvent,
-    ctx: PluginHookAgentContext,
+    ctx: PluginHookResolveExecEnvContext,
   ) => Promise<Record<string, string>> | Record<string, string>;
 };
 

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -86,7 +86,8 @@ export type PluginHookName =
   | "gateway_stop"
   | "before_dispatch"
   | "reply_dispatch"
-  | "before_install";
+  | "before_install"
+  | "resolve_exec_env";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -121,6 +122,7 @@ export const PLUGIN_HOOK_NAMES = [
   "before_dispatch",
   "reply_dispatch",
   "before_install",
+  "resolve_exec_env",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -712,6 +714,12 @@ export type PluginHookBeforeInstallResult = {
   blockReason?: string;
 };
 
+export type PluginHookResolveExecEnvEvent = {
+  sessionKey?: string;
+  toolName?: string;
+  host?: "gateway" | "sandbox" | "node";
+};
+
 export type PluginHookHandlerMap = {
   before_model_resolve: (
     event: PluginHookBeforeModelResolveEvent,
@@ -844,6 +852,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeInstallEvent,
     ctx: PluginHookBeforeInstallContext,
   ) => Promise<PluginHookBeforeInstallResult | void> | PluginHookBeforeInstallResult | void;
+  resolve_exec_env: (
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<Record<string, string>> | Record<string, string>;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -101,7 +101,8 @@ export type PluginHookName =
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install"
-  | "before_agent_run";
+  | "before_agent_run"
+  | "resolve_exec_env";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -140,6 +141,7 @@ export const PLUGIN_HOOK_NAMES = [
   "reply_dispatch",
   "before_install",
   "before_agent_run",
+  "resolve_exec_env",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -845,6 +847,13 @@ export type PluginHookBeforeAgentRunEvent = {
 /** Result type for before_agent_run. Returns pass/block or void (= pass). */
 export type PluginHookBeforeAgentRunResult = InputGateDecision | void;
 
+export type PluginHookResolveExecEnvEvent = {
+  sessionKey?: string;
+  toolName?: string;
+  host?: "gateway" | "sandbox" | "node";
+};
+
+
 export type PluginHookHandlerMap = {
   agent_turn_prepare: (
     event: PluginAgentTurnPrepareEvent,
@@ -997,6 +1006,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentRunEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentRunResult> | PluginHookBeforeAgentRunResult;
+  resolve_exec_env: (
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<Record<string, string>> | Record<string, string>;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -853,6 +853,7 @@ export type PluginHookResolveExecEnvEvent = {
   host?: "gateway" | "sandbox" | "node";
 };
 
+export type PluginHookResolveExecEnvContext = PluginHookAgentContext;
 
 export type PluginHookHandlerMap = {
   agent_turn_prepare: (
@@ -1008,7 +1009,7 @@ export type PluginHookHandlerMap = {
   ) => Promise<PluginHookBeforeAgentRunResult> | PluginHookBeforeAgentRunResult;
   resolve_exec_env: (
     event: PluginHookResolveExecEnvEvent,
-    ctx: PluginHookAgentContext,
+    ctx: PluginHookResolveExecEnvContext,
   ) => Promise<Record<string, string>> | Record<string, string>;
 };
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -71,6 +71,7 @@ import type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
   PluginHookResolveExecEnvEvent,
+  PluginHookResolveExecEnvContext,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -134,6 +135,7 @@ export type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
   PluginHookResolveExecEnvEvent,
+  PluginHookResolveExecEnvContext,
 };
 
 export type HookRunnerLogger = {

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -70,6 +70,7 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvEvent,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -132,6 +133,7 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvEvent,
 };
 
 export type HookRunnerLogger = {
@@ -1177,6 +1179,26 @@ export function createHookRunner(
     );
   }
 
+  /**
+   * Run resolve_exec_env hook.
+   * Allows plugins to contribute environment variables for exec tool execution.
+   * All plugin results are merged (later plugins override earlier ones for same keys).
+   */
+  async function runResolveExecEnv(
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<Record<string, string>> {
+    const result = await runModifyingHook<"resolve_exec_env", Record<string, string>>(
+      "resolve_exec_env",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({ ...acc, ...next }),
+      },
+    );
+    return result ?? {};
+  }
+
   // =========================================================================
   // Utility
   // =========================================================================
@@ -1237,6 +1259,7 @@ export function createHookRunner(
     runGatewayStop,
     // Install hooks
     runBeforeInstall,
+    runResolveExecEnv,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -84,6 +84,7 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvEvent,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -151,6 +152,7 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookResolveExecEnvEvent,
 };
 
 export type HookRunnerLogger = {
@@ -1458,6 +1460,26 @@ export function createHookRunner(
     );
   }
 
+  /**
+   * Run resolve_exec_env hook.
+   * Allows plugins to contribute environment variables for exec tool execution.
+   * All plugin results are merged (later plugins override earlier ones for same keys).
+   */
+  async function runResolveExecEnv(
+    event: PluginHookResolveExecEnvEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<Record<string, string>> {
+    const result = await runModifyingHook<"resolve_exec_env", Record<string, string>>(
+      "resolve_exec_env",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({ ...acc, ...next }),
+      },
+    );
+    return result ?? {};
+  }
+
   // =========================================================================
   // Utility
   // =========================================================================
@@ -1520,6 +1542,7 @@ export function createHookRunner(
     runCronChanged,
     // Install hooks
     runBeforeInstall,
+    runResolveExecEnv,
     // Utility
     hasHooks,
     getHookCount,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -85,6 +85,7 @@ import type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
   PluginHookResolveExecEnvEvent,
+  PluginHookResolveExecEnvContext,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -153,6 +154,7 @@ export type {
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
   PluginHookResolveExecEnvEvent,
+  PluginHookResolveExecEnvContext,
 };
 
 export type HookRunnerLogger = {


### PR DESCRIPTION
## Summary

- Add `resolve_exec_env` plugin hook allowing plugins to inject channel-specific environment variables into exec tool execution
- Hook fires after env construction in `bash-tools.exec.ts`, plugins return `Record<string, string>` which are merged into the exec environment
- Multiple plugins can contribute env vars; later plugins override earlier ones for the same key

## Motivation

Channel plugins (Feishu, Discord, Slack, Telegram, etc.) need to pass channel-specific env vars to exec commands (e.g. `FEISHU_APP_ID`, `DISCORD_GUILD_ID`). Currently this requires hardcoded references in core, violating the extension-agnostic principle. This hook enables any channel plugin to inject env vars generically.

| Channel | Example env vars |
|---------|-----------------|
| Feishu | `FEISHU_APP_ID`, `FEISHU_USER_ID`, `FEISHU_OPEN_ID` |
| Discord | `DISCORD_GUILD_ID`, `DISCORD_CHANNEL_ID` |
| Slack | `SLACK_WORKSPACE_ID`, `SLACK_CHANNEL_ID` |
| Telegram | `TELEGRAM_CHAT_ID`, `TELEGRAM_USER_ID` |

## Test plan

- [x] Run `pnpm test src/plugins/hook-resolve-exec-env.test.ts` (4 new tests)
- [x] Verify hook-types compile-time assertion passes
- [x] Run `pnpm test src/agents/bash-tools.exec` (existing tests still pass)

## Attribution

Original author: @lanzhi-lee (lizhan3@xiaomi.com)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)