### PR TITLE
GRO-448: propagate hooks/agent thread to delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/hooks: propagate `/hooks/agent` `thread` payloads into isolated delivery and idempotency replay scope, so webhook agent runs can target threaded destinations such as Telegram forum topics without cross-topic replay. Thanks @eywu.
 - Memory/LanceDB: let embedding config use provider-backed auth profiles, environment credentials, or provider config without a separate plugin `embedding.apiKey`, so OAuth-capable embedding providers can power auto-recall/capture. Fixes #68950. Thanks @malshaalan-ai.
 - Plugins/hooks: time out never-settling `agent_end` observation hooks after 30 seconds and log the plugin failure, so hung embedding endpoints no longer leave memory capture silently pending forever. Fixes #65544. Thanks @ghoc0099.
 - Gateway/config: serve runtime config schemas from the current plugin metadata snapshot and generated bundled channel schema metadata instead of rebuilding plugin channel config modules on every `config.get`/`config.schema`, preventing idle plugin-discovery CPU churn after upgrades. Fixes #73088. Thanks @sleitor and @geovansb.

--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -259,7 +259,7 @@ Query-string tokens are rejected.
       -d '{"message":"Summarize inbox","name":"Email","model":"openai/gpt-5.4"}'
     ```
 
-    Fields: `message` (required), `name`, `agentId`, `wakeMode`, `deliver`, `channel`, `to`, `model`, `fallbacks`, `thinking`, `timeoutSeconds`.
+    Fields: `message` (required), `name`, `agentId`, `wakeMode`, `deliver`, `channel`, `to`, `thread`, `model`, `fallbacks`, `thinking`, `timeoutSeconds`. Use `thread` with threaded destinations such as Telegram forum topics; it maps to `delivery.threadId` for the dispatched cron job.
 
   </Accordion>
   <Accordion title="Mapped hooks (POST /hooks/<name>)">

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -220,6 +220,7 @@ export type HookAgentPayload = {
   deliver: boolean;
   channel: HookMessageChannel;
   to?: string;
+  thread?: string;
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
@@ -420,6 +421,8 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
   }
   const toRaw = payload.to;
   const to = normalizeOptionalString(toRaw);
+  const threadRaw = payload.thread;
+  const thread = normalizeOptionalString(threadRaw);
   const modelRaw = payload.model;
   const model = normalizeOptionalString(modelRaw);
   if (modelRaw !== undefined && !model) {
@@ -445,6 +448,7 @@ export function normalizeAgentPayload(payload: Record<string, unknown>):
       deliver,
       channel,
       to,
+      thread,
       model,
       thinking,
       timeoutSeconds,

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -568,6 +568,48 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("propagates payload.thread into job delivery.threadId on /hooks/agent (GRO-448)", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      // 1. With thread present → delivery.threadId set
+      mockIsolatedRunOkOnce();
+      const resWithThread = await postHook(port, "/hooks/agent", {
+        message: "Review-GRO-XXX",
+        name: "Symphony",
+        channel: "telegram",
+        to: "-1003800016870",
+        thread: "15961",
+      });
+      expect(resWithThread.status).toBe(200);
+      await waitForSystemEvent(5_000);
+
+      const callWithThread = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { job?: { delivery?: { threadId?: string | number; channel?: string; to?: string } } }
+        | undefined;
+      expect(callWithThread?.job?.delivery?.channel).toBe("telegram");
+      expect(callWithThread?.job?.delivery?.to).toBe("-1003800016870");
+      expect(callWithThread?.job?.delivery?.threadId).toBe("15961");
+      drainSystemEvents(resolveMainKey());
+
+      // 2. Without thread → delivery.threadId undefined (backwards-compat)
+      mockIsolatedRunOkOnce();
+      const resNoThread = await postHook(port, "/hooks/agent", {
+        message: "Plain hook",
+        name: "NoThread",
+        channel: "telegram",
+        to: "-1003800016870",
+      });
+      expect(resNoThread.status).toBe(200);
+      await waitForSystemEvent(5_000);
+
+      const callNoThread = (cronIsolatedRun.mock.calls[0] as unknown[] | undefined)?.[0] as
+        | { job?: { delivery?: { threadId?: string | number } } }
+        | undefined;
+      expect(callNoThread?.job?.delivery?.threadId).toBeUndefined();
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
   test("dedupes repeated /hooks/agent deliveries by idempotency key", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     await withGatewayServer(async ({ port }) => {

--- a/src/gateway/server.hooks.test.ts
+++ b/src/gateway/server.hooks.test.ts
@@ -625,6 +625,57 @@ describe("gateway server hooks", () => {
     });
   });
 
+  test("scopes /hooks/agent idempotency replay by thread", async () => {
+    testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
+    await withGatewayServer(async ({ port }) => {
+      mockIsolatedRunOk();
+      const idempotencyKey = "hook-idem-thread-scope";
+
+      const first = await postHook(
+        port,
+        "/hooks/agent",
+        {
+          message: "Review-GRO-XXX",
+          name: "Symphony",
+          channel: "telegram",
+          to: "-1003800016870",
+          thread: "15961",
+        },
+        { headers: { "Idempotency-Key": idempotencyKey } },
+      );
+      expect(first.status).toBe(200);
+      const firstBody = (await first.json()) as { runId?: string };
+      await waitForSystemEvent(5_000);
+      drainSystemEvents(resolveMainKey());
+
+      const second = await postHook(
+        port,
+        "/hooks/agent",
+        {
+          message: "Review-GRO-XXX",
+          name: "Symphony",
+          channel: "telegram",
+          to: "-1003800016870",
+          thread: "14506",
+        },
+        { headers: { "Idempotency-Key": idempotencyKey } },
+      );
+      expect(second.status).toBe(200);
+      const secondBody = (await second.json()) as { runId?: string };
+      await waitForSystemEvent(5_000);
+
+      expect(firstBody.runId).toBeTruthy();
+      expect(secondBody.runId).toBeTruthy();
+      expect(secondBody.runId).not.toBe(firstBody.runId);
+      expect(cronIsolatedRun).toHaveBeenCalledTimes(2);
+      const secondCall = (cronIsolatedRun.mock.calls[1] as unknown[] | undefined)?.[0] as
+        | { job?: { delivery?: { threadId?: string | number } } }
+        | undefined;
+      expect(secondCall?.job?.delivery?.threadId).toBe("14506");
+      drainSystemEvents(resolveMainKey());
+    });
+  });
+
   test("dedupes hook retries even when trusted-proxy client IP changes", async () => {
     testState.hooksConfig = { enabled: true, token: HOOK_TOKEN };
     const configPath = process.env.OPENCLAW_CONFIG_PATH;

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -295,6 +295,7 @@ export function createHooksRequestHandler(
           deliver: normalized.value.deliver,
           channel: normalized.value.channel,
           to: normalized.value.to ?? null,
+          thread: normalized.value.thread ?? null,
           model: normalized.value.model ?? null,
           thinking: normalized.value.thinking ?? null,
           timeoutSeconds: normalized.value.timeoutSeconds ?? null,

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -42,6 +42,7 @@ export function createGatewayHooksRequestHandler(params: {
           mode: "announce" as const,
           channel: value.channel,
           to: value.to,
+          threadId: value.thread,
         }
       : { mode: "none" as const };
     const job: CronJob = {


### PR DESCRIPTION
## Summary\n- parse optional `thread` in /hooks/agent payloads\n- pass it through to CronJob delivery.threadId\n- add regression coverage for thread-present and thread-absent payloads\n\n## Test\n- `npm test -- src/gateway/server.hooks.test.ts`