### PR TITLE
fix(channels): release zombie task on stopChannel timeout (#71412)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Channels: release stale zombie task/abort entries after `stopChannel` times out so a subsequent `startChannel` call can register a fresh task instead of short-circuiting on the stale entry. Fixes #71412. Thanks @hclsys.
 - Agents/Codex: bound embedded-run cleanup, trajectory flushing, and command-lane task timeouts after runtime failures, so Discord and other chat sessions return to idle instead of staying stuck in processing. Thanks @vincentkoc.
 - Heartbeat/exec: consume successful metadata-only async exec completions silently so Telegram and other chat surfaces no longer ask users for missing command logs after `No session found`. Fixes #74595. Thanks @gkoch02.
 - Web fetch: add a documented `tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange` opt-in and thread it through cache keys and DNS/IP checks so trusted fake-IP proxy stacks using `fc00::/7` can work without broad private-network access. Fixes #74351. Thanks @jeffrey701.

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -96,12 +96,18 @@ function createTestPlugin(params?: {
   };
 }
 
-function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+function createDeferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (reason?: unknown) => void;
+} {
   let resolvePromise = () => {};
-  const promise = new Promise<void>((resolve) => {
+  let rejectPromise: (reason?: unknown) => void = () => {};
+  const promise = new Promise<void>((resolve, reject) => {
     resolvePromise = resolve;
+    rejectPromise = reject;
   });
-  return { promise, resolve: resolvePromise };
+  return { promise, resolve: resolvePromise, reject: rejectPromise };
 }
 
 function installTestRegistry(
@@ -278,7 +284,7 @@ describe("server-channels auto restart", () => {
     }
   });
 
-  it("does not allow a second account task to start when stop times out", async () => {
+  it("releases the zombie task when stop times out so the next start can register a fresh one (#71412)", async () => {
     const startAccount = vi.fn(
       async ({ abortSignal }: { abortSignal: AbortSignal }) =>
         await new Promise<void>(() => {
@@ -300,10 +306,67 @@ describe("server-channels auto restart", () => {
 
     const snapshot = manager.getRuntimeSnapshot();
     const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
-    expect(startAccount).toHaveBeenCalledTimes(1);
+    // After timeout, store.tasks/aborts is cleared so the next startChannel
+    // actually registers a new poll loop instead of silently no-op'ing.
+    expect(startAccount).toHaveBeenCalledTimes(2);
     expect(account?.running).toBe(true);
     expect(account?.restartPending).toBe(false);
-    expect(account?.lastError).toContain("channel stop timed out");
+    // lastError from the timed-out stop is overwritten by the successful restart;
+    // we just want to confirm a fresh start happened, not the stale error.
+  });
+
+  it("ignores status and settlement writes from a task replaced after stop timeout", async () => {
+    const firstTask = createDeferred();
+    const secondTask = createDeferred();
+    const contexts: ChannelGatewayContext<TestAccount>[] = [];
+    const startAccount = vi.fn(async (ctx: ChannelGatewayContext<TestAccount>) => {
+      contexts.push(ctx);
+      if (contexts.length === 1) {
+        return await firstTask.promise;
+      }
+      return await secondTask.promise;
+    });
+    installTestRegistry(
+      createTestPlugin({
+        startAccount,
+      }),
+    );
+    const manager = createManager();
+
+    await manager.startChannels();
+    const stopTask = manager.stopChannel("discord", DEFAULT_ACCOUNT_ID);
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopTask;
+    await manager.startChannel("discord", DEFAULT_ACCOUNT_ID);
+
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    contexts[1]?.setStatus({
+      accountId: DEFAULT_ACCOUNT_ID,
+      connected: true,
+      lastTransportActivityAt: 123,
+    });
+    contexts[0]?.setStatus({
+      accountId: DEFAULT_ACCOUNT_ID,
+      connected: false,
+      running: false,
+      restartPending: true,
+      reconnectAttempts: 99,
+      lastError: "stale status",
+    });
+    firstTask.reject(new Error("stale exit"));
+    await vi.advanceTimersByTimeAsync(20);
+
+    const snapshot = manager.getRuntimeSnapshot();
+    const account = snapshot.channelAccounts.discord?.[DEFAULT_ACCOUNT_ID];
+    expect(startAccount).toHaveBeenCalledTimes(2);
+    expect(account).toMatchObject({
+      running: true,
+      connected: true,
+      restartPending: false,
+      reconnectAttempts: 0,
+      lastError: null,
+      lastTransportActivityAt: 123,
+    });
   });
 
   it("marks enabled/configured when account descriptors omit them", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -493,6 +493,15 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             lastError: null,
             reconnectAttempts: preserveRestartAttempts ? (restartAttempts.get(rKey) ?? 0) : 0,
           });
+          let trackedPromise: Promise<unknown> | undefined;
+          const isCurrentTask = () =>
+            trackedPromise !== undefined && store.tasks.get(id) === trackedPromise;
+          const setRuntimeForCurrentTask = (patch: ChannelAccountSnapshot) => {
+            if (!isCurrentTask()) {
+              return;
+            }
+            setRuntime(channelId, id, patch);
+          };
           const task = Promise.resolve().then(() =>
             measureStartup(`channels.${channelId}.start-account`, () =>
               startAccount({
@@ -503,41 +512,41 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
                 abortSignal: abort.signal,
                 log,
                 getStatus: () => getRuntime(channelId, id),
-                setStatus: (next) => setRuntime(channelId, id, next),
+                setStatus: setRuntimeForCurrentTask,
                 ...(channelRuntimeForTask ? { channelRuntime: channelRuntimeForTask } : {}),
               }),
             ),
           );
-          const trackedPromise = task
+          trackedPromise = task
             .then(() => {
               if (abort.signal.aborted || manuallyStopped.has(rKey)) {
                 return;
               }
               const message = "channel exited without an error";
-              setRuntime(channelId, id, { accountId: id, lastError: message });
+              setRuntimeForCurrentTask({ accountId: id, lastError: message });
               log.error?.(`[${id}] ${message}`);
             })
             .catch((err) => {
               const message = formatErrorMessage(err);
-              setRuntime(channelId, id, { accountId: id, lastError: message });
+              setRuntimeForCurrentTask({ accountId: id, lastError: message });
               log.error?.(`[${id}] channel exited: ${message}`);
             })
             .finally(async () => {
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
-              setRuntime(channelId, id, {
+              setRuntimeForCurrentTask({
                 accountId: id,
                 running: false,
                 lastStopAt: Date.now(),
               });
             })
             .then(async () => {
-              if (manuallyStopped.has(rKey)) {
+              if (!isCurrentTask() || manuallyStopped.has(rKey)) {
                 return;
               }
               const attempt = (restartAttempts.get(rKey) ?? 0) + 1;
               restartAttempts.set(rKey, attempt);
               if (attempt > MAX_RESTART_ATTEMPTS) {
-                setRuntime(channelId, id, {
+                setRuntimeForCurrentTask({
                   accountId: id,
                   restartPending: false,
                   reconnectAttempts: attempt,
@@ -549,17 +558,17 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               log.info?.(
                 `[${id}] auto-restart attempt ${attempt}/${MAX_RESTART_ATTEMPTS} in ${Math.round(delayMs / 1000)}s`,
               );
-              setRuntime(channelId, id, {
+              setRuntimeForCurrentTask({
                 accountId: id,
                 restartPending: true,
                 reconnectAttempts: attempt,
               });
               try {
                 await sleepWithAbort(delayMs, abort.signal);
-                if (manuallyStopped.has(rKey)) {
+                if (!isCurrentTask() || manuallyStopped.has(rKey)) {
                   return;
                 }
-                if (store.tasks.get(id) === trackedPromise) {
+                if (trackedPromise && store.tasks.get(id) === trackedPromise) {
                   store.tasks.delete(id);
                 }
                 if (store.aborts.get(id) === abort) {
@@ -574,7 +583,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               }
             })
             .finally(() => {
-              if (store.tasks.get(id) === trackedPromise) {
+              if (trackedPromise && store.tasks.get(id) === trackedPromise) {
                 store.tasks.delete(id);
               }
               if (store.aborts.get(id) === abort) {
@@ -663,12 +672,32 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           log.warn?.(
             `[${id}] channel stop exceeded ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms after abort; continuing shutdown`,
           );
-          setRuntime(channelId, id, {
-            accountId: id,
-            running: true,
-            restartPending: false,
-            lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
-          });
+          // Release the stale task/abort references so the next startChannel
+          // can register a fresh polling loop. Without this, startChannelInternal
+          // sees the leftover store.tasks entry and silently no-ops, leaving the
+          // channel stuck "running: true, connected: true" with no live poll
+          // (e.g. after macOS sleep/wake on Telegram polling). The timed-out
+          // task may still be blocked on its HTTP read; when the next
+          // getUpdates fires Telegram returns 409 conflict and terminates it.
+          // (#71412)
+          if (store.aborts.get(id) === abort) {
+            store.aborts.delete(id);
+          }
+          const isLiveTask = task && store.tasks.get(id) === task;
+          if (isLiveTask) {
+            store.tasks.delete(id);
+          }
+          // Skip the status write when a concurrent startChannel has already
+          // registered a fresh task — writing running:false would clobber the
+          // live runtime with the stale timeout error (#71412).
+          if (isLiveTask || !store.tasks.has(id)) {
+            setRuntime(channelId, id, {
+              accountId: id,
+              running: false,
+              restartPending: false,
+              lastError: `channel stop timed out after ${CHANNEL_STOP_ABORT_TIMEOUT_MS}ms`,
+            });
+          }
           return;
         }
         store.aborts.delete(id);


### PR DESCRIPTION
## What

Fixes #71412 (resubmits the closed PR #71456 with steipete's fixup squashed in, rebased onto current main).

When `stopChannel` times out, the channel runtime currently:
1. Returns from the timeout branch without clearing `store.tasks` / `store.aborts` for the account
2. Marks the runtime `running: true` because the start path no-ops on the stale task entry
3. The existing regression test at `src/gateway/server-channels.test.ts` even codifies this — asserting that a second `startAccount` call is *blocked* after a stop timeout

This fix:

- Clears the stale `store.tasks` / `store.aborts` entries on the timeout path so the next `startChannel` registers a fresh poll loop instead of silently no-op'ing on the zombie task reference.
- Guards against the replaced (timed-out) task winning a settlement race against the new task by tracking `trackedPromise` per account: status writes, error reporting, restart-attempt accounting, and final cleanup all go through `setRuntimeForCurrentTask`, which short-circuits when the task that is calling back is not the current one.
- Updates the existing regression test from "second start is blocked" to "second start registers a fresh poll loop", and adds a new test pinning the replaced-task-status-ignore behavior.

## History

- @hclsys opened the original fix as #71456 on 2026-04-25.
- Greptile reviewed it; aisle flagged one finding.
- @steipete pushed a maintainer fixup (commit `61e6ae9fe3`) on top to harden the replaced-task settlement race.
- The PR aged past the empirical 20h TTM ceiling and was auto-closed under stale-PR hygiene before the bot-movement-counts rule was encoded into our review skill (added 2026-04-26). The clawsweeper "Keep this issue open and land PR #71456 or an equivalent core gateway fix" note remained in force.
- This PR resubmits both commits squashed onto current main, with the fix integrated into the `measureStartup(...)` wrapper that landed in the meantime so the existing startup-instrumentation hook is preserved.

## Verified locally

```
npx oxlint src/gateway/server-channels.ts src/gateway/server-channels.test.ts
# Found 0 warnings and 0 errors.

npx vitest run src/gateway/server-channels.test.ts
# Tests  26 passed (26)
```

## Pre-implement audit

1. **Existing-helper check.** No predicate / classifier introduced; the new `isCurrentTask` and `setRuntimeForCurrentTask` helpers are local closures over `trackedPromise` because they need access to the per-account scope. ✅
2. **Shared-helper caller check.** `setRuntime` continues to be called from non-task paths (start, stop, manual-stop). The new `setRuntimeForCurrentTask` only wraps task-callback writes. No silent contract change for other callers. ✅
3. **Broader-fix rival scan.** Issue #71412 has zero competing PRs; the maintainer review explicitly asks for this PR or equivalent. ✅

lobster-biscuit: 71412-zombie-task-resubmit

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
