### PR TITLE
fix(feishu): scope sequential queue by group session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: align group-message sequential queue keys with `groupSessionScope`, so separate topics or topic senders no longer block each other unnecessarily. (#72972) Thanks @AaronLuo00.
 - fix: block workspace CLOUDSDK_PYTHON override and always set trusted interpreter for gcloud. (#74492) Thanks @pgondhi987.
 - Providers/Z.AI: move the bundled GLM catalog and auth env metadata into the plugin manifest, so `models list --all --provider zai` shows the full known catalog without duplicated runtime seed data. Thanks @shakkernerd.
 - Providers/Qianfan and Providers/Stepfun: declare setup auth metadata (`api-key` method, `QIANFAN_API_KEY`, `STEPFUN_API_KEY`) in the plugin manifest so onboarding and `models setup` surface the expected env var without falling back to legacy `providerAuthEnvVars` runtime seed data. Thanks @shakkernerd.

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -28,7 +28,7 @@ import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
 import { createFeishuThreadBindingManager } from "./thread-bindings.js";
-import type { FeishuChatType, ResolvedFeishuAccount } from "./types.js";
+import type { FeishuChatType, FeishuConfig, ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
 
@@ -164,6 +164,7 @@ function normalizeFeishuChatType(value: unknown): FeishuChatType | undefined {
 type RegisterEventHandlersContext = {
   cfg: ClawdbotConfig;
   accountId: string;
+  feishuCfg?: FeishuConfig;
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
@@ -242,7 +243,7 @@ function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
-  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const { cfg, accountId, feishuCfg, runtime, chatHistories, fireAndForget } = context;
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const runFeishuHandler = async (params: { task: () => Promise<void>; errorMessage: string }) => {
@@ -274,7 +275,7 @@ function registerEventHandlers(
       recordProcessedMessage: recordProcessedFeishuMessage,
       getBotOpenId: (id) => botOpenIds.get(id),
       getBotName: (id) => botNames.get(id),
-      resolveSequentialKey: getFeishuSequentialKey,
+      resolveSequentialKey: (params) => getFeishuSequentialKey({ ...params, feishuCfg }),
     }),
     "im.message.message_read_v1": async () => {
       // Ignore read receipts
@@ -453,6 +454,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     registerEventHandlers(eventDispatcher, {
       cfg,
       accountId,
+      feishuCfg: account.config,
       runtime,
       chatHistories,
       fireAndForget: params.fireAndForget ?? true,

--- a/extensions/feishu/src/sequential-key.test.ts
+++ b/extensions/feishu/src/sequential-key.test.ts
@@ -1,30 +1,41 @@
 import { describe, expect, it } from "vitest";
 import type { FeishuMessageEvent } from "./bot.js";
 import { getFeishuSequentialKey } from "./sequential-key.js";
+import type { FeishuConfig } from "./types.js";
 
 function createTextEvent(params: {
   text: string;
   messageId?: string;
   chatId?: string;
+  chatType?: "p2p" | "group" | "topic_group";
+  rootId?: string;
+  threadId?: string;
+  senderOpenId?: string;
+  senderUserId?: string;
 }): FeishuMessageEvent {
   return {
     sender: {
       sender_id: {
-        open_id: "ou_sender_1",
-        user_id: "ou_user_1",
+        open_id: params.senderOpenId ?? "ou_sender_1",
+        user_id: params.senderUserId ?? "ou_user_1",
       },
       sender_type: "user",
     },
     message: {
       message_id: params.messageId ?? "om_message_1",
       chat_id: params.chatId ?? "oc_dm_chat",
-      chat_type: "p2p",
+      chat_type: params.chatType ?? "p2p",
       message_type: "text",
       content: JSON.stringify({ text: params.text }),
+      ...(params.rootId ? { root_id: params.rootId } : {}),
+      ...(params.threadId ? { thread_id: params.threadId } : {}),
     },
   } as FeishuMessageEvent;
 }
 
+function createFeishuConfig(params: Partial<FeishuConfig>): FeishuConfig {
+  return params as unknown as FeishuConfig;
+}
 describe("getFeishuSequentialKey", () => {
   it.each([
     [createTextEvent({ text: "hello" }), "feishu:default:oc_dm_chat"],
@@ -38,6 +49,139 @@ describe("getFeishuSequentialKey", () => {
         event,
       }),
     ).toBe(expected);
+  });
+
+  it("keeps group messages on the per-chat lane by default", () => {
+    const event = createTextEvent({
+      text: "hello",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+    });
+
+    expect(
+      getFeishuSequentialKey({
+        accountId: "default",
+        event,
+        feishuCfg: createFeishuConfig({}),
+      }),
+    ).toBe("feishu:default:oc_group");
+  });
+
+  it("scopes group_sender queues by sender", () => {
+    const feishuCfg = createFeishuConfig({ groupSessionScope: "group_sender" });
+    const first = createTextEvent({
+      text: "one",
+      chatId: "oc_group",
+      chatType: "group",
+      senderOpenId: "ou_sender_1",
+    });
+    const otherSender = createTextEvent({
+      text: "two",
+      chatId: "oc_group",
+      chatType: "group",
+      senderOpenId: "ou_sender_2",
+    });
+
+    expect(getFeishuSequentialKey({ accountId: "default", event: first, feishuCfg })).toBe(
+      "feishu:default:oc_group:sender:ou_sender_1",
+    );
+    expect(getFeishuSequentialKey({ accountId: "default", event: otherSender, feishuCfg })).toBe(
+      "feishu:default:oc_group:sender:ou_sender_2",
+    );
+  });
+
+  it("honors legacy topicSessionMode when resolving group queue lanes", () => {
+    const feishuCfg = createFeishuConfig({ topicSessionMode: "enabled" });
+    const event = createTextEvent({
+      text: "hello",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+    });
+
+    expect(getFeishuSequentialKey({ accountId: "default", event, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1",
+    );
+  });
+
+  it("scopes group_topic queues by thread topic", () => {
+    const feishuCfg = createFeishuConfig({ groupSessionScope: "group_topic" });
+    const first = createTextEvent({
+      text: "one",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+      messageId: "om_message_1",
+    });
+    const sameTopic = createTextEvent({
+      text: "two",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+      messageId: "om_message_2",
+    });
+    const otherTopic = createTextEvent({
+      text: "three",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_2",
+      messageId: "om_message_3",
+    });
+
+    expect(getFeishuSequentialKey({ accountId: "default", event: first, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1",
+    );
+    expect(getFeishuSequentialKey({ accountId: "default", event: sameTopic, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1",
+    );
+    expect(getFeishuSequentialKey({ accountId: "default", event: otherTopic, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_2",
+    );
+  });
+
+  it("scopes group_topic_sender queues by thread topic and sender", () => {
+    const feishuCfg = createFeishuConfig({ groupSessionScope: "group_topic_sender" });
+    const first = createTextEvent({
+      text: "one",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+      senderOpenId: "ou_sender_1",
+    });
+    const otherSender = createTextEvent({
+      text: "two",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+      senderOpenId: "ou_sender_2",
+    });
+
+    expect(getFeishuSequentialKey({ accountId: "default", event: first, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1:sender:ou_sender_1",
+    );
+    expect(getFeishuSequentialKey({ accountId: "default", event: otherSender, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1:sender:ou_sender_2",
+    );
+  });
+
+  it("honors per-group session scope overrides", () => {
+    const feishuCfg = createFeishuConfig({
+      groupSessionScope: "group",
+      groups: {
+        oc_group: { groupSessionScope: "group_topic" },
+      },
+    });
+    const event = createTextEvent({
+      text: "hello",
+      chatId: "oc_group",
+      chatType: "group",
+      rootId: "om_root_1",
+    });
+
+    expect(getFeishuSequentialKey({ accountId: "default", event, feishuCfg })).toBe(
+      "feishu:default:oc_group:topic:om_root_1",
+    );
   });
 
   it("keeps /btw on a stable per-chat lane across different message ids", () => {

--- a/extensions/feishu/src/sequential-key.ts
+++ b/extensions/feishu/src/sequential-key.ts
@@ -2,15 +2,19 @@ import {
   isAbortRequestText,
   isBtwRequestText,
 } from "openclaw/plugin-sdk/command-primitives-runtime";
+import { resolveFeishuGroupSession } from "./bot-content.js";
 import { parseFeishuMessageEvent, type FeishuMessageEvent } from "./bot.js";
+import { resolveFeishuGroupConfig } from "./policy.js";
+import { isFeishuGroupChatType, type FeishuConfig } from "./types.js";
 
 export function getFeishuSequentialKey(params: {
   accountId: string;
   event: FeishuMessageEvent;
   botOpenId?: string;
   botName?: string;
+  feishuCfg?: FeishuConfig;
 }): string {
-  const { accountId, event, botOpenId, botName } = params;
+  const { accountId, event, botOpenId, botName, feishuCfg } = params;
   const chatId = event.message.chat_id?.trim() || "unknown";
   const baseKey = `feishu:${accountId}:${chatId}`;
   const parsed = parseFeishuMessageEvent(event, botOpenId, botName);
@@ -22,6 +26,23 @@ export function getFeishuSequentialKey(params: {
 
   if (isBtwRequestText(text)) {
     return `${baseKey}:btw`;
+  }
+
+  if (isFeishuGroupChatType(event.message.chat_type)) {
+    const senderOpenId =
+      event.sender.sender_id.open_id?.trim() || event.sender.sender_id.user_id?.trim() || "unknown";
+    const groupSession = resolveFeishuGroupSession({
+      chatId,
+      senderOpenId,
+      messageId: event.message.message_id,
+      rootId: event.message.root_id,
+      threadId: event.message.thread_id,
+      chatType: event.message.chat_type,
+      groupConfig: resolveFeishuGroupConfig({ cfg: feishuCfg, groupId: chatId }),
+      feishuCfg,
+    });
+
+    return `feishu:${accountId}:${groupSession.peerId}`;
   }
 
   return baseKey;


### PR DESCRIPTION
## Summary

Fix Feishu inbound queue scoping so grouped sessions are not still serialized at the whole-chat level.

When `groupSessionScope` is configured as `group_topic` or `group_topic_sender`, Feishu conversations are already routed into separate sessions, but `getFeishuSequentialKey` still returned `feishu:<accountId>:<chatId>` for normal messages. That meant a long-running request in one Feishu group topic could block unrelated topics/senders in the same group.

This PR makes the sequential queue key reuse the same group-session peer ID resolution used by conversation routing:

- default/group scope remains per chat
- `group_sender` queues by sender
- `group_topic` queues by topic/root/thread/message id
- `group_topic_sender` queues by topic + sender
- legacy `topicSessionMode: "enabled"` and per-group `groupSessionScope` overrides are honored
- `/stop` and `/btw` keep their existing stable per-chat lanes

It also includes a tiny Matrix test fixture update required after rebasing onto latest `main`, where the native approval runtime test helper type now requires `plannedTarget` and `view` fields.

## Tests

- `pnpm test extensions/feishu/src/sequential-key.test.ts`
- `pnpm test extensions/matrix/src/approval-handler.runtime.test.ts`
- `pnpm test:extension feishu` — 60 files / 678 tests passed
- `pnpm check:test-types`
- `node scripts/run-oxlint.mjs --tsconfig tsconfig.oxlint.extensions.json extensions/feishu/src/monitor.account.ts extensions/feishu/src/sequential-key.ts extensions/feishu/src/sequential-key.test.ts extensions/matrix/src/approval-handler.runtime.test.ts`
