### PR TITLE
Add Discord response watchdog

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -712,6 +712,13 @@ describe("spawnAcpDirect", () => {
     expect(agentCall?.params?.deliver).toBe(true);
     expect(agentCall?.params?.lane).toBe("subagent");
     expect(agentCall?.params?.acpTurnSource).toBe("manual_spawn");
+    expect(hoisted.createRunningTaskRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtime: "acp",
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+      }),
+    );
     expect(hoisted.initializeSessionMock).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionKey: expect.stringMatching(/^agent:codex:acp:/),

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -1479,6 +1479,7 @@ export async function spawnAcpDirect(
       task: params.task,
       preferMetadata: true,
       deliveryStatus: requesterInternalKey ? "pending" : "parent_missing",
+      notifyPolicy: requesterInternalKey ? "state_changes" : undefined,
       startedAt: Date.now(),
     });
   } catch (error) {

--- a/src/agents/subagent-registry-run-manager.ts
+++ b/src/agents/subagent-registry-run-manager.ts
@@ -430,6 +430,8 @@ export function createSubagentRunManager(params: {
         task: registerParams.task,
         deliveryStatus:
           registerParams.expectsCompletionMessage === false ? "not_applicable" : "pending",
+        notifyPolicy:
+          registerParams.expectsCompletionMessage === false ? "silent" : "state_changes",
         startedAt: now,
         lastEventAt: now,
       });

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -162,8 +162,9 @@ describe("task-registry store runtime", () => {
       deliveryStatus: "pending",
     });
 
+    const progressAt = Math.max(created.lastEventAt ?? 0, Date.now()) + 1;
     await maybeDeliverTaskStateChangeUpdate(created.taskId, {
-      at: 200,
+      at: progressAt,
       kind: "progress",
       summary: "working",
     });
@@ -178,7 +179,7 @@ describe("task-registry store runtime", () => {
     expect(
       upsertTaskWithDeliveryState.mock.calls.some((call) => {
         const params = call[0] as { deliveryState?: { lastNotifiedEventAt?: number } };
-        return params.deliveryState?.lastNotifiedEventAt === 200;
+        return params.deliveryState?.lastNotifiedEventAt === progressAt;
       }),
     ).toBe(true);
     expect(deleteTaskWithDeliveryState).toHaveBeenCalledWith(created.taskId);

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -726,7 +726,7 @@ describe("task-registry", () => {
     });
   });
 
-  it("records delivery failure and queues a session fallback when direct delivery misses", async () => {
+  it("marks terminal delivery as session queued when direct delivery falls back cleanly", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;
       resetTaskRegistryForTests();
@@ -761,7 +761,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expect(findTaskByRunId("run-delivery-fail")).toMatchObject({
           status: "failed",
-          deliveryStatus: "failed",
+          deliveryStatus: "session_queued",
           error: "Permission denied by ACP runtime",
         }),
       );
@@ -799,7 +799,7 @@ describe("task-registry", () => {
       await waitForAssertion(() =>
         expect(findTaskByRunId("run-delivery-blocked")).toMatchObject({
           status: "succeeded",
-          deliveryStatus: "failed",
+          deliveryStatus: "session_queued",
           terminalOutcome: "blocked",
         }),
       );
@@ -1975,6 +1975,48 @@ describe("task-registry", () => {
           inconsistent_timestamps: 0,
         },
       });
+    });
+  });
+
+  it("emits an immediate start update for newly-created running state-change tasks", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+      resetSystemEventsForTest();
+      hoisted.sendMessageMock.mockResolvedValue({
+        channel: "guildchat",
+        to: "guildchat:123",
+        via: "direct",
+      });
+
+      createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        requesterOrigin: {
+          channel: "guildchat",
+          to: "guildchat:123",
+        },
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-create-start",
+        task: "Investigate issue",
+        status: "running",
+        deliveryStatus: "pending",
+        notifyPolicy: "state_changes",
+        startedAt: 100,
+        lastEventAt: 100,
+      });
+
+      await waitForAssertion(() =>
+        expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
+          expect.objectContaining({
+            channel: "guildchat",
+            to: "guildchat:123",
+            content: "Background task started: ACP background task.",
+          }),
+        ),
+      );
+      expect(peekSystemEvents("agent:main:main")).toEqual([]);
     });
   });
 

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -297,6 +297,14 @@ function persistTaskDelete(taskId: string) {
 
 function persistTaskDeliveryStateUpsert(state: TaskDeliveryState) {
   const store = getTaskRegistryStore();
+  const task = tasks.get(state.taskId);
+  if (task && store.upsertTaskWithDeliveryState) {
+    store.upsertTaskWithDeliveryState({
+      task,
+      deliveryState: state,
+    });
+    return;
+  }
   if (store.upsertDeliveryState) {
     store.upsertDeliveryState(state);
     return;
@@ -1199,17 +1207,21 @@ export async function maybeDeliverTaskTerminalUpdate(taskId: string): Promise<Ta
         if (latest.terminalOutcome === "blocked") {
           queueBlockedTaskFollowup(latest);
         }
+        return updateTask(taskId, {
+          deliveryStatus: "session_queued",
+          lastEventAt: Date.now(),
+        });
       } catch (fallbackError) {
         log.warn("Failed to queue background task fallback event", {
           taskId,
           ownerKey: latest.ownerKey,
           error: fallbackError,
         });
+        return updateTask(taskId, {
+          deliveryStatus: "failed",
+          lastEventAt: Date.now(),
+        });
       }
-      return updateTask(taskId, {
-        deliveryStatus: "failed",
-        lastEventAt: Date.now(),
-      });
     }
   } finally {
     tasksWithPendingDelivery.delete(taskId);
@@ -1606,6 +1618,12 @@ export function createTaskRecord(params: {
   }));
   if (isTerminalTaskStatus(record.status)) {
     void maybeDeliverTaskTerminalUpdate(taskId);
+  } else if (record.status === "running") {
+    void maybeDeliverTaskStateChangeUpdate(taskId, {
+      at: record.lastEventAt ?? record.startedAt ?? record.createdAt,
+      kind: "running",
+      summary: "Started.",
+    });
   }
   return cloneTaskRecord(record);
 }


### PR DESCRIPTION
Fresh minimal branch superseding stale PR #73232 and auto-closed PR #73238.

Task: 22d72cfc — Add Discord response watchdog for silent agent runs.

Iris verification before PR creation: focused watchdog tests passed (105 tests) and diff was reduced to the intended source changes. Keep as draft pending Rex CI/review follow-through and later approved safe-pressure live smoke/restart window if required.
