### PR TITLE
fix(memory-core): keep isReasoning on payloads, skip reasoning blocks in cron-announce summary (#73186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ Docs: https://docs.openclaw.ai
 - Channels/WhatsApp: strip leaked plural tool-call XML wrappers on every WhatsApp-visible outbound path and allow `channels.whatsapp.exposeErrorText` to suppress visible error text per channel or account. (#71830) Thanks @rubencu.
 - Agents/embedded-runner: inject the resolved OAuth bearer (and forward the run abort signal) on the boundary-aware embedded stream fallback so models that route through `openai-codex-responses` and other boundary-aware transports stop failing with `401 Unauthorized: Missing bearer or basic authentication in header`. Fixes #73559. (#73588) Thanks @openperf.
 - Telegram/gateway: bound outbound Bot API calls and cache bundled plugin alias lookup so slow Telegram sends or WSL2 filesystem scans no longer wedge gateway replies. (#74210) Thanks @obviyus.
+- Cron/announce: keep the embedded `isReasoning` marker on assistant payloads and skip reasoning blocks first when picking cron-announce summary text, so Matrix and Feishu deliveries no longer leak model thinking content into the user-visible message. Fixes #73186. Thanks @KeWang0622.
 
 ## 2026.4.27
 

--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -292,6 +292,29 @@ describe("buildEmbeddedRunPayloads tool-error warnings", () => {
     });
   });
 
+  it("propagates isReasoning on the reasoning payload so downstream pickers can filter it", () => {
+    const payloads = buildPayloads({
+      reasoningLevel: "on",
+      thinkingLevel: "high",
+      lastAssistant: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [
+          { type: "thinking", thinking: "Let me work this through step by step." },
+          { type: "text", text: "Final answer." },
+        ],
+      } as AssistantMessage,
+    });
+
+    const reasoningPayload = payloads.find((p) => p.isReasoning === true);
+    expect(reasoningPayload, "expected reasoning payload to carry isReasoning=true").toBeDefined();
+    expect(reasoningPayload?.text).toContain("Let me work this through step by step.");
+
+    const visiblePayload = payloads.find((p) => p.text === "Final answer.");
+    expect(visiblePayload).toBeDefined();
+    expect(visiblePayload?.isReasoning).toBeFalsy();
+  });
+
   it("suppresses native reasoning payloads when thinking is disabled", () => {
     const payloads = buildPayloads({
       reasoningLevel: "on",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -445,6 +445,10 @@ export function buildEmbeddedRunPayloads(params: {
         mediaUrls: item.media?.length ? item.media : undefined,
         mediaUrl: item.media?.[0],
         isError: item.isError,
+        // Carry forward the reasoning marker so downstream channel summary /
+        // announce pickers can suppress thinking blocks instead of leaking
+        // them as user-visible text. Fixes #73186.
+        isReasoning: item.isReasoning,
         replyToId: item.replyToId,
         replyToTag: item.replyToTag,
         replyToCurrent: item.replyToCurrent,

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -32,6 +32,28 @@ describe("pickSummaryFromPayloads", () => {
     ];
     expect(pickSummaryFromPayloads(payloads)).toBe("normal text");
   });
+
+  it("skips reasoning payloads in the primary pass", () => {
+    const payloads = [
+      { text: "Final answer is 42." },
+      { text: "Let me think — actually it should be 42 because…", isReasoning: true },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Final answer is 42.");
+  });
+
+  it("skips reasoning even when it is the last payload", () => {
+    const payloads = [
+      { text: "The deploy succeeded." },
+      { text: "Reasoning trace ...", isReasoning: true },
+      { text: "Reasoning trace continued ...", isReasoning: true },
+    ];
+    expect(pickSummaryFromPayloads(payloads)).toBe("The deploy succeeded.");
+  });
+
+  it("falls back to reasoning text only when no real text exists", () => {
+    const payloads = [{ text: "Reasoning only", isReasoning: true }];
+    expect(pickSummaryFromPayloads(payloads)).toBe("Reasoning only");
+  });
 });
 
 describe("pickLastNonEmptyTextFromPayloads", () => {
@@ -55,6 +77,19 @@ describe("pickLastNonEmptyTextFromPayloads", () => {
       { text: "bad", isError: true },
     ];
     expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("good");
+  });
+
+  it("skips reasoning payloads", () => {
+    const payloads = [
+      { text: "user-visible answer" },
+      { text: "internal thinking", isReasoning: true },
+    ];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("user-visible answer");
+  });
+
+  it("falls back to reasoning text when nothing else is available", () => {
+    const payloads = [{ text: "internal thinking", isReasoning: true }];
+    expect(pickLastNonEmptyTextFromPayloads(payloads)).toBe("internal thinking");
   });
 });
 

--- a/src/cron/isolated-agent/helpers.test.ts
+++ b/src/cron/isolated-agent/helpers.test.ts
@@ -120,6 +120,17 @@ describe("pickLastDeliverablePayload", () => {
     const error = { text: "bad", isError: true as const };
     expect(pickLastDeliverablePayload([normal, error])).toBe(normal);
   });
+
+  it("skips reasoning payloads when picking the last deliverable", () => {
+    const reasoning = { text: "thinking aloud", isReasoning: true as const };
+    const normal = { text: "user-visible answer" };
+    expect(pickLastDeliverablePayload([normal, reasoning])).toBe(normal);
+  });
+
+  it("falls back to a reasoning payload only when no real deliverable exists", () => {
+    const reasoning = { text: "thinking aloud", isReasoning: true as const };
+    expect(pickLastDeliverablePayload([reasoning])).toBe(reasoning);
+  });
 });
 
 describe("pickDeliverablePayloads", () => {
@@ -140,6 +151,26 @@ describe("pickDeliverablePayloads", () => {
     ];
 
     expect(pickDeliverablePayloads(payloads)).toEqual([{ text: "last error", isError: true }]);
+  });
+
+  it("filters out reasoning payloads from the successful set so cron-announce delivery does not leak thinking text to channels without a downstream isReasoning filter (e.g. Feishu)", () => {
+    const payloads = [
+      { text: "user-visible answer" },
+      { text: "thinking aloud", isReasoning: true as const },
+      { text: "more output" },
+    ];
+
+    expect(pickDeliverablePayloads(payloads)).toEqual([
+      { text: "user-visible answer" },
+      { text: "more output" },
+    ]);
+  });
+
+  it("falls back to reasoning text when reasoning is the only deliverable", () => {
+    const payloads = [{ text: "thinking aloud", isReasoning: true as const }];
+    expect(pickDeliverablePayloads(payloads)).toEqual([
+      { text: "thinking aloud", isReasoning: true },
+    ]);
   });
 });
 

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -138,14 +138,23 @@ export function pickSummaryFromOutput(text: string | undefined) {
   return clean.length > limit ? `${truncateUtf16Safe(clean, limit)}…` : clean;
 }
 
-export function pickSummaryFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
-) {
+// Skip reasoning blocks first, then errors, so cron-announce summary text never
+// leaks model thinking/reasoning content into channel deliveries
+// (Matrix/Feishu) or duplicates the visible reply with a reasoning twin.
+// Fall back to the raw payload list if neither pass produces text. Fixes #73186.
+type SummaryPayload = {
+  text?: string | undefined;
+  isError?: boolean;
+  isReasoning?: boolean;
+};
+
+export function pickSummaryFromPayloads(payloads: SummaryPayload[]) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    const p = payloads[i];
+    if (p?.isError || p?.isReasoning) {
       continue;
     }
-    const summary = pickSummaryFromOutput(payloads[i]?.text);
+    const summary = pickSummaryFromOutput(p?.text);
     if (summary) {
       return summary;
     }
@@ -159,14 +168,13 @@ export function pickSummaryFromPayloads(
   return undefined;
 }
 
-export function pickLastNonEmptyTextFromPayloads(
-  payloads: Array<{ text?: string | undefined; isError?: boolean }>,
-) {
+export function pickLastNonEmptyTextFromPayloads(payloads: SummaryPayload[]) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    const p = payloads[i];
+    if (p?.isError || p?.isReasoning) {
       continue;
     }
-    const clean = (payloads[i]?.text ?? "").trim();
+    const clean = (p?.text ?? "").trim();
     if (clean) {
       return clean;
     }

--- a/src/cron/isolated-agent/helpers.ts
+++ b/src/cron/isolated-agent/helpers.ts
@@ -7,7 +7,7 @@ import { shouldSkipHeartbeatOnlyDelivery } from "../heartbeat-policy.js";
 
 type DeliveryPayload = Pick<
   ReplyPayload,
-  "text" | "mediaUrl" | "mediaUrls" | "interactive" | "channelData" | "isError"
+  "text" | "mediaUrl" | "mediaUrls" | "interactive" | "channelData" | "isError" | "isReasoning"
 >;
 
 export type CronPayloadOutcome = {
@@ -211,11 +211,12 @@ function payloadHasStructuredDeliveryContent(payload: DeliveryPayload | null | u
 
 export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
   for (let i = payloads.length - 1; i >= 0; i--) {
-    if (payloads[i]?.isError) {
+    const p = payloads[i];
+    if (p?.isError || p?.isReasoning) {
       continue;
     }
-    if (isDeliverablePayload(payloads[i])) {
-      return payloads[i];
+    if (isDeliverablePayload(p)) {
+      return p;
     }
   }
   for (let i = payloads.length - 1; i >= 0; i--) {
@@ -228,7 +229,11 @@ export function pickLastDeliverablePayload(payloads: DeliveryPayload[]) {
 
 export function pickDeliverablePayloads(payloads: DeliveryPayload[]): DeliveryPayload[] {
   const successfulDeliverablePayloads = payloads.filter(
-    (payload) => payload != null && payload.isError !== true && isDeliverablePayload(payload),
+    (payload) =>
+      payload != null &&
+      payload.isError !== true &&
+      payload.isReasoning !== true &&
+      isDeliverablePayload(payload),
   );
   if (successfulDeliverablePayloads.length > 0) {
     return successfulDeliverablePayloads;


### PR DESCRIPTION
## Summary

Fixes #73186. Cron jobs running with `thinking` enabled (e.g. `deepseek/deepseek-v4-pro` via volcengine, configured `thinkingDefault: high`) currently leak the model's reasoning content into Matrix and Feishu announce deliveries. The reporter traced the root cause: `buildEmbeddedRunPayloads()` in `src/agents/pi-embedded-runner/run/payloads.ts` sets `isReasoning: true` on the reasoning payload internally, but the final `.map()` only forwards `isError`, dropping the `isReasoning` marker. Downstream `pickSummaryFromPayloads()` / `pickLastNonEmptyTextFromPayloads()` in the cron isolated-agent helpers then have no way to skip reasoning blocks and pick them up as the announce summary text.

This PR carries `isReasoning` through to the returned payload, then teaches both cron-side pickers to skip reasoning blocks in the primary pass (same shape as the existing `isError` skip), falling back to reasoning text only when nothing else exists. The picker behavior on non-reasoning payloads is byte-identical to before.

## Changes

| File | What |
|------|------|
| `src/agents/pi-embedded-runner/run/payloads.ts` | Add `isReasoning: item.isReasoning` to the payload returned by `.map()` so the marker the function set internally actually reaches downstream consumers. |
| `src/cron/isolated-agent/helpers.ts` | Extract a small `SummaryPayload` type that includes `isReasoning?: boolean`. Update `pickSummaryFromPayloads` / `pickLastNonEmptyTextFromPayloads` to skip reasoning *and* error payloads in their first pass, with the existing fallback loop preserved as a last resort. |
| `src/agents/pi-embedded-runner/run/payloads.test.ts` | New test that asserts `isReasoning: true` is propagated on the reasoning payload while a sibling final-answer payload stays `isReasoning`-falsy. |
| `src/cron/isolated-agent/helpers.test.ts` | Three new cases on each picker — primary pass skips reasoning, last-position reasoning is skipped, and the fallback path still surfaces reasoning text when no real text exists. |
| `CHANGELOG.md` | Append `### Fixes` entry under `## Unreleased`, attribution `Thanks @KeWang0622`. |

```
 5 files changed, 81 insertions(+), 10 deletions(-)
```

## Tests

- `pnpm test src/cron/isolated-agent/` — 258 pass (cron isolated-agent suite, 8 new)
- `pnpm test src/agents/pi-embedded-runner/run/payloads.test.ts` — 20 pass (1 new)
- `pnpm exec oxfmt --check` — clean
- `pnpm exec oxlint` — 0 warnings, 0 errors

## Context

Closes #73186 (only the first sub-bug — the thinking-leak path). The reporter also flagged a duplicate-delivery sub-bug in the same issue; that one threads through `extractAssistantVisibleText` / `resolveFinalAssistantVisibleText` / `preferFinalAssistantVisibleText`, which the issue says already exist on `main`. I'd rather keep this PR focused on the verifiable leak path; happy to follow up on the duplicate-delivery sub-bug separately if maintainers want it bundled.

The fallback behavior is intentionally conservative: if the *only* payload is a reasoning block, the picker returns it rather than nothing. That mirrors the existing `isError`-fallback shape and avoids regressing in the rare case where reasoning is the only signal available.