### PR TITLE
test claude-cli backend registration guardrails

### DIFF
--- a/extensions/anthropic/cli-migration.test.ts
+++ b/extensions/anthropic/cli-migration.test.ts
@@ -167,6 +167,32 @@ describe("anthropic cli migration", () => {
     });
   });
 
+  it("migrates legacy claude-cli embedded harness defaults to agentRuntime", () => {
+    const result = buildAnthropicCliMigrationResult({
+      agents: {
+        defaults: {
+          model: { primary: "claude-cli/claude-opus-4-7" },
+          embeddedHarness: { runtime: "claude-cli" },
+          models: {
+            "claude-cli/claude-opus-4-7": {},
+          },
+        } as never,
+      },
+    });
+
+    expect(result.configPatch).toMatchObject({
+      agents: {
+        defaults: {
+          model: { primary: "anthropic/claude-opus-4-7" },
+          agentRuntime: { id: "claude-cli" },
+          models: {
+            "anthropic/claude-opus-4-7": {},
+          },
+        },
+      },
+    });
+  });
+
   it("backfills the Claude CLI allowlist when older configs only stored sonnet", () => {
     const result = buildAnthropicCliMigrationResult({
       agents: {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { resolveCliBackendConfig } from "../agents/cli-backends.js";
 import { listAgentHarnessIds } from "../agents/harness/registry.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import {
@@ -3814,6 +3815,29 @@ module.exports = { id: "throws-after-import", register() {} };`,
     expect(scoped.plugins.map((entry) => entry.id)).toEqual(["deepseek"]);
     expect(scoped.plugins[0]?.status).toBe("loaded");
     expect(scoped.providers.map((entry) => entry.provider.id)).toEqual(["deepseek"]);
+  });
+
+  it("loads bundled anthropic claude-cli as a resolvable CLI backend", () => {
+    const scoped = loadOpenClawPlugins({
+      cache: false,
+      pluginSdkResolution: "dist",
+      config: {
+        plugins: {
+          enabled: true,
+          allow: ["anthropic"],
+          entries: {
+            anthropic: { enabled: true },
+          },
+        },
+      },
+      onlyPluginIds: ["anthropic"],
+    });
+
+    expect(scoped.plugins.map((entry) => entry.id)).toEqual(["anthropic"]);
+    expect(scoped.plugins[0]?.status).toBe("loaded");
+    expect((scoped.cliBackends ?? []).map((entry) => entry.backend.id)).toContain("claude-cli");
+    expect(resolveCliBackendConfig("claude-cli")?.config.command).toBe("claude");
+    expect(listAgentHarnessIds()).not.toContain("claude-cli");
   });
 
   it("does not replace active memory plugin registries during non-activating loads", () => {


### PR DESCRIPTION
## Summary

- Add a bundled Anthropic loader guardrail proving `claude-cli` is registered and resolvable as a CLI backend.
- Assert the same test does not register `claude-cli` as an embedded agent harness, matching the current runtime-family split.
- Add a legacy Anthropic CLI migration guardrail for `claude-cli/*` model refs plus old `embeddedHarness.runtime: "claude-cli"` configs, verifying they migrate to canonical `anthropic/*` model refs with `agentRuntime.id: "claude-cli"`.

## Scope

This PR is now test-only. It keeps the current design where CLI backends and embedded agent harnesses are separate runtime families. It no longer promotes CLI backends into the agent harness registry.

Fixes #72576

## Validation

- `corepack pnpm test extensions/anthropic/cli-migration.test.ts src/plugins/loader.test.ts -- -t "migrates legacy claude-cli|loads bundled anthropic claude-cli"`
- `PATH=/tmp/openclaw-pnpm-shim:$PATH corepack pnpm check:changed`