### PR TITLE
feat(whatsapp): honor disappearingMessagesSeconds for outbound replies (#71157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/WhatsApp: add `channels.whatsapp.disappearingMessagesSeconds` (and matching per-account override under `channels.whatsapp.accounts.<id>`) so outbound replies inherit the chat's disappearing-messages policy. The resolved positive integer is forwarded to Baileys as `MiscMessageGenerationOptions.ephemeralExpiration`; non-positive / non-finite values fall back to no override. Fixes #71157.
 - Codex: add Computer Use setup for Codex-mode agents, including `/codex computer-use status/install`, marketplace discovery, optional auto-install, and fail-closed MCP server checks before Codex-mode turns start. Fixes #72094. (#71842) Thanks @pash-openai.
 - Matrix/streaming: stream tool-progress updates into live Matrix preview edits by default when preview streaming is active, with `streaming.preview.toolProgress: false` to keep answer previews while hiding interim tool lines. Thanks @gumadeiras.
 - Plugins/models: wire manifest `modelCatalog.aliases` and `modelCatalog.suppressions` into model-catalog planning and built-in model suppression, with OpenAI stale Spark suppression now declared in the plugin manifest before runtime fallback. Thanks @shakkernerd.

--- a/extensions/whatsapp/src/accounts.test.ts
+++ b/extensions/whatsapp/src/accounts.test.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { resolveWhatsAppAccount, resolveWhatsAppAuthDir } from "./accounts.js";
+import {
+  resolveWhatsAppAccount,
+  resolveWhatsAppAuthDir,
+  resolveWhatsAppDisappearingExpiration,
+} from "./accounts.js";
 
 describe("resolveWhatsAppAuthDir", () => {
   const stubCfg = { channels: { whatsapp: { accounts: {} } } } as Parameters<
@@ -158,6 +162,67 @@ describe("resolveWhatsAppAuthDir", () => {
 
     expect(resolved.authDir).toMatch(/whatsapp[/\\]work$/);
     expect(resolved.name).toBeUndefined();
+  });
+
+  it("resolves disappearingMessagesSeconds with account-level override winning over channel-level (#71157)", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            disappearingMessagesSeconds: 86400,
+            accounts: {
+              work: {
+                disappearingMessagesSeconds: 60,
+              },
+            },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolved.disappearingMessagesSeconds).toBe(60);
+    expect(resolveWhatsAppDisappearingExpiration(resolved)).toBe(60);
+  });
+
+  it("inherits channel-level disappearingMessagesSeconds when account omits it (#71157)", () => {
+    const resolved = resolveWhatsAppAccount({
+      cfg: {
+        channels: {
+          whatsapp: {
+            disappearingMessagesSeconds: 604800,
+            accounts: { work: {} },
+          },
+        },
+      } as Parameters<typeof resolveWhatsAppAccount>[0]["cfg"],
+      accountId: "work",
+    });
+
+    expect(resolveWhatsAppDisappearingExpiration(resolved)).toBe(604800);
+  });
+
+  it("treats non-positive / non-finite disappearingMessagesSeconds as no override (#71157)", () => {
+    expect(
+      resolveWhatsAppDisappearingExpiration({ disappearingMessagesSeconds: 0 }),
+    ).toBeUndefined();
+    expect(
+      resolveWhatsAppDisappearingExpiration({ disappearingMessagesSeconds: -10 }),
+    ).toBeUndefined();
+    expect(
+      resolveWhatsAppDisappearingExpiration({ disappearingMessagesSeconds: Number.NaN }),
+    ).toBeUndefined();
+    expect(
+      resolveWhatsAppDisappearingExpiration({
+        disappearingMessagesSeconds: Number.POSITIVE_INFINITY,
+      }),
+    ).toBeUndefined();
+    expect(resolveWhatsAppDisappearingExpiration({})).toBeUndefined();
+  });
+
+  it("floors fractional disappearingMessagesSeconds to whole seconds (#71157)", () => {
+    expect(resolveWhatsAppDisappearingExpiration({ disappearingMessagesSeconds: 86400.7 })).toBe(
+      86400,
+    );
   });
 
   it("does not inherit default-account selfChatMode for named accounts", () => {

--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -38,6 +38,7 @@ export type ResolvedWhatsAppAccount = {
   textChunkLimit?: number;
   chunkMode?: "length" | "newline";
   mediaMaxMb?: number;
+  disappearingMessagesSeconds?: number;
   blockStreaming?: boolean;
   ackReaction?: WhatsAppAccountConfig["ackReaction"];
   reactionLevel?: WhatsAppAccountConfig["reactionLevel"];
@@ -149,6 +150,7 @@ export function resolveWhatsAppAccount(params: {
     textChunkLimit: merged.textChunkLimit,
     chunkMode: merged.chunkMode,
     mediaMaxMb: merged.mediaMaxMb,
+    disappearingMessagesSeconds: merged.disappearingMessagesSeconds,
     blockStreaming: merged.blockStreaming,
     ackReaction: merged.ackReaction,
     reactionLevel: merged.reactionLevel,
@@ -167,6 +169,25 @@ export function resolveWhatsAppMediaMaxBytes(
       ? account.mediaMaxMb
       : DEFAULT_WHATSAPP_MEDIA_MAX_MB;
   return mediaMaxMb * 1024 * 1024;
+}
+
+/**
+ * Resolve the effective disappearing-messages expiration for outbound replies.
+ *
+ * Returns a positive integer number of seconds when the operator opted in;
+ * returns `undefined` to mean "no OpenClaw override — let Baileys/WhatsApp
+ * apply the chat's own disappearing-messages policy." Non-positive, NaN, or
+ * non-finite values are dropped to match the documented opt-out semantics
+ * (`0`, `null`, omitted).
+ */
+export function resolveWhatsAppDisappearingExpiration(
+  account: Pick<ResolvedWhatsAppAccount, "disappearingMessagesSeconds">,
+): number | undefined {
+  const value = account.disappearingMessagesSeconds;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return Math.floor(value);
 }
 
 export function listEnabledWhatsAppAccounts(cfg: OpenClawConfig): ResolvedWhatsAppAccount[] {

--- a/extensions/whatsapp/src/inbound/send-api.test.ts
+++ b/extensions/whatsapp/src/inbound/send-api.test.ts
@@ -236,6 +236,67 @@ describe("createWebSendApi", () => {
     expect(sendMessage).toHaveBeenCalledWith("123@s.whatsapp.net", { text: "hello" });
   });
 
+  it("forwards positive ephemeralExpiration to Baileys MiscMessageGenerationOptions (#71157)", async () => {
+    await api.sendMessage("+1555", "hi", undefined, undefined, {
+      ephemeralExpiration: 86400,
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      { text: "hi" },
+      expect.objectContaining({ ephemeralExpiration: 86400 }),
+    );
+  });
+
+  it("merges ephemeralExpiration with quoted reply options (#71157)", async () => {
+    await api.sendMessage("+1555", "hi", undefined, undefined, {
+      ephemeralExpiration: 604800,
+      quotedMessageKey: {
+        id: "q1",
+        remoteJid: "1555@s.whatsapp.net",
+        fromMe: false,
+      },
+    });
+    expect(sendMessage).toHaveBeenCalledWith(
+      "1555@s.whatsapp.net",
+      { text: "hi" },
+      expect.objectContaining({
+        ephemeralExpiration: 604800,
+        quoted: expect.objectContaining({
+          key: expect.objectContaining({ id: "q1" }),
+        }),
+      }),
+    );
+  });
+
+  it("forwards ephemeralExpiration to the trailing voice-note text message (#71157)", async () => {
+    const payload = Buffer.from("aud");
+    await api.sendMessage("+1555", "voice text", payload, "audio/ogg", {
+      ephemeralExpiration: 60,
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      1,
+      "1555@s.whatsapp.net",
+      expect.objectContaining({ audio: payload, ptt: true }),
+      expect.objectContaining({ ephemeralExpiration: 60 }),
+    );
+    expect(sendMessage).toHaveBeenNthCalledWith(
+      2,
+      "1555@s.whatsapp.net",
+      { text: "voice text" },
+      expect.objectContaining({ ephemeralExpiration: 60 }),
+    );
+  });
+
+  it("does not pass MiscMessageGenerationOptions when ephemeralExpiration is non-positive (#71157)", async () => {
+    await api.sendMessage("+1555", "hi", undefined, undefined, { ephemeralExpiration: 0 });
+    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hi" });
+    sendMessage.mockClear();
+    await api.sendMessage("+1555", "hi2", undefined, undefined, {
+      ephemeralExpiration: Number.NaN,
+    });
+    expect(sendMessage).toHaveBeenCalledWith("1555@s.whatsapp.net", { text: "hi2" });
+  });
+
   it("preserves the quoted remoteJid provided by the outbound adapter", async () => {
     await api.sendMessage("+1555", "hello", undefined, undefined, {
       quotedMessageKey: {

--- a/extensions/whatsapp/src/inbound/send-api.ts
+++ b/extensions/whatsapp/src/inbound/send-api.ts
@@ -82,13 +82,24 @@ export function createWebSendApi(params: {
         participant: sendOptions?.quotedMessageKey?.participant,
         messageText: sendOptions?.quotedMessageKey?.messageText,
       });
-      const result = quotedOpts
-        ? await params.sock.sendMessage(jid, payload, quotedOpts)
+      const ephemeralExpiration = sendOptions?.ephemeralExpiration;
+      const ephemeralOpts: MiscMessageGenerationOptions | undefined =
+        typeof ephemeralExpiration === "number" &&
+        Number.isFinite(ephemeralExpiration) &&
+        ephemeralExpiration > 0
+          ? { ephemeralExpiration }
+          : undefined;
+      const mergedOpts: MiscMessageGenerationOptions | undefined =
+        quotedOpts && ephemeralOpts
+          ? { ...quotedOpts, ...ephemeralOpts }
+          : (quotedOpts ?? ephemeralOpts);
+      const result = mergedOpts
+        ? await params.sock.sendMessage(jid, payload, mergedOpts)
         : await params.sock.sendMessage(jid, payload);
       if (mediaBuffer && mediaType?.startsWith("audio/") && text.trim()) {
         const textPayload: AnyMessageContent = { text };
-        if (quotedOpts) {
-          await params.sock.sendMessage(jid, textPayload, quotedOpts);
+        if (mergedOpts) {
+          await params.sock.sendMessage(jid, textPayload, mergedOpts);
         } else {
           await params.sock.sendMessage(jid, textPayload);
         }

--- a/extensions/whatsapp/src/inbound/types.ts
+++ b/extensions/whatsapp/src/inbound/types.ts
@@ -20,6 +20,12 @@ export type ActiveWebSendOptions = {
   gifPlayback?: boolean;
   accountId?: string;
   fileName?: string;
+  /**
+   * Optional disappearing-message expiration (seconds). When present and
+   * positive, forwarded to Baileys' `MiscMessageGenerationOptions.ephemeralExpiration`
+   * so OpenClaw replies inherit the chat's disappearing-messages policy. (#71157)
+   */
+  ephemeralExpiration?: number;
 };
 
 export type ActiveWebListener = {

--- a/extensions/whatsapp/src/send.ts
+++ b/extensions/whatsapp/src/send.ts
@@ -12,6 +12,7 @@ import { createSubsystemLogger, getChildLogger } from "openclaw/plugin-sdk/runti
 import {
   resolveDefaultWhatsAppAccountId,
   resolveWhatsAppAccount,
+  resolveWhatsAppDisappearingExpiration,
   resolveWhatsAppMediaMaxBytes,
 } from "./accounts.js";
 import { getRegisteredWhatsAppConnectionController } from "./connection-controller-registry.js";
@@ -145,12 +146,18 @@ export async function sendMessageWhatsApp(
     await active.sendComposingTo(to);
     const hasExplicitAccountId = Boolean(options.accountId?.trim());
     const accountId = hasExplicitAccountId ? resolvedAccountId : undefined;
+    const ephemeralExpiration = resolveWhatsAppDisappearingExpiration(account);
     const sendOptions: ActiveWebSendOptions | undefined =
-      options.gifPlayback || accountId || documentFileName || options.quotedMessageKey
+      options.gifPlayback ||
+      accountId ||
+      documentFileName ||
+      options.quotedMessageKey ||
+      ephemeralExpiration !== undefined
         ? {
             ...(options.gifPlayback ? { gifPlayback: true } : {}),
             ...(documentFileName ? { fileName: documentFileName } : {}),
             ...(options.quotedMessageKey ? { quotedMessageKey: options.quotedMessageKey } : {}),
+            ...(ephemeralExpiration !== undefined ? { ephemeralExpiration } : {}),
             accountId,
           }
         : undefined;

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -84,6 +84,15 @@ type WhatsAppSharedConfig = {
   chunkMode?: "length" | "newline";
   /** Maximum media file size in MB. Default: 50. */
   mediaMaxMb?: number;
+  /**
+   * Default disappearing-message expiration (seconds) applied to outbound replies.
+   * Positive values are forwarded to Baileys as `ephemeralExpiration` so the
+   * agent's messages match the surrounding chat's disappearing-messages policy.
+   * 0 / undefined leaves WhatsApp/Baileys to fall back to the chat's own
+   * disappearing-messages setting (no OpenClaw override). The account-level
+   * setting overrides the channel-level setting when both are present.
+   */
+  disappearingMessagesSeconds?: number;
   /** Disable block streaming for this account. */
   blockStreaming?: boolean;
   /** Merge streamed block replies before sending. */


### PR DESCRIPTION
Re-opening — this was auto-closed by openclaw-barnacle when my queue was >10 PRs (now back under the cap). Same branch, no code changes; greptile already gave it 5/5 on the prior open.

Fixes #71157.

## What

Add `channels.whatsapp.disappearingMessagesSeconds` (and matching per-account override under `channels.whatsapp.accounts.<id>.disappearingMessagesSeconds`) so OpenClaw outbound replies inherit the surrounding chat's disappearing-messages policy. The resolved positive integer is forwarded to Baileys' \`MiscMessageGenerationOptions.ephemeralExpiration\` on every \`sock.sendMessage(...)\` call (text, media, the trailing voice-note text payload, and quoted replies).

## Resolution rules

| Value                                 | Behavior                                            |
|---------------------------------------|-----------------------------------------------------|
| Positive integer (e.g. \`86400\`)       | Forwarded to Baileys as \`ephemeralExpiration\`.      |
| \`0\` / omitted / \`null\`                | No OpenClaw override — Baileys uses chat policy.    |
| \`NaN\` / \`Infinity\` / negative         | Same as omitted (defensive).                        |
| Fractional (e.g. \`86400.7\`)           | Floored to whole seconds (\`86400\`).                 |
| Both channel + account values present | Account-level wins (consistent with \`mediaMaxMb\`).  |

## Tests

- \`accounts.test.ts\` — 4 new cases (override precedence, channel inheritance, non-positive collapses, fractional floors).
- \`inbound/send-api.test.ts\` — 4 new cases (positive forwarded, merges with quoted, voice-note trailing text, 0/NaN drops).
- 33/33 targeted + 41/41 regression (\`send.test.ts\`, \`outbound-base.test.ts\`, \`outbound-adapter.sendpayload.test.ts\`) green.

Original PR: #73080 (auto-closed by queue-cap bot, no review changes requested).