### PR TITLE
feat(channels): expose agentId on ChannelOutboundContext (#70905)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/plugin SDK: expose stable `agentId` on `ChannelOutboundContext` so channel plugins that model each agent as a distinct remote identity can attribute outbound sends without smuggling the id through display fields. Threaded from the existing upstream session/mirror context with the same precedence used for media-access scoping (`session > mirror`); `identity` (name/avatar/emoji/theme) remains the presentation-layer surface and is unchanged. Fixes #70905.
 - Codex: add Computer Use setup for Codex-mode agents, including `/codex computer-use status/install`, marketplace discovery, optional auto-install, and fail-closed MCP server checks before Codex-mode turns start. Fixes #72094. (#71842) Thanks @pash-openai.
 - Matrix/streaming: stream tool-progress updates into live Matrix preview edits by default when preview streaming is active, with `streaming.preview.toolProgress: false` to keep answer previews while hiding interim tool lines. Thanks @gumadeiras.
 - Plugins/models: wire manifest `modelCatalog.aliases` and `modelCatalog.suppressions` into model-catalog planning and built-in model suppression, with OpenAI stale Spark suppression now declared in the plugin manifest before runtime fallback. Thanks @shakkernerd.

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -31,6 +31,17 @@ export type ChannelOutboundContext = {
   formatting?: OutboundDeliveryFormattingOptions;
   threadId?: string | number | null;
   accountId?: string | null;
+  /**
+   * Stable routing/attribution identifier for the originating agent. Distinct
+   * from display `identity` (name/avatar/emoji/theme), which is presentation-
+   * layer metadata. Channel plugins that model each agent as a separate remote
+   * identity (one row/handle per agent rather than a shared bot with per-
+   * message costumes) need this id to attribute outbound sends without
+   * smuggling the value through display fields. Available on inbound-driven
+   * replies via the originating route AND on heartbeat/cron/sessions_send/
+   * autonomous paths via the upstream session/mirror context. (#70905)
+   */
+  agentId?: string;
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1367,6 +1367,92 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("propagates session.agentId into ChannelOutboundContext for adapter sendText (#70905)", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "m1" });
+    const customAdapter: ChannelOutboundAdapter = {
+      ...matrixOutboundForTest,
+      sendText,
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: "matrix", outbound: customAdapter }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: vi.fn() },
+      session: { key: "agent:scoped:main", agentId: "scoped-agent" },
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ agentId: "scoped-agent" }));
+  });
+
+  it("falls back to mirror.agentId when session.agentId is absent (#70905)", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "m1" });
+    const customAdapter: ChannelOutboundAdapter = {
+      ...matrixOutboundForTest,
+      sendText,
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: "matrix", outbound: customAdapter }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: vi.fn() },
+      mirror: { agentId: "mirror-agent", sessionKey: "agent:mirror:main" },
+    });
+
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ agentId: "mirror-agent" }));
+  });
+
+  it("omits agentId from ChannelOutboundContext when neither session nor mirror provides one (#70905)", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "m1" });
+    const customAdapter: ChannelOutboundAdapter = {
+      ...matrixOutboundForTest,
+      sendText,
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({ id: "matrix", outbound: customAdapter }),
+        },
+      ]),
+    );
+
+    await deliverOutboundPayloads({
+      cfg: matrixChunkConfig,
+      channel: "matrix",
+      to: "!room:example",
+      payloads: [{ text: "hello" }],
+      deps: { matrix: vi.fn() },
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    const ctx = sendText.mock.calls[0]?.[0] as { agentId?: unknown };
+    expect(ctx.agentId).toBeUndefined();
+  });
+
   it("calls failDelivery instead of ackDelivery on bestEffort partial failure", async () => {
     const { onError } = await runBestEffortPartialFailureDelivery();
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -133,6 +133,8 @@ type ChannelHandlerParams = {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  /** See ChannelOutboundContext.agentId — stable agent attribution. (#70905) */
+  agentId?: string;
   replyToId?: string | null;
   replyToMode?: ReplyToMode;
   formatting?: OutboundDeliveryFormattingOptions;
@@ -329,6 +331,7 @@ function createChannelOutboundContextBase(
     cfg: params.cfg,
     to: params.to,
     accountId: params.accountId,
+    agentId: params.agentId,
     replyToId: params.replyToId,
     replyToMode: params.replyToMode,
     formatting: params.formatting,
@@ -894,6 +897,11 @@ async function deliverOutboundPayloadsCore(
     to,
     deps,
     accountId,
+    // Mirror existing precedence used for media-access scoping (line above
+    // in resolveAgentScopedOutboundMediaAccess): session > mirror. Surfaces
+    // the same id to channel adapters so non-inbound paths (heartbeat, cron,
+    // sessions_send, autonomous turns) can attribute outbound sends. (#70905)
+    agentId: params.session?.agentId ?? params.mirror?.agentId,
     replyToId: params.replyToId,
     replyToMode: params.replyToMode,
     formatting: params.formatting,


### PR DESCRIPTION
Fixes #70905.

## Summary

Channel plugins that model each agent as a distinct remote identity
(one row/handle per agent rather than a single shared bot with per-
message display costumes) need a stable agent id when OpenClaw invokes
\`sendText\`/\`sendMedia\`/\`sendPayload\`. Today the adapter context
exposes only display-layer fields (\`identity.name\`,
\`identity.avatarUrl\`, \`identity.emoji\`, \`identity.theme\`);
affected plugins were forced to either resolve by display name
(fragile — names collide / change / aren't globally unique) or smuggle
the id through a display field (abuses render semantics).

The id is already in scope throughout the upstream outbound pipeline
(\`OutboundSessionContext.agentId\`, \`DeliveryMirror.agentId\`,
\`MessageActionRunnerContext\`, \`OutboundMirrorRoute\`,
\`SessionContext\`, \`MessageActionThreading\`).

## Fix

Add optional \`agentId?: string\` to \`ChannelOutboundContext\` (and
the corresponding internal \`ChannelHandlerParams\`) and thread it
from the upstream session/mirror context with the same
\`session > mirror\` precedence already used by
\`resolveAgentScopedOutboundMediaAccess\` (sibling line 858 in
\`deliver.ts\`):

\`\`\`ts
agentId: params.session?.agentId ?? params.mirror?.agentId,
\`\`\`

Surfaces the id to inbound-driven replies AND to non-inbound paths
(heartbeats, sessions_send tool calls, cron-triggered turns,
autonomous agent actions) — none of which previously had a stable
agent id at the adapter boundary.

Per clawsweeper review on the issue: \`agentId\` is stable routing /
attribution metadata distinct from the existing display \`identity\`
field. \`identity\` remains presentation-layer (name/avatar/emoji/
theme) and is unchanged.

## Tests

53 existing \`deliver.test.ts\` tests still pass. Added 3 new
regression cases:

- \`session.agentId\` propagates into the adapter \`sendText\` ctx.
- Falls back to \`mirror.agentId\` when \`session.agentId\` is absent.
- \`agentId\` is omitted from the adapter ctx when neither source
  provides one (no spurious \`undefined\` values for adapters that
  enumerate ctx keys).

\`\`\`
Test Files  1 passed (deliver.test.ts)
     Tests  56 passed (56)
\`\`\`

## Backward compatibility

\`agentId\` is optional. Adapters that don't read it see no behavior
change. The field is added alongside \`accountId\` so its scope and
optionality match an existing pattern.