### PR TITLE
docs: add -s -- flags to curl|bash install to prevent stdin consumption

### DIFF
--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -29,7 +29,7 @@ Need to install Node? See [Node setup](/install/node).
     <Tabs>
       <Tab title="macOS / Linux">
         ```bash
-        curl -fsSL https://openclaw.ai/install.sh | bash
+        curl -fsSL https://openclaw.ai/install.sh | bash -s --
         ```
         <img
   src="/assets/install-script.svg"
@@ -45,6 +45,7 @@ Need to install Node? See [Node setup](/install/node).
     </Tabs>
 
     <Note>
+    The `-s --` flags prevent the installer from consuming stdin when piped via `curl | bash`.
     Other install methods (Docker, Nix, npm): [Install](/install).
     </Note>
 


### PR DESCRIPTION
## Summary

Fixes #73814

The install.sh script uses interactive prompts (via gum) that consume stdin. When the script is piped via curl | bash, stdin is occupied by the script stream, causing the prompts to consume portions of the script itself, resulting in truncated function names and indefinite hangs.

## Solution

Added -s -- flags to the install command in the getting started documentation:
```bash
curl -fsSL https://openclaw.ai/install.sh | bash -s --
```

The -s -- flags prevent the bash subshell from allowing stdin to reach the script interactive prompts. This is a standard pattern for piped installation scripts.


## Testing

- Markdown linting passed (0 errors)
- Documentation renders correctly

## Disclosure

This contribution was developed with AI assistance.