### PR TITLE
fix(agents): load symlinked workspace bootstrap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/bootstrap: load fixed top-level workspace bootstrap files when they are explicit symlinks to readable external files while preserving hardlink, size, and extra-bootstrap boundary protections. Fixes #38622; refs #40210, #40230, #38650, and #38653. Thanks @LiudengZhang, @Sirius1942, and @openperf.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.
 - Gateway/reload: bound default restart deferral and SIGUSR1 restart drain to five minutes while preserving explicit `deferralTimeoutMs: 0` indefinite waits, so stale active work accounting cannot block config reloads forever. Thanks @vincentkoc.

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -15,6 +15,7 @@ import {
   ensureAgentWorkspace,
   filterBootstrapFilesForSession,
   isWorkspaceBootstrapPending,
+  loadExtraBootstrapFiles,
   loadWorkspaceBootstrapFiles,
   reconcileWorkspaceBootstrapCompletion,
   resolveWorkspaceBootstrapStatus,
@@ -324,6 +325,27 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
 
+  it("loads MEMORY.md through an explicit symlink to a readable external file", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-memory-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_MEMORY_FILENAME);
+      await fs.writeFile(outsideFile, "external memory", "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_MEMORY_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      expectSingleMemoryEntry(files, "external memory");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as missing", async () => {
     if (process.platform === "win32") {
       return;
@@ -350,6 +372,177 @@ describe("loadWorkspaceBootstrapFiles", () => {
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
       expect(agents?.missing).toBe(true);
       expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads fixed bootstrap files through relative symlinks to readable external files", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.writeFile(
+        path.join(outsideDir, DEFAULT_AGENTS_FILENAME),
+        "external agents",
+        "utf-8",
+      );
+      await fs.symlink(
+        path.join("..", "outside", DEFAULT_AGENTS_FILENAME),
+        path.join(workspaceDir, DEFAULT_AGENTS_FILENAME),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("external agents");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("loads fixed bootstrap files through absolute symlinks to readable external files", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_SOUL_FILENAME);
+      await fs.writeFile(outsideFile, "external soul", "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_SOUL_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const soul = files.find((file) => file.name === DEFAULT_SOUL_FILENAME);
+      expect(soul?.missing).toBe(false);
+      expect(soul?.content).toBe("external soul");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("treats dangling fixed bootstrap symlinks as missing", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.symlink(
+        path.join("..", "outside", DEFAULT_USER_FILENAME),
+        path.join(workspaceDir, DEFAULT_USER_FILENAME),
+      );
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const user = files.find((file) => file.name === DEFAULT_USER_FILENAME);
+      expect(user?.missing).toBe(true);
+      expect(user?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fixed bootstrap symlinks to hardlinked external targets", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_IDENTITY_FILENAME);
+      const outsideHardlink = path.join(outsideDir, "identity-hardlink.md");
+      await fs.writeFile(outsideFile, "external identity", "utf-8");
+      try {
+        await fs.link(outsideFile, outsideHardlink);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_IDENTITY_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const identity = files.find((file) => file.name === DEFAULT_IDENTITY_FILENAME);
+      expect(identity?.missing).toBe(true);
+      expect(identity?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fixed bootstrap symlinks to non-regular external targets", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      await fs.symlink(outsideDir, path.join(workspaceDir, DEFAULT_TOOLS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const tools = files.find((file) => file.name === DEFAULT_TOOLS_FILENAME);
+      expect(tools?.missing).toBe(true);
+      expect(tools?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fixed bootstrap symlinks to oversized external targets", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "x".repeat(2 * 1024 * 1024 + 1), "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps external symlinks excluded from extra bootstrap patterns", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "extra external agents", "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadExtraBootstrapFiles(workspaceDir, [DEFAULT_AGENTS_FILENAME]);
+      expect(files).toHaveLength(0);
     } finally {
       await fs.rm(rootDir, { recursive: true, force: true });
     }

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -429,6 +429,52 @@ describe("loadWorkspaceBootstrapFiles", () => {
     }
   });
 
+  it("rejects fixed bootstrap symlinks to external files with non-bootstrap target names", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, ".openclaw", "agents", "main", "agent");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, "auth-profiles.json");
+      await fs.writeFile(outsideFile, '{"version":1}', "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects fixed bootstrap symlinks into OpenClaw credential roots", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const credentialsDir = path.join(rootDir, ".openclaw", "credentials");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(credentialsDir, { recursive: true });
+      const outsideFile = path.join(credentialsDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "credential-root bootstrap", "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats dangling fixed bootstrap symlinks as missing", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -2,6 +2,7 @@ import syncFs from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { openBoundaryFile } from "../infra/boundary-file-read.js";
+import { openVerifiedFileSync } from "../infra/safe-open-sync.js";
 import {
   CANONICAL_ROOT_MEMORY_FILENAME,
   exactWorkspaceEntryExists,
@@ -54,6 +55,7 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
+  allowExternalFixedBootstrapSymlink?: boolean;
 }): Promise<WorkspaceGuardedReadResult> {
   const opened = await openBoundaryFile({
     absolutePath: params.filePath,
@@ -62,7 +64,76 @@ async function readWorkspaceFileWithGuards(params: {
     maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
   });
   if (!opened.ok) {
+    if (params.allowExternalFixedBootstrapSymlink) {
+      const loaded = readExternalFixedBootstrapSymlink(params);
+      if (loaded) {
+        return loaded;
+      }
+    }
     workspaceFileCache.delete(params.filePath);
+    return opened;
+  }
+
+  const identity = workspaceFileIdentity(opened.stat, opened.path);
+  const cached = workspaceFileCache.get(params.filePath);
+  if (cached && cached.identity === identity) {
+    syncFs.closeSync(opened.fd);
+    return { ok: true, content: cached.content };
+  }
+
+  try {
+    const content = syncFs.readFileSync(opened.fd, "utf-8");
+    workspaceFileCache.set(params.filePath, { content, identity });
+    return { ok: true, content };
+  } catch (error) {
+    workspaceFileCache.delete(params.filePath);
+    return { ok: false, reason: "io", error };
+  } finally {
+    syncFs.closeSync(opened.fd);
+  }
+}
+
+function isFixedTopLevelBootstrapPath(params: { filePath: string; workspaceDir: string }): boolean {
+  const resolvedFilePath = path.resolve(params.filePath);
+  const resolvedWorkspaceDir = path.resolve(params.workspaceDir);
+  const name = path.basename(resolvedFilePath);
+  return (
+    VALID_BOOTSTRAP_NAMES.has(name) && resolvedFilePath === path.join(resolvedWorkspaceDir, name)
+  );
+}
+
+function readExternalFixedBootstrapSymlink(params: {
+  filePath: string;
+  workspaceDir: string;
+}): WorkspaceGuardedReadResult | null {
+  if (!isFixedTopLevelBootstrapPath(params)) {
+    return null;
+  }
+
+  let linkStat: syncFs.Stats;
+  try {
+    linkStat = syncFs.lstatSync(params.filePath);
+  } catch (error) {
+    return { ok: false, reason: "path", error };
+  }
+  if (!linkStat.isSymbolicLink()) {
+    return null;
+  }
+
+  let targetPath: string;
+  try {
+    targetPath = syncFs.realpathSync(params.filePath);
+  } catch (error) {
+    return { ok: false, reason: "path", error };
+  }
+
+  const opened = openVerifiedFileSync({
+    filePath: targetPath,
+    resolvedPath: targetPath,
+    rejectHardlinks: true,
+    maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
+  });
+  if (!opened.ok) {
     return opened;
   }
 
@@ -651,6 +722,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
     const loaded = await readWorkspaceFileWithGuards({
       filePath: entry.filePath,
       workspaceDir: resolvedDir,
+      allowExternalFixedBootstrapSymlink: true,
     });
     if (loaded.ok) {
       result.push({

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -102,6 +102,15 @@ function isFixedTopLevelBootstrapPath(params: { filePath: string; workspaceDir: 
   );
 }
 
+function isKnownOpenClawCredentialRootPath(filePath: string): boolean {
+  const segments = path.resolve(filePath).split(path.sep).filter(Boolean);
+  return segments.some(
+    (segment, index) =>
+      segment === ".openclaw" &&
+      (segments[index + 1] === "agents" || segments[index + 1] === "credentials"),
+  );
+}
+
 function readExternalFixedBootstrapSymlink(params: {
   filePath: string;
   workspaceDir: string;
@@ -125,6 +134,13 @@ function readExternalFixedBootstrapSymlink(params: {
     targetPath = syncFs.realpathSync(params.filePath);
   } catch (error) {
     return { ok: false, reason: "path", error };
+  }
+
+  if (
+    path.basename(targetPath) !== path.basename(params.filePath) ||
+    isKnownOpenClawCredentialRootPath(targetPath)
+  ) {
+    return { ok: false, reason: "validation" };
   }
 
   const opened = openVerifiedFileSync({


### PR DESCRIPTION
## Summary
- Load explicit fixed workspace bootstrap files such as AGENTS.md, SOUL.md, USER.md, and MEMORY.md when they are symlinks to readable regular files outside the workspace.
- Keep the fallback scoped to fixed bootstrap files and preserve existing protections for hardlinks, non-regular files, dangling symlinks, oversized files, and extra/glob bootstrap paths.
- Add regression coverage for relative and absolute external symlinks, dangling symlinks, symlink-to-hardlinked target rejection, non-regular or oversized targets, and unchanged extra-bootstrap boundary behavior.

## Credit
This carries forward the user reports in #38622 and #40210 and preserves attribution for prior contributor work in https://github.com/openclaw/openclaw/pull/38650 by @Sirius1942 and https://github.com/openclaw/openclaw/pull/38653 by @openperf.

## Validation
- pnpm -s vitest run src/agents/workspace.test.ts
- pnpm check:changed

ProjectClownfish replacement details:
- Cluster: ghcrawl-156975-autonomous-smoke
- Source PRs: https://github.com/openclaw/openclaw/pull/38650, https://github.com/openclaw/openclaw/pull/38653
- Credit: Credit @shizenchan for the canonical report in #38622 and @makerofpr for the duplicate reproduction in #40210.; Credit @Sirius1942 and source PR https://github.com/openclaw/openclaw/pull/38650 for the original contributor attempt, while explaining that the replacement uses the workspace bootstrap reader layer instead of the fs-safe layer.; Credit @openperf and historical PR https://github.com/openclaw/openclaw/pull/38653 for the targeted workspace.ts approach and prior review-thread fixes.; Do not rely on or close security-routed #40230/#64472 as part of this non-security replacement path.
- Validation: pnpm -s vitest run src/agents/workspace.test.ts; pnpm check:changed
