### PR TITLE
feat(openrouter): inject cache_control for closed-source qwen models

### DIFF
--- a/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/proxy-stream-wrappers.ts
@@ -7,6 +7,7 @@ import { resolveProviderRequestPolicy } from "../provider-attribution.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import { applyAnthropicEphemeralCacheControlMarkers } from "./anthropic-cache-control-payload.js";
 import { isAnthropicModelRef } from "./anthropic-family-cache-semantics.js";
+import { isClosedSourceQwenModelRef } from "./qwen-family-cache-semantics.js";
 import { mapThinkingLevelToReasoningEffort } from "./reasoning-effort-utils.js";
 import { streamWithPayloadPatch } from "./stream-payload-utils.js";
 const KILOCODE_FEATURE_HEADER = "X-KILOCODE-FEATURE";
@@ -62,7 +63,7 @@ export function createOpenRouterSystemCacheWrapper(baseStreamFn: StreamFn | unde
     }).endpointClass;
     if (
       !modelId ||
-      !isAnthropicModelRef(modelId) ||
+      (!isAnthropicModelRef(modelId) && !isClosedSourceQwenModelRef(modelId)) ||
       !(
         endpointClass === "openrouter" ||
         (endpointClass === "default" && normalizeOptionalLowercaseString(provider) === "openrouter")

--- a/src/agents/pi-embedded-runner/qwen-family-cache-semantics.test.ts
+++ b/src/agents/pi-embedded-runner/qwen-family-cache-semantics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { isClosedSourceQwenModelRef } from "./qwen-family-cache-semantics.js";
+
+describe("isClosedSourceQwenModelRef", () => {
+  it("matches versioned commercial-tier qwen models", () => {
+    for (const id of [
+      "qwen/qwen3-max",
+      "qwen/qwen3-plus",
+      "qwen/qwen3-flash",
+      "qwen/qwen3.5-max",
+      "qwen/qwen3.5.1-max",
+      "qwen/qwen4-max",
+    ]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(true);
+    }
+  });
+
+  it("matches dated and preview snapshots", () => {
+    for (const id of [
+      "qwen/qwen3-max-2025-09-23",
+      "qwen/qwen3-max-2507",
+      "qwen/qwen3-plus-2025-01-25",
+      "qwen/qwen3.6-max-preview",
+    ]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(true);
+    }
+  });
+
+  it("is case-insensitive and tolerates surrounding whitespace", () => {
+    expect(isClosedSourceQwenModelRef("Qwen/Qwen3-Max")).toBe(true);
+    expect(isClosedSourceQwenModelRef(" qwen/qwen3-max ")).toBe(true);
+  });
+
+  it("rejects open-source qwen models", () => {
+    for (const id of [
+      "qwen/qwen3-235b-a22b",
+      "qwen/qwen3-235b-a22b-instruct-2507",
+      "qwen/qwen3-coder",
+      "qwen/qwen3-32b",
+      "qwen/qwq-32b",
+      "qwen/qwen-2.5-72b-instruct",
+    ]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(false);
+    }
+  });
+
+  it("rejects qwen models with middle qualifiers", () => {
+    for (const id of ["qwen/qwen3-coder-plus", "qwen/qwen3-coder-flash", "qwen/qwen3-vl-max"]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(false);
+    }
+  });
+
+  it("rejects unversioned rolling aliases", () => {
+    for (const id of ["qwen/qwen-max", "qwen/qwen-plus", "qwen/qwen-turbo", "qwen/qwen-flash"]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(false);
+    }
+  });
+
+  it("rejects turbo tier", () => {
+    for (const id of ["qwen/qwen3-turbo", "qwen/qwen3-turbo-2025-01-25"]) {
+      expect(isClosedSourceQwenModelRef(id)).toBe(false);
+    }
+  });
+});

--- a/src/agents/pi-embedded-runner/qwen-family-cache-semantics.ts
+++ b/src/agents/pi-embedded-runner/qwen-family-cache-semantics.ts
@@ -1,0 +1,8 @@
+import { normalizeLowercaseStringOrEmpty } from "../../shared/string-coerce.js";
+
+const QWEN_CLOSED_SOURCE_PATTERN =
+  /^qwen\/qwen\d+(\.\d+){0,2}-(plus|max|flash)(-preview|-\d{4}(-\d{2}-\d{2})?)?$/;
+
+export function isClosedSourceQwenModelRef(modelId: string): boolean {
+  return QWEN_CLOSED_SOURCE_PATTERN.test(normalizeLowercaseStringOrEmpty(modelId));
+}


### PR DESCRIPTION
## Summary

Extend the existing OpenRouter cache_control wrapper to cover Alibaba's closed-source qwen commercial line (`qwen3-max` / `qwen3-plus` / `qwen3-flash` and future versioned tiers), in addition to `anthropic/*` models.

## Why this is safe

Closed-source qwen models on OpenRouter are served **exclusively by Alibaba (DashScope)**, which implements Anthropic-compatible `cache_control: { type: "ephemeral" }` markers. Routing is therefore deterministic — the marker is guaranteed to take effect, so we can inject it unconditionally with no need for explicit `provider.only` routing.

Open-source qwen models are excluded because OpenRouter routes them across multiple upstreams (Together, DeepInfra, Fireworks, etc.), most of which do not support `cache_control`. Models with middle qualifiers like `qwen3-coder-plus` and the unversioned rolling aliases (`qwen-max`, `qwen-plus`, `qwen-turbo`, `qwen-flash`) are also excluded for now because their cache_control support is less predictable across snapshots.

## Match rule

```
/^qwen\/qwen\d+(\.\d+){0,2}-(plus|max|flash)(-preview|-\d{4}(-\d{2}-\d{2})?)?$/
```

Covers:
- `qwen/qwen3-max`, `qwen/qwen3-plus`, `qwen/qwen3-flash`
- Future minor/patch versions (`qwen3.5-max`, `qwen4-max`, ...)
- Dated snapshots (`qwen3-max-2025-09-23`, `qwen3-max-2507`)
- Preview tags (`qwen3.6-max-preview`)

Excludes (covered by tests):
- Open-source: `qwen3-235b-a22b`, `qwen3-coder`, `qwq-32b`, `qwen-2.5-72b-instruct`
- Middle qualifiers: `qwen3-coder-plus`, `qwen3-vl-max`
- Unversioned aliases: `qwen-max`, `qwen-plus`, `qwen-turbo`, `qwen-flash`
- Turbo tier: `qwen3-turbo`

## Test plan

- [x] Unit tests cover the truth table (7 cases, all passing)
- [x] Existing `proxy-stream-wrappers.test.ts` still passes
- [x] Live E2E verification — see results below

## Live E2E results

Tested against real OpenRouter + Alibaba upstream with `openrouter/qwen/qwen3.6-plus`, captured via `mitmdump`:

**Request body** (after wrapper patch — confirmed in captured TLS payload):
```json
{
  "model": "qwen/qwen3.6-plus",
  "messages": [
    {
      "role": "system",
      "content": [{
        "type": "text",
        "text": "...39228 chars...",
        "cache_control": { "type": "ephemeral" }
      }]
    },
    { "role": "user", "content": "Say hi in one word" }
  ]
}
```

**Response usage** (two identical-prefix calls, ~5s apart):

| Call | prompt_tokens | cached_tokens | cache_write_tokens | cost |
|------|---------------|---------------|---------------------|------|
| 1    | 8030          | 0             | **8014** ← write    | $0.003795 |
| 2    | 8030          | **8014** ← hit | 0                  | $0.000827 |

Cache hit on second call → **78% cost reduction** on the cached prefix portion. Confirms:

1. Wrapper injects `cache_control: { type: "ephemeral" }` on the system message for closed-source qwen
2. OpenRouter passes the marker through to Alibaba upstream
3. Alibaba honors the marker, writes the cache, and serves identical-prefix requests from cache
