### PR TITLE
fix: clarify macOS service PATH audit

### DIFF
--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -100,6 +100,47 @@ describe("auditGatewayServiceConfig", () => {
     ).toBe(true);
   });
 
+  it("does not require macOS LaunchAgent PATH entries for shell version managers", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/Users/test" },
+      platform: "darwin",
+      command: {
+        programArguments: ["/opt/homebrew/bin/node", "gateway"],
+        environment: {
+          PATH: "/Users/test/.local/bin:/Users/test/.npm-global/bin:/Users/test/bin:/Users/test/Library/pnpm:/Users/test/.local/share/pnpm:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin",
+        },
+      },
+    });
+
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathMissingDirs),
+    ).toBe(false);
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayPathNonMinimal),
+    ).toBe(false);
+  });
+
+  it("explains missing macOS LaunchAgent PATH entries as non-version-manager recommendations", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/Users/test" },
+      platform: "darwin",
+      command: {
+        programArguments: ["/opt/homebrew/bin/node", "gateway"],
+        environment: { PATH: "/opt/homebrew/bin:/usr/bin:/bin" },
+      },
+    });
+
+    const issue = audit.issues.find(
+      (entry) => entry.code === SERVICE_AUDIT_CODES.gatewayPathMissingDirs,
+    );
+    expect(issue).toMatchObject({
+      message:
+        "Gateway service PATH missing recommended non-version-manager dirs: /Users/test/.local/bin, /Users/test/.npm-global/bin, /Users/test/bin, /Users/test/Library/pnpm, /Users/test/.local/share/pnpm, /usr/local/bin",
+      detail:
+        "macOS LaunchAgents should prefer stable Homebrew/system paths; shell version-manager dirs such as nvm/fnm/volta/asdf are intentionally not required.",
+    });
+  });
+
   it("accepts Linux minimal PATH with user directories", async () => {
     const env = { HOME: "/tmp/openclaw-testuser", PNPM_HOME: "/opt/pnpm" };
     const minimalPath = buildMinimalServicePath({ platform: "linux", env });

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -414,6 +414,23 @@ function getEquivalentMinimalPathEntries(
   return normalizedExpected.has(normalizedEquivalent) ? [equivalent] : [];
 }
 
+function isVersionManagerServicePathEntry(entry: string): boolean {
+  const normalized = entry.replaceAll("\\", "/");
+  return (
+    normalized.includes("/.nvm") ||
+    normalized.includes("/.fnm/") ||
+    normalized.includes("/Library/Application Support/fnm/") ||
+    normalized.includes("/.volta/") ||
+    normalized.includes("/.asdf/") ||
+    normalized.includes("/.bun/") ||
+    normalized.includes("/.nix-profile/") ||
+    normalized.includes("/.n/") ||
+    normalized.includes("/.nodenv/") ||
+    normalized.includes("/.nodebrew/") ||
+    normalized.includes("/nvs/")
+  );
+}
+
 function auditGatewayServicePath(
   command: GatewayServiceCommand,
   issues: ServiceConfigIssue[],
@@ -440,7 +457,11 @@ function auditGatewayServicePath(
     .filter(Boolean);
   const normalizedParts = new Set(parts.map((entry) => normalizePathEntry(entry, platform)));
   const normalizedExpected = new Set(expected.map((entry) => normalizePathEntry(entry, platform)));
-  const missing = expected.filter((entry) => {
+  const expectedForMissing =
+    platform === "darwin"
+      ? expected.filter((entry) => !isVersionManagerServicePathEntry(entry))
+      : expected;
+  const missing = expectedForMissing.filter((entry) => {
     const normalized = normalizePathEntry(entry, platform);
     if (normalizedParts.has(normalized)) {
       return false;
@@ -452,7 +473,11 @@ function auditGatewayServicePath(
   if (missing.length > 0) {
     issues.push({
       code: SERVICE_AUDIT_CODES.gatewayPathMissingDirs,
-      message: `Gateway service PATH missing required dirs: ${missing.join(", ")}`,
+      message: `Gateway service PATH missing recommended non-version-manager dirs: ${missing.join(", ")}`,
+      detail:
+        platform === "darwin"
+          ? "macOS LaunchAgents should prefer stable Homebrew/system paths; shell version-manager dirs such as nvm/fnm/volta/asdf are intentionally not required."
+          : undefined,
       level: "recommended",
     });
   }


### PR DESCRIPTION
## Summary
- Treat macOS LaunchAgent PATH entries for shell version managers as optional, not required
- Keep warning when version-manager paths are actually present in the service PATH
- Clarify missing PATH diagnostics as recommended non-version-manager directories on macOS

## Why
`openclaw gateway status` could report missing nvm/fnm/volta/asdf/bun/nix directories as "required" on macOS. For LaunchAgents, stable Homebrew/system Node paths are preferred; shell version-manager paths are intentionally avoided because services do not load interactive shell init reliably.

## Tests
- `pnpm exec oxlint src/daemon/service-audit.ts src/daemon/service-audit.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts src/daemon/service-audit.test.ts`
