### PR TITLE
test: drop spurious await + redundant cast on plugin.register call sites

### DIFF
--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -567,7 +567,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },
@@ -591,7 +591,7 @@ describe("active-memory plugin", () => {
       agents: ["main"],
       allowedChatTypes: ["explicit"],
     };
-    await plugin.register(api as unknown as OpenClawPluginApi);
+    plugin.register(api as unknown as OpenClawPluginApi);
 
     const result = await hooks.before_prompt_build(
       { prompt: "what should i work on next?", messages: [] },

--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -72,9 +72,9 @@ describe("codex plugin", () => {
       registerMediaUnderstandingProvider: vi.fn(),
       registerProvider: vi.fn(),
       on: vi.fn(),
-    }) as ReturnType<typeof createTestPluginApi> & {
-      onConversationBindingResolved?: ReturnType<typeof vi.fn>;
-    };
+    });
+    // Simulate a capture-API runtime that has not yet wired the conversation
+    // binding hook, exercising the codex plugin's defensive registration path.
     delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved;
 
     expect(() => plugin.register(api)).not.toThrow();


### PR DESCRIPTION
## What

Restore `node scripts/run-oxlint-shards.mjs` to **0 errors** so the CI lint shard stops blocking unrelated PRs.

## Why now

Two regressions slipped into `extensions/active-memory/index.test.ts` (lines 570 and 594, added by the `#66285` / `#73502` test additions for explicit-chat-type classification) added `await plugin.register(api as unknown as OpenClawPluginApi)` calls. `plugin.register` is **synchronous** (declared as `register(api: OpenClawPluginApi)` in `extensions/active-memory/index.ts:2335`, with no return), so oxlint's `typescript-eslint(await-thenable)` rule flags both.

Combined with the two pre-existing oxlint findings on `extensions/codex/index.test.ts:75` (`no-unnecessary-type-assertion` + `no-redundant-type-constituents` from a redundant `as ReturnType<typeof createTestPluginApi> & { onConversationBindingResolved?: ... }` cast), the `oxlint:extensions` shard now exits 1 with `Found 0 warnings and 4 errors`, taking the whole `check-lint` job (and therefore every PR) down with it.

## Fix

- **`extensions/active-memory/index.test.ts:570, 594`** — drop the spurious `await`. Every other call site in the same file (lines 169, 544, 619, 642, 669, 692, 715, …) already calls `plugin.register(...)` without `await`; aligning these two restores the established convention and silences `await-thenable`.
- **`extensions/codex/index.test.ts:63-77`** — drop the `as ReturnType<typeof createTestPluginApi> & { onConversationBindingResolved?: ReturnType<typeof vi.fn> }` cast. `createTestPluginApi` already returns `OpenClawPluginApi`; the intersection adds nothing the test does not get from the existing `delete (api as { onConversationBindingResolved?: unknown }).onConversationBindingResolved` line below, which is what actually makes the capture-API scenario testable. A short comment now explains why the delete is there.

## Verified locally

```
node scripts/run-oxlint-shards.mjs
# [oxlint:scripts] Found 0 warnings and 0 errors.
# [oxlint:core]    Found 0 warnings and 0 errors.
# [oxlint:extensions] Found 0 warnings and 0 errors.

npx vitest run extensions/active-memory/index.test.ts
# Tests  88 passed (88)

npx vitest run extensions/codex/index.test.ts
# Tests  4 passed (4)
```

## Impact

This unblocks `check-lint` for every open PR. Currently flagged on at least:
- #73614 (logging tilde fix)
- and any PR opened after `f256eeba43` landed `await plugin.register(...)`.

## Pre-implement audit

- **Existing-helper / pattern reuse**: The fix is to align with the convention already used by 8+ call sites in the same file. ✅
- **Shared-helper caller check**: `plugin.register` is invoked only from tests; production code never awaits it either. ✅
- **Broader-fix rival scan**: Zero rival PRs touch these files for this reason. ✅

lobster-biscuit: ext-await-thenable-cleanup

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
