### PR TITLE
fix(telegram): scope native quote streaming guard to real quotes (#73505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
-- Channels/Telegram: scope the streaming-disable guard for native quote replies to actual user-selected quotes (`replyQuoteText` + resolvable `replyQuoteMessageId`), so plain `reply_to_message_id` replies under `channels.telegram.replyToMode: "first"` no longer trip `hasNativeQuoteReply` and silently fall back to whole-message delivery, while quote-bearing replies still skip the streaming preview path that `editMessageText` cannot re-send. Fixes #73505.
+- Channels/Telegram: scope the streaming-disable guard for native quote replies to actual user-selected quotes (`replyQuoteText` + resolvable `replyQuoteMessageId`), so plain `reply_to_message_id` replies under `channels.telegram.replyToMode: "first"` no longer trip `hasNativeQuoteReply` and silently fall back to whole-message delivery, while quote-bearing replies still skip the streaming preview path that `editMessageText` cannot re-send. Fixes #73505. Thanks @choury.
 
 ## 2026.4.27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 - Plugins/media: auto-enable provider plugins referenced by `agents.defaults.imageGenerationModel`, `videoGenerationModel`, and `musicGenerationModel` primary/fallback refs, so configured Google and MiniMax media providers do not stay disabled behind a restrictive plugin allowlist. Thanks @vincentkoc.
 - Memory-core/dreaming: retry managed dreaming cron registration after startup when the cron service is not reachable yet, so the scheduled Memory Dreaming Promotion sweep recovers without waiting for heartbeat traffic. Fixes #72841. Thanks @amknight.
+- Channels/Telegram: scope the streaming-disable guard for native quote replies to actual user-selected quotes (`replyQuoteText` + resolvable `replyQuoteMessageId`), so plain `reply_to_message_id` replies under `channels.telegram.replyToMode: "first"` no longer trip `hasNativeQuoteReply` and silently fall back to whole-message delivery, while quote-bearing replies still skip the streaming preview path that `editMessageText` cannot re-send. Fixes #73505.
 
 ## 2026.4.27
 

--- a/extensions/telegram/src/bot-message-dispatch.test.ts
+++ b/extensions/telegram/src/bot-message-dispatch.test.ts
@@ -473,6 +473,8 @@ describe("dispatchTelegramMessage draft streaming", () => {
   });
 
   it("passes native quote candidates for current message replies", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
     dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
       await dispatcherOptions.deliver({ text: "Hello", replyToId: "1001" }, { kind: "final" });
       return { queuedFinal: true };
@@ -492,7 +494,12 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     });
 
-    expect(createTelegramDraftStream).not.toHaveBeenCalled();
+    // A plain reply (no `ReplyToIsQuote`) is compatible with streaming —
+    // `editMessageText` on the preview message round-trips with
+    // `reply_to_message_id` unchanged. Native quote candidates are still
+    // attached for the eventual final delivery so the bot can fall back to
+    // a quote-bearing reply if a later send fails. See #73505.
+    expect(createTelegramDraftStream).toHaveBeenCalled();
     expect(deliverReplies).toHaveBeenCalledWith(
       expect.objectContaining({
         replies: [expect.objectContaining({ replyToId: "1001" })],
@@ -505,6 +512,43 @@ describe("dispatchTelegramMessage draft streaming", () => {
         },
       }),
     );
+  });
+
+  it("keeps answer draft preview for plain replies in groups with replyToMode set", async () => {
+    const draftStream = createDraftStream();
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Hello" });
+        await dispatcherOptions.deliver({ text: "Hello", replyToId: "1001" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    // Regression for #73505: when the user has set
+    // `channels.telegram.replyToMode: "first"` (or any non-`"off"` value)
+    // but the inbound message is a plain message — no quote selection — the
+    // streaming-disable guard should not fire. Before the fix, any
+    // candidate added by `addTelegramNativeQuoteCandidate` for the inbound
+    // message would flip `hasNativeQuoteReply` to true and silently
+    // disable the partial-stream preview.
+    await dispatchWithContext({
+      context: createContext({
+        msg: {
+          message_id: 1001,
+          text: "Original current message",
+        } as unknown as TelegramMessageContext["msg"],
+        ctxPayload: {
+          MessageSid: "1001",
+        } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      replyToMode: "first",
+      streamMode: "partial",
+    });
+
+    expect(createTelegramDraftStream).toHaveBeenCalled();
+    expect(draftStream.update).toHaveBeenCalledWith("Hello");
   });
 
   it("passes native quote candidates for explicit reply targets", async () => {

--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -392,8 +392,16 @@ export const dispatchTelegramMessage = async ({
       );
     }
   }
+  // Streaming is only incompatible with replies that carry a Telegram
+  // `quote` parameter — `editMessageText` cannot re-send the quote on each
+  // edit, so the preview path falls back to a single send. Plain
+  // `reply_to_message_id` (no quote) round-trips through `editMessageText`
+  // unchanged, so the streaming-disable guard must require an actual quote
+  // selection (text + resolvable message id), not just the presence of any
+  // candidate added by `addTelegramNativeQuoteCandidate` for the current
+  // inbound message. See #73505.
   const hasNativeQuoteReply =
-    replyToMode !== "off" && Object.keys(replyQuoteByMessageId).length > 0;
+    replyToMode !== "off" && replyQuoteText != null && replyQuoteMessageId != null;
   const canStreamAnswerDraft =
     previewStreamingEnabled &&
     !hasNativeQuoteReply &&


### PR DESCRIPTION
## What

Fixes #73505. When `channels.telegram.replyToMode` is set to anything other than `"off"`, partial-stream preview is silently disabled for plain replies even though `editMessageText` round-trips with `reply_to_message_id` unchanged. The result is that operators with `replyToMode: "first"` see no streaming preview at all — text appears only after the run completes.

## Root cause

`bot-message-dispatch.ts` builds a `replyQuoteByMessageId` map for native-quote candidate lookups during delivery, then computes:

```ts
const hasNativeQuoteReply =
  replyToMode !== "off" && Object.keys(replyQuoteByMessageId).length > 0;
```

Under `replyToMode !== "off"` the dispatcher unconditionally calls `addTelegramNativeQuoteCandidate(replyQuoteByMessageId, ctxPayload.MessageSid ?? msg.message_id, ...)` for the inbound message itself, so any inbound message with text populates the map and trips `hasNativeQuoteReply` → `canStreamAnswerDraft = false` → no preview lane.

The reason streaming is incompatible with native quote replies is the Telegram `quote` parameter, which `editMessageText` cannot re-send. Plain `reply_to_message_id` (no quote) does not have that constraint — and the dispatcher already passes `draftReplyToMessageId` into `createTelegramDraftStream`, which means the rest of the codepath is built to handle this case.

## Fix

Tighten the guard to require an actual user-selected quote, matching the same `replyQuoteText && replyQuoteMessageId != null` pattern already used a few lines above to gate `addTelegramNativeQuoteCandidate` for explicit reply targets:

```ts
const hasNativeQuoteReply =
  replyToMode !== "off" && replyQuoteText != null && replyQuoteMessageId != null;
```

`replyQuoteText` is only set when `ctxPayload.ReplyToIsQuote` is true, and `replyQuoteMessageId` is only set when that quote points at a non-external resolvable message. Together they describe the only case where streaming truly cannot work.

## Behavior preserved

- Quote-bearing replies (`ReplyToIsQuote=true` with text + resolvable id) still take the non-streaming path — covered by the existing `skips answer draft preview for same-chat selected quotes` test.
- `replyQuoteByMessageId` is still passed verbatim to `deliverReplies` for fallback handling — covered by the existing `passes native quote candidates for current message replies` and `passes native quote candidates for explicit reply targets` tests, which still assert the same map payload.

## Test changes

- `passes native quote candidates for current message replies` — flipped from asserting `createTelegramDraftStream` is NOT called to asserting it IS called. The map-payload assertion is unchanged: candidates are still attached for the eventual final delivery.
- New regression test `keeps answer draft preview for plain replies in groups with replyToMode set` — pins #73505 behavior directly with `replyToMode: "first"` + `streamMode: "partial"` + plain inbound message → expects `createTelegramDraftStream` and `draftStream.update("Hello")`.

## Verified locally

```
npx oxlint extensions/telegram/src/bot-message-dispatch.ts extensions/telegram/src/bot-message-dispatch.test.ts
# Found 0 warnings and 0 errors.

npx vitest run extensions/telegram/src/bot-message-dispatch.test.ts
# Tests  109 passed (109)

npx vitest run extensions/telegram/src/bot/delivery.test.ts
# Tests  41 passed (41)
```

lobster-biscuit: 73505-replytomode-streaming-guard

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
