### PR TITLE
fix(mattermost): honor threadId in message tool sends

### DIFF
--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -448,6 +448,59 @@ describe("mattermostPlugin", () => {
         }),
       );
     });
+
+    it("uses explicit threadId for send actions when replyToId is absent", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            threadId: " thread-root ",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "thread-root",
+        }),
+      );
+    });
+
+    it("prefers explicit replyToId over threadId for send actions", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            replyToId: "specific-reply",
+            threadId: "thread-root",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      expect(sendMessageMattermostMock).toHaveBeenCalledWith(
+        "channel:CHAN1",
+        "hello",
+        expect.objectContaining({
+          accountId: "default",
+          replyToId: "specific-reply",
+        }),
+      );
+    });
   });
 
   describe("outbound", () => {

--- a/extensions/mattermost/src/channel.test.ts
+++ b/extensions/mattermost/src/channel.test.ts
@@ -450,6 +450,50 @@ describe("mattermostPlugin", () => {
       expect(options.replyToId).toBe("post-root");
     });
 
+    it("uses threadId as replyToId fallback for direct send actions", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            threadId: " post-root ",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.accountId).toBe("default");
+      expect(options.replyToId).toBe("post-root");
+    });
+
+    it("preserves replyToId precedence over threadId for direct send actions", async () => {
+      const cfg = createMattermostTestConfig();
+
+      await mattermostPlugin.actions?.handleAction?.(
+        createMattermostActionContext({
+          action: "send",
+          params: {
+            to: "channel:CHAN1",
+            message: "hello",
+            replyToId: " explicit-root ",
+            threadId: " thread-root ",
+            replyTo: " legacy-root ",
+          },
+          cfg,
+          accountId: "default",
+        }),
+      );
+
+      const options = expectSingleMattermostSend("channel:CHAN1", "hello");
+      expect(options.accountId).toBe("default");
+      expect(options.replyToId).toBe("explicit-root");
+    });
+
     it("routes filePath send actions through Mattermost media upload options", async () => {
       const cfg = createMattermostTestConfig();
       const mediaReadFile = vi.fn(async () => Buffer.from("report"));

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -187,7 +187,9 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
     // Match the shared runner semantics: trim empty reply IDs away before
     // falling back from replyToId to replyTo on direct plugin calls.
     const replyToId =
-      normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
+      normalizeOptionalString(params.replyToId) ??
+      normalizeOptionalString(params.threadId) ??
+      normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
     const mediaUrl =

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -286,9 +286,11 @@ const mattermostMessageActions: ChannelMessageActionAdapter = {
         ? params.message
         : "";
     // Match the shared runner semantics: trim empty reply IDs away before
-    // falling back from replyToId to replyTo on direct plugin calls.
+    // falling back from replyToId to threadId to replyTo on direct plugin calls.
     const replyToId =
-      normalizeOptionalString(params.replyToId) ?? normalizeOptionalString(params.replyTo);
+      normalizeOptionalString(params.replyToId) ??
+      normalizeOptionalString(params.threadId) ??
+      normalizeOptionalString(params.replyTo);
     const resolvedAccountId = accountId || undefined;
 
     const attachmentMedia = collectMattermostAttachmentMedia(params);


### PR DESCRIPTION
## Summary
- rebases the Mattermost direct message-tool send fix onto current `main`
- treats explicit `threadId` as the fallback Mattermost root post id when `replyToId` is absent
- keeps `replyToId` precedence over `threadId`, and keeps legacy `replyTo` as the final fallback
- adds direct `handleAction` regression coverage for trimmed `threadId` and precedence behavior

## Why
Current `main` already ships the Mattermost attachment collector and media-root upload plumbing, but the direct Mattermost `message(action: "send")` plugin action path still computes `replyToId` only from `replyToId` / legacy `replyTo`.

That means agents that call the message tool with `threadId` but no `replyToId` can still produce a Mattermost post without the intended thread root. The shared outbound helpers already have this fallback; this PR makes the direct plugin action path match it.

Part of #67784.

## Real behavior proof

- Behavior or issue addressed: Direct OpenClaw Mattermost `message(action: "send")` calls with `threadId` and no `replyTo` / `replyToId` should create a Mattermost post whose `root_id` is the supplied thread root id.
- Real environment tested: Local OpenClaw 2026.6.6 Mattermost setup with the same direct `threadId` fallback applied; provider Mattermost; target channel id `qxpei1nhpiy8u8fb3b8xji4hrc`; thread root id `qt5z3w46nbd5fp5z1yymmcf7ch`.
- Exact steps or command run after this patch: Sent a Mattermost message through OpenClaw with `threadId: "qt5z3w46nbd5fp5z1yymmcf7ch"` and no `replyTo` / `replyToId`; recorded returned post id `bfqx13e4tiy8jj8o9nftmxeh1w`; queried Mattermost directly with `GET /api/v4/posts/bfqx13e4tiy8jj8o9nftmxeh1w`; checked returned post metadata.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): Copied live Mattermost API output after the direct send:

```json
{
  "id": "bfqx13e4tiy8jj8o9nftmxeh1w",
  "channel_id": "qxpei1nhpiy8u8fb3b8xji4hrc",
  "root_id": "qt5z3w46nbd5fp5z1yymmcf7ch"
}
```

- Observed result after fix: The post's `root_id` equals the supplied `threadId`, so the direct Mattermost send landed in the intended thread instead of the channel root.
- What was not tested: I did not run a maintainer-hosted Mattermost instance.
- Proof limitations or environment constraints: The live proof used Rey's configured Mattermost/OpenClaw setup with secrets redacted.

## Validation
- `./node_modules/.bin/oxfmt --check --threads=1 extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-mattermost.config.ts extensions/mattermost/src/channel.test.ts` -> 41 tests passed
- `OPENCLAW_CHECK_CHANGED_REMOTE_CHILD=1 CI=1 PNPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false corepack pnpm check:changed --base HEAD --head HEAD -- extensions/mattermost/src/channel.ts extensions/mattermost/src/channel.test.ts`
