### PR TITLE
fix(mcp): evict cached session runtime when transport closes unexpectedly

### DIFF
--- a/src/agents/pi-bundle-mcp-runtime.test.ts
+++ b/src/agents/pi-bundle-mcp-runtime.test.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createBundleMcpJsonSchemaValidator } from "./pi-bundle-mcp-runtime.js";
-import { cleanupBundleMcpHarness } from "./pi-bundle-mcp-test-harness.js";
+import {
+  cleanupBundleMcpHarness,
+  makeTempDir,
+  waitForFileText,
+  writeBundleProbeMcpServer,
+} from "./pi-bundle-mcp-test-harness.js";
 import {
   __testing,
   getOrCreateSessionMcpRuntime,
@@ -496,5 +502,56 @@ describe("session MCP runtime", () => {
     await expect(manager.sweepIdleRuntimes()).resolves.toBe(0);
     expect(manager.listSessionIds()).toEqual(["session-no-ttl"]);
     expect(disposed).toEqual([]);
+  });
+
+  it("evicts the cached session runtime when a stdio MCP child exits unexpectedly", async () => {
+    // Repro for the staleness bug: an MCP subprocess dies (idle-exit, OOM,
+    // crash) but SessionMcpRuntime keeps the cached BundleMcpSession. The
+    // SDK's Protocol nulls its _transport on transport.onclose, so every
+    // subsequent callTool throws "Not connected" until session rollover.
+    // Fix: wire transport.onclose to evict the runtime so the next
+    // getOrCreate respawns cleanly.
+    const tempDir = await makeTempDir("openclaw-mcp-onclose-");
+    const serverScriptPath = path.join(tempDir, "probe.mjs");
+    const pidPath = path.join(tempDir, "probe.pid");
+    await writeBundleProbeMcpServer(serverScriptPath, { pidPath });
+
+    const cfg = {
+      mcp: {
+        servers: {
+          probe: {
+            command: "node",
+            args: [serverScriptPath],
+            env: { BUNDLE_PROBE_TEXT: "alive" },
+          },
+        },
+      },
+    };
+
+    const runtime = await getOrCreateSessionMcpRuntime({
+      sessionId: "session-onclose",
+      sessionKey: "agent:test:session-onclose",
+      workspaceDir: tempDir,
+      cfg,
+    });
+    // Force catalog materialization → real spawn + connectWithTimeout, which
+    // is the moment the fix wires transport.onclose.
+    await runtime.getCatalog();
+    expect(__testing.getCachedSessionIds()).toContain("session-onclose");
+
+    const pidStr = await waitForFileText(pidPath, 5_000);
+    const pid = Number.parseInt(pidStr.trim(), 10);
+    expect(pid).toBeGreaterThan(0);
+    process.kill(pid, "SIGKILL");
+
+    // child.close → transport.onclose → onTransportClosed → manager.disposeSession
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      if (!__testing.getCachedSessionIds().includes("session-onclose")) {
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(__testing.getCachedSessionIds()).not.toContain("session-onclose");
   });
 });

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -12,7 +12,7 @@ import type {
 } from "@modelcontextprotocol/sdk/validation/types.js";
 import type { ErrorObject, ValidateFunction } from "ajv";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { logWarn } from "../logger.js";
+import { logInfo, logWarn } from "../logger.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { redactSensitiveUrlLikeString } from "../shared/net/redact-sensitive-url.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
@@ -273,10 +273,12 @@ export function createSessionMcpRuntime(params: {
           // and break its own _transport cleanup. Calling our handler before
           // the SDK's runs lets the manager evict the cached runtime in the
           // same tick the SDK nulls out Client._transport.
+          // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP SDK Transport interface uses onclose/onerror fields, not DOM EventTarget
           resolved.transport.onclose = () => {
             sessions.delete(serverName);
             params.onTransportClosed?.({ serverName });
           };
+          // oxlint-disable-next-line unicorn/prefer-add-event-listener -- MCP SDK Transport interface uses onclose/onerror fields, not DOM EventTarget
           resolved.transport.onerror = (error: Error) => {
             if (!disposed) {
               logWarn(
@@ -558,6 +560,9 @@ function createSessionMcpRuntimeManager(
           cfg: params.cfg,
           configFingerprint: nextFingerprint,
           onTransportClosed: ({ serverName }) => {
+            logInfo(
+              `bundle-mcp: retiring runtime for session ${params.sessionId} after transport "${serverName}" closed; next getOrCreate will respawn`,
+            );
             void disposeSessionInternal(params.sessionId).catch((error) => {
               logWarn(
                 `bundle-mcp: failed to retire runtime for session ${params.sessionId} ` +

--- a/src/agents/pi-bundle-mcp-runtime.ts
+++ b/src/agents/pi-bundle-mcp-runtime.ts
@@ -183,6 +183,16 @@ export function createSessionMcpRuntime(params: {
   sessionKey?: string;
   workspaceDir: string;
   cfg?: OpenClawConfig;
+  /**
+   * Invoked when a connected MCP transport for this runtime closes
+   * unexpectedly (child subprocess exit, stdio EOF, HTTP socket drop).
+   * The manager wires this to its own `disposeSession(sessionId)` so the
+   * cached `BundleMcpSession` — whose underlying `Client._transport` has
+   * been nulled by the SDK's Protocol.onclose — can't keep being returned
+   * by `getOrCreate`. Without it, every subsequent `callTool` throws
+   * "Not connected" until session rollover.
+   */
+  onTransportClosed?: (info: { serverName: string }) => void;
 }): SessionMcpRuntime {
   const { loaded, fingerprint: configFingerprint } = loadSessionMcpConfig({
     workspaceDir: params.workspaceDir,
@@ -255,6 +265,25 @@ export function createSessionMcpRuntime(params: {
             detachStderr: resolved.detachStderr,
           };
           sessions.set(serverName, session);
+
+          // Wire transport-close eviction BEFORE connectWithTimeout. The SDK's
+          // Protocol.connect reads the existing transport.onclose and chains
+          // around it (see @modelcontextprotocol/sdk shared/protocol.js); if
+          // we assigned afterward we'd overwrite the SDK's chained handler
+          // and break its own _transport cleanup. Calling our handler before
+          // the SDK's runs lets the manager evict the cached runtime in the
+          // same tick the SDK nulls out Client._transport.
+          resolved.transport.onclose = () => {
+            sessions.delete(serverName);
+            params.onTransportClosed?.({ serverName });
+          };
+          resolved.transport.onerror = (error: Error) => {
+            if (!disposed) {
+              logWarn(
+                `bundle-mcp: transport "${serverName}" error in session ${params.sessionId}: ${redactErrorUrls(error)}`,
+              );
+            }
+          };
 
           try {
             failIfDisposed();
@@ -458,6 +487,23 @@ function createSessionMcpRuntimeManager(
     idleSweepTimer = undefined;
   };
 
+  const disposeSessionInternal = async (sessionId: string): Promise<void> => {
+    const inFlight = createInFlight.get(sessionId);
+    createInFlight.delete(sessionId);
+    let runtime = runtimesBySessionId.get(sessionId);
+    if (!runtime && inFlight) {
+      runtime = await inFlight.promise.catch(() => undefined);
+    }
+    runtimesBySessionId.delete(sessionId);
+    idleTtlMsBySessionId.delete(sessionId);
+    if (!runtime) {
+      forgetSessionKeysForSessionId(sessionId);
+      return;
+    }
+    forgetSessionKeysForSessionId(sessionId);
+    await runtime.dispose();
+  };
+
   return {
     async getOrCreate(params) {
       const idleTtlMs = resolveSessionMcpRuntimeIdleTtlMs(params.cfg);
@@ -511,6 +557,14 @@ function createSessionMcpRuntimeManager(
           workspaceDir: params.workspaceDir,
           cfg: params.cfg,
           configFingerprint: nextFingerprint,
+          onTransportClosed: ({ serverName }) => {
+            void disposeSessionInternal(params.sessionId).catch((error) => {
+              logWarn(
+                `bundle-mcp: failed to retire runtime for session ${params.sessionId} ` +
+                  `after transport "${serverName}" closed: ${String(error)}`,
+              );
+            });
+          },
         }),
       ).then((runtime) => {
         runtime.markUsed();
@@ -535,22 +589,7 @@ function createSessionMcpRuntimeManager(
     resolveSessionId(sessionKey) {
       return sessionIdBySessionKey.get(sessionKey);
     },
-    async disposeSession(sessionId) {
-      const inFlight = createInFlight.get(sessionId);
-      createInFlight.delete(sessionId);
-      let runtime = runtimesBySessionId.get(sessionId);
-      if (!runtime && inFlight) {
-        runtime = await inFlight.promise.catch(() => undefined);
-      }
-      runtimesBySessionId.delete(sessionId);
-      idleTtlMsBySessionId.delete(sessionId);
-      if (!runtime) {
-        forgetSessionKeysForSessionId(sessionId);
-        return;
-      }
-      forgetSessionKeysForSessionId(sessionId);
-      await runtime.dispose();
-    },
+    disposeSession: disposeSessionInternal,
     async disposeAll() {
       clearIdleSweepTimer();
       const inFlightRuntimes = Array.from(createInFlight.values());


### PR DESCRIPTION
## Problem

When a stdio MCP child subprocess exits unexpectedly (idle-exit, OOM, external `SIGKILL`, crash), the MCP SDK's transport correctly fires `onclose` and the SDK's `Protocol._onclose` correctly nulls `Client._transport`. But `SessionMcpRuntime` keeps the cached `BundleMcpSession` in its closure-private `sessions` map, and the manager keeps the runtime in `runtimesBySessionId`.

The cache-hit branch in `getOrCreate` only checks `workspaceDir` and `configFingerprint`:

```ts
const existing = runtimesBySessionId.get(params.sessionId);
if (existing) {
  if (
    existing.workspaceDir !== params.workspaceDir ||
    existing.configFingerprint !== nextFingerprint
  ) {
    runtimesBySessionId.delete(params.sessionId);
    await existing.dispose();
  } else {
    existing.markUsed();
    idleTtlMsBySessionId.set(params.sessionId, idleTtlMs);
    return existing; // ← stale runtime returned here
  }
}
```

So every subsequent `getOrCreate` returns the same stale runtime, every `callTool` reaches `Protocol.request`, finds `_transport === undefined`, and throws `\"Not connected\"` — until session rollover, which for gateway-backed runs (`cleanupBundleMcpOnRunEnd: false`) may never happen during the agent's lifetime.

In production this surfaces as repeated `tool_call failed: Not connected` log lines from the same session for hours, with no recovery path other than restarting the gateway.

## Why the existing infrastructure already does 90% of the work

The plumbing for this fix is already complete end-to-end:

1. **`OpenClawStdioClientTransport` declares `onclose?` and fires it on `child.close`** (`src/agents/mcp-stdio-transport.ts:28, 76`):
   ```ts
   onclose?: () => void;
   // ...
   child.on(\"close\", () => {
     this.process = undefined;
     this.onclose?.();
   });
   ```

2. **The MCP SDK's `Protocol.connect` chains existing `transport.onclose` into its own `_onclose` cleanup** (`@modelcontextprotocol/sdk/dist/esm/shared/protocol.js:219-224`):
   ```js
   const _onclose = this.transport?.onclose;
   this._transport.onclose = () => {
     _onclose?.();
     this._onclose();
   };
   ```

3. **`disposeSessionInternal` is exactly the eviction we want** — idempotent, tolerates unknown sessionIds, removes from `runtimesBySessionId`, fires runtime dispose.

The single missing wire is the `transport.onclose` assignment inside `createSessionMcpRuntime`.

## Fix

Wire `transport.onclose` (and `transport.onerror` for parity) inside `createSessionMcpRuntime` immediately after `sessions.set(serverName, session)` and **before** `connectWithTimeout`.

**Ordering matters.** The SDK chains the existing `transport.onclose`; assigning afterward would overwrite the SDK's chained handler and break its own `_transport` cleanup. Calling our handler before the SDK's runs lets the manager evict the cached runtime in the same tick the SDK nulls out `Client._transport`.

Eviction routes through a new optional `onTransportClosed` callback param on `createSessionMcpRuntime`. This keeps the runtime decoupled from the global singleton — custom `createSessionMcpRuntimeManager` instances (including those used by tests) remain isolated. The manager's existing `disposeSession` body is extracted into a closure-private `disposeSessionInternal` helper that both the returned method and the new callback share. Idempotent dispose path means late-firing close handlers on already-disposed runtimes are safe.

The manager also `logInfo`s on the eviction path so operators have a grep-able signal (\"retiring runtime for session X after transport Y closed\") without needing downstream `after_tool_call` hooks to log it themselves.

## Why a new PR (vs the existing retire paths)

Adjacent fixes in this area:
- `#55090` — idle-TTL plumbing (`runtime.lastUsedAt`, `sweepIdleRuntimes`).
- `b34ece705f` (\"retire idle bundled MCP runtimes\"), `ccf2e77e8d` (\"retire one-shot subagent MCP runtimes\"), `cb16d22780` (\"retire bundled mcp runtimes on cron finish\") — explicit retirement at known lifecycle boundaries.
- `14f78debd5` (\"dispose transport on failed connect\") — leak fix when `client.connect()` itself throws.

None of these cover the connect-success-then-die case this PR addresses (i.e. a runtime that connected fine, served traffic, and now has a dead child).

## Test

`src/agents/pi-bundle-mcp-runtime.test.ts` adds an integration test that spawns a real probe MCP server (existing `writeBundleProbeMcpServer` harness with `pidPath`), forces catalog materialization (real `connectWithTimeout`), reads the child PID, sends `SIGKILL`, and polls the manager for up to 5s for eviction.

- **RED before fix:** test times out at 5s — `session-onclose` stays cached.
- **GREEN after fix:** transport `child.close` fires within ~tens of ms; manager evicts the session.

```
$ vitest run src/agents/pi-bundle-mcp-runtime.test.ts
 Test Files  2 passed (2)
      Tests  24 passed (24)
```

Test cleanup runs through the existing `cleanupBundleMcpHarness` `afterEach` hook — `makeTempDir` registers the dir with the shared `tempDirs[]` array which is `fs.rm`'d during teardown.

## Diff size

~70 lines added, 17 lines moved (the existing `disposeSession` body is extracted into `disposeSessionInternal`, not duplicated), plus an inline `oxlint-disable-next-line unicorn/prefer-add-event-listener` on each of the two `transport.on{close,error}` field assignments — the MCP SDK Transport interface declares these as fields (not DOM EventTarget methods), matching the same pattern used in `OpenClawStdioClientTransport` itself.

## Notes

**Behavioral change to `sessions` map on transport close.** The new `transport.onclose` handler calls `sessions.delete(serverName)` on the runtime's closure-private session map BEFORE the manager's `disposeSessionInternal` fires (which does the runtime-level `runtimesBySessionId.delete`). External callers iterating over `sessions` after a close are vanishingly unlikely (the map is closure-private, only `getCatalog` and `callTool` read it), but worth flagging in case any custom factory implementation exposes it.

This PR doesn't change subprocess sharing semantics (per-session subprocess model is enforced at three layers — `runtimesBySessionId` keyed by sessionId, runtime's closure-private `sessions` map, transport spawning fresh per `start()` call — and changing that is a much bigger architectural conversation).

The new `onTransportClosed` callback is optional; pre-existing direct callers of `createSessionMcpRuntime` are unaffected.

## Downstream

Several downstream OpenClaw consumers (including ours) have shipped reactive workarounds — `after_tool_call` hooks that detect the `\"Not connected\"` string, resolve `disposeSessionMcpRuntime` via runtime content-scan, and dispose. Those become deletable once this lands.