### PR TITLE
fix(cli): make crestodian exit non-zero on no-TTY (#73646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Crestodian: `openclaw crestodian` (and `pnpm openclaw crestodian`) now exits non-zero in non-TTY contexts instead of printing "needs an interactive TTY" and exiting 0, so shell scripts and CI flows reading `$?` can detect the failure and stop instead of proceeding as if Crestodian ran. Mirrors the existing behavior of `models auth login`, `secrets configure`, and the bare-root crestodian path. Fixes #73646. Thanks @bittoby.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - Active Memory: allow the hidden recall sub-agent to use both `memory_recall` and the legacy `memory_search`/`memory_get` memory tool contract, so bundled `memory-lancedb` recall works without breaking the default `memory-core` path. Fixes #73502. (#73584) Thanks @Takhoffman.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.

--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -112,4 +112,25 @@ describe("runCrestodian", () => {
     expect(onReadyCalls).toBe(1);
     expect(lines.join("\n")).not.toContain("Say: status");
   });
+
+  it("throws instead of exiting silently when no interactive TTY is available (#73646)", async () => {
+    // Regression for #73646: returning silently let the CLI wrapper fall
+    // through with `process.exitCode` unset, so shell scripts and CI flows
+    // saw exit 0 alongside the "needs an interactive TTY" message and
+    // proceeded as if Crestodian ran. Throwing routes through
+    // `runCommandWithRuntime`'s catch and exits 1, matching `models auth
+    // login`, `secrets configure`, and the bare-root crestodian path in
+    // `cli/run-main.ts:399-404`.
+    const { runtime } = createCrestodianTestRuntime();
+
+    await expect(
+      runCrestodian(
+        {
+          input: { isTTY: false } as unknown as NodeJS.ReadableStream,
+          output: { isTTY: false } as unknown as NodeJS.WritableStream,
+        },
+        runtime,
+      ),
+    ).rejects.toThrow(/needs an interactive TTY/iu);
+  });
 });

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -91,8 +91,12 @@ export async function runCrestodian(
   const inputIsTty = (input as { isTTY?: boolean }).isTTY === true;
   const outputIsTty = (output as { isTTY?: boolean }).isTTY === true;
   if (!interactive || !inputIsTty || !outputIsTty) {
-    runtime.error("Crestodian needs an interactive TTY. Use --message for one command.");
-    return;
+    // Throw so the CLI wrapper (`runCommandWithRuntime`) catches it and
+    // exits non-zero. Returning silently exited the process with code 0,
+    // which made shell scripts and CI flows treat the no-TTY error as
+    // success. Mirrors `models auth login`, `secrets configure`, and the
+    // bare-root crestodian path in `cli/run-main.ts:399-404`. See #73646.
+    throw new Error("Crestodian needs an interactive TTY. Use --message for one command.");
   }
 
   const runInteractiveTui =


### PR DESCRIPTION
## What

Fixes #73646. `pnpm openclaw crestodian < /dev/null` (and `node ./dist/index.js crestodian < /dev/null`) currently:

1. Detects no TTY
2. Prints `Crestodian needs an interactive TTY. Use --message for one command.` to stderr
3. Returns from `runCrestodian` cleanly — no thrown error, no `process.exitCode` set
4. The CLI wrapper `runCommandWithRuntime` only sets `runtime.exit(1)` in its catch path, so the silent return falls through and Node exits **0**

Shell scripts and CI flows reading `$?` see success and proceed as if Crestodian ran. The two in-tree sibling subcommands for the same condition (`models auth login`, `secrets configure`) both `throw new Error("…")` and exit non-zero. The bare-root crestodian path at `cli/run-main.ts:399-404` also already sets `process.exitCode = 1` directly. Crestodian-as-subcommand is the lone outlier.

## Fix

Replace the silent `runtime.error(...) + return` in `src/crestodian/crestodian.ts:93-96` with a `throw new Error(...)`. The CLI wrapper's catch then runs `runtime.error + exit(1)` and the process exits non-zero. Behavior matches the bare-root path and the `models auth login` / `secrets configure` precedents.

```ts
if (!interactive || !inputIsTty || !outputIsTty) {
  throw new Error("Crestodian needs an interactive TTY. Use --message for one command.");
}
```

## Verified locally

```
npx oxlint src/crestodian/crestodian.ts src/crestodian/crestodian.test.ts
# Found 0 warnings and 0 errors.

npx vitest run src/crestodian/crestodian.test.ts
# Tests  4 passed (4)
```

The new test pins the regression: `runCrestodian({ input: { isTTY: false }, output: { isTTY: false } })` rejects with `/needs an interactive TTY/` so the CLI wrapper's catch fires.

## Pre-implement audit

1. **Existing-helper check.** Error message + pattern reused verbatim from sibling subcommands (`models auth login`, `secrets configure`); `setup-token` uses the identical `throw new Error("… requires an interactive TTY.")` shape. ✅
2. **Shared-helper caller check.** `runCrestodian` is called from 4 sites — `cli/run-main.ts:423,433`, `cli/program/register.onboard.ts:182`, `cli/program/register.crestodian.ts:30` — all wrapped in `runCommandWithRuntime` (or `runCommandWithRuntime`-style catch in `run-main.ts`). All four catch paths surface the thrown error and exit non-zero. ✅
3. **Broader-fix rival scan.** Zero rival PRs reference #73646. ✅

## Note

#73562 (`plugins uninstall < /dev/null` exits 13) is a separate bug filed by the same reporter — wrong exit code there, but at least non-zero. Not addressed here.

lobster-biscuit: 73646-crestodian-no-tty-exit

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
