### PR TITLE
Add hook capability smoke gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1605,6 +1605,7 @@
     "release:plugins:npm:plan": "node --import tsx scripts/plugin-npm-release-plan.ts",
     "runtime-sidecars:check": "node --import tsx scripts/generate-runtime-sidecar-paths-baseline.ts --check",
     "runtime-sidecars:gen": "node --import tsx scripts/generate-runtime-sidecar-paths-baseline.ts --write",
+    "smoke:hook-capability": "node scripts/hook-capability-smoke.mjs",
     "stage:bundled-plugin-runtime-deps": "node scripts/stage-bundled-plugin-runtime-deps.mjs",
     "start": "node scripts/run-node.mjs",
     "test": "node scripts/test-projects.mjs",

--- a/scripts/hook-capability-smoke.mjs
+++ b/scripts/hook-capability-smoke.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const args = process.argv.slice(2);
+
+function readArg(name) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return undefined;
+  }
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${name} requires a value`);
+  }
+  return value;
+}
+
+const json = args.includes("--json");
+const skipTests = args.includes("--skip-tests");
+const outputPath = readArg("--output");
+
+function readRepoFile(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  return readFileSync(absolutePath, "utf8");
+}
+
+function checkSource(relativePath, description, matcher) {
+  let ok = false;
+  let detail = "";
+  try {
+    const source = readRepoFile(relativePath);
+    const result = matcher(source);
+    ok = result === true || result?.ok === true;
+    detail = typeof result === "object" && result?.detail ? result.detail : description;
+  } catch (error) {
+    detail = error instanceof Error ? error.message : String(error);
+  }
+  return { name: description, ok, file: relativePath, detail };
+}
+
+const sourceChecks = [
+  checkSource(
+    "src/plugins/hook-types.ts",
+    "llm_input is observe-only in the installed/source hook contract",
+    (source) => ({
+      ok: /llm_input:\s*\([^)]*\)\s*=>\s*Promise<void>\s*\|\s*void/.test(source),
+      detail: "expected llm_input handler return type Promise<void> | void",
+    }),
+  ),
+  checkSource(
+    "src/plugins/hook-types.ts",
+    "llm_output is observe-only in the installed/source hook contract",
+    (source) => ({
+      ok: /llm_output:\s*\([^)]*\)\s*=>\s*Promise<void>\s*\|\s*void/.test(source),
+      detail: "expected llm_output handler return type Promise<void> | void",
+    }),
+  ),
+  checkSource(
+    "src/plugins/inspect-shape.ts",
+    "plugin shape inspection keeps typed hooks separate from explicit capabilities",
+    (source) => ({
+      ok:
+        source.includes("buildPluginCapabilityEntries") &&
+        source.includes("typedHookCount") &&
+        source.includes("customHookCount"),
+      detail:
+        "expected inspect-shape to classify typed hooks separately from capability registrations",
+    }),
+  ),
+  checkSource(
+    "src/plugins/hook-types.ts",
+    "before_tool_call remains a modifying/blocking hook",
+    (source) => ({
+      ok: source.includes("PluginHookBeforeToolCallResult") && source.includes("before_tool_call"),
+      detail: "expected before_tool_call to reference PluginHookBeforeToolCallResult",
+    }),
+  ),
+  checkSource(
+    "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
+    "Codex dynamic tools have fail-closed before_tool_call coverage",
+    (source) => ({
+      ok: source.includes("fails closed when before_tool_call blocks a dynamic tool"),
+      detail: "expected Codex dynamic tool blocking contract test",
+    }),
+  ),
+  checkSource(
+    "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
+    "Codex dynamic tools have after_tool_call observation coverage",
+    (source) => ({
+      ok: source.includes("wraps unwrapped dynamic tools with before/after tool hooks"),
+      detail: "expected Codex dynamic tool before/after contract test",
+    }),
+  ),
+  checkSource(
+    "src/agents/harness/native-hook-relay.test.ts",
+    "Codex native PreToolUse relay has a blocking parity test",
+    (source) => ({
+      ok: source.includes(
+        "maps Codex PreToolUse to OpenClaw before_tool_call and blocks before execution",
+      ),
+      detail: "expected native relay test for Codex PreToolUse blocking",
+    }),
+  ),
+  checkSource(
+    "src/agents/harness/native-hook-relay.test.ts",
+    "Codex native PostToolUse relay has an observation parity test",
+    (source) => ({
+      ok: source.includes("maps Codex PostToolUse to OpenClaw after_tool_call observation"),
+      detail: "expected native relay test for Codex PostToolUse observation",
+    }),
+  ),
+  checkSource(
+    "src/agents/openclaw-owned-tool-runtime-contract.test.ts",
+    "OpenClaw-owned Pi tools have fail-closed before_tool_call coverage",
+    (source) => ({
+      ok: source.includes("fails closed when before_tool_call blocks a Pi dynamic tool"),
+      detail: "expected Pi dynamic tool blocking contract test",
+    }),
+  ),
+  checkSource(
+    "src/agents/openclaw-owned-tool-runtime-contract.test.ts",
+    "OpenClaw-owned Pi tools have after_tool_call observation coverage",
+    (source) => ({
+      ok: source.includes(
+        "preserves partially adjusted before_tool_call params through execution and after_tool_call",
+      ),
+      detail: "expected Pi dynamic tool after_tool_call contract test",
+    }),
+  ),
+];
+
+const vitestFiles = [
+  "src/agents/openclaw-owned-tool-runtime-contract.test.ts",
+  "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
+  "src/agents/harness/native-hook-relay.test.ts",
+  "src/plugins/wired-hooks-llm.test.ts",
+];
+
+let testResult = {
+  skipped: skipTests,
+  ok: true,
+  command: "not run",
+  status: 0,
+  stdout: "",
+  stderr: "",
+};
+
+if (!skipTests) {
+  const command = ["node", "scripts/run-vitest.mjs", "run", ...vitestFiles];
+  const result = spawnSync(command[0], command.slice(1), {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, CI: process.env.CI ?? "1" },
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  testResult = {
+    skipped: false,
+    ok: result.status === 0,
+    command: command.join(" "),
+    status: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+const packageJson = JSON.parse(readRepoFile("package.json"));
+const generatedAt = new Date().toISOString();
+const checksOk = sourceChecks.every((check) => check.ok);
+const ok = checksOk && testResult.ok;
+const summary = {
+  ok,
+  generatedAt,
+  packageVersion: packageJson.version,
+  sourceChecks,
+  testResult: {
+    skipped: testResult.skipped,
+    ok: testResult.ok,
+    command: testResult.command,
+    status: testResult.status,
+  },
+};
+
+function stripAnsi(text) {
+  const escapeCode = String.fromCharCode(27);
+  return String(text || "").replace(new RegExp(`${escapeCode}\\[[0-9;]*m`, "g"), "");
+}
+
+function escapeMarkdownTableCell(text) {
+  return String(text).replace(/\|/g, "\\|").replace(/\n/g, "<br>");
+}
+
+function tail(text, lines = 24) {
+  return stripAnsi(text).trim().split("\n").slice(-lines).join("\n");
+}
+
+function renderMarkdown() {
+  const status = ok ? "PASS" : "FAIL";
+  const rows = sourceChecks
+    .map(
+      (check) =>
+        `| ${check.ok ? "✅" : "❌"} | ${escapeMarkdownTableCell(check.name)} | \`${check.file}\` | ${escapeMarkdownTableCell(check.detail)} |`,
+    )
+    .join("\n");
+  const testTail = [tail(testResult.stdout), tail(testResult.stderr)].filter(Boolean).join("\n");
+  return (
+    `# OpenClaw hook capability smoke report\n\n` +
+    `Generated: ${generatedAt}\n` +
+    `OpenClaw package version: ${packageJson.version}\n` +
+    `Result: **${status}**\n\n` +
+    `## Capability checks\n\n` +
+    `| Status | Check | File | Detail |\n|---|---|---|---|\n${rows}\n\n` +
+    `## Focused verification\n\n` +
+    `Command: \`${testResult.command}\`\n\n` +
+    `Status: ${testResult.skipped ? "skipped" : testResult.status}\n\n` +
+    (testTail ? `\`\`\`text\n${testTail}\n\`\`\`\n\n` : "") +
+    `## Interpretation\n\n` +
+    `- OpenClaw-owned Pi tools and Codex app-server dynamic tools are expected to fail closed through \`before_tool_call\` and emit \`after_tool_call\` observations.\n` +
+    `- Codex-native \`PreToolUse\`/\`PostToolUse\` relay is expected to reach the same OpenClaw hook surfaces for harmless sentinel actions.\n` +
+    `- \`llm_input\` and \`llm_output\` stay typed-hook, observe-only surfaces in the current source/inspect contract; do not depend on prompt/response mutation until stable source/types change.\n` +
+    `- This is a dry-run upgrade gate. It does not enable fail-closed production enforcement by itself, and any production fail-closed rollout still needs Iris review.\n`
+  );
+}
+
+const markdown = renderMarkdown();
+if (outputPath) {
+  const absoluteOutputPath = path.resolve(process.cwd(), outputPath);
+  const outputDir = path.dirname(absoluteOutputPath);
+  if (!existsSync(outputDir)) {
+    mkdirSync(outputDir, { recursive: true });
+  }
+  writeFileSync(absoluteOutputPath, markdown);
+}
+
+if (json) {
+  console.log(JSON.stringify(summary, null, 2));
+} else {
+  console.log(markdown);
+}
+
+process.exit(ok ? 0 : 1);

--- a/shared/projects/system/audit/2026-04-27-openclaw-hook-capability-smoke-9f6c25b3.md
+++ b/shared/projects/system/audit/2026-04-27-openclaw-hook-capability-smoke-9f6c25b3.md
@@ -1,0 +1,55 @@
+# OpenClaw hook capability smoke report
+
+Generated: 2026-04-28T02:28:54.567Z
+OpenClaw package version: 2026.4.26
+Result: **PASS**
+
+## Capability checks
+
+| Status | Check                                                                         | File                                                                           | Detail                                                                                  |
+| ------ | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| ✅     | llm_input is observe-only in the installed/source hook contract               | `src/plugins/hook-types.ts`                                                    | expected llm_input handler return type Promise<void> \| void                            |
+| ✅     | llm_output is observe-only in the installed/source hook contract              | `src/plugins/hook-types.ts`                                                    | expected llm_output handler return type Promise<void> \| void                           |
+| ✅     | plugin shape inspection keeps typed hooks separate from explicit capabilities | `src/plugins/inspect-shape.ts`                                                 | expected inspect-shape to classify typed hooks separately from capability registrations |
+| ✅     | before_tool_call remains a modifying/blocking hook                            | `src/plugins/hook-types.ts`                                                    | expected before_tool_call to reference PluginHookBeforeToolCallResult                   |
+| ✅     | Codex dynamic tools have fail-closed before_tool_call coverage                | `extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts` | expected Codex dynamic tool blocking contract test                                      |
+| ✅     | Codex dynamic tools have after_tool_call observation coverage                 | `extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts` | expected Codex dynamic tool before/after contract test                                  |
+| ✅     | Codex native PreToolUse relay has a blocking parity test                      | `src/agents/harness/native-hook-relay.test.ts`                                 | expected native relay test for Codex PreToolUse blocking                                |
+| ✅     | Codex native PostToolUse relay has an observation parity test                 | `src/agents/harness/native-hook-relay.test.ts`                                 | expected native relay test for Codex PostToolUse observation                            |
+| ✅     | OpenClaw-owned Pi tools have fail-closed before_tool_call coverage            | `src/agents/openclaw-owned-tool-runtime-contract.test.ts`                      | expected Pi dynamic tool blocking contract test                                         |
+| ✅     | OpenClaw-owned Pi tools have after_tool_call observation coverage             | `src/agents/openclaw-owned-tool-runtime-contract.test.ts`                      | expected Pi dynamic tool after_tool_call contract test                                  |
+
+## Focused verification
+
+Command: `node scripts/run-vitest.mjs run src/agents/openclaw-owned-tool-runtime-contract.test.ts extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts src/agents/harness/native-hook-relay.test.ts src/plugins/wired-hooks-llm.test.ts`
+
+Status: 0
+
+```text
+RUN  v4.1.5 /mnt/iris_gateway_data_100gb/repos/openclaw-hook-capability-smoke-9f6c25b3
+
+ ✓  agents-core  ../../src/agents/harness/native-hook-relay.test.ts (33 tests) 346ms
+ ✓  agents-core  ../../src/agents/openclaw-owned-tool-runtime-contract.test.ts (4 tests) 60ms
+ ✓  agents-support  ../../src/agents/harness/native-hook-relay.test.ts (33 tests) 317ms
+ ✓  agents-support  ../../src/agents/openclaw-owned-tool-runtime-contract.test.ts (4 tests) 67ms
+ ✓  extensions  ../../extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts (7 tests) 115ms
+ ✓  plugins  ../../src/plugins/wired-hooks-llm.test.ts (5 tests) 455ms
+     ✓ 'runModelCallStarted invokes registere…'  445ms
+
+ Test Files  6 passed (6)
+      Tests  86 passed (86)
+   Start at  22:28:11
+   Duration  42.68s (transform 27.76s, setup 2.79s, import 37.36s, tests 1.36s, environment 1ms)
+stderr | ../../src/agents/openclaw-owned-tool-runtime-contract.test.ts > OpenClaw-owned tool runtime contract — Pi adapter > reports Pi dynamic tool execution errors through after_tool_call
+[tools] exec failed: tool failed raw_params={"command":"false"}
+
+stderr | ../../src/agents/openclaw-owned-tool-runtime-contract.test.ts > OpenClaw-owned tool runtime contract — Pi adapter > reports Pi dynamic tool execution errors through after_tool_call
+[tools] exec failed: tool failed raw_params={"command":"false"}
+```
+
+## Interpretation
+
+- OpenClaw-owned Pi tools and Codex app-server dynamic tools are expected to fail closed through `before_tool_call` and emit `after_tool_call` observations.
+- Codex-native `PreToolUse`/`PostToolUse` relay is expected to reach the same OpenClaw hook surfaces for harmless sentinel actions.
+- `llm_input` and `llm_output` stay typed-hook, observe-only surfaces in the current source/inspect contract; do not depend on prompt/response mutation until stable source/types change.
+- This is a dry-run upgrade gate. It does not enable fail-closed production enforcement by itself, and any production fail-closed rollout still needs Iris review.

--- a/test/scripts/hook-capability-smoke.test.ts
+++ b/test/scripts/hook-capability-smoke.test.ts
@@ -1,0 +1,62 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const SCRIPT_PATH = "scripts/hook-capability-smoke.mjs";
+
+describe("scripts/hook-capability-smoke.mjs", () => {
+  it("is wired into the root package scripts", () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+    expect(packageJson.scripts["smoke:hook-capability"]).toBe(`node ${SCRIPT_PATH}`);
+  });
+
+  it("reports dry-run parity status without needing to execute Vitest", () => {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, "--json", "--skip-tests"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+
+    const report = JSON.parse(result.stdout);
+    expect(report).toMatchObject({
+      ok: true,
+      testResult: {
+        skipped: true,
+        ok: true,
+        command: "not run",
+        status: 0,
+      },
+    });
+    expect(report.sourceChecks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "plugin shape inspection keeps typed hooks separate from explicit capabilities",
+          ok: true,
+          file: "src/plugins/inspect-shape.ts",
+        }),
+        expect.objectContaining({
+          name: "Codex native PreToolUse relay has a blocking parity test",
+          ok: true,
+          file: "src/agents/harness/native-hook-relay.test.ts",
+        }),
+        expect.objectContaining({
+          name: "Codex native PostToolUse relay has an observation parity test",
+          ok: true,
+          file: "src/agents/harness/native-hook-relay.test.ts",
+        }),
+        expect.objectContaining({
+          name: "OpenClaw-owned Pi tools have fail-closed before_tool_call coverage",
+          ok: true,
+          file: "src/agents/openclaw-owned-tool-runtime-contract.test.ts",
+        }),
+        expect.objectContaining({
+          name: "Codex dynamic tools have fail-closed before_tool_call coverage",
+          ok: true,
+          file: "extensions/codex/src/app-server/openclaw-owned-tool-runtime-contract.test.ts",
+        }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
Task: 9f6c25b3

Adds a dry-run hook capability smoke gate/report for Codex/native guardrail parity.

Rex verification before push:
- node --check
- scripts/hook-capability-smoke.mjs PASS (4 focused test files / 49 tests)
- hook-capability script test 2/2
- corepack pnpm check:changed PASS
- vet --staged no issues

Scope: PR/review only. No production enforcement, gateway restart, deploy, config write, destructive API call, billing/spend, or external commitment.