### PR TITLE
fix(amazon-bedrock): resolve 200K context window for Claude 3.x and unlisted Anthropic Bedrock variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- amazon-bedrock/discovery: backfill Claude 3.x context-window entries (Claude 3 Opus, Claude 3 Sonnet, Claude 3.5 Sonnet v1/v2, Claude 3.7 Sonnet, Claude Opus 4) and add an `anthropic.claude-(3|4)*` family fallback so unlisted Bedrock variants and region-prefixed inference profiles resolve to 200K instead of inheriting the conservative 32K discovery default and triggering compaction-restart loops on prompts that fit. Fixes #73328. Thanks @markthebest12.
 - Gateway/device tokens: stop echoing rotated bearer tokens from shared/admin `device.token.rotate` responses while preserving the same-device token handoff needed by token-only clients before reconnect. (#66773) Thanks @MoerAI.
 - Agents/sessions_spawn: resolve configured bare model aliases for spawn model overrides using the target agent runtime default provider, carrying forward the alias-specific #69029 review fixes from #59681 without the unrelated active-session pruning path. Fixes #59681. Thanks @HowdyDooToYou.
 - Control UI/Talk: keep Google Live browser sessions on the WebSocket transport instead of falling back to WebRTC, validate browser Google Live WebSocket endpoints, cap Gateway relay sessions per browser connection, and remove stale browser-native voice buttons that did not use the configured Talk/TTS provider. Thanks @BunsDev.

--- a/extensions/amazon-bedrock/discovery.test.ts
+++ b/extensions/amazon-bedrock/discovery.test.ts
@@ -181,6 +181,66 @@ describe("bedrock discovery", () => {
     });
   });
 
+  it("resolves a 200K context window for known Claude 3.x base models (#73328)", async () => {
+    mockSingleActiveSummary({
+      modelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      modelName: "Claude 3.5 Sonnet v2",
+      providerName: "anthropic",
+    });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    expect(models[0]).toMatchObject({
+      id: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+      contextWindow: 200_000,
+    });
+  });
+
+  it("falls back to the Anthropic family default for unlisted Claude variants (#73328)", async () => {
+    mockSingleActiveSummary({
+      modelId: "anthropic.claude-3-future-preview-v9:0",
+      modelName: "Claude 3 Future Preview",
+      providerName: "anthropic",
+    });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    expect(models[0]).toMatchObject({
+      id: "anthropic.claude-3-future-preview-v9:0",
+      contextWindow: 200_000,
+    });
+  });
+
+  it("resolves region-prefixed Claude inference profiles via the family fallback (#73328)", async () => {
+    sendMock
+      .mockResolvedValueOnce({
+        modelSummaries: [],
+      })
+      .mockResolvedValueOnce({
+        inferenceProfileSummaries: [
+          {
+            inferenceProfileId: "us.anthropic.claude-3-future-preview-v9:0",
+            inferenceProfileName: "US Claude 3 Future Preview",
+            status: "ACTIVE",
+            type: "SYSTEM_DEFINED",
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-future-preview-v9:0",
+              },
+            ],
+          },
+        ],
+      });
+
+    const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+
+    expect(models[0]).toMatchObject({
+      id: "us.anthropic.claude-3-future-preview-v9:0",
+      contextWindow: 200_000,
+    });
+  });
+
   it("caches results when refreshInterval is enabled", async () => {
     mockSingleActiveSummary();
 

--- a/extensions/amazon-bedrock/discovery.ts
+++ b/extensions/amazon-bedrock/discovery.ts
@@ -44,7 +44,12 @@ const DEFAULT_MAX_TOKENS = 4096;
  */
 const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
   // Anthropic Claude
+  "anthropic.claude-3-opus-20240229-v1:0": 200_000,
+  "anthropic.claude-3-sonnet-20240229-v1:0": 200_000,
+  "anthropic.claude-3-5-sonnet-20240620-v1:0": 200_000,
+  "anthropic.claude-3-5-sonnet-20241022-v2:0": 200_000,
   "anthropic.claude-3-7-sonnet-20250219-v1:0": 200_000,
+  "anthropic.claude-opus-4-20250514-v1:0": 200_000,
   "anthropic.claude-opus-4-7": 1_000_000,
   "anthropic.claude-opus-4-6-v1": 1_000_000,
   "anthropic.claude-opus-4-6-v1:0": 1_000_000,
@@ -113,9 +118,22 @@ const KNOWN_CONTEXT_WINDOWS: Record<string, number> = {
 };
 
 /**
- * Resolve the real context window for a Bedrock model ID.
- * Strips inference profile prefixes (us., eu., ap., global.) before lookup.
+ * Family-level context window fallbacks for Bedrock model IDs that are not
+ * explicitly listed in `KNOWN_CONTEXT_WINDOWS`. AWS does not expose token
+ * limits via the foundation-models API, so without these patterns any newly
+ * released or undocumented variant within a known family would silently inherit
+ * the conservative discovery default and trigger spurious context-overflow
+ * compaction loops on prompts that the model can actually handle. Each entry
+ * matches against the inference-profile-stripped model id.
+ *
+ * See https://github.com/openclaw/openclaw/issues/73328.
  */
+const KNOWN_CONTEXT_WINDOW_FAMILIES: ReadonlyArray<{ pattern: RegExp; contextWindow: number }> = [
+  // All Anthropic Claude 3.x and 4.x models on Bedrock are 200K unless an
+  // explicit entry above raises the value (e.g. the 1M Claude 4.6/4.7 tier).
+  { pattern: /^anthropic\.claude-(?:3|4)/, contextWindow: 200_000 },
+];
+
 function resolveKnownContextWindow(modelId: string): number | undefined {
   const stripped = modelId.replace(/^(?:us|eu|ap|apac|au|jp|global)\./, "");
   const candidates = [modelId, stripped];
@@ -129,6 +147,13 @@ function resolveKnownContextWindow(modelId: string): number | undefined {
       KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix] !== undefined
     ) {
       return KNOWN_CONTEXT_WINDOWS[withoutVersionSuffix];
+    }
+  }
+  for (const candidate of candidates) {
+    for (const family of KNOWN_CONTEXT_WINDOW_FAMILIES) {
+      if (family.pattern.test(candidate)) {
+        return family.contextWindow;
+      }
     }
   }
   return undefined;


### PR DESCRIPTION
## Summary

- Problem: `extensions/amazon-bedrock/discovery.ts` only listed a handful of Anthropic models in `KNOWN_CONTEXT_WINDOWS`. Common Bedrock IDs such as `anthropic.claude-3-opus-20240229-v1:0`, `anthropic.claude-3-sonnet-20240229-v1:0`, and `anthropic.claude-3-5-sonnet-2024{0620,1022}-v{1,2}:0` fell through to `defaults.contextWindow` (32K by default), so prompts well below the model's actual 200K window tripped context-overflow precheck and triggered auto-compaction restart loops.
- Why it matters: every Bedrock customer using a Claude 3.x base model that wasn't already enumerated saw the gateway's in-memory model registry advertise 32K and refuse prompts the model could otherwise serve.
- What changed: backfill the missing Claude 3 / 3.5 / Opus 4 base entries at 200K, then add a small `KNOWN_CONTEXT_WINDOW_FAMILIES` table with an `^anthropic\.claude-(3|4)` regex so unlisted future variants and region-prefixed inference profiles (`us.anthropic.claude-*`, `jp.anthropic.claude-*`, etc.) default to 200K. Explicit table entries still win for higher-tier (1M) Claude rows.
- What did NOT change (scope boundary): no other vendor families. The `defaultContextWindow` config knob is untouched. Inference-profile prefix stripping logic and existing strict matches are unchanged.

## Change Type

- [x] Bug fix

## Scope

- [x] amazon-bedrock plugin (provider discovery)

## Linked Issue/PR

- Closes #73328
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `KNOWN_CONTEXT_WINDOWS` was a hand-maintained map and missed the Claude 3 / 3.5 base IDs that most users encounter on Bedrock. There was no family-level fallback, so any unmatched model fell through to `resolveDefaultContextWindow` (32K default).
- Missing detection / guardrail: no test verified the family-level resolution; existing tests only cover Claude 3.7 / 4.x rows that happened to be in the map.
- Contributing context: AWS does not expose token-limit metadata via `ListFoundationModelsCommand`, so any unmatched model gets the conservative default.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `extensions/amazon-bedrock/discovery.test.ts`
- Scenarios the test locks in:
  - Claude 3.5 Sonnet v2 (`anthropic.claude-3-5-sonnet-20241022-v2:0`) resolves to 200K via the explicit table entry.
  - An unlisted future Claude 3 variant (`anthropic.claude-3-future-preview-v9:0`) resolves to 200K via the `KNOWN_CONTEXT_WINDOW_FAMILIES` fallback rather than 32K.
  - The same family fallback works for region-prefixed inference profiles (`us.anthropic.claude-3-future-preview-v9:0`).
- Why this is the smallest reliable guardrail: the bug surface is "missing entry / no fallback in `resolveKnownContextWindow`". The new tests pin both the table backfill and the family fallback, including the inference-profile prefix path.

## User-visible / Behavior Changes

- Bedrock-discovered Claude 3.x models now report 200K context windows in the gateway's in-memory model registry instead of 32K.
- Bedrock-discovered Anthropic models with IDs not listed in `KNOWN_CONTEXT_WINDOWS` default to 200K via family fallback instead of 32K.
- No other providers are affected.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Configure a Bedrock provider with default discovery and a Claude 3.5 Sonnet (or any unlisted Claude 3.x) model.
2. Boot the gateway and inspect the in-memory model registry / `/health/deep`.
3. Send a prompt totalling ~16K input tokens.

### Expected

- `contextWindow` reported as 200000 for `anthropic.claude-*` Bedrock models, no context-overflow precheck triggered for the 16K prompt.

### Actual (before fix)

- `contextWindow=32000`; the 16K prompt is treated as nearly full and triggers `[context-overflow-precheck] estimatedPromptTokens=16300 promptBudgetBeforeReserve=15616` → `Auto-compaction failed.*Restarting session`.

## Evidence

- Static reproduction is provided by the new unit tests in `extensions/amazon-bedrock/discovery.test.ts`. Live Bedrock validation requires AWS credentials and is left to CI / downstream verification.

## Human Verification

- Verified scenarios: TypeScript clean on touched files; new tests added next to existing `discovery.test.ts` Claude/Sonnet suite.
- Edge cases checked: explicit table entries still win (e.g. Claude Sonnet 4.6 @ 1M), region-prefixed inference profiles route through stripping then family fallback, non-Claude families (Llama, Mistral, etc.) untouched.
- What I did NOT verify: a live Bedrock call with AWS credentials; full `pnpm check` / `pnpm test` was not exercised locally, leaving CI as the verification surface.

## Compatibility / Migration

- Backward compatible? Yes — existing explicit table entries are unchanged. Only previously-incorrect 32K resolutions become 200K.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: a non-Anthropic Bedrock model id happens to start with `anthropic.claude-3` or `anthropic.claude-4`.
  - Mitigation: AWS's Bedrock model id namespace is provider-prefixed (`anthropic.`), so this regex is well-scoped to the Claude family. The explicit map still takes precedence and any future tier-bump (e.g. another 1M variant) just needs another explicit entry.
