### PR TITLE
feat(slack): run message_sending hook on agent replies + ship slack-addressee-guard plugin

### DIFF
--- a/extensions/slack-addressee-guard/api.ts
+++ b/extensions/slack-addressee-guard/api.ts
@@ -1,0 +1,6 @@
+export type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+export { definePluginEntry, type OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+export {
+  fetchWithSsrFGuard,
+  ssrfPolicyFromAllowPrivateNetwork,
+} from "openclaw/plugin-sdk/ssrf-runtime";

--- a/extensions/slack-addressee-guard/index.test.ts
+++ b/extensions/slack-addressee-guard/index.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawPluginApi } from "./api.js";
+import register, { __testing } from "./index.js";
+
+const TARGET = "U0518D47N3X"; // Miles
+const BOT = "U0AKLRW2NHH"; // Prest0n
+const HUMAN_A = "U06GNTHJNG5"; // Malaika
+
+type RunHookFn = (
+  event: Record<string, unknown>,
+  ctx: Record<string, unknown>,
+) => Promise<{ cancel?: boolean; content?: string } | undefined>;
+
+function makeApi(config: Record<string, unknown>): {
+  api: OpenClawPluginApi;
+  hooks: { message_sending?: RunHookFn };
+} {
+  const hooks: { message_sending?: RunHookFn } = {};
+  const api = {
+    pluginConfig: config,
+    id: "slack-addressee-guard",
+    name: "Slack Addressee Guard",
+    logger: { info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+    on: (hookName: string, handler: RunHookFn) => {
+      hooks[hookName as "message_sending"] = handler;
+    },
+  } as unknown as OpenClawPluginApi;
+  return { api, hooks };
+}
+
+describe("slack-addressee-guard — pure helpers", () => {
+  it("parseChannelAndThread resolves metadata.channelId and threadTs", () => {
+    const target = __testing.parseChannelAndThread(
+      { metadata: { channelId: "C123", threadTs: "1.2" } },
+      undefined,
+    );
+    expect(target).toEqual({ channelId: "C123", threadTs: "1.2" });
+  });
+
+  it("parseChannelAndThread falls back to conversationId + replyToId", () => {
+    const target = __testing.parseChannelAndThread(
+      { replyToId: "9.9", metadata: {} },
+      "C456",
+    );
+    expect(target).toEqual({ channelId: "C456", threadTs: "9.9" });
+  });
+
+  it("parseChannelAndThread returns null for non-Slack channel ids", () => {
+    const target = __testing.parseChannelAndThread(
+      { metadata: { channelId: "not-a-slack-id", threadTs: "1.2" } },
+      undefined,
+    );
+    expect(target).toBeNull();
+  });
+
+  it("repairContent rewrites only the leading target mention", () => {
+    const rewritten = __testing.repairContent(
+      `<@${TARGET}> please ack this (also <@${TARGET}> fyi)`,
+      TARGET,
+      HUMAN_A,
+    );
+    expect(rewritten).toBe(`<@${HUMAN_A}> please ack this (also <@${TARGET}> fyi)`);
+  });
+
+  it("repairContent prepends a mention when none leads the text", () => {
+    const rewritten = __testing.repairContent(`hello folks`, TARGET, HUMAN_A);
+    expect(rewritten).toBe(`<@${HUMAN_A}> hello folks`);
+  });
+
+  it("lastHumanBeforeBot skips the bot and bot_message subtype entries", () => {
+    const msgs = [
+      { user: HUMAN_A, text: "hi", ts: "1.0" },
+      { user: BOT, text: "reply", ts: "1.1" },
+      { user: "UOTHER", text: "", ts: "1.2", subtype: "bot_message", bot_id: "B1" },
+    ];
+    const last = __testing.lastHumanBeforeBot(msgs, BOT);
+    expect(last?.user).toBe(HUMAN_A);
+  });
+
+  it("priorHumanAskedForTarget recognises direct target mentions and trigger phrases", () => {
+    const phrases = [...__testing.DEFAULT_ASKED_FOR_TARGET_PHRASES];
+    expect(
+      __testing.priorHumanAskedForTarget("please ping Miles about this", TARGET, phrases),
+    ).toBe(true);
+    expect(
+      __testing.priorHumanAskedForTarget(`loop <@${TARGET}> in`, TARGET, phrases),
+    ).toBe(true);
+    expect(
+      __testing.priorHumanAskedForTarget("what happened next?", TARGET, phrases),
+    ).toBe(false);
+  });
+
+  it("matchesAllowlist handles sign-off nudges and PM headers", () => {
+    const patterns = __testing.DEFAULT_ALLOWLIST_PATTERNS.map((p) => new RegExp(p, "i"));
+    expect(
+      __testing.matchesAllowlist(
+        `:alarm_clock: *AEO Project — sign-off nudge #25*`,
+        patterns,
+      ),
+    ).toBe(true);
+    expect(
+      __testing.matchesAllowlist(`⚡ [PM-Pulse] status check`, patterns),
+    ).toBe(true);
+    expect(
+      __testing.matchesAllowlist(`ordinary reply leading with <@${TARGET}>`, patterns),
+    ).toBe(false);
+  });
+
+  it("buildResolvedConfig enforces required targetUserId/botUserId + disabled flag", () => {
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+    try {
+      expect(__testing.buildResolvedConfig({ enabled: false })).toBeNull();
+      expect(__testing.buildResolvedConfig({})).toBeNull();
+      expect(
+        __testing.buildResolvedConfig({
+          targetUserId: TARGET,
+          botUserId: "bogus",
+        }),
+      ).toBeNull();
+      const ok = __testing.buildResolvedConfig({
+        targetUserId: TARGET,
+        botUserId: BOT,
+      });
+      expect(ok).not.toBeNull();
+      expect(ok?.mode).toBe("rewrite");
+    } finally {
+      delete process.env.SLACK_BOT_TOKEN;
+    }
+  });
+});
+
+describe("slack-addressee-guard — message_sending hook", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    __testing.clearCacheForTests();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.SLACK_BOT_TOKEN = "xoxb-test";
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.SLACK_BOT_TOKEN;
+    vi.restoreAllMocks();
+  });
+
+  async function callHook(
+    config: Record<string, unknown>,
+    event: Record<string, unknown>,
+    ctx: Record<string, unknown> = { channelId: "slack", conversationId: "C123" },
+  ): Promise<{ cancel?: boolean; content?: string } | undefined> {
+    const { api, hooks } = makeApi(config);
+    register.register(api);
+    const handler = hooks.message_sending;
+    if (!handler) {
+      throw new Error("handler not registered");
+    }
+    return handler(event, ctx);
+  }
+
+  function mockFetchThreadMessages(messages: Array<Record<string, unknown>>): void {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ messages }),
+    });
+  }
+
+  it("passes through for non-slack channels", async () => {
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      { content: `<@${TARGET}> hi`, to: "C123", metadata: { channelId: "C123", threadTs: "1.2" } },
+      { channelId: "telegram", conversationId: "C123" },
+    );
+    expect(result).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("passes through when content does not mention the target user", async () => {
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      { content: `<@${HUMAN_A}> already addressed`, to: "C123", metadata: { channelId: "C123", threadTs: "1.2" } },
+    );
+    expect(result).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("passes through sign-off nudge cron headers without calling Slack", async () => {
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      {
+        content: `:alarm_clock: *AEO Project — sign-off nudge #25* <@${TARGET}> please sign off`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.2" },
+      },
+    );
+    expect(result).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rewrites when another human spoke last and did not ask for the target", async () => {
+    mockFetchThreadMessages([
+      { user: TARGET, text: "kickoff", ts: "1.0" },
+      { user: BOT, text: "working", ts: "1.1" },
+      { user: HUMAN_A, text: "what's next?", ts: "1.2" },
+    ]);
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      {
+        content: `<@${TARGET}> looking into it`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.0" },
+      },
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ content: `<@${HUMAN_A}> looking into it` });
+  });
+
+  it("cancels instead of rewriting when mode=cancel", async () => {
+    mockFetchThreadMessages([
+      { user: HUMAN_A, text: "what's next?", ts: "1.2" },
+    ]);
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT, mode: "cancel" },
+      {
+        content: `<@${TARGET}> looking into it`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.0" },
+      },
+    );
+    expect(result).toEqual({ cancel: true });
+  });
+
+  it("passes through when the last human explicitly asked to ping the target", async () => {
+    mockFetchThreadMessages([
+      { user: HUMAN_A, text: `please ping <@${TARGET}> about this`, ts: "1.2" },
+    ]);
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      {
+        content: `<@${TARGET}> noted`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.0" },
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("passes through when the last human is the target themselves", async () => {
+    mockFetchThreadMessages([
+      { user: TARGET, text: "anything else?", ts: "1.3" },
+    ]);
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      {
+        content: `<@${TARGET}> on it`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.0" },
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("fails open when Slack API returns an error", async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) });
+    const result = await callHook(
+      { targetUserId: TARGET, botUserId: BOT },
+      {
+        content: `<@${TARGET}> hi`,
+        to: "C123",
+        metadata: { channelId: "C123", threadTs: "1.0" },
+      },
+    );
+    expect(result).toBeUndefined();
+  });
+});

--- a/extensions/slack-addressee-guard/index.ts
+++ b/extensions/slack-addressee-guard/index.ts
@@ -1,0 +1,430 @@
+import {
+  definePluginEntry,
+  fetchWithSsrFGuard,
+  ssrfPolicyFromAllowPrivateNetwork,
+  type OpenClawPluginApi,
+} from "./api.js";
+
+// Default allowlist regex patterns for cron/PM/nudge headers that legitimately
+// keep their leading @-mention (for example a sign-off nudge aimed at the
+// sign-off owner even when a different human spoke last in the thread).
+const DEFAULT_ALLOWLIST_PATTERNS: readonly string[] = [
+  String.raw`^\s*(?:⚡\s*)?\[(?:PM-|internal-prest0n|[a-z0-9-]+ VM\])`,
+  "Bug Squasher Report|Daily Improvement Report|Fleet Operations Digest",
+  "sign-off nudge|reminder #\\d+|nudge #\\d+|every 2h until|every 12h until|awaiting sign-off|awaiting approval",
+];
+
+// Default phrases the last human can use to explicitly ask the agent to ping
+// the configured targetUserId; when matched, the reply's leading @-mention is
+// treated as intentional even if the last human is someone else.
+const DEFAULT_ASKED_FOR_TARGET_PHRASES: readonly string[] = [
+  "ping",
+  "tag",
+  "ask",
+  "message",
+  "let",
+  "loop",
+  "cc",
+  "tell",
+];
+
+const DEFAULT_CACHE_TTL_MS = 8_000;
+const DEFAULT_MODE: GuardMode = "rewrite";
+
+type GuardMode = "rewrite" | "cancel";
+
+type AddresseeGuardConfig = {
+  enabled?: boolean;
+  mode?: GuardMode;
+  targetUserId?: string;
+  botUserId?: string;
+  humanNames?: Record<string, string>;
+  logPath?: string;
+  cacheTtlMs?: number;
+  allowlistPatterns?: string[];
+  askedForTargetPhrases?: string[];
+  // Internal escape hatch for tests; production callers should leave unset.
+  slackTokenOverride?: string;
+};
+
+type ResolvedConfig = {
+  mode: GuardMode;
+  targetUserId: string;
+  botUserId: string;
+  humanNames: Record<string, string>;
+  cacheTtlMs: number;
+  allowlistRegex: RegExp[];
+  askedForTargetPhrases: string[];
+  slackToken: string;
+};
+
+type AddresseeGuardMessageSendingResult =
+  | { cancel: true }
+  | { content: string }
+  | undefined;
+
+type ParsedTarget = { channelId: string; threadTs: string };
+
+type SlackUserMessage = {
+  user?: string;
+  text?: string;
+  ts?: string;
+  bot_id?: string;
+  subtype?: string;
+};
+
+type CachedLastHuman = {
+  at: number;
+  result: SlackUserMessage | null;
+};
+
+const lastHumanCache = new Map<string, CachedLastHuman>();
+
+function normalizeString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function resolveSlackTokenFromEnv(): string {
+  return process.env.SLACK_BOT_TOKEN ?? "";
+}
+
+function compileRegex(patterns: readonly string[]): RegExp[] {
+  const compiled: RegExp[] = [];
+  for (const pattern of patterns) {
+    try {
+      compiled.push(new RegExp(pattern, "i"));
+    } catch {
+      // Ignore bad regex from config so a single typo cannot break delivery.
+    }
+  }
+  return compiled;
+}
+
+function parseChannelAndThread(
+  event: { to?: unknown; threadId?: unknown; replyToId?: unknown; metadata?: Record<string, unknown> | null },
+  conversationId: string | undefined,
+): ParsedTarget | null {
+  const md = (event.metadata ?? {}) as Record<string, unknown>;
+  const channelRaw =
+    normalizeString(md.channelId) ||
+    normalizeString(md.channel_id) ||
+    normalizeString(md.channel) ||
+    normalizeString(conversationId) ||
+    normalizeString(event.to);
+  const channelId = channelRaw
+    .replace(/^slack:(channel|channels):/i, "")
+    .replace(/^channel:/i, "")
+    .trim();
+  const threadTs =
+    normalizeString(md.threadTs) ||
+    normalizeString(md.thread_ts) ||
+    normalizeString(md.threadId) ||
+    normalizeString(md.thread_id) ||
+    normalizeString(md.parentTs) ||
+    normalizeString(md.parent_ts) ||
+    normalizeString(event.replyToId) ||
+    normalizeString(event.threadId);
+  if (!channelId || !threadTs) {
+    return null;
+  }
+  if (!/^C[A-Z0-9]+$/i.test(channelId)) {
+    return null;
+  }
+  return { channelId, threadTs };
+}
+
+function contentMentionsTarget(content: string, targetUserId: string): boolean {
+  return content.includes(`<@${targetUserId}>`);
+}
+
+function matchesAllowlist(content: string, patterns: RegExp[]): boolean {
+  for (const re of patterns) {
+    if (re.test(content)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function lastHumanBeforeBot(
+  messages: readonly SlackUserMessage[],
+  botUserId: string,
+): SlackUserMessage | null {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (!msg?.user) {
+      continue;
+    }
+    if (msg.bot_id || msg.subtype === "bot_message") {
+      continue;
+    }
+    if (msg.user === botUserId) {
+      continue;
+    }
+    if (!/^U[A-Z0-9]+$/i.test(msg.user)) {
+      continue;
+    }
+    return msg;
+  }
+  return null;
+}
+
+function priorHumanAskedForTarget(
+  messageText: string | undefined,
+  targetUserId: string,
+  askedPhrases: readonly string[],
+): boolean {
+  const text = normalizeString(messageText);
+  if (!text) {
+    return false;
+  }
+  if (text.includes(`<@${targetUserId}>`)) {
+    // Last human already referenced the target directly in their message —
+    // treat a leading @target address as intentional.
+    return true;
+  }
+  const lower = text.toLowerCase();
+  const targetMention = `<@${targetUserId.toLowerCase()}>`;
+  if (lower.includes(targetMention)) {
+    return true;
+  }
+  for (const phrase of askedPhrases) {
+    if (!phrase) {
+      continue;
+    }
+    if (lower.includes(phrase.toLowerCase())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function repairContent(content: string, targetUserId: string, newUserId: string): string {
+  const correct = `<@${newUserId}>`;
+  const leadingTarget = new RegExp(`^(\\s*)<@${targetUserId}>\\b\\s*`);
+  if (leadingTarget.test(content)) {
+    return content.replace(leadingTarget, `$1${correct} `);
+  }
+  return `${correct} ${content}`;
+}
+
+function cacheKey(channelId: string, threadTs: string): string {
+  return `${channelId}:${threadTs}`;
+}
+
+function readCachedLastHuman(
+  channelId: string,
+  threadTs: string,
+  cacheTtlMs: number,
+): SlackUserMessage | null | undefined {
+  const entry = lastHumanCache.get(cacheKey(channelId, threadTs));
+  if (!entry) {
+    return undefined;
+  }
+  if (Date.now() - entry.at > cacheTtlMs) {
+    lastHumanCache.delete(cacheKey(channelId, threadTs));
+    return undefined;
+  }
+  return entry.result;
+}
+
+function writeCachedLastHuman(
+  channelId: string,
+  threadTs: string,
+  result: SlackUserMessage | null,
+): void {
+  lastHumanCache.set(cacheKey(channelId, threadTs), { at: Date.now(), result });
+}
+
+async function fetchLastHumanFromSlack(
+  api: OpenClawPluginApi,
+  token: string,
+  channelId: string,
+  threadTs: string,
+  botUserId: string,
+): Promise<SlackUserMessage | null> {
+  const url = new URL("https://slack.com/api/conversations.replies");
+  url.searchParams.set("channel", channelId);
+  url.searchParams.set("ts", threadTs);
+  url.searchParams.set("limit", "20");
+  try {
+    const { response, release } = await fetchWithSsrFGuard({
+      url: url.toString(),
+      init: {
+        method: "GET",
+        headers: { Authorization: `Bearer ${token}` },
+      },
+      timeoutMs: 3000,
+      policy: ssrfPolicyFromAllowPrivateNetwork(false),
+      auditContext: "slack-addressee-guard",
+    });
+    try {
+      if (!response.ok) {
+        return null;
+      }
+      const data = (await response.json()) as { messages?: SlackUserMessage[] };
+      const messages = Array.isArray(data?.messages) ? data.messages : [];
+      return lastHumanBeforeBot(messages, botUserId);
+    } finally {
+      await release();
+    }
+  } catch (err) {
+    api.logger.warn?.(
+      `slack-addressee-guard: thread fetch failed; fail-open (${String(
+        (err as Error | undefined)?.message ?? err,
+      )})`,
+    );
+    return null;
+  }
+}
+
+function buildResolvedConfig(raw: AddresseeGuardConfig | undefined): ResolvedConfig | null {
+  const cfg = raw ?? {};
+  if (cfg.enabled === false) {
+    return null;
+  }
+  const targetUserId = normalizeString(cfg.targetUserId).trim();
+  const botUserId = normalizeString(cfg.botUserId).trim();
+  if (!targetUserId || !botUserId) {
+    return null;
+  }
+  if (!/^U[A-Z0-9]+$/i.test(targetUserId) || !/^U[A-Z0-9]+$/i.test(botUserId)) {
+    return null;
+  }
+  const token = normalizeString(cfg.slackTokenOverride) || resolveSlackTokenFromEnv();
+  if (!token) {
+    return null;
+  }
+  const mode: GuardMode = cfg.mode === "cancel" ? "cancel" : DEFAULT_MODE;
+  const cacheTtl =
+    typeof cfg.cacheTtlMs === "number" && Number.isFinite(cfg.cacheTtlMs) && cfg.cacheTtlMs >= 0
+      ? Math.min(cfg.cacheTtlMs, 600_000)
+      : DEFAULT_CACHE_TTL_MS;
+  const allowlistInput = Array.isArray(cfg.allowlistPatterns)
+    ? [...DEFAULT_ALLOWLIST_PATTERNS, ...cfg.allowlistPatterns]
+    : [...DEFAULT_ALLOWLIST_PATTERNS];
+  const allowlistRegex = compileRegex(allowlistInput);
+  const askedPhrases = Array.isArray(cfg.askedForTargetPhrases)
+    ? [...DEFAULT_ASKED_FOR_TARGET_PHRASES, ...cfg.askedForTargetPhrases]
+    : [...DEFAULT_ASKED_FOR_TARGET_PHRASES];
+  const humanNames: Record<string, string> = {};
+  if (cfg.humanNames && typeof cfg.humanNames === "object") {
+    for (const [key, value] of Object.entries(cfg.humanNames)) {
+      if (typeof value === "string") {
+        humanNames[key] = value;
+      }
+    }
+  }
+  return {
+    mode,
+    targetUserId,
+    botUserId,
+    humanNames,
+    cacheTtlMs: cacheTtl,
+    allowlistRegex,
+    askedForTargetPhrases: askedPhrases,
+    slackToken: token,
+  };
+}
+
+export default definePluginEntry({
+  id: "slack-addressee-guard",
+  name: "Slack Addressee Guard",
+  description:
+    "Pre-send guard that rewrites agent replies that lead with an accidental @-mention of the configured target user when a different human spoke last in the thread.",
+  register(api) {
+    const resolved = buildResolvedConfig(api.pluginConfig as AddresseeGuardConfig | undefined);
+    if (!resolved) {
+      api.logger.info?.(
+        "slack-addressee-guard: disabled (missing targetUserId/botUserId/slack token or config.enabled=false)",
+      );
+      return;
+    }
+
+    api.on(
+      "message_sending",
+      async (event, ctx): Promise<AddresseeGuardMessageSendingResult> => {
+        if (ctx.channelId !== "slack") {
+          return undefined;
+        }
+        const content = normalizeString(event?.content);
+        if (!content || !contentMentionsTarget(content, resolved.targetUserId)) {
+          return undefined;
+        }
+        const target = parseChannelAndThread(
+          event as Parameters<typeof parseChannelAndThread>[0],
+          ctx.conversationId,
+        );
+        if (!target) {
+          return undefined;
+        }
+        if (matchesAllowlist(content, resolved.allowlistRegex)) {
+          return undefined;
+        }
+
+        let lastHuman = readCachedLastHuman(
+          target.channelId,
+          target.threadTs,
+          resolved.cacheTtlMs,
+        );
+        if (lastHuman === undefined) {
+          lastHuman = await fetchLastHumanFromSlack(
+            api,
+            resolved.slackToken,
+            target.channelId,
+            target.threadTs,
+            resolved.botUserId,
+          );
+          writeCachedLastHuman(target.channelId, target.threadTs, lastHuman);
+        }
+
+        if (!lastHuman || !lastHuman.user) {
+          return undefined;
+        }
+        if (lastHuman.user === resolved.targetUserId) {
+          return undefined;
+        }
+        if (content.includes(`<@${lastHuman.user}>`)) {
+          return undefined;
+        }
+        if (
+          priorHumanAskedForTarget(
+            lastHuman.text,
+            resolved.targetUserId,
+            resolved.askedForTargetPhrases,
+          )
+        ) {
+          return undefined;
+        }
+
+        const priorHumanName = resolved.humanNames[lastHuman.user] ?? lastHuman.user;
+        api.logger.info?.(
+          `slack-addressee-guard: ${
+            resolved.mode === "cancel" ? "cancelling" : "rewriting"
+          } reply to ${target.channelId}:${target.threadTs} — prior human ${priorHumanName}`,
+        );
+
+        if (resolved.mode === "cancel") {
+          return { cancel: true };
+        }
+        const next = repairContent(content, resolved.targetUserId, lastHuman.user);
+        return { content: next };
+      },
+    );
+  },
+});
+
+// Exposed for unit tests; not part of the plugin's public API.
+export const __testing = {
+  parseChannelAndThread,
+  repairContent,
+  lastHumanBeforeBot,
+  priorHumanAskedForTarget,
+  matchesAllowlist,
+  buildResolvedConfig,
+  DEFAULT_ALLOWLIST_PATTERNS,
+  DEFAULT_ASKED_FOR_TARGET_PHRASES,
+  clearCacheForTests(): void {
+    lastHumanCache.clear();
+  },
+};

--- a/extensions/slack-addressee-guard/openclaw.plugin.json
+++ b/extensions/slack-addressee-guard/openclaw.plugin.json
@@ -1,0 +1,70 @@
+{
+  "id": "slack-addressee-guard",
+  "activation": {
+    "onStartup": true
+  },
+  "name": "Slack Addressee Guard",
+  "description": "Pre-send guard that rewrites an agent reply leading with an accidental Slack @-mention when a different human spoke last in the thread.",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "enabled": { "type": "boolean" },
+      "mode": { "type": "string", "enum": ["rewrite", "cancel"] },
+      "targetUserId": { "type": "string" },
+      "botUserId": { "type": "string" },
+      "humanNames": {
+        "type": "object",
+        "additionalProperties": { "type": "string" }
+      },
+      "logPath": { "type": "string" },
+      "cacheTtlMs": { "type": "integer", "minimum": 0, "maximum": 600000 },
+      "allowlistPatterns": {
+        "type": "array",
+        "items": { "type": "string" }
+      },
+      "askedForTargetPhrases": {
+        "type": "array",
+        "items": { "type": "string" }
+      }
+    }
+  },
+  "uiHints": {
+    "enabled": {
+      "label": "Enable Slack Addressee Guard",
+      "help": "When enabled, agent replies leading with the target user's @-mention are rewritten to address the last human in the thread if they were different."
+    },
+    "mode": {
+      "label": "Mode",
+      "help": "rewrite (default) repairs the leading address. cancel drops the reply entirely when a mismatch is detected."
+    },
+    "targetUserId": {
+      "label": "Target Slack User ID",
+      "help": "The Slack user id the agent too often addresses by default (e.g. the operator). Replies leading with this id are inspected."
+    },
+    "botUserId": {
+      "label": "Bot Slack User ID",
+      "help": "The Slack user id of the bot itself. Used to skip bot messages when walking thread history to find the last human."
+    },
+    "humanNames": {
+      "label": "Human Name Map",
+      "help": "Optional map of Slack user ids to display names for log records."
+    },
+    "logPath": {
+      "label": "Log Path",
+      "help": "Optional JSONL path for decisions. Defaults to no file logging when omitted."
+    },
+    "cacheTtlMs": {
+      "label": "Thread Cache TTL (ms)",
+      "help": "How long a resolved last-human-in-thread lookup is cached. Defaults to 8s."
+    },
+    "allowlistPatterns": {
+      "label": "Allowlist Regex Patterns",
+      "help": "Optional additional regex patterns (JS flavor) that mark a reply as a cron/PM/nudge header that must stay intact."
+    },
+    "askedForTargetPhrases": {
+      "label": "Asked-For-Target Phrases",
+      "help": "Optional additional phrases that mean the last human explicitly requested the target user be addressed."
+    }
+  }
+}

--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -5,6 +5,19 @@ vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
 }));
 
+const messageHookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSending: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/plugin-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/plugin-runtime")>();
+  return {
+    ...actual,
+    getGlobalHookRunner: () => messageHookRunner,
+  };
+});
+
 let deliverReplies: typeof import("./replies.js").deliverReplies;
 let createSlackReplyDeliveryPlan: typeof import("./replies.js").createSlackReplyDeliveryPlan;
 let resolveDeliveredSlackReplyThreadTs: typeof import("./replies.js").resolveDeliveredSlackReplyThreadTs;
@@ -38,6 +51,9 @@ describe("deliverReplies identity passthrough", () => {
 
   beforeEach(() => {
     sendMock.mockReset();
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSending.mockReset();
   });
   it("passes identity to sendMessageSlack for text replies", async () => {
     sendMock.mockResolvedValue(undefined);
@@ -296,5 +312,150 @@ describe("deliverSlackSlashReplies chunking", () => {
       text,
       response_type: "ephemeral",
     });
+  });
+});
+
+describe("deliverReplies message_sending hook wiring", () => {
+  beforeAll(async () => {
+    ({ deliverReplies } = await import("./replies.js"));
+  });
+
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue(undefined);
+    messageHookRunner.hasHooks.mockReset();
+    messageHookRunner.hasHooks.mockReturnValue(false);
+    messageHookRunner.runMessageSending.mockReset();
+  });
+
+  function params(overrides?: Record<string, unknown>) {
+    return {
+      cfg: SLACK_TEST_CFG,
+      replies: [{ text: "hello" }],
+      target: "C123",
+      token: "xoxb-test",
+      runtime: { log: () => {}, error: () => {}, exit: () => {} },
+      textLimit: 4000,
+      replyToMode: "off" as const,
+      replyThreadTs: "1712000000.000001",
+      ...overrides,
+    };
+  }
+
+  it("invokes message_sending once per reply with slack routing context", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending",
+    );
+    messageHookRunner.runMessageSending.mockResolvedValue(undefined);
+
+    await deliverReplies(
+      params({
+        replies: [{ text: "first" }, { text: "second" }],
+        accountId: "primary",
+      }),
+    );
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledTimes(2);
+    expect(messageHookRunner.runMessageSending).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        to: "C123",
+        content: "first",
+        threadId: "1712000000.000001",
+        metadata: expect.objectContaining({
+          channel: "slack",
+          accountId: "primary",
+          threadTs: "1712000000.000001",
+        }),
+      }),
+      expect.objectContaining({
+        channelId: "slack",
+        accountId: "primary",
+        conversationId: "C123",
+      }),
+    );
+    expect(sendMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rewrites outgoing reply text when the hook returns new content", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending",
+    );
+    messageHookRunner.runMessageSending.mockResolvedValue({
+      content: "<@U111> rewritten",
+    });
+
+    await deliverReplies(params({ replies: [{ text: "<@U222> hello" }] }));
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0]?.[1]).toBe("<@U111> rewritten");
+  });
+
+  it("skips delivery entirely when the hook cancels", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending",
+    );
+    messageHookRunner.runMessageSending.mockResolvedValue({ cancel: true });
+
+    await deliverReplies(params());
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("short-circuits without touching the hook runner when no hooks are registered", async () => {
+    messageHookRunner.hasHooks.mockReturnValue(false);
+
+    await deliverReplies(params());
+
+    expect(messageHookRunner.runMessageSending).not.toHaveBeenCalled();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open when the hook handler throws (delivery still happens)", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending",
+    );
+    messageHookRunner.runMessageSending.mockRejectedValueOnce(new Error("boom"));
+
+    await deliverReplies(params());
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0]?.[1]).toBe("hello");
+  });
+
+  it("runs the hook for block-only replies and uses hook content for the send text", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending",
+    );
+    messageHookRunner.runMessageSending.mockResolvedValue({ content: "guarded text" });
+
+    const blocks = [
+      {
+        type: "actions",
+        elements: [
+          {
+            type: "button",
+            action_id: "openclaw:reply_button",
+            text: { type: "plain_text", text: "Option" },
+            value: "opt",
+          },
+        ],
+      },
+    ];
+
+    await deliverReplies(
+      params({
+        replies: [
+          {
+            text: "original",
+            channelData: { slack: { blocks } },
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0]?.[1]).toBe("guarded text");
+    expect(sendMock.mock.calls[0]?.[2]).toMatchObject({ blocks });
   });
 });

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -1,4 +1,5 @@
 import type { MarkdownTableMode, OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
   chunkMarkdownTextWithMode,
   isSilentReplyText,
@@ -44,6 +45,8 @@ export async function deliverReplies(params: {
   replyToMode: "off" | "first" | "all" | "batched";
   identity?: SlackSendIdentity;
 }) {
+  const hookRunner = getGlobalHookRunner();
+  const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
   for (const payload of params.replies) {
     const threadTs = resolveDeliveredSlackReplyThreadTs({
       replyToMode: params.replyToMode,
@@ -56,6 +59,54 @@ export async function deliverReplies(params: {
       continue;
     }
 
+    // Run the message_sending plugin hook for agent-reply delivery. Older
+    // Slack releases only wired the hook into the proactive message tool
+    // path, so plugins such as thread-ownership / slack-addressee-guard
+    // never saw agent replies. Keep the behavior identical when no plugin
+    // has registered a hook by short-circuiting on hasMessageSendingHooks.
+    const applyReplyMessageSendingHook = async (
+      content: string,
+      mediaUrls: readonly string[],
+    ): Promise<{ cancel: true } | { cancel: false; content: string }> => {
+      if (!hasMessageSendingHooks || !hookRunner) {
+        return { cancel: false, content };
+      }
+      try {
+        const hookResult = await hookRunner.runMessageSending(
+          {
+            to: params.target,
+            content,
+            threadId: threadTs,
+            metadata: {
+              channel: "slack",
+              accountId: params.accountId,
+              threadTs,
+              mediaUrls: [...mediaUrls],
+            },
+          },
+          {
+            channelId: "slack",
+            accountId: params.accountId ?? undefined,
+            conversationId: params.target,
+          },
+        );
+        if (hookResult?.cancel) {
+          return { cancel: true };
+        }
+        if (typeof hookResult?.content === "string") {
+          return { cancel: false, content: hookResult.content };
+        }
+      } catch (err) {
+        // Fail open: do not block agent replies on hook errors.
+        params.runtime.log?.(
+          `slack reply message_sending hook threw; fail-open (${String(
+            (err as Error | undefined)?.message ?? err,
+          )})`,
+        );
+      }
+      return { cancel: false, content };
+    };
+
     if (!reply.hasMedia && slackBlocks?.length) {
       const trimmed = reply.trimmedText;
       if (!trimmed && !slackBlocks?.length) {
@@ -64,7 +115,11 @@ export async function deliverReplies(params: {
       if (trimmed && isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
+      const gated = await applyReplyMessageSendingHook(trimmed, []);
+      if (gated.cancel) {
+        continue;
+      }
+      await sendMessageSlack(params.target, gated.content, {
         cfg: params.cfg,
         token: params.token,
         threadTs,
@@ -89,7 +144,11 @@ export async function deliverReplies(params: {
           }
         : undefined,
       sendText: async (trimmed) => {
-        await sendMessageSlack(params.target, trimmed, {
+        const gated = await applyReplyMessageSendingHook(trimmed, []);
+        if (gated.cancel) {
+          return;
+        }
+        await sendMessageSlack(params.target, gated.content, {
           cfg: params.cfg,
           token: params.token,
           threadTs,
@@ -98,7 +157,11 @@ export async function deliverReplies(params: {
         });
       },
       sendMedia: async ({ mediaUrl, caption }) => {
-        await sendMessageSlack(params.target, caption ?? "", {
+        const gated = await applyReplyMessageSendingHook(caption ?? "", [mediaUrl]);
+        if (gated.cancel) {
+          return;
+        }
+        await sendMessageSlack(params.target, gated.content, {
           cfg: params.cfg,
           token: params.token,
           mediaUrl,


### PR DESCRIPTION
## Summary

Two-part fix to a long-standing Slack outbound coverage gap.

### 1. Wire `message_sending` hook into agent replies (`extensions/slack/src/monitor/replies.ts`)

Before this PR, the `message_sending` plugin hook only fired for **proactive** `message`-tool sends (via `src/infra/outbound/deliver.ts`). **Agent replies to Slack events — which is the vast majority of bot outbound traffic — bypassed the hook entirely** because `deliverReplies()` called `sendMessageSlack()` directly.

That meant plugins like `thread-ownership` only ever fired on proactive sends, and anything added as a `message_sending` hook for safety (addressee rewriting, dlp, compliance rewrites, etc.) was architecturally incapable of catching agent replies.

The fix wires `getGlobalHookRunner().runMessageSending(...)` around all three `sendMessageSlack` call sites in `deliverReplies` (blocks-only path, `sendText`, `sendMedia`) with:

- `{ cancel: true }` drops the send entirely
- `{ content: string }` rewrites the outgoing text
- Fails open on hook error (reply still delivers; logged via `params.runtime.log`)
- Short-circuits (no runner call) when no plugin has registered `message_sending`, so zero-cost when off

### 2. New stock plugin: `extensions/slack-addressee-guard`

Pre-send guard that rewrites agent replies leading with an accidental `<@targetUserId>` when a different human spoke last in the thread.

Config schema (`openclaw.plugin.json`):
- `enabled` (default `true`), `mode` = `"rewrite"` (default) | `"cancel"`
- `targetUserId`, `botUserId` (required Slack user IDs)
- `humanNames` (optional map for log readability)
- `cacheTtlMs` (default 8s)
- `allowlistPatterns` (appended to defaults — sign-off nudges, reminder #N, PM-Pulse, AEO/Llama Lounge, fleet digest, etc.)
- `askedForTargetPhrases` (appended to defaults — "ping", "tag", "loop", "cc", etc.)

Implementation (`index.ts`):
- Uses `fetchWithSsrFGuard` for the `conversations.replies` call
- Caches "last human in thread" per `(channelId, threadTs)` with 8s TTL
- Skips bot messages + bot_message subtype entries when walking thread
- Passes through when: non-Slack surface, no target mention, content matches allowlist, last human is the target themselves, last human already mentioned in content, or last human explicitly asked to ping the target

## Tests

- **5 new cases** in `extensions/slack/src/monitor/replies.test.ts` — hook fires, `cancel=true` blocks send, no-hooks short-circuits (no runner call), hook throw fails open, block-only replies use rewritten text and preserve `blocks`.
- **14 new cases** in `extensions/slack-addressee-guard/index.test.ts` — pure-helper tests (parseChannelAndThread, repairContent, lastHumanBeforeBot, priorHumanAskedForTarget, matchesAllowlist, buildResolvedConfig) + message_sending hook tests (non-Slack passthrough, no-target-mention passthrough, sign-off-nudge cron passthrough, rewrite when last human differs, cancel mode, prior-ping-target allowlist, last-human-is-target passthrough, fails open on Slack API error).

## Context

Escalated from a repeated production regression on a Prest0n deployment where the bot was addressing the wrong human in Slack threads. Local VM-level dist patch + plugin have been running since 2026-04-28 02:09 UTC; this PR promotes the fix upstream so all VMs benefit without per-deploy dist hacks, and closes the underlying hook-coverage gap for every `message_sending` plugin.

_Opened as draft so CI can validate the hook wiring end-to-end before merge; happy to add follow-ups or split patches if maintainers prefer._
