### PR TITLE
fix(google): widen createGoogleThinkingPayloadWrapper guard to cover Vertex and Gemini CLI APIs (#38327)

### DIFF
--- a/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
@@ -169,6 +169,9 @@ describe("createGoogleThinkingPayloadWrapper — Google API shape coverage (#383
       onPayload?.({
         config: { thinkingConfig: { thinkingBudget: -1 } },
       });
+      // Empty generator: payload capture happens via the onPayload callback above,
+      // so the iterable yields no chunks (mirrors the production guard's no-op path).
+      yield* [];
     });
     const wrapped = createGoogleThinkingPayloadWrapper(baseStreamFn as never, undefined);
     const generator = wrapped(model as never, { messages: [] } as never, {

--- a/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
-import { sanitizeGoogleThinkingPayload } from "./google-stream-wrappers.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGoogleThinkingPayloadWrapper,
+  sanitizeGoogleThinkingPayload,
+} from "./google-stream-wrappers.js";
 
 describe("sanitizeGoogleThinkingPayload — gemini-2.5-pro zero budget", () => {
   it("removes thinkingBudget=0 for gemini-2.5-pro", () => {
@@ -143,6 +146,70 @@ describe("sanitizeGoogleThinkingPayload — gemini-2.5-pro zero budget", () => {
     });
     expect(payload.config.thinkingConfig).toEqual({
       includeThoughts: true,
+      thinkingBudget: -1,
+    });
+  });
+});
+
+describe("createGoogleThinkingPayloadWrapper — Google API shape coverage (#38327)", () => {
+  // The wrapper's payload-sanitize step previously gated on a single
+  // `model.api === "google-generative-ai"` string. That guard left
+  // `google-vertex`, `google-gemini-cli`, and OpenAI-completions-shaped Vertex
+  // routes uncovered, so embedded-runner streams hit the unhandled negative
+  // `thinkingBudget` and crashed with "Cannot convert undefined or null to
+  // object" (issue #38327, still reproducing on v2026.4.21+ per fxstein's
+  // forensic notes on the issue).
+  async function runWrapper(model: { api: string; id: string; provider?: string }) {
+    let captured: Record<string, unknown> | undefined;
+    const baseStreamFn = vi.fn(async function* (_model: unknown, _ctx: unknown, options: unknown) {
+      const onPayload = (options as { onPayload?: (payload: unknown) => void } | undefined)
+        ?.onPayload;
+      onPayload?.({
+        config: { thinkingConfig: { thinkingBudget: -1 } },
+      });
+    });
+    const wrapped = createGoogleThinkingPayloadWrapper(baseStreamFn as never, undefined);
+    const generator = wrapped(model as never, { messages: [] } as never, {
+      onPayload: (payload: unknown) => {
+        captured = payload as Record<string, unknown>;
+      },
+    } as never) as AsyncIterable<unknown>;
+    for await (const _chunk of generator) {
+      // drain
+    }
+    return captured;
+  }
+
+  it("strips negative thinkingBudget for api=google-generative-ai (existing behavior preserved)", async () => {
+    const payload = await runWrapper({
+      api: "google-generative-ai",
+      id: "gemini-3.1-pro-preview",
+      provider: "google",
+    });
+    expect((payload?.config as { thinkingConfig?: unknown })?.thinkingConfig).toBeUndefined();
+  });
+
+  it("strips negative thinkingBudget for api=google-vertex (regression #38327)", async () => {
+    const payload = await runWrapper({
+      api: "google-vertex",
+      id: "gemini-3.1-pro-preview",
+      provider: "google-vertex",
+    });
+    expect((payload?.config as { thinkingConfig?: unknown })?.thinkingConfig).toBeUndefined();
+  });
+
+  it("strips negative thinkingBudget for api=google-gemini-cli (regression #38327)", async () => {
+    const payload = await runWrapper({
+      api: "google-gemini-cli",
+      id: "gemini-3.1-pro-preview",
+      provider: "google",
+    });
+    expect((payload?.config as { thinkingConfig?: unknown })?.thinkingConfig).toBeUndefined();
+  });
+
+  it("does not sanitize for unrelated APIs (api=anthropic stays untouched)", async () => {
+    const payload = await runWrapper({ api: "anthropic", id: "claude-sonnet-4.6" });
+    expect((payload?.config as { thinkingConfig?: unknown })?.thinkingConfig).toEqual({
       thinkingBudget: -1,
     });
   });

--- a/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
+++ b/src/agents/pi-embedded-runner/google-stream-wrappers.test.ts
@@ -154,11 +154,13 @@ describe("sanitizeGoogleThinkingPayload — gemini-2.5-pro zero budget", () => {
 describe("createGoogleThinkingPayloadWrapper — Google API shape coverage (#38327)", () => {
   // The wrapper's payload-sanitize step previously gated on a single
   // `model.api === "google-generative-ai"` string. That guard left
-  // `google-vertex`, `google-gemini-cli`, and OpenAI-completions-shaped Vertex
-  // routes uncovered, so embedded-runner streams hit the unhandled negative
-  // `thinkingBudget` and crashed with "Cannot convert undefined or null to
-  // object" (issue #38327, still reproducing on v2026.4.21+ per fxstein's
-  // forensic notes on the issue).
+  // `google-vertex` and `google-gemini-cli` routes uncovered, so
+  // embedded-runner streams hit the unhandled negative `thinkingBudget`
+  // and crashed with "Cannot convert undefined or null to object"
+  // (issue #38327, still reproducing on v2026.4.21+ per fxstein's
+  // forensic notes on the issue). OpenAI-completions-shaped Vertex
+  // routes (`Vertex Model Garden / OpenAI-compatible API`) remain out
+  // of scope of this guard widening.
   async function runWrapper(model: { api: string; id: string; provider?: string }) {
     let captured: Record<string, unknown> | undefined;
     const baseStreamFn = vi.fn(async function* (_model: unknown, _ctx: unknown, options: unknown) {

--- a/src/plugin-sdk/provider-stream-shared.ts
+++ b/src/plugin-sdk/provider-stream-shared.ts
@@ -605,12 +605,26 @@ function sanitizeGoogleThinkingConfigContainer(params: {
   }
 }
 
+// Google models can resolve through several `model.api` shapes depending on
+// transport: `google-generative-ai` (native Google SDK), `google-vertex`
+// (Vertex AI SDK), and `google-gemini-cli` (Gemini CLI). All three reach the
+// same payload patch path and need the negative-thinkingBudget sanitization.
+// The original guard checked only the first shape, leaving Vertex/CLI streams
+// crashing with "Cannot convert undefined or null to object" when pi-ai emits
+// an invalid `thinkingBudget` (issue #38327, still reproducing on v2026.4.21+
+// per fxstein's forensic analysis).
+const GOOGLE_THINKING_PAYLOAD_APIS = new Set<string>([
+  "google-generative-ai",
+  "google-vertex",
+  "google-gemini-cli",
+]);
+
 export function createGoogleThinkingPayloadWrapper(
   baseStreamFn: StreamFn | undefined,
   thinkingLevel?: GoogleThinkingInputLevel,
 ): StreamFn {
   return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
-    if (model.api === "google-generative-ai") {
+    if (GOOGLE_THINKING_PAYLOAD_APIS.has(model.api)) {
       sanitizeGoogleThinkingPayload({
         payload,
         modelId: model.id,


### PR DESCRIPTION
## Summary
On Google Vertex configs, embedded-runner streams crash with `Cannot convert undefined or null to object` because the existing `createGoogleThinkingPayloadWrapper` guard only sanitizes payloads when `model.api === "google-generative-ai"`. When pi-ai emits an invalid negative `thinkingBudget` for `google-vertex` and `google-gemini-cli` routes, that guard misses them and Vertex's auth chain blows up downstream.

This widens the guard to a small `Set` of all three known Google API shapes so the same negative-budget sanitization runs for every Google transport that already flows through the wrapper.

## Root Cause
- `src/plugin-sdk/provider-stream-shared.ts:601` (before): `if (model.api === "google-generative-ai") sanitizeGoogleThinkingPayload(...)`.
- `model.api` resolves to `"google-vertex"` for Vertex SDK paths and `"google-gemini-cli"` for Gemini CLI installs. Both produce the same `thinkingConfig: { thinkingBudget: -1 }` shape from pi-ai, but the guard short-circuits before sanitization, so the invalid budget reaches the request and Vertex serialization crashes.
- The closure of #33428 covered only the `google-generative-ai` shape and explicitly noted Codex's bypass-path concern. Forensic analysis from @fxstein on issue #38327 (2026-04-28) reconfirms the same crash is still reproducing on v2026.4.21+ for `google-vertex/gemini-3.1-pro-preview` and `google-vertex/gemini-3-flash-preview`, with a clean reference patch matching this fix shape.

## Changes
- `src/plugin-sdk/provider-stream-shared.ts`: introduce `GOOGLE_THINKING_PAYLOAD_APIS` set covering `google-generative-ai`, `google-vertex`, `google-gemini-cli`. The wrapper now sanitizes when `GOOGLE_THINKING_PAYLOAD_APIS.has(model.api)`. No behavior change for non-Google APIs (anthropic, openai, etc.) — they continue to bypass.
- `src/agents/pi-embedded-runner/google-stream-wrappers.test.ts`: add 4 wrapper-level regression tests covering each Google API shape plus a negative case asserting `api: "anthropic"` payloads stay untouched.

## Real behavior proof

- **Behavior or issue addressed**: Vertex / Gemini-CLI streams crash with `Cannot convert undefined or null to object` because `createGoogleThinkingPayloadWrapper`'s single-string guard skips sanitization on those two routes, leaving pi-ai's invalid `thinkingBudget: -1` in the payload. After this PR, the guard is a `Set<string>` covering all three Google API shapes (`google-generative-ai`, `google-vertex`, `google-gemini-cli`), so the same negative-budget sanitization fires for every Google transport that already flows through the wrapper. Issue: https://github.com/openclaw/openclaw/issues/38327 (still reproducing on `v2026.4.21+` per @fxstein's forensic notes on 2026-04-28).
- **Real environment tested**: Local OpenClaw checkout at `../openclaw-38327` on Windows 11 + Node 22.14. The smoke script reads the **patched production file `src/plugin-sdk/provider-stream-shared.ts` directly from the worktree**, locates the new `GOOGLE_THINKING_PAYLOAD_APIS` set literal verbatim, parses the API names out of the source text, then reconstructs the production membership check and exercises it against every Google API shape named in issue #38327 plus a negative-control set. No mocks, no test runner — the guard's actual source bytes drive the smoke. PR head: `f618188606f902f5f83217b3b53b93bfeb41eb0a`.
- **Exact steps or command run after this patch**: `git checkout fix/google-thinking-wrapper-vertex-cli-guard && node --experimental-strip-types ./smoke-pr73416.mts`, where `smoke-pr73416.mts` reads `src/plugin-sdk/provider-stream-shared.ts`, extracts the patched guard block (offset-pinned to `const GOOGLE_THINKING_PAYLOAD_APIS = new Set<string>...`), prints its SHA-256 and verbatim contents, then runs the membership check for every relevant `model.api` value.
- **Evidence after fix**: Terminal output captured locally on PR head `f618188606` (Windows 11 + Node 22.14, the patched guard block read from `src/plugin-sdk/provider-stream-shared.ts`, 541 bytes, SHA-256 `ece31c73a0f484803f9215d3c033561ebd738ff5b584fd130d6775904d238017`).

~~~text
$ node --experimental-strip-types ./smoke-pr73416.mts
=== Patched guard block extracted from src/plugin-sdk/provider-stream-shared.ts ===
offset: 19526 -> 20067 ( 541 bytes)
SHA-256: ece31c73a0f484803f9215d3c033561ebd738ff5b584fd130d6775904d238017
--- guard block (verbatim) ---
const GOOGLE_THINKING_PAYLOAD_APIS = new Set<string>([
  "google-generative-ai",
  "google-vertex",
  "google-gemini-cli",
]);

export function createGoogleThinkingPayloadWrapper(
  baseStreamFn: StreamFn | undefined,
  thinkingLevel?: GoogleThinkingInputLevel,
): StreamFn {
  return createPayloadPatchStreamWrapper(baseStreamFn, ({ payload, model }) => {
    if (GOOGLE_THINKING_PAYLOAD_APIS.has(model.api)) {
      sanitizeGoogleThinkingPayload({
        payload,
        modelId: model.id,
        thinkingLevel,
      });
    }
  });
}

=== Set membership (reconstructed from production source) ===
Guard set entries: [ 'google-gemini-cli', 'google-generative-ai', 'google-vertex' ]

=== Membership check for every Google API shape that issue #38327 names ===
  OK  isGoogleThinkingApi("google-generative-ai") = true (expected true)  — native Google SDK (covered BEFORE this PR)
  OK  isGoogleThinkingApi("google-vertex"       ) = true (expected true)  — Vertex AI SDK (regression #38327)
  OK  isGoogleThinkingApi("google-gemini-cli"   ) = true (expected true)  — Gemini CLI route (regression #38327)
  OK  isGoogleThinkingApi("openai-completions"  ) = false (expected false)  — OpenAI-compat (Vertex Model Garden) — must NOT match
  OK  isGoogleThinkingApi("anthropic"           ) = false (expected false)  — Anthropic — must NOT match
  OK  isGoogleThinkingApi("mistral"             ) = false (expected false)  — Mistral — must NOT match
  OK  isGoogleThinkingApi(""                    ) = false (expected false)  — empty string — must NOT match
~~~

- **Observed result after fix**: The patched guard block's verbatim contents — pinned by a 541-byte / SHA-256 `ece31c73a0f484803f9215d3c033561ebd738ff5b584fd130d6775904d238017` integrity check — contain exactly three API shapes: `google-generative-ai`, `google-vertex`, `google-gemini-cli`. The reconstructed membership check returns `true` for all three (so all three routes now reach `sanitizeGoogleThinkingPayload`) and `false` for non-Google shapes (`openai-completions`, `anthropic`, `mistral`, empty string), confirming the widening is scoped exactly to the three documented Google transports. `openai-completions` notably stays `false` — this preserves the explicit Vertex Model Garden / OpenAI-compatible carve-out described in the test comment block (`Vertex Model Garden / OpenAI-compatible API` routes are out of scope of this guard).
- **What was not tested**: A live `google-vertex` stream against a real Vertex AI Studio project with a `gemini-3-pro-preview` model was not exercised on the contributor machine (would need Vertex AI credentials, a billing-enabled GCP project, and an active service account). The fix is a pure guard-widening change inside `createGoogleThinkingPayloadWrapper`; the downstream `sanitizeGoogleThinkingPayload` is unchanged and already covered by the `sanitizeGoogleThinkingPayload — gemini-2.5-pro zero budget` test block in the same file. Maintainers may apply `proof: override` if a live Vertex stream recording is required; @fxstein's forensic notes on issue #38327 already contain the live `Cannot convert undefined or null to object` failure log against current main.

## Test

- `pnpm test src/agents/pi-embedded-runner/google-stream-wrappers.test.ts` — 15 passed (existing budget tests + 4 new wrapper-level regression cases for #38327)
- `pnpm test src/agents/pi-embedded-runner/google-stream-wrappers.test.ts src/agents/pi-embedded-runner/extra-params.google.test.ts` — 18 passed
- `pnpm lint:core` — exit 0

## Notes
- Scope: single guard widening; no API contract changes, no payload-shape changes, no provider-specific seam additions. Backwards-compatible by construction.
- Boundary: `src/plugin-sdk/provider-stream-shared.ts` is the documented Plugin SDK contract. This is an additive guard correction (per `src/plugin-sdk/AGENTS.md`: "additive, backwards-compatible changes are the default").
- Unrelated to the in-flight #43217 (gating on `model.reasoning`) and #72868 (thinkingBudget=0 injection on thinking-off). Those address other parts of the same family but neither widens the API guard. This PR is the narrow Vertex/CLI fix that fxstein's analysis specifically calls for.
- Root cause B in fxstein's report (gaxios `await import('node-fetch')` on Node 22+) is **not** addressed here because dependency patches require explicit approval per AGENTS.md. Happy to file a separate PR for the gaxios fallback if maintainers want.
- This is a re-attempt at the closed #33428's first commit, narrowed to just the API-shape guard and supported by a wrapper-level regression test.

Closes #38327
