### PR TITLE
fix(config): guard legacy agentRuntime regression

### DIFF
--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -12,12 +12,14 @@ vi.mock("../../config/config.js", () => ({
   readConfigFileSnapshot: readConfigFileSnapshotMock,
 }));
 
+type ConfigIssue = { path: string; message: string };
+
 function makeSnapshot() {
   return {
     exists: false,
     valid: true,
-    issues: [],
-    legacyIssues: [],
+    issues: [] as ConfigIssue[],
+    legacyIssues: [] as ConfigIssue[],
     path: "/tmp/openclaw.json",
   };
 }
@@ -115,7 +117,9 @@ describe("ensureConfigReady", () => {
   });
 
   it("does not exit for invalid config on allowlisted commands", async () => {
-    setInvalidSnapshot();
+    setInvalidSnapshot({
+      issues: [{ path: "agents.defaults", message: 'Unrecognized key: "agentRuntime"' }],
+    });
     const statusRuntime = await runEnsureConfigReady(["status"]);
     expect(statusRuntime.exit).not.toHaveBeenCalled();
 
@@ -127,6 +131,10 @@ describe("ensureConfigReady", () => {
 
     const gatewayRuntime = await runEnsureConfigReady(["gateway", "health"]);
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
+
+    const doctorRuntime = await runEnsureConfigReady(["doctor", "fix"]);
+    expect(doctorRuntime.exit).not.toHaveBeenCalled();
+    expect(doctorRuntime.error).toHaveBeenCalledWith(expect.stringContaining("agentRuntime"));
   });
 
   it("allows an explicit invalid-config override", async () => {

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -16,12 +16,14 @@ vi.mock("../../config/config.js", () => ({
   setRuntimeConfigSnapshot: setRuntimeConfigSnapshotMock,
 }));
 
+type ConfigIssue = { path: string; message: string };
+
 function makeSnapshot() {
   return {
     exists: false,
     valid: true,
-    issues: [],
-    legacyIssues: [],
+    issues: [] as ConfigIssue[],
+    legacyIssues: [] as ConfigIssue[],
     path: "/tmp/openclaw.json",
   };
 }
@@ -184,7 +186,9 @@ describe("ensureConfigReady", () => {
   });
 
   it("does not exit for invalid config on allowlisted commands", async () => {
-    setInvalidSnapshot();
+    setInvalidSnapshot({
+      issues: [{ path: "agents.defaults", message: 'Unrecognized key: "agentRuntime"' }],
+    });
     const statusRuntime = await runEnsureConfigReady(["status"]);
     expect(statusRuntime.exit).not.toHaveBeenCalled();
 
@@ -196,6 +200,10 @@ describe("ensureConfigReady", () => {
 
     const gatewayRuntime = await runEnsureConfigReady(["gateway", "health"]);
     expect(gatewayRuntime.exit).not.toHaveBeenCalled();
+
+    const doctorRuntime = await runEnsureConfigReady(["doctor", "fix"]);
+    expect(doctorRuntime.exit).not.toHaveBeenCalled();
+    expect(doctorRuntime.error).toHaveBeenCalledWith(expect.stringContaining("agentRuntime"));
   });
 
   it("allows an explicit invalid-config override", async () => {

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -55,6 +55,17 @@ describe("agent defaults schema", () => {
     ).not.toThrow();
   });
 
+  it("accepts agents.defaults.agentRuntime", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        agentRuntime: {
+          id: "claude-cli",
+          fallback: "none",
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts experimental.localModelLean", () => {
     const result = AgentDefaultsSchema.parse({
       experimental: {

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -151,7 +151,6 @@ describe("agent defaults schema", () => {
       AgentDefaultsSchema.parse({
         agentRuntime: {
           id: "claude-cli",
-          fallback: "none",
         },
       }),
     ).not.toThrow();

--- a/src/config/zod-schema.agent-defaults.test.ts
+++ b/src/config/zod-schema.agent-defaults.test.ts
@@ -146,6 +146,17 @@ describe("agent defaults schema", () => {
     );
   });
 
+  it("accepts agents.defaults.agentRuntime", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({
+        agentRuntime: {
+          id: "claude-cli",
+          fallback: "none",
+        },
+      }),
+    ).not.toThrow();
+  });
+
   it("accepts experimental.localModelLean", () => {
     const result = AgentDefaultsSchema.parse({
       experimental: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: users upgrading to 2026.4.24 reported `Config invalid` on `agents.defaults.agentRuntime`, which could block CLI workflows including the suggested `doctor --fix` recovery path.
- Main fix already landed: runtime/schema behavior was restored on `main` by direct commit [5b9be2c](https://github.com/openclaw/openclaw/commit/5b9be2cdb1c01a2896783c52f5f0654c5f22a249) (`fix: migrate agent runtime config`). GitHub's commit-to-PR lookup returns no associated PR for that commit.
- What this PR changes: adds targeted regression tests to lock two guarantees — `agents.defaults.agentRuntime` is accepted by schema validation, and config guard allowlisted commands (including `doctor fix`) do not hard-exit on invalid snapshots while still surfacing diagnostics.
- What this PR does not change: no runtime config parser behavior is changed here; this is test-only guardrail coverage for the already-landed fix.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #72872
- Main behavior fix: [5b9be2c](https://github.com/openclaw/openclaw/commit/5b9be2cdb1c01a2896783c52f5f0654c5f22a249) (direct `main` commit; no associated PR returned by GitHub commit-to-PR lookup)
- Related #70407
- [x] This PR adds regression tests for a bug/regression

## Root Cause (if applicable)

- Root cause of the shipped regression: a prior release path reportedly rejected a legacy/expected config key during startup validation. That runtime/schema behavior was already corrected on `main` by [5b9be2c](https://github.com/openclaw/openclaw/commit/5b9be2cdb1c01a2896783c52f5f0654c5f22a249).
- Missing detection / guardrail addressed by this PR: no focused regression tests were locking `agents.defaults.agentRuntime` acceptance + `doctor fix` allowlist behavior in the config guard test path.
- Contributing context (if known): repeated regressions in neighboring config keys show this startup validation surface is high-impact and needs explicit test locks.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/config/zod-schema.agent-defaults.test.ts`
  - `src/cli/program/config-guard.test.ts`
- Scenario the test should lock in:
  - schema accepts `agents.defaults.agentRuntime` values
  - invalid snapshot mentioning `Unrecognized key: "agentRuntime"` does not hard-exit allowlisted commands, including `doctor fix`, while still printing diagnostics.
- Why this is the smallest reliable guardrail: both checks run in fast unit suites and directly cover the two failure surfaces (schema acceptance and startup guard behavior) without introducing broader integration harness cost.
- Existing test that already covers this (if any): existing config-guard allowlist tests partially covered non-exit behavior; this PR adds the `agentRuntime`-specific assertion.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None. This PR adds tests only; the user-visible regression fix is already present on `main` in [5b9be2c](https://github.com/openclaw/openclaw/commit/5b9be2cdb1c01a2896783c52f5f0654c5f22a249).

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (dev harness) + Azure Crabbox
- Runtime/container: local Node + pnpm worktree; Azure Crabbox `amber-crab` (lease `cbx_e503b0866411`) with Node `v22.22.2` and pnpm `11.2.2`
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): synthetic invalid snapshot in test (`agents.defaults` → `Unrecognized key: "agentRuntime"`)

### Steps

1. Run `pnpm test -- src/config/zod-schema.agent-defaults.test.ts src/cli/program/config-guard.test.ts`
2. Run Azure Crabbox evidence: `collect-openclaw-evidence.sh --id amber-crab --name pr-73257-agent-runtime-proof --test src/config/zod-schema.agent-defaults.test.ts --test src/cli/program/config-guard.test.ts --command '<schema proof command>'`
3. Confirm the schema proof accepts id-only `agentRuntime` and rejects retired `fallback`.

### Expected

- Schema test accepts `agents.defaults.agentRuntime`.
- Config-guard allowlist test verifies `doctor fix` does not hard-exit and still emits key diagnostics.

### Actual

- Both expectations pass.
- Azure Crabbox focused test proof passed on the same two-file diff before rebase (merge commit `59b92227a710db43bd421c652322eb13ef6a35b7`): 2 Vitest shards passed, 41 tests passed. After rebasing onto current `origin/main`, focused local proof also passed on head `a09d162ab0414f2ba05c60ef22bcc78f8c0471bb`: 2 files passed, 41 tests passed.
- Schema proof: `AGENT_RUNTIME_SCHEMA_PROOF=idOnly:true;fallback:false;fallbackIssue:agentRuntime:Unrecognized key: "fallback"`.

### Real Behavior Proof

Behavior addressed: `agents.defaults.agentRuntime` remains accepted by schema validation with the supported id-only shape, and allowlisted invalid-config commands including `doctor fix` continue instead of hard-exiting while surfacing diagnostics.

Real environment tested: Azure Crabbox provider `azure`, slug `amber-crab`, lease `cbx_e503b0866411`, remote workdir `/work/crabbox/cbx_e503b0866411/openclaw-pr73257-evidence`; Node `v22.22.2`, pnpm `11.2.2`.

Exact steps or command run after this patch: `collect-openclaw-evidence.sh --id amber-crab --name pr-73257-agent-runtime-proof --test src/config/zod-schema.agent-defaults.test.ts --test src/cli/program/config-guard.test.ts --command '<schema proof command>'`.

Evidence after fix: `AGENT_RUNTIME_SCHEMA_PROOF=idOnly:true;fallback:false;fallbackIssue:agentRuntime:Unrecognized key: "fallback"`; Azure Crabbox: `src/config/zod-schema.agent-defaults.test.ts` passed 28 tests and `src/cli/program/config-guard.test.ts` passed 13 tests; post-rebase local focused proof also passed 41 tests.

Observed result after fix: Crabbox evidence run exited `0`; focused remote tests passed 2 shards / 41 tests; post-rebase focused local tests passed 2 files / 41 tests; id-only `agentRuntime` parsed successfully and retired `fallback` was rejected.

What was not tested: full cross-version upgrade flow on the originally affected macOS host; packaged npm global install reproduction end-to-end.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - targeted tests pass for schema + config guard paths locally
  - Azure Crabbox focused evidence passes on the PR merge ref
  - id-only `agents.defaults.agentRuntime` parses, while retired `agentRuntime.fallback` is rejected
- Edge cases checked:
  - allowlisted command path includes explicit `doctor fix` check for non-exit
  - schema proof confirms this PR does not re-lock the retired `fallback` contract
- What you did **not** verify:
  - full cross-version upgrade flow on affected macOS host
  - packaged npm global install reproduction end-to-end

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: this PR is test-only; if runtime behavior regresses in a new path, these tests may not catch every variant.
  - Mitigation: tests target the two highest-signal contracts for this incident class (schema acceptance + config-guard allowlist behavior), and can be extended if new repro details emerge.



