### PR TITLE
fix(feishu): carry forward DM fallback and topic labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: resolve DM sender display names through direct chat membership before contact fallback, scope sender-name caches per account, and keep topic thread labels off normal root-reply group sessions. Carries forward #38958 after #51032. Thanks @futuremind2026 and @jnuyao.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearFeishuSenderNameCache, resolveFeishuSenderName } from "./bot-sender-name.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const mockCreateFeishuClient = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({ createFeishuClient: mockCreateFeishuClient }));
+
+function makeAccount(accountId: string): ResolvedFeishuAccount {
+  return {
+    accountId,
+    selectionSource: "explicit",
+    enabled: true,
+    configured: true,
+    appId: `cli_${accountId}`,
+    appSecret: "secret",
+    domain: "feishu",
+    config: {
+      domain: "feishu",
+      connectionMode: "websocket",
+      webhookPath: "/feishu/events",
+      dmPolicy: "open",
+      reactionNotifications: "own",
+      groupPolicy: "allowlist",
+      typingIndicator: true,
+      resolveSenderNames: true,
+    },
+  };
+}
+
+function mockClient(params: {
+  memberName?: string;
+  memberId?: string;
+  memberError?: unknown;
+  contactName?: string;
+  contactError?: unknown;
+}) {
+  const chatMembersGet = vi.fn(async () => {
+    if (params.memberError) {
+      throw params.memberError;
+    }
+    return {
+      code: 0,
+      data: {
+        items: params.memberName
+          ? [
+              {
+                member_id: params.memberId ?? "ou_sender",
+                member_id_type: "open_id",
+                name: params.memberName,
+              },
+            ]
+          : [],
+      },
+    };
+  });
+  const contactUserGet = vi.fn(async () => {
+    if (params.contactError) {
+      throw params.contactError;
+    }
+    return { data: { user: params.contactName ? { name: params.contactName } : {} } };
+  });
+  return {
+    client: {
+      im: { chatMembers: { get: chatMembersGet } },
+      contact: { user: { get: contactUserGet } },
+    },
+    chatMembersGet,
+    contactUserGet,
+  };
+}
+
+describe("resolveFeishuSenderName", () => {
+  const log = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearFeishuSenderNameCache();
+  });
+
+  it("prefers direct chat member display names before contact fallback", async () => {
+    const account = makeAccount("default");
+    const { client, chatMembersGet, contactUserGet } = mockClient({
+      memberId: "ou_sender",
+      memberName: "DM Sender",
+      contactName: "Contact Sender",
+    });
+    mockCreateFeishuClient.mockReturnValue(client);
+
+    const first = await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender",
+      chatId: "oc_dm",
+      chatType: "p2p",
+      log,
+    });
+    const second = await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender",
+      chatId: "oc_dm",
+      chatType: "p2p",
+      log,
+    });
+
+    expect(first.name).toBe("DM Sender");
+    expect(second.name).toBe("DM Sender");
+    expect(chatMembersGet).toHaveBeenCalledTimes(1);
+    expect(contactUserGet).not.toHaveBeenCalled();
+  });
+
+  it("falls back to contact user names when direct members have no name", async () => {
+    const account = makeAccount("default");
+    const { client, contactUserGet } = mockClient({ contactName: "Contact Sender" });
+    mockCreateFeishuClient.mockReturnValue(client);
+
+    await expect(
+      resolveFeishuSenderName({
+        account,
+        senderId: "ou_sender",
+        chatId: "oc_dm",
+        chatType: "p2p",
+        log,
+      }),
+    ).resolves.toEqual({ name: "Contact Sender" });
+    expect(contactUserGet).toHaveBeenCalledOnce();
+  });
+
+  it("scopes direct member caches by account", async () => {
+    const accountA = makeAccount("acct_a");
+    const accountB = makeAccount("acct_b");
+    const clientA = mockClient({ memberId: "ou_sender", memberName: "Alice A" });
+    const clientB = mockClient({ memberId: "ou_sender", memberName: "Alice B" });
+    mockCreateFeishuClient.mockReturnValueOnce(clientA.client).mockReturnValueOnce(clientB.client);
+
+    await expect(
+      resolveFeishuSenderName({
+        account: accountA,
+        senderId: "ou_sender",
+        chatId: "oc_dm",
+        chatType: "p2p",
+        log,
+      }),
+    ).resolves.toEqual({ name: "Alice A" });
+    await expect(
+      resolveFeishuSenderName({
+        account: accountB,
+        senderId: "ou_sender",
+        chatId: "oc_dm",
+        chatType: "p2p",
+        log,
+      }),
+    ).resolves.toEqual({ name: "Alice B" });
+  });
+
+  it("scopes contact sender caches by account", async () => {
+    const accountA = makeAccount("acct_a");
+    const accountB = makeAccount("acct_b");
+    const clientA = mockClient({ contactName: "Contact A" });
+    const clientB = mockClient({ contactName: "Contact B" });
+    mockCreateFeishuClient.mockReturnValueOnce(clientA.client).mockReturnValueOnce(clientB.client);
+
+    await expect(
+      resolveFeishuSenderName({ account: accountA, senderId: "ou_sender", log }),
+    ).resolves.toEqual({ name: "Contact A" });
+    await expect(
+      resolveFeishuSenderName({ account: accountB, senderId: "ou_sender", log }),
+    ).resolves.toEqual({ name: "Contact B" });
+  });
+
+  it("propagates direct-member permission guidance when contact fallback has no name", async () => {
+    const account = makeAccount("default");
+    const { client } = mockClient({
+      memberError: {
+        response: {
+          data: {
+            code: 99991672,
+            msg: "permission denied https://open.feishu.cn/app/cli_default",
+          },
+        },
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue(client);
+
+    const result = await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender",
+      chatId: "oc_dm",
+      chatType: "p2p",
+      log,
+    });
+
+    expect(result.permissionError).toEqual(
+      expect.objectContaining({
+        code: 99991672,
+        grantUrl: "https://open.feishu.cn/app/cli_default",
+      }),
+    );
+  });
+});

--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -196,4 +196,42 @@ describe("resolveFeishuSenderName", () => {
       }),
     );
   });
+
+  it("keeps direct-member permission guidance when contact fallback hits stale contact scope", async () => {
+    const account = makeAccount("default");
+    const { client } = mockClient({
+      memberError: {
+        response: {
+          data: {
+            code: 99991672,
+            msg: "permission denied https://open.feishu.cn/app/cli_default",
+          },
+        },
+      },
+      contactError: {
+        response: {
+          data: {
+            code: 99991672,
+            msg: "permission denied: contact:contact.base:readonly https://open.feishu.cn/app/cli_default",
+          },
+        },
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue(client);
+
+    const result = await resolveFeishuSenderName({
+      account,
+      senderId: "ou_sender",
+      chatId: "oc_dm",
+      chatType: "p2p",
+      log,
+    });
+
+    expect(result.permissionError).toEqual(
+      expect.objectContaining({
+        code: 99991672,
+        grantUrl: "https://open.feishu.cn/app/cli_default",
+      }),
+    );
+  });
 });

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -16,6 +16,9 @@ type SenderNameResult = {
 type FeishuContactUserGetResponse = Awaited<
   ReturnType<ReturnType<typeof createFeishuClient>["contact"]["user"]["get"]>
 >;
+type FeishuChatMembersGetResponse = Awaited<
+  ReturnType<ReturnType<typeof createFeishuClient>["im"]["chatMembers"]["get"]>
+>;
 
 type FeishuLogger = (...args: unknown[]) => void;
 
@@ -25,6 +28,7 @@ const FEISHU_SCOPE_CORRECTIONS: Record<string, string> = {
 };
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const directMemberNameCache = new Map<string, { name: string; expireAt: number }>();
 
 function correctFeishuScopeInUrl(url: string): string {
   let corrected = url;
@@ -45,21 +49,42 @@ function extractPermissionError(err: unknown): FeishuPermissionError | null {
     return null;
   }
   const axiosErr = err as { response?: { data?: unknown } };
-  const data = axiosErr.response?.data;
+  const data = axiosErr.response?.data ?? err;
   if (!data || typeof data !== "object") {
     return null;
   }
-  const feishuErr = data as { code?: number; msg?: string };
+  const feishuErr = data as { code?: number; msg?: string; message?: string };
   if (feishuErr.code !== 99991672) {
     return null;
   }
-  const msg = feishuErr.msg ?? "";
+  const msg = feishuErr.msg ?? feishuErr.message ?? "";
   const urlMatch = msg.match(/https:\/\/[^\s,]+\/app\/[^\s,]+/);
   return {
     code: feishuErr.code,
     message: msg,
     grantUrl: urlMatch?.[0] ? correctFeishuScopeInUrl(urlMatch[0]) : undefined,
   };
+}
+
+function normalizeName(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function buildAccountCachePrefix(account: ResolvedFeishuAccount): string {
+  return `${account.accountId}:${account.appId ?? ""}`;
+}
+
+function buildSenderCacheKey(account: ResolvedFeishuAccount, senderId: string): string {
+  return `${buildAccountCachePrefix(account)}:sender:${senderId}`;
+}
+
+function buildDirectMemberCacheKey(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  senderId: string;
+}): string {
+  return `${buildAccountCachePrefix(params.account)}:dm:${params.chatId}:${params.senderId}`;
 }
 
 function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "union_id" {
@@ -73,12 +98,79 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
   return "user_id";
 }
 
-export async function resolveFeishuSenderName(params: {
+async function resolveFeishuDirectMemberName(params: {
   account: ResolvedFeishuAccount;
+  chatId: string;
   senderId: string;
   log: FeishuLogger;
 }): Promise<SenderNameResult> {
-  const { account, senderId, log } = params;
+  const { account, chatId, senderId, log } = params;
+  const normalizedChatId = chatId.trim();
+  if (!normalizedChatId) {
+    return {};
+  }
+
+  const cacheKey = buildDirectMemberCacheKey({ account, chatId: normalizedChatId, senderId });
+  const cached = directMemberNameCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) {
+    return { name: cached.name };
+  }
+
+  try {
+    const client = createFeishuClient(account);
+    const getChatMembers = client.im?.chatMembers?.get;
+    if (!getChatMembers) {
+      return {};
+    }
+    const memberIdType = resolveSenderLookupIdType(senderId);
+    const res: FeishuChatMembersGetResponse = await getChatMembers({
+      path: { chat_id: normalizedChatId },
+      params: { page_size: 10, member_id_type: memberIdType },
+    });
+    if (res.code !== undefined && res.code !== 0) {
+      const permErr = extractPermissionError(res);
+      if (permErr) {
+        return { permissionError: permErr };
+      }
+      log(`feishu: failed to resolve direct member name: code=${res.code} msg=${res.msg ?? ""}`);
+      return {};
+    }
+
+    const members = res.data?.items ?? [];
+    const matchedMember =
+      members.find((member) => member.member_id?.trim() === senderId) ??
+      (members.length === 1 ? members[0] : undefined);
+    const name = normalizeName(matchedMember?.name);
+    if (!name) {
+      return {};
+    }
+
+    directMemberNameCache.set(cacheKey, { name, expireAt: now + SENDER_NAME_TTL_MS });
+    return { name };
+  } catch (err) {
+    const permErr = extractPermissionError(err);
+    if (permErr) {
+      return { permissionError: permErr };
+    }
+    log(`feishu: failed to resolve direct member name for ${senderId}: ${String(err)}`);
+    return {};
+  }
+}
+
+export function clearFeishuSenderNameCache(): void {
+  senderNameCache.clear();
+  directMemberNameCache.clear();
+}
+
+export async function resolveFeishuSenderName(params: {
+  account: ResolvedFeishuAccount;
+  senderId: string;
+  chatId?: string;
+  chatType?: "p2p" | "private" | "group" | "topic_group";
+  log: FeishuLogger;
+}): Promise<SenderNameResult> {
+  const { account, senderId, chatId, chatType, log } = params;
   if (!account.configured) {
     return {};
   }
@@ -88,7 +180,22 @@ export async function resolveFeishuSenderName(params: {
     return {};
   }
 
-  const cached = senderNameCache.get(normalizedSenderId);
+  let directPermissionError: FeishuPermissionError | undefined;
+  if ((chatType === "p2p" || chatType === "private") && chatId) {
+    const directResult = await resolveFeishuDirectMemberName({
+      account,
+      chatId,
+      senderId: normalizedSenderId,
+      log,
+    });
+    if (directResult.name) {
+      return { name: directResult.name };
+    }
+    directPermissionError = directResult.permissionError;
+  }
+
+  const cacheKey = buildSenderCacheKey(account, normalizedSenderId);
+  const cached = senderNameCache.get(cacheKey);
   const now = Date.now();
   if (cached && cached.expireAt > now) {
     return { name: cached.name };
@@ -102,13 +209,14 @@ export async function resolveFeishuSenderName(params: {
       params: { user_id_type: userIdType },
     });
     const user = res.data?.user;
-    const name = user?.name ?? user?.nickname ?? user?.en_name;
+    const name =
+      normalizeName(user?.name) ?? normalizeName(user?.nickname) ?? normalizeName(user?.en_name);
 
     if (name) {
-      senderNameCache.set(normalizedSenderId, { name, expireAt: now + SENDER_NAME_TTL_MS });
+      senderNameCache.set(cacheKey, { name, expireAt: now + SENDER_NAME_TTL_MS });
       return { name };
     }
-    return {};
+    return directPermissionError ? { permissionError: directPermissionError } : {};
   } catch (err) {
     const permErr = extractPermissionError(err);
     if (permErr) {
@@ -120,6 +228,6 @@ export async function resolveFeishuSenderName(params: {
       return { permissionError: permErr };
     }
     log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
-    return {};
+    return directPermissionError ? { permissionError: directPermissionError } : {};
   }
 }

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -222,7 +222,7 @@ export async function resolveFeishuSenderName(params: {
     if (permErr) {
       if (shouldSuppressPermissionErrorNotice(permErr)) {
         log(`feishu: ignoring stale permission scope error: ${permErr.message}`);
-        return {};
+        return directPermissionError ? { permissionError: directPermissionError } : {};
       }
       log(`feishu: permission error resolving sender name: code=${permErr.code}`);
       return { permissionError: permErr };

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -750,6 +750,115 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("uses direct chatMembers sender names for Feishu DMs", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const chatMembersGet = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [{ member_id: "ou_dm_member", member_id_type: "open_id", name: "DM Member" }],
+      },
+    });
+    const contactUserGet = vi.fn().mockResolvedValue({ data: { user: { name: "Contact Name" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      im: { chatMembers: { get: chatMembersGet } },
+      contact: { user: { get: contactUserGet } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          appId: "cli_dm_member",
+          appSecret: "sec_dm_member", // pragma: allowlist secret
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou_dm_member" } },
+      message: {
+        message_id: "msg-dm-member-name",
+        chat_id: "oc-dm-member",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(chatMembersGet).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-member" },
+      params: { page_size: 10, member_id_type: "open_id" },
+    });
+    expect(contactUserGet).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("DM Member: hello"),
+        SenderName: "DM Member",
+      }),
+    );
+  });
+
+  it("passes direct-member permission guidance through DM contact fallback misses", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockCreateFeishuClient.mockReturnValue({
+      im: {
+        chatMembers: {
+          get: vi.fn().mockRejectedValue({
+            response: {
+              data: {
+                code: 99991672,
+                msg: "permission denied https://open.feishu.cn/app/cli_dm_perm",
+              },
+            },
+          }),
+        },
+      },
+      contact: {
+        user: {
+          get: vi.fn().mockResolvedValue({ data: { user: {} } }),
+        },
+      },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          appId: "cli_dm_perm",
+          appSecret: "sec_dm_perm", // pragma: allowlist secret
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-dm-perm" } },
+      message: {
+        message_id: "msg-dm-permission-guidance",
+        chat_id: "oc-dm-perm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining(
+          "Permission grant URL: https://open.feishu.cn/app/cli_dm_perm",
+        ),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-dm-perm: hello"),
+      }),
+    );
+  });
+
   it("propagates parent/root message ids into inbound context for reply reconstruction", async () => {
     mockGetMessageFeishu.mockResolvedValueOnce({
       messageId: "om_parent_001",
@@ -2561,6 +2670,12 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         replyToMessageId: "om_quote_reply",
         rootId: "om_original_msg",
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ThreadLabel: undefined,
+        MessageThreadId: undefined,
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -464,6 +464,8 @@ export async function handleFeishuMessage(params: {
     const senderResult = await resolveFeishuSenderName({
       account,
       senderId: ctx.senderOpenId,
+      chatId: ctx.chatId,
+      chatType: ctx.chatType,
       log,
     });
     if (senderResult.name) {
@@ -472,7 +474,7 @@ export async function handleFeishuMessage(params: {
 
     // Track permission error to inform agent later (with cooldown to avoid repetition)
     if (senderResult.permissionError) {
-      const appKey = account.appId ?? "default";
+      const appKey = `${account.accountId}:${account.appId ?? "default"}`;
       const now = Date.now();
       const lastNotified = permissionErrorNotifiedAt.get(appKey) ?? 0;
 

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -356,6 +356,38 @@ describe("sessions", () => {
     expect(store[sessionKey]?.origin?.chatType).toBe("group");
   });
 
+  it("updateLastRoute records topic thread labels in session origin", async () => {
+    const sessionKey = "agent:main:feishu:group:oc-group:topic:om-root";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateLastRoute-topic-label",
+      entries: {},
+    });
+
+    await updateLastRoute({
+      storePath,
+      sessionKey,
+      deliveryContext: {
+        channel: "feishu",
+        to: "oc-group",
+        threadId: "om-root",
+      },
+      ctx: {
+        Provider: "feishu",
+        Surface: "feishu",
+        ChatType: "group",
+        GroupSubject: "Engineering",
+        ThreadLabel: "Feishu thread in Engineering",
+        MessageThreadId: "om-root",
+        From: "feishu:group:oc-group:topic:om-root",
+      },
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.origin?.label).toBe("Feishu thread in Engineering");
+    expect(store[sessionKey]?.origin?.threadId).toBe("om-root");
+    expect(store[sessionKey]?.displayName).toBe("feishu:g-engineering");
+  });
+
   it("updateLastRoute skips missing sessions when creation is disabled", async () => {
     const sessionKey = "agent:main:demo-chat:group:room-123";
     const { storePath } = await createSessionStoreFixture({


### PR DESCRIPTION
## Summary

Carry forward the remaining Feishu display-name behavior from #38958 after #51032 already landed the group-name session label fix.

This replacement should stay narrow:
- keep #51032's group-name implementation as the baseline
- add/repair DM display-name fallback through chatMembers with contact fallback
- preserve resolveSenderNames opt-out semantics
- scope sender/direct-member caches by account and relevant chat/sender identifiers
- surface topic/root labels only for topic-scoped Feishu sessions
- propagate permission guidance when DM fallback lookup hits a Feishu permission error

Credit: this work is based on the implementation direction and review iterations from @futuremind2026 in https://github.com/openclaw/openclaw/pull/38958. The already-merged group-name baseline came from @jnuyao in https://github.com/openclaw/openclaw/pull/51032.

## Validation

- pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot-sender-name.test.ts
- pnpm exec vitest run src/config/sessions.test.ts
- pnpm check:changed

ProjectClownfish replacement details:
- Cluster: ghcrawl-156980-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/38958
- Credit: Credit @futuremind2026 and source PR https://github.com/openclaw/openclaw/pull/38958 for the broader Feishu DM fallback, cache-scoping, permission guidance, and topic-label implementation direction.; Preserve @jnuyao and merged PR https://github.com/openclaw/openclaw/pull/51032 as the landed Feishu group-name implementation; do not overwrite or duplicate that work.; Mention in the PR body that this replacement carries forward the remaining behavior from #38958 because ProjectClownfish cannot safely update the original contributor branch.
- Validation: pnpm exec vitest run --config vitest.extensions.config.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/bot-sender-name.test.ts; pnpm exec vitest run src/config/sessions.test.ts; pnpm check:changed
