### PR TITLE
fix(cli): await dynamic-import-driven eager registration in lazy CLI runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/lazy-runtime: await dynamic-import-driven eager registration in `registerCommandGroups` so `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` actually works. The previous fire-and-forget `void entry.register(program)` returned before any sub-command handler was attached, so commander's subsequent `parseAsync` raced the imports and rejected legitimate calls with `error: too many arguments for '<group>'`. The fix propagates async through `registerBrowserCli`, `registerCoreCliCommands`, `registerSubCliCommands`, `registerProgramCommands`, and `buildProgram`; all CLI bootstrap callsites are already in await contexts (`startupTrace.measure(...)`), so there is no behavior change in lazy mode. Thanks @hanamizuki.
 - Feishu: refresh inbound session delivery context for DM, group, and broadcast turns so later replies do not inherit stale WebChat routing. Fixes #78274.
 - QA-Lab/qa-channel: attach redacted agent tool-start traces to outbound `QaBusMessage` records so scenarios can assert actual tool use instead of relying only on reply text. Fixes #67637. Thanks @100yenadmin.
 - QA-Lab: fail live runtime parity reports when assistant-message usage is missing, preventing `0 vs 0` live token rows from being reported as passing proof. Fixes #80411. Thanks @100yenadmin.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/lazy-runtime: await dynamic-import-driven eager registration in `registerCommandGroups` so `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` actually works. The previous fire-and-forget `void entry.register(program)` returned before any sub-command handler was attached, so commander's subsequent `parseAsync` raced the imports and rejected legitimate calls with `error: too many arguments for '<group>'`. The fix propagates async through `registerBrowserCli`, `registerCoreCliCommands`, `registerSubCliCommands`, `registerProgramCommands`, and `buildProgram`; all CLI bootstrap callsites are already in await contexts (`startupTrace.measure(...)`), so there is no behavior change in lazy mode. Thanks @hanamizuki.
 - Infra/retry: keep jittered retry delays at or above server-supplied Retry-After lower bounds when the hint can be honored. Fixes #68541. (#68543) Thanks @Feelw00.
 - Redact persisted secret-shaped payloads [AI]. (#79006) Thanks @pgondhi987.
 - Agents: label `.openclaw/sandboxes` exec workdirs as sandbox runs in compact tool summaries instead of showing the full path.

--- a/extensions/browser/cli-metadata.ts
+++ b/extensions/browser/cli-metadata.ts
@@ -8,7 +8,7 @@ export default definePluginEntry({
     api.registerCli(
       async ({ program }) => {
         const { registerBrowserCli } = await import("./src/cli/browser-cli.js");
-        registerBrowserCli(program);
+        await registerBrowserCli(program);
       },
       { commands: ["browser"] },
     );

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -102,7 +102,7 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
   api.registerCli(
     async ({ program }) => {
       const { registerBrowserCli } = await import("./src/cli/browser-cli.js");
-      registerBrowserCli(program);
+      await registerBrowserCli(program);
     },
     { commands: ["browser"], descriptors: [BROWSER_CLI_DESCRIPTOR] },
   );

--- a/extensions/browser/plugin-registration.ts
+++ b/extensions/browser/plugin-registration.ts
@@ -106,7 +106,7 @@ export function registerBrowserPlugin(api: OpenClawPluginApi) {
   api.registerCli(
     async ({ program }) => {
       const { registerBrowserCli } = await import("./src/cli/browser-cli.js");
-      registerBrowserCli(program);
+      await registerBrowserCli(program);
     },
     { commands: ["browser"], descriptors: [BROWSER_CLI_DESCRIPTOR] },
   );

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -235,15 +235,31 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
 
-    await vi.waitFor(() =>
-      expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1),
-    );
+    // No vi.waitFor: eager registration must complete before registerBrowserCli
+    // resolves. Without an explicit await on the dynamic imports, the promises
+    // are fire-and-forget and the mocks have not yet been invoked when control
+    // returns to the test.
+    expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1);
     expect(inspectMocks.registerBrowserInspectCommands).toHaveBeenCalledTimes(1);
     expect(actionInputMocks.registerBrowserActionInputCommands).toHaveBeenCalledTimes(1);
     expect(actionObserveMocks.registerBrowserActionObserveCommands).toHaveBeenCalledTimes(1);
     expect(debugMocks.registerBrowserDebugCommands).toHaveBeenCalledTimes(1);
     expect(stateMocks.registerBrowserStateCommands).toHaveBeenCalledTimes(1);
+  });
+
+  it("eager mode dispatches subcommand handlers without racing parseAsync", async () => {
+    vi.stubEnv("OPENCLAW_DISABLE_LAZY_SUBCOMMANDS", "1");
+    const program = new Command();
+    program.name("openclaw");
+
+    const argv = ["node", "openclaw", "browser", "--browser-profile", "nuan", "status"];
+    await registerBrowserCli(program, argv);
+    await program.parseAsync(argv);
+
+    expect(manageMocks.statusAction).toHaveBeenCalledTimes(1);
+    const cmd = manageMocks.statusAction.mock.calls[0]?.[1] as Command | undefined;
+    expect(cmd?.parent?.opts()).toMatchObject({ browserProfile: "nuan" });
   });
 });

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -100,11 +100,11 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     vi.unstubAllEnvs();
   });
 
-  it("registers browser placeholders without loading handlers for help", () => {
+  it("registers browser placeholders without loading handlers for help", async () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
 
     const browser = program.commands.find((command) => command.name() === "browser");
     expect(browser?.commands.map((command) => command.name())).toContain("status");
@@ -123,7 +123,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "status"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "status"]);
 
     const browser = program.commands.find((command) => command.name() === "browser");
     expect(browser?.commands.map((command) => command.name())).toEqual(["status"]);
@@ -139,7 +139,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "doctor", "--deep"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "doctor", "--deep"]);
 
     await program.parseAsync(["browser", "doctor", "--deep"], { from: "user" });
 
@@ -154,7 +154,14 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--json", "open", "about:blank"]);
+    await registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "--json",
+      "open",
+      "about:blank",
+    ]);
 
     await program.parseAsync(["browser", "--json", "open", "about:blank"], { from: "user" });
 
@@ -167,7 +174,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
 
     const tabsProgram = new Command();
     tabsProgram.name("openclaw");
-    registerBrowserCli(tabsProgram, ["node", "openclaw", "browser", "--json", "tabs"]);
+    await registerBrowserCli(tabsProgram, ["node", "openclaw", "browser", "--json", "tabs"]);
 
     await tabsProgram.parseAsync(["browser", "--json", "tabs"], { from: "user" });
 

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -190,7 +190,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, [
+    await registerBrowserCli(program, [
       "node",
       "openclaw",
       "browser",
@@ -215,7 +215,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, [
+    await registerBrowserCli(program, [
       "node",
       "openclaw",
       "browser",

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -62,11 +62,11 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     vi.unstubAllEnvs();
   });
 
-  it("registers browser placeholders without loading handlers for help", () => {
+  it("registers browser placeholders without loading handlers for help", async () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
 
     const browser = program.commands.find((command) => command.name() === "browser");
     expect(browser?.commands.map((command) => command.name())).toContain("status");
@@ -85,7 +85,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "status"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "status"]);
 
     const browser = program.commands.find((command) => command.name() === "browser");
     expect(browser?.commands.map((command) => command.name())).toEqual(["status"]);
@@ -101,7 +101,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "doctor", "--deep"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "doctor", "--deep"]);
 
     await program.parseAsync(["browser", "doctor", "--deep"], { from: "user" });
 
@@ -115,7 +115,14 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--json", "open", "about:blank"]);
+    await registerBrowserCli(program, [
+      "node",
+      "openclaw",
+      "browser",
+      "--json",
+      "open",
+      "about:blank",
+    ]);
 
     await program.parseAsync(["browser", "--json", "open", "about:blank"], { from: "user" });
 
@@ -125,7 +132,7 @@ describe("registerBrowserCli lazy browser subcommands", () => {
 
     const tabsProgram = new Command();
     tabsProgram.name("openclaw");
-    registerBrowserCli(tabsProgram, ["node", "openclaw", "browser", "--json", "tabs"]);
+    await registerBrowserCli(tabsProgram, ["node", "openclaw", "browser", "--json", "tabs"]);
 
     await tabsProgram.parseAsync(["browser", "--json", "tabs"], { from: "user" });
 

--- a/extensions/browser/src/cli/browser-cli.lazy.test.ts
+++ b/extensions/browser/src/cli/browser-cli.lazy.test.ts
@@ -139,15 +139,31 @@ describe("registerBrowserCli lazy browser subcommands", () => {
     const program = new Command();
     program.name("openclaw");
 
-    registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
+    await registerBrowserCli(program, ["node", "openclaw", "browser", "--help"]);
 
-    await vi.waitFor(() =>
-      expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1),
-    );
+    // No vi.waitFor: eager registration must complete before registerBrowserCli
+    // resolves. Without an explicit await on the dynamic imports, the promises
+    // are fire-and-forget and the mocks have not yet been invoked when control
+    // returns to the test.
+    expect(manageMocks.registerBrowserManageCommands).toHaveBeenCalledTimes(1);
     expect(inspectMocks.registerBrowserInspectCommands).toHaveBeenCalledTimes(1);
     expect(actionInputMocks.registerBrowserActionInputCommands).toHaveBeenCalledTimes(1);
     expect(actionObserveMocks.registerBrowserActionObserveCommands).toHaveBeenCalledTimes(1);
     expect(debugMocks.registerBrowserDebugCommands).toHaveBeenCalledTimes(1);
     expect(stateMocks.registerBrowserStateCommands).toHaveBeenCalledTimes(1);
+  });
+
+  it("eager mode dispatches subcommand handlers without racing parseAsync", async () => {
+    vi.stubEnv("OPENCLAW_DISABLE_LAZY_SUBCOMMANDS", "1");
+    const program = new Command();
+    program.name("openclaw");
+
+    const argv = ["node", "openclaw", "browser", "--browser-profile", "nuan", "status"];
+    await registerBrowserCli(program, argv);
+    await program.parseAsync(argv);
+
+    expect(manageMocks.statusAction).toHaveBeenCalledTimes(1);
+    const cmd = manageMocks.statusAction.mock.calls[0]?.[1] as Command | undefined;
+    expect(cmd?.parent?.opts()).toMatchObject({ browserProfile: "nuan" });
   });
 });

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -143,21 +143,24 @@ function buildBrowserCommandGroups(params: {
   }));
 }
 
-function registerLazyBrowserCommands(
+async function registerLazyBrowserCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
   argv: string[],
-) {
+): Promise<void> {
   const { primary, commandPath } = resolveCliArgvInvocation(argv);
   const subcommand = primary === "browser" ? (commandPath[1] ?? null) : null;
-  registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts }), {
+  await registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts }), {
     eager: shouldEagerRegisterSubcommands(),
     primary: subcommand,
     registerPrimaryOnly: subcommand !== null,
   });
 }
 
-export function registerBrowserCli(program: Command, argv: string[] = process.argv) {
+export async function registerBrowserCli(
+  program: Command,
+  argv: string[] = process.argv,
+): Promise<void> {
   const browser = program
     .command("browser")
     .description("Manage OpenClaw's dedicated browser (Chrome/Chromium)")
@@ -186,5 +189,5 @@ export function registerBrowserCli(program: Command, argv: string[] = process.ar
 
   const parentOpts = (cmd: Command) => cmd.parent?.opts?.() as BrowserParentOpts;
 
-  registerLazyBrowserCommands(browser, parentOpts, argv);
+  await registerLazyBrowserCommands(browser, parentOpts, argv);
 }

--- a/extensions/browser/src/cli/browser-cli.ts
+++ b/extensions/browser/src/cli/browser-cli.ts
@@ -228,20 +228,23 @@ function resolveBrowserParentOpts(cmd: Command): BrowserParentOpts {
   return cmd.parent?.opts?.() as BrowserParentOpts;
 }
 
-function registerLazyBrowserCommands(
+async function registerLazyBrowserCommands(
   browser: Command,
   parentOpts: (cmd: Command) => BrowserParentOpts,
   argv: string[],
-) {
+): Promise<void> {
   const subcommand = resolveBrowserLazySubcommand(argv);
-  registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts }), {
+  await registerCommandGroups(browser, buildBrowserCommandGroups({ browser, parentOpts }), {
     eager: shouldEagerRegisterSubcommands(),
     primary: subcommand,
     registerPrimaryOnly: subcommand !== null,
   });
 }
 
-export function registerBrowserCli(program: Command, argv: string[] = process.argv) {
+export async function registerBrowserCli(
+  program: Command,
+  argv: string[] = process.argv,
+): Promise<void> {
   const browser = program
     .command("browser")
     .description("Manage OpenClaw's dedicated browser (Chrome/Chromium)")
@@ -270,5 +273,5 @@ export function registerBrowserCli(program: Command, argv: string[] = process.ar
 
   const parentOpts = resolveBrowserParentOpts;
 
-  registerLazyBrowserCommands(browser, parentOpts, argv);
+  await registerLazyBrowserCommands(browser, parentOpts, argv);
 }

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -26,18 +26,18 @@ vi.mock("./config-cli.js", () => ({
 }));
 
 describe("cli program (smoke)", () => {
-  let program = createProgram();
+  let program: Awaited<ReturnType<typeof buildProgram>>;
 
-  function createProgram() {
-    return buildProgram();
+  async function createProgram() {
+    return await buildProgram();
   }
 
   async function runProgram(argv: string[]) {
     await program.parseAsync(argv, { from: "user" });
   }
 
-  beforeEach(() => {
-    program = createProgram();
+  beforeEach(async () => {
+    program = await createProgram();
     vi.clearAllMocks();
     runTui.mockResolvedValue(undefined);
     runCrestodian.mockResolvedValue(undefined);

--- a/src/cli/program.smoke.test.ts
+++ b/src/cli/program.smoke.test.ts
@@ -26,10 +26,10 @@ vi.mock("./config-cli.js", () => ({
 }));
 
 describe("cli program (smoke)", () => {
-  let program = createProgram();
+  let program: Awaited<ReturnType<typeof buildProgram>>;
 
-  function createProgram() {
-    return buildProgram();
+  async function createProgram() {
+    return await buildProgram();
   }
 
   async function runProgram(argv: string[]) {
@@ -44,8 +44,8 @@ describe("cli program (smoke)", () => {
     return call[0];
   }
 
-  beforeEach(() => {
-    program = createProgram();
+  beforeEach(async () => {
+    program = await createProgram();
     vi.clearAllMocks();
     runTui.mockResolvedValue(undefined);
     runCrestodian.mockResolvedValue(undefined);

--- a/src/cli/program/build-program.test.ts
+++ b/src/cli/program/build-program.test.ts
@@ -64,12 +64,12 @@ describe("buildProgram", () => {
     vi.restoreAllMocks();
   });
 
-  it("wires context/help/preaction/command registration with shared context", () => {
+  it("wires context/help/preaction/command registration with shared context", async () => {
     const argv = ["node", "openclaw", "status"];
     const originalArgv = process.argv;
     process.argv = argv;
     try {
-      const program = buildProgram();
+      const program = await buildProgram();
       const ctx = createProgramContextMock.mock.results[0]?.value as ProgramContext;
 
       expect(program).toBeInstanceOf(Command);
@@ -83,7 +83,7 @@ describe("buildProgram", () => {
   });
 
   it("sets exitCode to 1 on argument errors (fixes #60905)", async () => {
-    const program = buildProgram();
+    const program = await buildProgram();
     program.command("test").description("Test command");
 
     const error = await expectCommanderExit(
@@ -96,7 +96,7 @@ describe("buildProgram", () => {
   });
 
   it("does not run the command action after an argument error", async () => {
-    const program = buildProgram();
+    const program = await buildProgram();
     const actionSpy = vi.fn();
     program.command("test").action(actionSpy);
 
@@ -106,7 +106,7 @@ describe("buildProgram", () => {
   });
 
   it("preserves exitCode 0 for help display", async () => {
-    const program = buildProgram();
+    const program = await buildProgram();
     program.command("test").description("Test command");
 
     const error = await expectCommanderExit(program.parseAsync(["--help"], { from: "user" }), 0);
@@ -116,7 +116,7 @@ describe("buildProgram", () => {
   });
 
   it("preserves exitCode 0 for version display", async () => {
-    const program = buildProgram();
+    const program = await buildProgram();
     program.version("1.0.0");
 
     const error = await expectCommanderExit(program.parseAsync(["--version"], { from: "user" }), 0);
@@ -126,7 +126,7 @@ describe("buildProgram", () => {
   });
 
   it("preserves non-zero exitCode for help error flows", async () => {
-    const program = buildProgram();
+    const program = await buildProgram();
     program.helpCommand("help [command]");
 
     const error = await expectCommanderExit(

--- a/src/cli/program/build-program.ts
+++ b/src/cli/program/build-program.ts
@@ -6,7 +6,7 @@ import { configureProgramHelp } from "./help.js";
 import { registerPreActionHooks } from "./preaction.js";
 import { setProgramContext } from "./program-context.js";
 
-export function buildProgram() {
+export async function buildProgram(): Promise<Command> {
   const program = new Command();
   program.enablePositionalOptions();
   // Preserve Commander-computed exit codes while still aborting parse flow.
@@ -23,7 +23,7 @@ export function buildProgram() {
   configureProgramHelp(program, ctx);
   registerPreActionHooks(program, ctx.programVersion);
 
-  registerProgramCommands(program, ctx, argv);
+  await registerProgramCommands(program, ctx, argv);
 
   return program;
 }

--- a/src/cli/program/build-program.version-alias.test.ts
+++ b/src/cli/program/build-program.version-alias.test.ts
@@ -14,25 +14,25 @@ describe("buildProgram version alias handling", () => {
     vi.restoreAllMocks();
   });
 
-  it("exits with version output for root -v", () => {
+  it("exits with version output for root -v", async () => {
     process.argv = ["node", "openclaw", "-v"];
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`process.exit:${String(code)}`);
     }) as typeof process.exit);
 
-    expect(() => buildProgram()).toThrow("process.exit:0");
+    await expect(buildProgram()).rejects.toThrow("process.exit:0");
     expect(logSpy).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("does not treat subcommand -v as root version alias", () => {
+  it("does not treat subcommand -v as root version alias", async () => {
     process.argv = ["node", "openclaw", "acp", "-v"];
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
       throw new Error(`unexpected process.exit:${String(code)}`);
     }) as typeof process.exit);
 
-    buildProgram();
+    await buildProgram();
     expect(exitSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -152,9 +152,13 @@ export async function registerCoreCliByName(
   return registerCommandGroupByName(program, resolveCoreCommandGroups(ctx, argv), name);
 }
 
-export function registerCoreCliCommands(program: Command, ctx: ProgramContext, argv: string[]) {
+export async function registerCoreCliCommands(
+  program: Command,
+  ctx: ProgramContext,
+  argv: string[],
+): Promise<void> {
   const { primary } = resolveCliArgvInvocation(argv);
-  registerCommandGroups(program, resolveCoreCommandGroups(ctx, argv), {
+  await registerCommandGroups(program, resolveCoreCommandGroups(ctx, argv), {
     eager: false,
     primary,
     registerPrimaryOnly: Boolean(primary && shouldRegisterPrimaryCommandOnly(argv)),

--- a/src/cli/program/command-registry.test.ts
+++ b/src/cli/program/command-registry.test.ts
@@ -112,23 +112,28 @@ describe("command-registry", () => {
     expect(found).toBe(false);
   });
 
-  it("registers doctor placeholder for doctor primary command", () => {
+  it("registers doctor placeholder for doctor primary command", async () => {
     const program = createProgram();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
+    await registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
 
     expect(namesOf(program)).toEqual(["doctor"]);
   });
 
-  it("narrows to the primary command when command help is requested", () => {
+  it("narrows to the primary command when command help is requested", async () => {
     const program = createProgram();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor", "--help"]);
+    await registerCoreCliCommands(program, testProgramContext, [
+      "node",
+      "openclaw",
+      "doctor",
+      "--help",
+    ]);
 
     expect(namesOf(program)).toEqual(["doctor"]);
   });
 
-  it("keeps all placeholders for root help", () => {
+  it("keeps all placeholders for root help", async () => {
     const program = createProgram();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "--help"]);
+    await registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "--help"]);
 
     const names = namesOf(program);
     expect(names).toContain("doctor");
@@ -151,7 +156,7 @@ describe("command-registry", () => {
 
   it("registers grouped core entry placeholders without duplicate command errors", async () => {
     const program = createProgram();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "vitest"]);
+    await registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "vitest"]);
     program.exitOverride();
     await withProcessArgv(["node", "openclaw", "status"], async () => {
       await program.parseAsync(["node", "openclaw", "status"]);
@@ -181,7 +186,7 @@ describe("command-registry", () => {
 
   it("replaces placeholders when loading a grouped entry by secondary command name", async () => {
     const program = createProgram();
-    registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
+    await registerCoreCliCommands(program, testProgramContext, ["node", "openclaw", "doctor"]);
     expect(namesOf(program)).toEqual(["doctor"]);
 
     const found = await registerCoreCliByName(program, testProgramContext, "dashboard");

--- a/src/cli/program/command-registry.ts
+++ b/src/cli/program/command-registry.ts
@@ -19,11 +19,11 @@ export {
 };
 export type { CommandRegistration };
 
-export function registerProgramCommands(
+export async function registerProgramCommands(
   program: Command,
   ctx: ProgramContext,
   argv: string[] = process.argv,
-) {
-  registerCoreCliCommands(program, ctx, argv);
-  registerSubCliCommands(program, argv);
+): Promise<void> {
+  await registerCoreCliCommands(program, ctx, argv);
+  await registerSubCliCommands(program, argv);
 }

--- a/src/cli/program/register-command-groups.ts
+++ b/src/cli/program/register-command-groups.ts
@@ -81,7 +81,9 @@ export async function registerCommandGroups(
     // entry.register typically performs a dynamic import, so firing them
     // without awaiting would race against the caller's subsequent
     // program.parseAsync and leave commands unregistered when argv is parsed.
-    await Promise.all(entries.map((entry) => entry.register(program)));
+    // Wrap in async so synchronous register implementations still flow through
+    // Promise.all without tripping the await-thenable lint rule.
+    await Promise.all(entries.map(async (entry) => entry.register(program)));
     return;
   }
 

--- a/src/cli/program/register-command-groups.ts
+++ b/src/cli/program/register-command-groups.ts
@@ -67,7 +67,7 @@ export function registerLazyCommandGroup(
   });
 }
 
-export function registerCommandGroups(
+export async function registerCommandGroups(
   program: Command,
   entries: readonly CommandGroupEntry[],
   params: {
@@ -75,11 +75,13 @@ export function registerCommandGroups(
     primary: string | null;
     registerPrimaryOnly: boolean;
   },
-) {
+): Promise<void> {
   if (params.eager) {
-    for (const entry of entries) {
-      void entry.register(program);
-    }
+    // Wait for all eager registrations to finish before returning. Each
+    // entry.register typically performs a dynamic import, so firing them
+    // without awaiting would race against the caller's subsequent
+    // program.parseAsync and leave commands unregistered when argv is parsed.
+    await Promise.all(entries.map((entry) => entry.register(program)));
     return;
   }
 

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -294,9 +294,12 @@ export async function registerSubCliByName(
   return registerCommandGroupByName(program, resolveSubCliCommandGroups(argv, context), name);
 }
 
-export function registerSubCliCommands(program: Command, argv: string[] = process.argv) {
+export async function registerSubCliCommands(
+  program: Command,
+  argv: string[] = process.argv,
+): Promise<void> {
   const { primary } = resolveCliArgvInvocation(argv);
-  registerCommandGroups(program, resolveSubCliCommandGroups(argv), {
+  await registerCommandGroups(program, resolveSubCliCommandGroups(argv), {
     eager: shouldEagerRegisterSubcommands(),
     primary,
     registerPrimaryOnly: Boolean(primary && shouldRegisterPrimarySubcommandOnly(argv)),

--- a/src/cli/program/register.subclis.test.ts
+++ b/src/cli/program/register.subclis.test.ts
@@ -87,13 +87,13 @@ describe("registerSubCliCommands", () => {
   const originalDisableLazySubcommands = process.env.OPENCLAW_DISABLE_LAZY_SUBCOMMANDS;
   const originalEnablePrivateQaCli = process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
 
-  const createRegisteredProgram = (argv: string[], name?: string) => {
+  const createRegisteredProgram = async (argv: string[], name?: string) => {
     process.argv = argv;
     const program = new Command();
     if (name) {
       program.name(name);
     }
-    registerSubCliCommands(program, process.argv);
+    await registerSubCliCommands(program, process.argv);
     return program;
   };
 
@@ -135,7 +135,7 @@ describe("registerSubCliCommands", () => {
   });
 
   it("registers the primary placeholder plus completion and dispatches", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "acp"]);
+    const program = await createRegisteredProgram(["node", "openclaw", "acp"]);
 
     expect(program.commands.map((cmd) => cmd.name())).toEqual(["acp", "completion"]);
 
@@ -145,8 +145,8 @@ describe("registerSubCliCommands", () => {
     expect(acpAction).toHaveBeenCalledTimes(1);
   });
 
-  it("registers placeholders for all subcommands when no primary", () => {
-    const program = createRegisteredProgram(["node", "openclaw"]);
+  it("registers placeholders for all subcommands when no primary", async () => {
+    const program = await createRegisteredProgram(["node", "openclaw"]);
 
     const names = program.commands.map((cmd) => cmd.name());
     expect(names).toContain("acp");
@@ -156,16 +156,19 @@ describe("registerSubCliCommands", () => {
     expect(registerAcpCli).not.toHaveBeenCalled();
   });
 
-  it("omits the qa placeholder when the private qa cli is disabled", () => {
+  it("omits the qa placeholder when the private qa cli is disabled", async () => {
     delete process.env.OPENCLAW_ENABLE_PRIVATE_QA_CLI;
 
-    const program = createRegisteredProgram(["node", "openclaw"]);
+    const program = await createRegisteredProgram(["node", "openclaw"]);
 
     expect(program.commands.map((cmd) => cmd.name())).not.toContain("qa");
   });
 
   it("re-parses argv for lazy subcommands", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "nodes", "list"], "openclaw");
+    const program = await createRegisteredProgram(
+      ["node", "openclaw", "nodes", "list"],
+      "openclaw",
+    );
 
     expect(program.commands.map((cmd) => cmd.name())).toEqual(["nodes", "completion"]);
 
@@ -176,7 +179,7 @@ describe("registerSubCliCommands", () => {
   });
 
   it("registers the infer placeholder and dispatches through the capability registrar", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "infer"], "openclaw");
+    const program = await createRegisteredProgram(["node", "openclaw", "infer"], "openclaw");
 
     expect(program.commands.map((cmd) => cmd.name())).toEqual(["infer", "completion"]);
 
@@ -187,7 +190,10 @@ describe("registerSubCliCommands", () => {
   });
 
   it("replaces placeholder when registering a subcommand by name", async () => {
-    const program = createRegisteredProgram(["node", "openclaw", "acp", "--help"], "openclaw");
+    const program = await createRegisteredProgram(
+      ["node", "openclaw", "acp", "--help"],
+      "openclaw",
+    );
 
     await registerSubCliByName(program, "acp");
 

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -72,10 +72,13 @@ export async function registerSubCliByName(
   return registerCommandGroupByName(program, resolveSubCliCommandGroups(argv, context), name);
 }
 
-export function registerSubCliCommands(program: Command, argv: string[] = process.argv) {
-  registerSubCliCommandsCore(program, argv);
+export async function registerSubCliCommands(
+  program: Command,
+  argv: string[] = process.argv,
+): Promise<void> {
+  await registerSubCliCommandsCore(program, argv);
   const { primary } = resolveCliArgvInvocation(argv);
-  registerCommandGroups(program, resolveSubCliCommandGroups(argv), {
+  await registerCommandGroups(program, resolveSubCliCommandGroups(argv), {
     eager: shouldEagerRegisterSubcommands(),
     primary,
     registerPrimaryOnly: Boolean(primary && shouldRegisterPrimarySubcommandOnly(argv)),


### PR DESCRIPTION
## Summary

Fixes a race in the eager path of the lazy CLI runtime introduced by `776d2ab65d fix(browser): lazy-load browser CLI runtime` (v2026.4.25).

### Background

The lazy CLI runtime registers placeholder sub-commands first and dynamically `import(...)`s the real handlers on demand. As a documented escape hatch, setting `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` should switch to eager mode where every sub-command is registered up front.

### Bug

`registerCommandGroups`'s eager path runs `void entry.register(program)` for every group and returns immediately. Each `entry.register` does `await import(...)` first, so the imports are in flight when the caller's `program.parseAsync(argv)` runs. By the time commander tries to dispatch a sub-command, none of the placeholders or real commands are attached yet — so it rejects with `error: too many arguments for '<group>'. Expected 0 arguments but got 1.` (Reproduced in tests; the original eager test had to use `vi.waitFor` to mask the race.)

### Fix

Switch eager path to `await Promise.all(entries.map((entry) => entry.register(program)))`. `registerCommandGroups` becomes async, and async propagates through `registerBrowserCli`, `registerCoreCliCommands`, `registerSubCliCommands`, `registerProgramCommands`, and `buildProgram`. All CLI bootstrap callsites are already in `await` contexts (`startupTrace.measure("build-program", () => buildProgram())`, and the `async` callback in `api.registerCli(...)`), so there is no surface change for lazy mode — only the eager fallback path becomes correct.

## Repro (no fix)

```bash
OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1 openclaw browser status
# error: too many arguments for 'browser'. Expected 0 arguments but got 1.
```

## Why no test caught it

The existing eager test `can eagerly register all browser groups for compatibility` used `vi.waitFor` to wait for the dynamic imports to eventually resolve. That made the test pass against the racy implementation; the production bug is precisely that nothing else in the framework waits.

This PR adds:

- An end-to-end eager-mode dispatch test that runs `openclaw browser status` under `OPENCLAW_DISABLE_LAZY_SUBCOMMANDS=1` and asserts the handler is reached without `parseAsync` racing the registrations.
- Updates to the existing eager test to drop `vi.waitFor` — the immediate-after-await assertion now succeeds because eager registration is properly awaited.

## Note on scope

This PR was originally a two-part fix (preserve parent options + await eager registration). The parent-options piece was reconciled with upstream's partial fix `01254500df fix(cli): preserve lazy command parent flags` and has been removed from this PR; only the eager-registration fix remains.

## Files changed

Production:
- `src/cli/program/register-command-groups.ts` — async + `await Promise.all(...)` in eager path
- `src/cli/program/command-registry-core.ts` / `register.subclis.ts` / `register.subclis-core.ts` / `command-registry.ts` / `build-program.ts` — async propagation
- `extensions/browser/src/cli/browser-cli.ts` — async propagation
- `extensions/browser/plugin-registration.ts` / `cli-metadata.ts` — `await registerBrowserCli(program)`

Tests:
- `extensions/browser/src/cli/browser-cli.lazy.test.ts` — eager dispatch test, drop `vi.waitFor`
- `src/cli/program.smoke.test.ts` / `build-program.test.ts` / `build-program.version-alias.test.ts` / `command-registry.test.ts` / `register.subclis.test.ts` — await async helpers

Changelog:
- `CHANGELOG.md` — Unreleased Fixes entry
