### PR TITLE
fix(cli): allow slower completion cache refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,6 +317,10 @@ Docs: https://docs.openclaw.ai
 - TTS/BlueBubbles: pre-transcode synthesized MP3 audio to opus-in-CAF (mono, 24 kHz — validated against macOS 15.x Messages.app's native voice-memo CAF descriptor) on macOS hosts before handing the file to BlueBubbles, so iMessage renders the result as a native voice-memo bubble with proper duration and waveform UI instead of a plain file attachment. Adds an opt-in `tts.voice.preferAudioFileFormat` channel capability and a magic-byte sniff for the CAF container so the host-local-media validator (which uses `file-type` and didn't recognize CAF natively) can verify the pre-transcoded buffer. Channels that don't opt in are unaffected. (#72586) Fixes #72506. Thanks @omarshahine.
 - Feishu: retry WebSocket startup failures with monitor-owned backoff while preserving SDK-local heartbeat defaults, so persistent-connection startup failures no longer leave the monitor hung. Fixes #68766; related #42354 and #55532. Thanks @alex-xuweilong, @120106835, @sirfengyu, and @tianhaocui.
 
+### Fixes
+
+- CLI/update: allow completion cache refreshes during package update and doctor repair to run for up to two minutes, and print start/finish messages so slower machines show progress before returning to follow-up tasks. Thanks @aaronescobar09.
+
 ## 2026.4.26
 
 ### Changes

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -550,9 +550,12 @@ describe("update-cli", () => {
         env: expect.objectContaining({
           OPENCLAW_COMPLETION_SKIP_PLUGIN_COMMANDS: "1",
         }),
-        timeout: 30_000,
+        timeout: 120_000,
       }),
     );
+    const logs = vi.mocked(runtimeCapture.log).mock.calls.map((call) => String(call[0]));
+    expect(logs.some((line) => line.includes("Refreshing shell completion cache"))).toBe(true);
+    expect(logs.some((line) => line.includes("Completion cache refreshed in"))).toBe(true);
   });
 
   it("logs friendly hint with manual refresh command when completion cache write times out", async () => {
@@ -575,7 +578,7 @@ describe("update-cli", () => {
     await updateCliShared.tryWriteCompletionCache(root, false);
 
     const logs = vi.mocked(runtimeCapture.log).mock.calls.map((call) => String(call[0]));
-    expect(logs.some((line) => line.includes("timed out after 30s"))).toBe(true);
+    expect(logs.some((line) => line.includes("timed out after 120s"))).toBe(true);
     expect(logs.some((line) => line.includes("openclaw completion --write-state"))).toBe(true);
     expect(logs.some((line) => line.includes("Error: spawnSync"))).toBe(false);
   });

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { formatDurationPrecise } from "../../infra/format-time/format-duration.ts";
 import { resolveOpenClawPackageRoot } from "../../infra/openclaw-root.js";
 import { readPackageName, readPackageVersion } from "../../infra/package-json.js";
 import { normalizePackageTagInput } from "../../infra/package-tag.js";
@@ -259,7 +260,7 @@ export async function resolveGlobalManager(params: {
   return byPresence ?? "npm";
 }
 
-const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 30_000;
+const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 120_000;
 const COMPLETION_CACHE_MANUAL_REFRESH_HINT =
   "Shell tab-completion may be stale; refresh manually with: openclaw completion --write-state";
 
@@ -269,6 +270,10 @@ export async function tryWriteCompletionCache(root: string, jsonMode: boolean): 
     return;
   }
 
+  if (!jsonMode) {
+    defaultRuntime.log(theme.muted("Refreshing shell completion cache..."));
+  }
+  const startedAt = Date.now();
   const result = spawnSync(resolveNodeRunner(), [binPath, "completion", "--write-state"], {
     cwd: root,
     env: {
@@ -278,6 +283,7 @@ export async function tryWriteCompletionCache(root: string, jsonMode: boolean): 
     encoding: "utf-8",
     timeout: COMPLETION_CACHE_WRITE_TIMEOUT_MS,
   });
+  const durationMs = Date.now() - startedAt;
 
   if (result.error) {
     if (!jsonMode) {
@@ -302,6 +308,12 @@ export async function tryWriteCompletionCache(root: string, jsonMode: boolean): 
       theme.warn(
         `Completion cache update failed${detail}. ${COMPLETION_CACHE_MANUAL_REFRESH_HINT}`,
       ),
+    );
+  }
+
+  if (result.status === 0 && !jsonMode) {
+    defaultRuntime.log(
+      theme.success(`Completion cache refreshed in ${formatDurationPrecise(durationMs)}.`),
     );
   }
 }

--- a/src/commands/doctor-completion.test.ts
+++ b/src/commands/doctor-completion.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  completionCacheExists: vi.fn(async () => false),
+  resolveOpenClawPackageRoot: vi.fn(async () => "/tmp/openclaw"),
+  resolveShellFromEnv: vi.fn(() => "zsh"),
+  spawnSync: vi.fn(() => ({
+    pid: 0,
+    output: [],
+    stdout: "",
+    stderr: "",
+    status: 0,
+    signal: null,
+  })),
+}));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return {
+    ...actual,
+    spawnSync: mocks.spawnSync,
+  };
+});
+
+vi.mock("../infra/openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: mocks.resolveOpenClawPackageRoot,
+}));
+
+vi.mock("../cli/completion-runtime.js", () => ({
+  completionCacheExists: mocks.completionCacheExists,
+  installCompletion: vi.fn(),
+  isCompletionInstalled: vi.fn(),
+  resolveCompletionCachePath: vi.fn(() => "/tmp/openclaw-completion.zsh"),
+  resolveShellFromEnv: mocks.resolveShellFromEnv,
+  usesSlowDynamicCompletion: vi.fn(),
+}));
+
+vi.mock("../terminal/note.js", () => ({
+  note: vi.fn(),
+}));
+
+const { ensureCompletionCacheExists } = await import("./doctor-completion.js");
+
+describe("doctor completion cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.completionCacheExists.mockResolvedValue(false);
+    mocks.resolveOpenClawPackageRoot.mockResolvedValue("/tmp/openclaw");
+    mocks.resolveShellFromEnv.mockReturnValue("zsh");
+    mocks.spawnSync.mockReturnValue({
+      pid: 0,
+      output: [],
+      stdout: "",
+      stderr: "",
+      status: 0,
+      signal: null,
+    });
+  });
+
+  it("allows slower completion cache generation during doctor repair", async () => {
+    await expect(ensureCompletionCacheExists("openclaw")).resolves.toBe(true);
+
+    expect(mocks.spawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      [path.join("/tmp/openclaw", "openclaw.mjs"), "completion", "--write-state"],
+      expect.objectContaining({
+        timeout: 120_000,
+      }),
+    );
+  });
+});

--- a/src/commands/doctor-completion.ts
+++ b/src/commands/doctor-completion.ts
@@ -16,7 +16,7 @@ import type { DoctorPrompter } from "./doctor-prompter.js";
 
 type CompletionShell = "zsh" | "bash" | "fish" | "powershell";
 
-const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 30_000;
+const COMPLETION_CACHE_WRITE_TIMEOUT_MS = 120_000;
 
 /** Generate the completion cache by spawning the CLI. */
 async function generateCompletionCache(): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Increase the completion cache refresh timeout used by package update and doctor repair from 30 seconds to 120 seconds.
- Print a start line and success duration for non-JSON update follow-up output so slower cache rebuilds show progress.
- Add regression coverage for the update and doctor completion-cache refresh paths.

## Root Cause

- On slower installs, `openclaw completion --write-state` can exceed 30 seconds even when it succeeds, so update follow-up treats a healthy cache rebuild as `spawnSync ... ETIMEDOUT`.
- The cache refresh is intended to be post-update follow-up work, but the raw timeout makes the update look broken and can leave operators unsure whether the gateway/startup path recovered cleanly.

## Evidence

- Issue #72842 reports the same failure after `openclaw update` on 2026.4.25: `Completion cache update failed: Error: spawnSync /usr/bin/node ETIMEDOUT`.
- PR #72850 improved the user-facing timeout message for #72842, but intentionally left the 30-second timeout and underlying slow-cache behavior out of scope.
- This PR is the follow-up for that remaining behavior: give the completion cache refresh longer to finish, and show progress while it is running.
- Local reproduction that motivated this PR: after updating to 2026.4.25 on macOS/Homebrew Node, update finished plugin work and then printed `Completion cache update failed: Error: spawnSync /opt/homebrew/Cellar/node@22/22.22.1_3/bin/node ETIMEDOUT`. In that local upgrade, the gateway did not appear to recover/start cleanly afterward, so the timeout was the visible post-update failure operators had to debug.
- Follow-up check against released 2026.4.26 on the same macOS/Homebrew Node install:
  - Installed release still contains `COMPLETION_CACHE_WRITE_TIMEOUT_MS = 30000` in both update and doctor completion paths.
  - Running the cache refresh directly with `OPENCLAW_COMPLETION_SKIP_PLUGIN_COMMANDS=1` completed successfully but took `36.28s` (`real 36.28`, `user 13.15`, `sys 24.34`).
  - Running the same command through `spawnSync(..., timeout: 30000)` reproduced the failure: `errorCode: "ETIMEDOUT"`, `errorMessage: "spawnSync /opt/homebrew/Cellar/node@22/22.22.1_3/bin/node ETIMEDOUT"`, duration `37518ms`.
  - A real `openclaw update --yes` from 2026.4.25 to 2026.4.26 also spent a long quiet period after `No plugin updates needed`; afterward the service restart readiness check failed before the gateway finished becoming ready. The gateway eventually reported `rpc.ok: true`, so this does not prove every gateway readiness issue is caused by completion cache, but it does confirm the shipped 30s completion-cache timeout is too short on this machine.

## Scope Boundary

- This does not claim to fix every possible gateway startup failure after update.
- It specifically prevents the completion-cache child process from being killed at 30 seconds in environments where cache generation is merely slow, and makes that slow step visible.
- The manual-refresh hint and friendlier ETIMEDOUT wording from #72850 are preserved.

## Validation

- `pnpm test src/cli/update-cli.test.ts src/commands/doctor-completion.test.ts`
- `pnpm check:changed -- --base upstream/main`
- Manual 2026.4.26 repro on macOS/Homebrew Node: direct completion cache refresh takes `36.28s`; `spawnSync` with the shipped `30000` ms timeout returns `ETIMEDOUT`.

## Related

- Related to #72842.
- Follow-up to #72850.
