### PR TITLE
Reconcile terminal task audit noise

### DIFF
--- a/src/tasks/task-registry.audit.test.ts
+++ b/src/tasks/task-registry.audit.test.ts
@@ -46,8 +46,8 @@ describe("task-registry audit", () => {
     });
 
     expect(findings.map((finding) => [finding.code, finding.task.taskId])).toEqual([
-      ["lost", "lost-task"],
       ["stale_running", "stale-running"],
+      ["lost", "lost-task"],
       ["missing_cleanup", "missing-cleanup"],
     ]);
   });
@@ -83,7 +83,7 @@ describe("task-registry audit", () => {
     });
   });
 
-  it("downgrades retained lost tasks with future cleanupAfter to warnings", () => {
+  it("classifies terminal lost tasks as warnings instead of active queue errors", () => {
     const now = Date.parse("2026-03-30T01:00:00.000Z");
     const findings = listTaskAuditFindings({
       now,
@@ -110,9 +110,10 @@ describe("task-registry audit", () => {
     expect(
       findings.map((finding) => [finding.task.taskId, finding.code, finding.severity]),
     ).toEqual([
-      ["lost-expired", "lost", "error"],
+      ["lost-expired", "lost", "warn"],
       ["lost-retained", "lost", "warn"],
     ]);
+    expect(findings.every((finding) => finding.severity === "warn")).toBe(true);
   });
 
   it("does not double-report lost tasks as missing cleanup", () => {
@@ -130,5 +131,45 @@ describe("task-registry audit", () => {
     });
 
     expect(findings.map((finding) => finding.code)).toEqual(["lost"]);
+  });
+
+  it("ignores tiny startedAt-before-createdAt ordering races", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "one-ms-race",
+          status: "succeeded",
+          createdAt: now,
+          startedAt: now - 1,
+          endedAt: now + 1,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings).toEqual([]);
+  });
+
+  it("still flags material startedAt-before-createdAt inconsistencies", () => {
+    const now = Date.parse("2026-03-30T01:00:00.000Z");
+    const findings = listTaskAuditFindings({
+      now,
+      tasks: [
+        createTask({
+          taskId: "material-skew",
+          status: "succeeded",
+          createdAt: now,
+          startedAt: now - 5_000,
+          endedAt: now + 1,
+          cleanupAfter: now + 60_000,
+        }),
+      ],
+    });
+
+    expect(findings.map((finding) => [finding.code, finding.detail])).toEqual([
+      ["inconsistent_timestamps", "startedAt is earlier than createdAt"],
+    ]);
   });
 });

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -17,6 +17,7 @@ export type TaskAuditOptions = {
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
+const TIMESTAMP_ORDERING_RACE_TOLERANCE_MS = 1_000;
 export { createEmptyTaskAuditSummary };
 export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
 
@@ -47,7 +48,7 @@ function taskReferenceAt(task: TaskRecord): number {
 }
 
 function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
-  if (task.startedAt && task.startedAt < task.createdAt) {
+  if (task.startedAt && task.startedAt + TIMESTAMP_ORDERING_RACE_TOLERANCE_MS < task.createdAt) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -128,14 +129,14 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
       const retainedUntilCleanup = typeof task.cleanupAfter === "number" && task.cleanupAfter > now;
       findings.push(
         createFinding({
-          severity: retainedUntilCleanup ? "warn" : "error",
+          severity: "warn",
           code: "lost",
           task,
           ageMs,
           detail: retainedUntilCleanup
             ? task.error?.trim() ||
               "task lost its backing session and is retained until cleanupAfter"
-            : task.error?.trim() || "task lost its backing session",
+            : task.error?.trim() || "terminal task lost its backing session",
         }),
       );
     }


### PR DESCRIPTION
Task: ebcee6b1

Reconciles terminal-only OpenClaw task audit noise so zero active queue pressure is not reported as misleading high-severity queue warnings.

Rex verification before push:
- unit-fast task-registry.audit.test.ts 6/6
- corepack pnpm check:changed PASS
- vet no issues

Scope: PR/review only. No deploy, restart, installed-bundle patch, merge, destructive API call, billing/spend, or external commitment.