### PR TITLE
fix(discord): expose native components on message sends

### DIFF
--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -166,6 +166,38 @@ describe("handleDiscordMessageAction", () => {
     );
   });
 
+  it("forwards Discord-native components from message edits", async () => {
+    const components = {
+      text: "Updated component",
+      container: { accentColor: 0x57f287 },
+      blocks: [{ type: "text", text: "✅ step one" }],
+    };
+
+    await handleDiscordMessageAction({
+      action: "edit",
+      params: {
+        channelId: "channel:123",
+        messageId: "m1",
+        components,
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "editMessage",
+        channelId: "123",
+        messageId: "m1",
+        content: "",
+        components,
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("does not use another provider's current target for Discord sends", async () => {
     await expect(
       handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -128,7 +128,18 @@ describe("handleDiscordMessageAction", () => {
   it("forwards Discord-native components from message sends", async () => {
     const components = {
       text: "Component fallback",
-      blocks: [{ type: "file", file: "attachment://report.txt" }],
+      container: { accentColor: 0x5865f2 },
+      blocks: [
+        {
+          type: "section",
+          text: "Quarterly report",
+          accessory: {
+            type: "thumbnail",
+            url: "https://example.com/report.png",
+          },
+        },
+        { type: "file", file: "attachment://report.txt" },
+      ],
     };
 
     await handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.test.ts
+++ b/extensions/discord/src/actions/handle-action.test.ts
@@ -125,6 +125,36 @@ describe("handleDiscordMessageAction", () => {
     );
   });
 
+  it("forwards Discord-native components from message sends", async () => {
+    const components = {
+      text: "Component fallback",
+      blocks: [{ type: "file", file: "attachment://report.txt" }],
+    };
+
+    await handleDiscordMessageAction({
+      action: "send",
+      params: {
+        to: "channel:123",
+        message: "hello",
+        components,
+      },
+      cfg: {
+        channels: { discord: { token: "tok" } },
+      } as OpenClawConfig,
+    });
+
+    expect(handleDiscordActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        to: "channel:123",
+        content: "hello",
+        components,
+      }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("does not use another provider's current target for Discord sends", async () => {
     await expect(
       handleDiscordMessageAction({

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -77,6 +77,7 @@ export async function handleDiscordMessageAction(
     }
     const asVoice = readBooleanParam(params, "asVoice") === true;
     const rawComponents =
+      params.components ??
       buildDiscordPresentationComponents(normalizeMessagePresentation(params.presentation)) ??
       buildDiscordInteractiveComponents(normalizeInteractiveReply(params.interactive));
     const hasComponents =

--- a/extensions/discord/src/actions/handle-action.ts
+++ b/extensions/discord/src/actions/handle-action.ts
@@ -126,7 +126,9 @@ export async function handleDiscordMessageAction(
     const question = readStringParam(params, "pollQuestion", {
       required: true,
     });
-    const answers = readStringArrayParam(params, "pollOption", { required: true });
+    const answers = readStringArrayParam(params, "pollOption", {
+      required: true,
+    });
     const allowMultiselect = readBooleanParam(params, "pollMulti");
     const durationHours = readNumberParam(params, "pollDurationHours", {
       integer: true,
@@ -149,7 +151,10 @@ export async function handleDiscordMessageAction(
   }
 
   if (action === "react") {
-    const messageIdRaw = resolveReactionMessageId({ args: params, toolContext: ctx.toolContext });
+    const messageIdRaw = resolveReactionMessageId({
+      args: params,
+      toolContext: ctx.toolContext,
+    });
     const messageId = normalizeOptionalStringifiedId(messageIdRaw) ?? "";
     if (!messageId) {
       throw new Error(
@@ -207,14 +212,19 @@ export async function handleDiscordMessageAction(
 
   if (action === "edit") {
     const messageId = readStringParam(params, "messageId", { required: true });
-    const content = readStringParam(params, "message", { required: true });
+    const rawComponents = params.components;
+    const content = readStringParam(params, "message", {
+      required: !rawComponents,
+      allowEmpty: true,
+    });
     return await handleDiscordAction(
       {
         action: "editMessage",
         accountId: accountId ?? undefined,
         channelId: resolveChannelId(),
         messageId,
-        content,
+        content: content ?? "",
+        ...(rawComponents ? { components: rawComponents } : {}),
       },
       cfg,
       actionOptions,

--- a/extensions/discord/src/actions/runtime.messaging.ts
+++ b/extensions/discord/src/actions/runtime.messaging.ts
@@ -16,7 +16,7 @@ import {
   withNormalizedTimestamp,
   readBooleanParam,
 } from "../runtime-api.js";
-import { sendDiscordComponentMessage } from "../send.components.js";
+import { editDiscordComponentMessage, sendDiscordComponentMessage } from "../send.components.js";
 import {
   createThreadDiscord,
   deleteMessageDiscord,
@@ -64,6 +64,7 @@ export const discordMessagingActionRuntime = {
   resolveDiscordChannelId,
   searchMessagesDiscord,
   sendDiscordComponentMessage,
+  editDiscordComponentMessage,
   sendMessageDiscord,
   sendPollDiscord,
   sendStickerDiscord,
@@ -429,9 +430,27 @@ export async function handleDiscordMessagingAction(
       const messageId = readStringParam(params, "messageId", {
         required: true,
       });
+      const rawComponents = params.components;
+      const componentSpec = rawComponents ? readDiscordComponentSpec(rawComponents) : null;
       const content = readStringParam(params, "content", {
-        required: true,
+        required: !componentSpec,
+        allowEmpty: true,
       });
+
+      if (componentSpec) {
+        const normalizedContent = content?.trim() ? content : undefined;
+        const payload = componentSpec.text
+          ? componentSpec
+          : { ...componentSpec, text: normalizedContent };
+        const result = await discordMessagingActionRuntime.editDiscordComponentMessage(
+          `channel:${channelId}`,
+          messageId,
+          payload,
+          { ...cfgOptions, ...(accountId ? { accountId } : {}) },
+        );
+        return jsonResult({ ok: true, result, components: true });
+      }
+
       const message = accountId
         ? await discordMessagingActionRuntime.editMessageDiscord(
             channelId,
@@ -595,7 +614,10 @@ export async function handleDiscordMessagingAction(
             accountId,
           })
         : await discordMessagingActionRuntime.listPinsDiscord(channelId, cfgOptions);
-      return jsonResult({ ok: true, pins: pins.map((pin) => normalizeMessage(pin)) });
+      return jsonResult({
+        ok: true,
+        pins: pins.map((pin) => normalizeMessage(pin)),
+      });
     }
     case "searchMessages": {
       if (!isActionEnabled("search")) {

--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -14,9 +14,13 @@ import {
   handleDiscordModerationAction,
 } from "./runtime.moderation.js";
 
-const originalDiscordMessagingActionRuntime = { ...discordMessagingActionRuntime };
+const originalDiscordMessagingActionRuntime = {
+  ...discordMessagingActionRuntime,
+};
 const originalDiscordGuildActionRuntime = { ...discordGuildActionRuntime };
-const originalDiscordModerationActionRuntime = { ...discordModerationActionRuntime };
+const originalDiscordModerationActionRuntime = {
+  ...discordModerationActionRuntime,
+};
 
 const discordSendMocks = {
   banMemberDiscord: vi.fn(async () => ({})),
@@ -33,6 +37,10 @@ const discordSendMocks = {
     name: "edited",
   })),
   editMessageDiscord: vi.fn(async () => ({})),
+  editDiscordComponentMessage: vi.fn(async () => ({
+    messageId: "m1",
+    channelId: "123",
+  })),
   fetchChannelPermissionsDiscord: vi.fn(async () => ({})),
   fetchMessageDiscord: vi.fn(async () => ({})),
   fetchReactionsDiscord: vi.fn(async () => ({})),
@@ -63,6 +71,8 @@ const {
   createThreadDiscord,
   deleteChannelDiscord,
   editChannelDiscord,
+  editDiscordComponentMessage,
+  editMessageDiscord,
   fetchReactionsDiscord,
   fetchMessageDiscord,
   kickMemberDiscord,
@@ -364,7 +374,9 @@ describe("handleDiscordMessagingAction", () => {
       },
     } as OpenClawConfig;
     await handleMessagingAction("readMessages", { channelId: "C1" }, enableAllActions, cfg);
-    expect(readMessagesDiscord).toHaveBeenCalledWith("C1", expect.any(Object), { cfg });
+    expect(readMessagesDiscord).toHaveBeenCalledWith("C1", expect.any(Object), {
+      cfg,
+    });
   });
 
   it("adds normalized timestamps to fetchMessage payloads", async () => {
@@ -378,7 +390,9 @@ describe("handleDiscordMessagingAction", () => {
       { guildId: "G1", channelId: "C1", messageId: "M1" },
       enableAllActions,
     );
-    const payload = result.details as { message?: { timestampMs?: number; timestampUtc?: string } };
+    const payload = result.details as {
+      message?: { timestampMs?: number; timestampUtc?: string };
+    };
 
     const expectedMs = Date.parse("2026-01-15T11:00:00.000Z");
     expect(payload.message?.timestampMs).toBe(expectedMs);
@@ -427,7 +441,9 @@ describe("handleDiscordMessagingAction", () => {
       enableAllActions,
     );
     const payload = result.details as {
-      results?: { messages?: Array<Array<{ timestampMs?: number; timestampUtc?: string }>> };
+      results?: {
+        messages?: Array<Array<{ timestampMs?: number; timestampUtc?: string }>>;
+      };
     };
 
     const expectedMs = Date.parse("2026-01-15T13:00:00.000Z");
@@ -509,6 +525,36 @@ describe("handleDiscordMessagingAction", () => {
         mediaLocalRoots: ["/tmp/agent-root"],
       }),
     );
+  });
+
+  it("edits Discord component messages when components are provided", async () => {
+    editDiscordComponentMessage.mockClear();
+    editMessageDiscord.mockClear();
+
+    await handleMessagingAction(
+      "editMessage",
+      {
+        channelId: "channel:123",
+        messageId: "m1",
+        components: {
+          text: "Updated component",
+          container: { accentColor: 0x57f287 },
+          blocks: [{ type: "text", text: "✅ step one" }],
+        },
+      },
+      enableAllActions,
+    );
+
+    expect(editDiscordComponentMessage).toHaveBeenCalledWith(
+      "channel:123",
+      "m1",
+      expect.objectContaining({
+        text: "Updated component",
+        container: { accentColor: 0x57f287 },
+      }),
+      { cfg: DISCORD_TEST_CFG },
+    );
+    expect(editMessageDiscord).not.toHaveBeenCalled();
   });
 
   it("forwards the optional filename into sendMessageDiscord", async () => {
@@ -755,7 +801,9 @@ describe("handleDiscordGuildAction - channel management", () => {
 
   it("deletes a channel", async () => {
     await handleGuildAction("channelDelete", { channelId: "C1" }, channelsEnabled);
-    expect(deleteChannelDiscord).toHaveBeenCalledWith("C1", { cfg: DISCORD_TEST_CFG });
+    expect(deleteChannelDiscord).toHaveBeenCalledWith("C1", {
+      cfg: DISCORD_TEST_CFG,
+    });
   });
 
   it("moves a channel", async () => {
@@ -839,7 +887,9 @@ describe("handleDiscordGuildAction - channel management", () => {
 
   it("deletes a category", async () => {
     await handleGuildAction("categoryDelete", { categoryId: "CAT1" }, channelsEnabled);
-    expect(deleteChannelDiscord).toHaveBeenCalledWith("CAT1", { cfg: DISCORD_TEST_CFG });
+    expect(deleteChannelDiscord).toHaveBeenCalledWith("CAT1", {
+      cfg: DISCORD_TEST_CFG,
+    });
   });
 
   it.each([
@@ -931,7 +981,13 @@ describe("handleDiscordAction per-account gating", () => {
     } as OpenClawConfig;
 
     await handleDiscordAction(
-      { action: "timeout", guildId: "G1", userId: "U1", durationMinutes: 5, accountId: "ops" },
+      {
+        action: "timeout",
+        guildId: "G1",
+        userId: "U1",
+        durationMinutes: 5,
+        accountId: "ops",
+      },
       cfg,
     );
     expect(timeoutMemberDiscord).toHaveBeenCalledWith(
@@ -953,7 +1009,13 @@ describe("handleDiscordAction per-account gating", () => {
 
     await expect(
       handleDiscordAction(
-        { action: "timeout", guildId: "G1", userId: "U1", durationMinutes: 5, accountId: "chat" },
+        {
+          action: "timeout",
+          guildId: "G1",
+          userId: "U1",
+          durationMinutes: 5,
+          accountId: "chat",
+        },
         cfg,
       ),
     ).rejects.toThrow(/Discord moderation is disabled/);
@@ -993,7 +1055,12 @@ describe("handleDiscordAction per-account gating", () => {
 
     await expect(
       handleDiscordAction(
-        { action: "channelCreate", guildId: "G1", name: "alerts", accountId: "ops" },
+        {
+          action: "channelCreate",
+          guildId: "G1",
+          name: "alerts",
+          accountId: "ops",
+        },
         cfg,
       ),
     ).rejects.toThrow(/channel management is disabled/i);
@@ -1015,7 +1082,12 @@ describe("handleDiscordAction per-account gating", () => {
     } as OpenClawConfig;
 
     await handleDiscordAction(
-      { action: "channelCreate", guildId: "G1", name: "alerts", accountId: "ops" },
+      {
+        action: "channelCreate",
+        guildId: "G1",
+        name: "alerts",
+        accountId: "ops",
+      },
       cfg,
     );
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -54,7 +54,7 @@ describe("discordMessageActions", () => {
 
     expect(discovery?.capabilities).toEqual(["presentation"]);
     expect(discovery?.schema).toMatchObject({
-      actions: ["send"],
+      actions: ["send", "edit"],
       visibility: "all-configured",
       properties: {
         components: {
@@ -120,7 +120,7 @@ describe("discordMessageActions", () => {
       } as OpenClawConfig,
     });
     expect(discovery?.schema).toMatchObject({
-      actions: ["send"],
+      actions: ["send", "edit"],
       visibility: "all-configured",
       properties: {
         components: {
@@ -132,17 +132,21 @@ describe("discordMessageActions", () => {
   });
 
   it.each(["read", "search"])("routes %s actions through gateway execution mode", (action) => {
-    expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
-      "gateway",
-    );
+    expect(
+      discordMessageActions.resolveExecutionMode?.({
+        action: action as never,
+      }),
+    ).toBe("gateway");
   });
 
   it.each(["send", "edit", "delete", "react", "pin", "poll"])(
     "routes %s actions through local execution mode",
     (action) => {
-      expect(discordMessageActions.resolveExecutionMode?.({ action: action as never })).toBe(
-        "local",
-      );
+      expect(
+        discordMessageActions.resolveExecutionMode?.({
+          action: action as never,
+        }),
+      ).toBe("local");
     },
   );
 

--- a/extensions/discord/src/channel-actions.test.ts
+++ b/extensions/discord/src/channel-actions.test.ts
@@ -53,7 +53,16 @@ describe("discordMessageActions", () => {
     });
 
     expect(discovery?.capabilities).toEqual(["presentation"]);
-    expect(discovery?.schema).toBeUndefined();
+    expect(discovery?.schema).toMatchObject({
+      actions: ["send"],
+      visibility: "all-configured",
+      properties: {
+        components: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+    });
     expect(discovery?.actions).toEqual(
       expect.arrayContaining(["send", "poll", "react", "reactions", "emoji-list", "permissions"]),
     );
@@ -100,7 +109,7 @@ describe("discordMessageActions", () => {
     expect(workDiscovery?.actions).not.toContain("poll");
   });
 
-  it("does not expose Discord-native message tool schema", () => {
+  it("exposes Discord components on the shared message tool schema", () => {
     const discovery = discordMessageActions.describeMessageTool?.({
       cfg: {
         channels: {
@@ -110,7 +119,16 @@ describe("discordMessageActions", () => {
         },
       } as OpenClawConfig,
     });
-    expect(discovery?.schema).toBeUndefined();
+    expect(discovery?.schema).toMatchObject({
+      actions: ["send"],
+      visibility: "all-configured",
+      properties: {
+        components: {
+          type: "object",
+          additionalProperties: true,
+        },
+      },
+    });
   });
 
   it.each(["read", "search"])("routes %s actions through gateway execution mode", (action) => {

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -32,7 +32,7 @@ const DISCORD_COMPONENTS_SCHEMA = Type.Optional(
     {
       additionalProperties: true,
       description:
-        'Discord-specific components payload for action: "send". Supports component blocks, buttons, selects, modals, and v2 containers.',
+        'OpenClaw Discord component message spec for action: "send". Use an object with text, blocks, modal, and/or container; runtime maps it to Discord components v1/v2.',
     },
   ),
 );
@@ -178,7 +178,7 @@ function describeDiscordMessageTool({
   return {
     actions: Array.from(actions),
     capabilities: ["presentation"],
-    schema: actions.has("send") ? buildDiscordMessageToolSchema() : null,
+    schema: buildDiscordMessageToolSchema(),
   };
 }
 

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -32,14 +32,14 @@ const DISCORD_COMPONENTS_SCHEMA = Type.Optional(
     {
       additionalProperties: true,
       description:
-        'OpenClaw Discord component message spec for action: "send". Use an object with text, blocks, modal, and/or container; runtime maps it to Discord components v1/v2.',
+        'OpenClaw Discord component message spec for action: "send" or action: "edit". Use an object with text, blocks, modal, and/or container; runtime maps it to Discord components v1/v2.',
     },
   ),
 );
 
 function buildDiscordMessageToolSchema(): NonNullable<ChannelMessageToolDiscovery["schema"]> {
   return {
-    actions: ["send"],
+    actions: ["send", "edit"],
     properties: {
       components: DISCORD_COMPONENTS_SCHEMA,
     },
@@ -71,7 +71,10 @@ function resolveScopedDiscordActionDiscovery(params: {
   if (!params.accountId) {
     return resolveDiscordActionDiscovery(params.cfg);
   }
-  const account = resolveDiscordAccount({ cfg: params.cfg, accountId: params.accountId });
+  const account = resolveDiscordAccount({
+    cfg: params.cfg,
+    accountId: params.accountId,
+  });
   if (!account.enabled || !account.token.trim()) {
     return null;
   }

--- a/extensions/discord/src/channel-actions.ts
+++ b/extensions/discord/src/channel-actions.ts
@@ -10,6 +10,7 @@ import type {
 import type { DiscordActionConfig } from "openclaw/plugin-sdk/config-types";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { extractToolSend } from "openclaw/plugin-sdk/tool-send";
+import { Type } from "typebox";
 import {
   createDiscordActionGate,
   listEnabledDiscordAccounts,
@@ -23,6 +24,27 @@ let discordChannelActionsRuntimePromise:
 async function loadDiscordChannelActionsRuntime() {
   discordChannelActionsRuntimePromise ??= import("./channel-actions.runtime.js");
   return await discordChannelActionsRuntimePromise;
+}
+
+const DISCORD_COMPONENTS_SCHEMA = Type.Optional(
+  Type.Object(
+    {},
+    {
+      additionalProperties: true,
+      description:
+        'Discord-specific components payload for action: "send". Supports component blocks, buttons, selects, modals, and v2 containers.',
+    },
+  ),
+);
+
+function buildDiscordMessageToolSchema(): NonNullable<ChannelMessageToolDiscovery["schema"]> {
+  return {
+    actions: ["send"],
+    properties: {
+      components: DISCORD_COMPONENTS_SCHEMA,
+    },
+    visibility: "all-configured",
+  };
 }
 
 function resolveDiscordActionDiscovery(cfg: Parameters<typeof listEnabledDiscordAccounts>[0]) {
@@ -156,6 +178,7 @@ function describeDiscordMessageTool({
   return {
     actions: Array.from(actions),
     capabilities: ["presentation"],
+    schema: actions.has("send") ? buildDiscordMessageToolSchema() : null,
   };
 }
 


### PR DESCRIPTION
## Summary

Fix Discord native `components` support on the shared `message` tool:

- exposes top-level `components` in Discord's message tool schema contribution for `action: "send"`
- forwards `params.components` through the Discord `send` message action into the existing Discord component sender
- keeps existing `presentation`/`interactive` fallbacks intact

## Repro / validation

Before this change, `message(action="send", components={...})` could upload the file attachment, but the Discord message readback showed `components: []` because the top-level `components` param was neither advertised in the schema nor forwarded by the Discord send action bridge.

Validated locally against Discord with a components v2 container containing:

- a `section` block with thumbnail accessory
- a separator
- a `file` block referencing `attachment://components-v2-file-test.txt`

Readback showed:

- `flags: 32768` (`IsComponentsV2`)
- non-empty `components`
- v2 container (`type: 17`)
- section (`type: 9`)
- file component (`type: 13`) with `attachment_id`

Note: Discord v2 sections require an accessory; a no-accessory section correctly fails validation with `Sections must have an accessory component`.

## Tests

- `pnpm exec vitest run extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.test.ts --maxWorkers=1`
- `pnpm exec oxfmt --check extensions/discord/src/channel-actions.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.ts extensions/discord/src/actions/handle-action.test.ts`
- `pnpm exec oxlint extensions/discord/src/channel-actions.ts extensions/discord/src/actions/handle-action.ts extensions/discord/src/channel-actions.test.ts extensions/discord/src/actions/handle-action.test.ts`
