### PR TITLE
fix(extensions/openai-codex): skip OAuth refresh when access_token JWT still valid

### DIFF
--- a/extensions/openai/openai-codex-provider.test.ts
+++ b/extensions/openai/openai-codex-provider.test.ts
@@ -13,6 +13,17 @@ vi.mock("./openai-codex-device-code.js", () => ({
 
 let buildOpenAICodexProviderPlugin: typeof import("./openai-codex-provider.js").buildOpenAICodexProviderPlugin;
 
+/**
+ * Mint a minimal JWT-shaped string with a configurable payload for testing.
+ * Only the payload base64url-encoding matters for `decodeCodexJwtPayload`;
+ * header and signature are arbitrary.
+ */
+function mintJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.test-signature`;
+}
+
 function createCodexTemplate(overrides: {
   id?: string;
   name?: string;
@@ -107,6 +118,217 @@ describe("openai codex provider", () => {
       access: "next-access",
       refresh: "next-refresh",
       expires: expect.any(Number),
+    });
+  });
+
+  describe("JWT exp short-circuit", () => {
+    it("skips HTTP refresh when access_token JWT exp is comfortably in the future", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      const tenDaysFromNowSec = Math.floor((Date.now() + 10 * 24 * 60 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: tenDaysFromNowSec }),
+        refresh: "refresh-token",
+        // Stale: this is the bug the patch heals — `expires` lags the JWT's
+        // own claim. The handler should return a corrected credential.
+        expires: Date.now() - 60_000,
+      };
+
+      const before = Date.now();
+      const result = await provider.refreshOAuth?.(credential);
+      const after = Date.now();
+
+      expect(refreshOpenAICodexTokenMock).not.toHaveBeenCalled();
+      // The returned `expires` is capped at now + 30 minutes (recheck
+      // boundary), so we periodically re-enter the refresh path to pick up
+      // server-side revocations / external rotations the JWT can't signal.
+      const RECHECK_MS = 30 * 60 * 1000;
+      const expires = (result as { expires?: number }).expires;
+      expect(expires).toBeGreaterThanOrEqual(before + RECHECK_MS);
+      expect(expires).toBeLessThanOrEqual(after + RECHECK_MS);
+      // Capped strictly below the JWT's actual exp.
+      expect(expires).toBeLessThan(tenDaysFromNowSec * 1000);
+      // Other fields preserved.
+      expect(result).toMatchObject({
+        type: "oauth",
+        provider: "openai-codex",
+        access: credential.access,
+        refresh: "refresh-token",
+      });
+    });
+
+    it("returns the JWT's exp directly when it is within the recheck window", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      // 10 minutes from now — past the 5-minute refresh margin (so we
+      // short-circuit), but within the 30-minute recheck window (so the
+      // cap does not apply). Result: returned `expires` equals JWT exp.
+      const tenMinFromNowSec = Math.floor((Date.now() + 10 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: tenMinFromNowSec }),
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+      };
+
+      const result = await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).not.toHaveBeenCalled();
+      expect((result as { expires?: number }).expires).toBe(tenMinFromNowSec * 1000);
+    });
+
+    it("falls through to HTTP refresh when JWT exp is within the 5-minute safety margin", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      // 4 minutes in the future — inside DEFAULT_OAUTH_REFRESH_MARGIN_MS
+      // (5 minutes). Must call HTTP refresh.
+      const fourMinFromNowSec = Math.floor((Date.now() + 4 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: fourMinFromNowSec }),
+        refresh: "refresh-token",
+        expires: fourMinFromNowSec * 1000,
+      };
+      refreshOpenAICodexTokenMock.mockResolvedValueOnce({
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 10 * 60 * 1000,
+      });
+
+      await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("reaches steady state — second call after short-circuit does not re-enter refresh", async () => {
+      // Adversarial regression: with too-tight margin, the synthetic
+      // `expires` could land inside hasUsableOAuthCredential's margin and
+      // re-trigger refresh on the next call (infinite short-circuit loop).
+      // Verify the synthetic `expires` is comfortably past the upstream
+      // 5-minute margin so subsequent reads of the credential are
+      // considered usable.
+      const provider = buildOpenAICodexProviderPlugin();
+      const tenDaysFromNowSec = Math.floor((Date.now() + 10 * 24 * 60 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: tenDaysFromNowSec }),
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+      };
+
+      const result = await provider.refreshOAuth?.(credential);
+
+      const expires = (result as { expires?: number }).expires ?? 0;
+      const FIVE_MIN_MS = 5 * 60 * 1000;
+      // Synthetic `expires` is at least 5 minutes (the upstream
+      // hasUsableOAuthCredential margin) past now, so the next call sees
+      // it as usable and bypasses refresh entirely.
+      expect(expires - Date.now()).toBeGreaterThan(FIVE_MIN_MS);
+    });
+
+    it("falls through to HTTP refresh when JWT exp is already in the past", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      const oneHourAgoSec = Math.floor((Date.now() - 60 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: oneHourAgoSec }),
+        refresh: "refresh-token",
+        expires: oneHourAgoSec * 1000,
+      };
+      refreshOpenAICodexTokenMock.mockResolvedValueOnce({
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+        expires: Date.now() + 10 * 60 * 1000,
+      });
+
+      await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to HTTP refresh when access_token is not a JWT (opaque string)", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: "sk-opaque-non-jwt-token",
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+      };
+      refreshOpenAICodexTokenMock.mockResolvedValueOnce({
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 10 * 60 * 1000,
+      });
+
+      await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to HTTP refresh when JWT payload is malformed", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      // 3-part shape but invalid base64url payload.
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: "header.@@@not-base64@@@.signature",
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+      };
+      refreshOpenAICodexTokenMock.mockResolvedValueOnce({
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 10 * 60 * 1000,
+      });
+
+      await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls through to HTTP refresh when JWT has no exp claim", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ sub: "user-123" }), // no exp
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+      };
+      refreshOpenAICodexTokenMock.mockResolvedValueOnce({
+        access: "next-access",
+        refresh: "next-refresh",
+        expires: Date.now() + 10 * 60 * 1000,
+      });
+
+      await provider.refreshOAuth?.(credential);
+
+      expect(refreshOpenAICodexTokenMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("preserves email and displayName in the short-circuited credential", async () => {
+      const provider = buildOpenAICodexProviderPlugin();
+      const tenDaysFromNowSec = Math.floor((Date.now() + 10 * 24 * 60 * 60 * 1000) / 1000);
+      const credential = {
+        type: "oauth" as const,
+        provider: "openai-codex",
+        access: mintJwt({ exp: tenDaysFromNowSec }),
+        refresh: "refresh-token",
+        expires: Date.now() - 60_000,
+        email: "user@example.com",
+        displayName: "User",
+      };
+
+      const result = await provider.refreshOAuth?.(credential);
+
+      expect(result).toMatchObject({
+        email: "user@example.com",
+        displayName: "User",
+      });
     });
   });
 

--- a/extensions/openai/openai-codex-provider.ts
+++ b/extensions/openai/openai-codex-provider.ts
@@ -6,6 +6,7 @@ import type {
 } from "openclaw/plugin-sdk/plugin-entry";
 import {
   CODEX_CLI_PROFILE_ID,
+  DEFAULT_OAUTH_REFRESH_MARGIN_MS,
   ensureAuthProfileStoreForLocalUpdate,
   listProfilesForProvider,
   type OAuthCredential,
@@ -33,7 +34,10 @@ import {
   OPENAI_CODEX_RESPONSES_BASE_URL,
 } from "./base-url.js";
 import { OPENAI_CODEX_DEFAULT_MODEL } from "./default-models.js";
-import { resolveCodexAuthIdentity } from "./openai-codex-auth-identity.js";
+import {
+  resolveCodexAccessTokenExpiry,
+  resolveCodexAuthIdentity,
+} from "./openai-codex-auth-identity.js";
 import { buildOpenAICodexProvider } from "./openai-codex-catalog.js";
 import { loginOpenAICodexDeviceCode } from "./openai-codex-device-code.js";
 import {
@@ -287,7 +291,46 @@ function withDefaultCodexContextMetadata(params: {
   };
 }
 
+// Cap the synthetic `expires` we write when short-circuiting refresh, so the
+// gateway periodically re-enters this path even when the JWT exp claim is
+// far in the future. This bounds exposure to two failure modes the JWT
+// itself can't reflect: (a) server-side token revocation, (b) external
+// rotation via `codex login` updating `~/.codex/auth.json` while OpenClaw
+// keeps using its mirrored copy. 30 minutes is conservative enough that an
+// operator-initiated re-login is picked up promptly without forcing an
+// HTTP refresh on every request.
+const CODEX_JWT_SHORTCIRCUIT_RECHECK_MS = 30 * 60 * 1000;
+
 async function refreshOpenAICodexOAuthCredential(cred: OAuthCredential) {
+  // Codex access tokens are typically JWTs whose `exp` claim is the source
+  // of truth. The cached `expires` field on the OAuth credential can lag
+  // the JWT (e.g. when a peer process consumed the refresh_token and
+  // rotated the access_token before the local mirror was written). When
+  // that drift hits, every request triggers an unconditional refresh, and
+  // concurrent gateway lanes race the same refresh_token — one rotates and
+  // the others 401 with `refresh_token_reused`.
+  //
+  // Short-circuit: if the cached access_token is a JWT whose own `exp`
+  // claim is beyond the standard refresh margin, skip the HTTP refresh and
+  // return the credential with `expires` corrected. The oauth manager's
+  // existing persistence path writes the corrected credential back so
+  // subsequent calls' `hasUsableOAuthCredential` short-circuits at the
+  // standard guard.
+  //
+  // The margin matches `DEFAULT_OAUTH_REFRESH_MARGIN_MS`; using anything
+  // smaller would cause the upstream `hasUsableOAuthCredential` guard to
+  // re-enter refresh on the next call, looping back through the
+  // short-circuit indefinitely.
+  const cachedAccessToken = typeof cred.access === "string" ? cred.access : "";
+  if (cachedAccessToken.length > 0) {
+    const jwtExpMs = resolveCodexAccessTokenExpiry(cachedAccessToken);
+    if (jwtExpMs && jwtExpMs - Date.now() > DEFAULT_OAUTH_REFRESH_MARGIN_MS) {
+      const recheckBoundary = Date.now() + CODEX_JWT_SHORTCIRCUIT_RECHECK_MS;
+      const correctedExpires = Math.min(jwtExpMs, recheckBoundary);
+      return { ...cred, expires: correctedExpires };
+    }
+  }
+
   try {
     const { refreshOpenAICodexToken } = await import("./openai-codex-provider.runtime.js");
     const refreshed = await refreshOpenAICodexToken(cred.refresh);


### PR DESCRIPTION
## Summary

The openai-codex provider attempts a token refresh on every model request, ignoring whether the cached access_token JWT is still valid per its own `exp` claim. When the cached `auth-profiles.json` `expires` field drifts behind the JWT, every request triggers refresh, concurrent gateway lanes race the same `refresh_token`, and most lanes 401 with `refresh_token_reused`. Codex requests silently demote to the configured fallback (typically OpenRouter / kimi-k2).

This patch adds a JWT exp short-circuit: if the cached access_token is a JWT with `exp` past the standard refresh margin, skip the HTTP refresh and return the credential with `expires` corrected — capped at 30 minutes so we periodically re-enter the refresh path to pick up server-side revocations and external rotations.

## Repro

1. ChatGPT-subscription Codex auth via `codex login`.
2. Run two or more concurrent codex/gpt-5.5 requests (e.g. multiple cron jobs firing simultaneously, or any handler that spawns nested LLM lanes).
3. Observe in gateway logs:
   ```
   [openai-codex] Token refresh failed: 401 ...refresh_token_reused
   [model-fallback/decision] requested=openai-codex/gpt-5.5 reason=auth next=openrouter/moonshotai/kimi-k2
   ```
4. `auth-profiles.json` `expires` becomes stale; subsequent requests hit the same loop until the JWT actually expires.

## Tracking issues

Likely fixes / addresses:
- #62247 — \"openai-codex OAuth provider ignores valid access token, always attempts refresh\"
- #62198 — \"OAuth refresh token race condition (concurrent cron jobs)\"
- #26322 — \"OAuth token refresh race condition causes spurious failovers\"
- #56960 — \"refresh_token_reused loop causes severe gateway event-loop degradation\"
- #57107 — \"Repeated refresh_token_reused after re-onboard / gateway restart\"

## Design

In `refreshOpenAICodexOAuthCredential`, decode the cached `access` token's JWT exp claim before the HTTP refresh:

- **Margin = `DEFAULT_OAUTH_REFRESH_MARGIN_MS`** (5 minutes). Matching the upstream `hasUsableOAuthCredential` margin guarantees the synthetic credential reaches steady state. A tighter margin would cause an infinite short-circuit loop in the 60s–5min JWT window (caught in code review).
- **Recheck cap = 30 minutes.** The JWT signature survives server-side revocation and external rotation (e.g. `codex login` overwriting `~/.codex/auth.json`). Without a cap, a 10-day JWT would lock OpenClaw onto a stale token for 10 days. The cap forces periodic re-evaluation; if the token has been replaced/revoked, the next recheck falls through to the actual refresh path. (Caught in adversarial review.)
- **No new lock primitives.** The existing in-process Promise gate (`oauth-manager.ts:248-252`), cross-process file lock (`oauth-manager.ts:325`), and persistence write (`oauth-manager.ts:434-435`) all do the right thing once unconditional refresh stops firing.

## What does NOT change

- Refresh schema or auth-profiles.json on-disk format.
- Other OAuth providers (anthropic, claude-cli, minimax) — separate auth flows.
- Lock primitives, persistence, or mirror logic.

## Test plan

- [x] New \"JWT exp short-circuit\" describe block, 8 cases:
  - JWT exp 10d in future → short-circuits, expires capped to ~now+30m, refresh NOT called.
  - JWT exp 10m in future (past 5m margin, within 30m recheck) → expires equals JWT exp directly.
  - JWT exp 4m in future (within 5m margin) → falls through to HTTP refresh.
  - JWT exp in past → falls through to HTTP refresh.
  - access_token is opaque (non-JWT) → falls through.
  - JWT payload malformed → falls through.
  - JWT has no `exp` claim → falls through.
  - email and displayName preserved on short-circuit.
  - Steady-state guarantee: synthetic `expires` is past the upstream 5m margin so subsequent reads bypass refresh.
- [x] Existing tests in `openai-codex-provider.test.ts`, `auth-bridge.test.ts`, `oauth-manager.test.ts` still pass: 72/72 across 4 files.

## Reviews

- Code review: caught margin mismatch (60s vs 5min upstream) → fixed with `DEFAULT_OAUTH_REFRESH_MARGIN_MS`.
- Adversarial review: caught revocation black hole → fixed with 30-minute recheck cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)