### PR TITLE
fix(tui): subscribe to live session transcript updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI: subscribe the bundled gateway client to live transcript updates for the active session and resync idle history without widening hidden-run fanout. Fixes #38829; refs #43341. Thanks @galen2017 and @baiyiyuni.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/crestodian/tui-backend.ts
+++ b/src/crestodian/tui-backend.ts
@@ -138,6 +138,14 @@ class CrestodianTuiBackend implements TuiBackend {
     return { ok: true, aborted: false };
   }
 
+  async subscribeSessionMessages(opts: Parameters<TuiBackend["subscribeSessionMessages"]>[0]) {
+    return { subscribed: false, key: opts.key };
+  }
+
+  async unsubscribeSessionMessages(opts: Parameters<TuiBackend["unsubscribeSessionMessages"]>[0]) {
+    return { subscribed: false, key: opts.key };
+  }
+
   async loadHistory(): Promise<{
     sessionId: string;
     messages: CrestodianHistoryMessage[];

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -191,6 +191,14 @@ export class EmbeddedTuiBackend implements TuiBackend {
     return { ok: true, aborted: true };
   }
 
+  async subscribeSessionMessages(opts: Parameters<TuiBackend["subscribeSessionMessages"]>[0]) {
+    return { subscribed: false, key: opts.key };
+  }
+
+  async unsubscribeSessionMessages(opts: Parameters<TuiBackend["unsubscribeSessionMessages"]>[0]) {
+    return { subscribed: false, key: opts.key };
+  }
+
   async loadHistory(opts: { sessionKey: string; limit?: number }) {
     const { cfg, storePath, entry } = loadSessionEntry(opts.sessionKey);
     const sessionId = entry?.sessionId;

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -30,6 +30,7 @@ import type {
   TuiBackend,
   TuiEvent,
   TuiModelChoice,
+  TuiSessionMessageSubscriptionResult,
   TuiSessionList,
 } from "./tui-backend.js";
 
@@ -187,6 +188,24 @@ export class GatewayChatClient implements TuiBackend {
       sessionKey: opts.sessionKey,
       runId: opts.runId,
     });
+  }
+
+  async subscribeSessionMessages(opts: {
+    key: string;
+  }): Promise<TuiSessionMessageSubscriptionResult> {
+    return await this.client.request<TuiSessionMessageSubscriptionResult>(
+      "sessions.messages.subscribe",
+      opts,
+    );
+  }
+
+  async unsubscribeSessionMessages(opts: {
+    key: string;
+  }): Promise<TuiSessionMessageSubscriptionResult> {
+    return await this.client.request<TuiSessionMessageSubscriptionResult>(
+      "sessions.messages.unsubscribe",
+      opts,
+    );
   }
 
   async loadHistory(opts: { sessionKey: string; limit?: number }) {

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -83,6 +83,15 @@ export type TuiModelChoice = {
   reasoning?: boolean;
 };
 
+export type TuiSessionMessageSubscriptionResult = {
+  subscribed: boolean;
+  key: string;
+};
+
+export type TuiSessionMessageSubscriptionOptions = {
+  key: string;
+};
+
 export type TuiBackend = {
   connection: {
     url: string;
@@ -100,6 +109,12 @@ export type TuiBackend = {
     sessionKey: string;
     runId: string;
   }) => Promise<{ ok: boolean; aborted: boolean }>;
+  subscribeSessionMessages: (
+    opts: TuiSessionMessageSubscriptionOptions,
+  ) => Promise<TuiSessionMessageSubscriptionResult>;
+  unsubscribeSessionMessages: (
+    opts: TuiSessionMessageSubscriptionOptions,
+  ) => Promise<TuiSessionMessageSubscriptionResult>;
   loadHistory: (opts: { sessionKey: string; limit?: number }) => Promise<unknown>;
   listSessions: (opts?: SessionsListParams) => Promise<TuiSessionList>;
   listAgents: () => Promise<TuiAgentsList>;

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -78,6 +78,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     const btw = createMockBtwPresenter();
     const tui = { requestRender: vi.fn() } as unknown as MockTui & HandlerTui;
     const setActivityStatus = vi.fn();
+    const refreshSessionInfo = vi.fn();
     const loadHistory = vi.fn();
     const localRunIds = new Set<string>();
     const localBtwRunIds = new Set<string>();
@@ -100,6 +101,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       tui,
       state,
       setActivityStatus,
+      refreshSessionInfo,
       loadHistory,
       noteLocalRunId,
       noteLocalBtwRunId,
@@ -128,6 +130,7 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       state,
       localMode: params?.localMode,
       setActivityStatus: context.setActivityStatus,
+      refreshSessionInfo: context.refreshSessionInfo,
       loadHistory: context.loadHistory,
       noteLocalRunId: context.noteLocalRunId,
       isLocalRunId: context.isLocalRunId,
@@ -465,6 +468,80 @@ describe("tui-event-handlers: handleAgentEvent", () => {
       sessionKey: state.currentSessionKey,
       state: "final",
       message: { content: [{ type: "text", text: "done" }] },
+    });
+
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads history when live transcript updates arrive for the active idle session", () => {
+    const { state, refreshSessionInfo, loadHistory, handleSessionMessageEvent } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: null,
+          currentSessionKey: "agent:main:main",
+        },
+      });
+
+    handleSessionMessageEvent({
+      sessionKey: state.currentSessionKey,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "from telegram" }],
+      },
+    });
+
+    expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
+    expect(loadHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores live transcript updates for other sessions", () => {
+    const { refreshSessionInfo, loadHistory, handleSessionMessageEvent } = createHandlersHarness({
+      state: {
+        activeChatRunId: null,
+        currentSessionKey: "agent:main:main",
+      },
+    });
+
+    handleSessionMessageEvent({
+      sessionKey: "agent:main:other",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "other session" }],
+      },
+    });
+
+    expect(refreshSessionInfo).not.toHaveBeenCalled();
+    expect(loadHistory).not.toHaveBeenCalled();
+  });
+
+  it("defers live transcript reloads while a local stream is active", () => {
+    const { state, loadHistory, noteLocalRunId, handleChatEvent, handleSessionMessageEvent } =
+      createHandlersHarness({
+        state: {
+          activeChatRunId: "run-active",
+          currentSessionKey: "agent:main:main",
+        },
+      });
+    noteLocalRunId("run-active");
+
+    handleSessionMessageEvent({
+      sessionKey: state.currentSessionKey,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "external reply" }],
+      },
+    });
+
+    expect(loadHistory).not.toHaveBeenCalled();
+
+    handleChatEvent({
+      runId: "run-active",
+      sessionKey: state.currentSessionKey,
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "local done" }],
+      },
     });
 
     expect(loadHistory).toHaveBeenCalledTimes(1);

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -514,9 +514,32 @@ export function createEventHandlers(context: EventHandlerContext) {
     tui.requestRender();
   };
 
+  const handleSessionMessageEvent = (payload: unknown) => {
+    if (!payload || typeof payload !== "object") {
+      return;
+    }
+    const evt = payload as { sessionKey?: unknown };
+    syncSessionKey();
+    if (
+      !isSameSessionKey(
+        typeof evt.sessionKey === "string" ? evt.sessionKey : undefined,
+        state.currentSessionKey,
+      )
+    ) {
+      return;
+    }
+    void refreshSessionInfo?.();
+    if (state.activeChatRunId) {
+      pendingHistoryRefresh = true;
+      return;
+    }
+    pendingHistoryRefresh = false;
+    void loadHistory?.();
+  };
+
   const dispose = () => {
     clearStreamingWatchdog();
   };
 
-  return { handleChatEvent, handleAgentEvent, handleBtwEvent, dispose };
+  return { handleChatEvent, handleAgentEvent, handleBtwEvent, handleSessionMessageEvent, dispose };
 }

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -3,6 +3,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
+  createTuiSessionMessageSubscriptionController,
   drainAndStopTuiSafely,
   isIgnorableTuiStopError,
   resolveCodexCliBin,
@@ -176,6 +177,80 @@ describe("resolveGatewayDisconnectState", () => {
     expect(state.connectionStatus).toBe("gateway disconnected: network timeout");
     expect(state.activityStatus).toBe("idle");
     expect(state.pairingHint).toBeUndefined();
+  });
+});
+
+describe("createTuiSessionMessageSubscriptionController", () => {
+  const createClient = () => ({
+    subscribeSessionMessages: vi.fn(async ({ key }: { key: string }) => ({
+      subscribed: true,
+      key,
+    })),
+    unsubscribeSessionMessages: vi.fn(async ({ key }: { key: string }) => ({
+      subscribed: false,
+      key,
+    })),
+  });
+
+  it("subscribes once to the active session", async () => {
+    const client = createClient();
+    const controller = createTuiSessionMessageSubscriptionController({
+      client,
+      getSessionKey: () => "agent:main:main",
+    });
+
+    await controller.syncActiveSessionSubscription();
+    await controller.syncActiveSessionSubscription();
+
+    expect(client.subscribeSessionMessages).toHaveBeenCalledTimes(1);
+    expect(client.subscribeSessionMessages).toHaveBeenCalledWith({ key: "agent:main:main" });
+    expect(client.unsubscribeSessionMessages).not.toHaveBeenCalled();
+    expect(controller.getActiveSubscriptionKey()).toBe("agent:main:main");
+  });
+
+  it("unsubscribes the stale session before subscribing the next session", async () => {
+    const client = createClient();
+    let sessionKey = "agent:main:main";
+    const controller = createTuiSessionMessageSubscriptionController({
+      client,
+      getSessionKey: () => sessionKey,
+    });
+
+    await controller.syncActiveSessionSubscription();
+    sessionKey = "agent:main:other";
+    await controller.syncActiveSessionSubscription();
+
+    expect(client.unsubscribeSessionMessages).toHaveBeenCalledWith({ key: "agent:main:main" });
+    expect(client.subscribeSessionMessages).toHaveBeenLastCalledWith({ key: "agent:main:other" });
+    expect(controller.getActiveSubscriptionKey()).toBe("agent:main:other");
+  });
+
+  it("resubscribes the same session after reconnect", async () => {
+    const client = createClient();
+    const controller = createTuiSessionMessageSubscriptionController({
+      client,
+      getSessionKey: () => "agent:main:main",
+    });
+
+    await controller.syncActiveSessionSubscription();
+    controller.markDisconnected();
+    await controller.syncActiveSessionSubscription();
+
+    expect(client.subscribeSessionMessages).toHaveBeenCalledTimes(2);
+  });
+
+  it("unsubscribes the active session on stop", async () => {
+    const client = createClient();
+    const controller = createTuiSessionMessageSubscriptionController({
+      client,
+      getSessionKey: () => "agent:main:main",
+    });
+
+    await controller.syncActiveSessionSubscription();
+    await controller.unsubscribeActiveSession();
+
+    expect(client.unsubscribeSessionMessages).toHaveBeenCalledWith({ key: "agent:main:main" });
+    expect(controller.getActiveSubscriptionKey()).toBeNull();
   });
 });
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -76,6 +76,77 @@ type RunTuiOptions = TuiOptions & {
   title?: string;
 };
 
+export function createTuiSessionMessageSubscriptionController(params: {
+  client: Pick<TuiBackend, "subscribeSessionMessages" | "unsubscribeSessionMessages">;
+  getSessionKey: () => string;
+  onError?: (message: string) => void;
+}) {
+  let activeKey: string | null = null;
+  let generation = 0;
+
+  const report = (action: string, key: string, err: unknown) => {
+    params.onError?.(`session message ${action} failed for ${key}: ${String(err)}`);
+  };
+
+  const unsubscribeKey = async (key: string, action: string) => {
+    try {
+      await params.client.unsubscribeSessionMessages({ key });
+    } catch (err) {
+      report(action, key, err);
+    }
+  };
+
+  const syncActiveSessionSubscription = async () => {
+    const key = params.getSessionKey().trim();
+    if (!key || key === activeKey) {
+      return;
+    }
+    const previousKey = activeKey;
+    activeKey = key;
+    const syncGeneration = ++generation;
+    if (previousKey) {
+      await unsubscribeKey(previousKey, "unsubscribe");
+    }
+    if (syncGeneration !== generation) {
+      return;
+    }
+    try {
+      const result = await params.client.subscribeSessionMessages({ key });
+      if (syncGeneration === generation && result.key.trim()) {
+        activeKey = result.key;
+      }
+    } catch (err) {
+      if (syncGeneration === generation) {
+        activeKey = null;
+      }
+      report("subscribe", key, err);
+    }
+  };
+
+  const unsubscribeActiveSession = async () => {
+    const key = activeKey;
+    generation++;
+    activeKey = null;
+    if (key) {
+      await unsubscribeKey(key, "unsubscribe");
+    }
+  };
+
+  const markDisconnected = () => {
+    generation++;
+    activeKey = null;
+  };
+
+  const getActiveSubscriptionKey = () => activeKey;
+
+  return {
+    syncActiveSessionSubscription,
+    unsubscribeActiveSession,
+    markDisconnected,
+    getActiveSubscriptionKey,
+  };
+}
+
 /** Resolve the absolute path to the `codex` CLI binary, or `null` if not installed. */
 export function resolveCodexCliBin(): string | null {
   try {
@@ -890,32 +961,41 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     setActivityStatus,
     clearLocalRunIds,
   });
-  const {
-    refreshAgents,
-    refreshSessionInfo,
-    applySessionInfoFromPatch,
-    loadHistory,
-    setSession,
-    abortActive,
-  } = sessionActions;
+  const { refreshAgents, refreshSessionInfo, applySessionInfoFromPatch, loadHistory, abortActive } =
+    sessionActions;
 
-  const { handleChatEvent, handleAgentEvent, handleBtwEvent } = createEventHandlers({
-    chatLog,
-    btw,
-    tui,
-    state,
-    localMode: isLocalMode,
-    setActivityStatus,
-    refreshSessionInfo,
-    loadHistory,
-    noteLocalRunId,
-    isLocalRunId,
-    forgetLocalRunId,
-    clearLocalRunIds,
-    isLocalBtwRunId,
-    forgetLocalBtwRunId,
-    clearLocalBtwRunIds,
+  const sessionMessageSubscription = createTuiSessionMessageSubscriptionController({
+    client,
+    getSessionKey: () => currentSessionKey,
+    onError: (message) => {
+      chatLog.addSystem(message);
+      tui.requestRender();
+    },
   });
+
+  const setSession = async (rawKey: string) => {
+    await sessionActions.setSession(rawKey);
+    await sessionMessageSubscription.syncActiveSessionSubscription();
+  };
+
+  const { handleChatEvent, handleAgentEvent, handleBtwEvent, handleSessionMessageEvent } =
+    createEventHandlers({
+      chatLog,
+      btw,
+      tui,
+      state,
+      localMode: isLocalMode,
+      setActivityStatus,
+      refreshSessionInfo,
+      loadHistory,
+      noteLocalRunId,
+      isLocalRunId,
+      forgetLocalRunId,
+      clearLocalRunIds,
+      isLocalBtwRunId,
+      forgetLocalBtwRunId,
+      clearLocalBtwRunIds,
+    });
 
   let finishTui: (() => void) | null = null;
   const requestExit = (result?: Partial<TuiResult>) => {
@@ -927,6 +1007,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       exitReason: result?.exitReason ?? "exit",
       ...(result?.crestodianMessage ? { crestodianMessage: result.crestodianMessage } : {}),
     };
+    void sessionMessageSubscription.unsubscribeActiveSession();
     client.stop();
     void drainAndStopTuiSafely(tui).then(() => {
       finishTui?.();
@@ -1061,6 +1142,9 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     if (evt.event === "agent") {
       handleAgentEvent(evt.payload);
     }
+    if (evt.event === "session.message") {
+      handleSessionMessageEvent(evt.payload);
+    }
   };
 
   client.onConnected = () => {
@@ -1073,6 +1157,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       await refreshAgents();
       updateHeader();
       await loadHistory();
+      await sessionMessageSubscription.syncActiveSessionSubscription();
       setConnectionStatus(
         isLocalMode ? "local ready" : reconnected ? "gateway reconnected" : "gateway connected",
         4000,
@@ -1091,6 +1176,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     isConnected = false;
     wasDisconnected = true;
     historyLoaded = false;
+    sessionMessageSubscription.markDisconnected();
     const disconnectState = isLocalMode
       ? {
           connectionStatus: `local runtime stopped${reason ? `: ${reason}` : ""}`,


### PR DESCRIPTION
## Summary
- Fixes #38829 by making the bundled TUI subscribe to live transcript updates for the active session.
- Covers the duplicate reproduction in #43341 without widening the gateway hidden-run chat fanout boundary discussed on #41964.
- Keeps #51691 as broader related multi-surface sync context outside this narrow fix.

## Plan
- Add subscribe/unsubscribe support in the TUI gateway client/backend for the active session transcript stream.
- Subscribe after connect and after session switches, unsubscribe stale sessions on switch/stop, and ignore events for non-active sessions.
- Handle `session.message` updates by appending or reloading history in a way that does not disrupt an active local stream.
- Add focused regression tests for cross-surface delivery, active-run deferral/history reload semantics, session switching/unsubscribe, and session filtering.

## Validation
- `pnpm check:changed`

## Credit
Thanks @galen2017 for #38829 and @baiyiyuni for #43341. Their reports define the canonical and duplicate reproduction paths for this fix.

ProjectClownfish replacement details:
- Cluster: ghcrawl-156978-autonomous-smoke
- Source PRs: none
- Credit: Credit #38829 by @galen2017 for the canonical TUI real-time message report.; Credit #43341 by @baiyiyuni for the duplicate Linux/Telegram reproduction and version-regression details.; Treat #51691 as related broader product context, not as the narrow bug fix scope.; Do not reuse #41964 as a source PR for this fix path because it is routed to central security handling.
- Validation: pnpm check:changed
