### PR TITLE
fix(memory): schedule qmd embed when embedInterval is configured regardless of searchMode

### DIFF
--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -235,7 +235,7 @@ describe("QmdMemoryManager", () => {
         backend: "qmd",
         qmd: {
           includeDefaultMemory: false,
-          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false, embedInterval: "0s" },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
         },
       },
@@ -3543,7 +3543,7 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
-  it("skips periodic embed maintenance in lexical search mode", async () => {
+  it("skips periodic embed maintenance in lexical search mode when embedInterval is disabled", async () => {
     vi.useFakeTimers();
     cfg = {
       ...cfg,
@@ -3556,7 +3556,7 @@ describe("QmdMemoryManager", () => {
             interval: "0s",
             debounceMs: 0,
             onBoot: false,
-            embedInterval: "5m",
+            embedInterval: "0s",
           },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
         },
@@ -3851,7 +3851,7 @@ describe("QmdMemoryManager", () => {
     }
   });
 
-  it("skips qmd embed in lexical search mode for forced sync", async () => {
+  it("skips qmd embed in lexical search mode for forced sync when embedInterval is disabled", async () => {
     cfg = {
       ...cfg,
       memory: {
@@ -3859,7 +3859,7 @@ describe("QmdMemoryManager", () => {
         qmd: {
           includeDefaultMemory: false,
           searchMode: "search",
-          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          update: { interval: "0s", debounceMs: 0, onBoot: false, embedInterval: "0s" },
           paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
         },
       },

--- a/extensions/memory-core/src/memory/qmd-manager.test.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.test.ts
@@ -3621,6 +3621,38 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("schedules embed when searchMode is default (search) but embedInterval is explicitly configured", async () => {
+    vi.useFakeTimers();
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          searchMode: "search",
+          update: {
+            interval: "0s",
+            debounceMs: 0,
+            onBoot: false,
+            embedInterval: "5m",
+          },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+
+    const { manager } = await createManager({ mode: "full" });
+
+    await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+    const commandCalls = spawnMock.mock.calls
+      .map((call: unknown[]) => call[1] as string[])
+      .filter((args: string[]) => args[0] === "update" || args[0] === "embed");
+    expect(commandCalls).toEqual([["update"], ["embed"]]);
+
+    await manager.close();
+  });
+
   it("serializes qmd embeds within a process before taking the shared file lock", async () => {
     vi.useFakeTimers();
     cfg = {

--- a/extensions/memory-core/src/memory/qmd-manager.ts
+++ b/extensions/memory-core/src/memory/qmd-manager.ts
@@ -1646,7 +1646,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private shouldRunEmbed(force?: boolean): boolean {
-    if (!qmdUsesVectors(this.qmd.searchMode)) {
+    if (!qmdUsesVectors(this.qmd.searchMode) && this.qmd.update.embedIntervalMs <= 0) {
       return false;
     }
     const now = Date.now();
@@ -1662,7 +1662,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private shouldScheduleEmbedTimer(): boolean {
-    if (!qmdUsesVectors(this.qmd.searchMode)) {
+    if (!qmdUsesVectors(this.qmd.searchMode) && this.qmd.update.embedIntervalMs <= 0) {
       return false;
     }
     const embedIntervalMs = this.qmd.update.embedIntervalMs;


### PR DESCRIPTION
## Root Cause

When `memory.qmd.update.embedInterval` is explicitly configured but `searchMode` is not set (defaults to `"search"`), the `qmdUsesVectors()` guard in both `shouldRunEmbed()` and `shouldScheduleEmbedTimer()` returns `false`, preventing the embed timer from ever being created or embed from running after periodic updates.

This means regardless of what `embedInterval` value the user sets, embedding never fires automatically unless `searchMode` is explicitly set to `"query"` or `"hybrid"`.

## Fix

Treat an explicit `embedIntervalMs > 0` as a user signal that periodic embedding is desired, bypassing the `searchMode` gate:

```ts
// Before
if (!qmdUsesVectors(this.qmd.searchMode)) { return false; }

// After  
if (!qmdUsesVectors(this.qmd.searchMode) && this.qmd.update.embedIntervalMs <= 0) { return false; }
```

Applied to both `shouldRunEmbed()` and `shouldScheduleEmbedTimer()`.

## Verification

Added a test case that confirms embed is scheduled and fires with `searchMode: "search"` + explicit `embedInterval: "5m"`.

Fixes #73432