### PR TITLE
fix(feishu): support text tag and nested arrays in interactive card parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
 - Channels/native commands: keep validated native slash command replies visible in group chats while preserving explicit owner allowlists for command authorization. (#73672) Thanks @obviyus.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
+- Feishu: extract text-tag and nested-array text from replied interactive cards, and fall back to direct post-format card content when element arrays are empty. Fixes #60380; supersedes #60383; carries forward #73203. Thanks @taozengabc and @lskun.
 
 ## 2026.4.27
 

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -168,6 +168,80 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("extracts text from nested array elements (table-like card layout)", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_nested",
+            chat_id: "oc_nested",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [
+                  [{ tag: "text", text: "Service Name" }, { tag: "text", text: "eip-admin-api" }],
+                  [{ tag: "text", text: "Alert" }, { tag: "text", text: "Health check failed 3 times" }],
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_nested",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_nested",
+        chatId: "oc_nested",
+        contentType: "interactive",
+        content: "Service Name\neip-admin-api\nAlert\nHealth check failed 3 times",
+      }),
+    );
+  });
+
+  it("extracts text from 'text' tag elements in interactive cards", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_text_tag",
+            chat_id: "oc_text_tag",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [
+                  { tag: "text", text: "plain text element" },
+                  { tag: "markdown", content: "markdown element" },
+                ],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_text_tag",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_text_tag",
+        chatId: "oc_text_tag",
+        contentType: "interactive",
+        content: "plain text element\nmarkdown element",
+      }),
+    );
+  });
+
   it("falls through empty interactive card element arrays and locale variants", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -180,8 +180,14 @@ describe("getMessageFeishu", () => {
             body: {
               content: JSON.stringify({
                 elements: [
-                  [{ tag: "text", text: "Service Name" }, { tag: "text", text: "eip-admin-api" }],
-                  [{ tag: "text", text: "Alert" }, { tag: "text", text: "Health check failed 3 times" }],
+                  [
+                    { tag: "text", text: "Service Name" },
+                    { tag: "text", text: "eip-admin-api" },
+                  ],
+                  [
+                    { tag: "text", text: "Alert" },
+                    { tag: "text", text: "Health check failed 3 times" },
+                  ],
                 ],
               }),
             },
@@ -327,6 +333,42 @@ describe("getMessageFeishu", () => {
         chatId: "oc_post_card",
         contentType: "interactive",
         content: "Card summary\n\n**fallback** body",
+      }),
+    );
+  });
+
+  it("falls back to direct post-format content when interactive card elements are empty", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_direct_post_card",
+            chat_id: "oc_direct_post_card",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                elements: [],
+                title: "Direct card summary",
+                content: [[{ tag: "text", text: "fallback body" }]],
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_direct_post_card",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_direct_post_card",
+        chatId: "oc_direct_post_card",
+        contentType: "interactive",
+        content: "Direct card summary\n\nfallback body",
       }),
     );
   });

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -252,23 +252,25 @@ function extractInteractiveElementsText(
   variables: Map<string, string>,
 ): string {
   const texts: string[] = [];
-  for (const element of elements) {
-    // Some cards use nested arrays (e.g. [[row1_col1, row1_col2], [row2_col1, ...]])
-    // for table-like layouts. Flatten one level and extract text from each cell.
+
+  function collectText(element: unknown): void {
     if (Array.isArray(element)) {
       for (const cell of element) {
-        const text = extractInteractiveElementText(cell, variables);
-        if (text !== undefined) {
-          texts.push(text);
-        }
+        collectText(cell);
       }
-      continue;
+      return;
     }
+
     const text = extractInteractiveElementText(element, variables);
     if (text !== undefined) {
       texts.push(text);
     }
   }
+
+  for (const element of elements) {
+    collectText(element);
+  }
+
   return texts.join("\n").trim();
 }
 

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -240,6 +240,10 @@ function extractInteractiveElementText(
   if (tag === "plain_text" && typeof element.content === "string") {
     return applyCardTemplateVariables(element.content, variables);
   }
+  // Support "text" tag used by custom cards (e.g. monitoring alerts)
+  if (tag === "text" && typeof element.text === "string") {
+    return applyCardTemplateVariables(element.text, variables);
+  }
   return undefined;
 }
 
@@ -249,6 +253,17 @@ function extractInteractiveElementsText(
 ): string {
   const texts: string[] = [];
   for (const element of elements) {
+    // Some cards use nested arrays (e.g. [[row1_col1, row1_col2], [row2_col1, ...]])
+    // for table-like layouts. Flatten one level and extract text from each cell.
+    if (Array.isArray(element)) {
+      for (const cell of element) {
+        const text = extractInteractiveElementText(cell, variables);
+        if (text !== undefined) {
+          texts.push(text);
+        }
+      }
+      continue;
+    }
     const text = extractInteractiveElementText(element, variables);
     if (text !== undefined) {
       texts.push(text);


### PR DESCRIPTION
## Problem

`parseInteractiveCardContent` only recognizes `div`, `markdown`, `lark_md`, and `plain_text` element tags. Two common card formats fall through to the `[Interactive Card]` placeholder:

1. **`text` tag elements** — used by custom cards (e.g. monitoring alert cards built with CardKit):
   ```json
   { "tag": "text", "text": "Service health check failed" }
   ```

2. **Nested array layouts** — table-like row structures common in monitoring/status cards:
   ```json
   {
     "elements": [
       [{"tag": "text", "text": "Service"}, {"tag": "text", "text": "eip-admin-api"}],
       [{"tag": "text", "text": "Alert"}, {"tag": "text", "text": "Health check failed 3 times"}]
     ]
   }
   ```

This causes loss of context when users quote-reply to card messages — the agent receives `[Interactive Card]` instead of the actual card content.

**Impact in production:** 33 occurrences over 4 weeks in our Feishu deployment, primarily in SLA monitoring groups where users quote alert cards to ask the agent for analysis.

## Fix

Two minimal changes in `extensions/feishu/src/send.ts`:

1. **Add `text` tag support** in `extractInteractiveElementText` — extracts `element.text` when `tag === "text"` and `text` is a string
2. **Flatten nested arrays** in `extractInteractiveElementsText` — when an element is itself an array (row of cells), iterate its children instead of skipping

Both changes are additive and do not affect existing parsing behavior for `div`, `markdown`, `lark_md`, or `plain_text` tags.

## Tests

Added two test cases in `send.test.ts`:
- Nested array elements (table-like card layout)
- `text` tag elements mixed with `markdown` elements

## Related

- #41609 — reports the same underlying issue
- #45936 — a broader fix attempt (DFS traversal + sanitization); this PR is a targeted minimal fix