### PR TITLE
feat(agents/cron): @default model sentinel resolves to defaults.primary at fire time

### DIFF
--- a/src/agents/model-default-sentinel.test.ts
+++ b/src/agents/model-default-sentinel.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  MODEL_DEFAULT_SENTINEL,
+  isModelDefaultSentinel,
+  normalizeStoredModelOverride,
+} from "./model-default-sentinel.js";
+
+describe("model-default-sentinel", () => {
+  describe("MODEL_DEFAULT_SENTINEL", () => {
+    it("is the literal string @default", () => {
+      expect(MODEL_DEFAULT_SENTINEL).toBe("@default");
+    });
+  });
+
+  describe("isModelDefaultSentinel", () => {
+    it("returns true for the bare sentinel", () => {
+      expect(isModelDefaultSentinel("@default")).toBe(true);
+    });
+
+    it("returns true for the sentinel with surrounding whitespace", () => {
+      expect(isModelDefaultSentinel("  @default  ")).toBe(true);
+      expect(isModelDefaultSentinel("\t@default\n")).toBe(true);
+    });
+
+    it("returns false for a real model identifier", () => {
+      expect(isModelDefaultSentinel("openai-codex/gpt-5.5")).toBe(false);
+      expect(isModelDefaultSentinel("anthropic/claude-opus-4-6")).toBe(false);
+      expect(isModelDefaultSentinel("gpt-5.5")).toBe(false);
+    });
+
+    it("returns false for sentinel-adjacent but non-matching strings", () => {
+      expect(isModelDefaultSentinel("default")).toBe(false);
+      expect(isModelDefaultSentinel("@latest")).toBe(false);
+      expect(isModelDefaultSentinel("@defaults")).toBe(false);
+      expect(isModelDefaultSentinel("@default-2")).toBe(false);
+      expect(isModelDefaultSentinel("provider/@default")).toBe(false);
+    });
+
+    it("returns false for non-string values", () => {
+      expect(isModelDefaultSentinel(undefined)).toBe(false);
+      expect(isModelDefaultSentinel(null)).toBe(false);
+      expect(isModelDefaultSentinel(0)).toBe(false);
+      expect(isModelDefaultSentinel({})).toBe(false);
+      expect(isModelDefaultSentinel([])).toBe(false);
+    });
+
+    it("is case-sensitive (sentinel is exactly @default)", () => {
+      expect(isModelDefaultSentinel("@DEFAULT")).toBe(false);
+      expect(isModelDefaultSentinel("@Default")).toBe(false);
+    });
+  });
+
+  describe("normalizeStoredModelOverride", () => {
+    it("returns undefined for the sentinel", () => {
+      expect(normalizeStoredModelOverride("@default")).toBeUndefined();
+      expect(normalizeStoredModelOverride("  @default  ")).toBeUndefined();
+    });
+
+    it("returns undefined for empty / whitespace / falsy values", () => {
+      expect(normalizeStoredModelOverride("")).toBeUndefined();
+      expect(normalizeStoredModelOverride("   ")).toBeUndefined();
+      expect(normalizeStoredModelOverride(undefined)).toBeUndefined();
+      expect(normalizeStoredModelOverride(null)).toBeUndefined();
+    });
+
+    it("returns the trimmed string for real model identifiers", () => {
+      expect(normalizeStoredModelOverride("openai-codex/gpt-5.5")).toBe("openai-codex/gpt-5.5");
+      expect(normalizeStoredModelOverride("  gpt-5.5  ")).toBe("gpt-5.5");
+    });
+
+    it("preserves model-list-shaped objects via the shared normalizer", () => {
+      expect(normalizeStoredModelOverride({ primary: "anthropic/claude-opus-4-6" })).toBe(
+        "anthropic/claude-opus-4-6",
+      );
+    });
+
+    it("returns undefined for objects whose primary is the sentinel", () => {
+      // Sentinel detection runs both before and after the underlying
+      // normalizer, so object-shape overrides like `{ primary: "@default" }`
+      // — which can appear in `agentConfigOverride.subagents.model` — also
+      // fall through to the live default instead of leaking the literal
+      // sentinel string into model resolution.
+      expect(normalizeStoredModelOverride({ primary: "@default" })).toBeUndefined();
+      expect(normalizeStoredModelOverride({ primary: "  @default  " })).toBeUndefined();
+    });
+
+    it("preserves real models embedded in objects with sentinel-shaped fallbacks", () => {
+      // Only `primary` is read by normalizeModelSelection; if the object's
+      // primary is a real model, we return it even if other fields contain
+      // the sentinel.
+      expect(
+        normalizeStoredModelOverride({
+          primary: "anthropic/claude-opus-4-6",
+          fallbacks: ["@default"],
+        }),
+      ).toBe("anthropic/claude-opus-4-6");
+    });
+  });
+});

--- a/src/agents/model-default-sentinel.ts
+++ b/src/agents/model-default-sentinel.ts
@@ -1,0 +1,39 @@
+import { normalizeModelSelection } from "./model-selection-shared.js";
+
+/**
+ * Reserved string that, when stored in a model-override field, instructs
+ * the dispatcher to resolve `defaults.primary` at execution time instead of
+ * pinning to a frozen value. The `@` prefix prevents collision with real
+ * model identifiers.
+ */
+export const MODEL_DEFAULT_SENTINEL = "@default";
+
+export function isModelDefaultSentinel(value: unknown): boolean {
+  return typeof value === "string" && value.trim() === MODEL_DEFAULT_SENTINEL;
+}
+
+/**
+ * Wrapper around `normalizeModelSelection` that returns `undefined` for the
+ * default sentinel as well as for empty/whitespace strings. Use this at every
+ * site that reads a stored model override (cron payload, session override,
+ * subagent spawn override, agent-config subagent override) so the existing
+ * precedence chain falls through to the live default.
+ *
+ * Sentinel detection runs both before AND after the underlying normalize
+ * step, so object-shaped inputs like `{ primary: "@default" }` also fall
+ * through (the bare-string check happens first; the post-normalize check
+ * catches anything `normalizeModelSelection` extracts).
+ *
+ * Do NOT use this when reading `defaults.primary` itself — operators do not
+ * write sentinels into the actual default.
+ */
+export function normalizeStoredModelOverride(value: unknown): string | undefined {
+  if (isModelDefaultSentinel(value)) {
+    return undefined;
+  }
+  const normalized = normalizeModelSelection(value);
+  if (isModelDefaultSentinel(normalized)) {
+    return undefined;
+  }
+  return normalized;
+}

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -409,6 +409,34 @@ describe("model-selection", () => {
         model: "kimi-code",
       });
     });
+
+    it("returns null when overrideModel is the @default sentinel", () => {
+      expect(
+        resolvePersistedOverrideModelRef({
+          defaultProvider: "anthropic",
+          overrideModel: "@default",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null when overrideModel is the @default sentinel with whitespace", () => {
+      expect(
+        resolvePersistedOverrideModelRef({
+          defaultProvider: "anthropic",
+          overrideModel: "  @default  ",
+        }),
+      ).toBeNull();
+    });
+
+    it("returns null even when an explicit overrideProvider is paired with the sentinel", () => {
+      expect(
+        resolvePersistedOverrideModelRef({
+          defaultProvider: "anthropic",
+          overrideProvider: "openai",
+          overrideModel: "@default",
+        }),
+      ).toBeNull();
+    });
   });
 
   describe("resolvePersistedSelectedModelRef", () => {

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -12,6 +12,7 @@ import {
 } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { isModelDefaultSentinel, normalizeStoredModelOverride } from "./model-default-sentinel.js";
 export { resolveThinkingDefault } from "./model-thinking-default.js";
 import {
   type ModelRef,
@@ -87,7 +88,7 @@ export function resolvePersistedOverrideModelRef(params: {
   const defaultProvider = params.defaultProvider.trim();
   const overrideProvider = params.overrideProvider?.trim();
   const overrideModel = params.overrideModel?.trim();
-  if (!overrideModel) {
+  if (!overrideModel || isModelDefaultSentinel(overrideModel)) {
     return null;
   }
   const encodedOverride = overrideProvider ? `${overrideProvider}/${overrideModel}` : overrideModel;
@@ -278,8 +279,13 @@ export function resolveSubagentSpawnModelSelection(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
+  // `@default` in the spawn override means "use the live default" — the
+  // sentinel-aware wrapper falls through to the configured/runtime default.
+  // Object-shape overrides (`{ primary, fallbacks }`) are deliberately not
+  // sentinel-aware: that form is reserved for `defaults.model` config,
+  // never a stored override.
   const raw =
-    normalizeModelSelection(params.modelOverride) ??
+    normalizeStoredModelOverride(params.modelOverride) ??
     resolveSubagentConfiguredModelSelection({
       cfg: params.cfg,
       agentId: params.agentId,

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.model.test.ts
@@ -170,4 +170,78 @@ describe("subagent spawn model + thinking plan", () => {
       }),
     ).toBe(0);
   });
+
+  describe("@default sentinel", () => {
+    it("treats spawn modelOverride '@default' as no override and falls through to configured default", () => {
+      const plan = resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "minimax/MiniMax-M2.7" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "@default",
+      });
+      expect(plan).toMatchObject({
+        status: "ok",
+        resolvedModel: "minimax/MiniMax-M2.7",
+      });
+    });
+
+    it("treats spawn modelOverride '@default' as no override and falls through to runtime default", () => {
+      const plan = resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig(),
+        targetAgentId: "research",
+        modelOverride: "@default",
+      });
+      expect(plan).toMatchObject({
+        status: "ok",
+        resolvedModel: `${DEFAULT_PROVIDER}/${DEFAULT_MODEL}`,
+      });
+    });
+
+    it("explicit non-sentinel override still wins over configured default", () => {
+      const plan = resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "minimax/MiniMax-M2.7" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "claude-haiku-4-5",
+      });
+      expect(plan).toMatchObject({
+        status: "ok",
+        resolvedModel: "claude-haiku-4-5",
+      });
+    });
+
+    it("'@default' with whitespace padding is still treated as the sentinel", () => {
+      const plan = resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "minimax/MiniMax-M2.7" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: "  @default  ",
+      });
+      expect(plan).toMatchObject({
+        status: "ok",
+        resolvedModel: "minimax/MiniMax-M2.7",
+      });
+    });
+
+    it("object-shape modelOverride { primary: '@default' } falls through to configured default", () => {
+      // Adversarial regression: previously the object form smuggled the
+      // sentinel string past the bare-string check and leaked literal
+      // "@default" into the dispatcher. Sentinel-aware post-normalize must
+      // catch it.
+      const plan = resolveSubagentModelAndThinkingPlan({
+        cfg: createConfig({
+          agents: { defaults: { subagents: { model: "minimax/MiniMax-M2.7" } } },
+        }),
+        targetAgentId: "research",
+        modelOverride: { primary: "@default" },
+      });
+      expect(plan).toMatchObject({
+        status: "ok",
+        resolvedModel: "minimax/MiniMax-M2.7",
+      });
+    });
+  });
 });

--- a/src/agents/subagent-spawn-plan.ts
+++ b/src/agents/subagent-spawn-plan.ts
@@ -67,6 +67,12 @@ export function resolveSubagentModelAndThinkingPlan(params: {
     };
   }
 
+  // `modelOverride` is typed `unknown` and may arrive as an object, number,
+  // etc. — only treat string values as user-supplied overrides; anything
+  // else (including the `@default` sentinel which `normalizeStoredModelOverride`
+  // already discards upstream) is "auto".
+  const userSuppliedOverride =
+    typeof params.modelOverride === "string" && params.modelOverride.trim().length > 0;
   return {
     status: "ok" as const,
     resolvedModel,
@@ -76,7 +82,7 @@ export function resolveSubagentModelAndThinkingPlan(params: {
       ...(resolvedModel
         ? {
             model: resolvedModel,
-            modelOverrideSource: params.modelOverride?.trim() ? "user" : "auto",
+            modelOverrideSource: userSuppliedOverride ? "user" : "auto",
           }
         : {}),
       ...thinkingPlan.initialSessionPatch,

--- a/src/cron/isolated-agent.model-overrides.test.ts
+++ b/src/cron/isolated-agent.model-overrides.test.ts
@@ -187,4 +187,134 @@ describe("runCronIsolatedAgentTurn model overrides", () => {
       expect(callArgs?.thinkLevel).toBe("low");
     });
   });
+
+  describe("@default sentinel", () => {
+    it("resolves payload model '@default' to the live agents.defaults.model", async () => {
+      await withTempHome(async (home) => {
+        const { res } = await runCronTurn(home, {
+          jobPayload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "@default" },
+        });
+
+        expect(res.status).toBe("ok");
+        // makeCfg() default is "anthropic/claude-opus-4-6"; the sentinel must
+        // fall through to that, not pin to the literal "@default" string.
+        const sentinelResolved = expectEmbeddedProviderModel({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        });
+        sentinelResolved.assert();
+      });
+    });
+
+    it("resolves payload model '  @default  ' (whitespace-padded) to the default", async () => {
+      await withTempHome(async (home) => {
+        const { res } = await runCronTurn(home, {
+          jobPayload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "  @default  " },
+        });
+
+        expect(res.status).toBe("ok");
+        const sentinelResolved = expectEmbeddedProviderModel({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        });
+        sentinelResolved.assert();
+      });
+    });
+
+    it("resolves stored session modelOverride '@default' to the live default", async () => {
+      await withTempHome(async (home) => {
+        const { res } = await runTurnWithStoredModelOverride(
+          home,
+          DEFAULT_AGENT_TURN_PAYLOAD,
+          "@default",
+        );
+
+        expect(res.status).toBe("ok");
+        const sentinelResolved = expectEmbeddedProviderModel({
+          provider: "anthropic",
+          model: "claude-opus-4-6",
+        });
+        sentinelResolved.assert();
+      });
+    });
+
+    it("follows the live default when defaults.primary changes between runs", async () => {
+      await withTempHome(async (home) => {
+        let res = (
+          await runCronTurn(home, {
+            cfgOverrides: {
+              agents: {
+                defaults: {
+                  model: { primary: "openai-codex/gpt-5.4" },
+                },
+              },
+            },
+            jobPayload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "@default" },
+          })
+        ).res;
+        expect(res.status).toBe("ok");
+        expectEmbeddedProviderModel({ provider: "openai-codex", model: "gpt-5.4" }).assert();
+
+        // Operator upgrades defaults.primary; same `@default` cron now follows.
+        res = (
+          await runCronTurn(home, {
+            cfgOverrides: {
+              agents: {
+                defaults: {
+                  model: { primary: "openai-codex/gpt-5.5" },
+                },
+              },
+            },
+            jobPayload: { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "@default" },
+          })
+        ).res;
+        expect(res.status).toBe("ok");
+        expectEmbeddedProviderModel({ provider: "openai-codex", model: "gpt-5.5" }).assert();
+      });
+    });
+
+    it("an explicit non-sentinel pin still wins over a default-sentinel session override", async () => {
+      await withTempHome(async (home) => {
+        const deterministicCatalog = [
+          { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        ];
+        vi.mocked(loadModelCatalog).mockResolvedValue(deterministicCatalog);
+
+        // Session has @default but payload pins openai/gpt-4.1-mini —
+        // payload precedence is unchanged.
+        const { res } = await runTurnWithStoredModelOverride(
+          home,
+          { kind: "agentTurn", message: DEFAULT_MESSAGE, model: "openai/gpt-4.1-mini" },
+          "@default",
+        );
+
+        expect(res.status).toBe("ok");
+        expectEmbeddedProviderModel({ provider: "openai", model: "gpt-4.1-mini" }).assert();
+      });
+    });
+
+    it("agents.defaults.subagents.model = '@default' falls through to defaults.primary", async () => {
+      // Adversarial regression: this code path used to call
+      // `normalizeModelSelection` (sentinel-blind) and then forward the
+      // literal "@default" string to `resolveAllowedModelRef`, producing a
+      // bogus model reference. With sentinel-aware normalization it falls
+      // through to the agents.defaults.model.primary value.
+      await withTempHome(async (home) => {
+        const { res } = await runCronTurn(home, {
+          cfgOverrides: {
+            agents: {
+              defaults: {
+                model: { primary: "openai-codex/gpt-5.5" },
+                subagents: { model: "@default" },
+              },
+            },
+          },
+          jobPayload: DEFAULT_AGENT_TURN_PAYLOAD,
+        });
+
+        expect(res.status).toBe("ok");
+        expectEmbeddedProviderModel({ provider: "openai-codex", model: "gpt-5.5" }).assert();
+      });
+    });
+  });
 });

--- a/src/cron/isolated-agent/model-selection.ts
+++ b/src/cron/isolated-agent/model-selection.ts
@@ -1,3 +1,4 @@
+import { normalizeStoredModelOverride } from "../../agents/model-default-sentinel.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { CronJob } from "../types.js";
 import {
@@ -5,7 +6,6 @@ import {
   DEFAULT_PROVIDER,
   getModelRefStatus,
   loadModelCatalog,
-  normalizeModelSelection,
   resolveAllowedModelRef,
   resolveConfiguredModelRef,
   resolveHooksGmailModel,
@@ -68,10 +68,13 @@ export async function resolveCronModelSelection(
     return catalog;
   };
 
+  // Agent-config subagent overrides flow through the sentinel-aware
+  // normalizer so `@default` (or `{ primary: "@default" }`) here also
+  // falls through to the live default.
   const subagentModelRaw =
-    normalizeModelSelection(params.agentConfigOverride?.subagents?.model) ??
-    normalizeModelSelection(params.agentConfigOverride?.model) ??
-    normalizeModelSelection(params.cfg.agents?.defaults?.subagents?.model);
+    normalizeStoredModelOverride(params.agentConfigOverride?.subagents?.model) ??
+    normalizeStoredModelOverride(params.agentConfigOverride?.model) ??
+    normalizeStoredModelOverride(params.cfg.agents?.defaults?.subagents?.model);
   if (subagentModelRaw) {
     const resolvedSubagent = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
@@ -108,8 +111,12 @@ export async function resolveCronModelSelection(
     }
   }
 
+  // `@default` in the stored payload means "follow defaults.primary at fire
+  // time" — fall through to the default already resolved above instead of
+  // pinning to a stale value. `normalizeStoredModelOverride` returns
+  // `undefined` for sentinels and empty/whitespace strings.
   const modelOverrideRaw = params.payload.kind === "agentTurn" ? params.payload.model : undefined;
-  const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
+  const modelOverride = normalizeStoredModelOverride(modelOverrideRaw);
   if (modelOverride !== undefined && modelOverride.length > 0) {
     const resolvedOverride = resolveAllowedModelRef({
       cfg: params.cfgWithAgentDefaults,
@@ -129,7 +136,9 @@ export async function resolveCronModelSelection(
   }
 
   if (!modelOverride && !hooksGmailModelApplied) {
-    const sessionModelOverride = params.sessionEntry.modelOverride?.trim();
+    // Same sentinel semantics as the payload override: `@default` means
+    // "no pin, use the live default."
+    const sessionModelOverride = normalizeStoredModelOverride(params.sessionEntry.modelOverride);
     if (sessionModelOverride) {
       const sessionProviderOverride =
         params.sessionEntry.providerOverride?.trim() || resolvedDefault.provider;


### PR DESCRIPTION
## Summary

Stored model identifiers on cron jobs and subagent spawns are frozen at registration. When `defaults.primary` is upgraded (e.g. `gpt-5.4 → gpt-5.5`), existing crons and pinned sessions keep firing on the old model until they are manually re-edited — a real, recurring operational pain across model generations.

This PR introduces a `@default` sentinel: operators store the literal string `"@default"` instead of a real model name, and the dispatcher resolves it to the live `defaults.primary` at execution time. Real model strings continue to work unchanged as explicit pins.

## Motivation

On a workspace freshly upgraded from `gpt-5.4 → gpt-5.5`:
- 21 live crons still firing on `gpt-5.4` / `gpt-4o-mini` because their `--model` was set at registration.
- 10+ subagent sessions pinned to older models the operator no longer uses.
- No mechanism, today, to say "use whatever's current" — `--clear-model` doesn't exist on `cron edit`.

`Option A` workaround (cron-by-cron `--model` re-edit on every upgrade) doesn't scale and has to be repeated every release. This PR is `Option C` — fix it at the dispatcher.

## Design

The sentinel is a single reserved string: `@default`. The `@` prefix prevents collision with any real model identifier.

Recognized at every site where a stored override could appear:

| Site | File |
|---|---|
| Cron payload `payload.model` | `src/cron/isolated-agent/model-selection.ts` |
| Cron session `sessionEntry.modelOverride` | same file |
| Cron agent-config `subagents.model` (incl. nested + `defaults.subagents.model`) | same file |
| Subagent spawn `modelOverride` (incl. object form `{ primary }`) | `src/agents/model-selection.ts` |
| Persisted session override `resolvePersistedOverrideModelRef` | same file |

The helper `normalizeStoredModelOverride` runs sentinel detection both **before** and **after** the underlying `normalizeModelSelection` call so object-shape inputs like `{ primary: "@default" }` also fall through (a regression caught by adversarial review).

`defaults.primary` itself is **not** sentinel-aware — operators don't write sentinels into the actual default. If they did, `resolveConfiguredModelRef` would fail naturally.

## Drive-by

`resolveSubagentModelAndThinkingPlan` was calling `.trim()` directly on `params.modelOverride` (typed `unknown`). This crashed on object-shape inputs. Fixed with a type-safe predicate.

## Test plan

- [x] New unit tests for `isModelDefaultSentinel` and `normalizeStoredModelOverride` — bare strings, whitespace, sentinel-shaped objects, sentinel-adjacent strings, casing, non-string types.
- [x] Cron integration: payload `@default` resolves to live default; session-stored `@default` falls through; agent-config `subagents.model: "@default"` falls through; explicit pin still wins; mid-test `defaults.primary` change is reflected on next run.
- [x] Subagent integration: spawn `modelOverride: "@default"` falls through to configured default; falls through to runtime default when no config; explicit pin still wins; whitespace-padded sentinel works; **object-form `{ primary: "@default" }` falls through** (adversarial regression).
- [x] Persisted override: `resolvePersistedOverrideModelRef` returns `null` for sentinel; with whitespace; with explicit `overrideProvider` paired.
- [x] All 320 existing tests across the touched suites still pass.

## Backwards compatibility

- Existing stored model strings: unchanged behavior.
- Existing pinned sessions: unchanged behavior.
- Cron storage schema: unchanged (`model?: string` already permits any string).
- CLI surface: unchanged (`openclaw cron add --model @default` already accepts the value as-is).

## Migration

After this lands, operators can run `openclaw cron edit <id> --model @default` for any cron they want to track the live default. There's no auto-migration — opt-in by intent, since some pins are deliberate.

## Known limitations / follow-ups

Adversarial review surfaced three latent risks not addressed in this PR:
1. Case-sensitivity: `@DEFAULT` is treated as a literal model. Documented; could be relaxed in a follow-up.
2. Unicode whitespace evasion: `"​@default"` (zero-width space) bypasses `trim()`. Extremely low likelihood; could be hardened later.
3. No telemetry signal when sentinel resolves to a paid premium default. Worth a `log.info` in a follow-up.

None are blockers — the bare-string happy path, the documented hot paths, and the adversarial-found object-form smuggling are all closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)