### PR TITLE
auto-reply + runner: suppress reasoning-prefaced silent replies end-to-end

### DIFF
--- a/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
+++ b/src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
@@ -78,6 +78,49 @@ describe("runEmbeddedPiAgent incomplete-turn safety", () => {
     expect(result.payloads?.[0]?.text).toContain("verify before retrying");
   });
 
+  it("does not surface couldn't-generate when last assistant is a reasoning-prefaced silent reply", async () => {
+    // Regression for the false-positive where Gemini emits its chain-of-thought
+    // as a "think\n...\nNO_REPLY" plain-text payload. The outbound silent-reply
+    // suppressor strips the assistant text, leaving `assistantTexts: []`. The
+    // classifier must consult `lastAssistant.content` directly so it does not
+    // surface "Agent couldn't generate a response" for an intentional silence.
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [],
+        didSendViaMessagingTool: false,
+        lastAssistant: {
+          stopReason: "stop",
+          provider: "google-vertex",
+          model: "gemini-3.1-pro-preview",
+          content: [
+            {
+              type: "text",
+              text: "think\nAnother advertisement. Ignore.NO_REPLY",
+            },
+          ],
+        } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      provider: "google-vertex",
+      model: "gemini-3.1-pro-preview",
+      runId: "run-incomplete-turn-reasoning-prefaced-silent",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    const payloads = result.payloads ?? [];
+    expect(payloads).not.toContainEqual(
+      expect.objectContaining({
+        isError: true,
+        text: expect.stringContaining("couldn't generate a response"),
+      }),
+    );
+  });
+
   it("synthesizes a silent cron payload from a trailing current-attempt NO_REPLY tool result", () => {
     const payload = resolveSilentToolResultReplyPayload({
       isCronTrigger: true,

--- a/src/agents/pi-embedded-runner/run/incomplete-turn.ts
+++ b/src/agents/pi-embedded-runner/run/incomplete-turn.ts
@@ -240,7 +240,7 @@ export function resolveIncompleteTurnPayloadText(params: {
     return null;
   }
 
-  if (hasOnlySilentAssistantReply(params.attempt.assistantTexts)) {
+  if (hasOnlySilentAssistantReply(params.attempt.assistantTexts, params.attempt.lastAssistant)) {
     return null;
   }
 
@@ -278,12 +278,49 @@ function joinAssistantTexts(assistantTexts?: readonly string[]): string {
   return (assistantTexts ?? []).join("\n\n").trim();
 }
 
-function hasOnlySilentAssistantReply(assistantTexts?: readonly string[]): boolean {
-  const nonEmptyTexts = (assistantTexts ?? []).filter((text) => text.trim().length > 0);
+function hasOnlySilentAssistantReply(
+  assistantTexts?: readonly string[],
+  lastAssistant?: AssistantMessage | null,
+): boolean {
+  const candidates = collectAssistantSilentReplyCandidates(assistantTexts, lastAssistant);
   return (
-    nonEmptyTexts.length > 0 &&
-    nonEmptyTexts.every((text) => isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN))
+    candidates.length > 0 &&
+    candidates.every((text) => isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN))
   );
+}
+
+/**
+ * Collects candidate assistant text strings that should be checked against
+ * `isSilentReplyPayloadText`.
+ *
+ * Pulls from two sources: `assistantTexts` (the openclaw run wrapper's
+ * post-chunker text collection — can be empty when streaming/chunking
+ * filters drop the assistant text before it reaches the wrapper) and
+ * `lastAssistant.content` text parts (the raw model output recorded in the
+ * session). The session text is the authoritative source for "did the
+ * assistant say a silent-reply sentinel?", and consulting it prevents the
+ * incomplete-turn warning from surfacing as a false positive on
+ * reasoning-prefaced silent replies (e.g. "think\n...\nNO_REPLY") that the
+ * outbound silent-reply suppressor correctly stripped from delivery.
+ */
+function collectAssistantSilentReplyCandidates(
+  assistantTexts?: readonly string[],
+  lastAssistant?: AssistantMessage | null,
+): string[] {
+  const collected: string[] = [];
+  for (const text of assistantTexts ?? []) {
+    if (typeof text === "string" && text.trim().length > 0) {
+      collected.push(text);
+    }
+  }
+  const lastAssistantText =
+    lastAssistant && typeof lastAssistant === "object"
+      ? readMessageTextContent(lastAssistant as AgentMessage)
+      : undefined;
+  if (lastAssistantText && lastAssistantText.trim().length > 0) {
+    collected.push(lastAssistantText);
+  }
+  return collected;
 }
 
 function isToolResultRole(role: string): boolean {
@@ -402,6 +439,17 @@ export function isReasoningOnlyAssistantTurn(message: unknown): boolean {
   if (!message || typeof message !== "object") {
     return false;
   }
+  // A reasoning-prefaced silent reply (for example "think\n...\nNO_REPLY"
+  // from Gemini's chain-of-thought leaking as plain text) is *intentional
+  // silence*, not a model that "didn't finish thinking." Without this guard
+  // the empty-response/reasoning-only/planning-only retry resolvers each
+  // re-trigger the model and the incomplete-turn classifier surfaces a
+  // "couldn't generate a response" warning even though the outbound
+  // silent-reply suppressor correctly stripped the noise from delivery.
+  const text = readMessageTextContent(message as AgentMessage);
+  if (text && isSilentReplyPayloadText(text, SILENT_REPLY_TOKEN)) {
+    return false;
+  }
   return assessLastAssistantMessage(message as AgentMessage) === "incomplete-text";
 }
 
@@ -423,6 +471,13 @@ function isEmptyResponseAssistantTurn(params: {
     return true;
   }
   if (assistant.stopReason === "error") {
+    return false;
+  }
+  // Reasoning-prefaced silent reply (for example "think\n...\nNO_REPLY") is
+  // intentional silence. Treat it the same as an exact NO_REPLY so the
+  // empty-response retry path doesn't burn tokens re-prompting Gemini.
+  const assistantText = readMessageTextContent(assistant as AgentMessage);
+  if (assistantText && isSilentReplyPayloadText(assistantText, SILENT_REPLY_TOKEN)) {
     return false;
   }
   if (

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 import {
+  isReasoningPrefacedSilentReply,
+  isSilentReplyPayloadText,
   isSilentReplyPrefixText,
   isSilentReplyText,
   startsWithSilentToken,
@@ -133,5 +135,88 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("NO_X")).toBe(false);
     expect(isSilentReplyPrefixText("NO_REPLY more")).toBe(false);
     expect(isSilentReplyPrefixText("NO-")).toBe(false);
+  });
+});
+
+describe("isReasoningPrefacedSilentReply", () => {
+  it("classifies reasoning preamble + trailing NO_REPLY as silent", () => {
+    const text =
+      "think\n" +
+      "The user's message is from Aftermath in the #general channel.\n" +
+      "The message is a self-promotional advertisement.\n" +
+      "Silence is the required action.\n" +
+      "Therefore, I should output NO_REPLY.NO_REPLY";
+    expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+  });
+
+  it("classifies single trailing NO_REPLY with reasoning preamble as silent", () => {
+    const text = "think\nThe user is saying hello. I will not reply.\nNO_REPLY";
+    expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+  });
+
+  it("accepts other reasoning heading words", () => {
+    for (const heading of ["thinking", "thought", "reasoning", "analysis"]) {
+      const text = `${heading}\nUser asked a trivial question.\nNO_REPLY`;
+      expect(isReasoningPrefacedSilentReply(text)).toBe(true);
+    }
+  });
+
+  it("accepts reasoning heading with trailing colon", () => {
+    expect(isReasoningPrefacedSilentReply("thinking:\nSome analysis.\nNO_REPLY")).toBe(true);
+  });
+
+  it("collapses doubled trailing NO_REPLY forms with inner punctuation", () => {
+    // The exact observed pattern from the bug report.
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY.NO_REPLY")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY NO_REPLY")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("think\nbody\nNO_REPLY. NO_REPLY")).toBe(true);
+  });
+
+  it("preserves #19537 — substantive replies ending with NO_REPLY are not silent", () => {
+    const substantive = "Here is the answer you asked for.\n\nNO_REPLY";
+    expect(isReasoningPrefacedSilentReply(substantive)).toBe(false);
+  });
+
+  it("returns false when message does not end with the silent token", () => {
+    expect(isReasoningPrefacedSilentReply("think\nbody\nactual reply")).toBe(false);
+  });
+
+  it("returns false for plain substantive text without reasoning preamble", () => {
+    expect(isReasoningPrefacedSilentReply("I should reply to this. NO_REPLY")).toBe(false);
+  });
+
+  it("returns false for empty or whitespace-only input", () => {
+    expect(isReasoningPrefacedSilentReply("")).toBe(false);
+    expect(isReasoningPrefacedSilentReply(undefined)).toBe(false);
+    expect(isReasoningPrefacedSilentReply("   ")).toBe(false);
+  });
+
+  it("returns true when only the silent token remains after trimming", () => {
+    expect(isReasoningPrefacedSilentReply("  NO_REPLY  ")).toBe(true);
+    expect(isReasoningPrefacedSilentReply("NO_REPLY.NO_REPLY")).toBe(true);
+  });
+
+  it("does not match when reasoning heading is followed inline by prose on same line", () => {
+    // A bare heading must be on its own line; inline "think the answer is X" is
+    // natural language and should not be suppressed.
+    expect(isReasoningPrefacedSilentReply("think the answer is yes\nNO_REPLY")).toBe(false);
+  });
+});
+
+describe("isSilentReplyPayloadText integration", () => {
+  it("returns true for reasoning-prefaced silent replies", () => {
+    expect(isSilentReplyPayloadText("think\nanalysis goes here\nNO_REPLY.NO_REPLY")).toBe(true);
+  });
+
+  it("still returns true for exact token", () => {
+    expect(isSilentReplyPayloadText("NO_REPLY")).toBe(true);
+  });
+
+  it("still returns true for JSON action envelope", () => {
+    expect(isSilentReplyPayloadText('{"action":"NO_REPLY"}')).toBe(true);
+  });
+
+  it("still returns false for substantive replies ending with NO_REPLY (#19537)", () => {
+    expect(isSilentReplyPayloadText("Here is a helpful response.\n\nNO_REPLY")).toBe(false);
   });
 });

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -29,6 +29,25 @@ function getSilentTrailingRegex(token: string): RegExp {
   return regex;
 }
 
+const silentReasoningTrailingRegexByToken = new Map<string, RegExp>();
+
+function getSilentReasoningTrailingRegex(token: string): RegExp {
+  const cached = silentReasoningTrailingRegexByToken.get(token);
+  if (cached) {
+    return cached;
+  }
+  const escaped = escapeRegExp(token);
+  // Dedicated, more tolerant trailing match for the reasoning-prefaced silent
+  // reply check: allows whitespace, asterisks, or common sentence punctuation
+  // to precede the trailing token so concluding model prose like
+  // "Therefore, I should output NO_REPLY.NO_REPLY" collapses cleanly. Kept
+  // separate from `getSilentTrailingRegex` to preserve the long-standing
+  // `stripSilentToken("interject.NO_REPLY")` no-op contract.
+  const regex = new RegExp(`(?:^|[\\s.:;,!?*]+)${escaped}\\s*$`, "i");
+  silentReasoningTrailingRegexByToken.set(token, regex);
+  return regex;
+}
+
 export function isSilentReplyText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
@@ -75,7 +94,11 @@ export function isSilentReplyPayloadText(
   text: string | undefined,
   token: string = SILENT_REPLY_TOKEN,
 ): boolean {
-  return isSilentReplyText(text, token) || isSilentReplyEnvelopeText(text, token);
+  return (
+    isSilentReplyText(text, token) ||
+    isSilentReplyEnvelopeText(text, token) ||
+    isReasoningPrefacedSilentReply(text, token)
+  );
 }
 
 /**
@@ -85,6 +108,70 @@ export function isSilentReplyPayloadText(
  */
 export function stripSilentToken(text: string, token: string = SILENT_REPLY_TOKEN): string {
   return text.replace(getSilentTrailingRegex(token), "").trim();
+}
+
+function stripTrailingSilentTokensTolerant(text: string, token: string): string {
+  const regex = getSilentReasoningTrailingRegex(token);
+  let current = text;
+  // Iterate so doubled/tripled trailing forms (for example
+  // "NO_REPLY.NO_REPLY" or "NO_REPLY NO_REPLY") collapse cleanly. Capped at 8
+  // iterations — in practice the loop exits after 1-3 passes.
+  for (let i = 0; i < 8; i++) {
+    const next = current.replace(regex, "").trim();
+    if (next === current) {
+      return current;
+    }
+    current = next;
+  }
+  return current;
+}
+
+// Matches a bare reasoning preamble at the start of the message: a word like
+// "think", "thinking", "thought", "reasoning", or "analysis" on its own line
+// (optionally followed by a colon) with nothing else on that line. Reasoning
+// models occasionally leak their chain-of-thought as plain text content when
+// structured thinking stream events are not produced; those messages must not
+// be treated as substantive replies when they are followed by a silent-reply
+// sentinel like NO_REPLY. The proper XML-tag stripper in
+// src/shared/text/reasoning-tags.ts cannot catch this form because there are
+// no tags to match.
+const BARE_REASONING_PREAMBLE_RE =
+  /^\s*(?:think(?:ing)?|thought|reasoning|analysis)\s*:?\s*(?:\r?\n|$)/i;
+
+/**
+ * Whether `text` is a reasoning-prefaced silent reply — a message that ends
+ * with the silent-reply token and whose preceding content is a bare reasoning
+ * preamble (not substantive user-visible content).
+ *
+ * Preserves the #19537 semantics: substantive replies that happen to end with
+ * NO_REPLY are still delivered. Only messages where the non-token content is
+ * a reasoning preamble are suppressed.
+ */
+export function isReasoningPrefacedSilentReply(
+  text: string | undefined,
+  token: string = SILENT_REPLY_TOKEN,
+): boolean {
+  if (!text) {
+    return false;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return false;
+  }
+  // Use the tolerant trailing strip so concluding model prose like
+  // "...I should output NO_REPLY.NO_REPLY" collapses even with inner
+  // punctuation between doubled tokens.
+  const withoutToken = stripTrailingSilentTokensTolerant(trimmed, token);
+  // Must actually end with the silent token (stripping changed the text).
+  if (withoutToken === trimmed) {
+    return false;
+  }
+  // All content was silent tokens → nothing left to classify.
+  if (!withoutToken) {
+    return true;
+  }
+  // The remaining content must start with a bare reasoning preamble.
+  return BARE_REASONING_PREAMBLE_RE.test(withoutToken);
 }
 
 const silentLeadingRegexByToken = new Map<string, RegExp>();


### PR DESCRIPTION
## Summary

Reasoning-prone models (notably Gemini 3.x) sometimes leak their chain-of-thought as plain text content that looks like `think\n<analysis>\nNO_REPLY` — a silent-reply sentinel preceded by a bare reasoning preamble. Two layers need to recognize this as intentional silence:

1. The **outbound silent-reply gate** — so the chain-of-thought doesn't get delivered to the messaging channel.
2. The **runner's incomplete-turn classifier and retry resolvers** — so the runner doesn't re-prompt the model on every spam decision and doesn't surface a "Agent couldn't generate a response" warning to users for an intentional silence.

This PR fixes both.

Supersedes / combines #69472. The first commit is the auto-reply suppressor from that PR; the second commit extends the same fix into the embedded runner so the incomplete-turn / reasoning-only / empty-response retry paths short-circuit the same way. Each commit is independently reviewable; the runner change depends on the auto-reply change to compile correctly (`isReasoningPrefacedSilentReply` is exported from `auto-reply/tokens.ts`).

Closes #69470, #69191 (silent-reply leak class).

## Production evidence

`pdd-public` agent on Discord with Gemini 3.1 Pro produced this exact assistant text on every spam-in-#general decision:

```
think
Another advertisement. Ignore.NO_REPLY
```

Before this PR:
- The auto-reply path delivered the literal text to the channel (chain-of-thought leak).
- After we patched the auto-reply suppressor (commit 1 here / #69472), the chain-of-thought stopped being delivered, but the runner saw `payloads=0 stopReason=stop` and:
  - re-prompted the model via the empty-response and reasoning-only retry paths (extra LLM cost on every spam message), and
  - posted "⚠️ Agent couldn't generate a response. Please try again." to the channel.

Both symptoms are gone with this PR.

## What's in each commit

### Commit 1 — `auto-reply: suppress reasoning-prefaced silent replies`

`src/auto-reply/tokens.ts` and `src/auto-reply/tokens.test.ts`. Adds `isReasoningPrefacedSilentReply` and wires it into `isSilentReplyPayloadText`. Uses a tolerant trailing-strip helper that handles doubled tokens (`NO_REPLY.NO_REPLY`) and reasoning preambles (`think`/`thinking`/`thought`/`reasoning`/`analysis`) on their own line. Public `stripSilentToken` is unchanged so the existing `interject.NO_REPLY` no-op contract is preserved (the existing test at `tokens.test.ts:64` continues to pass).

### Commit 2 — `incomplete-turn: don't surface 'couldn't generate' for silent replies`

`src/agents/pi-embedded-runner/run/incomplete-turn.ts` and `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`. Three call-site changes so the silent-reply classification flows into every code path that examines the assistant turn:

- `hasOnlySilentAssistantReply` now also reads `lastAssistant.content` text parts (`assistantTexts` can be empty when the streaming chunker filters drop the assistant text before the run wrapper records it).
- `isReasoningOnlyAssistantTurn` returns `false` when the message text classifies as a silent reply payload — silent NO_REPLY is intentional silence, not unfinished reasoning.
- `isEmptyResponseAssistantTurn` returns `false` for the same reason — gates the empty-response retry resolver against firing on intentional silence.

Regression test uses the exact production assistant payload from the Discord incident.

## Test plan

- `pnpm test src/auto-reply/tokens.test.ts` — passes (38 tests, includes new reasoning-preface and doubled-token cases).
- `pnpm test src/agents/pi-embedded-runner/run.incomplete-turn.test.ts` — passes (84 tests, includes new regression for the runner false positive).
- Deployed locally on the gateway that originally exhibited this; both symptoms gone after rebuild + restart.

## Notes for review

- The runner change is conservative — it only short-circuits when `isSilentReplyPayloadText` returns true. Without this PR's commit 1, the runner change is a no-op for the reasoning-prefaced case (and an exact-`NO_REPLY` already short-circuits via existing logic, so behavior on that path is unchanged).
- Both commits keep the existing `#19537` semantics: substantive replies that happen to end with `NO_REPLY` are still delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)