### PR TITLE
fix(auto-reply): allow voice-reply payloads through silent turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: allow voice-reply payloads (`audioAsVoice: true`) through silent turns so a NO_REPLY text reply paired with a TTS voice message still delivers the voice — silent suppresses the text portion, not the voice itself. Plain images, documents, and non-voice audio remain dropped on silent turns to match the upstream "silent = deliver nothing" default. Thanks @zqchris.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -381,6 +381,20 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("preserves voice-reply payloads through silent turns (audioAsVoice=true)", async () => {
+    // When an agent uses NO_REPLY as its text reply but also produced a
+    // voice message (audioAsVoice=true from TTS), the voice should still be
+    // delivered — silent suppresses the text portion, not the voice itself.
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      silentExpected: true,
+      payloads: [{ text: "NO_REPLY", mediaUrl: "file:///tmp/voice.opus", audioAsVoice: true }],
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]).toMatchObject({ audioAsVoice: true });
+  });
+
   it("suppresses warning text when silent media payloads fail normalization", async () => {
     const normalizeMediaPaths = async () => {
       throw new Error("file not found");

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -165,7 +165,16 @@ export async function buildReplyPayloads(params: {
       }),
     )
   ).filter(isRenderablePayload);
-  const silentFilteredPayloads = params.silentExpected ? [] : replyTaggedPayloads;
+  // Allow voice-reply payloads (audioAsVoice) through silent turns.
+  // When an agent uses NO_REPLY as its text reply but also produced a voice
+  // message (audioAsVoice=true from TTS), the voice should still be delivered —
+  // silent suppresses the text portion, not the voice reply itself.
+  //
+  // Regular media (plain images, documents, non-voice audio) is still dropped
+  // on silent turns to match the upstream semantic "silent = deliver nothing".
+  const silentFilteredPayloads = params.silentExpected
+    ? replyTaggedPayloads.filter((p) => p.audioAsVoice === true)
+    : replyTaggedPayloads;
 
   // Drop final payloads only when block streaming succeeded end-to-end.
   // If streaming aborted (e.g., timeout), fall back to final payloads.


### PR DESCRIPTION
## Summary

`buildReplyPayloads` currently drops *all* tagged reply payloads when `silentExpected` is true:

```ts
const silentFilteredPayloads = params.silentExpected ? [] : replyTaggedPayloads;
```

This is too aggressive when an agent uses `NO_REPLY` as its text reply but **also produced a voice message** (`audioAsVoice: true` from a TTS voice provider). The voice should still be delivered — `silent` is meant to suppress the *text* portion, not the agent's voice itself.

Real symptom: a Telegram voice delivery on a NO_REPLY turn loses its audio; the user only ever hears voice replies that come with non-NO_REPLY text. The same drop affects every channel that honors `audioAsVoice`.

## Fix

Keep `audioAsVoice: true` payloads on silent turns. Plain media (regular images, documents, non-voice audio) still drops, matching the existing "silent = deliver nothing" semantic.

```ts
const silentFilteredPayloads = params.silentExpected
  ? replyTaggedPayloads.filter((p) => p.audioAsVoice === true)
  : replyTaggedPayloads;
```

## Test plan

- [x] `pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts` — 26/26 (was 25, +1 covering `audioAsVoice` survives silent turn while plain media still drops)
- [x] `pnpm check:changed` clean
- [ ] Reviewer note: existing test at line ~374 ("drops all final payloads during silent turns, including media-only payloads") is *not* changed — its sample payload has no `audioAsVoice: true`, so it correctly still drops. The new test exercises the orthogonal case.
