### PR TITLE
fix(skills/discord): clarify message.send is sideband-only to prevent autoThread duplicate replies (#73278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 - CLI/infer: keep web-search fallback on missing provider API keys, preserve structured validation errors from the selected provider, and let per-request image describe prompts override configured media-entry prompts. (#63263) Thanks @Spolen23.
 - WhatsApp/Web: pass explicit Baileys socket timings into every WhatsApp Web socket and expose `web.whatsapp.*` keepalive, connect, and query timeout settings so unstable networks can avoid repeated 408 disconnect and opening-handshake timeout loops. Fixes #56365. (#73580) Thanks @velvet-shark.
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
+- Skills/Discord: clarify that `message.send` is for sideband traffic only — when `autoThread: true`, the runtime delivers the final conversational reply to the auto-created thread, so calling `message.send` for the same answer no longer produces duplicate parent-channel + thread replies. Fixes #73278. Thanks @KeWang0622.
 
 ## 2026.4.27
 

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -21,7 +21,7 @@ Use the `message` tool. No provider-specific `discord` tool exposed to the agent
 - Avoid Markdown tables in outbound Discord messages.
 - Mention users as `<@USER_ID>`.
 - Prefer Discord components v2 (`components`) for rich UI; use legacy `embeds` only when you must.
-- **Don't repeat your conversational reply via `message.send`.** The runtime already delivers your final assistant text to the originating channel — and when the channel is configured with `autoThread: true`, it delivers that reply to the auto-created thread, not the parent. Use `message.send` only for sideband traffic (proactive notifications to a different target, mid-turn status updates, posting to another channel/thread). Calling `message.send` for the same conversational answer the runtime is about to deliver produces duplicate replies in the parent channel + thread.
+- **Don't repeat your conversational reply via `message.send` when the runtime will deliver it on its own.** The clearest case: with `autoThread: true`, the runtime delivers your final assistant text to the auto-created thread — calling `message.send` for the same answer also posts it in the parent channel, producing the duplicate. Use `message.send` for traffic the runtime won't deliver on its own: proactive notifications, mid-turn status updates, or sends to a different channel / target / thread.
 
 ## Targets
 

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -21,6 +21,7 @@ Use the `message` tool. No provider-specific `discord` tool exposed to the agent
 - Avoid Markdown tables in outbound Discord messages.
 - Mention users as `<@USER_ID>`.
 - Prefer Discord components v2 (`components`) for rich UI; use legacy `embeds` only when you must.
+- **Don't repeat your conversational reply via `message.send`.** The runtime already delivers your final assistant text to the originating channel — and when the channel is configured with `autoThread: true`, it delivers that reply to the auto-created thread, not the parent. Use `message.send` only for sideband traffic (proactive notifications to a different target, mid-turn status updates, posting to another channel/thread). Calling `message.send` for the same conversational answer the runtime is about to deliver produces duplicate replies in the parent channel + thread.
 
 ## Targets
 


### PR DESCRIPTION
## Summary

Fixes #73278. When a Discord channel is configured with `autoThread: true`, mentions produce two user-visible replies: a manual `message.send` in the parent channel and the normal final assistant response delivered to the auto-created thread. The reporter traced this to two prompt sources telling the agent to use the `message` tool for channel replies — the global Codex developer instruction (`extensions/codex/src/app-server/thread-lifecycle.ts:226`) and the bundled Discord skill at `skills/discord/SKILL.md`.

The Codex instruction is shared across all channels, so I'd rather leave it to the maintainers to decide whether to narrow it. This PR only adds a Discord-specific clarification in `skills/discord/SKILL.md` — the skill is `allowed-tools: ["message"]` so its prompt is loaded only when working with Discord, and the new guideline distinguishes "use `message.send` for sideband traffic" from "let the runtime deliver your conversational reply." That removes the prompt that was causing Discord-only duplicate replies without changing behavior on other channels.

## Changes

| File | What |
|------|------|
| `skills/discord/SKILL.md` | New `## Guidelines` bullet explaining when to use `message.send` (sideband notifications, mid-turn updates, posting to a different target) vs when to let the runtime deliver the final conversational reply (the default — and the path `autoThread: true` uses to put the answer in the auto-created thread). |
| `CHANGELOG.md` | Append `### Fixes` entry under `## Unreleased`, attribution `Thanks @KeWang0622`. |

```
 2 files changed, 2 insertions(+)
```

## Tests

Skill content is documentation — no scoped tests to add. `pnpm exec oxfmt --check --threads=1 CHANGELOG.md skills/discord/SKILL.md` is clean. The behavior change is in the agent's understanding of when to call `message.send`, which the existing skill-loading + Discord channel integration tests already exercise.

## Context

Closes #73278.

Scope kept deliberately small. The reporter also noted the global Codex instruction at `thread-lifecycle.ts:226` ("If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply.") could be narrowed too, but that string applies across every channel — happy to follow up there if maintainers want a broader fix, but I didn't want to change cross-channel prompt behavior in a Discord-scoped PR.