### PR TITLE
fix(media): fallback to original buffer when image optimization fails

### DIFF
--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -653,7 +653,13 @@ export async function optimizeImageToJpeg(
     };
   }
 
-  throw new Error("Failed to optimize image");
+  // Fallback: return original buffer if optimization failed
+  return {
+    buffer: source,
+    optimizedSize: source.length,
+    resizeSide: 0,
+    quality: 0,
+  };
 }
 
 export { optimizeImageToPng };


### PR DESCRIPTION
## Problem
`optimizeImageToJpeg()` throws "Failed to optimize image" when all resize/quality combinations fail, blocking image analysis entirely.\n\n## Solution\nReturn the original buffer as fallback instead of throwing. This allows images to reach VLM models even when optimization fails.\n\n## Changes\n- Replace `throw new Error("Failed to optimize image")` with return of original buffer\n- Set `resizeSide: 0` and `quality: 0` to indicate no optimization was applied\n\n## Testing\n- Images that fail optimization now pass through to VLM models\n- Backward compatible: successful optimizations still return optimized data\n\nFixes #73424