### PR TITLE
fix(bluebubbles): tighten DM-vs-group routing across session route, reactions, chatGuid fallback, and short message ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles: tighten DM-vs-group routing across the outbound session route (`chat_guid:iMessage;-;...` DMs no longer classified as groups), reaction handling (drop group reactions that arrive without any chat identifier instead of synthesizing a `"group"` literal peerId), inbound `chatGuid` fallback (no longer fall back to the sender's DM chatGuid when resolving a group whose webhook omits chatGuid+chatId+chatIdentifier), and short message id resolution (carry caller chat context so a numeric short id reused after a long group conversation cannot silently resolve to a message in a different chat, with the same cross-chat guard applied to full GUIDs so retries cannot bypass it). Thanks @zqchris.
 - Agents/approvals: fail restart-interrupted sessions whose transcript tail is still `approval-pending` instead of replaying stale exec approval IDs into the new Gateway process after restart. Fixes #65486. Thanks @mjmai20682068-create.
 - CLI/Gateway: use method-specific least-privilege scopes for classified CLI Gateway calls while preserving legacy broad scopes for unclassified plugin methods, so read-only commands no longer create admin/write/pairing scope-upgrade prompts. Fixes #68634. Thanks @nightmusher.
 - Gateway/sessions: align `chat.history` and `sessions.list` thinking defaults with owning-agent and catalog-aware resolution so Control UI session defaults match backend runtime state. (#63418) Thanks @jpreagan.

--- a/extensions/bluebubbles/src/actions.test.ts
+++ b/extensions/bluebubbles/src/actions.test.ts
@@ -530,7 +530,15 @@ describe("bluebubblesMessageActions", () => {
         accountId: null,
       });
 
-      expect(resolveBlueBubblesMessageId).toHaveBeenCalledWith("1", { requireKnownShortId: true });
+      expect(resolveBlueBubblesMessageId).toHaveBeenCalledWith(
+        "1",
+        expect.objectContaining({
+          requireKnownShortId: true,
+          chatContext: expect.objectContaining({
+            chatGuid: "iMessage;-;+15551234567",
+          }),
+        }),
+      );
       expect(sendBlueBubblesReaction).toHaveBeenCalledWith(
         expect.objectContaining({
           messageGuid: "resolved-uuid",

--- a/extensions/bluebubbles/src/actions.ts
+++ b/extensions/bluebubbles/src/actions.ts
@@ -17,9 +17,11 @@ import {
   type ChannelMessageActionAdapter,
   type ChannelMessageActionName,
 } from "./actions-api.js";
+import type { BlueBubblesChatContext } from "./monitor-reply-cache.js";
 import { getCachedBlueBubblesPrivateApiStatus, isMacOS26OrHigher } from "./probe.js";
 import { normalizeSecretInputString } from "./secret-input.js";
 import {
+  buildBlueBubblesChatContextFromTarget,
   normalizeBlueBubblesHandle,
   normalizeBlueBubblesMessagingTarget,
   parseBlueBubblesTarget,
@@ -48,6 +50,32 @@ function mapTarget(raw: string): BlueBubblesSendTarget {
     kind: "handle",
     address: normalizeBlueBubblesHandle(parsed.to),
     service: parsed.service,
+  };
+}
+
+/**
+ * Collect any chat-identifying hints the action caller supplied, so short
+ * message id resolution can reject cross-chat collisions. The order of
+ * precedence mirrors resolveChatGuid: explicit chat* params first, then the
+ * `to`/`target` param, then the current session channel as a last resort.
+ */
+function buildChatContextFromActionParams(params: {
+  actionParams: Record<string, unknown>;
+  currentChannelId?: string;
+}): BlueBubblesChatContext {
+  const explicitChatGuid = readStringParam(params.actionParams, "chatGuid")?.trim();
+  const explicitChatIdentifier = readStringParam(params.actionParams, "chatIdentifier")?.trim();
+  const explicitChatId = readNumberParam(params.actionParams, "chatId", { integer: true });
+  const rawTarget =
+    readStringParam(params.actionParams, "to") ??
+    readStringParam(params.actionParams, "target") ??
+    params.currentChannelId ??
+    undefined;
+  const targetContext = buildBlueBubblesChatContextFromTarget(rawTarget);
+  return {
+    chatGuid: explicitChatGuid || targetContext.chatGuid,
+    chatIdentifier: explicitChatIdentifier || targetContext.chatIdentifier,
+    chatId: typeof explicitChatId === "number" ? explicitChatId : targetContext.chatId,
   };
 }
 
@@ -201,9 +229,15 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
             "Use action=react with messageId=<message_id>, emoji=<emoji>, and to/chatGuid to identify the chat.",
         );
       }
-      // Resolve short ID (e.g., "1", "2") to full UUID
+      // Resolve short ID (e.g., "1", "2") to full UUID, scoped to the chat the
+      // caller is acting on so a short ID from a different chat cannot be
+      // silently accepted (see cross-chat guard in resolveBlueBubblesMessageId).
       const messageId = runtime.resolveBlueBubblesMessageId(rawMessageId, {
         requireKnownShortId: true,
+        chatContext: buildChatContextFromActionParams({
+          actionParams: params,
+          currentChannelId: toolContext?.currentChannelId,
+        }),
       });
       const partIndex = readNumberParam(params, "partIndex", { integer: true });
       const resolvedChatGuid = await resolveChatGuid();
@@ -248,9 +282,14 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
             `Use action=edit with messageId=<message_id>, text=<new_content>.`,
         );
       }
-      // Resolve short ID (e.g., "1", "2") to full UUID
+      // Resolve short ID (e.g., "1", "2") to full UUID, scoped to the chat
+      // the caller is acting on (cross-chat guard).
       const messageId = runtime.resolveBlueBubblesMessageId(rawMessageId, {
         requireKnownShortId: true,
+        chatContext: buildChatContextFromActionParams({
+          actionParams: params,
+          currentChannelId: toolContext?.currentChannelId,
+        }),
       });
       const partIndex = readNumberParam(params, "partIndex", { integer: true });
       const backwardsCompatMessage = readStringParam(params, "backwardsCompatMessage");
@@ -274,9 +313,14 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
             "Use action=unsend with messageId=<message_id>.",
         );
       }
-      // Resolve short ID (e.g., "1", "2") to full UUID
+      // Resolve short ID (e.g., "1", "2") to full UUID, scoped to the chat
+      // the caller is acting on (cross-chat guard).
       const messageId = runtime.resolveBlueBubblesMessageId(rawMessageId, {
         requireKnownShortId: true,
+        chatContext: buildChatContextFromActionParams({
+          actionParams: params,
+          currentChannelId: toolContext?.currentChannelId,
+        }),
       });
       const partIndex = readNumberParam(params, "partIndex", { integer: true });
 
@@ -310,9 +354,14 @@ export const bluebubblesMessageActions: ChannelMessageActionAdapter = {
             `Use action=reply with messageId=<message_id>, message=<your reply>, target=<chat_target>.`,
         );
       }
-      // Resolve short ID (e.g., "1", "2") to full UUID
+      // Resolve short ID (e.g., "1", "2") to full UUID, scoped to the chat
+      // the caller is acting on (cross-chat guard).
       const messageId = runtime.resolveBlueBubblesMessageId(rawMessageId, {
         requireKnownShortId: true,
+        chatContext: buildChatContextFromActionParams({
+          actionParams: params,
+          currentChannelId: toolContext?.currentChannelId,
+        }),
       });
       const partIndex = readNumberParam(params, "partIndex", { integer: true });
 

--- a/extensions/bluebubbles/src/channel.ts
+++ b/extensions/bluebubbles/src/channel.ts
@@ -46,6 +46,7 @@ import { blueBubblesSetupAdapter } from "./setup-core.js";
 import { blueBubblesSetupWizard } from "./setup-surface.js";
 import { collectBlueBubblesStatusIssues } from "./status-issues.js";
 import {
+  buildBlueBubblesChatContextFromTarget,
   extractHandleFromChatGuid,
   inferBlueBubblesTargetChatType,
   looksLikeBlueBubblesExplicitTargetId,
@@ -320,7 +321,10 @@ export const bluebubblesPlugin: ChannelPlugin<ResolvedBlueBubblesAccount, BlueBu
           const runtime = await loadBlueBubblesChannelRuntime();
           const rawReplyToId = normalizeOptionalString(replyToId) ?? "";
           const replyToMessageGuid = rawReplyToId
-            ? runtime.resolveBlueBubblesMessageId(rawReplyToId, { requireKnownShortId: true })
+            ? runtime.resolveBlueBubblesMessageId(rawReplyToId, {
+                requireKnownShortId: true,
+                chatContext: buildBlueBubblesChatContextFromTarget(to),
+              })
             : "";
           return await runtime.sendMessageBlueBubbles(to, text, {
             cfg: cfg,

--- a/extensions/bluebubbles/src/media-send.ts
+++ b/extensions/bluebubbles/src/media-send.ts
@@ -14,6 +14,7 @@ import { resolveBlueBubblesMessageId } from "./monitor-reply-cache.js";
 import type { OpenClawConfig } from "./runtime-api.js";
 import { getBlueBubblesRuntime } from "./runtime.js";
 import { sendMessageBlueBubbles } from "./send.js";
+import { buildBlueBubblesChatContextFromTarget } from "./targets.js";
 
 const HTTP_URL_RE = /^https?:\/\//i;
 const MB = 1024 * 1024;
@@ -268,9 +269,14 @@ export async function sendBlueBubblesMedia(params: {
     }
   }
 
-  // Resolve short ID (e.g., "5") to full UUID
+  // Resolve short ID (e.g., "5") to full UUID, scoped to `to` so a short ID
+  // tied to a message in a different chat cannot silently redirect the media
+  // reply into the wrong conversation (cross-chat guard).
   const replyToMessageGuid = replyToId?.trim()
-    ? resolveBlueBubblesMessageId(replyToId.trim(), { requireKnownShortId: true })
+    ? resolveBlueBubblesMessageId(replyToId.trim(), {
+        requireKnownShortId: true,
+        chatContext: buildBlueBubblesChatContextFromTarget(to),
+      })
     : undefined;
 
   const attachmentResult = await sendBlueBubblesAttachment({

--- a/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
+++ b/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { buildBlueBubblesInboundChatResolveTarget } from "./monitor-processing.js";
+
+describe("buildBlueBubblesInboundChatResolveTarget", () => {
+  it("uses chat_id for group inbound when chatId is present", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: 42,
+      chatIdentifier: undefined,
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({ kind: "chat_id", chatId: 42 });
+  });
+
+  it("uses chat_identifier for group inbound when chatId missing but identifier present", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: undefined,
+      chatIdentifier: "iMessage;+;chat-abc",
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({
+      kind: "chat_identifier",
+      chatIdentifier: "iMessage;+;chat-abc",
+    });
+  });
+
+  it("prefers chat_id over chat_identifier when both are present for a group", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: 7,
+      chatIdentifier: "iMessage;+;chat-abc",
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({ kind: "chat_id", chatId: 7 });
+  });
+
+  it("REFUSES sender-handle fallback for group inbound with no chat identifiers", () => {
+    // This is the candidate-4 regression: BlueBubbles webhooks for tapbacks
+    // and certain reaction/updated-message events arrive without chatGuid/
+    // chatId/chatIdentifier. Falling through to { kind: "handle",
+    // address: senderId } would resolve the sender's DM chatGuid and
+    // poison every action keyed off it (ack reaction, mark-read, outbound
+    // reply cache), making group reactions land in DMs.
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: undefined,
+      chatIdentifier: undefined,
+      senderId: "+15551234567",
+    });
+    expect(target).toBeNull();
+  });
+
+  it("treats blank chatIdentifier as missing for group inbound", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: undefined,
+      chatIdentifier: "   ",
+      senderId: "+15551234567",
+    });
+    expect(target).toBeNull();
+  });
+
+  it("treats non-finite chatId as missing for group inbound", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: Number.NaN,
+      chatIdentifier: undefined,
+      senderId: "+15551234567",
+    });
+    expect(target).toBeNull();
+  });
+
+  it("treats null chatId/chatIdentifier as missing for group inbound", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: true,
+      chatId: null,
+      chatIdentifier: null,
+      senderId: "+15551234567",
+    });
+    expect(target).toBeNull();
+  });
+
+  it("uses sender handle for DM inbound (the chat IS the conversation with that sender)", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: false,
+      chatId: undefined,
+      chatIdentifier: undefined,
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({ kind: "handle", address: "+15551234567" });
+  });
+
+  it("uses sender handle for DM inbound even when chatId is present (preserves prior behavior)", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: false,
+      chatId: 99,
+      chatIdentifier: "iMessage;-;+15551234567",
+      senderId: "+15551234567",
+    });
+    expect(target).toEqual({ kind: "handle", address: "+15551234567" });
+  });
+
+  it("returns null for DM inbound with empty senderId", () => {
+    const target = buildBlueBubblesInboundChatResolveTarget({
+      isGroup: false,
+      chatId: undefined,
+      chatIdentifier: undefined,
+      senderId: "   ",
+    });
+    expect(target).toBeNull();
+  });
+});

--- a/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
+++ b/extensions/bluebubbles/src/monitor-processing-chat-resolve.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildBlueBubblesInboundChatResolveTarget } from "./monitor-processing.js";
+import {
+  _sanitizeBlueBubblesLogValueForTest,
+  buildBlueBubblesInboundChatResolveTarget,
+} from "./monitor-processing.js";
 
 describe("buildBlueBubblesInboundChatResolveTarget", () => {
   it("uses chat_id for group inbound when chatId is present", () => {
@@ -109,5 +112,26 @@ describe("buildBlueBubblesInboundChatResolveTarget", () => {
       senderId: "   ",
     });
     expect(target).toBeNull();
+  });
+});
+
+describe("BlueBubbles monitor log sanitization", () => {
+  it("redacts BlueBubbles query auth and Authorization headers", () => {
+    const input =
+      "GET /api/v1/attachment?password=secret&guid=socket-secret&token=api-token Authorization: Bearer abc123";
+
+    const sanitized = _sanitizeBlueBubblesLogValueForTest(input);
+
+    expect(sanitized).toContain("password=<redacted>");
+    expect(sanitized).toContain("guid=<redacted>");
+    expect(sanitized).toContain("token=<redacted>");
+    expect(sanitized).toContain("Authorization: Bearer <redacted>");
+    expect(sanitized).not.toContain("secret");
+    expect(sanitized).not.toContain("api-token");
+    expect(sanitized).not.toContain("abc123");
+  });
+
+  it("strips control characters before logging", () => {
+    expect(_sanitizeBlueBubblesLogValueForTest("one\ntwo\tt\u0000hree")).toBe("one two t hree");
   });
 });

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -354,6 +354,52 @@ export function logVerbose(
   }
 }
 
+export type BlueBubblesInboundChatResolveTarget =
+  | { readonly kind: "chat_id"; readonly chatId: number }
+  | { readonly kind: "chat_identifier"; readonly chatIdentifier: string }
+  | { readonly kind: "handle"; readonly address: string };
+
+/**
+ * Builds the fallback target used to look up a chatGuid when an inbound
+ * webhook arrives without one.
+ *
+ * Critically, group inbounds that lack every chat identifier (chatGuid /
+ * chatId / chatIdentifier all missing) MUST NOT fall through to the
+ * sender's handle. Resolving a group via the sender handle yields that
+ * sender's DM chatGuid, which then poisons every downstream action keyed
+ * off it: ack reactions land in the DM, the read receipt marks the DM,
+ * and the outbound reply cache stores the wrong chat — so a later short
+ * id resolved against that cache cannot detect the cross-chat reuse and
+ * the agent's react/reply silently target the DM instead of the group.
+ *
+ * Returns null in that unresolvable group case so the caller can skip
+ * actions that need a chatGuid rather than acting on a wrong one. DMs
+ * always resolve via the sender handle (the chat is, by definition, the
+ * conversation with that handle).
+ */
+export function buildBlueBubblesInboundChatResolveTarget(params: {
+  isGroup: boolean;
+  chatId?: number | null;
+  chatIdentifier?: string | null;
+  senderId: string;
+}): BlueBubblesInboundChatResolveTarget | null {
+  if (params.isGroup) {
+    if (typeof params.chatId === "number" && Number.isFinite(params.chatId)) {
+      return { kind: "chat_id", chatId: params.chatId };
+    }
+    const trimmedIdentifier = params.chatIdentifier?.trim();
+    if (trimmedIdentifier) {
+      return { kind: "chat_identifier", chatIdentifier: trimmedIdentifier };
+    }
+    return null;
+  }
+  const trimmedSender = params.senderId.trim();
+  if (!trimmedSender) {
+    return null;
+  }
+  return { kind: "handle", address: trimmedSender };
+}
+
 function logGroupAllowlistHint(params: {
   runtime: BlueBubblesRuntimeEnv;
   reason: string;
@@ -1295,13 +1341,13 @@ async function processMessageAfterDedupe(
   });
   let chatGuidForActions = chatGuid;
   if (!chatGuidForActions && baseUrl && password) {
-    const resolveTarget =
-      isGroup && (chatId || chatIdentifier)
-        ? chatId
-          ? ({ kind: "chat_id", chatId } as const)
-          : ({ kind: "chat_identifier", chatIdentifier: chatIdentifier ?? "" } as const)
-        : ({ kind: "handle", address: message.senderId } as const);
-    if (resolveTarget.kind !== "chat_identifier" || resolveTarget.chatIdentifier) {
+    const resolveTarget = buildBlueBubblesInboundChatResolveTarget({
+      isGroup,
+      chatId,
+      chatIdentifier,
+      senderId: message.senderId,
+    });
+    if (resolveTarget) {
       chatGuidForActions =
         (await resolveChatGuidForTarget({
           baseUrl,
@@ -1309,6 +1355,12 @@ async function processMessageAfterDedupe(
           target: resolveTarget,
           allowPrivateNetwork: isPrivateNetworkOptInEnabled(account.config),
         })) ?? undefined;
+    } else {
+      logVerbose(
+        core,
+        runtime,
+        `cannot resolve chatGuid for group inbound (chatGuid/chatId/chatIdentifier all missing); senderId=${message.senderId}`,
+      );
     }
   }
 

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1909,6 +1909,26 @@ export async function processReaction(
     return;
   }
 
+  // Group reaction with no chat identifiers cannot be routed safely. The
+  // peerId fallback below would degrade to the literal string "group", and
+  // resolveBlueBubblesConversationRoute would then synthesize a session key
+  // unrelated to any real binding — worse, an isGroup=false misclassification
+  // upstream would have routed this to the sender's DM session, surfacing
+  // a group tapback inside an unrelated 1:1 transcript. Drop+log instead.
+  if (
+    reaction.isGroup &&
+    !reaction.chatGuid &&
+    reaction.chatId == null &&
+    !reaction.chatIdentifier
+  ) {
+    logVerbose(
+      core,
+      runtime,
+      `dropping group reaction with no chat identifiers (senderId=${reaction.senderId} messageId=${reaction.messageId} action=${reaction.action})`,
+    );
+    return;
+  }
+
   const dmPolicy = account.config.dmPolicy ?? "pairing";
   const groupPolicy = account.config.groupPolicy ?? "allowlist";
   const storeAllowFrom = await readStoreAllowFromForDmPolicy({

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -629,7 +629,17 @@ function buildInboundHistorySnapshot(params: {
 }
 
 function sanitizeForLog(value: unknown, maxLen = 200): string {
-  const cleaned = String(value).replace(/[\r\n\t\p{C}]/gu, " ");
+  let cleaned = String(value).replace(/[\r\n\t\p{C}]/gu, " ");
+  // Redact common secret-bearing patterns before logging. BlueBubbles uses
+  // query-string auth (`?password=...`) by default, so attachment download
+  // failures and similar errors can carry the API password in the captured
+  // request URL; other libraries occasionally surface `Authorization: Bearer …`
+  // headers in error chains. Strip both before they reach the log sink (CWE-532).
+  cleaned = cleaned.replace(
+    /([?&](?:password|token|api[_-]?key|secret)=)[^&\s"]+/gi,
+    "$1<redacted>",
+  );
+  cleaned = cleaned.replace(/(authorization\s*:\s*(?:bearer|basic)\s+)[^\s"]+/gi, "$1<redacted>");
   return cleaned.length > maxLen ? cleaned.slice(0, maxLen) + "..." : cleaned;
 }
 

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1649,9 +1649,17 @@ async function processMessageAfterDedupe(
             privateApiEnabled && typeof payload.replyToId === "string"
               ? payload.replyToId.trim()
               : "";
-          // Resolve short ID (e.g., "5") to full UUID
+          // Resolve short ID (e.g., "5") to full UUID, scoped to the chat
+          // this deliver path is already routing for (cross-chat guard).
           const replyToMessageGuid = rawReplyToId
-            ? resolveBlueBubblesMessageId(rawReplyToId, { requireKnownShortId: true })
+            ? resolveBlueBubblesMessageId(rawReplyToId, {
+                requireKnownShortId: true,
+                chatContext: {
+                  chatGuid: chatGuidForActions ?? chatGuid,
+                  chatIdentifier,
+                  chatId,
+                },
+              })
             : "";
           const mediaList = resolveOutboundMediaUrls(payload);
           if (mediaList.length > 0) {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1359,7 +1359,7 @@ async function processMessageAfterDedupe(
       logVerbose(
         core,
         runtime,
-        `cannot resolve chatGuid for group inbound (chatGuid/chatId/chatIdentifier all missing); senderId=${message.senderId}`,
+        `cannot resolve chatGuid for group inbound (chatGuid/chatId/chatIdentifier all missing); senderId=${sanitizeForLog(message.senderId)}`,
       );
     }
   }
@@ -1915,16 +1915,21 @@ export async function processReaction(
   // unrelated to any real binding — worse, an isGroup=false misclassification
   // upstream would have routed this to the sender's DM session, surfacing
   // a group tapback inside an unrelated 1:1 transcript. Drop+log instead.
+  // Treat whitespace-only chatGuid/chatIdentifier as missing — a webhook
+  // sender that supplies " " or "\t" must not be able to satisfy the guard
+  // and have peerId degrade to the literal "group" anyway.
+  const trimmedReactionChatGuid = reaction.chatGuid?.trim();
+  const trimmedReactionChatIdentifier = reaction.chatIdentifier?.trim();
   if (
     reaction.isGroup &&
-    !reaction.chatGuid &&
+    !trimmedReactionChatGuid &&
     reaction.chatId == null &&
-    !reaction.chatIdentifier
+    !trimmedReactionChatIdentifier
   ) {
     logVerbose(
       core,
       runtime,
-      `dropping group reaction with no chat identifiers (senderId=${reaction.senderId} messageId=${reaction.messageId} action=${reaction.action})`,
+      `dropping group reaction with no chat identifiers (senderId=${sanitizeForLog(reaction.senderId)} messageId=${sanitizeForLog(reaction.messageId)} action=${sanitizeForLog(reaction.action)})`,
     );
     return;
   }

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -631,17 +631,20 @@ function buildInboundHistorySnapshot(params: {
 function sanitizeForLog(value: unknown, maxLen = 200): string {
   let cleaned = String(value).replace(/[\r\n\t\p{C}]/gu, " ");
   // Redact common secret-bearing patterns before logging. BlueBubbles uses
-  // query-string auth (`?password=...`) by default, so attachment download
-  // failures and similar errors can carry the API password in the captured
-  // request URL; other libraries occasionally surface `Authorization: Bearer …`
-  // headers in error chains. Strip both before they reach the log sink (CWE-532).
+  // query-string auth (`?password=...`, `?guid=...`, or `?token=...`) by
+  // default, so attachment download failures and similar errors can carry the
+  // API password in the captured request URL; other libraries occasionally
+  // surface `Authorization: Bearer ...` headers in error chains. Strip both
+  // before they reach the log sink (CWE-532).
   cleaned = cleaned.replace(
-    /([?&](?:password|token|api[_-]?key|secret)=)[^&\s"]+/gi,
+    /([?&](?:password|guid|token|api[_-]?key|secret)=)[^&\s"]+/gi,
     "$1<redacted>",
   );
   cleaned = cleaned.replace(/(authorization\s*:\s*(?:bearer|basic)\s+)[^\s"]+/gi, "$1<redacted>");
   return cleaned.length > maxLen ? cleaned.slice(0, maxLen) + "..." : cleaned;
 }
+
+export const _sanitizeBlueBubblesLogValueForTest = sanitizeForLog;
 
 /**
  * Signal object threaded through `processMessageAfterDedupe` so the outer
@@ -810,7 +813,7 @@ async function processMessageAfterDedupe(
       logVerbose(
         core,
         runtime,
-        `attachment retry failed for msgId=${message.messageId}: ${String(err)}`,
+        `attachment retry failed for msgId=${sanitizeForLog(message.messageId)}: ${sanitizeForLog(err)}`,
       );
     }
   }
@@ -904,18 +907,22 @@ async function processMessageAfterDedupe(
   }
 
   if (isSelfChatMessage && hasBlueBubblesSelfChatCopy(selfChatLookup)) {
-    logVerbose(core, runtime, `drop: reflected self-chat duplicate sender=${message.senderId}`);
+    logVerbose(
+      core,
+      runtime,
+      `drop: reflected self-chat duplicate sender=${sanitizeForLog(message.senderId)}`,
+    );
     return;
   }
 
   if (!rawBody) {
-    logVerbose(core, runtime, `drop: empty text sender=${message.senderId}`);
+    logVerbose(core, runtime, `drop: empty text sender=${sanitizeForLog(message.senderId)}`);
     return;
   }
   logVerbose(
     core,
     runtime,
-    `msg sender=${message.senderId} group=${isGroup} textLen=${text.length} attachments=${attachments.length} chatGuid=${message.chatGuid ?? ""} chatId=${message.chatId ?? ""}`,
+    `msg sender=${sanitizeForLog(message.senderId)} group=${isGroup} textLen=${text.length} attachments=${attachments.length} chatGuid=${sanitizeForLog(message.chatGuid ?? "")} chatId=${sanitizeForLog(message.chatId ?? "")}`,
   );
 
   const dmPolicy = account.config.dmPolicy ?? "pairing";
@@ -1011,8 +1018,14 @@ async function processMessageAfterDedupe(
         senderIdLine: `Your BlueBubbles sender id: ${message.senderId}`,
         meta: { name: message.senderName },
         onCreated: () => {
-          runtime.log?.(`[bluebubbles] pairing request sender=${message.senderId} created=true`);
-          logVerbose(core, runtime, `bluebubbles pairing request sender=${message.senderId}`);
+          runtime.log?.(
+            `[bluebubbles] pairing request sender=${sanitizeForLog(message.senderId)} created=true`,
+          );
+          logVerbose(
+            core,
+            runtime,
+            `bluebubbles pairing request sender=${sanitizeForLog(message.senderId)}`,
+          );
         },
         sendPairingReply: async (text) => {
           await sendMessageBlueBubbles(message.senderId, text, {
@@ -1025,10 +1038,10 @@ async function processMessageAfterDedupe(
           logVerbose(
             core,
             runtime,
-            `bluebubbles pairing reply failed for ${message.senderId}: ${String(err)}`,
+            `bluebubbles pairing reply failed for ${sanitizeForLog(message.senderId)}: ${sanitizeForLog(err)}`,
           );
           runtime.error?.(
-            `[bluebubbles] pairing reply failed sender=${message.senderId}: ${String(err)}`,
+            `[bluebubbles] pairing reply failed sender=${sanitizeForLog(message.senderId)}: ${sanitizeForLog(err)}`,
           );
         },
       });
@@ -1159,7 +1172,7 @@ async function processMessageAfterDedupe(
       logVerbose(
         core,
         runtime,
-        `bluebubbles: participant fallback lookup failed chat=${peerId}: ${String(err)}`,
+        `bluebubbles: participant fallback lookup failed chat=${sanitizeForLog(peerId)}: ${sanitizeForLog(err)}`,
       );
     }
   }
@@ -1225,7 +1238,7 @@ async function processMessageAfterDedupe(
           logVerbose(
             core,
             runtime,
-            `attachment download failed guid=${attachment.guid} err=${String(err)}`,
+            `attachment download failed guid=${sanitizeForLog(attachment.guid)} err=${sanitizeForLog(err)}`,
           );
         }
       }
@@ -1410,7 +1423,7 @@ async function processMessageAfterDedupe(
             logVerbose(
               core,
               runtime,
-              `ack reaction failed chatGuid=${chatGuidForActions} msg=${ackMessageId}: ${String(err)}`,
+              `ack reaction failed chatGuid=${sanitizeForLog(chatGuidForActions)} msg=${sanitizeForLog(ackMessageId)}: ${sanitizeForLog(err)}`,
             );
             return false;
           },
@@ -1425,9 +1438,9 @@ async function processMessageAfterDedupe(
         cfg: config,
         accountId: account.accountId,
       });
-      logVerbose(core, runtime, `marked read chatGuid=${chatGuidForActions}`);
+      logVerbose(core, runtime, `marked read chatGuid=${sanitizeForLog(chatGuidForActions)}`);
     } catch (err) {
-      runtime.error?.(`[bluebubbles] mark read failed: ${String(err)}`);
+      runtime.error?.(`[bluebubbles] mark read failed: ${sanitizeForLog(err)}`);
     }
   } else if (!sendReadReceipts) {
     logVerbose(core, runtime, "mark read skipped (sendReadReceipts=false)");
@@ -1569,7 +1582,7 @@ async function processMessageAfterDedupe(
         logVerbose(
           core,
           runtime,
-          `history backfill failed for ${historyIdentifier}: ${String(err)} (retries left=${Math.max(remainingAttempts, 0)} next_in_ms=${nextBackoffMs})`,
+          `history backfill failed for ${sanitizeForLog(historyIdentifier)}: ${sanitizeForLog(err)} (retries left=${Math.max(remainingAttempts, 0)} next_in_ms=${nextBackoffMs})`,
         );
       }
     }
@@ -1660,7 +1673,7 @@ async function processMessageAfterDedupe(
         cfg: config,
         accountId: account.accountId,
       }).catch((err) => {
-        runtime.error?.(`[bluebubbles] typing restart failed: ${String(err)}`);
+        runtime.error?.(`[bluebubbles] typing restart failed: ${sanitizeForLog(err)}`);
       });
     }, typingRestartDelayMs);
   };
@@ -1686,7 +1699,7 @@ async function processMessageAfterDedupe(
               accountId: account.accountId,
             });
           } catch (err) {
-            runtime.error?.(`[bluebubbles] typing start failed: ${String(err)}`);
+            runtime.error?.(`[bluebubbles] typing start failed: ${sanitizeForLog(err)}`);
           }
         },
         onIdle: () => {
@@ -1848,7 +1861,7 @@ async function processMessageAfterDedupe(
           if (info.kind === "final") {
             dedupeSignal.deliveryFailed = true;
           }
-          runtime.error?.(`BlueBubbles ${info.kind} reply failed: ${String(err)}`);
+          runtime.error?.(`BlueBubbles ${info.kind} reply failed: ${sanitizeForLog(err)}`);
         },
       },
       replyOptions: {

--- a/extensions/bluebubbles/src/monitor-reply-cache.test.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.test.ts
@@ -66,21 +66,25 @@ describe("resolveBlueBubblesMessageId chat-scoped short-id guard", () => {
     ).toThrow(/different chat/);
   });
 
-  it("fails open when caller cannot supply any chat identifier", () => {
-    const entry = seedMessage({
+  it("rejects empty chat context for privileged callers (fail-closed cross-chat scope)", () => {
+    seedMessage({
       accountId: "default",
       messageId: "uuid-no-ctx",
       chatGuid: "iMessage;+;chat240698944142298252",
     });
 
-    // Empty context means "caller could not derive any chat hint" (e.g.
-    // tool invocation with only messageId). Permit resolution; downstream
-    // API will still carry whatever chatGuid the call site provides.
-    const resolved = resolveBlueBubblesMessageId(entry.shortId, {
-      requireKnownShortId: true,
-      chatContext: {},
-    });
-    expect(resolved).toBe("uuid-no-ctx");
+    // Empty context = caller could not derive any chat hint. The previous
+    // behavior (fail-open) let a short id resolve without a chat scope —
+    // but short ids are global across all chats, so an action call without
+    // chat context could silently apply to the wrong conversation. Now
+    // requireKnownShortId callers must pass at least one identifier
+    // (chatGuid / chatIdentifier / chatId).
+    expect(() =>
+      resolveBlueBubblesMessageId("1", {
+        requireKnownShortId: true,
+        chatContext: {},
+      }),
+    ).toThrow(/requires a chat scope/);
   });
 
   it("falls back to chatIdentifier comparison when the caller has no chatGuid", () => {

--- a/extensions/bluebubbles/src/monitor-reply-cache.test.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.test.ts
@@ -148,15 +148,105 @@ describe("resolveBlueBubblesMessageId chat-scoped short-id guard", () => {
     ).toThrow(/different chat/);
   });
 
-  it("accepts a full uuid input unchanged regardless of chat context", () => {
-    // Non-numeric input is treated as a full GUID already; the guard does
-    // not apply. Callers supplying the full GUID have presumably resolved
-    // the chat themselves.
+  it("passes a full uuid through unchanged when not in the reply cache", () => {
+    // Cache miss falls through. Callers supplying a GUID that the cache
+    // hasn't observed get the input back so fresh-from-the-wire GUIDs
+    // (e.g. from a `find` API call) still work.
     const resolved = resolveBlueBubblesMessageId("1E7E6B6A-0000-4C6C-BCA7-000000000001", {
       requireKnownShortId: true,
       chatContext: { chatGuid: "iMessage;+;anything" },
     });
     expect(resolved).toBe("1E7E6B6A-0000-4C6C-BCA7-000000000001");
+  });
+
+  it("passes a full uuid through unchanged when caller supplies no chat context", () => {
+    // Belt-and-braces: even when the cache knows the GUID, callers that
+    // can't supply any chat hint at all (legacy tool invocations) fall
+    // through to preserve prior behavior.
+    seedMessage({
+      accountId: "default",
+      messageId: "uuid-known",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+    expect(resolveBlueBubblesMessageId("uuid-known")).toBe("uuid-known");
+    expect(resolveBlueBubblesMessageId("uuid-known", { chatContext: {} })).toBe("uuid-known");
+  });
+
+  it("accepts a full uuid that points at a same-chat cached entry", () => {
+    seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    const resolved = resolveBlueBubblesMessageId("uuid-in-group", {
+      chatContext: { chatGuid: "iMessage;+;chat240698944142298252" },
+    });
+    expect(resolved).toBe("uuid-in-group");
+  });
+
+  it("REJECTS a full uuid that points at a different chat in the cache", () => {
+    // Candidate-1 regression: the previous implementation only ran the
+    // cross-chat guard on numeric short ids. After the short-id guard
+    // landed, agents that retried with a full GUID (because the short id
+    // got rejected) silently bypassed the check. Group GUIDs reused in
+    // DM tool calls again leaked group reactions into DMs.
+    seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    expect(() =>
+      resolveBlueBubblesMessageId("uuid-in-group", {
+        chatContext: { chatGuid: "iMessage;-;+8618621181874" },
+      }),
+    ).toThrow(/different chat/);
+  });
+
+  it("uuid-path error message hints at fixing the chat target, not the id format", () => {
+    // The short-id error tells the agent to retry with the full GUID.
+    // For UUID input that's already failed, advising "use the full GUID"
+    // would be wrong — the agent already supplied one. Make the
+    // remediation hint differ so a retrying agent is steered toward
+    // fixing the chat target.
+    seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    try {
+      resolveBlueBubblesMessageId("uuid-in-group", {
+        chatContext: { chatGuid: "iMessage;-;+8618621181874" },
+      });
+      expect.fail("expected cross-chat guard to throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain("iMessage;+;chat240698944142298252");
+      expect(message).toContain("iMessage;-;+8618621181874");
+      expect(message).toContain("correct chat target");
+      expect(message).not.toContain("Retry with the full message GUID");
+    }
+  });
+
+  it("applies the chatIdentifier fallback to full uuid input as well", () => {
+    // Same handle-only-caller scenario as the short-id case: a tool
+    // invocation might only resolve the chatIdentifier (the bare handle).
+    // The guard must catch GUID reuse across mismatched chatIdentifiers
+    // even when the caller has no chatGuid hint.
+    seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+      chatIdentifier: "chat240698944142298252",
+    });
+
+    expect(() =>
+      resolveBlueBubblesMessageId("uuid-in-group", {
+        chatContext: { chatIdentifier: "+8618621181874" },
+      }),
+    ).toThrow(/different chat/);
   });
 
   it("reports the conflicting chats in the error message for debugability", () => {

--- a/extensions/bluebubbles/src/monitor-reply-cache.test.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetBlueBubblesShortIdState,
+  rememberBlueBubblesReplyCache,
+  resolveBlueBubblesMessageId,
+} from "./monitor-reply-cache.js";
+import { buildBlueBubblesChatContextFromTarget } from "./targets.js";
+
+describe("resolveBlueBubblesMessageId chat-scoped short-id guard", () => {
+  beforeEach(() => {
+    _resetBlueBubblesShortIdState();
+  });
+
+  afterEach(() => {
+    _resetBlueBubblesShortIdState();
+  });
+
+  function seedMessage(args: {
+    accountId: string;
+    messageId: string;
+    chatGuid?: string;
+    chatIdentifier?: string;
+    chatId?: number;
+  }) {
+    return rememberBlueBubblesReplyCache({
+      accountId: args.accountId,
+      messageId: args.messageId,
+      chatGuid: args.chatGuid,
+      chatIdentifier: args.chatIdentifier,
+      chatId: args.chatId,
+      timestamp: Date.now(),
+    });
+  }
+
+  it("returns the cached uuid when the short id resolves within the same chatGuid", () => {
+    const entry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    const resolved = resolveBlueBubblesMessageId(entry.shortId, {
+      requireKnownShortId: true,
+      chatContext: { chatGuid: "iMessage;+;chat240698944142298252" },
+    });
+
+    expect(resolved).toBe("uuid-in-group");
+  });
+
+  it("throws when a short id points at a message in a different chatGuid", () => {
+    const groupEntry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    // Agent tries to react in a DM but passes a short id that was allocated
+    // for a group message. Should throw instead of silently letting BB
+    // server route the tapback to the group (or worse, to an old DM that
+    // happens to share the short id slot).
+    expect(() =>
+      resolveBlueBubblesMessageId(groupEntry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatGuid: "iMessage;-;+8618621181874" },
+      }),
+    ).toThrow(/different chat/);
+  });
+
+  it("fails open when caller cannot supply any chat identifier", () => {
+    const entry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-no-ctx",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    // Empty context means "caller could not derive any chat hint" (e.g.
+    // tool invocation with only messageId). Permit resolution; downstream
+    // API will still carry whatever chatGuid the call site provides.
+    const resolved = resolveBlueBubblesMessageId(entry.shortId, {
+      requireKnownShortId: true,
+      chatContext: {},
+    });
+    expect(resolved).toBe("uuid-no-ctx");
+  });
+
+  it("falls back to chatIdentifier comparison when the caller has no chatGuid", () => {
+    const dmEntry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-dm-1",
+      chatIdentifier: "+8618621181874",
+    });
+
+    expect(
+      resolveBlueBubblesMessageId(dmEntry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatIdentifier: "+8618621181874" },
+      }),
+    ).toBe("uuid-dm-1");
+
+    expect(() =>
+      resolveBlueBubblesMessageId(dmEntry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatIdentifier: "+8618621185125" },
+      }),
+    ).toThrow(/different chat/);
+  });
+
+  it("catches a handle-only caller against a cached entry that carries chatGuid", () => {
+    // Real-world failure mode: inbound webhooks populate cached entries with
+    // chatGuid (group or DM). A caller that only resolved a handle supplies
+    // ctx.chatIdentifier without ctx.chatGuid. The guard must still catch
+    // the mismatch so a group short-id cannot slip through when the call is
+    // for a DM, which is exactly how group reactions were leaking into DMs.
+    const groupEntry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+      chatIdentifier: "chat240698944142298252",
+    });
+
+    expect(() =>
+      resolveBlueBubblesMessageId(groupEntry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatIdentifier: "+8618621181874" },
+      }),
+    ).toThrow(/different chat/);
+  });
+
+  it("falls back to chatId comparison when neither chatGuid nor chatIdentifier is available", () => {
+    const entry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-with-id",
+      chatId: 42,
+    });
+
+    expect(
+      resolveBlueBubblesMessageId(entry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatId: 42 },
+      }),
+    ).toBe("uuid-with-id");
+
+    expect(() =>
+      resolveBlueBubblesMessageId(entry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatId: 99 },
+      }),
+    ).toThrow(/different chat/);
+  });
+
+  it("accepts a full uuid input unchanged regardless of chat context", () => {
+    // Non-numeric input is treated as a full GUID already; the guard does
+    // not apply. Callers supplying the full GUID have presumably resolved
+    // the chat themselves.
+    const resolved = resolveBlueBubblesMessageId("1E7E6B6A-0000-4C6C-BCA7-000000000001", {
+      requireKnownShortId: true,
+      chatContext: { chatGuid: "iMessage;+;anything" },
+    });
+    expect(resolved).toBe("1E7E6B6A-0000-4C6C-BCA7-000000000001");
+  });
+
+  it("reports the conflicting chats in the error message for debugability", () => {
+    const entry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-in-group",
+      chatGuid: "iMessage;+;chat240698944142298252",
+    });
+
+    try {
+      resolveBlueBubblesMessageId(entry.shortId, {
+        requireKnownShortId: true,
+        chatContext: { chatGuid: "iMessage;-;+8618621181874" },
+      });
+      expect.fail("expected cross-chat guard to throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain("iMessage;+;chat240698944142298252");
+      expect(message).toContain("iMessage;-;+8618621181874");
+      expect(message).toContain("full message GUID");
+    }
+  });
+
+  it("still throws requireKnownShortId for unknown numeric inputs", () => {
+    expect(() =>
+      resolveBlueBubblesMessageId("999", {
+        requireKnownShortId: true,
+        chatContext: { chatGuid: "iMessage;+;anything" },
+      }),
+    ).toThrow(/no longer available/);
+  });
+
+  it("accepts same-chat short ids when the caller's target uses a non-canonical handle format", () => {
+    // Real-world: a cached entry carries the BlueBubbles-normalized handle
+    // (`+15551234567`) as its chatIdentifier. A tool call like
+    // `react to: "imessage:(555) 123-4567"` has to project into the same
+    // chatIdentifier before the guard compares — otherwise the raw handle
+    // `(555) 123-4567` would fail the mismatch check against the cached
+    // `+15551234567` and legitimate same-chat reactions/replies would be
+    // blocked.
+    const dmEntry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-dm-handle",
+      chatIdentifier: "+15551234567",
+    });
+    const cachedChatIdentifier = dmEntry.chatIdentifier;
+
+    for (const target of ["imessage:+15551234567", "sms:+15551234567", "+15551234567"]) {
+      const ctx = buildBlueBubblesChatContextFromTarget(target);
+      expect(ctx.chatIdentifier, `ctx.chatIdentifier for ${target}`).toBe(cachedChatIdentifier);
+      expect(
+        resolveBlueBubblesMessageId(dmEntry.shortId, {
+          requireKnownShortId: true,
+          chatContext: ctx,
+        }),
+        `resolve for ${target}`,
+      ).toBe("uuid-dm-handle");
+    }
+
+    // Mixed-case email handle: cached as lowercase; caller supplies mixed
+    // case. Still resolves.
+    const emailEntry = seedMessage({
+      accountId: "default",
+      messageId: "uuid-email",
+      chatIdentifier: "user@example.com",
+    });
+    const emailCtx = buildBlueBubblesChatContextFromTarget("imessage:User@Example.COM");
+    expect(emailCtx.chatIdentifier).toBe("user@example.com");
+    expect(
+      resolveBlueBubblesMessageId(emailEntry.shortId, {
+        requireKnownShortId: true,
+        chatContext: emailCtx,
+      }),
+    ).toBe("uuid-email");
+  });
+});

--- a/extensions/bluebubbles/src/monitor-reply-cache.test.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.test.ts
@@ -223,8 +223,10 @@ describe("resolveBlueBubblesMessageId chat-scoped short-id guard", () => {
       expect.fail("expected cross-chat guard to throw");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      expect(message).toContain("iMessage;+;chat240698944142298252");
-      expect(message).toContain("iMessage;-;+8618621181874");
+      // Chat identifiers redacted in error message (PII / log-stream hardening).
+      expect(message).toContain("chatGuid=<redacted>");
+      expect(message).not.toContain("iMessage;+;chat240698944142298252");
+      expect(message).not.toContain("iMessage;-;+8618621181874");
       expect(message).toContain("correct chat target");
       expect(message).not.toContain("Retry with the full message GUID");
     }
@@ -264,8 +266,10 @@ describe("resolveBlueBubblesMessageId chat-scoped short-id guard", () => {
       expect.fail("expected cross-chat guard to throw");
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      expect(message).toContain("iMessage;+;chat240698944142298252");
-      expect(message).toContain("iMessage;-;+8618621181874");
+      // Chat identifiers redacted in error message (PII / log-stream hardening).
+      expect(message).toContain("chatGuid=<redacted>");
+      expect(message).not.toContain("iMessage;+;chat240698944142298252");
+      expect(message).not.toContain("iMessage;-;+8618621181874");
       expect(message).toContain("full message GUID");
     }
   });

--- a/extensions/bluebubbles/src/monitor-reply-cache.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.ts
@@ -156,6 +156,20 @@ function describeChatForError(values: {
   return parts.length === 0 ? "<unknown chat>" : parts.join(", ");
 }
 
+function describeMessageIdForError(inputId: string, inputKind: "short" | "uuid"): string {
+  // Don't reflect the raw message id back into an error message that may end
+  // up in agent transcripts / tool results / log streams. Surface only the
+  // shape (numeric short id length range, or a UUID prefix) so callers can
+  // still tell which message id they typed (CWE-117 / CWE-200).
+  if (inputKind === "short") {
+    const len = inputId.length;
+    return `<short:${len}-digit>`;
+  }
+  // For UUID input, expose just an 8-char prefix; consumer can correlate
+  // against full GUID via the trace if needed.
+  return `<uuid:${inputId.slice(0, 8)}…>`;
+}
+
 function buildCrossChatError(
   inputId: string,
   inputKind: "short" | "uuid",
@@ -167,9 +181,20 @@ function buildCrossChatError(
       ? `Retry with the full message GUID to avoid cross-chat reactions/replies landing in the wrong conversation.`
       : `Retry with the correct chat target — even the full GUID cannot be reused across chats.`;
   return new Error(
-    `BlueBubbles message id "${inputId}" belongs to a different chat ` +
+    `BlueBubbles message id ${describeMessageIdForError(inputId, inputKind)} belongs to a different chat ` +
       `(${describeChatForError(cached)}) than the current call target ` +
       `(${describeChatForError(ctx)}). ${remediation}`,
+  );
+}
+
+function hasChatScope(ctx?: BlueBubblesChatContext): boolean {
+  if (!ctx) {
+    return false;
+  }
+  return Boolean(
+    normalizeOptionalString(ctx.chatGuid) ||
+    normalizeOptionalString(ctx.chatIdentifier) ||
+    typeof ctx.chatId === "number",
   );
 }
 
@@ -199,6 +224,17 @@ export function resolveBlueBubblesMessageId(
 
   // If it looks like a short ID (numeric), try to resolve it
   if (/^\d+$/.test(trimmed)) {
+    // Privileged callers (requireKnownShortId=true) MUST scope the resolution
+    // to a chat. Without a chat scope the cross-chat guard cannot detect when
+    // the short id belongs to a different chat than the action target — short
+    // ids are allocated from a single global counter across every account and
+    // chat, so an empty `chatContext={}` would otherwise let an action operate
+    // on a message in the wrong conversation (CWE-285).
+    if (opts?.requireKnownShortId && !hasChatScope(opts.chatContext)) {
+      throw new Error(
+        `BlueBubbles short message id "${describeMessageIdForError(trimmed, "short")}" requires a chat scope (chatGuid / chatIdentifier / chatId or a --to target).`,
+      );
+    }
     const uuid = blueBubblesShortIdToUuid.get(trimmed);
     if (uuid) {
       if (opts?.chatContext) {
@@ -211,7 +247,7 @@ export function resolveBlueBubblesMessageId(
     }
     if (opts?.requireKnownShortId) {
       throw new Error(
-        `BlueBubbles short message id "${trimmed}" is no longer available. Use MessageSidFull.`,
+        `BlueBubbles short message id ${describeMessageIdForError(trimmed, "short")} is no longer available. Use MessageSidFull.`,
       );
     }
     return trimmed;

--- a/extensions/bluebubbles/src/monitor-reply-cache.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.ts
@@ -160,16 +160,37 @@ function describeChatForError(values: {
   return parts.length === 0 ? "<unknown chat>" : parts.join(", ");
 }
 
+function buildCrossChatError(
+  inputId: string,
+  inputKind: "short" | "uuid",
+  cached: BlueBubblesReplyCacheEntry,
+  ctx: BlueBubblesChatContext,
+): Error {
+  const remediation =
+    inputKind === "short"
+      ? `Retry with the full message GUID to avoid cross-chat reactions/replies landing in the wrong conversation.`
+      : `Retry with the correct chat target — even the full GUID cannot be reused across chats.`;
+  return new Error(
+    `BlueBubbles message id "${inputId}" belongs to a different chat ` +
+      `(${describeChatForError(cached)}) than the current call target ` +
+      `(${describeChatForError(ctx)}). ${remediation}`,
+  );
+}
+
 /**
  * Resolves a short message ID (e.g., "1", "2") to a full BlueBubbles GUID.
  * Returns the input unchanged if it's already a GUID or not found in the mapping.
  *
  * When `chatContext` is provided, the resolved UUID's cached chat must match
- * the caller's chat or the call throws. This prevents a short ID that points
+ * the caller's chat or the call throws. This prevents a message id that points
  * at a message in chat A from being silently reused in chat B — the common
  * symptom being tapbacks and quoted replies landing in the wrong conversation
  * (e.g. a group reaction showing up in a DM) because short IDs are allocated
  * from a single global counter across every account and chat.
+ *
+ * The guard runs on both numeric short ids AND full GUIDs: an agent can paste
+ * a GUID it harvested from history, a previous tool result, or another chat's
+ * transcript, and that path used to bypass the cross-chat check entirely.
  */
 export function resolveBlueBubblesMessageId(
   shortOrUuid: string,
@@ -187,12 +208,7 @@ export function resolveBlueBubblesMessageId(
       if (opts?.chatContext) {
         const cached = blueBubblesReplyCacheByMessageId.get(uuid);
         if (cached && isCrossChatMismatch(cached, opts.chatContext)) {
-          throw new Error(
-            `BlueBubbles short message id "${trimmed}" belongs to a different chat ` +
-              `(${describeChatForError(cached)}) than the current call target ` +
-              `(${describeChatForError(opts.chatContext)}). Retry with the full message GUID ` +
-              `to avoid cross-chat reactions/replies landing in the wrong conversation.`,
-          );
+          throw buildCrossChatError(trimmed, "short", cached, opts.chatContext);
         }
       }
       return uuid;
@@ -202,9 +218,18 @@ export function resolveBlueBubblesMessageId(
         `BlueBubbles short message id "${trimmed}" is no longer available. Use MessageSidFull.`,
       );
     }
+    return trimmed;
   }
 
-  // Return as-is (either already a UUID or not found)
+  // Full GUID input — guard still applies. Cache miss falls through to
+  // returning the input unchanged so callers that supply a fresh-from-the-wire
+  // GUID (not yet seen by reply cache) keep working.
+  if (opts?.chatContext) {
+    const cached = blueBubblesReplyCacheByMessageId.get(trimmed);
+    if (cached && isCrossChatMismatch(cached, opts.chatContext)) {
+      throw buildCrossChatError(trimmed, "uuid", cached, opts.chatContext);
+    }
+  }
   return trimmed;
 }
 

--- a/extensions/bluebubbles/src/monitor-reply-cache.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.ts
@@ -81,13 +81,99 @@ export function rememberBlueBubblesReplyCache(
   return fullEntry;
 }
 
+export type BlueBubblesChatContext = {
+  chatGuid?: string;
+  chatIdentifier?: string;
+  chatId?: number;
+};
+
+/**
+ * Cross-chat guard: compare a cached entry's chat fields with a caller-provided
+ * context. Returns true when the two clearly reference different chats.
+ *
+ * Comparison rules mirror resolveReplyContextFromCache so outbound short-ID
+ * resolution and inbound reply-context lookup agree on scope:
+ *
+ *   - If both sides carry a chatGuid and they differ, that is the strongest
+ *     signal of a cross-chat reuse.
+ *   - Otherwise, if the caller has no chatGuid but both sides carry a
+ *     chatIdentifier and they differ, that is also a mismatch. This covers
+ *     handle-only callers (tapback into a DM where the caller only resolved
+ *     a handle) against cached entries that still carry chatGuid from the
+ *     inbound webhook.
+ *   - Otherwise, if the caller has neither chatGuid nor chatIdentifier but
+ *     both sides carry a chatId and they differ, that is also a mismatch.
+ *
+ * Absent identifiers on either side are treated as "no information" rather
+ * than a mismatch, so ambiguous calls fall through as-is.
+ */
+function isCrossChatMismatch(
+  cached: BlueBubblesReplyCacheEntry,
+  ctx: BlueBubblesChatContext,
+): boolean {
+  const cachedChatGuid = normalizeOptionalString(cached.chatGuid);
+  const ctxChatGuid = normalizeOptionalString(ctx.chatGuid);
+  if (cachedChatGuid && ctxChatGuid && cachedChatGuid !== ctxChatGuid) {
+    return true;
+  }
+  const cachedChatIdentifier = normalizeOptionalString(cached.chatIdentifier);
+  const ctxChatIdentifier = normalizeOptionalString(ctx.chatIdentifier);
+  if (
+    !ctxChatGuid &&
+    cachedChatIdentifier &&
+    ctxChatIdentifier &&
+    cachedChatIdentifier !== ctxChatIdentifier
+  ) {
+    return true;
+  }
+  const cachedChatId = typeof cached.chatId === "number" ? cached.chatId : undefined;
+  const ctxChatId = typeof ctx.chatId === "number" ? ctx.chatId : undefined;
+  if (
+    !ctxChatGuid &&
+    !ctxChatIdentifier &&
+    cachedChatId !== undefined &&
+    ctxChatId !== undefined &&
+    cachedChatId !== ctxChatId
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function describeChatForError(values: {
+  chatGuid?: string;
+  chatIdentifier?: string;
+  chatId?: number;
+}): string {
+  const parts: string[] = [];
+  const guid = normalizeOptionalString(values.chatGuid);
+  if (guid) {
+    parts.push(`chatGuid=${guid}`);
+  }
+  const identifier = normalizeOptionalString(values.chatIdentifier);
+  if (identifier) {
+    parts.push(`chatIdentifier=${identifier}`);
+  }
+  if (typeof values.chatId === "number") {
+    parts.push(`chatId=${values.chatId}`);
+  }
+  return parts.length === 0 ? "<unknown chat>" : parts.join(", ");
+}
+
 /**
  * Resolves a short message ID (e.g., "1", "2") to a full BlueBubbles GUID.
  * Returns the input unchanged if it's already a GUID or not found in the mapping.
+ *
+ * When `chatContext` is provided, the resolved UUID's cached chat must match
+ * the caller's chat or the call throws. This prevents a short ID that points
+ * at a message in chat A from being silently reused in chat B — the common
+ * symptom being tapbacks and quoted replies landing in the wrong conversation
+ * (e.g. a group reaction showing up in a DM) because short IDs are allocated
+ * from a single global counter across every account and chat.
  */
 export function resolveBlueBubblesMessageId(
   shortOrUuid: string,
-  opts?: { requireKnownShortId?: boolean },
+  opts?: { requireKnownShortId?: boolean; chatContext?: BlueBubblesChatContext },
 ): string {
   const trimmed = shortOrUuid.trim();
   if (!trimmed) {
@@ -98,6 +184,17 @@ export function resolveBlueBubblesMessageId(
   if (/^\d+$/.test(trimmed)) {
     const uuid = blueBubblesShortIdToUuid.get(trimmed);
     if (uuid) {
+      if (opts?.chatContext) {
+        const cached = blueBubblesReplyCacheByMessageId.get(uuid);
+        if (cached && isCrossChatMismatch(cached, opts.chatContext)) {
+          throw new Error(
+            `BlueBubbles short message id "${trimmed}" belongs to a different chat ` +
+              `(${describeChatForError(cached)}) than the current call target ` +
+              `(${describeChatForError(opts.chatContext)}). Retry with the full message GUID ` +
+              `to avoid cross-chat reactions/replies landing in the wrong conversation.`,
+          );
+        }
+      }
       return uuid;
     }
     if (opts?.requireKnownShortId) {

--- a/extensions/bluebubbles/src/monitor-reply-cache.ts
+++ b/extensions/bluebubbles/src/monitor-reply-cache.ts
@@ -111,31 +111,25 @@ function isCrossChatMismatch(
   cached: BlueBubblesReplyCacheEntry,
   ctx: BlueBubblesChatContext,
 ): boolean {
+  // Compare each identifier independently based on availability on both sides.
+  // Earlier versions gated chatIdentifier/chatId comparisons on `!ctxChatGuid`,
+  // which let any non-empty `ctx.chatGuid` suppress the fallback checks when
+  // the cached entry happened to lack chatGuid — letting a short id from
+  // chat A be reused while acting in chat B.
   const cachedChatGuid = normalizeOptionalString(cached.chatGuid);
   const ctxChatGuid = normalizeOptionalString(ctx.chatGuid);
-  if (cachedChatGuid && ctxChatGuid && cachedChatGuid !== ctxChatGuid) {
-    return true;
+  if (cachedChatGuid && ctxChatGuid) {
+    return cachedChatGuid !== ctxChatGuid;
   }
   const cachedChatIdentifier = normalizeOptionalString(cached.chatIdentifier);
   const ctxChatIdentifier = normalizeOptionalString(ctx.chatIdentifier);
-  if (
-    !ctxChatGuid &&
-    cachedChatIdentifier &&
-    ctxChatIdentifier &&
-    cachedChatIdentifier !== ctxChatIdentifier
-  ) {
-    return true;
+  if (cachedChatIdentifier && ctxChatIdentifier) {
+    return cachedChatIdentifier !== ctxChatIdentifier;
   }
   const cachedChatId = typeof cached.chatId === "number" ? cached.chatId : undefined;
   const ctxChatId = typeof ctx.chatId === "number" ? ctx.chatId : undefined;
-  if (
-    !ctxChatGuid &&
-    !ctxChatIdentifier &&
-    cachedChatId !== undefined &&
-    ctxChatId !== undefined &&
-    cachedChatId !== ctxChatId
-  ) {
-    return true;
+  if (cachedChatId !== undefined && ctxChatId !== undefined) {
+    return cachedChatId !== ctxChatId;
   }
   return false;
 }
@@ -145,17 +139,19 @@ function describeChatForError(values: {
   chatIdentifier?: string;
   chatId?: number;
 }): string {
+  // Surface only the *shape* of the chat target, never the raw identifier,
+  // to avoid leaking phone numbers / email addresses / chat GUIDs into
+  // error messages that may end up in agent transcripts, tool results,
+  // remote channel deliveries, or third-party log aggregators.
   const parts: string[] = [];
-  const guid = normalizeOptionalString(values.chatGuid);
-  if (guid) {
-    parts.push(`chatGuid=${guid}`);
+  if (normalizeOptionalString(values.chatGuid)) {
+    parts.push("chatGuid=<redacted>");
   }
-  const identifier = normalizeOptionalString(values.chatIdentifier);
-  if (identifier) {
-    parts.push(`chatIdentifier=${identifier}`);
+  if (normalizeOptionalString(values.chatIdentifier)) {
+    parts.push("chatIdentifier=<redacted>");
   }
   if (typeof values.chatId === "number") {
-    parts.push(`chatId=${values.chatId}`);
+    parts.push("chatId=<redacted>");
   }
   return parts.length === 0 ? "<unknown chat>" : parts.join(", ");
 }

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -2233,6 +2233,56 @@ describe("BlueBubbles webhook monitor", () => {
       expect(mockEnqueueSystemEvent).not.toHaveBeenCalled();
     });
 
+    it("drops group reactions that arrive with no chat identifiers", async () => {
+      // Real-world failure mode: BlueBubbles fires a reaction webhook with
+      // isGroup=true but omits chatGuid AND chatId AND chatIdentifier. The
+      // legacy code falls peerId back to the literal string "group" and
+      // resolves a session key unrelated to any real binding; if isGroup
+      // had been misclassified as false the same payload would have been
+      // routed to the sender's DM session instead — surfacing a group
+      // tapback inside an unrelated 1:1 transcript. Either way the event
+      // cannot be routed correctly, so drop it.
+      mockEnqueueSystemEvent.mockClear();
+      mockResolveRequireMention.mockReturnValue(false);
+
+      setupWebhookTarget({
+        account: createMockAccount({ groupPolicy: "open" }),
+      });
+
+      const payload = createTimestampedMessageReactionPayloadForTest({
+        isGroup: true,
+        // chatGuid / chatId / chatIdentifier intentionally omitted
+        associatedMessageType: 2000,
+        handle: { address: "+15559999999" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      expect(mockEnqueueSystemEvent).not.toHaveBeenCalled();
+    });
+
+    it("still enqueues group reactions when at least one chat identifier is present", async () => {
+      // Sanity check: the drop guard must not fire when the webhook does
+      // include a chatGuid.
+      mockEnqueueSystemEvent.mockClear();
+      mockResolveRequireMention.mockReturnValue(false);
+
+      setupWebhookTarget({
+        account: createMockAccount({ groupPolicy: "open" }),
+      });
+
+      const payload = createTimestampedMessageReactionPayloadForTest({
+        isGroup: true,
+        chatGuid: "iMessage;+;chat-known-123",
+        associatedMessageType: 2000,
+        handle: { address: "+15559999999" },
+      });
+
+      await dispatchWebhookPayload(payload);
+
+      expect(mockEnqueueSystemEvent).toHaveBeenCalled();
+    });
+
     it("maps reaction types to correct emojis", async () => {
       mockEnqueueSystemEvent.mockClear();
 

--- a/extensions/bluebubbles/src/session-route.test.ts
+++ b/extensions/bluebubbles/src/session-route.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "./runtime-api.js";
+import { resolveBlueBubblesOutboundSessionRoute } from "./session-route.js";
+
+const EMPTY_CFG = {} as OpenClawConfig;
+
+function call(target: string) {
+  return resolveBlueBubblesOutboundSessionRoute({
+    cfg: EMPTY_CFG,
+    agentId: "agent-1",
+    accountId: "default",
+    target,
+  });
+}
+
+describe("resolveBlueBubblesOutboundSessionRoute DM/group disambiguation", () => {
+  it("treats `chat_guid:` with `;-;` marker as a DM", () => {
+    // Candidate-2 regression: the previous implementation classified ANY
+    // chat_guid-prefixed target as a group, even DMs (BlueBubbles encodes
+    // DM chatGuids as `service;-;handle`). That made the same DM resolve
+    // to one sessionKey via handle form (`+15551234567`) and a different
+    // sessionKey via chat_guid form (`chat_guid:iMessage;-;+15551234567`),
+    // causing bound DM sessions to mis-route into a freshly synthesized
+    // "group" session key.
+    const route = call("bluebubbles:chat_guid:iMessage;-;+15551234567");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("direct");
+    expect(route?.chatType).toBe("direct");
+    expect(route?.from).toMatch(/^bluebubbles:/);
+    expect(route?.from).not.toMatch(/^group:/);
+  });
+
+  it("treats `chat_guid:` with `;+;` marker as a group", () => {
+    const route = call("bluebubbles:chat_guid:iMessage;+;chat-known-123");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("group");
+    expect(route?.chatType).toBe("group");
+    expect(route?.from).toMatch(/^group:/);
+  });
+
+  it("falls back to group when chat_guid lacks a recognizable marker", () => {
+    // Backwards-compatible default: pre-fix behavior was to treat all
+    // chat_guid forms as group. Preserve that for unknown shapes so we
+    // do not silently downgrade an actual group to direct.
+    const route = call("bluebubbles:chat_guid:weird-no-semicolons");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("group");
+  });
+
+  it("treats handle targets as direct", () => {
+    const route = call("bluebubbles:imessage:+15551234567");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("direct");
+    expect(route?.from).toMatch(/^bluebubbles:/);
+  });
+
+  it("keeps chat_id targets classified as group", () => {
+    const route = call("bluebubbles:chat_id:42");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("group");
+    expect(route?.peer.id).toBe("42");
+  });
+
+  it("keeps chat_identifier targets classified as group", () => {
+    const route = call("bluebubbles:chat_identifier:chat-abc");
+    expect(route).not.toBeNull();
+    expect(route?.peer.kind).toBe("group");
+    expect(route?.peer.id).toBe("chat-abc");
+  });
+
+  it("DM via chat_guid and DM via handle land on the same session key", () => {
+    // The point of disambiguation: a DM addressed two different ways must
+    // converge on the same sessionKey so existing bindings keep matching.
+    const handleRoute = call("bluebubbles:imessage:+15551234567");
+    const chatGuidRoute = call("bluebubbles:chat_guid:iMessage;-;+15551234567");
+    expect(handleRoute?.sessionKey).toBeDefined();
+    expect(chatGuidRoute?.sessionKey).toBeDefined();
+    // Both are direct now; sessionKey base derives from peer.id.
+    expect(handleRoute?.peer.kind).toBe(chatGuidRoute?.peer.kind);
+  });
+});

--- a/extensions/bluebubbles/src/session-route.test.ts
+++ b/extensions/bluebubbles/src/session-route.test.ts
@@ -3,10 +3,13 @@ import type { OpenClawConfig } from "./runtime-api.js";
 import { resolveBlueBubblesOutboundSessionRoute } from "./session-route.js";
 
 const EMPTY_CFG = {} as OpenClawConfig;
+const PER_PEER_CFG = {
+  session: { dmScope: "per-peer" },
+} as OpenClawConfig;
 
-function call(target: string) {
+function call(target: string, cfg = EMPTY_CFG) {
   return resolveBlueBubblesOutboundSessionRoute({
-    cfg: EMPTY_CFG,
+    cfg,
     agentId: "agent-1",
     accountId: "default",
     target,
@@ -25,8 +28,10 @@ describe("resolveBlueBubblesOutboundSessionRoute DM/group disambiguation", () =>
     const route = call("bluebubbles:chat_guid:iMessage;-;+15551234567");
     expect(route).not.toBeNull();
     expect(route?.peer.kind).toBe("direct");
+    expect(route?.peer.id).toBe("+15551234567");
     expect(route?.chatType).toBe("direct");
-    expect(route?.from).toMatch(/^bluebubbles:/);
+    expect(route?.from).toBe("bluebubbles:+15551234567");
+    expect(route?.to).toBe("bluebubbles:chat_guid:iMessage;-;+15551234567");
     expect(route?.from).not.toMatch(/^group:/);
   });
 
@@ -71,11 +76,14 @@ describe("resolveBlueBubblesOutboundSessionRoute DM/group disambiguation", () =>
   it("DM via chat_guid and DM via handle land on the same session key", () => {
     // The point of disambiguation: a DM addressed two different ways must
     // converge on the same sessionKey so existing bindings keep matching.
-    const handleRoute = call("bluebubbles:imessage:+15551234567");
-    const chatGuidRoute = call("bluebubbles:chat_guid:iMessage;-;+15551234567");
+    const handleRoute = call("bluebubbles:imessage:+15551234567", PER_PEER_CFG);
+    const chatGuidRoute = call("bluebubbles:chat_guid:iMessage;-;+15551234567", PER_PEER_CFG);
     expect(handleRoute?.sessionKey).toBeDefined();
     expect(chatGuidRoute?.sessionKey).toBeDefined();
-    // Both are direct now; sessionKey base derives from peer.id.
     expect(handleRoute?.peer.kind).toBe(chatGuidRoute?.peer.kind);
+    expect(handleRoute?.peer.id).toBe(chatGuidRoute?.peer.id);
+    expect(handleRoute?.from).toBe(chatGuidRoute?.from);
+    expect(handleRoute?.sessionKey).toBe(chatGuidRoute?.sessionKey);
+    expect(chatGuidRoute?.to).toBe("bluebubbles:chat_guid:iMessage;-;+15551234567");
   });
 });

--- a/extensions/bluebubbles/src/session-route.ts
+++ b/extensions/bluebubbles/src/session-route.ts
@@ -3,6 +3,7 @@ import {
   stripChannelTargetPrefix,
   type ChannelOutboundSessionRouteParams,
 } from "openclaw/plugin-sdk/channel-core";
+import { resolveGroupFlagFromChatGuid } from "./monitor-normalize.js";
 import { parseBlueBubblesTarget } from "./targets.js";
 
 export function resolveBlueBubblesOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
@@ -11,8 +12,21 @@ export function resolveBlueBubblesOutboundSessionRoute(params: ChannelOutboundSe
     return null;
   }
   const parsed = parseBlueBubblesTarget(stripped);
+  // chat_guid carries an explicit DM-vs-group marker (`;-;` for DMs,
+  // `;+;` for groups). Honor it so the same DM does not get one
+  // sessionKey for handle-form targets (`imessage:+1234`) and a
+  // different one for chat_guid-form targets
+  // (`chat_guid:iMessage;-;+1234`) — that mismatch made bound DM
+  // sessions mis-route the outbound back into a freshly-created
+  // "group" sessionKey.
+  const groupFromChatGuid =
+    parsed.kind === "chat_guid" ? resolveGroupFlagFromChatGuid(parsed.chatGuid) : undefined;
   const isGroup =
-    parsed.kind === "chat_id" || parsed.kind === "chat_guid" || parsed.kind === "chat_identifier";
+    parsed.kind === "chat_id" || parsed.kind === "chat_identifier"
+      ? true
+      : parsed.kind === "chat_guid"
+        ? (groupFromChatGuid ?? true)
+        : false;
   const peerId =
     parsed.kind === "chat_id"
       ? String(parsed.chatId)

--- a/extensions/bluebubbles/src/session-route.ts
+++ b/extensions/bluebubbles/src/session-route.ts
@@ -4,7 +4,7 @@ import {
   type ChannelOutboundSessionRouteParams,
 } from "openclaw/plugin-sdk/channel-core";
 import { resolveGroupFlagFromChatGuid } from "./monitor-normalize.js";
-import { parseBlueBubblesTarget } from "./targets.js";
+import { extractHandleFromChatGuid, parseBlueBubblesTarget } from "./targets.js";
 
 export function resolveBlueBubblesOutboundSessionRoute(params: ChannelOutboundSessionRouteParams) {
   const stripped = stripChannelTargetPrefix(params.target, "bluebubbles");
@@ -27,11 +27,15 @@ export function resolveBlueBubblesOutboundSessionRoute(params: ChannelOutboundSe
       : parsed.kind === "chat_guid"
         ? (groupFromChatGuid ?? true)
         : false;
+  const dmHandleFromChatGuid =
+    parsed.kind === "chat_guid" && groupFromChatGuid === false
+      ? extractHandleFromChatGuid(parsed.chatGuid)
+      : null;
   const peerId =
     parsed.kind === "chat_id"
       ? String(parsed.chatId)
       : parsed.kind === "chat_guid"
-        ? parsed.chatGuid
+        ? (dmHandleFromChatGuid ?? parsed.chatGuid)
         : parsed.kind === "chat_identifier"
           ? parsed.chatIdentifier
           : parsed.to;

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -426,3 +426,52 @@ export function formatBlueBubblesChatTarget(params: {
   }
   return "";
 }
+
+/**
+ * Derive a chat context ({chatGuid, chatIdentifier, chatId}) from a raw
+ * BlueBubbles target string such as `chat_guid:iMessage;+;chat123`,
+ * `chat_id:42`, `imessage:+15551234567`, or a bare handle. Returns an empty
+ * object for unparseable input.
+ *
+ * Used by short-ID message resolution to constrain short IDs to the chat the
+ * caller is acting on, preventing a short ID allocated for a message in one
+ * chat from silently pointing at a different chat on a later tool call.
+ */
+export function buildBlueBubblesChatContextFromTarget(raw: string | undefined | null): {
+  chatGuid?: string;
+  chatIdentifier?: string;
+  chatId?: number;
+} {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return {};
+  }
+  try {
+    const parsed = parseBlueBubblesTarget(trimmed);
+    if (parsed.kind === "chat_guid") {
+      return { chatGuid: parsed.chatGuid };
+    }
+    if (parsed.kind === "chat_identifier") {
+      return { chatIdentifier: parsed.chatIdentifier };
+    }
+    if (parsed.kind === "chat_id") {
+      return { chatId: parsed.chatId };
+    }
+    if (parsed.kind === "handle") {
+      // BlueBubbles chat records store DM handles in the third component of
+      // their chatGuid (service;-;address), and `chatIdentifier` on a chat
+      // record is typically the same address. Treat a handle target as a
+      // chatIdentifier hint; it disambiguates DM↔DM and DM↔group mixes.
+      // Normalize the handle (strip service prefix / whitespace / lowercase
+      // emails) so the comparison matches what the send path resolves to
+      // and what inbound webhooks write into the reply cache; otherwise
+      // formats like `imessage:(555) 123-4567` or mixed-case email handles
+      // would compare unequal against their normalized cached form and
+      // legitimate same-chat short IDs would be rejected as cross-chat.
+      return { chatIdentifier: normalizeBlueBubblesHandle(parsed.to) };
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}

--- a/extensions/googlechat/src/config-schema.ts
+++ b/extensions/googlechat/src/config-schema.ts
@@ -1,6 +1,3 @@
-import {
-  buildChannelConfigSchema,
-  GoogleChatConfigSchema,
-} from "openclaw/plugin-sdk/bundled-channel-config-schema";
+import { buildChannelConfigSchema, GoogleChatConfigSchema } from "../runtime-api.js";
 
 export const GoogleChatChannelConfigSchema = buildChannelConfigSchema(GoogleChatConfigSchema);

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -77,14 +77,16 @@ export async function resolveBareSessionResetPromptState(params: {
       ? params.hasBootstrapFileAccess()
       : (params.hasBootstrapFileAccess ?? true)
     : true;
-  const bootstrapMode = resolveBootstrapMode({
-    bootstrapPending,
-    runKind: "default",
-    isInteractiveUserFacing: true,
-    isPrimaryRun: params.isPrimaryRun ?? true,
-    isCanonicalWorkspace: params.isCanonicalWorkspace ?? true,
-    hasBootstrapFileAccess,
-  });
+  const bootstrapMode = !hasBootstrapFileAccess
+    ? "none"
+    : resolveBootstrapMode({
+        bootstrapPending,
+        runKind: "default",
+        isInteractiveUserFacing: true,
+        isPrimaryRun: params.isPrimaryRun ?? true,
+        isCanonicalWorkspace: params.isCanonicalWorkspace ?? true,
+        hasBootstrapFileAccess,
+      });
   return {
     bootstrapMode,
     prompt: buildBareSessionResetPrompt(params.cfg, params.nowMs, bootstrapMode),

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -77,16 +77,14 @@ export async function resolveBareSessionResetPromptState(params: {
       ? params.hasBootstrapFileAccess()
       : (params.hasBootstrapFileAccess ?? true)
     : true;
-  const bootstrapMode = !hasBootstrapFileAccess
-    ? "none"
-    : resolveBootstrapMode({
-        bootstrapPending,
-        runKind: "default",
-        isInteractiveUserFacing: true,
-        isPrimaryRun: params.isPrimaryRun ?? true,
-        isCanonicalWorkspace: params.isCanonicalWorkspace ?? true,
-        hasBootstrapFileAccess,
-      });
+  const bootstrapMode = resolveBootstrapMode({
+    bootstrapPending,
+    runKind: "default",
+    isInteractiveUserFacing: true,
+    isPrimaryRun: params.isPrimaryRun ?? true,
+    isCanonicalWorkspace: params.isCanonicalWorkspace ?? true,
+    hasBootstrapFileAccess,
+  });
   return {
     bootstrapMode,
     prompt: buildBareSessionResetPrompt(params.cfg, params.nowMs, bootstrapMode),

--- a/src/commands/doctor-plugin-manifests.test.ts
+++ b/src/commands/doctor-plugin-manifests.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
@@ -25,6 +26,16 @@ function makePluginWorkspace() {
       OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
       OPENCLAW_DISABLE_PLUGIN_DISCOVERY_CACHE: "1",
       OPENCLAW_DISABLE_PLUGIN_MANIFEST_CACHE: "1",
+    },
+  };
+}
+
+function configWithPluginLoadPath(pluginRoot: string): OpenClawConfig {
+  return {
+    plugins: {
+      load: {
+        paths: [pluginRoot],
+      },
     },
   };
 }
@@ -102,6 +113,7 @@ describe("doctor plugin manifest legacy contract repair", () => {
     });
 
     const migrations = collectLegacyPluginManifestContractMigrations({
+      config: configWithPluginLoadPath(pluginsRoot),
       env: {
         ...process.env,
       },
@@ -131,6 +143,7 @@ describe("doctor plugin manifest legacy contract repair", () => {
     });
 
     await maybeRepairLegacyPluginManifestContracts({
+      config: configWithPluginLoadPath(pluginsRoot),
       env: {
         ...process.env,
       },
@@ -168,6 +181,7 @@ describe("doctor plugin manifest legacy contract repair", () => {
     });
 
     const migrations = collectLegacyPluginManifestContractMigrations({
+      config: configWithPluginLoadPath(pluginsRoot),
       env: {
         ...process.env,
       },

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadPluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -81,6 +82,7 @@ function buildLegacyManifestContractMigration(params: {
 }
 
 export function collectLegacyPluginManifestContractMigrations(params?: {
+  config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   manifestRoots?: string[];
   workspaceDir?: string;
@@ -114,6 +116,7 @@ export function collectLegacyPluginManifestContractMigrations(params?: {
 
   for (const plugin of loadPluginManifestRegistry({
     cache: false,
+    ...(params?.config ? { config: params.config } : {}),
     ...(params?.env ? { env: params.env } : {}),
     ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   }).plugins) {
@@ -138,6 +141,7 @@ export function collectLegacyPluginManifestContractMigrations(params?: {
 }
 
 export async function maybeRepairLegacyPluginManifestContracts(params: {
+  config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   manifestRoots?: string[];
   workspaceDir?: string;
@@ -146,6 +150,7 @@ export async function maybeRepairLegacyPluginManifestContracts(params: {
   note?: typeof note;
 }): Promise<void> {
   const migrations = collectLegacyPluginManifestContractMigrations({
+    ...(params.config ? { config: params.config } : {}),
     ...(params.env ? { env: params.env } : {}),
     ...(params.manifestRoots ? { manifestRoots: params.manifestRoots } : {}),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),

--- a/src/commands/doctor-plugin-manifests.ts
+++ b/src/commands/doctor-plugin-manifests.ts
@@ -34,6 +34,14 @@ function readManifestJson(manifestPath: string): Record<string, unknown> | null 
   }
 }
 
+function manifestSeenKey(manifestPath: string): string {
+  try {
+    return fs.realpathSync.native(manifestPath);
+  } catch {
+    return path.resolve(manifestPath);
+  }
+}
+
 function buildLegacyManifestContractMigration(params: {
   manifestPath: string;
   raw: Record<string, unknown>;
@@ -99,10 +107,11 @@ export function collectLegacyPluginManifestContractMigrations(params?: {
         continue;
       }
       const manifestPath = path.join(root, entry.name, "openclaw.plugin.json");
-      if (seen.has(manifestPath)) {
+      const seenKey = manifestSeenKey(manifestPath);
+      if (seen.has(seenKey)) {
         continue;
       }
-      seen.add(manifestPath);
+      seen.add(seenKey);
       const raw = readManifestJson(manifestPath);
       if (!raw) {
         continue;
@@ -120,10 +129,11 @@ export function collectLegacyPluginManifestContractMigrations(params?: {
     ...(params?.env ? { env: params.env } : {}),
     ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   }).plugins) {
-    if (seen.has(plugin.manifestPath)) {
+    const seenKey = manifestSeenKey(plugin.manifestPath);
+    if (seen.has(seenKey)) {
       continue;
     }
-    seen.add(plugin.manifestPath);
+    seen.add(seenKey);
     const raw = readManifestJson(plugin.manifestPath);
     if (!raw) {
       continue;

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -223,6 +223,7 @@ async function runLegacyPluginManifestHealth(ctx: DoctorHealthFlowContext): Prom
   const { maybeRepairLegacyPluginManifestContracts } =
     await import("../commands/doctor-plugin-manifests.js");
   await maybeRepairLegacyPluginManifestContracts({
+    config: ctx.cfg,
     env: process.env,
     runtime: ctx.runtime,
     prompter: ctx.prompter,

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -795,6 +795,7 @@ describe("gateway server cron", () => {
   });
 
   test("ignores ambient disabled channel env when validating announce delivery", async () => {
+    vi.stubEnv("OPENCLAW_DISABLE_BUNDLED_PLUGINS", "1");
     vi.stubEnv("SLACK_BOT_TOKEN", "xoxb-ambient");
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "ambient-telegram");
     const { prevSkipCron } = await setupCronTestRun({

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -147,9 +147,11 @@ const expectedSortedCatalog = (): ModelCatalogRpcEntry[] => [
 
 describe("gateway server models + voicewake", () => {
   const listModels = async (params?: { view?: "default" | "configured" | "all" }) =>
-    params
-      ? rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list", params)
-      : rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list");
+    withEnvAsync({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () =>
+      params
+        ? await rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list", params)
+        : await rpcReq<{ models: ModelCatalogRpcEntry[] }>(ws, "models.list"),
+    );
 
   const seedPiCatalog = () => {
     piSdkMock.enabled = true;

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -330,6 +330,7 @@ describe("resolveBundledPluginsDir", () => {
     process.execArgv.length = 0;
     process.env.VITEST = "true";
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(overrideRoot, "extensions");
+    delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
     delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
 
     const bundledDir = resolveBundledPluginsDir();

--- a/src/plugins/bundled-dir.ts
+++ b/src/plugins/bundled-dir.ts
@@ -7,6 +7,7 @@ import { normalizeOptionalLowercaseString } from "../shared/string-coerce.js";
 import { resolveUserPath } from "../utils.js";
 
 const DISABLED_BUNDLED_PLUGINS_DIR = path.join(os.tmpdir(), "openclaw-empty-bundled-plugins");
+const TEST_TRUST_BUNDLED_PLUGINS_DIR_ENV = "OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR";
 let bundledPluginsDirOverrideForTest: string | undefined;
 
 export function areBundledPluginsDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
@@ -24,6 +25,20 @@ function isSourceCheckoutRoot(packageRoot: string): boolean {
     fs.existsSync(path.join(packageRoot, ".git")) &&
     fs.existsSync(path.join(packageRoot, "src")) &&
     fs.existsSync(path.join(packageRoot, "extensions"))
+  );
+}
+
+function isTruthyEnvValue(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function shouldTrustTestBundledPluginsDirOverride(env: NodeJS.ProcessEnv): boolean {
+  const isVitestProcess = Boolean(env.VITEST) || Boolean(process.env.VITEST);
+  return (
+    isVitestProcess &&
+    (isTruthyEnvValue(env[TEST_TRUST_BUNDLED_PLUGINS_DIR_ENV]) ||
+      isTruthyEnvValue(process.env[TEST_TRUST_BUNDLED_PLUGINS_DIR_ENV]))
   );
 }
 
@@ -183,6 +198,9 @@ export function resolveBundledPluginsDir(env: NodeJS.ProcessEnv = process.env): 
   if (override) {
     const resolvedOverride = resolveUserPath(override, env);
     if (fs.existsSync(resolvedOverride)) {
+      if (shouldTrustTestBundledPluginsDirOverride(env)) {
+        return path.resolve(resolvedOverride);
+      }
       const trustedOverride = resolveTrustedExistingOverride(resolvedOverride);
       if (trustedOverride) {
         return trustedOverride;

--- a/src/plugins/bundled-runtime-deps.ts
+++ b/src/plugins/bundled-runtime-deps.ts
@@ -1015,10 +1015,10 @@ function resolveExistingExternalBundledRuntimeDepsRoots(params: {
   packageRoot: string;
   env: NodeJS.ProcessEnv;
 }): string[] | null {
-  const packageRoot = path.resolve(params.packageRoot);
+  const packageRoot = realpathOrResolve(params.packageRoot);
   const externalBaseDirs = resolveBundledRuntimeDepsExternalBaseDirs(params.env);
   for (const externalBaseDir of externalBaseDirs) {
-    const relative = path.relative(path.resolve(externalBaseDir), packageRoot);
+    const relative = path.relative(realpathOrResolve(externalBaseDir), packageRoot);
     if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
       continue;
     }
@@ -1029,6 +1029,14 @@ function resolveExistingExternalBundledRuntimeDepsRoots(params: {
     return externalBaseDirs.map((baseDir) => path.join(baseDir, packageKey));
   }
   return null;
+}
+
+function realpathOrResolve(targetPath: string): string {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return path.resolve(targetPath);
+  }
 }
 
 function resolveSourceCheckoutRuntimeDepsCacheDir(params: {

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -5528,7 +5528,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
   });
 
   it("respects explicit disable in config", () => {
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "config-disable",
       body: `module.exports = { id: "config-disable", register() {} };`,

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -2785,7 +2785,7 @@ module.exports = {
     {
       label: "loads plugins from config paths",
       run: () => {
-        process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+        useNoBundledPlugins();
         const plugin = writePlugin({
           id: "allowed-config-path",
           filename: "allowed-config-path.cjs",
@@ -4373,7 +4373,7 @@ module.exports = { id: "throws-after-import", register() {} };`,
   });
 
   it("re-initializes global hook runner when serving registry from cache", () => {
-    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
+    useNoBundledPlugins();
     const plugin = writePlugin({
       id: "cache-hook-runner",
       filename: "cache-hook-runner.cjs",
@@ -6604,7 +6604,6 @@ module.exports = {
       {
         label: "enforces memory slot selection",
         loadRegistry: () => {
-          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
           const memoryA = writePlugin({
             id: "memory-a",
             body: memoryPluginBody("memory-a"),
@@ -6614,15 +6613,22 @@ module.exports = {
             body: memoryPluginBody("memory-b"),
           });
 
-          return loadOpenClawPlugins({
-            cache: false,
-            config: {
-              plugins: {
-                load: { paths: [memoryA.file, memoryB.file] },
-                slots: { memory: "memory-b" },
-              },
+          return withEnv(
+            {
+              OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+              OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
             },
-          });
+            () =>
+              loadOpenClawPlugins({
+                cache: false,
+                config: {
+                  plugins: {
+                    load: { paths: [memoryA.file, memoryB.file] },
+                    slots: { memory: "memory-b" },
+                  },
+                },
+              }),
+          );
         },
         assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
           const a = registry.plugins.find((entry) => entry.id === "memory-a");
@@ -6871,21 +6877,27 @@ module.exports = {
       {
         label: "disables memory plugins when slot is none",
         loadRegistry: () => {
-          process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
           const memory = writePlugin({
             id: "memory-off",
             body: memoryPluginBody("memory-off"),
           });
 
-          return loadOpenClawPlugins({
-            cache: false,
-            config: {
-              plugins: {
-                load: { paths: [memory.file] },
-                slots: { memory: "none" },
-              },
+          return withEnv(
+            {
+              OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+              OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
             },
-          });
+            () =>
+              loadOpenClawPlugins({
+                cache: false,
+                config: {
+                  plugins: {
+                    load: { paths: [memory.file] },
+                    slots: { memory: "none" },
+                  },
+                },
+              }),
+          );
         },
         assert: (registry: ReturnType<typeof loadOpenClawPlugins>) => {
           const entry = registry.plugins.find((item) => item.id === "memory-off");

--- a/test/setup.shared.ts
+++ b/test/setup.shared.ts
@@ -37,6 +37,9 @@ vi.mock("@mariozechner/clipboard", () => ({
 
 // Ensure Vitest environment is properly set.
 process.env.VITEST = "true";
+// Tests frequently point bundled plugin discovery at temp fixture roots. Production still rejects
+// arbitrary OPENCLAW_BUNDLED_PLUGINS_DIR overrides unless this Vitest-only opt-in is present.
+process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR ??= "1";
 // Config validation walks plugin manifests; keep an aggressive cache in tests to avoid
 // repeated filesystem discovery across suites/workers.
 process.env.OPENCLAW_PLUGIN_MANIFEST_CACHE_MS ??= "60000";


### PR DESCRIPTION
## Summary

Five interlocking BlueBubbles routing fixes for symptoms that all stem from the same family of problems: ambiguity between DM and group chat shapes leaking into peer-id / session-key resolution. Each commit is independently reviewable and tested; bundled because the cross-chat guard fixes (commits 4 and 5) are direct follow-ups to the short-id fix and only matter together.

The user-visible failure mode I hit repeatedly: reactions / tapbacks and quoted replies authored inside a group would intermittently land in a DM, targeting an old message the user could no longer see. The tool call looks successful; the chat archive shows a group reaction appearing in the DM transcript.

### 1. `fix(bluebubbles): scope short message id resolution to the caller's chat`

`resolveBlueBubblesMessageId` accepts `requireKnownShortId` but never validates that the resolved GUID is actually in the chat the caller is acting on. Short numeric ids (`"1"`, `"5"`) are allocated from a single global counter across every account and every chat, so reusing or mis-remembering one — common after a long group conversation — silently routes the action to a different chat.

Adds an optional `chatContext` parameter (chatGuid / chatIdentifier / chatId). When provided, looks up the resolved GUID's chat membership and rejects mismatches with a remediation hint pointing at the chat target rather than the id format.

### 2. `fix(bluebubbles): apply cross-chat guard to full message GUIDs as well`

Direct follow-up to #1. The first version of the guard only ran on numeric short ids. Once short-id mismatches started rejecting cross-chat reuses, agents would retry with the full GUID copied from history or a previous tool result, and that path bypassed the guard entirely. Apply the same `isCrossChatMismatch` check to full GUID input. Cache misses still fall through (callers may legitimately supply a fresh-from-the-wire GUID), but cache hits with a chat mismatch throw with the same remediation hint.

### 3. `fix(bluebubbles): refuse sender-DM fallback when resolving group inbound chatGuid`

When a BlueBubbles inbound webhook arrives without `chatGuid`, `processMessage` falls back to `resolveChatGuidForTarget`. The previous fallback target was:

```ts
isGroup && (chatId || chatIdentifier)
  ? <chat_id or chat_identifier>
  : { kind: "handle", address: message.senderId }
```

The `else` branch quietly covered two very different cases:

1. **DM with no chatGuid** — resolving via sender handle is correct.
2. **Group with no chatGuid AND no chatId AND no chatIdentifier** — resolving via sender handle returns *that sender's DM chatGuid*, then the rest of `processMessage` uses it for ack reactions, mark-read, outbound reply cache, etc. — every subsequent action lands in a DM with the sender instead of the group.

Split the fallback so the group-without-any-chat-hint case fails closed with a diagnostic instead of silently rerouting.

### 4. `fix(bluebubbles): drop group reactions that arrive without any chat identifier`

`processReaction` peer id calculation:

```ts
const peerId = reaction.isGroup
  ? (chatGuid ?? chatIdentifier ?? (chatId ? String(chatId) : "group"))
  : reaction.senderId;
```

If a `message-reaction` event arrives with `isGroup: true` and no chatGuid/chatId/chatIdentifier, `peerId` becomes the literal string `"group"` and `resolveBlueBubblesConversationRoute` synthesizes a session key unrelated to any real binding. The reaction surfaces in whatever session the binding fallback picks.

Drop these events with a debug log instead of routing them somewhere wrong.

### 5. `fix(bluebubbles): distinguish DM vs group chat_guid in outbound session route`

`resolveBlueBubblesOutboundSessionRoute` classified all `chat_guid:` prefixed targets as groups:

```ts
const isGroup =
  parsed.kind === "chat_id" ||
  parsed.kind === "chat_guid" ||
  parsed.kind === "chat_identifier";
```

But BlueBubbles encodes DM chatGuids in the same `chat_guid:` form — they look like `iMessage;-;+15551234567` (the `;-;` separator is the DM marker; groups use `;+;`). Treating those as groups gave the same DM two different sessionKeys depending on whether the caller addressed it as a handle (`bluebubbles:imessage:+15551234567`) or as a chat_guid (`bluebubbles:chat_guid:iMessage;-;+15551234567`). Use the separator to classify so DM and group chat_guids end up on the right session shape.

## Test plan

- [x] `pnpm test extensions/bluebubbles` — 545/545 passing on this branch
- [x] New regression tests added for each commit (`monitor-reply-cache.test.ts`, `monitor-processing-chat-resolve.test.ts`, `session-route.test.ts`)
- [x] `pnpm check:changed` — clean
- [ ] Manual verification recommended: a group reaction routed via short id `"5"` after a long group conversation no longer lands in a DM (pre-fix repro on patch/chris)

## Notes for reviewers

- All five commits authored against patch/chris over multiple weeks, then cherry-picked clean onto current `main`. No conflicts.
- Each commit is atomic and individually testable. Happy to split into multiple PRs if a reviewer prefers; the routing-guard family naturally clusters but I have no strong opinion on packaging.
- Commits 1+2 and commits 3+4+5 are the two natural sub-clusters if we want to land them in stages.
