### PR TITLE
fix(telegram): avoid false polling stall restarts

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -262,7 +262,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 - DM messages can carry `message_thread_id`; OpenClaw routes them with thread-aware session keys and preserves thread ID for replies.
 - Long polling uses grammY runner with per-chat/per-thread sequencing. Overall runner sink concurrency uses `agents.defaults.maxConcurrent`.
 - Long polling is guarded inside each gateway process so only one active poller can use a bot token at a time. If you still see `getUpdates` 409 conflicts, another OpenClaw gateway, script, or external poller is likely using the same token.
-- Long-polling watchdog restarts trigger after 120 seconds without completed `getUpdates` liveness by default. Increase `channels.telegram.pollingStallThresholdMs` only if your deployment still sees false polling-stall restarts during long-running work. The value is in milliseconds and is allowed from `30000` to `600000`; per-account overrides are supported.
+- Long-polling watchdog restarts trigger after 120 seconds without completed `getUpdates` liveness by default. Increase `channels.telegram.pollingStallThresholdMs` only if your deployment still sees false polling-stall restarts during long-running work. The value is in milliseconds and is allowed from `60000` to `600000`; per-account overrides are supported.
 - Telegram Bot API has no read-receipt support (`sendReadReceipts` does not apply).
 
 ## Feature reference
@@ -726,7 +726,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - `channels.telegram.chunkMode="newline"` prefers paragraph boundaries (blank lines) before length splitting.
     - `channels.telegram.mediaMaxMb` (default 100) caps inbound and outbound Telegram media size.
     - `channels.telegram.timeoutSeconds` overrides Telegram API client timeout (if unset, grammY default applies).
-    - `channels.telegram.pollingStallThresholdMs` defaults to `120000`; tune between `30000` and `600000` only for false-positive polling-stall restarts.
+    - `channels.telegram.pollingStallThresholdMs` defaults to `120000`; tune between `60000` and `600000` only for false-positive polling-stall restarts.
     - group context history uses `channels.telegram.historyLimit` or `messages.groupChat.historyLimit` (default 50); `0` disables.
     - reply/quote/forward supplemental context is currently passed as received.
     - Telegram allowlists primarily gate who can trigger the agent, not a full supplemental-context redaction boundary.

--- a/extensions/telegram/src/config-schema.test.ts
+++ b/extensions/telegram/src/config-schema.test.ts
@@ -67,7 +67,7 @@ describe("telegram custom commands schema", () => {
   });
 
   it("rejects pollingStallThresholdMs outside the watchdog bounds", () => {
-    expectTelegramConfigIssue({ pollingStallThresholdMs: 29_999 }, "pollingStallThresholdMs");
+    expectTelegramConfigIssue({ pollingStallThresholdMs: 59_999 }, "pollingStallThresholdMs");
     expectTelegramConfigIssue({ pollingStallThresholdMs: 600_001 }, "pollingStallThresholdMs");
   });
 

--- a/extensions/telegram/src/config-ui-hints.ts
+++ b/extensions/telegram/src/config-ui-hints.ts
@@ -95,7 +95,7 @@ export const telegramChannelConfigUiHints = {
   },
   pollingStallThresholdMs: {
     label: "Telegram Polling Stall Threshold (ms)",
-    help: "Milliseconds without completed Telegram getUpdates liveness before the polling watchdog restarts the polling runner. Default: 120000.",
+    help: "Milliseconds without completed Telegram getUpdates liveness before the polling watchdog restarts the polling runner. Default: 120000. Minimum: 60000.",
   },
   silentErrorReplies: {
     label: "Telegram Silent Error Replies",

--- a/extensions/telegram/src/monitor.test.ts
+++ b/extensions/telegram/src/monitor.test.ts
@@ -813,12 +813,12 @@ describe("monitorTelegramProvider (grammY)", () => {
       abortSignal: abort.signal,
       config: {
         agents: { defaults: { maxConcurrent: 2 } },
-        channels: { telegram: { pollingStallThresholdMs: 30_000 } },
+        channels: { telegram: { pollingStallThresholdMs: 60_000 } },
       },
     });
     await firstCycle.waitForRunStart();
 
-    vi.advanceTimersByTime(60_000);
+    vi.advanceTimersByTime(90_000);
     await secondCycle.waitForRunStart();
     await monitor;
 

--- a/extensions/telegram/src/polling-session.test.ts
+++ b/extensions/telegram/src/polling-session.test.ts
@@ -473,6 +473,38 @@ describe("TelegramPollingSession", () => {
     }
   });
 
+  it("clamps unsafe polling stall thresholds above the long-poll window", async () => {
+    const abort = new AbortController();
+    const botStop = vi.fn(async () => undefined);
+    const runnerStop = vi.fn(async () => undefined);
+    mockBotCapturingApiMiddleware(botStop);
+    const resolveFirstTask = mockLongRunningPollingCycle(runnerStop);
+    const watchdogHarness = installPollingStallWatchdogHarness([0, 0], 30_001);
+
+    const log = vi.fn();
+    const session = createPollingSession({
+      abortSignal: abort.signal,
+      log,
+      stallThresholdMs: 30_000,
+    });
+
+    try {
+      const runPromise = session.runUntilAbort();
+      const watchdog = await watchdogHarness.waitForWatchdog();
+      watchdog?.();
+
+      expect(runnerStop).not.toHaveBeenCalled();
+      expect(botStop).not.toHaveBeenCalled();
+      expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Polling stall detected"));
+
+      abort.abort();
+      resolveFirstTask();
+      await runPromise;
+    } finally {
+      watchdogHarness.restore();
+    }
+  });
+
   it("rebuilds the transport after a stalled polling cycle", async () => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     const abort = new AbortController();

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -23,7 +23,9 @@ const TELEGRAM_POLL_RESTART_POLICY = {
 };
 
 const DEFAULT_POLL_STALL_THRESHOLD_MS = 120_000;
-const MIN_POLL_STALL_THRESHOLD_MS = 30_000;
+// Keep the minimum above grammY's 30s getUpdates long-poll window to avoid
+// watchdog restarts caused by normal long-poll jitter.
+const MIN_POLL_STALL_THRESHOLD_MS = 60_000;
 const MAX_POLL_STALL_THRESHOLD_MS = 600_000;
 const POLL_WATCHDOG_INTERVAL_MS = 30_000;
 const POLL_STOP_GRACE_MS = 15_000;

--- a/src/config/bundled-channel-config-metadata.generated.ts
+++ b/src/config/bundled-channel-config-metadata.generated.ts
@@ -13817,7 +13817,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
         },
         pollingStallThresholdMs: {
           type: "integer",
-          minimum: 30000,
+          minimum: 60000,
           maximum: 600000,
         },
         retry: {
@@ -14858,7 +14858,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
               },
               pollingStallThresholdMs: {
                 type: "integer",
-                minimum: 30000,
+                minimum: 60000,
                 maximum: 600000,
               },
               retry: {
@@ -15247,7 +15247,7 @@ export const GENERATED_BUNDLED_CHANNEL_CONFIG_METADATA = [
       },
       pollingStallThresholdMs: {
         label: "Telegram Polling Stall Threshold (ms)",
-        help: "Milliseconds without completed Telegram getUpdates liveness before the polling watchdog restarts the polling runner. Default: 120000.",
+        help: "Milliseconds without completed Telegram getUpdates liveness before the polling watchdog restarts the polling runner. Default: 120000. Minimum: 60000.",
       },
       silentErrorReplies: {
         label: "Telegram Silent Error Replies",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -152,7 +152,7 @@ export type TelegramAccountConfig = {
   mediaMaxMb?: number;
   /** Telegram API client timeout in seconds (grammY ApiClientOptions). */
   timeoutSeconds?: number;
-  /** Telegram polling watchdog threshold in milliseconds. Default: 120000. */
+  /** Telegram polling watchdog threshold in milliseconds. Default: 120000. Minimum: 60000. */
   pollingStallThresholdMs?: number;
   /** Retry policy for outbound Telegram API calls. */
   retry?: OutboundRetryConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -241,7 +241,7 @@ export const TelegramAccountSchemaBase = z
     streaming: ChannelPreviewStreamingConfigSchema.optional(),
     mediaMaxMb: z.number().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
-    pollingStallThresholdMs: z.number().int().min(30_000).max(600_000).optional(),
+    pollingStallThresholdMs: z.number().int().min(60_000).max(600_000).optional(),
     retry: RetryConfigSchema,
     network: z
       .object({


### PR DESCRIPTION
## Summary
- raise the minimum Telegram polling stall threshold to 60s so it stays above grammY's 30s long-poll window
- reject unsafe low pollingStallThresholdMs values in config validation
- update Telegram docs and generated config metadata

## Testing
- node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/config-schema.test.ts
- NODE_OPTIONS=--max-old-space-size=4096 OPENCLAW_VITEST_MAX_WORKERS=1 node node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/polling-session.test.ts extensions/telegram/src/monitor.test.ts
- node --import tsx scripts/generate-bundled-channel-config-metadata.ts --check
- node scripts/format-docs.mjs --check docs/channels/telegram.md