### PR TITLE
Bound active-memory recall latency and jitter QMD startup

### DIFF
--- a/docs/concepts/active-memory.md
+++ b/docs/concepts/active-memory.md
@@ -37,7 +37,7 @@ when available:
           modelFallback: "google/gemini-3-flash",
           queryMode: "recent",
           promptStyle: "balanced",
-          timeoutMs: 15000,
+          timeoutMs: 3000,
           maxSummaryChars: 220,
           persistTranscripts: false,
           logging: true,
@@ -382,7 +382,7 @@ timeout budgets should grow with context size (`message` < `recent` < `full`).
     - you want a better balance of speed and conversational grounding
     - follow-up questions often depend on the last few turns
 
-    Start around `15000` ms for `config.timeoutMs`.
+    Start around `3000` to `5000` ms for `config.timeoutMs`.
 
   </Tab>
 
@@ -402,7 +402,7 @@ timeout budgets should grow with context size (`message` < `recent` < `full`).
     - the strongest recall quality matters more than latency
     - the conversation contains important setup far back in the thread
 
-    Start around `15000` ms or higher depending on thread size.
+    Start around `5000` ms or higher depending on thread size, but avoid making Active Memory part of the critical path for normal replies.
 
   </Tab>
 </Tabs>
@@ -558,24 +558,24 @@ plugins.entries.active-memory
 
 The most important fields are:
 
-| Key                         | Type                                                                                                 | Meaning                                                                                                |
-| --------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `enabled`                   | `boolean`                                                                                            | Enables the plugin itself                                                                              |
-| `config.agents`             | `string[]`                                                                                           | Agent ids that may use active memory                                                                   |
-| `config.model`              | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model |
-| `config.allowedChatTypes`   | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                    |
-| `config.allowedChatIds`     | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed      |
-| `config.deniedChatIds`      | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                |
-| `config.queryMode`          | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                      |
-| `config.promptStyle`        | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory   |
-| `config.thinking`           | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                  |
-| `config.promptOverride`     | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                       |
-| `config.promptAppend`       | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                               |
-| `config.timeoutMs`          | `number`                                                                                             | Hard timeout for the blocking memory sub-agent, capped at 120000 ms                                    |
-| `config.maxSummaryChars`    | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                          |
-| `config.logging`            | `boolean`                                                                                            | Emits active memory logs while tuning                                                                  |
-| `config.persistTranscripts` | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                     |
-| `config.transcriptDir`      | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                |
+| Key                         | Type                                                                                                 | Meaning                                                                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `enabled`                   | `boolean`                                                                                            | Enables the plugin itself                                                                                      |
+| `config.agents`             | `string[]`                                                                                           | Agent ids that may use active memory                                                                           |
+| `config.model`              | `string`                                                                                             | Optional blocking memory sub-agent model ref; when unset, active memory uses the current session model         |
+| `config.allowedChatTypes`   | `("direct" \| "group" \| "channel")[]`                                                               | Session types that may run Active Memory; defaults to direct-message style sessions                            |
+| `config.allowedChatIds`     | `string[]`                                                                                           | Optional per-conversation allowlist applied after `allowedChatTypes`; non-empty lists fail closed              |
+| `config.deniedChatIds`      | `string[]`                                                                                           | Optional per-conversation denylist that overrides allowed session types and allowed ids                        |
+| `config.queryMode`          | `"message" \| "recent" \| "full"`                                                                    | Controls how much conversation the blocking memory sub-agent sees                                              |
+| `config.promptStyle`        | `"balanced" \| "strict" \| "contextual" \| "recall-heavy" \| "precision-heavy" \| "preference-only"` | Controls how eager or strict the blocking memory sub-agent is when deciding whether to return memory           |
+| `config.thinking`           | `"off" \| "minimal" \| "low" \| "medium" \| "high" \| "xhigh" \| "adaptive" \| "max"`                | Advanced thinking override for the blocking memory sub-agent; default `off` for speed                          |
+| `config.promptOverride`     | `string`                                                                                             | Advanced full prompt replacement; not recommended for normal use                                               |
+| `config.promptAppend`       | `string`                                                                                             | Advanced extra instructions appended to the default or overridden prompt                                       |
+| `config.timeoutMs`          | `number`                                                                                             | Hard timeout for the deadline-bounded memory sub-agent; defaults to 3000 ms and falls back silently on timeout |
+| `config.maxSummaryChars`    | `number`                                                                                             | Maximum total characters allowed in the active-memory summary                                                  |
+| `config.logging`            | `boolean`                                                                                            | Emits active memory logs while tuning                                                                          |
+| `config.persistTranscripts` | `boolean`                                                                                            | Keeps blocking memory sub-agent transcripts on disk instead of deleting temp files                             |
+| `config.transcriptDir`      | `string`                                                                                             | Relative blocking memory sub-agent transcript directory under the agent sessions folder                        |
 
 Useful tuning fields:
 
@@ -602,7 +602,7 @@ Start with `recent`.
           agents: ["main"],
           queryMode: "recent",
           promptStyle: "balanced",
-          timeoutMs: 15000,
+          timeoutMs: 3000,
           maxSummaryChars: 220,
           logging: true,
         },

--- a/extensions/active-memory/index.test.ts
+++ b/extensions/active-memory/index.test.ts
@@ -185,9 +185,9 @@ describe("active-memory plugin", () => {
 
   it("registers a before_prompt_build hook", () => {
     expect(api.on).toHaveBeenCalledWith("before_prompt_build", expect.any(Function), {
-      timeoutMs: 150_000,
+      timeoutMs: 4_000,
     });
-    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(150_000);
+    expect(hookOptions.before_prompt_build?.timeoutMs).toBe(4_000);
   });
 
   it("runs recall without recording shared auth-profile failures", async () => {

--- a/extensions/active-memory/index.ts
+++ b/extensions/active-memory/index.ts
@@ -24,7 +24,7 @@ import {
 } from "openclaw/plugin-sdk/session-store-runtime";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 
-const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_TIMEOUT_MS = 3_000;
 const DEFAULT_AGENT_ID = "main";
 const DEFAULT_MAX_SUMMARY_CHARS = 220;
 const DEFAULT_RECENT_USER_TURNS = 2;
@@ -35,7 +35,7 @@ const DEFAULT_CACHE_TTL_MS = 15_000;
 const DEFAULT_MAX_CACHE_ENTRIES = 1000;
 const CACHE_SWEEP_INTERVAL_MS = 1000;
 const DEFAULT_MIN_TIMEOUT_MS = 250;
-const DEFAULT_SETUP_GRACE_TIMEOUT_MS = 30_000;
+const DEFAULT_SETUP_GRACE_TIMEOUT_MS = 0;
 const DEFAULT_QUERY_MODE = "recent" as const;
 const DEFAULT_QMD_SEARCH_MODE = "search" as const;
 const DEFAULT_TRANSCRIPT_DIR = "active-memory";
@@ -2431,7 +2431,7 @@ export default definePluginEntry({
       },
     });
 
-    const beforePromptBuildTimeoutMs = 120_000 + setupGraceTimeoutMs;
+    const beforePromptBuildTimeoutMs = DEFAULT_TIMEOUT_MS + setupGraceTimeoutMs + 1_000;
     api.on(
       "before_prompt_build",
       async (event, ctx) => {

--- a/src/gateway/server-startup-memory.ts
+++ b/src/gateway/server-startup-memory.ts
@@ -8,6 +8,8 @@ import {
 import { getActiveMemorySearchManager } from "../plugins/memory-runtime.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 
+const DEFAULT_QMD_STARTUP_JITTER_MS = 100;
+
 function shouldStartQmdBackgroundWork(qmd: ResolvedQmdConfig): boolean {
   return qmd.update.onBoot || qmd.update.intervalMs > 0 || qmd.update.embedIntervalMs > 0;
 }
@@ -35,12 +37,29 @@ function shouldEagerlyStartAgentMemory(params: {
   return hasExplicitAgentMemorySearchConfig(params.cfg, params.agentId);
 }
 
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    timeout.unref?.();
+  });
+}
+
+function resolveStartupJitterMs(params: { index: number; total: number }): number {
+  if (params.index <= 0 || params.total <= 1) {
+    return 0;
+  }
+  return Math.floor(Math.random() * DEFAULT_QMD_STARTUP_JITTER_MS);
+}
+
 export async function startGatewayMemoryBackend(params: {
   cfg: OpenClawConfig;
   log: { info?: (msg: string) => void; warn: (msg: string) => void };
 }): Promise<void> {
   const agentIds = listAgentIds(params.cfg);
-  const armedAgentIds: string[] = [];
+  const eagerAgentIds: string[] = [];
   const deferredAgentIds: string[] = [];
   for (const agentId of agentIds) {
     if (!resolveMemorySearchConfig(params.cfg, agentId)) {
@@ -67,7 +86,17 @@ export async function startGatewayMemoryBackend(params: {
       continue;
     }
 
-    const { manager, error } = await getActiveMemorySearchManager({ cfg: params.cfg, agentId });
+    eagerAgentIds.push(agentId);
+  }
+  const startupResults = await Promise.all(
+    eagerAgentIds.map(async (agentId, index) => {
+      await delay(resolveStartupJitterMs({ index, total: eagerAgentIds.length }));
+      const { manager, error } = await getActiveMemorySearchManager({ cfg: params.cfg, agentId });
+      return { agentId, manager, error };
+    }),
+  );
+  const armedAgentIds: string[] = [];
+  for (const { agentId, manager, error } of startupResults) {
     if (!manager) {
       params.log.warn(
         `qmd memory startup initialization failed for agent "${agentId}": ${error ?? "unknown error"}`,


### PR DESCRIPTION
## Summary

This patch applies the active-memory reliability approach proposed by @kinthaiofficial in #72015:

- reduce Active Memory's default recall deadline from 15s to 3s
- keep the `before_prompt_build` hook deadline-bounded so memory recall degrades instead of blocking normal replies
- remove the default 30s setup grace from the critical path
- stagger QMD startup initialization with a small jitter so multi-agent boot does not stampede memory backends
- update Active Memory docs to recommend low-latency recall budgets

The existing QMD search manager cache is already keyed per agent, so this keeps the change small and focuses on the blocking failure mode plus startup herd behavior.

## Tests

- `pnpm exec vitest run extensions/active-memory/index.test.ts src/gateway/server-startup-memory.test.ts`
- `pnpm tsgo:extensions:test`
- `pnpm tsgo:core:test`

Fixes #72015
