### PR TITLE
fix(auto-reply): keep stale-runtime imports from dropping replies across all lazy loaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Docs: https://docs.openclaw.ai
 - Web search: describe `web_search` as using the configured provider instead of hard-coding Brave when DuckDuckGo or another provider is active. Fixes #75088. Thanks @sun-rongyang.
 - Infra/tmp: tolerate concurrent temp-dir permission repairs by rechecking directories that another process already tightened, so parallel ACP subprocess startup no longer throws `Unsafe fallback OpenClaw temp dir`. Fixes #66867. Thanks @Kane808-AI and @jarvisz8.
 - Agents/compaction: add an opt-in `agents.defaults.compaction.midTurnPrecheck` mid-turn precheck that detects tool-loop context pressure and triggers compaction before the next tool call instead of waiting for end-of-turn. (#73499) Thanks @marchpure and @haoxingjun.
+- Auto-reply: extend stale-runtime `ERR_MODULE_NOT_FOUND` recovery to the five remaining lazy loaders in the reply pipeline so rotated dist chunks no longer crash in-flight replies. Closes #68466.
 
 ## 2026.4.29
 

--- a/src/auto-reply/reply/get-reply.stale-runtime-recovery.test.ts
+++ b/src/auto-reply/reply/get-reply.stale-runtime-recovery.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logVerbose } from "../../globals.js";
+import type { HookRunner } from "../../plugins/hooks.js";
+import {
+  buildGetReplyGroupCtx,
+  buildNativeResetContext,
+  createGetReplyContinueDirectivesResult,
+  createGetReplySessionState,
+  registerGetReplyRuntimeOverrides,
+} from "./get-reply.test-fixtures.js";
+import { loadGetReplyModuleForTest } from "./get-reply.test-loader.js";
+import "./get-reply.test-runtime-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  handleInlineActions: vi.fn(),
+  initSessionState: vi.fn(),
+  applyResetModelOverride: vi.fn(),
+  emitResetCommandHooks: vi.fn(),
+  stageSandboxMedia: vi.fn(),
+  hasHooks: vi.fn<HookRunner["hasHooks"]>(),
+  runBeforeAgentReply: vi.fn<HookRunner["runBeforeAgentReply"]>(),
+  getGlobalHookRunner: vi.fn(),
+  resolveOriginMessageProvider: vi.fn(),
+}));
+
+vi.mock("../../globals.js", () => ({
+  logVerbose: vi.fn(),
+}));
+
+vi.mock("./commands-core.js", () => ({
+  emitResetCommandHooks: (...args: unknown[]) => mocks.emitResetCommandHooks(...args),
+}));
+
+vi.mock("./origin-routing.js", () => ({
+  resolveOriginMessageProvider: (...args: unknown[]) => mocks.resolveOriginMessageProvider(...args),
+}));
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: (...args: unknown[]) => mocks.getGlobalHookRunner(...args),
+}));
+
+// The shared `get-reply.test-mocks.js` (loaded transitively via
+// `get-reply.test-runtime-mocks.js`) registers default mocks for the runtime
+// modules below that resolve to no-op promises. We override those defaults
+// here at module load via `vi.doMock` (runtime-registered, "last wins") so
+// the rejection paths exercised in this suite reach our hoisted handles.
+vi.doMock("./session-reset-model.runtime.js", () => ({
+  applyResetModelOverride: (...args: unknown[]) => mocks.applyResetModelOverride(...args),
+}));
+vi.doMock("./stage-sandbox-media.runtime.js", () => ({
+  stageSandboxMedia: (...args: unknown[]) => mocks.stageSandboxMedia(...args),
+}));
+vi.doMock("./commands-core.runtime.js", () => ({
+  emitResetCommandHooks: (...args: unknown[]) => mocks.emitResetCommandHooks(...args),
+}));
+
+registerGetReplyRuntimeOverrides(mocks);
+
+let getReplyFromConfig: typeof import("./get-reply.js").getReplyFromConfig;
+
+async function loadGetReplyRuntimeForTest() {
+  ({ getReplyFromConfig } = await loadGetReplyModuleForTest({ cacheKey: import.meta.url }));
+}
+
+function createContinueDirectivesResult(
+  overrides: { body?: string; resetHookTriggered?: boolean } = {},
+) {
+  return createGetReplyContinueDirectivesResult({
+    body: overrides.body ?? "hello world",
+    abortKey: "agent:main:telegram:-100123",
+    from: "telegram:user:42",
+    to: "telegram:-100123",
+    senderId: "42",
+    commandSource: "text",
+    senderIsOwner: false,
+    resetHookTriggered: overrides.resetHookTriggered ?? false,
+  });
+}
+
+describe("getReplyFromConfig stale-runtime recovery", () => {
+  beforeEach(async () => {
+    await loadGetReplyRuntimeForTest();
+    vi.stubEnv("OPENCLAW_ALLOW_SLOW_REPLY_TESTS", "1");
+    delete process.env.OPENCLAW_TEST_FAST;
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.handleInlineActions.mockReset();
+    mocks.initSessionState.mockReset();
+    mocks.applyResetModelOverride.mockReset();
+    mocks.emitResetCommandHooks.mockReset();
+    mocks.stageSandboxMedia.mockReset();
+    mocks.hasHooks.mockReset();
+    mocks.runBeforeAgentReply.mockReset();
+    mocks.getGlobalHookRunner.mockReset();
+    mocks.resolveOriginMessageProvider.mockReset();
+    vi.mocked(logVerbose).mockReset();
+
+    mocks.applyResetModelOverride.mockResolvedValue(undefined);
+    mocks.emitResetCommandHooks.mockResolvedValue(undefined);
+    mocks.stageSandboxMedia.mockResolvedValue(undefined);
+    mocks.hasHooks.mockImplementation((hookName) => hookName === "before_agent_reply");
+    mocks.runBeforeAgentReply.mockResolvedValue({ handled: false });
+    mocks.getGlobalHookRunner.mockReturnValue({
+      hasHooks: mocks.hasHooks,
+      runBeforeAgentReply: mocks.runBeforeAgentReply,
+    } as unknown as HookRunner);
+    mocks.resolveOriginMessageProvider.mockReturnValue("telegram");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("continues dispatching when session reset model override fails before reply routing", async () => {
+    mocks.applyResetModelOverride.mockRejectedValueOnce(
+      new Error(
+        "Cannot find module '/tmp/openclaw/dist/auto-reply/reply/session-reset-model.runtime-old.js'",
+      ),
+    );
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildNativeResetContext(),
+        sessionKey: "agent:main:telegram:direct:123",
+        isNewSession: true,
+        resetTriggered: true,
+        sessionScope: "per-sender",
+        triggerBodyNormalized: "/new",
+        bodyStripped: "/new",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+
+    const reply = await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(reply).toEqual({ text: "ok" });
+    expect(mocks.initSessionState).toHaveBeenCalledTimes(1);
+    expect(mocks.applyResetModelOverride).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveReplyDirectives).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining("session reset model override failed, proceeding without override"),
+    );
+  });
+
+  it("continues dispatching when reset command hooks fail before reply routing", async () => {
+    mocks.emitResetCommandHooks.mockRejectedValueOnce(
+      new Error(
+        "Cannot find module '/tmp/openclaw/dist/auto-reply/reply/commands-core.runtime-old.js'",
+      ),
+    );
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildNativeResetContext(),
+        sessionKey: "agent:main:telegram:direct:123",
+        isNewSession: true,
+        resetTriggered: true,
+        sessionScope: "per-sender",
+        triggerBodyNormalized: "/new",
+        bodyStripped: "",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue(
+      createGetReplyContinueDirectivesResult({
+        body: "/new",
+        abortKey: "telegram:slash:123",
+        from: "telegram:123",
+        to: "slash:123",
+        senderId: "123",
+        commandSource: "/new",
+        senderIsOwner: true,
+        resetHookTriggered: false,
+      }),
+    );
+    mocks.handleInlineActions.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+
+    const reply = await getReplyFromConfig(buildNativeResetContext(), undefined, {});
+
+    expect(reply).toEqual({ text: "ok" });
+    expect(mocks.emitResetCommandHooks).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining("reset command hooks failed, proceeding without emission"),
+    );
+  });
+
+  it("continues dispatching when before_agent_reply hook runner fails before reply routing", async () => {
+    mocks.runBeforeAgentReply.mockRejectedValueOnce(
+      new Error("Cannot find module '/tmp/openclaw/dist/plugins/hook-runner-global-old.js'"),
+    );
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildGetReplyGroupCtx({
+          OriginatingChannel: "Telegram",
+          Provider: "telegram",
+        }),
+        sessionKey: "agent:main:telegram:-100123",
+        sessionScope: "per-chat",
+        isGroup: true,
+        triggerBodyNormalized: "hello world",
+        bodyStripped: "hello world",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult());
+    mocks.handleInlineActions.mockResolvedValue({
+      kind: "continue",
+      directives: {},
+      abortedLastRun: false,
+    });
+
+    const reply = await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {});
+
+    // runPreparedReply is mocked to return undefined; the important assertion is
+    // that the failure was caught, logged, and the function did NOT throw.
+    expect(reply).toBeUndefined();
+    expect(mocks.runBeforeAgentReply).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "before_agent_reply hook runner failed, proceeding without plugin interception",
+      ),
+    );
+  });
+
+  it("continues dispatching when origin routing fails before reply routing", async () => {
+    mocks.resolveOriginMessageProvider.mockImplementationOnce(() => {
+      throw new Error(
+        "Cannot find module '/tmp/openclaw/dist/auto-reply/reply/origin-routing-old.js'",
+      );
+    });
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildGetReplyGroupCtx({
+          OriginatingChannel: "Telegram",
+          Provider: "telegram",
+        }),
+        sessionKey: "agent:main:telegram:-100123",
+        sessionScope: "per-chat",
+        isGroup: true,
+        triggerBodyNormalized: "hello world",
+        bodyStripped: "hello world",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult());
+    mocks.handleInlineActions.mockResolvedValue({
+      kind: "continue",
+      directives: {},
+      abortedLastRun: false,
+    });
+
+    const reply = await getReplyFromConfig(buildGetReplyGroupCtx(), undefined, {});
+
+    expect(reply).toBeUndefined();
+    expect(mocks.resolveOriginMessageProvider).toHaveBeenCalledTimes(1);
+    // origin routing is wrapped together with the hook runner; the recovery
+    // log message reflects the shared try/catch boundary.
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "before_agent_reply hook runner failed, proceeding without plugin interception",
+      ),
+    );
+  });
+
+  it("continues dispatching when sandbox media staging fails before reply routing", async () => {
+    mocks.stageSandboxMedia.mockRejectedValueOnce(
+      new Error(
+        "Cannot find module '/tmp/openclaw/dist/auto-reply/reply/stage-sandbox-media.runtime-old.js'",
+      ),
+    );
+    mocks.hasHooks.mockImplementation(() => false);
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildGetReplyGroupCtx({
+          OriginatingChannel: "Telegram",
+          Provider: "telegram",
+        }),
+        sessionKey: "agent:main:telegram:-100123",
+        sessionScope: "per-chat",
+        isGroup: true,
+        triggerBodyNormalized: "hello world",
+        bodyStripped: "hello world",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult());
+    mocks.handleInlineActions.mockResolvedValue({
+      kind: "continue",
+      directives: {},
+      abortedLastRun: false,
+    });
+
+    const ctx = buildGetReplyGroupCtx({
+      MediaPath: "/tmp/voice.ogg",
+      MediaUrl: "https://example.test/voice.ogg",
+      MediaType: "audio/ogg",
+    });
+
+    const reply = await getReplyFromConfig(ctx, undefined, {});
+
+    expect(reply).toBeUndefined();
+    expect(mocks.stageSandboxMedia).toHaveBeenCalledTimes(1);
+    expect(logVerbose).toHaveBeenCalledWith(
+      expect.stringContaining("sandbox media staging failed, proceeding without staged media"),
+    );
+  });
+
+  it("skips sandbox media staging when caller has already pre-staged media", async () => {
+    mocks.hasHooks.mockImplementation(() => false);
+    mocks.initSessionState.mockResolvedValue(
+      createGetReplySessionState({
+        sessionCtx: buildGetReplyGroupCtx({
+          OriginatingChannel: "Telegram",
+          Provider: "telegram",
+        }),
+        sessionKey: "agent:main:telegram:-100123",
+        sessionScope: "per-chat",
+        isGroup: true,
+        triggerBodyNormalized: "hello world",
+        bodyStripped: "hello world",
+      }),
+    );
+    mocks.resolveReplyDirectives.mockResolvedValue(createContinueDirectivesResult());
+    mocks.handleInlineActions.mockResolvedValue({
+      kind: "continue",
+      directives: {},
+      abortedLastRun: false,
+    });
+
+    const ctx = buildGetReplyGroupCtx({
+      MediaPath: "/tmp/voice.ogg",
+      MediaUrl: "https://example.test/voice.ogg",
+      MediaType: "audio/ogg",
+      MediaStaged: true,
+    });
+
+    await getReplyFromConfig(ctx, undefined, {});
+
+    expect(mocks.stageSandboxMedia).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -312,22 +312,29 @@ export async function getReplyFromConfig(
     bodyStripped,
   } = sessionState;
   if (resetTriggered && normalizeOptionalString(bodyStripped)) {
-    const { applyResetModelOverride } = await loadSessionResetModelRuntime();
-    await applyResetModelOverride({
-      cfg,
-      agentId,
-      resetTriggered,
-      bodyStripped,
-      sessionCtx,
-      ctx: finalized,
-      sessionEntry,
-      sessionStore,
-      sessionKey,
-      storePath,
-      defaultProvider,
-      defaultModel,
-      aliasIndex,
-    });
+    try {
+      const { applyResetModelOverride } = await loadSessionResetModelRuntime();
+      await applyResetModelOverride({
+        cfg,
+        agentId,
+        resetTriggered,
+        bodyStripped,
+        sessionCtx,
+        ctx: finalized,
+        sessionEntry,
+        sessionStore,
+        sessionKey,
+        storePath,
+        defaultProvider,
+        defaultModel,
+        aliasIndex,
+      });
+    } catch (err) {
+      sessionResetModelRuntimePromise = null;
+      logVerbose(
+        `session reset model override failed, proceeding without override: ${formatErrorMessage(err)}`,
+      );
+    }
   }
 
   const channelModelOverride = cfg.channels?.modelByChannel
@@ -524,18 +531,25 @@ export async function getReplyFromConfig(
     if (!resetMatch) {
       return;
     }
-    const { emitResetCommandHooks } = await loadCommandsCoreRuntime();
-    const action: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
-    await emitResetCommandHooks({
-      action,
-      ctx,
-      cfg,
-      command,
-      sessionKey,
-      sessionEntry,
-      previousSessionEntry,
-      workspaceDir,
-    });
+    try {
+      const { emitResetCommandHooks } = await loadCommandsCoreRuntime();
+      const action: ResetCommandAction = resetMatch[1] === "reset" ? "reset" : "new";
+      await emitResetCommandHooks({
+        action,
+        ctx,
+        cfg,
+        command,
+        sessionKey,
+        sessionEntry,
+        previousSessionEntry,
+        workspaceDir,
+      });
+    } catch (err) {
+      commandsCoreRuntimePromise = null;
+      logVerbose(
+        `reset command hooks failed, proceeding without emission: ${formatErrorMessage(err)}`,
+      );
+    }
   };
 
   const inlineActionResult = await handleInlineActions({
@@ -588,29 +602,37 @@ export async function getReplyFromConfig(
 
   // Allow plugins to intercept and return a synthetic reply before the LLM runs.
   if (!useFastTestBootstrap) {
-    const { getGlobalHookRunner } = await loadHookRunnerGlobal();
-    const hookRunner = getGlobalHookRunner();
-    if (hookRunner?.hasHooks("before_agent_reply")) {
-      const { resolveOriginMessageProvider } = await loadOriginRouting();
-      const hookMessageProvider = resolveOriginMessageProvider({
-        originatingChannel: sessionCtx.OriginatingChannel,
-        provider: sessionCtx.Provider,
-      });
-      const hookResult = await hookRunner.runBeforeAgentReply(
-        { cleanedBody },
-        {
-          agentId,
-          sessionKey: agentSessionKey,
-          sessionId,
-          workspaceDir,
-          messageProvider: hookMessageProvider,
-          trigger: opts?.isHeartbeat ? "heartbeat" : "user",
-          channelId: hookMessageProvider,
-        },
-      );
-      if (hookResult?.handled) {
-        return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };
+    try {
+      const { getGlobalHookRunner } = await loadHookRunnerGlobal();
+      const hookRunner = getGlobalHookRunner();
+      if (hookRunner?.hasHooks("before_agent_reply")) {
+        const { resolveOriginMessageProvider } = await loadOriginRouting();
+        const hookMessageProvider = resolveOriginMessageProvider({
+          originatingChannel: sessionCtx.OriginatingChannel,
+          provider: sessionCtx.Provider,
+        });
+        const hookResult = await hookRunner.runBeforeAgentReply(
+          { cleanedBody },
+          {
+            agentId,
+            sessionKey: agentSessionKey,
+            sessionId,
+            workspaceDir,
+            messageProvider: hookMessageProvider,
+            trigger: opts?.isHeartbeat ? "heartbeat" : "user",
+            channelId: hookMessageProvider,
+          },
+        );
+        if (hookResult?.handled) {
+          return hookResult.reply ?? { text: SILENT_REPLY_TOKEN };
+        }
       }
+    } catch (err) {
+      hookRunnerGlobalPromise = null;
+      originRoutingPromise = null;
+      logVerbose(
+        `before_agent_reply hook runner failed, proceeding without plugin interception: ${formatErrorMessage(err)}`,
+      );
     }
   }
 
@@ -619,14 +641,21 @@ export async function getReplyFromConfig(
   // staging a single-call contract instead of relying on relative-path no-op
   // semantics in stageSandboxMedia.
   if (!useFastTestBootstrap && sessionKey && !ctx.MediaStaged && hasInboundMedia(ctx)) {
-    const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
-    await stageSandboxMedia({
-      ctx,
-      sessionCtx,
-      cfg,
-      sessionKey,
-      workspaceDir,
-    });
+    try {
+      const { stageSandboxMedia } = await loadStageSandboxMediaRuntime();
+      await stageSandboxMedia({
+        ctx,
+        sessionCtx,
+        cfg,
+        sessionKey,
+        workspaceDir,
+      });
+    } catch (err) {
+      stageSandboxMediaRuntimePromise = null;
+      logVerbose(
+        `sandbox media staging failed, proceeding without staged media: ${formatErrorMessage(err)}`,
+      );
+    }
   }
 
   return runPreparedReply({

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -219,6 +219,13 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/pi-model-discovery-runtime": "src/agents/pi-model-discovery-runtime.ts",
     "link-understanding/apply.runtime": "src/link-understanding/apply.runtime.ts",
     "media-understanding/apply.runtime": "src/media-understanding/apply.runtime.ts",
+    "auto-reply/reply/session-reset-model.runtime":
+      "src/auto-reply/reply/session-reset-model.runtime.ts",
+    "auto-reply/reply/stage-sandbox-media.runtime":
+      "src/auto-reply/reply/stage-sandbox-media.runtime.ts",
+    "auto-reply/reply/commands-core.runtime": "src/auto-reply/reply/commands-core.runtime.ts",
+    "plugins/hook-runner-global": "src/plugins/hook-runner-global.ts",
+    "auto-reply/reply/origin-routing": "src/auto-reply/reply/origin-routing.ts",
     "commands/doctor/shared/plugin-registry-migration":
       "src/commands/doctor/shared/plugin-registry-migration.ts",
     "commands/status.summary.runtime": "src/commands/status.summary.runtime.ts",


### PR DESCRIPTION
## Summary

Extends the stale-runtime recovery shape introduced in `1fbe83d09` ("fix: keep link understanding from dropping replies") to the five remaining lazy-loader call sites in `src/auto-reply/reply/get-reply.ts`. Closes the loop on #68466, which the reporter explicitly framed as a "shared reply pipeline rather than Feishu-specific" issue.

The merged commit hardened `applyMediaUnderstandingIfNeeded` and `applyLinkUnderstandingIfNeeded`. The five sibling sites in the same file still let an `ERR_MODULE_NOT_FOUND` from a rotated `dist/` chunk crash an in-flight reply:

| Loader | Drops on stale-dist |
|---|---|
| `loadSessionResetModelRuntime` | `/new` and `/reset` model-override hop |
| `loadCommandsCoreRuntime` | reset-command hook emission |
| `loadHookRunnerGlobal` | every non-fast-test reply when the hooks bundle rotates |
| `loadOriginRouting` | sibling to hook-runner — wrapped together (a hook-runner failure should also skip origin routing) |
| `loadStageSandboxMediaRuntime` | every inbound-media reply |

Each site now mirrors `1fbe83d09` verbatim:

```ts
try {
  const { fn } = await loadXyzRuntime();
  await fn(...);
} catch (err) {
  xyzRuntimePromise = null;
  logVerbose(`xyz failed, proceeding without ...: ${formatErrorMessage(err)}`);
}
```

Also pins the affected runtime modules as stable `tsdown` chunks in `buildCoreDistEntries()` so rebuilt `dist/` trees do not strand already-running gateways on stale hashed chunk filenames in the first place — same upstream mitigation `1fbe83d09` applied to the media + link runtimes.

## Changes

- `src/auto-reply/reply/get-reply.ts` — wrap 5 lazy-loader sites with try/catch + cache-promise nullify + `logVerbose` recovery (sites #3+#4 share one try/catch block since a hook-runner failure should also skip origin routing).
- `tsdown.config.ts` — add 5 stable chunk entries.
- `src/auto-reply/reply/get-reply.stale-runtime-recovery.test.ts` — 5 new regression cases mirroring the merged PR's test shape (mockRejectedValueOnce with an `ERR_MODULE_NOT_FOUND`-style message, assert the reply still dispatches, the matching `apply*`/`emit*`/`get*` mock was called once, and `logVerbose` was called with the expected recovery string).

## Test plan

- [x] Targeted vitest — 16/16 pass across the 4 files touched by this change (`get-reply.message-hooks` 7, `get-reply.stale-runtime-recovery` 5 new, `get-reply.before-agent-reply` 2, `get-reply.reset-hooks-fallback` 2)
- [x] Pre-commit `oxfmt` clean
- [x] Branch rebased onto current `main` at `1fbe83d09`
- [ ] CI: type-check + full unit suite (local `tsc --noEmit` OOMed at 4GB — relying on CI for the type-check leg)

Refs: #68466, `1fbe83d09`
