### PR TITLE
feat(memory-lancedb): add memory_refresh tool for atomic replace and conflict preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Plugins/onboarding: let Manual setup install optional official plugins, including ClawHub-backed diagnostics with npm fallback, and expose the external Codex plugin as a selectable provider setup choice. Thanks @vincentkoc.
+- Memory/LanceDB: add `memory_refresh` tool for atomic replace and conflict preview, with per-id locking, rollback on insert failure, and a metadata-only audit log at `~/.openclaw/memory/refresh-audit.jsonl` written with `0o600` permissions. (#73788) Thanks @amittell.
 - Plugins/CLI: include package dependency install state in `openclaw plugins list --json` so scripts can spot missing plugin dependencies without runtime-loading plugins.
 - Discord/status: add degraded Discord transport and gateway event-loop starvation signals to `openclaw channels status`, `openclaw status --deep`, and fetch-timeout logs so intermittent socket resets do not look like a healthy running channel. (#76327) Thanks @joshavant.
 - Plugins/update: on the beta OpenClaw update channel, default-line npm and ClawHub plugin updates try `@beta` first and fall back to default/latest when no plugin beta release exists.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3012,6 +3012,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - QA-Lab: add `--pack personal-agent` for `openclaw qa suite` so maintainers can run the accepted personal-agent scenario pack by selector. (#82760) Thanks @iFiras-Max1.
 - QA-Lab: add a private Codex-vs-Pi runtime parity axis with runtime-pair suite runs, parity reports, and release-check wiring. (#80238) Thanks @100yenadmin.
 - Slack: add Slack assistant thread lifecycle support with assistant view manifest entries, suggested prompts, thread-scoped assistant sessions, and Slack-provided assistant context. Fixes #80787. Thanks @mobybot27.
+- Memory/LanceDB: add `memory_refresh` tool for atomic replace and conflict preview, with per-id locking, rollback on insert failure, and a metadata-only audit log at `~/.openclaw/memory/refresh-audit.jsonl` written with `0o600` permissions. (#73788) Thanks @amittell.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3012,7 +3012,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - QA-Lab: add `--pack personal-agent` for `openclaw qa suite` so maintainers can run the accepted personal-agent scenario pack by selector. (#82760) Thanks @iFiras-Max1.
 - QA-Lab: add a private Codex-vs-Pi runtime parity axis with runtime-pair suite runs, parity reports, and release-check wiring. (#80238) Thanks @100yenadmin.
 - Slack: add Slack assistant thread lifecycle support with assistant view manifest entries, suggested prompts, thread-scoped assistant sessions, and Slack-provided assistant context. Fixes #80787. Thanks @mobybot27.
-- Memory/LanceDB: add `memory_refresh` tool for atomic replace and conflict preview, with per-id locking, rollback on insert failure, and a metadata-only audit log at `~/.openclaw/memory/refresh-audit.jsonl` written with `0o600` permissions. (#73788) Thanks @amittell.
+- Memory/LanceDB: add `memory_refresh` tool for best-effort replace (process-mutex serialized delete-then-insert, not a storage-level transaction) and near-duplicate conflict preview, preserving the original memory id across a successful replace, with per-id locking, best-effort rollback on insert failure, and a metadata-only audit log at `~/.openclaw/memory/refresh-audit.jsonl` written with `0o600` permissions. (#73788) Thanks @amittell.
 
 ### Fixes
 

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -239,6 +239,45 @@ Agents also get LanceDB memory tools from the active memory plugin:
 - `memory_recall` for LanceDB-backed recall
 - `memory_store` for saving important facts, preferences, decisions, and entities
 - `memory_forget` for removing matching memories
+- `memory_refresh` for previewing similar memories or atomically replacing one by id
+
+### `memory_refresh`
+
+`memory_refresh` updates an existing memory in two phases so that agents can
+revise facts without losing the prior entry on a partial failure.
+
+Search-only mode (omit `memoryId`):
+
+- Embeds the proposed new `text` and returns up to three nearest LanceDB
+  matches.
+- Each candidate carries `id`, `text`, `category`, `importance`, and a
+  `similarity` score using the same `1 / (1 + L2)` metric as `memory_recall`,
+  so scores are directly comparable across the two tools.
+- Nothing is written to the database.
+
+Replace mode (`memoryId` provided):
+
+- Takes a per-id mutex so concurrent `memory_refresh` and `memory_forget`
+  calls on the same id serialize instead of racing.
+- Re-checks that the entry still exists inside the lock, then deletes the old
+  row and inserts the new one. The new row gets a fresh id; the old id is
+  reported as `details.old_id` and the new id as `details.new_id`.
+- `category` and `importance` are inherited from the existing entry when the
+  caller omits them, so a text-only refresh never silently resets metadata to
+  defaults.
+- If the insert fails after the delete, the original entry is restored under
+  its original id on a best-effort basis. The response includes
+  `details.error: "insert_failed"` and `details.restored_id` (the original id
+  on success, `null` if the rollback also failed).
+- A non-existent `memoryId` returns `details.error: "not_found"` without
+  writing or deleting anything.
+
+Each successful replace appends one JSON line to
+`~/.openclaw/memory/refresh-audit.jsonl`. The audit record contains only
+metadata (`ts`, `operation`, `old_id`, `new_id`, and the L2-derived
+`similarity`); memory text is intentionally never written to the audit log.
+The audit directory is created with mode `0o700` and the file with mode
+`0o600` so the trail is not world-readable on shared hosts.
 
 ## Storage
 

--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -256,6 +256,45 @@ Agents also get LanceDB memory tools from the active memory plugin:
 - `memory_recall` for LanceDB-backed recall
 - `memory_store` for saving important facts, preferences, decisions, and entities
 - `memory_forget` for removing matching memories
+- `memory_refresh` for previewing similar memories or atomically replacing one by id
+
+### `memory_refresh`
+
+`memory_refresh` updates an existing memory in two phases so that agents can
+revise facts without losing the prior entry on a partial failure.
+
+Search-only mode (omit `memoryId`):
+
+- Embeds the proposed new `text` and returns up to three nearest LanceDB
+  matches.
+- Each candidate carries `id`, `text`, `category`, `importance`, and a
+  `similarity` score using the same `1 / (1 + L2)` metric as `memory_recall`,
+  so scores are directly comparable across the two tools.
+- Nothing is written to the database.
+
+Replace mode (`memoryId` provided):
+
+- Takes a per-id mutex so concurrent `memory_refresh` and `memory_forget`
+  calls on the same id serialize instead of racing.
+- Re-checks that the entry still exists inside the lock, then deletes the old
+  row and inserts the new one. The new row gets a fresh id; the old id is
+  reported as `details.old_id` and the new id as `details.new_id`.
+- `category` and `importance` are inherited from the existing entry when the
+  caller omits them, so a text-only refresh never silently resets metadata to
+  defaults.
+- If the insert fails after the delete, the original entry is restored under
+  its original id on a best-effort basis. The response includes
+  `details.error: "insert_failed"` and `details.restored_id` (the original id
+  on success, `null` if the rollback also failed).
+- A non-existent `memoryId` returns `details.error: "not_found"` without
+  writing or deleting anything.
+
+Each successful replace appends one JSON line to
+`~/.openclaw/memory/refresh-audit.jsonl`. The audit record contains only
+metadata (`ts`, `operation`, `old_id`, `new_id`, and the L2-derived
+`similarity`); memory text is intentionally never written to the audit log.
+The audit directory is created with mode `0o700` and the file with mode
+`0o600` so the trail is not world-readable on shared hosts.
 
 ## Storage
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2373,9 +2373,8 @@ describe("memory plugin e2e", () => {
 
       // Check audit log was written
       auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
-      const auditContent = await import("node:fs/promises").then((fsPromises) =>
-        fsPromises.readFile(auditLogPath!, "utf8").catch(() => null),
-      );
+      const fsPromises = await import("node:fs/promises");
+      const auditContent = await fsPromises.readFile(auditLogPath!, "utf8").catch(() => null);
       expect(auditContent).not.toBeNull();
       const auditLine = JSON.parse(auditContent!.trim());
       expect(auditLine.operation).toBe("replaced");
@@ -2385,6 +2384,18 @@ describe("memory plugin e2e", () => {
       expect(auditLine.old_text).toBeUndefined();
       expect(auditLine.new_text).toBeUndefined();
       expect(auditLine.ts).toBeGreaterThan(0);
+
+      // Audit log directory and file must not be world-readable: the file
+      // contains memory ids and timestamps that should not leak across users
+      // on shared hosts where the process umask is permissive (e.g. 0o022).
+      // On non-POSIX platforms (Windows) mode bits are not meaningfully
+      // enforced, so skip the assertion there.
+      if (process.platform !== "win32") {
+        const fileStat = await fsPromises.stat(auditLogPath!);
+        expect(fileStat.mode & 0o777).toBe(0o600);
+        const dirStat = await fsPromises.stat(`${getTmpDir()}/.openclaw/memory`);
+        expect(dirStat.mode & 0o777).toBe(0o700);
+      }
     } finally {
       vi.doUnmock("openai");
       vi.doUnmock("@lancedb/lancedb");

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2374,7 +2374,7 @@ describe("memory plugin e2e", () => {
       // Check audit log was written
       auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
       const fsPromises = await import("node:fs/promises");
-      const auditContent = await fsPromises.readFile(auditLogPath!, "utf8").catch(() => null);
+      const auditContent = await fsPromises.readFile(auditLogPath, "utf8").catch(() => null);
       expect(auditContent).not.toBeNull();
       const auditLine = JSON.parse(auditContent!.trim());
       expect(auditLine.operation).toBe("replaced");
@@ -2391,7 +2391,7 @@ describe("memory plugin e2e", () => {
       // On non-POSIX platforms (Windows) mode bits are not meaningfully
       // enforced, so skip the assertion there.
       if (process.platform !== "win32") {
-        const fileStat = await fsPromises.stat(auditLogPath!);
+        const fileStat = await fsPromises.stat(auditLogPath);
         expect(fileStat.mode & 0o777).toBe(0o600);
         const dirStat = await fsPromises.stat(`${getTmpDir()}/.openclaw/memory`);
         expect(dirStat.mode & 0o777).toBe(0o700);

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2125,7 +2125,6 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("Random note")).toBe("other");
   });
 
-
   // ============================================================================
   // memory_refresh tests
   // ============================================================================
@@ -2137,7 +2136,6 @@ describe("memory plugin e2e", () => {
     queryWhere: ReturnType<typeof vi.fn>;
     tableAdd: ReturnType<typeof vi.fn>;
     tableDelete: ReturnType<typeof vi.fn>;
-    // oxlint-disable-next-line typescript/no-explicit-any
     registeredTools: any[];
   }) {
     return {
@@ -2161,7 +2159,6 @@ describe("memory plugin e2e", () => {
         error: vi.fn(),
         debug: vi.fn(),
       },
-      // oxlint-disable-next-line typescript/no-explicit-any
       registerTool: (tool: any, toolOpts: any) => {
         opts.registeredTools.push({ tool, opts: toolOpts });
       },
@@ -2217,7 +2214,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2235,7 +2234,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2246,7 +2244,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2298,7 +2295,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2318,14 +2317,12 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
 
       // Use tmpDir for audit log by temporarily pointing homedir there
       const originalHome = process.env.HOME;
       process.env.HOME = getTmpDir();
 
-      // oxlint-disable-next-line typescript/no-explicit-any
       let result: any;
       try {
         const mockApi = buildMockApiForRefresh({
@@ -2337,7 +2334,6 @@ describe("memory plugin e2e", () => {
           tableDelete,
           registeredTools,
         });
-        // oxlint-disable-next-line typescript/no-explicit-any
         memoryPlugin.register(mockApi as any);
 
         const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2413,7 +2409,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2431,7 +2429,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2442,7 +2439,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2505,7 +2501,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2523,7 +2521,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2534,7 +2531,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2605,7 +2601,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2623,7 +2621,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2634,7 +2631,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2683,7 +2679,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2701,7 +2699,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2712,7 +2709,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -2781,7 +2777,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -2799,7 +2797,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -2810,7 +2807,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -69,7 +69,7 @@ function createRuntimeLoader(
 }
 
 describe("memory plugin e2e", () => {
-  const { getDbPath } = installTmpDirHarness({ prefix: "openclaw-memory-test-" });
+  const { getDbPath, getTmpDir } = installTmpDirHarness({ prefix: "openclaw-memory-test-" });
 
   function parseConfig(overrides: Record<string, unknown> = {}) {
     return memoryPlugin.configSchema?.parse?.({
@@ -2123,6 +2123,722 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("My email is test@example.com")).toBe("entity");
     expect(detectCategory("The server is running on port 3000")).toBe("fact");
     expect(detectCategory("Random note")).toBe("other");
+  });
+
+
+  // ============================================================================
+  // memory_refresh tests
+  // ============================================================================
+
+  function buildMockApiForRefresh(opts: {
+    dbPath: string;
+    embeddingsCreate: ReturnType<typeof vi.fn>;
+    vectorSearch: ReturnType<typeof vi.fn>;
+    queryWhere: ReturnType<typeof vi.fn>;
+    tableAdd: ReturnType<typeof vi.fn>;
+    tableDelete: ReturnType<typeof vi.fn>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registeredTools: any[];
+  }) {
+    return {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+        },
+        dbPath: opts.dbPath,
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: (tool: any, toolOpts: any) => {
+        opts.registeredTools.push({ tool, opts: toolOpts });
+      },
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn(),
+      resolvePath: (p: string) => p,
+    };
+  }
+
+  test("memory_refresh search-only mode returns matches without writing to DB", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+
+    const mockSearchResults = [
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000001",
+        text: "Match one",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.8,
+        category: "fact",
+        createdAt: 1000,
+        _distance: 0.05,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000002",
+        text: "Match two",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.7,
+        category: "preference",
+        createdAt: 1001,
+        _distance: 0.1,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000003",
+        text: "Match three",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.6,
+        category: "other",
+        createdAt: 1002,
+        _distance: 0.2,
+      },
+    ];
+
+    const toArray = vi.fn(async () => mockSearchResults);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const queryWhere = vi.fn();
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 3),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Call without memoryId → search-only mode
+      const result = await refreshTool.execute("test-refresh-search", {
+        text: "user prefers dark theme",
+      });
+
+      expect(result.details.operation).toBe("search_only");
+      expect(result.details.matches).toHaveLength(3);
+      const matches = result.details.matches as Array<Record<string, unknown>>;
+      expect(matches[0]).toHaveProperty("similarity");
+      expect(matches[0].similarity).toBeGreaterThan(0);
+
+      // Verify nothing was written to the DB
+      expect(tableAdd).not.toHaveBeenCalled();
+      expect(tableDelete).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh atomic replace: old entry gone, new entry present, audit log written", async () => {
+    const existingId = "bbbbbbbb-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Old memory text that will be replaced",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const searchToArray = vi.fn(async () => []);
+    const searchLimit = vi.fn(() => ({ toArray: searchToArray }));
+    const vectorSearch = vi.fn(() => ({ limit: searchLimit }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    let auditLogPath: string | null = null;
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+
+      // Use tmpDir for audit log by temporarily pointing homedir there
+      const originalHome = process.env.HOME;
+      process.env.HOME = getTmpDir();
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      let result: any;
+      try {
+        const mockApi = buildMockApiForRefresh({
+          dbPath: getDbPath(),
+          embeddingsCreate,
+          vectorSearch,
+          queryWhere,
+          tableAdd,
+          tableDelete,
+          registeredTools,
+        });
+        // oxlint-disable-next-line typescript/no-explicit-any
+        memoryPlugin.register(mockApi as any);
+
+        const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+        expect(refreshTool).toBeDefined();
+
+        result = await refreshTool.execute("test-refresh-replace", {
+          text: "Updated memory text with new information",
+          category: "fact",
+          importance: 0.9,
+          memoryId: existingId,
+        });
+      } finally {
+        if (originalHome !== undefined) {
+          process.env.HOME = originalHome;
+        } else {
+          delete process.env.HOME;
+        }
+      }
+
+      expect(result).toBeDefined();
+      expect(result.details.operation).toBe("replaced");
+      expect(result.details.old_id).toBe(existingId);
+      expect(result.details.new_id).toBeDefined();
+      expect(result.details.old_text_preview).toContain("Old memory");
+
+      // Verify delete was called for old entry
+      expect(tableDelete).toHaveBeenCalledWith(`id = '${existingId}'`);
+
+      // Verify add was called for new entry
+      expect(tableAdd).toHaveBeenCalledTimes(1);
+      const addCall = (tableAdd.mock.calls as unknown[][][])[0]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(addCall.text).toBe("Updated memory text with new information");
+      expect(addCall.importance).toBe(0.9);
+
+      // Check audit log was written
+      auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
+      const auditContent = await import("node:fs/promises").then((fsPromises) =>
+        fsPromises.readFile(auditLogPath!, "utf8").catch(() => null),
+      );
+      expect(auditContent).not.toBeNull();
+      const auditLine = JSON.parse(auditContent!.trim());
+      expect(auditLine.operation).toBe("replaced");
+      expect(auditLine.old_id).toBe(existingId);
+      expect(auditLine.new_id).toBeDefined();
+      // Memory text is intentionally NOT written to audit logs to protect user privacy
+      expect(auditLine.old_text).toBeUndefined();
+      expect(auditLine.new_text).toBeUndefined();
+      expect(auditLine.ts).toBeGreaterThan(0);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace with non-existent ID returns error without creating entry", async () => {
+    const nonExistentId = "cccccccc-0000-0000-0000-000000000001";
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []); // empty → not found
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 0),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-notfound", {
+        text: "This text won't be stored",
+        memoryId: nonExistentId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("not_found");
+      expect(result.details.memoryId).toBe(nonExistentId);
+
+      // Verify nothing was written or deleted
+      expect(tableAdd).not.toHaveBeenCalled();
+      expect(tableDelete).not.toHaveBeenCalled();
+
+      // Verify the embedding API was not called — a stale/invalid memoryId
+      // should short-circuit before incurring an embedding round-trip.
+      expect(embeddingsCreate).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh best-effort rollback: restores original when insert fails", async () => {
+    const existingId = "dddddddd-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Original memory that must be restored",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.8,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // First call to add throws (new entry); second call succeeds (rollback restore)
+    let addCallCount = 0;
+    const tableAdd = vi.fn(async () => {
+      addCallCount++;
+      if (addCallCount === 1) {
+        throw new Error("Simulated insert failure");
+      }
+      // second call (rollback) succeeds
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-rollback", {
+        text: "New text that will fail to insert",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("insert_failed");
+      expect(result.details.rollbackWarning).toContain("restored");
+
+      // Verify delete was called (old entry was removed before the attempted insert)
+      expect(tableDelete).toHaveBeenCalledWith(`id = '${existingId}'`);
+
+      // Verify add was called twice: once for new entry (failed), once for rollback (succeeded)
+      expect(tableAdd).toHaveBeenCalledTimes(2);
+
+      // Second add call should restore original content with original ID
+      const rollbackAddCall = (tableAdd.mock.calls as unknown[][][])[1]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(rollbackAddCall.text).toBe(existingEntry.text);
+      expect(rollbackAddCall.importance).toBe(existingEntry.importance);
+      expect(rollbackAddCall.category).toBe(existingEntry.category);
+      // The rollback must preserve the original ID so callers are never left
+      // with a stale reference to a non-existent row.
+      expect(rollbackAddCall.id).toBe(existingEntry.id);
+
+      // The return value must expose the restored ID for the caller.
+      expect(result.details.restored_id).toBe(existingEntry.id);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh rollback failure: restored_id is null when both insert and rollback fail", async () => {
+    const existingId = "dddddddd-0000-0000-0000-000000000002";
+    const existingEntry = {
+      id: existingId,
+      text: "Memory that cannot be recovered",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.8,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // Both insert and rollback fail
+    const tableAdd = vi.fn(async () => {
+      throw new Error("Simulated storage failure");
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-double-fail", {
+        text: "New text that will fail to insert",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("insert_failed");
+      expect(result.details.success).toBe(false);
+      expect(result.details.rollbackWarning).toContain("DATA LOSS POSSIBLE");
+      // When rollback also failed, restored_id must be null — not the original ID.
+      expect(result.details.restored_id).toBeNull();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace inherits category and importance from existing when not provided", async () => {
+    const existingId = "eeeeeeee-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Old memory text",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.9, // non-default, to verify it is inherited
+      category: "decision" as const,
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Call with only text — omit category and importance entirely.
+      const result = await refreshTool.execute("test-refresh-inherit", {
+        text: "Updated text only - no category or importance supplied",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("replaced");
+
+      // The new entry must carry over the original category and importance.
+      const addCall = (tableAdd.mock.calls as unknown[][][])[0]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(addCall.text).toBe("Updated text only - no category or importance supplied");
+      expect(addCall.category).toBe("decision"); // inherited from existingEntry
+      expect(addCall.importance).toBe(0.9); // inherited from existingEntry
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh concurrent replace calls on same ID serialize: operations do not interleave", async () => {
+    const existingId = "ffffffff-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Original text",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    // Track the order of DB operations across both concurrent calls.
+    const callLog: string[] = [];
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+
+    // Static mock: getById always returns the same entry regardless of prior deletes.
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // tableDelete introduces a small async gap so that without the mutex the
+    // two calls' delete operations would both complete before either add fires,
+    // producing the interleaved log ["delete","delete","add","add"].
+    // With the mutex the expected log is ["delete","add","delete","add"].
+    const tableDelete = vi.fn(async () => {
+      callLog.push("delete");
+      await new Promise<void>((r) => setTimeout(r, 5));
+    });
+    const tableAdd = vi.fn(async () => {
+      callLog.push("add");
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Fire two replace calls simultaneously on the same memoryId.
+      const [result1, result2] = await Promise.all([
+        refreshTool.execute("concurrent-call-1", { text: "Update A", memoryId: existingId }),
+        refreshTool.execute("concurrent-call-2", { text: "Update B", memoryId: existingId }),
+      ]);
+
+      // Both calls must complete without throwing.
+      expect(result1).toBeDefined();
+      expect(result2).toBeDefined();
+
+      // Both succeed because the static mock always returns the entry.
+      expect(result1.details.operation).toBe("replaced");
+      expect(result2.details.operation).toBe("replaced");
+
+      // Serialized pattern: delete, add, delete, add.
+      // Interleaved (racy) pattern would be: delete, delete, add, add.
+      // The mutex guarantees the former.
+      expect(callLog).toEqual(["delete", "add", "delete", "add"]);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
   });
 
   test("memory_forget candidate list shows full UUIDs, not truncated IDs", async () => {

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2945,9 +2945,11 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("Random note")).toBe("other");
   });
 
-  // ============================================================================
+  // =====================================================================  });
+
   // memory_refresh tests
-  // ============================================================================
+  // =====================================================================  });
+
 
   function buildMockApiForRefresh(opts: {
     dbPath: string;
@@ -4609,6 +4611,311 @@ describe("memory plugin e2e", () => {
     expect(
       escapeMemoryForPrompt("Photo [media attached: media://inbound/abc123.jpg] was attached"),
     ).toBe("Photo was attached");
+  });
+
+  // --------------------------------------------------------------------------
+  // memory_refresh atomicity / threshold / id-preservation regression tests
+  //
+  // The "atomic" framing in the original memory_refresh description was
+  // misleading: the replace is a delete-then-insert sequence guarded by a
+  // process-local mutex, NOT a storage-level transaction. The tool description
+  // and parameter help text must therefore avoid the word "atomic" unless a
+  // future change actually exposes a transactional API (e.g. LanceDB
+  // mergeInsert) through this code path.
+  //
+  // The conflict-preview search threshold was originally 0.1 — the same loose
+  // value memory_recall uses to surface any related context. That is wrong for
+  // a "did you mean to replace one of these?" preview, which should only flag
+  // plausible near-duplicates. Raise to the db.search default (0.5).
+  // --------------------------------------------------------------------------
+  test("memory_refresh description avoids unqualified 'atomic' framing", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 0),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      memoryPlugin.register(mockApi as any);
+
+      const refreshRegistration = registeredTools.find(
+        (t) => t.opts?.name === "memory_refresh",
+      );
+      expect(refreshRegistration).toBeDefined();
+      const description = refreshRegistration.tool.description as string;
+
+      // The tool description must not promise atomicity it cannot deliver.
+      // Match "atomic" or "atomically" as standalone words so future copy
+      // changes that legitimately introduce a qualified phrase (for example
+      // "best-effort, not storage-level atomic") still fail this test until
+      // they are wired up to a real transactional implementation.
+      expect(description.toLowerCase()).not.toMatch(/\batomic(ally)?\b/);
+
+      // And it must say what the replace path actually does so callers are
+      // not surprised by the lack of a storage-level transaction.
+      expect(description.toLowerCase()).toContain("best-effort");
+
+      // The memoryId parameter help text must not promise atomicity either.
+      const paramsSchema = refreshRegistration.tool.parameters as {
+        properties?: { memoryId?: { description?: string } };
+      };
+      const memoryIdDescription = paramsSchema.properties?.memoryId?.description ?? "";
+      expect(memoryIdDescription.toLowerCase()).not.toMatch(/\batomic(ally)?\b/);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh conflict preview filters out low-similarity matches (threshold >= 0.5)", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+
+    // Mix three rows: one above the 0.5 threshold (_distance=0.05 -> 0.952),
+    // one above (_distance=0.5 -> 0.667), and one BELOW (_distance=2.0 -> 0.333).
+    // Under the old 0.1 threshold all three would pass; under the new 0.5
+    // threshold the third row is filtered out as a poor replacement candidate.
+    const mockRows = [
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000001",
+        text: "Highly relevant near-duplicate",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.8,
+        category: "fact",
+        createdAt: 1000,
+        _distance: 0.05,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000002",
+        text: "Moderately relevant",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.7,
+        category: "preference",
+        createdAt: 1001,
+        _distance: 0.5,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000003",
+        text: "Tangentially related (should be filtered by the stricter threshold)",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.4,
+        category: "other",
+        createdAt: 1002,
+        _distance: 2.0,
+      },
+    ];
+
+    const toArray = vi.fn(async () => mockRows);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const queryWhere = vi.fn();
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 3),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find(
+        (t) => t.opts?.name === "memory_refresh",
+      )?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-threshold", {
+        text: "candidate replacement text",
+      });
+
+      // Search-only mode is unchanged; only the threshold tightened.
+      expect(result.details.operation).toBe("search_only");
+
+      const matches = result.details.matches as Array<{
+        id: string;
+        similarity: number;
+      }>;
+
+      // Every surfaced match must clear the new threshold; the low-similarity
+      // tangential row (_distance=2.0 -> score ~0.333) must be dropped.
+      for (const m of matches) {
+        expect(m.similarity).toBeGreaterThanOrEqual(0.5);
+      }
+      const ids = matches.map((m) => m.id);
+      expect(ids).not.toContain("aaaaaaaa-0000-0000-0000-000000000003");
+
+      // No DB writes in search-only mode.
+      expect(tableAdd).not.toHaveBeenCalled();
+      expect(tableDelete).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace preserves the original memoryId across the delete+insert", async () => {
+    const existingId = "bbbbbbbb-1111-1111-1111-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Original memory text",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    const originalHome = process.env.HOME;
+    process.env.HOME = getTmpDir();
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find(
+        (t) => t.opts?.name === "memory_refresh",
+      )?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-id-preserve", {
+        text: "Updated memory text with new information",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("replaced");
+
+      // The stable id MUST survive the replace so callers can keep using
+      // whatever reference they cached before the refresh.
+      expect(result.details.old_id).toBe(existingId);
+      expect(result.details.new_id).toBe(existingId);
+
+      // The new row inserted into the table must carry the same id.
+      expect(tableAdd).toHaveBeenCalledTimes(1);
+      const addCall = (tableAdd.mock.calls as unknown[][][])[0]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(addCall.id).toBe(existingId);
+      expect(addCall.text).toBe("Updated memory text with new information");
+    } finally {
+      if (originalHome !== undefined) {
+        process.env.HOME = originalHome;
+      } else {
+        delete process.env.HOME;
+      }
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
   });
 });
 

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2945,7 +2945,6 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("Random note")).toBe("other");
   });
 
-
   // ============================================================================
   // memory_refresh tests
   // ============================================================================
@@ -2957,7 +2956,6 @@ describe("memory plugin e2e", () => {
     queryWhere: ReturnType<typeof vi.fn>;
     tableAdd: ReturnType<typeof vi.fn>;
     tableDelete: ReturnType<typeof vi.fn>;
-    // oxlint-disable-next-line typescript/no-explicit-any
     registeredTools: any[];
   }) {
     return {
@@ -2981,7 +2979,6 @@ describe("memory plugin e2e", () => {
         error: vi.fn(),
         debug: vi.fn(),
       },
-      // oxlint-disable-next-line typescript/no-explicit-any
       registerTool: (tool: any, toolOpts: any) => {
         opts.registeredTools.push({ tool, opts: toolOpts });
       },
@@ -3037,7 +3034,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3055,7 +3054,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3066,7 +3064,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3118,7 +3115,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3138,14 +3137,12 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
 
       // Use tmpDir for audit log by temporarily pointing homedir there
       const originalHome = process.env.HOME;
       process.env.HOME = getTmpDir();
 
-      // oxlint-disable-next-line typescript/no-explicit-any
       let result: any;
       try {
         const mockApi = buildMockApiForRefresh({
@@ -3157,7 +3154,6 @@ describe("memory plugin e2e", () => {
           tableDelete,
           registeredTools,
         });
-        // oxlint-disable-next-line typescript/no-explicit-any
         memoryPlugin.register(mockApi as any);
 
         const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3233,7 +3229,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3251,7 +3249,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3262,7 +3259,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3325,7 +3321,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3343,7 +3341,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3354,7 +3351,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3425,7 +3421,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3443,7 +3441,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3454,7 +3451,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3503,7 +3499,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3521,7 +3519,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3532,7 +3529,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
@@ -3601,7 +3597,9 @@ describe("memory plugin e2e", () => {
     vi.resetModules();
     vi.doMock("openai", () => ({
       default: class MockOpenAI {
-        embeddings = { create: embeddingsCreate };
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
       },
     }));
     vi.doMock("@lancedb/lancedb", () => ({
@@ -3619,7 +3617,6 @@ describe("memory plugin e2e", () => {
 
     try {
       const { default: memoryPlugin } = await import("./index.js");
-      // oxlint-disable-next-line typescript/no-explicit-any
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3630,7 +3627,6 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      // oxlint-disable-next-line typescript/no-explicit-any
       memoryPlugin.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -3194,7 +3194,7 @@ describe("memory plugin e2e", () => {
       // Check audit log was written
       auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
       const fsPromises = await import("node:fs/promises");
-      const auditContent = await fsPromises.readFile(auditLogPath!, "utf8").catch(() => null);
+      const auditContent = await fsPromises.readFile(auditLogPath, "utf8").catch(() => null);
       expect(auditContent).not.toBeNull();
       const auditLine = JSON.parse(auditContent!.trim());
       expect(auditLine.operation).toBe("replaced");
@@ -3211,7 +3211,7 @@ describe("memory plugin e2e", () => {
       // On non-POSIX platforms (Windows) mode bits are not meaningfully
       // enforced, so skip the assertion there.
       if (process.platform !== "win32") {
-        const fileStat = await fsPromises.stat(auditLogPath!);
+        const fileStat = await fsPromises.stat(auditLogPath);
         expect(fileStat.mode & 0o777).toBe(0o600);
         const dirStat = await fsPromises.stat(`${getTmpDir()}/.openclaw/memory`);
         expect(dirStat.mode & 0o777).toBe(0o700);

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2945,6 +2945,722 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("Random note")).toBe("other");
   });
 
+
+  // ============================================================================
+  // memory_refresh tests
+  // ============================================================================
+
+  function buildMockApiForRefresh(opts: {
+    dbPath: string;
+    embeddingsCreate: ReturnType<typeof vi.fn>;
+    vectorSearch: ReturnType<typeof vi.fn>;
+    queryWhere: ReturnType<typeof vi.fn>;
+    tableAdd: ReturnType<typeof vi.fn>;
+    tableDelete: ReturnType<typeof vi.fn>;
+    // oxlint-disable-next-line typescript/no-explicit-any
+    registeredTools: any[];
+  }) {
+    return {
+      id: "memory-lancedb",
+      name: "Memory (LanceDB)",
+      source: "test",
+      config: {},
+      pluginConfig: {
+        embedding: {
+          apiKey: OPENAI_API_KEY,
+          model: "text-embedding-3-small",
+        },
+        dbPath: opts.dbPath,
+        autoCapture: false,
+        autoRecall: false,
+      },
+      runtime: {},
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      // oxlint-disable-next-line typescript/no-explicit-any
+      registerTool: (tool: any, toolOpts: any) => {
+        opts.registeredTools.push({ tool, opts: toolOpts });
+      },
+      registerCli: vi.fn(),
+      registerService: vi.fn(),
+      on: vi.fn(),
+      resolvePath: (p: string) => p,
+    };
+  }
+
+  test("memory_refresh search-only mode returns matches without writing to DB", async () => {
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+
+    const mockSearchResults = [
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000001",
+        text: "Match one",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.8,
+        category: "fact",
+        createdAt: 1000,
+        _distance: 0.05,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000002",
+        text: "Match two",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.7,
+        category: "preference",
+        createdAt: 1001,
+        _distance: 0.1,
+      },
+      {
+        id: "aaaaaaaa-0000-0000-0000-000000000003",
+        text: "Match three",
+        vector: [0.1, 0.2, 0.3],
+        importance: 0.6,
+        category: "other",
+        createdAt: 1002,
+        _distance: 0.2,
+      },
+    ];
+
+    const toArray = vi.fn(async () => mockSearchResults);
+    const limit = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({ limit }));
+    const queryWhere = vi.fn();
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 3),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Call without memoryId → search-only mode
+      const result = await refreshTool.execute("test-refresh-search", {
+        text: "user prefers dark theme",
+      });
+
+      expect(result.details.operation).toBe("search_only");
+      expect(result.details.matches).toHaveLength(3);
+      const matches = result.details.matches as Array<Record<string, unknown>>;
+      expect(matches[0]).toHaveProperty("similarity");
+      expect(matches[0].similarity).toBeGreaterThan(0);
+
+      // Verify nothing was written to the DB
+      expect(tableAdd).not.toHaveBeenCalled();
+      expect(tableDelete).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh atomic replace: old entry gone, new entry present, audit log written", async () => {
+    const existingId = "bbbbbbbb-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Old memory text that will be replaced",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const searchToArray = vi.fn(async () => []);
+    const searchLimit = vi.fn(() => ({ toArray: searchToArray }));
+    const vectorSearch = vi.fn(() => ({ limit: searchLimit }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    let auditLogPath: string | null = null;
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+
+      // Use tmpDir for audit log by temporarily pointing homedir there
+      const originalHome = process.env.HOME;
+      process.env.HOME = getTmpDir();
+
+      // oxlint-disable-next-line typescript/no-explicit-any
+      let result: any;
+      try {
+        const mockApi = buildMockApiForRefresh({
+          dbPath: getDbPath(),
+          embeddingsCreate,
+          vectorSearch,
+          queryWhere,
+          tableAdd,
+          tableDelete,
+          registeredTools,
+        });
+        // oxlint-disable-next-line typescript/no-explicit-any
+        memoryPlugin.register(mockApi as any);
+
+        const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+        expect(refreshTool).toBeDefined();
+
+        result = await refreshTool.execute("test-refresh-replace", {
+          text: "Updated memory text with new information",
+          category: "fact",
+          importance: 0.9,
+          memoryId: existingId,
+        });
+      } finally {
+        if (originalHome !== undefined) {
+          process.env.HOME = originalHome;
+        } else {
+          delete process.env.HOME;
+        }
+      }
+
+      expect(result).toBeDefined();
+      expect(result.details.operation).toBe("replaced");
+      expect(result.details.old_id).toBe(existingId);
+      expect(result.details.new_id).toBeDefined();
+      expect(result.details.old_text_preview).toContain("Old memory");
+
+      // Verify delete was called for old entry
+      expect(tableDelete).toHaveBeenCalledWith(`id = '${existingId}'`);
+
+      // Verify add was called for new entry
+      expect(tableAdd).toHaveBeenCalledTimes(1);
+      const addCall = (tableAdd.mock.calls as unknown[][][])[0]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(addCall.text).toBe("Updated memory text with new information");
+      expect(addCall.importance).toBe(0.9);
+
+      // Check audit log was written
+      auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
+      const auditContent = await import("node:fs/promises").then((fsPromises) =>
+        fsPromises.readFile(auditLogPath!, "utf8").catch(() => null),
+      );
+      expect(auditContent).not.toBeNull();
+      const auditLine = JSON.parse(auditContent!.trim());
+      expect(auditLine.operation).toBe("replaced");
+      expect(auditLine.old_id).toBe(existingId);
+      expect(auditLine.new_id).toBeDefined();
+      // Memory text is intentionally NOT written to audit logs to protect user privacy
+      expect(auditLine.old_text).toBeUndefined();
+      expect(auditLine.new_text).toBeUndefined();
+      expect(auditLine.ts).toBeGreaterThan(0);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace with non-existent ID returns error without creating entry", async () => {
+    const nonExistentId = "cccccccc-0000-0000-0000-000000000001";
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => []); // empty → not found
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 0),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-notfound", {
+        text: "This text won't be stored",
+        memoryId: nonExistentId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("not_found");
+      expect(result.details.memoryId).toBe(nonExistentId);
+
+      // Verify nothing was written or deleted
+      expect(tableAdd).not.toHaveBeenCalled();
+      expect(tableDelete).not.toHaveBeenCalled();
+
+      // Verify the embedding API was not called — a stale/invalid memoryId
+      // should short-circuit before incurring an embedding round-trip.
+      expect(embeddingsCreate).not.toHaveBeenCalled();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh best-effort rollback: restores original when insert fails", async () => {
+    const existingId = "dddddddd-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Original memory that must be restored",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.8,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // First call to add throws (new entry); second call succeeds (rollback restore)
+    let addCallCount = 0;
+    const tableAdd = vi.fn(async () => {
+      addCallCount++;
+      if (addCallCount === 1) {
+        throw new Error("Simulated insert failure");
+      }
+      // second call (rollback) succeeds
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-rollback", {
+        text: "New text that will fail to insert",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("insert_failed");
+      expect(result.details.rollbackWarning).toContain("restored");
+
+      // Verify delete was called (old entry was removed before the attempted insert)
+      expect(tableDelete).toHaveBeenCalledWith(`id = '${existingId}'`);
+
+      // Verify add was called twice: once for new entry (failed), once for rollback (succeeded)
+      expect(tableAdd).toHaveBeenCalledTimes(2);
+
+      // Second add call should restore original content with original ID
+      const rollbackAddCall = (tableAdd.mock.calls as unknown[][][])[1]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(rollbackAddCall.text).toBe(existingEntry.text);
+      expect(rollbackAddCall.importance).toBe(existingEntry.importance);
+      expect(rollbackAddCall.category).toBe(existingEntry.category);
+      // The rollback must preserve the original ID so callers are never left
+      // with a stale reference to a non-existent row.
+      expect(rollbackAddCall.id).toBe(existingEntry.id);
+
+      // The return value must expose the restored ID for the caller.
+      expect(result.details.restored_id).toBe(existingEntry.id);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh rollback failure: restored_id is null when both insert and rollback fail", async () => {
+    const existingId = "dddddddd-0000-0000-0000-000000000002";
+    const existingEntry = {
+      id: existingId,
+      text: "Memory that cannot be recovered",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.8,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // Both insert and rollback fail
+    const tableAdd = vi.fn(async () => {
+      throw new Error("Simulated storage failure");
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-double-fail", {
+        text: "New text that will fail to insert",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("error");
+      expect(result.details.error).toBe("insert_failed");
+      expect(result.details.success).toBe(false);
+      expect(result.details.rollbackWarning).toContain("DATA LOSS POSSIBLE");
+      // When rollback also failed, restored_id must be null — not the original ID.
+      expect(result.details.restored_id).toBeNull();
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace inherits category and importance from existing when not provided", async () => {
+    const existingId = "eeeeeeee-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Old memory text",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.9, // non-default, to verify it is inherited
+      category: "decision" as const,
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Call with only text — omit category and importance entirely.
+      const result = await refreshTool.execute("test-refresh-inherit", {
+        text: "Updated text only - no category or importance supplied",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("replaced");
+
+      // The new entry must carry over the original category and importance.
+      const addCall = (tableAdd.mock.calls as unknown[][][])[0]?.[0]?.[0] as Record<
+        string,
+        unknown
+      >;
+      expect(addCall.text).toBe("Updated text only - no category or importance supplied");
+      expect(addCall.category).toBe("decision"); // inherited from existingEntry
+      expect(addCall.importance).toBe(0.9); // inherited from existingEntry
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh concurrent replace calls on same ID serialize: operations do not interleave", async () => {
+    const existingId = "ffffffff-0000-0000-0000-000000000001";
+    const existingEntry = {
+      id: existingId,
+      text: "Original text",
+      vector: [0.1, 0.2, 0.3],
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    // Track the order of DB operations across both concurrent calls.
+    const callLog: string[] = [];
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+    }));
+
+    // Static mock: getById always returns the same entry regardless of prior deletes.
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    // tableDelete introduces a small async gap so that without the mutex the
+    // two calls' delete operations would both complete before either add fires,
+    // producing the interleaved log ["delete","delete","add","add"].
+    // With the mutex the expected log is ["delete","add","delete","add"].
+    const tableDelete = vi.fn(async () => {
+      callLog.push("delete");
+      await new Promise<void>((r) => setTimeout(r, 5));
+    });
+    const tableAdd = vi.fn(async () => {
+      callLog.push("add");
+    });
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        embeddings = { create: embeddingsCreate };
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPlugin } = await import("./index.js");
+      // oxlint-disable-next-line typescript/no-explicit-any
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      // oxlint-disable-next-line typescript/no-explicit-any
+      memoryPlugin.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      // Fire two replace calls simultaneously on the same memoryId.
+      const [result1, result2] = await Promise.all([
+        refreshTool.execute("concurrent-call-1", { text: "Update A", memoryId: existingId }),
+        refreshTool.execute("concurrent-call-2", { text: "Update B", memoryId: existingId }),
+      ]);
+
+      // Both calls must complete without throwing.
+      expect(result1).toBeDefined();
+      expect(result2).toBeDefined();
+
+      // Both succeed because the static mock always returns the entry.
+      expect(result1.details.operation).toBe("replaced");
+      expect(result2.details.operation).toBe("replaced");
+
+      // Serialized pattern: delete, add, delete, add.
+      // Interleaved (racy) pattern would be: delete, delete, add, add.
+      // The mutex guarantees the former.
+      expect(callLog).toEqual(["delete", "add", "delete", "add"]);
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
   test("memory_forget candidate list shows full UUIDs, not truncated IDs", async () => {
     const fakeUuid1 = "890e1fae-1234-5678-abcd-ef0123456789";
     const fakeUuid2 = "a1b2c3d4-5678-9abc-def0-1234567890ab";

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -2945,11 +2945,9 @@ describe("memory plugin e2e", () => {
     expect(detectCategory("Random note")).toBe("other");
   });
 
-  // =====================================================================  });
-
+  // ============================================================================
   // memory_refresh tests
-  // =====================================================================  });
-
+  // ============================================================================
 
   function buildMockApiForRefresh(opts: {
     dbPath: string;
@@ -3055,7 +3053,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3066,7 +3064,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -3135,10 +3133,8 @@ describe("memory plugin e2e", () => {
       })),
     }));
 
-    let auditLogPath: string | null = null;
-
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
 
       // Use tmpDir for audit log by temporarily pointing homedir there
@@ -3156,7 +3152,7 @@ describe("memory plugin e2e", () => {
           tableDelete,
           registeredTools,
         });
-        memoryPlugin.register(mockApi as any);
+        memoryPluginUnderTest.register(mockApi as any);
 
         const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
         expect(refreshTool).toBeDefined();
@@ -3194,7 +3190,7 @@ describe("memory plugin e2e", () => {
       expect(addCall.importance).toBe(0.9);
 
       // Check audit log was written
-      auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
+      const auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
       const fsPromises = await import("node:fs/promises");
       const auditContent = await fsPromises.readFile(auditLogPath, "utf8").catch(() => null);
       expect(auditContent).not.toBeNull();
@@ -3218,6 +3214,81 @@ describe("memory plugin e2e", () => {
         const dirStat = await fsPromises.stat(`${getTmpDir()}/.openclaw/memory`);
         expect(dirStat.mode & 0o777).toBe(0o700);
       }
+    } finally {
+      vi.doUnmock("openai");
+      vi.doUnmock("@lancedb/lancedb");
+      vi.resetModules();
+    }
+  });
+
+  test("memory_refresh replace handles typed-array stored vectors from LanceDB", async () => {
+    const existingId = "bbbbbbbb-0000-0000-0000-000000000002";
+    const existingEntry = {
+      id: existingId,
+      text: "Old memory text stored with a typed vector",
+      vector: new Float32Array([0.1, 0.2, 0.3]),
+      importance: 0.7,
+      category: "fact",
+      createdAt: 1000,
+    };
+
+    const embeddingsCreate = vi.fn(async () => ({
+      data: [{ embedding: [0.15, 0.25, 0.35] }],
+    }));
+    const tableAdd = vi.fn(async () => undefined);
+    const tableDelete = vi.fn(async () => undefined);
+    const toArray = vi.fn(async () => [existingEntry]);
+    const queryWhere = vi.fn(() => ({ toArray }));
+    const vectorSearch = vi.fn(() => ({
+      limit: vi.fn(() => ({ toArray: vi.fn(async () => []) })),
+    }));
+
+    vi.resetModules();
+    vi.doMock("openai", () => ({
+      default: class MockOpenAI {
+        post = vi.fn((_path: string, opts: { body?: unknown }) =>
+          invokeEmbeddingCreate(embeddingsCreate, opts.body),
+        );
+      },
+    }));
+    vi.doMock("@lancedb/lancedb", () => ({
+      connect: vi.fn(async () => ({
+        tableNames: vi.fn(async () => ["memories"]),
+        openTable: vi.fn(async () => ({
+          vectorSearch,
+          query: vi.fn(() => ({ where: queryWhere })),
+          countRows: vi.fn(async () => 1),
+          add: tableAdd,
+          delete: tableDelete,
+        })),
+      })),
+    }));
+
+    try {
+      const { default: memoryPluginUnderTest } = await import("./index.js");
+      const registeredTools: any[] = [];
+      const mockApi = buildMockApiForRefresh({
+        dbPath: getDbPath(),
+        embeddingsCreate,
+        vectorSearch,
+        queryWhere,
+        tableAdd,
+        tableDelete,
+        registeredTools,
+      });
+      memoryPluginUnderTest.register(mockApi as any);
+
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
+      expect(refreshTool).toBeDefined();
+
+      const result = await refreshTool.execute("test-refresh-typed-vector", {
+        text: "Updated memory text with normalized stored vector",
+        memoryId: existingId,
+      });
+
+      expect(result.details.operation).toBe("replaced");
+      expect(tableDelete).toHaveBeenCalledWith(`id = '${existingId}'`);
+      expect(tableAdd).toHaveBeenCalledTimes(1);
     } finally {
       vi.doUnmock("openai");
       vi.doUnmock("@lancedb/lancedb");
@@ -3261,7 +3332,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3272,7 +3343,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -3353,7 +3424,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3364,7 +3435,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -3453,7 +3524,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3464,7 +3535,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -3531,7 +3602,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3542,7 +3613,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -3601,7 +3672,9 @@ describe("memory plugin e2e", () => {
     // With the mutex the expected log is ["delete","add","delete","add"].
     const tableDelete = vi.fn(async () => {
       callLog.push("delete");
-      await new Promise<void>((r) => setTimeout(r, 5));
+      await new Promise<void>((r) => {
+        setTimeout(r, 5);
+      });
     });
     const tableAdd = vi.fn(async () => {
       callLog.push("add");
@@ -3629,7 +3702,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -3640,7 +3713,7 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
       const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
@@ -4662,7 +4735,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -4673,11 +4746,9 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
-      const refreshRegistration = registeredTools.find(
-        (t) => t.opts?.name === "memory_refresh",
-      );
+      const refreshRegistration = registeredTools.find((t) => t.opts?.name === "memory_refresh");
       expect(refreshRegistration).toBeDefined();
       const description = refreshRegistration.tool.description as string;
 
@@ -4742,7 +4813,7 @@ describe("memory plugin e2e", () => {
         importance: 0.4,
         category: "other",
         createdAt: 1002,
-        _distance: 2.0,
+        _distance: 2,
       },
     ];
 
@@ -4773,7 +4844,7 @@ describe("memory plugin e2e", () => {
     }));
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -4784,11 +4855,9 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
-      const refreshTool = registeredTools.find(
-        (t) => t.opts?.name === "memory_refresh",
-      )?.tool;
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
 
       const result = await refreshTool.execute("test-refresh-threshold", {
@@ -4868,7 +4937,7 @@ describe("memory plugin e2e", () => {
     process.env.HOME = getTmpDir();
 
     try {
-      const { default: memoryPlugin } = await import("./index.js");
+      const { default: memoryPluginUnderTest } = await import("./index.js");
       const registeredTools: any[] = [];
       const mockApi = buildMockApiForRefresh({
         dbPath: getDbPath(),
@@ -4879,11 +4948,9 @@ describe("memory plugin e2e", () => {
         tableDelete,
         registeredTools,
       });
-      memoryPlugin.register(mockApi as any);
+      memoryPluginUnderTest.register(mockApi as any);
 
-      const refreshTool = registeredTools.find(
-        (t) => t.opts?.name === "memory_refresh",
-      )?.tool;
+      const refreshTool = registeredTools.find((t) => t.opts?.name === "memory_refresh")?.tool;
       expect(refreshTool).toBeDefined();
 
       const result = await refreshTool.execute("test-refresh-id-preserve", {

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -3193,9 +3193,8 @@ describe("memory plugin e2e", () => {
 
       // Check audit log was written
       auditLogPath = `${getTmpDir()}/.openclaw/memory/refresh-audit.jsonl`;
-      const auditContent = await import("node:fs/promises").then((fsPromises) =>
-        fsPromises.readFile(auditLogPath!, "utf8").catch(() => null),
-      );
+      const fsPromises = await import("node:fs/promises");
+      const auditContent = await fsPromises.readFile(auditLogPath!, "utf8").catch(() => null);
       expect(auditContent).not.toBeNull();
       const auditLine = JSON.parse(auditContent!.trim());
       expect(auditLine.operation).toBe("replaced");
@@ -3205,6 +3204,18 @@ describe("memory plugin e2e", () => {
       expect(auditLine.old_text).toBeUndefined();
       expect(auditLine.new_text).toBeUndefined();
       expect(auditLine.ts).toBeGreaterThan(0);
+
+      // Audit log directory and file must not be world-readable: the file
+      // contains memory ids and timestamps that should not leak across users
+      // on shared hosts where the process umask is permissive (e.g. 0o022).
+      // On non-POSIX platforms (Windows) mode bits are not meaningfully
+      // enforced, so skip the assertion there.
+      if (process.platform !== "win32") {
+        const fileStat = await fsPromises.stat(auditLogPath!);
+        expect(fileStat.mode & 0o777).toBe(0o600);
+        const dirStat = await fsPromises.stat(`${getTmpDir()}/.openclaw/memory`);
+        expect(dirStat.mode & 0o777).toBe(0o700);
+      }
     } finally {
       vi.doUnmock("openai");
       vi.doUnmock("@lancedb/lancedb");

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -8,6 +8,9 @@
 
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
+import { appendFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
 import OpenAI from "openai";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
@@ -148,6 +151,31 @@ function resolveAutoCaptureStartIndex(
     return cursor.nextIndex;
   }
   return 0;
+}
+
+// ============================================================================
+// Per-memoryId mutex
+// Serializes concurrent replace calls on the same ID so that a
+// delete/insert from one caller never races with another.
+// ============================================================================
+
+const _memoryLocks = new Map<string, Promise<void>>();
+
+function withMemoryLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const prev = _memoryLocks.get(id) ?? Promise.resolve();
+  let resolveLock!: () => void;
+  const next = new Promise<void>((r) => {
+    resolveLock = r;
+  });
+  _memoryLocks.set(id, next);
+  return prev
+    .then(() => fn())
+    .finally(() => {
+      resolveLock();
+      if (_memoryLocks.get(id) === next) {
+        _memoryLocks.delete(id);
+      }
+    });
 }
 
 // ============================================================================
@@ -292,6 +320,34 @@ class MemoryDB {
     }
     await this.table!.delete(`id = '${id}'`);
     return true;
+  }
+
+  async getById(id: string): Promise<MemoryEntry | null> {
+    await this.ensureInitialized();
+    // Validate UUID format to prevent injection
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+    const rows = await this.table!.query().where(`id = '${id}'`).toArray();
+    if (rows.length === 0) {
+      return null;
+    }
+    const row = rows[0];
+    return {
+      id: row.id as string,
+      text: row.text as string,
+      vector: row.vector as number[],
+      importance: row.importance as number,
+      category: row.category as MemoryEntry["category"],
+      createdAt: row.createdAt as number,
+    };
+  }
+
+  async storeRaw(entry: MemoryEntry): Promise<MemoryEntry> {
+    await this.ensureInitialized();
+    await this.table!.add([entry]);
+    return entry;
   }
 
   async count(): Promise<number> {
@@ -767,11 +823,15 @@ export default definePluginEntry({
           const { query, memoryId } = params as { query?: string; memoryId?: string };
 
           if (memoryId) {
-            await db.delete(memoryId);
-            return {
-              content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
-              details: { action: "deleted", id: memoryId },
-            };
+            // Acquire per-ID lock so that a concurrent memory_refresh replace
+            // on the same ID cannot race with this delete.
+            return withMemoryLock(memoryId, async () => {
+              await db.delete(memoryId);
+              return {
+                content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
+                details: { action: "deleted", id: memoryId },
+              };
+            });
           }
 
           if (query) {
@@ -789,11 +849,17 @@ export default definePluginEntry({
             }
 
             if (results.length === 1 && results[0].score > 0.9) {
-              await db.delete(results[0].entry.id);
-              return {
-                content: [{ type: "text", text: `Forgotten: "${results[0].entry.text}"` }],
-                details: { action: "deleted", id: results[0].entry.id },
-              };
+              const targetId = results[0].entry.id;
+              // Acquire per-ID lock before the auto-delete so that a concurrent
+              // memory_refresh replace cannot interleave its delete/insert between
+              // our search result selection and delete.
+              return withMemoryLock(targetId, async () => {
+                await db.delete(targetId);
+                return {
+                  content: [{ type: "text", text: `Forgotten: "${results[0].entry.text}"` }],
+                  details: { action: "deleted", id: targetId },
+                };
+              });
             }
 
             const list = results
@@ -826,6 +892,180 @@ export default definePluginEntry({
         },
       },
       { name: "memory_forget" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_refresh",
+        label: "Memory Refresh",
+        description:
+          "Search for existing memories similar to new content, or atomically replace a specific memory by ID. Use for updating facts without data loss: call without memoryId to preview similar memories, then call with memoryId to atomically replace.",
+        parameters: Type.Object({
+          text: Type.String({ description: "New memory content (required in execute mode)" }),
+          category: Type.Optional(
+            Type.Unsafe<MemoryCategory>({
+              type: "string",
+              enum: [...MEMORY_CATEGORIES],
+            }),
+          ),
+          importance: Type.Optional(
+            Type.Number({ description: "Importance 0.0-1.0 (default: inherited or 0.7)" }),
+          ),
+          memoryId: Type.Optional(
+            Type.String({
+              description:
+                "If provided: atomically replace this memory. If omitted: search-only mode.",
+            }),
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const { text, category, importance, memoryId } = params as {
+            text: string;
+            category?: MemoryEntry["category"];
+            importance?: number;
+            memoryId?: string;
+          };
+
+          // ------------------------------------------------------------------
+          // MODE 1: Search-only (no memoryId)
+          // Embed first, then search — no existence check needed here.
+          // ------------------------------------------------------------------
+          if (!memoryId) {
+            const vector = await embeddings.embed(text);
+            const results = await db.search(vector, 3, 0.1);
+            const matches = results.map((r) => ({
+              id: r.entry.id,
+              text: r.entry.text,
+              category: r.entry.category,
+              importance: r.entry.importance,
+              similarity: r.score,
+            }));
+
+            const summaryText =
+              matches.length === 0
+                ? "No similar memories found."
+                : `Found ${matches.length} similar memories:\n\n${matches
+                    .map(
+                      (m, i) =>
+                        `${i + 1}. [${m.id.slice(0, 8)}] (${(m.similarity * 100).toFixed(0)}%) ${m.text}`,
+                    )
+                    .join("\n")}`;
+
+            return {
+              content: [{ type: "text", text: summaryText }],
+              details: { operation: "search_only", matches },
+            };
+          }
+
+          // ------------------------------------------------------------------
+          // MODE 2: Atomic replace (memoryId provided)
+          // Check existence BEFORE calling embeddings.embed() so that a typo
+          // or stale ID returns immediately without a wasted API call.
+          // Wrapped in withMemoryLock so concurrent calls on the same ID
+          // serialize correctly (no interleaved delete/insert races).
+          // ------------------------------------------------------------------
+          return withMemoryLock(memoryId, async () => {
+            const existing = await db.getById(memoryId);
+            if (!existing) {
+              return {
+                content: [{ type: "text", text: `Memory ${memoryId} not found.` }],
+                details: { operation: "error", error: "not_found", memoryId },
+              };
+            }
+
+            // Inherit category and importance from the existing entry when the
+            // caller does not supply them, so a text-only update never silently
+            // resets metadata to defaults.
+            const resolvedCategory = category ?? existing.category;
+            const resolvedImportance = importance ?? existing.importance;
+
+            const vector = await embeddings.embed(text);
+            const oldTextPreview = existing.text.slice(0, 80);
+
+            // Delete the old entry
+            await db.delete(memoryId);
+
+            // Insert new entry — with best-effort rollback on failure
+            let newEntry: MemoryEntry;
+            let rollbackWarning: string | undefined;
+
+            try {
+              newEntry = await db.store({
+                text,
+                vector,
+                importance: resolvedImportance,
+                category: resolvedCategory,
+              });
+            } catch (insertErr) {
+              // Best-effort rollback: restore the original entry with its
+              // original ID so callers are never left with a stale reference
+              // to a non-existent ID.
+              let rollbackSucceeded = false;
+              try {
+                await db.storeRaw(existing);
+                rollbackSucceeded = true;
+                rollbackWarning = `Insert failed; original restored with original ID ${existing.id}. Insert error: ${String(insertErr)}`;
+              } catch (rollbackErr) {
+                rollbackWarning = `Insert failed AND rollback failed (DATA LOSS POSSIBLE). Insert: ${String(insertErr)}. Rollback: ${String(rollbackErr)}`;
+              }
+              return {
+                content: [{ type: "text", text: `Replace failed: ${rollbackWarning}` }],
+                details: {
+                  operation: "error",
+                  error: "insert_failed",
+                  success: false,
+                  rollbackWarning,
+                  ...(rollbackSucceeded ? { restored_id: existing.id } : { restored_id: null }),
+                },
+              };
+            }
+
+            // Compute similarity using 1/(1+L2) — the same metric used by
+            // memory_recall and db.search — so audit log entries are comparable.
+            let similarity: number | null = null;
+            if (existing.vector.length === vector.length) {
+              const l2sq = existing.vector.reduce((sum, v, i) => {
+                const diff = v - (vector[i] ?? 0);
+                return sum + diff * diff;
+              }, 0);
+              similarity = 1 / (1 + Math.sqrt(l2sq));
+            }
+
+            // Append to audit log (metadata only — memory text is private user data
+            // and must never be written to audit logs).
+            const auditLogPath = path.join(homedir(), ".openclaw", "memory", "refresh-audit.jsonl");
+            try {
+              await mkdir(path.dirname(auditLogPath), { recursive: true });
+              const auditEntry = {
+                ts: Date.now(),
+                operation: "replaced",
+                old_id: memoryId,
+                new_id: newEntry.id,
+                similarity,
+              };
+              await appendFile(auditLogPath, JSON.stringify(auditEntry) + "\n", "utf8");
+            } catch (auditErr) {
+              api.logger.warn(`memory-lancedb: audit log write failed: ${String(auditErr)}`);
+            }
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Replaced memory ${memoryId.slice(0, 8)}… → ${newEntry.id.slice(0, 8)}…\n\nOld: "${oldTextPreview}"\nNew: "${text.slice(0, 80)}"`,
+                },
+              ],
+              details: {
+                operation: "replaced",
+                old_id: memoryId,
+                new_id: newEntry.id,
+                old_text_preview: oldTextPreview,
+              },
+            };
+          });
+        },
+      },
+      { name: "memory_refresh" },
     );
 
     // ========================================================================

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -8,7 +8,7 @@
 
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile, chmod, mkdir, open, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
@@ -158,6 +158,11 @@ function resolveAutoCaptureStartIndex(
 // Serializes concurrent replace calls on the same ID so that a
 // delete/insert from one caller never races with another.
 // ============================================================================
+
+// Validates the UUID shape used by memory entry IDs. Hoisted to module scope
+// so delete/getById share a single source of truth instead of duplicating the
+// pattern at each call site.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const _memoryLocks = new Map<string, Promise<void>>();
 
@@ -314,8 +319,7 @@ class MemoryDB {
   async delete(id: string): Promise<boolean> {
     await this.ensureInitialized();
     // Validate UUID format to prevent injection
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(id)) {
+    if (!UUID_RE.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
     }
     await this.table!.delete(`id = '${id}'`);
@@ -325,8 +329,7 @@ class MemoryDB {
   async getById(id: string): Promise<MemoryEntry | null> {
     await this.ensureInitialized();
     // Validate UUID format to prevent injection
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(id)) {
+    if (!UUID_RE.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
     }
     const rows = await this.table!.query().where(`id = '${id}'`).toArray();
@@ -959,12 +962,30 @@ export default definePluginEntry({
 
           // ------------------------------------------------------------------
           // MODE 2: Atomic replace (memoryId provided)
-          // Check existence BEFORE calling embeddings.embed() so that a typo
+          // Pre-check existence BEFORE calling embeddings.embed() so a typo
           // or stale ID returns immediately without a wasted API call.
-          // Wrapped in withMemoryLock so concurrent calls on the same ID
-          // serialize correctly (no interleaved delete/insert races).
+          // Then embed OUTSIDE the per-id mutex so the slow remote call does
+          // not block other refreshes targeting the same id. Re-validate
+          // inside the lock to handle a concurrent forget/replace that
+          // dropped the row between the precheck and lock acquisition.
           // ------------------------------------------------------------------
+          const precheck = await db.getById(memoryId);
+          if (!precheck) {
+            return {
+              content: [{ type: "text", text: `Memory ${memoryId} not found.` }],
+              details: { operation: "error", error: "not_found", memoryId },
+            };
+          }
+
+          // Embed outside the lock — the remote API call dominates wall time
+          // for replace operations and has no shared state to protect.
+          const vector = await embeddings.embed(text);
+
           return withMemoryLock(memoryId, async () => {
+            // Re-validate inside the lock: a concurrent forget or another
+            // refresh that started between the precheck and lock acquisition
+            // could have removed the entry. Without this re-check the replace
+            // would resurrect a deleted memory under the same id.
             const existing = await db.getById(memoryId);
             if (!existing) {
               return {
@@ -979,7 +1000,6 @@ export default definePluginEntry({
             const resolvedCategory = category ?? existing.category;
             const resolvedImportance = importance ?? existing.importance;
 
-            const vector = await embeddings.embed(text);
             const oldTextPreview = existing.text.slice(0, 80);
 
             // Delete the old entry
@@ -1032,10 +1052,23 @@ export default definePluginEntry({
             }
 
             // Append to audit log (metadata only — memory text is private user data
-            // and must never be written to audit logs).
+            // and must never be written to audit logs). The directory and file
+            // are created with restrictive modes so the audit trail is not
+            // world-readable on multi-user hosts where the process umask is
+            // permissive (e.g. 0o022).
             const auditLogPath = path.join(homedir(), ".openclaw", "memory", "refresh-audit.jsonl");
             try {
-              await mkdir(path.dirname(auditLogPath), { recursive: true });
+              await mkdir(path.dirname(auditLogPath), { recursive: true, mode: 0o700 });
+              // Detect first-time creation so we can explicitly chmod after
+              // open(). open(path, "a", mode) honors mode only when the file
+              // does not yet exist, so for existing-but-loose files we still
+              // need an explicit chmod to enforce 0o600.
+              let preexisting = true;
+              try {
+                await stat(auditLogPath);
+              } catch {
+                preexisting = false;
+              }
               const auditEntry = {
                 ts: Date.now(),
                 operation: "replaced",
@@ -1043,7 +1076,17 @@ export default definePluginEntry({
                 new_id: newEntry.id,
                 similarity,
               };
-              await appendFile(auditLogPath, JSON.stringify(auditEntry) + "\n", "utf8");
+              const handle = await open(auditLogPath, "a", 0o600);
+              try {
+                await appendFile(handle, JSON.stringify(auditEntry) + "\n", "utf8");
+              } finally {
+                await handle.close();
+              }
+              if (!preexisting) {
+                // Belt-and-braces: even when open(..., 0o600) created the file,
+                // some platforms still apply the umask, so re-assert the mode.
+                await chmod(auditLogPath, 0o600);
+              }
             } catch (auditErr) {
               api.logger.warn(`memory-lancedb: audit log write failed: ${String(auditErr)}`);
             }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -8,7 +8,7 @@
 
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile, chmod, mkdir, open, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
@@ -201,6 +201,11 @@ function resolveAutoCaptureStartIndex(
 // delete/insert from one caller never races with another.
 // ============================================================================
 
+// Validates the UUID shape used by memory entry IDs. Hoisted to module scope
+// so delete/getById share a single source of truth instead of duplicating the
+// pattern at each call site.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const _memoryLocks = new Map<string, Promise<void>>();
 
 function withMemoryLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
@@ -370,8 +375,7 @@ class MemoryDB {
   async delete(id: string): Promise<boolean> {
     await this.ensureInitialized();
     // Validate UUID format to prevent injection
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(id)) {
+    if (!UUID_RE.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
     }
     await this.table!.delete(`id = '${id}'`);
@@ -381,8 +385,7 @@ class MemoryDB {
   async getById(id: string): Promise<MemoryEntry | null> {
     await this.ensureInitialized();
     // Validate UUID format to prevent injection
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(id)) {
+    if (!UUID_RE.test(id)) {
       throw new Error(`Invalid memory ID format: ${id}`);
     }
     const rows = await this.table!.query().where(`id = '${id}'`).toArray();
@@ -1890,12 +1893,30 @@ export default definePluginEntry({
 
           // ------------------------------------------------------------------
           // MODE 2: Atomic replace (memoryId provided)
-          // Check existence BEFORE calling embeddings.embed() so that a typo
+          // Pre-check existence BEFORE calling embeddings.embed() so a typo
           // or stale ID returns immediately without a wasted API call.
-          // Wrapped in withMemoryLock so concurrent calls on the same ID
-          // serialize correctly (no interleaved delete/insert races).
+          // Then embed OUTSIDE the per-id mutex so the slow remote call does
+          // not block other refreshes targeting the same id. Re-validate
+          // inside the lock to handle a concurrent forget/replace that
+          // dropped the row between the precheck and lock acquisition.
           // ------------------------------------------------------------------
+          const precheck = await db.getById(memoryId);
+          if (!precheck) {
+            return {
+              content: [{ type: "text", text: `Memory ${memoryId} not found.` }],
+              details: { operation: "error", error: "not_found", memoryId },
+            };
+          }
+
+          // Embed outside the lock — the remote API call dominates wall time
+          // for replace operations and has no shared state to protect.
+          const vector = await embeddings.embed(text);
+
           return withMemoryLock(memoryId, async () => {
+            // Re-validate inside the lock: a concurrent forget or another
+            // refresh that started between the precheck and lock acquisition
+            // could have removed the entry. Without this re-check the replace
+            // would resurrect a deleted memory under the same id.
             const existing = await db.getById(memoryId);
             if (!existing) {
               return {
@@ -1910,7 +1931,6 @@ export default definePluginEntry({
             const resolvedCategory = category ?? existing.category;
             const resolvedImportance = importance ?? existing.importance;
 
-            const vector = await embeddings.embed(text);
             const oldTextPreview = existing.text.slice(0, 80);
 
             // Delete the old entry
@@ -1963,10 +1983,23 @@ export default definePluginEntry({
             }
 
             // Append to audit log (metadata only — memory text is private user data
-            // and must never be written to audit logs).
+            // and must never be written to audit logs). The directory and file
+            // are created with restrictive modes so the audit trail is not
+            // world-readable on multi-user hosts where the process umask is
+            // permissive (e.g. 0o022).
             const auditLogPath = path.join(homedir(), ".openclaw", "memory", "refresh-audit.jsonl");
             try {
-              await mkdir(path.dirname(auditLogPath), { recursive: true });
+              await mkdir(path.dirname(auditLogPath), { recursive: true, mode: 0o700 });
+              // Detect first-time creation so we can explicitly chmod after
+              // open(). open(path, "a", mode) honors mode only when the file
+              // does not yet exist, so for existing-but-loose files we still
+              // need an explicit chmod to enforce 0o600.
+              let preexisting = true;
+              try {
+                await stat(auditLogPath);
+              } catch {
+                preexisting = false;
+              }
               const auditEntry = {
                 ts: Date.now(),
                 operation: "replaced",
@@ -1974,7 +2007,17 @@ export default definePluginEntry({
                 new_id: newEntry.id,
                 similarity,
               };
-              await appendFile(auditLogPath, JSON.stringify(auditEntry) + "\n", "utf8");
+              const handle = await open(auditLogPath, "a", 0o600);
+              try {
+                await appendFile(handle, JSON.stringify(auditEntry) + "\n", "utf8");
+              } finally {
+                await handle.close();
+              }
+              if (!preexisting) {
+                // Belt-and-braces: even when open(..., 0o600) created the file,
+                // some platforms still apply the umask, so re-assert the mode.
+                await chmod(auditLogPath, 0o600);
+              }
             } catch (auditErr) {
               api.logger.warn(`memory-lancedb: audit log write failed: ${String(auditErr)}`);
             }

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -246,6 +246,13 @@ const DEFAULT_AUTO_RECALL_OVERFETCH_LIMIT = 10;
 const DEFAULT_AUTO_RECALL_RESULT_CAP = 3;
 const DUPLICATE_SEARCH_LIMIT = 5;
 
+// Minimum similarity score for memory_refresh's conflict-preview search.
+// Mirrors the default minScore on MemoryDB.search so the preview only flags
+// entries that share meaningful similarity with the new text; lower values
+// (e.g. memory_recall's liberal 0.1) surface tangentially-related rows that
+// are poor replacement targets.
+const REFRESH_CONFLICT_MIN_SCORE = 0.5;
+
 function parsePositiveIntegerOption(value: string | undefined, flag: string): number | undefined {
   if (value === undefined) {
     return undefined;
@@ -308,12 +315,22 @@ class MemoryDB {
     }
   }
 
-  async store(entry: Omit<MemoryEntry, "id" | "createdAt">): Promise<MemoryEntry> {
+  async store(
+    entry: Omit<MemoryEntry, "id" | "createdAt">,
+    options: { id?: string } = {},
+  ): Promise<MemoryEntry> {
     await this.ensureInitialized();
+
+    // memory_refresh passes the existing id so a replace preserves the stable
+    // identifier callers may have cached. Validate the shape so a malformed id
+    // can never reach the SQL filter or the row payload.
+    if (options.id !== undefined && !UUID_RE.test(options.id)) {
+      throw new Error(`Invalid memory ID format: ${options.id}`);
+    }
 
     const fullEntry: MemoryEntry = {
       ...entry,
-      id: randomUUID(),
+      id: options.id ?? randomUUID(),
       createdAt: Date.now(),
     };
 
@@ -1833,7 +1850,7 @@ export default definePluginEntry({
         name: "memory_refresh",
         label: "Memory Refresh",
         description:
-          "Search for existing memories similar to new content, or atomically replace a specific memory by ID. Use for updating facts without data loss: call without memoryId to preview similar memories, then call with memoryId to atomically replace.",
+          "Search for existing memories similar to new content, or replace a specific memory by ID. Use for updating facts: call without memoryId to preview similar memories, then call with memoryId to perform a best-effort replace with process-level serialization. The replace path is NOT a storage-level transaction (LanceDB does not expose multi-statement transactions through this code path); it is a process-mutex-serialized delete-then-insert with best-effort rollback on insert failure. The replaced entry keeps its original id so any cached references stay valid.",
         parameters: Type.Object({
           text: Type.String({ description: "New memory content (required in execute mode)" }),
           category: Type.Optional(
@@ -1848,7 +1865,7 @@ export default definePluginEntry({
           memoryId: Type.Optional(
             Type.String({
               description:
-                "If provided: atomically replace this memory. If omitted: search-only mode.",
+                "If provided: best-effort replace of this memory (process-mutex serialized, not a storage-level transaction). If omitted: search-only mode.",
             }),
           ),
         }),
@@ -1863,10 +1880,17 @@ export default definePluginEntry({
           // ------------------------------------------------------------------
           // MODE 1: Search-only (no memoryId)
           // Embed first, then search — no existence check needed here.
+          // The minScore is intentionally stricter than memory_recall's
+          // liberal 0.1: a conflict preview is meant to surface plausible
+          // near-duplicates so the agent can decide whether to replace an
+          // existing entry. A loose threshold here drowns the agent in
+          // tangentially-related matches and encourages bad replace targets.
+          // Use the db.search default (0.5) so the preview only flags
+          // entries that share meaningful similarity with the new text.
           // ------------------------------------------------------------------
           if (!memoryId) {
             const vector = await embeddings.embed(text);
-            const results = await db.search(vector, 3, 0.1);
+            const results = await db.search(vector, 3, REFRESH_CONFLICT_MIN_SCORE);
             const matches = results.map((r) => ({
               id: r.entry.id,
               text: r.entry.text,
@@ -1892,7 +1916,30 @@ export default definePluginEntry({
           }
 
           // ------------------------------------------------------------------
-          // MODE 2: Atomic replace (memoryId provided)
+          // MODE 2: Best-effort replace (memoryId provided)
+          //
+          // ATOMICITY: This is NOT a storage-level atomic transaction.
+          // LanceDB's Table API does not expose multi-statement transactions
+          // through this code path, so the replace is implemented as a
+          // delete + insert sequence guarded by a per-id mutex.
+          //   - Serialized: concurrent memory_refresh/memory_forget calls on
+          //     the same id queue behind the mutex, so two concurrent
+          //     replaces never interleave their delete/insert pairs.
+          //   - Not serialized: cross-process writers (a second OpenClaw
+          //     process talking to the same LanceDB directory) can still
+          //     race; the mutex is process-local only.
+          //   - Not atomic: if the insert throws after the delete succeeds,
+          //     the entry is gone from the table. We attempt a best-effort
+          //     rollback by re-inserting the original row, but the rollback
+          //     itself can fail (network/disk error), in which case the
+          //     response carries restored_id: null and a rollbackWarning.
+          //
+          // ID PRESERVATION: The replace passes the existing memoryId through
+          // to db.store({ id: memoryId }) so the new row keeps the original
+          // stable identifier. Callers that cached the id before the refresh
+          // can keep using it after the refresh; old_id and new_id in the
+          // response will be equal on success.
+          //
           // Pre-check existence BEFORE calling embeddings.embed() so a typo
           // or stale ID returns immediately without a wasted API call.
           // Then embed OUTSIDE the per-id mutex so the slow remote call does
@@ -1941,12 +1988,17 @@ export default definePluginEntry({
             let rollbackWarning: string | undefined;
 
             try {
-              newEntry = await db.store({
-                text,
-                vector,
-                importance: resolvedImportance,
-                category: resolvedCategory,
-              });
+              // Preserve the original memoryId so callers that cached the id
+              // before the refresh keep a valid reference afterwards.
+              newEntry = await db.store(
+                {
+                  text,
+                  vector,
+                  importance: resolvedImportance,
+                  category: resolvedCategory,
+                },
+                { id: memoryId },
+              );
             } catch (insertErr) {
               // Best-effort rollback: restore the original entry with its
               // original ID so callers are never left with a stale reference
@@ -2022,11 +2074,15 @@ export default definePluginEntry({
               api.logger.warn(`memory-lancedb: audit log write failed: ${String(auditErr)}`);
             }
 
+            // The id is preserved across a successful replace, so render a
+            // single id rather than implying it changed. old_id and new_id
+            // are kept in details for callers/audit consumers that already
+            // depend on the field shape; on success they will be equal.
             return {
               content: [
                 {
                   type: "text",
-                  text: `Replaced memory ${memoryId.slice(0, 8)}… → ${newEntry.id.slice(0, 8)}…\n\nOld: "${oldTextPreview}"\nNew: "${text.slice(0, 80)}"`,
+                  text: `Replaced memory ${memoryId.slice(0, 8)}… (id preserved)\n\nOld: "${oldTextPreview}"\nNew: "${text.slice(0, 80)}"`,
                 },
               ],
               details: {

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -206,23 +206,91 @@ function resolveAutoCaptureStartIndex(
 // pattern at each call site.
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-const _memoryLocks = new Map<string, Promise<void>>();
+const memoryLocks = new Map<string, Promise<void>>();
 
 function withMemoryLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
-  const prev = _memoryLocks.get(id) ?? Promise.resolve();
+  const prev = memoryLocks.get(id) ?? Promise.resolve();
   let resolveLock!: () => void;
   const next = new Promise<void>((r) => {
     resolveLock = r;
   });
-  _memoryLocks.set(id, next);
+  memoryLocks.set(id, next);
   return prev
     .then(() => fn())
     .finally(() => {
       resolveLock();
-      if (_memoryLocks.get(id) === next) {
-        _memoryLocks.delete(id);
+      if (memoryLocks.get(id) === next) {
+        memoryLocks.delete(id);
       }
     });
+}
+
+function finiteVectorFromArrayLike(value: ArrayLike<unknown>): number[] | null {
+  const vector: number[] = [];
+  for (const item of Array.from(value)) {
+    if (typeof item !== "number" || !Number.isFinite(item)) {
+      return null;
+    }
+    vector.push(item);
+  }
+  return vector;
+}
+
+function normalizeStoredMemoryVector(value: unknown): number[] {
+  if (Array.isArray(value)) {
+    return finiteVectorFromArrayLike(value) ?? [];
+  }
+  if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+    return finiteVectorFromArrayLike(value as unknown as ArrayLike<unknown>) ?? [];
+  }
+  if (typeof value === "string") {
+    try {
+      const parsed = JSON.parse(value) as unknown;
+      const parsedVector = normalizeStoredMemoryVector(parsed);
+      if (parsedVector.length > 0) {
+        return parsedVector;
+      }
+    } catch {}
+    return [];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const record = value as Record<string, unknown>;
+  const toArray = record.toArray;
+  if (typeof toArray === "function") {
+    try {
+      const vector = normalizeStoredMemoryVector(toArray.call(value));
+      if (vector.length > 0) {
+        return vector;
+      }
+    } catch {}
+  }
+  for (const key of ["values", "data", "vector", "embedding"] as const) {
+    if (key in record) {
+      const vector = normalizeStoredMemoryVector(record[key]);
+      if (vector.length > 0) {
+        return vector;
+      }
+    }
+  }
+  if (typeof record.length === "number") {
+    return finiteVectorFromArrayLike(record as unknown as ArrayLike<unknown>) ?? [];
+  }
+  return [];
+}
+
+function scoreStoredVectorSimilarity(existingVector: unknown, nextVector: number[]): number | null {
+  const previousVector = normalizeStoredMemoryVector(existingVector);
+  if (previousVector.length === 0 || previousVector.length !== nextVector.length) {
+    return null;
+  }
+  let l2sq = 0;
+  for (let index = 0; index < previousVector.length; index += 1) {
+    const diff = previousVector[index] - (nextVector[index] ?? 0);
+    l2sq += diff * diff;
+  }
+  return 1 / (1 + Math.sqrt(l2sq));
 }
 
 // ============================================================================
@@ -2025,21 +2093,18 @@ export default definePluginEntry({
 
             // Compute similarity using 1/(1+L2) — the same metric used by
             // memory_recall and db.search — so audit log entries are comparable.
-            let similarity: number | null = null;
-            if (existing.vector.length === vector.length) {
-              const l2sq = existing.vector.reduce((sum, v, i) => {
-                const diff = v - (vector[i] ?? 0);
-                return sum + diff * diff;
-              }, 0);
-              similarity = 1 / (1 + Math.sqrt(l2sq));
-            }
+            // LanceDB may return stored vectors as typed arrays or array-like
+            // wrappers, so normalize before scoring instead of assuming
+            // Array.prototype.reduce exists.
+            const similarity = scoreStoredVectorSimilarity(existing.vector, vector);
 
             // Append to audit log (metadata only — memory text is private user data
             // and must never be written to audit logs). The directory and file
             // are created with restrictive modes so the audit trail is not
             // world-readable on multi-user hosts where the process umask is
             // permissive (e.g. 0o022).
-            const auditLogPath = path.join(homedir(), ".openclaw", "memory", "refresh-audit.jsonl");
+            const auditHome = process.env.HOME ?? homedir();
+            const auditLogPath = path.join(auditHome, ".openclaw", "memory", "refresh-audit.jsonl");
             try {
               await mkdir(path.dirname(auditLogPath), { recursive: true, mode: 0o700 });
               // Detect first-time creation so we can explicitly chmod after

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -8,6 +8,9 @@
 
 import { Buffer } from "node:buffer";
 import { randomUUID } from "node:crypto";
+import { appendFile, mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import path from "node:path";
 import type * as LanceDB from "@lancedb/lancedb";
 import type { AgentToolResult } from "openclaw/plugin-sdk/agent-core";
 import {
@@ -193,6 +196,31 @@ function resolveAutoCaptureStartIndex(
 }
 
 // ============================================================================
+// Per-memoryId mutex
+// Serializes concurrent replace calls on the same ID so that a
+// delete/insert from one caller never races with another.
+// ============================================================================
+
+const _memoryLocks = new Map<string, Promise<void>>();
+
+function withMemoryLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const prev = _memoryLocks.get(id) ?? Promise.resolve();
+  let resolveLock!: () => void;
+  const next = new Promise<void>((r) => {
+    resolveLock = r;
+  });
+  _memoryLocks.set(id, next);
+  return prev
+    .then(() => fn())
+    .finally(() => {
+      resolveLock();
+      if (_memoryLocks.get(id) === next) {
+        _memoryLocks.delete(id);
+      }
+    });
+}
+
+// ============================================================================
 // LanceDB Provider
 // ============================================================================
 
@@ -348,6 +376,34 @@ class MemoryDB {
     }
     await this.table!.delete(`id = '${id}'`);
     return true;
+  }
+
+  async getById(id: string): Promise<MemoryEntry | null> {
+    await this.ensureInitialized();
+    // Validate UUID format to prevent injection
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!uuidRegex.test(id)) {
+      throw new Error(`Invalid memory ID format: ${id}`);
+    }
+    const rows = await this.table!.query().where(`id = '${id}'`).toArray();
+    if (rows.length === 0) {
+      return null;
+    }
+    const row = rows[0];
+    return {
+      id: row.id as string,
+      text: row.text as string,
+      vector: row.vector as number[],
+      importance: row.importance as number,
+      category: row.category as MemoryEntry["category"],
+      createdAt: row.createdAt as number,
+    };
+  }
+
+  async storeRaw(entry: MemoryEntry): Promise<MemoryEntry> {
+    await this.ensureInitialized();
+    await this.table!.add([entry]);
+    return entry;
   }
 
   async count(): Promise<number> {
@@ -1698,11 +1754,15 @@ export default definePluginEntry({
           const { query, memoryId } = params as { query?: string; memoryId?: string };
 
           if (memoryId) {
-            await db.delete(memoryId);
-            return {
-              content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
-              details: { action: "deleted", id: memoryId },
-            };
+            // Acquire per-ID lock so that a concurrent memory_refresh replace
+            // on the same ID cannot race with this delete.
+            return withMemoryLock(memoryId, async () => {
+              await db.delete(memoryId);
+              return {
+                content: [{ type: "text", text: `Memory ${memoryId} forgotten.` }],
+                details: { action: "deleted", id: memoryId },
+              };
+            });
           }
 
           if (query) {
@@ -1720,11 +1780,17 @@ export default definePluginEntry({
             }
 
             if (results.length === 1 && results[0].score > 0.9) {
-              await db.delete(results[0].entry.id);
-              return {
-                content: [{ type: "text", text: `Forgotten: "${results[0].entry.text}"` }],
-                details: { action: "deleted", id: results[0].entry.id },
-              };
+              const targetId = results[0].entry.id;
+              // Acquire per-ID lock before the auto-delete so that a concurrent
+              // memory_refresh replace cannot interleave its delete/insert between
+              // our search result selection and delete.
+              return withMemoryLock(targetId, async () => {
+                await db.delete(targetId);
+                return {
+                  content: [{ type: "text", text: `Forgotten: "${results[0].entry.text}"` }],
+                  details: { action: "deleted", id: targetId },
+                };
+              });
             }
 
             const list = results
@@ -1757,6 +1823,180 @@ export default definePluginEntry({
         },
       },
       { name: "memory_forget" },
+    );
+
+    api.registerTool(
+      {
+        name: "memory_refresh",
+        label: "Memory Refresh",
+        description:
+          "Search for existing memories similar to new content, or atomically replace a specific memory by ID. Use for updating facts without data loss: call without memoryId to preview similar memories, then call with memoryId to atomically replace.",
+        parameters: Type.Object({
+          text: Type.String({ description: "New memory content (required in execute mode)" }),
+          category: Type.Optional(
+            Type.Unsafe<MemoryCategory>({
+              type: "string",
+              enum: [...MEMORY_CATEGORIES],
+            }),
+          ),
+          importance: Type.Optional(
+            Type.Number({ description: "Importance 0.0-1.0 (default: inherited or 0.7)" }),
+          ),
+          memoryId: Type.Optional(
+            Type.String({
+              description:
+                "If provided: atomically replace this memory. If omitted: search-only mode.",
+            }),
+          ),
+        }),
+        async execute(_toolCallId, params) {
+          const { text, category, importance, memoryId } = params as {
+            text: string;
+            category?: MemoryEntry["category"];
+            importance?: number;
+            memoryId?: string;
+          };
+
+          // ------------------------------------------------------------------
+          // MODE 1: Search-only (no memoryId)
+          // Embed first, then search — no existence check needed here.
+          // ------------------------------------------------------------------
+          if (!memoryId) {
+            const vector = await embeddings.embed(text);
+            const results = await db.search(vector, 3, 0.1);
+            const matches = results.map((r) => ({
+              id: r.entry.id,
+              text: r.entry.text,
+              category: r.entry.category,
+              importance: r.entry.importance,
+              similarity: r.score,
+            }));
+
+            const summaryText =
+              matches.length === 0
+                ? "No similar memories found."
+                : `Found ${matches.length} similar memories:\n\n${matches
+                    .map(
+                      (m, i) =>
+                        `${i + 1}. [${m.id.slice(0, 8)}] (${(m.similarity * 100).toFixed(0)}%) ${m.text}`,
+                    )
+                    .join("\n")}`;
+
+            return {
+              content: [{ type: "text", text: summaryText }],
+              details: { operation: "search_only", matches },
+            };
+          }
+
+          // ------------------------------------------------------------------
+          // MODE 2: Atomic replace (memoryId provided)
+          // Check existence BEFORE calling embeddings.embed() so that a typo
+          // or stale ID returns immediately without a wasted API call.
+          // Wrapped in withMemoryLock so concurrent calls on the same ID
+          // serialize correctly (no interleaved delete/insert races).
+          // ------------------------------------------------------------------
+          return withMemoryLock(memoryId, async () => {
+            const existing = await db.getById(memoryId);
+            if (!existing) {
+              return {
+                content: [{ type: "text", text: `Memory ${memoryId} not found.` }],
+                details: { operation: "error", error: "not_found", memoryId },
+              };
+            }
+
+            // Inherit category and importance from the existing entry when the
+            // caller does not supply them, so a text-only update never silently
+            // resets metadata to defaults.
+            const resolvedCategory = category ?? existing.category;
+            const resolvedImportance = importance ?? existing.importance;
+
+            const vector = await embeddings.embed(text);
+            const oldTextPreview = existing.text.slice(0, 80);
+
+            // Delete the old entry
+            await db.delete(memoryId);
+
+            // Insert new entry — with best-effort rollback on failure
+            let newEntry: MemoryEntry;
+            let rollbackWarning: string | undefined;
+
+            try {
+              newEntry = await db.store({
+                text,
+                vector,
+                importance: resolvedImportance,
+                category: resolvedCategory,
+              });
+            } catch (insertErr) {
+              // Best-effort rollback: restore the original entry with its
+              // original ID so callers are never left with a stale reference
+              // to a non-existent ID.
+              let rollbackSucceeded = false;
+              try {
+                await db.storeRaw(existing);
+                rollbackSucceeded = true;
+                rollbackWarning = `Insert failed; original restored with original ID ${existing.id}. Insert error: ${String(insertErr)}`;
+              } catch (rollbackErr) {
+                rollbackWarning = `Insert failed AND rollback failed (DATA LOSS POSSIBLE). Insert: ${String(insertErr)}. Rollback: ${String(rollbackErr)}`;
+              }
+              return {
+                content: [{ type: "text", text: `Replace failed: ${rollbackWarning}` }],
+                details: {
+                  operation: "error",
+                  error: "insert_failed",
+                  success: false,
+                  rollbackWarning,
+                  ...(rollbackSucceeded ? { restored_id: existing.id } : { restored_id: null }),
+                },
+              };
+            }
+
+            // Compute similarity using 1/(1+L2) — the same metric used by
+            // memory_recall and db.search — so audit log entries are comparable.
+            let similarity: number | null = null;
+            if (existing.vector.length === vector.length) {
+              const l2sq = existing.vector.reduce((sum, v, i) => {
+                const diff = v - (vector[i] ?? 0);
+                return sum + diff * diff;
+              }, 0);
+              similarity = 1 / (1 + Math.sqrt(l2sq));
+            }
+
+            // Append to audit log (metadata only — memory text is private user data
+            // and must never be written to audit logs).
+            const auditLogPath = path.join(homedir(), ".openclaw", "memory", "refresh-audit.jsonl");
+            try {
+              await mkdir(path.dirname(auditLogPath), { recursive: true });
+              const auditEntry = {
+                ts: Date.now(),
+                operation: "replaced",
+                old_id: memoryId,
+                new_id: newEntry.id,
+                similarity,
+              };
+              await appendFile(auditLogPath, JSON.stringify(auditEntry) + "\n", "utf8");
+            } catch (auditErr) {
+              api.logger.warn(`memory-lancedb: audit log write failed: ${String(auditErr)}`);
+            }
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `Replaced memory ${memoryId.slice(0, 8)}… → ${newEntry.id.slice(0, 8)}…\n\nOld: "${oldTextPreview}"\nNew: "${text.slice(0, 80)}"`,
+                },
+              ],
+              details: {
+                operation: "replaced",
+                old_id: memoryId,
+                new_id: newEntry.id,
+                old_text_preview: oldTextPreview,
+              },
+            };
+          });
+        },
+      },
+      { name: "memory_refresh" },
     );
 
     // ========================================================================

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -5,7 +5,7 @@
   },
   "kind": "memory",
   "contracts": {
-    "tools": ["memory_forget", "memory_recall", "memory_store"]
+    "tools": ["memory_forget", "memory_recall", "memory_refresh", "memory_store"]
   },
   "uiHints": {
     "embedding.apiKey": {

--- a/extensions/memory-lancedb/openclaw.plugin.json
+++ b/extensions/memory-lancedb/openclaw.plugin.json
@@ -9,7 +9,7 @@
   },
   "kind": "memory",
   "contracts": {
-    "tools": ["memory_forget", "memory_recall", "memory_store"]
+    "tools": ["memory_forget", "memory_recall", "memory_refresh", "memory_store"]
   },
   "uiHints": {
     "embedding.apiKey": {


### PR DESCRIPTION
## Problem

The `memory-lancedb` extension currently provides three tools: `memory_recall`, `memory_store`, and `memory_forget`. There is no atomic update/replace operation, which creates a data-loss window: if an agent calls `memory_forget` and then `memory_store` in sequence and the store fails, the original memory is gone with nothing to replace it.

Additionally, there is no way to preview similar memories before storing, so agents cannot detect conflicts before overwriting.

## Solution

Adds a `memory_refresh` tool that operates in two modes:

### Mode 1 - Search-only (no `memoryId`)

Call with only `text` to preview similar memories before committing:
- Embeds `text` using the same model as `memory_recall`
- Searches LanceDB for top 3 similar entries (with cosine similarity scores)
- Returns matches without storing anything

### Mode 2 - Atomic replace (`memoryId` provided)

Atomically replaces a specific memory:
1. Validates existence before embedding API call (no wasted API round-trip for stale IDs)
2. Inherits category and importance from existing entry when not supplied
3. Deletes old entry, inserts new entry with best-effort rollback on insert failure
4. Per-ID mutex prevents concurrent replace calls from interleaving
5. Appends metadata-only audit log to `~/.openclaw/memory/refresh-audit.jsonl`

`memory_forget` also uses the same per-ID mutex for correctness.

## Also included

Metadata stripping for `src/memory/session-files.ts buildSessionEntry`: strips Conversation info / inbound metadata blocks, leading directive tags (`[[reply_to_current]]` etc.), and DOW timestamp envelopes from user messages before indexing.

## Restoration note

Restores closed #43498 (closed 2026-03-16 to free a PR slot for #67475). Branch rebuilt from scratch against current main. Adapted to post-refactor memory-lancedb architecture (no lancedb-runtime.js boundary, direct @lancedb/lancedb import, session-files at src/memory/ not packages/memory-host-sdk/).

286 tests pass, 1 live test skipped (needs OPENAI_API_KEY). Clean build, no INEFFECTIVE_DYNAMIC_IMPORT warnings. No scope creep: only the 4 originally-touched files changed.



## Real behavior proof

- **Behavior or issue addressed**: Without `memory_refresh`, replacing a memory entry required `memory_forget` + `memory_store` as two separate tool calls, leaving a window where the entry is deleted before the replacement is written. Concurrent auto-recall or competing agent turns during that window returned incomplete context. The new tool serializes the delete-then-insert through a per-memory-ID mutex and preserves the original UUID across the replace so existing references remain valid.
- **Real environment tested**: `mac-mini.lan` production host (Kbot @Kebablebot / @RattyMcRatfaceBot), running `upgrade-2026.5.12` deployment which includes this commit. Plugin running live, serving real agent turns, with a populated `~/.openclaw/memory/lancedb/memories.lance` store.
- **Exact steps or command run after this patch**:
  ```bash
  ssh alexm@mac-mini.lan 'grep -E "memory-lancedb" ~/.openclaw/logs/gateway.log | tail -10'
  ssh alexm@mac-mini.lan 'grep -A1 "\"tools\"" /Users/alexm/.openclaw/openclaw/extensions/memory-lancedb/openclaw.plugin.json'
  ssh alexm@mac-mini.lan 'ls -la ~/.openclaw/memory/lancedb/'
  ```
- **Evidence after fix (live runtime log excerpt from `~/.openclaw/logs/gateway.log` on mac-mini.lan, 2026-05-17)**:
  ```
  2026-05-17T07:30:29.591-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  2026-05-17T08:00:37.543-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  2026-05-17T08:30:40.185-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  2026-05-17T09:00:57.556-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  2026-05-17T10:00:38.732-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  2026-05-17T10:30:30.471-04:00 [plugins] memory-lancedb: injecting 3 memories into context
  ```
  The memory-lancedb plugin is actively serving inference traffic on a host running 2026.5.12. The plugin manifest on the same host now lists the new tool:
  ```
      "tools": ["memory_forget", "memory_recall", "memory_refresh", "memory_store"]
  ```
  Combined with the on-disk store at `~/.openclaw/memory/lancedb/memories.lance/`, this is end-to-end evidence that `memory_refresh` is wired into a live plugin instance handling real agent turns, not just registered in a manifest.
- **Observed result after fix**: Tool exposed to agents on a live production gateway. Tool description self-discloses "best-effort replace with process-level serialization" rather than claiming storage-level atomicity (LanceDB Table API does not expose multi-statement transactions, and the mutex only serializes within the single gateway process). Conflict-preview minScore raised from 0.1 to 0.5 (matches `MemoryDB.search` default) so unrelated entries no longer surface as "similar". Replace path preserves the original UUID via the new optional `id` parameter on `MemoryDB.store`, so `details.old_id === details.new_id` on success.
- **What was not tested**: Behavior under a real cross-process race against a competing writer (single-gateway deployment can't produce that scenario). Behavior when LanceDB itself fails mid-insert (manual fault injection would be needed; the current rollback path is best-effort `storeRaw` of the captured pre-state and is documented as such).

