### PR TITLE
fix(bedrock): strip inferenceConfig.temperature for Opus 4.7 (#73663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Amazon Bedrock: strip `inferenceConfig.temperature` from Bedrock Converse payloads for the Opus 4.7 family (`anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`, `global.anthropic.claude-opus-4-7`), so requests stop tripping the Anthropic upstream `invalid_request_error: "temperature" is deprecated for this model.` `ValidationException`. Without this strip the embedded run hangs in `processing` until the watchdog fires (~140s) because the classifier does not surface the nested upstream error as a failover trigger. Mirrors the existing Mantle-Anthropic check in `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23`. Fixes #73663 (Bug 1). Thanks @bstanbury.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -158,6 +158,14 @@ function makeAppInferenceProfileDescriptor(modelId: string): never {
   } as never;
 }
 
+function makeBedrockClaudeModel(modelId: string): never {
+  return {
+    api: "bedrock-converse-stream",
+    provider: "amazon-bedrock",
+    id: modelId,
+  } as never;
+}
+
 /**
  * Call wrapStreamFn and then invoke the returned stream function, capturing
  * the payload via the onPayload hook that streamWithPayloadPatch installs.
@@ -294,6 +302,122 @@ describe("amazon-bedrock provider plugin", () => {
     ).toMatchObject({
       cacheRetention: "none",
     });
+  });
+
+  it.each([
+    ["anthropic.claude-opus-4-7"],
+    ["us.anthropic.claude-opus-4-7"],
+    ["global.anthropic.claude-opus-4-7"],
+  ])(
+    "drops inferenceConfig.temperature for Opus 4.7 Bedrock model %s (#73663)",
+    async (modelId) => {
+      // Anthropic upstream rejects Bedrock Converse requests for the Opus
+      // 4.7 family with `invalid_request_error: "temperature" is deprecated
+      // for this model.`. Without this strip, the run hangs in `processing`
+      // until the watchdog fires (~140s) because OpenClaw's failover
+      // classifier does not recognize the nested upstream error inside
+      // ValidationException.
+      const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+      const wrapped = provider.wrapStreamFn?.({
+        provider: "amazon-bedrock",
+        modelId,
+        streamFn: spyStreamFn,
+      } as never);
+      const result = wrapped?.(
+        makeBedrockClaudeModel(modelId),
+        { messages: [] } as never,
+        {},
+      ) as unknown as Record<string, unknown>;
+      // Apply the patch with a payload that mirrors what pi-ai builds when
+      // `temperature` was provided in agent options.
+      const payload: Record<string, unknown> = {
+        inferenceConfig: { temperature: 0.7, maxTokens: 32_000 },
+      };
+      expect(typeof result?.onPayload).toBe("function");
+      (result.onPayload as (p: Record<string, unknown>) => void)(payload);
+      expect(payload.inferenceConfig).toBeDefined();
+      expect(payload.inferenceConfig).not.toHaveProperty("temperature");
+      // maxTokens stays — only temperature is stripped.
+      expect(payload.inferenceConfig).toMatchObject({ maxTokens: 32_000 });
+    },
+  );
+
+  it("preserves inferenceConfig.temperature for Opus 4.6 Bedrock model (#73663 regression guard)", async () => {
+    // 4.6 still accepts temperature; only 4.7 onward changed upstream.
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-6-v1:0",
+      streamFn: spyStreamFn,
+    } as never);
+    const result = wrapped?.(
+      makeBedrockClaudeModel("us.anthropic.claude-opus-4-6-v1:0"),
+      { messages: [] } as never,
+      {},
+    ) as unknown as Record<string, unknown>;
+    const payload: Record<string, unknown> = {
+      inferenceConfig: { temperature: 0.7, maxTokens: 32_000 },
+    };
+    if (typeof result?.onPayload === "function") {
+      (result.onPayload as (p: Record<string, unknown>) => void)(payload);
+    }
+    // 4.6 keeps temperature.
+    expect(payload.inferenceConfig).toMatchObject({ temperature: 0.7, maxTokens: 32_000 });
+  });
+
+  it("strips inferenceConfig.temperature on the cache-injection fast path for Opus 4.7 ARN (#73663)", async () => {
+    // Greptile coverage gap follow-up: the no-cache-injection test fixtures
+    // use bare model IDs that do not match `isBedrockAppInferenceProfile`,
+    // so they only exercise path 1 in `wrapStreamFn`. App Inference
+    // Profile ARNs that match the Claude heuristic land on the fast path,
+    // and the strip must apply there too.
+    const opus47ArnHeuristic =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/us.anthropic.claude-opus-4-7";
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "amazon-bedrock",
+      modelId: opus47ArnHeuristic,
+      streamFn: spyStreamFn,
+    } as never);
+    const result = wrapped?.(
+      makeBedrockClaudeModel(opus47ArnHeuristic),
+      { messages: [] } as never,
+      {},
+    ) as unknown as Record<string, unknown>;
+    expect(typeof result?.onPayload).toBe("function");
+    const payload: Record<string, unknown> = {
+      inferenceConfig: { temperature: 0.7, maxTokens: 32_000 },
+      // Mirror the cache-eligible USER message shape so injectBedrockCachePoints has work to do.
+      messages: [{ role: "user", content: [{ text: "hello" }] }],
+    };
+    (result.onPayload as (p: Record<string, unknown>) => void)(payload);
+    expect(payload.inferenceConfig).not.toHaveProperty("temperature");
+    expect(payload.inferenceConfig).toMatchObject({ maxTokens: 32_000 });
+  });
+
+  it("does not throw on malformed inferenceConfig (string/null) for Opus 4.7 (#73663 aisle CWE-248)", async () => {
+    // aisle finding on PR #73675: using `in` directly on a non-object
+    // `inferenceConfig` (e.g. string/number) would throw `TypeError: right-
+    // hand side of 'in' should be an object` and abort the streaming
+    // request. Helper now guards `typeof inferenceConfig === "object"`.
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+    const wrapped = provider.wrapStreamFn?.({
+      provider: "amazon-bedrock",
+      modelId: "us.anthropic.claude-opus-4-7",
+      streamFn: spyStreamFn,
+    } as never);
+    const result = wrapped?.(
+      makeBedrockClaudeModel("us.anthropic.claude-opus-4-7"),
+      { messages: [] } as never,
+      {},
+    ) as unknown as Record<string, unknown>;
+    expect(typeof result?.onPayload).toBe("function");
+    const onPayload = result.onPayload as (p: Record<string, unknown>) => void;
+    // None of these should throw.
+    expect(() => onPayload({ inferenceConfig: "not-an-object" })).not.toThrow();
+    expect(() => onPayload({ inferenceConfig: null })).not.toThrow();
+    expect(() => onPayload({ inferenceConfig: 42 })).not.toThrow();
+    expect(() => onPayload({})).not.toThrow();
   });
 
   describe("guardrail config schema", () => {

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -21,6 +21,39 @@ type GuardrailConfig = {
   trace?: "enabled" | "disabled" | "enabled_full";
 };
 
+/**
+ * Anthropic upstream rejects Bedrock Converse requests for the Opus 4.7
+ * family with `invalid_request_error: "temperature" is deprecated for this
+ * model.`. Mirrors the existing Mantle-Anthropic check in
+ * `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23`. See
+ * #73663.
+ *
+ * Matches the family across regional and global inference profiles:
+ * `anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`,
+ * `global.anthropic.claude-opus-4-7`.
+ */
+function bedrockModelRejectsTemperature(modelId: string): boolean {
+  return modelId.includes("claude-opus-4-7");
+}
+
+/**
+ * Strip `inferenceConfig.temperature` from a Bedrock Converse payload in
+ * place, with belt-and-braces guards so a malformed `inferenceConfig`
+ * (string/number/null) cannot trip the `in` operator and abort the
+ * streaming request — see aisle finding on PR #73675 (CWE-248). Used by
+ * all three `wrapStreamFn` branches (no-cache, fast-path, slow-path) so
+ * any future code path that re-enters the wrap also gets the fix.
+ */
+function stripTemperatureFromInferenceConfig(payload: unknown): void {
+  if (!payload || typeof payload !== "object") {
+    return;
+  }
+  const inferenceConfig = (payload as { inferenceConfig?: unknown }).inferenceConfig;
+  if (inferenceConfig && typeof inferenceConfig === "object" && "temperature" in inferenceConfig) {
+    delete (inferenceConfig as Record<string, unknown>).temperature;
+  }
+}
+
 type AmazonBedrockPluginConfig = {
   discovery?: {
     enabled?: boolean;
@@ -391,7 +424,14 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
       // For opaque profile IDs, we'll resolve via GetInferenceProfile on first call.
       const heuristicMatch = needsCachePointInjection(modelId);
 
-      if (!region && !mayNeedCacheInjection) {
+      // Strip `inferenceConfig.temperature` for Opus 4.7 — Anthropic upstream
+      // rejects it with `invalid_request_error: "temperature" is deprecated
+      // for this model.`, which OpenClaw's runtime classifier does not
+      // currently surface as a failover-worthy error, so the run hangs in
+      // `processing` until a watchdog fires (#73663).
+      const dropTemperatureForOpus47 = bedrockModelRejectsTemperature(modelId);
+
+      if (!region && !mayNeedCacheInjection && !dropTemperatureForOpus47) {
         return wrapped;
       }
 
@@ -403,6 +443,11 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         const merged = Object.assign({}, options, region ? { region } : {});
 
         if (!mayNeedCacheInjection) {
+          if (dropTemperatureForOpus47) {
+            return streamWithPayloadPatch(underlying, streamModel, context, merged, (payload) => {
+              stripTemperatureFromInferenceConfig(payload);
+            });
+          }
           return underlying(streamModel, context, merged);
         }
 
@@ -421,6 +466,9 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
           // Fast path: ARN heuristic already identified this as Claude.
           return streamWithPayloadPatch(underlying, streamModel, context, merged, (payload) => {
             injectBedrockCachePoints(payload, cacheRetention);
+            if (dropTemperatureForOpus47) {
+              stripTemperatureFromInferenceConfig(payload);
+            }
           });
         }
 
@@ -435,6 +483,9 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
             const eligible = await resolveAppProfileCacheEligible(modelId, region);
             if (eligible && payload && typeof payload === "object") {
               injectBedrockCachePoints(payload as Record<string, unknown>, cacheRetention);
+            }
+            if (dropTemperatureForOpus47) {
+              stripTemperatureFromInferenceConfig(payload);
             }
             return originalOnPayload?.(payload, payloadModel);
           },


### PR DESCRIPTION
## What

Resubmits the fix for #73663 with all reviewer feedback from the closed PR #73675 already applied. The original PR was auto-closed by `openclaw-barnacle` for queue-cap reasons (>10 active hclsys PRs); the queue is now back at 10 and the closed-PR feedback is folded in.

Anthropic upstream rejects Bedrock Converse requests for the Opus 4.7 family with `invalid_request_error: "temperature" is deprecated for this model.`. The Bedrock SDK surfaces this as a `ValidationException`; OpenClaw's failover classifier does not currently surface the nested upstream error, so the embedded run hangs in `state=processing` until a watchdog fires at ~140s. Sessions are dead with no user-visible error and no failover.

## Fix

Strip `payload.inferenceConfig.temperature` for the Opus 4.7 family at the existing `wrapStreamFn` payload-patch boundary in `extensions/amazon-bedrock/register.sync.runtime.ts`. Mirrors `extensions/amazon-bedrock-mantle/mantle-anthropic.runtime.ts:23` (`requiresDefaultSampling`).

Now extracted as a module-level helper `stripTemperatureFromInferenceConfig(payload)` and reused at all three `wrapStreamFn` branches (no-cache, cache-injection-fast, cache-injection-slow). Helper guards against malformed `inferenceConfig` (string/number/null) so the `in` operator cannot throw `TypeError` and abort the streaming request.

```ts
function stripTemperatureFromInferenceConfig(payload: unknown): void {
  if (!payload || typeof payload !== "object") return;
  const inferenceConfig = (payload as { inferenceConfig?: unknown }).inferenceConfig;
  if (
    inferenceConfig &&
    typeof inferenceConfig === "object" &&
    "temperature" in inferenceConfig
  ) {
    delete (inferenceConfig as Record<string, unknown>).temperature;
  }
}
```

## Closed-PR feedback applied

This branch was originally PR #73675 (auto-closed on queue cap before maintainer review). The aisle and greptile findings on that PR are now addressed:

- **aisle CWE-248 (Low) on #73675**: TypeError/DoS risk from `in` operator on non-object `inferenceConfig`. Fixed by adding `typeof inferenceConfig === "object"` guard inside the helper. New regression test feeds `inferenceConfig: "string" | null | 42 | undefined` and asserts no throw.
- **greptile P2 (a)**: temperature-strip boilerplate duplicated across three branches. Fixed by extracting the helper and calling `stripTemperatureFromInferenceConfig(payload)` at each site.
- **greptile P2 (b)**: tests only exercised the no-cache-injection path. Fixed by adding a parameterized test for an Opus 4.7 application-inference-profile ARN that lands on the cache-injection fast path.

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341).** `requiresDefaultSampling(modelId)` already exists in `mantle-anthropic.runtime.ts:23` for the same family. Cross-extension boundaries make a shared export awkward; the new helpers are module-local with cross-references in their doc comments. ✅
2. **Shared-helper caller check (steipete #60623).** `streamWithPayloadPatch` is reused — same callback shape that already injects guardrails and cache points. No contract change for other callers. ✅
3. **Broader-fix rival scan (steipete #68270).** Zero rival PRs reference #73663. Bug 2 (failover classifier surfacing nested upstream errors inside ValidationException) is intentionally out of scope here — that is a separate fix in the failover state machine. ✅

## Verified locally

```
npx oxlint extensions/amazon-bedrock/register.sync.runtime.ts extensions/amazon-bedrock/index.test.ts
# Found 0 warnings and 0 errors.

npx vitest run extensions/amazon-bedrock/index.test.ts
# Tests  28 passed (28)
```

Tests cover:
- Bare model IDs `anthropic.claude-opus-4-7`, `us.anthropic.claude-opus-4-7`, `global.anthropic.claude-opus-4-7` (no-cache path)
- Opus 4.7 application inference profile ARN (cache-injection fast path)
- Opus 4.6 regression guard (temperature preserved)
- Malformed `inferenceConfig` payloads (helper does not throw)

lobster-biscuit: 73663-bedrock-opus-4-7-temperature

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.

---

Closes #73675 (auto-closed for queue-cap reasons).
