### PR TITLE
feat(copilot): dynamic model catalog from /models API

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -72,9 +72,7 @@ describe("codex plugin", () => {
       registerMediaUnderstandingProvider: vi.fn(),
       registerProvider: vi.fn(),
       on: vi.fn(),
-    }) as ReturnType<typeof createTestPluginApi> & {
-      onConversationBindingResolved?: ReturnType<typeof vi.fn>;
-    };
+    });
     delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved;
 
     expect(() => plugin.register(api)).not.toThrow();

--- a/extensions/github-copilot/index.ts
+++ b/extensions/github-copilot/index.ts
@@ -17,14 +17,73 @@ import {
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFirstGithubToken } from "./auth.js";
 import { githubCopilotMemoryEmbeddingProviderAdapter } from "./embeddings.js";
+import { fetchCopilotModels } from "./models-api.js";
+import { mapCopilotModels, type MappedCopilotModelWithCapabilities } from "./models-mapping.js";
 import { PROVIDER_ID, resolveCopilotForwardCompatModel } from "./models.js";
 import { buildGithubCopilotReplayPolicy } from "./replay-policy.js";
+import { resolveThinkingProfileFromCapabilities } from "./thinking.js";
 import { wrapCopilotProviderStream } from "./stream.js";
 
 const COPILOT_ENV_VARS = ["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 const DEFAULT_COPILOT_MODEL = "github-copilot/claude-opus-4.7";
 const DEFAULT_COPILOT_PROFILE_ID = "github-copilot:github";
-const COPILOT_XHIGH_MODEL_IDS = ["gpt-5.4", "gpt-5.3-codex", "gpt-5.2", "gpt-5.2-codex"] as const;
+
+/**
+ * Module-level cache for API-fetched model capabilities.
+ * Populated by fetchAndCacheModels() and consumed by resolveThinkingProfile().
+ */
+let cachedModelCapabilities = new Map<string, MappedCopilotModelWithCapabilities>();
+
+/** In-flight fetch promise to prevent concurrent API calls. */
+let fetchModelsPromise: Promise<MappedCopilotModelWithCapabilities[]> | null = null;
+
+async function fetchAndCacheModels(
+  config: OpenClawConfig | undefined,
+  env: NodeJS.ProcessEnv,
+): Promise<MappedCopilotModelWithCapabilities[]> {
+  if (cachedModelCapabilities.size > 0) {
+    return [...cachedModelCapabilities.values()];
+  }
+  if (fetchModelsPromise) {
+    return fetchModelsPromise;
+  }
+  fetchModelsPromise = (async () => {
+    try {
+      const { DEFAULT_COPILOT_API_BASE_URL, resolveCopilotApiToken } =
+        await loadGithubCopilotRuntime();
+      const { githubToken } = await resolveFirstGithubToken({
+        config,
+        env,
+      });
+      if (!githubToken) {
+        return [];
+      }
+      let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+      let apiToken: string | undefined;
+      try {
+        const token = await resolveCopilotApiToken({ githubToken, env });
+        baseUrl = token.baseUrl;
+        apiToken = token.token;
+      } catch {
+        return [];
+      }
+      if (!apiToken) {
+        return [];
+      }
+      const apiModels = await fetchCopilotModels(baseUrl, apiToken);
+      const mapped = mapCopilotModels(apiModels);
+      const newCache = new Map<string, MappedCopilotModelWithCapabilities>();
+      for (const m of mapped) {
+        newCache.set(m.id.toLowerCase(), m);
+      }
+      cachedModelCapabilities = newCache;
+      return mapped;
+    } finally {
+      fetchModelsPromise = null;
+    }
+  })();
+  return fetchModelsPromise;
+}
 
 type GithubCopilotPluginConfig = {
   discovery?: {
@@ -323,6 +382,7 @@ export default definePluginEntry({
             return null;
           }
           let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+          let apiToken: string | undefined;
           if (githubToken) {
             try {
               const token = await resolveCopilotApiToken({
@@ -330,35 +390,79 @@ export default definePluginEntry({
                 env: ctx.env,
               });
               baseUrl = token.baseUrl;
+              apiToken = token.token;
             } catch {
               baseUrl = DEFAULT_COPILOT_API_BASE_URL;
             }
           }
+
+          // Fetch models from Copilot API to get dynamic capabilities.
+          // Reuse the shared fetchAndCacheModels helper for in-flight deduplication.
+          const catalogModels = apiToken
+            ? await (async () => {
+                try {
+                  return await fetchAndCacheModels(ctx.config, ctx.env);
+                } catch {
+                  return [];
+                }
+              })()
+            : [];
+
           return {
             provider: {
               baseUrl,
-              models: [],
+              // Strip internal _copilotCapabilities before returning to catalog
+              models: catalogModels.map(({ _copilotCapabilities: _, ...model }) => model),
             },
           };
         },
       },
       resolveDynamicModel: (ctx) => resolveCopilotForwardCompatModel(ctx),
+      prepareDynamicModel: async (ctx) => {
+        // Lazily fetch model catalog from Copilot API when a model is requested
+        // but not yet in the cache. This ensures dynamic models get API-sourced
+        // capabilities even when catalog.run didn't execute during startup.
+        if (cachedModelCapabilities.size > 0) {
+          return;
+        }
+        try {
+          await fetchAndCacheModels(ctx.config, process.env);
+        } catch {
+          // Silently skip — resolveDynamicModel fallback handles unknown models
+        }
+      },
+      augmentModelCatalog: async (ctx) => {
+        // Add dynamically-fetched Copilot models to the model catalog so they
+        // appear in /models list. This runs during loadModelCatalog, after the
+        // static model registry is loaded.
+        try {
+          const models = await fetchAndCacheModels(
+            ctx.config,
+            ctx.env ?? process.env,
+          );
+          return models.map((m) => ({
+            id: m.id,
+            name: m.name,
+            provider: PROVIDER_ID,
+            contextWindow: m.contextWindow,
+            reasoning: m.reasoning,
+            input: m.input,
+          }));
+        } catch {
+          return [];
+        }
+      },
       wrapStreamFn: wrapCopilotProviderStream,
       buildReplayPolicy: ({ modelId }) => buildGithubCopilotReplayPolicy(modelId),
-      resolveThinkingProfile: ({ modelId }) => ({
-        levels: [
-          { id: "off" },
-          { id: "minimal" },
-          { id: "low" },
-          { id: "medium" },
-          { id: "high" },
-          ...(COPILOT_XHIGH_MODEL_IDS.includes(
-            (normalizeOptionalLowercaseString(modelId) ?? "") as never,
-          )
-            ? [{ id: "xhigh" as const }]
-            : []),
-        ],
-      }),
+      resolveThinkingProfile: ({ modelId }) => {
+        const lower = normalizeOptionalLowercaseString(modelId) ?? "";
+        const cached = cachedModelCapabilities.get(lower);
+        if (cached?._copilotCapabilities) {
+          return resolveThinkingProfileFromCapabilities(cached._copilotCapabilities);
+        }
+        // Fallback: basic heuristic when API data is not available
+        return resolveThinkingProfileFromCapabilities(undefined);
+      },
       prepareRuntimeAuth: async (ctx) => {
         const { resolveCopilotApiToken } = await loadGithubCopilotRuntime();
         const token = await resolveCopilotApiToken({

--- a/extensions/github-copilot/models-api.ts
+++ b/extensions/github-copilot/models-api.ts
@@ -1,0 +1,99 @@
+import { fetchWithSsrFGuard, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
+
+/**
+ * Fetch the model list from the Copilot API.
+ * Returns raw API model objects with capabilities/limits.
+ *
+ * API docs: https://docs.github.com/en/copilot/using-github-copilot/using-the-github-copilot-api
+ */
+
+export interface CopilotApiVisionLimits {
+  max_prompt_image_size?: number;
+  max_prompt_images?: number;
+  supported_media_types?: string[];
+}
+
+export interface CopilotApiModelLimits {
+  max_context_window_tokens?: number;
+  max_output_tokens?: number;
+  max_non_streaming_output_tokens?: number;
+  max_prompt_tokens?: number;
+  vision?: CopilotApiVisionLimits;
+}
+
+export interface CopilotApiModelSupports {
+  vision?: boolean;
+  tool_calls?: boolean;
+  streaming?: boolean;
+  parallel_tool_calls?: boolean;
+  structured_outputs?: boolean;
+  adaptive_thinking?: boolean;
+  max_thinking_budget?: number;
+  min_thinking_budget?: number;
+  reasoning_effort?: string[];
+}
+
+export interface CopilotApiModel {
+  id: string;
+  name: string;
+  version: string;
+  vendor: string;
+  family?: string;
+  type?: string;
+  supported_endpoints?: string[];
+  capabilities?: {
+    limits?: CopilotApiModelLimits;
+    supports?: CopilotApiModelSupports;
+    family?: string;
+    type?: string;
+  };
+}
+
+interface CopilotModelsResponse {
+  data: CopilotApiModel[];
+}
+
+// IDE headers required by the Copilot API to accept /models requests.
+const COPILOT_EDITOR_VERSION = "vscode/1.96.2";
+const COPILOT_EDITOR_PLUGIN_VERSION = "copilot-chat/0.35.0";
+const COPILOT_USER_AGENT = "GitHubCopilotChat/0.26.7";
+
+export async function fetchCopilotModels(
+  baseUrl: string,
+  apiToken: string,
+): Promise<CopilotApiModel[]> {
+  const url = `${baseUrl}/models`;
+  const ssrfPolicy: SsrFPolicy | undefined = (() => {
+    try {
+      const parsed = new URL(baseUrl);
+      return { allowedHostnames: [parsed.hostname] };
+    } catch {
+      return undefined;
+    }
+  })();
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        Accept: "application/json",
+        "Editor-Version": COPILOT_EDITOR_VERSION,
+        "Editor-Plugin-Version": COPILOT_EDITOR_PLUGIN_VERSION,
+        "User-Agent": COPILOT_USER_AGENT,
+        "Copilot-Integration-Id": "vscode-chat",
+      },
+      signal: AbortSignal.timeout(30_000),
+    },
+    policy: ssrfPolicy,
+    auditContext: "copilot-models",
+  });
+  try {
+    if (!response.ok) {
+      throw new Error(`Copilot /models API returned ${response.status}`);
+    }
+    const body = (await response.json()) as CopilotModelsResponse;
+    return body.data ?? [];
+  } finally {
+    await release();
+  }
+}

--- a/extensions/github-copilot/models-mapping.test.ts
+++ b/extensions/github-copilot/models-mapping.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "vitest";
+import type { CopilotApiModel } from "./models-api.js";
+import {
+  deduplicateModels,
+  isReasoningModel,
+  isUserFacingModel,
+  mapCopilotApiModel,
+  mapCopilotModels,
+  resolveInputModalities,
+  resolveTransportApiFromEndpoints,
+} from "./models-mapping.js";
+
+function makeApiModel(overrides: Partial<CopilotApiModel> = {}): CopilotApiModel {
+  return {
+    id: "test-model",
+    name: "Test Model",
+    version: "test-model",
+    vendor: "Test",
+    ...overrides,
+  };
+}
+
+describe("resolveTransportApiFromEndpoints", () => {
+  it("returns anthropic-messages for /v1/messages endpoint", () => {
+    expect(resolveTransportApiFromEndpoints("claude-sonnet-4.6", ["/v1/messages", "/chat/completions"]))
+      .toBe("anthropic-messages");
+  });
+
+  it("returns openai-responses for /responses endpoint", () => {
+    expect(resolveTransportApiFromEndpoints("gpt-5.4", ["/responses", "/chat/completions"]))
+      .toBe("openai-responses");
+  });
+
+  it("returns openai-completions for only /chat/completions", () => {
+    expect(resolveTransportApiFromEndpoints("gemini-3-flash", ["/chat/completions"]))
+      .toBe("openai-completions");
+  });
+
+  it("falls back to heuristic for claude models without endpoints", () => {
+    expect(resolveTransportApiFromEndpoints("claude-opus-4.7", []))
+      .toBe("anthropic-messages");
+  });
+
+  it("falls back to openai-responses for non-claude models without endpoints", () => {
+    expect(resolveTransportApiFromEndpoints("gpt-4o", []))
+      .toBe("openai-responses");
+  });
+
+  it("prefers /v1/messages over /responses when both present", () => {
+    expect(resolveTransportApiFromEndpoints("claude-sonnet-4.6", ["/v1/messages", "/responses"]))
+      .toBe("anthropic-messages");
+  });
+});
+
+describe("isReasoningModel", () => {
+  it("identifies codex models as reasoning", () => {
+    expect(isReasoningModel(makeApiModel({ id: "gpt-5.2-codex" }))).toBe(true);
+    expect(isReasoningModel(makeApiModel({ id: "gpt-5.3-codex" }))).toBe(true);
+  });
+
+  it("identifies o-series models as reasoning", () => {
+    expect(isReasoningModel(makeApiModel({ id: "o1" }))).toBe(true);
+    expect(isReasoningModel(makeApiModel({ id: "o3-mini" }))).toBe(true);
+  });
+
+  it("identifies models with xhigh reasoning_effort as reasoning", () => {
+    expect(isReasoningModel(makeApiModel({
+      id: "gpt-5.4",
+      capabilities: { supports: { reasoning_effort: ["low", "medium", "high", "xhigh"] } },
+    }))).toBe(true);
+  });
+
+  it("does not flag claude as reasoning", () => {
+    expect(isReasoningModel(makeApiModel({
+      id: "claude-opus-4.6",
+      capabilities: { supports: { reasoning_effort: ["low", "medium", "high"] } },
+    }))).toBe(false);
+  });
+
+  it("does not flag standard gpt as reasoning", () => {
+    expect(isReasoningModel(makeApiModel({ id: "gpt-4o" }))).toBe(false);
+  });
+});
+
+describe("resolveInputModalities", () => {
+  it("includes image for vision models", () => {
+    expect(resolveInputModalities(makeApiModel({
+      capabilities: { supports: { vision: true } },
+    }))).toEqual(["text", "image"]);
+  });
+
+  it("includes image when vision limits exist", () => {
+    expect(resolveInputModalities(makeApiModel({
+      capabilities: { limits: { vision: { max_prompt_images: 5 } } },
+    }))).toEqual(["text", "image"]);
+  });
+
+  it("returns text only for non-vision models", () => {
+    expect(resolveInputModalities(makeApiModel({
+      capabilities: { supports: { vision: false } },
+    }))).toEqual(["text"]);
+  });
+});
+
+describe("isUserFacingModel", () => {
+  it("filters out router models", () => {
+    expect(isUserFacingModel(makeApiModel({ id: "accounts/msft/routers/abc123" }))).toBe(false);
+  });
+
+  it("filters out embedding models by capability type", () => {
+    expect(isUserFacingModel(makeApiModel({
+      id: "text-embedding-3-small",
+      capabilities: { type: "embeddings" } as CopilotApiModel["capabilities"],
+    }))).toBe(false);
+  });
+
+  it("keeps regular chat models", () => {
+    expect(isUserFacingModel(makeApiModel({ id: "claude-opus-4.6" }))).toBe(true);
+  });
+});
+
+describe("deduplicateModels", () => {
+  it("keeps the entry with more capabilities", () => {
+    const models = [
+      makeApiModel({ id: "gpt-4o", capabilities: { supports: { streaming: true } } }),
+      makeApiModel({ id: "gpt-4o", capabilities: { supports: { streaming: true, vision: true, tool_calls: true } } }),
+    ];
+    const result = deduplicateModels(models);
+    expect(result).toHaveLength(1);
+    expect(result[0].capabilities?.supports?.vision).toBe(true);
+  });
+
+  it("preserves unique models", () => {
+    const models = [
+      makeApiModel({ id: "claude-opus-4.6" }),
+      makeApiModel({ id: "gpt-4o" }),
+    ];
+    expect(deduplicateModels(models)).toHaveLength(2);
+  });
+});
+
+describe("mapCopilotApiModel", () => {
+  it("maps context window and max tokens from API", () => {
+    const result = mapCopilotApiModel(makeApiModel({
+      id: "claude-opus-4.6-1m",
+      capabilities: {
+        limits: {
+          max_context_window_tokens: 1_000_000,
+          max_output_tokens: 64_000,
+        },
+      },
+    }));
+    expect(result.contextWindow).toBe(1_000_000);
+    expect(result.maxTokens).toBe(64_000);
+  });
+
+  it("uses defaults when API has no limits", () => {
+    const result = mapCopilotApiModel(makeApiModel({ id: "test" }));
+    expect(result.contextWindow).toBe(128_000);
+    expect(result.maxTokens).toBe(8_192);
+  });
+
+  it("preserves copilot capabilities metadata", () => {
+    const result = mapCopilotApiModel(makeApiModel({
+      id: "claude-opus-4.6",
+      capabilities: {
+        supports: {
+          adaptive_thinking: true,
+          max_thinking_budget: 32000,
+          min_thinking_budget: 1024,
+          reasoning_effort: ["low", "medium", "high"],
+          tool_calls: true,
+          streaming: true,
+        },
+      },
+    }));
+    expect(result._copilotCapabilities?.adaptiveThinking).toBe(true);
+    expect(result._copilotCapabilities?.maxThinkingBudget).toBe(32000);
+    expect(result._copilotCapabilities?.reasoningEffort).toEqual(["low", "medium", "high"]);
+  });
+
+  it("sets zero cost for all models", () => {
+    const result = mapCopilotApiModel(makeApiModel({ id: "test" }));
+    expect(result.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it("sets supportedReasoningEfforts in compat from API", () => {
+    const result = mapCopilotApiModel(makeApiModel({
+      id: "gpt-5.4",
+      capabilities: {
+        supports: { reasoning_effort: ["low", "medium", "high", "xhigh"] },
+      },
+    }));
+    expect(result.compat?.supportedReasoningEfforts).toEqual(["low", "medium", "high", "xhigh"]);
+  });
+
+  it("omits compat when model has no special flags", () => {
+    const result = mapCopilotApiModel(makeApiModel({
+      id: "test",
+      capabilities: { supports: { tool_calls: true, streaming: true } },
+    }));
+    expect(result.compat).toBeUndefined();
+  });
+});
+
+describe("mapCopilotModels", () => {
+  it("filters out embedding and router models", () => {
+    const models = [
+      makeApiModel({ id: "claude-opus-4.6", capabilities: { supports: { vision: true } } }),
+      makeApiModel({ id: "text-embedding-3-small", type: "embeddings" }),
+      makeApiModel({ id: "accounts/msft/routers/abc", vendor: "Fireworks" }),
+    ];
+    const result = mapCopilotModels(models);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("claude-opus-4.6");
+  });
+});

--- a/extensions/github-copilot/models-mapping.ts
+++ b/extensions/github-copilot/models-mapping.ts
@@ -1,0 +1,246 @@
+/**
+ * Map Copilot /models API response to OpenClaw model definitions.
+ *
+ * This module converts the raw Copilot API model capabilities into
+ * OpenClaw's ModelDefinitionConfig format, replacing the hardcoded
+ * MODEL_LIMITS table with live API data.
+ */
+
+import type { ModelApi } from "openclaw/plugin-sdk/provider-model-shared";
+import type { CopilotApiModel } from "./models-api.js";
+
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 8_192;
+
+/**
+ * Resolve OpenClaw transport API from Copilot supported_endpoints.
+ *
+ * Priority:
+ * 1. `/v1/messages` → anthropic-messages (Claude native)
+ * 2. `/responses` → openai-responses (GPT native)
+ * 3. `/chat/completions` → openai-completions (fallback)
+ * 4. Heuristic by model name
+ */
+export function resolveTransportApiFromEndpoints(
+  modelId: string,
+  endpoints?: string[],
+): ModelApi {
+  if (endpoints && endpoints.length > 0) {
+    // Prefer native transports
+    if (endpoints.includes("/v1/messages")) {
+      return "anthropic-messages";
+    }
+    if (endpoints.includes("/responses")) {
+      return "openai-responses";
+    }
+    if (endpoints.includes("/chat/completions")) {
+      return "openai-completions";
+    }
+  }
+  // Heuristic fallback
+  const lower = modelId.toLowerCase();
+  if (lower.includes("claude")) {
+    return "anthropic-messages";
+  }
+  return "openai-responses";
+}
+
+/**
+ * Determine the `reasoning` flag from API capabilities.
+ *
+ * A model is considered a "reasoning model" if it has reasoning_effort
+ * entries beyond just "medium" (the default). Models with xhigh or
+ * codex-style models are clearly reasoning models.
+ */
+export function isReasoningModel(model: CopilotApiModel): boolean {
+  const id = model.id.toLowerCase();
+  // Codex models are reasoning models
+  if (/(?:^|[-_.])codex(?:$|[-_.])/.test(id)) {
+    return true;
+  }
+  // o-series models (o1, o3, etc) are reasoning models
+  if (/^o\d/.test(id)) {
+    return true;
+  }
+  const effort = model.capabilities?.supports?.reasoning_effort;
+  if (effort && effort.includes("xhigh")) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Determine input modalities from API capabilities.
+ */
+export function resolveInputModalities(
+  model: CopilotApiModel,
+): Array<"text" | "image"> {
+  if (model.capabilities?.supports?.vision) {
+    return ["text", "image"];
+  }
+  // Also check if vision limits exist (some models may not set supports.vision but have vision limits)
+  if (model.capabilities?.limits?.vision) {
+    return ["text", "image"];
+  }
+  return ["text"];
+}
+
+/**
+ * Filter out internal/router models that aren't useful for end users.
+ */
+export function isUserFacingModel(model: CopilotApiModel): boolean {
+  const id = model.id;
+  // Skip router-based models (internal Microsoft routing)
+  if (id.startsWith("accounts/")) {
+    return false;
+  }
+  // Skip embedding models
+  if (model.capabilities?.type === "embeddings" || model.type === "embeddings") {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Deduplicate models by ID, preferring the entry with more capabilities.
+ *
+ * The Copilot API sometimes returns duplicate entries for the same model
+ * (e.g. multiple gpt-4o with different versions). Keep the one with the
+ * most useful capabilities.
+ */
+export function deduplicateModels(models: CopilotApiModel[]): CopilotApiModel[] {
+  const seen = new Map<string, CopilotApiModel>();
+  for (const model of models) {
+    const existing = seen.get(model.id);
+    if (!existing) {
+      seen.set(model.id, model);
+      continue;
+    }
+    // Prefer the entry with more capabilities
+    const existingScore = modelCapabilityScore(existing);
+    const newScore = modelCapabilityScore(model);
+    if (newScore > existingScore) {
+      seen.set(model.id, model);
+    }
+  }
+  return [...seen.values()];
+}
+
+function modelCapabilityScore(model: CopilotApiModel): number {
+  let score = 0;
+  const supports = model.capabilities?.supports;
+  if (supports?.vision) {
+    score += 1;
+  }
+  if (supports?.tool_calls) {
+    score += 1;
+  }
+  if (supports?.streaming) {
+    score += 1;
+  }
+  if (supports?.adaptive_thinking) {
+    score += 1;
+  }
+  if (supports?.reasoning_effort?.length) {
+    score += supports.reasoning_effort.length;
+  }
+  const limits = model.capabilities?.limits;
+  if (limits?.max_context_window_tokens) {
+    score += 1;
+  }
+  if (limits?.max_output_tokens) {
+    score += 1;
+  }
+  if (model.supported_endpoints?.length) {
+    score += model.supported_endpoints.length;
+  }
+  return score;
+}
+
+export interface CopilotModelCapabilities {
+  adaptiveThinking?: boolean;
+  maxThinkingBudget?: number;
+  minThinkingBudget?: number;
+  reasoningEffort?: string[];
+  toolCalls?: boolean;
+  streaming?: boolean;
+  parallelToolCalls?: boolean;
+  structuredOutputs?: boolean;
+}
+
+export interface MappedCopilotModel {
+  id: string;
+  name: string;
+  api: ModelApi;
+  contextWindow: number;
+  maxTokens: number;
+  reasoning: boolean;
+  input: Array<"text" | "image">;
+  cost: { input: 0; output: 0; cacheRead: 0; cacheWrite: 0 };
+  compat?: {
+    supportsTools?: boolean;
+    supportedReasoningEfforts?: string[];
+  };
+}
+
+/** Extended result with capability metadata for thinking profile resolution. */
+export interface MappedCopilotModelWithCapabilities extends MappedCopilotModel {
+  _copilotCapabilities?: CopilotModelCapabilities;
+}
+
+/**
+ * Map a single Copilot API model to an OpenClaw model definition.
+ */
+export function mapCopilotApiModel(model: CopilotApiModel): MappedCopilotModelWithCapabilities {
+  const api = resolveTransportApiFromEndpoints(model.id, model.supported_endpoints);
+  const limits = model.capabilities?.limits;
+  const supports = model.capabilities?.supports;
+
+  // Build compat config from API capabilities
+  const compat: MappedCopilotModel["compat"] = {};
+  if (supports?.tool_calls === false) {
+    compat.supportsTools = false;
+  }
+  if (supports?.reasoning_effort && supports.reasoning_effort.length > 0) {
+    compat.supportedReasoningEfforts = supports.reasoning_effort;
+  }
+
+  return {
+    id: model.id,
+    name: model.name || model.id,
+    api,
+    contextWindow: limits?.max_context_window_tokens ?? DEFAULT_CONTEXT_WINDOW,
+    maxTokens: limits?.max_output_tokens ?? DEFAULT_MAX_TOKENS,
+    reasoning: isReasoningModel(model),
+    input: resolveInputModalities(model),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ...(Object.keys(compat).length > 0 ? { compat } : {}),
+    // Only attach capabilities when the API provided meaningful data;
+    // an all-undefined object would mislead the thinking profile resolver.
+    ...(supports
+      ? {
+          _copilotCapabilities: {
+            adaptiveThinking: supports.adaptive_thinking,
+            maxThinkingBudget: supports.max_thinking_budget,
+            minThinkingBudget: supports.min_thinking_budget,
+            reasoningEffort: supports.reasoning_effort,
+            toolCalls: supports.tool_calls,
+            streaming: supports.streaming,
+            parallelToolCalls: supports.parallel_tool_calls,
+            structuredOutputs: supports.structured_outputs,
+          },
+        }
+      : {}),
+  };
+}
+
+/**
+ * Process the full Copilot API model list into OpenClaw model definitions.
+ *
+ * Filters out internal/embedding models, deduplicates, and maps capabilities.
+ */
+export function mapCopilotModels(apiModels: CopilotApiModel[]): MappedCopilotModelWithCapabilities[] {
+  const userFacing = apiModels.filter(isUserFacingModel);
+  const deduped = deduplicateModels(userFacing);
+  return deduped.map(mapCopilotApiModel);
+}

--- a/extensions/github-copilot/thinking.test.ts
+++ b/extensions/github-copilot/thinking.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { resolveThinkingProfileFromCapabilities } from "./thinking.js";
+
+describe("resolveThinkingProfileFromCapabilities", () => {
+  it("returns default levels when no capabilities provided", () => {
+    const profile = resolveThinkingProfileFromCapabilities(undefined);
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toContain("off");
+    expect(ids).toContain("medium");
+    expect(ids).toContain("high");
+  });
+
+  it("maps reasoning_effort levels to thinking levels", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      reasoningEffort: ["low", "medium", "high", "xhigh"],
+    });
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toContain("off");
+    expect(ids).toContain("minimal");
+    expect(ids).toContain("low");
+    expect(ids).toContain("medium");
+    expect(ids).toContain("high");
+    expect(ids).toContain("xhigh");
+  });
+
+  it("adds adaptive level for models with adaptive_thinking", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      adaptiveThinking: true,
+      reasoningEffort: ["low", "medium", "high"],
+    });
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toContain("adaptive");
+  });
+
+  it("does not add adaptive for non-adaptive models", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      adaptiveThinking: false,
+      reasoningEffort: ["low", "medium", "high"],
+    });
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).not.toContain("adaptive");
+  });
+
+  it("maps 'none' reasoning effort to 'off'", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      reasoningEffort: ["none", "low", "medium", "high"],
+    });
+    const ids = profile.levels.map((l) => l.id);
+    // "none" maps to "off" which is already in the base levels
+    expect(ids.filter((id) => id === "off")).toHaveLength(1);
+  });
+
+  it("sorts levels by rank", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      adaptiveThinking: true,
+      reasoningEffort: ["high", "low", "medium", "xhigh"],
+    });
+    const ranks = profile.levels.map((l) => l.rank ?? 0);
+    for (let i = 1; i < ranks.length; i++) {
+      expect(ranks[i]).toBeGreaterThanOrEqual(ranks[i - 1]);
+    }
+  });
+
+  it("handles models with only thinking budget and no reasoning_effort", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      maxThinkingBudget: 32000,
+      minThinkingBudget: 256,
+    });
+    // Should return default levels since no reasoning_effort
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toContain("off");
+    expect(ids).toContain("medium");
+  });
+
+  it("handles Claude-style capabilities", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      adaptiveThinking: true,
+      maxThinkingBudget: 32000,
+      minThinkingBudget: 1024,
+      reasoningEffort: ["low", "medium", "high"],
+      toolCalls: true,
+      streaming: true,
+    });
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toEqual(["off", "minimal", "low", "medium", "high", "adaptive"]);
+  });
+
+  it("handles GPT-5.4 style capabilities with xhigh", () => {
+    const profile = resolveThinkingProfileFromCapabilities({
+      reasoningEffort: ["low", "medium", "high", "xhigh"],
+      toolCalls: true,
+      streaming: true,
+    });
+    const ids = profile.levels.map((l) => l.id);
+    expect(ids).toEqual(["off", "minimal", "low", "medium", "high", "xhigh"]);
+  });
+});

--- a/extensions/github-copilot/thinking.ts
+++ b/extensions/github-copilot/thinking.ts
@@ -1,0 +1,117 @@
+/**
+ * Resolve Copilot thinking profile from API-provided capabilities.
+ *
+ * Maps the Copilot /models API capability fields to OpenClaw's
+ * ProviderThinkingProfile structure, supporting:
+ * - `adaptive_thinking` → enables adaptive/extended thinking
+ * - `reasoning_effort` → available thinking levels
+ * - `max_thinking_budget` / `min_thinking_budget` → budget constraints
+ */
+
+import type { ProviderThinkingProfile } from "openclaw/plugin-sdk/plugin-entry";
+import type { CopilotModelCapabilities } from "./models-mapping.js";
+
+// Inline from ProviderThinkingLevel since it's not exported from plugin-sdk
+type ThinkingLevelId =
+  | "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "max";
+type ThinkingLevel = { id: ThinkingLevelId; label?: string; rank?: number };
+
+/**
+ * Canonical ordering of thinking levels from lowest to highest.
+ */
+const LEVEL_RANK: Record<string, number> = {
+  off: 0,
+  none: 0,
+  minimal: 1,
+  low: 2,
+  medium: 3,
+  high: 4,
+  xhigh: 5,
+  adaptive: 6,
+  max: 7,
+};
+
+/**
+ * Map a Copilot reasoning_effort level to an OpenClaw thinking level id.
+ */
+function mapReasoningEffortLevel(
+  level: string,
+): ThinkingLevelId | null {
+  const lower = level.toLowerCase();
+  switch (lower) {
+    case "none":
+      return "off";
+    case "low":
+      return "low";
+    case "medium":
+      return "medium";
+    case "high":
+      return "high";
+    case "xhigh":
+      return "xhigh";
+    default:
+      return null;
+  }
+}
+
+/**
+ * Build a thinking profile from Copilot API capabilities.
+ *
+ * When capabilities are unavailable (API fetch failed), returns a
+ * basic default profile.
+ */
+export function resolveThinkingProfileFromCapabilities(
+  capabilities: CopilotModelCapabilities | undefined,
+): ProviderThinkingProfile {
+  // Default profile when no API data is available
+  if (!capabilities) {
+    return {
+      levels: [
+        { id: "off", rank: 0 },
+        { id: "minimal", rank: 1 },
+        { id: "low", rank: 2 },
+        { id: "medium", rank: 3 },
+        { id: "high", rank: 4 },
+      ],
+    };
+  }
+
+  const levels: ThinkingLevel[] = [{ id: "off", rank: 0 }];
+
+  // Add levels from reasoning_effort
+  const effortLevels = capabilities.reasoningEffort;
+  if (effortLevels && effortLevels.length > 0) {
+    // Always include minimal since OpenClaw uses it as the minimum "thinking on" level
+    levels.push({ id: "minimal", rank: 1 });
+
+    for (const level of effortLevels) {
+      const mapped = mapReasoningEffortLevel(level);
+      if (mapped && mapped !== "off") {
+        // Avoid duplicates
+        if (!levels.some((l) => l.id === mapped)) {
+          levels.push({ id: mapped, rank: LEVEL_RANK[mapped] ?? 3 });
+        }
+      }
+    }
+  } else {
+    // No reasoning_effort reported — provide basic levels
+    levels.push(
+      { id: "minimal", rank: 1 },
+      { id: "low", rank: 2 },
+      { id: "medium", rank: 3 },
+      { id: "high", rank: 4 },
+    );
+  }
+
+  // If model supports adaptive thinking (Claude), add adaptive level
+  if (capabilities.adaptiveThinking) {
+    if (!levels.some((l) => l.id === "adaptive")) {
+      levels.push({ id: "adaptive", rank: 6 });
+    }
+  }
+
+  // Sort by rank
+  levels.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+
+  return { levels };
+}

--- a/src/plugin-sdk/facade-activation-check.runtime.ts
+++ b/src/plugin-sdk/facade-activation-check.runtime.ts
@@ -94,7 +94,7 @@ function getFacadeManifestRegistry(params: {
 }): readonly PluginManifestRecord[] {
   return loadPluginManifestRegistry({
     config: getFacadeBoundaryResolvedConfig().config,
-    ...(params.env ? { env: params.env } : {}),
+    env: params.env,
   }).plugins;
 }
 
@@ -104,9 +104,7 @@ export function resolveRegistryPluginModuleLocation(params: {
   resolutionKey: string;
   env?: NodeJS.ProcessEnv;
 }): FacadeModuleLocation | null {
-  const registry = getFacadeManifestRegistry({
-    ...(params.env ? { env: params.env } : {}),
-  });
+  const registry = getFacadeManifestRegistry({ env: params.env });
   return resolveRegistryPluginModuleLocationFromRecords({
     registry,
     dirName: params.dirName,
@@ -208,9 +206,7 @@ function resolveBundledPluginManifestRecord(params: {
     return metadataRecord;
   }
 
-  const registry = getFacadeManifestRegistry({
-    ...(params.env ? { env: params.env } : {}),
-  });
+  const registry = getFacadeManifestRegistry({ env: params.env });
   const resolved =
     (params.location
       ? registry.find((plugin) => {

--- a/src/plugin-sdk/qa-runner-runtime.ts
+++ b/src/plugin-sdk/qa-runner-runtime.ts
@@ -91,7 +91,7 @@ function listDeclaredQaRunnerPlugins(
     qaRunners: NonNullable<PluginManifestRecord["qaRunners"]>;
   }
 > {
-  return loadPluginManifestRegistry({ ...(env ? { env } : {}) })
+  return loadPluginManifestRegistry(env ? { env } : {})
     .plugins.filter(
       (
         plugin,

--- a/src/plugins/web-search-providers.runtime.test.ts
+++ b/src/plugins/web-search-providers.runtime.test.ts
@@ -4,7 +4,6 @@ type RegistryModule = typeof import("./registry.js");
 type RuntimeModule = typeof import("./runtime.js");
 type WebSearchProvidersRuntimeModule = typeof import("./web-search-providers.runtime.js");
 type ManifestRegistryModule = typeof import("./manifest-registry.js");
-type InstalledManifestRegistryModule = typeof import("./manifest-registry-installed.js");
 type PluginAutoEnableModule = typeof import("../config/plugin-auto-enable.js");
 type WebSearchProvidersSharedModule = typeof import("./web-search-providers.shared.js");
 


### PR DESCRIPTION
## Summary

- Problem: The Copilot extension uses a static model table with conservative defaults (128K context, 8K max output). Models like `gpt-5.5` (400K context, 128K output) or `claude-opus-4.7` (200K context, 32K output) are either capped incorrectly or missing entirely. Thinking levels (e.g. `xhigh`) are hardcoded to a fixed list of model IDs.
- Why it matters: Users get wrong context window limits, missing models in `/models list`, and incorrect thinking level options — all of which degrade the Copilot experience without any visible error.
- What changed: Fetch the model list from the Copilot `/models` API at runtime. Three hooks (`catalog.run`, `augmentModelCatalog`, `prepareDynamicModel`) cooperate to populate capability-aware model definitions. A shared `fetchAndCacheModels` helper with in-flight deduplication ensures the API is called at most once per gateway lifecycle.
- What did NOT change (scope boundary): Auth flows, stream wrappers, replay policy, embedding provider, and the `resolveDynamicModel` catch-all fallback are untouched.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A (no existing issue)

## Root Cause (if applicable)

N/A — this is a new feature.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/github-copilot/models-mapping.test.ts`, `extensions/github-copilot/thinking.test.ts`
- Scenario the test should lock in: API response mapping (transport API resolution, vision detection, reasoning flag, deduplication, filtering) and thinking profile generation from API capabilities.
- Why this is the smallest reliable guardrail: The mapping logic is pure functions with no I/O — unit tests cover all edge cases. The fetch + caching layer relies on existing Copilot token infrastructure already covered by contract tests.
- If no new test is added, why not: 35 new tests added.

## User-visible / Behavior Changes

- `/models list github-copilot` now shows all models available on the user's Copilot plan (fetched from API), not just a hardcoded subset.
- Context window and max output tokens are accurate per-model instead of a flat 128K/8K default.
- Thinking levels (`xhigh`, `adaptive`) are determined from API capabilities instead of a hardcoded model ID list.
- Vision support is set per-model based on API data.

## Diagram (if applicable)

```text
Before:
[startup] -> hardcoded DEFAULT_MODEL_IDS -> models: [] in catalog -> resolveDynamicModel fallback (128K/8K defaults)

After:
[startup] -> catalog.run / augmentModelCatalog -> fetchAndCacheModels -> Copilot /models API
           -> accurate contextWindow, maxTokens, vision, thinking per model
[first model use] -> prepareDynamicModel -> fetchAndCacheModels (if not already cached)
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — reuses existing `resolveCopilotApiToken` infrastructure
- New/changed network calls? Yes — one new GET request to `{copilotBaseUrl}/models` during startup
  - Risk: API token is sent in Authorization header to the same Copilot API endpoint already used for chat completions and embeddings. No new trust boundary.
  - Mitigation: 30s timeout, graceful fallback to empty model list on failure.
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: Node.js v24.14.0
- Model/provider: GitHub Copilot (device login auth profile)
- Integration/channel: Telegram
- Relevant config: `plugins.entries.github-copilot.enabled: true`, auth via device login profile (no env vars)

### Steps

1. Configure GitHub Copilot via device login (`openclaw doctor`)
2. Start gateway
3. Run `/models list github-copilot`

### Expected

All models from the user's Copilot plan are listed with accurate context windows and capabilities.

### Actual

Before: Only hardcoded default models shown (10 models, all with 128K context).
After: All API-returned models shown (e.g. 20+ models with correct per-model limits).

## Evidence

- 35 new unit tests passing (models-mapping + thinking)
- All 91 extension tests passing
- Local gateway testing confirmed `/models list github-copilot` shows API-sourced models with correct context windows

## Human Verification (required)

- Verified scenarios: Gateway startup with device-login auth, `/models list` shows dynamic models, model switching works with correct context windows
- Edge cases checked: API timeout (falls back to empty), no auth profile (returns null), duplicate model entries (deduplicated)
- What you did **not** verify: CI/CD pipeline (relying on automated checks), non-Copilot provider interaction

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: Copilot `/models` API is unreachable or returns unexpected format
  - Mitigation: All three hooks have try/catch with graceful fallback. `resolveDynamicModel` catch-all still creates synthetic model definitions with conservative defaults. API call has 30s timeout.
- Risk: API returns models the user's plan doesn't actually support
  - Mitigation: The Copilot API already scopes the model list to the user's plan. If a model is listed but not usable, the API will return an error at request time (same as before).
