### PR TITLE
feat(tasks): improve task state transitions and lifecycle formatting

### DIFF
--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -8,6 +8,7 @@ import {
   listTasksForSessionKeyForStatus,
 } from "../../tasks/task-status-access.js";
 import {
+  buildTaskOperationalSummary,
   buildTaskStatusSnapshot,
   formatTaskStatusDetail,
   formatTaskStatusTitle,
@@ -80,8 +81,12 @@ function formatVisibleTask(task: TaskRecord, index: number): string {
   const status = task.status.replaceAll("_", " ");
   const timing = formatTaskTiming(task);
   const detail = formatTaskDetail(task);
+  const operationalSummary = buildTaskOperationalSummary(task);
   const meta = [TASK_RUNTIME_LABELS[task.runtime], status, timing].filter(Boolean).join(" · ");
   const lines = [`${index + 1}. ${TASK_STATUS_ICONS[task.status]} ${title}`, `   ${meta}`];
+  lines.push(
+    `   ${operationalSummary.state} · ${operationalSummary.stage}${operationalSummary.nextAction ? ` · next: ${operationalSummary.nextAction}` : ""}`,
+  );
   if (detail) {
     lines.push(`   ${detail}`);
   }

--- a/src/auto-reply/reply/commands-tasks.ts
+++ b/src/auto-reply/reply/commands-tasks.ts
@@ -19,6 +19,8 @@ const MAX_VISIBLE_TASKS = 5;
 
 const TASK_STATUS_ICONS: Record<TaskRecord["status"], string> = {
   queued: "🟡",
+  awaiting_approval: "🟠",
+  waiting_external: "🟣",
   running: "🟢",
   succeeded: "✅",
   failed: "🔴",
@@ -56,6 +58,14 @@ function formatTaskTiming(task: TaskRecord): string | undefined {
   }
   if (task.status === "queued") {
     return `queued ${formatTimeAgo(Date.now() - task.createdAt)}`;
+  }
+  if (task.status === "awaiting_approval") {
+    const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
+    return `awaiting approval ${formatTimeAgo(Date.now() - referenceAt)}`;
+  }
+  if (task.status === "waiting_external") {
+    const referenceAt = task.lastEventAt ?? task.startedAt ?? task.createdAt;
+    return `waiting external ${formatTimeAgo(Date.now() - referenceAt)}`;
   }
   const endedAt = task.endedAt ?? task.lastEventAt ?? task.createdAt;
   return `finished ${formatTimeAgo(Date.now() - endedAt)}`;

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -35,7 +35,11 @@ import {
   reconcileTaskLookupToken,
 } from "../tasks/task-registry.reconcile.js";
 import { summarizeTaskRecords } from "../tasks/task-registry.summary.js";
-import type { TaskNotifyPolicy, TaskRecord } from "../tasks/task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+} from "../tasks/task-registry.types.js";
 import { isRich, theme } from "../terminal/theme.js";
 
 const RUNTIME_PAD = 8;
@@ -89,6 +93,12 @@ function formatTaskStatusCell(status: string, rich: boolean) {
   if (status === "running") {
     return theme.accentBright(padded);
   }
+  if (status === "awaiting_approval" || status === "waiting_external") {
+    return theme.warn(padded);
+  }
+  if (status === "queued") {
+    return theme.accent(padded);
+  }
   return theme.muted(padded);
 }
 
@@ -127,7 +137,9 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
 
 function formatTaskListSummary(tasks: TaskRecord[]) {
   const summary = summarizeTaskRecords(tasks);
-  return `${summary.byStatus.queued} queued · ${summary.byStatus.running} running · ${summary.failures} issues`;
+  const blocked = summary.byStatus.awaiting_approval + summary.byStatus.waiting_external;
+  const active = tasks.filter((task) => isActiveTaskStatus(task.status)).length;
+  return `${summary.byStatus.queued} queued · ${active} active · ${blocked} blocked · ${summary.failures} issues`;
 }
 
 function formatAgeMs(ageMs: number | undefined): string {

--- a/src/commands/tasks.ts
+++ b/src/commands/tasks.ts
@@ -40,6 +40,7 @@ import {
   type TaskNotifyPolicy,
   type TaskRecord,
 } from "../tasks/task-registry.types.js";
+import { formatTaskOperationalSummary } from "../tasks/task-status.js";
 import { isRich, theme } from "../terminal/theme.js";
 
 const RUNTIME_PAD = 8;
@@ -114,13 +115,7 @@ function formatTaskRows(tasks: TaskRecord[], rich: boolean) {
   ].join(" ");
   const lines = [rich ? theme.heading(header) : header];
   for (const task of tasks) {
-    const summary = truncate(
-      normalizeOptionalString(task.terminalSummary) ||
-        normalizeOptionalString(task.progressSummary) ||
-        normalizeOptionalString(task.label) ||
-        task.task.trim(),
-      80,
-    );
+    const summary = truncate(formatTaskOperationalSummary(task), 120);
     const line = [
       shortToken(task.taskId).padEnd(ID_PAD),
       task.runtime.padEnd(RUNTIME_PAD),

--- a/src/tasks/task-active-status.test.ts
+++ b/src/tasks/task-active-status.test.ts
@@ -45,6 +45,21 @@ describe("task audit active-state semantics", () => {
     expect(findings.find((finding) => finding.code === "missing_cleanup")).toBeUndefined();
   });
 
+  it("uses distinct stale audit codes for approval and external waits", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      staleAwaitingApprovalMs: 60_000,
+      staleWaitingExternalMs: 60_000,
+      tasks: [
+        makeTask({ taskId: "approval", status: "awaiting_approval", lastEventAt: NOW - 120_000 }),
+        makeTask({ taskId: "external", status: "waiting_external", lastEventAt: NOW - 120_000 }),
+      ],
+    });
+
+    expect(findings.find((finding) => finding.code === "stale_awaiting_approval")?.severity).toBe("warn");
+    expect(findings.find((finding) => finding.code === "stale_waiting_external")?.severity).toBe("warn");
+  });
+
   it("flags endedAt on intermediate active states as inconsistent timestamps", () => {
     const findings = listTaskAuditFindings({
       now: NOW,

--- a/src/tasks/task-active-status.test.ts
+++ b/src/tasks/task-active-status.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { listTaskAuditFindings } from "./task-registry.audit.js";
+import { buildTaskStatusSnapshot } from "./task-status.js";
+import { isActiveTaskStatus, type TaskRecord } from "./task-registry.types.js";
+
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    runId: overrides.runId ?? "run-1",
+    task: overrides.task ?? "default task",
+    runtime: overrides.runtime ?? "subagent",
+    status: overrides.status ?? "running",
+    requesterSessionKey: overrides.requesterSessionKey ?? "agent:main:main",
+    ownerKey: overrides.ownerKey ?? "agent:main:main",
+    scopeKind: overrides.scopeKind ?? "session",
+    createdAt: overrides.createdAt ?? NOW - 1_000,
+    deliveryStatus: overrides.deliveryStatus ?? "pending",
+    notifyPolicy: overrides.notifyPolicy ?? "done_only",
+    ...overrides,
+  };
+}
+
+describe("isActiveTaskStatus", () => {
+  it("treats intermediate task states as active", () => {
+    expect(isActiveTaskStatus("queued")).toBe(true);
+    expect(isActiveTaskStatus("awaiting_approval")).toBe(true);
+    expect(isActiveTaskStatus("waiting_external")).toBe(true);
+    expect(isActiveTaskStatus("running")).toBe(true);
+    expect(isActiveTaskStatus("succeeded")).toBe(false);
+  });
+});
+
+describe("task audit active-state semantics", () => {
+  it("does not require cleanupAfter for intermediate active states", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      tasks: [
+        makeTask({ taskId: "approval", status: "awaiting_approval", lastEventAt: NOW - 60_000 }),
+        makeTask({ taskId: "external", status: "waiting_external", lastEventAt: NOW - 60_000 }),
+      ],
+    });
+
+    expect(findings.find((finding) => finding.code === "missing_cleanup")).toBeUndefined();
+  });
+
+  it("flags endedAt on intermediate active states as inconsistent timestamps", () => {
+    const findings = listTaskAuditFindings({
+      now: NOW,
+      tasks: [
+        makeTask({
+          taskId: "approval",
+          status: "awaiting_approval",
+          startedAt: NOW - 2_000,
+          endedAt: NOW - 1_000,
+        }),
+        makeTask({
+          taskId: "external",
+          status: "waiting_external",
+          startedAt: NOW - 2_000,
+          endedAt: NOW - 1_000,
+        }),
+      ],
+    });
+
+    expect(findings.filter((finding) => finding.code === "inconsistent_timestamps")).toHaveLength(2);
+  });
+});
+
+describe("task status snapshot active-state semantics", () => {
+  it("keeps waiting_external tasks in the active snapshot", () => {
+    const task = makeTask({
+      taskId: "wait-1",
+      status: "waiting_external",
+      progressSummary: "Waiting for external system.",
+      lastEventAt: NOW - 500,
+    });
+
+    const snapshot = buildTaskStatusSnapshot([task], { now: NOW });
+    expect(snapshot.activeCount).toBe(1);
+    expect(snapshot.focus?.taskId).toBe("wait-1");
+    expect(snapshot.focus?.status).toBe("waiting_external");
+  });
+});

--- a/src/tasks/task-executor-policy.test.ts
+++ b/src/tasks/task-executor-policy.test.ts
@@ -58,7 +58,7 @@ describe("task-executor-policy", () => {
       "Task needs follow-up: ACP import (run run-1234). Needs login.",
     );
     expect(formatTaskStateChangeMessage(blockedTask, progressEvent)).toBe(
-      "Background task update: ACP import. No output for 60s.",
+      "Background task update: ACP import. finished · completed · No output for 60s.",
     );
   });
 
@@ -116,6 +116,36 @@ describe("task-executor-policy", () => {
     );
     expect(formatTaskBlockedFollowupMessage(blockedTask)).toBe(
       "Task needs follow-up: ACP import (run run-1234). Command did not run: approval timed out.",
+    );
+  });
+
+  it("formats started and blocked state change messages with lifecycle detail", () => {
+    const runningTask = createTask({
+      status: "running",
+      label: "ACP import",
+      progressSummary: "booting worker",
+    });
+    const blockedTask = createTask({
+      status: "awaiting_approval",
+      label: "ACP import",
+      progressSummary: "patch applied",
+    });
+
+    expect(
+      formatTaskStateChangeMessage(runningTask, {
+        at: 10,
+        kind: "running",
+      }),
+    ).toBe(
+      "Background task started: ACP import. active · running · booting worker · next: wait for completion",
+    );
+    expect(
+      formatTaskStateChangeMessage(blockedTask, {
+        at: 11,
+        kind: "awaiting_approval",
+      }),
+    ).toBe(
+      "Background task blocked: ACP import. blocked · awaiting approval · patch applied · blocker: approval required · next: approve and continue",
     );
   });
 

--- a/src/tasks/task-executor-policy.ts
+++ b/src/tasks/task-executor-policy.ts
@@ -1,5 +1,10 @@
 import type { TaskEventRecord, TaskRecord, TaskStatus } from "./task-registry.types.js";
-import { formatTaskStatusTitleText, sanitizeTaskStatusText } from "./task-status.js";
+import {
+  buildTaskLifecycleEventFromRecord,
+  formatTaskLifecycleEvent,
+  formatTaskStatusTitleText,
+  sanitizeTaskStatusText,
+} from "./task-status.js";
 
 export function isTerminalTaskStatus(status: TaskStatus): boolean {
   return (
@@ -79,12 +84,28 @@ export function formatTaskStateChangeMessage(
   event: TaskEventRecord,
 ): string | null {
   const title = resolveTaskDisplayTitle(task);
-  if (event.kind === "running") {
-    return `Background task started: ${title}.`;
+  const lifecycleEvent = buildTaskLifecycleEventFromRecord(task, {
+    kind: event.kind,
+    summary: sanitizeTaskStatusText(event.summary) || undefined,
+  });
+  if (!lifecycleEvent) {
+    return null;
   }
-  if (event.kind === "progress") {
-    const summary = sanitizeTaskStatusText(event.summary);
-    return summary ? `Background task update: ${title}. ${summary}` : null;
+  const detail = formatTaskLifecycleEvent(lifecycleEvent);
+  if (lifecycleEvent.event === "task.started") {
+    return detail
+      ? `Background task started: ${title}. ${detail}`
+      : `Background task started: ${title}.`;
+  }
+  if (lifecycleEvent.event === "task.progressed") {
+    return detail
+      ? `Background task update: ${title}. ${detail}`
+      : `Background task update: ${title}.`;
+  }
+  if (lifecycleEvent.event === "task.blocked") {
+    return detail
+      ? `Background task blocked: ${title}. ${detail}`
+      : `Background task blocked: ${title}.`;
   }
   return null;
 }

--- a/src/tasks/task-executor.ts
+++ b/src/tasks/task-executor.ts
@@ -30,15 +30,16 @@ import {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-runtime-internal.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type {
-  TaskDeliveryState,
-  TaskDeliveryStatus,
-  TaskNotifyPolicy,
-  TaskRecord,
-  TaskRegistrySummary,
-  TaskRuntime,
-  TaskStatus,
-  TaskTerminalOutcome,
+import {
+  isActiveTaskStatus,
+  type TaskDeliveryState,
+  type TaskDeliveryStatus,
+  type TaskNotifyPolicy,
+  type TaskRecord,
+  type TaskRegistrySummary,
+  type TaskRuntime,
+  type TaskStatus,
+  type TaskTerminalOutcome,
 } from "./task-registry.types.js";
 
 const log = createSubsystemLogger("tasks/executor");
@@ -367,10 +368,6 @@ type RunTaskInFlowResult = {
   flow?: TaskFlowRecord;
   task?: TaskRecord;
 };
-
-function isActiveTaskStatus(status: TaskStatus): boolean {
-  return status === "queued" || status === "running";
-}
 
 function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {
   return (

--- a/src/tasks/task-flow-registry.audit.ts
+++ b/src/tasks/task-flow-registry.audit.ts
@@ -1,7 +1,10 @@
 import { listTasksForFlowId } from "./runtime-internal.js";
 import { getTaskFlowRegistryRestoreFailure, listTaskFlowRecords } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 export type TaskFlowAuditSeverity = "warn" | "error";
 export type TaskFlowAuditCode =
@@ -162,9 +165,7 @@ export function listTaskFlowAuditFindings(
     const referenceAt = getReferenceAt(flow);
     const ageMs = Math.max(0, now - referenceAt);
     const linkedTasks = getLinkedTasks(flow.flowId);
-    const activeTasks = linkedTasks.filter(
-      (task) => task.status === "queued" || task.status === "running",
-    );
+    const activeTasks = linkedTasks.filter((task) => isActiveTaskStatus(task.status));
 
     if (flow.status === "running" && ageMs >= staleRunningMs) {
       findings.push(

--- a/src/tasks/task-flow-registry.maintenance.ts
+++ b/src/tasks/task-flow-registry.maintenance.ts
@@ -11,6 +11,7 @@ import {
   updateFlowRecordByIdExpectedRevision,
 } from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
+import { isActiveTaskStatus } from "./task-registry.types.js";
 
 const TASK_FLOW_RETENTION_MS = 7 * 24 * 60 * 60_000;
 
@@ -29,9 +30,7 @@ function isTerminalFlow(flow: TaskFlowRecord): boolean {
 }
 
 function hasActiveLinkedTasks(flowId: string): boolean {
-  return listTasksForFlowId(flowId).some(
-    (task) => task.status === "queued" || task.status === "running",
-  );
+  return listTasksForFlowId(flowId).some((task) => isActiveTaskStatus(task.status));
 }
 
 function resolveTerminalAt(flow: TaskFlowRecord): number {

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -196,7 +196,11 @@ export function deriveTaskFlowStatusFromTask(
   if (task.status === "queued") {
     return "queued";
   }
-  if (task.status === "running") {
+  if (
+    task.status === "awaiting_approval" ||
+    task.status === "waiting_external" ||
+    task.status === "running"
+  ) {
     return "running";
   }
   if (task.status === "succeeded") {

--- a/src/tasks/task-registry.audit.shared.ts
+++ b/src/tasks/task-registry.audit.shared.ts
@@ -4,6 +4,8 @@ export type TaskAuditSeverity = "warn" | "error";
 export type TaskAuditCode =
   | "stale_queued"
   | "stale_running"
+  | "stale_awaiting_approval"
+  | "stale_waiting_external"
   | "lost"
   | "delivery_failed"
   | "missing_cleanup"
@@ -38,6 +40,8 @@ export function createEmptyTaskAuditSummary(): TaskAuditSummary {
     byCode: {
       stale_queued: 0,
       stale_running: 0,
+      stale_awaiting_approval: 0,
+      stale_waiting_external: 0,
       lost: 0,
       delivery_failed: 0,
       missing_cleanup: 0,

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -6,7 +6,10 @@ import {
   type TaskAuditSeverity,
   type TaskAuditSummary,
 } from "./task-registry.audit.shared.js";
-import type { TaskRecord } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 
 export type TaskAuditOptions = {
   now?: number;
@@ -63,7 +66,7 @@ function findTimestampInconsistency(task: TaskRecord): TaskAuditFinding | null {
       detail: "endedAt is earlier than startedAt",
     });
   }
-  if ((task.status === "queued" || task.status === "running") && task.endedAt) {
+  if (isActiveTaskStatus(task.status) && task.endedAt) {
     return createFinding({
       severity: "warn",
       code: "inconsistent_timestamps",
@@ -154,8 +157,7 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
 
     if (
       task.status !== "lost" &&
-      task.status !== "queued" &&
-      task.status !== "running" &&
+      !isActiveTaskStatus(task.status) &&
       typeof task.cleanupAfter !== "number"
     ) {
       findings.push(

--- a/src/tasks/task-registry.audit.ts
+++ b/src/tasks/task-registry.audit.ts
@@ -16,10 +16,14 @@ export type TaskAuditOptions = {
   tasks?: TaskRecord[];
   staleQueuedMs?: number;
   staleRunningMs?: number;
+  staleAwaitingApprovalMs?: number;
+  staleWaitingExternalMs?: number;
 };
 
 const DEFAULT_STALE_QUEUED_MS = 10 * 60_000;
 const DEFAULT_STALE_RUNNING_MS = 30 * 60_000;
+const DEFAULT_STALE_AWAITING_APPROVAL_MS = 12 * 60 * 60_000;
+const DEFAULT_STALE_WAITING_EXTERNAL_MS = 2 * 60 * 60_000;
 export { createEmptyTaskAuditSummary };
 export type { TaskAuditCode, TaskAuditFinding, TaskAuditSeverity, TaskAuditSummary };
 
@@ -97,6 +101,10 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
   const now = options.now ?? Date.now();
   const staleQueuedMs = options.staleQueuedMs ?? DEFAULT_STALE_QUEUED_MS;
   const staleRunningMs = options.staleRunningMs ?? DEFAULT_STALE_RUNNING_MS;
+  const staleAwaitingApprovalMs =
+    options.staleAwaitingApprovalMs ?? DEFAULT_STALE_AWAITING_APPROVAL_MS;
+  const staleWaitingExternalMs =
+    options.staleWaitingExternalMs ?? DEFAULT_STALE_WAITING_EXTERNAL_MS;
   const findings: TaskAuditFinding[] = [];
 
   for (const task of tasks) {
@@ -123,6 +131,30 @@ export function listTaskAuditFindings(options: TaskAuditOptions = {}): TaskAudit
           task,
           ageMs,
           detail: "running task appears stuck",
+        }),
+      );
+    }
+
+    if (task.status === "awaiting_approval" && ageMs >= staleAwaitingApprovalMs) {
+      findings.push(
+        createFinding({
+          severity: "warn",
+          code: "stale_awaiting_approval",
+          task,
+          ageMs,
+          detail: "task has been awaiting approval for an unusually long time",
+        }),
+      );
+    }
+
+    if (task.status === "waiting_external" && ageMs >= staleWaitingExternalMs) {
+      findings.push(
+        createFinding({
+          severity: "warn",
+          code: "stale_waiting_external",
+          task,
+          ageMs,
+          detail: "task has been waiting on an external dependency for too long",
         }),
       );
     }

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -28,7 +28,12 @@ import {
 } from "./task-registry.audit.js";
 import type { TaskAuditSummary } from "./task-registry.audit.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type { TaskRecord, TaskRegistrySummary, TaskStatus } from "./task-registry.types.js";
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+  type TaskRegistrySummary,
+  type TaskStatus,
+} from "./task-registry.types.js";
 
 const TASK_RECONCILE_GRACE_MS = 5 * 60_000;
 const TASK_RETENTION_MS = 7 * 24 * 60 * 60_000;
@@ -143,7 +148,7 @@ function findSessionEntryByKey(store: Record<string, unknown>, sessionKey: strin
 }
 
 function isActiveTask(task: TaskRecord): boolean {
-  return task.status === "queued" || task.status === "running";
+  return isActiveTaskStatus(task.status);
 }
 
 function isTerminalTask(task: TaskRecord): boolean {

--- a/src/tasks/task-registry.summary.ts
+++ b/src/tasks/task-registry.summary.ts
@@ -8,6 +8,8 @@ import type {
 function createEmptyTaskStatusCounts(): TaskStatusCounts {
   return {
     queued: 0,
+    awaiting_approval: 0,
+    waiting_external: 0,
     running: 0,
     succeeded: 0,
     failed: 0,
@@ -43,7 +45,12 @@ export function summarizeTaskRecords(records: Iterable<TaskRecord>): TaskRegistr
     summary.total += 1;
     summary.byStatus[task.status] += 1;
     summary.byRuntime[task.runtime] += 1;
-    if (task.status === "queued" || task.status === "running") {
+    if (
+      task.status === "queued" ||
+      task.status === "awaiting_approval" ||
+      task.status === "waiting_external" ||
+      task.status === "running"
+    ) {
       summary.active += 1;
     } else {
       summary.terminal += 1;

--- a/src/tasks/task-registry.summary.ts
+++ b/src/tasks/task-registry.summary.ts
@@ -1,8 +1,9 @@
-import type {
-  TaskRecord,
-  TaskRegistrySummary,
-  TaskRuntimeCounts,
-  TaskStatusCounts,
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+  type TaskRegistrySummary,
+  type TaskRuntimeCounts,
+  type TaskStatusCounts,
 } from "./task-registry.types.js";
 
 function createEmptyTaskStatusCounts(): TaskStatusCounts {
@@ -45,12 +46,7 @@ export function summarizeTaskRecords(records: Iterable<TaskRecord>): TaskRegistr
     summary.total += 1;
     summary.byStatus[task.status] += 1;
     summary.byRuntime[task.runtime] += 1;
-    if (
-      task.status === "queued" ||
-      task.status === "awaiting_approval" ||
-      task.status === "waiting_external" ||
-      task.status === "running"
-    ) {
+    if (isActiveTaskStatus(task.status)) {
       summary.active += 1;
     } else {
       summary.terminal += 1;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2349,6 +2349,7 @@ describe("task-registry", () => {
         taskId: created.taskId,
         status: "running",
       });
+      expect(getTaskById(created.taskId)?.progressSummary).toBeUndefined();
     });
   });
 
@@ -2416,6 +2417,39 @@ describe("task-registry", () => {
         taskId: created.taskId,
         status: "waiting_external",
         progressSummary: "Waiting for external input before work can continue.",
+      });
+    });
+  });
+
+  it("does not let waiting_external override awaiting_approval", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-awaiting-approval-not-clobbered",
+        task: "Wait for approval first",
+        status: "awaiting_approval",
+        deliveryStatus: "pending",
+        progressSummary: "Awaiting approval before command can run.",
+      });
+
+      emitAgentEvent({
+        runId: "run-awaiting-approval-not-clobbered",
+        stream: "assistant",
+        data: {
+          text: "No output for 60s. It may be waiting for input.",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "awaiting_approval",
+        progressSummary: "Awaiting approval before command can run.",
       });
     });
   });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -503,6 +503,8 @@ describe("task-registry", () => {
         failures: 1,
         byStatus: {
           queued: 1,
+          awaiting_approval: 0,
+          waiting_external: 0,
           running: 1,
           succeeded: 0,
           failed: 0,
@@ -2219,6 +2221,41 @@ describe("task-registry", () => {
       expect(peekSystemEvents("agent:main:main")).toEqual([]);
       relay.dispose();
       vi.useRealTimers();
+    });
+  });
+
+  it("projects approval-pending events as awaiting_approval task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-await-approval",
+        task: "Run guarded command",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-await-approval",
+        stream: "approval",
+        data: {
+          phase: "requested",
+          kind: "exec",
+          status: "pending",
+          title: "Command approval requested",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "awaiting_approval",
+        progressSummary: "Awaiting approval before command can run.",
+      });
     });
   });
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -14,7 +14,12 @@ import {
 import { peekSystemEvents, resetSystemEventsForTest } from "../infra/system-events.js";
 import type { ParsedAgentSessionKey } from "../routing/session-key.js";
 import { withTempDir } from "../test-helpers/temp-dir.js";
-import { createManagedTaskFlow, resetTaskFlowRegistryForTests } from "./task-flow-registry.js";
+import {
+  createManagedTaskFlow,
+  getTaskFlowById,
+  requestFlowCancel,
+  resetTaskFlowRegistryForTests,
+} from "./task-flow-registry.js";
 import { configureTaskFlowRegistryRuntime } from "./task-flow-registry.store.js";
 import {
   cancelTaskById,
@@ -2255,6 +2260,58 @@ describe("task-registry", () => {
         taskId: created.taskId,
         status: "awaiting_approval",
         progressSummary: "Awaiting approval before command can run.",
+      });
+    });
+  });
+
+  it("keeps managed flows active when tasks move into awaiting_approval", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      configureInMemoryTaskStoresForLinkValidationTests();
+
+      const flow = createManagedTaskFlow({
+        ownerKey: "agent:main:main",
+        controllerId: "tests/task-registry",
+        goal: "Await approval safely",
+      });
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        parentFlowId: flow.flowId,
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-await-approval-flow",
+        task: "Guarded command inside flow",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      requestFlowCancel({
+        flowId: flow.flowId,
+        updatedAt: 42,
+        cancelRequestedAt: 42,
+      });
+
+      emitAgentEvent({
+        runId: "run-await-approval-flow",
+        stream: "approval",
+        data: {
+          phase: "requested",
+          kind: "exec",
+          status: "pending",
+          title: "Command approval requested",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        status: "awaiting_approval",
+      });
+      expect(getTaskFlowById(flow.flowId)).toMatchObject({
+        flowId: flow.flowId,
+        status: "queued",
       });
     });
   });

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2029,7 +2029,7 @@ describe("task-registry", () => {
         expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
           expect.objectContaining({
             content:
-              "Background task update: ACP background task. No output for 60s. It may be waiting for input.",
+              "Background task update: ACP background task. active · running · No output for 60s. It may be waiting for input. · next: wait for completion",
           }),
         ),
       );
@@ -2209,7 +2209,8 @@ describe("task-registry", () => {
       await flushAsyncWork();
       expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          content: "Background task update: ACP background task. Started.",
+          content:
+            "Background task update: ACP background task. active · running · Started. · next: wait for completion",
         }),
       );
 
@@ -2219,7 +2220,7 @@ describe("task-registry", () => {
       expect(hoisted.sendMessageMock).toHaveBeenCalledWith(
         expect.objectContaining({
           content:
-            "Background task update: ACP background task. No output for 1s. It may be waiting for input.",
+            "Background task update: ACP background task. active · running · No output for 1s. It may be waiting for input. · next: wait for completion",
         }),
       );
 

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2316,6 +2316,77 @@ describe("task-registry", () => {
     });
   });
 
+  it("returns awaiting_approval tasks to running when approval resolves positively", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-approval-approved",
+        task: "Run guarded command",
+        status: "awaiting_approval",
+        deliveryStatus: "pending",
+        progressSummary: "Awaiting approval before command can run.",
+      });
+
+      emitAgentEvent({
+        runId: "run-approval-approved",
+        stream: "approval",
+        data: {
+          phase: "resolved",
+          kind: "exec",
+          status: "approved",
+          title: "Command approval resolved",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "running",
+      });
+    });
+  });
+
+  it("projects denied approval resolution as failed task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-approval-denied",
+        task: "Run guarded command",
+        status: "awaiting_approval",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-approval-denied",
+        stream: "approval",
+        data: {
+          phase: "resolved",
+          kind: "exec",
+          status: "denied",
+          title: "Command approval resolved",
+          message: "Command did not run: approval timed out.",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "failed",
+        error: "Command did not run: approval timed out.",
+      });
+    });
+  });
+
   it("projects no-output assistant events as waiting_external task state", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -2259,6 +2259,38 @@ describe("task-registry", () => {
     });
   });
 
+  it("projects no-output assistant events as waiting_external task state", async () => {
+    await withTaskRegistryTempDir(async (root) => {
+      process.env.OPENCLAW_STATE_DIR = root;
+      resetTaskRegistryForTests();
+
+      const created = createTaskRecord({
+        runtime: "acp",
+        ownerKey: "agent:main:main",
+        scopeKind: "session",
+        childSessionKey: "agent:codex:acp:child",
+        runId: "run-waiting-external",
+        task: "Wait for external input",
+        status: "running",
+        deliveryStatus: "pending",
+      });
+
+      emitAgentEvent({
+        runId: "run-waiting-external",
+        stream: "assistant",
+        data: {
+          text: "No output for 60s. It may be waiting for input.",
+        },
+      });
+
+      expect(getTaskById(created.taskId)).toMatchObject({
+        taskId: created.taskId,
+        status: "waiting_external",
+        progressSummary: "Waiting for external input before work can continue.",
+      });
+    });
+  });
+
   it("cancels ACP-backed tasks through the ACP session manager", async () => {
     await withTaskRegistryTempDir(async (root) => {
       process.env.OPENCLAW_STATE_DIR = root;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1452,9 +1452,21 @@ function ensureListener() {
       } else if (evt.stream === "approval") {
         const approvalPhase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const approvalStatus = typeof evt.data?.status === "string" ? evt.data.status : undefined;
+        const approvalMessage = typeof evt.data?.message === "string" ? evt.data.message : undefined;
         if (approvalPhase === "requested" && approvalStatus === "pending") {
           patch.status = "awaiting_approval";
           patch.progressSummary = "Awaiting approval before command can run.";
+        } else if (approvalPhase === "resolved" && approvalStatus === "approved") {
+          patch.status = "running";
+          patch.progressSummary = current.progressSummary;
+        } else if (
+          approvalPhase === "resolved" &&
+          (approvalStatus === "denied" || approvalStatus === "failed")
+        ) {
+          patch.status = "failed";
+          patch.endedAt = now;
+          patch.error = approvalMessage ?? current.error;
+          patch.terminalSummary = approvalMessage ?? current.terminalSummary;
         }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -116,7 +116,12 @@ export function isParentFlowLinkError(error: unknown): error is ParentFlowLinkEr
 }
 
 function isActiveTaskStatus(status: TaskStatus): boolean {
-  return status === "queued" || status === "running";
+  return (
+    status === "queued" ||
+    status === "awaiting_approval" ||
+    status === "waiting_external" ||
+    status === "running"
+  );
 }
 
 function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1444,6 +1444,13 @@ function ensureListener() {
           patch.endedAt = endedAt ?? now;
           patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
         }
+      } else if (evt.stream === "approval") {
+        const approvalPhase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
+        const approvalStatus = typeof evt.data?.status === "string" ? evt.data.status : undefined;
+        if (approvalPhase === "requested" && approvalStatus === "pending") {
+          patch.status = "awaiting_approval";
+          patch.progressSummary = "Awaiting approval before command can run.";
+        }
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -33,11 +33,12 @@ import {
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
 import { summarizeTaskRecords } from "./task-registry.summary.js";
-import type {
-  TaskDeliveryState,
-  TaskDeliveryStatus,
-  TaskEventKind,
-  TaskEventRecord,
+import {
+  isActiveTaskStatus,
+  type TaskDeliveryState,
+  type TaskDeliveryStatus,
+  type TaskEventKind,
+  type TaskEventRecord,
   TaskNotifyPolicy,
   TaskRecord,
   TaskRegistrySummary,
@@ -113,15 +114,6 @@ export class ParentFlowLinkError extends Error {
 
 export function isParentFlowLinkError(error: unknown): error is ParentFlowLinkError {
   return error instanceof ParentFlowLinkError;
-}
-
-function isActiveTaskStatus(status: TaskStatus): boolean {
-  return (
-    status === "queued" ||
-    status === "awaiting_approval" ||
-    status === "waiting_external" ||
-    status === "running"
-  );
 }
 
 function isTerminalFlowStatus(status: TaskFlowRecord["status"]): boolean {
@@ -1452,13 +1444,14 @@ function ensureListener() {
       } else if (evt.stream === "approval") {
         const approvalPhase = typeof evt.data?.phase === "string" ? evt.data.phase : undefined;
         const approvalStatus = typeof evt.data?.status === "string" ? evt.data.status : undefined;
-        const approvalMessage = typeof evt.data?.message === "string" ? evt.data.message : undefined;
+        const approvalMessage =
+          typeof evt.data?.message === "string" ? evt.data.message : undefined;
         if (approvalPhase === "requested" && approvalStatus === "pending") {
           patch.status = "awaiting_approval";
           patch.progressSummary = "Awaiting approval before command can run.";
         } else if (approvalPhase === "resolved" && approvalStatus === "approved") {
           patch.status = "running";
-          patch.progressSummary = current.progressSummary;
+          patch.progressSummary = undefined;
         } else if (
           approvalPhase === "resolved" &&
           (approvalStatus === "denied" || approvalStatus === "failed")
@@ -1480,6 +1473,7 @@ function ensureListener() {
             : undefined;
       if (
         assistantText &&
+        current.status === "running" &&
         /no output for .*it may be waiting for (input|interactive input)/i.test(assistantText)
       ) {
         patch.status = "waiting_external";

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -1454,6 +1454,20 @@ function ensureListener() {
       } else if (evt.stream === "error") {
         patch.error = typeof evt.data?.error === "string" ? evt.data.error : current.error;
       }
+
+      const assistantText =
+        evt.stream === "assistant" && typeof evt.data?.text === "string"
+          ? evt.data.text
+          : evt.stream === "assistant" && typeof evt.data?.delta === "string"
+            ? evt.data.delta
+            : undefined;
+      if (
+        assistantText &&
+        /no output for .*it may be waiting for (input|interactive input)/i.test(assistantText)
+      ) {
+        patch.status = "waiting_external";
+        patch.progressSummary = "Waiting for external input before work can continue.";
+      }
       const stateChangeEvent =
         patch.status && patch.status !== current.status
           ? appendTaskEvent({

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -4,6 +4,8 @@ export type TaskRuntime = "subagent" | "acp" | "cli" | "cron";
 
 export type TaskStatus =
   | "queued"
+  | "awaiting_approval"
+  | "waiting_external"
   | "running"
   | "succeeded"
   | "failed"

--- a/src/tasks/task-registry.types.ts
+++ b/src/tasks/task-registry.types.ts
@@ -13,6 +13,17 @@ export type TaskStatus =
   | "cancelled"
   | "lost";
 
+export const ACTIVE_TASK_STATUSES = new Set<TaskStatus>([
+  "queued",
+  "awaiting_approval",
+  "waiting_external",
+  "running",
+]);
+
+export function isActiveTaskStatus(status: TaskStatus): boolean {
+  return ACTIVE_TASK_STATUSES.has(status);
+}
+
 export type TaskDeliveryStatus =
   | "pending"
   | "delivered"

--- a/src/tasks/task-state-machine-minimal.test.ts
+++ b/src/tasks/task-state-machine-minimal.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { deriveTaskFlowStatusFromTask } from "./task-flow-registry.js";
+import { summarizeTaskRecords } from "./task-registry.summary.js";
+import type { TaskRecord } from "./task-registry.types.js";
+import { buildTaskStatusSnapshot, formatTaskStatusDetail } from "./task-status.js";
+
+const NOW = 1_000_000_000_000;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    runId: overrides.runId ?? "run-1",
+    task: overrides.task ?? "default task",
+    runtime: overrides.runtime ?? "subagent",
+    status: overrides.status ?? "running",
+    requesterSessionKey: overrides.requesterSessionKey ?? "agent:main:main",
+    ownerKey: overrides.ownerKey ?? "agent:main:main",
+    scopeKind: overrides.scopeKind ?? "session",
+    createdAt: overrides.createdAt ?? NOW - 1_000,
+    deliveryStatus: overrides.deliveryStatus ?? "pending",
+    notifyPolicy: overrides.notifyPolicy ?? "done_only",
+    ...overrides,
+  };
+}
+
+describe("task state machine minimal active states", () => {
+  it("counts awaiting_approval and waiting_external as active states", () => {
+    const summary = summarizeTaskRecords([
+      makeTask({ taskId: "a", status: "queued" }),
+      makeTask({ taskId: "b", status: "awaiting_approval" }),
+      makeTask({ taskId: "c", status: "waiting_external" }),
+      makeTask({ taskId: "d", status: "running" }),
+      makeTask({ taskId: "e", status: "failed" }),
+    ]);
+
+    expect(summary.active).toBe(4);
+    expect(summary.terminal).toBe(1);
+    expect(summary.byStatus.awaiting_approval).toBe(1);
+    expect(summary.byStatus.waiting_external).toBe(1);
+  });
+
+  it("shows awaiting_approval in active task snapshots and formats progress detail", () => {
+    const task = makeTask({
+      status: "awaiting_approval",
+      progressSummary: "Waiting for approval from user.",
+      lastEventAt: NOW - 100,
+    });
+
+    const snapshot = buildTaskStatusSnapshot([task], { now: NOW });
+    expect(snapshot.activeCount).toBe(1);
+    expect(snapshot.focus?.status).toBe("awaiting_approval");
+    expect(formatTaskStatusDetail(task)).toBe("Waiting for approval from user.");
+  });
+
+  it("maps intermediate active states to running task flows for now", () => {
+    expect(deriveTaskFlowStatusFromTask({ status: "awaiting_approval", terminalOutcome: undefined })).toBe(
+      "running",
+    );
+    expect(deriveTaskFlowStatusFromTask({ status: "waiting_external", terminalOutcome: undefined })).toBe(
+      "running",
+    );
+  });
+});

--- a/src/tasks/task-status.test.ts
+++ b/src/tasks/task-status.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { TaskRecord } from "./task-registry.types.js";
 import {
   buildTaskOperationalSummary,
+  buildTaskLifecycleEvent,
   buildTaskStatusSnapshot,
+  formatTaskLifecycleEvent,
   formatTaskOperationalSummary,
   formatTaskStatusDetail,
   formatTaskStatusTitle,
@@ -173,5 +175,150 @@ describe("task status formatting", () => {
     expect(formatTaskOperationalSummary(task)).toBe(
       "active · running · last good step: tests running · next: wait for completion",
     );
+  });
+});
+
+describe("task lifecycle events", () => {
+  it("builds a task.created event for queued tasks", () => {
+    const task = makeTask({ status: "queued" });
+    const event = buildTaskLifecycleEvent(task, "queued");
+
+    expect(event.event).toBe("task.created");
+    expect(event.state).toBe("active");
+    expect(event.stage).toBe("queued");
+    expect(event.fromStatus).toBe("queued");
+    expect(event.nextAction).toBe("wait for start");
+  });
+
+  it("builds a task.started event when transitioning from queued to running", () => {
+    const task = makeTask({ status: "running", progressSummary: "initializing" });
+    const event = buildTaskLifecycleEvent(task, "queued");
+
+    expect(event.event).toBe("task.started");
+    expect(event.state).toBe("active");
+    expect(event.fromStatus).toBe("queued");
+    expect(event.summary).toContain("initializing");
+  });
+
+  it("builds a task.blocked event for awaiting_approval", () => {
+    const task = makeTask({
+      status: "awaiting_approval",
+      progressSummary: "patch applied",
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.event).toBe("task.blocked");
+    expect(event.state).toBe("blocked");
+    expect(event.blocker).toBe("approval required");
+    expect(event.nextAction).toBe("approve and continue");
+  });
+
+  it("builds a task.blocked event for waiting_external", () => {
+    const task = makeTask({
+      status: "waiting_external",
+      progressSummary: "awaiting user input",
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.event).toBe("task.blocked");
+    expect(event.state).toBe("blocked");
+    expect(event.blocker).toBe("external dependency");
+  });
+
+  it("builds a task.completed event for succeeded tasks", () => {
+    const task = makeTask({
+      status: "succeeded",
+      terminalSummary: "All tests passed",
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.event).toBe("task.completed");
+    expect(event.state).toBe("finished");
+    expect(event.summary).toContain("All tests passed");
+  });
+
+  it("builds a task.failed event for failed tasks", () => {
+    const task = makeTask({
+      status: "failed",
+      error: "AssertionError: expected 2 to equal 3",
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.event).toBe("task.failed");
+    expect(event.state).toBe("failed");
+    expect(event.blocker).toContain("AssertionError");
+  });
+
+  it("builds a task.cancelled event for cancelled tasks", () => {
+    const task = makeTask({ status: "cancelled" });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.event).toBe("task.cancelled");
+    expect(event.state).toBe("cancelled");
+    expect(event.stage).toBe("cancelled");
+  });
+
+  it("omits fromStatus when previous status is not provided", () => {
+    const task = makeTask({ status: "running" });
+    const event = buildTaskLifecycleEvent(task);
+
+    expect(event.event).toBe("task.started");
+    expect(event.fromStatus).toBeUndefined();
+  });
+
+  it("formats a lifecycle event as a compact string", () => {
+    const task = makeTask({
+      status: "running",
+      progressSummary: "fetching data",
+    });
+    const event = buildTaskLifecycleEvent(task, "queued");
+    const formatted = formatTaskLifecycleEvent(event);
+
+    expect(formatted).toContain("active");
+    expect(formatted).toContain("running");
+    expect(formatted).toContain("from: queued");
+    expect(formatted).toContain("fetching data");
+  });
+
+  it("formats a blocked lifecycle event compactly", () => {
+    const task = makeTask({
+      status: "awaiting_approval",
+      progressSummary: "waiting for approval",
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+    const formatted = formatTaskLifecycleEvent(event);
+
+    expect(formatted).toContain("blocked");
+    expect(formatted).toContain("awaiting approval");
+    expect(formatted).toContain("blocker: approval required");
+    expect(formatted).toContain("next: approve and continue");
+  });
+
+  it("includes updatedAt when lastEventAt is set", () => {
+    const task = makeTask({
+      status: "succeeded",
+      lastEventAt: NOW,
+    });
+    const event = buildTaskLifecycleEvent(task, "running");
+
+    expect(event.updatedAt).toBe(NOW);
+  });
+
+  it("omits updatedAt when lastEventAt is not set", () => {
+    const task = makeTask({
+      status: "queued",
+      createdAt: NOW,
+    });
+    const event = buildTaskLifecycleEvent(task);
+
+    expect(event.updatedAt).toBeUndefined();
+  });
+
+  it("strips 'no action' from formatted output", () => {
+    const task = makeTask({ status: "succeeded" });
+    const event = buildTaskLifecycleEvent(task);
+    const formatted = formatTaskLifecycleEvent(event);
+
+    expect(formatted).not.toContain("no action");
   });
 });

--- a/src/tasks/task-status.test.ts
+++ b/src/tasks/task-status.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { TaskRecord } from "./task-registry.types.js";
 import {
+  buildTaskOperationalSummary,
   buildTaskStatusSnapshot,
+  formatTaskOperationalSummary,
   formatTaskStatusDetail,
   formatTaskStatusTitle,
   sanitizeTaskStatusText,
@@ -142,5 +144,34 @@ describe("task status formatting", () => {
         ].join("\n"),
       ),
     ).toBe("");
+  });
+
+  it("builds a blocked operational summary for approval waits", () => {
+    const task = makeTask({
+      status: "awaiting_approval",
+      progressSummary: "patch applied",
+    });
+
+    expect(buildTaskOperationalSummary(task)).toMatchObject({
+      state: "blocked",
+      stage: "awaiting approval",
+      lastGoodStep: "patch applied",
+      blocker: "approval required",
+      nextAction: "approve and continue",
+    });
+    expect(formatTaskOperationalSummary(task)).toBe(
+      "blocked · awaiting approval · last good step: patch applied · blocker: approval required · next: approve and continue",
+    );
+  });
+
+  it("builds an active operational summary for running work", () => {
+    const task = makeTask({
+      status: "running",
+      progressSummary: "tests running",
+    });
+
+    expect(formatTaskOperationalSummary(task)).toBe(
+      "active · running · last good step: tests running · next: wait for completion",
+    );
   });
 });

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -6,7 +6,12 @@ import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/sanitize-u
 import { truncateUtf16Safe } from "../utils.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
-const ACTIVE_TASK_STATUSES = new Set(["queued", "running"]);
+const ACTIVE_TASK_STATUSES = new Set([
+  "queued",
+  "awaiting_approval",
+  "waiting_external",
+  "running",
+]);
 const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
 export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
 export const TASK_STATUS_TITLE_MAX_CHARS = 80;
@@ -125,7 +130,12 @@ export function formatTaskStatusTitle(task: TaskRecord): string {
 }
 
 export function formatTaskStatusDetail(task: TaskRecord): string | undefined {
-  if (task.status === "running" || task.status === "queued") {
+  if (
+    task.status === "running" ||
+    task.status === "queued" ||
+    task.status === "awaiting_approval" ||
+    task.status === "waiting_external"
+  ) {
     return (
       sanitizeTaskStatusText(task.progressSummary, { maxChars: TASK_STATUS_DETAIL_MAX_CHARS }) ||
       undefined

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -4,10 +4,7 @@ import {
 } from "../agents/internal-runtime-context.js";
 import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import { truncateUtf16Safe } from "../utils.js";
-import {
-  isActiveTaskStatus,
-  type TaskRecord,
-} from "./task-registry.types.js";
+import { isActiveTaskStatus, type TaskRecord } from "./task-registry.types.js";
 const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
 export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
 export const TASK_STATUS_TITLE_MAX_CHARS = 80;
@@ -152,6 +149,99 @@ export function formatTaskStatusDetail(task: TaskRecord): string | undefined {
       maxChars: TASK_STATUS_DETAIL_MAX_CHARS,
     }) || undefined
   );
+}
+
+export type TaskOperationalSummary = {
+  state: "active" | "blocked" | "finished" | "failed" | "cancelled";
+  stage: string;
+  lastGoodStep?: string;
+  blocker?: string;
+  nextAction?: string;
+};
+
+function truncateTaskOperationalSegment(value: string, maxChars = 80): string {
+  return truncateTaskStatusText(value, maxChars);
+}
+
+export function buildTaskOperationalSummary(task: TaskRecord): TaskOperationalSummary {
+  const detail = formatTaskStatusDetail(task);
+  if (task.status === "queued") {
+    return {
+      state: "active",
+      stage: "queued",
+      ...(detail ? { lastGoodStep: detail } : {}),
+      nextAction: "wait for start",
+    };
+  }
+  if (task.status === "running") {
+    return {
+      state: "active",
+      stage: "running",
+      ...(detail ? { lastGoodStep: detail } : {}),
+      nextAction: "wait for completion",
+    };
+  }
+  if (task.status === "awaiting_approval") {
+    return {
+      state: "blocked",
+      stage: "awaiting approval",
+      ...(detail ? { lastGoodStep: detail } : {}),
+      blocker: "approval required",
+      nextAction: "approve and continue",
+    };
+  }
+  if (task.status === "waiting_external") {
+    return {
+      state: "blocked",
+      stage: "waiting external",
+      ...(detail ? { lastGoodStep: detail } : {}),
+      blocker: "external dependency",
+      nextAction: "wait for external result",
+    };
+  }
+  if (task.status === "succeeded") {
+    return {
+      state: "finished",
+      stage: "completed",
+      ...(detail ? { lastGoodStep: detail } : {}),
+      nextAction: "no action",
+    };
+  }
+  if (task.status === "cancelled") {
+    return {
+      state: "cancelled",
+      stage: "cancelled",
+      ...(detail ? { lastGoodStep: detail } : {}),
+    };
+  }
+  return {
+    state: "failed",
+    stage: task.status.replaceAll("_", " "),
+    ...(detail ? { blocker: detail } : {}),
+    nextAction: "inspect failure",
+  };
+}
+
+export function formatTaskOperationalSummary(
+  task: TaskRecord,
+  opts?: { maxChars?: number },
+): string {
+  const summary = buildTaskOperationalSummary(task);
+  const segments = [`${summary.state} · ${summary.stage}`];
+  if (summary.lastGoodStep) {
+    segments.push(
+      `last good step: ${truncateTaskOperationalSegment(summary.lastGoodStep, opts?.maxChars ?? 80)}`,
+    );
+  }
+  if (summary.blocker) {
+    segments.push(
+      `blocker: ${truncateTaskOperationalSegment(summary.blocker, opts?.maxChars ?? 80)}`,
+    );
+  }
+  if (summary.nextAction) {
+    segments.push(`next: ${summary.nextAction}`);
+  }
+  return segments.join(" · ");
 }
 
 export type TaskStatusSnapshot = {

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -159,6 +159,26 @@ export type TaskOperationalSummary = {
   nextAction?: string;
 };
 
+export type TaskLifecycleEvent = {
+  event:
+    | "task.created"
+    | "task.started"
+    | "task.progressed"
+    | "task.blocked"
+    | "task.completed"
+    | "task.failed"
+    | "task.cancelled";
+  taskId: string;
+  status: TaskRecord["status"];
+  state: TaskOperationalSummary["state"];
+  stage: string;
+  fromStatus?: TaskRecord["status"];
+  summary?: string;
+  blocker?: string;
+  nextAction?: string;
+  updatedAt?: number;
+};
+
 function truncateTaskOperationalSegment(value: string, maxChars = 80): string {
   return truncateTaskStatusText(value, maxChars);
 }
@@ -242,6 +262,98 @@ export function formatTaskOperationalSummary(
     segments.push(`next: ${summary.nextAction}`);
   }
   return segments.join(" · ");
+}
+
+export function buildTaskLifecycleEvent(
+  task: TaskRecord,
+  previousStatus?: TaskRecord["status"],
+): TaskLifecycleEvent {
+  const operational = buildTaskOperationalSummary(task);
+  const status = task.status;
+  let event: TaskLifecycleEvent["event"];
+  if (status === "queued") {
+    event = "task.created";
+  } else if (status === "running") {
+    event =
+      previousStatus === "queued" || previousStatus === undefined
+        ? "task.started"
+        : "task.progressed";
+  } else if (status === "awaiting_approval" || status === "waiting_external") {
+    event = "task.blocked";
+  } else if (status === "succeeded") {
+    event = "task.completed";
+  } else if (status === "failed" || status === "timed_out" || status === "lost") {
+    event = "task.failed";
+  } else if (status === "cancelled") {
+    event = "task.cancelled";
+  } else {
+    event = "task.progressed";
+  }
+  return {
+    event,
+    taskId: task.taskId,
+    status,
+    state: operational.state,
+    stage: operational.stage,
+    ...(previousStatus !== undefined ? { fromStatus: previousStatus } : {}),
+    ...(operational.lastGoodStep ? { summary: operational.lastGoodStep } : {}),
+    ...(operational.blocker ? { blocker: operational.blocker } : {}),
+    ...(operational.nextAction ? { nextAction: operational.nextAction } : {}),
+    ...(task.lastEventAt ? { updatedAt: task.lastEventAt } : {}),
+  };
+}
+
+export function formatTaskLifecycleEvent(event: TaskLifecycleEvent): string {
+  const parts: string[] = [event.state, event.stage];
+  if (event.fromStatus) {
+    parts.push(`from: ${event.fromStatus}`);
+  }
+  if (event.summary) {
+    parts.push(event.summary);
+  }
+  if (event.blocker) {
+    parts.push(`blocker: ${event.blocker}`);
+  }
+  if (event.nextAction && event.nextAction !== "no action") {
+    parts.push(`next: ${event.nextAction}`);
+  }
+  return parts.join(" · ");
+}
+
+export function buildTaskLifecycleEventFromRecord(
+  task: TaskRecord,
+  event: { kind: TaskRecord["status"] | "progress"; summary?: string },
+): TaskLifecycleEvent | null {
+  if (event.kind === "progress") {
+    const operational = buildTaskOperationalSummary(task);
+    return {
+      event: "task.progressed",
+      taskId: task.taskId,
+      status: task.status,
+      state: operational.state,
+      stage: operational.stage,
+      ...(event.summary ? { summary: event.summary } : {}),
+      ...(operational.blocker ? { blocker: operational.blocker } : {}),
+      ...(operational.nextAction ? { nextAction: operational.nextAction } : {}),
+      ...(task.lastEventAt ? { updatedAt: task.lastEventAt } : {}),
+    };
+  }
+  if (event.kind === "running") {
+    return buildTaskLifecycleEvent(task);
+  }
+  if (
+    event.kind === "awaiting_approval" ||
+    event.kind === "waiting_external" ||
+    event.kind === "succeeded" ||
+    event.kind === "failed" ||
+    event.kind === "timed_out" ||
+    event.kind === "cancelled" ||
+    event.kind === "lost" ||
+    event.kind === "queued"
+  ) {
+    return buildTaskLifecycleEvent(task);
+  }
+  return null;
 }
 
 export type TaskStatusSnapshot = {

--- a/src/tasks/task-status.ts
+++ b/src/tasks/task-status.ts
@@ -4,21 +4,17 @@ import {
 } from "../agents/internal-runtime-context.js";
 import { sanitizeUserFacingText } from "../agents/pi-embedded-helpers/sanitize-user-facing-text.js";
 import { truncateUtf16Safe } from "../utils.js";
-import type { TaskRecord } from "./task-registry.types.js";
-
-const ACTIVE_TASK_STATUSES = new Set([
-  "queued",
-  "awaiting_approval",
-  "waiting_external",
-  "running",
-]);
+import {
+  isActiveTaskStatus,
+  type TaskRecord,
+} from "./task-registry.types.js";
 const FAILURE_TASK_STATUSES = new Set(["failed", "timed_out", "lost"]);
 export const TASK_STATUS_RECENT_WINDOW_MS = 5 * 60_000;
 export const TASK_STATUS_TITLE_MAX_CHARS = 80;
 export const TASK_STATUS_DETAIL_MAX_CHARS = 120;
 
 function isActiveTask(task: TaskRecord): boolean {
-  return ACTIVE_TASK_STATUSES.has(task.status);
+  return isActiveTaskStatus(task.status);
 }
 
 function isFailureTask(task: TaskRecord): boolean {


### PR DESCRIPTION
## Summary
- add explicit intermediate active task states for approval waits and external waits
- propagate those active-state semantics across registry maintenance, flow guards, CLI views, and auto-reply task rendering
- add compressed operational summaries plus shared task lifecycle event formatting for state-change updates
- reuse the shared lifecycle formatter in task update delivery paths and extend focused task coverage

## Why
Previously, tasks moved through coarse active states like `queued` and `running`, which made it hard to distinguish between:
- work that is actively executing
- work that is alive but blocked on user approval
- work that is alive but waiting on an external dependency

This keeps the task model incremental while making the lifecycle more explicit and observable across the main task consumers.

## Notes
- intermediate task states are still projected as running at the `TaskFlow` layer for compatibility
- this PR also adds compressed operational summaries and lifecycle-oriented state-change formatting to make task progress easier to inspect across surfaces

## Testing
- OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:fast -- src/tasks/task-status.test.ts src/tasks/task-executor-policy.test.ts
- OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test:fast -- src/tasks/task-status.test.ts src/tasks/task-executor-policy.test.ts src/tasks/task-registry.test.ts src/tasks/task-registry.store.test.ts
- existing focused task-state tests retained in the PR history for intermediate active state semantics
