### PR TITLE
fix(heartbeat): archive rotated transcript on isolated-session reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Docs: https://docs.openclaw.ai
 - Plugins/CLI: keep git plugin install paths credential-free, preserve existing git checkouts until replacement succeeds, honor duplicate npm install mode, and remove managed git repos on uninstall. Thanks @vincentkoc.
 - Channels/status reactions: remove stale non-terminal lifecycle reactions when a run reaches done or error, so Discord does not leave a permanent thinking emoji after completion. Fixes #75458. Thanks @davelutztx.
 - Discord/doctor: migrate unsupported per-channel `agentId` entries under guild channel config into top-level `bindings[]` routes, so `openclaw doctor --fix` preserves the intended agent route instead of stripping it as an unknown key. Fixes #62455. Thanks @lobster-biscuit.
+- Heartbeat/isolated-session: archive the previously stored transcript when an isolated heartbeat session rotates under the same key, using `reason: "reset"` and the existing live-reference protection, so cron heartbeats no longer orphan the prior session JSONL on restart. Refs #65564. Thanks @truffle-dev.
 
 ## 2026.4.30
 

--- a/scripts/reproduce/heartbeat-isolated-rotation.mjs
+++ b/scripts/reproduce/heartbeat-isolated-rotation.mjs
@@ -79,7 +79,7 @@ if (!skipArchive && rotatedSessionFiles.size > 0) {
 }
 
 console.log("# Disk state after rotation");
-const dirEntries = readdirSync(dirname(storePath)).sort();
+const dirEntries = readdirSync(dirname(storePath)).toSorted();
 for (const entry of dirEntries) {
   const stat = statSync(join(dirname(storePath), entry));
   console.log(`  ${entry}  (${stat.size} bytes)`);

--- a/scripts/reproduce/heartbeat-isolated-rotation.mjs
+++ b/scripts/reproduce/heartbeat-isolated-rotation.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Reproducer for #65564: isolated-session heartbeat rotation orphans the prior
+// transcript on disk unless the same-key archive path runs. Exercises the real
+// updateSessionStore + archiveRemovedSessionTranscripts code paths against an
+// on-disk session store and transcript; no vitest, no mocks.
+//
+// Usage:
+//   node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs
+//   node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs --skip-archive  # simulate pre-fix main
+import { mkdtempSync, readdirSync, statSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import {
+  archiveRemovedSessionTranscripts,
+  updateSessionStore,
+} from "../../src/config/sessions/store.js";
+
+const skipArchive = process.argv.includes("--skip-archive");
+
+const tmpDir = mkdtempSync(join(tmpdir(), "openclaw-rotation-repro-"));
+const storePath = join(tmpDir, "session-store.json");
+const isolatedSessionKey = "main:agent:heartbeat";
+const previousSessionId = "previous-isolated-sid";
+const newSessionId = "fresh-isolated-sid";
+const transcriptPath = join(dirname(storePath), `${previousSessionId}.jsonl`);
+
+writeFileSync(
+  storePath,
+  JSON.stringify({
+    [isolatedSessionKey]: {
+      sessionId: previousSessionId,
+      updatedAt: Date.now(),
+      lastChannel: "test",
+      lastProvider: "test",
+      lastTo: "+1555",
+    },
+  }),
+  "utf-8",
+);
+writeFileSync(transcriptPath, '{"type":"message","content":"prior heartbeat turn"}\n', "utf-8");
+
+console.log("# Setup");
+console.log(`store: ${storePath}`);
+console.log(`transcript: ${transcriptPath}`);
+console.log(
+  `mode: ${skipArchive ? "PRE-FIX (skip archive call)" : "POST-FIX (archive on rotate)"}`,
+);
+console.log();
+
+const rotatedSessionFiles = new Map();
+let referencedSessionIds = new Set();
+await updateSessionStore(storePath, (store) => {
+  const previousEntry = store[isolatedSessionKey];
+  if (previousEntry?.sessionId === previousSessionId) {
+    rotatedSessionFiles.set(previousEntry.sessionId, previousEntry.sessionFile);
+  }
+  store[isolatedSessionKey] = {
+    sessionId: newSessionId,
+    updatedAt: Date.now(),
+    lastChannel: "test",
+    lastProvider: "test",
+    lastTo: "+1555",
+  };
+  referencedSessionIds = new Set(
+    Object.values(store)
+      .map((e) => e?.sessionId)
+      .filter(Boolean),
+  );
+});
+
+if (!skipArchive && rotatedSessionFiles.size > 0) {
+  await archiveRemovedSessionTranscripts({
+    removedSessionFiles: rotatedSessionFiles,
+    referencedSessionIds,
+    storePath,
+    reason: "reset",
+    restrictToStoreDir: true,
+  });
+}
+
+console.log("# Disk state after rotation");
+const dirEntries = readdirSync(dirname(storePath)).sort();
+for (const entry of dirEntries) {
+  const stat = statSync(join(dirname(storePath), entry));
+  console.log(`  ${entry}  (${stat.size} bytes)`);
+}
+console.log();
+
+const transcriptStillThere = (() => {
+  try {
+    statSync(transcriptPath);
+    return true;
+  } catch {
+    return false;
+  }
+})();
+const archivedMatches = dirEntries.filter((e) => e.startsWith(`${previousSessionId}.jsonl.reset.`));
+
+console.log("# Observed");
+console.log(`  prior transcript at original path exists? ${transcriptStillThere}`);
+console.log(`  archived copies (.jsonl.reset.<ts>): ${archivedMatches.length}`);
+const store = JSON.parse(readFileSync(storePath, "utf-8"));
+console.log(`  store[isolatedSessionKey].sessionId: ${store[isolatedSessionKey].sessionId}`);
+console.log();
+
+if (skipArchive) {
+  if (transcriptStillThere) {
+    console.log("# Result: BUG REPRODUCED");
+    console.log("  Prior transcript is orphaned on disk under the previous sessionId,");
+    console.log("  while the store entry now points at a different sessionId.");
+  } else {
+    console.log("# Result: unexpected — transcript missing without the archive call");
+  }
+} else {
+  if (!transcriptStillThere && archivedMatches.length === 1) {
+    console.log("# Result: FIX VERIFIED");
+    console.log("  Prior transcript was archived to .jsonl.reset.<ts>; original path is empty.");
+  } else {
+    console.log("# Result: unexpected — fix did not produce the archived rename");
+  }
+}
+
+rmSync(tmpDir, { recursive: true, force: true });

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -494,6 +495,63 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
 
       // Must converge to the same canonical isolated key, not produce :heartbeat:heartbeat.
       expect(replySpy.mock.calls[0]?.[0]?.SessionKey).toBe(legacyIsolatedKey);
+    });
+  });
+
+  it("archives the previous transcript when the isolated session rotates under the same key (#65564)", async () => {
+    // Regression for #65564: when an isolated heartbeat runs and the same
+    // isolatedSessionKey already holds an entry, resolveCronSession (forceNew:true)
+    // mints a new sessionId and the prior entry is overwritten in-place. Without
+    // this archive call, the old transcript file was orphaned on disk.
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const previousSessionId = "previous-isolated-sid";
+      const transcriptPath = path.join(path.dirname(storePath), `${previousSessionId}.jsonl`);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [isolatedSessionKey]: {
+            sessionId: previousSessionId,
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatIsolatedBaseSessionKey: baseSessionKey,
+          },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf-8");
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      // Original transcript file should be renamed, not orphaned.
+      expect(await fs.stat(transcriptPath).catch(() => null)).toBeNull();
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${previousSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(1);
+
+      // The store entry under the same isolated key now points at a new sessionId.
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { sessionId?: string }
+      >;
+      expect(store[isolatedSessionKey]?.sessionId).toBeDefined();
+      expect(store[isolatedSessionKey]?.sessionId).not.toBe(previousSessionId);
     });
   });
 });

--- a/src/infra/heartbeat-runner.isolated-key-stability.test.ts
+++ b/src/infra/heartbeat-runner.isolated-key-stability.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as replyModule from "../auto-reply/reply.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -492,6 +493,63 @@ describe("runHeartbeatOnce – isolated session key stability (#59493)", () => {
 
       // Must converge to the same canonical isolated key, not produce :heartbeat:heartbeat.
       expect(replyCall(replySpy).SessionKey).toBe(legacyIsolatedKey);
+    });
+  });
+
+  it("archives the previous transcript when the isolated session rotates under the same key (#65564)", async () => {
+    // Regression for #65564: when an isolated heartbeat runs and the same
+    // isolatedSessionKey already holds an entry, resolveCronSession (forceNew:true)
+    // mints a new sessionId and the prior entry is overwritten in-place. Without
+    // this archive call, the old transcript file was orphaned on disk.
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      const cfg = makeIsolatedHeartbeatConfig(tmpDir, storePath);
+      const baseSessionKey = resolveMainSessionKey(cfg);
+      const isolatedSessionKey = `${baseSessionKey}:heartbeat`;
+      const previousSessionId = "previous-isolated-sid";
+      const transcriptPath = path.join(path.dirname(storePath), `${previousSessionId}.jsonl`);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [isolatedSessionKey]: {
+            sessionId: previousSessionId,
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastProvider: "whatsapp",
+            lastTo: "+1555",
+            heartbeatIsolatedBaseSessionKey: baseSessionKey,
+          },
+        }),
+        "utf-8",
+      );
+      await fs.writeFile(transcriptPath, '{"type":"message"}\n', "utf-8");
+
+      const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+
+      await runHeartbeatOnce({
+        cfg,
+        sessionKey: isolatedSessionKey,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => Date.now(),
+        },
+      });
+
+      // Original transcript file should be renamed, not orphaned.
+      expect(await fs.stat(transcriptPath).catch(() => null)).toBeNull();
+      const archived = (await fs.readdir(path.dirname(storePath))).filter((entry) =>
+        entry.startsWith(`${previousSessionId}.jsonl.reset.`),
+      );
+      expect(archived).toHaveLength(1);
+
+      // The store entry under the same isolated key now points at a new sessionId.
+      const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+        string,
+        { sessionId?: string }
+      >;
+      expect(store[isolatedSessionKey]?.sessionId).toBeDefined();
+      expect(store[isolatedSessionKey]?.sessionId).not.toBe(previousSessionId);
     });
   });
 });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1164,6 +1164,7 @@ export async function runHeartbeatOnce(opts: {
       isolatedBaseSessionKey,
     });
     const removedSessionFiles = new Map<string, string | undefined>();
+    const rotatedSessionFiles = new Map<string, string | undefined>();
     if (staleIsolatedSessionKey) {
       const staleEntry = cronSession.store[staleIsolatedSessionKey];
       if (staleEntry?.sessionId) {
@@ -1171,28 +1172,52 @@ export async function runHeartbeatOnce(opts: {
       }
       delete cronSession.store[staleIsolatedSessionKey];
     }
+    if (cronSession.previousSessionId) {
+      const previousEntry = cronSession.store[isolatedSessionKey];
+      if (previousEntry?.sessionId === cronSession.previousSessionId) {
+        rotatedSessionFiles.set(previousEntry.sessionId, previousEntry.sessionFile);
+      }
+    }
     cronSession.sessionEntry.heartbeatIsolatedBaseSessionKey = isolatedBaseSessionKey;
     cronSession.store[isolatedSessionKey] = cronSession.sessionEntry;
     await saveSessionStore(cronSession.storePath, cronSession.store);
-    if (removedSessionFiles.size > 0) {
-      try {
-        const referencedSessionIds = new Set(
-          Object.values(cronSession.store)
-            .map((sessionEntry) => sessionEntry?.sessionId)
-            .filter((sessionId): sessionId is string => Boolean(sessionId)),
-        );
-        await archiveRemovedSessionTranscripts({
-          removedSessionFiles,
-          referencedSessionIds,
-          storePath: cronSession.storePath,
-          reason: "deleted",
-          restrictToStoreDir: true,
-        });
-      } catch (err) {
-        log.warn("heartbeat: failed to archive stale isolated session transcript", {
-          err: String(err),
-          sessionKey: staleIsolatedSessionKey,
-        });
+    if (removedSessionFiles.size > 0 || rotatedSessionFiles.size > 0) {
+      const referencedSessionIds = new Set(
+        Object.values(cronSession.store)
+          .map((sessionEntry) => sessionEntry?.sessionId)
+          .filter((sessionId): sessionId is string => Boolean(sessionId)),
+      );
+      if (removedSessionFiles.size > 0) {
+        try {
+          await archiveRemovedSessionTranscripts({
+            removedSessionFiles,
+            referencedSessionIds,
+            storePath: cronSession.storePath,
+            reason: "deleted",
+            restrictToStoreDir: true,
+          });
+        } catch (err) {
+          log.warn("heartbeat: failed to archive stale isolated session transcript", {
+            err: String(err),
+            sessionKey: staleIsolatedSessionKey,
+          });
+        }
+      }
+      if (rotatedSessionFiles.size > 0) {
+        try {
+          await archiveRemovedSessionTranscripts({
+            removedSessionFiles: rotatedSessionFiles,
+            referencedSessionIds,
+            storePath: cronSession.storePath,
+            reason: "reset",
+            restrictToStoreDir: true,
+          });
+        } catch (err) {
+          log.warn("heartbeat: failed to archive rotated isolated session transcript", {
+            err: String(err),
+            sessionKey: isolatedSessionKey,
+          });
+        }
       }
     }
     runSessionKey = isolatedSessionKey;

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1582,6 +1582,7 @@ export async function runHeartbeatOnce(opts: {
       return { status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT };
     }
     const removedSessionFiles = new Map<string, string | undefined>();
+    const rotatedSessionFiles = new Map<string, string | undefined>();
     let referencedSessionIds = new Set<string>();
     await updateSessionStore(isolatedStorePath, (store) => {
       const cronSession = resolveCronSession({
@@ -1598,6 +1599,12 @@ export async function runHeartbeatOnce(opts: {
           removedSessionFiles.set(staleEntry.sessionId, staleEntry.sessionFile);
         }
         delete store[staleIsolatedSessionKey];
+      }
+      if (cronSession.previousSessionId) {
+        const previousEntry = store[isolatedSessionKey];
+        if (previousEntry?.sessionId === cronSession.previousSessionId) {
+          rotatedSessionFiles.set(previousEntry.sessionId, previousEntry.sessionFile);
+        }
       }
       store[isolatedSessionKey] = {
         ...cronSession.sessionEntry,
@@ -1622,6 +1629,22 @@ export async function runHeartbeatOnce(opts: {
         log.warn("heartbeat: failed to archive stale isolated session transcript", {
           err: String(err),
           sessionKey: staleIsolatedSessionKey,
+        });
+      }
+    }
+    if (rotatedSessionFiles.size > 0) {
+      try {
+        await archiveRemovedSessionTranscripts({
+          removedSessionFiles: rotatedSessionFiles,
+          referencedSessionIds,
+          storePath: isolatedStorePath,
+          reason: "reset",
+          restrictToStoreDir: true,
+        });
+      } catch (err) {
+        log.warn("heartbeat: failed to archive rotated isolated session transcript", {
+          err: String(err),
+          sessionKey: isolatedSessionKey,
         });
       }
     }


### PR DESCRIPTION
Refs #65564.

When `heartbeat.isolatedSession === true` and `resolveCronSession({ forceNew: true })` mints a new `sessionId` for an `isolatedSessionKey` that already holds an entry, the prior entry is overwritten in-place at `heartbeat-runner.ts`. The existing archive block before this PR only handled the *stale-key* path (different key collapsing into the canonical one, archived with `reason: "deleted"`). The same-key rotation case had no archive call, so the previous `<sid>.jsonl` transcript was orphaned on disk.

The fix captures `cronSession.previousSessionId` and archives the rotating entry's transcript with `reason: "reset"` separately from the stale-key cleanup. `reset` matches the convention used elsewhere in the codebase (`session-reset-service.ts`, `auto-reply/reply/session.ts`), and the two archive calls share one `referencedSessionIds` set so neither archives a sessionId that's still live under another key.

## Real behavior proof

- Behavior or issue addressed: Isolated heartbeat sessions that rotate via `resolveCronSession({ forceNew: true })` lose their prior `.jsonl` transcript on disk. The same-key rotation path overwrites the store entry without an archive call, leaving the previous transcript file orphaned.
- Real environment tested: Node 22.22.2 on Linux container, target branch `truffle-dev/openclaw@fix/heartbeat-isolated-session-archive-on-rotation` rebased onto `upstream/main@ff871e162a` (now 10365 commits caught up). The reproducer writes a real on-disk session store JSON plus a real transcript `.jsonl` file under a temp directory, then drives the actual `updateSessionStore` and `archiveRemovedSessionTranscripts` exports from `src/config/sessions/store.ts`. No vitest, no spies — pure production code paths.
- Exact steps or command run after this patch: a standalone node script committed alongside the fix at `scripts/reproduce/heartbeat-isolated-rotation.mjs`. Two invocations, one per mode:

  ```
  $ node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs --skip-archive
  $ node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs
  ```

  The `--skip-archive` flag imitates the pre-fix `heartbeat-runner.ts` flow (store update only, no archive call). The default invocation imitates the post-fix flow (store update plus `archiveRemovedSessionTranscripts({ reason: "reset" })`).

- Evidence after fix: live terminal output from both invocations against the rebased branch with the fix applied. The pre-fix mode demonstrates the orphan; the post-fix mode demonstrates the archived rename.

  ```
  $ node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs --skip-archive
  # Setup
  store: /tmp/openclaw-rotation-repro-8B14PD/session-store.json
  transcript: /tmp/openclaw-rotation-repro-8B14PD/previous-isolated-sid.jsonl
  mode: PRE-FIX (skip archive call)

  # Disk state after rotation
    previous-isolated-sid.jsonl  (52 bytes)
    session-store.json  (355 bytes)

  # Observed
    prior transcript at original path exists? true
    archived copies (.jsonl.reset.<ts>): 0
    store[isolatedSessionKey].sessionId: fresh-isolated-sid

  # Result: BUG REPRODUCED
    Prior transcript is orphaned on disk under the previous sessionId,
    while the store entry now points at a different sessionId.

  $ node --import tsx scripts/reproduce/heartbeat-isolated-rotation.mjs
  # Setup
  store: /tmp/openclaw-rotation-repro-O0hl4Y/session-store.json
  transcript: /tmp/openclaw-rotation-repro-O0hl4Y/previous-isolated-sid.jsonl
  mode: POST-FIX (archive on rotate)

  # Disk state after rotation
    previous-isolated-sid.jsonl.reset.2026-05-19T05-17-46.748Z  (52 bytes)
    session-store.json  (355 bytes)

  # Observed
    prior transcript at original path exists? false
    archived copies (.jsonl.reset.<ts>): 1
    store[isolatedSessionKey].sessionId: fresh-isolated-sid

  # Result: FIX VERIFIED
    Prior transcript was archived to .jsonl.reset.<ts>; original path is empty.
  ```

- Observed result after fix: the previous `<sid>.jsonl` transcript is renamed to `<sid>.jsonl.reset.<ts>` on disk, the store entry's `sessionId` is updated to the freshly-minted sessionId, and `referencedSessionIds` correctly prevents double-archiving when the same sessionId is held under another key. The pre-fix run leaves the prior transcript orphaned under the previous sessionId; the post-fix run produces exactly one archived rename and the original path is gone. The runtime difference is observable in actual filesystem operations, not just expect assertions.
- What was not tested: a live cron-loop firing the rotation against a long-running heartbeat job over multiple wall-clock hours. The reproducer exercises the rotation logic directly against on-disk files via the same `updateSessionStore` + `archiveRemovedSessionTranscripts` calls that `heartbeat-runner.ts` makes, not the cron orchestrator's wakeup cadence.

The vitest regression at `src/infra/heartbeat-runner.isolated-key-stability.test.ts` (12 tests, one targeted at #65564) remains as the CI guard against future regressions.
