### PR TITLE
fix(cli): make crestodian exit non-zero on no-TTY (#73646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/Crestodian: `openclaw crestodian` (and `pnpm openclaw crestodian`) now exits non-zero in non-TTY contexts instead of printing "needs an interactive TTY" and exiting 0, so shell scripts and CI flows reading `$?` can detect the failure and stop instead of proceeding as if Crestodian ran. Mirrors the existing behavior of `models auth login`, `secrets configure`, and the bare-root crestodian path. Fixes #73646. Thanks @bittoby.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.
 - Active Memory: allow the hidden recall sub-agent to use both `memory_recall` and the legacy `memory_search`/`memory_get` memory tool contract, so bundled `memory-lancedb` recall works without breaking the default `memory-core` path. Fixes #73502. (#73584) Thanks @Takhoffman.
 - fix(device-pairing): validate callerScopes against resolved token scopes on repair [AI]. (#72925) Thanks @pgondhi987.

--- a/src/crestodian/crestodian.test.ts
+++ b/src/crestodian/crestodian.test.ts
@@ -112,4 +112,25 @@ describe("runCrestodian", () => {
     expect(onReadyCalls).toBe(1);
     expect(lines.join("\n")).not.toContain("Say: status");
   });
+
+  it("throws instead of exiting silently when no interactive TTY is available (#73646)", async () => {
+    // Regression for #73646: returning silently let the CLI wrapper fall
+    // through with `process.exitCode` unset, so shell scripts and CI flows
+    // saw exit 0 alongside the "needs an interactive TTY" message and
+    // proceeded as if Crestodian ran. Throwing routes through
+    // `runCommandWithRuntime`'s catch and exits 1, matching `models auth
+    // login`, `secrets configure`, and the bare-root crestodian path in
+    // `cli/run-main.ts:399-404`.
+    const { runtime } = createCrestodianTestRuntime();
+
+    await expect(
+      runCrestodian(
+        {
+          input: { isTTY: false } as unknown as NodeJS.ReadableStream,
+          output: { isTTY: false } as unknown as NodeJS.WritableStream,
+        },
+        runtime,
+      ),
+    ).rejects.toThrow(/needs an interactive TTY/iu);
+  });
 });

--- a/src/crestodian/crestodian.ts
+++ b/src/crestodian/crestodian.ts
@@ -91,8 +91,12 @@ export async function runCrestodian(
   const inputIsTty = (input as { isTTY?: boolean }).isTTY === true;
   const outputIsTty = (output as { isTTY?: boolean }).isTTY === true;
   if (!interactive || !inputIsTty || !outputIsTty) {
-    runtime.error("Crestodian needs an interactive TTY. Use --message for one command.");
-    return;
+    // Throw so the CLI wrapper (`runCommandWithRuntime`) catches it and
+    // exits non-zero. Returning silently exited the process with code 0,
+    // which made shell scripts and CI flows treat the no-TTY error as
+    // success. Mirrors `models auth login`, `secrets configure`, and the
+    // bare-root crestodian path in `cli/run-main.ts:399-404`. See #73646.
+    throw new Error("Crestodian needs an interactive TTY. Use --message for one command.");
   }
 
   const runInteractiveTui =


### PR DESCRIPTION
Fixes #73646.

Re-submitting the closed PR #73654 (auto-closed during overnight queue rotation) with no functional change. crestodian invoked without a TTY now exits non-zero with a clear stderr message instead of the silent zero-exit that broke CI scripts.

## What changed
- \`src/crestodian/crestodian.ts\` — early-return with non-zero exit + stderr line when stdout is not a TTY
- \`src/crestodian/crestodian.test.ts\` — coverage for the no-TTY path

## Test
\`\`\`
pnpm vitest run src/crestodian/crestodian.test.ts
\`\`\`

🦞 lobster-biscuit

---
Sign-Off: hclsys