### PR TITLE
CLI/status: share reconciled task snapshot across registry and audit summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2330,6 +2330,7 @@ Docs: https://docs.openclaw.ai
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
+- CLI/status (perf): reconcile inspectable tasks once per `openclaw status` invocation and share the snapshot across registry and audit summaries, eliminating a redundant `listTaskRecords` clone+sort that adds roughly 0.7-1.2 s of warm overhead on hosts with 10k+ task records. Fixes #73531. Thanks @slideshow-dingo.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - Active Memory: allow the hidden recall sub-agent to use both `memory_recall` and the legacy `memory_search`/`memory_get` memory tool contract, so bundled `memory-lancedb` recall works without breaking the default `memory-core` path. Fixes #73502. (#73584) Thanks @Takhoffman.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -71,9 +71,9 @@ vi.mock("../infra/system-events.js", () => ({
   peekSystemEvents: vi.fn(() => []),
 }));
 
-vi.mock("../tasks/task-registry.maintenance.js", () => ({
-  configureTaskRegistryMaintenance: vi.fn(),
-  getInspectableTaskRegistrySummary: vi.fn(() => ({
+const taskMaintenanceMocks = vi.hoisted(() => ({
+  reconcileInspectableTasks: vi.fn(() => [] as Array<Record<string, unknown>>),
+  getInspectableTaskRegistrySummary: vi.fn((_reconciledTasks?: Array<Record<string, unknown>>) => ({
     total: 0,
     active: 0,
     terminal: 0,
@@ -94,7 +94,7 @@ vi.mock("../tasks/task-registry.maintenance.js", () => ({
       cron: 0,
     },
   })),
-  getInspectableTaskAuditSummary: vi.fn(() => ({
+  getInspectableTaskAuditSummary: vi.fn((_reconciledTasks?: Array<Record<string, unknown>>) => ({
     total: 1,
     warnings: 1,
     errors: 0,
@@ -107,6 +107,13 @@ vi.mock("../tasks/task-registry.maintenance.js", () => ({
       inconsistent_timestamps: 0,
     },
   })),
+}));
+
+vi.mock("../tasks/task-registry.maintenance.js", () => ({
+  configureTaskRegistryMaintenance: vi.fn(),
+  reconcileInspectableTasks: taskMaintenanceMocks.reconcileInspectableTasks,
+  getInspectableTaskRegistrySummary: taskMaintenanceMocks.getInspectableTaskRegistrySummary,
+  getInspectableTaskAuditSummary: taskMaintenanceMocks.getInspectableTaskAuditSummary,
 }));
 
 vi.mock("../routing/session-key.js", () => ({
@@ -199,5 +206,22 @@ describe("getStatusSummary", () => {
     const summary = await getStatusSummary();
 
     expect(summary.sessions.recent[0]?.runtime).toBe("OpenAI Codex");
+  });
+
+  it("reconciles inspectable tasks once and shares the snapshot across summaries", async () => {
+    const sentinelTasks: Array<Record<string, unknown>> = [{ taskId: "shared-snapshot" }];
+    taskMaintenanceMocks.reconcileInspectableTasks.mockReturnValueOnce(sentinelTasks);
+
+    await getStatusSummary();
+
+    expect(taskMaintenanceMocks.reconcileInspectableTasks).toHaveBeenCalledTimes(1);
+    expect(taskMaintenanceMocks.getInspectableTaskRegistrySummary).toHaveBeenCalledTimes(1);
+    expect(taskMaintenanceMocks.getInspectableTaskAuditSummary).toHaveBeenCalledTimes(1);
+    expect(taskMaintenanceMocks.getInspectableTaskRegistrySummary.mock.calls[0]?.[0]).toBe(
+      sentinelTasks,
+    );
+    expect(taskMaintenanceMocks.getInspectableTaskAuditSummary.mock.calls[0]?.[0]).toBe(
+      sentinelTasks,
+    );
   });
 });

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -151,8 +151,12 @@ export async function getStatusSummary(
   taskMaintenanceModule.configureTaskRegistryMaintenance({
     cronStorePath: resolveCronStorePath(cfg.cron?.store),
   });
-  const tasks = taskMaintenanceModule.getInspectableTaskRegistrySummary();
-  const taskAudit = taskMaintenanceModule.getInspectableTaskAuditSummary();
+  // Reconcile once and share the snapshot across both summary derivations.
+  // Each helper otherwise repeats the same listTaskRecords clone+sort, which
+  // doubles status latency on hosts with large task ledgers (#73531).
+  const reconciledTasks = taskMaintenanceModule.reconcileInspectableTasks();
+  const tasks = taskMaintenanceModule.getInspectableTaskRegistrySummary(reconciledTasks);
+  const taskAudit = taskMaintenanceModule.getInspectableTaskAuditSummary(reconciledTasks);
 
   const resolved = resolveConfiguredStatusModelRef({
     cfg,

--- a/src/tasks/task-registry.maintenance.issue-73531.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-73531.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { AcpSessionStoreEntry } from "../acp/runtime/session-meta.js";
+import type { SessionEntry } from "../config/sessions.js";
+import type { ParsedAgentSessionKey } from "../routing/session-key.js";
+import {
+  getInspectableTaskAuditSummary,
+  getInspectableTaskRegistrySummary,
+  reconcileInspectableTasks,
+  resetTaskRegistryMaintenanceRuntimeForTests,
+  setTaskRegistryMaintenanceRuntimeForTests,
+  stopTaskRegistryMaintenanceForTests,
+} from "./task-registry.maintenance.js";
+import type { TaskRecord } from "./task-registry.types.js";
+
+type TaskRegistryMaintenanceRuntime = Parameters<
+  typeof setTaskRegistryMaintenanceRuntimeForTests
+>[0];
+
+afterEach(() => {
+  stopTaskRegistryMaintenanceForTests();
+  resetTaskRegistryMaintenanceRuntimeForTests();
+});
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  const now = Date.now();
+  return {
+    taskId: "task-test-" + Math.random().toString(36).slice(2),
+    runtime: "subagent",
+    requesterSessionKey: "agent:main:main",
+    ownerKey: "system:test",
+    scopeKind: "system",
+    task: "test task",
+    status: "succeeded",
+    deliveryStatus: "not_applicable",
+    notifyPolicy: "silent",
+    createdAt: now - 60_000,
+    startedAt: now - 60_000,
+    lastEventAt: now - 60_000,
+    endedAt: now - 60_000,
+    cleanupAfter: now + 60_000,
+    ...overrides,
+  };
+}
+
+function installCountingRuntime(tasks: TaskRecord[]): { listCalls: () => number } {
+  let listCallCount = 0;
+  const runtime: TaskRegistryMaintenanceRuntime = {
+    listAcpSessionEntries: async () => [],
+    readAcpSessionEntry: () =>
+      ({
+        cfg: {} as never,
+        storePath: "",
+        sessionKey: "",
+        storeSessionKey: "",
+        entry: undefined,
+        storeReadFailed: false,
+      }) satisfies AcpSessionStoreEntry,
+    loadSessionStore: () => ({}) as Record<string, SessionEntry>,
+    resolveStorePath: () => "",
+    isCronJobActive: () => false,
+    getAgentRunContext: () => undefined,
+    parseAgentSessionKey: (sessionKey: string | null | undefined): ParsedAgentSessionKey | null => {
+      if (!sessionKey) {
+        return null;
+      }
+      const [kind, agentId, ...rest] = sessionKey.split(":");
+      return kind === "agent" && agentId && rest.length > 0
+        ? { agentId, rest: rest.join(":") }
+        : null;
+    },
+    deleteTaskRecordById: () => false,
+    ensureTaskRegistryReady: () => {},
+    getTaskById: (taskId: string) => tasks.find((task) => task.taskId === taskId),
+    listTaskRecords: () => {
+      listCallCount += 1;
+      return tasks.map((task) => ({ ...task }));
+    },
+    markTaskLostById: () => null,
+    markTaskTerminalById: () => null,
+    maybeDeliverTaskTerminalUpdate: async () => null,
+    resolveTaskForLookupToken: () => undefined,
+    setTaskCleanupAfterById: () => null,
+    isCronRuntimeAuthoritative: () => false,
+    resolveCronStorePath: () => "/tmp/openclaw-test-cron/jobs.json",
+    loadCronStoreSync: () => ({ version: 1, jobs: [] }),
+    resolveCronRunLogPath: ({ jobId }) => jobId,
+    readCronRunLogEntriesSync: () => [],
+  };
+  setTaskRegistryMaintenanceRuntimeForTests(runtime);
+  return { listCalls: () => listCallCount };
+}
+
+describe("task-registry maintenance issue #73531", () => {
+  it("reconciles tasks exactly once when summaries reuse a shared snapshot", () => {
+    const { listCalls } = installCountingRuntime([
+      makeTask({ taskId: "task-1", status: "succeeded" }),
+      // Terminal task with no cleanupAfter trips the missing_cleanup audit warning
+      // so the audit summary returns non-trivial findings and we can assert the
+      // shared snapshot reaches the audit helper end-to-end.
+      makeTask({
+        taskId: "task-2",
+        status: "failed",
+        error: "boom",
+        cleanupAfter: undefined,
+      }),
+    ]);
+
+    const snapshot = reconcileInspectableTasks();
+    const registry = getInspectableTaskRegistrySummary(snapshot);
+    const audit = getInspectableTaskAuditSummary(snapshot);
+
+    expect(listCalls()).toBe(1);
+    expect(registry.total).toBe(2);
+    expect(registry.failures).toBe(1);
+    expect(audit.byCode.missing_cleanup).toBe(1);
+    expect(audit.warnings).toBeGreaterThanOrEqual(1);
+  });
+
+  it("falls back to reconciling when no snapshot is supplied", () => {
+    const { listCalls } = installCountingRuntime([
+      makeTask({ taskId: "task-zero-arg", status: "succeeded" }),
+    ]);
+
+    const registry = getInspectableTaskRegistrySummary();
+    const audit = getInspectableTaskAuditSummary();
+
+    expect(listCalls()).toBe(2);
+    expect(registry.total).toBe(1);
+    expect(audit).toBeDefined();
+  });
+});

--- a/src/tasks/task-registry.maintenance.issue-73531.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-73531.test.ts
@@ -68,6 +68,7 @@ function installCountingRuntime(tasks: TaskRecord[]): { listCalls: () => number 
         ? { agentId, rest: rest.join(":") }
         : null;
     },
+    hasActiveTaskForChildSessionKey: () => false,
     deleteTaskRecordById: () => false,
     ensureTaskRegistryReady: () => {},
     getTaskById: (taskId: string) => tasks.find((task) => task.taskId === taskId),

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -894,12 +894,14 @@ export function getInspectableActiveTaskRestartBlockers(): ActiveTaskRestartBloc
   return blockers;
 }
 
-export function getInspectableTaskRegistrySummary(): TaskRegistrySummary {
-  return summarizeTaskRecords(reconcileInspectableTasks());
+export function getInspectableTaskRegistrySummary(
+  reconciledTasks?: TaskRecord[],
+): TaskRegistrySummary {
+  return summarizeTaskRecords(reconciledTasks ?? reconcileInspectableTasks());
 }
 
-export function getInspectableTaskAuditSummary(): TaskAuditSummary {
-  const tasks = reconcileInspectableTasks();
+export function getInspectableTaskAuditSummary(reconciledTasks?: TaskRecord[]): TaskAuditSummary {
+  const tasks = reconciledTasks ?? reconcileInspectableTasks();
   return summarizeTaskAuditFindings(listTaskAuditFindings({ tasks }));
 }
 


### PR DESCRIPTION
## Summary

- Problem: `getStatusSummary()` invokes `getInspectableTaskRegistrySummary()` and `getInspectableTaskAuditSummary()` separately, and each helper independently reconciles the task list (`reconcileInspectableTasks()` -> `listTaskRecords()` deep clone + sort). On nodes with 10K+ task records the duplicated clone/sort adds roughly 0.7-1.2 s of warm overhead per `openclaw status`.
- Why it matters: `openclaw status` is the canonical operator probe and is used inside CI/cron health checks. Doubled latency makes status the slowest interactive CLI on busy nodes (#73531 reports 8-13 s cold, 5-9 s warm, half of which is the avoidable second reconcile).
- What changed: extend the two summary helpers in `src/tasks/task-registry.maintenance.ts` to accept an optional pre-reconciled `TaskRecord[]` snapshot, and update `src/commands/status.summary.ts` to call `reconcileInspectableTasks()` once and pass the same snapshot to both helpers.
- What did NOT change (scope boundary): all other call sites of the two helpers (`src/commands/tasks.ts:505/513/514`, `src/gateway/server.impl.ts:397`, `src/gateway/server-reload-handlers.ts:149`) keep their existing zero-arg behavior. The optional parameter is fully backwards compatible. No behavioral changes outside `getStatusSummary()`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73531
- Related: N/A
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: `getInspectableTaskRegistrySummary()` and `getInspectableTaskAuditSummary()` each call `reconcileInspectableTasks()` internally. `getStatusSummary()` calls both, so the same expensive `listTaskRecords()` clone+sort runs twice per status call.
- Missing detection / guardrail: there was no test asserting that one `getStatusSummary()` invocation reconciles tasks once. Both helpers were independently exercised but never measured together.
- Contributing context: warm reconcile takes 327-407 ms on a moderately active 10K-task node (per #73531 profiling), so the duplicate cost is operator-visible but easy to overlook when sized against the rest of `status` work.

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/tasks/task-registry.maintenance.issue-73531.test.ts` (new): instruments `listTaskRecords` via the existing maintenance-runtime harness and asserts a shared snapshot reconciles tasks exactly once across both helpers; second case locks the zero-arg fallback contract.
  - `src/commands/status.summary.test.ts`: new case `"reconciles inspectable tasks once and shares the snapshot across summaries"` asserts `reconcileInspectableTasks` is called exactly once per `getStatusSummary()` and that both helpers receive the same array reference.
- Scenario the test should lock in: any future change that reintroduces an independent reconcile inside the status path will fail both tests.
- Why this is the smallest reliable guardrail: the unit test pins the helper API contract, and the integration test pins the call-site behavior. Together they cover the regression at both layers without requiring an end-to-end status invocation.

## User-visible / Behavior Changes

`openclaw status` and `openclaw status --json` complete faster on hosts with large task ledgers. No flag, config, or output-shape changes. Nothing else changes.

## Diagram

```text
Before (per `openclaw status`):
  reconcileInspectableTasks()  ->  listTaskRecords() clone+sort  (327-407 ms warm)
  reconcileInspectableTasks()  ->  listTaskRecords() clone+sort  (327-407 ms warm) <- redundant

After:
  reconcileInspectableTasks()  ->  listTaskRecords() clone+sort  (327-407 ms warm)
                                      \-> registry summary
                                      \-> audit summary
```

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Redundant `reconcileInspectableTasks()` invocation inside `getStatusSummary()` doubles the warm `listTaskRecords()` clone+sort cost on every `openclaw status` call (per #73531).
- **Real environment tested:** LXC build sandbox, Ubuntu 24.04, 4 cores / 6 GB RAM, Node 22.22.2. Built this PR branch (`fix/status-reconcile-task-cache` @ `dc31d721`) into dist; ran a real dev gateway from the patched dist; ran `openclaw status` against it as a real WebSocket client.
- **Exact steps or command run after this patch:**
  1. `git checkout fix/status-reconcile-task-cache && pnpm install --prefer-offline && pnpm build`
  2. `node dist/index.js gateway run --dev --port [redacted] --auth none --bind loopback --reset` (started, ready in ~2s)
  3. `time node dist/index.js status --url ws://[redacted-ip]:18790 --no-color` (cold + warm pair)
  4. `node dist/index.js status --url ws://[redacted-ip]:18790 --json` to confirm both `tasks` and `taskAudit` blocks emit consistently from the shared snapshot.
- **Evidence after fix (terminal capture):**

```
$ node dist/index.js --version
OpenClaw 2026.5.6 (dc31d72)

$ tail -20 /tmp/gw.log
[gateway] http server listening (8 plugins: acpx, browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 2.0s)
[gateway] log file: /tmp/openclaw/openclaw-2026-05-08.log
[gateway] starting channels and sidecars...
[plugins] embedded acpx runtime backend registered lazily
[browser/server] Browser control listening on http://[redacted-ip]:18792/ (auth=token)
[gateway] ready
[heartbeat] started

$ time node dist/index.js status --url ws://[redacted-ip]:18790 --no-color | head -20
OpenClaw status

Overview
┌──────────────────────┬──────────────────────────────────────────────────────────────────────────┐
│ Item                 │ Value                                                                    │
├──────────────────────┼──────────────────────────────────────────────────────────────────────────┤
│ OS                   │ linux 6.17.13-1-pve (x64) · node 22.22.2                                 │
│ Channel              │ dev (fix/status-reconcile-task-cache)                                    │
│ Git                  │ fix/status-reconcile-task-cache · @ dc31d721                             │
│ Agents               │ 1 · no bootstrap files · sessions 1 · default dev active 39h ago         │
│ Tasks                │ none                                                                     │
│ Sessions             │ 1 active · default gpt-5.5 (200k ctx)                                    │
└──────────────────────┴──────────────────────────────────────────────────────────────────────────┘
real    0m2.195s   # cold call
real    0m2.045s   # warm call (steady state)

$ node dist/index.js status --url ws://[redacted-ip]:18790 --json | jq '{ runtimeVersion, tasks, taskAudit }' | head -25
{
  "runtimeVersion": "2026.5.6",
  "tasks": {
    "total": 0,
    "active": 0,
    "terminal": 0,
    "byStatus": { "queued": 0, "running": 0, "succeeded": 0, "failed": 0, "timed_out": 0, "cancelled": 0, "lost": 0 },
    "byRuntime": { "subagent": 0, "acp": 0, "cli": 0, "cron": 0 }
  },
  "taskAudit": {
    "total": 0,
    "warnings": 0,
    "errors": 0
  }
}
```

- **Observed result after fix:**
  - Patched dist boots, becomes `[gateway] ready` in ~2s, and serves `gateway.status` over WebSocket cleanly.
  - `openclaw status` against the patched build returns identical-shape output to baseline, including the `tasks` and `taskAudit` blocks that now share the single reconciled snapshot.
  - Warm-call wall time is ~2.0s on this empty-ledger sandbox (no real perf delta visible because there are 0 tasks); the perf claim is mathematical: with N≥10K tasks, removing the second `reconcileInspectableTasks()` call eliminates one 327-407 ms warm clone+sort per status invocation, per the #73531 reporter's profile.
  - The call-count contract that locks this in (`expected listCalls === 1` per `getStatusSummary()`) is asserted by the new `src/tasks/task-registry.maintenance.issue-73531.test.ts` file plus the integration smoke in `src/commands/status.summary.test.ts`. Vitest output is included below as supplemental evidence — the live runtime check above is the primary proof that nothing regressed in the actual `gateway.status` round trip.
- **What was not tested:** Live perf delta on a 10K-task production node. The sandbox has 0 tasks so wall-time savings would be in the noise. The regression tests pin the call-count contract; the perf claim is grounded in #73531's profile.

## Repro + Verification

### Environment

- OS: Linux 6.8.0 (CT 112 prbuild sandbox: Ubuntu 24.04, 4 cores, 6 GB RAM)
- Runtime/container: Node 22, OpenClaw 2026.4.27
- Model/provider: N/A (CLI-only path)
- Integration/channel: N/A
- Relevant config: default

### Steps

1. `pnpm test src/tasks/task-registry.maintenance.issue-73531.test.ts` -> 2 tests pass.
2. `pnpm test src/commands/status.summary.test.ts` -> 5 tests pass (existing 4 + new shared-snapshot assertion).
3. `pnpm test src/tasks/task-registry.test.ts src/tasks/task-registry.maintenance.issue-60299.test.ts src/commands/status.test.ts src/commands/tasks.test.ts src/gateway/server.reload.test.ts src/gateway/server-methods/server-methods.test.ts` -> 168 tests pass; no regressions in any helper consumer.

### Expected

`reconcileInspectableTasks()` called exactly once per `getStatusSummary()`; both helpers receive the same array reference.

### Actual

Matches expected. RED phase confirmed: against unmodified source the new helper test reports `expected 3 to be 1` (one explicit reconcile + two helpers each reconciling internally).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [x] Perf numbers (if relevant)

Perf numbers from #73531 reporter: warm `reconcileInspectableTasks()` is 327-407 ms on a 10K-task node, cold is 3.6-5.9 s. Removing the second invocation reclaims one warm cycle per status call.

## Human Verification

- Verified scenarios:
  - TDD red->green on the new helper test (red = listCalls 3, green = listCalls 1).
  - Existing zero-arg call sites in `tasks.ts`, `server.impl.ts`, `server-reload-handlers.ts` unchanged at runtime; their tests still pass.
  - Integration test in `status.summary.test.ts` confirms reference-equality of the shared snapshot.
  - `pnpm tsgo` (core) and `pnpm check:test-types` (core+extensions test types) both clean.
  - `pnpm exec oxlint --type-aware` and `pnpm exec oxfmt --check` clean on touched files.
- Edge cases checked:
  - Optional parameter omitted -> falls back to internal `reconcileInspectableTasks()` (covered by the second test in the new file).
  - `tasks.ts --apply` flow still calls the audit helper twice (before + after maintenance), intentionally on different snapshots; left untouched.
- What you did **not** verify: live `openclaw status` end-to-end timing on a real 10K-task node. The regression tests lock the call-count contract; the perf claim is grounded in the issue's profiling data.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: the new optional parameter could mislead third-party callers into passing a non-reconciled `TaskRecord[]`.
  - Mitigation: parameter is named `reconciledTasks` to document the contract; helpers fall back to `reconcileInspectableTasks()` when the parameter is omitted, so the safe default is preserved.
