### PR TITLE
docs(exec): note sandbox-active rejection of per-call host=node from auto

### DIFF
--- a/docs/nodes/index.md
+++ b/docs/nodes/index.md
@@ -170,7 +170,7 @@ Or per session:
 Once set, any `exec` call with `host=node` runs on the node host (subject to the
 node allowlist/approvals).
 
-`host=auto` will not implicitly choose the node on its own, but an explicit per-call `host=node` request is allowed from `auto`. If you want node exec to be the default for the session, set `tools.exec.host=node` or `/exec host=node ...` explicitly.
+`host=auto` will not implicitly choose the node on its own. An explicit per-call `host=node` request is allowed from `auto` only when no sandbox runtime is active for the session; with a sandbox active, `auto` keeps execution in the sandbox and rejects per-call host overrides. If you want node exec to be the default for the session, set `tools.exec.host=node` or `/exec host=node ...` explicitly.
 
 Related:
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -186,7 +186,7 @@ YOLO is the default host behavior unless you tighten it explicitly:
 - `tools.exec.host=auto` chooses **where** exec runs: sandbox when available, otherwise gateway.
 - YOLO chooses **how** host exec is approved: `security=full` plus `ask=off`.
 - In YOLO mode, OpenClaw does **not** add a separate heuristic command-obfuscation approval gate or script-preflight rejection layer on top of the configured host exec policy.
-- `auto` does not make gateway routing a free override from a sandboxed session. A per-call `host=node` request is allowed from `auto`; `host=gateway` is only allowed from `auto` when no sandbox runtime is active. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
+- `auto` does not make gateway or node routing a free override from a sandboxed session. Per-call `host=node` and `host=gateway` are both only allowed from `auto` when no sandbox runtime is active; with a sandbox active, `auto` keeps execution in the sandbox and rejects per-call host overrides. For a stable non-auto default, set `tools.exec.host` or use `/exec host=...` explicitly.
 
 </Warning>
 

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -64,7 +64,7 @@ Notes:
 
 - `host` defaults to `auto`: sandbox when sandbox runtime is active for the session, otherwise gateway.
 - `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector; hostname-like values are rejected before the command runs.
-- `auto` is the default routing strategy, not a wildcard. Per-call `host=node` is allowed from `auto`; per-call `host=gateway` is only allowed when no sandbox runtime is active.
+- `auto` is the default routing strategy, not a wildcard. Per-call `host=node` and per-call `host=gateway` are both only allowed from `auto` when no sandbox runtime is active. With a sandbox active, `auto` keeps execution in the sandbox and per-call host overrides are rejected.
 - With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`; a live sandbox means it stays in the sandbox.
 - `elevated` escapes the sandbox onto the configured host path: `gateway` by default, or `node` when `tools.exec.host=node` (or the session default is `host=node`). It is only available when elevated access is enabled for the current session/provider.
 - `gateway`/`node` approvals are controlled by `~/.openclaw/exec-approvals.json`.


### PR DESCRIPTION
## Summary

- Problem: three docs pages claim per-call `host=node` from `tools.exec.host=auto` is allowed, with the sandbox-active caveat applied only to `host=gateway`. Runtime intentionally rejects per-call `host=node` from `auto` when a sandbox runtime is active too. The mismatch is what #61009 (and the prior clawsweeper review on it) flagged on the public docs site.
- Why it matters: a reader following the docs sets `tools.exec.host=auto` and tries a per-call `host=node` from a sandboxed session; it is rejected without obvious explanation.
- What changed: `docs/tools/exec.md`, `docs/tools/exec-approvals.md`, and `docs/nodes/index.md` now extend the same sandbox-active caveat to `host=node` and state explicitly that, with a sandbox active, `auto` keeps execution in the sandbox and rejects per-call host overrides.
- What did NOT change (scope boundary): no runtime, test, or config change. Behavior on a non-sandboxed session is unchanged. Wording elsewhere about `host=auto` defaulting and `elevated` is unchanged.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] UI / DX

## Linked Issue/PR

- Closes #61009
- [ ] This PR fixes a bug or regression

(The doc surface mis-described existing runtime behavior; runtime itself is correct.)

## Root Cause (if applicable)

- Root cause: the `host=gateway` clause was tightened with the sandbox-active caveat when the runtime guard was added (per CHANGELOG.md, sandboxed `tools.exec.host=auto` should not honor per-call host overrides while a sandbox runtime is active), but the parallel `host=node` clause in three docs pages was not updated.
- Missing detection / guardrail: no docs/runtime contract test pins doc claims about exec routing against runtime behavior.
- Contributing context (if known): the prior clawsweeper review on #61009 enumerated exactly these three doc pages and the runtime/test pair that contradicts them.

## Regression Test Plan (if applicable)

N/A — docs only. The runtime invariants this docs change describes are already covered by:

- `src/agents/bash-tools.exec-runtime.test.ts` — `rejects per-call host=node override from auto when sandbox is available`
- and the corresponding allow tests for `sandboxAvailable: false`.

## User-visible / Behavior Changes

None. Docs wording only.

## Diagram (if applicable)

```text
Before docs (host=node clause from auto):
  sandbox active    + per-call host=node  ->  docs say ALLOWED, runtime REJECTS  (mismatch)
  no sandbox active + per-call host=node  ->  docs say ALLOWED, runtime ALLOWS

After docs:
  sandbox active    + per-call host=node  ->  docs and runtime both say REJECTED
  no sandbox active + per-call host=node  ->  docs and runtime both say ALLOWED
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (docs review)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open the three updated docs pages (`docs/tools/exec.md`, `docs/tools/exec-approvals.md`, `docs/nodes/index.md`).
2. Find the previously asymmetric `host=node` vs `host=gateway` wording from `auto`.
3. Confirm the new wording matches the existing runtime guard in `src/agents/bash-tools.exec-runtime.ts` (`isRequestedExecTargetAllowed`) and the regression test that locks it.

### Expected

Three docs pages now describe the same sandbox-active rejection rule that runtime + tests enforce.

### Actual

Same as expected.

## Evidence

- [x] Failing test/log before + passing after — N/A (docs only, runtime tests already pass and lock the behavior the docs now describe)

## Human Verification (required)

- Verified scenarios: read each updated paragraph in context against the surrounding doc; cross-checked against `src/agents/bash-tools.exec-runtime.ts:223` and the regression test at `src/agents/bash-tools.exec-runtime.test.ts`.
- Edge cases checked: `auto` + no sandbox path is unchanged in docs and remains `allowed` in runtime.
- What you did not verify: live docs-site rebuild (assumed maintainer-side process).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

None. Docs-only clarification of existing behavior.
