### PR TITLE
fix(cron): backfill missing job ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: assign stable ids to hand-authored jobs that omit both `id` and legacy `jobId`, preventing runtime state from being attributed to the wrong job. Fixes #72849. Thanks @the-Nile-jones.
 - Gateway/device tokens: stop echoing rotated bearer tokens from shared/admin `device.token.rotate` responses while preserving the same-device token handoff needed by token-only clients before reconnect. (#66773) Thanks @MoerAI.
 - Agents/subagents: enforce `subagents.allowAgents` for explicit same-agent `sessions_spawn(agentId=...)` calls instead of auto-allowing requester self-targets. Fixes #72827. Thanks @oiGaDio.
 - ACP/sessions_spawn: let explicit `sessions_spawn(runtime="acp")` bootstrap turns run while `acp.dispatch.enabled=false` still blocks automatic ACP thread dispatch. Fixes #63591. Thanks @moeedahmed.

--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -145,6 +145,8 @@ Retention and pruning are controlled in config:
 
 <Note>
 If you have cron jobs from before the current delivery and store format, run `openclaw doctor --fix`. Doctor normalizes legacy cron fields (`jobId`, `schedule.cron`, top-level delivery fields including legacy `threadId`, payload `provider` delivery aliases) and migrates simple `notify: true` webhook fallback jobs to explicit webhook delivery when `cron.webhook` is configured.
+
+Hand-authored jobs that omit both `id` and legacy `jobId` are assigned stable ids the next time the Gateway loads the cron store. This keeps runtime state keyed per job instead of allowing multiple id-less rows to share one state slot.
 </Note>
 
 ## Common edits

--- a/src/cron/service/store.test.ts
+++ b/src/cron/service/store.test.ts
@@ -152,6 +152,80 @@ describe("cron service store seam coverage", () => {
     expect(raw.jobs[0]?.id).toBeUndefined();
   });
 
+  it("generates and persists unique ids for hand-authored jobs missing ids", async () => {
+    const { storePath } = await makeStorePath();
+    const firstNextRunAtMs = STORE_TEST_NOW - 30_000;
+    const secondNextRunAtMs = STORE_TEST_NOW - 15_000;
+
+    await fs.mkdir(path.dirname(storePath), { recursive: true });
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          version: 1,
+          jobs: [
+            {
+              name: "missing id one",
+              enabled: true,
+              createdAtMs: STORE_TEST_NOW - 60_000,
+              updatedAtMs: STORE_TEST_NOW - 60_000,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "one" },
+              state: { nextRunAtMs: firstNextRunAtMs },
+            },
+            {
+              name: "missing id two",
+              enabled: true,
+              createdAtMs: STORE_TEST_NOW - 45_000,
+              updatedAtMs: STORE_TEST_NOW - 45_000,
+              schedule: { kind: "every", everyMs: 60_000 },
+              sessionTarget: "main",
+              wakeMode: "now",
+              payload: { kind: "systemEvent", text: "two" },
+              state: { nextRunAtMs: secondNextRunAtMs },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const state = createStoreTestState(storePath);
+
+    await ensureLoaded(state, { skipRecompute: true });
+
+    const loadedIds = state.store?.jobs.map((job) => job.id) ?? [];
+    expect(loadedIds).toHaveLength(2);
+    expect(new Set(loadedIds).size).toBe(2);
+    expect(loadedIds.every((id) => typeof id === "string" && id.length > 0)).toBe(true);
+    expect(state.store?.jobs[0]?.state.nextRunAtMs).toBe(firstNextRunAtMs);
+    expect(state.store?.jobs[1]?.state.nextRunAtMs).toBe(secondNextRunAtMs);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ storePath, jobId: loadedIds[0], jobName: "missing id one" }),
+      expect.stringContaining("missing id"),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ storePath, jobId: loadedIds[1], jobName: "missing id two" }),
+      expect.stringContaining("missing id"),
+    );
+
+    const persistedConfig = JSON.parse(await fs.readFile(storePath, "utf8")) as {
+      jobs: Array<{ id?: string; state?: unknown }>;
+    };
+    expect(persistedConfig.jobs.map((job) => job.id)).toEqual(loadedIds);
+    expect(persistedConfig.jobs.map((job) => job.state)).toEqual([{}, {}]);
+
+    const persistedState = JSON.parse(
+      await fs.readFile(storePath.replace(/\.json$/, "-state.json"), "utf8"),
+    ) as { jobs: Record<string, { state?: { nextRunAtMs?: number } }> };
+    expect(persistedState.jobs[loadedIds[0]]?.state?.nextRunAtMs).toBe(firstNextRunAtMs);
+    expect(persistedState.jobs[loadedIds[1]]?.state?.nextRunAtMs).toBe(secondNextRunAtMs);
+  });
+
   it("preserves disabled jobs when persisted booleans roundtrip through string values", async () => {
     const { storePath } = await makeStorePath();
 

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import { normalizeCronJobIdentityFields } from "../normalize-job-identity.js";
 import { normalizeCronJobInput } from "../normalize.js";
@@ -53,9 +54,16 @@ export async function ensureLoaded(
   const fileMtimeMs = await getFileMtimeMs(state.deps.storePath);
   const loaded = await loadCronStore(state.deps.storePath);
   const jobs = (loaded.jobs ?? []) as unknown as CronJob[];
+  let canonicalShapeChanged = false;
   for (const [index, job] of jobs.entries()) {
     const raw = job as unknown as Record<string, unknown>;
     const { legacyJobIdIssue } = normalizeCronJobIdentityFields(raw);
+    let generatedMissingId = false;
+    if (typeof raw.id !== "string" || raw.id.trim().length === 0) {
+      raw.id = randomUUID();
+      generatedMissingId = true;
+      canonicalShapeChanged = true;
+    }
     let normalized: Record<string, unknown> | null;
     try {
       normalized = normalizeCronJobInput(raw);
@@ -77,6 +85,16 @@ export async function ensureLoaded(
       state.deps.log.warn(
         { storePath: state.deps.storePath, jobId: resolvedId },
         "cron: job used legacy jobId field; normalized id in memory (run openclaw doctor --fix to persist canonical shape)",
+      );
+    }
+    if (generatedMissingId) {
+      state.deps.log.warn(
+        {
+          storePath: state.deps.storePath,
+          jobId: hydrated.id,
+          jobName: typeof hydrated.name === "string" ? hydrated.name : undefined,
+        },
+        "cron: job missing id; generated a stable id and will persist canonical shape",
       );
     }
     // Persisted legacy jobs may predate the required `enabled` field.
@@ -132,6 +150,10 @@ export async function ensureLoaded(
 
   if (!opts?.skipRecompute) {
     recomputeNextRuns(state);
+  }
+
+  if (canonicalShapeChanged) {
+    await persist(state);
   }
 }
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -648,6 +648,13 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   if (!store) {
     return;
   }
+  if (typeof result.jobId !== "string" || result.jobId.trim().length === 0) {
+    state.deps.log.error(
+      { jobId: result.jobId },
+      "cron: refusing to apply run outcome without a valid job id",
+    );
+    return;
+  }
   const jobs = store.jobs;
   const job = jobs.find((entry) => entry.id === result.jobId);
   if (!job) {


### PR DESCRIPTION
## Summary
- generate and persist stable IDs for hand-authored cron jobs missing both `id` and legacy `jobId`
- guard cron outcome application from invalid job IDs so runtime state cannot match an id-less row
- document the auto-backfill behavior and add a changelog entry

Fixes #72849.

## Tests
- `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- test src/cron/service/store.test.ts src/cron/service/timer.test.ts src/cron/service/timer.regression.test.ts`
- `CI=true OPENCLAW_LOCAL_CHECK=0 npm exec pnpm@10.33.0 -- run check:changed`