### PR TITLE
fix(codex,discord): stop duplicate channel reply when autoThread routes to a thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- codex/discord: clarify the embedded developer instructions and bundled Discord skill so the agent emits the normal current-conversation reply as the final assistant message (which OpenClaw delivery routes to the originating channel/thread, including auto-created threads) and only invokes the `message` tool for explicit out-of-band actions, eliminating the duplicate `message.send` reply in the parent channel that landed alongside the thread reply on `autoThread: true` mentions. Fixes #73278. Thanks @solavrc.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/codex/src/app-server/thread-lifecycle.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.ts
@@ -223,7 +223,7 @@ export function buildDeveloperInstructions(params: EmbeddedRunAttemptParams): st
   const promptOverlay = renderCodexRuntimePromptOverlay(params);
   const sections = [
     "You are running inside OpenClaw. Use OpenClaw dynamic tools for messaging, cron, sessions, and host actions when available.",
-    "Preserve the user's existing channel/session context. If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply.",
+    "Preserve the user's existing channel/session context. For your normal reply to the current conversation, just emit the final assistant message — OpenClaw routes it back to the originating channel, thread, or DM (including auto-created threads). Reserve the OpenClaw messaging tool for explicit out-of-band actions: sending to a different channel/conversation, reactions, edits, reads, thread/channel management, or presence operations. Do not call the messaging tool to deliver the same conversational reply that should already be the final assistant response.",
     promptOverlay,
     params.extraSystemPrompt,
     params.skillsSnapshot?.prompt,

--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -7,7 +7,9 @@ allowed-tools: ["message"]
 
 # Discord (Via `message`)
 
-Use the `message` tool. No provider-specific `discord` tool exposed to the agent.
+Use the `message` tool for explicit Discord operations: sending to a different channel/thread/user than the current turn, reactions, edits/unsend, reads, thread/channel management, or presence. No provider-specific `discord` tool is exposed to the agent.
+
+For your normal reply to the current conversation (including a mention that triggered an `autoThread`), do not call the `message` tool — just emit the final assistant message and OpenClaw delivery will route it to the originating channel, DM, or auto-created thread. Calling `message.send` for the same conversational reply causes a duplicate to land in the parent channel alongside the thread reply.
 
 ## Musts
 


### PR DESCRIPTION
## Summary

- Problem: when a Discord channel mention triggers `autoThread: true`, the user sees two replies — one `message.send` reply in the parent channel **and** a normal final-assistant reply in the auto-created thread. The duplicate comes from the model being told (twice) to call the OpenClaw messaging tool for channel replies, even for the conversational reply that OpenClaw delivery is already going to route to the right surface.
- Why it matters: every Discord `autoThread` mention handled by the Codex embedded harness produces a confusing duplicate reply across two surfaces.
- What changed: the Codex embedded developer-instruction sentence in `extensions/codex/src/app-server/thread-lifecycle.ts` and the `skills/discord/SKILL.md` overview now distinguish "normal current-conversation reply" (just emit the final assistant message; OpenClaw routes it) from "explicit out-of-band action" (use the `message` tool: send to a different conversation, reactions, edits, reads, thread/channel/presence ops).
- What did NOT change (scope boundary): no runtime/routing logic, no `dynamic-tools` wiring, no `disableMessageTool` plumbing. Only the prompt strings the agent reads.

## Change Type

- [x] Bug fix

## Scope

- [x] codex extension (embedded harness developer instructions)
- [x] discord skill (SKILL.md overview)

## Linked Issue/PR

- Closes #73278
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: two prompt sources told the agent the same thing — "use the OpenClaw messaging tool" for channel replies — without distinguishing the conversational reply (which OpenClaw delivery already routes back to the originating channel/thread) from explicit messaging operations. The model then called `message.send` *and* produced a final assistant response, so the parent channel got the manual send and the auto-created thread got the normal final response.
  - `extensions/codex/src/app-server/thread-lifecycle.ts:226` — embedded developer instructions said "If sending a channel reply, use the OpenClaw messaging tool instead of describing that you would reply."
  - `skills/discord/SKILL.md` overview said "Use the `message` tool." with no carve-out for the current-conversation reply.
- Missing detection / guardrail: prompt strings, no test surface.
- Contributing context: `autoThread: true` makes the duplicate especially visible because the two surfaces (parent vs thread) diverge.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Documentation/prompt change verified by review
- Target test or file: prompt strings only; no behavioural code changed.
- Why this is the smallest reliable guardrail: the bug surface is the wording of two prompt sources. A unit test would only re-assert the new wording verbatim. The fix is reviewed against the issue's failure mode and the existing `message` tool semantics.

## User-visible / Behavior Changes

- Discord `autoThread: true` mentions now produce a single normal reply in the auto-created thread instead of a manual `message.send` reply in the parent channel plus the thread reply.
- Behaviour for explicit `message` tool actions (send to a different conversation, react, edit/unsend, read, thread/channel/presence ops) is unchanged.
- Other channels are unaffected — the developer-instruction wording applies to the embedded Codex harness in general, but the fix preserves "OpenClaw routes the final assistant message back to the originating channel/session" which was already the runtime behaviour.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (this PR removes a duplicate outbound `message.send`)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Run OpenClaw `2026.4.26` with a Discord channel configured for `autoThread: true`.
2. Mention OpenClaw in that parent channel.
3. Observe replies in the parent channel and the auto-created thread.

### Expected

- Single normal conversational reply lands in the auto-created thread. The parent channel does not receive an additional `message.send` reply for the same turn.

### Actual (before fix)

- Manual `message.send` reply lands in the parent channel **and** a separate final assistant response lands in the auto-created thread.

## Evidence

- Reviewed both prompt sources against the issue's reproduction. The fix narrows the messaging-tool guidance to the explicit out-of-band cases the `message` tool already supports (`send` to another conversation, reactions, edits, reads, thread/channel management, presence) and explicitly tells the agent to emit the conversational reply as the final assistant message.

## Human Verification

- Verified scenarios: TypeScript clean on the touched `.ts` file; both prompt strings rewritten consistently.
- Edge cases checked: explicit out-of-band `message` actions (different channel/user, react, edit, read, thread management, presence) — still covered. `autoThread: true` mention path — single thread reply.
- What I did NOT verify: a live Discord run with `autoThread: true`; full `pnpm check` / `pnpm test` was not exercised locally, leaving CI as the verification surface.

## Compatibility / Migration

- Backward compatible? Yes (prompt-only change, no API/config surface).
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

- Risk: an existing skill or workflow that intentionally relied on the embedded harness *also* sending the conversational reply via `message.send` (e.g., to set Discord-specific options like `silent: true` or `components`).
  - Mitigation: such workflows should be expressed as an explicit `message.send` to a specific `to:` target with the desired flags — exactly the explicit out-of-band case the new guidance still encourages. The default conversational reply path is now consistent with how OpenClaw delivery already routes the final assistant message.
