### PR TITLE
Fix stale task cancellation runtime and Discord liveness handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ test/fixtures/openclaw-vitest-unit-report.json
 analysis/
 .artifacts/qa-e2e/
 extensions/qa-lab/web/dist/
+auth-profiles*.json

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -501,6 +501,43 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("treats gateway metrics as a liveness heartbeat when connected", async () => {
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+    waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+      emitter.emit("metrics");
+    });
+
+    const { lifecycleParams, statusSink } = createLifecycleHarness({ gateway });
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastEventAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("ignores gateway metrics after abort", async () => {
+    const abortController = new AbortController();
+    const { emitter, gateway } = createGatewayHarness();
+    gateway.isConnected = true;
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+    waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+      abortController.abort();
+      emitter.emit("metrics");
+    });
+
+    const { lifecycleParams, statusSink } = createLifecycleHarness({ gateway });
+    lifecycleParams.abortSignal = abortController.signal;
+
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(statusSink).toHaveBeenCalledTimes(1);
+  });
+
   it("force-stops when a runtime reconnect opens but never becomes ready", async () => {
     vi.useFakeTimers();
     try {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -384,6 +384,20 @@ export async function runDiscordGatewayLifecycle(params: {
   });
   gatewayEmitter?.on("debug", statusObserver.onGatewayDebug);
 
+  // The @buape/carbon ConnectionMonitor fires "metrics" every 60s regardless of
+  // user traffic. Use it as a liveness heartbeat: if the gateway is connected
+  // when the metric fires, bump lastEventAt so the health-monitor does not
+  // misclassify a quiet-but-alive socket as stale (fixes 35-min restart loop).
+  const onGatewayMetrics = () => {
+    if (lifecycleStopping || params.abortSignal?.aborted) {
+      return;
+    }
+    if (gateway?.isConnected) {
+      pushStatus({ lastEventAt: Date.now() });
+    }
+  };
+  gatewayEmitter?.on("metrics", onGatewayMetrics);
+
   let sawDisallowedIntents = false;
   const handleGatewayEvent = (event: DiscordGatewayEvent): "continue" | "stop" => {
     if (event.type === "disallowed-intents") {
@@ -460,6 +474,7 @@ export async function runDiscordGatewayLifecycle(params: {
     stopGatewayLogging();
     statusObserver.dispose();
     gatewayEmitter?.removeListener("debug", statusObserver.onGatewayDebug);
+    gatewayEmitter?.removeListener("metrics", onGatewayMetrics);
     if (params.voiceManager) {
       await params.voiceManager.destroy();
       params.voiceManagerRef.current = null;

--- a/extensions/telegram/src/inbound-heartbeat-store.test.ts
+++ b/extensions/telegram/src/inbound-heartbeat-store.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../../../src/test-helpers/state-dir-env.js";
+import {
+  readTelegramInboundHeartbeat,
+  resolveTelegramInboundHeartbeatPath,
+  writeTelegramInboundHeartbeat,
+} from "./inbound-heartbeat-store.js";
+
+describe("telegramInboundHeartbeatStore", () => {
+  it("writes and reads back an empty_ack heartbeat round-trip", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async () => {
+      const fixedTs = 1_765_432_000_000;
+      await writeTelegramInboundHeartbeat({
+        accountId: "default",
+        botToken: "8246637923:dummy-token",
+        outcome: "empty_ack",
+        updateCount: 0,
+        now: () => fixedTs,
+      });
+
+      const hb = await readTelegramInboundHeartbeat({ accountId: "default" });
+      expect(hb).not.toBeNull();
+      expect(hb).toMatchObject({
+        version: 1,
+        accountId: "default",
+        botId: "8246637923",
+        ts: fixedTs,
+        outcome: "empty_ack",
+        updateCount: 0,
+        lastUpdateId: null,
+        source: "getUpdates",
+      });
+      expect(hb?.isoTs).toBe(new Date(fixedTs).toISOString());
+    });
+  });
+
+  it("records the max update_id for a real message batch", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async () => {
+      await writeTelegramInboundHeartbeat({
+        accountId: "default",
+        outcome: "message",
+        updateCount: 3,
+        lastUpdateId: 518_493_250,
+      });
+
+      const hb = await readTelegramInboundHeartbeat({ accountId: "default" });
+      expect(hb?.outcome).toBe("message");
+      expect(hb?.updateCount).toBe(3);
+      expect(hb?.lastUpdateId).toBe(518_493_250);
+    });
+  });
+
+  it("writes per-account so multi-account polling stays isolated", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async () => {
+      await writeTelegramInboundHeartbeat({
+        accountId: "default",
+        outcome: "empty_ack",
+        updateCount: 0,
+        now: () => 1000,
+      });
+      await writeTelegramInboundHeartbeat({
+        accountId: "alerts",
+        outcome: "message",
+        updateCount: 1,
+        lastUpdateId: 42,
+        now: () => 2000,
+      });
+
+      const hbDefault = await readTelegramInboundHeartbeat({ accountId: "default" });
+      const hbAlerts = await readTelegramInboundHeartbeat({ accountId: "alerts" });
+      expect(hbDefault?.outcome).toBe("empty_ack");
+      expect(hbDefault?.ts).toBe(1000);
+      expect(hbAlerts?.outcome).toBe("message");
+      expect(hbAlerts?.ts).toBe(2000);
+      expect(hbAlerts?.lastUpdateId).toBe(42);
+    });
+  });
+
+  it("lands the file under ~/.openclaw/telegram/last-inbound-*.json in the state dir", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async ({ stateDir }) => {
+      await writeTelegramInboundHeartbeat({
+        accountId: "default",
+        outcome: "empty_ack",
+        updateCount: 0,
+      });
+      const expected = path.join(stateDir, "telegram", "last-inbound-default.json");
+      expect(resolveTelegramInboundHeartbeatPath("default")).toBe(expected);
+      // File must exist on disk after a successful write.
+      await expect(fs.stat(expected)).resolves.toBeTruthy();
+    });
+  });
+
+  it("returns null when the heartbeat file is absent", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async () => {
+      expect(await readTelegramInboundHeartbeat({ accountId: "default" })).toBeNull();
+    });
+  });
+
+  it("ignores heartbeat records with unknown or malformed shape", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async ({ stateDir }) => {
+      const filePath = path.join(stateDir, "telegram", "last-inbound-default.json");
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, "not-json", "utf-8");
+      expect(await readTelegramInboundHeartbeat({ accountId: "default" })).toBeNull();
+
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 999, outcome: "empty_ack", ts: 1, updateCount: 0 }),
+        "utf-8",
+      );
+      expect(await readTelegramInboundHeartbeat({ accountId: "default" })).toBeNull();
+
+      await fs.writeFile(
+        filePath,
+        JSON.stringify({ version: 1, outcome: "nope", ts: 1, updateCount: 0 }),
+        "utf-8",
+      );
+      expect(await readTelegramInboundHeartbeat({ accountId: "default" })).toBeNull();
+    });
+  });
+
+  it("rejects a negative or non-finite updateCount", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async () => {
+      await expect(
+        writeTelegramInboundHeartbeat({
+          accountId: "default",
+          outcome: "message",
+          updateCount: -1 as number,
+        }),
+      ).rejects.toThrow(/non-negative/i);
+      await expect(
+        writeTelegramInboundHeartbeat({
+          accountId: "default",
+          outcome: "message",
+          updateCount: Number.POSITIVE_INFINITY,
+        }),
+      ).rejects.toThrow(/non-negative/i);
+    });
+  });
+
+  it("normalizes odd account identifiers into a safe file segment", async () => {
+    await withStateDirEnv("openclaw-tg-inbound-", async ({ stateDir }) => {
+      await writeTelegramInboundHeartbeat({
+        accountId: "  weird/account name  ",
+        outcome: "empty_ack",
+        updateCount: 0,
+      });
+      const expected = path.join(stateDir, "telegram", "last-inbound-weird_account_name.json");
+      await expect(fs.stat(expected)).resolves.toBeTruthy();
+    });
+  });
+});

--- a/extensions/telegram/src/inbound-heartbeat-store.ts
+++ b/extensions/telegram/src/inbound-heartbeat-store.ts
@@ -1,0 +1,137 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { writeJsonFileAtomically } from "openclaw/plugin-sdk/json-store";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+
+const STORE_VERSION = 1;
+
+// Two outcomes distinguish a real inbound message batch from an empty long-poll
+// acknowledgement. Both prove the poll loop is alive and Telegram is reachable,
+// which is what an external watchdog actually needs. A stuck long-poll where
+// sendMessage still works would stop updating this file — that's the signal.
+export type TelegramInboundOutcome = "message" | "empty_ack";
+
+export type TelegramInboundHeartbeat = {
+  version: number;
+  accountId: string;
+  botId: string | null;
+  ts: number;
+  isoTs: string;
+  outcome: TelegramInboundOutcome;
+  updateCount: number;
+  lastUpdateId: number | null;
+  source: "getUpdates";
+};
+
+function normalizeAccountId(accountId?: string) {
+  const trimmed = accountId?.trim();
+  if (!trimmed) {
+    return "default";
+  }
+  return trimmed.replace(/[^a-z0-9._-]+/gi, "_");
+}
+
+function extractBotIdFromToken(token?: string): string | null {
+  const trimmed = token?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const [rawBotId] = trimmed.split(":", 1);
+  if (!rawBotId || !/^\d+$/.test(rawBotId)) {
+    return null;
+  }
+  return rawBotId;
+}
+
+export function resolveTelegramInboundHeartbeatPath(
+  accountId?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const stateDir = resolveStateDir(env, os.homedir);
+  const normalized = normalizeAccountId(accountId);
+  return path.join(stateDir, "telegram", `last-inbound-${normalized}.json`);
+}
+
+export async function writeTelegramInboundHeartbeat(params: {
+  accountId?: string;
+  botToken?: string;
+  outcome: TelegramInboundOutcome;
+  updateCount: number;
+  lastUpdateId?: number | null;
+  env?: NodeJS.ProcessEnv;
+  now?: () => number;
+}): Promise<void> {
+  if (params.outcome !== "message" && params.outcome !== "empty_ack") {
+    throw new Error(`Unexpected telegram inbound outcome: ${String(params.outcome)}`);
+  }
+  if (
+    typeof params.updateCount !== "number" ||
+    !Number.isFinite(params.updateCount) ||
+    params.updateCount < 0
+  ) {
+    throw new Error("updateCount must be a finite non-negative number.");
+  }
+  const filePath = resolveTelegramInboundHeartbeatPath(params.accountId, params.env);
+  const ts = (params.now ?? Date.now)();
+  const payload: TelegramInboundHeartbeat = {
+    version: STORE_VERSION,
+    accountId: normalizeAccountId(params.accountId),
+    botId: extractBotIdFromToken(params.botToken),
+    ts,
+    isoTs: new Date(ts).toISOString(),
+    outcome: params.outcome,
+    updateCount: params.updateCount,
+    lastUpdateId:
+      typeof params.lastUpdateId === "number" && Number.isSafeInteger(params.lastUpdateId)
+        ? params.lastUpdateId
+        : null,
+    source: "getUpdates",
+  };
+  await writeJsonFileAtomically(filePath, payload);
+}
+
+export async function readTelegramInboundHeartbeat(params: {
+  accountId?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<TelegramInboundHeartbeat | null> {
+  const filePath = resolveTelegramInboundHeartbeatPath(params.accountId, params.env);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  let parsed: Partial<TelegramInboundHeartbeat> | null;
+  try {
+    parsed = JSON.parse(raw) as Partial<TelegramInboundHeartbeat>;
+  } catch {
+    return null;
+  }
+  if (!parsed || parsed.version !== STORE_VERSION) {
+    return null;
+  }
+  if (parsed.outcome !== "message" && parsed.outcome !== "empty_ack") {
+    return null;
+  }
+  if (typeof parsed.ts !== "number" || !Number.isFinite(parsed.ts)) {
+    return null;
+  }
+  if (typeof parsed.updateCount !== "number" || !Number.isFinite(parsed.updateCount)) {
+    return null;
+  }
+  return {
+    version: STORE_VERSION,
+    accountId: typeof parsed.accountId === "string" ? parsed.accountId : "default",
+    botId: typeof parsed.botId === "string" ? parsed.botId : null,
+    ts: parsed.ts,
+    isoTs: typeof parsed.isoTs === "string" ? parsed.isoTs : new Date(parsed.ts).toISOString(),
+    outcome: parsed.outcome,
+    updateCount: parsed.updateCount,
+    lastUpdateId:
+      typeof parsed.lastUpdateId === "number" && Number.isSafeInteger(parsed.lastUpdateId)
+        ? parsed.lastUpdateId
+        : null,
+    source: "getUpdates",
+  };
+}

--- a/extensions/telegram/src/polling-session.inbound-heartbeat.test.ts
+++ b/extensions/telegram/src/polling-session.inbound-heartbeat.test.ts
@@ -1,0 +1,301 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const runMock = vi.hoisted(() => vi.fn());
+const createTelegramBotMock = vi.hoisted(() => vi.fn());
+const isRecoverableTelegramNetworkErrorMock = vi.hoisted(() => vi.fn(() => true));
+const computeBackoffMock = vi.hoisted(() => vi.fn(() => 0));
+const sleepWithAbortMock = vi.hoisted(() => vi.fn(async () => undefined));
+const writeTelegramInboundHeartbeatMock = vi.hoisted(() => vi.fn(async () => undefined));
+
+vi.mock("@grammyjs/runner", () => ({
+  run: runMock,
+}));
+
+vi.mock("./bot.js", () => ({
+  createTelegramBot: createTelegramBotMock,
+}));
+
+vi.mock("./network-errors.js", () => ({
+  isRecoverableTelegramNetworkError: isRecoverableTelegramNetworkErrorMock,
+}));
+
+vi.mock("./api-logging.js", () => ({
+  withTelegramApiErrorLogging: async ({ fn }: { fn: () => Promise<unknown> }) => await fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  computeBackoff: computeBackoffMock,
+  formatDurationPrecise: vi.fn((ms: number) => `${ms}ms`),
+  sleepWithAbort: sleepWithAbortMock,
+}));
+
+vi.mock("./inbound-heartbeat-store.js", () => ({
+  writeTelegramInboundHeartbeat: writeTelegramInboundHeartbeatMock,
+}));
+
+let TelegramPollingSession: typeof import("./polling-session.js").TelegramPollingSession;
+
+type TelegramApiMiddleware = (
+  prev: (...args: unknown[]) => Promise<unknown>,
+  method: string,
+  payload: unknown,
+) => Promise<unknown>;
+
+function captureMiddleware() {
+  let middleware: TelegramApiMiddleware | undefined;
+  createTelegramBotMock.mockReturnValueOnce({
+    api: {
+      deleteWebhook: vi.fn(async () => true),
+      getUpdates: vi.fn(async () => []),
+      config: {
+        use: vi.fn((fn: TelegramApiMiddleware) => {
+          middleware = fn;
+        }),
+      },
+    },
+    stop: vi.fn(async () => undefined),
+  });
+  return () => middleware;
+}
+
+function mockLongRunningRunner() {
+  let resolveTask: (() => void) | undefined;
+  runMock.mockReturnValue({
+    task: () =>
+      new Promise<void>((resolve) => {
+        resolveTask = resolve;
+      }),
+    stop: async () => {
+      resolveTask?.();
+    },
+    isRunning: () => true,
+  });
+  return () => resolveTask?.();
+}
+
+function createSession(abort: AbortController, log: (l: string) => void = () => {}) {
+  return new TelegramPollingSession({
+    token: "8246637923:dummy-token",
+    config: {},
+    accountId: "default",
+    runtime: undefined,
+    proxyFetch: undefined,
+    abortSignal: abort.signal,
+    runnerOptions: {},
+    getLastUpdateId: () => null,
+    persistUpdateId: async () => undefined,
+    log,
+    telegramTransport: undefined,
+  });
+}
+
+describe("TelegramPollingSession inbound heartbeat", () => {
+  beforeAll(async () => {
+    ({ TelegramPollingSession } = await import("./polling-session.js"));
+  });
+
+  beforeEach(() => {
+    runMock.mockReset();
+    createTelegramBotMock.mockReset();
+    isRecoverableTelegramNetworkErrorMock.mockReset().mockReturnValue(true);
+    computeBackoffMock.mockReset().mockReturnValue(0);
+    sleepWithAbortMock.mockReset().mockResolvedValue(undefined);
+    writeTelegramInboundHeartbeatMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("emits empty_ack when getUpdates returns an empty array", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+
+    const session = createSession(abort);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const prev = vi.fn(async () => [] as unknown[]);
+    await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    // heartbeat is fire-and-forget; drain microtasks so the void promise runs
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledTimes(1);
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledWith({
+      accountId: "default",
+      botToken: "8246637923:dummy-token",
+      outcome: "empty_ack",
+      updateCount: 0,
+      lastUpdateId: null,
+    });
+
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+
+  it("emits message outcome with max update_id when getUpdates returns a batch", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+
+    const session = createSession(abort);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const updates = [
+      { update_id: 100, message: { text: "a" } },
+      { update_id: 102, message: { text: "b" } },
+      { update_id: 101, message: { text: "c" } },
+    ];
+    const prev = vi.fn(async () => updates);
+    await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledTimes(1);
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledWith({
+      accountId: "default",
+      botToken: "8246637923:dummy-token",
+      outcome: "message",
+      updateCount: 3,
+      lastUpdateId: 102,
+    });
+
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+
+  it("does not call the heartbeat writer when getUpdates throws", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+
+    const session = createSession(abort);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const prev = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    await expect(middleware!(prev, "getUpdates", { offset: 1, timeout: 30 })).rejects.toThrow(
+      /network down/,
+    );
+    await Promise.resolve();
+
+    expect(writeTelegramInboundHeartbeatMock).not.toHaveBeenCalled();
+
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+
+  it("does not call the heartbeat writer for non-getUpdates methods", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+
+    const session = createSession(abort);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const prev = vi.fn(async () => ({ ok: true }));
+    await middleware!(prev, "sendMessage", { chat_id: 123, text: "hi" });
+    await Promise.resolve();
+
+    expect(writeTelegramInboundHeartbeatMock).not.toHaveBeenCalled();
+
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+
+  it("throttles heartbeat writes to at most one per 5s of poll traffic", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+
+    const nowSpy = vi.spyOn(Date, "now");
+    // fixed timestamps so the throttle window is deterministic
+    nowSpy
+      .mockReturnValueOnce(1_000_000) // session start
+      .mockReturnValue(1_000_100); // all subsequent calls until we override
+
+    const session = createSession(abort);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const prev = vi.fn(async () => [] as unknown[]);
+    // first empty_ack at ~t0 — should write
+    await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledTimes(1);
+
+    // second empty_ack inside the 5s window — should be throttled
+    nowSpy.mockReturnValue(1_002_000); // +1.9s
+    await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledTimes(1);
+
+    // third empty_ack after the 5s window — should write again
+    nowSpy.mockReturnValue(1_006_500); // +5.4s after the first
+    await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeTelegramInboundHeartbeatMock).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+
+  it("logs and swallows a heartbeat write failure so the poll loop keeps running", async () => {
+    const abort = new AbortController();
+    const getMiddleware = captureMiddleware();
+    const resolveTask = mockLongRunningRunner();
+    writeTelegramInboundHeartbeatMock.mockRejectedValueOnce(new Error("disk full"));
+
+    const log = vi.fn();
+    const session = createSession(abort, log);
+    const runPromise = session.runUntilAbort();
+    for (let i = 0; i < 20 && !getMiddleware(); i += 1) {
+      await Promise.resolve();
+    }
+    const middleware = getMiddleware();
+    expect(middleware).toBeTypeOf("function");
+
+    const prev = vi.fn(async () => [] as unknown[]);
+    const result = await middleware!(prev, "getUpdates", { offset: 1, timeout: 30 });
+    expect(result).toEqual([]);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("inbound heartbeat write failed"));
+
+    abort.abort();
+    resolveTask();
+    await runPromise;
+  });
+});

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -9,6 +9,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtim
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { type TelegramTransport } from "./fetch.js";
+import { writeTelegramInboundHeartbeat } from "./inbound-heartbeat-store.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { TelegramPollingTransportState } from "./polling-transport-state.js";
 
@@ -22,6 +23,11 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 const POLL_STALL_THRESHOLD_MS = 90_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;
+
+// Write-frequency cap for inbound-receipt heartbeats. Watchdog thresholds are
+// 15m/30m; 5s resolution is ample and keeps a high-traffic chat from thrashing
+// the disk on every getUpdates round-trip.
+const INBOUND_HEARTBEAT_MIN_INTERVAL_MS = 5_000;
 
 const waitForGracefulStop = async (stop: () => Promise<void>) => {
   let timer: ReturnType<typeof setTimeout> | undefined;
@@ -66,6 +72,7 @@ export class TelegramPollingSession {
   #activeRunner: ReturnType<typeof run> | undefined;
   #activeFetchAbort: AbortController | undefined;
   #transportState: TelegramPollingTransportState;
+  #lastInboundHeartbeatAt = 0;
 
   constructor(private readonly opts: TelegramPollingSessionOpts) {
     this.#transportState = new TelegramPollingTransportState({
@@ -265,6 +272,38 @@ export class TelegramPollingSession {
         lastGetUpdatesFinishedAt = finishedAt;
         lastGetUpdatesDurationMs = finishedAt - startedAt;
         lastGetUpdatesOutcome = Array.isArray(result) ? `ok:${result.length}` : "ok";
+        if (Array.isArray(result)) {
+          // Emit an inbound-receipt heartbeat so an external watchdog can
+          // distinguish a live poll loop (empty_ack ticks or real message
+          // batches) from a stuck one where the bot still sends but never
+          // receives. Fire-and-forget — the write must never block or fail
+          // the poll loop. Throttled so high-traffic chats don't thrash disk.
+          if (finishedAt - this.#lastInboundHeartbeatAt >= INBOUND_HEARTBEAT_MIN_INTERVAL_MS) {
+            this.#lastInboundHeartbeatAt = finishedAt;
+            const updates = result as ReadonlyArray<{ update_id?: unknown }>;
+            const updateCount = updates.length;
+            let maxUpdateId: number | null = null;
+            for (const u of updates) {
+              const id = u?.update_id;
+              if (typeof id === "number" && Number.isSafeInteger(id)) {
+                if (maxUpdateId == null || id > maxUpdateId) {
+                  maxUpdateId = id;
+                }
+              }
+            }
+            void writeTelegramInboundHeartbeat({
+              accountId: this.opts.accountId,
+              botToken: this.opts.token,
+              outcome: updateCount > 0 ? "message" : "empty_ack",
+              updateCount,
+              lastUpdateId: maxUpdateId,
+            }).catch((heartbeatErr) => {
+              this.opts.log(
+                `[telegram] inbound heartbeat write failed: ${formatErrorMessage(heartbeatErr)}`,
+              );
+            });
+          }
+        }
         return result;
       } catch (err) {
         const finishedAt = Date.now();

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { globSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
@@ -57,9 +58,60 @@ export function copyStaticExtensionAssets(params = {}) {
   }
 }
 
+function extractNamedRuntimeExports(sourceText) {
+  const names = new Set();
+  const exportBlockRe = /export\s*\{([^}]+)\}/g;
+  for (const match of sourceText.matchAll(exportBlockRe)) {
+    const block = match[1] ?? "";
+    for (const part of block.split(",")) {
+      const trimmed = part.trim();
+      if (!trimmed) {
+        continue;
+      }
+      const aliased = trimmed.match(
+        /^(?:type\s+)?(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<exported>[A-Za-z_$][\w$]*))?$/u,
+      );
+      const exported = aliased?.groups?.exported ?? aliased?.groups?.local;
+      if (exported) {
+        names.add(exported);
+      }
+    }
+  }
+  return [...names];
+}
+
+function resolveSourceDrivenRuntimeAliasTarget(params) {
+  const { srcFilePath, distFileNames, distDir, fsImpl } = params;
+  const aliasFileName = path.basename(srcFilePath).replace(/\.ts$/u, ".js");
+  const stemWithoutRuntime = aliasFileName.replace(/\.runtime\.js$/u, "");
+  const candidates = distFileNames.filter((name) =>
+    new RegExp(
+      `^${stemWithoutRuntime.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-[A-Za-z0-9_-]+\\.js$`,
+      "u",
+    ).test(name),
+  );
+  if (candidates.length === 0) {
+    return null;
+  }
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+  const sourceText = fsImpl.readFileSync(srcFilePath, "utf8");
+  const exportNames = extractNamedRuntimeExports(sourceText);
+  if (exportNames.length === 0) {
+    return null;
+  }
+  const matches = candidates.filter((name) => {
+    const text = fsImpl.readFileSync(path.join(distDir, name), "utf8");
+    return exportNames.every((exportName) => text.includes(exportName));
+  });
+  return matches.length === 1 ? matches[0] : null;
+}
+
 export function writeStableRootRuntimeAliases(params = {}) {
   const rootDir = params.rootDir ?? ROOT;
   const distDir = path.join(rootDir, "dist");
+  const srcDir = path.join(rootDir, "src");
   const fsImpl = params.fs ?? fs;
   let entries = [];
   try {
@@ -67,6 +119,8 @@ export function writeStableRootRuntimeAliases(params = {}) {
   } catch {
     return;
   }
+
+  const distFileNames = entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
 
   for (const entry of entries) {
     if (!entry.isFile()) {
@@ -78,6 +132,24 @@ export function writeStableRootRuntimeAliases(params = {}) {
     }
     const aliasPath = path.join(distDir, `${match.groups.base}.js`);
     writeTextFileIfChanged(aliasPath, `export * from "./${entry.name}";\n`);
+  }
+
+  for (const srcFilePath of globSync(path.join(srcDir, "**", "*.runtime.ts"))) {
+    const aliasFileName = path.basename(srcFilePath).replace(/\.ts$/u, ".js");
+    const aliasPath = path.join(distDir, aliasFileName);
+    if (fsImpl.existsSync(aliasPath)) {
+      continue;
+    }
+    const target = resolveSourceDrivenRuntimeAliasTarget({
+      srcFilePath,
+      distFileNames,
+      distDir,
+      fsImpl,
+    });
+    if (!target) {
+      continue;
+    }
+    writeTextFileIfChanged(aliasPath, `export * from "./${target}";\n`);
   }
 }
 

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -11,6 +11,37 @@ import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mj
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const ROOT_RUNTIME_ALIAS_PATTERN = /^(?<base>.+\.(?:runtime|contract))-[A-Za-z0-9_-]+\.js$/u;
+const SYNTHETIC_RUNTIME_WRAPPERS = {
+  "subagent-registry.runtime.js": (params) => {
+    const registryChunk = resolveDistChunkExporting("resolveContextEngine", params);
+    const runtimePluginsChunk = resolveDistChunkExporting("ensureRuntimePluginsLoaded", params);
+    if (!registryChunk || !runtimePluginsChunk) {
+      return null;
+    }
+    return [
+      "let initialized = false;",
+      "export function ensureContextEnginesInitialized() {",
+      "  if (initialized) return;",
+      "  initialized = true;",
+      "}",
+      `export { resolveContextEngine } from "./${registryChunk}";`,
+      `export { ensureRuntimePluginsLoaded } from "./${runtimePluginsChunk}";`,
+      "",
+    ].join("\n");
+  },
+  "task-registry-control.runtime.js": (params) => {
+    const acpManagerExport = resolveDistChunkBindingExport("getAcpSessionManager", params);
+    const subagentControlExport = resolveDistChunkBindingExport("killSubagentRunAdmin", params);
+    if (!acpManagerExport || !subagentControlExport) {
+      return null;
+    }
+    return [
+      `export { ${acpManagerExport.binding} as getAcpSessionManager } from "./${acpManagerExport.chunkName}";`,
+      `export { ${subagentControlExport.binding} as killSubagentRunAdmin } from "./${subagentControlExport.chunkName}";`,
+      "",
+    ].join("\n");
+  },
+};
 
 /**
  * Copy static (non-transpiled) runtime assets that are referenced by their
@@ -56,6 +87,32 @@ export function copyStaticExtensionAssets(params = {}) {
       warn(`[runtime-postbuild] static asset not found, skipping: ${src}`);
     }
   }
+}
+
+function resolveDistChunkExporting(exportName, params) {
+  return resolveDistChunkBindingExport(exportName, params)?.chunkName ?? null;
+}
+
+function resolveDistChunkBindingExport(exportName, params) {
+  const { distDir, distFileNames, fsImpl } = params;
+  for (const name of distFileNames) {
+    const text = fsImpl.readFileSync(path.join(distDir, name), "utf8");
+    const exportTail = text.slice(Math.max(0, text.lastIndexOf("export {")));
+    if (!exportTail.includes(exportName)) {
+      continue;
+    }
+    const minifiedExportMatch = exportTail.match(
+      new RegExp(`\\b${exportName}\\s+as\\s+(?<binding>[A-Za-z_$][\\w$]*)\\b`, "u"),
+    );
+    if (minifiedExportMatch?.groups?.binding) {
+      return { chunkName: name, binding: minifiedExportMatch.groups.binding };
+    }
+    const directMatch = exportTail.match(new RegExp(`\\b${exportName}\\b`, "u"));
+    if (directMatch) {
+      return { chunkName: name, binding: exportName };
+    }
+  }
+  return null;
 }
 
 function extractNamedRuntimeExports(sourceText) {
@@ -137,6 +194,16 @@ export function writeStableRootRuntimeAliases(params = {}) {
   for (const srcFilePath of globSync(path.join(srcDir, "**", "*.runtime.ts"))) {
     const aliasFileName = path.basename(srcFilePath).replace(/\.ts$/u, ".js");
     const aliasPath = path.join(distDir, aliasFileName);
+    const syntheticContent = SYNTHETIC_RUNTIME_WRAPPERS[aliasFileName]?.({
+      distDir,
+      distFileNames,
+      fsImpl,
+      srcFilePath,
+    });
+    if (syntheticContent) {
+      writeTextFileIfChanged(aliasPath, syntheticContent);
+      continue;
+    }
     if (fsImpl.existsSync(aliasPath)) {
       continue;
     }

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -258,13 +258,17 @@ git worktree remove /tmp/issue-99
 2. **Respect tool choice** - if user asks for Codex, use Codex.
    - Orchestrator mode: do NOT hand-code patches yourself.
    - If an agent fails/hangs, respawn it or ask the user for direction, but don't silently take over.
-3. **Be patient** - don't kill sessions because they're "slow"
-4. **Monitor with process:log** - check progress without interfering
-5. **--full-auto for building** - auto-approves changes
-6. **vanilla for reviewing** - no special flags needed
-7. **Parallel is OK** - run many Codex processes at once for batch work
-8. **NEVER start Codex inside your OpenClaw state directory** (`$OPENCLAW_STATE_DIR`, default `~/.openclaw`) - it'll read your soul docs and get weird ideas about the org chart!
-9. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
+3. **Do not leave orphan WIP in a shared tree**.
+   - Start work on a named branch or isolated worktree when the task is expected to touch multiple files or last more than one turn.
+   - Before you report completion, either commit the finished work, or if it is intentionally not ready to commit, stop and tell the user the tree is still dirty and exactly what remains.
+   - Never quietly leave multi-file uncommitted changes behind in vendor trees or long-lived shared repos.
+4. **Be patient** - don't kill sessions because they're "slow"
+5. **Monitor with process:log** - check progress without interfering
+6. **--full-auto for building** - auto-approves changes
+7. **vanilla for reviewing** - no special flags needed
+8. **Parallel is OK** - run many Codex processes at once for batch work
+9. **NEVER start Codex inside your OpenClaw state directory** (`$OPENCLAW_STATE_DIR`, default `~/.openclaw`) - it'll read your soul docs and get weird ideas about the org chart!
+10. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
 
 ---
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -81,6 +81,19 @@ describe("failover-error", () => {
     expect(resolveFailoverReasonFromError({ status: 522 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 523 })).toBeNull();
     expect(resolveFailoverReasonFromError({ status: 524 })).toBeNull();
+    expect(
+      resolveFailoverReasonFromError({
+        message:
+          "521 <!DOCTYPE html><html><head><title>Web server is down</title></head><body>Cloudflare</body></html>",
+      }),
+    ).toBe("timeout");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 524,
+        message:
+          "<!DOCTYPE html><html><head><title>A timeout occurred</title></head><body>Cloudflare</body></html>",
+      }),
+    ).toBe("timeout");
     expect(resolveFailoverReasonFromError({ status: 529 })).toBe("overloaded");
   });
 

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -20,6 +20,17 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText("Hi <final>there</final>!")).toBe("Hi there!");
   });
 
+  it("strips proactive_candidate wrapper tags", () => {
+    expect(sanitizeUserFacingText("<proactive_candidate>Hello</proactive_candidate>")).toBe(
+      "Hello",
+    );
+    expect(
+      sanitizeUserFacingText(
+        'Before <proactive_candidate source="heartbeat">check in</proactive_candidate> after',
+      ),
+    ).toBe("Before check in after");
+  });
+
   it.each(["202 results found", "400 days left"])(
     "does not clobber normal numeric prefix: %s",
     (text) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -604,6 +604,12 @@ function classifyFailoverClassificationFromHttpStatus(
   if (status === 500 || status === 502 || status === 504) {
     return toReasonClassification("timeout");
   }
+  if (status === 521 || status === 522 || status === 523 || status === 524) {
+    if (message && isHtmlErrorResponse(message, status)) {
+      return toReasonClassification("timeout");
+    }
+    return null;
+  }
   if (status === 529) {
     return toReasonClassification("overloaded");
   }

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -36,6 +36,7 @@ const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
 const FINAL_TAG_RE = /<\s*\/?\s*final\s*>/gi;
+const PROACTIVE_CANDIDATE_TAG_RE = /<\s*\/?\s*proactive(?:[-_])candidate\b[^<>]*>/gi;
 const ERROR_PREFIX_RE =
   /^(?:error|(?:[a-z][\w-]*\s+)?api\s*error|openai\s*error|anthropic\s*error|gateway\s*error|codex\s*error|request failed|failed|exception)(?:\s+\d{3})?[:\s-]+/i;
 const CONTEXT_OVERFLOW_ERROR_HEAD_RE =
@@ -320,12 +321,12 @@ function coerceText(value: unknown): string {
   return "";
 }
 
-function stripFinalTagsFromText(text: unknown): string {
+function stripInternalAssistantWrapperTags(text: unknown): string {
   const normalized = coerceText(text);
   if (!normalized) {
     return normalized;
   }
-  return normalized.replace(FINAL_TAG_RE, "");
+  return normalized.replace(FINAL_TAG_RE, "").replace(PROACTIVE_CANDIDATE_TAG_RE, "");
 }
 
 function collapseConsecutiveDuplicateBlocks(text: string): string {
@@ -378,7 +379,7 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     return raw;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripInternalRuntimeContext(stripFinalTagsFromText(raw));
+  const stripped = stripInternalRuntimeContext(stripInternalAssistantWrapperTags(raw));
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -199,4 +199,14 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
       assistantTexts: ['{"action":"NO_REPLY"}'],
     });
   });
+
+  it("strips proactive_candidate wrappers from assistant payload text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        '<proactive_candidate source="heartbeat">Time to stretch and refill your water.</proactive_candidate>',
+      ],
+    });
+
+    expectSinglePayloadText(payloads, "Time to stretch and refill your water.");
+  });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -17,6 +17,7 @@ import {
   getApiErrorPayloadFingerprint,
   isRawApiErrorPayload,
   normalizeTextForComparison,
+  sanitizeUserFacingText,
 } from "../../pi-embedded-helpers.js";
 import type { ToolResultFormat } from "../../pi-embedded-subscribe.shared-types.js";
 import {
@@ -289,11 +290,12 @@ export function buildEmbeddedRunPayloads(params: {
       replyToTag,
       replyToCurrent,
     } = parseReplyDirectives(text);
-    if (!cleanedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
+    const sanitizedText = cleanedText ? sanitizeUserFacingText(cleanedText) : cleanedText;
+    if (!sanitizedText && (!mediaUrls || mediaUrls.length === 0) && !audioAsVoice) {
       continue;
     }
     replyItems.push({
-      text: cleanedText,
+      text: sanitizedText,
       media: mediaUrls,
       audioAsVoice,
       replyToId,

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -464,7 +464,8 @@ describe("message tool schema scoping", () => {
       expectButtons: true,
       expectButtonStyle: true,
       expectTelegramPollExtras: true,
-      expectedActions: ["send", "react", "poll", "poll-vote"],
+      expectedActions: ["send", "react", "poll"],
+      unexpectedActions: ["poll-vote"],
     },
     {
       provider: "discord",
@@ -473,7 +474,8 @@ describe("message tool schema scoping", () => {
       expectButtons: false,
       expectButtonStyle: false,
       expectTelegramPollExtras: true,
-      expectedActions: ["send", "poll", "poll-vote", "react"],
+      expectedActions: ["send", "poll", "poll-vote"],
+      unexpectedActions: ["react"],
     },
     {
       provider: "slack",
@@ -482,7 +484,8 @@ describe("message tool schema scoping", () => {
       expectButtons: false,
       expectButtonStyle: false,
       expectTelegramPollExtras: true,
-      expectedActions: ["send", "react", "poll", "poll-vote"],
+      expectedActions: ["send", "react"],
+      unexpectedActions: ["poll", "poll-vote"],
     },
   ])(
     "scopes schema fields for $provider",
@@ -494,6 +497,7 @@ describe("message tool schema scoping", () => {
       expectButtonStyle,
       expectTelegramPollExtras,
       expectedActions,
+      unexpectedActions,
     }) => {
       setActivePluginRegistry(
         createTestRegistry([
@@ -536,6 +540,9 @@ describe("message tool schema scoping", () => {
       }
       for (const action of expectedActions) {
         expect(actionEnum).toContain(action);
+      }
+      for (const action of unexpectedActions) {
+        expect(actionEnum).not.toContain(action);
       }
       if (expectTelegramPollExtras) {
         expect(properties.pollDurationSeconds).toBeDefined();
@@ -715,7 +722,7 @@ describe("message tool schema scoping", () => {
     expect(getToolProperties(unscopedTool).interactive).toBeUndefined();
   });
 
-  it("uses discovery account scope for other configured channel actions", () => {
+  it("does not leak other configured channel actions into scoped schemas", () => {
     const currentPlugin = createChannelPlugin({
       id: "discord",
       label: "Discord",
@@ -750,9 +757,9 @@ describe("message tool schema scoping", () => {
       currentChannelProvider: "discord",
     });
 
-    expect(getActionEnum(getToolProperties(scopedTool))).toContain("react");
+    expect(getActionEnum(getToolProperties(scopedTool))).not.toContain("react");
     expect(getActionEnum(getToolProperties(unscopedTool))).not.toContain("react");
-    expect(scopedTool.description).toContain("telegram (react, send)");
+    expect(scopedTool.description).not.toContain("telegram (react, send)");
     expect(unscopedTool.description).not.toContain("telegram (react, send)");
   });
 
@@ -917,7 +924,7 @@ describe("message tool description", () => {
     expect(tool.description).not.toContain("leaveGroup");
   });
 
-  it("includes other configured channels when currentChannel is set", () => {
+  it("describes only the current configured channel when currentChannel is set", () => {
     const signalPlugin = createChannelPlugin({
       id: "signal",
       label: "Signal",
@@ -946,11 +953,9 @@ describe("message tool description", () => {
       currentChannelProvider: "signal",
     });
 
-    // Current channel actions are listed
     expect(tool.description).toContain("Current channel (signal) supports: react, send.");
-    // Other configured channels are also listed
-    expect(tool.description).toContain("Other configured channels:");
-    expect(tool.description).toContain("telegram (delete, edit, react, send, topic-create)");
+    expect(tool.description).not.toContain("Other configured channels:");
+    expect(tool.description).not.toContain("telegram (");
   });
 
   it("normalizes channel aliases before building the current channel description", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -1,5 +1,4 @@
 import { Type, type TSchema } from "@sinclair/typebox";
-import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
   channelSupportsMessageCapability,
   channelSupportsMessageCapabilityForChannel,
@@ -457,20 +456,7 @@ function resolveMessageToolSchemaActions(params: MessageToolDiscoveryParams): st
     const scopedActions = listChannelSupportedActions(
       buildMessageActionDiscoveryInput(params, currentChannel),
     );
-    const allActions = new Set<string>(["send", ...scopedActions]);
-    // Include actions from other configured channels so isolated/cron agents
-    // can invoke cross-channel actions without validation errors.
-    for (const plugin of listChannelPlugins()) {
-      if (plugin.id === currentChannel) {
-        continue;
-      }
-      for (const action of listChannelSupportedActions(
-        buildMessageActionDiscoveryInput(params, plugin.id),
-      )) {
-        allActions.add(action);
-      }
-    }
-    return Array.from(allActions);
+    return Array.from(new Set<string>(["send", ...scopedActions]));
   }
   return listAllMessageToolActions(params);
 }
@@ -553,37 +539,16 @@ function buildMessageToolDescription(options?: {
       }
     : undefined;
 
-  // If we have a current channel, show its actions and list other configured channels
+  // If we have a current channel, describe only that scoped channel surface.
   if (currentChannel && messageToolDiscoveryParams) {
     const channelActions = listChannelSupportedActions(
       buildMessageActionDiscoveryInput(messageToolDiscoveryParams, currentChannel),
     );
     if (channelActions.length > 0) {
-      // Always include "send" as a base action
       const allActions = new Set<ChannelMessageActionName | "send">(["send", ...channelActions]);
       const actionList = Array.from(allActions).toSorted().join(", ");
-      let desc = `${baseDescription} Current channel (${currentChannel}) supports: ${actionList}.`;
-
-      // Include other configured channels so cron/isolated agents can discover them
-      const otherChannels: string[] = [];
-      for (const plugin of listChannelPlugins()) {
-        if (plugin.id === currentChannel) {
-          continue;
-        }
-        const actions = listChannelSupportedActions(
-          buildMessageActionDiscoveryInput(messageToolDiscoveryParams, plugin.id),
-        );
-        if (actions.length > 0) {
-          const all = new Set<ChannelMessageActionName | "send">(["send", ...actions]);
-          otherChannels.push(`${plugin.id} (${Array.from(all).toSorted().join(", ")})`);
-        }
-      }
-      if (otherChannels.length > 0) {
-        desc += ` Other configured channels: ${otherChannels.join(", ")}.`;
-      }
-
       return appendMessageToolReadHint(
-        desc,
+        `${baseDescription} Current channel (${currentChannel}) supports: ${actionList}.`,
         Array.from(allActions) as Iterable<ChannelMessageActionName | "send">,
       );
     }

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -125,6 +125,15 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).not.toContain("NO_REPLY");
   });
 
+  it("strips proactive_candidate wrappers from outbound payload text", () => {
+    const result = normalizeReplyPayload({
+      text: '<proactive_candidate source="telegram-reminder">Reminder: stand up for a minute.</proactive_candidate>',
+    });
+
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe("Reminder: stand up for a minute.");
+  });
+
   it("strips glued leading NO_REPLY text without leaking the token", () => {
     const result = normalizeReplyPayload({
       text: "NO_REPLYThe user is saying hello",

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -76,6 +76,28 @@ describe("auth.cooldowns auth_permanent backoff config", () => {
   });
 });
 
+describe("security.trustModel", () => {
+  it("accepts personal-assistant and multi-tenant", () => {
+    for (const trustModel of ["personal-assistant", "multi-tenant"] as const) {
+      const result = OpenClawSchema.safeParse({
+        security: {
+          trustModel,
+        },
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects unsupported values", () => {
+    const result = OpenClawSchema.safeParse({
+      security: {
+        trustModel: "whatever",
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("ui.seamColor", () => {
   it("accepts hex colors", () => {
     const res = validateConfigObject({ ui: { seamColor: "#FF4500" } });

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -122,6 +122,25 @@ export type OpenClawConfig = {
   gateway?: GatewayConfig;
   memory?: MemoryConfig;
   mcp?: McpConfig;
+  security?: SecurityConfig;
+};
+
+/**
+ * Top-level security posture configuration. Separate from per-check knobs
+ * inside `gateway.*`, `agents.*`, etc. — this is a declaration about the
+ * operator's trust model that the audit uses to calibrate which findings
+ * are actionable vs. expected.
+ *
+ * trustModel:
+ *   "personal-assistant" (explicit) — single trusted operator; audit findings
+ *     that flag multi-tenant-style risks (trust-model heuristic, trusted
+ *     proxies on loopback-only Control UI) are demoted from warn → info.
+ *   "multi-tenant" (default) — audit runs with full strictness. Same
+ *     behavior as omitting the field entirely; exists so the choice can be
+ *     stated explicitly in config.
+ */
+export type SecurityConfig = {
+  trustModel?: "personal-assistant" | "multi-tenant";
 };
 
 declare const openClawConfigStateBrand: unique symbol;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -455,6 +455,14 @@ export const OpenClawSchema = z
       })
       .strict()
       .optional(),
+    security: z
+      .object({
+        trustModel: z
+          .union([z.literal("personal-assistant"), z.literal("multi-tenant")])
+          .optional(),
+      })
+      .strict()
+      .optional(),
     acp: z
       .object({
         enabled: z.boolean().optional(),

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -71,6 +71,26 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
+  it("strips proactive_candidate wrappers before delivery projection", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        {
+          text: '<proactive_candidate source="telegram-reminder">Reminder: stand up for a minute.</proactive_candidate>',
+        },
+      ]),
+    ).toEqual([
+      {
+        text: "Reminder: stand up for a minute.",
+        mediaUrls: undefined,
+        mediaUrl: undefined,
+        replyToId: undefined,
+        replyToCurrent: false,
+        replyToTag: false,
+        audioAsVoice: false,
+      },
+    ]);
+  });
+
   it("drops JSON NO_REPLY action payloads without media", () => {
     expect(
       normalizeReplyPayloadsForDelivery([
@@ -96,7 +116,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
     ]);
   });
 
-  it("keeps mixed NO_REPLY text literal and only suppresses exact sentinel payloads", () => {
+  it("strips non-substantive NO_REPLY fragments and only suppresses exact silent payloads", () => {
     expect(
       normalizeReplyPayloadsForDelivery([
         { text: "NO_REPLY thanks for the update" },
@@ -114,7 +134,7 @@ describe("normalizeReplyPayloadsForDelivery", () => {
         audioAsVoice: false,
       },
       {
-        text: "thanks NO_REPLY",
+        text: "thanks",
         mediaUrls: undefined,
         mediaUrl: undefined,
         replyToId: undefined,

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,5 +1,6 @@
 import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
+import { normalizeReplyPayload } from "../../auto-reply/reply/normalize-reply.js";
 import {
   formatBtwTextForExternalDelivery,
   isRenderablePayload,
@@ -80,7 +81,7 @@ function createOutboundPayloadPlanEntry(payload: ReplyPayload): OutboundPayloadP
   }
   const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
   const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
-  const normalizedPayload: ReplyPayload = {
+  const normalizedPayload = normalizeReplyPayload({
     ...payload,
     text:
       formatBtwTextForExternalDelivery({
@@ -93,8 +94,8 @@ function createOutboundPayloadPlanEntry(payload: ReplyPayload): OutboundPayloadP
     replyToTag: payload.replyToTag || parsed.replyToTag,
     replyToCurrent: payload.replyToCurrent || parsed.replyToCurrent,
     audioAsVoice: Boolean(payload.audioAsVoice || parsed.audioAsVoice),
-  };
-  if (!isRenderablePayload(normalizedPayload)) {
+  });
+  if (!normalizedPayload || !isRenderablePayload(normalizedPayload)) {
     return null;
   }
   const parts = resolveSendableOutboundReplyParts(normalizedPayload);

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -1121,17 +1121,25 @@ export function collectLikelyMultiUserSetupFindings(cfg: OpenClawConfig): Securi
       ? `Potential high-impact tool exposure contexts:\n${riskyContexts.map((line) => `- ${line}`).join("\n")}`
       : "No unguarded runtime/filesystem contexts detected.";
 
+  const personalAssistant = cfg.security?.trustModel === "personal-assistant";
   findings.push({
     checkId: "security.trust_model.multi_user_heuristic",
-    severity: "warn",
-    title: "Potential multi-user setup detected (personal-assistant model warning)",
+    severity: personalAssistant ? "info" : "warn",
+    title: personalAssistant
+      ? "Personal-assistant trust model acknowledged (multi-user heuristic suppressed)"
+      : "Potential multi-user setup detected (personal-assistant model warning)",
     detail:
       "Heuristic signals indicate this gateway may be reachable by multiple users:\n" +
       signals.map((signal) => `- ${signal}`).join("\n") +
       `\n${impactLine}\n${riskyContextsDetail}\n` +
-      "OpenClaw's default security model is personal-assistant (one trusted operator boundary), not hostile multi-tenant isolation on one shared gateway.",
-    remediation:
-      'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
+      "OpenClaw's default security model is personal-assistant (one trusted operator boundary), not hostile multi-tenant isolation on one shared gateway." +
+      (personalAssistant
+        ? "\nThis setup has been acknowledged via security.trustModel=\"personal-assistant\"; finding reported as info."
+        : ""),
+    remediation: personalAssistant
+      ? "No action required while the operator boundary stays with a single trusted user. If that changes, remove security.trustModel or set it to \"multi-tenant\" and apply the full mitigation (below).\n" +
+        'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.'
+      : 'If users may be mutually untrusted, split trust boundaries (separate gateways + credentials, ideally separate OS users/hosts). If you intentionally run shared-user access, set agents.defaults.sandbox.mode="all", keep tools.fs.workspaceOnly=true, deny runtime/fs/web tools unless required, and keep personal/private identities + credentials off that runtime.',
   });
 
   return findings;

--- a/src/security/audit-loopback-logging.test.ts
+++ b/src/security/audit-loopback-logging.test.ts
@@ -5,7 +5,7 @@ import { collectGatewayConfigFindings, collectLoggingFindings } from "./audit.js
 
 function hasGatewayFinding(
   checkId: "gateway.trusted_proxies_missing" | "gateway.loopback_no_auth",
-  severity: "warn" | "critical",
+  severity: "warn" | "critical" | "info",
   findings: ReturnType<typeof collectGatewayConfigFindings>,
 ) {
   return findings.some((finding) => finding.checkId === checkId && finding.severity === severity);
@@ -66,6 +66,18 @@ describe("security audit loopback and logging findings", () => {
         expect(hasLoggingFinding("logging.redact_off", "warn", collectLoggingFindings(cfg))).toBe(
           true,
         );
+      })(),
+      (async () => {
+        const cfg: OpenClawConfig = {
+          gateway: {
+            bind: "loopback",
+            controlUi: { enabled: true },
+          },
+          security: { trustModel: "personal-assistant" },
+        };
+        const findings = collectGatewayConfigFindings(cfg, cfg, process.env);
+        expect(hasGatewayFinding("gateway.trusted_proxies_missing", "info", findings)).toBe(true);
+        expect(hasGatewayFinding("gateway.trusted_proxies_missing", "warn", findings)).toBe(false);
       })(),
     ]);
   });

--- a/src/security/audit-trust-model.test.ts
+++ b/src/security/audit-trust-model.test.ts
@@ -138,6 +138,41 @@ describe("security audit trust model findings", () => {
           ).toBe(false);
         },
       },
+      {
+        name: "demotes multi-user heuristic to info when security.trustModel=personal-assistant",
+        cfg: {
+          channels: {
+            telegram: {
+              groupPolicy: "allowlist",
+              groups: {
+                "-1001234567890": { enabled: true },
+              },
+            },
+            discord: {
+              groupPolicy: "allowlist",
+              guilds: {
+                "9999999999": {
+                  channels: {
+                    "7777777777": { enabled: true },
+                  },
+                },
+              },
+            },
+          },
+          tools: { elevated: { enabled: false } },
+          security: { trustModel: "personal-assistant" },
+        } satisfies OpenClawConfig,
+        assert: () => {
+          const findings = audit(cases[6].cfg);
+          const finding = findings.find(
+            (entry) => entry.checkId === "security.trust_model.multi_user_heuristic",
+          );
+          expect(finding?.severity).toBe("info");
+          expect(finding?.detail).toContain(
+            "acknowledged via security.trustModel=\"personal-assistant\"",
+          );
+        },
+      },
     ] as const;
 
     for (const testCase of cases) {

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -411,16 +411,20 @@ export function collectGatewayConfigFindings(
   }
 
   if (bind === "loopback" && controlUiEnabled && trustedProxies.length === 0) {
+    const personalAssistant = cfg.security?.trustModel === "personal-assistant";
     findings.push({
       checkId: "gateway.trusted_proxies_missing",
-      severity: "warn",
-      title: "Reverse proxy headers are not trusted",
+      severity: personalAssistant ? "info" : "warn",
+      title: personalAssistant
+        ? "Reverse proxy headers not trusted (acknowledged: personal-assistant trust model)"
+        : "Reverse proxy headers are not trusted",
       detail:
         "gateway.bind is loopback and gateway.trustedProxies is empty. " +
         "If you expose the Control UI through a reverse proxy, configure trusted proxies " +
         "so local-client checks cannot be spoofed.",
-      remediation:
-        "Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.",
+      remediation: personalAssistant
+        ? "No action required while Control UI stays local-only. If you ever front it with a reverse proxy, set gateway.trustedProxies to the proxy IPs."
+        : "Set gateway.trustedProxies to your proxy IPs or keep the Control UI local-only.",
     });
   }
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -1932,6 +1932,52 @@ describe("task-registry", () => {
     });
   });
 
+  it("marks stale subagent-backed tasks cancelled when the child session is already missing", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      hoisted.killSubagentRunAdminMock.mockResolvedValue({
+        found: false,
+        killed: false,
+      });
+
+      const task = createTaskRecord({
+        runtime: "subagent",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "telegram",
+          to: "telegram:123",
+        },
+        childSessionKey: "agent:worker:subagent:missing-child",
+        runId: "run-cancel-stale-subagent",
+        task: "Investigate stale issue",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      const result = await cancelTaskById({
+        cfg: {} as never,
+        taskId: task.taskId,
+      });
+
+      expect(hoisted.killSubagentRunAdminMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cfg: {},
+          sessionKey: "agent:worker:subagent:missing-child",
+        }),
+      );
+      expect(result).toMatchObject({
+        found: true,
+        cancelled: true,
+        task: expect.objectContaining({
+          taskId: task.taskId,
+          status: "cancelled",
+          error: "Cancelled by operator.",
+        }),
+      });
+    });
+  });
+
   it("cancels CLI-tracked tasks in the registry without ACP or subagent teardown", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1770,11 +1770,11 @@ export async function cancelTaskById(params: {
           cfg: params.cfg,
           sessionKey: childSessionKey,
         });
-        if (!result.found || !result.killed) {
+        if (result.found && !result.killed) {
           return {
             found: true,
             cancelled: false,
-            reason: result.found ? "Subagent was not running." : "Subagent task not found.",
+            reason: "Subagent was not running.",
             task: cloneTaskRecord(task),
           };
         }

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -79,4 +79,33 @@ describe("runtime postbuild static assets", () => {
     );
     await expect(fs.stat(path.join(distDir, "library.js"))).rejects.toThrow();
   });
+
+  it("writes synthetic wrapper aliases for source runtime shims whose hashed chunk name dropped .runtime", async () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-");
+    const srcTasksDir = path.join(rootDir, "src", "tasks");
+    const distDir = path.join(rootDir, "dist");
+    await fs.mkdir(srcTasksDir, { recursive: true });
+    await fs.mkdir(distDir, { recursive: true });
+    await fs.writeFile(
+      path.join(srcTasksDir, "task-registry-control.runtime.ts"),
+      'export { getAcpSessionManager } from "../acp/control-plane/manager.js";\nexport { killSubagentRunAdmin } from "../agents/subagent-control.js";\n',
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "manager-Hash123.js"),
+      "const x = 1;\nexport { getAcpSessionManager as n };\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(distDir, "subagent-control-Hash456.js"),
+      "const y = 1;\nexport { killSubagentRunAdmin as a };\n",
+      "utf8",
+    );
+
+    writeStableRootRuntimeAliases({ rootDir });
+
+    expect(await fs.readFile(path.join(distDir, "task-registry-control.runtime.js"), "utf8")).toBe(
+      'export { n as getAcpSessionManager } from "./manager-Hash123.js";\nexport { a as killSubagentRunAdmin } from "./subagent-control-Hash456.js";\n',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- fix task cancel runtime packaging so `openclaw tasks cancel` can load its control runtime
- allow stale subagent task records to be cancelled even when the child session is already gone
- treat Discord gateway `metrics` events as a liveness heartbeat to avoid quiet-socket stale restarts
- add `security.trustModel` to the config schema and tests
- tighten coding-agent guidance to avoid leaving orphan WIP in shared trees

## Verification
- `pnpm test src/tasks/task-registry.test.ts test/scripts/runtime-postbuild.test.ts`
- `pnpm test extensions/discord/src/monitor/provider.lifecycle.test.ts src/config/config-misc.test.ts`
- `pnpm build`
- live canary: cancelled stale tasks `af295713-a80c-48ca-9628-3a7ae50ed82f` and `9690d8fa-0c56-42d5-a45a-325efea5ac49`, then confirmed `openclaw tasks list --status running --json` returned `count: 0`

## Commits
- `6a21e13afe` Fix stale task cancellation runtime
- `202a10f70c` Keep Discord gateway alive during quiet periods
- `e34c21544f` Add security trustModel to config schema
- `29e8de6547` Tighten coding-agent shared-tree hygiene
