### PR TITLE
feat(chat/ios): photos-picker-style attachment thumbnails with persistent add-more tile

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -172,41 +172,90 @@ struct OpenClawChatComposer: View {
         #endif
     }
 
+    // Photos-picker-style thumbnail strip. Tiles shrink to fit the row width so all
+    // selected images stay visible; falls back to horizontal scroll past the minimum.
+    private static let attachmentTileMax: CGFloat = 64
+    private static let attachmentTileMin: CGFloat = 36
+    private static let attachmentTileSpacing: CGFloat = 6
+
     private var attachmentsStrip: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 6) {
-                ForEach(
-                    self.viewModel.attachments,
-                    id: \OpenClawPendingAttachment.id)
-                { (att: OpenClawPendingAttachment) in
-                    HStack(spacing: 6) {
-                        if let img = att.preview {
-                            OpenClawPlatformImageFactory.image(img)
-                                .resizable()
-                                .scaledToFill()
-                                .frame(width: 22, height: 22)
-                                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                        } else {
-                            Image(systemName: "photo")
-                        }
+        AttachmentsStripLayout(
+            viewModel: self.viewModel,
+            tileMax: Self.attachmentTileMax,
+            tileMin: Self.attachmentTileMin,
+            spacing: Self.attachmentTileSpacing,
+            addMore: { size in AnyView(self.addMoreTile(size: size)) },
+            tile: { att, size in AnyView(self.attachmentTile(att, size: size)) }
+        )
+        .frame(height: Self.attachmentTileMax)
+        .padding(.horizontal, 4)
+    }
 
-                        Text(att.fileName)
-                            .lineLimit(1)
-
-                        Button {
-                            self.viewModel.removeAttachment(att.id)
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                        }
-                        .buttonStyle(.plain)
+    private func attachmentTile(_ att: OpenClawPendingAttachment, size: CGFloat) -> some View {
+        ZStack(alignment: .topTrailing) {
+            Group {
+                if let img = att.preview {
+                    OpenClawPlatformImageFactory.image(img)
+                        .resizable()
+                        .scaledToFill()
+                } else {
+                    ZStack {
+                        Color.accentColor.opacity(0.12)
+                        Image(systemName: "photo")
+                            .foregroundStyle(.secondary)
                     }
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-                    .background(Color.accentColor.opacity(0.08))
-                    .clipShape(Capsule())
                 }
             }
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(OpenClawChatTheme.composerBorder, lineWidth: 0.5))
+            .accessibilityLabel(Text(att.fileName))
+
+            Button {
+                self.viewModel.removeAttachment(att.id)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.6))
+                    .padding(2)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove attachment")
+            .offset(x: 4, y: -4)
         }
+        .frame(width: size, height: size)
+    }
+
+    // Trailing "+" tile so the add-more affordance is always visible alongside
+    // the thumbnails, independent of the toolbar's focus-compaction state.
+    @ViewBuilder
+    private func addMoreTile(size: CGFloat) -> some View {
+        #if os(macOS)
+        Button {
+            self.pickFilesMac()
+        } label: {
+            AddMoreTileLabel(size: size)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Add Image")
+        #else
+        PhotosPicker(selection: self.$pickerItems, maxSelectionCount: 8, matching: .images) {
+            AddMoreTileLabel(size: size)
+        }
+        // Mirror the .onChange handler from `attachmentPicker` here so that
+        // photo selections still load when the toolbar is hidden (composer
+        // focused / keyboard up). Without this, `attachmentPicker` is removed
+        // from the view tree by the `if self.showsToolbar` branch and its
+        // .onChange stops observing — selections would silently drop.
+        // `loadPhotosPickerItems` is idempotent on the same items snapshot.
+        .onChange(of: self.pickerItems) { _, newItems in
+            Task { await self.loadPhotosPickerItems(newItems) }
+        }
+        .accessibilityLabel("Add Image")
+        #endif
     }
 
     private var editor: some View {
@@ -777,3 +826,70 @@ enum ChatComposerPasteSupport {
     }
 }
 #endif
+
+@MainActor
+private struct AttachmentsStripLayout: View {
+    let viewModel: OpenClawChatViewModel
+    let tileMax: CGFloat
+    let tileMin: CGFloat
+    let spacing: CGFloat
+    let addMore: (CGFloat) -> AnyView
+    let tile: (OpenClawPendingAttachment, CGFloat) -> AnyView
+
+    var body: some View {
+        GeometryReader { proxy in
+            self.content(availableWidth: proxy.size.width)
+        }
+    }
+
+    @ViewBuilder
+    private func content(availableWidth: CGFloat) -> some View {
+        let tileCount = self.viewModel.attachments.count + 1 // +1 for add-more
+        let spacingTotal = self.spacing * CGFloat(max(tileCount - 1, 0))
+        let idealSize = (availableWidth - spacingTotal) / CGFloat(max(tileCount, 1))
+        let clamped = min(self.tileMax, max(self.tileMin, idealSize))
+        let fitsInline = idealSize >= self.tileMin
+
+        Group {
+            if fitsInline {
+                HStack(spacing: self.spacing) {
+                    self.rowItems(tileSize: clamped)
+                }
+            } else {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: self.spacing) {
+                        self.rowItems(tileSize: self.tileMin)
+                    }
+                }
+            }
+        }
+        .frame(width: availableWidth, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private func rowItems(tileSize: CGFloat) -> some View {
+        ForEach(self.viewModel.attachments, id: \OpenClawPendingAttachment.id) { att in
+            self.tile(att, tileSize)
+        }
+        self.addMore(tileSize)
+    }
+}
+
+private struct AddMoreTileLabel: View {
+    let size: CGFloat
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.accentColor.opacity(0.10))
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .strokeBorder(
+                    Color.accentColor.opacity(0.45),
+                    style: StrokeStyle(lineWidth: 1, dash: [3, 3]))
+            Image(systemName: "plus")
+                .font(.system(size: max(14, self.size * 0.35), weight: .semibold))
+                .foregroundStyle(Color.accentColor)
+        }
+        .frame(width: self.size, height: self.size)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a thumbnail strip + "+" tile to the chat composer's attachment row so users can review, remove, and add more attachments while the keyboard is up and the toolbar is compacted.

- **Problem**: when the iOS keyboard is up the composer compacts and the attachment toolbar (with its PhotosPicker) is removed from the view tree. Once a user has selected one image, there's no way to review, remove, or add more without dismissing the keyboard. The "+1 more attachment" affordance also dies in compacted state.
- **Why it matters**: this isn't only an aesthetic fix. The iOS app is increasingly used as a real working surface, not a passive notification stream:
  - **On-the-go debugging / bug reports.** Filing a context-rich report from a phone while commuting (e.g. on a bus) typically means: type a description, attach a screenshot, type more, attach another screenshot, send. Today, every "attach another" round-trip requires dismissing the keyboard, breaking flow and losing focus.
  - **Mobile-first development workflows.** Developers using OpenClaw from their phone want to iterate the way they would on desktop — attach, review, remove a wrong attachment, add another, all without losing the composer.
  - **Multi-image context for chat/agent turns.** Many agent flows benefit from multiple screenshots in one turn ("here's the UI, here's the log, here's the network panel"). The current one-shot picker forces serial messages instead of one well-formed turn.
- **What changed**: render selected attachments as a horizontal thumbnail strip with a remove ("×") affordance per tile, and a trailing `+` tile that opens a fresh `PhotosPicker`. Both the toolbar PhotosPicker and the in-strip PhotosPicker share the same `pickerItems` state and the same `.onChange` loader, so additions from either path go through one code path.
- **What did NOT change**: send pipeline, image processing pipeline (PR #73710 owns that), max attachments policy, focus/keyboard handling.

> **AI-assisted PR.** Implemented with Claude (Opus 4.7) under direction of repo owner (\@Wong1dev). **Build-verified only at this commit** (`fab05552`) — package builds clean on Swift 6.2; physical-device validation against the post-Greptile-fix build is pending and will be confirmed in a follow-up comment with screenshots. The motivation comes from the author's own commute-time mobile-debug usage of OpenClaw on iOS; this PR is the missing affordance for that workflow. Greptile review feedback addressed in code (mirrored `.onChange` to fix focused-state silent drop; removed dead `addMoreTileLabel`). SwiftUI snapshot-test harness deferred (see Risks). Maintainer judgment requested on visual polish.
>
> **Reviewers are encouraged to test on their own iPhone**, not just the simulator — the focused/compacted composer state behaves differently with a real keyboard, and the one-handed-on-the-go motivation only really shows up under physical-device use.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #73710 (image processing pipeline; this PR is the UI side)
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- **Root cause**: the attachment toolbar (and its `.onChange(of: pickerItems)` handler) is conditionally inserted into the view tree based on focus state. When the keyboard is up the toolbar is removed, taking the only `.onChange` handler with it — so any picker selection from a child view fires no loader.
- **Missing detection / guardrail**: no UI test asserting that picker selections are loaded in the focused/compacted state.
- **Contributing context**: original design assumed attachments only enter via the toolbar PhotosPicker, which was always present. Adding a second PhotosPicker (the `+` tile) in a sibling view exposed the conditional-handler problem.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [x] End-to-end test (snapshot or UI test)
  - [ ] Existing coverage already sufficient
- Target test or file: a future `ChatComposerSnapshotTests` / `ChatComposerUITests` (no snapshot harness exists in `OpenClawKitTests` today; pulling in `swift-snapshot-testing` is bigger than this PR's scope).
- Scenario the test should lock in: focused state + select image from `+` tile → attachment appears in strip.
- Why this is the smallest reliable guardrail: SwiftUI conditional view trees are easy to regress without a snapshot or UI test.
- If no new test is added, why not: harness not present in this package; tracking as a follow-up. The fix is mirrored `.onChange` directly on the `+`-tile PhotosPicker so the handler exists wherever the picker exists.

## User-visible / Behavior Changes

- Selected image attachments now render as a horizontal thumbnail strip in the composer.
- Each thumbnail has a remove ("×") affordance.
- A trailing `+` tile opens the PhotosPicker to add more, even with the keyboard up.
- Compacted-state attachment additions no longer silently drop.

## Diagram (if applicable)

```text
Before (focused/compacted):
[textfield][send]
(toolbar hidden → PhotosPicker hidden → can't add or remove)

After (focused/compacted):
[textfield][send]
[ thumb1 × ][ thumb2 × ][ + ]   ← always present, regardless of focus state
```

## Security Impact (required)

- New permissions/capabilities? **No** (uses the existing PhotosPicker permission)
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: macOS 26 (host); target is iOS via SwiftPM
- Runtime/container: Swift 6.2, Xcode 26
- Integration/channel: chat composer (iOS app)
- Relevant config: none

### Steps

1. `cd apps/shared/OpenClawKit`
2. `swift build`

### Expected

- Build succeeds with no warnings on the touched file.

### Actual

- Build succeeds in ~3.5 s.

## Evidence

- [x] Failing test/log before + passing after — N/A (no test harness for this layer; build-clean is the bar)
- [ ] Trace/log snippets
- [ ] Screenshot/recording — **TODO**: before/after screenshots from a physical iPhone (focused composer with one attachment vs. focused composer with thumbnail strip + `+` tile) will be attached as a follow-up comment. Reviewers wanting to reproduce: run a Debug build on a real device, focus the composer, attach an image from the toolbar PhotosPicker, then try to add a second one without dismissing the keyboard — on `main` you can't; on this branch the `+` tile makes it work.
- [ ] Perf numbers — N/A

## Human Verification (required)

- Verified scenarios (at this commit): package builds clean against Swift 6.2; existing test suites unaffected (compile-only).
- Edge cases reasoned about (not yet device-verified at this commit): 0 attachments (strip absent), 1 attachment, multiple, remove last (strip collapses), focused-state add via the new `+` tile path. Code path traced — mirrored `.onChange` is on the same view as the picker, so an addition cannot fire without the loader.
- What I did **not** verify on a physical device at this commit: focused-composer + add-via-`+`-tile + remove + send round-trip on a real iPhone with a real keyboard; iPad / large-screen iOS where the composer doesn't compact. Pending follow-up comment with screenshots.
- Author's earlier mobile usage of OpenClaw motivated the PR but predates the post-Greptile fix; that's why the post-fix build is what needs the device test, not the original implementation.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

Greptile review (2 threads) addressed in code and resolved. GitHub Codex review answered with a top-level comment; only outstanding ask is a snapshot-test harness, deferred as scoped follow-up (not blocking this PR).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk**: visual regression on iPad / large-screen iOS where the composer doesn't compact.
  - **Mitigation**: maintainer device-validation; layout uses standard SwiftUI `HStack` inside a `ScrollView` that already exists for the toolbar.
- **Risk**: dual `.onChange` handlers double-load picker items.
  - **Mitigation**: `loadPhotosPickerItems` is idempotent on the same items snapshot; comment in source explains the intentional duplication.
- **Risk**: missing snapshot tests means a future SwiftUI refactor could re-break the focused-state path.
  - **Mitigation**: tracked as follow-up to add `swift-snapshot-testing` for this package; fix is documented inline.


