### PR TITLE
fix(mattermost): hydrate thread starter context

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -524,6 +524,13 @@ export async function fetchMattermostUserTeams(
   return await client.request<MattermostTeam[]>(`/users/${userId}/teams`);
 }
 
+export async function fetchMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<MattermostPost> {
+  return await client.request<MattermostPost>(`/posts/${postId}`);
+}
+
 export async function updateMattermostPost(
   client: MattermostClient,
   postId: string,

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -9,6 +9,7 @@ import {
   canFinalizeMattermostPreviewInPlace,
   deliverMattermostReplyWithDraftPreview,
   evaluateMattermostMentionGate,
+  hydrateMattermostThreadContext,
   MattermostRetryableInboundError,
   processMattermostReplayGuardedPost,
   resolveMattermostReactionChannelId,
@@ -74,6 +75,63 @@ function createDraftStreamMock(postId: string | undefined = "preview-post-1") {
 beforeEach(() => {
   vi.clearAllMocks();
   updateMattermostPostSpy.mockResolvedValue({ id: "patched" } as never);
+});
+
+describe("hydrateMattermostThreadContext", () => {
+  it("hydrates reply and thread starter bodies from the root post", async () => {
+    const client = createMattermostClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      id: "root-1",
+      user_id: "user-1",
+      message: "root context",
+      file_ids: ["file-1"],
+    });
+
+    const context = await hydrateMattermostThreadContext({
+      client,
+      currentPostId: "reply-1",
+      threadRootId: "root-1",
+      resolveUserInfo: vi.fn(async () => ({ id: "user-1", username: "alice" })),
+    });
+
+    expect(client.request).toHaveBeenCalledWith("/posts/root-1");
+    expect(context).toEqual({
+      replyToBody: "root context\n[Mattermost file]",
+      replyToSender: "alice",
+      threadStarterBody: "root context\n[Mattermost file]",
+    });
+  });
+
+  it("skips hydration when there is no separate thread root", async () => {
+    const client = createMattermostClientMock();
+
+    await expect(
+      hydrateMattermostThreadContext({
+        client,
+        currentPostId: "root-1",
+        threadRootId: "root-1",
+      }),
+    ).resolves.toEqual({});
+
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("fails open when the root post cannot be fetched", async () => {
+    const client = createMattermostClientMock();
+    const log = vi.fn();
+    vi.mocked(client.request).mockRejectedValueOnce(new Error("not found"));
+
+    await expect(
+      hydrateMattermostThreadContext({
+        client,
+        currentPostId: "reply-1",
+        threadRootId: "root-1",
+        log,
+      }),
+    ).resolves.toEqual({});
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("failed to hydrate thread context"));
+  });
 });
 
 function evaluateMentionGateForMessage(params: { cfg: OpenClawConfig; threadRootId?: string }) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -10,6 +10,7 @@ import { getMattermostRuntime } from "../runtime.js";
 import { resolveMattermostAccount, resolveMattermostReplyToMode } from "./accounts.js";
 import {
   createMattermostClient,
+  fetchMattermostPost,
   fetchMattermostMe,
   normalizeMattermostBaseUrl,
   updateMattermostPost,
@@ -420,6 +421,72 @@ function buildMattermostAttachmentPlaceholder(mediaList: MattermostMediaInfo[]):
   const suffix = mediaList.length === 1 ? label : `${label}s`;
   const tag = allImages ? "<media:image>" : "<media:document>";
   return `${tag} (${mediaList.length} ${suffix})`;
+}
+
+export type MattermostHydratedThreadContext = {
+  replyToBody?: string;
+  replyToSender?: string;
+  threadStarterBody?: string;
+};
+
+function buildMattermostPostContextBody(post: MattermostPost): string | undefined {
+  const body = normalizeOptionalString(post.message) ?? "";
+  const fileCount = (post.file_ids ?? []).filter((fileId) =>
+    normalizeOptionalString(fileId),
+  ).length;
+  const filePlaceholder = fileCount
+    ? `[Mattermost ${fileCount === 1 ? "file" : `${fileCount} files`}]`
+    : "";
+  return normalizeOptionalString([body, filePlaceholder].filter(Boolean).join("\n"));
+}
+
+function formatMattermostContextSender(user: MattermostUser | null, fallbackUserId: string) {
+  return (
+    normalizeOptionalString(user?.username) ??
+    normalizeOptionalString(user?.nickname) ??
+    normalizeOptionalString([user?.first_name, user?.last_name].filter(Boolean).join(" ")) ??
+    fallbackUserId
+  );
+}
+
+export async function hydrateMattermostThreadContext(params: {
+  client: MattermostClient;
+  currentPostId?: string | null;
+  threadRootId?: string | null;
+  resolveUserInfo?: (userId: string) => Promise<MattermostUser | null>;
+  log?: (message: string) => void;
+}): Promise<MattermostHydratedThreadContext> {
+  const rootPostId = normalizeOptionalString(params.threadRootId);
+  if (!rootPostId || rootPostId === normalizeOptionalString(params.currentPostId)) {
+    return {};
+  }
+
+  try {
+    const rootPost = await fetchMattermostPost(params.client, rootPostId);
+    const body = buildMattermostPostContextBody(rootPost);
+    if (!body) {
+      return {};
+    }
+
+    const rootSenderId = normalizeOptionalString(rootPost.user_id);
+    const rootSender = rootSenderId
+      ? formatMattermostContextSender(
+          params.resolveUserInfo ? await params.resolveUserInfo(rootSenderId) : null,
+          rootSenderId,
+        )
+      : undefined;
+
+    return {
+      replyToBody: body,
+      replyToSender: rootSender,
+      threadStarterBody: body,
+    };
+  } catch (error) {
+    params.log?.(
+      `mattermost: failed to hydrate thread context root=${rootPostId}: ${String(error)}`,
+    );
+    return {};
+  }
 }
 
 function buildMattermostWsUrl(baseUrl: string): string {
@@ -1539,6 +1606,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 timestamp: entry.timestamp,
               }))
             : undefined;
+        const hydratedThreadContext = await hydrateMattermostThreadContext({
+          client,
+          currentPostId: post.id,
+          threadRootId,
+          resolveUserInfo,
+          log: logVerboseMessage,
+        });
         const ctxPayload = core.channel.reply.finalizeInboundContext({
           Body: combinedBody,
           BodyForAgent: bodyText,
@@ -1572,6 +1646,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             allMessageIds.length > 1 ? allMessageIds[allMessageIds.length - 1] : undefined,
           ReplyToId: effectiveReplyToId,
           MessageThreadId: effectiveReplyToId,
+          ReplyToBody: hydratedThreadContext.replyToBody,
+          ReplyToSender: hydratedThreadContext.replyToSender,
+          ThreadStarterBody: hydratedThreadContext.threadStarterBody,
           Timestamp: typeof post.create_at === "number" ? post.create_at : undefined,
           WasMentioned: kind !== "direct" ? mentionDecision.effectiveWasMentioned : undefined,
           CommandAuthorized: commandAuthorized,


### PR DESCRIPTION
## Summary
- fetches the Mattermost thread root post for inbound thread replies
- populates `ReplyToBody`, `ReplyToSender`, and `ThreadStarterBody` in the finalized inbound context
- includes file placeholders when the root post contains attachments
- fails open if the root post cannot be fetched, preserving existing message delivery

## Why
Mattermost inbound handling preserved only thread ids (`ReplyToId` / `MessageThreadId`). That let OpenClaw route replies into the right thread, but agents could not see the text of the parent/root post. Threaded replies therefore lost the most important context unless the transcript already happened to contain it.

## Validation
- `pnpm exec oxfmt --check extensions/mattermost/src/mattermost/client.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts`
- `pnpm exec vitest run extensions/mattermost/src/mattermost/monitor.test.ts`
- `pnpm check:changed`
