### PR TITLE
fix: normalise wiki lint links

### DIFF
--- a/extensions/memory-wiki/src/lint.test.ts
+++ b/extensions/memory-wiki/src/lint.test.ts
@@ -8,6 +8,64 @@ import { createMemoryWikiTestHarness } from "./test-helpers.js";
 const { createVault } = createMemoryWikiTestHarness();
 
 describe("lintMemoryWikiVault", () => {
+  it("resolves title, slug, fragment, and imported source-path wikilinks", async () => {
+    const { rootDir, config } = await createVault({
+      prefix: "memory-wiki-lint-links-",
+      config: {
+        vault: { renderMode: "obsidian" },
+      },
+    });
+    await Promise.all(
+      ["sources", "syntheses"].map((dir) => fs.mkdir(path.join(rootDir, dir), { recursive: true })),
+    );
+
+    await fs.writeFile(
+      path.join(rootDir, "sources", "bridge-alpha.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "source",
+          id: "source.bridge.alpha",
+          title: "Imported Alpha Source",
+          sourceType: "memory-bridge",
+          sourcePath: "/workspace/research notes/Alpha System Overview.md",
+          bridgeRelativePath: "research notes/Alpha System Overview.md",
+          bridgeWorkspaceDir: "/workspace",
+        },
+        body: [
+          "# Imported Alpha Source",
+          "",
+          "[[Alpha Database#Evidence]]",
+          "[[alpha-database]]",
+          "[[syntheses/alpha-db#Details]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      path.join(rootDir, "syntheses", "alpha-db.md"),
+      renderWikiMarkdown({
+        frontmatter: {
+          pageType: "synthesis",
+          id: "synthesis.alpha.db",
+          title: "Alpha Database",
+          sourceIds: ["source.bridge.alpha"],
+        },
+        body: [
+          "# Alpha Database",
+          "",
+          "[[research notes/Alpha System Overview#Quote]]",
+          "[[Alpha System Overview]]",
+          "[[alpha-system-overview]]",
+        ].join("\n"),
+      }),
+      "utf8",
+    );
+
+    const result = await lintMemoryWikiVault(config);
+
+    expect(result.issues.filter((issue) => issue.code === "broken-wikilink")).toEqual([]);
+  });
+
   it("detects duplicate ids, provenance gaps, contradictions, and open questions", async () => {
     const { rootDir, config } = await createVault({
       prefix: "memory-wiki-lint-",

--- a/extensions/memory-wiki/src/lint.ts
+++ b/extensions/memory-wiki/src/lint.ts
@@ -4,6 +4,7 @@ import {
   replaceManagedMarkdownBlock,
   withTrailingNewline,
 } from "openclaw/plugin-sdk/memory-host-markdown";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import {
   assessPageFreshness,
   buildClaimContradictionClusters,
@@ -12,7 +13,7 @@ import {
 import { compileMemoryWikiVault } from "./compile.js";
 import type { ResolvedMemoryWikiConfig } from "./config.js";
 import { appendMemoryWikiLog } from "./log.js";
-import { renderWikiMarkdown, type WikiPageSummary } from "./markdown.js";
+import { renderWikiMarkdown, slugifyWikiSegment, type WikiPageSummary } from "./markdown.js";
 
 export type MemoryWikiLintIssue = {
   severity: "error" | "warning";
@@ -50,18 +51,63 @@ function toExpectedPageType(page: WikiPageSummary): string {
   return page.kind;
 }
 
+function normalizeLintTarget(value: string): string {
+  const withoutFragment = value.trim().replace(/\\/g, "/").split("#")[0] ?? "";
+  const withoutQuery = withoutFragment.split("?")[0] ?? "";
+  return normalizeLowercaseStringOrEmpty(
+    withoutQuery
+      .replace(/\.md$/i, "")
+      .replace(/^\.\/+/, "")
+      .replace(/\/+$/, ""),
+  );
+}
+
+function addTargetKey(keys: Set<string>, raw: string | undefined) {
+  const normalized = raw ? normalizeLintTarget(raw) : "";
+  if (!normalized) {
+    return;
+  }
+  keys.add(normalized);
+  const basename = path.basename(normalized);
+  keys.add(basename);
+  keys.add(slugifyWikiSegment(normalized));
+  keys.add(slugifyWikiSegment(basename));
+}
+
+function addPathSuffixTargetKeys(keys: Set<string>, raw: string | undefined) {
+  const normalized = raw ? normalizeLintTarget(raw) : "";
+  if (!normalized) {
+    return;
+  }
+  const parts = normalized.split("/").filter(Boolean);
+  for (let index = 0; index < parts.length; index += 1) {
+    addTargetKey(keys, parts.slice(index).join("/"));
+  }
+}
+
+function buildPageLinkTargetKeys(page: WikiPageSummary): Set<string> {
+  const keys = new Set<string>();
+  addTargetKey(keys, page.relativePath);
+  addTargetKey(keys, page.title);
+  addTargetKey(keys, page.id);
+  addPathSuffixTargetKeys(keys, page.sourcePath);
+  addPathSuffixTargetKeys(keys, page.bridgeRelativePath);
+  addPathSuffixTargetKeys(keys, page.unsafeLocalRelativePath);
+  return keys;
+}
+
 function collectBrokenLinkIssues(pages: WikiPageSummary[]): MemoryWikiLintIssue[] {
   const validTargets = new Set<string>();
   for (const page of pages) {
-    const withoutExtension = page.relativePath.replace(/\.md$/i, "");
-    validTargets.add(withoutExtension);
-    validTargets.add(path.basename(withoutExtension));
+    for (const target of buildPageLinkTargetKeys(page)) {
+      validTargets.add(target);
+    }
   }
 
   const issues: MemoryWikiLintIssue[] = [];
   for (const page of pages) {
     for (const linkTarget of page.linkTargets) {
-      if (!validTargets.has(linkTarget)) {
+      if (!validTargets.has(normalizeLintTarget(linkTarget))) {
         issues.push({
           severity: "warning",
           category: "links",


### PR DESCRIPTION
## Summary

- Problem: `openclaw wiki lint` can report existing imported wiki pages as `broken-wikilink` when links use page titles, slug variants, fragments, or original source-path suffixes.
- Why it matters: imported evidence should not need provenance-damaging rewrites just to satisfy lint.
- What changed: memory-wiki lint now indexes pages by normalised path, basename, title, slug variants, and imported source-path suffixes, and strips fragments/query strings before checking link targets.
- What did NOT change (scope boundary): wiki compile, ingest, page rendering, and markdown link extraction remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #73574
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: memory-wiki lint compared raw link targets against only exact extensionless relative paths and basenames.
- Missing detection / guardrail: lint coverage did not include title-style, slug-style, fragment, or imported source-path link variants.
- Contributing context (if known): imported evidence can preserve source-authored link forms that differ from generated wiki filenames.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/memory-wiki/src/lint.test.ts`
- Scenario the test should lock in: existing pages linked by title, slug, fragment-bearing path, and imported source-path suffix do not produce `broken-wikilink` issues.
- Why this is the smallest reliable guardrail: the bug is isolated to lint target normalisation.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw wiki lint` should produce fewer false-positive `broken-wikilink` warnings for imported wiki pages whose links already resolve by title, slug, fragment-stripped path, or imported source-path suffix.

## Diagram (if applicable)

```text
Before:
[[Alpha Database#Evidence]] -> raw target check -> false broken-wikilink

After:
[[Alpha Database#Evidence]] -> normalised lookup -> existing page match
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): memory-wiki
- Relevant config (redacted): N/A

### Steps

1. Compile or create memory-wiki pages containing links such as `[[Alpha Database#Evidence]]`, `[[alpha-database]]`, and source-path suffix links.
2. Run memory-wiki lint.
3. Inspect `broken-wikilink` results.

### Expected

- Existing pages are not reported as broken links when referenced by title, slug, fragment-stripped path, or imported source-path suffix.

### Actual

- Current main only compares raw targets against exact extensionless relative paths and basenames, so valid imported links can be reported as broken.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local command evidence:

- `git diff --check HEAD~1..HEAD` passed.
- Added-line scan for unwanted tool-name references returned no matches.
- `pnpm exec oxfmt --write --threads=1 extensions/memory-wiki/src/lint.ts extensions/memory-wiki/src/lint.test.ts` was attempted locally and with elevated permissions, but Corepack timed out downloading `pnpm 10.33.0` from the registry.
- `pnpm test extensions/memory-wiki/src/lint.test.ts` was attempted locally and with elevated permissions, but Corepack timed out downloading `pnpm 10.33.0` from the registry.

## Human Verification (required)

- Verified scenarios: source-level resolver now strips fragments/query suffixes and indexes title, slug, relative-path, basename, and imported source-path suffix keys.
- Edge cases checked: missing targets still flow through the existing warning path; source-path suffixes do not require changing stored provenance.
- What you did **not** verify: local formatter or Vitest execution, because this machine cannot download the required pnpm version through Corepack. CI should run the focused regression.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: lint could accept links that are ambiguous across multiple pages.
  - Mitigation: this only suppresses broken-link warnings when a normalised target matches an existing page key; it does not change compile output or page routing.
