### PR TITLE
Add configurable WebChat send shortcut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/WebChat: add a persisted send-shortcut chooser so users can switch the chat composer from plain Enter sends to Cmd+Enter on macOS or Ctrl+Enter on Windows/Linux while Enter inserts a newline, avoiding accidental IME or multiline sends. Fixes #8147; refs #39821. Thanks @moomx and @Liutingxun5548.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -596,6 +596,11 @@
   gap: 4px;
 }
 
+.agent-chat__toolbar-left {
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
 .agent-chat__input-btn,
 .agent-chat__toolbar .btn--ghost {
   display: inline-flex;
@@ -663,6 +668,28 @@
   white-space: nowrap;
   flex-shrink: 0;
   align-self: center;
+}
+
+.agent-chat__send-shortcut-select {
+  height: 30px;
+  max-width: 138px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 0 22px 0 8px;
+  cursor: pointer;
+}
+
+.agent-chat__send-shortcut-select:hover,
+.agent-chat__send-shortcut-select:focus-visible {
+  color: var(--text);
+  background: var(--bg-hover);
+  border-color: var(--border);
+  outline: none;
 }
 
 .chat-send-btn {

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -2,6 +2,7 @@
 
 import { render } from "lit";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createStorageMock } from "../../test-helpers/storage.ts";
 import type { AppViewState } from "../app-view-state.ts";
 import {
   createModelCatalog,
@@ -308,6 +309,39 @@ async function flushTasks() {
   await vi.dynamicImportSettled();
 }
 
+let restoreLocalStorageForTest: (() => void) | null = null;
+let restoreNavigatorPlatformForTest: (() => void) | null = null;
+
+function stubLocalStorageForTest(storage: Storage): void {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: storage,
+  });
+  restoreLocalStorageForTest = () => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, "localStorage", descriptor);
+    } else {
+      delete (globalThis as { localStorage?: Storage }).localStorage;
+    }
+  };
+}
+
+function stubNavigatorPlatformForTest(platform: string): void {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "platform");
+  Object.defineProperty(navigator, "platform", {
+    configurable: true,
+    value: platform,
+  });
+  restoreNavigatorPlatformForTest = () => {
+    if (descriptor) {
+      Object.defineProperty(navigator, "platform", descriptor);
+    } else {
+      delete (navigator as { platform?: string }).platform;
+    }
+  };
+}
+
 function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {}) {
   const container = document.createElement("div");
   render(
@@ -389,7 +423,45 @@ function renderChatView(overrides: Partial<Parameters<typeof renderChat>[0]> = {
   return container;
 }
 
+function dispatchComposerEnter(
+  textarea: HTMLTextAreaElement,
+  init: {
+    shiftKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+    isComposing?: boolean;
+    keyCode?: number;
+  } = {},
+): KeyboardEvent {
+  const event = new KeyboardEvent("keydown", {
+    key: "Enter",
+    bubbles: true,
+    cancelable: true,
+    shiftKey: init.shiftKey,
+    ctrlKey: init.ctrlKey,
+    metaKey: init.metaKey,
+  });
+  if (init.isComposing !== undefined) {
+    Object.defineProperty(event, "isComposing", {
+      configurable: true,
+      value: init.isComposing,
+    });
+  }
+  if (init.keyCode !== undefined) {
+    Object.defineProperty(event, "keyCode", {
+      configurable: true,
+      value: init.keyCode,
+    });
+  }
+  textarea.dispatchEvent(event);
+  return event;
+}
+
 afterEach(() => {
+  restoreLocalStorageForTest?.();
+  restoreLocalStorageForTest = null;
+  restoreNavigatorPlatformForTest?.();
+  restoreNavigatorPlatformForTest = null;
   loadSessionsMock.mockClear();
   refreshVisibleToolsEffectiveForCurrentSessionMock.mockClear();
   resetChatAttachmentPayloadStoreForTest();
@@ -449,6 +521,98 @@ describe("chat voice controls", () => {
 
     expect(container.querySelector('[aria-label="Start Talk"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Voice input"]')).toBeNull();
+  });
+});
+
+describe("chat composer send shortcut", () => {
+  it("keeps Enter-to-send as the default while preserving Shift+Enter and IME composition", () => {
+    const onSend = vi.fn();
+    const container = renderChatView({ connected: true, draft: "hello", onSend });
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+
+    expect(textarea).not.toBeNull();
+    expect(textarea?.placeholder).toContain("Enter to send");
+
+    const plainEnter = dispatchComposerEnter(textarea!);
+    expect(plainEnter.defaultPrevented).toBe(true);
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    const shiftEnter = dispatchComposerEnter(textarea!, { shiftKey: true });
+    expect(shiftEnter.defaultPrevented).toBe(false);
+    expect(onSend).toHaveBeenCalledTimes(1);
+
+    const composingEnter = dispatchComposerEnter(textarea!, {
+      isComposing: true,
+      keyCode: 229,
+    });
+    expect(composingEnter.defaultPrevented).toBe(false);
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets plain Enter insert a newline when Ctrl+Enter sending is selected", () => {
+    const storage = createStorageMock();
+    storage.setItem("openclaw.control.chatSendShortcut.v1", "modifier-enter");
+    stubLocalStorageForTest(storage);
+    const onSend = vi.fn();
+    const container = renderChatView({ connected: true, draft: "hello", onSend });
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+
+    expect(textarea).not.toBeNull();
+    expect(textarea?.placeholder).toContain("Ctrl+Enter to send");
+
+    const plainEnter = dispatchComposerEnter(textarea!);
+    expect(plainEnter.defaultPrevented).toBe(false);
+    expect(onSend).not.toHaveBeenCalled();
+
+    const shiftEnter = dispatchComposerEnter(textarea!, { shiftKey: true });
+    expect(shiftEnter.defaultPrevented).toBe(false);
+    expect(onSend).not.toHaveBeenCalled();
+
+    const ctrlEnter = dispatchComposerEnter(textarea!, { ctrlKey: true });
+    expect(ctrlEnter.defaultPrevented).toBe(true);
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses Cmd+Enter for the modifier shortcut on macOS", () => {
+    stubNavigatorPlatformForTest("MacIntel");
+    const storage = createStorageMock();
+    storage.setItem("openclaw.control.chatSendShortcut.v1", "modifier-enter");
+    stubLocalStorageForTest(storage);
+    const onSend = vi.fn();
+    const container = renderChatView({ connected: true, draft: "hello", onSend });
+    const textarea = container.querySelector<HTMLTextAreaElement>("textarea");
+
+    expect(textarea).not.toBeNull();
+    expect(textarea?.placeholder).toContain("Cmd+Enter to send");
+
+    const ctrlEnter = dispatchComposerEnter(textarea!, { ctrlKey: true });
+    expect(ctrlEnter.defaultPrevented).toBe(false);
+    expect(onSend).not.toHaveBeenCalled();
+
+    const cmdEnter = dispatchComposerEnter(textarea!, { metaKey: true });
+    expect(cmdEnter.defaultPrevented).toBe(true);
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the selected send shortcut from the composer control", () => {
+    const storage = createStorageMock();
+    stubLocalStorageForTest(storage);
+    const onRequestUpdate = vi.fn();
+    const container = renderChatView({ onRequestUpdate });
+    const select = container.querySelector<HTMLSelectElement>(".agent-chat__send-shortcut-select");
+
+    expect(select).not.toBeNull();
+    expect(select?.value).toBe("enter");
+
+    select!.value = "modifier-enter";
+    select!.dispatchEvent(new Event("change", { bubbles: true }));
+
+    expect(storage.getItem("openclaw.control.chatSendShortcut.v1")).toBe("modifier-enter");
+    expect(onRequestUpdate).toHaveBeenCalledTimes(1);
+    const nextContainer = renderChatView();
+    expect(
+      nextContainer.querySelector<HTMLSelectElement>(".agent-chat__send-shortcut-select")?.value,
+    ).toBe("modifier-enter");
   });
 });
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -1,6 +1,7 @@
 import { html, nothing, type TemplateResult } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { repeat } from "lit/directives/repeat.js";
+import { getSafeLocalStorage } from "../../local-storage.ts";
 import type { CompactionStatus, FallbackStatus } from "../app-tool-stream.ts";
 import {
   getChatAttachmentPreviewUrl,
@@ -131,6 +132,52 @@ export type ChatProps = {
 
 const pinnedMessagesMap = new Map<string, PinnedMessages>();
 const deletedMessagesMap = new Map<string, DeletedMessages>();
+const CHAT_SEND_SHORTCUT_STORAGE_KEY = "openclaw.control.chatSendShortcut.v1";
+
+type ChatSendShortcut = "enter" | "modifier-enter";
+
+function normalizeChatSendShortcut(value: unknown): ChatSendShortcut {
+  return value === "modifier-enter" ? "modifier-enter" : "enter";
+}
+
+function loadChatSendShortcutPreference(): ChatSendShortcut {
+  try {
+    return normalizeChatSendShortcut(
+      getSafeLocalStorage()?.getItem(CHAT_SEND_SHORTCUT_STORAGE_KEY),
+    );
+  } catch {
+    return "enter";
+  }
+}
+
+function persistChatSendShortcutPreference(value: ChatSendShortcut): void {
+  try {
+    getSafeLocalStorage()?.setItem(CHAT_SEND_SHORTCUT_STORAGE_KEY, value);
+  } catch {
+    // best-effort local UI preference
+  }
+}
+
+function isApplePlatform(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  return /\b(Mac|iPhone|iPad|iPod)/i.test(navigator.platform);
+}
+
+function sendModifierLabel(): "Cmd" | "Ctrl" {
+  return isApplePlatform() ? "Cmd" : "Ctrl";
+}
+
+function isSendShortcutEvent(e: KeyboardEvent, shortcut: ChatSendShortcut): boolean {
+  if (e.key !== "Enter" || e.shiftKey) {
+    return false;
+  }
+  if (shortcut === "enter") {
+    return true;
+  }
+  return isApplePlatform() ? e.metaKey : e.ctrlKey;
+}
 
 function getPinnedMessages(sessionKey: string): PinnedMessages {
   return getOrCreateSessionCacheValue(
@@ -734,11 +781,15 @@ export function renderChat(props: ChatProps) {
   const deleted = getDeletedMessages(props.sessionKey);
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
   const tokens = tokenEstimate(props.draft);
+  const sendShortcut = loadChatSendShortcutPreference();
+  const modifierLabel = sendModifierLabel();
+  const sendShortcutHint =
+    sendShortcut === "modifier-enter" ? `${modifierLabel}+Enter to send` : "Enter to send";
 
   const placeholder = props.connected
     ? hasAttachments
       ? "Add a message or paste more images..."
-      : `Message ${props.assistantName || "agent"} (Enter to send)`
+      : `Message ${props.assistantName || "agent"} (${sendShortcutHint})`
     : "Connect to the gateway to start chatting...";
 
   const requestUpdate = props.onRequestUpdate ?? (() => {});
@@ -1010,8 +1061,8 @@ export function renderChat(props: ChatProps) {
       return;
     }
 
-    // Send on Enter (without shift)
-    if (e.key === "Enter" && !e.shiftKey) {
+    // Send on the selected Enter shortcut. In modifier mode, plain Enter remains a newline.
+    if (isSendShortcutEvent(e, sendShortcut)) {
       if (e.isComposing || e.keyCode === 229) {
         return;
       }
@@ -1182,6 +1233,20 @@ export function renderChat(props: ChatProps) {
                 `
               : nothing}
             ${tokens ? html`<span class="agent-chat__token-count">${tokens}</span>` : nothing}
+            <select
+              class="agent-chat__send-shortcut-select"
+              aria-label="Send shortcut"
+              title="Send shortcut"
+              .value=${sendShortcut}
+              @change=${(event: Event) => {
+                const next = normalizeChatSendShortcut((event.target as HTMLSelectElement).value);
+                persistChatSendShortcutPreference(next);
+                requestUpdate();
+              }}
+            >
+              <option value="enter">Enter sends</option>
+              <option value="modifier-enter">${modifierLabel}+Enter sends</option>
+            </select>
           </div>
 
           ${renderChatRunControls({


### PR DESCRIPTION
Fixes https://github.com/openclaw/openclaw/issues/8147.

This adds a narrow WebChat/Control UI send-shortcut preference so users can avoid accidental sends while composing with IME or multi-line text. The implementation should update the composer keydown behavior, the visible send hint, preference persistence, and focused tests for plain Enter, Shift+Enter, IME composition, and Cmd/Ctrl+Enter.

Related prior feedback: https://github.com/openclaw/openclaw/issues/39821. Credit to @moomx for the canonical report and @Liutingxun5548 for the duplicate Control UI shortcut request.

Validation: pnpm check:changed.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156934-autonomous-smoke
- Source PRs: none
- Credit: Credit #8147 author @moomx for the canonical IME/configurable send-hotkey request.; Mention closed duplicate #39821 by @Liutingxun5548 as related prior feedback on Cmd/Ctrl+Enter expectations.
- Validation: pnpm check:changed
