### PR TITLE
Add tool-call failure guardrails

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.test.ts
@@ -629,6 +629,22 @@ describe("createOpenClawCodingTools", () => {
     }
   });
 
+  it("returns actionable guidance for missing read paths", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-missing-read-"));
+    try {
+      const tools = createOpenClawCodingTools({ workspaceDir: tmpDir });
+      const { readTool } = expectReadWriteEditTools(tools);
+
+      await expect(
+        readTool?.execute("tool-missing-read", {
+          path: "does-not-exist.txt",
+        }),
+      ).rejects.toThrow(/read: file not found: does-not-exist\.txt.*Verify the exact path/i);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects legacy alias parameters", async () => {
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-legacy-alias-"));
     try {

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -112,6 +112,23 @@ function getToolResultText(result: AgentToolResult<unknown>): string | undefined
   return textBlocks.join("\n");
 }
 
+function isMissingFileError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ENOENT" || code === "ENOTDIR") {
+    return true;
+  }
+  const message = typeof error === "string" ? error : error instanceof Error ? error.message : "";
+  return /\b(?:ENOENT|ENOTDIR)\b|no such file or directory|not a directory/i.test(message);
+}
+
+function createReadMissingFileError(error: unknown, filePath: string): Error {
+  const message =
+    `read: file not found: ${filePath}. ` +
+    "Verify the exact path before retrying (for example with exec `ls`, `find`, or `pwd`), " +
+    "and use an absolute path or a path relative to the workspace.";
+  return new Error(message, { cause: error });
+}
+
 function withToolResultText(
   result: AgentToolResult<unknown>,
   text: string,
@@ -680,14 +697,22 @@ export function createOpenClawReadTool(
     execute: async (toolCallId, params, signal) => {
       const record = getToolParamsRecord(params);
       assertRequiredParams(record, REQUIRED_PARAM_GROUPS.read, base.name);
-      const result = await executeReadWithAdaptivePaging({
-        base,
-        toolCallId,
-        args: record ?? {},
-        signal,
-        maxBytes: resolveAdaptiveReadMaxBytes(options),
-      });
       const filePath = typeof record?.path === "string" ? record.path : "<unknown>";
+      let result: AgentToolResult<unknown>;
+      try {
+        result = await executeReadWithAdaptivePaging({
+          base,
+          toolCallId,
+          args: record ?? {},
+          signal,
+          maxBytes: resolveAdaptiveReadMaxBytes(options),
+        });
+      } catch (error) {
+        if (isMissingFileError(error)) {
+          throw createReadMissingFileError(error, filePath);
+        }
+        throw error;
+      }
       const strippedDetailsResult = stripReadTruncationContentDetails(result);
       const normalizedResult = await normalizeReadImageResult(strippedDetailsResult, filePath);
       return sanitizeToolResultImages(

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -972,6 +972,31 @@ describe("message tool description", () => {
 
     expect(tool.description).toContain("Supports actions: send, broadcast.");
   });
+
+  it("rejects unsupported channel actions before dispatch", async () => {
+    const signalPlugin = createChannelPlugin({
+      id: "signal",
+      label: "Signal",
+      docsPath: "/channels/signal",
+      blurb: "Signal test plugin.",
+      actions: ["send", "react"],
+    });
+
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "signal", source: "test", plugin: signalPlugin }]),
+    );
+
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "signal",
+      runMessageAction: mocks.runMessageAction as never,
+    });
+
+    await expect(tool.execute("1", { action: "read", threadId: "thread-1" })).rejects.toThrow(
+      /message action "read" is not supported by channel "signal".*Supported actions.*react/i,
+    );
+    expect(mocks.runMessageAction).not.toHaveBeenCalled();
+  });
 });
 
 describe("message tool reasoning tag sanitization", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -649,6 +649,35 @@ function appendMessageToolReadHint(
   return description;
 }
 
+function validateChannelSupportsMessageAction(
+  params: MessageToolDiscoveryParams & {
+    action: ChannelMessageActionName;
+    requestedChannel?: unknown;
+  },
+) {
+  if (params.action === "send" || params.action === "broadcast") {
+    return;
+  }
+  const requestedChannel =
+    typeof params.requestedChannel === "string"
+      ? normalizeMessageChannel(params.requestedChannel)
+      : undefined;
+  const channel = requestedChannel ?? normalizeMessageChannel(params.currentChannelProvider);
+  if (!channel) {
+    return;
+  }
+  const supported = listChannelSupportedActions(buildMessageActionDiscoveryInput(params, channel));
+  if (supported.length === 0 || supported.includes(params.action)) {
+    return;
+  }
+  const supportedList = ["send", "broadcast", ...supported].toSorted().join(", ");
+  throw new Error(
+    `message action "${params.action}" is not supported by channel "${channel}". ` +
+      `Supported actions for this channel: ${supportedList}. ` +
+      "Choose a supported action or pass channel for a configured provider that supports it.",
+  );
+}
+
 export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
   const loadConfigForTool = options?.getRuntimeConfig ?? getRuntimeConfig;
   const getScopedSecretTargetsForTool =
@@ -765,6 +794,22 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       if (accountId) {
         params.accountId = accountId;
       }
+
+      validateChannelSupportsMessageAction({
+        cfg,
+        action,
+        requestedChannel: params.channel,
+        currentChannelProvider: options?.currentChannelProvider,
+        currentChannelId: options?.currentChannelId,
+        currentThreadTs: options?.currentThreadTs,
+        currentMessageId: options?.currentMessageId,
+        currentAccountId: accountId,
+        sessionKey: options?.agentSessionKey,
+        sessionId: options?.sessionId,
+        agentId: resolvedAgentId,
+        requesterSenderId: options?.requesterSenderId,
+        senderIsOwner: options?.senderIsOwner,
+      });
 
       const gatewayResolved = resolveGatewayOptions({
         gatewayUrl: readStringParam(params, "gatewayUrl", { trim: false }),


### PR DESCRIPTION
Implements guardrails for recurring OpenClaw tool-call failure classes from task 7d0f53dc.\n\nChanges:\n- read tool adds actionable guidance for missing-file ENOENT/ENOTDIR path failures\n- message tool rejects unsupported channel actions before dispatch when action discovery is available\n- preserves send/broadcast and unknown-discovery behavior\n\nVerification from Rex:\n- focused Vitest: 2 files / 61 tests passed\n- corepack pnpm oxfmt --check on touched files\n- corepack pnpm tsc -p tsconfig.core.test.agents.json --noEmit\n- PATH=/tmp/openclaw-pnpm-shim:$PATH corepack pnpm check:changed\n- vet: no issues\n\nNo deploy, restart, config mutation, destructive API, billing, customer/vendor/legal action.