### PR TITLE
fix: add auth profile listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
 - Channels/native commands: keep validated native slash command replies visible in group chats while preserving explicit owner allowlists for command authorization. (#73672) Thanks @obviyus.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
+- CLI/auth: add a read-only `openclaw auth list` alias and `openclaw models auth list` so scripts can inspect configured auth profile ids without hanging or printing secrets. Fixes #73305. Thanks @hcostaBR and @xialonglee.
 
 ## 2026.4.27
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -20,7 +20,7 @@ apply across the CLI.
 | Messaging and agents | [`message`](/cli/message) · [`agent`](/cli/agent) · [`agents`](/cli/agents) · [`acp`](/cli/acp) · [`mcp`](/cli/mcp)                                                                                                                       |
 | Health and sessions  | [`status`](/cli/status) · [`health`](/cli/health) · [`sessions`](/cli/sessions)                                                                                                                                                           |
 | Gateway and logs     | [`gateway`](/cli/gateway) · [`logs`](/cli/logs) · [`system`](/cli/system)                                                                                                                                                                 |
-| Models and inference | [`models`](/cli/models) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`wiki`](/cli/wiki)                                                                                          |
+| Models and inference | [`models`](/cli/models) · `auth` (see [`models`](/cli/models#auth-profiles)) · [`infer`](/cli/infer) · `capability` (alias for [`infer`](/cli/infer)) · [`memory`](/cli/memory) · [`wiki`](/cli/wiki)                                     |
 | Network and nodes    | [`directory`](/cli/directory) · [`nodes`](/cli/nodes) · [`devices`](/cli/devices) · [`node`](/cli/node)                                                                                                                                   |
 | Runtime and sandbox  | [`approvals`](/cli/approvals) · `exec-policy` (see [`approvals`](/cli/approvals)) · [`sandbox`](/cli/sandbox) · [`tui`](/cli/tui) · `chat`/`terminal` (aliases for [`tui --local`](/cli/tui)) · [`browser`](/cli/browser)                 |
 | Automation           | [`cron`](/cli/cron) · [`tasks`](/cli/tasks) · [`hooks`](/cli/hooks) · [`webhooks`](/cli/webhooks)                                                                                                                                         |
@@ -221,6 +221,10 @@ openclaw [--dev] [--profile <name>] <command>
     fallbacks list|add|remove|clear
     image-fallbacks list|add|remove|clear
     scan
+    auth list|add|login|login-github-copilot|setup-token|paste-token
+    auth order get|set|clear
+  auth
+    list
   infer (alias: capability)
     list
     inspect
@@ -231,8 +235,6 @@ openclaw [--dev] [--profile <name>] <command>
     video generate|describe|providers
     web search|fetch|providers
     embedding create|providers
-    auth add|login|login-github-copilot|setup-token|paste-token
-    auth order get|set|clear
   sandbox
     list
     recreate

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -152,10 +152,15 @@ openclaw models fallbacks list
 
 ```bash
 openclaw models auth add
+openclaw models auth list
+openclaw auth list
 openclaw models auth login --provider <id>
 openclaw models auth setup-token --provider <id>
 openclaw models auth paste-token
 ```
+
+`models auth list` and the shorter `auth list` alias show configured auth
+profiles without printing raw API keys, tokens, or OAuth access tokens.
 
 `models auth add` is the interactive auth helper. It can launch a provider auth
 flow (OAuth/API key) or guide you into manual token paste, depending on the
@@ -165,7 +170,7 @@ provider you choose.
 `openclaw plugins list` to see which providers are installed.
 Use `openclaw models auth --agent <id> <subcommand>` to write auth results to a
 specific configured agent store. The parent `--agent` flag is honored by
-`add`, `login`, `setup-token`, `paste-token`, and `login-github-copilot`.
+`add`, `list`, `login`, `setup-token`, `paste-token`, and `login-github-copilot`.
 
 Examples:
 

--- a/src/cli/auth-cli.test.ts
+++ b/src/cli/auth-cli.test.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runRegisteredCli } from "../test-utils/command-runner.js";
+import { registerAuthCli } from "./auth-cli.js";
+
+const mocks = vi.hoisted(() => ({
+  modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../commands/models/auth-list.js", () => ({
+  modelsAuthListCommand: mocks.modelsAuthListCommand,
+}));
+
+describe("auth cli", () => {
+  beforeEach(() => {
+    mocks.modelsAuthListCommand.mockClear();
+  });
+
+  it("registers auth list", () => {
+    const program = new Command();
+    registerAuthCli(program);
+
+    const auth = program.commands.find((command) => command.name() === "auth");
+    expect(auth).toBeDefined();
+    expect(auth?.commands.find((command) => command.name() === "list")).toBeDefined();
+  });
+
+  it("passes list flags through to the auth list command", async () => {
+    await runRegisteredCli({
+      register: registerAuthCli,
+      argv: ["auth", "--agent", "poe", "list", "--json"],
+    });
+
+    expect(mocks.modelsAuthListCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "poe",
+        json: true,
+        plain: false,
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/src/cli/auth-cli.ts
+++ b/src/cli/auth-cli.ts
@@ -1,0 +1,39 @@
+import type { Command } from "commander";
+import { defaultRuntime } from "../runtime.js";
+import { resolveOptionFromCommand, runCommandWithRuntime } from "./cli-utils.js";
+
+function runAuthCommand(action: () => Promise<void>) {
+  return runCommandWithRuntime(defaultRuntime, action);
+}
+
+export function registerAuthCli(program: Command) {
+  const auth = program.command("auth").description("Manage model auth profiles");
+  auth.option("--agent <id>", "Agent id to inspect");
+  auth.action(() => {
+    auth.help();
+  });
+
+  auth
+    .command("list")
+    .description("List configured model auth profiles")
+    .option("--agent <id>", "Agent id to inspect")
+    .option("--json", "Output JSON", false)
+    .option("--plain", "Print profile ids only", false)
+    .action(async (opts, command) => {
+      const agent =
+        (opts.agent as string | undefined) ??
+        resolveOptionFromCommand<string>(command, "agent") ??
+        resolveOptionFromCommand<string>(auth, "agent");
+      await runAuthCommand(async () => {
+        const { modelsAuthListCommand } = await import("../commands/models/auth-list.js");
+        await modelsAuthListCommand(
+          {
+            json: Boolean(opts.json),
+            plain: Boolean(opts.plain),
+            agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+}

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -42,6 +42,10 @@ export type CliCommandCatalogEntry = {
 
 export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
+    commandPath: ["auth"],
+    policy: { loadPlugins: "never", networkProxy: "bypass", ensureCliPath: false },
+  },
+  {
     commandPath: ["crestodian"],
     policy: { bypassConfigGuard: true, loadPlugins: "never", ensureCliPath: false },
   },

--- a/src/cli/models-cli.test.ts
+++ b/src/cli/models-cli.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   noopAsync: vi.fn(async () => undefined),
   modelsAuthAddCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthLoginCommand: vi.fn().mockResolvedValue(undefined),
+  modelsAuthListCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthPasteTokenCommand: vi.fn().mockResolvedValue(undefined),
   modelsAuthSetupTokenCommand: vi.fn().mockResolvedValue(undefined),
 }));
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 const {
   modelsAuthAddCommand,
   modelsAuthLoginCommand,
+  modelsAuthListCommand,
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
   modelsStatusCommand,
@@ -27,6 +29,7 @@ vi.mock("../commands/models.js", () => ({
   modelsAliasesRemoveCommand: mocks.noopAsync,
   modelsAuthAddCommand: mocks.noopAsync,
   modelsAuthLoginCommand: mocks.modelsAuthLoginCommand,
+  modelsAuthListCommand: mocks.modelsAuthListCommand,
   modelsAuthOrderClearCommand: mocks.noopAsync,
   modelsAuthOrderGetCommand: mocks.noopAsync,
   modelsAuthOrderSetCommand: mocks.noopAsync,
@@ -60,6 +63,9 @@ vi.mock("../commands/models/auth.js", () => ({
   modelsAuthLoginCommand: mocks.modelsAuthLoginCommand,
   modelsAuthPasteTokenCommand: mocks.modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand: mocks.modelsAuthSetupTokenCommand,
+}));
+vi.mock("../commands/models/auth-list.js", () => ({
+  modelsAuthListCommand: mocks.modelsAuthListCommand,
 }));
 vi.mock("../commands/models/auth-order.js", () => ({
   modelsAuthOrderClearCommand: mocks.noopAsync,
@@ -97,6 +103,7 @@ describe("models cli", () => {
   beforeEach(() => {
     modelsAuthAddCommand.mockClear();
     modelsAuthLoginCommand.mockClear();
+    modelsAuthListCommand.mockClear();
     modelsAuthPasteTokenCommand.mockClear();
     modelsAuthSetupTokenCommand.mockClear();
     modelsStatusCommand.mockClear();
@@ -160,6 +167,12 @@ describe("models cli", () => {
       args: ["models", "auth", "--agent", "poe", "add"],
       command: modelsAuthAddCommand,
       expected: { agent: "poe" },
+    },
+    {
+      label: "list",
+      args: ["models", "auth", "--agent", "poe", "list", "--json"],
+      command: modelsAuthListCommand,
+      expected: { agent: "poe", json: true },
     },
     {
       label: "login",

--- a/src/cli/models-cli.ts
+++ b/src/cli/models-cli.ts
@@ -290,6 +290,28 @@ export function registerModelsCli(program: Command) {
   });
 
   auth
+    .command("list")
+    .description("List configured model auth profiles")
+    .option("--agent <id>", "Agent id to inspect")
+    .option("--json", "Output JSON", false)
+    .option("--plain", "Print profile ids only", false)
+    .action(async (opts, command) => {
+      const agent =
+        (opts.agent as string | undefined) ?? resolveOptionFromCommand<string>(command, "agent");
+      await runModelsCommand(async () => {
+        const { modelsAuthListCommand } = await import("../commands/models/auth-list.js");
+        await modelsAuthListCommand(
+          {
+            json: Boolean(opts.json),
+            plain: Boolean(opts.plain),
+            agent,
+          },
+          defaultRuntime,
+        );
+      });
+    });
+
+  auth
     .command("add")
     .description("Interactive auth helper (provider auth or paste token)")
     .action(async (command) => {

--- a/src/cli/program/register.subclis-core.ts
+++ b/src/cli/program/register.subclis-core.ts
@@ -75,6 +75,11 @@ async function registerSubCliWithPluginCommands(
 const entrySpecs: readonly CommandGroupDescriptorSpec<SubCliRegistrar>[] = [
   ...defineImportedProgramCommandGroupSpecs([
     {
+      commandNames: ["auth"],
+      loadModule: () => import("../auth-cli.js"),
+      exportName: "registerAuthCli",
+    },
+    {
       commandNames: ["acp"],
       loadModule: () => import("../acp-cli.js"),
       exportName: "registerAcpCli",

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -5,6 +5,11 @@ import { isPrivateQaCliEnabled } from "./private-qa-cli.js";
 export type SubCliDescriptor = NamedCommandDescriptor;
 
 const subCliCommandCatalog = defineCommandDescriptorCatalog([
+  {
+    name: "auth",
+    description: "Inspect model auth profiles",
+    hasSubcommands: true,
+  },
   { name: "acp", description: "Agent Control Protocol tools", hasSubcommands: true },
   {
     name: "gateway",

--- a/src/commands/models.ts
+++ b/src/commands/models.ts
@@ -10,6 +10,7 @@ export {
   modelsAuthPasteTokenCommand,
   modelsAuthSetupTokenCommand,
 } from "./models/auth.js";
+export { modelsAuthListCommand } from "./models/auth-list.js";
 export {
   modelsAuthOrderClearCommand,
   modelsAuthOrderGetCommand,

--- a/src/commands/models/auth-list.test.ts
+++ b/src/commands/models/auth-list.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAuthListProfileRows,
+  formatAuthListText,
+} from "./auth-list.js";
+import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
+
+describe("auth list", () => {
+  it("summarises auth profiles without exposing secrets", () => {
+    const now = Date.UTC(2026, 3, 28, 12);
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai:work": {
+          type: "oauth",
+          provider: "openai",
+          access: "fake-oauth-access",
+          refresh: "fake-oauth-refresh",
+          expires: now + 60 * 60 * 1000,
+          email: "user@example.com",
+        },
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "fake-api-key-value",
+        },
+        "minimax:ref": {
+          type: "token",
+          provider: "minimax",
+          tokenRef: { source: "env", provider: "default", id: "MINIMAX_TOKEN" },
+        },
+      },
+    };
+
+    const profiles = buildAuthListProfileRows(store, now);
+    expect(profiles).toEqual([
+      {
+        id: "anthropic:default",
+        provider: "anthropic",
+        type: "api_key",
+        account: null,
+        credential: "api-key",
+        status: "ok",
+        expiresAt: null,
+      },
+      {
+        id: "minimax:ref",
+        provider: "minimax",
+        type: "token",
+        account: null,
+        credential: "token-ref",
+        status: "ok",
+        expiresAt: null,
+      },
+      {
+        id: "openai:work",
+        provider: "openai",
+        type: "oauth",
+        account: "user@example.com",
+        credential: "oauth",
+        status: "expires in 1h",
+        expiresAt: now + 60 * 60 * 1000,
+      },
+    ]);
+
+    const text = formatAuthListText({
+      agentId: "main",
+      agentDir: "/tmp/openclaw-agent",
+      storePath: "/tmp/openclaw-agent/auth-profiles.json",
+      profiles,
+    });
+
+    expect(text).toContain("anthropic:default");
+    expect(text).toContain("api-key");
+    expect(text).toContain("oauth");
+    expect(text).not.toContain("fake-api-key-value");
+    expect(text).not.toContain("fake-oauth-access");
+    expect(text).not.toContain("fake-oauth-refresh");
+  });
+
+  it("marks unusable profiles before expiry status", () => {
+    const now = Date.UTC(2026, 3, 28, 12);
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "anthropic:default": {
+          type: "api_key",
+          provider: "anthropic",
+          key: "fake-api-key-value",
+        },
+      },
+      usageStats: {
+        "anthropic:default": {
+          cooldownUntil: now + 30 * 60 * 1000,
+        },
+      },
+    };
+
+    expect(buildAuthListProfileRows(store, now)[0]?.status).toBe("cooldown 30m");
+  });
+});

--- a/src/commands/models/auth-list.ts
+++ b/src/commands/models/auth-list.ts
@@ -1,0 +1,180 @@
+import { resolveAgentDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { formatRemainingShort } from "../../agents/auth-health.js";
+import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles/paths.js";
+import { loadAuthProfileStoreWithoutExternalProfiles } from "../../agents/auth-profiles/store.js";
+import type {
+  AuthProfileCredential,
+  AuthProfileStore,
+} from "../../agents/auth-profiles/types.js";
+import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../../runtime.js";
+import { normalizeOptionalString } from "../../shared/string-coerce.js";
+import { shortenHomePath } from "../../utils.js";
+import { loadValidConfigOrThrow, resolveKnownAgentId } from "./shared.js";
+
+export type AuthListProfileRow = {
+  id: string;
+  provider: string;
+  type: AuthProfileCredential["type"];
+  account: string | null;
+  credential: "api-key" | "api-key-ref" | "token" | "token-ref" | "oauth" | "missing";
+  status: string;
+  expiresAt: number | null;
+};
+
+export type AuthListResult = {
+  agentId: string;
+  agentDir: string;
+  storePath: string;
+  profiles: AuthListProfileRow[];
+};
+
+function resolveCredentialKind(profile: AuthProfileCredential): AuthListProfileRow["credential"] {
+  if (profile.type === "api_key") {
+    if (profile.keyRef) {
+      return "api-key-ref";
+    }
+    return profile.key ? "api-key" : "missing";
+  }
+  if (profile.type === "token") {
+    if (profile.tokenRef) {
+      return "token-ref";
+    }
+    return profile.token ? "token" : "missing";
+  }
+  return profile.access ? "oauth" : "missing";
+}
+
+function resolveProfileExpiresAt(profile: AuthProfileCredential): number | null {
+  if (profile.type === "api_key") {
+    return null;
+  }
+  return typeof profile.expires === "number" ? profile.expires : null;
+}
+
+function resolveProfileStatus(params: {
+  store: AuthProfileStore;
+  profileId: string;
+  profile: AuthProfileCredential;
+  credential: AuthListProfileRow["credential"];
+  nowMs: number;
+}): string {
+  const unusableUntil = resolveProfileUnusableUntilForDisplay(params.store, params.profileId);
+  if (unusableUntil && params.nowMs < unusableUntil) {
+    const stats = params.store.usageStats?.[params.profileId];
+    const kind =
+      typeof stats?.disabledUntil === "number" && params.nowMs < stats.disabledUntil
+        ? "disabled"
+        : "cooldown";
+    return `${kind} ${formatRemainingShort(unusableUntil - params.nowMs)}`;
+  }
+  if (params.credential === "missing") {
+    return "missing";
+  }
+  const expiresAt = resolveProfileExpiresAt(params.profile);
+  if (!expiresAt) {
+    return "ok";
+  }
+  if (expiresAt <= params.nowMs) {
+    return "expired";
+  }
+  return `expires in ${formatRemainingShort(expiresAt - params.nowMs)}`;
+}
+
+export function buildAuthListProfileRows(
+  store: AuthProfileStore,
+  nowMs = Date.now(),
+): AuthListProfileRow[] {
+  return Object.entries(store.profiles)
+    .map(([profileId, profile]) => {
+      const credential = resolveCredentialKind(profile);
+      return {
+        id: profileId,
+        provider: profile.provider,
+        type: profile.type,
+        account:
+          normalizeOptionalString(profile.email) ??
+          normalizeOptionalString(profile.displayName) ??
+          null,
+        credential,
+        status: resolveProfileStatus({
+          store,
+          profileId,
+          profile,
+          credential,
+          nowMs,
+        }),
+        expiresAt: resolveProfileExpiresAt(profile),
+      };
+    })
+    .toSorted((a, b) => a.provider.localeCompare(b.provider) || a.id.localeCompare(b.id));
+}
+
+function pad(value: string, width: number): string {
+  return value.length >= width ? value : `${value}${" ".repeat(width - value.length)}`;
+}
+
+export function formatAuthListText(result: AuthListResult): string {
+  const lines = [
+    `Agent: ${result.agentId}`,
+    `Auth store: ${shortenHomePath(result.storePath)}`,
+    "",
+  ];
+
+  if (result.profiles.length === 0) {
+    lines.push("No auth profiles found.");
+    return lines.join("\n");
+  }
+
+  const headers = ["Profile", "Provider", "Type", "Credential", "Account", "Status"];
+  const rows = result.profiles.map((profile) => [
+    profile.id,
+    profile.provider,
+    profile.type,
+    profile.credential,
+    profile.account ?? "-",
+    profile.status,
+  ]);
+  const widths = headers.map((header, index) =>
+    Math.max(header.length, ...rows.map((row) => row[index]?.length ?? 0)),
+  );
+  lines.push(headers.map((header, index) => pad(header, widths[index] ?? header.length)).join("  "));
+  lines.push(widths.map((width) => "-".repeat(width)).join("  "));
+  for (const row of rows) {
+    lines.push(row.map((value, index) => pad(value, widths[index] ?? value.length)).join("  "));
+  }
+  return lines.join("\n");
+}
+
+export async function modelsAuthListCommand(
+  opts: {
+    agent?: string;
+    json?: boolean;
+    plain?: boolean;
+  },
+  runtime: RuntimeEnv,
+) {
+  const cfg = await loadValidConfigOrThrow();
+  const agentId =
+    resolveKnownAgentId({ cfg, rawAgentId: opts.agent }) ?? resolveDefaultAgentId(cfg);
+  const agentDir = resolveAgentDir(cfg, agentId);
+  const store = loadAuthProfileStoreWithoutExternalProfiles(agentDir);
+  const result: AuthListResult = {
+    agentId,
+    agentDir,
+    storePath: resolveAuthStorePathForDisplay(agentDir),
+    profiles: buildAuthListProfileRows(store),
+  };
+
+  if (opts.json) {
+    writeRuntimeJson(runtime, result);
+    return;
+  }
+  if (opts.plain) {
+    for (const profile of result.profiles) {
+      runtime.log(profile.id);
+    }
+    return;
+  }
+  runtime.log(formatAuthListText(result));
+}


### PR DESCRIPTION
## Summary

- Problem: `openclaw auth list` is currently unavailable for users trying to inspect saved model auth profiles.
- Why it matters: scripts and troubleshooting flows need a read-only way to confirm configured auth profile ids without reading `auth-profiles.json` directly.
- What changed: added `openclaw auth list` plus `openclaw models auth list`, with text, JSON, and plain output that does not print raw API keys, tokens, or OAuth access tokens.
- What did NOT change (scope boundary): no auth creation, refresh, login, secret resolution, or provider probing behaviour changed.

Fixes #73305.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73305
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the model auth CLI had login/setup/order helpers but no read-only list subcommand, and there was no top-level `auth` command registered.
- Missing detection / guardrail: command-registration tests did not cover the expected `auth list` affordance.
- Contributing context (if known): users had to read the auth store JSON directly to inspect saved profiles.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/cli/auth-cli.test.ts`, `src/cli/models-cli.test.ts`, `src/commands/models/auth-list.test.ts`
- Scenario the test should lock in: both CLI surfaces route to the same read-only list command, and formatted output does not include stored secret values.
- Why this is the smallest reliable guardrail: the bug is command wiring plus output sanitisation, so command-level and formatter unit tests cover the regression without provider/network setup.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw auth list` and `openclaw models auth list` now print configured model auth profile metadata. `--json` emits structured metadata and `--plain` emits profile ids only.

## Diagram (if applicable)

N/A

```text
Before:
openclaw auth list -> unknown command

After:
openclaw auth list -> read auth profile store -> redacted profile summary
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: this adds a read-only CLI command for existing local auth profile metadata. Output intentionally reports credential kind/status only and tests assert raw API keys and OAuth token values are not printed.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw auth list`.
2. Run `openclaw models auth list --json`.

### Expected

- Commands print auth profile metadata without raw secret values.

### Actual

- Current release reports `auth` as unavailable or leaves users without a read-only profile-listing command.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local command evidence:

- `git diff --check HEAD~1..HEAD` passed.
- `pnpm install` was attempted twice but blocked before tests by Corepack registry timeouts while downloading `pnpm 10.33.0` (`UND_ERR_CONNECT_TIMEOUT`).

## Human Verification (required)

- Verified scenarios: source-level command wiring for `auth list` and `models auth list`; formatter tests cover redaction of API key, token, and OAuth values.
- Edge cases checked: missing credential marker, OAuth expiry display, cooldown status precedence.
- What you did **not** verify: local Vitest/typecheck/format, because this machine could not download pnpm through Corepack. CI should run the new test files.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: auth metadata output could accidentally reveal secret material.
  - Mitigation: the formatter reports only credential kind and status, and unit coverage asserts raw key/token values are absent.
