### PR TITLE
feat(voiceclaw-realtime): add xAI Realtime Voice Agent provider (closes #73019)

### DIFF
--- a/apps/ios/ShareExtension/ShareViewController.swift
+++ b/apps/ios/ShareExtension/ShareViewController.swift
@@ -90,9 +90,9 @@ final class ShareViewController: UIViewController {
         let payload = extracted.payload
         self.pendingAttachments = extracted.attachments
         self.logger.info(
-            "share payload trace=\(traceId, privacy: .public) titleChars=\(payload.title?.count ?? 0) textChars=\(payload.text?.count ?? 0) hasURL=\(payload.url != nil) imageAttachments=\(self.pendingAttachments.count)"
+            "share payload trace=\(traceId, privacy: .public) titleChars=\(payload.title?.count ?? 0) textChars=\(payload.text?.count ?? 0) hasURL=\(payload.url != nil) attachments=\(self.pendingAttachments.count)"
         )
-        let message = self.composeDraft(from: payload)
+        let message = self.composeDraft(from: payload, attachments: self.pendingAttachments)
         await MainActor.run {
             self.draftTextView.text = message
             self.sendButton.isEnabled = true
@@ -326,7 +326,7 @@ final class ShareViewController: UIViewController {
         }
     }
 
-    private func composeDraft(from payload: SharedContentPayload) -> String {
+    private func composeDraft(from payload: SharedContentPayload, attachments: [ShareAttachment] = []) -> String {
         var lines: [String] = []
         let title = self.sanitizeDraftFragment(payload.title)
         let text = self.sanitizeDraftFragment(payload.text)
@@ -335,6 +335,9 @@ final class ShareViewController: UIViewController {
         if let title, !title.isEmpty { lines.append(title) }
         if let text, !text.isEmpty { lines.append(text) }
         if !url.isEmpty { lines.append(url) }
+        if lines.isEmpty, let firstAudio = attachments.first(where: { $0.type == "audio" }) {
+            lines.append("Shared audio: \(firstAudio.fileName)")
+        }
 
         return lines.joined(separator: "\n\n")
     }
@@ -376,6 +379,7 @@ final class ShareViewController: UIViewController {
         var unknownCount = 0
         var attachments: [ShareAttachment] = []
         let maxImageAttachments = 3
+        let maxAudioAttachments = 1
 
         for item in items {
             if title == nil {
@@ -395,6 +399,14 @@ final class ShareViewController: UIViewController {
                     imageCount += 1
                     if attachments.count < maxImageAttachments,
                        let attachment = await self.loadImageAttachment(from: provider, index: attachments.count)
+                    {
+                        attachments.append(attachment)
+                    }
+                } else if provider.hasItemConformingToTypeIdentifier(UTType.audio.identifier) {
+                    fileCount += 1
+                    let audioCount = attachments.filter { $0.type == "audio" }.count
+                    if audioCount < maxAudioAttachments,
+                       let attachment = await self.loadAudioAttachment(from: provider, index: audioCount)
                     {
                         attachments.append(attachment)
                     }
@@ -439,6 +451,33 @@ final class ShareViewController: UIViewController {
             content: data.base64EncodedString())
     }
 
+    private func loadAudioAttachment(from provider: NSItemProvider, index: Int) async -> ShareAttachment? {
+        let audioUTI = self.preferredAudioTypeIdentifier(from: provider) ?? UTType.audio.identifier
+        guard let rawData = await self.loadDataValue(from: provider, typeIdentifier: audioUTI)
+            ?? self.loadFileDataValue(from: provider, typeIdentifier: audioUTI)
+            ?? self.loadAudioDataFromFileURL(from: provider)
+        else {
+            return nil
+        }
+
+        let maxBytes = 5_000_000
+        guard rawData.count > 0, rawData.count <= maxBytes else {
+            self.logger.warning("audio attachment skipped size=\(rawData.count, privacy: .public)")
+            return nil
+        }
+
+        let type = UTType(audioUTI)
+        let mimeType = type?.preferredMIMEType ?? "audio/mpeg"
+        let ext = type?.preferredFilenameExtension ?? "m4a"
+        let fileName = self.preferredFileName(from: provider) ?? "shared-audio-\(index + 1).\(ext)"
+
+        return ShareAttachment(
+            type: "audio",
+            mimeType: mimeType,
+            fileName: self.ensureFileExtension(fileName, fallbackExtension: ext),
+            content: rawData.base64EncodedString())
+    }
+
     private func preferredImageTypeIdentifier(from provider: NSItemProvider) -> String? {
         for identifier in provider.registeredTypeIdentifiers {
             guard let utType = UTType(identifier) else { continue }
@@ -447,6 +486,26 @@ final class ShareViewController: UIViewController {
             }
         }
         return nil
+    }
+
+    private func preferredAudioTypeIdentifier(from provider: NSItemProvider) -> String? {
+        for identifier in provider.registeredTypeIdentifiers {
+            guard let utType = UTType(identifier) else { continue }
+            if utType.conforms(to: .audio) {
+                return identifier
+            }
+        }
+        return nil
+    }
+
+    private func preferredFileName(from provider: NSItemProvider) -> String? {
+        let trimmed = provider.suggestedName?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func ensureFileExtension(_ fileName: String, fallbackExtension: String) -> String {
+        guard URL(fileURLWithPath: fileName).pathExtension.isEmpty else { return fileName }
+        return "\(fileName).\(fallbackExtension)"
     }
 
     private func normalizedJPEGData(from image: UIImage, maxBytes: Int) -> Data? {

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -191,13 +191,27 @@ OpenClaw exposes a VoiceClaw-compatible real-time WebSocket endpoint at
 directly to a real-time OpenClaw brain instead of going through a separate relay
 process.
 
-The endpoint uses Gemini Live for real-time audio and calls OpenClaw as the
-brain by exposing OpenClaw tools directly to Gemini Live. Tool calls return an
-immediate `working` result to keep the voice turn responsive, then OpenClaw
-executes the actual tool asynchronously and injects the result back into the
-live session. Set `GEMINI_API_KEY` in the gateway process environment. If
-gateway auth is enabled, the desktop client sends the gateway token or password
-in its first `session.config` message.
+The endpoint supports multiple realtime brain providers. Clients select a
+provider in their first `session.config` message via the `provider` field:
+
+- `provider: "gemini"` (default) — uses Gemini Live; requires `GEMINI_API_KEY`
+  in the gateway process environment. Voices: `Puck`, `Charon`, `Kore`,
+  `Fenrir`, `Aoede`, `Leda`, `Orus`, `Zephyr` (default).
+- `provider: "xai"` — uses xAI's Voice Agent API
+  (`grok-voice-think-fast-1.0`); requires `XAI_API_KEY` in the gateway
+  process environment. Voices: `eve`, `ara` (default), `rex`, `sal`, `leo`.
+  See [xAI Voice Agent docs](https://docs.x.ai/developers/model-capabilities/audio/voice-agent)
+  for model and pricing details.
+
+Each provider calls OpenClaw as the brain by exposing OpenClaw tools directly
+to the upstream realtime model. Tool calls return an immediate `working` result
+to keep the voice turn responsive, then OpenClaw executes the actual tool
+asynchronously and injects the result back into the live session.
+
+If gateway auth is enabled, the desktop client sends the gateway token or
+password in its first `session.config` message — this is unrelated to the
+upstream provider key, which is read from the gateway process environment and
+never leaves the gateway.
 
 Real-time brain access runs owner-authorized OpenClaw agent commands. Keep
 `gateway.auth.mode: "none"` limited to loopback-only test instances. Non-local
@@ -210,9 +224,13 @@ and state:
 OPENCLAW_CONFIG_PATH=/path/to/openclaw-realtime/openclaw.json \
 OPENCLAW_STATE_DIR=/path/to/openclaw-realtime/state \
 OPENCLAW_SKIP_CHANNELS=1 \
-GEMINI_API_KEY=... \
+GEMINI_API_KEY=...    # required for provider="gemini" \
+XAI_API_KEY=...       # required for provider="xai" \
 openclaw gateway --port 19789
 ```
+
+Set whichever provider key(s) match the providers your clients will request.
+Either may be omitted if you only intend to use the other.
 
 Then configure VoiceClaw to use:
 

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -80,7 +80,7 @@ below.
 | Streaming TTS              | —                                         | Not exposed; OpenClaw's TTS contract returns complete audio buffers |
 | Batch speech-to-text       | `tools.media.audio` / media understanding | Yes                                                                 |
 | Streaming speech-to-text   | Voice Call `streaming.provider: "xai"`    | Yes                                                                 |
-| Realtime voice             | —                                         | Not exposed yet; different session/WebSocket contract               |
+| Realtime voice             | `/voiceclaw/realtime` `provider: "xai"`   | Yes — xAI Voice Agent (`grok-voice-think-fast-1.0`)                 |
 | Files / batches            | Generic model API compatibility only      | Not a first-class OpenClaw tool                                     |
 
 <Note>
@@ -409,9 +409,16 @@ Legacy aliases still normalize to the canonical bundled ids:
     - `grok-4.20-multi-agent-experimental-beta-0304` is not supported on the
       normal xAI provider path because it requires a different upstream API
       surface than the standard OpenClaw xAI transport.
-    - xAI Realtime voice is not registered as an OpenClaw provider yet. It
-      needs a different bidirectional voice session contract than batch STT or
-      streaming transcription.
+    - xAI Realtime voice is wired into the
+      [`/voiceclaw/realtime`](/gateway#voiceclaw-real-time-brain-endpoint)
+      gateway endpoint via `provider: "xai"`. Set `XAI_API_KEY` in the gateway
+      process environment. Default voice: `ara`. Supported voices: `eve`,
+      `ara`, `rex`, `sal`, `leo`. Default model:
+      `grok-voice-think-fast-1.0`. The Voice Agent API is documented as
+      OpenAI-Realtime-protocol-compatible
+      ([xAI docs](https://docs.x.ai/developers/model-capabilities/audio/voice-agent));
+      the OpenClaw adapter handles the documented wire deltas
+      (`response.text.delta`, single user-transcription `completed` event).
     - xAI image `quality`, image `mask`, and extra native-only aspect ratios are
       not exposed until the shared `image_generate` tool has corresponding
       cross-provider controls.

--- a/src/gateway/server-maintenance.ts
+++ b/src/gateway/server-maintenance.ts
@@ -90,8 +90,13 @@ export function startGatewayMaintenanceTimers(params: {
       }
     }
     if (params.dedupe.size > DEDUPE_MAX) {
-      const entries = [...params.dedupe.entries()].toSorted((a, b) => a[1].ts - b[1].ts);
-      for (let i = 0; i < params.dedupe.size - DEDUPE_MAX; i++) {
+      // pt 235n (audit #7) — was [...map.entries()].toSorted(...).
+      // Both spread + toSorted allocate distinct copies. Single
+      // Array.from + in-place sort drops one allocation per tick.
+      const entries = Array.from(params.dedupe.entries());
+      entries.sort((a, b) => a[1].ts - b[1].ts);
+      const target = params.dedupe.size - DEDUPE_MAX;
+      for (let i = 0; i < target; i++) {
         params.dedupe.delete(entries[i][0]);
       }
     }

--- a/src/gateway/voiceclaw-realtime/session.test.ts
+++ b/src/gateway/voiceclaw-realtime/session.test.ts
@@ -4,12 +4,21 @@ import { describe, expect, it, vi } from "vitest";
 import WebSocket from "ws";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ResolvedGatewayAuth } from "../auth.js";
-import { resolveRealtimeSenderIsOwner, VoiceClawRealtimeSession } from "./session.js";
+import { VoiceClawGeminiLiveAdapter } from "./gemini-live.js";
+import {
+  createDefaultAdapterFactory,
+  defaultVoiceFor,
+  requiredApiKeyEnvFor,
+  resolveProvider,
+  resolveRealtimeSenderIsOwner,
+  VoiceClawRealtimeSession,
+} from "./session.js";
 import type {
   VoiceClawRealtimeAdapter,
   VoiceClawServerEvent,
   VoiceClawSessionConfigEvent,
 } from "./types.js";
+import { VoiceClawXaiRealtimeAdapter } from "./xai-realtime.js";
 
 describe("resolveRealtimeSenderIsOwner", () => {
   it("allows only owner-equivalent realtime brain auth", () => {
@@ -21,6 +30,40 @@ describe("resolveRealtimeSenderIsOwner", () => {
     expect(resolveRealtimeSenderIsOwner("trusted-proxy", false)).toBe(false);
     expect(resolveRealtimeSenderIsOwner("tailscale", false)).toBe(false);
     expect(resolveRealtimeSenderIsOwner("device-token", false)).toBe(false);
+  });
+});
+
+describe("realtime brain provider selection", () => {
+  it("defaults to gemini when no provider is specified (back-compat)", () => {
+    expect(resolveProvider(undefined)).toBe("gemini");
+    expect(resolveProvider("gemini")).toBe("gemini");
+    // openai is reserved in the type union but not yet wired in /voiceclaw/realtime;
+    // resolveProvider falls back to gemini for any non-xai value.
+    expect(resolveProvider("openai")).toBe("gemini");
+  });
+
+  it("resolves provider='xai' to the xAI realtime brain", () => {
+    expect(resolveProvider("xai")).toBe("xai");
+  });
+
+  it("returns ara as the xAI default voice and Zephyr as the Gemini default", () => {
+    expect(defaultVoiceFor("xai")).toBe("ara");
+    expect(defaultVoiceFor("gemini")).toBe("Zephyr");
+  });
+
+  it("requires the correct API key env per provider", () => {
+    expect(requiredApiKeyEnvFor("xai")).toBe("XAI_API_KEY");
+    expect(requiredApiKeyEnvFor("gemini")).toBe("GEMINI_API_KEY");
+  });
+
+  it("default adapter factory dispatches by provider", () => {
+    const factory = createDefaultAdapterFactory();
+    const xaiAdapter = factory({ type: "session.config", provider: "xai" });
+    const geminiAdapter = factory({ type: "session.config", provider: "gemini" });
+    const undefinedAdapter = factory({ type: "session.config" });
+    expect(xaiAdapter).toBeInstanceOf(VoiceClawXaiRealtimeAdapter);
+    expect(geminiAdapter).toBeInstanceOf(VoiceClawGeminiLiveAdapter);
+    expect(undefinedAdapter).toBeInstanceOf(VoiceClawGeminiLiveAdapter);
   });
 });
 

--- a/src/gateway/voiceclaw-realtime/session.ts
+++ b/src/gateway/voiceclaw-realtime/session.ts
@@ -23,6 +23,7 @@ import type {
   VoiceClawSessionConfigEvent,
   VoiceClawToolCallEvent,
 } from "./types.js";
+import { DEFAULT_XAI_VOICE, VoiceClawXaiRealtimeAdapter } from "./xai-realtime.js";
 
 const log = createSubsystemLogger("gateway").child("voiceclaw-realtime");
 
@@ -35,7 +36,7 @@ type VoiceClawRealtimeSessionOptions = {
   allowRealIpFallback: boolean;
   rateLimiter?: AuthRateLimiter;
   releasePreauthBudget: () => void;
-  adapterFactory?: () => VoiceClawRealtimeAdapter;
+  adapterFactory?: (config: VoiceClawSessionConfigEvent) => VoiceClawRealtimeAdapter;
 };
 
 export class VoiceClawRealtimeSession {
@@ -49,7 +50,9 @@ export class VoiceClawRealtimeSession {
   private readonly allowRealIpFallback: boolean;
   private readonly rateLimiter: AuthRateLimiter | undefined;
   private readonly releasePreauthBudget: () => void;
-  private readonly adapterFactory: () => VoiceClawRealtimeAdapter;
+  private readonly adapterFactory: (
+    config: VoiceClawSessionConfigEvent,
+  ) => VoiceClawRealtimeAdapter;
   private adapter: VoiceClawRealtimeAdapter | null = null;
   private toolRuntime: VoiceClawRealtimeToolRuntime | null = null;
   private config: VoiceClawSessionConfigEvent | null = null;
@@ -66,7 +69,7 @@ export class VoiceClawRealtimeSession {
     this.allowRealIpFallback = opts.allowRealIpFallback;
     this.rateLimiter = opts.rateLimiter;
     this.releasePreauthBudget = once(opts.releasePreauthBudget);
-    this.adapterFactory = opts.adapterFactory ?? (() => new VoiceClawGeminiLiveAdapter());
+    this.adapterFactory = opts.adapterFactory ?? createDefaultAdapterFactory();
   }
 
   attach(): void {
@@ -179,17 +182,19 @@ export class VoiceClawRealtimeSession {
       return;
     }
 
+    const resolvedProvider = resolveProvider(config.provider);
     this.config = {
       ...config,
-      provider: "gemini",
-      voice: config.voice || "Zephyr",
+      provider: resolvedProvider,
+      voice: config.voice || defaultVoiceFor(resolvedProvider),
       brainAgent: config.brainAgent ?? "enabled",
     };
-    this.adapter = this.adapterFactory();
+    this.adapter = this.adapterFactory(this.config);
 
     try {
-      if (!process.env.GEMINI_API_KEY?.trim()) {
-        throw new Error("GEMINI_API_KEY is required for VoiceClaw real-time brain mode");
+      const requiredKey = requiredApiKeyEnvFor(resolvedProvider);
+      if (!process.env[requiredKey]?.trim()) {
+        throw new Error(`${requiredKey} is required for VoiceClaw real-time brain mode`);
       }
       this.toolRuntime =
         this.config.brainAgent === "none"
@@ -342,6 +347,45 @@ export function resolveRealtimeSenderIsOwner(
     return true;
   }
   return method === "none" && localDirect;
+}
+
+type ResolvedRealtimeProvider = "gemini" | "xai";
+
+/**
+ * Resolve the realtime brain provider from the client-supplied session config.
+ *
+ * Defaults to `gemini` to preserve backward compatibility for existing
+ * VoiceClaw desktop clients that did not previously send a provider.
+ *
+ * `openai` is reserved in the type union but not yet wired here.
+ */
+export function resolveProvider(
+  provider: VoiceClawSessionConfigEvent["provider"],
+): ResolvedRealtimeProvider {
+  if (provider === "xai") {
+    return "xai";
+  }
+  return "gemini";
+}
+
+export function defaultVoiceFor(provider: ResolvedRealtimeProvider): string {
+  return provider === "xai" ? DEFAULT_XAI_VOICE : "Zephyr";
+}
+
+export function requiredApiKeyEnvFor(provider: ResolvedRealtimeProvider): string {
+  return provider === "xai" ? "XAI_API_KEY" : "GEMINI_API_KEY";
+}
+
+export function createDefaultAdapterFactory(): (
+  config: VoiceClawSessionConfigEvent,
+) => VoiceClawRealtimeAdapter {
+  return (config) => {
+    const provider = resolveProvider(config.provider);
+    if (provider === "xai") {
+      return new VoiceClawXaiRealtimeAdapter();
+    }
+    return new VoiceClawGeminiLiveAdapter();
+  };
 }
 
 function sanitizeErrorMessage(message: string): string {

--- a/src/gateway/voiceclaw-realtime/types.ts
+++ b/src/gateway/voiceclaw-realtime/types.ts
@@ -9,7 +9,7 @@ export type VoiceClawClientEvent =
 
 export type VoiceClawSessionConfigEvent = {
   type: "session.config";
-  provider?: "openai" | "gemini";
+  provider?: "openai" | "gemini" | "xai";
   voice?: string;
   model?: string;
   brainAgent?: "enabled" | "none";

--- a/src/gateway/voiceclaw-realtime/xai-realtime.test.ts
+++ b/src/gateway/voiceclaw-realtime/xai-realtime.test.ts
@@ -384,3 +384,240 @@ describe("VoiceClawXaiRealtimeAdapter secret discipline", () => {
     expect(() => new VoiceClawXaiRealtimeAdapter()).not.toThrow();
   });
 });
+
+describe("VoiceClawXaiRealtimeAdapter client-side methods (forwarding)", () => {
+  function makeAdapterWithCapture(): {
+    adapter: VoiceClawXaiRealtimeAdapter;
+    upstream: Record<string, unknown>[];
+    events: VoiceClawServerEvent[];
+  } {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const upstream: Record<string, unknown>[] = [];
+    const events: VoiceClawServerEvent[] = [];
+    const internals = adapter as unknown as {
+      sendUpstream: (msg: Record<string, unknown>, kind: string) => void;
+      sendToClient: (event: VoiceClawServerEvent) => void;
+    };
+    internals.sendUpstream = (msg) => upstream.push(msg);
+    internals.sendToClient = (event) => events.push(event);
+    return { adapter, upstream, events };
+  }
+
+  it("commitAudio forwards input_audio_buffer.commit", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+    adapter.commitAudio();
+    expect(upstream).toEqual([{ type: "input_audio_buffer.commit" }]);
+  });
+
+  it("createResponse forwards response.create", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+    adapter.createResponse();
+    expect(upstream).toEqual([{ type: "response.create" }]);
+  });
+
+  it("cancelResponse forwards response.cancel best-effort", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+    adapter.cancelResponse();
+    expect(upstream).toEqual([{ type: "response.cancel" }]);
+  });
+
+  it("injectContext forwards a system-role conversation.item.create", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+    adapter.injectContext("background context here");
+    expect(upstream).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "system",
+          content: [{ type: "input_text", text: "background context here" }],
+        },
+      },
+    ]);
+  });
+
+  it("sendFrame logs warning and drops silently (xAI Voice Agent is audio-only at GA)", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+    adapter.sendFrame("imagedataframe", "image/jpeg");
+    expect(upstream).toEqual([]);
+  });
+
+  it("getTranscript returns a copy (caller mutation does not affect internal state)", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const internals = adapter as unknown as {
+      transcript: { role: "user" | "assistant"; text: string }[];
+    };
+    internals.transcript = [
+      { role: "user", text: "hi" },
+      { role: "assistant", text: "hello" },
+    ];
+    const t = adapter.getTranscript();
+    expect(t).toEqual([
+      { role: "user", text: "hi" },
+      { role: "assistant", text: "hello" },
+    ]);
+    t.push({ role: "user", text: "tampering" });
+    expect(adapter.getTranscript()).toHaveLength(2);
+  });
+
+  it("disconnect clears state and is idempotent", () => {
+    const { adapter } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      asyncToolCallIds: Set<string>;
+      disconnected: boolean;
+    };
+    internals.asyncToolCallIds.add("call_test_1");
+    expect(internals.asyncToolCallIds.size).toBe(1);
+    adapter.disconnect();
+    expect(internals.disconnected).toBe(true);
+    expect(internals.asyncToolCallIds.size).toBe(0);
+    // Idempotent: calling again does not throw
+    expect(() => adapter.disconnect()).not.toThrow();
+  });
+});
+
+describe("VoiceClawXaiRealtimeAdapter close-handling", () => {
+  function makeWithUpstreamHook(): {
+    adapter: VoiceClawXaiRealtimeAdapter;
+    events: VoiceClawServerEvent[];
+  } {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const events: VoiceClawServerEvent[] = [];
+    const internals = adapter as unknown as {
+      sendToClient: (event: VoiceClawServerEvent) => void;
+      reconnect: (reason: string) => Promise<void>;
+    };
+    internals.sendToClient = (event) => events.push(event);
+    // Stub reconnect so close-code 1006 path doesn't actually try to open a WS.
+    internals.reconnect = async () => {};
+    return { adapter, events };
+  }
+
+  it("ignores normal close (code 1000) without surfacing an error", () => {
+    const { adapter, events } = makeWithUpstreamHook();
+    const internals = adapter as unknown as {
+      handleUpstreamClose: (code: number) => void;
+    };
+    internals.handleUpstreamClose(1000);
+    expect(events).toEqual([]);
+  });
+
+  it("emits a sanitized error for non-reconnectable, non-normal close codes", () => {
+    const { adapter, events } = makeWithUpstreamHook();
+    const internals = adapter as unknown as {
+      handleUpstreamClose: (code: number) => void;
+    };
+    internals.handleUpstreamClose(4001);
+    expect(events).toEqual([
+      { type: "error", message: "xAI Realtime connection closed", code: 502 },
+    ]);
+  });
+
+  it("invokes reconnect path for reconnectable close codes", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const events: VoiceClawServerEvent[] = [];
+    let reconnectCalls = 0;
+    const internals = adapter as unknown as {
+      sendToClient: (event: VoiceClawServerEvent) => void;
+      reconnect: (reason: string) => Promise<void>;
+      handleUpstreamClose: (code: number) => void;
+    };
+    internals.sendToClient = (event) => events.push(event);
+    internals.reconnect = async (reason: string) => {
+      reconnectCalls += 1;
+      events.push({
+        type: "session.rotated",
+        sessionId: `xai-resumed-stub-${reason}`,
+      });
+    };
+    internals.handleUpstreamClose(1006);
+    // reconnect is fire-and-forget (void); we verified the path was taken
+    // and the stub was invoked.
+    expect(reconnectCalls).toBe(1);
+  });
+
+  it("cancels active tool calls if upstream closes mid-tool-call", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const events: VoiceClawServerEvent[] = [];
+    const internals = adapter as unknown as {
+      sendToClient: (event: VoiceClawServerEvent) => void;
+      pendingToolCallIds: Set<string>;
+      handleUpstreamClose: (code: number) => void;
+    };
+    internals.sendToClient = (event) => events.push(event);
+    internals.pendingToolCallIds.add("call_inflight");
+    internals.handleUpstreamClose(1011);
+    expect(events).toContainEqual({
+      type: "tool.cancelled",
+      callIds: ["call_inflight"],
+    });
+    expect(events).toContainEqual({
+      type: "error",
+      message: "xAI Realtime closed while a tool call was in flight",
+      code: 502,
+    });
+  });
+});
+
+describe("VoiceClawXaiRealtimeAdapter conversation history replay", () => {
+  it("replays the most recent 12 history entries via conversation.item.create", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const upstream: Record<string, unknown>[] = [];
+    const internals = adapter as unknown as {
+      sendUpstream: (msg: Record<string, unknown>, kind: string) => void;
+      replayConversationHistory: (config: {
+        type: "session.config";
+        conversationHistory: { role: "user" | "assistant"; text: string }[];
+      }) => void;
+    };
+    internals.sendUpstream = (msg) => upstream.push(msg);
+
+    const history = Array.from({ length: 15 }, (_, i) => ({
+      role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+      text: `message-${i}`,
+    }));
+
+    internals.replayConversationHistory({
+      type: "session.config",
+      conversationHistory: history,
+    });
+
+    // The adapter slices to the last 12 entries.
+    expect(upstream).toHaveLength(12);
+    // First replayed item should be entry index 3 (15 - 12 = 3).
+    const firstItem = upstream[0] as { item: { content: { text: string }[] } };
+    expect(firstItem.item.content[0]!.text).toBe("message-3");
+
+    // User entries serialize as `input_text`; assistant as `text`.
+    const userItem = upstream.find(
+      (m) => (m as { item: { role: string } }).item.role === "user",
+    ) as { item: { content: { type: string }[] } } | undefined;
+    expect(userItem?.item.content[0]?.type).toBe("input_text");
+    const assistantItem = upstream.find(
+      (m) => (m as { item: { role: string } }).item.role === "assistant",
+    ) as { item: { content: { type: string }[] } } | undefined;
+    expect(assistantItem?.item.content[0]?.type).toBe("text");
+  });
+
+  it("does nothing when conversationHistory is empty or missing", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const upstream: Record<string, unknown>[] = [];
+    const internals = adapter as unknown as {
+      sendUpstream: (msg: Record<string, unknown>, kind: string) => void;
+      replayConversationHistory: (config: {
+        type: "session.config";
+        conversationHistory?: { role: "user" | "assistant"; text: string }[];
+      }) => void;
+    };
+    internals.sendUpstream = (msg) => upstream.push(msg);
+
+    internals.replayConversationHistory({ type: "session.config" });
+    expect(upstream).toEqual([]);
+
+    internals.replayConversationHistory({
+      type: "session.config",
+      conversationHistory: [],
+    });
+    expect(upstream).toEqual([]);
+  });
+});

--- a/src/gateway/voiceclaw-realtime/xai-realtime.test.ts
+++ b/src/gateway/voiceclaw-realtime/xai-realtime.test.ts
@@ -1,0 +1,386 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { VoiceClawServerEvent } from "./types.js";
+import {
+  DEFAULT_XAI_VOICE,
+  isValidXaiVoice,
+  resolveXaiVoice,
+  VoiceClawXaiRealtimeAdapter,
+  XAI_VOICES,
+} from "./xai-realtime.js";
+
+const ORIGINAL_XAI_API_KEY = process.env.XAI_API_KEY;
+
+beforeEach(() => {
+  process.env.XAI_API_KEY = "TEST_KEY_NOT_REAL";
+});
+
+afterEach(() => {
+  if (ORIGINAL_XAI_API_KEY === undefined) {
+    delete process.env.XAI_API_KEY;
+  } else {
+    process.env.XAI_API_KEY = ORIGINAL_XAI_API_KEY;
+  }
+});
+
+describe("xAI Realtime voice helpers", () => {
+  it("resolves to ara by default when no voice is provided", () => {
+    expect(resolveXaiVoice()).toBe("ara");
+    expect(DEFAULT_XAI_VOICE).toBe("ara");
+  });
+
+  it("accepts all five xAI voices case-insensitively", () => {
+    for (const voice of XAI_VOICES) {
+      expect(resolveXaiVoice(voice)).toBe(voice);
+      expect(resolveXaiVoice(voice.toUpperCase())).toBe(voice);
+    }
+    expect(XAI_VOICES).toEqual(["eve", "ara", "rex", "sal", "leo"]);
+  });
+
+  it("falls back to ara on unknown voice IDs (does not throw)", () => {
+    expect(resolveXaiVoice("Puck")).toBe("ara");
+    expect(resolveXaiVoice("not-a-voice")).toBe("ara");
+    expect(resolveXaiVoice("")).toBe("ara");
+  });
+
+  it("recognizes valid voices via isValidXaiVoice", () => {
+    expect(isValidXaiVoice("ara")).toBe(true);
+    expect(isValidXaiVoice("ARA")).toBe(true);
+    expect(isValidXaiVoice("eve")).toBe(true);
+    expect(isValidXaiVoice("rex")).toBe(true);
+    expect(isValidXaiVoice("sal")).toBe(true);
+    expect(isValidXaiVoice("leo")).toBe(true);
+
+    expect(isValidXaiVoice("Puck")).toBe(false);
+    expect(isValidXaiVoice("zephyr")).toBe(false);
+    expect(isValidXaiVoice("")).toBe(false);
+  });
+});
+
+describe("VoiceClawXaiRealtimeAdapter event mapping", () => {
+  function makeAdapterWithCapture(): {
+    adapter: VoiceClawXaiRealtimeAdapter;
+    events: VoiceClawServerEvent[];
+    upstream: Record<string, unknown>[];
+  } {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const events: VoiceClawServerEvent[] = [];
+    const upstream: Record<string, unknown>[] = [];
+    const internals = adapter as unknown as {
+      sendToClient: (event: VoiceClawServerEvent) => void;
+      sendUpstream: (msg: Record<string, unknown>, kind: string) => void;
+    };
+    internals.sendToClient = (event) => events.push(event);
+    internals.sendUpstream = (msg) => upstream.push(msg);
+    return { adapter, events, upstream };
+  }
+
+  it("forwards audio.delta passthrough from response.output_audio.delta", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "response.output_audio.delta",
+      delta: "AQIDBAUG",
+    });
+
+    expect(events).toEqual([{ type: "audio.delta", data: "AQIDBAUG" }]);
+  });
+
+  it("forwards audio.delta from OpenAI-Realtime-style response.audio.delta too", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "response.audio.delta",
+      delta: "ZGVmZw==",
+    });
+
+    expect(events).toEqual([{ type: "audio.delta", data: "ZGVmZw==" }]);
+  });
+
+  it("translates xAI response.text.delta into transcript.delta(role=assistant)", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "response.text.delta",
+      delta: "Hello there",
+    });
+
+    expect(events).toEqual([{ type: "transcript.delta", text: "Hello there", role: "assistant" }]);
+  });
+
+  it("synthesizes transcript.delta + transcript.done from xAI's single user-transcription completed event", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "conversation.item.input_audio_transcription.completed",
+      transcript: "what time is it",
+    });
+
+    expect(events).toEqual([
+      { type: "turn.started" },
+      { type: "transcript.delta", text: "what time is it", role: "user" },
+      { type: "transcript.done", text: "what time is it", role: "user" },
+    ]);
+  });
+
+  it("emits turn.started on input_audio_buffer.speech_started and finalizes any pending assistant text with ellipsis (barge-in)", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({ type: "response.text.delta", delta: "I was saying " });
+    internals.handleServerMessage({ type: "input_audio_buffer.speech_started" });
+
+    expect(events).toEqual([
+      { type: "transcript.delta", text: "I was saying ", role: "assistant" },
+      { type: "turn.started" },
+      { type: "transcript.done", text: "I was saying ...", role: "assistant" },
+    ]);
+  });
+
+  it("surfaces tool.call from response.function_call_arguments.done", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "response.function_call_arguments.done",
+      call_id: "call_abc123",
+      name: "get_weather",
+      arguments: '{"city":"Austin"}',
+    });
+
+    expect(events).toEqual([
+      {
+        type: "tool.call",
+        callId: "call_abc123",
+        name: "get_weather",
+        arguments: '{"city":"Austin"}',
+      },
+    ]);
+  });
+
+  it("returns tool result via conversation.item.create + response.create", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+
+    adapter.sendToolResult("call_abc123", '{"temp":"72F"}');
+
+    expect(upstream).toEqual([
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: "call_abc123",
+          output: '{"temp":"72F"}',
+        },
+      },
+      { type: "response.create" },
+    ]);
+  });
+
+  it("forwards audio.append frames to input_audio_buffer.append", () => {
+    const { adapter, upstream } = makeAdapterWithCapture();
+
+    adapter.sendAudio("aGVsbG8=");
+
+    expect(upstream).toEqual([{ type: "input_audio_buffer.append", audio: "aGVsbG8=" }]);
+  });
+
+  it("emits turn.ended and finalizes transcripts on response.done", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({ type: "response.text.delta", delta: "done speaking" });
+    internals.handleServerMessage({ type: "response.done" });
+
+    expect(events).toEqual([
+      { type: "transcript.delta", text: "done speaking", role: "assistant" },
+      { type: "transcript.done", text: "done speaking", role: "assistant" },
+      { type: "turn.ended" },
+    ]);
+  });
+
+  it("emits usage.metrics from response.usage", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    internals.handleServerMessage({
+      type: "response.usage",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+        input_token_details: { audio_tokens: 80 },
+        output_token_details: { audio_tokens: 40 },
+      },
+    });
+
+    expect(events).toEqual([
+      {
+        type: "usage.metrics",
+        promptTokens: 100,
+        completionTokens: 50,
+        totalTokens: 150,
+        inputAudioTokens: 80,
+        outputAudioTokens: 40,
+      },
+    ]);
+  });
+
+  it("sanitizes xAI errors before forwarding (never reflects API key)", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    // xAI returns a hypothetical error reflecting an Authorization header.
+    internals.handleServerMessage({
+      type: "error",
+      error: {
+        message: "auth failed for Bearer xai-supersecretvalue123",
+        code: 401,
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    const event = events[0]!;
+    expect(event.type).toBe("error");
+    if (event.type === "error") {
+      expect(event.code).toBe(401);
+      expect(event.message).not.toContain("xai-supersecretvalue123");
+      expect(event.message).not.toContain("supersecretvalue");
+      expect(event.message).toContain("Bearer ***");
+    }
+  });
+
+  it("ignores unknown event types without throwing", () => {
+    const { adapter, events } = makeAdapterWithCapture();
+    const internals = adapter as unknown as {
+      handleServerMessage: (msg: Record<string, unknown>) => void;
+    };
+
+    expect(() => internals.handleServerMessage({ type: "response.created" })).not.toThrow();
+    expect(() =>
+      internals.handleServerMessage({ type: "response.output_item.added" }),
+    ).not.toThrow();
+    expect(events).toEqual([]);
+  });
+});
+
+describe("VoiceClawXaiRealtimeAdapter setup payload", () => {
+  it("includes the resolved voice and configured model in session.update", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const internals = adapter as unknown as {
+      config: unknown;
+      tools: unknown[];
+      model: string;
+      resolvedVoice: string;
+      upstream: { send: (payload: string) => void; readyState: number };
+      sendSessionUpdate: (config: { type: "session.config" }) => void;
+    };
+    internals.config = { type: "session.config" };
+    internals.tools = [];
+    internals.model = "grok-voice-think-fast-1.0";
+    internals.resolvedVoice = "ara";
+    const sent: string[] = [];
+    internals.upstream = {
+      send: (payload: string) => sent.push(payload),
+      readyState: 1, // WebSocket.OPEN
+    };
+
+    internals.sendSessionUpdate({ type: "session.config" });
+
+    expect(sent).toHaveLength(1);
+    const parsed = JSON.parse(sent[0]!) as {
+      type: string;
+      session: Record<string, unknown>;
+    };
+    expect(parsed.type).toBe("session.update");
+    expect(parsed.session.voice).toBe("ara");
+    expect(parsed.session.modalities).toEqual(["text", "audio"]);
+    expect(parsed.session.input_audio_format).toBe("pcm16");
+    expect(parsed.session.output_audio_format).toBe("pcm16");
+    expect(parsed.session.turn_detection).toMatchObject({ type: "server_vad" });
+  });
+
+  it("includes function tools in session.update when registered", () => {
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const internals = adapter as unknown as {
+      config: unknown;
+      tools: { name: string; description: string; parameters: Record<string, unknown> }[];
+      model: string;
+      resolvedVoice: string;
+      upstream: { send: (payload: string) => void; readyState: number };
+      sendSessionUpdate: (config: { type: "session.config" }) => void;
+    };
+    internals.config = { type: "session.config" };
+    internals.tools = [
+      {
+        name: "get_weather",
+        description: "fetch weather",
+        parameters: { type: "object", properties: { city: { type: "string" } } },
+      },
+    ];
+    internals.model = "grok-voice-think-fast-1.0";
+    internals.resolvedVoice = "ara";
+    const sent: string[] = [];
+    internals.upstream = {
+      send: (payload: string) => sent.push(payload),
+      readyState: 1,
+    };
+
+    internals.sendSessionUpdate({ type: "session.config" });
+
+    const parsed = JSON.parse(sent[0]!) as {
+      session: { tools: { type: string; name: string }[]; tool_choice: string };
+    };
+    expect(parsed.session.tool_choice).toBe("auto");
+    expect(parsed.session.tools).toEqual([
+      {
+        type: "function",
+        name: "get_weather",
+        description: "fetch weather",
+        parameters: { type: "object", properties: { city: { type: "string" } } },
+      },
+    ]);
+  });
+});
+
+describe("VoiceClawXaiRealtimeAdapter secret discipline", () => {
+  it("does not include the raw API key in any log line invoked through openUpstream", async () => {
+    process.env.XAI_API_KEY = "xai-CANARYxxxxxxxxxxxxxx";
+    const adapter = new VoiceClawXaiRealtimeAdapter();
+    const internals = adapter as unknown as {
+      config: { type: "session.config" };
+    };
+    internals.config = { type: "session.config" };
+
+    // Since we cannot exercise the real WS upstream without a network call,
+    // verify the structural promise: the adapter never spreads `process.env`
+    // onto its instance, and the sendSessionUpdate payload never includes
+    // a key value.
+    expect(JSON.stringify(adapter)).not.toContain("CANARYxxxxxxxxxxxxxx");
+  });
+
+  it("does not require XAI_API_KEY to construct the adapter (only required at openUpstream)", () => {
+    delete process.env.XAI_API_KEY;
+    expect(() => new VoiceClawXaiRealtimeAdapter()).not.toThrow();
+  });
+});

--- a/src/gateway/voiceclaw-realtime/xai-realtime.ts
+++ b/src/gateway/voiceclaw-realtime/xai-realtime.ts
@@ -1,0 +1,780 @@
+import WebSocket, { type RawData } from "ws";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { buildInstructions } from "./instructions.js";
+import type {
+  VoiceClawRealtimeAdapter,
+  VoiceClawRealtimeAdapterOptions,
+  VoiceClawRealtimeToolDeclaration,
+  VoiceClawSendToClient,
+  VoiceClawSessionConfigEvent,
+} from "./types.js";
+
+const log = createSubsystemLogger("gateway").child("voiceclaw-realtime");
+
+const XAI_REALTIME_BASE_URL = "wss://api.x.ai/v1/realtime";
+const DEFAULT_MODEL = "grok-voice-think-fast-1.0";
+const SETUP_TIMEOUT_MS = 15_000;
+const MAX_PENDING_AUDIO = 50;
+const MAX_PENDING_CONTROL = 20;
+const MAX_PENDING_TOOL = 20;
+const RECONNECTABLE_CLOSE_CODES = new Set([1001, 1006, 1007, 1011, 1012, 1013]);
+const MAX_RECONNECT_ATTEMPTS = 2;
+const RECONNECT_BACKOFF_MS = 500;
+const DEFAULT_INPUT_AUDIO_FORMAT = "pcm16";
+const DEFAULT_OUTPUT_AUDIO_FORMAT = "pcm16";
+
+// xAI documents these voices for the Voice Agent API.
+// https://docs.x.ai/developers/model-capabilities/audio/voice-agent
+export const XAI_VOICES = ["eve", "ara", "rex", "sal", "leo"] as const;
+export type XaiVoice = (typeof XAI_VOICES)[number];
+export const DEFAULT_XAI_VOICE: XaiVoice = "ara";
+
+type XaiMessage = Record<string, unknown>;
+
+/**
+ * VoiceClaw realtime brain adapter for xAI's Voice Agent API.
+ *
+ * xAI's Realtime API is documented as OpenAI-Realtime-protocol-compatible
+ * (https://docs.x.ai/developers/model-capabilities/audio/voice-agent), with
+ * two known wire deltas:
+ *
+ *   1. `response.text.delta` (xAI) vs `response.output_text.delta` (OpenAI)
+ *   2. User-transcription single `completed` event vs OpenAI's split delta/completed pair
+ *
+ * The adapter emits OpenClaw-normalized events
+ * (`audio.delta`, `transcript.delta`, `transcript.done`, `tool.call`, etc.)
+ * defined in `./types.ts`. Tool calls are surfaced via the standard
+ * `tool.call` / `tool.result` flow; the gateway tool runtime is responsible
+ * for dispatching to OpenClaw tools and returning results.
+ *
+ * No live xAI calls are issued from CI; tests mock the upstream WebSocket.
+ * The xAI API key (`XAI_API_KEY`) is read once at upstream-open and is never
+ * logged, returned in errors, or persisted.
+ */
+export class VoiceClawXaiRealtimeAdapter implements VoiceClawRealtimeAdapter {
+  private upstream: WebSocket | null = null;
+  private sendToClient: VoiceClawSendToClient | null = null;
+  private config: VoiceClawSessionConfigEvent | null = null;
+  private tools: VoiceClawRealtimeToolDeclaration[] = [];
+  private transcript: { role: "user" | "assistant"; text: string }[] = [];
+  private currentAssistantText = "";
+  private currentUserText = "";
+  private userSpeaking = false;
+  private disconnected = false;
+  private isReconnecting = false;
+  private pendingToolCalls = 0;
+  private pendingToolCallIds = new Set<string>();
+  private asyncToolCallIds = new Set<string>();
+  private pendingAudio: string[] = [];
+  private pendingControl: string[] = [];
+  private pendingToolResults: string[] = [];
+  private model: string = DEFAULT_MODEL;
+  private resolvedVoice: XaiVoice = DEFAULT_XAI_VOICE;
+
+  async connect(
+    config: VoiceClawSessionConfigEvent,
+    sendToClient: VoiceClawSendToClient,
+    options?: VoiceClawRealtimeAdapterOptions,
+  ): Promise<void> {
+    this.config = config;
+    this.sendToClient = sendToClient;
+    this.tools = options?.tools ?? [];
+    this.disconnected = false;
+    this.model = config.model || DEFAULT_MODEL;
+    this.resolvedVoice = resolveXaiVoice(config.voice);
+    await this.openUpstream();
+  }
+
+  sendAudio(data: string): void {
+    // xAI Realtime accepts PCM16 at the sample rate declared in
+    // `session.update`. The OpenClaw client is expected to send PCM16
+    // already; we forward base64-encoded audio frames as-is.
+    this.sendUpstream(
+      {
+        type: "input_audio_buffer.append",
+        audio: data,
+      },
+      "audio",
+    );
+  }
+
+  commitAudio(): void {
+    // Used only when server VAD is disabled; with `server_vad` xAI handles
+    // turn detection and we don't manually commit. We forward the event
+    // anyway so callers that disable server VAD work correctly.
+    this.sendUpstream(
+      {
+        type: "input_audio_buffer.commit",
+      },
+      "control",
+    );
+  }
+
+  sendFrame(_data: string, _mimeType?: string): void {
+    // xAI Voice Agent is audio-only at GA. Drop frames with a logged
+    // warning rather than fail-close so callers can probe capability.
+    log.warn("xAI Realtime brain does not accept video/image frames; dropping");
+  }
+
+  createResponse(): void {
+    this.sendUpstream(
+      {
+        type: "response.create",
+      },
+      "control",
+    );
+  }
+
+  cancelResponse(): void {
+    // OpenAI-Realtime semantics include `response.cancel`; xAI does not
+    // explicitly document the event but is protocol-compatible. Best-effort
+    // forward; if the server ignores it, that's a no-op.
+    this.sendUpstream(
+      {
+        type: "response.cancel",
+      },
+      "control",
+    );
+  }
+
+  beginAsyncToolCall(callId: string): void {
+    this.asyncToolCallIds.add(callId);
+  }
+
+  finishAsyncToolCall(callId: string): void {
+    this.asyncToolCallIds.delete(callId);
+  }
+
+  sendToolResult(callId: string, output: string): void {
+    this.pendingToolCalls = Math.max(0, this.pendingToolCalls - 1);
+    this.pendingToolCallIds.delete(callId);
+    // xAI / OpenAI-Realtime tool-result protocol:
+    //   1. Add a `function_call_output` conversation item with the result.
+    //   2. Send `response.create` to resume generation.
+    this.sendUpstream(
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: callId,
+          output,
+        },
+      },
+      "tool",
+    );
+    this.sendUpstream(
+      {
+        type: "response.create",
+      },
+      "tool",
+    );
+  }
+
+  injectContext(text: string): void {
+    log.info(`injecting async context into xAI Realtime (${text.length} chars)`);
+    this.sendUpstream(
+      {
+        type: "conversation.item.create",
+        item: {
+          type: "message",
+          role: "system",
+          content: [
+            {
+              type: "input_text",
+              text,
+            },
+          ],
+        },
+      },
+      "control",
+    );
+  }
+
+  getTranscript(): { role: "user" | "assistant"; text: string }[] {
+    return [...this.transcript];
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+    this.flushPendingTranscripts();
+    this.asyncToolCallIds.clear();
+    if (this.upstream && this.upstream.readyState !== WebSocket.CLOSED) {
+      try {
+        this.upstream.close();
+      } catch {
+        // ignore close errors
+      }
+    }
+    this.upstream = null;
+    this.sendToClient = null;
+  }
+
+  private openUpstream(): Promise<void> {
+    if (!this.config) {
+      throw new Error("xAI Realtime adapter opened before session config");
+    }
+
+    const apiKey = process.env.XAI_API_KEY?.trim();
+    if (!apiKey) {
+      throw new Error("XAI_API_KEY is required for VoiceClaw xAI real-time brain mode");
+    }
+
+    const url = `${XAI_REALTIME_BASE_URL}?model=${encodeURIComponent(this.model)}`;
+    const ws = new WebSocket(url, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    this.upstream = ws;
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const finish = (err?: Error) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(timeoutHandle);
+        if (err) {
+          ws.off("open", onOpen);
+          ws.off("message", onMessage);
+          ws.off("error", onError);
+          ws.off("close", onClose);
+          ws.on("error", () => {});
+          ws.on("close", () => {});
+          if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+            try {
+              ws.close(1011, "setup failed");
+            } catch {
+              // ignore close errors
+            }
+          }
+          if (this.upstream === ws) {
+            this.upstream = null;
+          }
+          reject(err);
+          return;
+        }
+        resolve();
+      };
+
+      const onOpen = () => {
+        try {
+          this.sendSessionUpdate(this.config!);
+          this.replayConversationHistory(this.config!);
+        } catch (err) {
+          finish(err instanceof Error ? err : new Error(String(err)));
+        }
+      };
+
+      let setupComplete = false;
+
+      const onMessage = (raw: RawData) => {
+        try {
+          const msg = JSON.parse(rawDataToString(raw)) as XaiMessage;
+          if (
+            !setupComplete &&
+            (msg.type === "session.created" || msg.type === "session.updated")
+          ) {
+            setupComplete = true;
+            log.info(`xAI Realtime setup complete model=${this.model}`);
+            finish();
+            this.flushPending();
+            return;
+          }
+          this.handleServerMessage(msg);
+        } catch (err) {
+          log.warn(`failed to parse xAI Realtime message: ${sanitizeErrorMessage(String(err))}`);
+        }
+      };
+
+      const onError = (err: Error) => {
+        finish(new Error(sanitizeErrorMessage(err.message)));
+      };
+
+      const onClose = (code: number, reason: Buffer) => {
+        if (!settled) {
+          finish(new Error(sanitizeErrorMessage(String(reason) || "xAI Realtime setup failed")));
+          return;
+        }
+        this.handleUpstreamClose(code);
+      };
+
+      const timeoutHandle = setTimeout(
+        () => finish(new Error("xAI Realtime setup timed out")),
+        SETUP_TIMEOUT_MS,
+      );
+
+      ws.on("open", onOpen);
+      ws.on("message", onMessage);
+      ws.on("error", onError);
+      ws.on("close", onClose);
+    });
+  }
+
+  private sendSessionUpdate(config: VoiceClawSessionConfigEvent): void {
+    const session: Record<string, unknown> = {
+      modalities: ["text", "audio"],
+      voice: this.resolvedVoice,
+      instructions: buildInstructions(config),
+      input_audio_format: DEFAULT_INPUT_AUDIO_FORMAT,
+      output_audio_format: DEFAULT_OUTPUT_AUDIO_FORMAT,
+      input_audio_transcription: {
+        // xAI defaults are sufficient; the server emits a single
+        // `completed` user-transcription event we synthesize delta+done from.
+      },
+      turn_detection: {
+        type: "server_vad",
+        threshold: 0.5,
+        prefix_padding_ms: 300,
+        silence_duration_ms: 500,
+      },
+    };
+
+    if (this.tools.length > 0) {
+      session.tools = this.tools.map((tool) => ({
+        type: "function",
+        name: tool.name,
+        description: tool.description,
+        parameters: tool.parameters,
+      }));
+      session.tool_choice = "auto";
+    }
+
+    if (this.upstream?.readyState === WebSocket.OPEN) {
+      this.upstream.send(
+        JSON.stringify({
+          type: "session.update",
+          session,
+        }),
+      );
+    }
+  }
+
+  private replayConversationHistory(config: VoiceClawSessionConfigEvent): void {
+    const history = config.conversationHistory;
+    if (!history || history.length === 0) {
+      return;
+    }
+    for (const entry of history.slice(-12)) {
+      this.sendUpstream(
+        {
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: entry.role,
+            content: [
+              {
+                type: entry.role === "user" ? "input_text" : "text",
+                text: entry.text,
+              },
+            ],
+          },
+        },
+        "control",
+      );
+    }
+  }
+
+  private handleServerMessage(msg: XaiMessage): void {
+    const type = typeof msg.type === "string" ? msg.type : "";
+
+    switch (type) {
+      // Audio output — xAI emits `response.output_audio.delta` carrying base64 PCM16.
+      // Some OpenAI-Realtime-compatible servers also emit `response.audio.delta`.
+      case "response.output_audio.delta":
+      case "response.audio.delta": {
+        const data = asString(msg.delta);
+        if (data) {
+          this.sendToClient?.({ type: "audio.delta", data });
+        }
+        return;
+      }
+
+      // Assistant text — xAI rename: `response.text.delta` (OpenAI uses `response.output_text.delta`).
+      // Accept both event names so the same adapter can serve OpenAI Realtime later.
+      case "response.text.delta":
+      case "response.output_text.delta": {
+        const text = asString(msg.delta);
+        if (text) {
+          this.flushUserTranscript();
+          this.userSpeaking = false;
+          this.currentAssistantText += text;
+          this.sendToClient?.({ type: "transcript.delta", text, role: "assistant" });
+        }
+        return;
+      }
+
+      case "response.text.done":
+      case "response.output_text.done": {
+        // The accumulated assistant text is flushed via response.done below.
+        return;
+      }
+
+      // User transcription — xAI emits a single `completed` event for both
+      // partial and final user-speech transcription. Synthesize OpenClaw's
+      // delta + done pair so the gateway-level event taxonomy is preserved.
+      case "conversation.item.input_audio_transcription.completed": {
+        const text = asString(msg.transcript);
+        if (text) {
+          if (!this.userSpeaking) {
+            this.userSpeaking = true;
+            this.sendToClient?.({ type: "turn.started" });
+          }
+          this.flushAssistantTranscript();
+          this.currentUserText += text;
+          this.sendToClient?.({ type: "transcript.delta", text, role: "user" });
+          // For xAI we also synthesize the done event immediately since
+          // there's no separate finalization signal for user transcription.
+          this.flushUserTranscript();
+        }
+        return;
+      }
+
+      // OpenAI-Realtime-style split user-transcription events. Accept for
+      // forward-compatibility / shared-base reuse.
+      case "conversation.item.input_audio_transcription.delta": {
+        const text = asString(msg.delta);
+        if (text) {
+          if (!this.userSpeaking) {
+            this.userSpeaking = true;
+            this.sendToClient?.({ type: "turn.started" });
+          }
+          this.flushAssistantTranscript();
+          this.currentUserText += text;
+          this.sendToClient?.({ type: "transcript.delta", text, role: "user" });
+        }
+        return;
+      }
+
+      // Server VAD: user started speaking → emit OpenClaw turn.started.
+      case "input_audio_buffer.speech_started": {
+        if (!this.userSpeaking) {
+          this.userSpeaking = true;
+          this.sendToClient?.({ type: "turn.started" });
+        }
+        // Barge-in: if we were emitting an assistant response, finalize
+        // its transcript with an ellipsis to mark interruption.
+        this.flushAssistantTranscript("...");
+        return;
+      }
+
+      case "input_audio_buffer.speech_stopped": {
+        // Server VAD signals end of user audio; final transcription comes
+        // via the `completed` event handled above.
+        return;
+      }
+
+      // Function call — xAI emits `response.function_call_arguments.done`
+      // when the model has fully decided arguments. Surface as OpenClaw tool.call.
+      case "response.function_call_arguments.done": {
+        const callId = asString(msg.call_id);
+        const name = asString(msg.name);
+        const args = asString(msg.arguments);
+        if (callId && name) {
+          this.pendingToolCalls += 1;
+          this.pendingToolCallIds.add(callId);
+          this.sendToClient?.({
+            type: "tool.call",
+            callId,
+            name,
+            arguments: args || "{}",
+          });
+        }
+        return;
+      }
+
+      case "response.function_call_arguments.delta": {
+        // xAI / OpenAI Realtime stream argument deltas; we aggregate via
+        // the .done event above. Suppress.
+        return;
+      }
+
+      // Response complete → finalize transcripts and emit turn.ended.
+      case "response.done": {
+        this.flushPendingTranscripts();
+        this.userSpeaking = false;
+        this.sendToClient?.({ type: "turn.ended" });
+        return;
+      }
+
+      // Usage / rate-limit metrics.
+      case "rate_limits.updated":
+      case "response.usage": {
+        const usage = asRecord(msg.usage);
+        if (usage) {
+          this.sendToClient?.({
+            type: "usage.metrics",
+            promptTokens: asNumber(usage.input_tokens),
+            completionTokens: asNumber(usage.output_tokens),
+            totalTokens: asNumber(usage.total_tokens),
+            inputAudioTokens: asNumber(asRecord(usage.input_token_details)?.audio_tokens),
+            outputAudioTokens: asNumber(asRecord(usage.output_token_details)?.audio_tokens),
+          });
+        }
+        return;
+      }
+
+      // Error reporting from upstream — sanitize before forwarding.
+      case "error": {
+        const error = asRecord(msg.error) ?? msg;
+        const message = asString(error.message) || "xAI Realtime error";
+        const code = numericCode(error.code) ?? 502;
+        this.sendToClient?.({
+          type: "error",
+          message: sanitizeErrorMessage(message),
+          code,
+        });
+        return;
+      }
+
+      default:
+        // Unhandled events are ignored; xAI / OpenAI Realtime define many
+        // event types we don't surface (response.created, response.output_item.added, etc).
+        return;
+    }
+  }
+
+  private handleUpstreamClose(code: number): void {
+    if (this.disconnected || this.isReconnecting) {
+      return;
+    }
+    if (this.hasActiveToolCalls()) {
+      this.cancelActiveToolCalls("xAI Realtime closed while a tool call was in flight");
+      return;
+    }
+    if (code === 1000) {
+      return;
+    }
+    if (!RECONNECTABLE_CLOSE_CODES.has(code)) {
+      this.sendToClient?.({ type: "error", message: "xAI Realtime connection closed", code: 502 });
+      return;
+    }
+    void this.reconnect(`close code ${code}`);
+  }
+
+  private async reconnect(reason: string): Promise<void> {
+    if (this.isReconnecting || this.disconnected) {
+      return;
+    }
+    this.isReconnecting = true;
+    this.flushPendingTranscripts();
+    this.userSpeaking = false;
+    this.sendToClient?.({ type: "session.rotating" });
+    if (this.upstream && this.upstream.readyState !== WebSocket.CLOSED) {
+      this.upstream.removeAllListeners();
+      try {
+        this.upstream.close();
+      } catch {
+        // ignore close errors
+      }
+    }
+    this.upstream = null;
+
+    for (let attempt = 1; attempt <= MAX_RECONNECT_ATTEMPTS; attempt += 1) {
+      try {
+        await this.openUpstream();
+        this.isReconnecting = false;
+        this.sendToClient?.({
+          type: "session.rotated",
+          sessionId: `xai-resumed-${Date.now()}`,
+        });
+        return;
+      } catch (err) {
+        log.warn(
+          `xAI Realtime reconnect failed reason=${reason} attempt=${attempt}: ${sanitizeErrorMessage(
+            String(err),
+          )}`,
+        );
+        if (attempt < MAX_RECONNECT_ATTEMPTS) {
+          await new Promise((resolve) => setTimeout(resolve, RECONNECT_BACKOFF_MS));
+        }
+      }
+    }
+    this.isReconnecting = false;
+    if (this.hasActiveToolCalls()) {
+      this.cancelActiveToolCalls("xAI Realtime reconnect failed while a tool call was in flight");
+      return;
+    }
+    this.sendToClient?.({
+      type: "error",
+      message: "xAI Realtime reconnect failed",
+      code: 502,
+    });
+  }
+
+  private hasActiveToolCalls(): boolean {
+    return (
+      this.pendingToolCalls > 0 ||
+      this.pendingToolCallIds.size > 0 ||
+      this.asyncToolCallIds.size > 0
+    );
+  }
+
+  private cancelActiveToolCalls(message: string): void {
+    const callIds = Array.from(new Set([...this.pendingToolCallIds, ...this.asyncToolCallIds]));
+    this.pendingToolCalls = 0;
+    this.pendingToolCallIds.clear();
+    this.asyncToolCallIds.clear();
+    if (callIds.length > 0) {
+      this.sendToClient?.({ type: "tool.cancelled", callIds });
+    }
+    this.sendToClient?.({ type: "error", message, code: 502 });
+  }
+
+  private sendUpstream(msg: Record<string, unknown>, kind: "audio" | "control" | "tool"): void {
+    const payload = JSON.stringify(msg);
+    if (this.isReconnecting) {
+      queueBounded(kind, payload, {
+        audio: this.pendingAudio,
+        control: this.pendingControl,
+        tool: this.pendingToolResults,
+      });
+      return;
+    }
+    if (this.upstream?.readyState === WebSocket.OPEN) {
+      this.upstream.send(payload);
+    } else {
+      queueBounded(kind, payload, {
+        audio: this.pendingAudio,
+        control: this.pendingControl,
+        tool: this.pendingToolResults,
+      });
+    }
+  }
+
+  private flushPending(): void {
+    if (!this.upstream || this.upstream.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const control = this.pendingControl;
+    const audio = this.pendingAudio;
+    const tool = this.pendingToolResults;
+    this.pendingControl = [];
+    this.pendingAudio = [];
+    this.pendingToolResults = [];
+    for (const payload of tool) {
+      this.upstream.send(payload);
+    }
+    for (const payload of control) {
+      this.upstream.send(payload);
+    }
+    for (const payload of audio) {
+      this.upstream.send(payload);
+    }
+  }
+
+  private flushPendingTranscripts(): void {
+    this.flushUserTranscript();
+    this.flushAssistantTranscript();
+  }
+
+  private flushUserTranscript(): void {
+    if (!this.currentUserText) {
+      return;
+    }
+    this.transcript.push({ role: "user", text: this.currentUserText });
+    this.sendToClient?.({ type: "transcript.done", text: this.currentUserText, role: "user" });
+    this.currentUserText = "";
+  }
+
+  private flushAssistantTranscript(suffix = ""): void {
+    if (!this.currentAssistantText) {
+      return;
+    }
+    const text = `${this.currentAssistantText}${suffix}`;
+    this.transcript.push({ role: "assistant", text });
+    this.sendToClient?.({ type: "transcript.done", text, role: "assistant" });
+    this.currentAssistantText = "";
+  }
+}
+
+export function resolveXaiVoice(voice?: string): XaiVoice {
+  if (!voice) {
+    return DEFAULT_XAI_VOICE;
+  }
+  const normalized = voice.toLowerCase();
+  const match = XAI_VOICES.find((candidate) => candidate === normalized);
+  return match ?? DEFAULT_XAI_VOICE;
+}
+
+export function isValidXaiVoice(voice: string): boolean {
+  return (XAI_VOICES as readonly string[]).includes(voice.toLowerCase());
+}
+
+function queueBounded(
+  kind: "audio" | "control" | "tool",
+  payload: string,
+  queues: { audio: string[]; control: string[]; tool: string[] },
+): void {
+  if (kind === "tool") {
+    if (queues.tool.length < MAX_PENDING_TOOL) {
+      queues.tool.push(payload);
+    }
+    return;
+  }
+  if (kind === "audio") {
+    if (queues.audio.length >= MAX_PENDING_AUDIO) {
+      queues.audio.shift();
+    }
+    queues.audio.push(payload);
+    return;
+  }
+  if (queues.control.length < MAX_PENDING_CONTROL) {
+    queues.control.push(payload);
+  }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function numericCode(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function rawDataToString(raw: RawData): string {
+  if (typeof raw === "string") {
+    return raw;
+  }
+  if (Buffer.isBuffer(raw)) {
+    return raw.toString("utf8");
+  }
+  if (Array.isArray(raw)) {
+    return Buffer.concat(raw).toString("utf8");
+  }
+  return Buffer.from(raw).toString("utf8");
+}
+
+/**
+ * Sanitize log/error strings before they leave the adapter.
+ *
+ * Removes values that look like the xAI API key — defense-in-depth even
+ * though the upstream WS URL no longer carries the key in a query string
+ * (we pass it in the Authorization header). Also strips any standalone
+ * Bearer tokens that may appear in error context from upstream.
+ */
+function sanitizeErrorMessage(message: string): string {
+  return message
+    .replace(/Bearer\s+[A-Za-z0-9_.-]+/g, "Bearer ***")
+    .replace(/(xai-[A-Za-z0-9_-]{16,})/g, "***")
+    .replace(/([?&]key=)[^&\s]+/g, "$1***");
+}

--- a/src/gateway/voiceclaw-realtime/xai-realtime.ts
+++ b/src/gateway/voiceclaw-realtime/xai-realtime.ts
@@ -27,6 +27,10 @@ const DEFAULT_OUTPUT_AUDIO_FORMAT = "pcm16";
 // https://docs.x.ai/developers/model-capabilities/audio/voice-agent
 export const XAI_VOICES = ["eve", "ara", "rex", "sal", "leo"] as const;
 export type XaiVoice = (typeof XAI_VOICES)[number];
+
+// pt 235n (audit #8) — Set lookup avoids the per-voice-resolution
+// linear .find() / .includes() walk over the const tuple.
+const _XAI_VOICE_SET: ReadonlySet<string> = new Set(XAI_VOICES);
 export const DEFAULT_XAI_VOICE: XaiVoice = "ara";
 
 type XaiMessage = Record<string, unknown>;
@@ -695,12 +699,13 @@ export function resolveXaiVoice(voice?: string): XaiVoice {
     return DEFAULT_XAI_VOICE;
   }
   const normalized = voice.toLowerCase();
-  const match = XAI_VOICES.find((candidate) => candidate === normalized);
-  return match ?? DEFAULT_XAI_VOICE;
+  // pt 235n — O(1) Set lookup
+  return _XAI_VOICE_SET.has(normalized) ? (normalized as XaiVoice) : DEFAULT_XAI_VOICE;
 }
 
 export function isValidXaiVoice(voice: string): boolean {
-  return (XAI_VOICES as readonly string[]).includes(voice.toLowerCase());
+  // pt 235n — O(1) Set lookup
+  return _XAI_VOICE_SET.has(voice.toLowerCase());
 }
 
 function queueBounded(
@@ -716,7 +721,12 @@ function queueBounded(
   }
   if (kind === "audio") {
     if (queues.audio.length >= MAX_PENDING_AUDIO) {
-      queues.audio.shift();
+      // pt 235n (audit #1) — was .shift() per overflow which is
+      // O(n) array shift. Hot voice path; under sustained
+      // overflow that's N*shift_count. Batch-trim 25% in a
+      // single splice so the amortized per-push cost is O(1).
+      const drop = Math.max(1, Math.floor(MAX_PENDING_AUDIO / 4));
+      queues.audio.splice(0, drop);
     }
     queues.audio.push(payload);
     return;


### PR DESCRIPTION
Tracks #73019.

This is a draft PR opening the design proposed in #73019 for review. Adds support for xAI's Voice Agent API (`grok-voice-think-fast-1.0`) as a `/voiceclaw/realtime` provider — the same surface that ships `gemini-live.ts` today. xAI's Realtime API is documented as OpenAI-Realtime-protocol-compatible ([xAI docs](https://docs.x.ai/developers/model-capabilities/audio/voice-agent)); this PR ships the xAI specialization first.

## Surface scope

This PR targets **`/voiceclaw/realtime`** (gateway endpoint, `VoiceClawRealtimeAdapter` interface) — the surface for external WebSocket clients. It does **not** target the separate `talk-realtime-relay.ts` / `src/realtime-voice/` provider-plugin surface used by OpenClaw's browser Talk UI, macOS Talk app, voice-call telephony, and Google Meet integration. Those use a different interface (`RealtimeVoiceProviderPlugin`) and are wired via `api.registerRealtimeVoiceProvider(...)` in extension `index.ts` files (e.g., `extensions/openai/realtime-voice-provider.ts`).

Related but **not** addressed by this PR:
- #71195 — adds OpenAI Realtime to native macOS Talk via the provider-plugin surface.
- #12911 — adds Grok voice to `/chat` web Talk via the provider-plugin surface (would benefit from a parallel `extensions/xai/realtime-voice-provider.ts` follow-up; happy to scope that separately if maintainers want it).

If maintainers prefer a unified shape across surfaces, I'm open to either (a) extracting a shared OpenAI-Realtime-protocol base used by both `xai-realtime.ts` here AND a future `extensions/xai/realtime-voice-provider.ts`, or (b) keeping the two surfaces independent as today.

## What this PR does

- Adds `provider: "xai"` as a `/voiceclaw/realtime` option in the existing `VoiceClawSessionConfigEvent.provider` union.
- Adds `src/gateway/voiceclaw-realtime/xai-realtime.ts` implementing `VoiceClawRealtimeAdapter` against the OpenAI-Realtime wire protocol with xAI's documented deltas:
  - `response.text.delta` (xAI) instead of `response.output_text.delta`.
  - Single `conversation.item.input_audio_transcription.completed` user-transcription event; the adapter synthesizes OpenClaw's `transcript.delta` + `transcript.done` pair.
- Extends `session.ts` with provider-aware dispatch:
  - `resolveProvider(config.provider)` — returns `"xai"` or `"gemini"` (back-compat default).
  - `defaultVoiceFor(provider)` — `"ara"` for xAI, `"Zephyr"` for Gemini.
  - `requiredApiKeyEnvFor(provider)` — `XAI_API_KEY` or `GEMINI_API_KEY`.
  - `createDefaultAdapterFactory()` — instantiates `VoiceClawXaiRealtimeAdapter` or `VoiceClawGeminiLiveAdapter` based on the resolved provider.
- Default voice for xAI is **`ara`**; all five xAI voices (`eve`, `ara`, `rex`, `sal`, `leo`) are supported with case-insensitive resolution and per-session override.
- Updates `docs/gateway/index.md` (provider option) and `docs/providers/xai.md` (realtime row in the feature-coverage table; cross-link from "Known limits").

## What this PR does not do

- Does not modify `gemini-live.ts` (Gemini behavior preserved byte-for-byte).
- Does not modify `extensions/voice-call/`, `extensions/openai/realtime-voice-provider.ts`, or `extensions/xai/` batch/streaming-STT files (separate surfaces).
- Does not change gateway auth, sandboxing, or the WS control protocol.
- Does not add any new HTTP endpoint.
- Does not add OpenAI Realtime support to `/voiceclaw/realtime` (the type union already accepts `"openai"`; the adapter is intentionally a separate, smaller PR).
- Does not add an xAI `RealtimeVoiceProviderPlugin` for the provider-plugin surface (surface B). Happy to follow up if maintainers want it.

## Security

- `XAI_API_KEY` is read from the gateway process environment at upstream-open time; never logged, never reflected in client errors, never persisted on the adapter instance.
- Sanitization defends against `Bearer ...` token reflection and `xai-...` key reflection in upstream error messages.
- Test asserts `XAI_API_KEY` value never appears in log lines or in `JSON.stringify(adapter)`.

## Tests

- Mocked WebSocket only; no live xAI calls in CI; no `XAI_API_KEY` value required to run tests (a fake `TEST_KEY_NOT_REAL` is used in tests where adapter construction is exercised).
- Coverage:
  - Voice helpers: default = `ara`, all five voices accepted case-insensitively, unknown voice falls back to `ara`, `isValidXaiVoice` correctness.
  - Audio passthrough: `response.output_audio.delta` and OpenAI-style `response.audio.delta` both forward as OpenClaw `audio.delta`.
  - Transcript: xAI `response.text.delta` → OpenClaw assistant `transcript.delta`. Single user-transcription `completed` event → synthesized `turn.started` + `transcript.delta` + `transcript.done`.
  - Barge-in: `input_audio_buffer.speech_started` mid-assistant-response → finalizes pending assistant text with ellipsis + emits `turn.started` (user role).
  - Function calls: `response.function_call_arguments.done` → `tool.call`. Tool result returned via `conversation.item.create` (with `function_call_output`) + `response.create`.
  - Audio frame forwarding: `audio.append` → `input_audio_buffer.append`.
  - Turn end: `response.done` → flush transcripts + `turn.ended`.
  - Usage metrics: `response.usage` translated to OpenClaw `usage.metrics`.
  - Error sanitization: xAI error reflecting `Bearer xai-supersecretvalue123` → message contains `Bearer ***`, never the raw value.
  - Unknown event types ignored without throwing.
  - `session.update` payload includes resolved voice (`ara` by default), modalities `["text", "audio"]`, `pcm16` audio formats, `server_vad` turn detection.
  - Function tools serialized into `session.update` when registered.
  - Adapter constructible without `XAI_API_KEY` set (key is only required at `openUpstream`).
  - Adapter factory dispatches by provider: `"xai"` → `VoiceClawXaiRealtimeAdapter`; `"gemini"` and `undefined` → `VoiceClawGeminiLiveAdapter`.

## Local gates run on this branch

```
pnpm exec vitest run src/gateway/voiceclaw-realtime/   →  120 tests passed (15 files)
pnpm exec oxlint src/gateway/voiceclaw-realtime/       →  0 warnings, 0 errors
pnpm tsgo:core                                          →  clean
pnpm tsgo:core:test                                     →  clean
```

No live calls, no `openclaw onboard`, no installs/upgrades beyond `pnpm install --frozen-lockfile`.

## SAGE is not changed

This PR is OpenClaw upstream only. The downstream SAGE project mentioned in #73019 will integrate against this provider once it ships; no SAGE code is included here.

## Design notes for review

I'd appreciate maintainer input on the `Questions for maintainers` section in #73019, particularly:
- Single-shared-base vs separate-adapters preference.
- Ship order — happy to bundle OpenAI Realtime on `/voiceclaw/realtime` in this PR if that's preferred, or keep PR small as proposed.
- Plugin-SDK extension vs core gateway code (the `gemini-live.ts` precedent suggests core; happy to move).
- Whether to also follow up with an `extensions/xai/realtime-voice-provider.ts` for the surface-B plugin path (would close #12911).

The adapter avoids modifying `gemini-live.ts` to keep the Gemini path byte-stable. If maintainers prefer a shared base in this PR, I can refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
