### PR TITLE
fix: allow custom control UI origins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Active Memory docs: document the `cacheTtlMs` 1000-120000 ms range and 15000 ms default so setup snippets do not lead users past the schema limit. Fixes #65708. (#65737) Thanks @WuKongAI-CMU.
 - fix(agents): canonicalize provider aliases in byProvider tool policy lookup [AI]. (#72917) Thanks @pgondhi987.
 - fix(security): block npm_execpath injection from workspace .env [AI-assisted]. (#73262) Thanks @pgondhi987.
+- Gateway/Control UI: match custom-scheme browser origins such as `tauri://localhost` against explicit `gateway.controlUi.allowedOrigins` entries, so desktop wrappers do not need wildcard origins. Fixes #46520. Thanks @mosidevv.
 - Tools/web_fetch: decode response bodies from raw bytes using declared HTTP, XML, or HTML meta charsets before extraction, so Shift_JIS and other legacy-charset pages no longer return mojibake. Fixes #72916. Thanks @amknight.
 - Active Memory: skip payload-less `memory_search` transcript tool results when building debug telemetry, so newer empty entries no longer hide the latest useful debug payload. (#68773) Thanks @SimbaKingjoe.
 - Channels/Discord: bound message read/search REST calls, route those actions through Gateway execution, and fall back to `CommandTargetSessionKey` for inbound hook session keys so Discord reads do not hang and hooks still fire when `SessionKey` is empty. Fixes #73431. (#73521) Thanks @amknight.

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -57,6 +57,24 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: true as const, matchedBy: "allowlist" as const },
     },
     {
+      name: "accepts allowlisted custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "tauri://LOCALHOST",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "rejects unlisted custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "electron://localhost",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: false as const, reason: "origin not allowed" },
+    },
+    {
       name: "rejects missing origin",
       input: {
         requestHost: "gateway.example.com:18789",

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -110,6 +110,60 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: true as const, matchedBy: "allowlist" as const },
     },
     {
+      name: "accepts allowlisted app custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "app://localhost",
+        allowedOrigins: ["app://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "accepts allowlisted electron custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "electron://localhost",
+        allowedOrigins: ["electron://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "accepts allowlisted tauri custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "tauri://LOCALHOST",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: true as const, matchedBy: "allowlist" as const },
+    },
+    {
+      name: "rejects unlisted custom-scheme origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "electron://localhost",
+        allowedOrigins: ["tauri://localhost"],
+      },
+      expected: { ok: false as const, reason: "origin not allowed" },
+    },
+    {
+      name: "rejects hostless file opaque origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "file:///tmp/openclaw.html",
+        allowedOrigins: ["file://"],
+      },
+      expected: { ok: false as const, reason: "origin missing or invalid" },
+    },
+    {
+      name: "rejects hostless data opaque origins",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "data:text/plain,hello",
+        allowedOrigins: ["data:text/plain,hello"],
+      },
+      expected: { ok: false as const, reason: "origin missing or invalid" },
+    },
+    {
       name: "rejects missing origin",
       input: {
         requestHost: "gateway.example.com:18789",
@@ -130,6 +184,14 @@ describe("checkBrowserOrigin", () => {
       input: {
         requestHost: "gateway.example.com:18789",
         origin: "not a url",
+      },
+      expected: { ok: false as const, reason: "origin missing or invalid" },
+    },
+    {
+      name: "rejects malformed standard origin URLs",
+      input: {
+        requestHost: "gateway.example.com:18789",
+        origin: "http://localhost:abc",
       },
       expected: { ok: false as const, reason: "origin missing or invalid" },
     },

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -20,8 +20,12 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    const origin =
+      url.origin === "null" && url.protocol && url.host
+        ? `${url.protocol}//${url.host}`
+        : url.origin;
     return {
-      origin: normalizeLowercaseStringOrEmpty(url.origin),
+      origin: normalizeLowercaseStringOrEmpty(origin),
       host: normalizeLowercaseStringOrEmpty(url.host),
       hostname: normalizeLowercaseStringOrEmpty(url.hostname),
     };

--- a/src/gateway/origin-check.ts
+++ b/src/gateway/origin-check.ts
@@ -23,9 +23,19 @@ function parseOrigin(
   }
   try {
     const url = new URL(trimmed);
+    const host = normalizeLowercaseStringOrEmpty(url.host);
+    const origin =
+      url.origin && url.origin !== "null"
+        ? normalizeLowercaseStringOrEmpty(url.origin)
+        : url.protocol && host
+          ? normalizeLowercaseStringOrEmpty(`${url.protocol}//${host}`)
+          : "";
+    if (!origin) {
+      return null;
+    }
     return {
-      origin: normalizeLowercaseStringOrEmpty(url.origin),
-      host: normalizeLowercaseStringOrEmpty(url.host),
+      origin,
+      host,
       hostname: normalizeLowercaseStringOrEmpty(url.hostname),
     };
   } catch {

--- a/src/gateway/server.auth.browser-hardening.test.ts
+++ b/src/gateway/server.auth.browser-hardening.test.ts
@@ -277,36 +277,51 @@ describe("gateway auth browser hardening", () => {
       origin: ALLOWED_BROWSER_ORIGIN,
       ok: true,
     },
-  ])("keeps non-proxy browser-origin behavior unchanged: $name", async ({ origin, ok }) => {
-    const { writeConfigFile } = await import("../config/config.js");
-    testState.gatewayAuth = { mode: "token", token: "secret" };
-    await writeConfigFile({
-      gateway: {
-        controlUi: {
-          allowedOrigins: [ALLOWED_BROWSER_ORIGIN],
+    {
+      name: "accepts allowlisted custom-scheme origins",
+      origin: "tauri://localhost",
+      allowedOrigins: ["tauri://localhost"],
+      ok: true,
+    },
+    {
+      name: "rejects unlisted non-loopback custom-scheme origins",
+      origin: "electron://attacker.example",
+      allowedOrigins: ["tauri://localhost"],
+      ok: false,
+    },
+  ])(
+    "keeps non-proxy browser-origin behavior unchanged: $name",
+    async ({ origin, allowedOrigins, ok }) => {
+      const { writeConfigFile } = await import("../config/config.js");
+      testState.gatewayAuth = { mode: "token", token: "secret" };
+      await writeConfigFile({
+        gateway: {
+          controlUi: {
+            allowedOrigins: allowedOrigins ?? [ALLOWED_BROWSER_ORIGIN],
+          },
         },
-      },
-    });
+      });
 
-    await withGatewayServer(async ({ port }) => {
-      const ws = await openWs(port, { origin });
-      try {
-        const res = await connectReq(ws, {
-          token: "secret",
-          client: TEST_OPERATOR_CLIENT,
-          device: null,
-        });
-        expect(res.ok).toBe(ok);
-        if (ok) {
-          expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
-        } else {
-          expectOriginNotAllowed(res);
+      await withGatewayServer(async ({ port }) => {
+        const ws = await openWs(port, { origin });
+        try {
+          const res = await connectReq(ws, {
+            token: "secret",
+            client: TEST_OPERATOR_CLIENT,
+            device: null,
+          });
+          expect(res.ok).toBe(ok);
+          if (ok) {
+            expect((res.payload as { type?: string } | undefined)?.type).toBe("hello-ok");
+          } else {
+            expectOriginNotAllowed(res);
+          }
+        } finally {
+          ws.close();
         }
-      } finally {
-        ws.close();
-      }
-    });
-  });
+      });
+    },
+  );
 
   test("rejects non-local browser origins for non-control-ui clients", async () => {
     await expectBrowserOriginConnectRejected({});


### PR DESCRIPTION
## What Problem This Solves

`gateway.controlUi.allowedOrigins` supports explicit browser origin allowlists, but hosted custom desktop-app origins such as `tauri://localhost`, `electron://localhost`, and `app://localhost` currently fail exact matching. The root cause is WHATWG URL behaviour: `new URL("tauri://localhost").origin` serialises as `null`, so the Gateway compares the configured `tauri://localhost` allowlist entry with `null` and rejects the browser WebSocket connection.

This matters for Tauri/Electron-style Control UI wrappers because operators currently have to use wildcard origins even when they want a specific origin allowlist.

## Summary

- Preserve normal `URL.origin` behaviour for standard web origins.
- For parsed hosted opaque origins only, reconstruct the exact `protocol//host` value before matching against `gateway.controlUi.allowedOrigins`.
- Keep configured allowlist values as exact trimmed/lowercase strings, plus the existing `*` behaviour.
- Do not add wildcard, prefix, or scheme-pattern policy.
- Keep literal `Origin: null`, malformed origins, hostless `file:`/`data:` origins, and unlisted custom origins rejected.

## Linked Issue

Closes #46520.

## Evidence

Validation added in this branch:

- `src/gateway/origin-check.test.ts` covers exact allowlist success for `app://localhost`, `electron://localhost`, and `tauri://localhost`.
- `src/gateway/origin-check.test.ts` covers rejection for an unlisted hosted custom-scheme origin.
- `src/gateway/origin-check.test.ts` covers fail-closed behaviour for literal `Origin: null`, malformed origins, `file:` origins, and `data:` origins.
- `src/gateway/server.auth.browser-hardening.test.ts` starts a real Gateway, configures `gateway.controlUi.allowedOrigins`, opens a WebSocket with a browser `Origin` header, and verifies both sides of the runtime boundary:
  - `Origin: tauri://localhost` with `allowedOrigins: ["tauri://localhost"]` reaches `hello-ok`.
  - `Origin: electron://attacker.example` with `allowedOrigins: ["tauri://localhost"]` is rejected through the existing `CONTROL_UI_ORIGIN_NOT_ALLOWED` path.

Local verification:

- `git diff --check upstream/main...HEAD` passed.
- Local Vitest could not run in this worktree because dependency verification attempted registry fetches and repeatedly timed out with npm `ETIMEDOUT` before Vitest started. GitHub CI is running the branch with dependencies available.

## Security Impact

- New permissions/capabilities: No.
- Secrets/tokens handling changed: No.
- New/changed network calls: No.
- Command/tool execution surface changed: No.
- Data access scope changed: No.

The security boundary remains explicit allowlist matching. The parser fallback only changes the parsed origin string for successfully parsed URLs that have both a protocol and a host.

## Compatibility

Backward compatible. No config, migration, or docs changes are required.
