### PR TITLE
fix(cron): accept delivery.threadId in protocol schema (#73017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/protocol: allow `delivery.threadId` (string or number) on every CronDelivery variant so Telegram forum-topic ids and other thread-routed announcements pass schema validation. The runtime types in `src/cron/types.ts` already declared `threadId?: string | number`, but the API schema rejected it because `additionalProperties: false` was set on every variant. Mirrors the existing `ConfigDeliveryContextSchema` shape. Fixes #73017.
 - Channels/sessions: prevent guarded inbound session recording from creating route-only phantom sessions while still allowing last-route updates for sessions that already exist. Carries forward #73009. Thanks @jzakirov.
 - Plugins/runtime deps: stage bundled plugin dependencies imported by mirrored root dist chunks, so packaged memory and status commands do not miss `chokidar` or similar root-chunk dependencies after update. Fixes #72882 and #72970; carries forward #72992. Thanks @shrimpy8, @colin-chang, and @Schnup03.
 - Agents/runtime context: deliver hidden runtime context through prompt-local system context while keeping the transcript-only custom entry out of provider user turns, and strip stale copied runtime-context prefaces from user-facing replies. Fixes #72386; carries forward #72969. Thanks @jhsmith409.

--- a/src/gateway/protocol/cron.schema.test.ts
+++ b/src/gateway/protocol/cron.schema.test.ts
@@ -1,0 +1,52 @@
+import AjvPkg from "ajv";
+import { describe, expect, it } from "vitest";
+import { CronDeliverySchema } from "./schema/cron.js";
+
+describe("CronDeliverySchema (#73017)", () => {
+  const Ajv = AjvPkg as unknown as new (opts?: object) => import("ajv").default;
+  const validate = new Ajv({ strict: false }).compile(CronDeliverySchema);
+
+  it("accepts threadId as a string on announce delivery", () => {
+    expect(
+      validate({
+        mode: "announce",
+        channel: "telegram",
+        to: "123456789",
+        threadId: "topic-42",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts threadId as a number on announce delivery", () => {
+    expect(
+      validate({
+        mode: "announce",
+        channel: "telegram",
+        to: "123456789",
+        threadId: 42,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts threadId on noop and webhook variants", () => {
+    expect(validate({ mode: "none", threadId: "thr" })).toBe(true);
+    expect(
+      validate({
+        mode: "webhook",
+        to: "https://example.test/hook",
+        threadId: 7,
+      }),
+    ).toBe(true);
+  });
+
+  it("still rejects truly unexpected properties (additionalProperties:false invariant preserved)", () => {
+    expect(
+      validate({
+        mode: "announce",
+        channel: "telegram",
+        to: "123",
+        bogusField: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -186,6 +186,13 @@ const CronDeliverySharedProperties = {
   accountId: Type.Optional(NonEmptyString),
   bestEffort: Type.Optional(Type.Boolean()),
   failureDestination: Type.Optional(CronFailureDestinationSchema),
+  // Forward-compatible alias for routing announcements to chat threads
+  // (e.g. Telegram forum topic ids). The TypeScript types in
+  // `src/cron/types.ts` already declare `threadId?: string | number`, but
+  // the runtime API schema rejected it because `additionalProperties:false`
+  // is set on every CronDelivery* variant. Mirrors the existing
+  // `ConfigDeliveryContextSchema` shape in `config.ts`. (#73017)
+  threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
 };
 
 const CronDeliveryNoopSchema = Type.Object(


### PR DESCRIPTION
Fixes #73017.

## Summary

The TypeScript types in \`src/cron/types.ts\` declare
\`threadId?: string | number\` on every cron delivery shape (lines 29
and 53), and downstream code paths already plumb it through
(\`isolated-agent/run-executor.ts:160\`,
\`channel-output-policy.ts:42\`, etc.). But the runtime API schema in
\`src/gateway/protocol/schema/cron.ts\` did not include \`threadId\` in
\`CronDeliverySharedProperties\`, and every CronDelivery variant uses
\`additionalProperties: false\`. Result: any cron job with
\`delivery.threadId\` set was rejected at \`cron.add\` validation with
\`unexpected property 'threadId'\` — locking out Telegram forum-topic
routing through the delivery layer entirely.

## Fix

Add to \`CronDeliverySharedProperties\`:

\`\`\`ts
threadId: Type.Optional(Type.Union([Type.String(), Type.Number()])),
\`\`\`

This propagates to all four call sites (the three CronDelivery*
variants and \`CronDeliveryPatchSchema\`) via the existing spread.
Mirrors the existing \`ConfigDeliveryContextSchema\` shape in
\`src/gateway/protocol/schema/config.ts:15\` for consistency.

## Tests

New focused schema test \`src/gateway/protocol/cron.schema.test.ts\`
asserts:

- \`threadId: \"topic-42\"\` accepted on \`announce\` delivery
- \`threadId: 42\` accepted on \`announce\` delivery
- \`threadId\` accepted on \`none\` and \`webhook\` variants too
- Genuinely unexpected properties (e.g. \`bogusField\`) still rejected
  — \`additionalProperties: false\` invariant preserved.

\`\`\`
Test Files  2 passed (cron.schema.test.ts: 4, channels.schema.test.ts: 1)
     Tests  8 passed (8)
\`\`\`

Existing 3 \`cron-protocol-conformance.test.ts\` tests still pass.