### PR TITLE
Errors: rewrite 403 HTML auth pages

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -414,6 +414,12 @@ describe("formatRawAssistantErrorForUi", () => {
       "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
     );
   });
+
+  it("preserves a clean ellipsis when truncating fallback error text", () => {
+    const raw = "x".repeat(601);
+
+    expect(formatRawAssistantErrorForUi(raw)).toBe(`${"x".repeat(600)}\u2026`);
+  });
 });
 
 describe("raw API error payload helpers", () => {

--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -208,6 +208,18 @@ describe("formatAssistantErrorText", () => {
     );
   });
 
+  it("does not misclassify embedded 403 HTML pages as rate limits or transport failures", () => {
+    const msg = makeAssistantError(
+      'Error: fetch failed: 403 <html><head><title>Forbidden</title></head><body>Try again in 30 seconds after login.</body></html>',
+    );
+    const result = formatAssistantErrorText(msg);
+    expect(result).toBe(
+      "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
+    );
+    expect(result).not.toContain("rate limit");
+    expect(result).not.toContain("DNS lookup");
+  });
+
   it("returns a friendly message for empty stream chunk errors", () => {
     const msg = makeAssistantError("request ended without sending any chunks");
     expect(formatAssistantErrorText(msg)).toBe("LLM request timed out.");
@@ -391,6 +403,15 @@ describe("formatRawAssistantErrorForUi", () => {
 
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The provider returned an HTML error page instead of an API response. This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. Retry in a moment or check provider status.",
+    );
+  });
+
+  it("sanitizes 403 HTML auth pages into a clean re-auth message", () => {
+    const htmlError =
+      '403 <html><head><title>Forbidden</title></head><body>challenge</body></html>';
+
+    expect(formatRawAssistantErrorForUi(htmlError)).toBe(
+      "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
     );
   });
 });

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1412,6 +1412,14 @@ describe("classifyProviderRuntimeFailureKind", () => {
     ).toBe("auth_html_403");
   });
 
+  it("classifies embedded HTML 403 auth failures", () => {
+    expect(
+      classifyProviderRuntimeFailureKind(
+        "Error: fetch failed: 403 <!DOCTYPE html><html><body>Access denied</body></html>",
+      ),
+    ).toBe("auth_html_403");
+  });
+
   it("classifies proxy, dns, timeout, schema, sandbox, and replay failures", () => {
     expect(classifyProviderRuntimeFailureKind("407 Proxy Authentication Required")).toBe("proxy");
     expect(

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -160,6 +160,17 @@ describe("sanitizeUserFacingText", () => {
     ).toBe("LLM request failed: connection refused by the provider endpoint.");
   });
 
+  it("prefers HTML 403 auth copy over transport or rate-limit hints", () => {
+    const text =
+      'Error: fetch failed: 403 <html><head><title>Forbidden</title></head><body>Try again in 30 seconds after login.</body></html>';
+    const result = sanitizeUserFacingText(text, { errorContext: true });
+    expect(result).toBe(
+      "Authentication failed with an HTML 403 response from the provider. Re-authenticate and verify your provider account access.",
+    );
+    expect(result).not.toContain("rate limit");
+    expect(result).not.toContain("DNS lookup");
+  });
+
   it.each(["disk full", "ENOSPC: no space left on device"])(
     "rewrites disk-space failures with errorContext: %s",
     (input) => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -2,9 +2,9 @@ import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
+  extractHtmlHttpError,
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
-  isCloudflareOrHtmlErrorPage,
   parseApiErrorInfo,
 } from "../../shared/assistant-error-format.js";
 import {
@@ -37,16 +37,13 @@ import {
   matchesProviderContextOverflow,
 } from "./provider-error-patterns.js";
 import {
-  BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
   formatDiskSpaceErrorCopy,
   formatRateLimitOrOverloadedErrorCopy,
   formatTransportErrorCopy,
-  getApiErrorPayloadFingerprint,
   isInvalidStreamingEventOrderError,
   isLikelyHttpErrorText,
   isRawApiErrorPayload,
-  sanitizeUserFacingText,
 } from "./sanitize-user-facing-text.js";
 import type { FailoverReason } from "./types.js";
 
@@ -377,6 +374,13 @@ function isHtmlErrorResponse(raw: string, status?: number): boolean {
   if (!trimmed) {
     return false;
   }
+  const htmlError = extractHtmlHttpError(trimmed);
+  if (htmlError) {
+    if (typeof status === "number" && Number.isFinite(status) && htmlError.code !== status) {
+      return false;
+    }
+    return true;
+  }
   const candidate = extractLeadingHttpStatus(trimmed) ? trimmed : stripErrorPrefix(trimmed);
   const inferred =
     typeof status === "number" && Number.isFinite(status)
@@ -395,6 +399,14 @@ function isTransportHtmlErrorStatus(status: number | undefined): boolean {
     status === 499 ||
     (typeof status === "number" && status >= 500 && status < 600)
   );
+}
+
+function shouldPreferHtmlHttpErrorCopy(raw: string): boolean {
+  const htmlError = extractHtmlHttpError(raw);
+  if (!htmlError) {
+    return false;
+  }
+  return htmlError.code === 401 || htmlError.code === 403;
 }
 
 function isOpenAICodexScopeContext(raw: string, provider?: string): boolean {
@@ -901,6 +913,7 @@ export function classifyProviderRuntimeFailureKind(
   const normalizedSignal = typeof signal === "string" ? { message: signal } : signal;
   const message = normalizedSignal.message?.trim() ?? "";
   const status = inferSignalStatus(normalizedSignal);
+  const htmlError = message ? extractHtmlHttpError(message) : null;
 
   if (!message && typeof status !== "number") {
     return "empty_response";
@@ -930,7 +943,8 @@ export function classifyProviderRuntimeFailureKind(
     return "proxy";
   }
   if (message && isHtmlErrorResponse(message, status)) {
-    return status === 403 ? "auth_html_403" : "upstream_html";
+    const htmlStatus = htmlError?.code ?? status;
+    return htmlStatus === 403 ? "auth_html_403" : "upstream_html";
   }
   const failoverClassification = classifyFailoverSignal({
     ...normalizedSignal,
@@ -1104,6 +1118,10 @@ export function formatAssistantErrorText(
   const invalidRequest = raw.match(/"type":"invalid_request_error".*?"message":"([^"]+)"/);
   if (invalidRequest?.[1]) {
     return `LLM request rejected: ${invalidRequest[1]}`;
+  }
+
+  if (shouldPreferHtmlHttpErrorCopy(raw)) {
+    return formatRawAssistantErrorForUi(raw);
   }
 
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -1,5 +1,6 @@
 import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import {
+  extractHtmlHttpError,
   extractLeadingHttpStatus,
   formatRawAssistantErrorForUi,
   isCloudflareOrHtmlErrorPage,
@@ -364,6 +365,14 @@ export function isLikelyHttpErrorText(raw: string): boolean {
   return HTTP_ERROR_HINTS.some((hint) => message.includes(hint));
 }
 
+function shouldPreferHtmlHttpErrorCopy(raw: string): boolean {
+  const htmlError = extractHtmlHttpError(raw);
+  if (!htmlError) {
+    return false;
+  }
+  return htmlError.code === 401 || htmlError.code === 403;
+}
+
 export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: boolean }): string {
   const raw = coerceChatContentText(text);
   if (!raw) {
@@ -413,6 +422,10 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
 
     if (isInvalidStreamingEventOrderError(trimmed)) {
       return "LLM request failed: provider returned an invalid streaming response. Please try again.";
+    }
+
+    if (shouldPreferHtmlHttpErrorCopy(trimmed)) {
+      return formatRawAssistantErrorForUi(trimmed);
     }
 
     if (isRawApiErrorPayload(trimmed) || isLikelyHttpErrorText(trimmed)) {

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -257,5 +257,5 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return `${prefix}${type}: ${info.message}`;
   }
 
-  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}â€¦` : trimmed;
+  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}\u2026` : trimmed;
 }

--- a/src/shared/assistant-error-format.ts
+++ b/src/shared/assistant-error-format.ts
@@ -11,6 +11,8 @@ const HTTP_STATUS_CODE_PREFIX_RE = new RegExp(
 );
 const HTML_ERROR_PREFIX_RE = /^\s*(?:<!doctype\s+html\b|<html\b)/i;
 const HTML_CLOSE_RE = /<\/html>/i;
+const EMBEDDED_HTML_HTTP_ERROR_RE =
+  /\b(?:http\s*)?([45]\d{2})\s+((?:<!doctype\s+html\b|<html\b)[\s\S]*)/i;
 const CLOUDFLARE_HTML_ERROR_CODES = new Set([521, 522, 523, 524, 525, 526, 530]);
 const STANDALONE_HTML_ERROR_HINT_RE =
   /\bcloudflare\b|cdn-cgi\/challenge-platform|challenge-error-text|enable javascript and cookies to continue|access denied|forbidden|service unavailable|bad gateway|web server is down|captcha|attention required/i;
@@ -91,12 +93,48 @@ export function extractLeadingHttpStatus(raw: string): { code: number; rest: str
   return { code, rest: (match[2] ?? "").trim() };
 }
 
+function isHtmlErrorDocument(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (!trimmed || !HTML_ERROR_PREFIX_RE.test(trimmed)) {
+    return false;
+  }
+  return HTML_CLOSE_RE.test(trimmed) || /<(?:head|body)\b/i.test(trimmed);
+}
+
+export function extractHtmlHttpError(raw?: string): { code: number; rest: string } | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const leadingStatus = extractLeadingHttpStatus(trimmed);
+  if (
+    leadingStatus &&
+    leadingStatus.code >= 400 &&
+    Number.isFinite(leadingStatus.code) &&
+    isHtmlErrorDocument(leadingStatus.rest)
+  ) {
+    return leadingStatus;
+  }
+
+  const embeddedMatch = trimmed.match(EMBEDDED_HTML_HTTP_ERROR_RE);
+  if (!embeddedMatch) {
+    return null;
+  }
+
+  const code = Number(embeddedMatch[1]);
+  const rest = embeddedMatch[2]?.trim() ?? "";
+  if (!Number.isFinite(code) || code < 400 || !isHtmlErrorDocument(rest)) {
+    return null;
+  }
+  return { code, rest };
+}
+
 export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
   const trimmed = raw.trim();
   if (!trimmed) {
     return false;
   }
-
   if (
     HTML_ERROR_PREFIX_RE.test(trimmed) &&
     HTML_CLOSE_RE.test(trimmed) &&
@@ -105,7 +143,7 @@ export function isCloudflareOrHtmlErrorPage(raw: string): boolean {
     return true;
   }
 
-  const status = extractLeadingHttpStatus(trimmed);
+  const status = extractHtmlHttpError(trimmed);
   if (!status || status.code < 500) {
     return false;
   }
@@ -181,13 +219,22 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return "LLM request failed with an unknown error.";
   }
 
-  const leadingStatus = extractLeadingHttpStatus(trimmed);
-  const isHtmlChallenge = isCloudflareOrHtmlErrorPage(trimmed);
-  if (leadingStatus && isHtmlChallenge) {
-    return `The AI service is temporarily unavailable (HTTP ${leadingStatus.code}). Please try again in a moment.`;
+  const htmlError = extractHtmlHttpError(trimmed);
+  if (htmlError) {
+    if (htmlError.code === 401 || htmlError.code === 403) {
+      return `Authentication failed with an HTML ${htmlError.code} response from the provider. Re-authenticate and verify your provider account access.`;
+    }
+    if (htmlError.code >= 500 || CLOUDFLARE_HTML_ERROR_CODES.has(htmlError.code)) {
+      return `The AI service is temporarily unavailable (HTTP ${htmlError.code}). Please try again in a moment.`;
+    }
+    return (
+      "The provider returned an HTML error page instead of an API response. " +
+      "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +
+      "Retry in a moment or check provider status."
+    );
   }
 
-  if (isHtmlChallenge) {
+  if (isCloudflareOrHtmlErrorPage(trimmed)) {
     return (
       "The provider returned an HTML error page instead of an API response. " +
       "This usually means a CDN or gateway (e.g. Cloudflare) blocked the request. " +
@@ -210,5 +257,5 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
     return `${prefix}${type}: ${info.message}`;
   }
 
-  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+  return trimmed.length > 600 ? `${trimmed.slice(0, 600)}â€¦` : trimmed;
 }


### PR DESCRIPTION
## Summary

Fix incorrect user-facing error reporting when provider requests return `403` HTML auth/challenge pages.

Previously these failures could be surfaced as transport or rate-limit style errors, which sent users down the wrong debugging path. This change detects embedded and direct HTML auth pages earlier and keeps them on the authentication failure path instead.

## What changed

- detect embedded/direct HTML HTTP error pages in shared assistant error formatting
- preserve `403` HTML auth failures as auth-specific runtime classification
- prefer auth HTML copy before transport/rate-limit rewrites in user-facing sanitizers
- add regression coverage for formatter, sanitizer, and runtime classification paths

## Verification

Passed:
- `pnpm test src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
- `pnpm test src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts`
- `pnpm test src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts`
- `pnpm test src/agents/pi-embedded-subscribe.handlers.lifecycle.test.ts`

AI-assisted PR.