### PR TITLE
fix(control-ui): copy code blocks from rendered textContent (#69605)

### DIFF
--- a/ui/src/ui/chat/code-block-copy.test.ts
+++ b/ui/src/ui/chat/code-block-copy.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { toSanitizedMarkdownHtml } from "../markdown.js";
+import { resolveCodeBlockCopyText } from "./code-block-copy.ts";
+
+function renderToContainer(markdown: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = toSanitizedMarkdownHtml(markdown);
+  return container;
+}
+
+describe("resolveCodeBlockCopyText (#69605)", () => {
+  it("returns the rendered code only, not surrounding prose", () => {
+    const md = [
+      "Here is some prose.",
+      "",
+      "```js",
+      "function hello() {",
+      '  return "world";',
+      "}",
+      "```",
+      "",
+      "And more prose.",
+    ].join("\n");
+    const container = renderToContainer(md);
+    const btn = container.querySelector(".code-block-copy");
+
+    const text = resolveCodeBlockCopyText(btn);
+
+    expect(text).not.toContain("Here is some prose");
+    expect(text).not.toContain("And more prose");
+    expect(text).toContain("function hello()");
+    expect(text).toContain('return "world"');
+  });
+
+  it("handles a click that lands on the inner Copy label span", () => {
+    const md = "before\n\n```\nthe-only-code\n```\n\nafter";
+    const container = renderToContainer(md);
+    const innerLabel = container.querySelector(".code-block-copy__idle");
+    expect(innerLabel).not.toBeNull();
+
+    // Simulate the bubble-target search the click handler performs.
+    const btn = innerLabel?.closest(".code-block-copy") as HTMLElement | null;
+    expect(btn).not.toBeNull();
+
+    const text = resolveCodeBlockCopyText(btn);
+    expect(text.trim()).toBe("the-only-code");
+  });
+
+  it("returns each block's content when a message has multiple blocks", () => {
+    const md = [
+      "Intro.",
+      "",
+      "```js",
+      "first()",
+      "```",
+      "",
+      "Middle prose.",
+      "",
+      "```py",
+      "second()",
+      "```",
+      "",
+      "Outro.",
+    ].join("\n");
+    const container = renderToContainer(md);
+    const buttons = Array.from(container.querySelectorAll(".code-block-copy"));
+    expect(buttons).toHaveLength(2);
+
+    expect(resolveCodeBlockCopyText(buttons[0]).trim()).toBe("first()");
+    expect(resolveCodeBlockCopyText(buttons[1]).trim()).toBe("second()");
+  });
+
+  it("falls back to data-code when the wrapper has no rendered <code> element", () => {
+    const button = document.createElement("button");
+    button.className = "code-block-copy";
+    button.dataset.code = "fallback-text";
+
+    expect(resolveCodeBlockCopyText(button)).toBe("fallback-text");
+  });
+
+  it("returns an empty string when the button is missing", () => {
+    expect(resolveCodeBlockCopyText(null)).toBe("");
+    expect(resolveCodeBlockCopyText(undefined)).toBe("");
+  });
+
+  it("preserves HTML-special characters in code (round-trips < > &)", () => {
+    // Inside a fenced block, the source `&amp;` is literal user content, not
+    // an HTML entity. textContent must round-trip those literal characters
+    // exactly so what the user sees is what gets copied.
+    const md = "before\n\n```html\n<div>x & y</div>\n```\n\nafter";
+    const container = renderToContainer(md);
+    const btn = container.querySelector(".code-block-copy");
+
+    const text = resolveCodeBlockCopyText(btn);
+    expect(text).toContain("<div>");
+    expect(text).toContain("x & y");
+    expect(text).toContain("</div>");
+  });
+});

--- a/ui/src/ui/chat/code-block-copy.ts
+++ b/ui/src/ui/chat/code-block-copy.ts
@@ -1,0 +1,30 @@
+// Helpers for resolving the text payload of a code-block "Copy" button click.
+//
+// The rendered DOM looks like:
+//   <div class="code-block-wrapper">
+//     <div class="code-block-header">
+//       <span class="code-block-lang">js</span>
+//       <button class="code-block-copy" data-code="...">Copy</button>
+//     </div>
+//     <pre><code class="language-js">...</code></pre>
+//   </div>
+//
+// Reading from the rendered <code>'s textContent is the most reliable source —
+// it always matches what the user sees, even when `data-code` was stripped by
+// sanitization, normalized differently across browsers, or simply empty.
+// The `data-code` attribute remains a fallback for the (rare) case where the
+// wrapper or rendered <code> element cannot be located, e.g. partial DOMs in
+// tests or non-default markdown rendering.
+
+export function resolveCodeBlockCopyText(btn: Element | null | undefined): string {
+  if (!btn) {
+    return "";
+  }
+  const wrapper = btn.closest(".code-block-wrapper");
+  const codeEl = wrapper?.querySelector("pre > code");
+  const fromDom = codeEl?.textContent;
+  if (fromDom !== null && fromDom !== undefined) {
+    return fromDom;
+  }
+  return (btn as HTMLElement).dataset?.code ?? "";
+}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -15,6 +15,7 @@ import { buildChatItems } from "../chat/build-chat-items.ts";
 import { renderChatQueue } from "../chat/chat-queue.ts";
 import { buildRawSidebarContent } from "../chat/chat-sidebar-raw.ts";
 import { renderWelcomeState, resolveAssistantDisplayAvatar } from "../chat/chat-welcome.ts";
+import { resolveCodeBlockCopyText } from "../chat/code-block-copy.ts";
 import { renderContextNotice } from "../chat/context-notice.ts";
 import { DeletedMessages } from "../chat/deleted-messages.ts";
 import { exportChatMarkdown } from "../chat/export.ts";
@@ -746,11 +747,14 @@ export function renderChat(props: ChatProps) {
   const sidebarOpen = Boolean(props.sidebarOpen && props.onCloseSidebar);
 
   const handleCodeBlockCopy = (e: Event) => {
-    const btn = (e.target as HTMLElement).closest(".code-block-copy");
+    const target = e.target as HTMLElement | null;
+    const btn = target?.closest(".code-block-copy") as HTMLElement | null;
     if (!btn) {
       return;
     }
-    const code = (btn as HTMLElement).dataset.code ?? "";
+    e.preventDefault();
+    e.stopPropagation();
+    const code = resolveCodeBlockCopyText(btn);
     navigator.clipboard.writeText(code).then(
       () => {
         btn.classList.add("copied");


### PR DESCRIPTION
## Summary

Fixes #69605. In the Control UI WebChat, clicking the **Copy** button on a fenced code block could end up pasting the entire assistant message instead of just the code, because the previous handler relied solely on the `data-code` attribute. That attribute round-trips through `escapeHtml` → DOMPurify → DOM `dataset.code`, which can normalize differently across browsers (multi-line attribute whitespace, encoding edge cases) and silently produces an empty string in some sanitization paths — leaving whatever was previously on the clipboard intact.

The fix reads the **rendered** `<pre><code>` `textContent` first, which always matches exactly what the user sees in the chat bubble, and keeps `data-code` as a fallback for partial DOMs (e.g. tests).

## Changes

- `ui/src/ui/chat/code-block-copy.ts`: new `resolveCodeBlockCopyText(btn)` helper. Walks `btn → .code-block-wrapper → pre > code` and returns its `textContent`; falls back to `dataset.code`; returns `""` when nothing is found.
- `ui/src/ui/views/chat.ts`: `handleCodeBlockCopy` now calls the helper, and also calls `e.preventDefault()` + `e.stopPropagation()` so no parent listener can override the `clipboard.writeText` call.
- `ui/src/ui/chat/code-block-copy.test.ts`: 6 cases (pure code only / no surrounding prose, click target inside the inner Copy label span, multiple blocks in one message, missing wrapper falls back to `data-code`, missing button returns `""`, HTML special chars round-trip).
- `CHANGELOG.md`: single-line entry under `## Unreleased > ### Fixes`.

## Test plan

- [x] `pnpm exec vitest run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/chat/code-block-copy.test.ts` — 6/6 pass.
- [x] `pnpm tsgo:core` clean.
- [x] `pnpm run lint:core` clean.
- [x] `pnpm exec oxfmt --check` clean.
- [ ] Manual: open `http://127.0.0.1:18789/`, send a message with a fenced code block, click **Copy**, paste — should be only the code.

## Suggested CHANGELOG entry

This PR intentionally does not touch `CHANGELOG.md` to avoid hot-file rebase conflicts that have been closing rebased fix PRs. Maintainers can drop the following line under `## Unreleased > ### Fixes` at merge time:

- Control UI/WebChat: copy code-block "Copy" button now reads from the rendered `<pre><code>` `textContent` instead of the `data-code` attribute, with the attribute kept as a fallback, so the copied payload always matches what the user sees even when sanitization or browser quirks normalize the attribute differently; the click handler also stops event propagation so no parent listener can override the writeText. Fixes #69605. Thanks @juan-flores077.