### PR TITLE
feat(agents): expose agent session key as $OPENCLAW_SESSION_KEY in exec env

### DIFF
--- a/src/agents/bash-tools.exec.session-key.test.ts
+++ b/src/agents/bash-tools.exec.session-key.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecApprovalsResolved } from "../infra/exec-approvals.js";
+import { captureEnv } from "../test-utils/env.js";
+import { sanitizeBinaryOutput } from "./shell-utils.js";
+
+const isWin = process.platform === "win32";
+const FOREGROUND_TEST_YIELD_MS = 120_000;
+type GetShellPathFromLoginShell = typeof import("../infra/shell-env.js").getShellPathFromLoginShell;
+const shellEnvMocks = vi.hoisted(() => ({
+  getShellPathFromLoginShell: vi.fn<GetShellPathFromLoginShell>(() => "/usr/bin:/bin"),
+  resolveShellEnvFallbackTimeoutMs: vi.fn(() => 1234),
+}));
+
+vi.mock("../infra/shell-env.js", async () => {
+  const mod =
+    await vi.importActual<typeof import("../infra/shell-env.js")>("../infra/shell-env.js");
+  return {
+    ...mod,
+    getShellPathFromLoginShell: shellEnvMocks.getShellPathFromLoginShell,
+    resolveShellEnvFallbackTimeoutMs: shellEnvMocks.resolveShellEnvFallbackTimeoutMs,
+  };
+});
+
+vi.mock("../infra/exec-approvals.js", async () => {
+  const mod = await vi.importActual<typeof import("../infra/exec-approvals.js")>(
+    "../infra/exec-approvals.js",
+  );
+  return { ...mod, resolveExecApprovals: () => createExecApprovals() };
+});
+
+let createExecTool: typeof import("./bash-tools.exec.js").createExecTool;
+
+function createExecApprovals(): ExecApprovalsResolved {
+  return {
+    path: "/tmp/exec-approvals.json",
+    socketPath: "/tmp/exec-approvals.sock",
+    token: "token",
+    defaults: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    agent: {
+      security: "full",
+      ask: "off",
+      askFallback: "full",
+      autoAllowSkills: false,
+    },
+    agentSources: {
+      security: "defaults.security",
+      ask: "defaults.ask",
+      askFallback: "defaults.askFallback",
+    },
+    allowlist: [],
+    file: {
+      version: 1,
+      socket: { path: "/tmp/exec-approvals.sock", token: "token" },
+      defaults: {
+        security: "full",
+        ask: "off",
+        askFallback: "full",
+        autoAllowSkills: false,
+      },
+      agents: {},
+    },
+  };
+}
+
+const normalizeText = (value?: string) =>
+  sanitizeBinaryOutput(value ?? "")
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .trim();
+
+describe("exec OPENCLAW_SESSION_KEY env injection", () => {
+  let envSnapshot: ReturnType<typeof captureEnv>;
+
+  beforeAll(async () => {
+    ({ createExecTool } = await import("./bash-tools.exec.js"));
+  });
+
+  beforeEach(() => {
+    envSnapshot = captureEnv(["PATH", "SHELL", "OPENCLAW_SESSION_KEY"]);
+    shellEnvMocks.getShellPathFromLoginShell.mockReset();
+    shellEnvMocks.getShellPathFromLoginShell.mockReturnValue("/usr/bin:/bin");
+    shellEnvMocks.resolveShellEnvFallbackTimeoutMs.mockReset();
+    shellEnvMocks.resolveShellEnvFallbackTimeoutMs.mockReturnValue(1234);
+  });
+
+  afterEach(() => {
+    envSnapshot.restore();
+  });
+
+  it("exposes defaults.sessionKey as $OPENCLAW_SESSION_KEY for host=gateway commands", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:eva:msteams:direct:test-session",
+    });
+    const result = await tool.execute("call-session-key", {
+      command: 'printf "%s" "${OPENCLAW_SESSION_KEY:-MISSING}"',
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("agent:eva:msteams:direct:test-session");
+  });
+
+  it("does not set $OPENCLAW_SESSION_KEY when defaults.sessionKey is absent", async () => {
+    if (isWin) {
+      return;
+    }
+    delete process.env.OPENCLAW_SESSION_KEY;
+
+    const tool = createExecTool({ host: "gateway", security: "full", ask: "off" });
+    const result = await tool.execute("call-no-session-key", {
+      command: 'printf "%s" "${OPENCLAW_SESSION_KEY:-NOT_SET}"',
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("NOT_SET");
+  });
+
+  it("does not overwrite a caller-supplied OPENCLAW_SESSION_KEY in params.env", async () => {
+    if (isWin) {
+      return;
+    }
+
+    const tool = createExecTool({
+      host: "gateway",
+      security: "full",
+      ask: "off",
+      sessionKey: "agent:eva:msteams:direct:from-defaults",
+    });
+    const result = await tool.execute("call-caller-wins", {
+      command: 'printf "%s" "${OPENCLAW_SESSION_KEY:-MISSING}"',
+      env: { OPENCLAW_SESSION_KEY: "caller-wins" },
+      yieldMs: FOREGROUND_TEST_YIELD_MS,
+    });
+    const value = normalizeText(result.content.find((c) => c.type === "text")?.text);
+
+    expect(value).toBe("caller-wins");
+  });
+});

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1605,6 +1605,17 @@ export function createExecTool(
         applyPathPrepend(env, defaultPathPrepend);
       }
 
+      // Expose the agent's session key as `OPENCLAW_SESSION_KEY` so commands
+      // executed under this turn can reference it without derivation. Use case:
+      // session-aware HTTP backends (e.g. signed-session proxies) require a
+      // header that maps to the agent's runtime session — exposing it here
+      // means the agent uses `-H "X-Session: $OPENCLAW_SESSION_KEY"` instead
+      // of inferring the format from upstream 401 reasons. Caller-supplied env
+      // wins to preserve override semantics (e.g. tests injecting a fixed key).
+      if (defaults?.sessionKey && env.OPENCLAW_SESSION_KEY === undefined) {
+        env.OPENCLAW_SESSION_KEY = defaults.sessionKey;
+      }
+
       if (host === "node") {
         return executeNodeHostCommand({
           command: params.command,


### PR DESCRIPTION
## What

When the agent runtime has a `defaults.sessionKey` (every agent run does — it's the agent's session identifier), expose it to spawned commands as the `OPENCLAW_SESSION_KEY` environment variable. Caller-supplied env wins on conflict so explicit overrides keep working (tests, fixtures).

## Why

Sibling services often need to verify which agent/session a request originates from. Today, agents have to derive the session key string by hand and inject it into HTTP headers explicitly. That's brittle — agents discover the contract from upstream 401 reasons rather than from the runtime. With this change, an agent can simply reference `$OPENCLAW_SESSION_KEY` in any shell command (e.g. `curl -H "X-Session-Id: $OPENCLAW_SESSION_KEY" …`) and the runtime guarantees the value is correct.

Symmetric with the existing `OPENCLAW_SHELL` env var injection in `bash-tools.exec-runtime.ts:559` — same pattern, different env var. The injection lives in `bash-tools.exec.ts` after PATH manipulation but before host dispatch, so it covers the full env-resolution pipeline (sandbox + gateway).

## Scope

Covers the **in-process gateway exec path** (where most agent commands run, including in-container Docker deployments).

The `host=node` exec path is **intentionally out of scope** — that path uses `params.requestedEnv` only and forwards a separate env channel to the remote node. Agents on remote nodes that need the session key should request it explicitly via the exec `env` parameter, just as they do today. Documented in the commit message.

## Tests

- **New:** `src/agents/bash-tools.exec.session-key.test.ts` — 3 cases:
  1. Sets `$OPENCLAW_SESSION_KEY` when `defaults.sessionKey` is provided
  2. Does NOT set when `defaults.sessionKey` is absent
  3. Caller-supplied `params.env.OPENCLAW_SESSION_KEY` wins over the default (override semantics preserved)
- **Existing:** `bash-tools.exec.path.test.ts` (26 cases) and `bash-tools.exec-host-{gateway,node}.test.ts` (37 cases combined) all pass unchanged.

Total: 67/67 green on this branch against latest `main`.

## Verification commands

```sh
pnpm test src/agents/bash-tools.exec.session-key.test.ts
pnpm test src/agents/bash-tools.exec.path.test.ts
pnpm test src/agents/bash-tools.exec-host-gateway.test.ts
pnpm test src/agents/bash-tools.exec-host-node.test.ts
```

## Related

This is the runtime-side half of a session-aware-backend pattern. We have a downstream proxy that requires session-keyed HMAC verification on every agent-originated HTTP call; today our agent has to inject the right header from a self-derived session key. With this change, our skill prompts can reference `$OPENCLAW_SESSION_KEY` directly and the runtime guarantees correctness — fewer ways for the agent to get it wrong.