### PR TITLE
fix(slack): load thread history when prior session is stale

### DIFF
--- a/extensions/slack/src/monitor/config.runtime.ts
+++ b/extensions/slack/src/monitor/config.runtime.ts
@@ -1,9 +1,14 @@
 export { getRuntimeConfig } from "openclaw/plugin-sdk/runtime-config-snapshot";
 export { isDangerousNameMatchingEnabled } from "openclaw/plugin-sdk/dangerous-name-runtime";
 export {
+  evaluateSessionFreshness,
+  loadSessionStore,
   readSessionUpdatedAt,
   recordSessionMetaFromInbound,
+  resolveChannelResetConfig,
   resolveSessionKey,
+  resolveSessionResetPolicy,
+  resolveSessionStoreEntry,
   resolveStorePath,
   updateLastRoute,
 } from "openclaw/plugin-sdk/session-store-runtime";

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.test.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
 import type { App } from "@slack/bolt";
 import { resolveEnvelopeFormatOptions } from "openclaw/plugin-sdk/channel-inbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { clearSessionStoreCacheForTest } from "openclaw/plugin-sdk/session-store-runtime";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SlackMessageEvent } from "../../types.js";
 import { resolveSlackThreadContextData } from "./prepare-thread-context.js";
 import {
@@ -9,6 +11,33 @@ import {
   createSlackSessionStoreFixture,
   createSlackTestAccount,
 } from "./prepare.test-helpers.js";
+
+function seedThreadSessionTimestamp(
+  storePath: string,
+  sessionKey: string,
+  updatedAt: number,
+): void {
+  seedThreadSessionEntry(storePath, sessionKey, { updatedAt });
+}
+
+function seedThreadSessionEntry(
+  storePath: string,
+  sessionKey: string,
+  fields: { updatedAt: number; sessionStartedAt?: number; lastInteractionAt?: number },
+): void {
+  const normalized = sessionKey.trim().toLowerCase();
+  const entry: Record<string, unknown> = {
+    sessionId: normalized,
+    updatedAt: fields.updatedAt,
+  };
+  if (fields.sessionStartedAt !== undefined) {
+    entry.sessionStartedAt = fields.sessionStartedAt;
+  }
+  if (fields.lastInteractionAt !== undefined) {
+    entry.lastInteractionAt = fields.lastInteractionAt;
+  }
+  fs.writeFileSync(storePath, JSON.stringify({ [normalized]: entry }, null, 2));
+}
 
 describe("resolveSlackThreadContextData", () => {
   const storeFixture = createSlackSessionStoreFixture("openclaw-slack-thread-context-");
@@ -198,5 +227,169 @@ describe("resolveSlackThreadContextData", () => {
     expect(result.threadStarterBody).toBeUndefined();
     expect(result.threadHistoryBody).toContain("allowed follow-up");
     expect(result.threadHistoryBody).not.toContain("self starter");
+  });
+
+  describe("session-freshness gate (#33507)", () => {
+    beforeEach(() => {
+      clearSessionStoreCacheForTest();
+    });
+
+    async function resolveThreadContextWithFreshnessGate(params: {
+      seedUpdatedAt?: number;
+      seedEntry?: { updatedAt: number; sessionStartedAt?: number; lastInteractionAt?: number };
+      now: number;
+      cfg: OpenClawConfig;
+    }) {
+      const { storePath } = storeFixture.makeTmpStorePath();
+      if (params.seedEntry) {
+        seedThreadSessionEntry(storePath, "thread-session", params.seedEntry);
+      } else if (params.seedUpdatedAt !== undefined) {
+        seedThreadSessionTimestamp(storePath, "thread-session", params.seedUpdatedAt);
+      }
+      const replies = vi.fn().mockResolvedValue({
+        messages: [
+          { text: "old message", user: "U1", ts: "100.000" },
+          { text: "current message", user: "U1", ts: "101.000" },
+        ],
+        response_metadata: { next_cursor: "" },
+      });
+      const ctx = createInboundSlackTestContext({
+        cfg: params.cfg,
+        appClient: { conversations: { replies } } as unknown as App["client"],
+        defaultRequireMention: false,
+        replyToMode: "all",
+      });
+      ctx.botUserId = "U_BOT";
+      ctx.botId = "B1";
+      ctx.resolveUserName = async (id: string) => ({ name: id === "U1" ? "Alice" : undefined });
+
+      const result = await resolveSlackThreadContextData({
+        ctx,
+        account: createSlackTestAccount({ thread: { initialHistoryLimit: 20 } }),
+        message: createThreadMessage(),
+        isThreadReply: true,
+        threadTs: "100.000",
+        threadStarter: null,
+        roomLabel: "#general",
+        storePath,
+        sessionKey: "thread-session",
+        allowFromLower: ["u1"],
+        allowNameMatching: false,
+        contextVisibilityMode: "allowlist",
+        envelopeOptions: resolveEnvelopeFormatOptions({} as OpenClawConfig),
+        effectiveDirectMedia: null,
+        cfg: params.cfg,
+        now: params.now,
+      });
+
+      return { replies, result };
+    }
+
+    it("loads thread history when no prior session timestamp exists (truly new session)", async () => {
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        // no seed → readSessionUpdatedAt returns undefined
+        now: Date.UTC(2026, 3, 27, 12),
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).toHaveBeenCalledTimes(1);
+      expect(result.threadHistoryBody).toBeDefined();
+    });
+
+    it("loads thread history when prior session is stale by idle timeout (#33507)", async () => {
+      const now = Date.UTC(2026, 3, 27, 12);
+      const updatedAt = now - 10 * 60_000; // 10 minutes ago
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        seedUpdatedAt: updatedAt,
+        now,
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+          session: { reset: { mode: "idle", idleMinutes: 1 } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).toHaveBeenCalledTimes(1);
+      expect(result.threadHistoryBody).toBeDefined();
+      expect(result.threadSessionPreviousTimestamp).toBe(updatedAt);
+    });
+
+    it("loads thread history when prior session is stale by daily reset (#33507)", async () => {
+      const now = Date.UTC(2026, 3, 27, 12); // 12:00 UTC
+      const updatedAt = Date.UTC(2026, 3, 26, 12); // 24h before, prior to today's 04:00 reset
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        seedUpdatedAt: updatedAt,
+        now,
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+          session: { reset: { mode: "daily", atHour: 4 } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).toHaveBeenCalledTimes(1);
+      expect(result.threadHistoryBody).toBeDefined();
+    });
+
+    it("skips thread history when prior session is fresh within the idle window", async () => {
+      const now = Date.UTC(2026, 3, 27, 12);
+      const updatedAt = now - 30_000; // 30 seconds ago
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        seedUpdatedAt: updatedAt,
+        now,
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+          session: { reset: { mode: "idle", idleMinutes: 5 } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).not.toHaveBeenCalled();
+      expect(result.threadHistoryBody).toBeUndefined();
+      expect(result.threadSessionPreviousTimestamp).toBe(updatedAt);
+    });
+
+    it("loads thread history when sessionStartedAt is past daily-reset boundary even if updatedAt is fresh", async () => {
+      // Session was started >24h ago and crossed today's 04:00 reset, but
+      // updatedAt is recent (within minutes). evaluateSessionFreshness must
+      // see sessionStartedAt to detect the daily reset; updatedAt-only would
+      // miss it and skip thread history while initSessionState resets the
+      // transcript.
+      const now = Date.UTC(2026, 3, 27, 12);
+      const sessionStartedAt = Date.UTC(2026, 3, 26, 12); // 24h before, prior to today's 04:00 reset
+      const updatedAt = now - 30_000; // 30 seconds ago — looks fresh on updatedAt alone
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        seedEntry: { updatedAt, sessionStartedAt },
+        now,
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+          session: { reset: { mode: "daily", atHour: 4 } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).toHaveBeenCalledTimes(1);
+      expect(result.threadHistoryBody).toBeDefined();
+      expect(result.threadSessionPreviousTimestamp).toBe(updatedAt);
+    });
+
+    it("loads thread history when lastInteractionAt is past idle boundary even if updatedAt is fresh", async () => {
+      // lastInteractionAt is past the idle-reset window but updatedAt was
+      // touched recently by metadata writes. The freshness check must see
+      // lastInteractionAt to trigger the idle reset.
+      const now = Date.UTC(2026, 3, 27, 12);
+      const lastInteractionAt = now - 10 * 60_000; // 10 minutes ago
+      const updatedAt = now - 30_000; // 30 seconds ago — looks fresh on updatedAt alone
+      const { replies, result } = await resolveThreadContextWithFreshnessGate({
+        seedEntry: { updatedAt, lastInteractionAt },
+        now,
+        cfg: {
+          channels: { slack: { enabled: true, replyToMode: "all", groupPolicy: "open" } },
+          session: { reset: { mode: "idle", idleMinutes: 1 } },
+        } as OpenClawConfig,
+      });
+
+      expect(replies).toHaveBeenCalledTimes(1);
+      expect(result.threadHistoryBody).toBeDefined();
+      expect(result.threadSessionPreviousTimestamp).toBe(updatedAt);
+    });
   });
 });

--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context.ts
@@ -1,5 +1,5 @@
 import { formatInboundEnvelope } from "openclaw/plugin-sdk/channel-inbound";
-import type { ContextVisibilityMode } from "openclaw/plugin-sdk/config-types";
+import type { ContextVisibilityMode, OpenClawConfig } from "openclaw/plugin-sdk/config-types";
 import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import {
   filterSupplementalContextItems,
@@ -8,7 +8,13 @@ import {
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import type { SlackMessageEvent } from "../../types.js";
 import { resolveSlackAllowListMatch } from "../allow-list.js";
-import { readSessionUpdatedAt } from "../config.runtime.js";
+import {
+  evaluateSessionFreshness,
+  loadSessionStore,
+  resolveChannelResetConfig,
+  resolveSessionResetPolicy,
+  resolveSessionStoreEntry,
+} from "../config.runtime.js";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackMediaResult } from "../media-types.js";
 import { resolveSlackThreadHistory, type SlackThreadStarter } from "../thread.js";
@@ -67,6 +73,8 @@ export async function resolveSlackThreadContextData(params: {
     typeof import("openclaw/plugin-sdk/channel-inbound").resolveEnvelopeFormatOptions
   >;
   effectiveDirectMedia: SlackMediaResult[] | null;
+  cfg?: OpenClawConfig;
+  now?: number;
 }): Promise<SlackThreadContextData> {
   const isCurrentBotAuthor = (author: { userId?: string; botId?: string }): boolean =>
     Boolean(
@@ -149,12 +157,40 @@ export async function resolveSlackThreadContextData(params: {
   }
 
   const threadInitialHistoryLimit = params.account.config?.thread?.initialHistoryLimit ?? 20;
-  threadSessionPreviousTimestamp = readSessionUpdatedAt({
-    storePath: params.storePath,
+  // Load the full session entry so the freshness check sees the same lifecycle
+  // timestamps initSessionState evaluates (sessionStartedAt for daily resets,
+  // lastInteractionAt for idle resets). An updatedAt-only check can disagree
+  // with the reset decision when updatedAt is recent but a lifecycle timestamp
+  // is past its boundary.
+  const sessionStore = loadSessionStore(params.storePath);
+  const { existing: sessionEntry } = resolveSessionStoreEntry({
+    store: sessionStore,
     sessionKey: params.sessionKey,
   });
+  threadSessionPreviousTimestamp = sessionEntry?.updatedAt;
 
-  if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
+  // A stale (past daily-reset / past idle window) session must be treated the
+  // same as no timestamp — the session was effectively reset, so the agent
+  // will see an empty transcript and needs thread history loaded again.
+  // Without this check, the bot replies blind on the first message after a reset (#33507).
+  const isEffectivelyNewSession =
+    !sessionEntry ||
+    !evaluateSessionFreshness({
+      updatedAt: sessionEntry.updatedAt,
+      sessionStartedAt: sessionEntry.sessionStartedAt,
+      lastInteractionAt: sessionEntry.lastInteractionAt,
+      now: params.now ?? Date.now(),
+      policy: resolveSessionResetPolicy({
+        sessionCfg: params.cfg?.session,
+        resetType: "thread",
+        resetOverride: resolveChannelResetConfig({
+          sessionCfg: params.cfg?.session,
+          channel: "slack",
+        }),
+      }),
+    }).fresh;
+
+  if (threadInitialHistoryLimit > 0 && isEffectivelyNewSession) {
     const threadHistory = await resolveSlackThreadHistory({
       channelId: params.message.channel,
       threadTs: params.threadTs,

--- a/extensions/slack/src/monitor/message-handler/prepare.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare.ts
@@ -689,6 +689,7 @@ export async function prepareSlackMessage(params: {
     contextVisibilityMode,
     envelopeOptions,
     effectiveDirectMedia,
+    cfg: ctx.cfg,
   });
 
   // Use direct media (including forwarded attachment media) if available, else thread starter media


### PR DESCRIPTION
## Summary

Fixes #33507. The thread-history fetch in `resolveSlackThreadContextData` is gated only on the absence of a prior session timestamp:

```ts
if (threadInitialHistoryLimit > 0 && !threadSessionPreviousTimestamp) {
```

After a daily or idle session reset, the prior timestamp is non-null but the session is effectively new — the agent's transcript is empty and needs the thread history. With the strict null check, the gate evaluates "existing session," skips history, and the agent replies blind on the first message in the thread after the reset.

## Reproduction (still on current `main`)

1. Configure a Slack channel with `session: { reset: { mode: "daily", atHour: 4 } }` (the default) or `{ mode: "idle", idleMinutes: 1 }`.
2. Have an active thread conversation; session `updatedAt` is written.
3. Wait until after the configured reset (idle window or 04:00 local time).
4. Post a new message in the same Slack thread.
5. The agent's first reply has no awareness of prior thread context — thread history fetch was skipped because the gate saw a non-null timestamp.

## Fix

Widen the gate to also load history when `evaluateSessionFreshness` reports the prior session is stale:

```ts
const isEffectivelyNewSession =
  !threadSessionPreviousTimestamp ||
  !evaluateSessionFreshness({
    updatedAt: threadSessionPreviousTimestamp,
    now: params.now ?? Date.now(),
    policy: resolveSessionResetPolicy({
      sessionCfg: params.cfg?.session,
      resetType: "thread",
      resetOverride: resolveChannelResetConfig({
        sessionCfg: params.cfg?.session,
        channel: "slack",
      }),
    }),
  }).fresh;

if (threadInitialHistoryLimit > 0 && isEffectivelyNewSession) {
```

Fresh sessions still skip the fetch, so the existing optimization (avoid redundant history fetch when transcript already covers it) is preserved.

## Scope

- Reuses the existing reset-policy machinery via `openclaw/plugin-sdk/session-store-runtime` — no new helpers, no store schema changes, no `skipCache` option.
- Adds two optional params to `resolveSlackThreadContextData` (`cfg`, `now`) to keep the function testable. The `prepare.ts` caller passes `ctx.cfg`.
- 4 files changed: `+165/-3` (most of which is regression tests).

## Tests

4 new cases in `prepare-thread-context.test.ts` covering:
- truly-new session (no timestamp) → loads history (existing behavior preserved)
- stale-by-idle (session past `idleMinutes` window) → loads history (the fix)
- stale-by-daily (session before today's `atHour` reset) → loads history (the fix)
- fresh-within-idle window → still skips history (existing optimization preserved)

Results:
- 9/9 tests in `prepare-thread-context.test.ts`
- 102/102 across `extensions/slack/src/monitor/message-handler/`

## Why a fresh PR

Prior fix attempt #33519 bundled this fix with a separate concern (#34389 implicit-mention timeout), introduced an exported helper, and added a `skipCache` option to `readSessionUpdatedAt`. That PR was closed by the openclaw-barnacle stale bot without merging. This PR is scoped narrowly to #33507 only — single concern, single subsystem, no schema changes.