### PR TITLE
Add Control UI session kind filter

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -99,7 +99,7 @@ Imported themes are stored only in the current browser profile. They are not wri
   <Accordion title="Channels, instances, sessions, dreams">
     - Channels: built-in plus bundled/external plugin channels status, QR login, and per-channel config (`channels.status`, `web.login.*`, `config.patch`).
     - Instances: presence list + refresh (`system-presence`).
-    - Sessions: list + per-session model/thinking/fast/verbose/trace/reasoning overrides (`sessions.list`, `sessions.patch`).
+    - Sessions: list + chat-header kind filtering + per-session model/thinking/fast/verbose/trace/reasoning overrides (`sessions.list`, `sessions.patch`).
     - Dreams: dreaming status, enable/disable toggle, and Dream Diary reader (`doctor.memory.status`, `doctor.memory.dreamDiary`, `config.patch`).
   </Accordion>
   <Accordion title="Cron, skills, nodes, exec approvals">

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -1043,6 +1043,60 @@
   font-size: 13px;
 }
 
+.session-kind-filter {
+  position: relative;
+}
+
+.session-kind-filter summary {
+  list-style: none;
+}
+
+.session-kind-filter summary::-webkit-details-marker {
+  display: none;
+}
+
+.session-kind-filter__menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 45;
+  display: grid;
+  gap: 2px;
+  min-width: 180px;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--card);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.28);
+}
+
+.session-kind-filter__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.2;
+  cursor: pointer;
+}
+
+.session-kind-filter__item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.session-kind-filter__item input {
+  margin: 0;
+}
+
+.session-kind-filter__count {
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Controls separator */
 .chat-controls__separator {
   color: rgba(255, 255, 255, 0.4);

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -447,9 +447,22 @@
   .chat-mobile-controls-wrapper .chat-controls-dropdown .chat-controls__thinking {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     gap: 6px;
     padding: 4px 0;
     justify-content: center;
+  }
+
+  .chat-mobile-controls-wrapper .session-kind-filter {
+    position: static;
+    width: 100%;
+  }
+
+  .chat-mobile-controls-wrapper .session-kind-filter__menu {
+    position: static;
+    min-width: 100%;
+    margin-top: 6px;
+    box-shadow: none;
   }
 
   .chat-mobile-controls-wrapper .chat-controls-dropdown .btn--icon {

--- a/ui/src/ui/app-render.helpers.browser.test.ts
+++ b/ui/src/ui/app-render.helpers.browser.test.ts
@@ -1,8 +1,9 @@
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
 import { t } from "../i18n/index.ts";
-import { renderChatControls } from "./app-render.helpers.ts";
+import { renderChatControls, renderChatMobileToggle } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import { createDefaultSessionKindVisibility } from "./session-kind-filter.ts";
 
 function createState(overrides: Partial<AppViewState> = {}) {
   return {
@@ -10,13 +11,13 @@ function createState(overrides: Partial<AppViewState> = {}) {
     chatLoading: false,
     onboarding: false,
     sessionKey: "main",
-    sessionsHideCron: true,
+    sessionsVisibleKinds: createDefaultSessionKindVisibility(),
     sessionsResult: {
       ts: 0,
       path: "",
       count: 0,
       defaults: { modelProvider: "openai", model: "gpt-5", contextTokens: null },
-      sessions: [],
+      sessions: [{ key: "agent:main:cron:nightly", kind: "direct", updatedAt: 1 }],
     },
     settings: {
       gatewayUrl: "",
@@ -46,24 +47,36 @@ describe("chat header controls (browser)", () => {
     render(renderChatControls(createState()), container);
     await Promise.resolve();
 
-    const buttons = Array.from(
-      container.querySelectorAll<HTMLButtonElement>(".chat-controls .btn--icon[data-tooltip]"),
+    const controls = Array.from(
+      container.querySelectorAll<HTMLElement>(".chat-controls .btn--icon[data-tooltip]"),
     );
 
-    expect(buttons).toHaveLength(5);
+    expect(controls).toHaveLength(5);
 
-    const labels = buttons.map((button) => button.getAttribute("data-tooltip"));
+    const labels = controls.map((button) => button.getAttribute("data-tooltip"));
     expect(labels).toEqual([
       t("chat.refreshTitle"),
       t("chat.thinkingToggle"),
       t("chat.toolCallsToggle"),
       t("chat.focusToggle"),
-      t("chat.showCronSessions"),
+      "Filter sessions (1 hidden)",
     ]);
 
-    for (const button of buttons) {
+    for (const button of controls) {
       expect(button.getAttribute("title")).toBe(button.getAttribute("data-tooltip"));
       expect(button.getAttribute("aria-label")).toBe(button.getAttribute("data-tooltip"));
     }
+  });
+
+  it("renders the same session kind filter in the mobile chat settings dropdown", async () => {
+    const container = document.createElement("div");
+    render(renderChatMobileToggle(createState()), container);
+    await Promise.resolve();
+
+    const labels = Array.from(
+      container.querySelectorAll<HTMLLabelElement>(".session-kind-filter__item"),
+    ).map((label) => label.textContent?.replace(/\s+/g, " ").trim());
+
+    expect(labels).toEqual(["Main/direct", "Groups", "Subagents", "Dreaming", "Cron 1", "Other"]);
   });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -35,11 +35,16 @@ import {
   isCronSessionKey,
   parseSessionKey,
   resolveAssistantAttachmentAuthToken,
+  resolveSessionDropdownKind,
   resolveSessionOptionGroups,
   resolveSessionDisplayName,
   switchChatSession,
 } from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
+import {
+  createDefaultSessionKindVisibility,
+  type SessionKindVisibility,
+} from "./session-kind-filter.ts";
 import type { SessionsListResult } from "./types.ts";
 
 type SessionRow = SessionsListResult["sessions"][number];
@@ -52,10 +57,11 @@ function labelsForSessionOptions(params: {
   sessionKey: string;
   sessions?: SessionRow[];
   agentsList?: AppViewState["agentsList"];
+  sessionsVisibleKinds?: Partial<SessionKindVisibility>;
 }) {
   const groups = resolveSessionOptionGroups(
     {
-      sessionsHideCron: true,
+      sessionsVisibleKinds: params.sessionsVisibleKinds ?? createDefaultSessionKindVisibility(),
       agentsList: params.agentsList ?? null,
     } as AppViewState,
     params.sessionKey,
@@ -405,7 +411,91 @@ describe("isCronSessionKey", () => {
   });
 });
 
+describe("resolveSessionDropdownKind", () => {
+  it("classifies regular main and direct sessions as main", () => {
+    expect(resolveSessionDropdownKind(row({ key: "main" }))).toBe("main");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:main" }))).toBe("main");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:discord:direct:u-1" }))).toBe("main");
+  });
+
+  it("classifies group sessions from row kind or key shape", () => {
+    expect(
+      resolveSessionDropdownKind(row({ key: "agent:main:discord:direct:u-1", kind: "group" })),
+    ).toBe("group");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:discord:group:g-1" }))).toBe("group");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:slack:channel:c-1" }))).toBe("group");
+  });
+
+  it("classifies subagent, cron, dreaming, and fallback sessions exactly", () => {
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:subagent:child-1" }))).toBe(
+      "subagent",
+    );
+    expect(resolveSessionDropdownKind(row({ key: "cron:nightly" }))).toBe("cron");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:cron:nightly" }))).toBe("cron");
+    expect(
+      resolveSessionDropdownKind(row({ key: "agent:main:dreaming-narrative-light-workspace-1" })),
+    ).toBe("dreaming");
+    expect(resolveSessionDropdownKind(row({ key: "agent:main:custom-plugin-run" }))).toBe("other");
+  });
+});
+
 describe("resolveSessionOptionGroups", () => {
+  it("filters hidden session kinds while preserving the active session", () => {
+    const activeSubagent = "agent:main:subagent:active";
+    const labels = labelsForSessionOptions({
+      sessionKey: activeSubagent,
+      sessionsVisibleKinds: {
+        ...createDefaultSessionKindVisibility(),
+        subagent: false,
+        dreaming: false,
+        other: false,
+      },
+      sessions: [
+        row({ key: "agent:main:discord:direct:u-1", label: "Regular DM" }),
+        row({ key: activeSubagent, label: "Active child" }),
+        row({ key: "agent:main:subagent:hidden", label: "Hidden child" }),
+        row({
+          key: "agent:main:dreaming-narrative-light-workspace-1",
+          label: "Dreaming run",
+        }),
+        row({ key: "agent:main:custom-plugin-run", label: "Plugin run" }),
+      ],
+    });
+
+    expect(labels).toContain("Regular DM");
+    expect(labels).toContain("Subagent: Active child");
+    expect(labels).not.toContain("Subagent: Hidden child");
+    expect(labels).not.toContain("Dreaming run");
+    expect(labels).not.toContain("Plugin run");
+  });
+
+  it("keeps cron sessions hidden by default", () => {
+    const labels = labelsForSessionOptions({
+      sessionKey: "agent:main:main",
+      sessions: [
+        row({ key: "agent:main:main" }),
+        row({ key: "agent:main:cron:nightly", label: "nightly" }),
+      ],
+    });
+
+    expect(labels).not.toContain("Cron: nightly");
+  });
+
+  it("keeps global and unknown rows out of the picker unless selected", () => {
+    const labels = labelsForSessionOptions({
+      sessionKey: "agent:main:main",
+      sessionsVisibleKinds: createDefaultSessionKindVisibility(),
+      sessions: [
+        row({ key: "agent:main:main" }),
+        row({ key: "global", kind: "global", label: "Global" }),
+        row({ key: "unknown", kind: "unknown", label: "Unknown" }),
+      ],
+    });
+
+    expect(labels).not.toContain("Global");
+    expect(labels).not.toContain("Unknown");
+  });
+
   it("prefers grouped session labels over display names", () => {
     const sessionKey = "agent:main:subagent:4f2146de-887b-4176-9abe-91140082959b";
     const labels = labelsForSessionOptions({

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -18,11 +18,25 @@ import { loadSessions } from "./controllers/sessions.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
 import { parseAgentSessionKey } from "./session-key.ts";
+import {
+  SESSION_DROPDOWN_KINDS,
+  resolveSessionDropdownKind,
+  resolveSessionKindVisibility,
+  setSessionKindVisible,
+  type SessionDropdownKind,
+  type SessionKindVisibility,
+} from "./session-kind-filter.ts";
 import { normalizeOptionalString } from "./string-coerce.ts";
 import type { ThemeMode } from "./theme.ts";
 import type { SessionsListResult } from "./types.ts";
 
-export { isCronSessionKey, parseSessionKey, resolveSessionDisplayName, resolveSessionOptionGroups };
+export {
+  isCronSessionKey,
+  parseSessionKey,
+  resolveSessionDisplayName,
+  resolveSessionDropdownKind,
+  resolveSessionOptionGroups,
+};
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -137,7 +151,16 @@ export function renderTab(state: AppViewState, tab: Tab, opts?: { collapsed?: bo
   `;
 }
 
-function renderCronFilterIcon(hiddenCount: number) {
+const SESSION_KIND_LABELS: Record<SessionDropdownKind, string> = {
+  main: "Main/direct",
+  group: "Groups",
+  subagent: "Subagents",
+  dreaming: "Dreaming",
+  cron: "Cron",
+  other: "Other",
+};
+
+function renderSessionKindFilterIcon(hiddenCount: number) {
   return html`
     <span style="position: relative; display: inline-flex; align-items: center;">
       <svg
@@ -151,8 +174,9 @@ function renderCronFilterIcon(hiddenCount: number) {
         stroke-linejoin="round"
         aria-hidden="true"
       >
-        <circle cx="12" cy="12" r="10"></circle>
-        <polyline points="12 6 12 12 16 14"></polyline>
+        <path d="M3 5h18"></path>
+        <path d="M6 12h12"></path>
+        <path d="M10 19h4"></path>
       </svg>
       ${hiddenCount > 0
         ? html`<span
@@ -179,11 +203,78 @@ export function renderChatSessionSelect(state: AppViewState) {
   return renderChatSessionSelectBase(state, switchChatSession);
 }
 
+function countHiddenSessionKinds(
+  sessionKey: string,
+  sessions: SessionsListResult | null,
+  visibility: SessionKindVisibility,
+): Record<SessionDropdownKind, number> {
+  const counts = SESSION_DROPDOWN_KINDS.reduce<Record<SessionDropdownKind, number>>(
+    (next, kind) => {
+      next[kind] = 0;
+      return next;
+    },
+    {} as Record<SessionDropdownKind, number>,
+  );
+  for (const row of sessions?.sessions ?? []) {
+    if (row.key === sessionKey || row.kind === "global" || row.kind === "unknown") {
+      continue;
+    }
+    const kind = resolveSessionDropdownKind(row);
+    if (!visibility[kind]) {
+      counts[kind] += 1;
+    }
+  }
+  return counts;
+}
+
+function renderSessionKindFilter(state: AppViewState) {
+  const visibility = resolveSessionKindVisibility(state.sessionsVisibleKinds);
+  const hiddenCounts = countHiddenSessionKinds(state.sessionKey, state.sessionsResult, visibility);
+  const hiddenTotal = SESSION_DROPDOWN_KINDS.reduce((total, kind) => total + hiddenCounts[kind], 0);
+  const title = hiddenTotal > 0 ? `Filter sessions (${hiddenTotal} hidden)` : "Filter sessions";
+
+  return html`
+    <details class="session-kind-filter">
+      <summary
+        class="btn btn--sm btn--icon ${hiddenTotal > 0 ? "active" : ""}"
+        role="button"
+        title=${title}
+        aria-label=${title}
+        data-tooltip=${title}
+      >
+        ${renderSessionKindFilterIcon(hiddenTotal)}
+      </summary>
+      <div class="session-kind-filter__menu" role="group" aria-label="Session filters">
+        ${SESSION_DROPDOWN_KINDS.map((kind) => {
+          const label = SESSION_KIND_LABELS[kind];
+          const hiddenCount = hiddenCounts[kind];
+          return html`
+            <label class="session-kind-filter__item">
+              <input
+                type="checkbox"
+                .checked=${visibility[kind]}
+                @change=${(e: Event) => {
+                  const checked = (e.currentTarget as HTMLInputElement).checked;
+                  state.sessionsVisibleKinds = setSessionKindVisible(
+                    state.sessionsVisibleKinds,
+                    kind,
+                    checked,
+                  );
+                }}
+              />
+              <span>${label}</span>
+              ${hiddenCount > 0
+                ? html`<span class="session-kind-filter__count">${hiddenCount}</span>`
+                : nothing}
+            </label>
+          `;
+        })}
+      </div>
+    </details>
+  `;
+}
+
 export function renderChatControls(state: AppViewState) {
-  const hideCron = state.sessionsHideCron ?? true;
-  const hiddenCronCount = hideCron
-    ? countHiddenCronSessions(state.sessionKey, state.sessionsResult)
-    : 0;
   const disableThinkingToggle = state.onboarding;
   const disableFocusToggle = state.onboarding;
   const showThinking = state.onboarding ? false : state.settings.chatShowThinking;
@@ -197,11 +288,6 @@ export function renderChatControls(state: AppViewState) {
     ? t("chat.onboardingDisabled")
     : t("chat.toolCallsToggle");
   const focusLabel = disableFocusToggle ? t("chat.onboardingDisabled") : t("chat.focusToggle");
-  const cronLabel = hideCron
-    ? hiddenCronCount > 0
-      ? t("chat.showCronSessionsHidden", { count: String(hiddenCronCount) })
-      : t("chat.showCronSessions")
-    : t("chat.hideCronSessions");
   const toolCallsIcon = html`
     <svg
       width="18"
@@ -338,18 +424,7 @@ export function renderChatControls(state: AppViewState) {
       >
         ${focusIcon}
       </button>
-      <button
-        class="btn btn--sm btn--icon ${hideCron ? "active" : ""}"
-        @click=${() => {
-          state.sessionsHideCron = !hideCron;
-        }}
-        aria-pressed=${hideCron}
-        title=${cronLabel}
-        aria-label=${cronLabel}
-        data-tooltip=${cronLabel}
-      >
-        ${renderCronFilterIcon(hiddenCronCount)}
-      </button>
+      ${renderSessionKindFilter(state)}
     </div>
   `;
 }
@@ -523,6 +598,7 @@ export function renderChatMobileToggle(state: AppViewState) {
             >
               ${focusIcon}
             </button>
+            ${renderSessionKindFilter(state)}
           </div>
         </div>
       </div>
@@ -554,15 +630,6 @@ async function refreshSessionOptions(state: AppViewState) {
     includeGlobal: true,
     includeUnknown: true,
   });
-}
-
-/** Count sessions with a cron: key that would be hidden when hideCron=true. */
-function countHiddenCronSessions(sessionKey: string, sessions: SessionsListResult | null): number {
-  if (!sessions?.sessions) {
-    return 0;
-  }
-  // Don't count the currently active session even if it's a cron.
-  return sessions.sessions.filter((s) => isCronSessionKey(s.key) && s.key !== sessionKey).length;
 }
 
 type ThemeModeOption = { id: ThemeMode; label: string; short: string };

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -15,6 +15,7 @@ import type {
 import type { EmbedSandboxMode } from "./embed-sandbox.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
+import type { SessionKindVisibility } from "./session-kind-filter.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
 import type { UiSettings } from "./storage.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
@@ -256,7 +257,7 @@ export type AppViewState = {
   sessionsFilterLimit: string;
   sessionsIncludeGlobal: boolean;
   sessionsIncludeUnknown: boolean;
-  sessionsHideCron: boolean;
+  sessionsVisibleKinds: SessionKindVisibility;
   sessionsSearchQuery: string;
   sessionsSortColumn: "key" | "kind" | "updated" | "tokens";
   sessionsSortDir: "asc" | "desc";

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -85,6 +85,10 @@ import { importCustomThemeFromUrl } from "./custom-theme.ts";
 import type { GatewayBrowserClient, GatewayHelloOk } from "./gateway.ts";
 import type { Tab } from "./navigation.ts";
 import { resolveAgentIdFromSessionKey } from "./session-key.ts";
+import {
+  createDefaultSessionKindVisibility,
+  type SessionKindVisibility,
+} from "./session-kind-filter.ts";
 import type { SidebarContent } from "./sidebar-content.ts";
 import { loadLocalUserIdentity, loadSettings, type UiSettings } from "./storage.ts";
 import { VALID_THEME_NAMES, type ResolvedTheme, type ThemeMode, type ThemeName } from "./theme.ts";
@@ -369,7 +373,7 @@ export class OpenClawApp extends LitElement {
   @state() sessionsFilterLimit = "120";
   @state() sessionsIncludeGlobal = true;
   @state() sessionsIncludeUnknown = false;
-  @state() sessionsHideCron = true;
+  @state() sessionsVisibleKinds: SessionKindVisibility = createDefaultSessionKindVisibility();
   @state() sessionsSearchQuery = "";
   @state() sessionsSortColumn: "key" | "kind" | "updated" | "tokens" = "updated";
   @state() sessionsSortDir: "asc" | "desc" = "desc";

--- a/ui/src/ui/chat/session-controls.ts
+++ b/ui/src/ui/chat/session-controls.ts
@@ -10,6 +10,11 @@ import { refreshVisibleToolsEffectiveForCurrentSession } from "../controllers/ag
 import { loadSessions } from "../controllers/sessions.ts";
 import { pushUniqueTrimmedSelectOption } from "../select-options.ts";
 import { parseAgentSessionKey } from "../session-key.ts";
+import {
+  isCronSessionKey,
+  resolveSessionDropdownKind,
+  resolveSessionKindVisibility,
+} from "../session-kind-filter.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 import {
   listThinkingLevelLabels,
@@ -442,24 +447,7 @@ export function resolveSessionDisplayName(
   return fallbackName;
 }
 
-export function isCronSessionKey(key: string): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(key);
-  if (!normalized) {
-    return false;
-  }
-  if (normalized.startsWith("cron:")) {
-    return true;
-  }
-  if (!normalized.startsWith("agent:")) {
-    return false;
-  }
-  const parts = normalized.split(":").filter(Boolean);
-  if (parts.length < 3) {
-    return false;
-  }
-  const rest = parts.slice(2).join(":");
-  return rest.startsWith("cron:");
-}
+export { isCronSessionKey, resolveSessionDropdownKind };
 
 type SessionOptionEntry = {
   key: string;
@@ -480,7 +468,7 @@ export function resolveSessionOptionGroups(
   sessions: SessionsListResult | null,
 ): SessionOptionGroup[] {
   const rows = sessions?.sessions ?? [];
-  const hideCron = state.sessionsHideCron ?? true;
+  const visibleKinds = resolveSessionKindVisibility(state.sessionsVisibleKinds);
   const byKey = new Map<string, SessionsListResult["sessions"][number]>();
   for (const row of rows) {
     byKey.set(row.key, row);
@@ -529,7 +517,7 @@ export function resolveSessionOptionGroups(
     if (row.key !== sessionKey && (row.kind === "global" || row.kind === "unknown")) {
       continue;
     }
-    if (hideCron && row.key !== sessionKey && isCronSessionKey(row.key)) {
+    if (row.key !== sessionKey && !visibleKinds[resolveSessionDropdownKind(row)]) {
       continue;
     }
     addOption(row.key);

--- a/ui/src/ui/session-kind-filter.ts
+++ b/ui/src/ui/session-kind-filter.ts
@@ -1,0 +1,117 @@
+import { parseAgentSessionKey, isSubagentSessionKey } from "./session-key.ts";
+import { normalizeLowercaseStringOrEmpty } from "./string-coerce.ts";
+import type { SessionsListResult } from "./types.ts";
+
+export const SESSION_DROPDOWN_KINDS = [
+  "main",
+  "group",
+  "subagent",
+  "dreaming",
+  "cron",
+  "other",
+] as const;
+
+export type SessionDropdownKind = (typeof SESSION_DROPDOWN_KINDS)[number];
+
+export type SessionKindVisibility = Record<SessionDropdownKind, boolean>;
+
+export const DEFAULT_SESSION_KIND_VISIBILITY = {
+  main: true,
+  group: true,
+  subagent: true,
+  dreaming: true,
+  cron: false,
+  other: true,
+} as const satisfies SessionKindVisibility;
+
+export function createDefaultSessionKindVisibility(): SessionKindVisibility {
+  return { ...DEFAULT_SESSION_KIND_VISIBILITY };
+}
+
+export function resolveSessionKindVisibility(
+  value: Partial<SessionKindVisibility> | null | undefined,
+): SessionKindVisibility {
+  return SESSION_DROPDOWN_KINDS.reduce<SessionKindVisibility>((next, kind) => {
+    next[kind] =
+      typeof value?.[kind] === "boolean" ? value[kind] : DEFAULT_SESSION_KIND_VISIBILITY[kind];
+    return next;
+  }, {} as SessionKindVisibility);
+}
+
+export function setSessionKindVisible(
+  value: Partial<SessionKindVisibility> | null | undefined,
+  kind: SessionDropdownKind,
+  visible: boolean,
+): SessionKindVisibility {
+  return {
+    ...resolveSessionKindVisibility(value),
+    [kind]: visible,
+  };
+}
+
+export function isCronSessionKey(key: string | undefined | null): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(key);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.startsWith("cron:")) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(normalized);
+  return normalizeLowercaseStringOrEmpty(parsed?.rest).startsWith("cron:");
+}
+
+export function isDreamingSessionKey(key: string | undefined | null): boolean {
+  const normalized = normalizeLowercaseStringOrEmpty(key);
+  if (!normalized) {
+    return false;
+  }
+  if (normalized.startsWith("dreaming-narrative-")) {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(normalized);
+  return normalizeLowercaseStringOrEmpty(parsed?.rest).startsWith("dreaming-narrative-");
+}
+
+function isMainSessionKey(key: string): boolean {
+  if (key === "main") {
+    return true;
+  }
+  const parsed = parseAgentSessionKey(key);
+  return parsed?.rest === "main";
+}
+
+function isDirectSessionKey(key: string): boolean {
+  const parsed = parseAgentSessionKey(key);
+  const rest = parsed?.rest ?? key;
+  const parts = normalizeLowercaseStringOrEmpty(rest).split(":").filter(Boolean);
+  return parts.length >= 3 && parts[1] === "direct";
+}
+
+function isGroupSessionKey(key: string): boolean {
+  const parsed = parseAgentSessionKey(key);
+  const rest = parsed?.rest ?? key;
+  const normalized = normalizeLowercaseStringOrEmpty(rest);
+  return normalized.includes(":group:") || normalized.includes(":channel:");
+}
+
+export function resolveSessionDropdownKind(
+  row: Pick<SessionsListResult["sessions"][number], "key" | "kind">,
+): SessionDropdownKind {
+  if (isCronSessionKey(row.key)) {
+    return "cron";
+  }
+  if (isSubagentSessionKey(row.key)) {
+    return "subagent";
+  }
+  if (isDreamingSessionKey(row.key)) {
+    return "dreaming";
+  }
+  if (row.kind === "group" || isGroupSessionKey(row.key)) {
+    return "group";
+  }
+  if (isMainSessionKey(row.key) || isDirectSessionKey(row.key)) {
+    return "main";
+  }
+  return "other";
+}

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -13,6 +13,7 @@ import { buildRawSidebarContent } from "../chat/chat-sidebar-raw.ts";
 import { renderWelcomeState } from "../chat/chat-welcome.ts";
 import { renderChatSessionSelect } from "../chat/session-controls.ts";
 import type { GatewayBrowserClient } from "../gateway.ts";
+import { createDefaultSessionKindVisibility } from "../session-kind-filter.ts";
 import type { ModelCatalogEntry } from "../types.ts";
 import type { ChatQueueItem } from "../ui-types.ts";
 import { renderChat } from "./chat.ts";
@@ -240,7 +241,7 @@ function createChatHeaderState(
   const state = {
     sessionKey: "main",
     connected: true,
-    sessionsHideCron: true,
+    sessionsVisibleKinds: createDefaultSessionKindVisibility(),
     sessionsResult: createSessionsListResult({
       model: currentModel,
       modelProvider: currentModelProvider,


### PR DESCRIPTION
## Summary

- Adds a Control UI chat-header session kind filter for main/direct, group, subagent, dreaming, cron, and other sessions.
- Keeps filtering UI-local so `sessions.list` params and gateway protocol stay unchanged.
- Preserves the selected session in the dropdown even when its kind is hidden, and exposes the same filter on desktop and mobile.
- Documents the new chat-header filtering surface.

Fixes #73222

## Testing

- `corepack pnpm test ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/app-render.helpers.browser.test.ts ui/src/ui/controllers/sessions.test.ts --typecheck`
- `corepack pnpm exec oxfmt --check --threads=1 <changed files>`
- `corepack pnpm exec oxlint ui/src/ui/session-kind-filter.ts`
- `git diff --check origin/main...HEAD`
- Ralph architect verification pass

## Not Tested

- Blacksmith Testbox `pnpm check:changed` could not run because local Blacksmith auth timed out before warmup.
- `ui/src/ui/views/chat.test.ts` is currently excluded by the repo's UI Vitest shard; the fixture update is covered indirectly by the session select render/type path above.
