### PR TITLE
docs(gateway): clarify reachability across VMs and tailnets

### DIFF
--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -35,7 +35,9 @@ network boundary issues, not broken Gateway startup.
 
    ```bash
    openclaw config get gateway.bind
-   ss -ltnp | grep ':18789'
+   ss -ltnp | grep ':18789'        # Linux
+   lsof -i :18789                  # macOS
+   netstat -ano | findstr :18789   # Windows PowerShell/cmd
    ```
 
    `127.0.0.1:18789` means only processes in that same network namespace can

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -15,6 +15,64 @@ This repo supports “remote over SSH” by keeping a single Gateway (the master
 - The Gateway WebSocket binds to **loopback** on your configured port (defaults to 18789).
 - For remote use, you forward that loopback port over SSH (or use a tailnet/VPN and tunnel less).
 
+## Gateway reachability checklist
+
+Use this when the Gateway works on the machine running OpenClaw but another
+host, VM, WSL2 distro, phone, or node cannot reach it. Most failures here are
+network boundary issues, not broken Gateway startup.
+
+1. **Check the Gateway locally on the Gateway host:**
+
+   ```bash
+   openclaw gateway status
+   curl -i http://127.0.0.1:18789/health
+   ```
+
+   If loopback fails on the Gateway host, debug the service before looking at
+   LAN, VM, or Tailnet routing.
+
+2. **Confirm what address the Gateway is bound to:**
+
+   ```bash
+   openclaw config get gateway.bind
+   ss -ltnp | grep ':18789'
+   ```
+
+   `127.0.0.1:18789` means only processes in that same network namespace can
+   connect. `0.0.0.0:18789`, a LAN IP, or a Tailscale IP means it is exposed
+   beyond loopback and must have Gateway auth enabled.
+
+3. **Identify the network boundary you are crossing:**
+   - **Host ↔ VM/container (OrbStack, Docker, dev containers):** loopback inside
+     the guest is not the host loopback. Either use the VM's published/forwarded
+     address, bind deliberately, or keep the Gateway loopback-only and use SSH or
+     Tailscale Serve.
+   - **Windows ↔ WSL2:** WSL2 `172.x` addresses are NAT-internal and often are
+     not reachable from the LAN or phones. Treat WSL2 as a VM boundary; prefer a
+     tunnel, Tailscale, or a Gateway running on a stable host.
+   - **LAN devices:** verify the Gateway host firewall allows the port, the
+     client is on the same network/VLAN, and you are using the host's LAN IP, not
+     `127.0.0.1`.
+   - **Tailnet devices:** prefer Tailscale Serve for the Control UI/WebSocket, or
+     bind to the Tailnet address only with auth enabled.
+
+4. **Pick the safest access pattern:**
+
+   | Need                              | Recommended pattern                                               |
+   | --------------------------------- | ----------------------------------------------------------------- |
+   | Same machine only                 | Keep `gateway.bind: "loopback"`.                                  |
+   | Laptop/operator to remote Gateway | Keep loopback and use SSH local forwarding.                       |
+   | Phones/nodes across networks      | Use Tailscale Serve or a Tailnet-only bind.                       |
+   | Temporary debugging across LAN    | Bind to LAN briefly with token/password auth and a firewall rule. |
+   | Last-resort NAT traversal         | Use a reverse SSH tunnel to a host you control.                   |
+
+<Warning>
+Do not switch to a LAN or `0.0.0.0` bind just to make discovery easier unless
+you have enabled Gateway auth (`gateway.auth.token`, password auth, or a trusted
+identity-aware proxy). Broad binds without auth expose operator-grade access to
+the network.
+</Warning>
+
 ## Common VPN and tailnet setups
 
 Think of the **Gateway host** as where the agent lives. It owns sessions, auth profiles, channels, and state. Your laptop, desktop, and nodes connect to that host.

--- a/docs/gateway/remote.md
+++ b/docs/gateway/remote.md
@@ -15,6 +15,64 @@ This repo supports "remote over SSH" by keeping a single Gateway (the master) ru
 - The Gateway WebSocket binds to **loopback** on your configured port (defaults to 18789).
 - For remote use, you forward that loopback port over SSH (or use a tailnet/VPN and tunnel less).
 
+## Gateway reachability checklist
+
+Use this when the Gateway works on the machine running OpenClaw but another
+host, VM, WSL2 distro, phone, or node cannot reach it. Most failures here are
+network boundary issues, not broken Gateway startup.
+
+1. **Check the Gateway locally on the Gateway host:**
+
+   ```bash
+   openclaw gateway status
+   curl -i http://127.0.0.1:18789/health
+   ```
+
+   If loopback fails on the Gateway host, debug the service before looking at
+   LAN, VM, or Tailnet routing.
+
+2. **Confirm what address the Gateway is bound to:**
+
+   ```bash
+   openclaw config get gateway.bind
+   ss -ltnp | grep ':18789'
+   ```
+
+   `127.0.0.1:18789` means only processes in that same network namespace can
+   connect. `0.0.0.0:18789`, a LAN IP, or a Tailscale IP means it is exposed
+   beyond loopback and must have Gateway auth enabled.
+
+3. **Identify the network boundary you are crossing:**
+   - **Host ↔ VM/container (OrbStack, Docker, dev containers):** loopback inside
+     the guest is not the host loopback. Either use the VM's published/forwarded
+     address, bind deliberately, or keep the Gateway loopback-only and use SSH or
+     Tailscale Serve.
+   - **Windows ↔ WSL2:** WSL2 `172.x` addresses are NAT-internal and often are
+     not reachable from the LAN or phones. Treat WSL2 as a VM boundary; prefer a
+     tunnel, Tailscale, or a Gateway running on a stable host.
+   - **LAN devices:** verify the Gateway host firewall allows the port, the
+     client is on the same network/VLAN, and you are using the host's LAN IP, not
+     `127.0.0.1`.
+   - **Tailnet devices:** prefer Tailscale Serve for the Control UI/WebSocket, or
+     bind to the Tailnet address only with auth enabled.
+
+4. **Pick the safest access pattern:**
+
+   | Need                              | Recommended pattern                                               |
+   | --------------------------------- | ----------------------------------------------------------------- |
+   | Same machine only                 | Keep `gateway.bind: "loopback"`.                                  |
+   | Laptop/operator to remote Gateway | Keep loopback and use SSH local forwarding.                       |
+   | Phones/nodes across networks      | Use Tailscale Serve or a Tailnet-only bind.                       |
+   | Temporary debugging across LAN    | Bind to LAN briefly with token/password auth and a firewall rule. |
+   | Last-resort NAT traversal         | Use a reverse SSH tunnel to a host you control.                   |
+
+<Warning>
+Do not switch to a LAN or `0.0.0.0` bind just to make discovery easier unless
+you have enabled Gateway auth (`gateway.auth.token`, password auth, or a trusted
+identity-aware proxy). Broad binds without auth expose operator-grade access to
+the network.
+</Warning>
+
 ## Common VPN and tailnet setups
 
 Think of the **Gateway host** as where the agent lives. It owns sessions, auth profiles, channels, and state. Your laptop, desktop, and nodes connect to that host.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -62,6 +62,15 @@ openclaw config get meta.lastTouchedVersion
 For intentional downgrade or emergency recovery only, set `OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS=1` for the single command. Leave it unset for normal operation.
 </Warning>
 
+## Gateway works locally but not from LAN, VM, WSL2, or Tailscale
+
+If `openclaw gateway status` is healthy on the Gateway host but another machine
+or node cannot connect, follow the [Gateway reachability checklist](/gateway/remote#gateway-reachability-checklist).
+
+Common causes are loopback-only binds, VM/container NAT boundaries, WSL2 `172.x`
+addresses that are not LAN-routable, host firewalls, or using LAN exposure when
+Tailscale Serve/SSH forwarding would be safer.
+
 ## Anthropic 429 extra usage required for long context
 
 Use this when logs/errors include: `HTTP 429: rate_limit_error: Extra usage is required for long context requests`.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -118,7 +118,6 @@ Common causes are loopback-only binds, VM/container NAT boundaries, WSL2 `172.x`
 addresses that are not LAN-routable, host firewalls, or using LAN exposure when
 Tailscale Serve/SSH forwarding would be safer.
 
-
 ## Anthropic 429 extra usage required for long context
 
 Use this when logs/errors include: `HTTP 429: rate_limit_error: Extra usage is required for long context requests`.

--- a/docs/gateway/troubleshooting.md
+++ b/docs/gateway/troubleshooting.md
@@ -109,6 +109,16 @@ Related:
 - [Skills config](/tools/skills-config#symlinked-sibling-repos)
 - [Configuration examples](/gateway/configuration-examples#symlinked-sibling-skill-repo)
 
+## Gateway works locally but not from LAN, VM, WSL2, or Tailscale
+
+If `openclaw gateway status` is healthy on the Gateway host but another machine
+or node cannot connect, follow the [Gateway reachability checklist](/gateway/remote#gateway-reachability-checklist).
+
+Common causes are loopback-only binds, VM/container NAT boundaries, WSL2 `172.x`
+addresses that are not LAN-routable, host firewalls, or using LAN exposure when
+Tailscale Serve/SSH forwarding would be safer.
+
+
 ## Anthropic 429 extra usage required for long context
 
 Use this when logs/errors include: `HTTP 429: rate_limit_error: Extra usage is required for long context requests`.


### PR DESCRIPTION
## Summary
- add a Gateway reachability checklist for loopback/LAN/VM/WSL2/Tailscale cases
- call out OrbStack/container and WSL2 NAT caveats
- link the checklist from Gateway troubleshooting
- keep the newer skill-symlink troubleshooting section while rebasing onto current `upstream/main`

Fixes #73152

## Real behavior proof
- **Behavior or issue addressed:** Users with a healthy local gateway but failed LAN/VM/WSL2/Tailscale connectivity lacked a clear docs path for checking bind address, NAT/firewall boundaries, and safer Tailscale/SSH exposure options.
- **Real environment tested:** Local OpenClaw docs checkout for PR #73249 on Linux/Node 22 after rebasing onto current `upstream/main`.
- **Exact steps or command run after this patch:** Ran `grep -n "Gateway reachability checklist\|WSL2\|Tailscale Serve\|Cross-platform port checks" docs/gateway/remote.md docs/gateway/troubleshooting.md | head -30` from the patched checkout, then ran the docs lint gate.
- **Evidence after fix:** Copied terminal output from the after-fix grep:

  ```text
  docs/gateway/remote.md:18:## Gateway reachability checklist
  docs/gateway/remote.md:21:host, VM, WSL2 distro, phone, or node cannot reach it. Most failures here are
  docs/gateway/remote.md:51:     Tailscale Serve.
  docs/gateway/remote.md:52:   - **Windows ↔ WSL2:** WSL2 `172.x` addresses are NAT-internal and often are
  docs/gateway/remote.md:58:   - **Tailnet devices:** prefer Tailscale Serve for the Control UI/WebSocket, or
  docs/gateway/troubleshooting.md:112:## Gateway works locally but not from LAN, VM, WSL2, or Tailscale
  docs/gateway/troubleshooting.md:115:or node cannot connect, follow the [Gateway reachability checklist](/gateway/remote#gateway-reachability-checklist).
  ```

- **Observed result after fix:** The remote gateway docs now expose a named reachability checklist and the troubleshooting page links directly to it with WSL2/Tailscale wording present.
- **What was not tested:** I did not publish the docs site or click through a built docs UI; validation was limited to direct file inspection plus markdown lint.

## Validation
- `CI=true pnpm lint:docs`
- `git diff --check`
