### PR TITLE
docs(imessage): drop dmHistoryLimit from supported list; field is a no-op (#73172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/iMessage: remove iMessage from the documented `dmHistoryLimit` supported-providers list and add a note that the field is currently a no-op for iMessage — the schema accepts it for forward compatibility, but the `imsg rpc` watch path delivers inbound messages individually and there is no current adapter that decodes prior outbound iMessage content for replay. Stops users from configuring `channels.imessage.dmHistoryLimit` and assuming DM history is being injected. Refs #73172. Thanks @Orionation.
 - Providers/NVIDIA: add the NVIDIA provider with API-key onboarding, setup docs, static catalog metadata, and literal model-ref picker support so NVIDIA hosted models can be selected with their provider prefix intact. (#71204) Thanks @eleqtrizit.
 - Messages: add global `messages.visibleReplies` so operators can require visible output to go through `message(action=send)` for any source chat, while `messages.groupChat.visibleReplies` stays available as the group/channel override. Thanks @scoootscooob.
 - Gateway/dev: run `pnpm gateway:watch` through a named tmux session by default, with `gateway:watch:raw` and `OPENCLAW_GATEWAY_WATCH_TMUX=0` for foreground mode, so repeated starts respawn an inspectable watcher without trapping the invoking agent shell. Thanks @vincentkoc.

--- a/docs/gateway/config-channels.md
+++ b/docs/gateway/config-channels.md
@@ -814,7 +814,16 @@ Visible replies are controlled separately. Group/channel rooms default to `messa
 
 Resolution: per-DM override → provider default → no limit (all retained).
 
-Supported: `telegram`, `whatsapp`, `discord`, `slack`, `signal`, `imessage`, `msteams`.
+Supported: `telegram`, `whatsapp`, `discord`, `slack`, `signal`, `msteams`.
+
+> [!NOTE]
+> iMessage is not in the supported list above: the schema currently accepts
+> `channels.imessage.dmHistoryLimit` for forward-compatibility, but the
+> iMessage runtime does not implement direct-message history injection — the
+> `imsg rpc` watch path delivers each inbound message individually and there
+> is no current adapter that decodes prior outbound iMessage content for
+> replay. Configuring this field has no effect today; track #73172 for
+> updates if a testable iMessage DM-history adapter lands.
 
 #### Self-chat mode
 


### PR DESCRIPTION
Fixes #73172.

@steipete's deep review on the issue listed two acceptable paths; this is **option 2 (docs-honest)**: remove iMessage from the documented `dmHistoryLimit` supported list and add a NOTE explaining the schema-vs-runtime mismatch. The schema field stays accepted for backward compat; runtime behavior unchanged.

## What changed
- \`docs/gateway/config-channels.md:812\` — drop \`imessage\` from the supported list
- Added a NOTE block referencing #73172 for the runtime gap

11 LOC, docs-only. No code paths touched.

## Why option 2 over option 1
Option 1 (implement a testable iMessage DM-history adapter) is macOS-specific and can't be dev-tested on Linux/CI. Option 2 closes the user-facing surprise without claiming a runtime contract we can't honor.

## Test
- \`pnpm lint:docs\` clean
- Schema field still accepted (backward compat preserved)

🦞 lobster-biscuit

---
Sign-Off: hclsys