### PR TITLE
fix(gateway): exit non-zero when restarting as PID 1 in container (#73178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/restart: when running as PID 1 inside a container with no detected supervisor (Docker, Docker Swarm, Kubernetes without a parent process supervisor), restart-triggering signals now exit the entrypoint with code 75 (`EX_TEMPFAIL`) instead of spawning an unsupervised detached sibling and exiting 0. Orchestrators with `restart_policy.condition: on-failure` / `restartPolicy: OnFailure` will now relaunch the task instead of marking it complete and leaving the service stuck at 0/1 replicas. Fixes #73178.
 - Gateway/startup: keep value-option foreground starts on the gateway fast path and skip proxy bootstrap unless proxy env is configured, reducing normal gateway startup RSS and avoiding full CLI graph loading. Thanks @vincentkoc.
 - Subagents/models: persist `sessions_spawn.model` and configured subagent models as child-session model overrides before the first turn, so spawned subagents actually run on the requested provider/model instead of reverting to the target agent default. Fixes #73180. Thanks @danielzinhu99.
 - Backup: skip installed plugin `extensions/*/node_modules` dependency trees while keeping plugin manifests and source files in archives, so local backups avoid rebuildable npm payload bloat. Fixes #64144. Thanks @BrilliantWang.

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -254,6 +254,18 @@ export async function runGatewayLoop(params: {
       exitProcess(0);
       return;
     }
+    if (respawn.mode === "orchestrator") {
+      // Container PID 1 with no supervisor hint: exit non-zero so Docker /
+      // Kubernetes / Swarm `on-failure` restart policies relaunch the
+      // entrypoint instead of marking the task complete. EX_TEMPFAIL (75)
+      // signals "transient failure, please restart" without colliding with
+      // EX_USAGE (64) or generic exit 1. See #73178.
+      gatewayLog.info(
+        `restart mode: orchestrator restart (${respawn.detail ?? "pid-1 unsupervised"})`,
+      );
+      exitProcess(75);
+      return;
+    }
     if (respawn.mode === "failed") {
       await writeStabilityBundle("gateway.restart_respawn_failed");
       gatewayLog.warn(

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -27,6 +27,7 @@ const originalArgv = [...process.argv];
 const originalExecArgv = [...process.execArgv];
 const envSnapshot = captureFullEnv();
 const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+const originalPidDescriptor = Object.getOwnPropertyDescriptor(process, "pid");
 
 function setPlatform(platform: string) {
   if (!originalPlatformDescriptor) {
@@ -38,6 +39,16 @@ function setPlatform(platform: string) {
   });
 }
 
+function setPid(pid: number) {
+  if (!originalPidDescriptor) {
+    return;
+  }
+  Object.defineProperty(process, "pid", {
+    ...originalPidDescriptor,
+    value: pid,
+  });
+}
+
 afterEach(() => {
   envSnapshot.restore();
   process.argv = [...originalArgv];
@@ -46,6 +57,9 @@ afterEach(() => {
   triggerOpenClawRestartMock.mockClear();
   if (originalPlatformDescriptor) {
     Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
+  if (originalPidDescriptor) {
+    Object.defineProperty(process, "pid", originalPidDescriptor);
   }
 });
 
@@ -232,6 +246,44 @@ describe("restartGatewayProcessWithFreshPid", () => {
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("failed");
     expect(result.detail).toContain("spawn failed");
+  });
+
+  it("returns orchestrator mode when running as PID 1 without supervisor hints (#73178)", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+    setPlatform("linux");
+    setPid(1);
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("orchestrator");
+    expect(result.detail).toContain("pid-1");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("PID 1 with a supervisor hint still returns supervised, not orchestrator (#73178)", () => {
+    delete process.env.OPENCLAW_NO_RESPAWN;
+    clearSupervisorHints();
+    setPlatform("linux");
+    setPid(1);
+    process.env.OPENCLAW_SYSTEMD_UNIT = "openclaw-gateway.service";
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("supervised");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("PID 1 with OPENCLAW_NO_RESPAWN=1 still returns disabled, not orchestrator (#73178)", () => {
+    clearSupervisorHints();
+    setPlatform("linux");
+    setPid(1);
+    process.env.OPENCLAW_NO_RESPAWN = "1";
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("disabled");
+    expect(spawnMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -4,7 +4,7 @@ import { formatErrorMessage } from "./errors.js";
 import { triggerOpenClawRestart } from "./restart.js";
 import { detectRespawnSupervisor } from "./supervisor-markers.js";
 
-type RespawnMode = "spawned" | "supervised" | "disabled" | "failed";
+type RespawnMode = "spawned" | "supervised" | "disabled" | "failed" | "orchestrator";
 
 export type GatewayRespawnResult = {
   mode: RespawnMode;
@@ -36,6 +36,9 @@ function spawnDetachedGatewayProcess(): { child: ChildProcess; pid?: number } {
  * Attempt to restart this process with a fresh PID.
  * - supervised environments (launchd/systemd/schtasks): caller should exit and let supervisor restart
  * - OPENCLAW_NO_RESPAWN=1: caller should keep in-process restart behavior (tests/dev)
+ * - PID 1 in a container without a known supervisor: caller should exit non-zero
+ *   so the orchestrator (Docker/Swarm/Kubernetes) restarts the entrypoint task
+ *   rather than seeing a clean exit and marking the task complete (#73178).
  * - otherwise: spawn detached child with current argv/execArgv, then caller exits
  */
 export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
@@ -64,6 +67,18 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     return {
       mode: "disabled",
       detail: "win32: detached respawn unsupported without Scheduled Task markers",
+    };
+  }
+  if (process.pid === 1) {
+    // Inside a container with no supervisor hint, PID 1 *is* the orchestrator's
+    // tracked process. Spawning a detached sibling and exiting clean leaves the
+    // orchestrator marking the task complete (Docker Swarm `restart_policy.
+    // condition: on-failure`, K8s `restartPolicy: OnFailure`, etc.) — the new
+    // sibling is unsupervised and the service stays at 0/1 until human
+    // intervention. Defer the restart to the orchestrator instead.
+    return {
+      mode: "orchestrator",
+      detail: "pid-1 unsupervised: orchestrator should restart entrypoint",
     };
   }
 


### PR DESCRIPTION
Fixes #73178.

## Root cause

When the gateway runs as **PID 1 inside a container with no detected supervisor** (Docker / Docker Swarm with \`restart_policy.condition: on-failure\`, Kubernetes with \`restartPolicy: OnFailure\`, etc.), the \"full process restart\" path in \`src/cli/gateway-cli/run-loop.ts\` (line 254) spawns a detached sibling Node process via \`restartGatewayProcessWithFreshPid()\` and then exits PID 1 with code 0.

The orchestrator interprets exit 0 as a successful completion and **does not restart the task**. The detached child is unsupervised by the orchestrator, the service stays at \`0/1\` replicas, and only a manual redeploy recovers. The user reports five clean \"Complete\" task shutdowns over 19 hours.

## Fix

Adopt suggested-fix option 2 from the issue: exit non-zero when intentionally restarting as PID 1 unsupervised, so \`on-failure\` policies relaunch the container.

Add a new respawn mode \`orchestrator\` that fires when **all** of:
- \`OPENCLAW_NO_RESPAWN\` is unset, AND
- no supervisor hint is present (\`detectRespawnSupervisor()\` returns null — no launchd/systemd/Windows scheduled-task markers), AND
- \`process.pid === 1\` (we are the container entrypoint).

The run-loop honors this mode by exiting with code **75** (\`EX_TEMPFAIL\` — \"transient failure, please restart\"), which:
- doesn't collide with \`EX_USAGE\` (64) or generic exit 1
- is what BSD daemons use to signal restart intent
- triggers \`on-failure\` and \`OnFailure\` restart policies

Other paths are unchanged:
- Supervised (launchd KeepAlive, systemd unit, schtasks): same behavior, exit 0.
- \`OPENCLAW_NO_RESPAWN=1\`: same behavior, in-process restart.
- Non-PID-1 unsupervised processes (host-launched node CLI): same behavior, detached spawn + exit 0.

I picked option 2 over option 1 (in-place \`execve\`) because Node has no first-class \`execve\`-style API; the workarounds (\`child_process\` + signal forwarding, or pre-loading a wrapper that calls \`execvp\` via N-API) are substantially more invasive than this surgical mode addition.

## Files

- \`src/infra/process-respawn.ts\` — new \`orchestrator\` mode + PID-1 detection guard before the spawn-detached fallback.
- \`src/cli/gateway-cli/run-loop.ts\` — handle \`mode === \"orchestrator\"\` by logging + \`exitProcess(75)\`.
- \`src/infra/process-respawn.test.ts\` — 3 new cases: PID 1 unsupervised → orchestrator mode; PID 1 + supervisor hint → still supervised; PID 1 + \`OPENCLAW_NO_RESPAWN\` → still disabled. Adds a \`setPid()\` helper following the existing \`setPlatform()\` pattern.
- \`CHANGELOG.md\`.

## Verification

- \`pnpm vitest run src/infra/process-respawn.test.ts\` → 20/20 passing (3 new + all existing).
- \`pnpm vitest run src/cli/gateway-cli/run-loop.test.ts\` → 15/15 passing (no regression).

## Operator-visible change

The startup banner will continue to show identical behavior on macOS / systemd / Windows installs. On Docker / Swarm / K8s deploys, the gateway logs:

\`\`\`
[gateway] restart mode: orchestrator restart (pid-1 unsupervised: orchestrator should restart entrypoint)
\`\`\`

…and exits 75. Existing \`restart_policy.condition: on-failure\` and \`restartPolicy: OnFailure\` configs will now relaunch the container. The README docs for \`restart_policy.condition: any\` workaround can be left in place but will no longer be load-bearing for the documented config-edit-triggers-restart flow.