### PR TITLE
feat(mattermost): toggle draft-preview streaming via channels.mattermost.streaming.draftPreview (#73211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Channels/Mattermost: add `channels.mattermost.streaming.draftPreview` (and matching per-account override under `channels.mattermost.accounts.<id>.streaming.draftPreview`) so operators can opt out of the in-place placeholder/`PUT /posts/{id}` draft-preview streaming added in #47838. The default remains `true` (existing behavior); `false` skips the placeholder + intermediate updates so the final reply is delivered through the normal outbound chunker. Account-level overrides channel-level. Fixes #73211.
 - Dependencies: refresh provider and tooling dependencies, including AWS SDK, PI runtime packages, AJV, Feishu SDK, Anthropic SDK, tokenjuice, and native TypeScript/oxlint tooling. Thanks @dependabot.
 - Matrix/QA: add live Matrix approval scenarios for exec metadata, chunked fallback, plugin approvals, deny reactions, thread targeting, and `target: "both"` delivery, with redacted artifacts preserving safe approval summaries. Thanks @gumadeiras.
 - Codex: add Computer Use setup for Codex-mode agents, including `/codex computer-use status/install`, marketplace discovery, optional auto-install, and fail-closed MCP server checks before Codex-mode turns start. Fixes #72094. (#71842) Thanks @pash-openai.

--- a/extensions/mattermost/src/mattermost/accounts.test.ts
+++ b/extensions/mattermost/src/mattermost/accounts.test.ts
@@ -135,4 +135,58 @@ describe("resolveMattermostReplyToMode", () => {
       callbackPath: "/hooks/work",
     });
   });
+
+  it("defaults draftPreview to true when streaming is unset (#73211)", () => {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: {
+            accounts: {
+              default: { botToken: "tok", baseUrl: "https://chat.example.com" },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "default",
+    });
+    expect(account.draftPreview).toBe(true);
+  });
+
+  it("honors channels.mattermost.streaming.draftPreview=false at the channel level (#73211)", () => {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: {
+            streaming: { draftPreview: false },
+            accounts: {
+              default: { botToken: "tok", baseUrl: "https://chat.example.com" },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "default",
+    });
+    expect(account.draftPreview).toBe(false);
+  });
+
+  it("lets account-level streaming.draftPreview override channel-level (#73211)", () => {
+    const account = resolveMattermostAccount({
+      cfg: {
+        channels: {
+          mattermost: {
+            streaming: { draftPreview: false },
+            accounts: {
+              ops: {
+                botToken: "tok",
+                baseUrl: "https://chat.example.com",
+                streaming: { draftPreview: true },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig,
+      accountId: "ops",
+    });
+    expect(account.draftPreview).toBe(true);
+  });
 });

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -36,6 +36,7 @@ export type ResolvedMattermostAccount = {
   chunkMode?: MattermostAccountConfig["chunkMode"];
   blockStreaming?: boolean;
   blockStreamingCoalesce?: MattermostAccountConfig["blockStreamingCoalesce"];
+  draftPreview: boolean;
 };
 
 const mattermostAccountHelpers = createAccountListHelpers("mattermost");
@@ -59,8 +60,12 @@ function mergeMattermostAccountConfig(
       | undefined,
     accountId,
     omitKeys: ["defaultAccount"],
-    nestedObjectKeys: ["commands"],
+    nestedObjectKeys: ["commands", "streaming"],
   });
+}
+
+function resolveMattermostDraftPreview(config: MattermostAccountConfig): boolean {
+  return config.streaming?.draftPreview !== false;
 }
 
 function resolveMattermostRequireMention(config: MattermostAccountConfig): boolean | undefined {
@@ -123,6 +128,7 @@ export function resolveMattermostAccount(params: {
     blockStreaming: resolveChannelStreamingBlockEnabled(merged) ?? merged.blockStreaming,
     blockStreamingCoalesce:
       resolveChannelStreamingBlockCoalesce(merged) ?? merged.blockStreamingCoalesce,
+    draftPreview: resolveMattermostDraftPreview(merged),
   };
 }
 

--- a/extensions/mattermost/src/mattermost/accounts.ts
+++ b/extensions/mattermost/src/mattermost/accounts.ts
@@ -36,7 +36,13 @@ export type ResolvedMattermostAccount = {
   chunkMode?: MattermostAccountConfig["chunkMode"];
   blockStreaming?: boolean;
   blockStreamingCoalesce?: MattermostAccountConfig["blockStreamingCoalesce"];
-  draftPreview: boolean;
+  /**
+   * Resolved Mattermost draft-preview enablement. `undefined` is treated as
+   * `true` by the monitor pipeline (preserves existing behavior); set to
+   * `false` via `channels.mattermost.streaming.draftPreview` (or the matching
+   * per-account field) to opt out. (#73211)
+   */
+  draftPreview?: boolean;
 };
 
 const mattermostAccountHelpers = createAccountListHelpers("mattermost");

--- a/extensions/mattermost/src/mattermost/draft-stream.test.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { MattermostClient } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import {
+  buildMattermostToolStatusText,
+  createDisabledMattermostDraftStream,
+  createMattermostDraftStream,
+} from "./draft-stream.js";
 
 type RequestRecord = {
   path: string;
@@ -249,5 +253,29 @@ describe("buildMattermostToolStatusText", () => {
 
   it("falls back to a generic running tool status", () => {
     expect(buildMattermostToolStatusText({ name: "exec" })).toBe("Running `exec`…");
+  });
+});
+
+describe("createDisabledMattermostDraftStream (#73211)", () => {
+  it("matches the MattermostDraftStream shape and resolves to no-ops", async () => {
+    const stream = createDisabledMattermostDraftStream();
+    expect(stream.postId()).toBeUndefined();
+    expect(stream.update("hello")).toBeUndefined();
+    expect(stream.forceNewMessage()).toBeUndefined();
+    await expect(stream.flush()).resolves.toBeUndefined();
+    await expect(stream.clear()).resolves.toBeUndefined();
+    await expect(stream.discardPending()).resolves.toBeUndefined();
+    await expect(stream.seal()).resolves.toBeUndefined();
+    await expect(stream.stop()).resolves.toBeUndefined();
+  });
+
+  it("does not issue any client requests for repeated update calls", async () => {
+    const stream = createDisabledMattermostDraftStream();
+    stream.update("partial 1");
+    stream.update("partial 2");
+    stream.update("partial 3");
+    await stream.flush();
+    await stream.seal();
+    expect(stream.postId()).toBeUndefined();
   });
 });

--- a/extensions/mattermost/src/mattermost/draft-stream.ts
+++ b/extensions/mattermost/src/mattermost/draft-stream.ts
@@ -20,6 +20,27 @@ export type MattermostDraftStream = {
   forceNewMessage: () => void;
 };
 
+/**
+ * Disabled draft-preview stub. Used when
+ * `channels.mattermost.streaming.draftPreview` resolves to `false` so the
+ * monitor pipeline keeps the same call shape but the in-place placeholder /
+ * `PUT /posts/{id}` traffic is suppressed; the final reply is delivered by
+ * the normal outbound chunker path. (#73211)
+ */
+export function createDisabledMattermostDraftStream(): MattermostDraftStream {
+  const noopAsync = async (): Promise<void> => undefined;
+  return {
+    update: () => undefined,
+    flush: noopAsync,
+    postId: () => undefined,
+    clear: noopAsync,
+    discardPending: noopAsync,
+    seal: noopAsync,
+    stop: noopAsync,
+    forceNewMessage: () => undefined,
+  };
+}
+
 export function normalizeMattermostDraftText(text: string, maxChars: number): string {
   const trimmed = text.trim();
   if (!trimmed) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -17,7 +17,11 @@ import {
   type MattermostPost,
   type MattermostUser,
 } from "./client.js";
-import { buildMattermostToolStatusText, createMattermostDraftStream } from "./draft-stream.js";
+import {
+  buildMattermostToolStatusText,
+  createDisabledMattermostDraftStream,
+  createMattermostDraftStream,
+} from "./draft-stream.js";
 import {
   computeInteractionCallbackUrl,
   createMattermostInteractionHandler,
@@ -1632,14 +1636,16 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             },
           },
         });
-        const draftStream = createMattermostDraftStream({
-          client,
-          channelId,
-          rootId: effectiveReplyToId,
-          throttleMs: 1200,
-          log: logVerboseMessage,
-          warn: logVerboseMessage,
-        });
+        const draftStream = account.draftPreview
+          ? createMattermostDraftStream({
+              client,
+              channelId,
+              rootId: effectiveReplyToId,
+              throttleMs: 1200,
+              log: logVerboseMessage,
+              warn: logVerboseMessage,
+            })
+          : createDisabledMattermostDraftStream();
         let lastPartialText = "";
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1636,16 +1636,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             },
           },
         });
-        const draftStream = account.draftPreview
-          ? createMattermostDraftStream({
-              client,
-              channelId,
-              rootId: effectiveReplyToId,
-              throttleMs: 1200,
-              log: logVerboseMessage,
-              warn: logVerboseMessage,
-            })
-          : createDisabledMattermostDraftStream();
+        const draftStream =
+          account.draftPreview !== false
+            ? createMattermostDraftStream({
+                client,
+                channelId,
+                rootId: effectiveReplyToId,
+                throttleMs: 1200,
+                log: logVerboseMessage,
+                warn: logVerboseMessage,
+              })
+            : createDisabledMattermostDraftStream();
         let lastPartialText = "";
         const previewState: MattermostDraftPreviewState = {
           finalizedViaPreviewPost: false,

--- a/extensions/mattermost/src/types.ts
+++ b/extensions/mattermost/src/types.ts
@@ -55,6 +55,19 @@ export type MattermostAccountConfig = {
   blockStreaming?: boolean;
   /** Merge streamed block replies before sending. */
   blockStreamingCoalesce?: BlockStreamingCoalesceConfig;
+  /** Mattermost-specific streaming overrides. */
+  streaming?: {
+    /**
+     * Toggle Mattermost's "draft preview" feature: a placeholder post is
+     * created via `POST /posts` and updated in-place via `PUT /posts/{id}`
+     * as intermediate state arrives (tool activity, thinking, partial
+     * replies). When `false`, OpenClaw skips the placeholder/in-place
+     * update path and only sends the final reply through the normal
+     * outbound chunker. Default: `true` (preserves existing behavior).
+     * (#73211)
+     */
+    draftPreview?: boolean;
+  };
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
   /**


### PR DESCRIPTION
Fixes #73211.

## Diagnosis

The Mattermost channel's \"draft preview\" streaming feature (introduced in #47838 / 2026.4.20) is **hardcoded and always on**:

- \`extensions/mattermost/src/mattermost/monitor.ts:1635\` unconditionally calls \`createMattermostDraftStream\`, which creates a placeholder post via \`POST /posts\` and then updates it in-place via \`PUT /posts/{id}\` on every intermediate state change (tool activity, thinking, partial replies).
- The Mattermost config schema has no field controlling this, the docs don't mention it, and any extra \`streaming\` block in the config is silently dropped by schema validation.

## Fix

Add \`channels.mattermost.streaming.draftPreview?: boolean\` (with the same shape on per-account configs):

\`\`\`json5
{
  channels: {
    mattermost: {
      streaming: { draftPreview: false },         // channel-level
      accounts: {
        ops: { streaming: { draftPreview: true } } // per-account override wins
      }
    }
  }
}
\`\`\`

Default remains \`true\` (existing behavior preserved). When \`false\`, the monitor pipeline substitutes a no-op \`MattermostDraftStream\` stub from \`createDisabledMattermostDraftStream()\` — the call shape is unchanged but the placeholder/in-place traffic is suppressed; the final reply is delivered by the normal outbound chunker.

Account-level overrides channel-level, consistent with how the existing \`blockStreaming\` and \`replyToMode\` knobs resolve.

## Files

- \`extensions/mattermost/src/types.ts\` — add \`streaming?: { draftPreview?: boolean }\` to \`MattermostAccountConfig\`.
- \`extensions/mattermost/src/mattermost/accounts.ts\` — surface \`draftPreview\` on \`ResolvedMattermostAccount\`; add \`\"streaming\"\` to \`nestedObjectKeys\` so per-account overrides don't fully replace the channel-level block.
- \`extensions/mattermost/src/mattermost/draft-stream.ts\` — export a small \`createDisabledMattermostDraftStream()\` factory.
- \`extensions/mattermost/src/mattermost/monitor.ts\` — gate \`createMattermostDraftStream\` on \`account.draftPreview\`.
- \`extensions/mattermost/src/mattermost/accounts.test.ts\` — 3 new cases (default true; channel-level false; account-level beats channel-level).
- \`extensions/mattermost/src/mattermost/draft-stream.test.ts\` — 2 new cases (no-op shape; repeated update calls don't issue requests).
- \`CHANGELOG.md\`.

## Verification

- \`pnpm vitest run extensions/mattermost/src/mattermost/{draft-stream,accounts,monitor}.test.ts\` → 67/67 passing (5 new + 62 existing).