### PR TITLE
feat(bluebubbles): fetch quoted message via SSRF-guarded API on reply cache miss + surface attachment download errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- BlueBubbles: fetch quoted message bodies from the BlueBubbles API through the SSRF-guarded client when the in-memory reply cache misses (webhooks may include only `replyToGuid` without the quoted body), and surface attachment download failures at error level instead of only verbose so silently-dropped inbound images are visible without enabling debug logging. Thanks @zqchris.
 - Gateway/startup: keep value-option foreground starts on the gateway fast path and skip proxy bootstrap unless proxy env is configured, reducing normal gateway startup RSS and avoiding full CLI graph loading. Thanks @vincentkoc.
 - Subagents/models: persist `sessions_spawn.model` and configured subagent models as child-session model overrides before the first turn, so spawned subagents actually run on the requested provider/model instead of reverting to the target agent default. Fixes #73180. Thanks @danielzinhu99.
 - Backup: skip installed plugin `extensions/*/node_modules` dependency trees while keeping plugin manifests and source files in archives, so local backups avoid rebuildable npm payload bloat. Fixes #64144. Thanks @BrilliantWang.

--- a/extensions/bluebubbles/src/history.ts
+++ b/extensions/bluebubbles/src/history.ts
@@ -198,8 +198,9 @@ export async function fetchBlueBubblesMessageByGuid(
 
   let baseUrl: string;
   let password: string;
+  let allowPrivateNetwork = false;
   try {
-    ({ baseUrl, password } = resolveAccount(opts));
+    ({ baseUrl, password, allowPrivateNetwork } = resolveAccount(opts));
   } catch {
     return null;
   }
@@ -207,14 +208,23 @@ export async function fetchBlueBubblesMessageByGuid(
   // Strip part-index prefix (e.g. "p:0/msg-guid" → "msg-guid")
   const bareGuid = trimmed.includes("/") ? trimmed.split("/").pop()! : trimmed;
 
-  const url = buildBlueBubblesApiUrl({
+  // Route through the SSRF-guarded client (matches fetchBlueBubblesHistory):
+  // a bare blueBubblesFetchWithTimeout call without `ssrfPolicy` skips the
+  // private-network guard entirely, defeating the SSRF defense for the
+  // BlueBubbles Private API endpoint.
+  const client = createBlueBubblesClientFromParts({
     baseUrl,
-    path: `/api/v1/message/${encodeURIComponent(bareGuid)}`,
     password,
+    allowPrivateNetwork,
+    timeoutMs: opts.timeoutMs ?? 5000,
   });
 
   try {
-    const res = await blueBubblesFetchWithTimeout(url, { method: "GET" }, opts.timeoutMs ?? 5000);
+    const res = await client.request({
+      method: "GET",
+      path: `/api/v1/message/${encodeURIComponent(bareGuid)}`,
+      timeoutMs: opts.timeoutMs ?? 5000,
+    });
     if (!res.ok) {
       return null;
     }

--- a/extensions/bluebubbles/src/history.ts
+++ b/extensions/bluebubbles/src/history.ts
@@ -181,3 +181,60 @@ export async function fetchBlueBubblesHistory(
   // If none of the API paths worked, return empty history
   return { entries: [], resolved: false };
 }
+
+/**
+ * Fetch a single message by GUID from BlueBubbles API.
+ * Used as a fallback when the reply cache misses and the webhook
+ * did not include the quoted message body.
+ */
+export async function fetchBlueBubblesMessageByGuid(
+  messageGuid: string,
+  opts: BlueBubblesChatOpts = {},
+): Promise<{ text?: string; sender?: string } | null> {
+  const trimmed = messageGuid.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  let baseUrl: string;
+  let password: string;
+  try {
+    ({ baseUrl, password } = resolveAccount(opts));
+  } catch {
+    return null;
+  }
+
+  // Strip part-index prefix (e.g. "p:0/msg-guid" → "msg-guid")
+  const bareGuid = trimmed.includes("/") ? trimmed.split("/").pop()! : trimmed;
+
+  const url = buildBlueBubblesApiUrl({
+    baseUrl,
+    path: `/api/v1/message/${encodeURIComponent(bareGuid)}`,
+    password,
+  });
+
+  try {
+    const res = await blueBubblesFetchWithTimeout(url, { method: "GET" }, opts.timeoutMs ?? 5000);
+    if (!res.ok) {
+      return null;
+    }
+    const data = (await res.json().catch(() => null)) as Record<string, unknown> | null;
+    if (!data) {
+      return null;
+    }
+    // Response may be { data: { ... } } or direct message object
+    const msg = (data["data"] as Record<string, unknown> | undefined) ?? data;
+    const text =
+      (typeof msg["text"] === "string" ? msg["text"].trim() : undefined) ||
+      (typeof msg["body"] === "string" ? msg["body"].trim() : undefined) ||
+      undefined;
+    const handle = msg["handle"] as Record<string, unknown> | undefined;
+    const sender =
+      (typeof handle?.["address"] === "string" ? handle["address"].trim() : undefined) ||
+      (typeof msg["sender"] === "string" ? msg["sender"].trim() : undefined) ||
+      (msg["is_from_me"] === true || msg["isFromMe"] === true ? "me" : undefined);
+    return text || sender ? { text, sender } : null;
+  } catch {
+    return null;
+  }
+}

--- a/extensions/bluebubbles/src/history.ts
+++ b/extensions/bluebubbles/src/history.ts
@@ -206,7 +206,14 @@ export async function fetchBlueBubblesMessageByGuid(
   }
 
   // Strip part-index prefix (e.g. "p:0/msg-guid" → "msg-guid")
-  const bareGuid = trimmed.includes("/") ? trimmed.split("/").pop()! : trimmed;
+  const bareGuid = trimmed.includes("/") ? (trimmed.split("/").pop() ?? "") : trimmed;
+  // Reject empty / pathological GUIDs before they reach the path. A trailing
+  // `/` would yield an empty bareGuid and turn the request into a list query
+  // against `/api/v1/message/`; a malformed GUID would let an attacker steer
+  // arbitrary BlueBubbles routes via the encoded segment (CWE-20).
+  if (!bareGuid || bareGuid.length > 128 || !/^[A-Za-z0-9._:-]+$/.test(bareGuid)) {
+    return null;
+  }
 
   // Route through the SSRF-guarded client (matches fetchBlueBubblesHistory):
   // a bare blueBubblesFetchWithTimeout call without `ssrfPolicy` skips the

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1166,6 +1166,9 @@ async function processMessageAfterDedupe(
             mediaTypes.push(saved.contentType);
           }
         } catch (err) {
+          runtime.error?.(
+            `[bluebubbles] attachment download failed guid=${attachment.guid} err=${String(err)}`,
+          );
           logVerbose(
             core,
             runtime,

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -16,7 +16,7 @@ import {
 import { markBlueBubblesChatRead, sendBlueBubblesTyping } from "./chat.js";
 import { createBlueBubblesClientFromParts } from "./client.js";
 import { resolveBlueBubblesConversationRoute } from "./conversation-route.js";
-import { fetchBlueBubblesHistory } from "./history.js";
+import { fetchBlueBubblesHistory, fetchBlueBubblesMessageByGuid } from "./history.js";
 import {
   claimBlueBubblesInboundMessage,
   commitBlueBubblesCoalescedMessageIds,
@@ -1207,6 +1207,35 @@ async function processMessageAfterDedupe(
           runtime,
           `reply-context cache hit replyToId=${replyToId} sender=${replyToSender ?? ""} body="${preview}"`,
         );
+      }
+    }
+
+    // Fallback: fetch the quoted message from BlueBubbles API when cache missed body.
+    if (!replyToBody && baseUrl && password) {
+      try {
+        const fetched = await fetchBlueBubblesMessageByGuid(replyToId, {
+          cfg: config,
+          accountId: account.accountId,
+          timeoutMs: 5000,
+        });
+        if (fetched) {
+          if (fetched.text) {
+            replyToBody = fetched.text;
+          }
+          if (!replyToSender && fetched.sender) {
+            replyToSender = fetched.sender;
+          }
+          if (core.logging.shouldLogVerbose()) {
+            const preview = (fetched.text ?? "").replace(/\s+/g, " ").slice(0, 120);
+            logVerbose(
+              core,
+              runtime,
+              `reply-context API fallback replyToId=${replyToId} sender=${replyToSender ?? ""} body="${preview}"`,
+            );
+          }
+        }
+      } catch {
+        // Best-effort; proceed without reply body.
       }
     }
   }

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1166,14 +1166,12 @@ async function processMessageAfterDedupe(
             mediaTypes.push(saved.contentType);
           }
         } catch (err) {
+          const safeGuid = sanitizeForLog(attachment.guid, 80);
+          const safeErr = sanitizeForLog(err);
           runtime.error?.(
-            `[bluebubbles] attachment download failed guid=${attachment.guid} err=${String(err)}`,
+            `[bluebubbles] attachment download failed guid=${safeGuid} err=${safeErr}`,
           );
-          logVerbose(
-            core,
-            runtime,
-            `attachment download failed guid=${attachment.guid} err=${String(err)}`,
-          );
+          logVerbose(core, runtime, `attachment download failed guid=${safeGuid} err=${safeErr}`);
         }
       }
     }
@@ -1214,7 +1212,13 @@ async function processMessageAfterDedupe(
     }
 
     // Fallback: fetch the quoted message from BlueBubbles API when cache missed body.
-    if (!replyToBody && baseUrl && password) {
+    // Validate replyToId shape before issuing an outbound API call so a webhook
+    // payload with an oversized / pathological replyToId cannot drive arbitrary
+    // outbound load. Real BlueBubbles GUIDs are alnum + `-` + `:` and short
+    // numeric ids are 1-6 digits; 128 chars is comfortable headroom.
+    const replyToIdValid =
+      replyToId.length > 0 && replyToId.length <= 128 && /^[A-Za-z0-9._:-]+$/.test(replyToId);
+    if (!replyToBody && baseUrl && password && replyToIdValid) {
       try {
         const fetched = await fetchBlueBubblesMessageByGuid(replyToId, {
           cfg: config,
@@ -1229,11 +1233,14 @@ async function processMessageAfterDedupe(
             replyToSender = fetched.sender;
           }
           if (core.logging.shouldLogVerbose()) {
-            const preview = (fetched.text ?? "").replace(/\s+/g, " ").slice(0, 120);
+            const preview = sanitizeForLog(
+              (fetched.text ?? "").replace(/\s+/g, " ").slice(0, 120),
+              120,
+            );
             logVerbose(
               core,
               runtime,
-              `reply-context API fallback replyToId=${replyToId} sender=${replyToSender ?? ""} body="${preview}"`,
+              `reply-context API fallback replyToId=${sanitizeForLog(replyToId, 80)} sender=${sanitizeForLog(replyToSender ?? "", 80)} body="${preview}"`,
             );
           }
         }

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -583,7 +583,17 @@ function buildInboundHistorySnapshot(params: {
 }
 
 function sanitizeForLog(value: unknown, maxLen = 200): string {
-  const cleaned = String(value).replace(/[\r\n\t\p{C}]/gu, " ");
+  let cleaned = String(value).replace(/[\r\n\t\p{C}]/gu, " ");
+  // Redact common secret-bearing patterns before logging. BlueBubbles uses
+  // query-string auth (`?password=...`) by default, so attachment download
+  // failures and similar errors can carry the API password in the captured
+  // request URL; other libraries occasionally surface `Authorization: Bearer …`
+  // headers in error chains. Strip both before they reach the log sink (CWE-532).
+  cleaned = cleaned.replace(
+    /([?&](?:password|token|api[_-]?key|secret)=)[^&\s"]+/gi,
+    "$1<redacted>",
+  );
+  cleaned = cleaned.replace(/(authorization\s*:\s*(?:bearer|basic)\s+)[^\s"]+/gi, "$1<redacted>");
   return cleaned.length > maxLen ? cleaned.slice(0, maxLen) + "..." : cleaned;
 }
 
@@ -1202,11 +1212,15 @@ async function processMessageAfterDedupe(
       }
       replyToShortId = cached.shortId;
       if (core.logging.shouldLogVerbose()) {
-        const preview = (cached.body ?? "").replace(/\s+/g, " ").slice(0, 120);
+        // Quoted-message body is end-user content (potentially private chat
+        // text). Verbose logs may be persisted or shipped to remote
+        // aggregators, so log only metadata (length, presence) — never the
+        // text itself (CWE-532).
+        const bodyLen = (cached.body ?? "").length;
         logVerbose(
           core,
           runtime,
-          `reply-context cache hit replyToId=${replyToId} sender=${replyToSender ?? ""} body="${preview}"`,
+          `reply-context cache hit replyToId=${sanitizeForLog(replyToId, 80)} sender=${sanitizeForLog(replyToSender ?? "", 80)} bodyLen=${bodyLen}`,
         );
       }
     }
@@ -1233,14 +1247,13 @@ async function processMessageAfterDedupe(
             replyToSender = fetched.sender;
           }
           if (core.logging.shouldLogVerbose()) {
-            const preview = sanitizeForLog(
-              (fetched.text ?? "").replace(/\s+/g, " ").slice(0, 120),
-              120,
-            );
+            // Same redaction rationale as the cache-hit path above: log only
+            // metadata, not the quoted text itself.
+            const bodyLen = (fetched.text ?? "").length;
             logVerbose(
               core,
               runtime,
-              `reply-context API fallback replyToId=${sanitizeForLog(replyToId, 80)} sender=${sanitizeForLog(replyToSender ?? "", 80)} body="${preview}"`,
+              `reply-context API fallback replyToId=${sanitizeForLog(replyToId, 80)} sender=${sanitizeForLog(replyToSender ?? "", 80)} bodyLen=${bodyLen}`,
             );
           }
         }


### PR DESCRIPTION
## Summary

Three small, related BlueBubbles enhancements bundled because the SSRF guard fix only makes sense in the context of the new feature it hardens:

### 1. `bluebubbles: fetch quoted message from API when reply cache misses`

When a user replies to a message in iMessage, the BlueBubbles webhook may include only `replyToGuid` without the quoted message body. The in-memory reply cache (6h TTL, 2000 entries) doesn't always have it — e.g. after a Gateway restart, or when the original message is older than the cache window. Today the agent receives a reply with no context for what was replied to.

Adds a fallback that fetches the message by GUID from `/api/v1/message/<guid>` so the agent can see the quoted content when the cache misses. Falls back gracefully (returns `null`, no throw) on auth/network/parse errors so the existing reply path keeps working when the API is unreachable.

### 2. `fix(bluebubbles): route quoted-message API fallback through SSRF-guarded client`

Direct follow-up to #1 from a self-review: `fetchBlueBubblesMessageByGuid` initially called `blueBubblesFetchWithTimeout` directly without threading `ssrfPolicy`, which is the only switch that puts the request on the SSRF-guarded fetch path. Same shape as `fetchBlueBubblesHistory` in this file, which correctly uses `createBlueBubblesClientFromParts` to get the SSRF-aware client.

Switch to the same client construction (`resolveAccount` returns `allowPrivateNetwork`; `client.request` applies the SSRF policy). Drop the now-unused `buildBlueBubblesApiUrl` + `blueBubblesFetchWithTimeout` import. Same threat model as #68234's typed-client consolidation — this codepath was missed there.

### 3. `fix(bluebubbles): surface attachment download failures at error level`

`processMessage`'s attachment download catch block only called `logVerbose`, so download failures were invisible under normal log levels. I hit a real case where a pinned-dispatcher compat bug silently dropped every inbound image attachment, and the agent only saw the upstream-generated `<media:image> (1 image)` placeholder text — there was nothing in the log to indicate the actual download had failed.

Adds a `runtime.error` call alongside the existing `logVerbose` so future download failures are visible at default log level, while keeping verbose detail for debug sessions. Three lines.

## Test plan

- [x] `pnpm test extensions/bluebubbles` — 511/511 passing
- [x] `pnpm check:changed` — clean
- [ ] Manual: replying in iMessage to a message older than reply-cache TTL surfaces the quoted body in the agent transcript (pre-fix: empty/orphan)

## Notes for reviewers

- Commit 1 is the feature, commit 2 is a same-day SSRF-guard self-review fix. Happy to squash if preferred — kept separate so the threat model rationale stays visible in history.
- Commit 3 is independent and could be its own PR; bundled because it's a 3-line observability fix that complements the same channel.
