### PR TITLE
[codex] Fix Discord current-conversation reply guidance

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -1,5 +1,21 @@
+import type { EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { describe, expect, it } from "vitest";
-import { resolveReasoningEffort } from "./thread-lifecycle.js";
+import { buildDeveloperInstructions, resolveReasoningEffort } from "./thread-lifecycle.js";
+
+describe("buildDeveloperInstructions", () => {
+  it("keeps current conversation replies on final delivery instead of the message tool", () => {
+    const instructions = buildDeveloperInstructions({} as EmbeddedRunAttemptParams);
+
+    expect(instructions).toContain("For normal replies to the current conversation");
+    expect(instructions).toContain("answer in your final response");
+    expect(instructions).toContain(
+      "Use the OpenClaw messaging tool only for explicit messaging actions",
+    );
+    expect(instructions).not.toContain(
+      "If sending a channel reply, use the OpenClaw messaging tool",
+    );
+  });
+});
 
 describe("resolveReasoningEffort (#71946)", () => {
   describe("modern Codex models (none/low/medium/high/xhigh enum)", () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -223,7 +223,7 @@ export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): st
   const promptOverlay = renderCodexRuntimePromptOverlay(params);
   const sections = [
     "You are running inside OpenClaw. Use OpenClaw dynamic tools for messaging, cron, sessions, and host actions when available.",
-    "Preserve the user's existing channel/session context. If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply.",
+    "Preserve the user's existing channel/session context. For normal replies to the current conversation, answer in your final response; OpenClaw will deliver it. Use the OpenClaw messaging tool only for explicit messaging actions such as reading, reacting, sending to another conversation, or posting a requested notification.",
     promptOverlay,
     params.extraSystemPrompt,
     params.skillsSnapshot?.prompt,

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -7,11 +7,13 @@ allowed-tools: ["message"]
 
 # Discord (Via `message`)
 
-Use the `message` tool. No provider-specific `discord` tool exposed to the agent.
+Use the `message` tool for Discord operations that cannot be handled by normal final reply delivery. No provider-specific `discord` tool is exposed to the agent.
+
+For a normal reply to the current Discord conversation, answer in your final response and let OpenClaw deliver it. Do not use `message.send` or `message.thread-reply` to send the same conversational reply.
 
 ## Musts
 
-- Always: `channel: "discord"`.
+- For message-tool actions, always pass `channel: "discord"`.
 - Respect gating: `channels.discord.actions.*` (some default off: `roles`, `moderation`, `presence`, `channels`).
 - Prefer explicit ids: `guildId`, `channelId`, `messageId`, `userId`.
 - Multi-account: optional `accountId`.


### PR DESCRIPTION
## Summary

- Problem: Discord `autoThread: true` channel mentions can produce a parent-channel `message.send` reply plus a normal final response in the created thread.
- Why it matters: users see confusing duplicate replies across two Discord surfaces even though final thread delivery is working.
- What changed: Codex runtime guidance and the bundled Discord skill now direct normal current-conversation replies through the final assistant response, reserving the `message` tool for explicit messaging actions.
- What did NOT change (scope boundary): no Discord delivery mechanics, auto-thread creation logic, or message-tool implementation changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73278
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the Codex runtime developer instruction told agents to use the OpenClaw messaging tool for channel replies, while the bundled Discord skill broadly said to use `message`. In an auto-threaded Discord mention, that can steer the model to manually send a parent-channel reply before OpenClaw delivers the normal final response to the created thread.
- Missing detection / guardrail: there was no test locking in that current-conversation replies should stay on final response delivery rather than message-tool sends.
- Contributing context (if known): the final thread delivery path appeared to work; the duplicate was caused by prompt/tool guidance encouraging an extra manual send.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/codex/src/app-server/thread-lifecycle.test.ts`
- Scenario the test should lock in: developer instructions say normal current-conversation replies use final response delivery, and no longer include the older guidance to use the messaging tool for channel replies.
- Why this is the smallest reliable guardrail: the regression came from injected runtime guidance, so testing the generated developer instructions catches the exact failure vector without depending on model behavior.
- Existing test that already covers this (if any): none found.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Discord agents should be less likely to send duplicate current-conversation replies through the `message` tool when normal OpenClaw final response delivery can route the reply correctly.

## Diagram (if applicable)

```text
Before:
Discord mention -> autoThread creates thread -> agent may call message.send(parent) -> final response delivers(thread) -> duplicate replies

After:
Discord mention -> autoThread creates thread -> agent answers in final response -> OpenClaw delivers(thread) -> one normal reply
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.4.1 / Darwin 25.4.0 arm64
- Runtime/container: npm global OpenClaw `2026.4.26 (be8c246)` for the observed behavior; local repo checkout for the fix
- Model/provider: Codex app-server embedded agent session; exact upstream model for the observed Discord turn is not known
- Integration/channel (if any): Discord channel with `autoThread: true`
- Relevant config (redacted): Discord `autoThread: true`, `includeThreadStarter: true`, thread bindings enabled

### Steps

1. Mention OpenClaw in a Discord parent channel configured with `autoThread: true`.
2. Observe OpenClaw create a thread for the mention.
3. Observe the agent send a parent-channel `message.send` conversational reply and also finish with a final response delivered to the thread.

### Expected

- One normal conversational reply is delivered to the created thread.
- No extra parent-channel conversational reply is sent through `message.send`.

### Actual

- The observed 2026.4.26 session sent a manual parent-channel reply and a different final response in the thread.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence summary:

- The observed session included a `message.send` call to the parent channel/thread starter, followed by normal final-response delivery to the auto-created thread.
- The official 2026.4.26 npm package contained runtime guidance equivalent to `If sending a channel reply, use the OpenClaw messaging tool...` and a bundled Discord skill that broadly said to use `message`.
- Local package/runtime copies were compared with npm registry tarballs and matched, so this was not caused by a leftover local bundle edit.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Compared local OpenClaw package/runtime files against registry tarballs for the relevant versions to rule out a lingering local bundle patch.
  - Confirmed the duplicate path was manual `message.send` plus normal final response delivery, not double delivery by the Discord final-response path.
  - Ran `pnpm exec vitest run extensions/codex/src/app-server/thread-lifecycle.test.ts`.
  - Ran `pnpm test:extension codex`.
- Edge cases checked:
  - The fix preserves explicit `message` tool use for non-normal-reply Discord operations such as reads, reactions, notifications, and sends to another conversation.
- What you did **not** verify:
  - A live Discord end-to-end run against a locally patched OpenClaw build.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the new wording might discourage legitimate explicit Discord sends.
  - Mitigation: both runtime and skill text explicitly keep the messaging tool available for reads, reactions, notifications, sending to another conversation, and other explicit messaging actions.

## AI-assisted disclosure

- This PR is AI-assisted.
- Testing degree: targeted local testing plus the bundled Codex extension test lane.
- I understand the code and prompt changes in this PR.
