### PR TITLE
fix(browser): emit MEDIA: with absolute path so reply media validator accepts it (#73796)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser/CLI: emit `MEDIA:` lines with an absolute path so the shared media validator accepts browser screenshot and snapshot output, fixing silent media-delivery failures when the home directory is abbreviated. Fixes #73796. Thanks @hclsys.
 - Agents/Codex: bound embedded-run cleanup, trajectory flushing, and command-lane task timeouts after runtime failures, so Discord and other chat sessions return to idle instead of staying stuck in processing. Thanks @vincentkoc.
 - Heartbeat/exec: consume successful metadata-only async exec completions silently so Telegram and other chat surfaces no longer ask users for missing command logs after `No session found`. Fixes #74595. Thanks @gkoch02.
 - Web fetch: add a documented `tools.web.fetch.ssrfPolicy.allowIpv6UniqueLocalRange` opt-in and thread it through cache keys and DNS/IP checks so trusted fake-IP proxy stacks using `fc00::/7` can work without broad private-network access. Fixes #74351. Thanks @jeffrey701.

--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -190,7 +190,7 @@ describe("browser cli snapshot defaults", () => {
     sharedMocks.callBrowserRequest.mockResolvedValueOnce({
       ok: true,
       path: absolutePath,
-    });
+    } as never);
     await runBrowserInspect(["screenshot", "tab-1"]);
     const mediaLines = runtimeLogs.filter((line) => line.startsWith("MEDIA:"));
     expect(mediaLines).toEqual([`MEDIA:${absolutePath}`]);
@@ -207,10 +207,36 @@ describe("browser cli snapshot defaults", () => {
       url: "https://example.com",
       snapshot: "ok",
       imagePath: absolutePath,
-    });
+    } as never);
     await runBrowserInspect(["snapshot"]);
     const mediaLines = runtimeLogs.filter((line) => line.startsWith("MEDIA:"));
     expect(mediaLines).toEqual([`MEDIA:${absolutePath}`]);
+    expect(mediaLines[0]).not.toMatch(/^MEDIA:~/);
+  });
+
+  it("emits snapshot --out MEDIA: with absolute path for ai snapshots (regression for #73796)", async () => {
+    const fs = await import("node:fs/promises");
+    const os = await import("node:os");
+    const path = await import("node:path");
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-snap-out-"));
+    const outPath = path.join(tmpDir, "snap.txt");
+    const homeDir = process.env.HOME ?? "/home/test-user";
+    const imagePath = `${homeDir}/.openclaw/media/browser/snap-out.png`;
+    sharedMocks.callBrowserRequest.mockResolvedValueOnce({
+      ok: true,
+      format: "ai",
+      targetId: "t1",
+      url: "https://example.com",
+      snapshot: "ok",
+      imagePath,
+    } as never);
+    try {
+      await runBrowserInspect(["snapshot", "--out", outPath]);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+    const mediaLines = runtimeLogs.filter((line) => line.startsWith("MEDIA:"));
+    expect(mediaLines).toEqual([`MEDIA:${imagePath}`]);
     expect(mediaLines[0]).not.toMatch(/^MEDIA:~/);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-inspect.test.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.test.ts
@@ -4,7 +4,7 @@ import { createCliRuntimeCapture } from "../../test-support.js";
 import * as browserCliSharedModule from "./browser-cli-shared.js";
 import * as cliCoreApiModule from "./core-api.js";
 
-const { defaultRuntime: runtime, resetRuntimeCapture } = createCliRuntimeCapture();
+const { defaultRuntime: runtime, resetRuntimeCapture, runtimeLogs } = createCliRuntimeCapture();
 
 const gatewayMocks = vi.hoisted(() => ({
   callGatewayFromCli: vi.fn(async () => ({
@@ -182,5 +182,35 @@ describe("browser cli snapshot defaults", () => {
       targetId: "tab-1",
       labels: true,
     });
+  });
+
+  it("emits screenshot MEDIA: with absolute path so the shared media validator accepts it (regression for #73796)", async () => {
+    const homeDir = process.env.HOME ?? "/home/test-user";
+    const absolutePath = `${homeDir}/.openclaw/media/browser/abc.png`;
+    sharedMocks.callBrowserRequest.mockResolvedValueOnce({
+      ok: true,
+      path: absolutePath,
+    });
+    await runBrowserInspect(["screenshot", "tab-1"]);
+    const mediaLines = runtimeLogs.filter((line) => line.startsWith("MEDIA:"));
+    expect(mediaLines).toEqual([`MEDIA:${absolutePath}`]);
+    expect(mediaLines[0]).not.toMatch(/^MEDIA:~/);
+  });
+
+  it("emits snapshot MEDIA: with absolute path for ai snapshots (regression for #73796)", async () => {
+    const homeDir = process.env.HOME ?? "/home/test-user";
+    const absolutePath = `${homeDir}/.openclaw/media/browser/snap.png`;
+    sharedMocks.callBrowserRequest.mockResolvedValueOnce({
+      ok: true,
+      format: "ai",
+      targetId: "t1",
+      url: "https://example.com",
+      snapshot: "ok",
+      imagePath: absolutePath,
+    });
+    await runBrowserInspect(["snapshot"]);
+    const mediaLines = runtimeLogs.filter((line) => line.startsWith("MEDIA:"));
+    expect(mediaLines).toEqual([`MEDIA:${absolutePath}`]);
+    expect(mediaLines[0]).not.toMatch(/^MEDIA:~/);
   });
 });

--- a/extensions/browser/src/cli/browser-cli-inspect.ts
+++ b/extensions/browser/src/cli/browser-cli-inspect.ts
@@ -48,7 +48,7 @@ export function registerBrowserInspectCommands(
           defaultRuntime.writeJson(result);
           return;
         }
-        defaultRuntime.log(`MEDIA:${shortenHomePath(result.path)}`);
+        defaultRuntime.log(`MEDIA:${result.path}`);
       } catch (err) {
         defaultRuntime.error(danger(String(err)));
         defaultRuntime.exit(1);
@@ -128,7 +128,7 @@ export function registerBrowserInspectCommands(
           } else {
             defaultRuntime.log(shortenHomePath(opts.out));
             if (result.format === "ai" && result.imagePath) {
-              defaultRuntime.log(`MEDIA:${shortenHomePath(result.imagePath)}`);
+              defaultRuntime.log(`MEDIA:${result.imagePath}`);
             }
           }
           return;
@@ -142,7 +142,7 @@ export function registerBrowserInspectCommands(
         if (result.format === "ai") {
           defaultRuntime.log(result.snapshot);
           if (result.imagePath) {
-            defaultRuntime.log(`MEDIA:${shortenHomePath(result.imagePath)}`);
+            defaultRuntime.log(`MEDIA:${result.imagePath}`);
           }
           return;
         }


### PR DESCRIPTION
Fixes #73796.

## Problem

The browser CLI emits `MEDIA:<path>` lines wrapped with \`shortenHomePath\`, producing tilde-prefixed paths like \`MEDIA:~/.openclaw/media/browser/abc.png\`. The agent then forwards that line verbatim into its reply, where the shared media validator (\`isLikelyLocalPath\` / \`hasTraversalOrHomeDirPrefix\` in \`src/media/parse.ts\`) treats any \`~\`-prefixed path as a home-dir traversal candidate and rejects it. Telegram (and other channels) silently drop the attachment with \"⚠️ Media failed\" even though the screenshot succeeded.

## Fix

Stop emitting the tilde form on the **machine-readable** \`MEDIA:\` line. The browser CLI now logs \`MEDIA:<absolute-path>\` at all three sites (screenshot command, snapshot AI image, and the \`--out\` AI snapshot). \`/Users/...\` and \`/home/...\` paths are accepted by the existing parser; real \`../\` traversal stays blocked.

The visual log of \`--out\` (line 129, the human-readable file path summary) keeps \`shortenHomePath\` — only the agent-consumed \`MEDIA:\` line is changed.

This matches the \"stop machine-readable browser MEDIA output from using shortenHomePath\" path that clawsweeper recommended in its triage of #73796 — keeps the parser's security contract intact (no parser change, no test changes there).

## What changed

| Location | Before | After |
|---|---|---|
| \`browser-cli-inspect.ts:51\` (screenshot) | \`MEDIA:\${shortenHomePath(result.path)}\` | \`MEDIA:\${result.path}\` |
| \`browser-cli-inspect.ts:131\` (snapshot --out AI) | \`MEDIA:\${shortenHomePath(result.imagePath)}\` | \`MEDIA:\${result.imagePath}\` |
| \`browser-cli-inspect.ts:145\` (snapshot AI image) | \`MEDIA:\${shortenHomePath(result.imagePath)}\` | \`MEDIA:\${result.imagePath}\` |

\`shortenHomePath\` import stays — line 129 still uses it for the human-readable \`--out\` path log.

## Tests

Two regression tests added in \`browser-cli-inspect.test.ts\`:
- \`emits screenshot MEDIA: with absolute path so the shared media validator accepts it (regression for #73796)\`
- \`emits snapshot MEDIA: with absolute path for ai snapshots (regression for #73796)\`

Both assert the emitted line equals \`MEDIA:<abs-path>\` and does NOT match \`/^MEDIA:~/\`.

\`\`\`
pnpm vitest run --config test/vitest/vitest.extension-browser.config.ts extensions/browser/src/cli/browser-cli-inspect.test.ts
# 10 passed (was 8, +2 regression tests)

pnpm vitest run --config test/vitest/vitest.extension-browser.config.ts
# 1017 passed | 1 skipped
\`\`\`

## Why not change the parser

The parser's tilde-rejection is **intentional** — \`MEDIA:~/.ssh/id_rsa\` is in the existing rejected-paths test list (\`src/media/parse.test.ts:64\`) so an agent can't ask for private files via tilde. Changing the parser to expand \`~\` would require adding a separate boundary check downstream and might widen the attack surface unintentionally. Fixing the producer is smaller and surgical.

🦞 lobster-biscuit

---
Sign-Off: hclsys