### PR TITLE
fix(silent-reply): classify :thread: sessionKeys as internal to stop spurious rewrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ Docs: https://docs.openclaw.ai
 - fix(logging): add redaction patterns for Tencent Cloud, Alibaba Cloud, HuggingFace and Replicate API keys (#58162). Thanks @gavyngong
 - Pairing: surface unexpected allowlist filesystem stat errors instead of treating the allowlist as missing, so permission and I/O failures are visible during pairing authorization checks. (#63324) Thanks @franciscomaestre.
 - macOS app: reserve layout space for exec approval command details so the allow dialog no longer overlaps the command, context, and action buttons. (#75470) Thanks @ngutman.
+- Auto-reply/silent replies: treat verified topic and thread session turns as internal for silent-reply policy, so provider-created direct or group threads can stay quiet without leaking fallback filler text. (#73400) Thanks @zqchris.
 
 ## 2026.4.29
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3032,6 +3032,54 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliverReplies).not.toHaveBeenCalled();
   });
 
+  it("passes trusted DM-topic silent-reply context into buffered dispatch", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123:thread:123:777",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "allow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "agent:main:telegram:direct:123:thread:123:777",
+          TrustedThreadSessionKey: true,
+        }),
+        dispatcherOptions: expect.objectContaining({
+          silentReplyContext: expect.objectContaining({
+            sessionKey: "agent:main:telegram:direct:123:thread:123:777",
+            surface: "telegram",
+            conversationType: "internal",
+            trustThreadSessionKey: true,
+          }),
+        }),
+      }),
+    );
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("rewrites no-visible-response DM thread turns when the thread suffix is mismatched", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -3000,6 +3000,117 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(deliveredReplies?.[0]?.text?.trim()).not.toBe("NO_REPLY");
   });
 
+  it("keeps no-visible-response trusted DM thread turns silent", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123:thread:123:777",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "allow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
+  it("rewrites no-visible-response DM thread turns when the thread suffix is mismatched", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+    deliverReplies.mockResolvedValueOnce({ delivered: true });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:direct:123:thread:123:999",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "allow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    const deliveredReplies = deliverReplies.mock.calls[0]?.[0]?.replies;
+    expect(deliveredReplies?.[0]?.text).toEqual(expect.any(String));
+    expect(deliveredReplies?.[0]?.text?.trim()).not.toBe("NO_REPLY");
+  });
+
+  it("keeps no-visible-response trusted forum thread turns on internal policy", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockResolvedValue({
+      queuedFinal: false,
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        isGroup: true,
+        primaryCtx: {
+          message: { chat: { id: 123, type: "supergroup" } },
+        } as TelegramMessageContext["primaryCtx"],
+        msg: {
+          chat: { id: 123, type: "supergroup" },
+          message_id: 456,
+          message_thread_id: 777,
+        } as TelegramMessageContext["msg"],
+        threadSpec: { id: 777, scope: "forum" },
+        ctxPayload: {
+          SessionKey: "agent:main:telegram:group:123:thread:123:777",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      cfg: {
+        agents: {
+          defaults: {
+            silentReply: {
+              direct: "disallow",
+              group: "disallow",
+              internal: "allow",
+            },
+            silentReplyRewrite: {
+              direct: true,
+              group: true,
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+    });
+
+    expect(deliverReplies).not.toHaveBeenCalled();
+  });
+
   it("does not add silent-reply fallback after visible block delivery", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -62,6 +62,7 @@ import {
   buildTelegramNativeQuoteCandidate,
   type TelegramNativeQuoteCandidateByMessageId,
 } from "./bot/native-quote.js";
+import { isTrustedTelegramPolicyThreadSessionKey } from "./bot/thread-policy.js";
 import type { TelegramStreamMode } from "./bot/types.js";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { createTelegramDraftStream } from "./draft-stream.js";
@@ -645,6 +646,11 @@ export const dispatchTelegramMessage = async ({
     chatId: String(chatId),
     accountId: route.accountId,
     sessionKeyForInternalHooks: ctxPayload.SessionKey,
+    trustThreadSessionKey: isTrustedTelegramPolicyThreadSessionKey({
+      sessionKey: ctxPayload.SessionKey,
+      chatId,
+      thread: threadSpec,
+    }),
     mirrorIsGroup: isGroup,
     mirrorGroupId: isGroup ? String(chatId) : undefined,
     token: opts.token,
@@ -1306,11 +1312,17 @@ export const dispatchTelegramMessage = async ({
       ctxPayload.CommandSource === "native"
         ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
         : ctxPayload.SessionKey;
+    const trustPolicyThreadSessionKey = isTrustedTelegramPolicyThreadSessionKey({
+      sessionKey: policySessionKey,
+      chatId,
+      thread: threadSpec,
+    });
     const silentReplyFallback = projectOutboundPayloadPlanForDelivery(
       createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
         cfg,
         sessionKey: policySessionKey,
         surface: "telegram",
+        trustThreadSessionKey: trustPolicyThreadSessionKey,
       }),
     );
     if (silentReplyFallback.length > 0) {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -671,6 +671,18 @@ export const dispatchTelegramMessage = async ({
   };
   const silentErrorReplies = telegramCfg.silentErrorReplies === true;
   const isDmTopic = !isGroup && threadSpec.scope === "dm" && threadSpec.id != null;
+  const policySessionKey =
+    ctxPayload.CommandSource === "native"
+      ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
+      : ctxPayload.SessionKey;
+  const trustPolicyThreadSessionKey = isTrustedTelegramPolicyThreadSessionKey({
+    sessionKey: policySessionKey,
+    chatId,
+    thread: threadSpec,
+  });
+  const dispatchCtxPayload = trustPolicyThreadSessionKey
+    ? { ...ctxPayload, TrustedThreadSessionKey: true }
+    : ctxPayload;
   let queuedFinal = false;
   let hadErrorReplyFailureOrSkip = false;
   let isFirstTurnInSession = false;
@@ -870,10 +882,21 @@ export const dispatchTelegramMessage = async ({
             record: context.turn.record,
             runDispatch: () =>
               telegramDeps.dispatchReplyWithBufferedBlockDispatcher({
-                ctx: ctxPayload,
+                ctx: dispatchCtxPayload,
                 cfg,
                 dispatcherOptions: {
                   ...replyPipeline,
+                  ...(trustPolicyThreadSessionKey
+                    ? {
+                        silentReplyContext: {
+                          cfg,
+                          sessionKey: policySessionKey,
+                          surface: "telegram",
+                          conversationType: "internal" as const,
+                          trustThreadSessionKey: true,
+                        },
+                      }
+                    : {}),
                   beforeDeliver: async (payload) => payload,
                   deliver: async (payload, info) => {
                     if (isDispatchSuperseded()) {
@@ -1308,15 +1331,6 @@ export const dispatchTelegramMessage = async ({
   }
 
   if (!queuedFinal && !sentFallback && !dispatchError && !deliverySummary.delivered) {
-    const policySessionKey =
-      ctxPayload.CommandSource === "native"
-        ? (ctxPayload.CommandTargetSessionKey ?? ctxPayload.SessionKey)
-        : ctxPayload.SessionKey;
-    const trustPolicyThreadSessionKey = isTrustedTelegramPolicyThreadSessionKey({
-      sessionKey: policySessionKey,
-      chatId,
-      thread: threadSpec,
-    });
     const silentReplyFallback = projectOutboundPayloadPlanForDelivery(
       createOutboundPayloadPlan([{ text: "NO_REPLY" }], {
         cfg,

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -51,6 +51,7 @@ import {
   sendChunkedTelegramReplyText,
   type DeliveryProgress as ReplyThreadDeliveryProgress,
 } from "./reply-threading.js";
+import { isTrustedTelegramPolicyThreadSessionKey } from "./thread-policy.js";
 
 const VOICE_FORBIDDEN_MARKER = "VOICE_MESSAGES_FORBIDDEN";
 const CAPTION_TOO_LONG_RE = /caption is too long/i;
@@ -672,6 +673,7 @@ export async function deliverReplies(params: {
   accountId?: string;
   sessionKeyForInternalHooks?: string;
   policySessionKey?: string;
+  trustThreadSessionKey?: boolean;
   mirrorIsGroup?: boolean;
   mirrorGroupId?: string;
   token: string;
@@ -729,6 +731,13 @@ export async function deliverReplies(params: {
       cfg: params.cfg,
       sessionKey: params.policySessionKey ?? params.sessionKeyForInternalHooks,
       surface: "telegram",
+      trustThreadSessionKey:
+        params.trustThreadSessionKey ??
+        isTrustedTelegramPolicyThreadSessionKey({
+          sessionKey: params.policySessionKey ?? params.sessionKeyForInternalHooks,
+          chatId: params.chatId,
+          thread: params.thread,
+        }),
     }),
   );
   const originalExactSilentCount = candidateReplies.filter(

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -376,6 +376,57 @@ describe("deliverReplies", () => {
     expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
   });
 
+  it("suppresses exact NO_REPLY for trusted direct Telegram thread sessions", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 122, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:direct:123:thread:123:42",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+      thread: { id: 42, scope: "dm" },
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses policy session key thread trust for exact NO_REPLY policy", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 123, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:slash:123",
+      policySessionKey: "agent:test:telegram:direct:123:thread:123:42",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+      thread: { id: 42, scope: "dm" },
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("keeps mismatched direct Telegram thread suffixes on direct NO_REPLY policy", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 124, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      sessionKeyForInternalHooks: "agent:test:telegram:direct:123:thread:123:99",
+      replies: [{ text: "NO_REPLY" }],
+      runtime,
+      bot,
+      thread: { id: 42, scope: "dm" },
+    });
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toEqual(expect.any(String));
+    expect(sendMessage.mock.calls[0]?.[1]?.trim()).not.toBe("NO_REPLY");
+  });
+
   it("suppresses exact NO_REPLY for group Telegram sessions", async () => {
     const runtime = createRuntime(false);
     const sendMessage = vi.fn().mockResolvedValue({ message_id: 13, chat: { id: "123" } });

--- a/extensions/telegram/src/bot/thread-policy.ts
+++ b/extensions/telegram/src/bot/thread-policy.ts
@@ -1,0 +1,56 @@
+import { parseThreadSessionSuffix } from "openclaw/plugin-sdk/routing";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/text-runtime";
+import type { TelegramThreadSpec } from "./helpers.js";
+
+function isStructuredThreadSessionKeyForCandidate(
+  sessionKey: string | undefined | null,
+  candidateThreadId: string,
+): boolean {
+  const raw = normalizeOptionalString(sessionKey);
+  const normalizedCandidate = normalizeLowercaseStringOrEmpty(candidateThreadId);
+  if (!raw || !normalizedCandidate) {
+    return false;
+  }
+  const { baseSessionKey, threadId } = parseThreadSessionSuffix(raw);
+  if (!baseSessionKey || !threadId) {
+    return false;
+  }
+  const normalizedBase = normalizeLowercaseStringOrEmpty(baseSessionKey);
+  const normalizedThreadId = normalizeLowercaseStringOrEmpty(threadId);
+  if (normalizedBase.includes(":thread:") || normalizedThreadId.includes(":thread:")) {
+    return false;
+  }
+  return normalizedThreadId === normalizedCandidate;
+}
+
+export function isTrustedTelegramPolicyThreadSessionKey(params: {
+  sessionKey: string | undefined | null;
+  chatId: string | number | undefined | null;
+  thread: TelegramThreadSpec | null | undefined;
+}): boolean {
+  const threadId = params.thread?.id;
+  if (threadId == null) {
+    return false;
+  }
+  const normalizedThreadId = normalizeOptionalString(String(threadId));
+  if (!normalizedThreadId) {
+    return false;
+  }
+  const candidateThreadIds = new Set<string>([normalizedThreadId]);
+  const normalizedChatId = normalizeOptionalString(
+    params.chatId == null ? undefined : String(params.chatId),
+  );
+  if (normalizedChatId) {
+    candidateThreadIds.add(`${normalizedChatId}:${normalizedThreadId}`);
+    candidateThreadIds.add(`${normalizedChatId}:topic:${normalizedThreadId}`);
+  }
+  for (const candidateThreadId of candidateThreadIds) {
+    if (isStructuredThreadSessionKeyForCandidate(params.sessionKey, candidateThreadId)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/auto-reply/dispatch.test.ts
+++ b/src/auto-reply/dispatch.test.ts
@@ -349,6 +349,42 @@ describe("withReplyDispatcher", () => {
     );
   });
 
+  it("uses provider-verified thread trust for silent-reply dispatcher context", async () => {
+    hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
+      dispatcher: createDispatcher([]),
+      replyOptions: {},
+      markDispatchIdle: vi.fn(),
+      markRunComplete: vi.fn(),
+    });
+    hoisted.dispatchReplyFromConfigMock.mockResolvedValueOnce({ text: "ok" });
+
+    await dispatchInboundMessageWithBufferedDispatcher({
+      ctx: buildTestCtx({
+        SessionKey: "agent:test:telegram:direct:123:thread:123:42",
+        MessageThreadId: "42",
+        TrustedThreadSessionKey: true,
+        ChatType: "direct",
+        Surface: "telegram",
+      }),
+      cfg: {} as OpenClawConfig,
+      dispatcherOptions: {
+        deliver: async () => undefined,
+      },
+      replyResolver: async () => ({ text: "ok" }),
+    });
+
+    expect(hoisted.createReplyDispatcherWithTypingMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        silentReplyContext: expect.objectContaining({
+          sessionKey: "agent:test:telegram:direct:123:thread:123:42",
+          surface: "telegram",
+          conversationType: "internal",
+          trustThreadSessionKey: true,
+        }),
+      }),
+    );
+  });
+
   it("does not copy source conversation type onto cross-session native silent-reply targets", async () => {
     hoisted.createReplyDispatcherWithTypingMock.mockReturnValueOnce({
       dispatcher: createDispatcher([]),

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -5,7 +5,10 @@ import {
   toPluginMessageContext,
 } from "../hooks/message-hook-mappers.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
-import type { SilentReplyConversationType } from "../shared/silent-reply-policy.js";
+import {
+  isTrustedStructuredThreadSessionKey,
+  type SilentReplyConversationType,
+} from "../shared/silent-reply-policy.js";
 import { withReplyDispatcher } from "./dispatch-dispatcher.js";
 import { dispatchReplyFromConfig } from "./reply/dispatch-from-config.js";
 import type { DispatchFromConfigResult } from "./reply/dispatch-from-config.types.js";
@@ -31,12 +34,21 @@ function resolveDispatcherSilentReplyContext(
     finalized.CommandSource === "native"
       ? (finalized.CommandTargetSessionKey ?? finalized.SessionKey)
       : finalized.SessionKey;
-  const chatType = normalizeChatType(finalized.ChatType);
-  const conversationType: SilentReplyConversationType | undefined =
+  const isNativeCrossSession =
     finalized.CommandSource === "native" &&
     finalized.CommandTargetSessionKey &&
-    finalized.CommandTargetSessionKey !== finalized.SessionKey
-      ? undefined
+    finalized.CommandTargetSessionKey !== finalized.SessionKey;
+  const hasTrustedThreadSessionKey =
+    !isNativeCrossSession &&
+    isTrustedStructuredThreadSessionKey({
+      sessionKey: policySessionKey,
+      threadId: finalized.MessageThreadId,
+    });
+  const chatType = normalizeChatType(finalized.ChatType);
+  const conversationType: SilentReplyConversationType | undefined = isNativeCrossSession
+    ? undefined
+    : hasTrustedThreadSessionKey
+      ? "internal"
       : chatType === "direct"
         ? "direct"
         : chatType === "group" || chatType === "channel"
@@ -47,6 +59,7 @@ function resolveDispatcherSilentReplyContext(
     sessionKey: policySessionKey,
     surface: finalized.Surface ?? finalized.Provider,
     conversationType,
+    trustThreadSessionKey: hasTrustedThreadSessionKey,
   };
 }
 

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -40,10 +40,11 @@ function resolveDispatcherSilentReplyContext(
     finalized.CommandTargetSessionKey !== finalized.SessionKey;
   const hasTrustedThreadSessionKey =
     !isNativeCrossSession &&
-    isTrustedStructuredThreadSessionKey({
-      sessionKey: policySessionKey,
-      threadId: finalized.MessageThreadId,
-    });
+    (finalized.TrustedThreadSessionKey === true ||
+      isTrustedStructuredThreadSessionKey({
+        sessionKey: policySessionKey,
+        threadId: finalized.MessageThreadId,
+      }));
   const chatType = normalizeChatType(finalized.ChatType);
   const conversationType: SilentReplyConversationType | undefined = isNativeCrossSession
     ? undefined

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1254,6 +1254,71 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("routes trusted threaded replies with internal policy context", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "imessage:+15550001111",
+      ExplicitDeliverRoute: true,
+      MessageThreadId: "thread-1",
+      SessionKey: "agent:main:imessage:direct:+15550001111:thread:thread-1",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "imessage",
+        policyConversationType: "internal",
+        policySessionKey: "agent:main:imessage:direct:+15550001111:thread:thread-1",
+        to: "imessage:+15550001111",
+      }),
+    );
+  });
+
+  it("routes mismatched threaded replies with parent direct policy context", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "imessage:+15550001111",
+      ExplicitDeliverRoute: true,
+      MessageThreadId: "provider-thread",
+      SessionKey: "agent:main:imessage:direct:+15550001111:thread:caller",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "imessage",
+        policyConversationType: "direct",
+        to: "imessage:+15550001111",
+      }),
+    );
+  });
+
   it("routes media-only tool results when summaries are suppressed", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1287,6 +1287,40 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("routes provider-verified chat-scoped thread replies with internal policy context", async () => {
+    setNoAbort();
+    mocks.routeReply.mockClear();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "webchat",
+      Surface: "webchat",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      ExplicitDeliverRoute: true,
+      MessageThreadId: "42",
+      TrustedThreadSessionKey: true,
+      SessionKey: "agent:main:telegram:direct:123:thread:123:42",
+    });
+
+    const replyResolver = async (
+      _ctx: MsgContext,
+      _opts?: GetReplyOptions,
+      _cfg?: OpenClawConfig,
+    ) => ({ text: "hi" }) satisfies ReplyPayload;
+    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
+
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    expect(mocks.routeReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "telegram",
+        policyConversationType: "internal",
+        policySessionKey: "agent:main:telegram:direct:123:thread:123:42",
+        to: "telegram:123",
+      }),
+    );
+  });
+
   it("routes mismatched threaded replies with parent direct policy context", async () => {
     setNoAbort();
     mocks.routeReply.mockClear();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -202,6 +202,7 @@ const resolveRoutedPolicyConversationType = (
     return undefined;
   }
   if (
+    ctx.TrustedThreadSessionKey === true ||
     isTrustedStructuredThreadSessionKey({
       sessionKey: ctx.SessionKey,
       threadId: ctx.MessageThreadId,

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -58,6 +58,10 @@ import { getGlobalHookRunner, getGlobalPluginRegistry } from "../../plugins/hook
 import { isAcpSessionKey } from "../../routing/session-key.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import {
+  isTrustedStructuredThreadSessionKey,
+  type SilentReplyConversationType,
+} from "../../shared/silent-reply-policy.js";
+import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -189,13 +193,21 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
 
 const resolveRoutedPolicyConversationType = (
   ctx: FinalizedMsgContext,
-): "direct" | "group" | undefined => {
+): SilentReplyConversationType | undefined => {
   if (
     ctx.CommandSource === "native" &&
     ctx.CommandTargetSessionKey &&
     ctx.CommandTargetSessionKey !== ctx.SessionKey
   ) {
     return undefined;
+  }
+  if (
+    isTrustedStructuredThreadSessionKey({
+      sessionKey: ctx.SessionKey,
+      threadId: ctx.MessageThreadId,
+    })
+  ) {
+    return "internal";
   }
   const chatType = normalizeChatType(ctx.ChatType);
   if (chatType === "direct") {

--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -82,6 +82,48 @@ describe("resolvePromptSilentReplyConversationType", () => {
     ).toBe("group");
   });
 
+  it("treats trusted threaded prompt sessions as internal", () => {
+    expect(
+      resolvePromptSilentReplyConversationType({
+        ctx: buildGetReplyCtx({
+          ChatType: "direct",
+          MessageThreadId: "435427284:300118",
+          SessionKey: "agent:main:telegram:direct:435427284:thread:435427284:300118",
+        }),
+      }),
+    ).toBe("internal");
+    expect(
+      resolvePromptSilentReplyConversationType({
+        ctx: buildGetReplyGroupCtx({
+          ChatType: "group",
+          MessageThreadId: "456",
+          SessionKey: "agent:main:discord:group:123:thread:456",
+        }),
+      }),
+    ).toBe("internal");
+  });
+
+  it("keeps malformed or mismatched threaded prompt sessions on parent chat policy", () => {
+    expect(
+      resolvePromptSilentReplyConversationType({
+        ctx: buildGetReplyCtx({
+          ChatType: "direct",
+          MessageThreadId: "two",
+          SessionKey: "agent:main:telegram:direct:123:thread:one:thread:two",
+        }),
+      }),
+    ).toBe("direct");
+    expect(
+      resolvePromptSilentReplyConversationType({
+        ctx: buildGetReplyCtx({
+          ChatType: "direct",
+          MessageThreadId: "provider-thread",
+          SessionKey: "agent:main:telegram:direct:123:thread:caller",
+        }),
+      }),
+    ).toBe("direct");
+  });
+
   it("does not override a native cross-session target policy with the source chat type", () => {
     expect(
       resolvePromptSilentReplyConversationType({

--- a/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
+++ b/src/auto-reply/reply/get-reply-run.exec-hint.test.ts
@@ -94,6 +94,16 @@ describe("resolvePromptSilentReplyConversationType", () => {
     ).toBe("internal");
     expect(
       resolvePromptSilentReplyConversationType({
+        ctx: buildGetReplyCtx({
+          ChatType: "direct",
+          MessageThreadId: "300118",
+          TrustedThreadSessionKey: true,
+          SessionKey: "agent:main:telegram:direct:435427284:thread:435427284:300118",
+        }),
+      }),
+    ).toBe("internal");
+    expect(
+      resolvePromptSilentReplyConversationType({
         ctx: buildGetReplyGroupCtx({
           ChatType: "group",
           MessageThreadId: "456",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -23,7 +23,10 @@ import {
   isSubagentSessionKey,
   normalizeMainKey,
 } from "../../routing/session-key.js";
-import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
+import {
+  isTrustedStructuredThreadSessionKey,
+  type SilentReplyConversationType,
+} from "../../shared/silent-reply-policy.js";
 import { normalizeOptionalString } from "../../shared/string-coerce.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { hasControlCommand } from "../command-detection.js";
@@ -75,7 +78,10 @@ type AgentDefaults = NonNullable<OpenClawConfig["agents"]>["defaults"];
 type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node">;
 
 export function resolvePromptSilentReplyConversationType(params: {
-  ctx: Pick<MsgContext, "ChatType" | "CommandSource" | "CommandTargetSessionKey" | "SessionKey">;
+  ctx: Pick<
+    MsgContext,
+    "ChatType" | "CommandSource" | "CommandTargetSessionKey" | "MessageThreadId" | "SessionKey"
+  >;
   inboundSessionKey?: string;
 }): SilentReplyConversationType | undefined {
   const sourceSessionKey = params.inboundSessionKey ?? params.ctx.SessionKey;
@@ -85,6 +91,14 @@ export function resolvePromptSilentReplyConversationType(params: {
     params.ctx.CommandTargetSessionKey !== sourceSessionKey
   ) {
     return undefined;
+  }
+  if (
+    isTrustedStructuredThreadSessionKey({
+      sessionKey: sourceSessionKey,
+      threadId: params.ctx.MessageThreadId,
+    })
+  ) {
+    return "internal";
   }
   const chatType = normalizeChatType(params.ctx.ChatType);
   if (chatType === "direct") {
@@ -410,6 +424,10 @@ export async function runPreparedReply(
     sessionKey: runtimePolicySessionKey,
     surface: promptSessionCtx.Surface ?? promptSessionCtx.Provider,
     conversationType: silentReplyConversationType,
+    trustThreadSessionKey: isTrustedStructuredThreadSessionKey({
+      sessionKey: runtimePolicySessionKey,
+      threadId: promptSessionCtx.MessageThreadId,
+    }),
   });
   const useFastReplyRuntime = shouldUseReplyFastTestRuntime({
     cfg,

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -80,7 +80,12 @@ type ExecOverrides = Pick<ExecToolDefaults, "host" | "security" | "ask" | "node"
 export function resolvePromptSilentReplyConversationType(params: {
   ctx: Pick<
     MsgContext,
-    "ChatType" | "CommandSource" | "CommandTargetSessionKey" | "MessageThreadId" | "SessionKey"
+    | "ChatType"
+    | "CommandSource"
+    | "CommandTargetSessionKey"
+    | "MessageThreadId"
+    | "SessionKey"
+    | "TrustedThreadSessionKey"
   >;
   inboundSessionKey?: string;
 }): SilentReplyConversationType | undefined {
@@ -93,6 +98,7 @@ export function resolvePromptSilentReplyConversationType(params: {
     return undefined;
   }
   if (
+    params.ctx.TrustedThreadSessionKey === true ||
     isTrustedStructuredThreadSessionKey({
       sessionKey: sourceSessionKey,
       threadId: params.ctx.MessageThreadId,
@@ -419,15 +425,18 @@ export async function runPreparedReply(
     ctx: promptSessionCtx,
     inboundSessionKey: ctx.SessionKey,
   });
+  const hasTrustedThreadSessionKey =
+    promptSessionCtx.TrustedThreadSessionKey === true ||
+    isTrustedStructuredThreadSessionKey({
+      sessionKey: runtimePolicySessionKey,
+      threadId: promptSessionCtx.MessageThreadId,
+    });
   const silentReplySettings = resolveSilentReplySettings({
     cfg,
     sessionKey: runtimePolicySessionKey,
     surface: promptSessionCtx.Surface ?? promptSessionCtx.Provider,
     conversationType: silentReplyConversationType,
-    trustThreadSessionKey: isTrustedStructuredThreadSessionKey({
-      sessionKey: runtimePolicySessionKey,
-      threadId: promptSessionCtx.MessageThreadId,
-    }),
+    trustThreadSessionKey: hasTrustedThreadSessionKey,
   });
   const useFastReplyRuntime = shouldUseReplyFastTestRuntime({
     cfg,

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -63,6 +63,7 @@ export type ReplyDispatcherOptions = {
     sessionKey?: string;
     surface?: string;
     conversationType?: SilentReplyConversationType;
+    trustThreadSessionKey?: boolean;
   };
   responsePrefix?: string;
   transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
@@ -144,6 +145,7 @@ function resolveSilentFinalPayload(params: {
     sessionKey: context.sessionKey,
     surface: context.surface,
     conversationType: context.conversationType,
+    trustThreadSessionKey: context.trustThreadSessionKey,
   });
   if (resolvedSettings.policy === "allow") {
     return undefined;

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -117,6 +117,39 @@ describe("createReplyDispatcher", () => {
     expect(deliver).not.toHaveBeenCalled();
   });
 
+  it("drops exact NO_REPLY final payloads for trusted chat-scoped thread sessions", async () => {
+    const deliver = vi.fn().mockResolvedValue(undefined);
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          silentReply: {
+            direct: "disallow",
+            group: "allow",
+            internal: "allow",
+          },
+          silentReplyRewrite: {
+            direct: true,
+          },
+        },
+      },
+    };
+    const dispatcher = createReplyDispatcher({
+      deliver,
+      silentReplyContext: {
+        cfg,
+        sessionKey: "agent:main:telegram:direct:123:thread:123:42",
+        surface: "telegram",
+        conversationType: "internal",
+        trustThreadSessionKey: true,
+      },
+    });
+
+    expect(dispatcher.sendFinalReply({ text: SILENT_REPLY_TOKEN })).toBe(false);
+
+    await dispatcher.waitForIdle();
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
   it("strips heartbeat tokens and applies responsePrefix", async () => {
     const deliver = vi.fn().mockResolvedValue(undefined);
     const onHeartbeatStrip = vi.fn();

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -202,6 +202,12 @@ export type MsgContext = {
   ForceSenderIsOwnerFalse?: boolean;
   /** Thread identifier (Telegram topic id or Matrix thread event id). */
   MessageThreadId?: string | number;
+  /**
+   * Trusted runtime assertion that the structured thread suffix in SessionKey
+   * refers to this provider turn. Use when the provider's canonical
+   * MessageThreadId differs from the session-key suffix shape.
+   */
+  TrustedThreadSessionKey?: boolean;
   /** Platform-native channel/conversation id (e.g. Slack DM channel "D…" id). */
   NativeChannelId?: string;
   /** Stable provider-native direct-peer id when a DM room/user mapping must survive later writes. */

--- a/src/config/silent-reply.ts
+++ b/src/config/silent-reply.ts
@@ -15,6 +15,7 @@ type ResolveSilentReplyParams = {
   sessionKey?: string;
   surface?: string;
   conversationType?: SilentReplyConversationType;
+  trustThreadSessionKey?: boolean;
 };
 
 function resolveSilentReplyConversationContext(params: ResolveSilentReplyParams): {
@@ -28,6 +29,7 @@ function resolveSilentReplyConversationContext(params: ResolveSilentReplyParams)
     sessionKey: params.sessionKey,
     surface: params.surface,
     conversationType: params.conversationType,
+    trustThreadSessionKey: params.trustThreadSessionKey,
   });
   const normalizedSurface = normalizeLowercaseStringOrEmpty(params.surface);
   const surface = normalizedSurface ? params.cfg?.surfaces?.[normalizedSurface] : undefined;

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -59,6 +59,7 @@ type OutboundPayloadPlanContext = {
   sessionKey?: string;
   surface?: string;
   conversationType?: SilentReplyConversationType;
+  trustThreadSessionKey?: boolean;
   /**
    * When true, bare silent payloads are dropped instead of being rewritten to
    * visible fallback text. Set by callers that know the parent session has at
@@ -192,6 +193,7 @@ export function createOutboundPayloadPlan(
     sessionKey: context.sessionKey,
     surface: context.surface,
     conversationType: context.conversationType,
+    trustThreadSessionKey: context.trustThreadSessionKey,
   });
   const hasPendingSpawnedChildren =
     context.hasPendingSpawnedChildren ?? resolvePendingSpawnedChildren(context.sessionKey);

--- a/src/infra/outbound/session-context.test.ts
+++ b/src/infra/outbound/session-context.test.ts
@@ -135,6 +135,15 @@ describe("buildOutboundSessionContext", () => {
     ).toEqual({
       conversationType: "direct",
     });
+
+    expect(
+      buildOutboundSessionContext({
+        cfg: {} as never,
+        conversationType: "internal",
+      }),
+    ).toEqual({
+      conversationType: "internal",
+    });
   });
 
   it("falls back to isGroup when no explicit conversation type is provided", () => {

--- a/src/infra/outbound/session-context.ts
+++ b/src/infra/outbound/session-context.ts
@@ -2,7 +2,10 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { SilentReplyConversationType } from "../../shared/silent-reply-policy.js";
-import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import {
+  normalizeOptionalLowercaseString,
+  normalizeOptionalString,
+} from "../../shared/string-coerce.js";
 
 export type OutboundSessionContext = {
   /** Canonical session key used for internal hook dispatch. */
@@ -40,17 +43,20 @@ export function buildOutboundSessionContext(params: {
 }): OutboundSessionContext | undefined {
   const key = normalizeOptionalString(params.sessionKey);
   const policyKey = normalizeOptionalString(params.policySessionKey);
+  const normalizedPolicyType = normalizeOptionalLowercaseString(params.conversationType);
   const normalizedChatType = normalizeChatType(params.conversationType ?? undefined);
   const conversationType: SilentReplyConversationType | undefined =
-    normalizedChatType === "group" || normalizedChatType === "channel"
-      ? "group"
-      : normalizedChatType === "direct"
-        ? "direct"
-        : params.isGroup === true
-          ? "group"
-          : params.isGroup === false
-            ? "direct"
-            : undefined;
+    normalizedPolicyType === "internal"
+      ? "internal"
+      : normalizedChatType === "group" || normalizedChatType === "channel"
+        ? "group"
+        : normalizedChatType === "direct"
+          ? "direct"
+          : params.isGroup === true
+            ? "group"
+            : params.isGroup === false
+              ? "direct"
+              : undefined;
   const explicitAgentId = normalizeOptionalString(params.agentId);
   const requesterAccountId = normalizeOptionalString(params.requesterAccountId);
   const requesterSenderId = normalizeOptionalString(params.requesterSenderId);

--- a/src/shared/silent-reply-policy.test.ts
+++ b/src/shared/silent-reply-policy.test.ts
@@ -3,6 +3,8 @@ import {
   DEFAULT_SILENT_REPLY_POLICY,
   DEFAULT_SILENT_REPLY_REWRITE,
   classifySilentReplyConversationType,
+  isStructuredThreadSessionKey,
+  isTrustedStructuredThreadSessionKey,
   resolveSilentReplyPolicyFromPolicies,
   resolveSilentReplyRewriteFromPolicies,
   resolveSilentReplyRewriteText,
@@ -29,6 +31,78 @@ describe("classifySilentReplyConversationType", () => {
         sessionKey: "agent:main:discord:group:123",
       }),
     ).toBe("group");
+  });
+
+  it("uses trusted structured thread keys as internal", () => {
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:telegram:direct:435427284:thread:435427284:300118",
+        trustThreadSessionKey: true,
+      }),
+    ).toBe("internal");
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:discord:group:123:thread:456",
+        trustThreadSessionKey: true,
+      }),
+    ).toBe("internal");
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:cron:job-id:run:run-id:thread:dreaming-narrative-light",
+        trustThreadSessionKey: true,
+      }),
+    ).toBe("internal");
+  });
+
+  it("keeps caller-shaped or malformed thread keys on parent conversation policy", () => {
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:telegram:direct:123:thread:caller",
+      }),
+    ).toBe("direct");
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:discord:group:123:thread:456",
+      }),
+    ).toBe("group");
+    expect(
+      classifySilentReplyConversationType({
+        sessionKey: "agent:main:telegram:direct:123:thread:one:thread:two",
+        trustThreadSessionKey: true,
+      }),
+    ).toBe("direct");
+  });
+
+  it("recognizes only one structured thread suffix", () => {
+    expect(
+      isStructuredThreadSessionKey("agent:main:telegram:direct:123:thread:435427284:300118"),
+    ).toBe(true);
+    expect(isStructuredThreadSessionKey("agent:main:telegram:direct:123")).toBe(false);
+    expect(isStructuredThreadSessionKey("agent:main:telegram:direct:123:thread:")).toBe(false);
+    expect(
+      isStructuredThreadSessionKey("agent:main:telegram:direct:123:thread:one:thread:two"),
+    ).toBe(false);
+  });
+
+  it("trusts structured thread keys only when the context thread id matches", () => {
+    expect(
+      isTrustedStructuredThreadSessionKey({
+        sessionKey: "agent:main:telegram:direct:123:thread:435427284:300118",
+        threadId: "435427284:300118",
+      }),
+    ).toBe(true);
+    expect(
+      isTrustedStructuredThreadSessionKey({
+        sessionKey: "agent:main:telegram:direct:123:thread:caller",
+        threadId: "provider-thread",
+      }),
+    ).toBe(false);
+    expect(
+      isTrustedStructuredThreadSessionKey({
+        sessionKey: "agent:main:telegram:direct:123:thread:one:thread:two",
+        threadId: "two",
+      }),
+    ).toBe(false);
   });
 
   it("treats webchat as direct by default and unknown surfaces as internal", () => {

--- a/src/shared/silent-reply-policy.ts
+++ b/src/shared/silent-reply-policy.ts
@@ -1,4 +1,5 @@
-import { normalizeLowercaseStringOrEmpty } from "./string-coerce.js";
+import { parseThreadSessionSuffix } from "../sessions/session-key-utils.js";
+import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "./string-coerce.js";
 
 export type SilentReplyPolicy = "allow" | "disallow";
 export type SilentReplyConversationType = "direct" | "group" | "internal";
@@ -58,15 +59,65 @@ function hashSeed(seed: string): number {
   return hash;
 }
 
+function parseStructuredThreadSessionKey(sessionKey: string | undefined | null): {
+  baseSessionKey: string;
+  threadId: string;
+} | null {
+  const raw = normalizeOptionalString(sessionKey);
+  if (!raw) {
+    return null;
+  }
+  const { baseSessionKey, threadId } = parseThreadSessionSuffix(raw);
+  if (!baseSessionKey || !threadId) {
+    return null;
+  }
+  const normalizedBase = normalizeLowercaseStringOrEmpty(baseSessionKey);
+  const normalizedThreadId = normalizeLowercaseStringOrEmpty(threadId);
+  if (normalizedBase.includes(":thread:") || normalizedThreadId.includes(":thread:")) {
+    return null;
+  }
+  return { baseSessionKey, threadId };
+}
+
+export function isStructuredThreadSessionKey(sessionKey: string | undefined | null): boolean {
+  return parseStructuredThreadSessionKey(sessionKey) != null;
+}
+
+// Session keys are caller-controlled in a few dispatch paths, so only the
+// provider/runtime thread id can turn a structured suffix into internal policy.
+export function isTrustedStructuredThreadSessionKey(params: {
+  sessionKey: string | undefined | null;
+  threadId: string | number | undefined | null;
+}): boolean {
+  const expectedThreadId = normalizeOptionalString(
+    params.threadId == null ? undefined : String(params.threadId),
+  );
+  if (!expectedThreadId) {
+    return false;
+  }
+  const parsed = parseStructuredThreadSessionKey(params.sessionKey);
+  if (!parsed) {
+    return false;
+  }
+  return (
+    normalizeLowercaseStringOrEmpty(parsed.threadId) ===
+    normalizeLowercaseStringOrEmpty(expectedThreadId)
+  );
+}
+
 export function classifySilentReplyConversationType(params: {
   sessionKey?: string;
   surface?: string;
   conversationType?: SilentReplyConversationType;
+  trustThreadSessionKey?: boolean;
 }): SilentReplyConversationType {
   if (params.conversationType) {
     return params.conversationType;
   }
   const normalizedSessionKey = normalizeLowercaseStringOrEmpty(params.sessionKey);
+  if (params.trustThreadSessionKey === true && isStructuredThreadSessionKey(params.sessionKey)) {
+    return "internal";
+  }
   if (normalizedSessionKey.includes(":group:") || normalizedSessionKey.includes(":channel:")) {
     return "group";
   }


### PR DESCRIPTION
## Summary

`classifySilentReplyConversationType` evaluates session-key kind in priority order. The current ordering puts `:group:` / `:channel:` first, then `:direct:` / `:dm:`, then surface fallback. **It does not handle `:thread:` at all.**

OpenClaw-internal subagent / ACP / cron-spawned threads anchor under their parent session — e.g. `agent:main:telegram:direct:435427284:thread:435427284:300118` (a Telegram topic-bound subagent thread) or `agent:main:cron:job-id:run:run-id:thread:dreaming-narrative-light` (dreaming narrative subagent run).

These keys match `.includes(":direct:")` first and get classified as direct conversations, then run through the silent-reply rewrite path. **Result: internal thread replies that intentionally stayed silent get overwritten with one of `SILENT_REPLY_REWRITE_TEXTS` ("All quiet on my side.", "Standing by.", etc.), surfacing as random filler text on internal turns.**

The fix: check for `:thread:` *before* the `:direct:` / `:dm:` branch so any threaded session is classified as internal regardless of its parent surface.

## Diff

3 lines of source plus 2 regression tests:

```ts
// src/shared/silent-reply-policy.ts
if (normalizedSessionKey.includes(":group:") || normalizedSessionKey.includes(":channel:")) {
  return "group";
}
+ if (normalizedSessionKey.includes(":thread:")) {
+   return "internal";
+ }
if (normalizedSessionKey.includes(":direct:") || normalizedSessionKey.includes(":dm:")) {
  return "direct";
}
```

## Test plan

- [x] `pnpm test src/shared/silent-reply-policy.test.ts` — 9/9 passing on this branch (was 8/8, +1 covering the threaded-under-direct case and a cron-thread case)
- [x] `pnpm check:changed` clean
- [ ] Reviewer can verify no `:thread:` substring legitimately appears in any direct/group sessionKey scheme that would cause this to misclassify a real conversation as internal — happy to discuss if there's a counter-example.
