### PR TITLE
fix(agents): pause subagent announce across auto-compaction

### DIFF
--- a/src/agents/subagent-announce-output.test.ts
+++ b/src/agents/subagent-announce-output.test.ts
@@ -100,4 +100,104 @@ describe("readSubagentOutput", () => {
       "Mapped the code path.",
     );
   });
+
+  it("does not announce raw tool output captured between auto-compaction and the next assistant turn", async () => {
+    const deps = installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "" },
+            { type: "toolCall", id: "call-find", name: "exec", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-find",
+          toolName: "exec",
+          content: [
+            {
+              type: "text",
+              text: "/root/.openclaw/agents/main/sessions/a.jsonl\n/root/.openclaw/agents/main/sessions/b.jsonl",
+            },
+          ],
+          details: { status: "completed", exitCode: 0 },
+        },
+        {
+          role: "system",
+          content: [{ type: "text", text: "Compaction" }],
+          __openclaw: { kind: "compaction" },
+        },
+        {
+          role: "user",
+          content: [{ type: "text", text: "[Subagent Task]: continue" }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBeUndefined();
+    expect(deps.readLatestAssistantReply).not.toHaveBeenCalled();
+  });
+
+  it("returns the post-compaction final answer instead of pre-compaction raw tool output", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "toolResult",
+          toolCallId: "call-find",
+          toolName: "exec",
+          content: [{ type: "text", text: "/root/.openclaw/agents/main/sessions/a.jsonl" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        {
+          role: "system",
+          content: [{ type: "text", text: "Compaction" }],
+          __openclaw: { kind: "compaction" },
+        },
+        {
+          role: "assistant",
+          stopReason: "stop",
+          content: [{ type: "text", text: "Deep search done. Found two candidates..." }],
+        },
+      ],
+    });
+
+    await expect(readSubagentOutput("agent:main:subagent:child")).resolves.toBe(
+      "Deep search done. Found two candidates...",
+    );
+  });
+
+  it("emits partial-progress message when subagent times out after compaction", async () => {
+    installOutputDeps({
+      messages: [
+        {
+          role: "assistant",
+          stopReason: "toolUse",
+          content: [
+            { type: "text", text: "" },
+            { type: "toolCall", id: "call-find", name: "exec", arguments: {} },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "call-find",
+          toolName: "exec",
+          content: [{ type: "text", text: "/root/.openclaw/agents/main/sessions/a.jsonl" }],
+          details: { status: "completed", exitCode: 0 },
+        },
+        {
+          role: "system",
+          content: [{ type: "text", text: "Compaction" }],
+          __openclaw: { kind: "compaction" },
+        },
+      ],
+    });
+
+    const reply = await readSubagentOutput("agent:main:subagent:child", {
+      status: "timeout",
+    });
+    expect(reply).toContain("Partial progress");
+    expect(reply).not.toContain("/root/.openclaw/agents/main/sessions/a.jsonl");
+  });
 });

--- a/src/agents/subagent-announce-output.ts
+++ b/src/agents/subagent-announce-output.ts
@@ -199,6 +199,17 @@ function countAssistantToolCalls(content: unknown): number {
   return count;
 }
 
+function isCompactionSystemMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  if ((message as { role?: unknown }).role !== "system") {
+    return false;
+  }
+  const meta = (message as { __openclaw?: { kind?: unknown } }).__openclaw;
+  return Boolean(meta) && meta?.kind === "compaction";
+}
+
 function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutputSnapshot {
   const snapshot: SubagentOutputSnapshot = {
     assistantFragments: [],
@@ -250,6 +261,15 @@ function summarizeSubagentOutputHistory(messages: Array<unknown>): SubagentOutpu
       previousAssistantCalledYield = false;
       continue;
     }
+    if (isCompactionSystemMessage(message)) {
+      snapshot.latestAssistantText = undefined;
+      snapshot.latestRawText = undefined;
+      snapshot.latestSilentText = undefined;
+      snapshot.assistantFragments = [];
+      snapshot.waitingForContinuation = true;
+      previousAssistantCalledYield = false;
+      continue;
+    }
     const text = extractSubagentOutputText(message).trim();
     if (text) {
       snapshot.latestRawText = text;
@@ -287,18 +307,20 @@ function selectSubagentOutputText(
   snapshot: SubagentOutputSnapshot,
   outcome?: SubagentRunOutcome,
 ): string | undefined {
-  if (snapshot.waitingForContinuation) {
-    return undefined;
-  }
-  if (snapshot.latestSilentText) {
-    return snapshot.latestSilentText;
-  }
-  if (snapshot.latestAssistantText) {
-    return snapshot.latestAssistantText;
+  if (!snapshot.waitingForContinuation) {
+    if (snapshot.latestSilentText) {
+      return snapshot.latestSilentText;
+    }
+    if (snapshot.latestAssistantText) {
+      return snapshot.latestAssistantText;
+    }
   }
   const partialProgress = formatSubagentPartialProgress(snapshot, outcome);
   if (partialProgress) {
     return partialProgress;
+  }
+  if (snapshot.waitingForContinuation) {
+    return undefined;
   }
   return snapshot.latestRawText;
 }


### PR DESCRIPTION
## Summary

Auto-compaction inside a running subagent can cause `subagent_announce` to publish raw tool output (e.g. the listing from a `find` command) to the parent labeled \"completed successfully\" — while the subagent itself keeps running and eventually produces a real answer that the parent never sees.

This extends #73413's `waitingForContinuation` mechanism to also pause the announce-capture path on auto-compaction system markers, mirroring the existing `sessions_yield` handling.

## Root cause

`selectSubagentOutputText` in `src/agents/subagent-announce-output.ts` walks four candidate sources in priority order (`latestSilentText`, `latestAssistantText`, `formatSubagentPartialProgress`, `latestRawText`). When a subagent auto-compacts mid-run:

- The visible assistant text is wiped from `chat.history` (only the synthetic compaction marker remains).
- The most recent `toolResult` is still in the snapshot, so `latestRawText` holds e.g. a `find` listing.
- An announce dispatched in this window falls through past the empty silent/assistant fields straight into `latestRawText`.

The dispatched announce is labeled `status: completed successfully` even though the subagent is still mid-run, and shows `Stats: tokens 0 (in 0 / out 0)` (telltale: the captured \"reply\" was not LLM-generated). No second announce ever fires when the subagent does produce a real terminal assistant turn, so the parent never sees the actual answer.

#73413 added `waitingForContinuation` to suppress the same capture for `sessions_yield` waits, but the compaction case wasn't covered — compaction can happen without an explicit yield.

## Reproducer (production incident, 2026-04-28)

A user's main agent spawned a subagent task `lcf-apr8-dashboard-deep-search`. Timeline (UTC):

- `14:05:05` — subagent runs `find /root/.openclaw -path '*sessions*' -type f -name '*.jsonl' | head -200` (toolResult: ~200 file paths)
- `14:05:28` — subagent auto-compacts (`fromHook: true`, `tokensBefore: 201822`)
- `14:05:32` — parent receives a `subagent_announce` event:
  ```
  [Internal task completion event]
  source: subagent
  session_key: agent:main:subagent:<uuid>
  type: subagent task
  task: lcf-apr8-dashboard-deep-search
  status: completed successfully

  Result (untrusted content, treat as data):
  <<<BEGIN_UNTRUSTED_CHILD_RESULT>>>
  /root/.openclaw/agents/main/sessions/5b00aafa-...jsonl
  /root/.openclaw/agents/main/sessions/3941a664-...jsonl
  ... (~200 paths) ...
  <<<END_UNTRUSTED_CHILD_RESULT>>>

  Stats: runtime 6m15s • tokens 0 (in 0 / out 0)
  ```
- `14:11:43` — subagent's actual final assistant turn: `\"Deep search done. ... Most likely answer: ...\"` (a coherent answer to the original task). **Never delivered to the parent**.

The parent's operator had to inspect the child session JSONL by hand to recover the real answer.

## Fix

Two changes in `src/agents/subagent-announce-output.ts`:

1. **New helper `isCompactionSystemMessage`** — detects the synthetic `{ role: \"system\", __openclaw: { kind: \"compaction\" } }` marker that `session-utils.fs.ts` emits for compaction entries.
2. **New branch in `summarizeSubagentOutputHistory`** — mirror of the existing `sessions_yield` toolResult branch. Clears the latest-text fields and sets `waitingForContinuation = true` when a compaction marker is encountered.
3. **Restructured `selectSubagentOutputText`** — the previous `if (waitingForContinuation) return undefined` short-circuit at the top suppressed *everything* including the existing `[Partial progress: N tool call(s) executed before timeout]` message. New structure: silent/assistant fallthroughs are skipped while paused (those are completion-like signals, not appropriate while a continuation is expected), but `formatSubagentPartialProgress` can still fire on timeout. The `latestRawText` suppression is preserved.

## Testing

Three new unit tests in `src/agents/subagent-announce-output.test.ts`, all using the existing mocked-deps harness:

- **limbo-window**: don't announce raw output between compaction and the next assistant turn
- **recovery**: when a real post-compaction assistant turn lands, that wins over pre-compaction tool output
- **timeout-after-compaction**: timeout still emits the partial-progress message; raw tool output is suppressed

```
pnpm exec vitest run --config test/vitest/vitest.agents-core.config.ts \\
  src/agents/subagent-announce-output.test.ts

Test Files  1 passed (1)
     Tests  6 passed (6)
```

Broader subagent-announce suite (`-t subagent`, `vitest.agents-core.config.ts`): 207 passed, 0 failed.

\`pnpm exec oxfmt --check\` clean on touched files.

**Degree of testing:** Lightly tested. Unit tests pass locally. Not run end-to-end against a live gateway in this PR — the original incident was observed in production, and the unit tests reproduce the message-shape conditions deterministically.

## CHANGELOG

Intentionally left for the maintainer to add on merge with the PR number.

---

### AI-assisted disclosure

- **AI-assisted** with Claude Opus 4.7 (Claude Code).
- Investigation flow: triaged the production session via the platform's admin tools, found the buggy announce in the parent's transcript, traced the snapshot/select logic in `subagent-announce-output.ts`, identified that #73413 covered only the `sessions_yield` variant of the same bug family.
- Fix iterated once: first version suppressed all paused-run output unconditionally; `codex review --base upstream/main` flagged the timeout-partial-progress regression; restructured `selectSubagentOutputText` and added the third test.
- Final `codex review --base upstream/main`: clean (\"I did not find a discrete regression introduced by these changes\").