### PR TITLE
fix(gateway): honor ssh transport loopback endpoint in security check

### DIFF
--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -672,6 +672,28 @@ describe("buildGatewayConnectionDetails", () => {
     expect(details.remoteFallbackNote).toBeUndefined();
   });
 
+  it("maps ssh transport remote url to loopback tunnel endpoint", () => {
+    getRuntimeConfig.mockReturnValue({
+      gateway: {
+        mode: "remote",
+        bind: "tailnet",
+        remote: {
+          transport: "ssh",
+          url: "ws://203.0.113.10:18789/ws",
+          sshTarget: "user@203.0.113.10",
+        },
+      },
+    });
+    resolveGatewayPort.mockReturnValue(18800);
+    pickPrimaryTailnetIPv4.mockReturnValue("100.64.0.9");
+
+    const details = buildGatewayConnectionDetails();
+
+    expect(details.url).toBe("ws://127.0.0.1:18789/ws");
+    expect(details.urlSource).toBe("config gateway.remote.url (ssh tunnel local endpoint)");
+    expect(details.bindDetail).toBeUndefined();
+  });
+
   it("uses env OPENCLAW_GATEWAY_URL when set", () => {
     getRuntimeConfig.mockReturnValue({ gateway: { mode: "local", bind: "loopback" } });
     resolveGatewayPort.mockReturnValue(18800);

--- a/src/gateway/connection-details.ts
+++ b/src/gateway/connection-details.ts
@@ -17,6 +17,19 @@ type GatewayConnectionDetailResolvers = {
   resolveGatewayPort?: (cfg?: OpenClawConfig, env?: NodeJS.ProcessEnv) => number;
 };
 
+function resolveSshTunnelLoopbackUrl(remoteUrl: string): string {
+  try {
+    const parsed = new URL(remoteUrl);
+    const scheme = parsed.protocol === "wss:" ? "wss" : "ws";
+    const port = parsed.port || (scheme === "wss" ? "443" : "80");
+    const suffix = `${parsed.pathname || ""}${parsed.search || ""}${parsed.hash || ""}`;
+    return `${scheme}://127.0.0.1:${port}${suffix}`;
+  } catch {
+    // Fallback to the default local gateway endpoint shape.
+    return "ws://127.0.0.1:18789";
+  }
+}
+
 export function buildGatewayConnectionDetailsWithResolvers(
   options: {
     config?: OpenClawConfig;
@@ -45,14 +58,20 @@ export function buildGatewayConnectionDetailsWithResolvers(
     : normalizeOptionalString(process.env.OPENCLAW_GATEWAY_URL);
   const urlOverride = cliUrlOverride ?? envUrlOverride;
   const remoteUrl = normalizeOptionalString(remote?.url);
+  const sshTransport = isRemoteMode && remote?.transport === "ssh";
+  const sshLoopbackUrl = !urlOverride && sshTransport && remoteUrl
+    ? resolveSshTunnelLoopbackUrl(remoteUrl)
+    : null;
   const remoteMisconfigured = isRemoteMode && !urlOverride && !remoteUrl;
   const urlSourceHint =
     options.urlSource ?? (cliUrlOverride ? "cli" : envUrlOverride ? "env" : undefined);
-  const url = urlOverride || remoteUrl || localUrl;
+  const url = urlOverride || sshLoopbackUrl || remoteUrl || localUrl;
   const urlSource = urlOverride
     ? urlSourceHint === "env"
       ? "env OPENCLAW_GATEWAY_URL"
       : "cli --url"
+    : sshLoopbackUrl
+      ? "config gateway.remote.url (ssh tunnel local endpoint)"
     : remoteUrl
       ? "config gateway.remote.url"
       : remoteMisconfigured


### PR DESCRIPTION
## Summary
- map `gateway.remote.transport=ssh` connections to a loopback tunnel endpoint derived from `gateway.remote.url`
- ensure websocket security checks validate the effective local tunnel URL instead of treating SSH remote hosts as direct plaintext ws targets
- add test coverage for ssh transport URL mapping in `buildGatewayConnectionDetails`

## Test plan
- [x] static lint diagnostics for changed files are clean
- [ ] `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/call.test.ts -t \"buildGatewayConnectionDetails\"` *(requires dev deps; unavailable in this workspace checkout)*

Made with [Cursor](https://cursor.com)