### PR TITLE
fix(agents): skip implicit provider discovery when models.mode is replace [AI-assisted]

### DIFF
--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -56,24 +56,31 @@ export async function resolveProvidersForModelsJsonWithDeps(
 ): Promise<Record<string, ProviderConfig>> {
   const { cfg, agentDir, env } = params;
   const explicitProviders = cfg.models?.providers ?? {};
-  const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
-  const implicitProviders = await resolveImplicitProvidersImpl({
-    agentDir,
-    config: cfg,
-    env,
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
-    explicitProviders,
-    ...(params.pluginMetadataSnapshot
-      ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
-      : {}),
-    ...(params.providerDiscoveryProviderIds
-      ? { providerDiscoveryProviderIds: params.providerDiscoveryProviderIds }
-      : {}),
-    ...(params.providerDiscoveryTimeoutMs !== undefined
-      ? { providerDiscoveryTimeoutMs: params.providerDiscoveryTimeoutMs }
-      : {}),
-    ...(params.providerDiscoveryEntriesOnly === true ? { providerDiscoveryEntriesOnly: true } : {}),
-  });
+  const mode = cfg.models?.mode ?? "merge";
+  let implicitProviders: Record<string, ProviderConfig> = {};
+  if (mode !== "replace") {
+    const resolveImplicitProvidersImpl = deps?.resolveImplicitProviders ?? resolveImplicitProviders;
+    implicitProviders =
+      (await resolveImplicitProvidersImpl({
+        agentDir,
+        config: cfg,
+        env,
+        ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+        explicitProviders,
+        ...(params.pluginMetadataSnapshot
+          ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
+          : {}),
+        ...(params.providerDiscoveryProviderIds
+          ? { providerDiscoveryProviderIds: params.providerDiscoveryProviderIds }
+          : {}),
+        ...(params.providerDiscoveryTimeoutMs !== undefined
+          ? { providerDiscoveryTimeoutMs: params.providerDiscoveryTimeoutMs }
+          : {}),
+        ...(params.providerDiscoveryEntriesOnly === true
+          ? { providerDiscoveryEntriesOnly: true }
+          : {}),
+      })) ?? {};
+  }
   return mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,

--- a/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
+++ b/src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import {
+  planOpenClawModelsJsonWithDeps,
+  resolveProvidersForModelsJsonWithDeps,
+} from "./models-config.plan.js";
+import type { ProviderConfig } from "./models-config.providers.secrets.js";
+
+function createExplicitProvider(id: string): ProviderConfig {
+  return {
+    baseUrl: `https://${id}.example/v1`,
+    api: "openai-completions",
+    apiKey: `${id.toUpperCase()}_API_KEY`,
+    models: [
+      {
+        id: `${id}-model`,
+        name: `${id} model`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 8192,
+        maxTokens: 4096,
+      },
+    ],
+  };
+}
+
+describe("models-config replace mode skips implicit discovery", () => {
+  it("does not call resolveImplicitProviders when mode is replace", async () => {
+    let implicitProvidersCalled = false;
+
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "replace",
+            providers: {
+              custom: createExplicitProvider("custom"),
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-replace-mode-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async () => {
+          implicitProvidersCalled = true;
+          return { implicit: createExplicitProvider("implicit") };
+        },
+      },
+    );
+
+    expect(implicitProvidersCalled).toBe(false);
+    expect(providers["custom"]).toBeDefined();
+    expect(providers["implicit"]).toBeUndefined();
+  });
+
+  it("returns only explicit providers when mode is replace", async () => {
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "replace",
+            providers: {
+              "my-provider": createExplicitProvider("my-provider"),
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-replace-mode-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async () => {
+          throw new Error("should not be called in replace mode");
+        },
+      },
+    );
+
+    expect(Object.keys(providers)).toEqual(["my-provider"]);
+    expect(providers["my-provider"]?.baseUrl).toBe("https://my-provider.example/v1");
+  });
+
+  it("still calls resolveImplicitProviders when mode is merge", async () => {
+    let implicitProvidersCalled = false;
+
+    const providers = await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "merge",
+            providers: {
+              custom: createExplicitProvider("custom"),
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-replace-mode-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async () => {
+          implicitProvidersCalled = true;
+          return { implicit: createExplicitProvider("implicit") };
+        },
+      },
+    );
+
+    expect(implicitProvidersCalled).toBe(true);
+    expect(providers["custom"]).toBeDefined();
+    expect(providers["implicit"]).toBeDefined();
+  });
+
+  it("still calls resolveImplicitProviders when mode is unset (defaults to merge)", async () => {
+    let implicitProvidersCalled = false;
+
+    await resolveProvidersForModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            providers: {},
+          },
+        },
+        agentDir: "/tmp/openclaw-replace-mode-test",
+        env: {},
+      },
+      {
+        resolveImplicitProviders: async () => {
+          implicitProvidersCalled = true;
+          return {};
+        },
+      },
+    );
+
+    expect(implicitProvidersCalled).toBe(true);
+  });
+
+  it("skips implicit discovery in planOpenClawModelsJsonWithDeps when mode is replace", async () => {
+    let implicitProvidersCalled = false;
+
+    const plan = await planOpenClawModelsJsonWithDeps(
+      {
+        cfg: {
+          models: {
+            mode: "replace",
+            providers: {
+              custom: createExplicitProvider("custom"),
+            },
+          },
+        },
+        agentDir: "/tmp/openclaw-replace-mode-test",
+        env: {},
+        existingRaw: "",
+        existingParsed: null,
+      },
+      {
+        resolveImplicitProviders: async () => {
+          implicitProvidersCalled = true;
+          return { implicit: createExplicitProvider("implicit") };
+        },
+      },
+    );
+
+    expect(implicitProvidersCalled).toBe(false);
+    expect(plan.action).toBe("write");
+    if (plan.action === "write") {
+      const parsed = JSON.parse(plan.contents) as { providers: Record<string, unknown> };
+      expect(parsed.providers["custom"]).toBeDefined();
+      expect(parsed.providers["implicit"]).toBeUndefined();
+    }
+  });
+});


### PR DESCRIPTION
> 🤖 AI-assisted (built with Claude Code via Hermes orchestration). Test level: fully tested. Prompt summary available on request.

## Summary
- Problem: `models.mode="replace"` is documented to use only explicitly configured providers, but `resolveProvidersForModelsJsonWithDeps` unconditionally calls `resolveImplicitProviders()`, causing unnecessary provider discovery and 72+ second startup delays.
- Why it matters: Users who explicitly set `models.mode="replace"` to avoid implicit provider discovery still get the full discovery cost, defeating the purpose of the config.
- What changed: Guarded the `resolveImplicitProviders` call with a `mode !== "replace"` check so replace mode skips implicit discovery entirely and uses only explicit providers.
- What did NOT change (scope boundary): No changes to merge mode behavior, no changes to provider discovery logic itself, no changes to how explicit providers are handled.

## Change Type (select all)
- [x] Bug fix

## Scope (select all touched areas)
- [x] Core agent runtime

## Linked Issue/PR
- Closes #66957
- [x] This PR fixes a bug or regression

## Root Cause
- Root cause: `resolveProvidersForModelsJsonWithDeps` called `resolveImplicitProviders` unconditionally at line 58, before any mode-specific handling. The mode check only happened later in `resolveProvidersForMode()` which only affects merge behavior, not whether implicit discovery runs.
- Missing detection / guardrail: No test for the `replace` mode skipping implicit provider discovery.
- Contributing context: The mode handling in `resolveProvidersForMode` was only designed for merge-vs-replace provider merging, not for gating discovery itself.

## Regression Test Plan
- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `src/agents/models-config.replace-mode-skip-implicit-discovery.test.ts`
- Scenario the test should lock in: When `models.mode="replace"`, `resolveImplicitProviders` is never called and only explicit providers are returned.
- Why this is the smallest reliable guardrail: The test injects a mock `resolveImplicitProviders` and verifies it is/isn't called based on the mode setting.

## User-visible / Behavior Changes
- Users with `models.mode="replace"` will see significantly faster startup (no implicit provider discovery delay).

## Diagram (if applicable)
N/A

## Security Impact (required)
- New permissions/capabilities? No
- This fix only changes when implicit provider discovery runs. No security surface changes.
