### PR TITLE
fix(logging): expand leading tilde in logging.file (#73587)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,7 @@ Docs: https://docs.openclaw.ai
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
+- Logging/gateway: expand a leading `~` in `logging.file` before `fs.mkdirSync`, so configured paths like `~/.openclaw/logs/gateway.log` no longer crash gateway startup with `ENOENT: no such file or directory, mkdir '~/...'` and trigger a launchd / systemd respawn loop. Reuses the existing `expandHomePrefix` helper from `infra/home-dir.ts`. Fixes #73587. Thanks @gabrielexito-stack.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - Active Memory: allow the hidden recall sub-agent to use both `memory_recall` and the legacy `memory_search`/`memory_get` memory tool contract, so bundled `memory-lancedb` recall works without breaking the default `memory-core` path. Fixes #73502. (#73584) Thanks @Takhoffman.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.

--- a/src/logging/logger.settings.test.ts
+++ b/src/logging/logger.settings.test.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { __test__ } from "./logger.js";
 
@@ -33,5 +35,50 @@ describe("shouldSkipMutatingLoggingConfigRead", () => {
     expect(__test__.shouldSkipMutatingLoggingConfigRead(["node", "openclaw", "status"])).toBe(
       false,
     );
+  });
+});
+
+function effectiveHome(): string {
+  // Mirror the resolution order used by `resolveEffectiveHomeDir` in
+  // `infra/home-dir.ts` so this test stays correct under the per-suite
+  // `OPENCLAW_HOME` / `HOME` overrides that the harness sets up.
+  const explicit = process.env.OPENCLAW_HOME;
+  if (explicit) {
+    return path.resolve(explicit);
+  }
+  if (process.env.HOME) {
+    return path.resolve(process.env.HOME);
+  }
+  if (process.env.USERPROFILE) {
+    return path.resolve(process.env.USERPROFILE);
+  }
+  return path.resolve(os.homedir());
+}
+
+describe("resolveActiveLogFile (#73587)", () => {
+  it("expands a leading tilde to the home directory", () => {
+    // Regression for #73587: configured `logging.file` paths come straight from
+    // `openclaw.json`, where `~/.openclaw/logs/gateway.log` is the natural way
+    // to spell "the user's home". Before the fix, the literal string was
+    // passed to `fs.mkdirSync`, which crashed the gateway with
+    // `ENOENT: no such file or directory, mkdir '~/.openclaw/logs'` and
+    // produced a launchd / systemd respawn loop.
+    const home = effectiveHome();
+    const resolved = __test__.resolveActiveLogFile("~/.openclaw/logs/gateway.log");
+    expect(resolved).toBe(path.join(home, ".openclaw/logs/gateway.log"));
+  });
+
+  it("leaves absolute paths unchanged", () => {
+    const resolved = __test__.resolveActiveLogFile("/var/log/openclaw/gateway.log");
+    expect(resolved).toBe("/var/log/openclaw/gateway.log");
+  });
+
+  it("expands tildes inside rolling-path inputs and keeps the rolling pattern", () => {
+    const home = effectiveHome();
+    const resolved = __test__.resolveActiveLogFile("~/.openclaw/logs/openclaw-2026-04-28.log");
+    // The rolling pattern matcher fires on the basename, so the tilde-expanded
+    // directory becomes the rolling target while the dated filename is kept.
+    expect(resolved.startsWith(path.join(home, ".openclaw/logs"))).toBe(true);
+    expect(path.basename(resolved)).toMatch(/^openclaw-\d{4}-\d{2}-\d{2}\.log$/u);
   });
 });

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -11,6 +11,7 @@ import {
   isValidDiagnosticTraceId,
   type DiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
 import {
   POSIX_OPENCLAW_TMP_DIR,
@@ -673,6 +674,7 @@ export function resetLogger() {
 
 export const __test__ = {
   shouldSkipMutatingLoggingConfigRead,
+  resolveActiveLogFile,
 };
 
 function formatLocalDate(date: Date): string {
@@ -692,10 +694,16 @@ function rollingPathForDate(dir: string, date: Date): string {
 }
 
 function resolveActiveLogFile(file: string): string {
-  if (!isRollingPath(file)) {
-    return file;
+  // Configured `logging.file` paths can come straight from `openclaw.json`, so a
+  // leading `~` is a shell-only construct that `fs.mkdirSync` cannot handle.
+  // Expand it here so the directory creation in `buildLogger` no longer crashes
+  // the gateway with `ENOENT: no such file or directory, mkdir '~/...'`. See
+  // #73587.
+  const expanded = expandHomePrefix(file);
+  if (!isRollingPath(expanded)) {
+    return expanded;
   }
-  return rollingPathForDate(path.dirname(file), new Date());
+  return rollingPathForDate(path.dirname(expanded), new Date());
 }
 
 function isRollingPath(file: string): boolean {


### PR DESCRIPTION
## What

Fixes #73587. After updating from `2026.4.24` to `2026.4.26`, gateways with `openclaw.json` `logging.file` set to a `~/`-prefixed path crash on startup with `ENOENT: no such file or directory, mkdir '~/...'` and (under launchd / systemd) enter a tight respawn loop that takes the entire stack down — gateway, channels, sidecars, crons.

## Root cause

`logging.file` paths come straight from `openclaw.json`. `~` is a shell construct; Node's `fs.mkdirSync` does not expand it. `resolveActiveLogFile` in `src/logging/logger.ts` was returning the literal string, and `buildLogger` then called `fs.mkdirSync(path.dirname(activeFile), { recursive: true })` on `'~/.openclaw/logs'` directly:

```
[openclaw] CLI failed: Error: ENOENT: no such file or directory, mkdir '~/.openclaw/logs'
    at Object.mkdirSync (node:fs:1334:26)
    at buildLogger (file:///.../node_modules/openclaw/dist/logger-BYIbL3gn.js:433:5)
```

The same config worked under `2026.4.24`, so this is a regression where an earlier expansion site was bypassed.

## Fix

Reuse the existing `expandHomePrefix` helper from `src/infra/home-dir.ts` inside `resolveActiveLogFile`. The helper is already used by `state-migrations.ts:1125` and `exec-allowlist-pattern.ts:74`, follows the same `OPENCLAW_HOME` / `HOME` / `USERPROFILE` / `os.homedir()` resolution order as the rest of the codebase, and short-circuits cleanly when the input does not start with `~`. With the expansion happening up front, both the `isRollingPath` matcher (which inspects the basename, unchanged) and the downstream `fs.mkdirSync` see an absolute path.

```ts
function resolveActiveLogFile(file: string): string {
  const expanded = expandHomePrefix(file);
  if (!isRollingPath(expanded)) {
    return expanded;
  }
  return rollingPathForDate(path.dirname(expanded), new Date());
}
```

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341 lesson).** `grep` finds `expandHomePrefix` already exported from `src/infra/home-dir.ts` and used at two production call sites. Reuse rather than introduce a new helper. ✅
2. **Shared-helper caller check (steipete #60623 lesson).** `resolveActiveLogFile` is module-private and called only from `buildLogger` (line 521 + line 532). No silent contract change for other callers. ✅
3. **Broader-fix rival scan (steipete #68270 lesson).** Zero rival PRs reference #73587. ✅

## Test changes

Three new regression tests in `src/logging/logger.settings.test.ts`, exposed via the existing `__test__` export:

- `expands a leading tilde to the home directory` — pins the `~/.openclaw/logs/gateway.log` → `<home>/.openclaw/logs/gateway.log` shape.
- `leaves absolute paths unchanged` — guards against an over-eager helper.
- `expands tildes inside rolling-path inputs and keeps the rolling pattern` — confirms the rolling-pattern detection still fires when the input is `~/.openclaw/logs/openclaw-YYYY-MM-DD.log`.

The tests resolve the effective home with the same precedence the production helper uses (`OPENCLAW_HOME` → `HOME` → `USERPROFILE` → `os.homedir()`), so they remain stable under the per-suite home-dir overrides the harness sets up.

## Verified locally

```
npx oxlint src/logging/logger.ts src/logging/logger.settings.test.ts
# Found 0 warnings and 0 errors.

npx vitest run src/logging/logger.settings.test.ts
# Tests  6 passed (6)

npx vitest run src/logging/redact.test.ts src/logging/logger-redaction-behavior.test.ts
# Tests  36 passed (36)
```

(Two pre-existing `src/logging/`-suite-level failures in `logger-redaction-behavior.test.ts` and `redact.test.ts` reproduce on plain `main` without this patch and are independent of this change — confirmed via stash + re-run on the `f256eeba43` baseline.)

lobster-biscuit: 73587-logging-file-tilde-expand

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
