### PR TITLE
Add observe-first MCP runtime guardrails

### DIFF
--- a/src/agents/mcp-runtime-guardrails.test.ts
+++ b/src/agents/mcp-runtime-guardrails.test.ts
@@ -1,0 +1,525 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OpenClawSchema } from "../config/zod-schema.js";
+import {
+  createMcpRuntimeGuardrails,
+  createMcpToolCircuitBreaker,
+  createToolRuntimeBudgetLedger,
+  resolveToolAnnotation,
+} from "./mcp-runtime-guardrails.js";
+
+vi.mock("../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+import { logWarn } from "../logger.js";
+const mockLogWarn = vi.mocked(logWarn);
+
+beforeEach(() => {
+  mockLogWarn.mockClear();
+});
+
+// ---- Circuit breaker tests ----
+
+describe("McpToolCircuitBreaker", () => {
+  it("starts closed and records success without warnings or block", async () => {
+    const cb = createMcpToolCircuitBreaker({});
+    let called = false;
+    const result = await cb.run({ serverName: "srv", toolName: "tool" }, async () => {
+      called = true;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(called).toBe(true);
+    const snap = cb.getSnapshot();
+    expect(snap.wouldBlockCount).toBe(0);
+    expect(snap.states[0]).toMatchObject({ state: "closed", consecutiveFailures: 0 });
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("opens after failureThreshold consecutive failures for the same key", async () => {
+    const cb = createMcpToolCircuitBreaker({ cfg: { circuitBreaker: { failureThreshold: 3 } } });
+    const fail = () => Promise.reject(new Error("boom"));
+
+    for (let i = 0; i < 2; i++) {
+      await expect(cb.run({ serverName: "srv", toolName: "tool" }, fail)).rejects.toThrow("boom");
+    }
+    expect(cb.getSnapshot().states[0].state).toBe("closed");
+
+    await expect(cb.run({ serverName: "srv", toolName: "tool" }, fail)).rejects.toThrow("boom");
+    expect(cb.getSnapshot().states[0].state).toBe("open");
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining("circuit opening"));
+  });
+
+  it("keeps a different tool on the same server in closed state", async () => {
+    const cb = createMcpToolCircuitBreaker({ cfg: { circuitBreaker: { failureThreshold: 2 } } });
+    const fail = () => Promise.reject(new Error("boom"));
+
+    for (let i = 0; i < 2; i++) {
+      await expect(cb.run({ serverName: "srv", toolName: "toolA" }, fail)).rejects.toThrow();
+    }
+    expect(cb.getSnapshot().states.find((s) => s.key === "srv::toolA")?.state).toBe("open");
+
+    // toolB should remain closed
+    const result = await cb.run({ serverName: "srv", toolName: "toolB" }, async () => "ok");
+    expect(result).toBe("ok");
+    expect(cb.getSnapshot().states.find((s) => s.key === "srv::toolB")?.state).toBe("closed");
+  });
+
+  it("enters half_open after cooldown and closes on successful probe", async () => {
+    let now = 1_000;
+    const cb = createMcpToolCircuitBreaker({
+      cfg: { circuitBreaker: { failureThreshold: 1, recoveryTimeoutMs: 5_000 } },
+      now: () => now,
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    expect(cb.getSnapshot().states[0].state).toBe("open");
+
+    // advance past cooldown
+    now += 6_000;
+    const result = await cb.run({ serverName: "srv", toolName: "t" }, async () => "probe-ok");
+    expect(result).toBe("probe-ok");
+    expect(cb.getSnapshot().states[0].state).toBe("closed");
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining("circuit closing"));
+  });
+
+  it("reopens after a failed half_open probe", async () => {
+    let now = 1_000;
+    const cb = createMcpToolCircuitBreaker({
+      cfg: { circuitBreaker: { failureThreshold: 1, recoveryTimeoutMs: 5_000 } },
+      now: () => now,
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    now += 6_000;
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    expect(cb.getSnapshot().states[0].state).toBe("open");
+  });
+
+  it("observe-only mode does not block; snapshot marks wouldBlockCount", async () => {
+    let now = 1_000;
+    const cb = createMcpToolCircuitBreaker({
+      cfg: { circuitBreaker: { failureThreshold: 1, recoveryTimeoutMs: 9_000 } },
+      now: () => now,
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    expect(cb.getSnapshot().states[0].state).toBe("open");
+
+    // Circuit is open but observe-only — call should still be made (and fail)
+    now += 1_000;
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow("fail");
+    expect(cb.getSnapshot().wouldBlockCount).toBe(1);
+  });
+
+  it("enforcement mode (enforceForTesting=true) throws when circuit is open", async () => {
+    let now = 1_000;
+    const cb = createMcpToolCircuitBreaker({
+      cfg: { circuitBreaker: { failureThreshold: 1, recoveryTimeoutMs: 9_000 } },
+      now: () => now,
+      enforceForTesting: true,
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    expect(cb.getSnapshot().states[0].state).toBe("open");
+
+    now += 100;
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow(
+      /circuit open.*retry after/,
+    );
+    // underlying fn was never called (enforcement blocked it)
+    expect(cb.getSnapshot().wouldBlockCount).toBe(1);
+  });
+
+  it("deduplicates would-block warnings within the recovery timeout window", async () => {
+    let now = 1_000;
+    const cb = createMcpToolCircuitBreaker({
+      cfg: {
+        circuitBreaker: { failureThreshold: 1, recoveryTimeoutMs: 10_000 },
+      },
+      now: () => now,
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    mockLogWarn.mockClear();
+
+    // Multiple would-block calls within the recovery window → only one warn
+    for (let i = 0; i < 5; i++) {
+      now += 500;
+      await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow();
+    }
+    const wouldBlockWarns = mockLogWarn.mock.calls.filter(([m]) => m.includes("would_block"));
+    expect(wouldBlockWarns).toHaveLength(1);
+  });
+
+  it("disabled circuit breaker passes calls through without tracking state", async () => {
+    const cb = createMcpToolCircuitBreaker({
+      cfg: { circuitBreaker: { enabled: false, failureThreshold: 1 } },
+    });
+    const fail = () => Promise.reject(new Error("fail"));
+    await expect(cb.run({ serverName: "srv", toolName: "t" }, fail)).rejects.toThrow("fail");
+    expect(cb.getSnapshot().states).toHaveLength(0);
+  });
+});
+
+// ---- Budget ledger tests ----
+
+describe("ToolRuntimeBudgetLedger", () => {
+  it("counts total calls and per-tool calls", () => {
+    const ledger = createToolRuntimeBudgetLedger({});
+    const ann = { costWeight: 1, irreversible: false };
+    ledger.beforeCall({ serverName: "s", toolName: "a", annotation: ann });
+    ledger.afterCall({ serverName: "s", toolName: "a", annotation: ann, ok: true });
+    ledger.afterCall({ serverName: "s", toolName: "b", annotation: ann, ok: true });
+
+    const snap = ledger.getSnapshot();
+    expect(snap.totalCalls).toBe(2);
+    expect(snap.callsByKey["s::a"]).toBe(1);
+    expect(snap.callsByKey["s::b"]).toBe(1);
+  });
+
+  it("emits a single threshold warning when session call count is reached", () => {
+    const ledger = createToolRuntimeBudgetLedger({
+      cfg: { budget: { warnAfterCallsPerSession: 3 } },
+    });
+    const ann = { costWeight: 1, irreversible: false };
+    for (let i = 0; i < 2; i++) {
+      ledger.afterCall({ serverName: "s", toolName: "t", annotation: ann, ok: true });
+    }
+    expect(ledger.getSnapshot().warningsEmitted).toHaveLength(0);
+
+    const { warningKeys } = ledger.afterCall({
+      serverName: "s",
+      toolName: "t",
+      annotation: ann,
+      ok: true,
+    });
+    expect(warningKeys).toEqual(["calls_per_session:3"]);
+    expect(ledger.getSnapshot().warningsEmitted).toEqual(["calls_per_session:3"]);
+
+    // Fourth call — warning must not repeat
+    const { warningKeys: wk2 } = ledger.afterCall({
+      serverName: "s",
+      toolName: "t",
+      annotation: ann,
+      ok: true,
+    });
+    expect(wk2).toHaveLength(0);
+    expect(ledger.getSnapshot().warningsEmitted).toHaveLength(1);
+  });
+
+  it("applies weighted cost and emits warning when threshold is reached", () => {
+    const ledger = createToolRuntimeBudgetLedger({
+      cfg: { budget: { warnAfterWeightedCostPerSession: 10 } },
+    });
+    const ann = { costWeight: 4, irreversible: false };
+    for (let i = 0; i < 2; i++) {
+      ledger.afterCall({ serverName: "s", toolName: "t", annotation: ann, ok: true });
+    }
+    expect(ledger.getSnapshot().totalWeightedCost).toBe(8);
+    expect(ledger.getSnapshot().warningsEmitted).toHaveLength(0);
+
+    ledger.afterCall({ serverName: "s", toolName: "t", annotation: ann, ok: true });
+    expect(ledger.getSnapshot().totalWeightedCost).toBe(12);
+    expect(ledger.getSnapshot().warningsEmitted).toEqual(["weighted_cost_per_session:10"]);
+  });
+
+  it("emits irreversible call warning when annotation marks the call irreversible", () => {
+    const ledger = createToolRuntimeBudgetLedger({
+      cfg: { budget: { warnAfterIrreversibleCallsPerSession: 1 } },
+    });
+    const ann = { costWeight: 1, irreversible: true };
+    const { warningKeys } = ledger.afterCall({
+      serverName: "s",
+      toolName: "dangerous",
+      annotation: ann,
+      ok: true,
+    });
+    expect(warningKeys[0]).toMatch(/^irreversible_calls:/);
+    expect(ledger.getSnapshot().irreversibleCalls).toBe(1);
+  });
+
+  it("emits burst-window warning with fake clock", () => {
+    let now = 1_000;
+    const ledger = createToolRuntimeBudgetLedger({
+      cfg: { budget: { burstWindowMs: 5_000, warnAfterCallsPerBurstWindow: 3 } },
+      now: () => now,
+    });
+    const ann = { costWeight: 1, irreversible: false };
+
+    for (let i = 0; i < 2; i++) {
+      const { warningKeys } = ledger.afterCall({
+        serverName: "s",
+        toolName: "t",
+        annotation: ann,
+        ok: true,
+      });
+      expect(warningKeys).toHaveLength(0);
+    }
+
+    // Third call within burst window
+    const { warningKeys } = ledger.afterCall({
+      serverName: "s",
+      toolName: "t",
+      annotation: ann,
+      ok: true,
+    });
+    expect(warningKeys).toEqual(["burst_calls:3"]);
+
+    // Advance past burst window — old timestamps pruned; new calls should not trigger again
+    now += 6_000;
+    for (let i = 0; i < 2; i++) {
+      ledger.afterCall({ serverName: "s", toolName: "t", annotation: ann, ok: true });
+    }
+    // Warning already deduped; same key won't fire again
+    expect(ledger.getSnapshot().warningsEmitted).toHaveLength(1);
+  });
+
+  it("disabled budget ledger does not count calls", () => {
+    const ledger = createToolRuntimeBudgetLedger({
+      cfg: { budget: { enabled: false } },
+    });
+    const ann = { costWeight: 5, irreversible: true };
+    ledger.afterCall({ serverName: "s", toolName: "t", annotation: ann, ok: true });
+    const snap = ledger.getSnapshot();
+    expect(snap.totalCalls).toBe(0);
+    expect(snap.totalWeightedCost).toBe(0);
+  });
+});
+
+// ---- Annotation resolution tests ----
+
+describe("resolveToolAnnotation", () => {
+  it("returns default annotation when no tools config is provided", () => {
+    expect(resolveToolAnnotation("srv", "tool")).toEqual({ costWeight: 1, irreversible: false });
+  });
+
+  it("uses exact match before wildcard", () => {
+    const tools = {
+      "srv::tool": { costWeight: 10, irreversible: true },
+      "srv::*": { costWeight: 2 },
+    };
+    expect(resolveToolAnnotation("srv", "tool", tools)).toEqual({
+      costWeight: 10,
+      irreversible: true,
+    });
+  });
+
+  it("falls back to wildcard when no exact match", () => {
+    const tools = { "srv::*": { costWeight: 3 } };
+    expect(resolveToolAnnotation("srv", "other", tools)).toEqual({
+      costWeight: 3,
+      irreversible: false,
+    });
+  });
+
+  it("falls back to default when neither exact nor wildcard matches", () => {
+    const tools = { "other::*": { costWeight: 3 } };
+    expect(resolveToolAnnotation("srv", "tool", tools)).toEqual({
+      costWeight: 1,
+      irreversible: false,
+    });
+  });
+
+  it("invalid costWeight (zero) falls back to default and warns once", () => {
+    const warnedKeys = new Set<string>();
+    const tools = { "srv::tool": { costWeight: 0 } };
+
+    const ann1 = resolveToolAnnotation("srv", "tool", tools, warnedKeys);
+    expect(ann1.costWeight).toBe(1);
+    expect(mockLogWarn).toHaveBeenCalledWith(expect.stringContaining("invalid costWeight"));
+
+    mockLogWarn.mockClear();
+    const ann2 = resolveToolAnnotation("srv", "tool", tools, warnedKeys);
+    expect(ann2.costWeight).toBe(1);
+    expect(mockLogWarn).not.toHaveBeenCalled();
+  });
+
+  it("invalid costWeight (negative) falls back to default", () => {
+    const tools = { "srv::tool": { costWeight: -5 } };
+    const ann = resolveToolAnnotation("srv", "tool", tools, new Set());
+    expect(ann.costWeight).toBe(1);
+  });
+
+  it("invalid costWeight (NaN) falls back to default", () => {
+    const tools = { "srv::tool": { costWeight: Number.NaN } };
+    const ann = resolveToolAnnotation("srv", "tool", tools, new Set());
+    expect(ann.costWeight).toBe(1);
+  });
+});
+
+// ---- Combined guardrails facade tests ----
+
+describe("createMcpRuntimeGuardrails", () => {
+  it("getSnapshot returns combined circuit breaker and budget state", async () => {
+    const guardrails = createMcpRuntimeGuardrails({
+      cfg: {
+        circuitBreaker: { failureThreshold: 2 },
+        budget: { warnAfterCallsPerSession: 5 },
+      },
+    });
+
+    await guardrails.circuitBreaker.run({ serverName: "s", toolName: "t" }, async () => "ok");
+    guardrails.budgetLedger.afterCall({
+      serverName: "s",
+      toolName: "t",
+      annotation: { costWeight: 1, irreversible: false },
+      ok: true,
+    });
+
+    const snap = guardrails.getSnapshot();
+    expect(snap.circuitBreaker.states[0]).toMatchObject({ state: "closed" });
+    expect(snap.budget.totalCalls).toBe(1);
+  });
+
+  it("resolveAnnotation uses exact match and falls back to wildcard then default", () => {
+    const guardrails = createMcpRuntimeGuardrails({
+      cfg: {
+        tools: {
+          "srv::exact": { costWeight: 7, irreversible: true },
+          "srv::*": { costWeight: 2 },
+        },
+      },
+    });
+
+    expect(guardrails.resolveAnnotation("srv", "exact")).toEqual({
+      costWeight: 7,
+      irreversible: true,
+    });
+    expect(guardrails.resolveAnnotation("srv", "other")).toEqual({
+      costWeight: 2,
+      irreversible: false,
+    });
+    expect(guardrails.resolveAnnotation("unknown", "tool")).toEqual({
+      costWeight: 1,
+      irreversible: false,
+    });
+  });
+
+  it("invalid annotation warns once across repeated calls", () => {
+    const guardrails = createMcpRuntimeGuardrails({
+      cfg: { tools: { "srv::bad": { costWeight: -1 } } },
+    });
+
+    guardrails.resolveAnnotation("srv", "bad");
+    const warnCallsAfterFirst = mockLogWarn.mock.calls.length;
+
+    guardrails.resolveAnnotation("srv", "bad");
+    guardrails.resolveAnnotation("srv", "bad");
+    expect(mockLogWarn.mock.calls.length).toBe(warnCallsAfterFirst);
+  });
+
+  it("dispose of the runtime object does not prevent snapshot from being called", async () => {
+    const guardrails = createMcpRuntimeGuardrails({});
+    const snap = guardrails.getSnapshot();
+    expect(snap.budget.totalCalls).toBe(0);
+    expect(snap.circuitBreaker.states).toHaveLength(0);
+  });
+});
+
+// ---- Config/schema tests ----
+
+describe("mcp.runtimeGuardrails zod schema", () => {
+  it("accepts a valid full runtimeGuardrails config", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: {
+        runtimeGuardrails: {
+          circuitBreaker: { enabled: true, failureThreshold: 3, recoveryTimeoutMs: 60_000 },
+          budget: {
+            enabled: true,
+            warnAfterCallsPerSession: 50,
+            warnAfterWeightedCostPerSession: 100,
+            warnAfterIrreversibleCallsPerSession: 1,
+            burstWindowMs: 60_000,
+            warnAfterCallsPerBurstWindow: 20,
+          },
+          tools: {
+            "srv::tool": { costWeight: 5, irreversible: true },
+            "srv::*": { costWeight: 2 },
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts mcp.runtimeGuardrails omitted entirely", () => {
+    const result = OpenClawSchema.safeParse({ mcp: { servers: {} } });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects failureThreshold of zero (must be positive int)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { circuitBreaker: { failureThreshold: 0 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative failureThreshold", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { circuitBreaker: { failureThreshold: -1 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects zero recoveryTimeoutMs (must be positive)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { circuitBreaker: { recoveryTimeoutMs: 0 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative costWeight in tool annotation", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { tools: { "srv::tool": { costWeight: -1 } } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects zero costWeight in tool annotation (must be positive finite)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { tools: { "srv::tool": { costWeight: 0 } } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects observeOnly override because runtime guardrails are always observe-only", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { observeOnly: false } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects halfOpenMaxCalls until probe concurrency is implemented", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { circuitBreaker: { halfOpenMaxCalls: 2 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys inside circuitBreaker (strict object)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { circuitBreaker: { unknownKey: 1 } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys inside budget (strict object)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { budget: { unknownKey: true } } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys inside runtimeGuardrails (strict object)", () => {
+    const result = OpenClawSchema.safeParse({
+      mcp: { runtimeGuardrails: { unexpectedKey: 1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/agents/mcp-runtime-guardrails.ts
+++ b/src/agents/mcp-runtime-guardrails.ts
@@ -1,0 +1,436 @@
+import type { McpRuntimeGuardrailsConfig, McpToolAnnotationConfig } from "../config/types.mcp.js";
+import { logWarn } from "../logger.js";
+
+// ---- Snapshot types (exported for tests and status surfaces) ----
+
+export type McpToolCircuitState = {
+  key: string;
+  state: "closed" | "open" | "half_open";
+  consecutiveFailures: number;
+  openedAt?: number;
+  lastFailureAt?: number;
+  lastSuccessAt?: number;
+  nextProbeAt?: number;
+};
+
+export type McpCircuitBreakerSnapshot = {
+  enabled: boolean;
+  observeOnly: boolean;
+  states: McpToolCircuitState[];
+  wouldBlockCount: number;
+};
+
+export type McpBudgetLedgerSnapshot = {
+  enabled: boolean;
+  observeOnly: boolean;
+  totalCalls: number;
+  totalWeightedCost: number;
+  irreversibleCalls: number;
+  callsByKey: Record<string, number>;
+  warningsEmitted: string[];
+};
+
+export type McpRuntimeGuardrailSnapshot = {
+  circuitBreaker: McpCircuitBreakerSnapshot;
+  budget: McpBudgetLedgerSnapshot;
+};
+
+// ---- Option types ----
+
+export type McpToolCircuitBreakerOptions = {
+  enabled?: boolean;
+  failureThreshold?: number;
+  recoveryTimeoutMs?: number;
+};
+
+export type ToolRuntimeBudgetOptions = {
+  enabled?: boolean;
+  warnAfterCallsPerSession?: number;
+  warnAfterWeightedCostPerSession?: number;
+  warnAfterIrreversibleCallsPerSession?: number;
+  burstWindowMs?: number;
+  warnAfterCallsPerBurstWindow?: number;
+};
+
+export type ToolRuntimeAnnotation = Required<McpToolAnnotationConfig>;
+
+// ---- Annotation resolution ----
+
+const DEFAULT_ANNOTATION: ToolRuntimeAnnotation = { costWeight: 1, irreversible: false };
+
+export function resolveToolAnnotation(
+  serverName: string,
+  toolName: string,
+  tools?: Record<string, McpToolAnnotationConfig>,
+  invalidAnnotationWarnedKeys?: Set<string>,
+): ToolRuntimeAnnotation {
+  if (!tools) {
+    return DEFAULT_ANNOTATION;
+  }
+
+  const exactKey = `${serverName}::${toolName}`;
+  const wildcardKey = `${serverName}::*`;
+  const matchKey = exactKey in tools ? exactKey : wildcardKey in tools ? wildcardKey : undefined;
+
+  if (!matchKey) {
+    return DEFAULT_ANNOTATION;
+  }
+
+  const raw = tools[matchKey];
+  let costWeight = raw.costWeight ?? 1;
+
+  if (!Number.isFinite(costWeight) || costWeight <= 0) {
+    const warnKey = `invalid_cost_weight:${matchKey}`;
+    if (!invalidAnnotationWarnedKeys?.has(warnKey)) {
+      invalidAnnotationWarnedKeys?.add(warnKey);
+      logWarn(`bundle-mcp: invalid costWeight for annotation "${matchKey}"; using default 1`);
+    }
+    costWeight = 1;
+  }
+
+  return { costWeight, irreversible: raw.irreversible ?? false };
+}
+
+// ---- Circuit breaker ----
+
+type CircuitBreakerResolvedOptions = {
+  enabled: boolean;
+  observeOnly: boolean;
+  failureThreshold: number;
+  recoveryTimeoutMs: number;
+};
+
+function resolveCircuitBreakerOptions(
+  cfg?: McpRuntimeGuardrailsConfig,
+  enforceForTesting?: boolean,
+): CircuitBreakerResolvedOptions {
+  const cb = cfg?.circuitBreaker;
+  return {
+    enabled: cb?.enabled !== false,
+    observeOnly: enforceForTesting !== true,
+    failureThreshold: cb?.failureThreshold ?? 3,
+    recoveryTimeoutMs: cb?.recoveryTimeoutMs ?? 60_000,
+  };
+}
+
+export type McpToolCircuitBreaker = {
+  run<T>(tool: { serverName: string; toolName: string }, fn: () => Promise<T>): Promise<T>;
+  getSnapshot(): McpCircuitBreakerSnapshot;
+};
+
+export function createMcpToolCircuitBreaker(opts: {
+  cfg?: McpRuntimeGuardrailsConfig;
+  now?: () => number;
+  enforceForTesting?: boolean;
+}): McpToolCircuitBreaker {
+  const options = resolveCircuitBreakerOptions(opts.cfg, opts.enforceForTesting);
+  const { enabled, observeOnly, failureThreshold, recoveryTimeoutMs } = options;
+  const now = opts.now ?? Date.now;
+  const states = new Map<string, McpToolCircuitState>();
+  let wouldBlockCount = 0;
+  const lastWouldBlockWarnAt = new Map<string, number>();
+
+  function getOrInitState(key: string): McpToolCircuitState {
+    let state = states.get(key);
+    if (!state) {
+      state = { key, state: "closed", consecutiveFailures: 0 };
+      states.set(key, state);
+    }
+    return state;
+  }
+
+  return {
+    async run({ serverName, toolName }, fn) {
+      const key = `${serverName}::${toolName}`;
+
+      if (!enabled) {
+        return fn();
+      }
+
+      const state = getOrInitState(key);
+      const nowMs = now();
+
+      if (state.state === "open") {
+        if (nowMs >= (state.nextProbeAt ?? 0)) {
+          // Cooldown elapsed — move to half-open for a probe
+          state.state = "half_open";
+        } else {
+          // Still in cooldown
+          wouldBlockCount += 1;
+          const lastWarn = lastWouldBlockWarnAt.get(key) ?? 0;
+          if (lastWarn === 0 || nowMs - lastWarn > recoveryTimeoutMs) {
+            logWarn(
+              `bundle-mcp: circuit open for "${key}" (would_block, observe_only=${String(observeOnly)})`,
+            );
+            lastWouldBlockWarnAt.set(key, nowMs);
+          }
+          if (!observeOnly) {
+            const retryAfterMs = Math.max(0, (state.nextProbeAt ?? 0) - nowMs);
+            throw new Error(
+              `bundle-mcp: tool "${key}" circuit open; retry after ${retryAfterMs}ms`,
+            );
+          }
+          // observe-only: fall through and make the call anyway
+        }
+      }
+
+      const wasHalfOpen = state.state === "half_open";
+
+      try {
+        const result = await fn();
+
+        if (state.state !== "closed") {
+          logWarn(`bundle-mcp: circuit closing for "${key}" after successful probe`);
+        }
+        state.state = "closed";
+        state.consecutiveFailures = 0;
+        state.lastSuccessAt = now();
+
+        return result;
+      } catch (error) {
+        state.consecutiveFailures += 1;
+        state.lastFailureAt = now();
+
+        if (wasHalfOpen || state.consecutiveFailures >= failureThreshold) {
+          const previousState = state.state;
+          state.state = "open";
+          state.openedAt = now();
+          state.nextProbeAt = state.openedAt + recoveryTimeoutMs;
+          if (previousState !== "open") {
+            logWarn(
+              `bundle-mcp: circuit opening for "${key}" after ${state.consecutiveFailures} failure(s)`,
+            );
+          }
+        }
+
+        throw error;
+      }
+    },
+
+    getSnapshot(): McpCircuitBreakerSnapshot {
+      return {
+        enabled,
+        observeOnly,
+        states: Array.from(states.values(), (s) => Object.assign({}, s)),
+        wouldBlockCount,
+      };
+    },
+  };
+}
+
+// ---- Budget ledger ----
+
+type BudgetResolvedOptions = {
+  enabled: boolean;
+  observeOnly: boolean;
+  warnAfterCallsPerSession?: number;
+  warnAfterWeightedCostPerSession?: number;
+  warnAfterIrreversibleCallsPerSession?: number;
+  burstWindowMs: number;
+  warnAfterCallsPerBurstWindow?: number;
+};
+
+function resolveBudgetOptions(cfg?: McpRuntimeGuardrailsConfig): BudgetResolvedOptions {
+  const b = cfg?.budget;
+  return {
+    enabled: b?.enabled !== false,
+    observeOnly: true,
+    warnAfterCallsPerSession: b?.warnAfterCallsPerSession,
+    warnAfterWeightedCostPerSession: b?.warnAfterWeightedCostPerSession,
+    warnAfterIrreversibleCallsPerSession: b?.warnAfterIrreversibleCallsPerSession,
+    burstWindowMs: b?.burstWindowMs ?? 60_000,
+    warnAfterCallsPerBurstWindow: b?.warnAfterCallsPerBurstWindow,
+  };
+}
+
+export type ToolRuntimeBudgetLedger = {
+  beforeCall(params: { serverName: string; toolName: string; annotation: ToolRuntimeAnnotation }): {
+    warningKeys: string[];
+  };
+  afterCall(params: {
+    serverName: string;
+    toolName: string;
+    annotation: ToolRuntimeAnnotation;
+    ok: boolean;
+  }): { warningKeys: string[] };
+  getSnapshot(): McpBudgetLedgerSnapshot;
+};
+
+export function createToolRuntimeBudgetLedger(opts: {
+  cfg?: McpRuntimeGuardrailsConfig;
+  now?: () => number;
+}): ToolRuntimeBudgetLedger {
+  const options = resolveBudgetOptions(opts.cfg);
+  const now = opts.now ?? Date.now;
+  let totalCalls = 0;
+  let totalWeightedCost = 0;
+  let irreversibleCalls = 0;
+  const callsByKey = new Map<string, number>();
+  const burstTimestampsByKey = new Map<string, number[]>();
+  const globalBurstTimestamps: number[] = [];
+  const warningsEmittedSet = new Set<string>();
+  const warningsEmitted: string[] = [];
+
+  function pruneWindow(timestamps: number[], nowMs: number, windowMs: number): void {
+    const cutoff = nowMs - windowMs;
+    let i = 0;
+    while (i < timestamps.length && timestamps[i] <= cutoff) {
+      i++;
+    }
+    if (i > 0) {
+      timestamps.splice(0, i);
+    }
+  }
+
+  function emitWarning(warningKey: string, message: string): string[] {
+    if (warningsEmittedSet.has(warningKey)) {
+      return [];
+    }
+    warningsEmittedSet.add(warningKey);
+    warningsEmitted.push(warningKey);
+    logWarn(`bundle-mcp: budget warning [${warningKey}]: ${message}`);
+    return [warningKey];
+  }
+
+  return {
+    beforeCall() {
+      return { warningKeys: [] };
+    },
+
+    afterCall({ serverName, toolName, annotation }) {
+      if (!options.enabled) {
+        return { warningKeys: [] };
+      }
+
+      const key = `${serverName}::${toolName}`;
+      const nowMs = now();
+      const newWarnings: string[] = [];
+
+      totalCalls += 1;
+      callsByKey.set(key, (callsByKey.get(key) ?? 0) + 1);
+
+      totalWeightedCost += annotation.costWeight;
+
+      if (annotation.irreversible) {
+        irreversibleCalls += 1;
+      }
+
+      // Burst window tracking
+      if (!burstTimestampsByKey.has(key)) {
+        burstTimestampsByKey.set(key, []);
+      }
+      const keyTs = burstTimestampsByKey.get(key)!;
+      pruneWindow(keyTs, nowMs, options.burstWindowMs);
+      keyTs.push(nowMs);
+
+      pruneWindow(globalBurstTimestamps, nowMs, options.burstWindowMs);
+      globalBurstTimestamps.push(nowMs);
+
+      // Session call threshold
+      if (
+        options.warnAfterCallsPerSession != null &&
+        totalCalls >= options.warnAfterCallsPerSession
+      ) {
+        newWarnings.push(
+          ...emitWarning(
+            `calls_per_session:${options.warnAfterCallsPerSession}`,
+            `total MCP calls reached ${totalCalls} (threshold: ${options.warnAfterCallsPerSession})`,
+          ),
+        );
+      }
+
+      // Session weighted cost threshold
+      if (
+        options.warnAfterWeightedCostPerSession != null &&
+        totalWeightedCost >= options.warnAfterWeightedCostPerSession
+      ) {
+        newWarnings.push(
+          ...emitWarning(
+            `weighted_cost_per_session:${options.warnAfterWeightedCostPerSession}`,
+            `total weighted cost reached ${totalWeightedCost} (threshold: ${options.warnAfterWeightedCostPerSession})`,
+          ),
+        );
+      }
+
+      // Irreversible call threshold
+      if (
+        options.warnAfterIrreversibleCallsPerSession != null &&
+        annotation.irreversible &&
+        irreversibleCalls >= options.warnAfterIrreversibleCallsPerSession
+      ) {
+        newWarnings.push(
+          ...emitWarning(
+            `irreversible_calls:${options.warnAfterIrreversibleCallsPerSession}:${key}`,
+            `irreversible call to "${key}" (total irreversible: ${irreversibleCalls})`,
+          ),
+        );
+      }
+
+      // Burst window threshold
+      if (
+        options.warnAfterCallsPerBurstWindow != null &&
+        globalBurstTimestamps.length >= options.warnAfterCallsPerBurstWindow
+      ) {
+        newWarnings.push(
+          ...emitWarning(
+            `burst_calls:${options.warnAfterCallsPerBurstWindow}`,
+            `${globalBurstTimestamps.length} MCP calls in burst window (threshold: ${options.warnAfterCallsPerBurstWindow})`,
+          ),
+        );
+      }
+
+      return { warningKeys: newWarnings };
+    },
+
+    getSnapshot(): McpBudgetLedgerSnapshot {
+      return {
+        enabled: options.enabled,
+        observeOnly: options.observeOnly,
+        totalCalls,
+        totalWeightedCost,
+        irreversibleCalls,
+        callsByKey: Object.fromEntries(callsByKey.entries()),
+        warningsEmitted: [...warningsEmitted],
+      };
+    },
+  };
+}
+
+// ---- Combined guardrails facade ----
+
+export type McpRuntimeGuardrails = {
+  circuitBreaker: McpToolCircuitBreaker;
+  budgetLedger: ToolRuntimeBudgetLedger;
+  resolveAnnotation(serverName: string, toolName: string): ToolRuntimeAnnotation;
+  getSnapshot(): McpRuntimeGuardrailSnapshot;
+};
+
+export function createMcpRuntimeGuardrails(opts: {
+  cfg?: McpRuntimeGuardrailsConfig;
+  now?: () => number;
+  /** For tests only: disable observe-only so enforcement can be exercised. */
+  enforceForTesting?: boolean;
+}): McpRuntimeGuardrails {
+  const circuitBreaker = createMcpToolCircuitBreaker(opts);
+  const budgetLedger = createToolRuntimeBudgetLedger(opts);
+  const invalidAnnotationWarnedKeys = new Set<string>();
+
+  return {
+    circuitBreaker,
+    budgetLedger,
+    resolveAnnotation(serverName, toolName) {
+      return resolveToolAnnotation(
+        serverName,
+        toolName,
+        opts.cfg?.tools,
+        invalidAnnotationWarnedKeys,
+      );
+    },
+    getSnapshot(): McpRuntimeGuardrailSnapshot {
+      return {
+        circuitBreaker: circuitBreaker.getSnapshot(),
+        budget: budgetLedger.getSnapshot(),
+      };
+    },
+  };
+}

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -18,6 +18,7 @@ import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { loadEmbeddedPiMcpConfig } from "./embedded-pi-mcp.js";
 import { isMcpConfigRecord } from "./mcp-config-shared.js";
+import { createMcpRuntimeGuardrails } from "./mcp-runtime-guardrails.js";
 import { resolveMcpTransport } from "./mcp-transport.js";
 import { sanitizeServerName } from "./pi-bundle-mcp-names.js";
 import type {
@@ -196,6 +197,9 @@ export function createSessionMcpRuntime(params: {
   let catalog: McpToolCatalog | null = null;
   let catalogInFlight: Promise<McpToolCatalog> | undefined;
   const sessions = new Map<string, BundleMcpSession>();
+  const guardrails = createMcpRuntimeGuardrails({
+    cfg: params.cfg?.mcp?.runtimeGuardrails,
+  });
   const failIfDisposed = () => {
     if (disposed) {
       throw createDisposedError(params.sessionId);
@@ -355,10 +359,25 @@ export function createSessionMcpRuntime(params: {
       if (!session) {
         throw new Error(`bundle-mcp server "${serverName}" is not connected`);
       }
-      return (await session.client.callTool({
-        name: toolName,
-        arguments: isMcpConfigRecord(input) ? input : {},
-      })) as CallToolResult;
+
+      const annotation = guardrails.resolveAnnotation(serverName, toolName);
+      guardrails.budgetLedger.beforeCall({ serverName, toolName, annotation });
+      try {
+        const result = (await guardrails.circuitBreaker.run({ serverName, toolName }, () =>
+          session.client.callTool({
+            name: toolName,
+            arguments: isMcpConfigRecord(input) ? input : {},
+          }),
+        )) as CallToolResult;
+        guardrails.budgetLedger.afterCall({ serverName, toolName, annotation, ok: true });
+        return result;
+      } catch (error) {
+        guardrails.budgetLedger.afterCall({ serverName, toolName, annotation, ok: false });
+        throw error;
+      }
+    },
+    getGuardrailSnapshot() {
+      return guardrails.getSnapshot();
     },
     async dispose() {
       if (disposed) {

--- a/src/agents/pi-bundle-mcp-types.ts
+++ b/src/agents/pi-bundle-mcp-types.ts
@@ -1,6 +1,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { TSchema } from "typebox";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { McpRuntimeGuardrailSnapshot } from "./mcp-runtime-guardrails.js";
 import type { AnyAgentTool } from "./tools/common.js";
 
 export type BundleMcpToolRuntime = {
@@ -43,6 +44,7 @@ export type SessionMcpRuntime = {
   getCatalog: () => Promise<McpToolCatalog>;
   markUsed: () => void;
   callTool: (serverName: string, toolName: string, input: unknown) => Promise<CallToolResult>;
+  getGuardrailSnapshot?: () => McpRuntimeGuardrailSnapshot;
   dispose: () => Promise<void>;
 };
 

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -23427,6 +23427,83 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
             description:
               "Idle TTL in milliseconds for session-scoped bundled MCP runtimes. Defaults to 10 minutes; set 0 to disable idle eviction.",
           },
+          runtimeGuardrails: {
+            type: "object",
+            properties: {
+              circuitBreaker: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  failureThreshold: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  recoveryTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                },
+                additionalProperties: false,
+              },
+              budget: {
+                type: "object",
+                properties: {
+                  enabled: {
+                    type: "boolean",
+                  },
+                  warnAfterCallsPerSession: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  warnAfterWeightedCostPerSession: {
+                    type: "number",
+                    exclusiveMinimum: 0,
+                  },
+                  warnAfterIrreversibleCallsPerSession: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  burstWindowMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                  warnAfterCallsPerBurstWindow: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
+                },
+                additionalProperties: false,
+              },
+              tools: {
+                type: "object",
+                propertyNames: {
+                  type: "string",
+                },
+                additionalProperties: {
+                  type: "object",
+                  properties: {
+                    costWeight: {
+                      type: "number",
+                      exclusiveMinimum: 0,
+                    },
+                    irreversible: {
+                      type: "boolean",
+                    },
+                  },
+                  additionalProperties: false,
+                },
+              },
+            },
+            additionalProperties: false,
+          },
         },
         additionalProperties: false,
         title: "MCP",

--- a/src/config/types.mcp.ts
+++ b/src/config/types.mcp.ts
@@ -20,6 +20,32 @@ export type McpServerConfig = {
   [key: string]: unknown;
 };
 
+export type McpToolAnnotationConfig = {
+  /** Relative cost weight for observe-first runtime budget accounting. Defaults to 1. */
+  costWeight?: number;
+  /** Whether this tool call is considered irreversible for warning/approval hints. */
+  irreversible?: boolean;
+};
+
+export type McpRuntimeGuardrailsConfig = {
+  /** Runtime guardrails are observe-only. Enforcement requires a separate reviewed code change. */
+  circuitBreaker?: {
+    enabled?: boolean;
+    failureThreshold?: number;
+    recoveryTimeoutMs?: number;
+  };
+  budget?: {
+    enabled?: boolean;
+    warnAfterCallsPerSession?: number;
+    warnAfterWeightedCostPerSession?: number;
+    warnAfterIrreversibleCallsPerSession?: number;
+    burstWindowMs?: number;
+    warnAfterCallsPerBurstWindow?: number;
+  };
+  /** Tool annotations keyed by `server::tool` or `server::*`. */
+  tools?: Record<string, McpToolAnnotationConfig>;
+};
+
 export type McpConfig = {
   /** Named MCP server definitions managed by OpenClaw. */
   servers?: Record<string, McpServerConfig>;
@@ -29,4 +55,6 @@ export type McpConfig = {
    * Defaults to 10 minutes. Set to 0 to disable idle eviction.
    */
   sessionIdleTtlMs?: number;
+  /** Warning-only bundled MCP runtime guardrails. */
+  runtimeGuardrails?: McpRuntimeGuardrailsConfig;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -230,10 +230,43 @@ const McpServerSchema = z
   })
   .catchall(z.unknown());
 
+const McpToolAnnotationSchema = z
+  .object({
+    costWeight: z.number().finite().positive().optional(),
+    irreversible: z.boolean().optional(),
+  })
+  .strict();
+
+const McpRuntimeGuardrailsSchema = z
+  .object({
+    circuitBreaker: z
+      .object({
+        enabled: z.boolean().optional(),
+        failureThreshold: z.number().int().positive().optional(),
+        recoveryTimeoutMs: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    budget: z
+      .object({
+        enabled: z.boolean().optional(),
+        warnAfterCallsPerSession: z.number().int().positive().optional(),
+        warnAfterWeightedCostPerSession: z.number().finite().positive().optional(),
+        warnAfterIrreversibleCallsPerSession: z.number().int().positive().optional(),
+        burstWindowMs: z.number().int().positive().optional(),
+        warnAfterCallsPerBurstWindow: z.number().int().positive().optional(),
+      })
+      .strict()
+      .optional(),
+    tools: z.record(z.string(), McpToolAnnotationSchema).optional(),
+  })
+  .strict();
+
 const McpConfigSchema = z
   .object({
     servers: z.record(z.string(), McpServerSchema).optional(),
     sessionIdleTtlMs: z.number().finite().min(0).optional(),
+    runtimeGuardrails: McpRuntimeGuardrailsSchema.optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary
- Adds observe-first MCP runtime guardrails around bundle MCP tool execution.
- Tracks per-tool circuit state, budget/rate observations, and runtime snapshots.
- Keeps production behavior observe-only; fail-closed enforcement is test-helper-only and not exposed through public config.

## Verification
- `corepack pnpm vitest run src/agents/mcp-runtime-guardrails.test.ts` — 38 tests passed
- `PATH=/tmp/openclaw-pnpm-shim:$PATH corepack pnpm check:changed` — passed

## Guardrails
- No deploy, gateway restart, production config write, Promptise dependency, or fail-closed runtime enforcement in this PR.
