### PR TITLE
fix(agents): drop blank-text ContentBlocks on every Anthropic transcript path (#73640)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Anthropic: drop blank `{ type: "text", text: "" }` content blocks from user, toolResult, error-stopped assistant, images-only assistant, and `preserveSignatures` assistant transcript paths in `sanitizeSessionMessagesImages`, so Anthropic's `Validation error: The text field in the ContentBlock object … is blank.` 400 stops wedging sessions whose transcript accumulated an empty-text block from one of the previously unfiltered branches. Extracted as a shared `dropEmptyTextBlocks` helper used at all five sites. Fixes #73640. Thanks @jowhee327.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - Active Memory: allow the hidden recall sub-agent to use both `memory_recall` and the legacy `memory_search`/`memory_get` memory tool contract, so bundled `memory-lancedb` recall works without breaking the default `memory-core` path. Fixes #73502. (#73584) Thanks @Takhoffman.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -307,7 +307,14 @@ describe("sanitizeSessionMessagesImages", () => {
       expect(content?.[0]?.thought_signature).toBeUndefined();
     });
 
-    it("preserves interleaved thinking block order when signatures are preserved", async () => {
+    it("preserves interleaved thinking block order when signatures are preserved and drops blank-text companions", async () => {
+      // Anthropic's API rejects requests whose `messages.N.content.K` carries
+      // a `{ type: "text", text: "" }` block with `Validation error: The text
+      // field in the ContentBlock object … is blank.`. Even when
+      // `preserveSignatures: true` is on (Antigravity Claude), companion
+      // blank-text blocks still need to be dropped — only thinking,
+      // redacted_thinking, and the actual text payloads need to survive in
+      // their original order. See #73640.
       const input = castAgentMessages([
         {
           role: "assistant",
@@ -338,7 +345,6 @@ describe("sanitizeSessionMessagesImages", () => {
       expect(content?.map((block) => block.type)).toEqual([
         "thinking",
         "text",
-        "text",
         "redacted_thinking",
         "text",
       ]);
@@ -347,11 +353,79 @@ describe("sanitizeSessionMessagesImages", () => {
         thinking: "first",
         thought_signature: "sig-1",
       });
-      expect(content?.[1]).toMatchObject({ type: "text", text: "" });
-      expect(content?.[3]).toMatchObject({
+      expect(content?.[1]).toMatchObject({ type: "text", text: "visible" });
+      expect(content?.[2]).toMatchObject({
         type: "redacted_thinking",
         thought_signature: "sig-2",
       });
+      expect(content?.[3]).toMatchObject({ type: "text", text: "tail" });
+    });
+
+    it("drops blank-text content blocks on user, toolResult, and error-stopped assistant turns (#73640)", async () => {
+      // Regression for #73640: Anthropic 400 fired on every transcript path
+      // that previously bypassed empty-text filtering — user content,
+      // toolResult content, error-stopped assistant content, and the
+      // images-only sanitize mode for non-error assistants. Confirm all four
+      // paths now drop the empty text block while leaving real content
+      // (text payload, tool_use, tool_result, image, thinking) intact.
+      const input = castAgentMessages([
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "" },
+            { type: "text", text: "user-said" },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolUseId: "tu-1",
+          toolName: "search",
+          content: [
+            { type: "text", text: "" },
+            { type: "text", text: "tool-result" },
+          ],
+        },
+        {
+          role: "assistant",
+          stopReason: "error",
+          content: [
+            { type: "text", text: "" },
+            { type: "text", text: "assistant-error-detail" },
+          ],
+        },
+      ]);
+
+      const fullMode = await sanitizeSessionMessagesImages(input, "test");
+      expect(fullMode).toHaveLength(3);
+      expect(
+        (fullMode[0] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["user-said"]);
+      expect(
+        (fullMode[1] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["tool-result"]);
+      expect(
+        (fullMode[2] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["assistant-error-detail"]);
+
+      // images-only sanitize mode covers the same assistant path that
+      // previously bypassed empty-text filtering altogether.
+      const imagesOnly = await sanitizeSessionMessagesImages(
+        castAgentMessages([
+          {
+            role: "assistant",
+            content: [
+              { type: "text", text: "" },
+              { type: "text", text: "non-error-assistant" },
+            ],
+          },
+        ]),
+        "test",
+        { sanitizeMode: "images-only" },
+      );
+      expect(imagesOnly).toHaveLength(1);
+      expect(
+        (imagesOnly[0] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["non-error-assistant"]);
     });
   });
 });

--- a/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts
@@ -427,6 +427,58 @@ describe("sanitizeSessionMessagesImages", () => {
         (imagesOnly[0] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
       ).toEqual(["non-error-assistant"]);
     });
+
+    it("skips emitting messages whose content is entirely blank-text on user, toolResult, and non-error assistant paths (#73640 follow-up)", async () => {
+      // Greptile P1 follow-up on #73658: dropping blank-text blocks alone is
+      // not enough — if a message's content was *only* blank-text blocks,
+      // the filtered array is `[]`, and Anthropic rejects `content: []`
+      // with the same family of 400 errors that wedge the session. Mirror
+      // the assistant full-mode path's `if (finalContent.length === 0)
+      // continue` skip on the user, toolResult, and non-error
+      // assistant-images-only paths.
+      //
+      // Error-stopped assistant messages are explicitly NOT skipped here
+      // (see the `keeps empty assistant error messages` regression above).
+      // Downstream replay / classifier depends on those staying in the
+      // transcript, and they are not re-sent to Anthropic.
+      const fullMode = await sanitizeSessionMessagesImages(
+        castAgentMessages([
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "" },
+              { type: "text", text: "   " },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolUseId: "tu-2",
+            toolName: "search",
+            content: [{ type: "text", text: "" }],
+          },
+          // A message with at least one real block must still survive.
+          { role: "user", content: [{ type: "text", text: "kept" }] },
+        ]),
+        "test",
+      );
+      expect(fullMode).toHaveLength(1);
+      expect(
+        (fullMode[0] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["kept"]);
+
+      const imagesOnly = await sanitizeSessionMessagesImages(
+        castAgentMessages([
+          { role: "assistant", content: [{ type: "text", text: "" }] },
+          { role: "assistant", content: [{ type: "text", text: "kept" }] },
+        ]),
+        "test",
+        { sanitizeMode: "images-only" },
+      );
+      expect(imagesOnly).toHaveLength(1);
+      expect(
+        (imagesOnly[0] as { content?: Array<{ text?: string }> }).content?.map((b) => b.text),
+      ).toEqual(["kept"]);
+    });
   });
 });
 

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -7,12 +7,29 @@ import { stripThoughtSignatures } from "./bootstrap.js";
 
 type ContentBlock = AgentToolResult<unknown>["content"][number];
 
-function isThinkingOrRedactedBlock(block: unknown): boolean {
-  if (!block || typeof block !== "object") {
-    return false;
-  }
-  const rec = block as { type?: unknown };
-  return rec.type === "thinking" || rec.type === "redacted_thinking";
+/**
+ * Drop `{ type: "text", text: "" }` blocks (whitespace-only counts as empty)
+ * from a content array. Anthropic's API rejects a request whose
+ * `messages.N.content.K` contains a `ContentBlock` with a blank `text` field
+ * with `Validation error: The text field in the ContentBlock object at … is
+ * blank.`. Once that 400 fires for a session, every subsequent turn replays
+ * the same transcript and hits the same error — the session is wedged.
+ *
+ * This helper is intentionally permissive: it only rewrites text blocks and
+ * passes everything else through (tool_use, tool_result, image, thinking,
+ * redacted_thinking, …). See #73640.
+ */
+function dropEmptyTextBlocks<T>(content: readonly T[]): T[] {
+  return content.filter((block) => {
+    if (!block || typeof block !== "object") {
+      return true;
+    }
+    const rec = block as { type?: unknown; text?: unknown };
+    if (rec.type !== "text") {
+      return true;
+    }
+    return typeof rec.text === "string" && rec.text.trim().length > 0;
+  });
 }
 
 export function isEmptyAssistantMessageContent(
@@ -82,8 +99,12 @@ export async function sanitizeSessionMessagesImages(
     if (role === "toolResult") {
       const toolMsg = msg as Extract<AgentMessage, { role: "toolResult" }>;
       const content = Array.isArray(toolMsg.content) ? toolMsg.content : [];
+      // Drop blank-text content blocks before passing to image sanitization
+      // so Anthropic's `text field … is blank` 400 cannot fire on toolResult
+      // payloads. See #73640.
+      const filtered = dropEmptyTextBlocks(content);
       const nextContent = (await sanitizeContentBlocksImages(
-        content,
+        filtered,
         label,
         imageSanitization,
       )) as unknown as typeof toolMsg.content;
@@ -95,8 +116,10 @@ export async function sanitizeSessionMessagesImages(
       const userMsg = msg as Extract<AgentMessage, { role: "user" }>;
       const content = userMsg.content;
       if (Array.isArray(content)) {
+        // Same blank-text guard for user content blocks (#73640).
+        const filtered = dropEmptyTextBlocks(content as unknown as ContentBlock[]);
         const nextContent = (await sanitizeContentBlocksImages(
-          content as unknown as ContentBlock[],
+          filtered,
           label,
           imageSanitization,
         )) as unknown as typeof userMsg.content;
@@ -110,8 +133,10 @@ export async function sanitizeSessionMessagesImages(
       if (assistantMsg.stopReason === "error") {
         const content = assistantMsg.content;
         if (Array.isArray(content)) {
+          // Same blank-text guard for error-stopped assistant turns (#73640).
+          const filtered = dropEmptyTextBlocks(content as unknown as ContentBlock[]);
           const nextContent = (await sanitizeContentBlocksImages(
-            content as unknown as ContentBlock[],
+            filtered,
             label,
             imageSanitization,
           )) as unknown as typeof assistantMsg.content;
@@ -127,8 +152,12 @@ export async function sanitizeSessionMessagesImages(
           ? content // Keep signatures for Antigravity Claude
           : stripThoughtSignatures(content, options?.sanitizeThoughtSignatures); // Strip for Gemini
         if (!allowNonImageSanitization) {
+          // images-only mode: still drop blank-text blocks so Anthropic does
+          // not 400 on the next request (#73640). Image sanitization alone
+          // does not touch text blocks.
+          const filtered = dropEmptyTextBlocks(strippedContent as unknown as ContentBlock[]);
           const nextContent = (await sanitizeContentBlocksImages(
-            strippedContent as unknown as ContentBlock[],
+            filtered,
             label,
             imageSanitization,
           )) as unknown as typeof assistantMsg.content;
@@ -136,20 +165,15 @@ export async function sanitizeSessionMessagesImages(
           continue;
         }
 
-        const filteredContent =
-          options?.preserveSignatures &&
-          strippedContent.some((block) => isThinkingOrRedactedBlock(block))
-            ? strippedContent
-            : strippedContent.filter((block) => {
-                if (!block || typeof block !== "object") {
-                  return true;
-                }
-                const rec = block as { type?: unknown; text?: unknown };
-                if (rec.type !== "text" || typeof rec.text !== "string") {
-                  return true;
-                }
-                return rec.text.trim().length > 0;
-              });
+        // Full mode: drop blank-text blocks unconditionally. Previously
+        // this branch kept the original content when preserveSignatures was
+        // set AND a thinking/redacted block was present, which meant
+        // companion blank-text blocks survived and Anthropic would 400 on
+        // the next request. Dropping empties is safe — `dropEmptyTextBlocks`
+        // only filters `{ type: "text", text: "" }` and passes thinking,
+        // redacted_thinking, tool_use, tool_result, and image blocks
+        // through unchanged. See #73640.
+        const filteredContent = dropEmptyTextBlocks(strippedContent as unknown as ContentBlock[]);
         const finalContent = (await sanitizeContentBlocksImages(
           filteredContent as unknown as ContentBlock[],
           label,

--- a/src/agents/pi-embedded-helpers/images.ts
+++ b/src/agents/pi-embedded-helpers/images.ts
@@ -108,6 +108,12 @@ export async function sanitizeSessionMessagesImages(
         label,
         imageSanitization,
       )) as unknown as typeof toolMsg.content;
+      // Skip emitting a content-empty toolResult so we do not trade the
+      // `text field is blank` 400 for a `content array is empty` 400 — the
+      // assistant full-mode path below already does the same skip.
+      if (nextContent.length === 0) {
+        continue;
+      }
       out.push({ ...toolMsg, content: nextContent });
       continue;
     }
@@ -123,6 +129,11 @@ export async function sanitizeSessionMessagesImages(
           label,
           imageSanitization,
         )) as unknown as typeof userMsg.content;
+        // Same content-empty skip as toolResult: an empty user content
+        // array is also rejected by Anthropic.
+        if ((nextContent as unknown as readonly unknown[]).length === 0) {
+          continue;
+        }
         out.push({ ...userMsg, content: nextContent });
         continue;
       }
@@ -134,6 +145,11 @@ export async function sanitizeSessionMessagesImages(
         const content = assistantMsg.content;
         if (Array.isArray(content)) {
           // Same blank-text guard for error-stopped assistant turns (#73640).
+          // Note: error-stopped assistant messages with `content: []` are
+          // intentionally preserved (downstream replay/classifier relies on
+          // them — see `keeps empty assistant error messages` regression).
+          // Anthropic 400 risk is bounded here because error turns are not
+          // re-sent in the next request.
           const filtered = dropEmptyTextBlocks(content as unknown as ContentBlock[]);
           const nextContent = (await sanitizeContentBlocksImages(
             filtered,
@@ -161,6 +177,11 @@ export async function sanitizeSessionMessagesImages(
             label,
             imageSanitization,
           )) as unknown as typeof assistantMsg.content;
+          // Mirror the assistant full-mode skip so we do not emit a
+          // content-empty assistant message in images-only mode either.
+          if ((nextContent as unknown as readonly unknown[]).length === 0) {
+            continue;
+          }
           out.push({ ...assistantMsg, content: nextContent });
           continue;
         }


### PR DESCRIPTION
## What

Fixes #73640. Anthropic's API rejects requests whose `messages.N.content.K` carries a `{ type: "text", text: "" }` block:

```
Validation error: The text field in the ContentBlock object at messages.64.content.0 is blank. Add text to the text field, and try again.
```

Once that 400 fires for a session, every subsequent turn replays the same transcript and hits the same error — the session is wedged with no per-turn recovery path.

## Root cause

`sanitizeSessionMessagesImages` in `src/agents/pi-embedded-helpers/images.ts` was the only place filtering empty-text blocks before the provider call, but it only did so on a single narrow path: `role === "assistant"` AND `stopReason !== "error"` AND `sanitizeMode === "full"` AND (when `preserveSignatures` is on) no thinking/redacted_thinking block present.

Empty `{ type: "text", text: "" }` blocks survived for **five** other branches:

1. `role === "user"` content arrays — only image sanitization ran, never touched text blocks
2. `role === "toolResult"` content arrays — same
3. `role === "assistant"` with `stopReason === "error"` — bypassed the filter entirely
4. `role === "assistant"` under `sanitizeMode === "images-only"` — bypassed the filter
5. `role === "assistant"` with `preserveSignatures` AND thinking block — kept original content including blank text

Any one of those five paths could produce a transcript Anthropic rejects.

## Fix

Extract the inlined empty-text filter into a small `dropEmptyTextBlocks(content)` helper at the top of the file, and apply it uniformly to all five sites:

```ts
function dropEmptyTextBlocks<T>(content: readonly T[]): T[] {
  return content.filter((block) => {
    if (!block || typeof block !== "object") return true;
    const rec = block as { type?: unknown; text?: unknown };
    if (rec.type !== "text") return true;
    return typeof rec.text === "string" && rec.text.trim().length > 0;
  });
}
```

The helper only rewrites text blocks; thinking, redacted_thinking, tool_use, tool_result, and image blocks pass through unchanged. The previous `isThinkingOrRedactedBlock` carve-out (which kept blank-text companions when a thinking block was present under `preserveSignatures`) is removed because dropping empties never disturbs thinking-block ordering — and it still triggered the 400.

## Test changes

- Updated the existing `preserves interleaved thinking block order when signatures are preserved` regression test (the canary for the `preserveSignatures` branch). Title now ends `… and drops blank-text companions`. The test still pins thinking / redacted_thinking ordering; the blank-text companion is now expected to be dropped.
- New test `drops blank-text content blocks on user, toolResult, and error-stopped assistant turns (#73640)` pinning the four previously-unfiltered branches in one go.

## Verified locally

```
npx oxlint src/agents/pi-embedded-helpers/images.ts
# Found 0 warnings and 0 errors.

npx vitest run \
  src/agents/pi-embedded-helpers.sanitize-session-messages-images.removes-empty-assistant-text-blocks-but-preserves.test.ts \
  src/agents/pi-embedded-runner.sanitize-session-history.policy.test.ts \
  src/agents/pi-embedded-runner.sanitize-session-history.test.ts
# Tests  116 passed (116)
```

## Pre-implement audit

1. **Existing-helper check.** The empty-text filter shape was already inlined in the working assistant-full-mode branch (`images.ts:143-152`); the new helper is the natural extraction. `isEmptyAssistantMessageContent` (same file, line 35) uses an identical predicate and is left in place because it serves a different caller (full-message classifier vs per-block filter). ✅
2. **Shared-helper caller check.** `dropEmptyTextBlocks` is module-private. The 5 call sites are all inside `sanitizeSessionMessagesImages`. No external contract change. ✅
3. **Broader-fix rival scan.** Zero rival PRs on #73640. ✅

lobster-biscuit: 73640-anthropic-empty-text-content-block

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
