### PR TITLE
fix(memory_search): surface session-transcript hits with corpus=sessions, not corpus=memory (#72885)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/memory_search: surface session-transcript hits with `corpus: "sessions"` instead of flattening them to `corpus: "memory"`, so downstream consumers can distinguish durable memory-file hits from session-backed hits. The hit's underlying `source` now drives the surfaced `corpus` (`source: "sessions"` → `corpus: "sessions"`; otherwise `corpus: "memory"`). Fixes #72885.
 - Gateway/device tokens: stop echoing rotated bearer tokens from shared/admin `device.token.rotate` responses while preserving the same-device token handoff needed by token-only clients before reconnect. (#66773) Thanks @MoerAI.
 - Control UI/Talk: keep Google Live browser sessions on the WebSocket transport instead of falling back to WebRTC, validate browser Google Live WebSocket endpoints, cap Gateway relay sessions per browser connection, and remove stale browser-native voice buttons that did not use the configured Talk/TTS provider. Thanks @BunsDev.
 - Gateway/startup: reuse config snapshot plugin manifests for startup auto-enable before plugin bootstrap plans plugin loading. Thanks @shakkernerd.

--- a/extensions/memory-core/src/tools.test.ts
+++ b/extensions/memory-core/src/tools.test.ts
@@ -1,10 +1,18 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getMemorySearchManagerMockConfigs,
   resetMemoryToolMockState,
   setMemoryBackend,
   setMemorySearchImpl,
 } from "./memory-tool-manager-mock.js";
+
+// Bypass session visibility filtering so corpus-surfacing tests can exercise
+// the source -> corpus mapping even without a real session guard. Visibility
+// is covered separately by session-search-visibility tests. (#72885)
+vi.mock("./session-search-visibility.js", () => ({
+  filterMemorySearchHitsBySessionVisibility: async (params: { hits: unknown }) => params.hits,
+}));
+
 import { createMemorySearchTool } from "./tools.js";
 import {
   asOpenClawConfig,
@@ -149,5 +157,80 @@ describe("memory_search unavailable payloads", () => {
     await tool.execute("patched-config", { query: "provider switch" });
 
     expect(getMemorySearchManagerMockConfigs()).toEqual([patchedConfig]);
+  });
+});
+
+describe("memory_search corpus surfacing (#72885)", () => {
+  beforeEach(() => {
+    resetMemoryToolMockState({ searchImpl: async () => [] });
+  });
+
+  it("surfaces session-transcript hits with corpus=sessions, not corpus=memory", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "agents/main/sessions/abc-123.jsonl",
+        startLine: 1,
+        endLine: 4,
+        score: 0.91,
+        snippet: "transcript hit",
+        source: "sessions" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("call_session_corpus", { query: "transcript" });
+    const details = result.details as { results: Array<{ corpus: string; source: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.source).toBe("sessions");
+    expect(details.results[0]?.corpus).toBe("sessions");
+  });
+
+  it("surfaces durable memory-file hits with corpus=memory", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 4,
+        score: 0.95,
+        snippet: "memory hit",
+        source: "memory" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("call_memory_corpus", { query: "memory" });
+    const details = result.details as { results: Array<{ corpus: string; source: string }> };
+    expect(details.results).toHaveLength(1);
+    expect(details.results[0]?.source).toBe("memory");
+    expect(details.results[0]?.corpus).toBe("memory");
+  });
+
+  it("preserves source/corpus alignment across mixed-source result sets", async () => {
+    setMemorySearchImpl(async () => [
+      {
+        path: "MEMORY.md",
+        startLine: 1,
+        endLine: 2,
+        score: 0.95,
+        snippet: "memory",
+        source: "memory" as const,
+      },
+      {
+        path: "agents/main/sessions/abc-123.jsonl",
+        startLine: 1,
+        endLine: 2,
+        score: 0.92,
+        snippet: "transcript",
+        source: "sessions" as const,
+      },
+    ]);
+
+    const tool = createMemorySearchToolOrThrow();
+    const result = await tool.execute("call_mixed", { query: "anything" });
+    const details = result.details as { results: Array<{ corpus: string; source: string }> };
+    expect(details.results).toHaveLength(2);
+    for (const hit of details.results) {
+      expect(hit.corpus).toBe(hit.source);
+    }
   });
 });

--- a/extensions/memory-core/src/tools.ts
+++ b/extensions/memory-core/src/tools.ts
@@ -222,7 +222,11 @@ export function createMemorySearchTool(options: {
           const searchStartedAt = Date.now();
           let rawResults: MemorySearchResult[] = [];
           let surfacedMemoryResults: Array<
-            Record<string, unknown> & { corpus: "memory"; score: number; path: string }
+            Record<string, unknown> & {
+              corpus: "memory" | "sessions";
+              score: number;
+              path: string;
+            }
           > = [];
           let provider: string | undefined;
           let model: string | undefined;
@@ -278,9 +282,13 @@ export function createMemorySearchTool(options: {
               status.backend === "qmd"
                 ? clampResultsByInjectedChars(decorated, resolved.qmd?.limits.maxInjectedChars)
                 : decorated;
+            // Carry the underlying hit `source` through as the surfaced
+            // `corpus`. Hardcoding `"memory"` here flattened session
+            // transcript hits and made provenance indistinguishable from
+            // durable memory-file hits in the tool response (#72885).
             surfacedMemoryResults = memoryResults.map((result) => ({
               ...result,
-              corpus: "memory" as const,
+              corpus: result.source === "sessions" ? ("sessions" as const) : ("memory" as const),
             }));
             const sleepTimezone = resolveMemoryDeepDreamingConfig({
               pluginConfig: resolveMemoryCorePluginConfig(cfg),


### PR DESCRIPTION
Fixes #72885.

## Summary

\`memory_search\` was hardcoding \`corpus: \"memory\" as const\` for
every surfaced hit, even when the underlying
\`MemorySearchResult.source\` was \`\"sessions\"\`. That flattened
provenance at the last step: downstream consumers couldn't distinguish
durable memory-file hits from session-transcript hits in the tool
response, even though the corpus selection contract
(\`memory\` / \`sessions\` / \`wiki\` / \`all\`) and the hit's
\`source\` field both already carry the distinction.

## Fix

Drive the surfaced \`corpus\` from the hit's \`source\`:

\`\`\`diff
-              corpus: \"memory\" as const,
+              corpus: result.source === \"sessions\" ? (\"sessions\" as const) : (\"memory\" as const),
\`\`\`

Widens the \`surfacedMemoryResults\` element type to
\`corpus: \"memory\" | \"sessions\"\` accordingly.

## Tests

4 existing memory_search tests still pass. Added 3 new regression
tests in \`tools.test.ts\` under \`describe(\"memory_search corpus
surfacing (#72885)\")\`:

- Session-source hits surface as \`corpus: \"sessions\"\`.
- Memory-source hits surface as \`corpus: \"memory\"\`.
- Mixed-source result sets keep \`corpus === source\` for every hit.

Visibility filtering is still enforced upstream by
\`filterMemorySearchHitsBySessionVisibility\`. The new tests mock that
helper to a no-op so the corpus-surfacing assertion isolates the bug;
visibility behavior itself is covered by
\`session-search-visibility.test.ts\`.

\`\`\`
Test Files  3 passed (tools.test.ts: 7, tools.citations.test.ts: 12, tools.recall-tracking.test.ts: 5)
     Tests  24 passed (24)
\`\`\`