### PR TITLE
fix(gateway): isolate startup task failures with Promise.allSettled [AI-assisted]

### DIFF
--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -54,7 +54,12 @@ export async function prepareGatewayPluginBootstrap(params: {
         }),
       );
     }
-    await Promise.all(startupTasks);
+    const results = await Promise.allSettled(startupTasks);
+    for (const result of results) {
+      if (result.status === "rejected") {
+        params.log.error(`Startup task failed: ${String(result.reason)}`);
+      }
+    }
   }
 
   initSubagentRegistry();

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -149,7 +149,7 @@ export function ensurePluginRegistryLoaded(options?: {
       activationSourceConfig: scopedActivationSourceConfig,
     },
     {
-      throwOnLoadError: true,
+      throwOnLoadError: false,
       ...(hasExplicitPluginIdScope(requestedPluginIds) ||
       shouldForwardChannelScope({ scope, scopedLoad }) ||
       hasNonEmptyPluginIdScope(expectedChannelPluginIds)


### PR DESCRIPTION
## Summary

Prevent a single failing startup task or broken plugin from crashing the entire gateway bootstrap process.

## Problem

1. `gateway/server-startup-plugins.ts` used `Promise.all([startupTaskA, startupTaskB])`. If `runStartupSessionMigration()` threw (e.g. SQLite lock), the rejection propagated uncaught and gateway exited.
2. `plugins/runtime/runtime-registry-loader.ts` set `throwOnLoadError: true`. If `loadOpenClawPlugins()` encountered a broken plugin (missing runtime module, bad `register()` export, etc.), it threw `PluginLoadFailureError` and the caller crashed.

## Fix

| File | Before | After |
|------|--------|-------|
| `gateway/server-startup-plugins.ts` | `Promise.all(startupTasks)` — one failure crashes gateway | `Promise.allSettled` + per-task error logging |
| `plugins/runtime/runtime-registry-loader.ts` | `throwOnLoadError: true` — broken plugin kills system | `throwOnLoadError: false` — broken plugin marked `status: "error"`, others continue |

## Risk

- Very low. Both changes only affect the failure path; success paths are identical.
- Bad plugins already had rollback logic; they just now don't crash the process.

## Testing

- [x] `pnpm build` passes
- [x] `pnpm check:changed` passes