### PR TITLE
feat(agents): allow opting out of git init on agents.create

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -893,6 +893,20 @@ public struct NodePairRejectParams: Codable, Sendable {
     }
 }
 
+public struct NodePairRemoveParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String)
+    {
+        self.nodeid = nodeid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
 public struct NodePairVerifyParams: Codable, Sendable {
     public let nodeid: String
     public let token: String
@@ -2689,19 +2703,22 @@ public struct AgentsCreateParams: Codable, Sendable {
     public let model: String?
     public let emoji: String?
     public let avatar: String?
+    public let gitinit: Bool?
 
     public init(
         name: String,
         workspace: String,
         model: String?,
         emoji: String?,
-        avatar: String?)
+        avatar: String?,
+        gitinit: Bool?)
     {
         self.name = name
         self.workspace = workspace
         self.model = model
         self.emoji = emoji
         self.avatar = avatar
+        self.gitinit = gitinit
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2710,6 +2727,7 @@ public struct AgentsCreateParams: Codable, Sendable {
         case model
         case emoji
         case avatar
+        case gitinit = "gitInit"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -893,6 +893,20 @@ public struct NodePairRejectParams: Codable, Sendable {
     }
 }
 
+public struct NodePairRemoveParams: Codable, Sendable {
+    public let nodeid: String
+
+    public init(
+        nodeid: String)
+    {
+        self.nodeid = nodeid
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeid = "nodeId"
+    }
+}
+
 public struct NodePairVerifyParams: Codable, Sendable {
     public let nodeid: String
     public let token: String
@@ -2689,19 +2703,22 @@ public struct AgentsCreateParams: Codable, Sendable {
     public let model: String?
     public let emoji: String?
     public let avatar: String?
+    public let gitinit: Bool?
 
     public init(
         name: String,
         workspace: String,
         model: String?,
         emoji: String?,
-        avatar: String?)
+        avatar: String?,
+        gitinit: Bool?)
     {
         self.name = name
         self.workspace = workspace
         self.model = model
         self.emoji = emoji
         self.avatar = avatar
+        self.gitinit = gitinit
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2710,6 +2727,7 @@ public struct AgentsCreateParams: Codable, Sendable {
         case model
         case emoji
         case avatar
+        case gitinit = "gitInit"
     }
 }
 

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -85,6 +85,21 @@ describe("ensureAgentWorkspace", () => {
     expect((await readWorkspaceState(tempDir)).setupCompletedAt).toBeUndefined();
   });
 
+  it("skips git init for brand new workspaces when gitInit is false", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({
+      dir: tempDir,
+      ensureBootstrapFiles: true,
+      gitInit: false,
+    });
+
+    await expect(fs.access(path.join(tempDir, ".git"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expectBootstrapSeeded(tempDir);
+  });
+
   it("recovers partial initialization by creating BOOTSTRAP.md when marker is missing", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await writeWorkspaceFile({ dir: tempDir, name: DEFAULT_AGENTS_FILENAME, content: "existing" });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -447,7 +447,10 @@ async function isGitAvailable(): Promise<boolean> {
   return gitAvailabilityPromise;
 }
 
-async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
+async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean, enabled: boolean) {
+  if (!enabled) {
+    return;
+  }
   if (!isBrandNewWorkspace) {
     return;
   }
@@ -467,6 +470,13 @@ async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
 export async function ensureAgentWorkspace(params?: {
   dir?: string;
   ensureBootstrapFiles?: boolean;
+  /**
+   * When `true` (default), brand-new workspaces are initialized as a local
+   * git repository (`git init`). Pass `false` to opt out — useful for hosts
+   * that manage versioning or backups outside of git, or that don't want
+   * agents to perceive the workspace as a tracked repo.
+   */
+  gitInit?: boolean;
 }): Promise<{
   dir: string;
   agentsPath?: string;
@@ -584,7 +594,7 @@ export async function ensureAgentWorkspace(params?: {
   if (stateDirty) {
     await writeWorkspaceSetupState(statePath, state);
   }
-  await ensureGitRepo(dir, isBrandNewWorkspace);
+  await ensureGitRepo(dir, isBrandNewWorkspace, params?.gitInit !== false);
 
   return {
     dir,

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -62,6 +62,13 @@ export const AgentsCreateParamsSchema = Type.Object(
     model: Type.Optional(NonEmptyString),
     emoji: Type.Optional(Type.String()),
     avatar: Type.Optional(Type.String()),
+    /**
+     * When omitted or `true`, brand-new workspaces are initialized as a
+     * local git repo (`git init`). Pass `false` to skip git init — useful
+     * for hosts that manage versioning/backups outside git or that don't
+     * want agents to perceive the workspace as a tracked repository.
+     */
+    gitInit: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -494,7 +494,11 @@ export const agentsHandlers: GatewayRequestHandlers = {
     // Ensure workspace & transcripts exist BEFORE writing config so a failure
     // here does not leave a broken config entry behind.
     const skipBootstrap = Boolean(nextConfig.agents?.defaults?.skipBootstrap);
-    await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: !skipBootstrap });
+    await ensureAgentWorkspace({
+      dir: workspaceDir,
+      ensureBootstrapFiles: !skipBootstrap,
+      gitInit: params.gitInit,
+    });
     await fs.mkdir(resolveSessionTranscriptsDirForAgent(agentId), { recursive: true });
 
     const persistedIdentity = normalizeIdentityForFile(resolveAgentIdentity(nextConfig, agentId));


### PR DESCRIPTION
## Summary

`ensureAgentWorkspace()` unconditionally runs `git init` for brand-new
workspaces. This PR adds an opt-out: a new `gitInit` boolean parameter
on both the `agents.create` RPC and `ensureAgentWorkspace()`. Default
behavior is unchanged.

## Why

Hosts that embed OpenClaw sometimes:

- manage versioning/backups outside git (per-day tarball snapshots, etc.)
- store binary artifacts (images, video, audio) in agent workspaces and
  don't want a `.git/` repo bloating from accumulated binary history
- run agents whose underlying LLM (e.g. Codex) interprets a `.git/`
  directory as a tracked repo and starts proposing \`git commit\` as
  part of every plan, wasting tokens

The current workaround is to `rm -rf <workspace>/.git/` after every
`agents.create` call, which is awkward and racy.

## Changes

- `src/agents/workspace.ts`: `ensureAgentWorkspace` accepts an optional
  `gitInit?: boolean`. `ensureGitRepo` gains an `enabled` parameter and
  short-circuits when false. Default remains \`true\`.
- `src/gateway/protocol/schema/agents-models-skills.ts`: adds the
  optional `gitInit` boolean to `AgentsCreateParamsSchema`.
- `src/gateway/server-methods/agents.ts`: forwards `params.gitInit` to
  `ensureAgentWorkspace`.
- `src/agents/workspace.test.ts`: regression test confirming
  `gitInit: false` produces a workspace with no `.git/` directory.

## Test plan

- [x] \`npx vitest run src/agents/workspace.test.ts\` — 24/24 pass
- [x] \`npx tsc --noEmit\` — clean (exit 0)
- [ ] Reviewer suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)