### PR TITLE
Add bounded status gateway auth fallback

### DIFF
--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -178,6 +178,36 @@ describe("resolveGatewayProbeSnapshot", () => {
     expect(result.gatewayReachable).toBe(true);
     expect(result.gatewayProbe?.error).toBe("missing scope: operator.read; warn");
   });
+
+  it("bounds probe auth resolution so status scans can fall back", async () => {
+    mocks.resolveGatewayProbeTarget.mockReturnValue({
+      mode: "local",
+      gatewayMode: "local",
+      remoteUrlMissing: false,
+    });
+    mocks.resolveGatewayProbeAuthResolution.mockReturnValue(new Promise(() => {}));
+    mocks.probeGateway.mockResolvedValue({
+      ok: false,
+      url: "ws://127.0.0.1:18789",
+      connectLatencyMs: null,
+      error: "timeout",
+      close: null,
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    const result = await resolveGatewayProbeSnapshot({
+      cfg: {},
+      opts: { timeoutMs: 1 },
+    });
+
+    expect(mocks.probeGateway).toHaveBeenCalledWith(expect.objectContaining({ auth: {} }));
+    expect(result.gatewayProbeAuth).toEqual({});
+    expect(result.gatewayProbe?.error).toContain("gateway probe auth resolution timed out");
+    expect(result.gatewayProbeAuthWarning).toBeUndefined();
+  });
 });
 
 describe("resolveSharedMemoryStatusSnapshot", () => {

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -83,6 +83,23 @@ export function hasExplicitMemorySearchConfig(cfg: OpenClawConfig, agentId: stri
   );
 }
 
+function withGatewayProbeFallback<T>(params: {
+  promise: Promise<T>;
+  timeoutMs: number;
+  fallback: () => T;
+}): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  const fallbackPromise = new Promise<T>((resolve) => {
+    timeout = setTimeout(() => resolve(params.fallback()), Math.max(1, params.timeoutMs));
+    timeout.unref?.();
+  });
+  return Promise.race([params.promise, fallbackPromise]).finally(() => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  });
+}
+
 export function resolveMemoryPluginStatus(cfg: OpenClawConfig): MemoryPluginStatus {
   const pluginsEnabled = cfg.plugins?.enabled !== false;
   if (!pluginsEnabled) {
@@ -115,10 +132,18 @@ export async function resolveGatewayProbeSnapshot(params: {
   const shouldProbe =
     params.opts.skipProbe !== true &&
     (!remoteUrlMissing || params.opts.probeWhenRemoteUrlMissing === true);
+  const authTimeoutMs = Math.min(params.opts.all ? 5000 : 2500, params.opts.timeoutMs ?? 10_000);
   const gatewayProbeAuthResolution = shouldResolveAuth
-    ? await loadGatewayProbeModule().then(({ resolveGatewayProbeAuthResolution }) =>
-        resolveGatewayProbeAuthResolution(params.cfg),
-      )
+    ? await withGatewayProbeFallback({
+        promise: loadGatewayProbeModule().then(({ resolveGatewayProbeAuthResolution }) =>
+          resolveGatewayProbeAuthResolution(params.cfg),
+        ),
+        timeoutMs: authTimeoutMs,
+        fallback: () => ({
+          auth: {},
+          warning: `gateway probe auth resolution timed out after ${authTimeoutMs}ms; probing without configured auth credentials.`,
+        }),
+      })
     : { auth: {}, warning: undefined };
   let gatewayProbeAuthWarning = gatewayProbeAuthResolution.warning;
   const gatewayProbe = shouldProbe


### PR DESCRIPTION
## Summary
- add a bounded fallback when resolving gateway auth for deep/status scans
- preserve existing status behavior while avoiding hangs when auth lookup stalls
- keep promised Discord decision digest artifact path present for tool-call audit output

## Verification
- `git diff --check`
- focused Vitest `status.scan.shared` 6/6
- `tsc -p tsconfig.core.json --noEmit`
- `oxfmt --check` on touched status files
- tool-call-audit node tests 11/11
- `vet` no issues

Opened by Iris from Rex's verified fork branch for task `52563c3a` after Martins/Iris internal unblock. No deploy/restart/merge performed.