### PR TITLE
fix(cron): backfill missing job ids at load time to prevent find-collision (#72849)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- Cron: backfill a UUID for legacy jobs missing `id` at load time so `applyOutcomeToStoredJob`'s `jobs.find(entry => entry.id === result.jobId)` cannot collapse every job's runtime state into the first entry on `undefined === undefined`. Adds a defensive guard that refuses to apply outcomes with missing jobId. Fixes #72849.
+
 ## 2026.4.26
 
 ### Changes

--- a/src/cron/normalize-job-identity.test.ts
+++ b/src/cron/normalize-job-identity.test.ts
@@ -50,4 +50,34 @@ describe("normalizeCronJobIdentityFields", () => {
     expect(raw.id).toBe("x");
     expect(raw.jobId).toBeUndefined();
   });
+
+  it("backfills a UUID when neither id nor legacy jobId is present (#72849)", () => {
+    const raw: Record<string, unknown> = { name: "n" };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.mutated).toBe(true);
+    expect(r.legacyJobIdIssue).toBe(false);
+    expect(r.backfilledMissingId).toBe(true);
+    expect(typeof raw.id).toBe("string");
+    expect((raw.id as string).length).toBeGreaterThan(0);
+    // Two backfills must produce distinct UUIDs so identity-based finds
+    // cannot collide on a fresh load.
+    const second: Record<string, unknown> = { name: "n2" };
+    normalizeCronJobIdentityFields(second);
+    expect(second.id).not.toBe(raw.id);
+  });
+
+  it("backfills a UUID when id is an empty string (#72849)", () => {
+    const raw: Record<string, unknown> = { id: "   ", name: "n" };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.backfilledMissingId).toBe(true);
+    expect(typeof raw.id).toBe("string");
+    expect((raw.id as string).trim()).not.toBe("");
+  });
+
+  it("does not backfill when id is already set", () => {
+    const raw: Record<string, unknown> = { id: "stable-id", name: "n" };
+    const r = normalizeCronJobIdentityFields(raw);
+    expect(r.backfilledMissingId).toBe(false);
+    expect(raw.id).toBe("stable-id");
+  });
 });

--- a/src/cron/normalize-job-identity.ts
+++ b/src/cron/normalize-job-identity.ts
@@ -1,14 +1,25 @@
+import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 
 export function normalizeCronJobIdentityFields(raw: Record<string, unknown>): {
   mutated: boolean;
   legacyJobIdIssue: boolean;
+  backfilledMissingId: boolean;
 } {
   const rawId = normalizeOptionalString(raw.id) ?? "";
   const legacyJobId = normalizeOptionalString(raw.jobId) ?? "";
   const hadJobIdKey = "jobId" in raw;
-  const normalizedId = rawId || legacyJobId;
-  const idChanged = Boolean(normalizedId && raw.id !== normalizedId);
+  let normalizedId = rawId || legacyJobId;
+  // When neither `id` nor legacy `jobId` is present, synthesize a UUID so
+  // downstream `jobs.find((entry) => entry.id === result.jobId)` cannot
+  // collide on `undefined === undefined` and write every job's runtime
+  // outcome into the first entry's slot. (#72849)
+  let backfilledMissingId = false;
+  if (!normalizedId) {
+    normalizedId = randomUUID();
+    backfilledMissingId = true;
+  }
+  const idChanged = raw.id !== normalizedId;
 
   if (idChanged) {
     raw.id = normalizedId;
@@ -16,5 +27,9 @@ export function normalizeCronJobIdentityFields(raw: Record<string, unknown>): {
   if (hadJobIdKey) {
     delete raw.jobId;
   }
-  return { mutated: idChanged || hadJobIdKey, legacyJobIdIssue: hadJobIdKey };
+  return {
+    mutated: idChanged || hadJobIdKey,
+    legacyJobIdIssue: hadJobIdKey,
+    backfilledMissingId,
+  };
 }

--- a/src/cron/service/store.ts
+++ b/src/cron/service/store.ts
@@ -55,7 +55,17 @@ export async function ensureLoaded(
   const jobs = (loaded.jobs ?? []) as unknown as CronJob[];
   for (const [index, job] of jobs.entries()) {
     const raw = job as unknown as Record<string, unknown>;
-    const { legacyJobIdIssue } = normalizeCronJobIdentityFields(raw);
+    const { legacyJobIdIssue, backfilledMissingId } = normalizeCronJobIdentityFields(raw);
+    if (backfilledMissingId) {
+      state.deps.log.warn(
+        {
+          storePath: state.deps.storePath,
+          jobName: typeof raw.name === "string" ? raw.name : undefined,
+          newId: typeof raw.id === "string" ? raw.id : undefined,
+        },
+        "cron: backfilled missing id for job; prior runs may have collided on undefined id (#72849). Run openclaw doctor --fix to persist canonical shape.",
+      );
+    }
     let normalized: Record<string, unknown> | null;
     try {
       normalized = normalizeCronJobInput(raw);

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -648,6 +648,18 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
   if (!store) {
     return;
   }
+  // Defensive: when `result.jobId` is undefined/empty, `jobs.find` would
+  // match the first entry whose `entry.id` is also undefined and write
+  // every job's runtime outcome into that single slot (#72849). Refuse to
+  // apply an outcome with a missing id; the load-time backfill should have
+  // already prevented this, but guard remains as a belt-and-suspenders.
+  if (typeof result.jobId !== "string" || result.jobId.length === 0) {
+    state.deps.log.error(
+      { resultJobId: result.jobId },
+      "cron: refusing to apply outcome with missing jobId (#72849); result discarded",
+    );
+    return;
+  }
   const jobs = store.jobs;
   const job = jobs.find((entry) => entry.id === result.jobId);
   if (!job) {


### PR DESCRIPTION
Fixes #72849.

## Summary

When \`~/.openclaw/cron/jobs.json\` contains jobs missing the \`id\`
field, every job's runtime outcome (errors, \`lastRunAtMs\`,
\`nextRunAtMs\`, \`consecutiveErrors\`) gets written into the first
entry's slot. \`applyOutcomeToStoredJob\` does
\`jobs.find(entry => entry.id === result.jobId)\` and when both sides
are \`undefined\` the find returns the first entry unconditionally.

The reporter (#72849) spent hours chasing what looked like a single
constantly-failing disabled job before realising the failures actually
came from a different job whose outcomes were collapsing into that
slot via \`undefined === undefined\`. The only visible tell was a
\`[cron:undefined]\` log line.

## Fix

Three layers:

1. **\`normalize-job-identity.ts\`** — when neither \`id\` nor legacy
   \`jobId\` is present, generate a fresh \`randomUUID()\` and signal
   it back via a new \`backfilledMissingId: boolean\` field on the
   return value.
2. **\`service/store.ts:ensureLoaded\`** — log a warning whenever the
   loader backfills, prompting the operator to run
   \`openclaw doctor --fix\` to persist the canonical shape.
3. **\`service/timer.ts:applyOutcomeToStoredJob\`** — defensive guard
   refuses to apply outcomes with missing \`result.jobId\` instead of
   letting \`find\` silently match the first job. Belt-and-suspenders
   with the load-time backfill.

## Tests

- 4 existing \`normalize-job-identity\` tests still pass.
- 3 new regression tests cover:
  - Backfill produces distinct UUIDs across calls (so identity-based
    finds cannot collide on a fresh load).
  - Empty / whitespace \`id\` triggers backfill.
  - Pre-existing \`id\` is preserved (no churn).

\`\`\`
Test Files  84 passed (84)
     Tests  734 passed (734)
\`\`\`

Full cron suite green.