### PR TITLE
Add sessions_yield completion truth metadata

### DIFF
--- a/src/agents/completion-truth.export.test.ts
+++ b/src/agents/completion-truth.export.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  createCompletionTruthPublicHostHook,
+  normalizeSessionsHistoryMessages,
+  selectCompletionTruth,
+} from "./completion-truth.js";
+
+describe("completion-truth internal barrel", () => {
+  it("exports the internal completion truth seam for agent runtime code", () => {
+    expect(
+      selectCompletionTruth({
+        realtimeHint: {
+          source: "sessions_yield",
+          status: "yielded",
+          worker_id: "hint",
+        },
+      }),
+    ).toMatchObject({
+      source: "realtimeHint",
+      result: {
+        source: "sessions_yield",
+        status: "yielded",
+        worker_id: "hint",
+      },
+    });
+
+    expect(createCompletionTruthPublicHostHook()).toEqual(
+      expect.objectContaining({
+        yieldQueue: expect.any(Object),
+        toolResultQueue: expect.any(Object),
+      }),
+    );
+
+    expect(
+      normalizeSessionsHistoryMessages([
+        {
+          role: "tool",
+          name: "sessions_yield",
+          result: {
+            source: "sessions_yield",
+            status: "yielded",
+            worker_id: "done",
+          },
+        },
+      ]),
+    ).toEqual([
+      {
+        role: "tool",
+        toolName: "sessions_yield",
+        toolResult: {
+          source: "sessions_yield",
+          status: "yielded",
+          worker_id: "done",
+        },
+      },
+    ]);
+  });
+
+  it("keeps completion truth off public package/plugin-sdk exports", () => {
+    const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8")) as {
+      exports?: Record<string, unknown>;
+    };
+    const exportKeys = Object.keys(packageJson.exports ?? {});
+    const pluginAgentHarness = fs.readFileSync("src/plugin-sdk/agent-harness.ts", "utf8");
+    const pluginAgentHarnessRuntime = fs.readFileSync(
+      "src/plugin-sdk/agent-harness-runtime.ts",
+      "utf8",
+    );
+    const piTools = fs.readFileSync("src/agents/pi-tools.ts", "utf8");
+    const publicOptionsStart = piTools.indexOf("export type OpenClawCodingToolsOptions");
+    const internalOptionsStart = piTools.indexOf("type InternalOpenClawCodingToolsOptions");
+    expect(publicOptionsStart).toBeGreaterThanOrEqual(0);
+    expect(internalOptionsStart).toBeGreaterThan(publicOptionsStart);
+    const publicOptions = piTools.slice(publicOptionsStart, internalOptionsStart);
+
+    expect(exportKeys.filter((key) => key.includes("completion-truth"))).toEqual([]);
+    expect(exportKeys.filter((key) => key.includes("completionTruth"))).toEqual([]);
+    expect(exportKeys.filter((key) => key.includes("completion-truth"))).not.toContain(
+      "./plugin-sdk/completion-truth",
+    );
+    expect(pluginAgentHarness).not.toContain("createOpenClawCodingToolsInternal");
+    expect(pluginAgentHarnessRuntime).not.toContain("CompletionWorkerOutput");
+    expect(pluginAgentHarnessRuntime).not.toContain("CompletionTruthSelection");
+    expect(pluginAgentHarnessRuntime).not.toContain("completion-truth");
+    expect(publicOptions).not.toContain("onCompletionTruth");
+    expect(publicOptions).not.toContain("SessionsYieldCompletionOutput");
+  });
+});

--- a/src/agents/completion-truth.ts
+++ b/src/agents/completion-truth.ts
@@ -1,0 +1,5 @@
+export * from "./completion-truth/host-runtime.js";
+export * from "./completion-truth/selector.js";
+export * from "./completion-truth/sessions-yield.js";
+export * from "./completion-truth/transcript.js";
+export * from "./completion-truth/types.js";

--- a/src/agents/completion-truth/host-runtime.test.ts
+++ b/src/agents/completion-truth/host-runtime.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  awaitCompletionTruthFromPublicHost,
+  createCompletionTruthPublicHostHook,
+  createOnToolResultForwarder,
+  createOnYieldForwarder,
+  resolveCompletionTruthFromPublicHost,
+} from "./host-runtime.js";
+import type { CompletionWorkerOutput } from "./types.js";
+
+function parseEnvelope(raw: string): CompletionWorkerOutput {
+  return JSON.parse(raw) as CompletionWorkerOutput;
+}
+
+describe("completion truth public host runtime", () => {
+  it("waits briefly for toolResult and prefers it over existing realtime hint", async () => {
+    const hook = createCompletionTruthPublicHostHook();
+    createOnYieldForwarder(hook)(JSON.stringify({ source: "hint", status: "yielded" }));
+    setTimeout(() => createOnToolResultForwarder(hook)({ source: "tool", status: "done" }), 10);
+
+    await expect(
+      awaitCompletionTruthFromPublicHost({
+        hook,
+        timeoutMs: 100,
+        waitPolicy: { toolResultPriorityWindowMs: 50 },
+        parseRealtimeHint: parseEnvelope,
+      }),
+    ).resolves.toEqual({ source: "tool", status: "done" });
+  });
+
+  it("returns selected source observability for toolResult", async () => {
+    const hook = createCompletionTruthPublicHostHook();
+    createOnToolResultForwarder(hook)({ source: "tool", status: "done" });
+
+    await expect(
+      resolveCompletionTruthFromPublicHost({
+        hook,
+        timeoutMs: 50,
+        waitPolicy: { toolResultPriorityWindowMs: 10 },
+        parseRealtimeHint: parseEnvelope,
+      }),
+    ).resolves.toMatchObject({
+      output: { source: "tool", status: "done" },
+      selection: {
+        source: "toolResult",
+        confidence: "high",
+      },
+    });
+  });
+
+  it("falls back to realtime hint after toolResult priority window", async () => {
+    const hook = createCompletionTruthPublicHostHook();
+    createOnYieldForwarder(hook)(JSON.stringify({ source: "hint", status: "yielded" }));
+
+    await expect(
+      awaitCompletionTruthFromPublicHost({
+        hook,
+        timeoutMs: 80,
+        waitPolicy: { toolResultPriorityWindowMs: 5 },
+        parseRealtimeHint: parseEnvelope,
+      }),
+    ).resolves.toEqual({ source: "hint", status: "yielded" });
+  });
+
+  it("fails explicitly when no candidate is available", async () => {
+    const hook = createCompletionTruthPublicHostHook();
+
+    await expect(
+      awaitCompletionTruthFromPublicHost({
+        hook,
+        timeoutMs: 10,
+        waitPolicy: { toolResultPriorityWindowMs: 5 },
+        parseRealtimeHint: parseEnvelope,
+      }),
+    ).rejects.toThrow(/Failed to resolve completion truth/);
+  });
+});

--- a/src/agents/completion-truth/host-runtime.ts
+++ b/src/agents/completion-truth/host-runtime.ts
@@ -1,0 +1,176 @@
+import { selectCompletionTruth } from "./selector.js";
+import type {
+  CompletionTruthCandidates,
+  CompletionWorkerOutput,
+  ResolvedCompletionTruth,
+} from "./types.js";
+
+export interface HostYieldCollector {
+  waitForNextYield(timeoutMs: number): Promise<string>;
+}
+
+export class YieldMessageQueue implements HostYieldCollector {
+  private readonly pendingMessages: string[] = [];
+  private readonly waiters: Array<{
+    resolve: (message: string) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  push(message: string): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+      return;
+    }
+    this.pendingMessages.push(message);
+  }
+
+  waitForNextYield(timeoutMs: number): Promise<string> {
+    const next = this.pendingMessages.shift();
+    if (next !== undefined) {
+      return Promise.resolve(next);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const index = this.waiters.findIndex((entry) => entry.timer === timer);
+        if (index >= 0) {
+          this.waiters.splice(index, 1);
+        }
+        reject(new Error(`Timed out waiting for yield after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.waiters.push({ resolve, reject, timer });
+    });
+  }
+}
+
+export class WorkerOutputQueue<T = CompletionWorkerOutput> {
+  private readonly pendingResults: T[] = [];
+  private readonly waiters: Array<{
+    resolve: (result: T) => void;
+    reject: (error: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  push(result: T): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(result);
+      return;
+    }
+    this.pendingResults.push(result);
+  }
+
+  shift(): T | undefined {
+    return this.pendingResults.shift();
+  }
+
+  waitForNextResult(timeoutMs: number): Promise<T> {
+    const next = this.shift();
+    if (next !== undefined) {
+      return Promise.resolve(next);
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const index = this.waiters.findIndex((entry) => entry.timer === timer);
+        if (index >= 0) {
+          this.waiters.splice(index, 1);
+        }
+        reject(new Error(`Timed out waiting for toolResult after ${timeoutMs}ms`));
+      }, timeoutMs);
+      this.waiters.push({ resolve, reject, timer });
+    });
+  }
+}
+
+export interface CompletionTruthWaitPolicy {
+  toolResultPriorityWindowMs: number;
+}
+
+export interface CompletionTruthPublicHostHook<T = CompletionWorkerOutput> {
+  yieldQueue: YieldMessageQueue;
+  toolResultQueue: WorkerOutputQueue<T>;
+}
+
+export function createCompletionTruthPublicHostHook<
+  T = CompletionWorkerOutput,
+>(): CompletionTruthPublicHostHook<T> {
+  return {
+    yieldQueue: new YieldMessageQueue(),
+    toolResultQueue: new WorkerOutputQueue<T>(),
+  };
+}
+
+export function createOnYieldForwarder(hook: CompletionTruthPublicHostHook) {
+  return (message: string) => hook.yieldQueue.push(message);
+}
+
+export function createOnToolResultForwarder<T>(hook: CompletionTruthPublicHostHook<T>) {
+  return (result: T) => hook.toolResultQueue.push(result);
+}
+
+function remainingTimeoutMs(params: { timeoutMs?: number; elapsedMs: number }): number | undefined {
+  if (params.timeoutMs === undefined) {
+    return undefined;
+  }
+  return Math.max(1, params.timeoutMs - params.elapsedMs);
+}
+
+export async function resolveCompletionTruthFromPublicHost<T = CompletionWorkerOutput>(params: {
+  hook: CompletionTruthPublicHostHook<T>;
+  parseRealtimeHint: (rawMessage: string) => T;
+  timeoutMs?: number;
+  waitPolicy?: Partial<CompletionTruthWaitPolicy>;
+}): Promise<ResolvedCompletionTruth<T>> {
+  const waitPolicy: CompletionTruthWaitPolicy = {
+    toolResultPriorityWindowMs: 500,
+    ...params.waitPolicy,
+  };
+  const startedAt = Date.now();
+  const priorityWindowMs = Math.min(
+    waitPolicy.toolResultPriorityWindowMs,
+    params.timeoutMs ?? waitPolicy.toolResultPriorityWindowMs,
+  );
+
+  const candidates: CompletionTruthCandidates<T> = {};
+  try {
+    candidates.toolResult = await params.hook.toolResultQueue.waitForNextResult(priorityWindowMs);
+  } catch {
+    const fallbackTimeoutMs = remainingTimeoutMs({
+      elapsedMs: Date.now() - startedAt,
+      ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
+    });
+    try {
+      const rawHint = await params.hook.yieldQueue.waitForNextYield(fallbackTimeoutMs ?? 60_000);
+      candidates.realtimeHint = params.parseRealtimeHint(rawHint);
+    } catch {
+      // Selector below owns explicit no-candidate failure.
+    }
+  }
+
+  const resolution = selectCompletionTruth(candidates);
+  if (resolution.result !== undefined) {
+    return {
+      output: resolution.result,
+      selection: {
+        source: resolution.source,
+        confidence: resolution.confidence,
+        ...(resolution.notes ? { notes: resolution.notes } : {}),
+      },
+    };
+  }
+  throw new Error(
+    `Failed to resolve completion truth: ${resolution.notes?.join("; ") ?? "no result available"}`,
+  );
+}
+
+export async function awaitCompletionTruthFromPublicHost<T = CompletionWorkerOutput>(params: {
+  hook: CompletionTruthPublicHostHook<T>;
+  parseRealtimeHint: (rawMessage: string) => T;
+  timeoutMs?: number;
+  waitPolicy?: Partial<CompletionTruthWaitPolicy>;
+}): Promise<T> {
+  return (await resolveCompletionTruthFromPublicHost(params)).output;
+}

--- a/src/agents/completion-truth/selector.test.ts
+++ b/src/agents/completion-truth/selector.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { selectCompletionTruth } from "./selector.js";
+
+const toolResult = { source: "tool", status: "done", worker_id: "tool" };
+const transcriptResult = {
+  source: "transcript",
+  status: "done",
+  worker_id: "transcript",
+};
+const artifactPacket = {
+  source: "artifact",
+  status: "done",
+  worker_id: "artifact",
+};
+const realtimeHint = { source: "hint", status: "yielded", worker_id: "hint" };
+
+describe("selectCompletionTruth", () => {
+  it("prefers toolResult over lower-priority sources", () => {
+    expect(
+      selectCompletionTruth({
+        toolResult,
+        transcriptResult,
+        verificationArtifact: { packet: artifactPacket },
+        realtimeHint,
+      }),
+    ).toMatchObject({
+      source: "toolResult",
+      confidence: "high",
+      result: toolResult,
+    });
+  });
+
+  it("falls through truth hierarchy in order", () => {
+    expect(selectCompletionTruth({ transcriptResult, realtimeHint })).toMatchObject({
+      source: "transcriptResult",
+      result: transcriptResult,
+    });
+    expect(
+      selectCompletionTruth({
+        verificationArtifact: { packet: artifactPacket },
+        realtimeHint,
+      }),
+    ).toMatchObject({
+      source: "verificationArtifact",
+      result: artifactPacket,
+    });
+    expect(selectCompletionTruth({ realtimeHint })).toMatchObject({
+      source: "realtimeHint",
+      confidence: "low",
+      result: realtimeHint,
+    });
+  });
+
+  it("returns none when no candidate exists", () => {
+    expect(selectCompletionTruth({})).toMatchObject({
+      kind: "none",
+      source: "none",
+      confidence: "none",
+    });
+  });
+});

--- a/src/agents/completion-truth/selector.ts
+++ b/src/agents/completion-truth/selector.ts
@@ -1,0 +1,54 @@
+import type { CompletionTruthCandidates, CompletionTruthResolution } from "./types.js";
+
+export function selectCompletionTruth<T>(
+  candidates: CompletionTruthCandidates<T>,
+): CompletionTruthResolution<T> {
+  if (candidates.toolResult !== undefined) {
+    return {
+      kind: "resolved",
+      source: "toolResult",
+      confidence: "high",
+      result: candidates.toolResult,
+      notes: ["selected explicit tool result"],
+    };
+  }
+
+  if (candidates.transcriptResult !== undefined) {
+    return {
+      kind: "resolved",
+      source: "transcriptResult",
+      confidence: "high",
+      result: candidates.transcriptResult,
+      notes: ["selected explicit transcript completion record"],
+    };
+  }
+
+  if (candidates.verificationArtifact?.packet !== undefined) {
+    return {
+      kind: "resolved",
+      source: "verificationArtifact",
+      confidence: "medium",
+      result: candidates.verificationArtifact.packet,
+      notes: ["selected explicit verification artifact packet"],
+    };
+  }
+
+  if (candidates.realtimeHint !== undefined) {
+    return {
+      kind: "resolved",
+      source: "realtimeHint",
+      confidence: "low",
+      result: candidates.realtimeHint,
+      notes: ["selected realtime hint fallback"],
+    };
+  }
+
+  return {
+    kind: "none",
+    source: "none",
+    confidence: "none",
+    notes: ["no completion truth candidate available"],
+  };
+}
+
+export const resolveCompletionTruth = selectCompletionTruth;

--- a/src/agents/completion-truth/sessions-yield.ts
+++ b/src/agents/completion-truth/sessions-yield.ts
@@ -1,0 +1,23 @@
+import type { CompletionWorkerOutput } from "./types.js";
+
+export type SessionsYieldCompletionOutput = Omit<CompletionWorkerOutput, "source" | "status"> & {
+  source: "sessions_yield";
+  status: "yielded";
+  message: string;
+  sessionId: string;
+  toolCallId: string;
+};
+
+export function buildSessionsYieldCompletionOutput(params: {
+  message: string;
+  sessionId: string;
+  toolCallId: string;
+}): SessionsYieldCompletionOutput {
+  return {
+    source: "sessions_yield",
+    status: "yielded",
+    message: params.message,
+    sessionId: params.sessionId,
+    toolCallId: params.toolCallId,
+  };
+}

--- a/src/agents/completion-truth/transcript.test.ts
+++ b/src/agents/completion-truth/transcript.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSessionsHistoryMessages, selectTranscriptResult } from "./transcript.js";
+
+describe("transcript completion selection", () => {
+  it("normalizes structured sessions-history-like tool records", () => {
+    const records = normalizeSessionsHistoryMessages([
+      {
+        role: "tool",
+        name: "sessions_yield",
+        result: {
+          source: "sessions_yield",
+          status: "yielded",
+          worker_id: "done",
+        },
+        created_at: "2026-04-25T00:00:00.000Z",
+      },
+    ]);
+
+    expect(records).toEqual([
+      {
+        role: "tool",
+        toolName: "sessions_yield",
+        toolResult: {
+          source: "sessions_yield",
+          status: "yielded",
+          worker_id: "done",
+        },
+        createdAt: "2026-04-25T00:00:00.000Z",
+      },
+    ]);
+    expect(selectTranscriptResult(records)).toEqual({
+      source: "sessions_yield",
+      status: "yielded",
+      worker_id: "done",
+    });
+  });
+
+  it("selects the newest explicit completion tool record", () => {
+    expect(
+      selectTranscriptResult([
+        {
+          role: "tool",
+          toolName: "sessions_yield",
+          toolResult: {
+            source: "sessions_yield",
+            status: "yielded",
+            worker_id: "old",
+          },
+        },
+        {
+          role: "tool",
+          toolName: "worker_completion",
+          toolResult: {
+            source: "worker_completion",
+            status: "done",
+            worker_id: "new",
+          },
+        },
+      ]),
+    ).toEqual({
+      source: "worker_completion",
+      status: "done",
+      worker_id: "new",
+    });
+  });
+
+  it("does not parse assistant prose as tool result", () => {
+    const records = normalizeSessionsHistoryMessages([
+      { role: "assistant", content: '{"worker_id":"fake"}' },
+    ]);
+    expect(selectTranscriptResult(records)).toBeUndefined();
+  });
+
+  it("fails explicitly for malformed completion tool records", () => {
+    expect(() =>
+      selectTranscriptResult([{ role: "tool", toolName: "sessions_yield", toolResult: "bad" }]),
+    ).toThrow(/Invalid transcript completion record/);
+  });
+
+  it("rejects object completion records without required envelope fields", () => {
+    expect(() =>
+      selectTranscriptResult([
+        {
+          role: "tool",
+          toolName: "sessions_yield",
+          toolResult: { worker_id: "loose" },
+        },
+      ]),
+    ).toThrow(/Invalid transcript completion record/);
+  });
+});

--- a/src/agents/completion-truth/transcript.ts
+++ b/src/agents/completion-truth/transcript.ts
@@ -1,0 +1,94 @@
+import type { CompletionWorkerOutput } from "./types.js";
+
+export interface TranscriptRecord<T = unknown> {
+  role: "assistant" | "tool" | "system" | "user";
+  content?: string;
+  toolName?: string;
+  toolResult?: T;
+  createdAt?: string;
+}
+
+export interface SessionsHistoryLikeMessage {
+  role?: unknown;
+  content?: unknown;
+  toolName?: unknown;
+  tool_name?: unknown;
+  name?: unknown;
+  toolResult?: unknown;
+  tool_result?: unknown;
+  result?: unknown;
+  createdAt?: unknown;
+  created_at?: unknown;
+}
+
+const COMPLETION_TOOL_NAMES = new Set(["sessions_yield", "worker_completion"]);
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function readRole(value: unknown): TranscriptRecord["role"] | undefined {
+  return value === "assistant" || value === "tool" || value === "system" || value === "user"
+    ? value
+    : undefined;
+}
+
+function isCompletionWorkerOutput(value: unknown): value is CompletionWorkerOutput {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return typeof record.source === "string" && typeof record.status === "string";
+}
+
+export function normalizeSessionsHistoryMessages(
+  messages: SessionsHistoryLikeMessage[],
+): TranscriptRecord[] {
+  const records: TranscriptRecord[] = [];
+  for (const message of messages) {
+    const role = readRole(message.role);
+    if (role === undefined) {
+      continue;
+    }
+
+    const record: TranscriptRecord = { role };
+    const content = readOptionalString(message.content);
+    const toolName = readOptionalString(message.toolName ?? message.tool_name ?? message.name);
+    const createdAt = readOptionalString(message.createdAt ?? message.created_at);
+    const toolResult = message.toolResult ?? message.tool_result ?? message.result;
+
+    if (content !== undefined) {
+      record.content = content;
+    }
+    if (toolName !== undefined) {
+      record.toolName = toolName;
+    }
+    if (createdAt !== undefined) {
+      record.createdAt = createdAt;
+    }
+    if (toolResult !== undefined) {
+      record.toolResult = toolResult;
+    }
+    records.push(record);
+  }
+  return records;
+}
+
+export function selectTranscriptResult(
+  records: TranscriptRecord[],
+): CompletionWorkerOutput | undefined {
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index];
+    if (!record || record.role !== "tool" || !record.toolName) {
+      continue;
+    }
+    if (!COMPLETION_TOOL_NAMES.has(record.toolName)) {
+      continue;
+    }
+    if (isCompletionWorkerOutput(record.toolResult)) {
+      return record.toolResult;
+    }
+    throw new Error(`Invalid transcript completion record for tool ${record.toolName}`);
+  }
+  return undefined;
+}

--- a/src/agents/completion-truth/types.ts
+++ b/src/agents/completion-truth/types.ts
@@ -1,0 +1,43 @@
+export type CompletionWorkerOutput = {
+  /** Internal producer of this completion truth envelope. */
+  source: string;
+  /** Producer-specific completion status. */
+  status: string;
+  [key: string]: unknown;
+};
+
+export type CompletionTruthSource =
+  | "toolResult"
+  | "transcriptResult"
+  | "verificationArtifact"
+  | "realtimeHint"
+  | "none";
+
+export interface CompletionTruthCandidates<T = CompletionWorkerOutput> {
+  toolResult?: T;
+  transcriptResult?: T;
+  verificationArtifact?: {
+    packet?: T;
+    code?: string;
+  };
+  realtimeHint?: T;
+}
+
+export interface CompletionTruthResolution<T = CompletionWorkerOutput> {
+  kind: "resolved" | "none";
+  source: CompletionTruthSource;
+  confidence: "high" | "medium" | "low" | "none";
+  result?: T;
+  notes?: string[];
+}
+
+export interface CompletionTruthSelection {
+  source: CompletionTruthSource;
+  confidence: CompletionTruthResolution["confidence"];
+  notes?: string[];
+}
+
+export interface ResolvedCompletionTruth<T = CompletionWorkerOutput> {
+  output: T;
+  selection: CompletionTruthSelection;
+}

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -13,6 +13,7 @@ import type { GatewayMessageChannel } from "../utils/message-channel.js";
 import { resolveAgentWorkspaceDir, resolveSessionAgentIds } from "./agent-scope.js";
 import { listProfilesForProvider } from "./auth-profiles.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
+import type { SessionsYieldCompletionOutput } from "./completion-truth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
 import { applyNodesToolWorkspaceGuard } from "./openclaw-tools.nodes-workspace-guard.js";
 import {
@@ -305,6 +306,8 @@ export function createOpenClawTools(
     spawnWorkspaceDir?: string;
     /** Callback invoked when sessions_yield tool is called. */
     onYield?: (message: string) => Promise<void> | void;
+    /** Internal callback carrying explicit sessions_yield completion truth. */
+    onCompletionTruth?: (output: SessionsYieldCompletionOutput) => Promise<void> | void;
     /** Allow plugin tools for this tool set to late-bind the gateway subagent. */
     allowGatewaySubagentBinding?: boolean;
   } & SpawnedToolContext,
@@ -561,6 +564,7 @@ export function createOpenClawTools(
     createSessionsYieldTool({
       sessionId: options?.sessionId,
       onYield: options?.onYield,
+      onCompletionTruth: options?.onCompletionTruth,
     }),
     createSubagentsTool({
       agentSessionKey: options?.agentSessionKey,

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -981,7 +981,7 @@ describe("sanitizeSessionHistory", () => {
 
     expect(result).toEqual([
       {
-        ...(messages[0] as Record<string, unknown>),
+        ...(messages[0] as unknown as Record<string, unknown>),
         usage: makeZeroUsageSnapshot(),
       },
     ]);

--- a/src/agents/pi-embedded-runner.sessions-yield-completion-truth.live.test.ts
+++ b/src/agents/pi-embedded-runner.sessions-yield-completion-truth.live.test.ts
@@ -1,0 +1,257 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { resolveLiveDirectModel } from "./live-cache-test-support.js";
+import { isLiveTestEnabled } from "./live-test-helpers.js";
+import { runEmbeddedPiAgent } from "./pi-embedded-runner.js";
+
+const LIVE = isLiveTestEnabled();
+const SESSIONS_YIELD_TRUTH_LIVE = isTruthyEnvValue(
+  process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH,
+);
+const describeLive = LIVE && SESSIONS_YIELD_TRUTH_LIVE ? describe : describe.skip;
+
+const LIVE_TIMEOUT_MS = 4 * 60_000;
+const MODEL_RESOLVE_TIMEOUT_MS = 120_000;
+const RUN_TIMEOUT_MS = 120_000;
+const YIELD_MESSAGE = "LIVE-SMOKE waiting for worker completion truth";
+const REQUESTED_PROVIDER =
+  process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_PROVIDER?.trim().toLowerCase();
+const EXPLICIT_PROVIDER_ID =
+  process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_PROVIDER_ID?.trim();
+const EXPLICIT_MODEL_ID = process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_MODEL?.trim();
+const EXPLICIT_API_KEY = process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_API_KEY?.trim();
+const EXPLICIT_BASE_URL =
+  process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_BASE_URL?.trim();
+const EXPLICIT_API = process.env.OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_API?.trim() as
+  | "anthropic-messages"
+  | "openai-responses"
+  | undefined;
+
+type ResolvedFixture = {
+  model: {
+    provider: string;
+    id: string;
+    api: "anthropic-messages" | "openai-responses";
+    baseUrl?: string;
+    contextWindow?: number;
+    maxTokens?: number;
+    reasoning?: boolean;
+    input?: Array<"text" | "image">;
+  };
+  apiKey: string;
+};
+
+function resolveDefaultProviderBaseUrl(model: ResolvedFixture["model"]): string {
+  if (model.provider === "anthropic") {
+    return "https://api.anthropic.com/v1";
+  }
+  return "https://api.openai.com/v1";
+}
+
+function resolveProviderBaseUrl(model: ResolvedFixture["model"]): string {
+  const candidate = (model as { baseUrl?: unknown }).baseUrl;
+  return typeof candidate === "string" && candidate.trim().length > 0
+    ? candidate
+    : resolveDefaultProviderBaseUrl(model);
+}
+
+function resolveEmbeddedModelApi(
+  model: ResolvedFixture["model"],
+): "anthropic-messages" | "openai-responses" {
+  return model.api;
+}
+
+function buildEmbeddedModelDefinition(model: ResolvedFixture["model"]) {
+  const contextWindowCandidate = (model as { contextWindow?: unknown }).contextWindow;
+  const maxTokensCandidate = (model as { maxTokens?: unknown }).maxTokens;
+  const reasoningCandidate = (model as { reasoning?: unknown }).reasoning;
+  const inputCandidate = (model as { input?: unknown }).input;
+  const contextWindow =
+    typeof contextWindowCandidate === "number" && Number.isFinite(contextWindowCandidate)
+      ? Math.max(1, Math.trunc(contextWindowCandidate))
+      : 128_000;
+  const maxTokens =
+    typeof maxTokensCandidate === "number" && Number.isFinite(maxTokensCandidate)
+      ? Math.max(1, Math.trunc(maxTokensCandidate))
+      : 8_192;
+  const input =
+    Array.isArray(inputCandidate) &&
+    inputCandidate.every((value) => value === "text" || value === "image")
+      ? [...inputCandidate]
+      : (["text", "image"] as Array<"text" | "image">);
+  return {
+    id: model.id,
+    name: model.id,
+    api: resolveEmbeddedModelApi(model),
+    reasoning: typeof reasoningCandidate === "boolean" ? reasoningCandidate : false,
+    input,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow,
+    maxTokens,
+  };
+}
+
+function buildEmbeddedRunnerConfig(params: ResolvedFixture): OpenClawConfig {
+  const provider = params.model.provider;
+  const modelKey = `${provider}/${params.model.id}`;
+  return {
+    models: {
+      providers: {
+        [provider]: {
+          api: resolveEmbeddedModelApi(params.model),
+          auth: "api-key",
+          apiKey: params.apiKey,
+          baseUrl: resolveProviderBaseUrl(params.model),
+          models: [buildEmbeddedModelDefinition(params.model)],
+        },
+      },
+    },
+    agents: {
+      defaults: {
+        models: {
+          [modelKey]: {
+            params: {
+              temperature: 0,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function resolveFixture(): Promise<ResolvedFixture> {
+  if (EXPLICIT_PROVIDER_ID && EXPLICIT_MODEL_ID && EXPLICIT_API_KEY && EXPLICIT_API) {
+    return {
+      model: {
+        provider: EXPLICIT_PROVIDER_ID,
+        id: EXPLICIT_MODEL_ID,
+        api: EXPLICIT_API,
+        baseUrl: EXPLICIT_BASE_URL,
+        contextWindow: 128_000,
+        maxTokens: 8_192,
+        reasoning: EXPLICIT_API === "anthropic-messages",
+        input: ["text", "image"],
+      },
+      apiKey: EXPLICIT_API_KEY,
+    };
+  }
+
+  const provider = REQUESTED_PROVIDER === "openai" ? "openai" : "anthropic";
+  if (provider === "openai") {
+    const resolved = await resolveLiveDirectModel({
+      provider: "openai",
+      api: "openai-responses",
+      envVar: "OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_MODEL",
+      preferredModelIds: ["gpt-5.4", "gpt-5.5"],
+    });
+    return {
+      model: {
+        provider: resolved.model.provider,
+        id: resolved.model.id,
+        api: "openai-responses",
+        baseUrl: (resolved.model as { baseUrl?: string }).baseUrl,
+        contextWindow: (resolved.model as { contextWindow?: number }).contextWindow,
+        maxTokens: (resolved.model as { maxTokens?: number }).maxTokens,
+        reasoning: (resolved.model as { reasoning?: boolean }).reasoning,
+        input: (resolved.model as { input?: Array<"text" | "image"> }).input,
+      },
+      apiKey: resolved.apiKey,
+    };
+  }
+  const resolved = await resolveLiveDirectModel({
+    provider: "anthropic",
+    api: "anthropic-messages",
+    envVar: "OPENCLAW_LIVE_SESSIONS_YIELD_COMPLETION_TRUTH_MODEL",
+    preferredModelIds: ["claude-sonnet-4-6", "claude-opus-4-6"],
+  });
+  return {
+    model: {
+      provider: resolved.model.provider,
+      id: resolved.model.id,
+      api: "anthropic-messages",
+      baseUrl: (resolved.model as { baseUrl?: string }).baseUrl,
+      contextWindow: (resolved.model as { contextWindow?: number }).contextWindow,
+      maxTokens: (resolved.model as { maxTokens?: number }).maxTokens,
+      reasoning: (resolved.model as { reasoning?: boolean }).reasoning,
+      input: (resolved.model as { input?: Array<"text" | "image"> }).input,
+    },
+    apiKey: resolved.apiKey,
+  };
+}
+
+function logLiveStep(message: string): void {
+  process.stderr.write(`[live-sessions-yield-truth] ${message}\n`);
+}
+
+describeLive("runEmbeddedPiAgent sessions_yield completion truth (live)", () => {
+  let fixture: ResolvedFixture;
+  let tempRoot: string;
+  let agentDir: string;
+  let workspaceDir: string;
+  let sessionFile: string;
+
+  beforeAll(async () => {
+    fixture = await resolveFixture();
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-live-yield-truth-"));
+    agentDir = path.join(tempRoot, "agent");
+    workspaceDir = path.join(tempRoot, "workspace");
+    sessionFile = path.join(tempRoot, "session.jsonl");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.mkdir(workspaceDir, { recursive: true });
+    logLiveStep(`model=${fixture.model.provider}/${fixture.model.id}`);
+  }, MODEL_RESOLVE_TIMEOUT_MS);
+
+  afterAll(async () => {
+    if (tempRoot) {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    "resolves explicit toolResult completion truth for a real sessions_yield turn",
+    async () => {
+      const result = await runEmbeddedPiAgent({
+        sessionId: `live-yield-truth-${Date.now()}`,
+        sessionKey: `live-yield-truth:${Date.now()}`,
+        sessionFile,
+        workspaceDir,
+        agentDir,
+        config: buildEmbeddedRunnerConfig(fixture),
+        provider: fixture.model.provider,
+        model: fixture.model.id,
+        timeoutMs: RUN_TIMEOUT_MS,
+        runId: `run-live-yield-truth-${Date.now()}`,
+        prompt: [
+          "Call the sessions_yield tool exactly once.",
+          `Use this exact message: ${YIELD_MESSAGE}`,
+          "Do not call any other tool.",
+          "Do not answer with normal text.",
+        ].join("\n"),
+        extraSystemPrompt:
+          "For this live smoke, your only valid action is one sessions_yield tool call with the exact requested message.",
+        toolsAllow: ["sessions_yield"],
+        cleanupBundleMcpOnRunEnd: true,
+      });
+
+      expect(result.meta.stopReason).toBe("end_turn");
+      expect(result.meta.pendingToolCalls).toBeUndefined();
+      expect(result.meta.completion?.truth).toMatchObject({
+        source: "sessions_yield",
+        status: "yielded",
+        message: YIELD_MESSAGE,
+      });
+      expect(result.meta.completion?.truth).not.toHaveProperty("sessionId");
+      expect(result.meta.completion?.truth).not.toHaveProperty("toolCallId");
+      expect(result.meta.completion?.truthSelection).toMatchObject({
+        source: "toolResult",
+        confidence: "high",
+      });
+    },
+    LIVE_TIMEOUT_MS,
+  );
+});

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -2534,6 +2534,9 @@ export async function runEmbeddedPiAgent(
           const terminalPayloads = emptyAssistantReplyIsSilent
             ? [{ text: SILENT_REPLY_TOKEN }]
             : payloadsForTerminalPath;
+          // Completion truth is emitted by the internal PI attempt path only.
+          // Keep the wider shape local instead of expanding the plugin harness
+          // result contract with private runner observability metadata.
           const attemptCompletionTruth = attempt as typeof attempt &
             EmbeddedRunAttemptCompletionTruth;
           attempt.setTerminalLifecycleMeta?.({

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -37,6 +37,7 @@ import {
   resolveSessionKeyForRequest,
   resolveStoredSessionKeyForSessionId,
 } from "../command/session.js";
+import type { CompletionTruthSelection, CompletionWorkerOutput } from "../completion-truth.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { isStrictAgenticExecutionContractActive } from "../execution-contract.js";
 import {
@@ -159,6 +160,16 @@ import type {
   EmbeddedRunLivenessState,
 } from "./types.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "./usage-accumulator.js";
+
+type EmbeddedRunAttemptCompletionTruth = {
+  completionTruth?: CompletionWorkerOutput;
+  completionTruthSelection?: CompletionTruthSelection;
+};
+
+function redactCompletionTruthForMeta(truth: CompletionWorkerOutput): CompletionWorkerOutput {
+  const { sessionId: _sessionId, toolCallId: _toolCallId, ...redacted } = truth;
+  return redacted;
+}
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
@@ -2523,6 +2534,8 @@ export async function runEmbeddedPiAgent(
           const terminalPayloads = emptyAssistantReplyIsSilent
             ? [{ text: SILENT_REPLY_TOKEN }]
             : payloadsForTerminalPath;
+          const attemptCompletionTruth = attempt as typeof attempt &
+            EmbeddedRunAttemptCompletionTruth;
           attempt.setTerminalLifecycleMeta?.({
             replayInvalid,
             livenessState,
@@ -2590,6 +2603,12 @@ export async function runEmbeddedPiAgent(
               completion: {
                 ...(stopReason ? { stopReason } : {}),
                 ...(stopReason ? { finishReason: stopReason } : {}),
+                ...(attemptCompletionTruth.completionTruth
+                  ? { truth: redactCompletionTruthForMeta(attemptCompletionTruth.completionTruth) }
+                  : {}),
+                ...(attemptCompletionTruth.completionTruthSelection
+                  ? { truthSelection: attemptCompletionTruth.completionTruthSelection }
+                  : {}),
                 ...(stopReason?.toLowerCase().includes("refusal") ? { refusal: true } : {}),
               },
               contextManagement:

--- a/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.spawn-workspace.test-support.ts
@@ -434,6 +434,10 @@ vi.mock("../../cache-trace.js", () => ({
 vi.mock("../../pi-tools.js", () => ({
   createOpenClawCodingTools: (options?: { workspaceDir?: string; spawnWorkspaceDir?: string }) =>
     hoisted.createOpenClawCodingToolsMock(options),
+  createOpenClawCodingToolsInternal: (options?: {
+    workspaceDir?: string;
+    spawnWorkspaceDir?: string;
+  }) => hoisted.createOpenClawCodingToolsMock(options),
   resolveToolLoopDetectionConfig: () => undefined,
 }));
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -74,6 +74,14 @@ import {
   resolveChannelMessageToolHints,
   resolveChannelReactionGuidance,
 } from "../../channel-tools.js";
+import {
+  createCompletionTruthPublicHostHook,
+  createOnToolResultForwarder,
+  createOnYieldForwarder,
+  resolveCompletionTruthFromPublicHost,
+  type CompletionTruthSelection,
+  type CompletionWorkerOutput,
+} from "../../completion-truth.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawReferencePaths } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
@@ -114,7 +122,10 @@ import {
   findClientToolNameConflicts,
   toClientToolDefinitions,
 } from "../../pi-tool-definition-adapter.js";
-import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import {
+  createOpenClawCodingToolsInternal,
+  resolveToolLoopDetectionConfig,
+} from "../../pi-tools.js";
 import {
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
@@ -701,9 +712,12 @@ function collectAttemptExplicitToolAllowlistSources(params: {
   ]);
 }
 
-export async function runEmbeddedAttempt(
-  params: EmbeddedRunAttemptParams,
-): Promise<EmbeddedRunAttemptResult> {
+export async function runEmbeddedAttempt(params: EmbeddedRunAttemptParams): Promise<
+  EmbeddedRunAttemptResult & {
+    completionTruth?: CompletionWorkerOutput;
+    completionTruthSelection?: CompletionTruthSelection;
+  }
+> {
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
   const runAbortController = new AbortController();
   configureEmbeddedAttemptHttpRuntime({ timeoutMs: params.timeoutMs });
@@ -850,6 +864,9 @@ export async function runEmbeddedAttempt(
     });
     const diagnosticRunStartedAt = Date.now();
     let diagnosticRunCompleted = false;
+    const completionTruthHook = createCompletionTruthPublicHostHook();
+    const forwardCompletionTruth = createOnToolResultForwarder(completionTruthHook);
+    const forwardYieldHint = createOnYieldForwarder(completionTruthHook);
     emitDiagnosticRunCompleted = (outcome, err) => {
       if (diagnosticRunCompleted) {
         return;
@@ -868,7 +885,7 @@ export async function runEmbeddedAttempt(
       params.disableTools || isRawModelRun
         ? []
         : (() => {
-            const allTools = createOpenClawCodingTools({
+            const allTools = createOpenClawCodingToolsInternal({
               agentId: sessionAgentId,
               ...buildEmbeddedAttemptToolRunContext({ ...params, trace: runTrace }),
               exec: {
@@ -926,9 +943,11 @@ export async function runEmbeddedAttempt(
               forceMessageTool: params.forceMessageTool,
               authProfileStore: params.authProfileStore,
               recordToolPrepStage: (name) => corePluginToolStages.mark(name),
+              onCompletionTruth: forwardCompletionTruth,
               onYield: (message) => {
                 yieldDetected = true;
                 yieldMessage = message;
+                forwardYieldHint(message);
                 queueYieldInterruptForSession?.();
                 runAbortController.abort("sessions_yield");
                 abortSessionForYield?.();
@@ -1035,6 +1054,8 @@ export async function runEmbeddedAttempt(
     // Track sessions_yield tool invocation (callback pattern, like clientToolCallDetected)
     let yieldDetected = false;
     let yieldMessage: string | null = null;
+    let completionTruth: CompletionWorkerOutput | undefined;
+    let completionTruthSelection: CompletionTruthSelection | undefined;
     // Late-binding reference so onYield can abort the session (declared after tool creation)
     let abortSessionForYield: (() => void) | null = null;
     let queueYieldInterruptForSession: (() => void) | null = null;
@@ -3081,6 +3102,31 @@ export async function runEmbeddedAttempt(
               sessionId: params.sessionId,
             });
             stripSessionsYieldArtifacts(activeSession);
+            try {
+              const resolvedCompletionTruth = await resolveCompletionTruthFromPublicHost({
+                hook: completionTruthHook,
+                parseRealtimeHint: (rawMessage) => ({
+                  source: "sessions_yield",
+                  status: "yielded",
+                  message: rawMessage,
+                  sessionId: params.sessionId,
+                  toolCallId: "unknown",
+                }),
+                timeoutMs: 1_000,
+                waitPolicy: { toolResultPriorityWindowMs: 100 },
+              });
+              completionTruth = resolvedCompletionTruth.output;
+              completionTruthSelection = resolvedCompletionTruth.selection;
+            } catch (err) {
+              completionTruthSelection = {
+                source: "none",
+                confidence: "none",
+                notes: [formatErrorMessage(err)],
+              };
+              log.warn(
+                `failed to resolve sessions_yield completion truth: ${formatErrorMessage(err)}`,
+              );
+            }
             if (yieldMessage) {
               await persistSessionsYieldContextMessage(activeSession, yieldMessage);
             }
@@ -3628,6 +3674,8 @@ export async function runEmbeddedAttempt(
         // truthiness predicates keep working without a `.length` check.
         clientToolCalls: completedClientToolCalls.length > 0 ? completedClientToolCalls : undefined,
         yieldDetected: yieldDetected || undefined,
+        completionTruth,
+        completionTruthSelection,
       };
     } finally {
       if (trajectoryRecorder && !trajectoryEndRecorded) {

--- a/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
+++ b/src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts
@@ -15,6 +15,22 @@ import { isEmbeddedPiRunActive, queueEmbeddedPiMessage } from "./runs.js";
 
 let runEmbeddedPiAgent: typeof import("./run.js").runEmbeddedPiAgent;
 
+type AttemptResultWithCompletionTruth = ReturnType<typeof makeAttemptResult> & {
+  completionTruth?: Record<string, unknown>;
+  completionTruthSelection?: Record<string, unknown>;
+};
+
+function makeAttemptResultWithCompletionTruth(
+  overrides: Parameters<typeof makeAttemptResult>[0] & {
+    completionTruth?: Record<string, unknown>;
+    completionTruthSelection?: Record<string, unknown>;
+  },
+): AttemptResultWithCompletionTruth {
+  return makeAttemptResult(
+    overrides as Parameters<typeof makeAttemptResult>[0],
+  ) as AttemptResultWithCompletionTruth;
+}
+
 describe("sessions_yield orchestration", () => {
   beforeAll(async () => {
     ({ runEmbeddedPiAgent } = await loadRunOverflowCompactionHarness());
@@ -56,8 +72,90 @@ describe("sessions_yield orchestration", () => {
     expect(queueEmbeddedPiMessage(sessionId, "subagent result")).toBe(false);
   });
 
-  it("clientToolCalls takes precedence over yieldDetected", async () => {
-    // Edge case: both flags set (shouldn't happen, but clientToolCalls wins)
+  it("propagates resolved completion truth into run completion meta", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResultWithCompletionTruth({
+        promptError: null,
+        yieldDetected: true,
+        completionTruth: {
+          source: "sessions_yield",
+          status: "yielded",
+          message: "Waiting for worker",
+          sessionId: "yield-truth-session",
+          toolCallId: "call-1",
+        },
+        completionTruthSelection: {
+          source: "toolResult",
+          confidence: "high",
+          notes: ["selected explicit tool result"],
+        },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      sessionId: "yield-truth-session",
+      runId: "run-yield-completion-truth",
+    });
+
+    expect(result.meta.completion).toMatchObject({
+      stopReason: "end_turn",
+      truth: {
+        source: "sessions_yield",
+        status: "yielded",
+        message: "Waiting for worker",
+      },
+      truthSelection: {
+        source: "toolResult",
+        confidence: "high",
+      },
+    });
+    expect(result.meta.completion?.truth).not.toHaveProperty("sessionId");
+    expect(result.meta.completion?.truth).not.toHaveProperty("toolCallId");
+  });
+
+  it("propagates realtimeHint completion truth fallback into run completion meta", async () => {
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResultWithCompletionTruth({
+        promptError: null,
+        yieldDetected: true,
+        completionTruth: {
+          source: "sessions_yield",
+          status: "yielded",
+          message: "fallback realtime hint",
+          sessionId: "yield-realtime-hint-session",
+          toolCallId: "unknown",
+        },
+        completionTruthSelection: {
+          source: "realtimeHint",
+          confidence: "low",
+          notes: ["selected realtime hint fallback"],
+        },
+      }),
+    );
+
+    const result = await runEmbeddedPiAgent({
+      ...overflowBaseRunParams,
+      sessionId: "yield-realtime-hint-session",
+      runId: "run-yield-completion-truth-realtime-hint",
+    });
+
+    expect(result.meta.completion).toMatchObject({
+      stopReason: "end_turn",
+      truth: {
+        source: "sessions_yield",
+        status: "yielded",
+        message: "fallback realtime hint",
+      },
+      truthSelection: {
+        source: "realtimeHint",
+        confidence: "low",
+      },
+    });
+  });
+
+  it("clientToolCall takes precedence over yieldDetected", async () => {
+    // Edge case: both flags set (shouldn't happen, but clientToolCall wins)
     mockedRunEmbeddedAttempt.mockResolvedValueOnce(
       makeAttemptResult({
         promptError: null,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -4,6 +4,9 @@ import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-contex
 import type { FallbackAttempt } from "../model-fallback.types.js";
 import type { MessagingToolSend } from "../pi-embedded-messaging.types.js";
 
+// Keep these trace types local to embedded runner metadata. They intentionally
+// mirror the redacted completion-truth shape without exporting the internal
+// completion-truth contract through runner meta/public trace surfaces.
 export type CompletionTruthTrace = {
   /** Internal producer of this completion truth envelope. */
   source: string;

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -4,6 +4,20 @@ import type { DiagnosticTraceContext } from "../../infra/diagnostic-trace-contex
 import type { FallbackAttempt } from "../model-fallback.types.js";
 import type { MessagingToolSend } from "../pi-embedded-messaging.types.js";
 
+export type CompletionTruthTrace = {
+  /** Internal producer of this completion truth envelope. */
+  source: string;
+  /** Producer-specific completion status. */
+  status: string;
+  [key: string]: unknown;
+};
+
+export type CompletionTruthSelectionTrace = {
+  source: "toolResult" | "transcriptResult" | "verificationArtifact" | "realtimeHint" | "none";
+  confidence: "high" | "medium" | "low" | "none";
+  notes?: string[];
+};
+
 export type EmbeddedPiAgentMeta = {
   sessionId: string;
   sessionFile?: string;
@@ -101,6 +115,10 @@ export type CompletionTrace = {
   finishReason?: string;
   stopReason?: string;
   refusal?: boolean;
+  /** Redacted completion truth resolved from internal host/runtime signals. */
+  truth?: CompletionTruthTrace;
+  /** Source/confidence metadata for the selected completion truth. */
+  truthSelection?: CompletionTruthSelectionTrace;
 };
 
 export type ContextManagementTrace = {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -22,6 +22,7 @@ import type { ProcessToolDefaults } from "./bash-tools.process.js";
 import { execSchema, processSchema } from "./bash-tools.schemas.js";
 import { listChannelAgentTools } from "./channel-tools.js";
 import { shouldSuppressManagedWebSearchTool } from "./codex-native-web-search.js";
+import type { SessionsYieldCompletionOutput } from "./completion-truth.js";
 import { resolveImageSanitizationLimits } from "./image-sanitization.js";
 import type { ModelAuthMode } from "./model-auth.js";
 import { resolveOpenClawPluginToolsForOptions } from "./openclaw-plugin-tools.js";
@@ -264,7 +265,7 @@ export const __testing = {
   applyModelProviderToolPolicy,
 } as const;
 
-export function createOpenClawCodingTools(options?: {
+export type OpenClawCodingToolsOptions = {
   agentId?: string;
   exec?: ExecToolDefaults & ProcessToolDefaults;
   messageProvider?: string;
@@ -371,7 +372,20 @@ export function createOpenClawCodingTools(options?: {
   onYield?: (message: string) => Promise<void> | void;
   /** Optional instrumentation callback for tool preparation stage timing. */
   recordToolPrepStage?: (name: string) => void;
-}): AnyAgentTool[] {
+};
+
+type InternalOpenClawCodingToolsOptions = OpenClawCodingToolsOptions & {
+  /** Internal callback carrying explicit sessions_yield completion truth. */
+  onCompletionTruth?: (output: SessionsYieldCompletionOutput) => Promise<void> | void;
+};
+
+export function createOpenClawCodingTools(options?: OpenClawCodingToolsOptions): AnyAgentTool[] {
+  return createOpenClawCodingToolsInternal(options);
+}
+
+export function createOpenClawCodingToolsInternal(
+  options?: InternalOpenClawCodingToolsOptions,
+): AnyAgentTool[] {
   const execToolName = "exec";
   const sandbox = options?.sandbox?.enabled ? options.sandbox : undefined;
   const isMemoryFlushRun = options?.trigger === "memory";
@@ -723,6 +737,7 @@ export function createOpenClawCodingTools(options?: {
           senderIsOwner: options?.senderIsOwner,
           sessionId: options?.sessionId,
           onYield: options?.onYield,
+          onCompletionTruth: options?.onCompletionTruth,
           allowGatewaySubagentBinding: options?.allowGatewaySubagentBinding,
           recordToolPrepStage: options?.recordToolPrepStage,
         })

--- a/src/agents/tools/sessions-yield-tool.test.ts
+++ b/src/agents/tools/sessions-yield-tool.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import {
+  createCompletionTruthPublicHostHook,
+  createOnToolResultForwarder,
+  resolveCompletionTruthFromPublicHost,
+} from "../completion-truth.js";
 import { createSessionsYieldTool } from "./sessions-yield-tool.js";
 
 describe("sessions_yield tool", () => {
@@ -15,17 +20,121 @@ describe("sessions_yield tool", () => {
 
   it("invokes onYield callback with default message", async () => {
     const onYield = vi.fn();
-    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      onYield,
+    });
     const result = await tool.execute("call-1", {});
-    expect(result.details).toMatchObject({ status: "yielded", message: "Turn yielded." });
+    expect(result.details).toMatchObject({
+      status: "yielded",
+      message: "Turn yielded.",
+    });
     expect(onYield).toHaveBeenCalledOnce();
     expect(onYield).toHaveBeenCalledWith("Turn yielded.");
   });
 
+  it("forwards an explicit completion truth envelope before yielding", async () => {
+    const calls: string[] = [];
+    const onYield = vi.fn(() => {
+      calls.push("yield");
+    });
+    const onCompletionTruth = vi.fn(() => {
+      calls.push("completion");
+    });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      onYield,
+      onCompletionTruth,
+    });
+
+    await tool.execute("call-1", { message: "Waiting for fact-checker" });
+
+    expect(calls).toEqual(["completion", "yield"]);
+    expect(onCompletionTruth).toHaveBeenCalledWith({
+      source: "sessions_yield",
+      status: "yielded",
+      message: "Waiting for fact-checker",
+      sessionId: "test-session",
+      toolCallId: "call-1",
+    });
+  });
+
+  it("keeps yielding when completion truth observer fails", async () => {
+    for (const onCompletionTruth of [
+      vi.fn(async () => {
+        throw new Error("observer async failed");
+      }),
+      vi.fn(() => {
+        throw new Error("observer sync failed");
+      }),
+    ]) {
+      const onYield = vi.fn();
+      const tool = createSessionsYieldTool({
+        sessionId: "test-session",
+        onYield,
+        onCompletionTruth,
+      });
+
+      const result = await tool.execute("call-1", { message: "Keep yielding" });
+
+      expect(result.details).toMatchObject({
+        status: "yielded",
+        message: "Keep yielding",
+      });
+      expect(onCompletionTruth).toHaveBeenCalledOnce();
+      expect(onYield).toHaveBeenCalledOnce();
+      expect(onYield).toHaveBeenCalledWith("Keep yielding");
+    }
+  });
+
+  it("real tool execution resolves completion truth from toolResult", async () => {
+    const hook = createCompletionTruthPublicHostHook();
+    const onYield = vi.fn();
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      onYield,
+      onCompletionTruth: createOnToolResultForwarder(hook),
+    });
+
+    await tool.execute("call-1", { message: "Waiting for worker" });
+
+    await expect(
+      resolveCompletionTruthFromPublicHost({
+        hook,
+        parseRealtimeHint: (rawMessage) => ({
+          source: "sessions_yield",
+          status: "yielded",
+          message: rawMessage,
+          sessionId: "test-session",
+          toolCallId: "unknown",
+        }),
+        timeoutMs: 100,
+        waitPolicy: { toolResultPriorityWindowMs: 10 },
+      }),
+    ).resolves.toMatchObject({
+      output: {
+        source: "sessions_yield",
+        status: "yielded",
+        message: "Waiting for worker",
+        sessionId: "test-session",
+        toolCallId: "call-1",
+      },
+      selection: {
+        source: "toolResult",
+        confidence: "high",
+      },
+    });
+  });
+
   it("passes the custom message through the yield callback", async () => {
     const onYield = vi.fn();
-    const tool = createSessionsYieldTool({ sessionId: "test-session", onYield });
-    const result = await tool.execute("call-1", { message: "Waiting for fact-checker" });
+    const tool = createSessionsYieldTool({
+      sessionId: "test-session",
+      onYield,
+    });
+    const result = await tool.execute("call-1", {
+      message: "Waiting for fact-checker",
+    });
     expect(result.details).toMatchObject({
       status: "yielded",
       message: "Waiting for fact-checker",

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -39,7 +39,7 @@ export function createSessionsYieldTool(opts?: {
         toolCallId: _toolCallId,
       });
       try {
-        Promise.resolve(opts.onCompletionTruth?.(completionOutput)).catch(() => {
+        void Promise.resolve(opts.onCompletionTruth?.(completionOutput)).catch(() => {
           // Completion truth is observability metadata. It must never block the
           // control-plane yield callback that cleanly aborts the active run.
         });

--- a/src/agents/tools/sessions-yield-tool.ts
+++ b/src/agents/tools/sessions-yield-tool.ts
@@ -1,4 +1,8 @@
 import { Type } from "typebox";
+import {
+  buildSessionsYieldCompletionOutput,
+  type SessionsYieldCompletionOutput,
+} from "../completion-truth.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readStringParam } from "./common.js";
 
@@ -9,6 +13,7 @@ const SessionsYieldToolSchema = Type.Object({
 export function createSessionsYieldTool(opts?: {
   sessionId?: string;
   onYield?: (message: string) => Promise<void> | void;
+  onCompletionTruth?: (output: SessionsYieldCompletionOutput) => Promise<void> | void;
 }): AnyAgentTool {
   return {
     label: "Yield",
@@ -23,7 +28,24 @@ export function createSessionsYieldTool(opts?: {
         return jsonResult({ status: "error", error: "No session context" });
       }
       if (!opts?.onYield) {
-        return jsonResult({ status: "error", error: "Yield not supported in this context" });
+        return jsonResult({
+          status: "error",
+          error: "Yield not supported in this context",
+        });
+      }
+      const completionOutput = buildSessionsYieldCompletionOutput({
+        message,
+        sessionId: opts.sessionId,
+        toolCallId: _toolCallId,
+      });
+      try {
+        Promise.resolve(opts.onCompletionTruth?.(completionOutput)).catch(() => {
+          // Completion truth is observability metadata. It must never block the
+          // control-plane yield callback that cleanly aborts the active run.
+        });
+      } catch {
+        // Completion truth is observability metadata. It must never block the
+        // control-plane yield callback that cleanly aborts the active run.
       }
       await opts.onYield(message);
       return jsonResult({ status: "yielded", message });


### PR DESCRIPTION
## Summary

This patch adds an internal completion truth seam for `sessions_yield` and wires it through the embedded runner so parent/session orchestration can observe an explicit, trustworthy completion source.

For a real `sessions_yield` turn, the expected selected source is:

```ts
result.meta.completion.truthSelection.source === "toolResult"
```

## What changed

- Added internal `src/agents/completion-truth/` module:
  - source-priority selector
  - public-host/runtime queues
  - sessions_yield envelope builder
  - transcript-result normalizer/selector
- Added an internal `onCompletionTruth` callback to `sessions_yield` tooling.
- Wired embedded runner yield-abort handling to resolve completion truth from the explicit tool result, with low-confidence realtime-hint fallback.
- Added `meta.completion.truth` and `meta.completion.truthSelection` on run result completion meta.
- Redacted raw internal `sessionId` / `toolCallId` before truth metadata leaves the runner.
- Kept completion truth off plugin SDK / public package exports.
- Kept public `createOpenClawCodingTools` options free of `onCompletionTruth`; runner uses internal `createOpenClawCodingToolsInternal`.

## Safety / boundaries

- `onCompletionTruth` is best-effort observability and cannot block the `onYield` control path.
- Both async rejection and sync throw from the observer are covered.
- Completion truth resolver failure records `truthSelection: none` and still allows clean yield completion.
- No npm-global runtime patch.
- No plugin SDK export.
- No transcript polling expansion.
- No artifact auto-discovery.
- No source merge/speculative reconciliation.

## Tests / validation

Initial pre-rebase local validation on the original source baseline:

```text
git diff --check: passed
targeted oxlint: 0 warnings / 0 errors
focused tests: 6 files / 26 tests passed
full typecheck: passed
plugin SDK leakage grep: no internal completion-truth leakage
secret scan: no suspicious real key/token patterns
```

Post-rebase validation against current `main`:

```text
git diff --check: passed
focused tests: 9 files / 40 tests passed
```

Focused test command:

```bash
npx vitest run \
  src/agents/completion-truth.export.test.ts \
  src/agents/completion-truth/*.test.ts \
  src/agents/tools/sessions-yield-tool.test.ts \
  src/agents/pi-embedded-runner/sessions-yield.orchestration.test.ts \
  --config test/vitest/vitest.config.ts
```

Gated live smoke was also validated earlier with `nowcoding/gpt-5.5`:

```text
src/agents/pi-embedded-runner.sessions-yield-completion-truth.live.test.ts
result.meta.completion.truthSelection.source === "toolResult"
```

### Post-rebase local typecheck note

After rebasing onto current `main`, full local typecheck currently reports errors outside this PR's changed file set, including `extensions/acpx/src/claude-agent-acp-completion.test.ts` missing `@agentclientprotocol/claude-agent-acp` and existing casts in `src/agents/pi-embedded-runner/run/attempt.test.ts`. The PR-specific focused tests pass after conflict resolution.

## Reviewer notes

A deterministic non-live fake-provider/stream full-path test is not included in this patch. A first e2e attempt was withdrawn because current provider routing / harness did not reliably hit the mocked stream. The real path is covered by the gated live smoke. If default-CI full-path coverage is required, the next step should be a dedicated fake provider stream harness.

## Commit

```text
dee59cf6 Add sessions_yield completion truth metadata
```
