### PR TITLE
feat(profile): add privacy-safe profile export and import

### DIFF
--- a/docs/cli/profile.md
+++ b/docs/cli/profile.md
@@ -1,0 +1,70 @@
+---
+summary: "CLI reference for `openclaw profile` (privacy-safe local profile portability)"
+read_when:
+  - You want to move OpenClaw personalization to a new device
+  - You want a smaller, privacy-safe archive than a full state backup
+title: "Profile"
+---
+
+# `openclaw profile`
+
+Create or import a privacy-safe profile archive for portable OpenClaw personalization.
+
+```bash
+openclaw profile export
+openclaw profile export --output ~/Backups
+openclaw profile export --dry-run --json
+openclaw profile export --verify
+openclaw profile import ./2026-04-28T00-00-00.000Z-openclaw-profile.openclaw-profile.tar.gz
+openclaw profile import ./profile.openclaw-profile.tar.gz --dry-run --json
+```
+
+## What gets exported
+
+Profile archives are intentionally narrower than `openclaw backup`.
+
+They include:
+
+- Portable config fields: `ui`, `agents`, `skills`, `plugins.entries`, `plugins.slots`, `tools`, `memory`, and `mcp`
+- Agent workspace profile files: `AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `TOOLS.md`, `HEARTBEAT.md`, `BOOT.md`, and `MEMORY.md`
+- Agent workspace memory files under `memory/**/*.md`
+- Portable plugin install records projected from `plugins/installs.json`, so supported plugins can be reinstalled or refreshed on the target machine
+
+Agent-local path fields such as `agents.defaults.workspace`, `agents.list[].workspace`, and
+`agents.list[].agentDir` are removed from the exported config.
+
+Plugin registry cache entries are not copied. Profile export only keeps portable install metadata
+for registry-backed sources such as npm, ClawHub, or marketplace records; local `path`/`archive`
+records, cached manifest paths, install paths, timestamps, and generated plugin registry entries
+are omitted.
+
+## What does not get exported
+
+Profile archives do not include:
+
+- `auth-profiles.json`, `models.json`, `credentials/`, `secrets`, or `env`
+- `sessions/`, `media/`, `logs/`, `tasks/`, or cache directories
+- Gateway service state, channel credentials, OAuth tokens, API keys, or passwords
+
+Use `openclaw backup create` when you need a disaster-recovery archive of local state.
+Use `openclaw profile export` when you want to move personalization to another device without
+copying raw sessions or credentials.
+
+## Import behavior
+
+`openclaw profile import` is non-destructive:
+
+- Existing config fields are not overwritten.
+- Existing workspace files are skipped.
+- Existing plugin install records are skipped.
+- Imported plugin records rebuild the target machine's plugin index instead of copying the
+  source machine's generated plugin registry cache.
+- `--dry-run --json` reports what would be applied and what would be skipped.
+
+If the target machine needs provider credentials, configure them after import with `openclaw configure`
+or the relevant provider setup command.
+
+## Related
+
+- [Backup](/cli/backup)
+- [Agent workspace](/concepts/agent-workspace)

--- a/src/cli/program/command-registry-core.ts
+++ b/src/cli/program/command-registry-core.ts
@@ -82,6 +82,11 @@ const coreEntrySpecs: readonly CommandGroupDescriptorSpec<
         exportName: "registerBackupCommand",
       },
       {
+        commandNames: ["profile"],
+        loadModule: () => import("./register.profile.js"),
+        exportName: "registerProfileCommand",
+      },
+      {
         commandNames: ["migrate"],
         loadModule: () => import("./register.migrate.js"),
         exportName: "registerMigrateCommand",

--- a/src/cli/program/core-command-descriptors.ts
+++ b/src/cli/program/core-command-descriptors.ts
@@ -36,6 +36,11 @@ const coreCliCommandCatalog = defineCommandDescriptorCatalog([
     hasSubcommands: true,
   },
   {
+    name: "profile",
+    description: "Export and import privacy-safe OpenClaw profile archives",
+    hasSubcommands: true,
+  },
+  {
     name: "migrate",
     description: "Import state from another agent system",
     hasSubcommands: true,

--- a/src/cli/program/register.profile.test.ts
+++ b/src/cli/program/register.profile.test.ts
@@ -1,0 +1,85 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerProfileCommand } from "./register.profile.js";
+
+const mocks = vi.hoisted(() => ({
+  profileExportCommand: vi.fn(),
+  profileImportCommand: vi.fn(),
+  runtime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../commands/profile.js", () => ({
+  profileExportCommand: mocks.profileExportCommand,
+  profileImportCommand: mocks.profileImportCommand,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: mocks.runtime,
+}));
+
+describe("registerProfileCommand", () => {
+  async function runCli(args: string[]) {
+    const program = new Command();
+    registerProfileCommand(program);
+    await program.parseAsync(args, { from: "user" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.profileExportCommand.mockResolvedValue(undefined);
+    mocks.profileImportCommand.mockResolvedValue(undefined);
+  });
+
+  it("runs profile export with forwarded options", async () => {
+    await runCli(["profile", "export", "--output", "/tmp/profiles", "--json", "--dry-run"]);
+
+    expect(mocks.profileExportCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        output: "/tmp/profiles",
+        json: true,
+        dryRun: true,
+        verify: false,
+      }),
+    );
+  });
+
+  it("forwards --verify to profile export", async () => {
+    await runCli(["profile", "export", "--verify"]);
+
+    expect(mocks.profileExportCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        verify: true,
+      }),
+    );
+  });
+
+  it("runs profile import with forwarded options", async () => {
+    await runCli(["profile", "import", "/tmp/profile.openclaw-profile.tar.gz", "--json"]);
+
+    expect(mocks.profileImportCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        archive: "/tmp/profile.openclaw-profile.tar.gz",
+        json: true,
+        dryRun: false,
+      }),
+    );
+  });
+
+  it("forwards --dry-run to profile import", async () => {
+    await runCli(["profile", "import", "/tmp/profile.openclaw-profile.tar.gz", "--dry-run"]);
+
+    expect(mocks.profileImportCommand).toHaveBeenCalledWith(
+      mocks.runtime,
+      expect.objectContaining({
+        dryRun: true,
+      }),
+    );
+  });
+});

--- a/src/cli/program/register.profile.ts
+++ b/src/cli/program/register.profile.ts
@@ -1,0 +1,85 @@
+import type { Command } from "commander";
+import { profileExportCommand, profileImportCommand } from "../../commands/profile.js";
+import { defaultRuntime } from "../../runtime.js";
+import { formatDocsLink } from "../../terminal/links.js";
+import { theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+import { formatHelpExamples } from "../help-format.js";
+
+export function registerProfileCommand(program: Command) {
+  const profile = program
+    .command("profile")
+    .description("Export and import privacy-safe OpenClaw profile archives")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/profile", "docs.openclaw.ai/cli/profile")}\n`,
+    );
+
+  profile
+    .command("export")
+    .description("Write a profile archive for portable config, memory, and persona files")
+    .option("--output <path>", "Archive path or destination directory")
+    .option("--json", "Output JSON", false)
+    .option("--dry-run", "Print the profile export plan without writing the archive", false)
+    .option("--verify", "Verify the archive after writing it", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          ["openclaw profile export", "Create a profile archive in the current directory."],
+          [
+            "openclaw profile export --output ~/Backups",
+            "Write the profile archive into an existing backup directory.",
+          ],
+          [
+            "openclaw profile export --dry-run --json",
+            "Preview portable profile contents without writing an archive.",
+          ],
+          [
+            "openclaw profile export --verify",
+            "Create the archive and validate its manifest and payload layout.",
+          ],
+        ])}`,
+    )
+    .action(async (opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await profileExportCommand(defaultRuntime, {
+          output: opts.output as string | undefined,
+          json: Boolean(opts.json),
+          dryRun: Boolean(opts.dryRun),
+          verify: Boolean(opts.verify),
+        });
+      });
+    });
+
+  profile
+    .command("import")
+    .description("Import a profile archive without overwriting local profile files")
+    .argument("<archive>", "Profile archive path")
+    .option("--json", "Output JSON", false)
+    .option("--dry-run", "Preview import changes without writing files", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            "openclaw profile import ./my.openclaw-profile.tar.gz",
+            "Import portable profile config and memory into this machine.",
+          ],
+          [
+            "openclaw profile import ./my.openclaw-profile.tar.gz --dry-run --json",
+            "Preview imported fields and skipped local files.",
+          ],
+        ])}`,
+    )
+    .action(async (archive, opts) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await profileImportCommand(defaultRuntime, {
+          archive: archive as string,
+          json: Boolean(opts.json),
+          dryRun: Boolean(opts.dryRun),
+        });
+      });
+    });
+}

--- a/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
+++ b/src/commands/doctor-bundled-plugin-runtime-deps.test.ts
@@ -12,10 +12,19 @@ import { maybeRepairBundledPluginRuntimeDeps } from "./doctor-bundled-plugin-run
 import type { DoctorPrompter } from "./doctor-prompter.js";
 
 type InstalledRuntimeDeps = BundledRuntimeDepsInstallParams[];
+const trustedPackageRoots: string[] = [];
 
 function writeJson(filePath: string, value: unknown) {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+function makeTrustedPackageRoot(): string {
+  const trustedRoot = path.resolve("dist", "extensions");
+  fs.mkdirSync(trustedRoot, { recursive: true });
+  const root = fs.mkdtempSync(path.join(trustedRoot, "openclaw-doctor-bundled-"));
+  trustedPackageRoots.push(root);
+  return root;
 }
 
 function writeBundledChannelPlugin(root: string, id: string, dependencies: Record<string, string>) {
@@ -161,6 +170,9 @@ function createRuntime(options: { logs?: string[]; errors?: string[] } = {}): Ru
 describe("doctor bundled plugin runtime deps", () => {
   afterEach(() => {
     vi.useRealTimers();
+    for (const root of trustedPackageRoots.splice(0)) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("skips source checkouts", () => {
@@ -491,6 +503,9 @@ describe("doctor bundled plugin runtime deps", () => {
       runtime: createRuntime(),
       prompter: createNonInteractivePrompter(),
       packageRoot: root,
+      env: {
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      },
       config: {
         plugins: { enabled: true },
       },
@@ -636,6 +651,7 @@ describe("doctor bundled plugin runtime deps", () => {
       runtime: createRuntime(),
       prompter: createNonInteractivePrompter(),
       packageRoot: root,
+      includeConfiguredChannels: true,
       config: {
         plugins: { enabled: true },
         channels: { telegram: { enabled: true } },
@@ -751,7 +767,7 @@ describe("doctor bundled plugin runtime deps", () => {
   });
 
   it("repairs deps for configured channel owner plugins", async () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-bundled-"));
+    const root = makeTrustedPackageRoot();
     writeJson(path.join(root, "package.json"), { name: "openclaw" });
     writeBundledChannelOwnerPlugin(root, "chat-bridge", ["telegram"], { grammy: "1.37.0" });
     const installed = createInstalledRuntimeDeps();

--- a/src/commands/profile.test.ts
+++ b/src/commands/profile.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from "vitest";
+import type { RuntimeEnv } from "../runtime.js";
+
+const mocks = vi.hoisted(() => ({
+  createProfileArchive: vi.fn(),
+  importProfileArchive: vi.fn(),
+  writeRuntimeJson: vi.fn(),
+}));
+
+vi.mock("../infra/profile-portability.js", () => ({
+  createProfileArchive: mocks.createProfileArchive,
+  importProfileArchive: mocks.importProfileArchive,
+  formatProfileExportSummary: () => ["export summary"],
+  formatProfileImportSummary: () => ["import summary"],
+}));
+
+vi.mock("../runtime.js", async () => {
+  const actual = await vi.importActual<typeof import("../runtime.js")>("../runtime.js");
+  return {
+    ...actual,
+    writeRuntimeJson: mocks.writeRuntimeJson,
+  };
+});
+
+const { profileExportCommand, profileImportCommand } = await import("./profile.js");
+
+function createRuntime(): RuntimeEnv {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("profile commands", () => {
+  it("writes JSON for profile export", async () => {
+    const result = {
+      archivePath: "/tmp/profile.openclaw-profile.tar.gz",
+      dryRun: true,
+    };
+    mocks.createProfileArchive.mockResolvedValueOnce(result);
+    const runtime = createRuntime();
+
+    await profileExportCommand(runtime, { json: true, dryRun: true });
+
+    expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(runtime, result);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
+  it("writes JSON for profile import", async () => {
+    const result = {
+      archivePath: "/tmp/profile.openclaw-profile.tar.gz",
+      dryRun: true,
+    };
+    mocks.importProfileArchive.mockResolvedValueOnce(result);
+    const runtime = createRuntime();
+
+    await profileImportCommand(runtime, {
+      archive: "/tmp/profile.openclaw-profile.tar.gz",
+      json: true,
+      dryRun: true,
+    });
+
+    expect(mocks.writeRuntimeJson).toHaveBeenCalledWith(runtime, result);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/profile.ts
+++ b/src/commands/profile.ts
@@ -1,0 +1,44 @@
+import {
+  createProfileArchive,
+  formatProfileExportSummary,
+  formatProfileImportSummary,
+  importProfileArchive,
+  type ProfileExportOptions,
+  type ProfileExportResult,
+  type ProfileImportOptions,
+  type ProfileImportResult,
+} from "../infra/profile-portability.js";
+import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+
+export type {
+  ProfileExportOptions,
+  ProfileExportResult,
+  ProfileImportOptions,
+  ProfileImportResult,
+};
+
+export async function profileExportCommand(
+  runtime: RuntimeEnv,
+  opts: ProfileExportOptions = {},
+): Promise<ProfileExportResult> {
+  const result = await createProfileArchive(opts);
+  if (opts.json) {
+    writeRuntimeJson(runtime, result);
+  } else {
+    runtime.log(formatProfileExportSummary(result).join("\n"));
+  }
+  return result;
+}
+
+export async function profileImportCommand(
+  runtime: RuntimeEnv,
+  opts: ProfileImportOptions,
+): Promise<ProfileImportResult> {
+  const result = await importProfileArchive(opts);
+  if (opts.json) {
+    writeRuntimeJson(runtime, result);
+  } else {
+    runtime.log(formatProfileImportSummary(result).join("\n"));
+  }
+  return result;
+}

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
+import {
+  __setModelCatalogImportForTest,
+  resetModelCatalogCacheForTest,
+} from "../agents/model-catalog.js";
+import { buildModelsProviderData } from "../auto-reply/reply/commands-models.js";
 import { resolveMainSessionKeyFromConfig } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { drainSystemEvents } from "../infra/system-events.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -21,6 +27,8 @@ import {
   testState,
   withGatewayServer as withMinimalGatewayServer,
 } from "./test-helpers.js";
+
+type PiDiscoveryRuntimeModule = typeof import("../agents/pi-model-discovery-runtime.js");
 
 const hoisted = vi.hoisted(() => {
   const cronInstances: Array<{
@@ -877,6 +885,108 @@ describe("gateway hot reload", () => {
 
       expect(hoisted.disposeAllSessionMcpRuntimes).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("makes newly available catalog models visible in-process after hot reload", async () => {
+    type TestRegistryEntry = { provider: string; id: string; name: string };
+    let registryEntries: TestRegistryEntry[] = [
+      { provider: "ollama", id: "existing", name: "Existing" },
+    ];
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          ModelRegistry: class {
+            getAll() {
+              return registryEntries;
+            }
+          },
+        }) as unknown as PiDiscoveryRuntimeModule,
+    );
+    resetModelCatalogCacheForTest();
+
+    try {
+      await withNonMinimalGatewayServer(async () => {
+        const onHotReload = hoisted.getOnHotReload();
+        expect(onHotReload).toBeTypeOf("function");
+
+        const baseConfig: OpenClawConfig = {
+          agents: {
+            defaults: {
+              model: {
+                primary: "ollama/existing",
+              },
+            },
+          },
+          models: {
+            providers: {
+              ollama: {
+                baseUrl: "http://127.0.0.1:11434",
+                api: "ollama",
+                apiKey: "ollama-local",
+                models: [
+                  {
+                    id: "existing",
+                    name: "Existing",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 128_000,
+                    maxTokens: 8192,
+                  },
+                ],
+              },
+            },
+          },
+        };
+
+        const before = await buildModelsProviderData(baseConfig);
+        expect([...(before.byProvider.get("ollama") ?? new Set()).values()]).toEqual(["existing"]);
+
+        registryEntries = [
+          ...registryEntries,
+          { provider: "ollama", id: "glm-5.1:cloud", name: "GLM 5.1 Cloud" },
+        ];
+
+        const nextConfig = structuredClone(baseConfig);
+        await onHotReload?.(
+          {
+            changedPaths: ["models.providers.ollama.models"],
+            restartGateway: false,
+            restartReasons: [],
+            hotReasons: ["models.providers.ollama.models"],
+            reloadHooks: false,
+            restartGmailWatcher: false,
+            restartCron: false,
+            restartHeartbeat: false,
+            restartChannels: new Set(),
+            noopPaths: [],
+          },
+          nextConfig,
+        );
+
+        __setModelCatalogImportForTest(
+          async () =>
+            ({
+              discoverAuthStorage: () => ({}),
+              ModelRegistry: class {
+                getAll() {
+                  return registryEntries;
+                }
+              },
+            }) as unknown as PiDiscoveryRuntimeModule,
+        );
+        const after = await buildModelsProviderData(nextConfig);
+        expect([...(after.byProvider.get("ollama") ?? new Set()).values()]).toEqual([
+          "existing",
+          "glm-5.1:cloud",
+        ]);
+        expect(hoisted.resetModelCatalogCache).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      __setModelCatalogImportForTest();
+      resetModelCatalogCacheForTest();
+    }
   });
 
   it("serves secrets.reload immediately after startup without race failures", async () => {

--- a/src/infra/profile-portability.test.ts
+++ b/src/infra/profile-portability.test.ts
@@ -1,0 +1,615 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { afterEach, describe, expect, it } from "vitest";
+import { resetConfigRuntimeState } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import {
+  buildSafeProfileConfig,
+  createProfileArchive,
+  importProfileArchive,
+} from "./profile-portability.js";
+
+async function readArchiveEntries(archivePath: string): Promise<string[]> {
+  const entries: string[] = [];
+  await tar.t({
+    file: archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      entries.push(entry.path);
+    },
+  });
+  return entries;
+}
+
+async function readArchiveManifest(archivePath: string): Promise<{
+  configPaths: string[];
+  assets: Array<{ kind: string; archivePath: string; relativePath?: string }>;
+}> {
+  const manifest = await readArchiveEntry(archivePath, "/manifest.json");
+  return JSON.parse(manifest) as {
+    configPaths: string[];
+    assets: Array<{ kind: string; archivePath: string; relativePath?: string }>;
+  };
+}
+
+async function readArchiveEntry(archivePath: string, entrySuffix: string): Promise<string> {
+  let manifest = "";
+  await tar.t({
+    file: archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      if (!entry.path.endsWith(entrySuffix)) {
+        entry.resume();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      entry.on("data", (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      entry.on("end", () => {
+        manifest = Buffer.concat(chunks).toString("utf8");
+      });
+    },
+  });
+  return manifest;
+}
+
+async function writeJson(pathname: string, value: unknown): Promise<void> {
+  await fs.mkdir(path.dirname(pathname), { recursive: true });
+  await fs.writeFile(pathname, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function writeProfileArchiveFixture(
+  archivePath: string,
+  entries: Record<string, string>,
+): Promise<void> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-archive-"));
+  try {
+    for (const [entryPath, contents] of Object.entries(entries)) {
+      const filePath = path.join(tempDir, ...entryPath.split("/"));
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, contents, "utf8");
+    }
+    await tar.c(
+      {
+        cwd: tempDir,
+        file: archivePath,
+        gzip: true,
+        portable: true,
+      },
+      Object.keys(entries),
+    );
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+describe("profile portability", () => {
+  let tempHomes: TempHomeEnv[] = [];
+
+  async function createHome(prefix: string): Promise<TempHomeEnv> {
+    const env = await createTempHomeEnv(prefix);
+    tempHomes.push(env);
+    resetConfigRuntimeState();
+    return env;
+  }
+
+  afterEach(async () => {
+    resetConfigRuntimeState();
+    for (const tempHome of tempHomes.toReversed()) {
+      await tempHome.restore();
+    }
+    tempHomes = [];
+  });
+
+  it("exports only privacy-safe profile config and workspace files", async () => {
+    const tempHome = await createHome("openclaw-profile-export-");
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-out-"));
+    try {
+      await writeJson(path.join(stateDir, "openclaw.json"), {
+        env: { vars: { OPENAI_API_KEY: "secret" } },
+        gateway: { auth: { token: "secret-token-value" } },
+        ui: {
+          assistant: {
+            name: "Portable",
+          },
+        },
+        agents: {
+          defaults: {
+            workspace: workspaceDir,
+            repoRoot: "/tmp/local-repo",
+            model: "openai/gpt-5.4",
+          },
+          list: [
+            {
+              id: "main",
+              workspace: workspaceDir,
+              agentDir: path.join(stateDir, "agents", "main", "agent"),
+              name: "Main",
+            },
+          ],
+        },
+        plugins: {
+          slots: { memory: "memory-core" },
+          entries: { "memory-core": { enabled: true } },
+        },
+        skills: {
+          entries: {
+            "web-skill": {
+              enabled: true,
+              config: {
+                mode: "portable",
+                privateKey: "skill-config-private-key",
+                encryptKey: "skill-config-encrypt-key",
+                encryption_key: "skill-config-encryption-key",
+              },
+            },
+          },
+        },
+        memory: { backend: "qmd" },
+      });
+      await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+      await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "# agents\n", "utf8");
+      await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "# memory\n", "utf8");
+      await fs.writeFile(path.join(workspaceDir, "memory", "2026-04-28.md"), "daily\n", "utf8");
+      await fs.mkdir(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, "agents", "main", "sessions", "s.jsonl"), "{}\n");
+      await fs.mkdir(path.join(stateDir, "media"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, "media", "image.png"), "not-exported");
+      await writeJson(path.join(stateDir, "plugins", "installs.json"), {
+        plugins: [
+          {
+            pluginId: "memory-core",
+            manifestPath: path.join(stateDir, "plugins", "cache", "memory-core", "plugin.json"),
+            rootDir: path.join(stateDir, "plugins", "cache", "memory-core"),
+          },
+        ],
+        installRecords: {
+          "memory-core": {
+            source: "npm",
+            spec: "memory-core",
+            sourcePath: path.join(stateDir, "plugins", "sources", "memory-core"),
+            installPath: path.join(stateDir, "plugins", "cache", "memory-core"),
+            installedAt: "2026-04-28T00:00:00.000Z",
+            privateKey: "plugin-install-private-key",
+            encryptKey: "plugin-install-encrypt-key",
+          },
+          "local-only": {
+            source: "path",
+            spec: path.join(tempHome.home, "private-plugin"),
+            sourcePath: path.join(tempHome.home, "private-plugin"),
+            installPath: path.join(stateDir, "plugins", "cache", "local-only"),
+          },
+        },
+      });
+      await writeJson(path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"), {
+        version: 1,
+        profiles: { secret: { type: "api_key", key: "secret" } },
+      });
+
+      const result = await createProfileArchive({
+        output: outputDir,
+        verify: true,
+        nowMs: Date.UTC(2026, 3, 28),
+      });
+
+      expect(result.verified).toBe(true);
+      expect(result.workspaceFiles.map((file) => file.relativePath)).toEqual(
+        expect.arrayContaining(["AGENTS.md", "MEMORY.md", "memory/2026-04-28.md"]),
+      );
+      const entries = await readArchiveEntries(result.archivePath);
+      const joinedEntries = entries.join("\n");
+      expect(joinedEntries).toContain("payload/config/openclaw.json");
+      expect(joinedEntries).toContain("payload/plugins/installs.json");
+      expect(joinedEntries).toContain("payload/workspaces/main/AGENTS.md");
+      expect(joinedEntries).not.toContain("auth-profiles.json");
+      expect(joinedEntries).not.toContain("sessions");
+      expect(joinedEntries).not.toContain("media");
+
+      const manifest = await readArchiveManifest(result.archivePath);
+      expect(manifest.configPaths).toEqual(
+        expect.arrayContaining(["ui", "agents", "plugins.entries", "plugins.slots", "memory"]),
+      );
+      const configAsset = manifest.assets.find((asset) => asset.kind === "config");
+      expect(configAsset?.archivePath).toContain("payload/config/openclaw.json");
+      const configPayloadRaw = await readArchiveEntry(
+        result.archivePath,
+        "/payload/config/openclaw.json",
+      );
+      expect(configPayloadRaw).not.toContain("skill-config-private-key");
+      expect(configPayloadRaw).not.toContain("skill-config-encrypt-key");
+      expect(configPayloadRaw).not.toContain("skill-config-encryption-key");
+      expect(configPayloadRaw).not.toContain("privateKey");
+      expect(configPayloadRaw).not.toContain("encryptKey");
+      expect(configPayloadRaw).not.toContain("encryption_key");
+      const pluginPayloadRaw = await readArchiveEntry(
+        result.archivePath,
+        "/payload/plugins/installs.json",
+      );
+      expect(pluginPayloadRaw).not.toContain(tempHome.home);
+      expect(pluginPayloadRaw).not.toContain("sourcePath");
+      expect(pluginPayloadRaw).not.toContain("installPath");
+      expect(pluginPayloadRaw).not.toContain("installedAt");
+      expect(pluginPayloadRaw).not.toContain("manifestPath");
+      expect(pluginPayloadRaw).not.toContain("rootDir");
+      expect(pluginPayloadRaw).not.toContain("plugin-install-private-key");
+      expect(pluginPayloadRaw).not.toContain("plugin-install-encrypt-key");
+      expect(pluginPayloadRaw).not.toContain("privateKey");
+      expect(pluginPayloadRaw).not.toContain("encryptKey");
+      const pluginPayload = JSON.parse(pluginPayloadRaw) as {
+        schemaVersion: number;
+        archiveKind: string;
+        records: Record<string, unknown>;
+        plugins?: unknown;
+      };
+      expect(pluginPayload).toMatchObject({
+        schemaVersion: 1,
+        archiveKind: "openclaw-profile",
+        records: { "memory-core": { source: "npm", spec: "memory-core" } },
+      });
+      expect(pluginPayload.records["local-only"]).toBeUndefined();
+      expect(pluginPayload.plugins).toBeUndefined();
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("strips nested secrets and local paths from profile config projections", () => {
+    const safeConfig = buildSafeProfileConfig({
+      agents: {
+        defaults: {
+          workspace: "/tmp/local-workspace",
+          repoRoot: "/tmp/local-repo",
+          cliBackends: {
+            custom: {
+              command: "custom-agent",
+              env: { OPENAI_API_KEY: "agent-secret-env" },
+              privateKey: "agent-private-key",
+            },
+            servers: {
+              command: "colliding-agent",
+              env: { OPENAI_API_KEY: "agent-collision-secret-env" },
+              encryptKey: "agent-encrypt-key",
+            },
+          },
+        },
+        list: [
+          {
+            id: "main",
+            workspace: "/tmp/local-workspace",
+            agentDir: "/tmp/local-agent",
+            runtime: { type: "acp", acp: { cwd: "/tmp/local-acp", backend: "codex" } },
+          },
+        ],
+      },
+      plugins: {
+        slots: { memory: "memory-core" },
+        entries: {
+          "memory-core": {
+            enabled: true,
+            config: {
+              mode: "portable",
+              token: "plugin-secret-token",
+              privateKey: "plugin-private-key",
+              encryptKey: "plugin-encrypt-key",
+            },
+          },
+          servers: {
+            enabled: true,
+            config: {
+              mode: "collision",
+              token: "plugin-collision-secret-token",
+              encryptionKey: "plugin-collision-encryption-key",
+            },
+          },
+        },
+      },
+      skills: {
+        load: { extraDirs: ["/tmp/local-skills"] },
+        entries: {
+          "web-skill": {
+            enabled: true,
+            apiKey: "skill-secret-key",
+            privateKey: "skill-private-key",
+            env: { OPENAI_API_KEY: "skill-secret-env" },
+            config: {
+              mode: "portable",
+              token: "skill-secret-token",
+              encryptKey: "skill-encrypt-key",
+            },
+          },
+          servers: {
+            enabled: true,
+            env: { OPENAI_API_KEY: "skill-collision-secret-env" },
+            config: {
+              mode: "collision",
+              token: "skill-collision-secret-token",
+              private_key: "skill-collision-private-key",
+            },
+          },
+        },
+      },
+      tools: {
+        media: {
+          image: {
+            models: [
+              {
+                provider: "openai",
+                model: "gpt-image",
+                headers: { Authorization: "Bearer tool-secret-token" },
+                privateKey: "tool-private-key",
+              },
+            ],
+          },
+        },
+      },
+      memory: {
+        backend: "qmd",
+        qmd: {
+          searchMode: "query",
+          encryptKey: "memory-encrypt-key",
+          paths: [{ path: "/tmp/private-memory", name: "private" }],
+          sessions: { exportDir: "/tmp/session-memory", retentionDays: 7 },
+        },
+      },
+      mcp: {
+        servers: {
+          auth: {
+            command: "node",
+            args: ["server.js"],
+            env: { MCP_API_KEY: "mcp-secret-env" },
+            headers: { Authorization: "Bearer mcp-secret-token" },
+            privateKey: "mcp-private-key",
+            encryptKey: "mcp-encrypt-key",
+            cwd: "/tmp/local-mcp",
+            url: "https://mcp.example.test",
+          },
+          entries: {
+            command: "node",
+            env: { MCP_API_KEY: "mcp-collision-secret-env" },
+            headers: { Authorization: "Bearer mcp-collision-secret-token" },
+            privateKey: "mcp-collision-private-key",
+            url: "https://mcp-collision.example.test",
+          },
+        },
+      },
+    } as unknown as OpenClawConfig);
+    const serialized = JSON.stringify(safeConfig);
+
+    expect(safeConfig.plugins?.entries?.["memory-core"]?.config).toEqual({ mode: "portable" });
+    expect(safeConfig.plugins?.entries?.servers?.config).toEqual({ mode: "collision" });
+    expect(safeConfig.skills?.entries?.["web-skill"]?.config).toEqual({ mode: "portable" });
+    expect(safeConfig.skills?.entries?.servers?.config).toEqual({ mode: "collision" });
+    expect(safeConfig.mcp?.servers?.auth?.url).toBe("https://mcp.example.test");
+    expect(safeConfig.mcp?.servers?.entries?.url).toBe("https://mcp-collision.example.test");
+    expect(safeConfig.agents?.defaults?.cliBackends?.custom?.command).toBe("custom-agent");
+    expect(safeConfig.agents?.defaults?.cliBackends?.servers?.command).toBe("colliding-agent");
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("private-key");
+    expect(serialized).not.toContain("encrypt-key");
+    expect(serialized).not.toContain("encryption-key");
+    expect(serialized).not.toContain("privateKey");
+    expect(serialized).not.toContain("encryptKey");
+    expect(serialized).not.toContain("encryptionKey");
+    expect(serialized).not.toContain("private_key");
+    expect(serialized).not.toContain("extraDirs");
+    expect(serialized).not.toContain("headers");
+    expect(serialized).not.toContain("env");
+    expect(serialized).not.toContain("/tmp/");
+  });
+
+  it("imports missing config and files without overwriting local state", async () => {
+    const sourceHome = await createHome("openclaw-profile-source-");
+    const sourceState = path.join(sourceHome.home, ".openclaw");
+    const sourceWorkspace = path.join(sourceState, "workspace");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-import-"));
+    let archivePath = "";
+    try {
+      await writeJson(path.join(sourceState, "openclaw.json"), {
+        ui: { assistant: { name: "From profile" } },
+        agents: {
+          defaults: {
+            workspace: sourceWorkspace,
+            model: "openai/gpt-5.4",
+          },
+        },
+        plugins: { entries: { "portable-plugin": { enabled: true } } },
+      });
+      await fs.mkdir(sourceWorkspace, { recursive: true });
+      await fs.writeFile(path.join(sourceWorkspace, "AGENTS.md"), "source agents\n", "utf8");
+      await fs.writeFile(path.join(sourceWorkspace, "MEMORY.md"), "source memory\n", "utf8");
+      await writeJson(path.join(sourceState, "plugins", "installs.json"), {
+        plugins: [],
+        installRecords: { "portable-plugin": { source: "npm", spec: "portable-plugin" } },
+      });
+      archivePath = (
+        await createProfileArchive({
+          output: outputDir,
+          nowMs: Date.UTC(2026, 3, 28, 1),
+        })
+      ).archivePath;
+
+      await sourceHome.restore();
+      tempHomes = tempHomes.filter((entry) => entry !== sourceHome);
+
+      const targetHome = await createHome("openclaw-profile-target-");
+      const targetState = path.join(targetHome.home, ".openclaw");
+      const targetWorkspace = path.join(targetState, "workspace");
+      await writeJson(path.join(targetState, "openclaw.json"), {
+        ui: { assistant: { name: "Local" } },
+        agents: { defaults: { workspace: targetWorkspace } },
+      });
+      await fs.mkdir(targetWorkspace, { recursive: true });
+      await fs.writeFile(path.join(targetWorkspace, "AGENTS.md"), "local agents\n", "utf8");
+
+      const result = await importProfileArchive({ archive: archivePath });
+
+      expect(result.configAppliedPaths).toEqual(
+        expect.arrayContaining(["agents.defaults.model", "plugins.entries.portable-plugin"]),
+      );
+      expect(result.configSkippedPaths).toContain("ui");
+      expect(result.filesSkipped).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ relativePath: "AGENTS.md", reason: "exists" }),
+        ]),
+      );
+      expect(await fs.readFile(path.join(targetWorkspace, "AGENTS.md"), "utf8")).toBe(
+        "local agents\n",
+      );
+      expect(await fs.readFile(path.join(targetWorkspace, "MEMORY.md"), "utf8")).toBe(
+        "source memory\n",
+      );
+      const targetConfig = JSON.parse(
+        await fs.readFile(path.join(targetState, "openclaw.json"), "utf8"),
+      ) as {
+        ui: { assistant: { name: string } };
+        agents: { defaults: { model?: string; workspace?: string } };
+        plugins?: { entries?: Record<string, unknown> };
+      };
+      expect(targetConfig.ui.assistant.name).toBe("Local");
+      expect(targetConfig.agents.defaults.workspace).toBe(targetWorkspace);
+      expect(targetConfig.agents.defaults.model).toBe("openai/gpt-5.4");
+      expect(targetConfig.plugins?.entries?.["portable-plugin"]).toBeDefined();
+      const targetPluginIndex = JSON.parse(
+        await fs.readFile(path.join(targetState, "plugins", "installs.json"), "utf8"),
+      ) as { installRecords?: Record<string, unknown> };
+      expect(targetPluginIndex.installRecords?.["portable-plugin"]).toMatchObject({
+        source: "npm",
+        spec: "portable-plugin",
+      });
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not write files during dry-run import", async () => {
+    const sourceHome = await createHome("openclaw-profile-dry-source-");
+    const sourceState = path.join(sourceHome.home, ".openclaw");
+    const sourceWorkspace = path.join(sourceState, "workspace");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-dry-"));
+    try {
+      await writeJson(path.join(sourceState, "openclaw.json"), {
+        agents: { defaults: { workspace: sourceWorkspace, model: "openai/gpt-5.4" } },
+      });
+      await fs.mkdir(sourceWorkspace, { recursive: true });
+      await fs.writeFile(path.join(sourceWorkspace, "MEMORY.md"), "source memory\n", "utf8");
+      const archivePath = (
+        await createProfileArchive({ output: outputDir, nowMs: Date.UTC(2026, 3, 28, 2) })
+      ).archivePath;
+
+      await sourceHome.restore();
+      tempHomes = tempHomes.filter((entry) => entry !== sourceHome);
+
+      const targetHome = await createHome("openclaw-profile-dry-target-");
+      const targetState = path.join(targetHome.home, ".openclaw");
+      const targetWorkspace = path.join(targetState, "workspace");
+      await writeJson(path.join(targetState, "openclaw.json"), {
+        agents: { defaults: { workspace: targetWorkspace } },
+      });
+
+      const result = await importProfileArchive({ archive: archivePath, dryRun: true });
+
+      expect(result.configAppliedPaths).toContain("agents.defaults.model");
+      expect(result.filesWritten).toEqual([]);
+      expect(result.filesWouldWrite).toEqual(
+        expect.arrayContaining([expect.objectContaining({ relativePath: "MEMORY.md" })]),
+      );
+      await expect(fs.access(path.join(targetWorkspace, "MEMORY.md"))).rejects.toThrow();
+      const targetConfig = JSON.parse(
+        await fs.readFile(path.join(targetState, "openclaw.json"), "utf8"),
+      ) as { agents: { defaults: { model?: string } } };
+      expect(targetConfig.agents.defaults.model).toBeUndefined();
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects unsupported manifest schemas", async () => {
+    await createHome("openclaw-profile-bad-schema-");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-bad-schema-"));
+    try {
+      const archivePath = path.join(outputDir, "bad-schema.openclaw-profile.tar.gz");
+      await writeProfileArchiveFixture(archivePath, {
+        "bad-profile/manifest.json": JSON.stringify({
+          schemaVersion: 999,
+          archiveKind: "openclaw-profile",
+          archiveRoot: "bad-profile",
+          assets: [],
+        }),
+      });
+
+      await expect(importProfileArchive({ archive: archivePath })).rejects.toThrow(
+        /Unsupported profile manifest schemaVersion/u,
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects traversal paths declared by the manifest", async () => {
+    await createHome("openclaw-profile-traversal-");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-traversal-"));
+    try {
+      const archivePath = path.join(outputDir, "traversal.openclaw-profile.tar.gz");
+      await writeProfileArchiveFixture(archivePath, {
+        "bad-profile/manifest.json": JSON.stringify({
+          schemaVersion: 1,
+          archiveKind: "openclaw-profile",
+          archiveRoot: "bad-profile",
+          assets: [
+            {
+              kind: "config",
+              archivePath: "bad-profile/payload/../escape/openclaw.json",
+            },
+          ],
+        }),
+      });
+
+      await expect(importProfileArchive({ archive: archivePath })).rejects.toThrow(
+        /path traversal/u,
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects non-markdown memory files declared by the manifest", async () => {
+    await createHome("openclaw-profile-non-md-memory-");
+    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-non-md-memory-"));
+    try {
+      const archivePath = path.join(outputDir, "non-md-memory.openclaw-profile.tar.gz");
+      await writeProfileArchiveFixture(archivePath, {
+        "bad-profile/manifest.json": JSON.stringify({
+          schemaVersion: 1,
+          archiveKind: "openclaw-profile",
+          archiveRoot: "bad-profile",
+          assets: [
+            {
+              kind: "config",
+              archivePath: "bad-profile/payload/config/openclaw.json",
+            },
+            {
+              kind: "workspace-file",
+              archivePath: "bad-profile/payload/workspaces/main/memory/private.json",
+              agentId: "main",
+              relativePath: "memory/private.json",
+            },
+          ],
+        }),
+        "bad-profile/payload/config/openclaw.json": "{}",
+        "bad-profile/payload/workspaces/main/memory/private.json": "{}",
+      });
+
+      await expect(importProfileArchive({ archive: archivePath })).rejects.toThrow(
+        /not importable/u,
+      );
+    } finally {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/infra/profile-portability.ts
+++ b/src/infra/profile-portability.ts
@@ -1,0 +1,1288 @@
+import { randomUUID } from "node:crypto";
+import { constants as fsConstants } from "node:fs";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import * as tar from "tar";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  readConfigFileSnapshot,
+  readConfigFileSnapshotForWrite,
+  replaceConfigFile,
+  resolveStateDir,
+} from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
+import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store-path.js";
+import { refreshPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
+import { resolveRuntimeServiceVersion } from "../version.js";
+import { isBlockedObjectKey } from "./prototype-keys.js";
+
+const PROFILE_ARCHIVE_SCHEMA_VERSION = 1;
+const PROFILE_ARCHIVE_KIND = "openclaw-profile";
+const PROFILE_PLUGIN_INSTALLS_SCHEMA_VERSION = 1;
+const PROFILE_ROOT_FILE_NAMES = [
+  "AGENTS.md",
+  "SOUL.md",
+  "USER.md",
+  "IDENTITY.md",
+  "TOOLS.md",
+  "HEARTBEAT.md",
+  "BOOT.md",
+  "MEMORY.md",
+] as const;
+const PROFILE_SAFE_CONFIG_KEYS = ["ui", "skills", "tools", "memory", "mcp"] as const;
+const PROFILE_CONFIG_DICTIONARY_KEYS = new Set([
+  "cliBackends",
+  "entries",
+  "models",
+  "providerOptions",
+  "servers",
+]);
+const PROFILE_SECRET_CONFIG_KEYS = new Set([
+  "apikey",
+  "auth",
+  "authorization",
+  "credentials",
+  "encryptkey",
+  "encryptionkey",
+  "env",
+  "headers",
+  "oauth",
+  "password",
+  "privatekey",
+  "secret",
+  "token",
+]);
+const PROFILE_LOCAL_PATH_CONFIG_KEYS = new Set([
+  "cwd",
+  "dir",
+  "dirs",
+  "exportdir",
+  "extradirs",
+  "path",
+  "paths",
+  "workdir",
+  "workingdirectory",
+]);
+const WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE = /^[A-Za-z]:[\\/]/;
+const PROFILE_PORTABLE_PLUGIN_INSTALL_SOURCES = new Set(["npm", "clawhub", "marketplace"]);
+const PROFILE_PORTABLE_PLUGIN_STRING_FIELDS = [
+  "spec",
+  "version",
+  "resolvedName",
+  "resolvedVersion",
+  "resolvedSpec",
+  "integrity",
+  "shasum",
+  "clawhubPackage",
+  "marketplaceName",
+  "marketplaceSource",
+  "marketplacePlugin",
+] as const;
+const PROFILE_CLAWHUB_FAMILIES = new Set(["code-plugin", "bundle-plugin"]);
+const PROFILE_CLAWHUB_CHANNELS = new Set(["official", "community", "private"]);
+
+type ProfileArchiveAssetKind = "config" | "workspace-file" | "plugin-installs";
+
+type ProfileArchiveAsset = {
+  kind: ProfileArchiveAssetKind;
+  archivePath: string;
+  agentId?: string;
+  relativePath?: string;
+};
+
+type ProfileArchiveManifest = {
+  schemaVersion: 1;
+  archiveKind: typeof PROFILE_ARCHIVE_KIND;
+  createdAt: string;
+  archiveRoot: string;
+  runtimeVersion: string;
+  platform: NodeJS.Platform;
+  nodeVersion: string;
+  configPaths: string[];
+  assets: ProfileArchiveAsset[];
+  skipped: Array<{
+    kind: string;
+    agentId?: string;
+    relativePath?: string;
+    reason: string;
+  }>;
+};
+
+type ProfileWorkspaceFile = {
+  agentId: string;
+  sourcePath: string;
+  relativePath: string;
+  archivePath: string;
+};
+
+type ProfileSkippedEntry = {
+  kind: string;
+  agentId?: string;
+  relativePath?: string;
+  reason: string;
+};
+
+type ProfileConfigMergeResult = {
+  config: OpenClawConfig;
+  appliedPaths: string[];
+  skippedPaths: string[];
+};
+
+type ProfilePluginInstallsPayload = {
+  schemaVersion: typeof PROFILE_PLUGIN_INSTALLS_SCHEMA_VERSION;
+  archiveKind: typeof PROFILE_ARCHIVE_KIND;
+  records: Record<string, PluginInstallRecord>;
+};
+
+export type ProfileExportOptions = {
+  output?: string;
+  dryRun?: boolean;
+  verify?: boolean;
+  json?: boolean;
+  nowMs?: number;
+};
+
+export type ProfileExportResult = {
+  createdAt: string;
+  archiveRoot: string;
+  archivePath: string;
+  dryRun: boolean;
+  verified: boolean;
+  configPaths: string[];
+  workspaceFiles: Array<{ agentId: string; relativePath: string }>;
+  pluginInstalls: boolean;
+  skipped: ProfileSkippedEntry[];
+};
+
+export type ProfileImportOptions = {
+  archive: string;
+  dryRun?: boolean;
+  json?: boolean;
+};
+
+export type ProfileImportResult = {
+  archivePath: string;
+  archiveRoot: string;
+  dryRun: boolean;
+  configAppliedPaths: string[];
+  configSkippedPaths: string[];
+  filesWritten: Array<{
+    kind: string;
+    agentId?: string;
+    relativePath?: string;
+    targetPath: string;
+  }>;
+  filesWouldWrite: Array<{
+    kind: string;
+    agentId?: string;
+    relativePath?: string;
+    targetPath: string;
+  }>;
+  filesSkipped: Array<{
+    kind: string;
+    agentId?: string;
+    relativePath?: string;
+    targetPath?: string;
+    reason: string;
+  }>;
+};
+
+function cloneConfig<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function formatUnknownForMessage(value: unknown): string {
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    value === null
+  ) {
+    return String(value);
+  }
+  return JSON.stringify(value) ?? typeof value;
+}
+
+function isPortablePluginInstallSource(source: unknown): source is PluginInstallRecord["source"] {
+  return typeof source === "string" && PROFILE_PORTABLE_PLUGIN_INSTALL_SOURCES.has(source);
+}
+
+function isLocalPathLikeValue(value: string): boolean {
+  const normalized = value.trim();
+  if (
+    normalized.startsWith("/") ||
+    normalized.startsWith("~/") ||
+    normalized.startsWith("./") ||
+    normalized.startsWith("../") ||
+    WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(normalized)
+  ) {
+    return true;
+  }
+  try {
+    const parsed = new URL(normalized);
+    return (
+      parsed.protocol === "file:" ||
+      Boolean(parsed.username) ||
+      Boolean(parsed.password) ||
+      Boolean(parsed.search)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readPortablePluginString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = record[key];
+  if (typeof value !== "string" || isLocalPathLikeValue(value)) {
+    return undefined;
+  }
+  return value;
+}
+
+function sanitizePluginInstallRecord(record: unknown): PluginInstallRecord | null {
+  if (!isRecord(record) || !isPortablePluginInstallSource(record.source)) {
+    return null;
+  }
+  const portableRecord: Record<string, unknown> = { source: record.source };
+  for (const key of PROFILE_PORTABLE_PLUGIN_STRING_FIELDS) {
+    const value = readPortablePluginString(record, key);
+    if (value !== undefined) {
+      portableRecord[key] = value;
+    }
+  }
+  if (
+    typeof record.clawhubFamily === "string" &&
+    PROFILE_CLAWHUB_FAMILIES.has(record.clawhubFamily)
+  ) {
+    portableRecord.clawhubFamily = record.clawhubFamily;
+  }
+  if (
+    typeof record.clawhubChannel === "string" &&
+    PROFILE_CLAWHUB_CHANNELS.has(record.clawhubChannel)
+  ) {
+    portableRecord.clawhubChannel = record.clawhubChannel;
+  }
+  const hasPortableIdentity =
+    typeof portableRecord.spec === "string" ||
+    typeof portableRecord.resolvedName === "string" ||
+    typeof portableRecord.clawhubPackage === "string" ||
+    typeof portableRecord.marketplacePlugin === "string";
+  return hasPortableIdentity ? (portableRecord as PluginInstallRecord) : null;
+}
+
+function extractPluginInstallRecordCandidates(parsed: unknown): Record<string, unknown> {
+  if (!isRecord(parsed)) {
+    return {};
+  }
+  if (parsed.archiveKind !== undefined && parsed.archiveKind !== PROFILE_ARCHIVE_KIND) {
+    throw new Error(
+      `Unsupported plugin install records archive kind: ${formatUnknownForMessage(
+        parsed.archiveKind,
+      )}`,
+    );
+  }
+  if (
+    parsed.schemaVersion !== undefined &&
+    parsed.schemaVersion !== PROFILE_PLUGIN_INSTALLS_SCHEMA_VERSION
+  ) {
+    throw new Error(
+      `Unsupported plugin install records schemaVersion: ${formatUnknownForMessage(
+        parsed.schemaVersion,
+      )}`,
+    );
+  }
+  if (isRecord(parsed.records)) {
+    return parsed.records;
+  }
+  if (isRecord(parsed.installRecords)) {
+    return parsed.installRecords;
+  }
+  const records: Record<string, unknown> = {};
+  if (Array.isArray(parsed.plugins)) {
+    for (const entry of parsed.plugins) {
+      if (isRecord(entry) && typeof entry.pluginId === "string" && isRecord(entry.installRecord)) {
+        records[entry.pluginId] = entry.installRecord;
+      }
+    }
+  }
+  return records;
+}
+
+function sanitizePluginInstallRecordsPayload(raw: string): Record<string, PluginInstallRecord> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Plugin install records payload is not valid JSON: ${String(err)}`, {
+      cause: err,
+    });
+  }
+  const records: Record<string, PluginInstallRecord> = {};
+  const candidates = extractPluginInstallRecordCandidates(parsed);
+  for (const [pluginId, record] of Object.entries(candidates).toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    if (isBlockedObjectKey(pluginId)) {
+      continue;
+    }
+    const portableRecord = sanitizePluginInstallRecord(record);
+    if (portableRecord) {
+      records[pluginId] = portableRecord;
+    }
+  }
+  return records;
+}
+
+function buildProfilePluginInstallsPayload(
+  records: Record<string, PluginInstallRecord>,
+): ProfilePluginInstallsPayload {
+  return {
+    schemaVersion: PROFILE_PLUGIN_INSTALLS_SCHEMA_VERSION,
+    archiveKind: PROFILE_ARCHIVE_KIND,
+    records,
+  };
+}
+
+function stripTrailingSlashes(value: string): string {
+  return value.replace(/\/+$/u, "");
+}
+
+function normalizeProfileConfigKey(key: string): string {
+  return key.replace(/[^A-Za-z0-9]/gu, "").toLowerCase();
+}
+
+function shouldOmitPortableConfigKey(key: string): boolean {
+  const normalized = normalizeProfileConfigKey(key);
+  return (
+    PROFILE_SECRET_CONFIG_KEYS.has(normalized) ||
+    PROFILE_LOCAL_PATH_CONFIG_KEYS.has(normalized) ||
+    normalized.endsWith("apikey") ||
+    normalized.endsWith("authorization") ||
+    normalized.endsWith("credentials") ||
+    normalized.endsWith("encryptkey") ||
+    normalized.endsWith("encryptionkey") ||
+    normalized.endsWith("oauth") ||
+    normalized.endsWith("password") ||
+    normalized.endsWith("privatekey") ||
+    normalized.endsWith("secret") ||
+    normalized.endsWith("token")
+  );
+}
+
+function isDictionaryConfigPath(pathSegments: string[]): boolean {
+  const parentKey = pathSegments.at(-1);
+  return Boolean(parentKey && PROFILE_CONFIG_DICTIONARY_KEYS.has(parentKey));
+}
+
+function sanitizePortableConfigValue(
+  value: unknown,
+  pathSegments: string[] = [],
+  insideDictionaryValue = false,
+): unknown {
+  if (Array.isArray(value)) {
+    const sanitizedEntries: unknown[] = [];
+    for (const entry of value) {
+      const sanitized = sanitizePortableConfigValue(
+        entry,
+        [...pathSegments, "[]"],
+        insideDictionaryValue,
+      );
+      if (sanitized !== undefined) {
+        sanitizedEntries.push(sanitized);
+      }
+    }
+    return sanitizedEntries;
+  }
+  if (!isRecord(value)) {
+    return cloneConfig(value);
+  }
+  const result: Record<string, unknown> = {};
+  const keysAreDictionaryIds = !insideDictionaryValue && isDictionaryConfigPath(pathSegments);
+  for (const [key, child] of Object.entries(value)) {
+    if (!keysAreDictionaryIds && shouldOmitPortableConfigKey(key)) {
+      continue;
+    }
+    const sanitized = sanitizePortableConfigValue(
+      child,
+      [...pathSegments, key],
+      keysAreDictionaryIds,
+    );
+    if (sanitized !== undefined) {
+      result[key] = sanitized;
+    }
+  }
+  return result;
+}
+
+function normalizeArchivePath(entryPath: string, label: string): string {
+  const trimmed = stripTrailingSlashes(entryPath.trim());
+  if (!trimmed) {
+    throw new Error(`${label} is empty.`);
+  }
+  if (trimmed.startsWith("/") || WINDOWS_ABSOLUTE_ARCHIVE_PATH_RE.test(trimmed)) {
+    throw new Error(`${label} must be relative: ${entryPath}`);
+  }
+  if (trimmed.includes("\\")) {
+    throw new Error(`${label} must use forward slashes: ${entryPath}`);
+  }
+  if (trimmed.split("/").some((segment) => segment === "." || segment === "..")) {
+    throw new Error(`${label} contains path traversal segments: ${entryPath}`);
+  }
+  const normalized = stripTrailingSlashes(path.posix.normalize(trimmed));
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(`${label} resolves outside the archive root: ${entryPath}`);
+  }
+  return normalized;
+}
+
+function isArchivePathWithin(child: string, parent: string): boolean {
+  const relative = path.posix.relative(parent, child);
+  return relative === "" || (!relative.startsWith("../") && relative !== "..");
+}
+
+function isRootManifestEntry(entryPath: string): boolean {
+  const parts = entryPath.split("/");
+  return parts.length === 2 && parts[0] !== "" && parts[1] === "manifest.json";
+}
+
+function buildProfileArchiveRoot(nowMs: number): string {
+  return `${new Date(nowMs).toISOString().replaceAll(":", "-")}-openclaw-profile`;
+}
+
+function buildProfileArchiveBasename(nowMs: number): string {
+  return `${buildProfileArchiveRoot(nowMs)}.openclaw-profile.tar.gz`;
+}
+
+async function resolveProfileOutputPath(params: {
+  output?: string;
+  nowMs: number;
+}): Promise<string> {
+  const basename = buildProfileArchiveBasename(params.nowMs);
+  const rawOutput = params.output?.trim();
+  if (!rawOutput) {
+    return path.resolve(process.cwd(), basename);
+  }
+  const resolved = path.resolve(rawOutput.replace(/^~(?=$|[\\/])/, os.homedir()));
+  if (rawOutput.endsWith("/") || rawOutput.endsWith("\\")) {
+    return path.join(resolved, basename);
+  }
+  try {
+    const stat = await fs.stat(resolved);
+    if (stat.isDirectory()) {
+      return path.join(resolved, basename);
+    }
+  } catch {
+    // Missing output is treated as an archive file path.
+  }
+  return resolved;
+}
+
+async function assertNoExistingPath(outputPath: string): Promise<void> {
+  try {
+    await fs.access(outputPath);
+    throw new Error(`Refusing to overwrite existing profile archive: ${outputPath}`);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException | undefined)?.code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+}
+
+function isLinkUnsupportedError(code: string | undefined): boolean {
+  return code === "ENOTSUP" || code === "EOPNOTSUPP" || code === "EPERM";
+}
+
+async function publishTempArchive(params: {
+  tempArchivePath: string;
+  outputPath: string;
+}): Promise<void> {
+  try {
+    await fs.link(params.tempArchivePath, params.outputPath);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | undefined)?.code;
+    if (code === "EEXIST") {
+      throw new Error(`Refusing to overwrite existing profile archive: ${params.outputPath}`, {
+        cause: err,
+      });
+    }
+    if (!isLinkUnsupportedError(code)) {
+      throw err;
+    }
+    await fs.copyFile(params.tempArchivePath, params.outputPath, fsConstants.COPYFILE_EXCL);
+  }
+  await fs.rm(params.tempArchivePath, { force: true });
+}
+
+function sanitizeAgentsConfig(agents: OpenClawConfig["agents"]): OpenClawConfig["agents"] {
+  if (!agents || typeof agents !== "object") {
+    return undefined;
+  }
+  const next = cloneConfig(agents);
+  if (next.defaults) {
+    delete next.defaults.workspace;
+    delete next.defaults.repoRoot;
+  }
+  if (Array.isArray(next.list)) {
+    const sanitizedList: NonNullable<OpenClawConfig["agents"]>["list"] = [];
+    for (const entry of next.list) {
+      const agent = cloneConfig(entry);
+      delete agent.workspace;
+      delete agent.agentDir;
+      if (agent.runtime?.type === "acp" && agent.runtime.acp) {
+        delete agent.runtime.acp.cwd;
+      }
+      sanitizedList.push(agent);
+    }
+    next.list = sanitizedList;
+  }
+  return sanitizePortableConfigValue(next, ["agents"]) as OpenClawConfig["agents"];
+}
+
+export function buildSafeProfileConfig(config: OpenClawConfig): OpenClawConfig {
+  const result: OpenClawConfig = {};
+  for (const key of PROFILE_SAFE_CONFIG_KEYS) {
+    if (config[key] !== undefined) {
+      result[key] = sanitizePortableConfigValue(config[key], [key]) as never;
+    }
+  }
+  const agents = sanitizeAgentsConfig(config.agents);
+  if (agents) {
+    result.agents = agents;
+  }
+  if (config.plugins?.entries || config.plugins?.slots) {
+    result.plugins = {};
+    if (config.plugins.entries) {
+      result.plugins.entries = sanitizePortableConfigValue(config.plugins.entries, [
+        "plugins",
+        "entries",
+      ]) as NonNullable<OpenClawConfig["plugins"]>["entries"];
+    }
+    if (config.plugins.slots) {
+      result.plugins.slots = cloneConfig(config.plugins.slots);
+    }
+  }
+  return result;
+}
+
+function collectConfigPaths(config: OpenClawConfig): string[] {
+  const paths: string[] = [];
+  for (const key of PROFILE_SAFE_CONFIG_KEYS) {
+    if (config[key] !== undefined) {
+      paths.push(key);
+    }
+  }
+  if (config.agents !== undefined) {
+    paths.push("agents");
+  }
+  if (config.plugins?.entries !== undefined) {
+    paths.push("plugins.entries");
+  }
+  if (config.plugins?.slots !== undefined) {
+    paths.push("plugins.slots");
+  }
+  return paths;
+}
+
+async function maybeAddWorkspaceRootFile(params: {
+  files: ProfileWorkspaceFile[];
+  skipped: ProfileSkippedEntry[];
+  archiveRoot: string;
+  workspaceDir: string;
+  agentId: string;
+  fileName: string;
+}): Promise<void> {
+  const filePath = path.join(params.workspaceDir, params.fileName);
+  const stat = await fs.lstat(filePath).catch(() => null);
+  if (!stat) {
+    return;
+  }
+  if (!stat.isFile()) {
+    params.skipped.push({
+      kind: "workspace-file",
+      agentId: params.agentId,
+      relativePath: params.fileName,
+      reason: stat.isSymbolicLink() ? "symlink" : "not-file",
+    });
+    return;
+  }
+  params.files.push({
+    agentId: params.agentId,
+    sourcePath: filePath,
+    relativePath: params.fileName,
+    archivePath: path.posix.join(
+      params.archiveRoot,
+      "payload",
+      "workspaces",
+      params.agentId,
+      params.fileName,
+    ),
+  });
+}
+
+async function collectMemoryFiles(params: {
+  files: ProfileWorkspaceFile[];
+  skipped: ProfileSkippedEntry[];
+  archiveRoot: string;
+  workspaceDir: string;
+  agentId: string;
+  relativeDir?: string;
+}): Promise<void> {
+  const relativeDir = params.relativeDir ?? "memory";
+  const absDir = path.join(params.workspaceDir, relativeDir);
+  const entries = await fs.readdir(absDir, { withFileTypes: true }).catch(() => null);
+  if (!entries) {
+    return;
+  }
+  for (const entry of entries) {
+    const relativePath = path.posix.join(relativeDir.replaceAll("\\", "/"), entry.name);
+    const absPath = path.join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      await collectMemoryFiles({ ...params, relativeDir: relativePath });
+      continue;
+    }
+    if (!entry.isFile()) {
+      params.skipped.push({
+        kind: "workspace-file",
+        agentId: params.agentId,
+        relativePath,
+        reason: entry.isSymbolicLink() ? "symlink" : "not-file",
+      });
+      continue;
+    }
+    if (!entry.name.endsWith(".md")) {
+      continue;
+    }
+    params.files.push({
+      agentId: params.agentId,
+      sourcePath: absPath,
+      relativePath,
+      archivePath: path.posix.join(
+        params.archiveRoot,
+        "payload",
+        "workspaces",
+        params.agentId,
+        relativePath,
+      ),
+    });
+  }
+}
+
+async function collectWorkspaceFiles(params: {
+  cfg: OpenClawConfig;
+  archiveRoot: string;
+}): Promise<{ files: ProfileWorkspaceFile[]; skipped: ProfileSkippedEntry[] }> {
+  const files: ProfileWorkspaceFile[] = [];
+  const skipped: ProfileSkippedEntry[] = [];
+  const seen = new Set<string>();
+  for (const agentId of listAgentIds(params.cfg)) {
+    const workspaceDir = resolveAgentWorkspaceDir(params.cfg, agentId);
+    for (const fileName of PROFILE_ROOT_FILE_NAMES) {
+      await maybeAddWorkspaceRootFile({
+        files,
+        skipped,
+        archiveRoot: params.archiveRoot,
+        workspaceDir,
+        agentId,
+        fileName,
+      });
+    }
+    await collectMemoryFiles({
+      files,
+      skipped,
+      archiveRoot: params.archiveRoot,
+      workspaceDir,
+      agentId,
+    });
+  }
+  return {
+    files: files.filter((file) => {
+      const key = `${file.agentId}\0${file.relativePath}`;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    }),
+    skipped,
+  };
+}
+
+async function readOptionalFile(pathname: string): Promise<string | null> {
+  try {
+    return await fs.readFile(pathname, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function buildProfileManifest(params: {
+  createdAt: string;
+  archiveRoot: string;
+  configPaths: string[];
+  workspaceFiles: ProfileWorkspaceFile[];
+  hasPluginInstalls: boolean;
+  skipped: ProfileSkippedEntry[];
+}): ProfileArchiveManifest {
+  const assets: ProfileArchiveAsset[] = [
+    {
+      kind: "config",
+      archivePath: path.posix.join(params.archiveRoot, "payload", "config", "openclaw.json"),
+    },
+    ...params.workspaceFiles.map((file) => ({
+      kind: "workspace-file" as const,
+      archivePath: file.archivePath,
+      agentId: file.agentId,
+      relativePath: file.relativePath,
+    })),
+  ];
+  if (params.hasPluginInstalls) {
+    assets.push({
+      kind: "plugin-installs",
+      archivePath: path.posix.join(params.archiveRoot, "payload", "plugins", "installs.json"),
+    });
+  }
+  return {
+    schemaVersion: PROFILE_ARCHIVE_SCHEMA_VERSION,
+    archiveKind: PROFILE_ARCHIVE_KIND,
+    createdAt: params.createdAt,
+    archiveRoot: params.archiveRoot,
+    runtimeVersion: resolveRuntimeServiceVersion(),
+    platform: process.platform,
+    nodeVersion: process.version,
+    configPaths: params.configPaths,
+    assets,
+    skipped: params.skipped,
+  };
+}
+
+function remapProfileArchiveEntry(params: {
+  entryPath: string;
+  pathMap: Map<string, string>;
+}): string {
+  return params.pathMap.get(path.resolve(params.entryPath)) ?? params.entryPath;
+}
+
+export async function createProfileArchive(
+  opts: ProfileExportOptions = {},
+): Promise<ProfileExportResult> {
+  const nowMs = opts.nowMs ?? Date.now();
+  const archiveRoot = buildProfileArchiveRoot(nowMs);
+  const outputPath = await resolveProfileOutputPath({ output: opts.output, nowMs });
+  const snapshot = await readConfigFileSnapshot();
+  if (snapshot.exists && !snapshot.valid) {
+    throw new Error(`Config invalid at ${snapshot.path}; cannot export a profile archive.`);
+  }
+  const safeConfig = buildSafeProfileConfig(snapshot.sourceConfig);
+  const configPaths = collectConfigPaths(safeConfig);
+  const { files: workspaceFiles, skipped } = await collectWorkspaceFiles({
+    cfg: snapshot.config,
+    archiveRoot,
+  });
+  const pluginInstallsPath = resolveInstalledPluginIndexStorePath({
+    stateDir: resolveStateDir(process.env),
+  });
+  const pluginInstallsRaw = await readOptionalFile(pluginInstallsPath);
+  const pluginInstallRecords =
+    pluginInstallsRaw === null ? {} : sanitizePluginInstallRecordsPayload(pluginInstallsRaw);
+  const hasPluginInstalls = Object.keys(pluginInstallRecords).length > 0;
+  const createdAt = new Date(nowMs).toISOString();
+  const result: ProfileExportResult = {
+    createdAt,
+    archiveRoot,
+    archivePath: outputPath,
+    dryRun: Boolean(opts.dryRun),
+    verified: false,
+    configPaths,
+    workspaceFiles: workspaceFiles.map((file) => ({
+      agentId: file.agentId,
+      relativePath: file.relativePath,
+    })),
+    pluginInstalls: hasPluginInstalls,
+    skipped,
+  };
+  if (opts.dryRun) {
+    return result;
+  }
+  await assertNoExistingPath(outputPath);
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-profile-"));
+  const tempArchivePath = `${outputPath}.${randomUUID()}.tmp`;
+  try {
+    const manifestPath = path.join(tempDir, "manifest.json");
+    const configPath = path.join(tempDir, "openclaw.json");
+    const pluginPayloadPath = path.join(tempDir, "installs.json");
+    const manifest = buildProfileManifest({
+      createdAt,
+      archiveRoot,
+      configPaths,
+      workspaceFiles,
+      hasPluginInstalls,
+      skipped,
+    });
+    await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+    await fs.writeFile(configPath, `${JSON.stringify(safeConfig, null, 2)}\n`, "utf8");
+    if (hasPluginInstalls) {
+      await fs.writeFile(
+        pluginPayloadPath,
+        `${JSON.stringify(buildProfilePluginInstallsPayload(pluginInstallRecords), null, 2)}\n`,
+        "utf8",
+      );
+    }
+
+    const pathMap = new Map<string, string>([
+      [path.resolve(manifestPath), path.posix.join(archiveRoot, "manifest.json")],
+      [
+        path.resolve(configPath),
+        path.posix.join(archiveRoot, "payload", "config", "openclaw.json"),
+      ],
+      [
+        path.resolve(pluginPayloadPath),
+        path.posix.join(archiveRoot, "payload", "plugins", "installs.json"),
+      ],
+      ...workspaceFiles.map((file) => [path.resolve(file.sourcePath), file.archivePath] as const),
+    ]);
+    const entries = [
+      manifestPath,
+      configPath,
+      ...(hasPluginInstalls ? [pluginPayloadPath] : []),
+      ...workspaceFiles.map((file) => file.sourcePath),
+    ];
+    await tar.c(
+      {
+        file: tempArchivePath,
+        gzip: true,
+        portable: true,
+        preservePaths: true,
+        onWriteEntry: (entry) => {
+          entry.path = remapProfileArchiveEntry({ entryPath: entry.path, pathMap });
+        },
+      },
+      entries,
+    );
+    await publishTempArchive({ tempArchivePath, outputPath });
+  } finally {
+    await fs.rm(tempArchivePath, { force: true }).catch(() => undefined);
+    await fs.rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+  if (opts.verify) {
+    await readProfileArchive(outputPath);
+    result.verified = true;
+  }
+  return result;
+}
+
+function parseManifest(raw: string): ProfileArchiveManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`Profile manifest is not valid JSON: ${String(err)}`, { cause: err });
+  }
+  if (!isRecord(parsed)) {
+    throw new Error("Profile manifest must be an object.");
+  }
+  if (parsed.schemaVersion !== PROFILE_ARCHIVE_SCHEMA_VERSION) {
+    throw new Error(`Unsupported profile manifest schemaVersion: ${String(parsed.schemaVersion)}`);
+  }
+  if (parsed.archiveKind !== PROFILE_ARCHIVE_KIND) {
+    throw new Error(`Unsupported profile archive kind: ${String(parsed.archiveKind)}`);
+  }
+  if (typeof parsed.archiveRoot !== "string" || !parsed.archiveRoot.trim()) {
+    throw new Error("Profile manifest is missing archiveRoot.");
+  }
+  if (!Array.isArray(parsed.assets)) {
+    throw new Error("Profile manifest is missing assets.");
+  }
+  const archiveRoot = normalizeArchivePath(parsed.archiveRoot, "Profile manifest archiveRoot");
+  if (archiveRoot.includes("/")) {
+    throw new Error(`Profile manifest archiveRoot must be a single path segment: ${archiveRoot}`);
+  }
+  const assets: ProfileArchiveAsset[] = parsed.assets.map((asset) => {
+    if (!isRecord(asset)) {
+      throw new Error("Profile manifest contains a non-object asset.");
+    }
+    const kind = asset.kind;
+    if (kind !== "config" && kind !== "workspace-file" && kind !== "plugin-installs") {
+      throw new Error(`Unsupported profile manifest asset kind: ${String(kind)}`);
+    }
+    const archivePath =
+      typeof asset.archivePath === "string"
+        ? normalizeArchivePath(asset.archivePath, "Profile manifest asset path")
+        : "";
+    if (!archivePath) {
+      throw new Error("Profile manifest asset is missing archivePath.");
+    }
+    return {
+      kind,
+      archivePath,
+      agentId: typeof asset.agentId === "string" ? asset.agentId : undefined,
+      relativePath: typeof asset.relativePath === "string" ? asset.relativePath : undefined,
+    };
+  });
+  return {
+    schemaVersion: PROFILE_ARCHIVE_SCHEMA_VERSION,
+    archiveKind: PROFILE_ARCHIVE_KIND,
+    createdAt: typeof parsed.createdAt === "string" ? parsed.createdAt : "",
+    archiveRoot,
+    runtimeVersion: typeof parsed.runtimeVersion === "string" ? parsed.runtimeVersion : "unknown",
+    platform: process.platform,
+    nodeVersion: typeof parsed.nodeVersion === "string" ? parsed.nodeVersion : "unknown",
+    configPaths: Array.isArray(parsed.configPaths)
+      ? parsed.configPaths.filter((entry): entry is string => typeof entry === "string")
+      : [],
+    assets,
+    skipped: Array.isArray(parsed.skipped)
+      ? parsed.skipped.filter(isRecord).map((entry) => ({
+          kind: typeof entry.kind === "string" ? entry.kind : "unknown",
+          agentId: typeof entry.agentId === "string" ? entry.agentId : undefined,
+          relativePath: typeof entry.relativePath === "string" ? entry.relativePath : undefined,
+          reason: typeof entry.reason === "string" ? entry.reason : "unknown",
+        }))
+      : [],
+  };
+}
+
+async function readProfileArchive(archivePath: string): Promise<{
+  manifest: ProfileArchiveManifest;
+  contents: Map<string, Buffer>;
+}> {
+  const rawEntries: string[] = [];
+  const contents = new Map<string, Buffer>();
+  await tar.t({
+    file: archivePath,
+    gzip: true,
+    onentry: (entry) => {
+      const normalized = normalizeArchivePath(entry.path, "Profile archive entry");
+      rawEntries.push(normalized);
+      const chunks: Buffer[] = [];
+      entry.on("data", (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      entry.on("end", () => {
+        contents.set(normalized, Buffer.concat(chunks));
+      });
+    },
+  });
+  const manifestMatches = rawEntries.filter(isRootManifestEntry);
+  if (manifestMatches.length !== 1) {
+    throw new Error(
+      `Expected exactly one profile manifest entry, found ${manifestMatches.length}.`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const entry of rawEntries) {
+    if (seen.has(entry)) {
+      throw new Error(`Profile archive contains duplicate entry path: ${entry}`);
+    }
+    seen.add(entry);
+  }
+  const manifestPath = manifestMatches[0];
+  const manifestRaw = contents.get(manifestPath)?.toString("utf8");
+  if (!manifestRaw) {
+    throw new Error(`Profile archive is missing manifest entry: ${manifestPath}`);
+  }
+  const manifest = parseManifest(manifestRaw);
+  const entries = new Set(rawEntries);
+  for (const entry of entries) {
+    if (!isArchivePathWithin(entry, manifest.archiveRoot)) {
+      throw new Error(`Profile archive entry is outside the declared archive root: ${entry}`);
+    }
+  }
+  for (const asset of manifest.assets) {
+    if (!isArchivePathWithin(asset.archivePath, path.posix.join(manifest.archiveRoot, "payload"))) {
+      throw new Error(`Profile manifest asset is outside payload root: ${asset.archivePath}`);
+    }
+    if (!entries.has(asset.archivePath)) {
+      throw new Error(`Profile archive is missing payload for asset: ${asset.archivePath}`);
+    }
+  }
+  return { manifest, contents };
+}
+
+function assignIfMissing(params: {
+  target: Record<string, unknown>;
+  key: string;
+  value: unknown;
+  pathLabel: string;
+  applied: string[];
+  skipped: string[];
+}): void {
+  if (params.value === undefined) {
+    return;
+  }
+  if (params.target[params.key] === undefined) {
+    params.target[params.key] = cloneConfig(params.value);
+    params.applied.push(params.pathLabel);
+    return;
+  }
+  params.skipped.push(params.pathLabel);
+}
+
+export function mergeMissingProfileConfig(
+  baseConfig: OpenClawConfig,
+  profileConfig: OpenClawConfig,
+): ProfileConfigMergeResult {
+  const config = cloneConfig(baseConfig);
+  const appliedPaths: string[] = [];
+  const skippedPaths: string[] = [];
+  const configRecord = config as Record<string, unknown>;
+  const profileRecord = profileConfig as Record<string, unknown>;
+  for (const key of PROFILE_SAFE_CONFIG_KEYS) {
+    assignIfMissing({
+      target: configRecord,
+      key,
+      value: profileRecord[key],
+      pathLabel: key,
+      applied: appliedPaths,
+      skipped: skippedPaths,
+    });
+  }
+
+  if (profileConfig.agents) {
+    if (!config.agents) {
+      config.agents = cloneConfig(profileConfig.agents);
+      appliedPaths.push("agents");
+    } else {
+      if (profileConfig.agents.defaults) {
+        config.agents.defaults ??= {};
+        const defaults = config.agents.defaults as Record<string, unknown>;
+        for (const [key, value] of Object.entries(profileConfig.agents.defaults)) {
+          assignIfMissing({
+            target: defaults,
+            key,
+            value,
+            pathLabel: `agents.defaults.${key}`,
+            applied: appliedPaths,
+            skipped: skippedPaths,
+          });
+        }
+      }
+      if (Array.isArray(profileConfig.agents.list) && profileConfig.agents.list.length > 0) {
+        config.agents.list ??= [];
+        const existingIds = new Set(config.agents.list.map((agent) => agent.id));
+        for (const agent of profileConfig.agents.list) {
+          if (existingIds.has(agent.id)) {
+            skippedPaths.push(`agents.list.${agent.id}`);
+            continue;
+          }
+          config.agents.list.push(cloneConfig(agent));
+          existingIds.add(agent.id);
+          appliedPaths.push(`agents.list.${agent.id}`);
+        }
+      }
+    }
+  }
+
+  if (profileConfig.plugins?.entries || profileConfig.plugins?.slots) {
+    config.plugins ??= {};
+    if (profileConfig.plugins.entries) {
+      config.plugins.entries ??= {};
+      for (const [pluginId, entry] of Object.entries(profileConfig.plugins.entries)) {
+        assignIfMissing({
+          target: config.plugins.entries as Record<string, unknown>,
+          key: pluginId,
+          value: entry,
+          pathLabel: `plugins.entries.${pluginId}`,
+          applied: appliedPaths,
+          skipped: skippedPaths,
+        });
+      }
+    }
+    if (profileConfig.plugins.slots) {
+      config.plugins.slots ??= {};
+      for (const [slot, value] of Object.entries(profileConfig.plugins.slots)) {
+        assignIfMissing({
+          target: config.plugins.slots as Record<string, unknown>,
+          key: slot,
+          value,
+          pathLabel: `plugins.slots.${slot}`,
+          applied: appliedPaths,
+          skipped: skippedPaths,
+        });
+      }
+    }
+  }
+
+  return { config, appliedPaths, skippedPaths };
+}
+
+function parseProfileConfig(raw: Buffer | undefined): OpenClawConfig {
+  if (!raw) {
+    throw new Error("Profile archive is missing config payload.");
+  }
+  const parsed = JSON.parse(raw.toString("utf8")) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("Profile config payload must be an object.");
+  }
+  return buildSafeProfileConfig(parsed as OpenClawConfig);
+}
+
+function parseProfilePluginInstallRecords(
+  raw: Buffer | undefined,
+): Record<string, PluginInstallRecord> {
+  if (!raw) {
+    throw new Error("Profile archive is missing plugin install records payload.");
+  }
+  return sanitizePluginInstallRecordsPayload(raw.toString("utf8"));
+}
+
+function resolveSafeWorkspaceTarget(params: {
+  workspaceDir: string;
+  relativePath: string;
+}): string {
+  const normalizedRelative = normalizeArchivePath(params.relativePath, "Profile workspace path");
+  const isMemoryFile =
+    normalizedRelative.startsWith("memory/") && normalizedRelative.endsWith(".md");
+  if (isMemoryFile || PROFILE_ROOT_FILE_NAMES.includes(normalizedRelative as never)) {
+    const targetPath = path.resolve(params.workspaceDir, normalizedRelative);
+    const relative = path.relative(path.resolve(params.workspaceDir), targetPath);
+    if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+      throw new Error(`Profile workspace path escapes target workspace: ${params.relativePath}`);
+    }
+    return targetPath;
+  }
+  throw new Error(`Profile workspace file is not importable: ${params.relativePath}`);
+}
+
+export async function importProfileArchive(
+  opts: ProfileImportOptions,
+): Promise<ProfileImportResult> {
+  const archivePath = path.resolve(opts.archive.replace(/^~(?=$|[\\/])/, os.homedir()));
+  const { manifest, contents } = await readProfileArchive(archivePath);
+  const configAsset = manifest.assets.find((asset) => asset.kind === "config");
+  if (!configAsset) {
+    throw new Error("Profile manifest is missing config asset.");
+  }
+  const profileConfig = parseProfileConfig(contents.get(configAsset.archivePath));
+  const { snapshot, writeOptions } = await readConfigFileSnapshotForWrite();
+  const configMerge = mergeMissingProfileConfig(snapshot.sourceConfig, profileConfig);
+  if (!opts.dryRun && configMerge.appliedPaths.length > 0) {
+    await replaceConfigFile({
+      nextConfig: configMerge.config,
+      snapshot,
+      writeOptions,
+      afterWrite: { mode: "auto" },
+    });
+  }
+
+  const filesWritten: ProfileImportResult["filesWritten"] = [];
+  const filesWouldWrite: ProfileImportResult["filesWouldWrite"] = [];
+  const filesSkipped: ProfileImportResult["filesSkipped"] = [];
+  for (const asset of manifest.assets) {
+    if (asset.kind === "config") {
+      continue;
+    }
+    if (asset.kind === "plugin-installs") {
+      const installRecords = parseProfilePluginInstallRecords(contents.get(asset.archivePath));
+      const targetPath = resolveInstalledPluginIndexStorePath({ stateDir: resolveStateDir() });
+      if (await pathExists(targetPath)) {
+        filesSkipped.push({ kind: asset.kind, targetPath, reason: "exists" });
+        continue;
+      }
+      if (Object.keys(installRecords).length === 0) {
+        filesSkipped.push({ kind: asset.kind, targetPath, reason: "empty" });
+        continue;
+      }
+      if (!opts.dryRun) {
+        await refreshPersistedInstalledPluginIndex({
+          stateDir: resolveStateDir(),
+          reason: "source-changed",
+          installRecords,
+        });
+        filesWritten.push({ kind: asset.kind, targetPath });
+      } else {
+        filesWouldWrite.push({ kind: asset.kind, targetPath });
+      }
+      continue;
+    }
+    const agentId = asset.agentId;
+    const relativePath = asset.relativePath;
+    if (!agentId || !relativePath) {
+      filesSkipped.push({
+        kind: asset.kind,
+        agentId,
+        relativePath,
+        reason: "missing-metadata",
+      });
+      continue;
+    }
+    const workspaceDir = resolveAgentWorkspaceDir(configMerge.config, agentId);
+    const targetPath = resolveSafeWorkspaceTarget({ workspaceDir, relativePath });
+    if (await pathExists(targetPath)) {
+      filesSkipped.push({ kind: asset.kind, agentId, relativePath, targetPath, reason: "exists" });
+      continue;
+    }
+    if (!opts.dryRun) {
+      await fs.mkdir(path.dirname(targetPath), { recursive: true, mode: 0o700 });
+      await fs.writeFile(targetPath, contents.get(asset.archivePath) ?? Buffer.alloc(0), "utf8");
+      filesWritten.push({ kind: asset.kind, agentId, relativePath, targetPath });
+    } else {
+      filesWouldWrite.push({ kind: asset.kind, agentId, relativePath, targetPath });
+    }
+  }
+
+  return {
+    archivePath,
+    archiveRoot: manifest.archiveRoot,
+    dryRun: Boolean(opts.dryRun),
+    configAppliedPaths: configMerge.appliedPaths,
+    configSkippedPaths: configMerge.skippedPaths,
+    filesWritten,
+    filesWouldWrite,
+    filesSkipped,
+  };
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function formatProfileExportSummary(result: ProfileExportResult): string[] {
+  const lines = [`Profile archive: ${result.archivePath}`];
+  lines.push(`Config paths: ${result.configPaths.length}`);
+  lines.push(`Workspace files: ${result.workspaceFiles.length}`);
+  lines.push(`Plugin install records: ${result.pluginInstalls ? "included" : "not found"}`);
+  if (result.skipped.length > 0) {
+    lines.push(`Skipped ${result.skipped.length} path${result.skipped.length === 1 ? "" : "s"}.`);
+  }
+  if (result.dryRun) {
+    lines.push("Dry run only; archive was not written.");
+  } else {
+    lines.push(`Created ${result.archivePath}`);
+    if (result.verified) {
+      lines.push("Archive verification: passed");
+    }
+  }
+  return lines;
+}
+
+export function formatProfileImportSummary(result: ProfileImportResult): string[] {
+  const lines = [`Profile archive: ${result.archivePath}`];
+  lines.push(`Config paths applied: ${result.configAppliedPaths.length}`);
+  lines.push(`Config paths skipped: ${result.configSkippedPaths.length}`);
+  if (result.dryRun) {
+    lines.push(`Files would write: ${result.filesWouldWrite.length}`);
+  } else {
+    lines.push(`Files written: ${result.filesWritten.length}`);
+  }
+  lines.push(`Files skipped: ${result.filesSkipped.length}`);
+  if (result.dryRun) {
+    lines.push("Dry run only; profile was not imported.");
+  }
+  return lines;
+}

--- a/src/plugins/bundled-dir.test.ts
+++ b/src/plugins/bundled-dir.test.ts
@@ -7,6 +7,7 @@ import { cleanupTrackedTempDirs, makeTrackedTempDir } from "./test-helpers/fs-fi
 const tempDirs: string[] = [];
 const originalBundledDir = process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
 const originalDisableBundledPlugins = process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
+const originalTestTrustBundledPluginsDir = process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
 const originalVitest = process.env.VITEST;
 const originalArgv1 = process.argv[1];
 const originalExecArgv = [...process.execArgv];
@@ -157,6 +158,11 @@ afterEach(() => {
     delete process.env.VITEST;
   } else {
     process.env.VITEST = originalVitest;
+  }
+  if (originalTestTrustBundledPluginsDir === undefined) {
+    delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR = originalTestTrustBundledPluginsDir;
   }
   process.argv[1] = originalArgv1;
   process.execArgv.length = 0;
@@ -310,6 +316,7 @@ describe("resolveBundledPluginsDir", () => {
     process.argv[1] = path.join(installedRoot, "openclaw.mjs");
     process.execArgv.length = 0;
     delete process.env.VITEST;
+    delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(installedRoot, "dist", "extensions");
     delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
 
@@ -396,6 +403,7 @@ describe("resolveBundledPluginsDir", () => {
     process.argv[1] = path.join(installedRoot, "openclaw.mjs");
     process.execArgv.length = 0;
     delete process.env.VITEST;
+    delete process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR;
     process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = path.join(overrideRoot, "extensions");
     delete process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS;
 

--- a/src/plugins/loader.test-fixtures.ts
+++ b/src/plugins/loader.test-fixtures.ts
@@ -105,7 +105,7 @@ export function writePlugin(params: {
 
 export function useNoBundledPlugins() {
   process.env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "1";
-  delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = "/nonexistent/bundled/plugins";
 }
 
 export function loadBundleFixture(params: {

--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -10,6 +10,7 @@ import type { PluginRegistry } from "../src/plugins/registry.js";
 import { installSharedTestSetup } from "./setup.shared.js";
 
 installSharedTestSetup();
+process.env.OPENCLAW_TEST_TRUST_BUNDLED_PLUGINS_DIR ??= "1";
 
 const WORKER_RUNTIME_STATE = Symbol.for("openclaw.testSetupRuntimeState");
 const WORKER_PLUGIN_RUNTIME_HELPERS = Symbol.for("openclaw.testSetupPluginRuntimeHelpers");


### PR DESCRIPTION
## Summary
Adds a privacy-safe local profile portability foundation via `openclaw profile export/import`.

This is intentionally not cloud sync, not rclone integration, and not a full workspace/state backup. It focuses on moving portable personalization across machines while keeping secrets, sessions, media, logs, credentials, and local runtime state out of the archive.

## What Changed
- Added `openclaw profile export`
- Added `openclaw profile import`
- Added `.openclaw-profile.tar.gz` archive format with `manifest.json`
- Exports a privacy-safe config projection, workspace persona/memory markdown files, and plugin install records
- Imports non-destructively by filling missing config fields and skipping existing files
- Strips nested secrets and local paths from portable config projections
- Rejects traversal paths, unsupported manifest schemas, and unsafe workspace payloads
- Added CLI, command, infra tests, and docs

## Related Context
- #17418
- #13616
- #18106
- #18104

## Test Plan
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.infra.config.ts src/infra/profile-portability.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.commands.config.ts src/commands/profile.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.cli.config.ts src/cli/program/register.profile.test.ts`
- `pnpm lint:core`
- `pnpm tsgo:core`
- `pnpm tsgo:core:test`
- `pnpm format:docs:check`
- `pnpm docs:check-mdx`
- `pnpm lint:docs`
