### PR TITLE
fix(build): write runtime-postbuild stamp from build pipeline (#73151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Build/runtime-postbuild: write `dist/.runtime-postbuildstamp` from `scripts/runtime-postbuild.mjs` itself so a successful `pnpm build` no longer leaves the next `pnpm openclaw` invocation re-running the runtime artifact resync with `missing_runtime_postbuild_stamp`. Stamp shape (`syncedAt`, `head`) matches the runner's own writer so downstream readers in `run-node.mjs` are unaffected. Fixes #73151.
 - Memory/Ollama: resolve `memorySearch.provider` custom provider ids through their configured `models.providers.<id>.api` owner, so multi-GPU Ollama setups can dedicate embeddings to providers such as `ollama-5080` without losing the Ollama adapter or local auth semantics. Fixes #73150. Thanks @oneandrewwang.
 - CLI/memory: skip eager context-window warmup for `openclaw memory` commands so memory search does not race unrelated model metadata discovery. Fixes #73123. Thanks @oalansilva and @neeravmakwana.
 - CLI/Telegram: route Telegram `message send` and poll actions through the running Gateway when available, so packaged installs use the staged `grammy` runtime deps and CLI sends return instead of hanging after the Telegram channel is active. Fixes #73140. Thanks @oalansilva.

--- a/scripts/runtime-postbuild-stamp.mjs
+++ b/scripts/runtime-postbuild-stamp.mjs
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveGitHead } from "./build-stamp.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const STAMP_FILE = ".runtime-postbuildstamp";
+
+/**
+ * Write `dist/.runtime-postbuildstamp` so that the runner's
+ * `resolveRuntimePostBuildRequirement` check (`scripts/run-node.mjs`) does not
+ * fall through to a redundant runtime artifact resync after a normal
+ * `pnpm build` whose pipeline already invoked `runtime-postbuild`.
+ *
+ * Stamp shape mirrors what the runner writes after its own resync, so the
+ * downstream readers in `run-node.mjs` (mtime, head fields) work unchanged.
+ *
+ * Best-effort: failures only delay the next CLI startup by one resync cycle,
+ * so we log via `warn` and keep going. This matches the existing fall-back
+ * behavior in the runner's stamp writer. See #73151.
+ */
+export function writeRuntimePostBuildStamp(params = {}) {
+  const cwd = params.cwd ?? params.rootDir ?? ROOT;
+  const fsImpl = params.fs ?? fs;
+  const now = params.now ?? Date.now;
+  const warn = params.warn ?? console.warn;
+  const distRoot = path.join(cwd, "dist");
+  const stampPath = path.join(distRoot, STAMP_FILE);
+  try {
+    fsImpl.mkdirSync(distRoot, { recursive: true });
+    const head = resolveGitHead({ cwd, spawnSync: params.spawnSync });
+    const stamp = head ? { syncedAt: now(), head } : { syncedAt: now() };
+    fsImpl.writeFileSync(stampPath, `${JSON.stringify(stamp, null, 2)}\n`, "utf8");
+    return stampPath;
+  } catch (error) {
+    warn(
+      `[runtime-postbuild] failed to write stamp ${stampPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
 import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
 import { writeTextFileIfChanged } from "./runtime-postbuild-shared.mjs";
+import { writeRuntimePostBuildStamp } from "./runtime-postbuild-stamp.mjs";
 import { stageBundledPluginRuntimeDeps } from "./stage-bundled-plugin-runtime-deps.mjs";
 import { stageBundledPluginRuntime } from "./stage-bundled-plugin-runtime.mjs";
 import { writeOfficialChannelCatalog } from "./write-official-channel-catalog.mjs";
@@ -89,6 +90,10 @@ export function runRuntimePostBuild(params = {}) {
   stageBundledPluginRuntime(params);
   writeStableRootRuntimeAliases(params);
   copyStaticExtensionAssets(params);
+  // Drop a stamp so the runner skips a redundant resync on the next
+  // `pnpm openclaw` invocation. See scripts/run-node.mjs
+  // resolveRuntimePostBuildRequirement and #73151.
+  writeRuntimePostBuildStamp(params);
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/test/scripts/runtime-postbuild-stamp.test.ts
+++ b/test/scripts/runtime-postbuild-stamp.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { writeRuntimePostBuildStamp } from "../../scripts/runtime-postbuild-stamp.mjs";
+import { createScriptTestHarness } from "./test-helpers.js";
+
+const { createTempDir } = createScriptTestHarness();
+
+describe("writeRuntimePostBuildStamp (#73151)", () => {
+  it("writes dist/.runtime-postbuildstamp with syncedAt and head fields", () => {
+    const cwd = createTempDir("openclaw-runtime-postbuild-stamp-");
+    const fakeNow = 1_700_000_000_000;
+    const fakeSpawnSync = vi.fn(() => ({
+      status: 0,
+      stdout: "deadbeefcafef00d\n",
+    }));
+    const stampPath = writeRuntimePostBuildStamp({
+      cwd,
+      now: () => fakeNow,
+      spawnSync: fakeSpawnSync as never,
+    });
+    expect(stampPath).toBe(path.join(cwd, "dist", ".runtime-postbuildstamp"));
+    const written = JSON.parse(fs.readFileSync(stampPath as string, "utf8"));
+    expect(written).toEqual({ syncedAt: fakeNow, head: "deadbeefcafef00d" });
+  });
+
+  it("omits the head field when git rev-parse fails", () => {
+    const cwd = createTempDir("openclaw-runtime-postbuild-stamp-");
+    const fakeSpawnSync = vi.fn(() => ({ status: 128, stdout: "" }));
+    const stampPath = writeRuntimePostBuildStamp({
+      cwd,
+      now: () => 42,
+      spawnSync: fakeSpawnSync as never,
+    });
+    const written = JSON.parse(fs.readFileSync(stampPath as string, "utf8"));
+    expect(written).toEqual({ syncedAt: 42 });
+  });
+
+  it("accepts rootDir as an alias for cwd (matches runtime-postbuild.mjs param shape)", () => {
+    const rootDir = createTempDir("openclaw-runtime-postbuild-stamp-");
+    const fakeSpawnSync = vi.fn(() => ({ status: 0, stdout: "abc\n" }));
+    const stampPath = writeRuntimePostBuildStamp({
+      rootDir,
+      now: () => 100,
+      spawnSync: fakeSpawnSync as never,
+    });
+    expect(stampPath).toBe(path.join(rootDir, "dist", ".runtime-postbuildstamp"));
+  });
+
+  it("logs a warning and returns null when the stamp write fails", () => {
+    const cwd = createTempDir("openclaw-runtime-postbuild-stamp-");
+    const warn = vi.fn();
+    const fakeFs = {
+      mkdirSync: () => {
+        throw new Error("EACCES: simulated");
+      },
+      writeFileSync: () => {
+        throw new Error("should not reach");
+      },
+    };
+    const result = writeRuntimePostBuildStamp({
+      cwd,
+      fs: fakeFs as never,
+      warn,
+      now: () => 0,
+      spawnSync: vi.fn(() => ({ status: 0, stdout: "" })) as never,
+    });
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("EACCES: simulated"));
+  });
+});


### PR DESCRIPTION
Fixes #73151.

## Diagnosis

After a successful \`pnpm build\` whose output includes \`[build-all] runtime-postbuild\`, \`dist/.runtime-postbuildstamp\` does not exist, so the next \`pnpm openclaw <cmd>\` invocation prints:

\`\`\`text
[openclaw] Syncing runtime artifacts (missing_runtime_postbuild_stamp - runtime postbuild stamp missing).
\`\`\`

…and re-runs the runtime artifact resync.

Looking at where the stamp is *actually* written:

- \`scripts/run-node.mjs\` writes it after the runner's own resync (\`writeRuntimePostBuildStamp\` at \`run-node.mjs:757\`, called from \`syncRuntimeArtifactsAndStamp\` and the in-runner build path at line 917).
- \`scripts/runtime-postbuild.mjs\` (the step the build pipeline runs via \`scripts/build-all.mjs\` and the top-level \`pnpm build\` package script) **never writes it.**
- \`scripts/build-stamp.mjs\` writes \`.buildstamp\`, not \`.runtime-postbuildstamp\`.

So \`resolveRuntimePostBuildRequirement\` (\`run-node.mjs:348\`) reads a missing stamp file and returns \`{ shouldSync: true, reason: \"missing_runtime_postbuild_stamp\" }\` even though the build pipeline just ran the postbuild step.

## Fix

Extract the stamp-writing logic into a small standalone helper (\`scripts/runtime-postbuild-stamp.mjs\`) and call it at the end of \`runRuntimePostBuild\`. The stamp shape — \`{ syncedAt, head }\` — mirrors exactly what the runner's own writer produces, so the downstream \`mtime\` / \`head\` readers in \`run-node.mjs\` (\`resolveRuntimePostBuildRequirement\`) work unchanged.

## Files

- \`scripts/runtime-postbuild-stamp.mjs\` — new helper.
- \`scripts/runtime-postbuild.mjs\` — call \`writeRuntimePostBuildStamp\` at the end of \`runRuntimePostBuild\`.
- \`test/scripts/runtime-postbuild-stamp.test.ts\` — 4 cases (stamp shape with head, head omitted on git failure, accepts \`rootDir\` alias, swallows write failures with a warning).
- \`CHANGELOG.md\`.

## Verification

- New tests: \`pnpm vitest run test/scripts/runtime-postbuild-stamp.test.ts test/scripts/runtime-postbuild.test.ts\` → 8/8 passing.
- Runner regression: \`pnpm vitest run src/infra/run-node.test.ts\` → 37/37 passing (the runner side that *reads* the stamp is unchanged and still validates against the same shape).

## Why a separate helper

\`run-node.mjs\` already had \`writeRuntimePostBuildStamp(deps)\` inline, but it's coupled to the runner's \`deps\` shape (logging, path resolver). The build pipeline runs \`runtime-postbuild.mjs\` standalone via \`node scripts/runtime-postbuild.mjs\` with no runner context, so a small standalone helper that takes optional \`{ cwd, fs, now, spawnSync, warn }\` is the cleanest contact point. Both call sites can converge on it later if maintainers prefer.