### PR TITLE
fix(providers): accept moonshotai as alias for direct moonshot provider (#73876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Moonshot: accept `moonshotai` (and `moonshot-ai`) as aliases for the direct Moonshot provider in `normalizeProviderId`, so model refs copied from OpenRouter or Moonshot AI's own branding (e.g. `moonshotai/kimi-k2.6`) resolve to the direct provider instead of failing with `Unknown model`. Existing `moonshot/<model>` configs, auth profiles, plugin id, and docs are unchanged. Fixes #73876. Thanks @jimdawdy-hub.
 - Security/audit: recognize dangerous node command IDs as valid `gateway.nodes.denyCommands` entries, so audit only warns on real typos or unsupported patterns. (#56923) Thanks @chziyue.
 - Telegram/exec approvals: stop treating general Telegram chat allowlists and `defaultTo` routes as native exec approvers; Telegram now uses explicit `execApprovals.approvers` or owner identity from `commands.ownerAllowFrom`, matching the first-pairing owner bootstrap path. Thanks @pashpashpash.
 - Chat commands: route sensitive group `/diagnostics` and `/export-trajectory` approvals and results to a private owner route, preferring same-surface DMs before falling back to the first configured owner route, so Discord group invocations can land in Telegram when that is the primary owner interface. Thanks @pashpashpash.

--- a/src/agents/provider-id.test.ts
+++ b/src/agents/provider-id.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { findNormalizedProviderValue, normalizeProviderId } from "./provider-id.js";
+
+describe("normalizeProviderId", () => {
+  it("returns lowercased input for unknown providers", () => {
+    expect(normalizeProviderId("openai")).toBe("openai");
+    expect(normalizeProviderId("OpenAI")).toBe("openai");
+    expect(normalizeProviderId("ANTHROPIC")).toBe("anthropic");
+  });
+
+  it("aliases qwen variants to qwen", () => {
+    expect(normalizeProviderId("modelstudio")).toBe("qwen");
+    expect(normalizeProviderId("qwencloud")).toBe("qwen");
+  });
+
+  it("aliases zai variants to zai", () => {
+    expect(normalizeProviderId("z.ai")).toBe("zai");
+    expect(normalizeProviderId("z-ai")).toBe("zai");
+    expect(normalizeProviderId("Z.AI")).toBe("zai");
+  });
+
+  it("aliases kimi variants to kimi", () => {
+    expect(normalizeProviderId("kimi-code")).toBe("kimi");
+    expect(normalizeProviderId("kimi-coding")).toBe("kimi");
+  });
+
+  it("aliases moonshotai to moonshot (regression for #73876)", () => {
+    expect(normalizeProviderId("moonshotai")).toBe("moonshot");
+    expect(normalizeProviderId("MoonshotAI")).toBe("moonshot");
+    expect(normalizeProviderId("MOONSHOTAI")).toBe("moonshot");
+  });
+
+  it("aliases moonshot-ai to moonshot (regression for #73876)", () => {
+    expect(normalizeProviderId("moonshot-ai")).toBe("moonshot");
+    expect(normalizeProviderId("Moonshot-AI")).toBe("moonshot");
+  });
+
+  it("preserves canonical moonshot id (no double-aliasing, regression for #73876)", () => {
+    expect(normalizeProviderId("moonshot")).toBe("moonshot");
+  });
+
+  it("aliases bedrock variants to amazon-bedrock", () => {
+    expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
+    expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");
+  });
+
+  it("aliases volcengine legacy names", () => {
+    expect(normalizeProviderId("bytedance")).toBe("volcengine");
+    expect(normalizeProviderId("doubao")).toBe("volcengine");
+  });
+
+  it("returns empty string for empty/whitespace input", () => {
+    expect(normalizeProviderId("")).toBe("");
+    expect(normalizeProviderId("   ")).toBe("");
+  });
+});
+
+describe("findNormalizedProviderValue", () => {
+  it("returns undefined for missing entries", () => {
+    expect(findNormalizedProviderValue(undefined, "moonshot")).toBeUndefined();
+    expect(findNormalizedProviderValue({}, "moonshot")).toBeUndefined();
+  });
+
+  it("matches via canonical key when caller passes alias (regression for #73876)", () => {
+    const entries = { moonshot: { apiKey: "k" } };
+    expect(findNormalizedProviderValue(entries, "moonshotai")).toEqual({ apiKey: "k" });
+    expect(findNormalizedProviderValue(entries, "moonshot-ai")).toEqual({ apiKey: "k" });
+  });
+
+  it("matches via alias key when caller passes canonical (regression for #73876)", () => {
+    const entries = { moonshotai: { apiKey: "k" } };
+    expect(findNormalizedProviderValue(entries, "moonshot")).toEqual({ apiKey: "k" });
+  });
+
+  it("preserves existing kimi alias matching", () => {
+    const entries = { kimi: { apiKey: "k" } };
+    expect(findNormalizedProviderValue(entries, "kimi-code")).toEqual({ apiKey: "k" });
+  });
+});

--- a/src/agents/provider-id.ts
+++ b/src/agents/provider-id.ts
@@ -17,6 +17,14 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "kimi" || normalized === "kimi-code" || normalized === "kimi-coding") {
     return "kimi";
   }
+  // OpenRouter and Moonshot AI's own branding use the `moonshotai` org slug;
+  // openclaw's direct Moonshot provider is registered as `moonshot`. Accept
+  // `moonshotai` as an alias so users who copy `moonshotai/kimi-k2.6` from
+  // OpenRouter (without the `openrouter/` prefix) resolve to the direct
+  // Moonshot provider instead of `Unknown model: moonshotai/...`. See #73876.
+  if (normalized === "moonshotai" || normalized === "moonshot-ai") {
+    return "moonshot";
+  }
   if (normalized === "bedrock" || normalized === "aws-bedrock") {
     return "amazon-bedrock";
   }


### PR DESCRIPTION
Fixes #73876.

## Problem

OpenRouter's catalog and Moonshot AI's own branding both use the \`moonshotai\` org slug (e.g. \`moonshotai/kimi-k2.6\` is what users see at openrouter.ai). openclaw's direct Moonshot provider is registered as \`moonshot\`, so users who copy the model ref from OpenRouter without the \`openrouter/\` prefix hit \`Unknown model: moonshotai/kimi-k2.6\` despite having a working direct Moonshot API key.

The bug-report author (jimdawdy-hub) cites the existing \`xiaomi/mimo-v2-flash\` ↔ \`openrouter/xiaomi/mimo-v2-flash\` symmetry as the desired contract: direct provider names should match OpenRouter org slugs; the \`openrouter/\` prefix should act as a clean scope operator.

## Fix

Add \`moonshotai\` and \`moonshot-ai\` to the \`normalizeProviderId\` alias list so they resolve to the canonical \`moonshot\` provider id, matching the existing alias pattern used for \`qwencloud\` → \`qwen\`, \`z.ai\` → \`zai\`, \`kimi-code\` → \`kimi\`, etc.

Existing \`moonshot/<model>\` configs, auth profiles, plugin id (\`moonshot\`), and docs are entirely unchanged. The fix is purely a normalization expansion.

## Why this shape over the alternatives

- **vs. renaming the provider to \`moonshotai\`**: would break every existing \`moonshot/\` config, auth profile, manifest plugin id, and docs reference. The alias path is backward-compatible by construction.
- **vs. a separate \`PROVIDER_ALIASES\` map**: \`normalizeProviderId\` already encodes 5 alias families (qwen/zai/opencode/kimi/bedrock/volcengine) inline. Following the established pattern keeps the surface coherent.

## Tests

Added \`src/agents/provider-id.test.ts\` — the first dedicated unit test for \`normalizeProviderId\` / \`findNormalizedProviderValue\`. 14 cases:

- All existing aliases (qwen, zai, kimi, bedrock, volcengine) — guards against regressions
- New moonshotai / moonshot-ai mappings (3 case-variant tests)
- Canonical \`moonshot\` preserved (no double-aliasing)
- \`findNormalizedProviderValue\` matching alias keys against canonical entries and vice versa

\`\`\`
pnpm vitest run src/agents/provider-id.test.ts
→ 14 passed (all new)

pnpm vitest run src/agents/model-ref-shared.test.ts \\
  src/agents/model-selection.test.ts \\
  src/agents/provider-id.test.ts
→ 222 passed (208 pre-existing + 14 new, no regressions)
\`\`\`

End-to-end trace: \`parseStaticModelRef\` (model-ref-shared.ts:56) calls \`normalizeProviderId\` on the provider segment of the slash-form ref, so \`moonshotai/kimi-k2.6\` → \`moonshot/kimi-k2.6\` flows through the entire resolution path.

🦞 lobster-biscuit

---
Sign-Off: hclsys