### PR TITLE
Add MCP readiness gate for advertised skills

### DIFF
--- a/extensions/qa-channel/setup-entry.ts
+++ b/extensions/qa-channel/setup-entry.ts
@@ -1,4 +1,9 @@
-import { defineSetupPluginEntry } from "openclaw/plugin-sdk/channel-core";
-import { qaChannelPlugin } from "./src/channel.js";
+import { defineBundledChannelSetupEntry } from "openclaw/plugin-sdk/channel-entry-contract";
 
-export default defineSetupPluginEntry(qaChannelPlugin);
+export default defineBundledChannelSetupEntry({
+  importMetaUrl: import.meta.url,
+  plugin: {
+    specifier: "./channel-plugin-api.js",
+    exportName: "qaChannelPlugin",
+  },
+});

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -35,7 +35,7 @@
         "../dist/plugin-sdk/src/plugin-sdk/secret-ref-runtime.d.ts"
       ],
       "openclaw/plugin-sdk/ssrf-runtime": ["../dist/plugin-sdk/src/plugin-sdk/ssrf-runtime.d.ts"],
-      "@openclaw/qa-channel/api.js": ["../dist/plugin-sdk/extensions/qa-channel/api.d.ts"],
+      "@openclaw/qa-channel/api.js": ["../extensions/qa-channel/api.ts"],
       "@openclaw/*.js": ["../packages/plugin-sdk/dist/extensions/*.d.ts", "../extensions/*"],
       "@openclaw/*": ["../packages/plugin-sdk/dist/extensions/*", "../extensions/*"],
       "@openclaw/plugin-sdk/*": ["../dist/plugin-sdk/src/plugin-sdk/*.d.ts"]

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -41,7 +41,7 @@
       "openclaw/plugin-sdk/ssrf-runtime": [
         "../../dist/plugin-sdk/src/plugin-sdk/ssrf-runtime.d.ts"
       ],
-      "@openclaw/qa-channel/api.js": ["../../dist/plugin-sdk/extensions/qa-channel/api.d.ts"],
+      "@openclaw/qa-channel/api.js": ["../qa-channel/api.ts"],
       "@openclaw/*.js": ["../../packages/plugin-sdk/dist/extensions/*.d.ts", "../*"],
       "@openclaw/*": ["../*"],
       "@openclaw/plugin-sdk/*": ["../../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],

--- a/scripts/lib/extension-package-boundary.ts
+++ b/scripts/lib/extension-package-boundary.ts
@@ -48,7 +48,7 @@ export const EXTENSION_PACKAGE_BOUNDARY_BASE_PATHS = {
     "../dist/plugin-sdk/src/plugin-sdk/secret-ref-runtime.d.ts",
   ],
   "openclaw/plugin-sdk/ssrf-runtime": ["../dist/plugin-sdk/src/plugin-sdk/ssrf-runtime.d.ts"],
-  "@openclaw/qa-channel/api.js": ["../dist/plugin-sdk/extensions/qa-channel/api.d.ts"],
+  "@openclaw/qa-channel/api.js": ["../extensions/qa-channel/api.ts"],
   "@openclaw/*.js": ["../packages/plugin-sdk/dist/extensions/*.d.ts", "../extensions/*"],
   "@openclaw/*": ["../packages/plugin-sdk/dist/extensions/*", "../extensions/*"],
   "@openclaw/plugin-sdk/*": ["../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],
@@ -94,7 +94,7 @@ export const EXTENSION_PACKAGE_BOUNDARY_XAI_PATHS = {
   "openclaw/plugin-sdk/provider-web-search-contract": [
     "../../dist/plugin-sdk/src/plugin-sdk/provider-web-search-contract.d.ts",
   ],
-  "@openclaw/qa-channel/api.js": ["../../dist/plugin-sdk/extensions/qa-channel/api.d.ts"],
+  "@openclaw/qa-channel/api.js": ["../qa-channel/api.ts"],
   "@openclaw/*.js": ["../../packages/plugin-sdk/dist/extensions/*.d.ts", "../*"],
   "@openclaw/*": ["../*"],
   "@openclaw/plugin-sdk/*": ["../../dist/plugin-sdk/src/plugin-sdk/*.d.ts"],

--- a/scripts/mcp-readiness-smoke.mjs
+++ b/scripts/mcp-readiness-smoke.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const args = new Set(process.argv.slice(2));
+const dryRun = args.has("--dry-run") || !args.has("--verify-callable");
+const root = process.env.OPENCLAW_HOME || path.join(os.homedir(), ".openclaw");
+const mcporterHome = path.join(os.homedir(), ".mcporter", "mcporter.json");
+const workspaces = fs.existsSync(root)
+  ? fs
+      .readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name.startsWith("workspace"))
+      .map((entry) => path.join(root, entry.name))
+  : [];
+const configPaths = [
+  mcporterHome,
+  ...workspaces.map((dir) => path.join(dir, "config", "mcporter.json")),
+];
+
+function readJson(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function listDeclaredServers(filePath) {
+  const parsed = readJson(filePath);
+  const servers = parsed?.mcpServers;
+  if (!servers || typeof servers !== "object" || Array.isArray(servers)) {
+    return [];
+  }
+  return Object.keys(servers).toSorted();
+}
+
+function runMcporterConfigList(cwd) {
+  const result = spawnSync("mcporter", ["config", "list", "--output", "json"], {
+    cwd,
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  return {
+    ok: result.status === 0,
+    status: result.status,
+    stdout: (result.stdout || "").slice(0, 500),
+    stderr: (result.stderr || "").slice(0, 500),
+  };
+}
+
+const rows = [];
+for (const filePath of configPaths) {
+  const declared = listDeclaredServers(filePath);
+  if (declared.length === 0) {
+    continue;
+  }
+  const workspaceDir = filePath.endsWith(path.join("config", "mcporter.json"))
+    ? path.dirname(path.dirname(filePath))
+    : root;
+  const configList = dryRun ? undefined : runMcporterConfigList(workspaceDir);
+  rows.push({
+    config: filePath,
+    workspaceDir,
+    declared,
+    dryRun,
+    configList,
+  });
+}
+
+console.log(
+  JSON.stringify({ generated_at: new Date().toISOString(), dryRun, configs: rows }, null, 2),
+);
+if (rows.length === 0) {
+  process.exitCode = 2;
+}

--- a/src/agents/cache-trace.ts
+++ b/src/agents/cache-trace.ts
@@ -14,6 +14,7 @@ export type CacheTraceStage =
   | "cache:result"
   | "cache:state"
   | "session:loaded"
+  | "session:raw-model-run"
   | "session:sanitized"
   | "session:limited"
   | "prompt:before"

--- a/src/agents/command/attempt-execution.cli.test.ts
+++ b/src/agents/command/attempt-execution.cli.test.ts
@@ -544,6 +544,7 @@ describe("CLI attempt execution", () => {
     await runAgentAttempt({
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",
+      originalProvider: "anthropic",
       cfg: {
         agents: {
           defaults: {

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-engine.test.ts
@@ -261,7 +261,7 @@ describe("runEmbeddedAttempt context engine sessionKey forwarding", () => {
       runBeforeAgentStart: vi.fn(async () => ({ prependContext: "legacy hook context" })),
       runLlmInput,
     });
-    const seen: { prompt?: string; messages?: unknown[] } = {};
+    const seen: { prompt?: string; messages?: unknown[]; systemPrompt?: string } = {};
 
     const result = await createContextEngineAttemptRunner({
       contextEngine: createTestContextEngine({

--- a/src/agents/skills.test.ts
+++ b/src/agents/skills.test.ts
@@ -506,6 +506,59 @@ describe("buildWorkspaceSkillsPrompt", () => {
     expect(prompt).not.toContain("Hidden from the prompt");
     expect(prompt).not.toContain(path.join(hiddenSkillDir, "SKILL.md"));
   });
+
+  it("hides MCP-backed skills from the prompt until readiness marks them callable", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "mcp-memory");
+
+    await writeSkill({
+      dir: skillDir,
+      name: "mcp-memory",
+      description: "Use memory MCP",
+      metadata: JSON.stringify({ openclaw: { mcp: { server: "memory" } } }),
+    });
+
+    const prompt = buildWorkspaceSkillsPrompt(workspaceDir, resolveTestSkillDirs(workspaceDir));
+
+    expect(prompt).not.toContain("mcp-memory");
+    expect(prompt).not.toContain("Use memory MCP");
+  });
+
+  it("shows MCP-backed skills when the readiness file verifies a callable owner", async () => {
+    const workspaceDir = await makeWorkspace();
+    const skillDir = path.join(workspaceDir, "skills", "mcp-supabase");
+    const readinessDir = path.join(workspaceDir, "config");
+
+    await writeSkill({
+      dir: skillDir,
+      name: "mcp-supabase",
+      description: "Use Supabase MCP",
+      metadata: JSON.stringify({ openclaw: { mcp: { server: "supabase" } } }),
+    });
+    await fs.mkdir(readinessDir, { recursive: true });
+    await fs.writeFile(
+      path.join(readinessDir, "mcp-readiness.json"),
+      JSON.stringify({
+        skills: {
+          "mcp-supabase": {
+            declared: true,
+            callable: true,
+            owner: "rex",
+            last_verified_at: "2026-04-27T05:56:00Z",
+          },
+        },
+      }),
+    );
+
+    const prompt = buildWorkspaceSkillsPrompt(workspaceDir, {
+      ...resolveTestSkillDirs(workspaceDir),
+      agentId: "rex",
+    });
+
+    expect(prompt).toContain("mcp-supabase");
+    expect(prompt).toContain("Use Supabase MCP");
+    expect(prompt).toContain(path.join(skillDir, "SKILL.md"));
+  });
 });
 
 describe("applySkillEnvOverrides", () => {

--- a/src/agents/skills/frontmatter.ts
+++ b/src/agents/skills/frontmatter.ts
@@ -194,12 +194,21 @@ export function resolveOpenClawMetadata(
   const requires = resolveOpenClawManifestRequires(metadataObj);
   const install = resolveOpenClawManifestInstall(metadataObj, parseInstallSpec);
   const osRaw = resolveOpenClawManifestOs(metadataObj);
+  const mcpRaw =
+    typeof metadataObj.mcp === "object" && metadataObj.mcp !== null
+      ? (metadataObj.mcp as Record<string, unknown>)
+      : undefined;
+  const mcpServer = readStringValue(mcpRaw?.server);
+  const mcpTools = normalizeStringList(mcpRaw?.tools);
   return {
     always: typeof metadataObj.always === "boolean" ? metadataObj.always : undefined,
     emoji: readStringValue(metadataObj.emoji),
     homepage: readStringValue(metadataObj.homepage),
     skillKey: readStringValue(metadataObj.skillKey),
     primaryEnv: readStringValue(metadataObj.primaryEnv),
+    mcp: mcpServer
+      ? { server: mcpServer, ...(mcpTools.length > 0 ? { tools: mcpTools } : {}) }
+      : undefined,
     os: osRaw.length > 0 ? osRaw : undefined,
     requires: requires,
     install: install.length > 0 ? install : undefined,

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -22,6 +22,10 @@ export type OpenClawSkillMetadata = {
   primaryEnv?: string;
   emoji?: string;
   homepage?: string;
+  mcp?: {
+    server: string;
+    tools?: string[];
+  };
   os?: string[];
   requires?: {
     bins?: string[];

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -98,6 +98,93 @@ function isSkillVisibleInAvailableSkillsPrompt(entry: SkillEntry): boolean {
   return entry.skill.disableModelInvocation !== true;
 }
 
+type McpReadinessRecord = {
+  declared?: boolean;
+  callable?: boolean;
+  owner?: string;
+  last_verified_at?: string;
+};
+
+type McpReadinessFile = {
+  generated_at?: string;
+  skills?: Record<string, McpReadinessRecord>;
+  servers?: Record<string, McpReadinessRecord>;
+};
+
+function readMcpReadinessFile(filePath: string): McpReadinessFile | undefined {
+  try {
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return undefined;
+    }
+    return parsed as McpReadinessFile;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveMcpReadinessFiles(workspaceDir: string): string[] {
+  const candidates = [
+    path.join(workspaceDir, "config", "mcp-readiness.json"),
+    path.join(CONFIG_DIR, "mcp-readiness.json"),
+  ];
+  return candidates.filter((candidate, index, all) => all.indexOf(candidate) === index);
+}
+
+function isMcpReadinessOwnerAllowed(
+  owner: string | undefined,
+  agentId: string | undefined,
+): boolean {
+  const normalizedOwner = owner?.trim().toLowerCase();
+  if (!normalizedOwner) {
+    return true;
+  }
+  if (["shared", "fleet", "all", "global"].includes(normalizedOwner)) {
+    return true;
+  }
+  return Boolean(agentId && normalizedOwner === agentId.trim().toLowerCase());
+}
+
+function isMcpReadinessRecordCallable(
+  record: McpReadinessRecord | undefined,
+  agentId: string | undefined,
+): boolean {
+  return (
+    record?.declared === true &&
+    record.callable === true &&
+    isMcpReadinessOwnerAllowed(record.owner, agentId)
+  );
+}
+
+function isMcpSkillRuntimeReady(params: {
+  entry: SkillEntry;
+  workspaceDir: string;
+  agentId?: string;
+}): boolean {
+  const mcp = params.entry.metadata?.mcp;
+  if (!mcp) {
+    return true;
+  }
+
+  for (const filePath of resolveMcpReadinessFiles(params.workspaceDir)) {
+    const readiness = readMcpReadinessFile(filePath);
+    if (!readiness) {
+      continue;
+    }
+    const skillRecord = readiness.skills?.[params.entry.skill.name];
+    if (isMcpReadinessRecordCallable(skillRecord, params.agentId)) {
+      return true;
+    }
+    const serverRecord = readiness.servers?.[mcp.server];
+    if (isMcpReadinessRecordCallable(serverRecord, params.agentId)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function filterSkillEntries(
   entries: SkillEntry[],
   config?: OpenClawConfig,
@@ -781,7 +868,11 @@ function resolveWorkspaceSkillPromptState(
     effectiveSkillFilter,
     opts?.eligibility,
   );
-  const promptEntries = eligible.filter((entry) => isSkillVisibleInAvailableSkillsPrompt(entry));
+  const promptEntries = eligible.filter(
+    (entry) =>
+      isSkillVisibleInAvailableSkillsPrompt(entry) &&
+      isMcpSkillRuntimeReady({ entry, workspaceDir, agentId: opts?.agentId }),
+  );
   const remoteNote = opts?.eligibility?.remote?.note?.trim();
   const resolvedSkills = promptEntries.map((entry) => entry.skill);
   // Derive prompt-facing skills with compacted paths (e.g. ~/...) once.

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   PluginHookGatewayContext,
   PluginHookGatewayStartEvent,
@@ -27,6 +27,16 @@ const hoisted = vi.hoisted(() => {
     resolved: 0,
     failed: 0,
   }));
+  const resolveAgentModelPrimaryValue = vi.fn(() => "");
+  const normalizeProviderId = vi.fn((provider: string) => provider.toLowerCase());
+  const resolveOpenClawAgentDir = vi.fn(() => "/tmp/openclaw-state/agents/default/agent");
+  const isCliProvider = vi.fn(() => false);
+  const resolveConfiguredModelRef = vi.fn(() => ({
+    provider: "openai",
+    model: "gpt-5.4",
+  }));
+  const resolveEmbeddedAgentRuntime = vi.fn(() => "pi");
+  const ensureOpenClawModelsJson = vi.fn(async () => undefined);
   return {
     startPluginServices,
     startGmailWatcherWithLogs,
@@ -46,6 +56,13 @@ const hoisted = vi.hoisted(() => {
     refreshLatestUpdateRestartSentinel,
     getAcpRuntimeBackend,
     reconcilePendingSessionIdentities,
+    resolveAgentModelPrimaryValue,
+    normalizeProviderId,
+    resolveOpenClawAgentDir,
+    isCliProvider,
+    resolveConfiguredModelRef,
+    resolveEmbeddedAgentRuntime,
+    ensureOpenClawModelsJson,
   };
 });
 
@@ -123,6 +140,36 @@ vi.mock("../infra/update-startup.js", () => ({
   scheduleGatewayUpdateCheck: hoisted.scheduleGatewayUpdateCheck,
 }));
 
+vi.mock("../config/model-input.js", () => ({
+  resolveAgentModelPrimaryValue: hoisted.resolveAgentModelPrimaryValue,
+}));
+
+vi.mock("../agents/provider-id.js", () => ({
+  normalizeProviderId: hoisted.normalizeProviderId,
+}));
+
+vi.mock("../agents/agent-paths.js", () => ({
+  resolveOpenClawAgentDir: hoisted.resolveOpenClawAgentDir,
+}));
+
+vi.mock("../agents/defaults.js", () => ({
+  DEFAULT_MODEL: "gpt-5.4",
+  DEFAULT_PROVIDER: "openai",
+}));
+
+vi.mock("../agents/model-selection.js", () => ({
+  isCliProvider: hoisted.isCliProvider,
+  resolveConfiguredModelRef: hoisted.resolveConfiguredModelRef,
+}));
+
+vi.mock("../agents/pi-embedded-runner/runtime.js", () => ({
+  resolveEmbeddedAgentRuntime: hoisted.resolveEmbeddedAgentRuntime,
+}));
+
+vi.mock("../agents/models-config.js", () => ({
+  ensureOpenClawModelsJson: hoisted.ensureOpenClawModelsJson,
+}));
+
 vi.mock("./server-tailscale.js", () => ({
   startGatewayTailscaleExposure: hoisted.startGatewayTailscaleExposure,
 }));
@@ -137,6 +184,8 @@ type PostAttachRuntimeDeps = NonNullable<Parameters<typeof startGatewayPostAttac
 
 describe("startGatewayPostAttachRuntime", () => {
   beforeEach(() => {
+    vi.stubEnv("OPENCLAW_SKIP_CHANNELS", "0");
+    vi.stubEnv("OPENCLAW_SKIP_PROVIDERS", "0");
     hoisted.startPluginServices.mockClear();
     hoisted.startGmailWatcherWithLogs.mockClear();
     hoisted.loadInternalHooks.mockClear();
@@ -155,6 +204,21 @@ describe("startGatewayPostAttachRuntime", () => {
     hoisted.getAcpRuntimeBackend.mockReset();
     hoisted.getAcpRuntimeBackend.mockReturnValue(null);
     hoisted.reconcilePendingSessionIdentities.mockClear();
+    hoisted.resolveAgentModelPrimaryValue.mockReset();
+    hoisted.resolveAgentModelPrimaryValue.mockReturnValue("");
+    hoisted.normalizeProviderId.mockClear();
+    hoisted.resolveOpenClawAgentDir.mockClear();
+    hoisted.isCliProvider.mockReset();
+    hoisted.isCliProvider.mockReturnValue(false);
+    hoisted.resolveConfiguredModelRef.mockClear();
+    hoisted.resolveEmbeddedAgentRuntime.mockReset();
+    hoisted.resolveEmbeddedAgentRuntime.mockReturnValue("pi");
+    hoisted.ensureOpenClawModelsJson.mockReset();
+    hoisted.ensureOpenClawModelsJson.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("re-enables startup-gated methods after post-attach sidecars start", async () => {
@@ -247,11 +311,56 @@ describe("startGatewayPostAttachRuntime", () => {
 
       expect(prewarm).toHaveBeenCalledTimes(1);
       expect(log.warn).toHaveBeenCalledWith(
-        "startup model warmup timed out after 25ms; continuing channel startup",
+        "startup model warmup timed out after 25ms; continuing without waiting",
       );
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("starts channels without waiting for primary model prewarm completion", async () => {
+    let resolvePrewarm!: () => void;
+    const prewarmPrimaryModel = vi.fn(
+      async () =>
+        await new Promise<undefined>((resolve) => {
+          resolvePrewarm = () => resolve(undefined);
+        }),
+    );
+    const startChannels = vi.fn(async () => undefined);
+
+    const sidecarsPromise = startGatewaySidecars({
+      cfg: {
+        hooks: { internal: { enabled: false } },
+        agents: { defaults: { model: "openai/gpt-5.4" } },
+      } as never,
+      pluginRegistry: createPostAttachParams().pluginRegistry,
+      defaultWorkspaceDir: "/tmp/openclaw-workspace",
+      deps: {} as never,
+      startChannels,
+      prewarmPrimaryModel: prewarmPrimaryModel as never,
+      log: { warn: vi.fn() },
+      logHooks: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
+      logChannels: {
+        info: vi.fn(),
+        error: vi.fn(),
+      },
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(prewarmPrimaryModel).toHaveBeenCalledTimes(1);
+        expect(startChannels).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 2_000 },
+    );
+    await sidecarsPromise;
+
+    resolvePrewarm();
+    await Promise.resolve();
   });
 
   it("keeps startup-gated methods unavailable while sidecars are still resuming", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -174,11 +174,32 @@ async function prewarmConfiguredPrimaryModelWithTimeout(
   }).then(() => {
     if (!settled) {
       params.log.warn(
-        `startup model warmup timed out after ${params.timeoutMs ?? PRIMARY_MODEL_PREWARM_TIMEOUT_MS}ms; continuing channel startup`,
+        `startup model warmup timed out after ${params.timeoutMs ?? PRIMARY_MODEL_PREWARM_TIMEOUT_MS}ms; continuing without waiting`,
       );
     }
   });
   await Promise.race([warmup, timeout]);
+}
+
+function schedulePrimaryModelPrewarm(
+  params: {
+    cfg: OpenClawConfig;
+    log: { warn: (msg: string) => void };
+    startupTrace?: GatewayStartupTrace;
+  },
+  prewarm: typeof prewarmConfiguredPrimaryModel = prewarmConfiguredPrimaryModel,
+): void {
+  void measureStartup(params.startupTrace, "sidecars.model-prewarm", () =>
+    prewarmConfiguredPrimaryModelWithTimeout(
+      {
+        cfg: params.cfg,
+        log: params.log,
+      },
+      prewarm,
+    ),
+  ).catch((err) => {
+    params.log.warn(`startup model warmup failed: ${String(err)}`);
+  });
 }
 
 export async function startGatewaySidecars(params: {
@@ -187,6 +208,7 @@ export async function startGatewaySidecars(params: {
   defaultWorkspaceDir: string;
   deps: CliDeps;
   startChannels: () => Promise<void>;
+  prewarmPrimaryModel?: typeof prewarmConfiguredPrimaryModel;
   log: { warn: (msg: string) => void };
   logHooks: {
     info: (msg: string) => void;
@@ -308,11 +330,13 @@ export async function startGatewaySidecars(params: {
   await measureStartup(params.startupTrace, "sidecars.channels", async () => {
     if (!skipChannels) {
       try {
-        await measureStartup(params.startupTrace, "sidecars.model-prewarm", () =>
-          prewarmConfiguredPrimaryModelWithTimeout({
+        schedulePrimaryModelPrewarm(
+          {
             cfg: params.cfg,
             log: params.log,
-          }),
+            startupTrace: params.startupTrace,
+          },
+          params.prewarmPrimaryModel,
         );
         await measureStartup(params.startupTrace, "sidecars.channel-start", () =>
           params.startChannels(),
@@ -636,4 +660,5 @@ export async function startGatewayPostAttachRuntime(
 export const __testing = {
   prewarmConfiguredPrimaryModel,
   prewarmConfiguredPrimaryModelWithTimeout,
+  schedulePrimaryModelPrewarm,
 };

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -147,6 +147,10 @@ export const sharedVitestConfig = {
         find: "openclaw/plugin-sdk",
         replacement: path.join(repoRoot, "src", "plugin-sdk", "index.ts"),
       },
+      {
+        find: "@openclaw/qa-channel/api.js",
+        replacement: path.join(repoRoot, "extensions", "qa-channel", "api.ts"),
+      },
     ],
   },
   test: {


### PR DESCRIPTION
## Summary
- filters MCP-backed advertised skills behind verified readiness metadata
- adds readiness parsing for skill metadata and config/mcp-readiness.json
- adds dry-run smoke script for mcporter/readiness mismatch checks

## Verification
Reported by Rex before PR creation:
- focused skills Vitest: 22/22 pass
- targeted oxlint: 0 errors
- tsgo core test: pass
- mcp-readiness smoke dry-run: found 6 configs, no mutation
- check:changed: pass
- vet: no issues

No deploy, gateway restart, package update, fleet config mutation, destructive action, billing/spend, or public/customer/vendor/legal commitment performed.