### PR TITLE
feat(line): add native sticker send support

### DIFF
--- a/docs/channels/line.md
+++ b/docs/channels/line.md
@@ -178,10 +178,19 @@ messages.
         cancelLabel: "No",
         cancelData: "no",
       },
+      sticker: { packageId: "446", stickerId: "1988" },
     },
   },
 }
 ```
+
+`sticker` sends a native LINE sticker via the Messaging API. Both `packageId` and
+`stickerId` must be numeric strings drawn from LINE's allowlisted stickers
+(see [LINE sticker list](https://developers.line.biz/en/docs/messaging-api/sticker-list/)).
+Non-numeric IDs are dropped with a verbose log; the rest of the payload still
+ships. Authors can also embed a `STICKER:packageId:stickerId` directive on its
+own line in agent text to populate `channelData.line.sticker` automatically;
+directives inside fenced code blocks are preserved as plain text.
 
 The LINE plugin also ships a `/card` command for Flex message presets:
 

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig, PluginRuntime } from "../api.js";
 import { lineConfigAdapter } from "./config-adapter.js";
 import { resolveLineGroupRequireMention } from "./group-policy.js";
 import { lineOutboundAdapter } from "./outbound.js";
-import { setLineRuntime } from "./runtime.js";
+import { clearLineRuntime, setLineRuntime } from "./runtime.js";
 
 type LineRuntimeMocks = {
   pushMessageLine: ReturnType<typeof vi.fn>;
@@ -94,6 +94,11 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
 }
 
 describe("line outbound sendPayload", () => {
+  afterEach(() => {
+    clearLineRuntime();
+    vi.restoreAllMocks();
+  });
+
   it("sends flex message without dropping text", async () => {
     const { runtime, mocks } = createRuntime();
     setLineRuntime(runtime);

--- a/extensions/line/src/channel.sendPayload.test.ts
+++ b/extensions/line/src/channel.sendPayload.test.ts
@@ -11,6 +11,7 @@ type LineRuntimeMocks = {
   pushFlexMessage: ReturnType<typeof vi.fn>;
   pushTemplateMessage: ReturnType<typeof vi.fn>;
   pushLocationMessage: ReturnType<typeof vi.fn>;
+  pushStickerMessage: ReturnType<typeof vi.fn>;
   pushTextMessageWithQuickReplies: ReturnType<typeof vi.fn>;
   createQuickReplyItems: ReturnType<typeof vi.fn>;
   buildTemplateMessageFromPayload: ReturnType<typeof vi.fn>;
@@ -26,6 +27,7 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
   const pushFlexMessage = vi.fn(async () => ({ messageId: "m-flex", chatId: "c1" }));
   const pushTemplateMessage = vi.fn(async () => ({ messageId: "m-template", chatId: "c1" }));
   const pushLocationMessage = vi.fn(async () => ({ messageId: "m-loc", chatId: "c1" }));
+  const pushStickerMessage = vi.fn(async () => ({ messageId: "m-sticker", chatId: "c1" }));
   const pushTextMessageWithQuickReplies = vi.fn(async () => ({
     messageId: "m-quick",
     chatId: "c1",
@@ -57,6 +59,7 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
         pushFlexMessage,
         pushTemplateMessage,
         pushLocationMessage,
+        pushStickerMessage,
         pushTextMessageWithQuickReplies,
         createQuickReplyItems,
         buildTemplateMessageFromPayload,
@@ -78,6 +81,7 @@ function createRuntime(): { runtime: PluginRuntime; mocks: LineRuntimeMocks } {
       pushFlexMessage,
       pushTemplateMessage,
       pushLocationMessage,
+      pushStickerMessage,
       pushTextMessageWithQuickReplies,
       createQuickReplyItems,
       buildTemplateMessageFromPayload,
@@ -440,6 +444,124 @@ describe("line outbound sendPayload", () => {
         cfg,
       }),
     ).rejects.toThrow(/require previewimageurl/i);
+  });
+
+  it("sends sticker via pushStickerMessage when channelData.line.sticker is present", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    const payload = {
+      text: "Thanks!",
+      channelData: {
+        line: {
+          sticker: { packageId: "446", stickerId: "1988" },
+        },
+      },
+    };
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:6",
+      text: payload.text,
+      payload,
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushStickerMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.pushStickerMessage).toHaveBeenCalledWith("line:user:6", "446", "1988", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:6", "Thanks!", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
+  });
+
+  it("sends sticker-only payload (no text) without invoking text send", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:7",
+      text: "",
+      payload: {
+        channelData: {
+          line: {
+            sticker: { packageId: "789", stickerId: "10855" },
+          },
+        },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushStickerMessage).toHaveBeenCalledWith("line:user:7", "789", "10855", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
+    expect(mocks.pushMessageLine).not.toHaveBeenCalled();
+  });
+
+  it("drops sticker with non-numeric packageId and still sends remaining text", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:8",
+      text: "Hello",
+      payload: {
+        text: "Hello",
+        channelData: {
+          line: {
+            sticker: { packageId: "abc", stickerId: "1988" },
+          },
+        },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushStickerMessage).not.toHaveBeenCalled();
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:8", "Hello", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
+  });
+
+  it("drops sticker with non-numeric stickerId and still sends remaining text", async () => {
+    const { runtime, mocks } = createRuntime();
+    setLineRuntime(runtime);
+    const cfg = { channels: { line: {} } } as OpenClawConfig;
+
+    await lineOutboundAdapter.sendPayload!({
+      to: "line:user:9",
+      text: "Hello",
+      payload: {
+        text: "Hello",
+        channelData: {
+          line: {
+            sticker: { packageId: "446", stickerId: "" },
+          },
+        },
+      },
+      accountId: "default",
+      cfg,
+    });
+
+    expect(mocks.pushStickerMessage).not.toHaveBeenCalled();
+    expect(mocks.pushMessageLine).toHaveBeenCalledWith("line:user:9", "Hello", {
+      verbose: false,
+      accountId: "default",
+      cfg,
+    });
   });
 });
 

--- a/extensions/line/src/outbound.runtime.ts
+++ b/extensions/line/src/outbound.runtime.ts
@@ -5,6 +5,7 @@ export {
   pushLocationMessage,
   pushMessageLine,
   pushMessagesLine,
+  pushStickerMessage,
   pushTemplateMessage,
   pushTextMessageWithQuickReplies,
   sendMessageLine,

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -74,6 +74,19 @@ function isNumericIdString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0 && /^[0-9]+$/.test(value);
 }
 
+function validateStickerIds(sticker: { packageId: string; stickerId: string }): boolean {
+  const { packageId, stickerId } = sticker;
+  if (isNumericIdString(packageId) && isNumericIdString(stickerId)) {
+    return true;
+  }
+  logVerbose(
+    `line: dropping sticker payload with non-numeric ids (packageId length=${
+      typeof packageId === "string" ? packageId.length : "n/a"
+    }, stickerId length=${typeof stickerId === "string" ? stickerId.length : "n/a"})`,
+  );
+  return false;
+}
+
 export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>["outbound"]> = {
   deliveryMode: "direct",
   chunker: (text, limit) => getLineRuntime().channel.text.chunkMarkdownText(text, limit),
@@ -206,21 +219,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         });
       }
 
-      if (lineData.sticker) {
-        const { packageId, stickerId } = lineData.sticker;
-        if (isNumericIdString(packageId) && isNumericIdString(stickerId)) {
-          lastResult = await sendSticker(to, packageId, stickerId, {
-            verbose: false,
-            cfg,
-            accountId: accountId ?? undefined,
-          });
-        } else {
-          logVerbose(
-            `line: dropping sticker payload with non-numeric ids (packageId length=${
-              typeof packageId === "string" ? packageId.length : "n/a"
-            }, stickerId length=${typeof stickerId === "string" ? stickerId.length : "n/a"})`,
-          );
-        }
+      if (lineData.sticker && validateStickerIds(lineData.sticker)) {
+        lastResult = await sendSticker(to, lineData.sticker.packageId, lineData.sticker.stickerId, {
+          verbose: false,
+          cfg,
+          accountId: accountId ?? undefined,
+        });
       }
 
       for (const flexMsg of processed.flexMessages) {
@@ -279,21 +283,12 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           longitude: lineData.location.longitude,
         });
       }
-      if (lineData.sticker) {
-        const { packageId, stickerId } = lineData.sticker;
-        if (isNumericIdString(packageId) && isNumericIdString(stickerId)) {
-          quickReplyMessages.push({
-            type: "sticker",
-            packageId,
-            stickerId,
-          });
-        } else {
-          logVerbose(
-            `line: dropping sticker payload with non-numeric ids (packageId length=${
-              typeof packageId === "string" ? packageId.length : "n/a"
-            }, stickerId length=${typeof stickerId === "string" ? stickerId.length : "n/a"})`,
-          );
-        }
+      if (lineData.sticker && validateStickerIds(lineData.sticker)) {
+        quickReplyMessages.push({
+          type: "sticker",
+          packageId: lineData.sticker.packageId,
+          stickerId: lineData.sticker.stickerId,
+        });
       }
       for (const flexMsg of processed.flexMessages) {
         quickReplyMessages.push({

--- a/extensions/line/src/outbound.ts
+++ b/extensions/line/src/outbound.ts
@@ -4,6 +4,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import { logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { type ChannelPlugin, type ResolvedLineAccount } from "./channel-api.js";
 import { resolveLineOutboundMedia, type LineOutboundMediaResolved } from "./outbound-media.js";
 import { getLineRuntime } from "./runtime.js";
@@ -69,10 +70,15 @@ function buildLineMediaMessageObject(
   }
 }
 
+function isNumericIdString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && /^[0-9]+$/.test(value);
+}
+
 export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>["outbound"]> = {
   deliveryMode: "direct",
   chunker: (text, limit) => getLineRuntime().channel.text.chunkMarkdownText(text, limit),
   textChunkLimit: 5000,
+  supportsLineNativePayload: true,
   sendPayload: async ({ to, payload, accountId, cfg }) => {
     const runtime = getLineRuntime();
     const outboundRuntime = await loadLineOutboundRuntime();
@@ -83,6 +89,7 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
     const sendFlex = lineRuntime?.pushFlexMessage ?? outboundRuntime.pushFlexMessage;
     const sendTemplate = lineRuntime?.pushTemplateMessage ?? outboundRuntime.pushTemplateMessage;
     const sendLocation = lineRuntime?.pushLocationMessage ?? outboundRuntime.pushLocationMessage;
+    const sendSticker = lineRuntime?.pushStickerMessage ?? outboundRuntime.pushStickerMessage;
     const sendQuickReplies =
       lineRuntime?.pushTextMessageWithQuickReplies ??
       outboundRuntime.pushTextMessageWithQuickReplies;
@@ -199,6 +206,23 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
         });
       }
 
+      if (lineData.sticker) {
+        const { packageId, stickerId } = lineData.sticker;
+        if (isNumericIdString(packageId) && isNumericIdString(stickerId)) {
+          lastResult = await sendSticker(to, packageId, stickerId, {
+            verbose: false,
+            cfg,
+            accountId: accountId ?? undefined,
+          });
+        } else {
+          logVerbose(
+            `line: dropping sticker payload with non-numeric ids (packageId length=${
+              typeof packageId === "string" ? packageId.length : "n/a"
+            }, stickerId length=${typeof stickerId === "string" ? stickerId.length : "n/a"})`,
+          );
+        }
+      }
+
       for (const flexMsg of processed.flexMessages) {
         const flexContents = flexMsg.contents;
         lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
@@ -254,6 +278,22 @@ export const lineOutboundAdapter: NonNullable<ChannelPlugin<ResolvedLineAccount>
           latitude: lineData.location.latitude,
           longitude: lineData.location.longitude,
         });
+      }
+      if (lineData.sticker) {
+        const { packageId, stickerId } = lineData.sticker;
+        if (isNumericIdString(packageId) && isNumericIdString(stickerId)) {
+          quickReplyMessages.push({
+            type: "sticker",
+            packageId,
+            stickerId,
+          });
+        } else {
+          logVerbose(
+            `line: dropping sticker payload with non-numeric ids (packageId length=${
+              typeof packageId === "string" ? packageId.length : "n/a"
+            }, stickerId length=${typeof stickerId === "string" ? stickerId.length : "n/a"})`,
+          );
+        }
       }
       for (const flexMsg of processed.flexMessages) {
         quickReplyMessages.push({

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -384,4 +384,80 @@ describe("parseLineDirectives", () => {
       expect(getLineData(result).quickReplies).toEqual(["A", "B"]);
     });
   });
+
+  describe("STICKER directive", () => {
+    it("parses STICKER directive variants and removes directive line from text", () => {
+      const cases: Array<{
+        text: string;
+        sticker?: { packageId: string; stickerId: string };
+        outputText?: string;
+      }> = [
+        {
+          text: "Hello\nSTICKER:446:1988",
+          sticker: { packageId: "446", stickerId: "1988" },
+          outputText: "Hello",
+        },
+        {
+          text: "STICKER:789:10855\nThanks!",
+          sticker: { packageId: "789", stickerId: "10855" },
+          outputText: "Thanks!",
+        },
+        {
+          text: "STICKER:6325:10979904",
+          sticker: { packageId: "6325", stickerId: "10979904" },
+          outputText: undefined,
+        },
+        {
+          text: "Plain text without directive",
+          sticker: undefined,
+          outputText: "Plain text without directive",
+        },
+        {
+          text: "STICKER:446:abc",
+          sticker: undefined,
+          outputText: "STICKER:446:abc",
+        },
+        {
+          text: "Hello STICKER:446:1988 world",
+          sticker: undefined,
+          outputText: "Hello STICKER:446:1988 world",
+        },
+      ];
+
+      for (const testCase of cases) {
+        const result = parseLineDirectives({ text: testCase.text });
+        expect(getLineData(result).sticker).toEqual(testCase.sticker);
+        if (testCase.outputText !== undefined) {
+          expect(result.text).toBe(testCase.outputText);
+        } else {
+          expect(result.text).toBeUndefined();
+        }
+      }
+    });
+
+    it("preserves STICKER inside fenced code block as plain text", () => {
+      const result = parseLineDirectives({
+        text: "See:\n```\nSTICKER:446:1988\n```\nThanks!",
+      });
+      expect(getLineData(result).sticker).toBeUndefined();
+      expect(result.text).toContain("```\nSTICKER:446:1988\n```");
+    });
+
+    it("does not overwrite existing channelData.line.sticker", () => {
+      const existing = { packageId: "100", stickerId: "200" };
+      const result = parseLineDirectives({
+        text: "STICKER:446:1988\nHi",
+        channelData: { line: { sticker: existing } },
+      });
+      expect(getLineData(result).sticker).toEqual(existing);
+      expect(result.text).toBe("STICKER:446:1988\nHi");
+    });
+
+    it("hasLineDirectives detects STICKER directive", () => {
+      expect(hasLineDirectives("STICKER:446:1988")).toBe(true);
+      expect(hasLineDirectives("Hello\nSTICKER:789:10855\nthanks")).toBe(true);
+      expect(hasLineDirectives("STICKER:abc:1988")).toBe(false);
+      expect(hasLineDirectives("STICKER:446:1988 trailing")).toBe(false);
+    });
+  });
 });

--- a/extensions/line/src/reply-payload-transform.test.ts
+++ b/extensions/line/src/reply-payload-transform.test.ts
@@ -459,5 +459,13 @@ describe("parseLineDirectives", () => {
       expect(hasLineDirectives("STICKER:abc:1988")).toBe(false);
       expect(hasLineDirectives("STICKER:446:1988 trailing")).toBe(false);
     });
+
+    it("hasLineDirectives ignores STICKER inside fenced code block", () => {
+      // Guard against parseLineDirectives running its text-normalization step
+      // when the only STICKER directive is inside a fenced code block.
+      expect(hasLineDirectives("See:\n```\nSTICKER:446:1988\n```\nThanks!")).toBe(false);
+      // Mixed: fenced block first, then a real directive on its own line.
+      expect(hasLineDirectives("```\nSTICKER:446:1988\n```\nSTICKER:789:10855")).toBe(true);
+    });
   });
 });

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -34,7 +34,7 @@ function extractStickerDirective(
   let stickerId: string | undefined;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    if (/^```/.test(line.trim())) {
+    if (line.trim().startsWith("```")) {
       inFence = !inFence;
       continue;
     }

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -359,9 +359,25 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
 }
 
 export function hasLineDirectives(text: string): boolean {
-  return (
+  if (
     /\[\[(quick_replies|location|confirm|buttons|media_player|event|agenda|device|appletv_remote):/i.test(
       text,
-    ) || /^STICKER:[0-9]+:[0-9]+\s*$/m.test(text)
-  );
+    )
+  ) {
+    return true;
+  }
+  // STICKER directive: fence-aware line scan, mirroring extractStickerDirective
+  // so directives inside fenced code blocks do not trigger parseLineDirectives
+  // and its trailing text-normalization step.
+  let inFence = false;
+  for (const line of text.split("\n")) {
+    if (line.trim().startsWith("```")) {
+      inFence = !inFence;
+      continue;
+    }
+    if (!inFence && /^STICKER:[0-9]+:[0-9]+\s*$/.test(line)) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/extensions/line/src/reply-payload-transform.ts
+++ b/extensions/line/src/reply-payload-transform.ts
@@ -22,7 +22,44 @@ import type { LineChannelData } from "./types.js";
  * - [[agenda: title | event1_title:event1_time, event2_title:event2_time, ...]]
  * - [[device: name | type | status | ctrl1:data1, ctrl2:data2]]
  * - [[appletv_remote: name | status]]
+ * - STICKER:packageId:stickerId (line-anchored, mirrors core MEDIA: convention)
  */
+function extractStickerDirective(
+  text: string,
+): { stickerPackageId: string; stickerStickerId: string; remaining: string } | undefined {
+  const lines = text.split("\n");
+  let inFence = false;
+  let matchedIndex = -1;
+  let packageId: string | undefined;
+  let stickerId: string | undefined;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (/^```/.test(line.trim())) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      continue;
+    }
+    const m = line.match(/^STICKER:([0-9]+):([0-9]+)\s*$/);
+    if (m) {
+      matchedIndex = i;
+      packageId = m[1];
+      stickerId = m[2];
+      break;
+    }
+  }
+  if (matchedIndex < 0 || !packageId || !stickerId) {
+    return undefined;
+  }
+  lines.splice(matchedIndex, 1);
+  return {
+    stickerPackageId: packageId,
+    stickerStickerId: stickerId,
+    remaining: lines.join("\n"),
+  };
+}
+
 export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
   let text = payload.text;
   if (!text) {
@@ -301,6 +338,17 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
     text = text.replace(deviceMatch[0], "").trim();
   }
 
+  if (!lineData.sticker) {
+    const stickerHit = extractStickerDirective(text);
+    if (stickerHit) {
+      lineData.sticker = {
+        packageId: stickerHit.stickerPackageId,
+        stickerId: stickerHit.stickerStickerId,
+      };
+      text = stickerHit.remaining;
+    }
+  }
+
   text = text.replace(/\n{3,}/g, "\n\n").trim();
 
   result.text = text || undefined;
@@ -311,7 +359,9 @@ export function parseLineDirectives(payload: ReplyPayload): ReplyPayload {
 }
 
 export function hasLineDirectives(text: string): boolean {
-  return /\[\[(quick_replies|location|confirm|buttons|media_player|event|agenda|device|appletv_remote):/i.test(
-    text,
+  return (
+    /\[\[(quick_replies|location|confirm|buttons|media_player|event|agenda|device|appletv_remote):/i.test(
+      text,
+    ) || /^STICKER:[0-9]+:[0-9]+\s*$/m.test(text)
   );
 }

--- a/extensions/line/src/runtime.ts
+++ b/extensions/line/src/runtime.ts
@@ -9,6 +9,7 @@ type LineChannelRuntime = {
   pushLocationMessage?: typeof import("./send.js").pushLocationMessage;
   pushMessageLine?: typeof import("./send.js").pushMessageLine;
   pushMessagesLine?: typeof import("./send.js").pushMessagesLine;
+  pushStickerMessage?: typeof import("./send.js").pushStickerMessage;
   pushTemplateMessage?: typeof import("./send.js").pushTemplateMessage;
   pushTextMessageWithQuickReplies?: typeof import("./send.js").pushTextMessageWithQuickReplies;
   resolveLineAccount?: typeof import("./accounts.js").resolveLineAccount;

--- a/extensions/line/src/send.ts
+++ b/extensions/line/src/send.ts
@@ -17,6 +17,7 @@ type LocationMessage = messagingApi.LocationMessage;
 type FlexMessage = messagingApi.FlexMessage;
 type FlexContainer = messagingApi.FlexContainer;
 type TemplateMessage = messagingApi.TemplateMessage;
+type StickerMessage = messagingApi.StickerMessage;
 type QuickReply = messagingApi.QuickReply;
 type QuickReplyItem = messagingApi.QuickReplyItem;
 
@@ -151,6 +152,14 @@ export function createLocationMessage(location: {
     address: location.address.slice(0, 100),
     latitude: location.latitude,
     longitude: location.longitude,
+  };
+}
+
+export function createStickerMessage(packageId: string, stickerId: string): StickerMessage {
+  return {
+    type: "sticker",
+    packageId,
+    stickerId,
   };
 }
 
@@ -393,6 +402,18 @@ export async function pushTemplateMessage(
 ): Promise<LineSendResult> {
   return pushLineMessages(to, [template], opts, {
     verboseMessage: (chatId) => `line: pushed template message to ${chatId}`,
+  });
+}
+
+export async function pushStickerMessage(
+  to: string,
+  packageId: string,
+  stickerId: string,
+  opts: LinePushOpts,
+): Promise<LineSendResult> {
+  return pushLineMessages(to, [createStickerMessage(packageId, stickerId)], opts, {
+    errorContext: "push sticker message",
+    verboseMessage: (chatId) => `line: pushed sticker to ${chatId}`,
   });
 }
 

--- a/extensions/line/src/skills/line-sticker/SKILL.md
+++ b/extensions/line/src/skills/line-sticker/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: line-sticker
+description: Use the LINE sticker directive to send a native LINE sticker (in addition to or instead of text) when replying on a LINE conversation.
+---
+
+When replying on a LINE chat, you can send a native LINE sticker by emitting a
+`STICKER:packageId:stickerId` directive on its own line in your reply text. The
+LINE plugin parses the directive, removes that line from the user-visible text,
+and sends the sticker through the LINE Messaging API.
+
+## Format
+
+```
+STICKER:<packageId>:<stickerId>
+```
+
+- The directive must occupy its **own line** (no surrounding text on the same line).
+- `packageId` and `stickerId` must both be **numeric strings**.
+- The directive can be combined with regular text. Other lines are sent as a normal text message.
+- Directives **inside fenced code blocks** are preserved as plain text and **not** parsed.
+
+## Choosing IDs
+
+Use only stickers from LINE's allowlist for Messaging API bots:
+[https://developers.line.biz/en/docs/messaging-api/sticker-list/](https://developers.line.biz/en/docs/messaging-api/sticker-list/).
+
+Pick a small, fixed set (typically 5-20) of `packageId`/`stickerId` pairs that
+fit the deployment's tone, and reference them by purpose (e.g., greeting, OK,
+sorry). Keep the catalog inside the deployment's prompt rather than hardcoding it
+in this skill.
+
+## Invalid ID handling
+
+If `packageId` or `stickerId` is not a numeric string, the LINE plugin **drops
+the sticker** (verbose log emitted) and still delivers the rest of the message.
+If LINE's API rejects the IDs (unknown sticker, sticker not in the bot allowlist),
+the request fails with an HTTP 400 from the LINE API.
+
+## Example
+
+```
+Thanks for letting me know!
+STICKER:446:1988
+```
+
+This delivers a text message ("Thanks for letting me know!") followed by a
+sticker from package 446. The directive line itself is removed from the text.

--- a/extensions/line/src/skills/line-sticker/SKILL.md
+++ b/extensions/line/src/skills/line-sticker/SKILL.md
@@ -43,5 +43,10 @@ Thanks for letting me know!
 STICKER:446:1988
 ```
 
-This delivers a text message ("Thanks for letting me know!") followed by a
-sticker from package 446. The directive line itself is removed from the text.
+This delivers a sticker (from package 446) together with the surrounding
+text. The directive line itself is removed from the user-visible text.
+The LINE plugin dispatches sticker-bearing payloads with the same ordering
+as the existing LINE-native carriers (`flexMessage` / `templateMessage` /
+`location`): the native message first, then any text chunks. Authors who
+need a strict text-then-sticker sequence should send two separate replies
+rather than relying on placement of the directive within a single reply.

--- a/extensions/line/src/types.ts
+++ b/extensions/line/src/types.ts
@@ -138,4 +138,5 @@ export type LineChannelData = {
   };
   flexMessage?: LineFlexMessagePayload;
   templateMessage?: LineTemplateMessagePayload;
+  sticker?: { packageId: string; stickerId: string };
 };

--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,8 +1,11 @@
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
 
 describe("block-reply-coalescer channelData bypass", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
   afterEach(() => {
     vi.useRealTimers();
   });

--- a/src/auto-reply/reply/block-reply-coalescer.test.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.test.ts
@@ -1,0 +1,70 @@
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBlockReplyCoalescer } from "./block-reply-coalescer.js";
+
+describe("block-reply-coalescer channelData bypass", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function createHarness() {
+    const flushes: ReplyPayload[] = [];
+    const coalescer = createBlockReplyCoalescer({
+      config: { minChars: 1, maxChars: 200, idleMs: 100, joiner: " " },
+      shouldAbort: () => false,
+      onFlush: (payload) => {
+        flushes.push(payload);
+      },
+    });
+    return { flushes, coalescer };
+  }
+
+  it("immediately flushes channelData-only payload without buffering", async () => {
+    const { flushes, coalescer } = createHarness();
+
+    coalescer.enqueue({
+      channelData: { line: { sticker: { packageId: "446", stickerId: "1988" } } },
+    });
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].channelData?.line).toEqual({
+      sticker: { packageId: "446", stickerId: "1988" },
+    });
+    coalescer.stop();
+  });
+
+  it("flushes buffered text before dispatching channelData-only payload", async () => {
+    vi.useFakeTimers();
+    const { flushes, coalescer } = createHarness();
+
+    coalescer.enqueue({ text: "Hello" });
+    coalescer.enqueue({
+      channelData: { line: { sticker: { packageId: "446", stickerId: "1988" } } },
+    });
+
+    expect(flushes.map((p) => p.text ?? null)).toEqual(["Hello", null]);
+    expect(flushes[1].channelData?.line).toEqual({
+      sticker: { packageId: "446", stickerId: "1988" },
+    });
+    coalescer.stop();
+  });
+
+  it("does not drop channelData-only payload when text and media are absent", () => {
+    const { flushes, coalescer } = createHarness();
+
+    coalescer.enqueue({ channelData: { line: { quickReplies: ["A", "B"] } } });
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0].channelData?.line).toEqual({ quickReplies: ["A", "B"] });
+    coalescer.stop();
+  });
+
+  it("ignores empty channelData object (treats as no channelData)", () => {
+    const { flushes, coalescer } = createHarness();
+
+    coalescer.enqueue({ channelData: {} });
+
+    expect(flushes).toHaveLength(0);
+    coalescer.stop();
+  });
+});

--- a/src/auto-reply/reply/block-reply-coalescer.ts
+++ b/src/auto-reply/reply/block-reply-coalescer.ts
@@ -86,7 +86,10 @@ export function createBlockReplyCoalescer(params: {
     const hasMedia = reply.hasMedia;
     const text = reply.text;
     const hasText = reply.hasText;
-    if (hasMedia) {
+    const hasChannelData = Boolean(
+      payload.channelData && Object.keys(payload.channelData).length > 0,
+    );
+    if (hasMedia || hasChannelData) {
       void flush({ force: true });
       void onFlush(payload);
       return;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -83,6 +83,7 @@ export type ChannelOutboundAdapter = {
   pollMaxOptions?: number;
   supportsPollDurationSeconds?: boolean;
   supportsAnonymousPolls?: boolean;
+  /** LINE-only: declared here for the capability-declaration shape; routing gate deferred. */
   supportsLineNativePayload?: boolean;
   normalizePayload?: (params: { payload: ReplyPayload }) => ReplyPayload | null;
   shouldSkipPlainTextSanitization?: (params: { payload: ReplyPayload }) => boolean;

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -83,6 +83,7 @@ export type ChannelOutboundAdapter = {
   pollMaxOptions?: number;
   supportsPollDurationSeconds?: boolean;
   supportsAnonymousPolls?: boolean;
+  supportsLineNativePayload?: boolean;
   normalizePayload?: (params: { payload: ReplyPayload }) => ReplyPayload | null;
   shouldSkipPlainTextSanitization?: (params: { payload: ReplyPayload }) => boolean;
   resolveEffectiveTextChunkLimit?: (params: {


### PR DESCRIPTION
## Summary

- Problem: LINE plugin can send text, image, video, audio, location, flex, template, and quick replies on the outbound path, but cannot send the native stickerMessage type, which is a first-class message format on LINE.
- Why it matters: stickers are heavily used in LINE conversations as standalone replies. Bots that cannot return them feel out of place in LINE chat culture, and there is no first-party send path today.
- What changed: route stickers through `channelData.line.sticker` (mirrors the existing `flexMessage` / `templateMessage` / `location` carriers), add `pushStickerMessage`, add a `STICKER:packageId:stickerId` directive parsed inside the existing `parseLineDirectives`, declare a new `supportsLineNativePayload` outbound capability flag, and fix a long-standing block-reply-coalescer bug that silently dropped channelData-only payloads.
- What did NOT change (scope boundary): no inbound sticker enrichment for AI prompts, no bundled sticker catalog (Skill instructions hold IDs), no browser-based catalog editor, no Telegram/Discord/Matrix changes, no `ReplyPayload.sticker` core field, no edits to the core `parseReplyDirectives`, no pipeline-wide refactor.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #64784 (partial fix: send-only path lands here, inbound `[StickerInfo ...]` enrichment will follow in a separate PR)
- Related #65270 (superseded — closed at https://github.com/openclaw/openclaw/pull/65270#issuecomment-4332497560 in favor of this narrower replacement following the split-scope approach clawsweeper recommended)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For the block-reply-coalescer drop bug:

- Root cause: `block-reply-coalescer.enqueue` early-returned on `!hasText`, only checking text/media via `resolveSendableOutboundReplyParts`. Payloads carrying just `channelData` (e.g., `flexMessage`, `templateMessage`, `location`, the new `sticker`, or any future channelData-only delivery) were silently dropped before reaching `onFlush`.
- Missing detection / guardrail: no test exercised the channelData-only path. The `hasMedia` bypass right above the dropped path was the right symmetric pattern but was never extended.
- Contributing context: existing channelData carriers usually shipped with text or media too, masking the gap. Sticker is the first carrier intended to ship standalone.

For the new feature: N/A.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/block-reply-coalescer.test.ts` (new)
- Scenario the test should lock in: channelData-only payloads (no text, no media) bypass the coalescer's `!hasText` early return and reach `onFlush`, plus buffered text flushes before the channelData payload is dispatched.
- Why this is the smallest reliable guardrail: a focused unit test on the coalescer enqueue path catches the same class of bug for any future channelData carrier without depending on full pipeline integration.
- Existing test that already covers this (if any): none — the coalescer was only covered indirectly via `reply-utils.test.ts`.
- If no new test is added, why not: N/A (a new test file is added).

## User-visible / Behavior Changes

- LINE bots can return native stickers by emitting either `channelData.line.sticker = { packageId, stickerId }` directly or a line-anchored `STICKER:packageId:stickerId` directive in agent text (parser is fence-aware; non-numeric IDs are dropped with a verbose log and the rest of the payload still ships).
- ChannelData-only payloads (no text, no media) are no longer silently dropped by the block-reply coalescer. Any existing `channelData` carrier (flex / template / location) used standalone now reaches the channel adapter as intended.
- New bundled `extensions/line/src/skills/line-sticker/SKILL.md` documents the directive format. No bundled sticker catalog ships in this PR (Skill authors choose IDs from LINE's allowlisted packages: https://developers.line.biz/en/docs/messaging-api/sticker-list/).

## Diagram (if applicable)

```text
Before (channelData-only payload through block-reply-coalescer):
  enqueue(payload) -> hasMedia? no -> hasText? no -> RETURN (silently dropped)

After:
  enqueue(payload) -> hasMedia? || hasChannelData? -> flush buffered text -> onFlush(payload)
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — new outbound LINE Messaging API call (`pushStickerMessage`) over the existing channel access token. No new credentials or transport. Sticker IDs are validated as numeric strings before the call; non-numeric IDs are dropped locally with a verbose log so malformed input never reaches the LINE API. LINE's API server-side rejects unknown IDs.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22 / pnpm 10.33.0
- Model/provider: provider-agnostic (any agent that emits a `STICKER:packageId:stickerId` line)
- Integration/channel: LINE Messaging API
- Relevant config (redacted): standard LINE channel access token + channel secret

### Steps

1. Configure LINE channel as documented in `docs/channels/line.md`.
2. Have the agent emit a reply containing `STICKER:446:1988` on its own line (Moon package).
3. Optionally precede or follow the directive with normal text.

### Expected

- Bot delivers a native LINE sticker (Moon happy) plus the surrounding text. Directive line itself is removed from the user-visible text.
- For invalid IDs (non-numeric), the sticker is dropped with a verbose log and the remaining text is still delivered.
- For directives inside fenced code blocks (```), the directive is preserved as plain text.

### Actual

- Matches expected in the targeted unit tests. I did not run a live end-to-end test against a production LINE official account from this branch; see Human Verification for the exact coverage boundary.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after — new `block-reply-coalescer.test.ts` covers the dropped-channelData-only-payload regression. Without the 3-line bypass, the new "immediately flushes channelData-only payload" test fails (no flush observed).
- [x] Trace/log snippets — `codex review --base upstream/main` on the diff: "I did not find any discrete, actionable regressions in the diff against the merge base. The sticker support additions, directive parsing, and channelData coalescer bypass are internally consistent and covered by targeted tests."

Local gate results against `upstream/main` base:

- `pnpm tsgo:src` / `pnpm tsgo:src:test` / `pnpm tsgo:extensions` / `pnpm tsgo:extensions:test` — pass
- `pnpm lint:core` — pass (0 warnings, 0 errors)
- `pnpm lint:extensions` — pass.
- `pnpm exec oxfmt --check` on touched files — pass
- `pnpm test:contracts:channels` — pass
- `node scripts/check-src-extension-import-boundary.mjs --json` — `[]` (no boundary violations)
- `pnpm build` — pass
- `node scripts/test-projects.mjs --changed upstream/main` — run 5 times consecutively after rebasing onto upstream/main `0b82a7e718`. The three test files added or modified by this PR (`block-reply-coalescer.test.ts`, `channel.sendPayload.test.ts`, `reply-payload-transform.test.ts`) pass deterministically across all 5 runs. Other unit-fast files surface intermittent failures (this PR touches none of them):
  - `src/plugin-activation-boundary.test.ts` (1 test) — 3 / 5 runs
  - `src/video-generation/provider-registry.test.ts` (3 tests) — 2 / 5 runs
  - `src/flows/channel-setup.status.test.ts` (3 tests) — 1 / 5 runs
  - `src/flows/provider-flow.test.ts` (7 tests) — 1 / 5 runs (down from 7 / 7 before defensive `clearLineRuntime` and `vi.restoreAllMocks` afterEach were added to `channel.sendPayload.test.ts`)
  - The fluctuation is consistent with the unit-fast Vitest project's `isolate: false` setting at `test/vitest/vitest.unit-fast.config.ts:20`, which shares module / global state across files in the same worker. clawsweeper's review on this PR explicitly recognises ordering / isolation as outside this PR's scope: https://github.com/openclaw/openclaw/pull/73378#issuecomment-4333263223
- `actionlint` (CI workflow check) failed on this commit while downloading the `actionlint` binary from GitHub releases (`curl: (22) The requested URL returned error: 502`, retried 5 times by the workflow). The failure is in a download step inside `.github/workflows/`, which this PR does not modify (`git diff --name-only upstream/main..HEAD | grep '^\.github/'` is empty). The check should pass once GitHub's release CDN recovers.

## Human Verification (required)

- Verified scenarios: targeted unit tests for sticker dispatch (text + sticker, sticker-only, non-numeric packageId drop, non-numeric stickerId drop), STICKER directive parsing (numeric variants, fence preservation, no-overwrite, `hasLineDirectives` detection), and block-reply-coalescer channelData bypass (channelData-only sticker, buffered-text-flush ordering, quickReplies-only carrier, empty channelData object guard).
- Edge cases checked: empty `channelData` object treated as "no channelData"; existing `channelData.line.sticker` not overwritten by directive parser; trailing-content `STICKER:446:1988 trailing` correctly rejected by the line-anchored matcher.
- What I did **not** verify: live end-to-end against a production LINE official account from this branch. The unit tests cover the dispatch + parser + coalescer paths; a live LINE handshake uses the same code paths as the existing flex / template / location carriers, which are already exercised by the unchanged outbound runtime.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes` — `LineChannelData.sticker` is an optional new field. The `supportsLineNativePayload` capability flag is also optional; existing adapters that omit it continue to function identically. The block-reply-coalescer bypass is a strict superset of prior behavior (it adds a new fast-path for channelData-only payloads; payloads that previously reached `onFlush` continue to reach it).
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: maintainer rejects the 3-line core bypass as too broad for a LINE feature PR.
  - Mitigation: the bypass is a general fix, not LINE-specific. It mirrors the existing `hasMedia` bypass exactly and unblocks any future channelData-only payload (existing flex / template / location carriers used standalone, plus the new sticker). If split is preferred, the bypass commit (`fix(core): ...`) is already isolated and can be reposted as a standalone PR.
- Risk: `supportsLineNativePayload` is added to `ChannelOutboundAdapter` but not yet consulted on a routing path, so reviewers may flag it as an unused field.
  - Mitigation: this is intentional. The flag is a capability declaration shape; its only consumers in this PR are the LINE adapter (declares `true`) and the type contract. Wiring the flag into a routing gate (e.g., gateway send-side `INVALID_REQUEST` for non-LINE channels) would expand scope outside the LINE plugin and is deferred to a follow-up that adds cross-channel sticker abstraction.
- Risk: directive-format ambiguity (`STICKER:446:1988` could appear inside agent prose).
  - Mitigation: the matcher is line-anchored (`^STICKER:[0-9]+:[0-9]+\s*$`), numeric-only, fence-aware, and skips when `channelData.line.sticker` is already set. Any embedded form (`Hello STICKER:446:1988 world`) is preserved as plain text.
- Risk: catalog removal versus the prior PR (#65270) that bundled 14 packages / 416 stickers.
  - Mitigation: per the split-scope recommendation (clawsweeper, on #65270), bundled catalog data ships separately on ClawHub. The new SKILL.md documents the directive shape and points authors to LINE's official allowlist.
- Risk: STICKER directive parsing from agent reply text is part of the LINE plugin's directive surface and could in principle let an upstream prompt that contaminates agent output cause an unintended sticker send.
  - Mitigation: the parser only accepts numeric `packageId` / `stickerId` strings on a dedicated line, LINE's server-side allowlist of bot-permitted packages bounds which IDs the API accepts at send time, and applications that need a stricter policy can layer their own `(packageId, stickerId)` allowlist before submitting `channelData.line.sticker`.

## AI-assisted

- [x] Mark as AI-assisted
- Tooling: implementation drafted with Claude Code, then locally verified via `pnpm check:changed --base upstream/main` (typecheck + lint + format) plus `node scripts/test-projects.mjs --changed upstream/main` (36 Vitest shards) and `codex review --base upstream/main` (no findings).
- Author signoff: I read and own the diff; the description above is mine.
