### PR TITLE
feat(session): add includeArchived to chat.history and sessions_history

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4533,21 +4533,25 @@ public struct ChatHistoryParams: Codable, Sendable {
     public let sessionkey: String
     public let limit: Int?
     public let maxchars: Int?
+    public let includearchived: Bool?
 
     public init(
         sessionkey: String,
         limit: Int?,
-        maxchars: Int?)
+        maxchars: Int?,
+        includearchived: Bool?)
     {
         self.sessionkey = sessionkey
         self.limit = limit
         self.maxchars = maxchars
+        self.includearchived = includearchived
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case limit
         case maxchars = "maxChars"
+        case includearchived = "includeArchived"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -4533,21 +4533,25 @@ public struct ChatHistoryParams: Codable, Sendable {
     public let sessionkey: String
     public let limit: Int?
     public let maxchars: Int?
+    public let includearchived: Bool?
 
     public init(
         sessionkey: String,
         limit: Int?,
-        maxchars: Int?)
+        maxchars: Int?,
+        includearchived: Bool?)
     {
         self.sessionkey = sessionkey
         self.limit = limit
         self.maxchars = maxchars
+        self.includearchived = includearchived
     }
 
     private enum CodingKeys: String, CodingKey {
         case sessionkey = "sessionKey"
         case limit
         case maxchars = "maxChars"
+        case includearchived = "includeArchived"
     }
 }
 

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -84,3 +84,55 @@ describe("sessions_history redaction", () => {
     expect(result.details).toMatchObject({ contentRedacted: true });
   });
 });
+
+describe("sessions_history includeArchived plumbing", () => {
+  beforeAll(async () => {
+    previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-sessions-history-include-archived-"));
+    useLoggingConfig("plumbing.json", { redactSensitive: "off" });
+    ({ createSessionsHistoryTool } = await import("./sessions-history-tool.js"));
+  });
+
+  afterAll(() => {
+    if (previousConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+    }
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function createToolCapturingChatHistoryCall(): {
+    tool: ReturnType<typeof createSessionsHistoryTool>;
+    capturedParams: Array<Record<string, unknown>>;
+  } {
+    const capturedParams: Array<Record<string, unknown>> = [];
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        if (request.method === "chat.history") {
+          capturedParams.push(request.params as Record<string, unknown>);
+          return { messages: [] } as T;
+        }
+        return {} as T;
+      },
+    });
+    return { tool, capturedParams };
+  }
+
+  it("forwards includeArchived=true to the chat.history gateway call", async () => {
+    const { tool, capturedParams } = createToolCapturingChatHistoryCall();
+    await tool.execute("call-1", { sessionKey: "main", includeArchived: true });
+    expect(capturedParams).toHaveLength(1);
+    expect(capturedParams[0]).toMatchObject({ includeArchived: true });
+  });
+
+  it("forwards includeArchived=false when omitted (default)", async () => {
+    const { tool, capturedParams } = createToolCapturingChatHistoryCall();
+    await tool.execute("call-1", { sessionKey: "main" });
+    expect(capturedParams).toHaveLength(1);
+    expect(capturedParams[0]).toMatchObject({ includeArchived: false });
+  });
+});

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -27,6 +27,11 @@ const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: Type.Optional(Type.Number({ minimum: 1 })),
   includeTools: Type.Optional(Type.Boolean()),
+  // When true, include messages from `.reset.<ts>` archives chained with the
+  // primary transcript so the agent can recover cross-reset context. Reset
+  // boundaries appear as synthetic system messages with kind="session-reset".
+  // Default false keeps the historical behavior (primary transcript only).
+  includeArchived: Type.Optional(Type.Boolean()),
 });
 
 const SESSIONS_HISTORY_MAX_BYTES = 80 * 1024;
@@ -248,9 +253,10 @@ export function createSessionsHistoryTool(opts?: {
           ? Math.max(1, Math.floor(params.limit))
           : undefined;
       const includeTools = Boolean(params.includeTools);
+      const includeArchived = Boolean(params.includeArchived);
       const result = await gatewayCall<{ messages: Array<unknown> }>({
         method: "chat.history",
-        params: { sessionKey: resolvedKey, limit },
+        params: { sessionKey: resolvedKey, limit, includeArchived },
       });
       const rawMessages = Array.isArray(result?.messages) ? result.messages : [];
       const selectedMessages = includeTools ? rawMessages : stripToolMessages(rawMessages);

--- a/src/gateway/protocol/schema/logs-chat.ts
+++ b/src/gateway/protocol/schema/logs-chat.ts
@@ -28,6 +28,11 @@ export const ChatHistoryParamsSchema = Type.Object(
     sessionKey: NonEmptyString,
     limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
     maxChars: Type.Optional(Type.Integer({ minimum: 1, maximum: 500_000 })),
+    // When true, include messages from all `.reset.<ts>` archives chained with
+    // the primary transcript in chronological order. Each reset boundary is
+    // surfaced as a synthetic system message ({ __openclaw.kind: "session-reset" })
+    // so callers can render dividers. Defaults to false (current behavior).
+    includeArchived: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -90,6 +90,7 @@ import {
   resolveGatewayModelSupportsImages,
   resolveDeletedAgentIdFromSessionKey,
   readSessionMessages,
+  readSessionMessagesIncludingArchives,
   resolveSessionModelRef,
 } from "../session-utils.js";
 import { formatForLog } from "../ws-log.js";
@@ -1499,17 +1500,22 @@ export const chatHandlers: GatewayRequestHandlers = {
       );
       return;
     }
-    const { sessionKey, limit, maxChars } = params as {
+    const { sessionKey, limit, maxChars, includeArchived } = params as {
       sessionKey: string;
       limit?: number;
       maxChars?: number;
+      includeArchived?: boolean;
     };
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
     const sessionAgentId = resolveSessionAgentId({ sessionKey, config: cfg });
     const resolvedSessionModel = resolveSessionModelRef(cfg, entry, sessionAgentId);
     const localMessages =
-      sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
+      sessionId && storePath
+        ? includeArchived === true
+          ? readSessionMessagesIncludingArchives(sessionId, storePath, entry?.sessionFile)
+          : readSessionMessages(sessionId, storePath, entry?.sessionFile)
+        : [];
     const rawMessages = augmentChatHistoryWithCliSessionImports({
       entry,
       provider: resolvedSessionModel.provider,

--- a/src/gateway/session-transcript-files.fs.ts
+++ b/src/gateway/session-transcript-files.fs.ts
@@ -130,6 +130,53 @@ export function archiveFileOnDisk(filePath: string, reason: ArchiveFileReason): 
   return archived;
 }
 
+export type ResetArchiveEntry = {
+  path: string;
+  timestamp: number;
+  archivedAt: string;
+};
+
+/**
+ * Lists all `<sessionId>.jsonl.reset.<ts>` archives across the given directories,
+ * sorted oldest-first by parsed archive timestamp. Used by chat.history
+ * (`includeArchived=true`) to chain archived segments before the primary
+ * transcript. Unparseable / non-matching files are skipped silently.
+ */
+export function listResetArchivesForSession(
+  sessionId: string,
+  searchDirs: readonly string[],
+): ResetArchiveEntry[] {
+  if (!sessionId) {
+    return [];
+  }
+  const prefix = `${sessionId}.jsonl.reset.`;
+  const result: ResetArchiveEntry[] = [];
+  for (const dir of searchDirs) {
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.startsWith(prefix)) {
+        continue;
+      }
+      const ts = parseSessionArchiveTimestamp(entry.name, "reset");
+      if (ts == null) {
+        continue;
+      }
+      result.push({
+        path: path.join(dir, entry.name),
+        timestamp: ts,
+        archivedAt: entry.name.slice(prefix.length),
+      });
+    }
+  }
+  result.sort((a, b) => a.timestamp - b.timestamp);
+  return result;
+}
+
 export function archiveSessionTranscripts(opts: {
   sessionId: string;
   storePath: string | undefined;

--- a/src/gateway/session-utils.fs.test.ts
+++ b/src/gateway/session-utils.fs.test.ts
@@ -9,6 +9,7 @@ import {
   readLastMessagePreviewFromTranscript,
   readLatestSessionUsageFromTranscript,
   readSessionMessages,
+  readSessionMessagesIncludingArchives,
   readSessionTitleFieldsFromTranscript,
   readSessionPreviewItemsFromTranscript,
   resolveSessionTranscriptCandidates,
@@ -603,6 +604,136 @@ describe("readSessionMessages", () => {
       expect((out[0] as { __openclaw?: { seq?: number } }).__openclaw?.seq).toBe(1);
     },
   );
+});
+
+describe("readSessionMessagesIncludingArchives", () => {
+  let tmpDir: string;
+  let storePath: string;
+
+  registerTempSessionStore(
+    "openclaw-session-history-include-archived-",
+    (nextTmpDir, nextStorePath) => {
+      tmpDir = nextTmpDir;
+      storePath = nextStorePath;
+    },
+  );
+
+  afterEach(() => {
+    for (const f of fs.readdirSync(tmpDir)) {
+      if (f.endsWith(".jsonl") || f.includes(".reset.") || f.includes(".deleted.")) {
+        fs.rmSync(path.join(tmpDir, f));
+      }
+    }
+  });
+
+  test("returns same as readSessionMessages when no archives exist", () => {
+    const sessionId = "ee000000-0000-4000-8000-000000000001";
+    writeTranscript(tmpDir, sessionId, buildBasicSessionTranscript(sessionId, "hi", "hello"));
+
+    const baseline = readSessionMessages(sessionId, storePath);
+    const out = readSessionMessagesIncludingArchives(sessionId, storePath);
+    expect(out).toEqual(baseline);
+  });
+
+  test("returns archive content when primary missing", () => {
+    const sessionId = "ee000000-0000-4000-8000-000000000002";
+    const archivePath = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+    fs.writeFileSync(
+      archivePath,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "archived msg" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const out = readSessionMessagesIncludingArchives(sessionId, storePath);
+    // archive content + 1 boundary marker (no primary, so just 1 user msg + 1 boundary)
+    expect(out).toHaveLength(2);
+    expect((out[0] as { content: unknown }).content).toBe("archived msg");
+    const boundary = out[1] as {
+      role: string;
+      __openclaw: { kind: string; archivedAt: string };
+    };
+    expect(boundary.role).toBe("system");
+    expect(boundary.__openclaw.kind).toBe("session-reset");
+    expect(boundary.__openclaw.archivedAt).toBe("2026-03-12T04-00-00.000Z");
+  });
+
+  test("chains multiple archives chronologically before primary with boundary markers", () => {
+    const sessionId = "ee000000-0000-4000-8000-000000000003";
+    const olderArchive = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-10T04-00-00.000Z`);
+    const newerArchive = path.join(tmpDir, `${sessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`);
+    fs.writeFileSync(
+      olderArchive,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "older msg" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    fs.writeFileSync(
+      newerArchive,
+      [
+        JSON.stringify({ type: "session", version: 1, id: sessionId }),
+        JSON.stringify({ message: { role: "user", content: "newer msg" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { message: { role: "user", content: "current msg" } },
+    ]);
+
+    const out = readSessionMessagesIncludingArchives(sessionId, storePath);
+    // older msg, [reset boundary 03-10], newer msg, [reset boundary 03-12], current msg
+    expect(out).toHaveLength(5);
+    expect((out[0] as { content: unknown }).content).toBe("older msg");
+    expect((out[1] as { __openclaw: { archivedAt: string } }).__openclaw.archivedAt).toBe(
+      "2026-03-10T04-00-00.000Z",
+    );
+    expect((out[2] as { content: unknown }).content).toBe("newer msg");
+    expect((out[3] as { __openclaw: { archivedAt: string } }).__openclaw.archivedAt).toBe(
+      "2026-03-12T04-00-00.000Z",
+    );
+    expect((out[4] as { content: unknown }).content).toBe("current msg");
+  });
+
+  test("returns empty when neither primary nor any archive exists", () => {
+    const sessionId = "ee000000-0000-4000-8000-000000000004";
+    const out = readSessionMessagesIncludingArchives(sessionId, storePath);
+    expect(out).toHaveLength(0);
+  });
+
+  test("ignores archives belonging to a different session id", () => {
+    const sessionId = "ee000000-0000-4000-8000-000000000005";
+    const otherSessionId = "ee000000-0000-4000-8000-00000000FFFF";
+    const otherArchive = path.join(
+      tmpDir,
+      `${otherSessionId}.jsonl.reset.2026-03-12T04-00-00.000Z`,
+    );
+    fs.writeFileSync(
+      otherArchive,
+      [
+        JSON.stringify({ type: "session", version: 1, id: otherSessionId }),
+        JSON.stringify({ message: { role: "user", content: "should not appear" } }),
+      ].join("\n"),
+      "utf-8",
+    );
+    writeTranscript(tmpDir, sessionId, [
+      { type: "session", version: 1, id: sessionId },
+      { message: { role: "user", content: "primary only" } },
+    ]);
+
+    const out = readSessionMessagesIncludingArchives(sessionId, storePath);
+    expect(out).toHaveLength(1);
+    expect((out[0] as { content: unknown }).content).toBe("primary only");
+  });
+
+  test("returns empty array when sessionId is empty string", () => {
+    const out = readSessionMessagesIncludingArchives("", storePath);
+    expect(out).toHaveLength(0);
+  });
 });
 
 describe("readSessionPreviewItemsFromTranscript", () => {

--- a/src/gateway/session-utils.fs.ts
+++ b/src/gateway/session-utils.fs.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { SessionManager, type SessionEntry } from "@mariozechner/pi-coding-agent";
 import { deriveSessionTotalTokens, hasNonzeroUsage, normalizeUsage } from "../agents/usage.js";
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
@@ -13,6 +14,7 @@ import {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  listResetArchivesForSession,
 } from "./session-transcript-files.fs.js";
 import type { SessionPreviewItem } from "./session-utils.types.js";
 
@@ -201,10 +203,111 @@ export function readSessionMessages(
   return messages;
 }
 
+/**
+ * Reads messages from a single transcript file using line-by-line parsing.
+ * Used for chained archive segments where we want every recorded message
+ * verbatim (no SessionManager active-branch filtering, since archives are
+ * immutable historical snapshots and the user explicitly asked to recover
+ * cross-reset context via includeArchived).
+ */
+function readArchivedTranscriptMessages(filePath: string): unknown[] {
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(filePath, "utf-8").split(/\r?\n/);
+  } catch {
+    return [];
+  }
+  const messages: unknown[] = [];
+  let messageSeq = 0;
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed?.message) {
+        messageSeq += 1;
+        messages.push(
+          attachOpenClawTranscriptMeta(parsed.message, {
+            ...(typeof parsed.id === "string" ? { id: parsed.id } : {}),
+            seq: messageSeq,
+          }),
+        );
+        continue;
+      }
+      if (parsed?.type === "compaction") {
+        const ts = typeof parsed.timestamp === "string" ? Date.parse(parsed.timestamp) : Number.NaN;
+        const timestamp = Number.isFinite(ts) ? ts : Date.now();
+        messageSeq += 1;
+        messages.push({
+          role: "system",
+          content: [{ type: "text", text: "Compaction" }],
+          timestamp,
+          __openclaw: {
+            kind: "compaction",
+            id: typeof parsed.id === "string" ? parsed.id : undefined,
+            seq: messageSeq,
+          },
+        });
+      }
+    } catch {
+      // ignore malformed lines
+    }
+  }
+  return messages;
+}
+
+/**
+ * Returns chat history for a session including all archived `.reset.<ts>`
+ * segments chained chronologically before the primary transcript. Each reset
+ * boundary is surfaced as a synthetic system message
+ * (`__openclaw.kind: "session-reset"`) so callers can render dividers without
+ * mistaking it for real user/assistant content.
+ *
+ * This is the read path for `chat.history` / `sessions_history` when
+ * `includeArchived=true`. It is a user-explicit opt-in (not an automatic
+ * fallback) so it is consistent with `/reset` semantics: the user is asking
+ * for the recovery view, not having archived content silently re-injected.
+ *
+ * The primary segment goes through `readSessionMessages` so it benefits from
+ * the SessionManager active-branch logic for tree-format transcripts. Archive
+ * segments use line-by-line parsing because archives predate or sit outside
+ * the live branching state and we want every recorded message preserved.
+ */
+export function readSessionMessagesIncludingArchives(
+  sessionId: string,
+  storePath: string | undefined,
+  sessionFile?: string,
+): unknown[] {
+  if (!sessionId) {
+    return [];
+  }
+  const candidates = resolveSessionTranscriptCandidates(sessionId, storePath, sessionFile);
+  const searchDirs = Array.from(new Set(candidates.map((c) => path.dirname(c))));
+  const archives = listResetArchivesForSession(sessionId, searchDirs);
+
+  const combined: unknown[] = [];
+  for (const archive of archives) {
+    combined.push(...readArchivedTranscriptMessages(archive.path));
+    combined.push({
+      role: "system",
+      content: [{ type: "text", text: `Session reset (${archive.archivedAt})` }],
+      timestamp: archive.timestamp,
+      __openclaw: {
+        kind: "session-reset",
+        archivedAt: archive.archivedAt,
+      },
+    });
+  }
+  combined.push(...readSessionMessages(sessionId, storePath, sessionFile));
+  return combined;
+}
+
 export {
   archiveFileOnDisk,
   archiveSessionTranscripts,
   cleanupArchivedSessionTranscripts,
+  listResetArchivesForSession,
   resolveSessionTranscriptCandidates,
 } from "./session-transcript-files.fs.js";
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -102,6 +102,7 @@ export {
   readSessionTitleFieldsFromTranscript,
   readSessionPreviewItemsFromTranscript,
   readSessionMessages,
+  readSessionMessagesIncludingArchives,
   resolveSessionTranscriptCandidates,
 } from "./session-utils.fs.js";
 export { canonicalizeSpawnedByForAgent, resolveSessionStoreKey } from "./session-store-key.js";


### PR DESCRIPTION
## Summary

Implements the read-only path of [#45003](https://github.com/openclaw/openclaw/issues/45003)'s 3-PR roadmap: give agents and `chat.history` callers a way to recover context that lives in `.reset.<ts>` archives, **without** resurrecting those archives as live sessions.

This PR closes the three concrete upstream gaps identified by clawsweeper / Codex review on [issue #45003 (2026-04-28T22:20:54Z)](https://github.com/openclaw/openclaw/issues/45003#issuecomment-4337189378):

> - sessions_history has no archive selector
> - chat.history reads current active transcript only
> - Protocol schema has no archived-history parameter

## Changes

### Protocol (additive, backwards-compatible)

- `src/gateway/protocol/schema/logs-chat.ts` — `ChatHistoryParamsSchema` gains an optional `includeArchived: boolean`. Default `false` preserves all current behavior.

### Gateway helpers

- `src/gateway/session-transcript-files.fs.ts` — new `listResetArchivesForSession(sessionId, searchDirs)` lists every `<sessionId>.jsonl.reset.<ts>` archive sorted oldest-first.
- `src/gateway/session-utils.fs.ts` — new `readSessionMessagesIncludingArchives(sessionId, storePath, sessionFile)` chains archive segments before the primary transcript with synthetic system messages tagged `__openclaw.kind: "session-reset"` so callers can render dividers. Archive segments are parsed line-by-line; the primary segment delegates to the existing `readSessionMessages` so it still gets `SessionManager` active-branch treatment for tree-format transcripts.

### Gateway handler

- `src/gateway/server-methods/chat.ts` — `chat.history` reads `includeArchived` from params and dispatches to the new aggregator only when explicitly `true`.

### Agent tool

- `src/agents/tools/sessions-history-tool.ts` — `SessionsHistoryToolSchema` gains optional `includeArchived`. The tool forwards the flag verbatim to the `chat.history` call.

## Tests

- `src/gateway/session-utils.fs.test.ts` — 6 new tests:
  - default behavior unchanged when no archives exist
  - archive content surfaced when primary missing
  - multiple archives chained chronologically before primary, each with a session-reset boundary marker
  - empty result when neither primary nor any archive exists
  - other sessions' archives are not pulled in
  - empty `sessionId` short-circuits
- `src/agents/tools/sessions-history-tool.test.ts` — 2 new tests verifying the param is plumbed through from tool → `chat.history`.

## Design notes

This is the **read-only** path of the #45003 roadmap. It does not rename, move, or otherwise mutate archive files: archives stay archived, the user opts into visibility for one query at a time. That keeps it consistent with the existing "archive lifecycle is one-way" precedent (`sessions.delete` has no undo) and avoids the compaction-chain checkpoint and session-memory-hook double-summary risks that come with any unarchive/restore design.

`includeArchived` is also a user-explicit opt-in (not an automatic fallback), so it is consistent with `/reset` semantics: the user is asking for the recovery view, not having archived content silently re-injected into automated paths.

## Verification

- Scoped tests: `pnpm test src/gateway/session-utils.fs.test.ts` — 60/60 pass (54 originals + 6 new).
- Type-check: `pnpm tsgo:core` introduces 0 new errors on the touched files (verified by stash-toggle baseline comparison).
- Manual: production gateway built from this branch and started on `:18789` against the local production data dir; `chat.history` RPC with `includeArchived: true` returns chained archive segments with `session-reset` boundary markers, while the default (`false` / omitted) returns the same set as before.

## Related work

- Fixes part of #45003 (PR 3 of the original 3-PR roadmap).
- Companion PRs in the same area, **all touching disjoint code paths**:
  - #60409 — `chat.history` fallback to most recent reset archive when primary is missing (PR 1 of the roadmap; in flight, CI green).
  - #71537 — `session-memory` hook + `session-logs` skill archive support (touches `src/hooks/bundled/session-memory/*`, no overlap with this PR).
  - #68765 — compaction checkpoint chain reset semantics; explicitly defers non-chained reset-archive fallback to #60409.
