### PR TITLE
fix(mattermost): honor streaming mode for draft preview

### DIFF
--- a/extensions/mattermost/src/config-schema-core.ts
+++ b/extensions/mattermost/src/config-schema-core.ts
@@ -78,6 +78,40 @@ const MattermostNetworkSchema = z
   .strict()
   .optional();
 
+const MattermostStreamingBlockSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    coalesce: BlockStreamingCoalesceSchema.optional(),
+  })
+  .strict();
+
+const MattermostStreamingPreviewChunkSchema = z
+  .object({
+    minChars: z.number().int().positive().optional(),
+    maxChars: z.number().int().positive().optional(),
+    breakPreference: z
+      .union([z.literal("paragraph"), z.literal("newline"), z.literal("sentence")])
+      .optional(),
+  })
+  .strict();
+
+const MattermostStreamingPreviewSchema = z
+  .object({
+    chunk: MattermostStreamingPreviewChunkSchema.optional(),
+    toolProgress: z.boolean().optional(),
+  })
+  .strict();
+
+const MattermostStreamingSchema = z
+  .object({
+    mode: z.enum(["off", "partial", "block", "progress"]).optional(),
+    chunkMode: z.enum(["length", "newline"]).optional(),
+    preview: MattermostStreamingPreviewSchema.optional(),
+    block: MattermostStreamingBlockSchema.optional(),
+  })
+  .strict()
+  .optional();
+
 const MattermostAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -96,6 +130,7 @@ const MattermostAccountSchemaBase = z
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     textChunkLimit: z.number().int().positive().optional(),
+    streaming: MattermostStreamingSchema,
     chunkMode: z.enum(["length", "newline"]).optional(),
     blockStreaming: z.boolean().optional(),
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),

--- a/extensions/mattermost/src/config-schema.test.ts
+++ b/extensions/mattermost/src/config-schema.test.ts
@@ -29,6 +29,23 @@ describe("MattermostConfigSchema", () => {
     expect(result.success).toBe(true);
   });
 
+  it("accepts canonical streaming mode at top-level and account-level", () => {
+    const result = MattermostConfigSchema.safeParse({
+      streaming: {
+        mode: "off",
+        chunkMode: "newline",
+        preview: { toolProgress: false },
+        block: { enabled: true, coalesce: { minChars: 120, idleMs: 500 } },
+      },
+      accounts: {
+        secondary: {
+          streaming: { mode: "partial" },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
   it("accepts groups with requireMention", () => {
     const result = MattermostConfigSchema.safeParse({
       groups: {

--- a/extensions/mattermost/src/mattermost/monitor.test.ts
+++ b/extensions/mattermost/src/mattermost/monitor.test.ts
@@ -9,6 +9,7 @@ import {
   canFinalizeMattermostPreviewInPlace,
   deliverMattermostReplyWithDraftPreview,
   evaluateMattermostMentionGate,
+  isMattermostDraftPreviewEnabled,
   MattermostRetryableInboundError,
   processMattermostReplayGuardedPost,
   resolveMattermostReactionChannelId,
@@ -296,6 +297,32 @@ describe("shouldClearMattermostDraftPreview", () => {
 });
 
 describe("deliverMattermostReplyWithDraftPreview", () => {
+  it("bypasses preview finalization when draft preview is disabled", async () => {
+    const draftStream = createDraftStreamMock();
+    const deliverFinal = vi.fn(async () => {});
+
+    await deliverMattermostReplyWithDraftPreview({
+      payload: { text: "Final answer", replyToId: "child-post-789" } as never,
+      info: { kind: "final" },
+      kind: "channel",
+      client: createMattermostClientMock(),
+      draftPreviewEnabled: false,
+      draftStream,
+      effectiveReplyToId: "thread-root-456",
+      resolvePreviewFinalText: (text) => text?.trim(),
+      previewState: { finalizedViaPreviewPost: false },
+      logVerboseMessage: vi.fn(),
+      deliverFinal,
+    });
+
+    expect(deliverFinal).toHaveBeenCalledTimes(1);
+    expect(draftStream.flush).not.toHaveBeenCalled();
+    expect(draftStream.discardPending).not.toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.seal).not.toHaveBeenCalled();
+    expect(updateMattermostPostSpy).not.toHaveBeenCalled();
+  });
+
   it("suppresses reasoning-prefixed finals before preview finalization", async () => {
     const draftStream = createDraftStreamMock();
     const deliverFinal = vi.fn(async () => {});
@@ -450,6 +477,16 @@ describe("deliverMattermostReplyWithDraftPreview", () => {
       "preview-post-1",
       expect.objectContaining({ message: "↓ See below." }),
     );
+  });
+});
+
+describe("isMattermostDraftPreviewEnabled", () => {
+  it("keeps draft preview enabled by default", () => {
+    expect(isMattermostDraftPreviewEnabled({})).toBe(true);
+  });
+
+  it("disables draft preview when streaming mode is off", () => {
+    expect(isMattermostDraftPreviewEnabled({ streaming: { mode: "off" } })).toBe(false);
   });
 });
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1,4 +1,5 @@
 import { deliverFinalizableDraftPreview } from "openclaw/plugin-sdk/channel-lifecycle";
+import { resolveChannelPreviewStreamMode } from "openclaw/plugin-sdk/channel-streaming";
 import { createClaimableDedupe, type ClaimableDedupe } from "openclaw/plugin-sdk/persistent-dedupe";
 import { isReasoningReplyPayload } from "openclaw/plugin-sdk/reply-payload";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -7,6 +8,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/text-runtime";
 import { getMattermostRuntime } from "../runtime.js";
+import type { MattermostAccountConfig } from "../types.js";
 import { resolveMattermostAccount, resolveMattermostReplyToMode } from "./accounts.js";
 import {
   createMattermostClient,
@@ -280,11 +282,16 @@ type MattermostDraftPreviewState = {
   finalizedViaPreviewPost: boolean;
 };
 
+export function isMattermostDraftPreviewEnabled(config: MattermostAccountConfig): boolean {
+  return resolveChannelPreviewStreamMode(config, "partial") !== "off";
+}
+
 type MattermostDraftPreviewDeliverParams = {
   payload: ReplyPayload;
   info: { kind: "tool" | "block" | "final" };
   kind: ChatType;
   client: MattermostClient;
+  draftPreviewEnabled?: boolean;
   draftStream: Pick<
     ReturnType<typeof createMattermostDraftStream>,
     "flush" | "postId" | "clear" | "discardPending" | "seal"
@@ -300,6 +307,11 @@ export async function deliverMattermostReplyWithDraftPreview(
   params: MattermostDraftPreviewDeliverParams,
 ): Promise<void> {
   if (isReasoningReplyPayload(params.payload)) {
+    return;
+  }
+
+  if (params.draftPreviewEnabled === false) {
+    await params.deliverFinal();
     return;
   }
 
@@ -1640,6 +1652,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           log: logVerboseMessage,
           warn: logVerboseMessage,
         });
+        const draftPreviewEnabled = isMattermostDraftPreviewEnabled(account.config);
+        const disableBlockStreaming = draftPreviewEnabled
+          ? true
+          : typeof account.blockStreaming === "boolean"
+            ? !account.blockStreaming
+            : true;
         let lastPartialText = "";
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,
@@ -1681,6 +1699,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         };
 
         const updateDraftFromPartial = (text?: string) => {
+          if (!draftPreviewEnabled) {
+            return;
+          }
           const cleaned = text?.trim();
           if (!cleaned) {
             return;
@@ -1710,6 +1731,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 info,
                 kind,
                 client,
+                draftPreviewEnabled,
                 draftStream,
                 effectiveReplyToId,
                 resolvePreviewFinalText,
@@ -1754,25 +1776,29 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 dispatcher,
                 replyOptions: {
                   ...replyOptions,
-                  disableBlockStreaming: true,
+                  disableBlockStreaming,
                   onModelSelected,
-                  onPartialReply: (payload) => {
-                    updateDraftFromPartial(payload.text);
-                  },
-                  onAssistantMessageStart: () => {
-                    lastPartialText = "";
-                  },
-                  onReasoningEnd: () => {
-                    lastPartialText = "";
-                  },
-                  onReasoningStream: async () => {
-                    if (!lastPartialText) {
-                      draftStream.update("Thinking…");
-                    }
-                  },
-                  onToolStart: async (payload) => {
-                    draftStream.update(buildMattermostToolStatusText(payload));
-                  },
+                  ...(draftPreviewEnabled
+                    ? {
+                        onPartialReply: (payload) => {
+                          updateDraftFromPartial(payload.text);
+                        },
+                        onAssistantMessageStart: () => {
+                          lastPartialText = "";
+                        },
+                        onReasoningEnd: () => {
+                          lastPartialText = "";
+                        },
+                        onReasoningStream: async () => {
+                          if (!lastPartialText) {
+                            draftStream.update("Thinking…");
+                          }
+                        },
+                        onToolStart: async (payload) => {
+                          draftStream.update(buildMattermostToolStatusText(payload));
+                        },
+                      }
+                    : {}),
                 },
               }),
           });

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -1,3 +1,4 @@
+import type { ChannelPreviewStreamingConfig } from "openclaw/plugin-sdk/channel-streaming";
 import type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "./runtime-api.js";
 import type { SecretInput } from "./secret-input.js";
 
@@ -49,6 +50,8 @@ export type MattermostAccountConfig = {
   groupPolicy?: GroupPolicy;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
+  /** Preview/block streaming configuration for Mattermost replies. */
+  streaming?: ChannelPreviewStreamingConfig;
   /** Chunking mode: "length" (default) splits by size; "newline" splits on every newline. */
   chunkMode?: "length" | "newline";
   /** Disable block streaming for this account. */


### PR DESCRIPTION
## Problem
Mattermost draft preview streaming is always active for inbound replies. Users can try to configure `channels.mattermost.streaming`, but the Mattermost plugin schema did not accept the canonical streaming object and the inbound runtime ignored preview mode entirely.

## Root cause
The Mattermost config schema only exposed legacy chunk/block fields, while the inbound monitor unconditionally created the draft preview path, forced `disableBlockStreaming: true`, registered partial/reasoning/tool draft update callbacks, and attempted final in-place preview edits.

## Complete fix boundary
- Accept the canonical Mattermost `streaming` object at top-level and account-level config.
- Resolve Mattermost draft preview mode from `streaming.mode`, defaulting to current behavior (`partial`).
- When `streaming.mode` is `off`, skip draft preview update callbacks and bypass preview finalization so final replies use normal delivery.
- Keep generic block streaming disabled when preview is off unless the account explicitly enables block streaming.
- Add regression tests for schema input and the downstream final delivery path.

## What intentionally did not change
- Default Mattermost behavior remains draft preview enabled when `streaming` is omitted.
- No new `draftPreview` alias was added; this uses the existing canonical `streaming.mode` shape used by channel streaming config.
- Low-level draft stream mechanics, slash replies, button interactions, and model picker replies were not changed because they do not own the inbound draft preview bug.

## Tests run
- `pnpm exec vitest run --config test/vitest/vitest.extension-mattermost.config.ts extensions/mattermost/src/config-schema.test.ts extensions/mattermost/src/mattermost/monitor.test.ts`
- `pnpm tsgo:extensions`
- `pnpm exec oxlint --tsconfig tsconfig.oxlint.extensions.json extensions/mattermost/src/config-schema-core.ts extensions/mattermost/src/config-schema.test.ts extensions/mattermost/src/mattermost/monitor.ts extensions/mattermost/src/mattermost/monitor.test.ts extensions/mattermost/src/types.ts`
- `pnpm check:bundled-channel-config-metadata`
- `pnpm exec vitest run --config test/vitest/vitest.extension-mattermost.config.ts`
- `pnpm test:extensions:package-boundary`

## Linked issue
Fixes #73211

## CI red analysis
Current CI has three red checks:
- `checks-node-core-fast-support`: failed in `src/acp/persistent-bindings.lifecycle.test.ts` around `resetAcpSessionInPlace` binding lifecycle assertions. This PR does not touch ACP/session binding code; unrelated.
- `checks-node-agentic-control-plane`: failed in `src/gateway/server-restart-sentinel.test.ts` around restart message/sentinel assertions. This PR does not touch gateway restart/sentinel code; unrelated.
- `checks-node-core`: aggregate failed because non-dist Node shards failed, caused by the two failures above; unrelated to this diff.

Mattermost-relevant CI passed: `check-lint`, `check-prod-types`, `check-test-types`, `check-additional-extension-package-boundary`, all `checks-node-extensions-*`, and Greptile Review. Greptile also reviewed the diff with confidence 5/5 and found no correctness or security concerns.