### PR TITLE
fix(minimax): request hex TTS output explicitly

### DIFF
--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -332,6 +332,8 @@ describe("buildMinimaxSpeechProvider", () => {
       const body = JSON.parse(init!.body as string);
       expect(body.model).toBe("speech-2.8-hd");
       expect(body.text).toBe("Hello world");
+      expect(body.stream).toBe(false);
+      expect(body.output_format).toBe("hex");
       expect(body.voice_setting.voice_id).toBe("English_expressive_narrator");
       expect(transcodeAudioBufferToOpusMock).not.toHaveBeenCalled();
     });

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -437,6 +437,8 @@ describe("buildMinimaxSpeechProvider", () => {
       const body = firstFetchBody();
       expect(body.model).toBe("speech-2.8-hd");
       expect(body.text).toBe("Hello world");
+      expect(body.stream).toBe(false);
+      expect(body.output_format).toBe("hex");
       expect((body.voice_setting as Record<string, unknown>).voice_id).toBe(
         "English_expressive_narrator",
       );

--- a/extensions/minimax/speech-provider.test.ts
+++ b/extensions/minimax/speech-provider.test.ts
@@ -408,7 +408,7 @@ describe("buildMinimaxSpeechProvider", () => {
       return JSON.parse(init.body) as Record<string, unknown>;
     }
 
-    it("makes correct API call and decodes hex response", async () => {
+    it("requests non-streaming hex audio and decodes the hex response", async () => {
       const hexAudio = Buffer.from("fake-audio-data").toString("hex");
       const mockFetch = vi.mocked(globalThis.fetch);
       mockFetch.mockResolvedValueOnce(

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -80,6 +80,8 @@ export async function minimaxTTS(params: {
         body: JSON.stringify({
           model,
           text,
+          stream: false,
+          output_format: "hex",
           voice_setting: {
             voice_id: voiceId,
             speed,

--- a/extensions/minimax/tts.ts
+++ b/extensions/minimax/tts.ts
@@ -83,6 +83,8 @@ export async function minimaxTTS(params: {
         body: JSON.stringify({
           model,
           text,
+          stream: false,
+          output_format: "hex",
           voice_setting: {
             voice_id: voiceId,
             speed,


### PR DESCRIPTION
## Summary
- send \`output_format: "hex"\` in MiniMax TTS requests
- send \`stream: false\` explicitly for the non-streaming path
- extend the MiniMax speech-provider test to lock the request shape

## What Problem This Solves
The MiniMax provider decodes \`data.audio\` as hex, but the request did not explicitly ask the API for hex output. This makes the integration brittle and can break TTS/voice-note generation depending on API defaults.

## Evidence
**Command:**
\`\`\`bash
curl -X POST "https://api.minimax.io/v1/t2a_v2" \
  -H "Authorization: Bearer <MINIMAX_API_KEY>" \
  -H "Content-Type: application/json" \
  -d {
