### PR TITLE
fix(minimax): add provider auth aliases to manifest (fixes #63823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Docs: https://docs.openclaw.ai
 - Context Engine: gracefully fall back to the legacy engine when a third-party context engine plugin fails at resolution time (unregistered id, factory throw, or contract violation), preventing a full gateway outage on every channel. (#66930) Thanks @openperf.
 - Control UI/chat: keep optimistic user message cards visible during active sends by deferring same-session history reloads until the active run ends, including aborted and errored runs. (#66997) Thanks @scotthuang and @vincentkoc.
 - Media/Slack: allow host-local CSV and Markdown uploads only when the fallback buffer actually decodes as text, so real plain-text files work without letting opaque non-text blobs renamed to `.csv` or `.md` slip past the host-read guard. (#67047) Thanks @Unayung.
+- MiniMax: add `providerAuthAliases` for `minimax-cn` and `minimax-portal-cn` to the plugin manifest so CN endpoint auth resolves correctly instead of silently falling back to other providers. Fixes #63823. Thanks @kamusis.
 
 ## 2026.4.14
 

--- a/extensions/minimax/index.test.ts
+++ b/extensions/minimax/index.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import type { StreamFn } from "@mariozechner/pi-agent-core";
 import type { Context, Model } from "@mariozechner/pi-ai";
 import { describe, expect, it, vi } from "vitest";
@@ -301,6 +303,19 @@ describe("minimax provider hooks", () => {
       baseUrl: "https://api.minimax.io/anthropic",
       api: "anthropic-messages",
       authHeader: true,
+    });
+  });
+});
+
+describe("minimax manifest", () => {
+  it("declares its CN provider auth aliases in the manifest", () => {
+    const pluginJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "openclaw.plugin.json"), "utf-8"),
+    ) as Record<string, unknown>;
+
+    expect(pluginJson.providerAuthAliases).toEqual({
+      "minimax-cn": "minimax",
+      "minimax-portal-cn": "minimax-portal",
     });
   });
 });

--- a/extensions/minimax/openclaw.plugin.json
+++ b/extensions/minimax/openclaw.plugin.json
@@ -8,6 +8,10 @@
     "minimax": ["MINIMAX_API_KEY"],
     "minimax-portal": ["MINIMAX_OAUTH_TOKEN", "MINIMAX_API_KEY"]
   },
+  "providerAuthAliases": {
+    "minimax-cn": "minimax",
+    "minimax-portal-cn": "minimax-portal"
+  },
   "providerAuthChoices": [
     {
       "provider": "minimax-portal",


### PR DESCRIPTION
## Problem

MiniMax CN endpoint authentication has been failing since OpenClaw's new Provider Auth Aliases system was introduced. This new system requires plugins to explicitly declare alias mappings in their manifest file via the `providerAuthAliases` field.

**Issue**: #63823

## Root Cause

The MiniMax plugin was missing the `providerAuthAliases` declaration in its manifest, causing:

1. Auth resolution fails when `minimax-cn` alias is activated for CN endpoints
2. System cannot find matching auth profile (`minimax:cn`)
3. 401 authentication error
4. **Automatic fallback to other models (Google Gemini, xAI, etc.)**

Every user who updates OpenClaw experiences this issue silently - they think they're using MiniMax but it's actually falling back to another model.

## Solution

Added `providerAuthAliases` field to `extensions/minimax/openclaw.plugin.json`:

```json
"providerAuthAliases": {
  "minimax-cn": "minimax",
  "minimax-portal-cn": "minimax-portal"
}
```

Also includes manifest assertion test (as recommended by Greptile) to prevent accidental desynchronization of aliases in future edits.

## Verification

✅ Tested locally - MiniMax CN endpoint now authenticates successfully without fallback
✅ No more silent model switching
✅ Session logs confirm proper provider resolution

## Impact

**Severity: CRITICAL**

- Affects all users who configured MiniMax CN endpoint
- Every `openclaw update` overwrites local patches, requiring manual re-patching
- Silent fallback means users may not realize they're not using their configured model

## Changes

- Added `providerAuthAliases` to manifest
- Added test assertion to verify manifest correctness
- Follows established pattern from volcengine and byteplus extensions