### PR TITLE
fix(telegram): handle edited message updates

### DIFF
--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -2107,11 +2107,10 @@ export const registerTelegramHandlers = ({
         latestMsg: normalizedMsg,
         isGroup,
         isForum,
-        timer: setTimeout(() => {}, 0),
+        timer: setTimeout(async () => {
+          await flushEdit(entry);
+        }, editedMessageDebounceMs),
       };
-      entry.timer = setTimeout(async () => {
-        await flushEdit(entry);
-      }, editedMessageDebounceMs);
       editedMessageBuffer.set(bufferKey, entry);
     }
   });

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -145,6 +145,23 @@ export const registerTelegramHandlers = ({
       ? Math.max(10, Math.floor(opts.testTimings.mediaGroupFlushMs))
       : MEDIA_GROUP_TIMEOUT_MS;
 
+  const DEFAULT_EDITED_MESSAGE_DEBOUNCE_MS = 2500;
+  const editedMessageDebounceMs =
+    typeof opts.testTimings?.editedMessageDebounceMs === "number" &&
+    Number.isFinite(opts.testTimings.editedMessageDebounceMs)
+      ? Math.max(10, Math.floor(opts.testTimings.editedMessageDebounceMs))
+      : DEFAULT_EDITED_MESSAGE_DEBOUNCE_MS;
+
+  type EditedMessageEntry = {
+    latestCtxForDedupe: TelegramUpdateKeyContext;
+    latestCtx: TelegramContext;
+    latestMsg: Message;
+    isGroup: boolean;
+    isForum: boolean;
+    timer: ReturnType<typeof setTimeout>;
+  };
+  const editedMessageBuffer = new Map<string, EditedMessageEntry>();
+
   const mediaGroupBuffer = new Map<string, MediaGroupEntry>();
   let mediaGroupProcessing: Promise<void> = Promise.resolve();
 
@@ -2027,5 +2044,75 @@ export const registerTelegramHandlers = ({
       oversizeLogMessage: "channel post media exceeds size limit",
       errorMessage: "channel_post handler failed",
     });
+  });
+
+  // Handle edited_message updates — streaming bots edit the same message repeatedly as tokens
+  // arrive. We debounce per (chatId, messageId) so only the final version reaches the pipeline.
+  bot.on("edited_message", async (ctx) => {
+    const msg = ctx.editedMessage;
+    if (!msg) {
+      return;
+    }
+    // Skip our own bot's edits to avoid echo loops.
+    if (msg.from?.id != null && msg.from.id === ctx.me?.id) {
+      return;
+    }
+    const chatId = msg.chat.id;
+    const messageId = msg.message_id;
+    const bufferKey = `${chatId}:${messageId}`;
+
+    const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
+    const isForum = await resolveTelegramForumFlag({
+      chatId,
+      chatType: msg.chat.type,
+      isGroup,
+      isForum: msg.chat.is_forum,
+      getChat,
+    });
+    const normalizedMsg = withResolvedTelegramForumFlag(msg, isForum);
+    const syntheticCtx = buildSyntheticContext(ctx, normalizedMsg);
+
+    const flushEdit = async (entry: EditedMessageEntry) => {
+      editedMessageBuffer.delete(bufferKey);
+      await handleInboundMessageLike({
+        ctxForDedupe: entry.latestCtxForDedupe,
+        ctx: entry.latestCtx,
+        msg: entry.latestMsg,
+        chatId,
+        isGroup: entry.isGroup,
+        isForum: entry.isForum,
+        messageThreadId: entry.latestMsg.message_thread_id,
+        senderId: entry.latestMsg.from?.id != null ? String(entry.latestMsg.from.id) : "",
+        senderUsername: entry.latestMsg.from?.username ?? "",
+        requireConfiguredGroup: false,
+        sendOversizeWarning: false,
+        oversizeLogMessage: "edited message media exceeds size limit",
+        errorMessage: "edited_message handler failed",
+      });
+    };
+
+    const existing = editedMessageBuffer.get(bufferKey);
+    if (existing) {
+      clearTimeout(existing.timer);
+      existing.latestCtxForDedupe = ctx;
+      existing.latestCtx = syntheticCtx;
+      existing.latestMsg = normalizedMsg;
+      existing.timer = setTimeout(async () => {
+        await flushEdit(existing);
+      }, editedMessageDebounceMs);
+    } else {
+      const entry: EditedMessageEntry = {
+        latestCtxForDedupe: ctx,
+        latestCtx: syntheticCtx,
+        latestMsg: normalizedMsg,
+        isGroup,
+        isForum,
+        timer: setTimeout(() => {}, 0),
+      };
+      entry.timer = setTimeout(async () => {
+        await flushEdit(entry);
+      }, editedMessageDebounceMs);
+      editedMessageBuffer.set(bufferKey, entry);
+    }
   });
 };

--- a/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test-harness.ts
@@ -142,6 +142,7 @@ async function dispatchHarnessReplies(
       params.dispatcherOptions.onError?.(err, { kind: "final" });
     }
   }
+  params.dispatcherOptions.typingCallbacks?.onIdle?.();
   return {
     queuedFinal: finalCount > 0,
     counts: {

--- a/extensions/telegram/src/bot.edited-message.test.ts
+++ b/extensions/telegram/src/bot.edited-message.test.ts
@@ -1,0 +1,188 @@
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TelegramBotOptions } from "./bot.types.js";
+
+const harness = await import("./bot.create-telegram-bot.test-harness.js");
+const {
+  getLoadConfigMock,
+  getLoadSessionStoreMock,
+  getOnHandler,
+  onSpy,
+  replySpy,
+  telegramBotDepsForTest,
+  telegramBotRuntimeForTest,
+} = harness;
+
+const { createTelegramBotCore, setTelegramBotRuntimeForTest } = await import("./bot-core.js");
+
+let createTelegramBot: (opts: TelegramBotOptions) => ReturnType<typeof createTelegramBotCore>;
+
+const loadConfig = getLoadConfigMock();
+getLoadSessionStoreMock(); // initializes the shared mock; harness beforeEach keeps it reset
+
+// Debounce short enough to keep tests fast without being so tight that the
+// test-framework's own async overhead causes flakiness.
+const EDIT_DEBOUNCE_MS = 30;
+const TELEGRAM_TEST_TIMINGS = {
+  mediaGroupFlushMs: 20,
+  textFragmentGapMs: 30,
+  editedMessageDebounceMs: EDIT_DEBOUNCE_MS,
+} as const;
+
+const ORIGINAL_TZ = process.env.TZ;
+
+describe("edited_message handler", () => {
+  beforeAll(async () => {
+    process.env.TZ = "UTC";
+    setTelegramBotRuntimeForTest(
+      telegramBotRuntimeForTest as unknown as Parameters<typeof setTelegramBotRuntimeForTest>[0],
+    );
+  });
+
+  afterAll(() => {
+    process.env.TZ = ORIGINAL_TZ;
+  });
+
+  beforeEach(() => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+    replySpy.mockImplementation(async () => undefined);
+    loadConfig.mockReturnValue({
+      channels: { telegram: { dmPolicy: "open", allowFrom: ["*"] } },
+    });
+    createTelegramBot = (opts) =>
+      createTelegramBotCore({ ...opts, telegramDeps: telegramBotDepsForTest });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeEditCtx(params: {
+    chatId: number;
+    chatType?: string;
+    messageId: number;
+    fromId: number;
+    username?: string;
+    text: string;
+    updateId: number;
+    botId?: number;
+  }) {
+    return {
+      update: { update_id: params.updateId },
+      editedMessage: {
+        chat: { id: params.chatId, type: params.chatType ?? "private" },
+        message_id: params.messageId,
+        from: { id: params.fromId, username: params.username ?? "streamer" },
+        text: params.text,
+        date: 1736380800,
+      },
+      me: { id: params.botId ?? 99, username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    };
+  }
+
+  // Wait past the debounce window and allow the full async processing chain to drain.
+  const waitForFlush = () => new Promise<void>((r) => setTimeout(r, EDIT_DEBOUNCE_MS * 10));
+
+  it("registers an edited_message handler on the bot", () => {
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = onSpy.mock.calls.find((c) => c[0] === "edited_message")?.[1];
+    expect(handler).toBeDefined();
+  });
+
+  it("dispatches to the inbound pipeline after the debounce window", async () => {
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler(
+      makeEditCtx({ chatId: 7, messageId: 42, fromId: 5, text: "final text", updateId: 200 }),
+    );
+
+    // Debounce has not elapsed — pipeline should not have fired yet.
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await waitForFlush();
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(String(payload.Body)).toContain("final text");
+  });
+
+  it("coalesces rapid edits and only dispatches the final version", async () => {
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler(
+      makeEditCtx({ chatId: 7, messageId: 42, fromId: 5, text: "chunk one", updateId: 301 }),
+    );
+    await handler(
+      makeEditCtx({ chatId: 7, messageId: 42, fromId: 5, text: "chunk one two", updateId: 302 }),
+    );
+    await handler(
+      makeEditCtx({
+        chatId: 7,
+        messageId: 42,
+        fromId: 5,
+        text: "chunk one two three",
+        updateId: 303,
+      }),
+    );
+
+    expect(replySpy).not.toHaveBeenCalled();
+
+    await waitForFlush();
+
+    // Only one dispatch — the final version wins.
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(String(payload.Body)).toContain("chunk one two three");
+  });
+
+  it("treats edits to different message_ids as independent", async () => {
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler(
+      makeEditCtx({ chatId: 7, messageId: 10, fromId: 5, text: "msg A edit", updateId: 401 }),
+    );
+    await handler(
+      makeEditCtx({ chatId: 7, messageId: 11, fromId: 5, text: "msg B edit", updateId: 402 }),
+    );
+
+    await waitForFlush();
+
+    expect(replySpy).toHaveBeenCalledTimes(2);
+    const bodies = replySpy.mock.calls.map((c) => String((c[0] as Record<string, unknown>).Body));
+    expect(bodies.some((b) => b.includes("msg A edit"))).toBe(true);
+    expect(bodies.some((b) => b.includes("msg B edit"))).toBe(true);
+  });
+
+  it("skips edits authored by the bot itself", async () => {
+    createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+    const handler = getOnHandler("edited_message") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    // fromId === botId — our own outgoing message being edited.
+    await handler(
+      makeEditCtx({
+        chatId: 7,
+        messageId: 42,
+        fromId: 99,
+        text: "bot self-edit",
+        updateId: 501,
+        botId: 99,
+      }),
+    );
+
+    await waitForFlush();
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/telegram/src/bot.types.ts
+++ b/extensions/telegram/src/bot.types.ts
@@ -23,6 +23,7 @@ export type TelegramBotOptions = {
   testTimings?: {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
+    editedMessageDebounceMs?: number;
   };
   /** Pre-resolved Telegram transport to reuse across bot instances. If not provided, creates a new one. */
   telegramTransport?: TelegramTransport;


### PR DESCRIPTION
## Summary

- Problem: Telegram `edited_message` updates were included in allowed updates but had no registered handler, so edited/streaming Telegram messages were silently dropped after the initial partial message.
- Why it matters: Streaming bots commonly edit the same Telegram message as tokens arrive, causing OpenClaw to process only the first truncated chunk.
- What changed: Added Telegram `edited_message` handling with per-`chatId:messageId` debounce so rapid edits coalesce into one final inbound dispatch.
- What did NOT change (scope boundary): This PR does not rewrite/remove the originally processed message from session history and does not handle `edited_channel_post`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72873
- Related #20173
- Related #9656
- Related #53654
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Telegram plugin registered handlers for `message` and `channel_post`, but not `edited_message`.
- Missing detection / guardrail: There was no focused test covering Telegram edited-message updates.
- Contributing context (if known): `edited_message` was already present in allowed updates, so Telegram could send these updates but the plugin dropped them.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/telegram/src/bot.edited-message.test.ts`
- Scenario the test should lock in: Telegram edited messages are registered, debounced, coalesced by message id, and bot-authored edits are skipped.
- Why this is the smallest reliable guardrail: The issue is isolated to Telegram handler registration and dispatch behavior, so focused extension tests cover the fix without needing a full live Telegram test.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A — new focused tests were added.

## User-visible / Behavior Changes

Telegram edited messages are now processed after a short debounce. For streaming edits, OpenClaw receives the final edited version instead of only the initial partial message.

## Diagram (if applicable)

```text
Before:
Telegram edited_message -> no handler -> dropped

After:
Telegram edited_message -> debounce by chatId:messageId -> latest edit dispatched
```

## AI-Assisted

- [x] AI-assisted (Claude Code / claude-sonnet-4-6)
- [x] Testing: fully tested — 5 focused unit tests added, `pnpm check:changed` and `pnpm test:changed` pass
- [ ] Prompts/session log: available on request
- [x] I understand what the code does
- [ ] `codex review --base origin/main`: not run (no Codex access)
