### PR TITLE
fix(agents): warm context-window cache for the gateway daemon

### DIFF
--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -4,6 +4,7 @@ import {
   applyConfiguredContextWindows,
   applyDiscoveredContextWindows,
   resolveContextTokensForModel,
+  shouldEagerWarmContextWindowCache,
 } from "./context.js";
 import { createSessionManagerRuntimeRegistry } from "./pi-hooks/session-manager-runtime-registry.js";
 
@@ -452,5 +453,48 @@ describe("resolveContextTokensForModel", () => {
     });
 
     expect(result).toBe(160_000);
+  });
+});
+
+describe("shouldEagerWarmContextWindowCache", () => {
+  it("warms the cache for the long-running gateway daemon (node dist/index.js gateway)", () => {
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/home/u/.npm-global/lib/node_modules/openclaw/dist/index.js",
+        "gateway",
+        "--port",
+        "18789",
+      ]),
+    ).toBe(true);
+  });
+
+  it("warms the cache for the openclaw CLI gateway invocation", () => {
+    // Short-lived `openclaw gateway status` and friends. The warmup is async
+    // and best-effort, so it does not block CLI exit; we just need the cache
+    // populated for any synchronous lookups that follow.
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/usr/bin/openclaw",
+        "gateway",
+        "status",
+      ]),
+    ).toBe(true);
+  });
+
+  it("still skips warmup for help/version invocations", () => {
+    expect(
+      shouldEagerWarmContextWindowCache(["/usr/bin/node", "/usr/bin/openclaw", "--version"]),
+    ).toBe(false);
+    expect(
+      shouldEagerWarmContextWindowCache(["/usr/bin/node", "/usr/bin/openclaw", "--help"]),
+    ).toBe(false);
+  });
+
+  it("does not warm when imported from a generic Node script (plugin-sdk surface)", () => {
+    expect(
+      shouldEagerWarmContextWindowCache(["/usr/bin/node", "/some/random/script.js", "gateway"]),
+    ).toBe(false);
   });
 });

--- a/src/agents/context.test.ts
+++ b/src/agents/context.test.ts
@@ -483,6 +483,19 @@ describe("shouldEagerWarmContextWindowCache", () => {
     ).toBe(true);
   });
 
+  it("warms the cache for a dev-checkout daemon entry", () => {
+    // Local source builds run as `node /home/u/git/openclaw/dist/index.js
+    // gateway ...`. The ancestor-directory check still recognises this as a
+    // genuine OpenClaw entry, not a generic Node script.
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/home/u/git/openclaw/dist/index.js",
+        "gateway",
+      ]),
+    ).toBe(true);
+  });
+
   it("still skips warmup for help/version invocations", () => {
     expect(
       shouldEagerWarmContextWindowCache(["/usr/bin/node", "/usr/bin/openclaw", "--version"]),
@@ -493,8 +506,47 @@ describe("shouldEagerWarmContextWindowCache", () => {
   });
 
   it("does not warm when imported from a generic Node script (plugin-sdk surface)", () => {
+    // The bundled plugin-sdk can be imported by arbitrary downstream Node
+    // scripts. If those scripts happen to be named index.js, we must not
+    // trigger eager warmup, because that cascades into
+    // ensureOpenClawModelsJson() and breaks dist/source singleton
+    // assumptions for plugin-sdk consumers.
     expect(
       shouldEagerWarmContextWindowCache(["/usr/bin/node", "/some/random/script.js", "gateway"]),
+    ).toBe(false);
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/some/random/project/index.js",
+        "gateway",
+      ]),
+    ).toBe(false);
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/home/u/projects/my-cool-tool/dist/index.mjs",
+        "gateway",
+      ]),
+    ).toBe(false);
+  });
+
+  it("does not match substrings of openclaw in ancestor directory names", () => {
+    // The ancestor check must compare basenames exactly, not as substrings.
+    // A directory called `my-openclaw-fork` or `openclaw-extras` is not the
+    // canonical install layout and should not trigger warmup.
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/home/u/projects/my-openclaw-fork/dist/index.js",
+        "gateway",
+      ]),
+    ).toBe(false);
+    expect(
+      shouldEagerWarmContextWindowCache([
+        "/usr/bin/node",
+        "/home/u/openclaw-extras/dist/index.js",
+        "gateway",
+      ]),
     ).toBe(false);
   });
 });

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -106,22 +106,54 @@ function loadModelsConfigRuntime() {
 }
 
 function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
-  const entryBasename = normalizeLowercaseStringOrEmpty(path.basename(argv[1] ?? ""));
-  return (
+  const entryPath = argv[1] ?? "";
+  const entryBasename = normalizeLowercaseStringOrEmpty(path.basename(entryPath));
+  if (
     entryBasename === "openclaw" ||
     entryBasename === "openclaw.mjs" ||
     entryBasename === "entry.js" ||
-    entryBasename === "entry.mjs" ||
-    // The bundled gateway daemon (and any direct invocation of dist/index.js)
-    // launches as `node .../dist/index.js gateway ...`, so argv[1] basename is
-    // `index.js`. Without this, the gateway service never eager-warms the
-    // context-window cache, leaving long-running synchronous lookups
-    // (allowAsyncLoad: false) to fall back to DEFAULT_CONTEXT_TOKENS until
-    // the first agent run completes — which then persists the wrong window
-    // onto the session record.
-    entryBasename === "index.js" ||
-    entryBasename === "index.mjs"
-  );
+    entryBasename === "entry.mjs"
+  ) {
+    return true;
+  }
+  // The bundled gateway daemon (and any direct invocation of dist/index.js)
+  // launches as `node .../dist/index.js gateway ...`, so argv[1] basename is
+  // `index.js`. Without recognising that, the gateway service never
+  // eager-warms the context-window cache, leaving long-running synchronous
+  // lookups (allowAsyncLoad: false) to fall back to DEFAULT_CONTEXT_TOKENS
+  // until the first agent run completes — which then persists the wrong
+  // window onto the session record.
+  //
+  // Bare `index.js` / `index.mjs` is far too generic to match on its own (it
+  // would fire for every plugin-sdk consumer that happens to be named
+  // index.js). Require an ancestor directory named `openclaw` in the entry
+  // path so this only matches genuine OpenClaw entries (npm-global install:
+  // `.../node_modules/openclaw/dist/index.js`; dev checkout:
+  // `.../git/openclaw/dist/index.js`).
+  if (entryBasename !== "index.js" && entryBasename !== "index.mjs") {
+    return false;
+  }
+  return entryPathHasOpenClawAncestor(entryPath);
+}
+
+function entryPathHasOpenClawAncestor(entryPath: string): boolean {
+  if (!entryPath) {
+    return false;
+  }
+  // Walk parent directories looking for one whose lowercased basename is
+  // exactly `openclaw`. We deliberately avoid substring matches (e.g.
+  // `my-openclaw-fork`) and only accept the canonical directory name to keep
+  // the boundary tight for plugin-sdk consumers.
+  let current = path.dirname(entryPath);
+  let previous = "";
+  while (current && current !== previous) {
+    if (normalizeLowercaseStringOrEmpty(path.basename(current)) === "openclaw") {
+      return true;
+    }
+    previous = current;
+    current = path.dirname(current);
+  }
+  return false;
 }
 
 function getCommandPathFromArgv(argv: string[]): string[] {

--- a/src/agents/context.ts
+++ b/src/agents/context.ts
@@ -111,7 +111,16 @@ function isLikelyOpenClawCliProcess(argv: string[] = process.argv): boolean {
     entryBasename === "openclaw" ||
     entryBasename === "openclaw.mjs" ||
     entryBasename === "entry.js" ||
-    entryBasename === "entry.mjs"
+    entryBasename === "entry.mjs" ||
+    // The bundled gateway daemon (and any direct invocation of dist/index.js)
+    // launches as `node .../dist/index.js gateway ...`, so argv[1] basename is
+    // `index.js`. Without this, the gateway service never eager-warms the
+    // context-window cache, leaving long-running synchronous lookups
+    // (allowAsyncLoad: false) to fall back to DEFAULT_CONTEXT_TOKENS until
+    // the first agent run completes — which then persists the wrong window
+    // onto the session record.
+    entryBasename === "index.js" ||
+    entryBasename === "index.mjs"
   );
 }
 
@@ -147,7 +156,13 @@ const SKIP_EAGER_WARMUP_PRIMARY_COMMANDS = new Set([
   "config",
   "directory",
   "doctor",
-  "gateway",
+  // NOTE: `gateway` is intentionally NOT in this set. The long-running gateway
+  // daemon launches with primary command `gateway`, and it needs the
+  // context-window cache warm so that synchronous lookups (allowAsyncLoad:
+  // false) on the status/session paths return real model windows instead of
+  // falling back to DEFAULT_CONTEXT_TOKENS. Short-lived `gateway status` /
+  // `gateway restart` CLI invocations also call into this set; the warmup is
+  // async and best-effort, so it does not block their exit.
   "health",
   "hooks",
   "logs",


### PR DESCRIPTION
## What

The long-running gateway daemon never warms the context-window cache, so synchronous lookups on the status path return `DEFAULT_CONTEXT_TOKENS = 200_000` until the first agent run completes. That value then gets persisted onto the session record and ratchets every subsequent model switch to the wrong context window.

## How to reproduce

1. Configure `agents.defaults.models["github-copilot/claude-opus-4.6-1m"] = { alias: "opus1m" }` (Copilot's `/models` advertises 1,000,000 input tokens for this id).
2. Restart the gateway daemon.
3. In a fresh session, run `📊 session_status` immediately. It reports `Context: …/200k` instead of `…/1000k`.
4. Switch to `claude-opus-4.6` (`/model opus`) - it also reports 200K, even though pi-ai's catalog has it at 1M.
5. Switch back to `claude-opus-4.6-1m` - still 200K.

The 200K comes from `lookupContextTokens(...) ?? DEFAULT_CONTEXT_TOKENS` in `getSessionDefaults` and the equivalent in `status-message.ts`. The persisted value is then read by subsequent status calls via `entry.contextTokens`, so the wrong window sticks until something explicitly clears or overwrites it.

## Root cause

The gateway daemon launches via systemd as:

```
ExecStart=/usr/bin/node /home/.../dist/index.js gateway --port 18789
```

Which means `argv[0]="node"`, `argv[1]="/home/.../dist/index.js"`, `argv[2]="gateway"`.

Two things conspire to disable eager cache warmup for the daemon:

1. `isLikelyOpenClawCliProcess` only matches `argv[1]` basenames `openclaw`, `openclaw.mjs`, `entry.js`, `entry.mjs`. The bundled `dist/index.js` entry is not recognised, so the function returns `false`.
2. `SKIP_EAGER_WARMUP_PRIMARY_COMMANDS` includes `"gateway"`. Even when the recognition above is fixed, the primary command `gateway` would still be skipped.

So `shouldEagerWarmContextWindowCache()` returns `false` for the daemon and the cache load is never kicked off at startup. Every `allowAsyncLoad: false` lookup returns `undefined` until the first agent run happens to warm the cache through some other path - by which point the 200K fallback has already been persisted onto the session record.

## Fix

- Recognise `index.js` / `index.mjs` as legitimate OpenClaw entry basenames in `isLikelyOpenClawCliProcess`.
- Drop `gateway` from `SKIP_EAGER_WARMUP_PRIMARY_COMMANDS`. The warmup is async and best-effort, so short-lived `openclaw gateway status` / `gateway restart` CLI invocations don't pay any blocking cost.

I left a comment block in the skip list explaining why `gateway` must not return - this is the kind of thing that's easy to add back without realising the daemon depends on it.

## Test plan

- New unit tests in `src/agents/context.test.ts` cover:
  - the gateway daemon argv shape (`node dist/index.js gateway --port ...`)
  - the CLI `gateway status` shape
  - help/version invocations (still skipped)
  - generic plugin-sdk-style imports from random Node scripts (still skipped, since `index.js` is too generic to match without an OpenClaw-specific path)
- Manually verified locally: after rebuilding and restarting the gateway, `📊 session_status` reports the correct context window for each Copilot Claude variant on a fresh session, and switching between models (`/model opus`, `/model opus1m`, `/model opus47`) updates the displayed window correctly instead of pinning at 200K.

## Notes

There's a separate, narrower issue in `applyDiscoveredContextWindows` where the cache stores bare model ids and uses min-of-all-providers. That can still under-report when the same bare id appears under both `anthropic` (200K) and `github-copilot` (1M) - but with the daemon warmup fixed, the qualified-then-bare lookup chain in `resolveContextTokensForModel` finds the right value first for the cases I've seen. Happy to follow up with a per-provider key if maintainers want.
