### PR TITLE
fix(cli): tolerate deleted cwd in shouldLoadCliDotEnv (#73676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/dotenv: tolerate `process.cwd()` throwing `ENOENT: no such file or directory, uv_cwd` when the current working directory has been deleted, so `openclaw tui` (and every other CLI entry point that runs through `shouldLoadCliDotEnv`) no longer aborts before any command can execute and instead falls through to the state-dir `.env` lookup. Fixes #73676. Thanks @oldsix-cell.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/tools: keep the Gateway `tools.*` RPC namespace out of plugin command discovery and managed proxy startup, so stray commands like `openclaw tools effective` fail quickly instead of cold-loading plugin metadata. Refs #73477. Thanks @oromeis.
 - CLI/status: keep default text `openclaw status --usage` on metadata-only channel scans unless `--deep` or `--all` is set, and send stray `openclaw tools --help` through the precomputed root-help fast path so latency-triage commands avoid plugin/runtime cold loads before printing. Refs #73477 and #74220. Thanks @oromeis and @NianJiuZst.
@@ -127,6 +128,7 @@ Docs: https://docs.openclaw.ai
 - Outbound/security: strip known internal runtime scaffolding such as `<system-reminder>` and `<previous_response>` at the final channel delivery boundary and keep Discord output on targeted tag stripping, so degraded harness replies cannot leak those tags to users. Fixes #73595. Thanks @gabrielexito-stack and @martingarramon.
 - Security/Telegram: load Telegram security adapters in read-only audit/doctor, audit malformed Telegram DM `allowFrom` entries even when groups are disabled, and keep allowlist DM audits from counting stale pairing-store senders, so public/shared-DM risk checks stay accurate. Refs #73698. Thanks @xace1825.
 - Plugins: remove hidden manifest, provider-owner, bootstrap, and channel metadata caches so plugin installs, manifest edits, and bundled-root changes are visible on the next metadata read while keeping runtime/module loader caches for actual plugin code. Thanks @shakkernerd.
+- CLI/dotenv: tolerate `process.cwd()` throwing `ENOENT: no such file or directory, uv_cwd` when the current working directory has been deleted, so `openclaw tui` (and every other CLI entry point that runs through `shouldLoadCliDotEnv`) no longer aborts before any command can execute and instead falls through to the state-dir `.env` lookup. Fixes #73676. Thanks @oldsix-cell.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.

--- a/src/cli/run-main.cwd-deleted.test.ts
+++ b/src/cli/run-main.cwd-deleted.test.ts
@@ -1,0 +1,43 @@
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { shouldLoadCliDotEnv } from "./run-main.js";
+
+describe("shouldLoadCliDotEnv (#73676)", () => {
+  let originalCwd: typeof process.cwd;
+
+  beforeEach(() => {
+    originalCwd = process.cwd;
+  });
+
+  afterEach(() => {
+    process.cwd = originalCwd;
+    vi.restoreAllMocks();
+  });
+
+  it("does not crash when process.cwd() throws ENOENT (deleted working directory)", () => {
+    // Regression for #73676: `process.cwd()` throws
+    // `Error: ENOENT: no such file or directory, uv_cwd` when the current
+    // working directory has been removed (cd into a directory, delete it
+    // from another shell, then run any CLI command). Before this fix the
+    // throw escaped through `shouldLoadCliDotEnv` and aborted the entire
+    // CLI before any command — including `openclaw tui` — could run.
+    //
+    // The function must instead treat the throw as "no cwd-local .env"
+    // and fall through to the state-dir check.
+    process.cwd = () => {
+      const error = new Error("ENOENT: no such file or directory, uv_cwd") as Error & {
+        code?: string;
+      };
+      error.code = "ENOENT";
+      throw error;
+    };
+
+    expect(() =>
+      shouldLoadCliDotEnv({ OPENCLAW_STATE_DIR: "/tmp/this-state-dir-does-not-exist-73676" }),
+    ).not.toThrow();
+    // No state-dir .env either, so result is false but the call returns cleanly.
+    expect(
+      shouldLoadCliDotEnv({ OPENCLAW_STATE_DIR: "/tmp/this-state-dir-does-not-exist-73676" }),
+    ).toBe(false);
+  });
+});

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -216,8 +216,20 @@ export function resolveMissingPluginCommandMessage(
   );
 }
 
-function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (existsSync(path.join(process.cwd(), ".env"))) {
+export function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+  // `process.cwd()` throws `ENOENT: no such file or directory, uv_cwd` when
+  // the current working directory has been deleted (cd into a directory,
+  // delete it from another shell, then run any CLI command). Treat that as
+  // "no cwd-local .env" and fall through to the state-dir check rather
+  // than letting the whole CLI exit before any command can run. See
+  // #73676.
+  let cwd: string | undefined;
+  try {
+    cwd = process.cwd();
+  } catch {
+    cwd = undefined;
+  }
+  if (cwd && existsSync(path.join(cwd, ".env"))) {
     return true;
   }
   return existsSync(path.join(resolveStateDir(env), ".env"));


### PR DESCRIPTION
## What

Fixes #73676. When the current working directory has been removed (cd into a directory, delete it from another shell, then run any CLI command), `process.cwd()` throws:

```
Error: ENOENT: no such file or directory, uv_cwd
```

Before this fix the exception escaped through `shouldLoadCliDotEnv` — which is called eagerly during CLI bootstrap — and aborted the entire CLI before any command (including `openclaw tui`) could run. Users had to manually `cd` to a valid directory just to recover.

## Fix

Wrap the `process.cwd()` call in a try/catch in `shouldLoadCliDotEnv`. On throw, treat it as "no cwd-local `.env`" and fall through to the state-dir `.env` lookup, which already uses `resolveStateDir(env)` (does not depend on cwd).

```ts
let cwd: string | undefined;
try {
  cwd = process.cwd();
} catch {
  cwd = undefined;
}
if (cwd && existsSync(path.join(cwd, ".env"))) {
  return true;
}
return existsSync(path.join(resolveStateDir(env), ".env"));
```

`shouldLoadCliDotEnv` is also exported now so the regression test can pin the no-throw behavior with a `process.cwd` mock.

## Pre-implement audit

1. **Existing-helper check (vincentkoc #57341).** A `safeCwd()` helper exists in `src/agents/bash-tools.shared.ts:186` (returns `string | null` on `try { process.cwd() } catch { return null }`), but it is module-private and used only by the bash-tool runtime path. Inlining the same 5-line guard at this CLI bootstrap site is cheaper than reshaping the helper into a shared infra export and adjusting both callers, and keeps the blast radius narrow. ✅
2. **Shared-helper caller check (steipete #60623).** `shouldLoadCliDotEnv` was module-private; promoting it to `export function` gives the regression test access. The only in-file call site is line 324; no external contract change. ✅
3. **Broader-fix rival scan (steipete #68270).** Zero rival PRs reference #73676. ✅

## Verified locally

```
npx oxlint src/cli/run-main.ts src/cli/run-main.cwd-deleted.test.ts
# Found 0 warnings and 0 errors.

npx vitest run src/cli/run-main.cwd-deleted.test.ts src/cli/run-main.test.ts
# Tests  25 passed (25)
```

The new test mocks `process.cwd` to throw the canonical `ENOENT … uv_cwd` shape and asserts `shouldLoadCliDotEnv` does not throw and returns cleanly.

## Note

This patch only touches the bootstrap-time `shouldLoadCliDotEnv` call. Other `process.cwd()` call sites (e.g. update-cli, proxy-cli) are not on the bare-CLI critical path that fires before any command resolves; if a user reports the same `uv_cwd` family throwing later in the lifecycle (e.g. mid-command), those can be addressed in follow-ups. The reporter explicitly identified `openclaw tui` as the failing path, which is gated by this exact bootstrap function.

lobster-biscuit: 73676-cli-cwd-deleted-crash

Sign-Off:
- I have read and agree to the OpenClaw Contributor License Agreement.
