### PR TITLE
fix(tui): autocomplete plugin commands like active-memory

### DIFF
--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getSlashCommands, helpText, parseCommand } from "./commands.js";
+import { getBuiltinSlashCommands, helpText, parseCommand } from "./commands.js";
 
 describe("parseCommand", () => {
   it("normalizes aliases and keeps command args", () => {
@@ -15,9 +15,9 @@ describe("parseCommand", () => {
   });
 });
 
-describe("getSlashCommands", () => {
+describe("getBuiltinSlashCommands", () => {
   it("provides level completions for built-in toggles", () => {
-    const commands = getSlashCommands();
+    const commands = getBuiltinSlashCommands();
     const verbose = commands.find((command) => command.name === "verbose");
     const activation = commands.find((command) => command.name === "activation");
     expect(verbose?.getArgumentCompletions?.("o")).toEqual([
@@ -29,12 +29,10 @@ describe("getSlashCommands", () => {
     ]);
   });
 
-  it("keeps session status on the shared command path and exposes gateway status separately", () => {
-    const commands = getSlashCommands();
-    const status = commands.find((command) => command.name === "status");
+  it("exposes gateway status and crestodian on the built-in command path", () => {
+    const commands = getBuiltinSlashCommands();
     const gatewayStatus = commands.find((command) => command.name === "gateway-status");
     const crestodian = commands.find((command) => command.name === "crestodian");
-    expect(status?.description).toBe("Show current status.");
     expect(gatewayStatus?.description).toBe("Show gateway status summary");
     expect(crestodian?.description).toBe("Return to Crestodian");
   });

--- a/src/tui/commands.test.ts
+++ b/src/tui/commands.test.ts
@@ -38,7 +38,7 @@ describe("getBuiltinSlashCommands", () => {
   });
 
   it("uses session-provided thinking levels for completions", () => {
-    const commands = getSlashCommands({
+    const commands = getBuiltinSlashCommands({
       provider: "ollama",
       model: "qwen3:0.6b",
       thinkingLevels: [

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -1,7 +1,5 @@
 import type { SlashCommand } from "@mariozechner/pi-tui";
-import { listChatCommands, listChatCommandsForConfig } from "../auto-reply/commands-registry.js";
 import { formatThinkingLevels, listThinkingLevelLabels } from "../auto-reply/thinking.js";
-import type { OpenClawConfig } from "../config/types.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 const VERBOSE_LEVELS = ["on", "off"];
@@ -18,7 +16,6 @@ export type ParsedCommand = {
 };
 
 export type SlashCommandOptions = {
-  cfg?: OpenClawConfig;
   provider?: string;
   model?: string;
   thinkingLevels?: Array<{ id: string; label: string }>;
@@ -55,7 +52,7 @@ export function parseCommand(input: string): ParsedCommand {
   };
 }
 
-export function getSlashCommands(options: SlashCommandOptions = {}): SlashCommand[] {
+export function getBuiltinSlashCommands(options: SlashCommandOptions = {}): SlashCommand[] {
   const thinkLevels =
     options.thinkingLevels?.map((level) => level.label) ??
     listThinkingLevelLabels(options.provider, options.model);
@@ -136,20 +133,6 @@ export function getSlashCommands(options: SlashCommandOptions = {}): SlashComman
     { name: "exit", description: "Exit the TUI" },
     { name: "quit", description: "Exit the TUI" },
   ];
-
-  const seen = new Set(commands.map((command) => command.name));
-  const gatewayCommands = options.cfg ? listChatCommandsForConfig(options.cfg) : listChatCommands();
-  for (const command of gatewayCommands) {
-    const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
-    for (const alias of aliases) {
-      const name = alias.replace(/^\//, "").trim();
-      if (!name || seen.has(name)) {
-        continue;
-      }
-      seen.add(name);
-      commands.push({ name, description: command.description });
-    }
-  }
 
   return commands;
 }

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -3,6 +3,21 @@ import { isEmbeddedMode, setEmbeddedMode } from "../infra/embedded-mode.js";
 import { defaultRuntime } from "../runtime.js";
 
 const agentCommandFromIngressMock = vi.fn();
+type LocalCommandEntry = {
+  key: string;
+  description: string;
+  textAliases: string[];
+};
+type LocalPluginCommandEntry = {
+  name: string;
+  description: string;
+  pluginId: string;
+  acceptsArgs: boolean;
+};
+const { listChatCommandsForConfigMock, listPluginCommandsMock } = vi.hoisted(() => ({
+  listChatCommandsForConfigMock: vi.fn<() => LocalCommandEntry[]>(() => []),
+  listPluginCommandsMock: vi.fn<() => LocalPluginCommandEntry[]>(() => []),
+}));
 let registeredListener: ((evt: unknown) => void) | undefined;
 
 vi.mock("../agents/agent-command.js", () => ({
@@ -41,6 +56,10 @@ vi.mock("../agents/defaults.js", () => ({
 vi.mock("../agents/model-selection.js", () => ({
   buildAllowedModelSet: ({ catalog }: { catalog: unknown[] }) => ({ allowedCatalog: catalog }),
   resolveThinkingDefault: () => undefined,
+}));
+
+vi.mock("../auto-reply/commands-registry.js", () => ({
+  listChatCommandsForConfig: () => listChatCommandsForConfigMock(),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -112,6 +131,10 @@ vi.mock("../gateway/server-methods/agent-timestamp.js", () => ({
   timestampOptsFromConfig: () => ({}),
 }));
 
+vi.mock("../plugins/commands.js", () => ({
+  listPluginCommands: () => listPluginCommandsMock(),
+}));
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (error?: unknown) => void;
@@ -133,6 +156,10 @@ describe("EmbeddedTuiBackend", () => {
 
   beforeEach(() => {
     agentCommandFromIngressMock.mockReset();
+    listChatCommandsForConfigMock.mockReset();
+    listPluginCommandsMock.mockReset();
+    listChatCommandsForConfigMock.mockReturnValue([]);
+    listPluginCommandsMock.mockReturnValue([]);
     registeredListener = undefined;
     setEmbeddedMode(false);
     defaultRuntime.log = originalRuntimeLog;
@@ -328,6 +355,36 @@ describe("EmbeddedTuiBackend", () => {
           sessionKey: "agent:main:main",
           state: "final",
         },
+      },
+    ]);
+  });
+
+  it("lists local registry and plugin commands via listCommands", async () => {
+    const { EmbeddedTuiBackend } = await import("./embedded-backend.js");
+    listChatCommandsForConfigMock.mockReturnValue([
+      {
+        key: "status",
+        description: "Show current status.",
+        textAliases: ["/status"],
+      },
+    ]);
+    listPluginCommandsMock.mockReturnValue([
+      {
+        name: "ACTIVE-MEMORY",
+        description: "Enable, disable, or inspect Active Memory for this session.",
+        pluginId: "active-memory",
+        acceptsArgs: true,
+      },
+    ]);
+    const backend = new EmbeddedTuiBackend();
+
+    const commands = await backend.listCommands({ provider: "openai" });
+
+    expect(commands).toEqual([
+      { name: "status", description: "Show current status." },
+      {
+        name: "active-memory",
+        description: "Enable, disable, or inspect Active Memory for this session.",
       },
     ]);
   });

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -4,7 +4,6 @@ import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildAllowedModelSet, resolveThinkingDefault } from "../agents/model-selection.js";
 import { listChatCommandsForConfig } from "../auto-reply/commands-registry.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
@@ -50,7 +49,6 @@ import { setEmbeddedMode } from "../infra/embedded-mode.js";
 import { listPluginCommands } from "../plugins/commands.js";
 import { defaultRuntime } from "../runtime.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import type {
   ChatSendOptions,

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -3,6 +3,8 @@ import { agentCommandFromIngress } from "../agents/agent-command.js";
 import { resolveSessionAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { buildAllowedModelSet, resolveThinkingDefault } from "../agents/model-selection.js";
+import { listChatCommandsForConfig } from "../auto-reply/commands-registry.js";
+import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
@@ -45,12 +47,16 @@ import {
 import { applySessionsPatchToStore } from "../gateway/sessions-patch.js";
 import { type AgentEventPayload, onAgentEvent } from "../infra/agent-events.js";
 import { setEmbeddedMode } from "../infra/embedded-mode.js";
+import { listPluginCommands } from "../plugins/commands.js";
 import { defaultRuntime } from "../runtime.js";
+import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
+import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import type {
   ChatSendOptions,
   TuiAgentsList,
   TuiBackend,
+  TuiCommandChoice,
   TuiEvent,
   TuiModelChoice,
   TuiSessionList,
@@ -329,6 +335,30 @@ export class EmbeddedTuiBackend implements TuiBackend {
       contextWindow: entry.contextWindow,
       reasoning: entry.reasoning,
     }));
+  }
+
+  async listCommands(_opts?: { agentId?: string; provider?: string }): Promise<TuiCommandChoice[]> {
+    const cfg = getRuntimeConfig();
+    const seen = new Set<string>();
+    const commands: TuiCommandChoice[] = [];
+    const pushIfMissing = (name: string, description?: string) => {
+      const normalizedName = normalizeLowercaseStringOrEmpty(name.replace(/^\//, "").trim());
+      if (!normalizedName || seen.has(normalizedName)) {
+        return;
+      }
+      seen.add(normalizedName);
+      commands.push({ name: normalizedName, description });
+    };
+    for (const command of listChatCommandsForConfig(cfg)) {
+      const aliases = command.textAliases.length > 0 ? command.textAliases : [`/${command.key}`];
+      for (const alias of aliases) {
+        pushIfMissing(alias, command.description);
+      }
+    }
+    for (const pluginCommand of listPluginCommands()) {
+      pushIfMissing(pluginCommand.name, pluginCommand.description);
+    }
+    return commands;
   }
 
   private abortSessionRuns(sessionKey: string) {

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -570,4 +570,43 @@ describe("GatewayChatClient", () => {
     await expect(historyPromise).resolves.toEqual({ messages: [] });
     expect(request).toHaveBeenCalledTimes(2);
   });
+
+  it("lists text-scope commands for autocomplete and deduplicates aliases", async () => {
+    const client = new GatewayChatClient({
+      url: "ws://127.0.0.1:18789",
+      token: "test-token",
+      allowInsecureLocalOperatorUi: true,
+    });
+    const request = vi.fn().mockResolvedValue({
+      commands: [
+        {
+          name: "active-memory",
+          description: "Enable, disable, or inspect Active Memory for this session.",
+          source: "plugin",
+          scope: "text",
+          acceptsArgs: true,
+          textAliases: ["/active-memory", "/ACTIVE-MEMORY"],
+        },
+      ],
+    });
+    (client as unknown as { client: { request: typeof request } }).client.request = request;
+
+    const commands = await client.listCommands({
+      agentId: "default",
+      provider: "openai",
+    });
+
+    expect(request).toHaveBeenCalledWith("commands.list", {
+      agentId: "default",
+      provider: "openai",
+      scope: "text",
+      includeArgs: false,
+    });
+    expect(commands).toEqual([
+      {
+        name: "active-memory",
+        description: "Enable, disable, or inspect Active Memory for this session.",
+      },
+    ]);
+  });
 });

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -16,6 +16,7 @@ import {
   GATEWAY_CLIENT_NAMES,
 } from "../gateway/protocol/client-info.js";
 import {
+  type CommandsListResult,
   type HelloOk,
   PROTOCOL_VERSION,
   type SessionsListParams,
@@ -29,6 +30,7 @@ import type {
   ChatSendOptions,
   TuiAgentsList,
   TuiBackend,
+  TuiCommandChoice,
   TuiEvent,
   TuiModelChoice,
   TuiSessionList,
@@ -252,6 +254,33 @@ export class GatewayChatClient implements TuiBackend {
   async listModels(): Promise<GatewayModelChoice[]> {
     const res = await this.client.request("models.list");
     return Array.isArray(res?.models) ? res.models : [];
+  }
+
+  async listCommands(opts?: { agentId?: string; provider?: string }): Promise<TuiCommandChoice[]> {
+    const result = await this.client.request<CommandsListResult>("commands.list", {
+      ...(opts?.agentId ? { agentId: opts.agentId } : {}),
+      ...(opts?.provider ? { provider: opts.provider } : {}),
+      scope: "text",
+      includeArgs: false,
+    });
+    const entries = Array.isArray(result?.commands) ? result.commands : [];
+    const seen = new Set<string>();
+    const commands: TuiCommandChoice[] = [];
+    for (const entry of entries) {
+      const aliases = [entry.name, ...(Array.isArray(entry.textAliases) ? entry.textAliases : [])];
+      for (const alias of aliases) {
+        const normalized = alias.replace(/^\//, "").trim().toLowerCase();
+        if (!normalized || seen.has(normalized)) {
+          continue;
+        }
+        seen.add(normalized);
+        commands.push({
+          name: normalized,
+          description: entry.description,
+        });
+      }
+    }
+    return commands;
   }
 }
 

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -85,6 +85,11 @@ export type TuiModelChoice = {
   reasoning?: boolean;
 };
 
+export type TuiCommandChoice = {
+  name: string;
+  description?: string;
+};
+
 export type TuiBackend = {
   connection: {
     url: string;
@@ -109,4 +114,5 @@ export type TuiBackend = {
   resetSession: (key: string, reason?: "new" | "reset") => Promise<unknown>;
   getGatewayStatus: () => Promise<unknown>;
   listModels: () => Promise<TuiModelChoice[]>;
+  listCommands?: (opts?: { agentId?: string; provider?: string }) => Promise<TuiCommandChoice[]>;
 };

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -22,6 +22,7 @@ function createHarness(params?: {
   setSession?: SetSessionMock;
   loadHistory?: LoadHistoryMock;
   refreshSessionInfo?: ReturnType<typeof vi.fn>;
+  refreshRemoteCommands?: ReturnType<typeof vi.fn>;
   applySessionInfoFromPatch?: ReturnType<typeof vi.fn>;
   setActivityStatus?: SetActivityStatusMock;
   isConnected?: boolean;
@@ -42,6 +43,8 @@ function createHarness(params?: {
   const loadHistory =
     params?.loadHistory ?? (vi.fn().mockResolvedValue(undefined) as LoadHistoryMock);
   const refreshSessionInfo = params?.refreshSessionInfo ?? vi.fn().mockResolvedValue(undefined);
+  const refreshRemoteCommands =
+    params?.refreshRemoteCommands ?? vi.fn().mockResolvedValue(undefined);
   const applySessionInfoFromPatch = params?.applySessionInfoFromPatch ?? vi.fn();
   const setActivityStatus = params?.setActivityStatus ?? (vi.fn() as SetActivityStatusMock);
   const openOverlay = vi.fn();
@@ -74,6 +77,7 @@ function createHarness(params?: {
     loadHistory,
     setSession,
     refreshAgents: vi.fn(),
+    refreshRemoteCommands: refreshRemoteCommands as never,
     abortActive: vi.fn(),
     setActivityStatus,
     formatSessionKey: vi.fn(),
@@ -100,6 +104,7 @@ function createHarness(params?: {
     requestRender,
     loadHistory,
     refreshSessionInfo,
+    refreshRemoteCommands,
     applySessionInfoFromPatch,
     runAuthFlow,
     setActivityStatus,
@@ -255,12 +260,16 @@ describe("tui command handlers", () => {
   });
 
   it("leaves a Crestodian breadcrumb after switching agents", async () => {
-    const { handleCommand, addSystem, setSession, state } = createHarness();
+    const refreshRemoteCommands = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand, addSystem, setSession, state } = createHarness({
+      refreshRemoteCommands,
+    });
 
     await handleCommand("/agent Work");
 
     expect(state.currentAgentId).toBe("work");
     expect(setSession).toHaveBeenCalledWith("");
+    expect(refreshRemoteCommands).toHaveBeenCalledWith(true);
     expect(addSystem).toHaveBeenCalledWith("agent set to work; use /crestodian to return");
   });
 
@@ -431,5 +440,23 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("activation set to always");
     expect(applySessionInfoFromPatch).toHaveBeenCalledWith({ groupActivation: "always" });
     expect(refreshSessionInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces remote command refresh after /model succeeds", async () => {
+    const patchSession = vi.fn().mockResolvedValue({
+      key: "agent:main:main",
+      entry: { modelProvider: "openai", model: "gpt-5.4" },
+    });
+    const refreshSessionInfo = vi.fn().mockResolvedValue(undefined);
+    const refreshRemoteCommands = vi.fn().mockResolvedValue(undefined);
+    const { handleCommand } = createHarness({
+      patchSession,
+      refreshSessionInfo,
+      refreshRemoteCommands,
+    });
+
+    await handleCommand("/model openai/gpt-5.4");
+
+    expect(refreshRemoteCommands).toHaveBeenCalledWith(true);
   });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -40,6 +40,7 @@ type CommandHandlerContext = {
   loadHistory: () => Promise<void>;
   setSession: (key: string) => Promise<void>;
   refreshAgents: () => Promise<void>;
+  refreshRemoteCommands: (force?: boolean) => Promise<void>;
   abortActive: () => Promise<void>;
   setActivityStatus: (text: string) => void;
   formatSessionKey: (key: string) => string;
@@ -72,6 +73,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
     loadHistory,
     setSession,
     refreshAgents,
+    refreshRemoteCommands,
     abortActive,
     setActivityStatus,
     formatSessionKey,
@@ -86,6 +88,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
   const setAgent = async (id: string) => {
     state.currentAgentId = normalizeAgentId(id);
     await setSession("");
+    await refreshRemoteCommands(true);
     chatLog.addSystem(`agent set to ${state.currentAgentId}; use /crestodian to return`);
   };
 
@@ -135,6 +138,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
           chatLog.addSystem(`model set to ${value}`);
           applySessionInfoFromPatch(result);
           await refreshSessionInfo();
+          await refreshRemoteCommands(true);
         } catch (err) {
           chatLog.addSystem(`model set failed: ${String(err)}`);
         }
@@ -393,6 +397,7 @@ export function createCommandHandlers(context: CommandHandlerContext) {
             chatLog.addSystem(`model set to ${args}`);
             applySessionInfoFromPatch(result);
             await refreshSessionInfo();
+            await refreshRemoteCommands(true);
           } catch (err) {
             chatLog.addSystem(`model set failed: ${String(err)}`);
           }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -30,6 +30,7 @@ type SessionActionContext = {
   updateHeader: () => void;
   updateFooter: () => void;
   updateAutocompleteProvider: () => void;
+  refreshRemoteCommands?: (force?: boolean) => Promise<void>;
   setActivityStatus: (text: string) => void;
   clearLocalRunIds?: () => void;
 };
@@ -61,6 +62,7 @@ export function createSessionActions(context: SessionActionContext) {
     updateHeader,
     updateFooter,
     updateAutocompleteProvider,
+    refreshRemoteCommands,
     setActivityStatus,
     clearLocalRunIds,
   } = context;
@@ -371,6 +373,8 @@ export function createSessionActions(context: SessionActionContext) {
 
   const setSession = async (rawKey: string) => {
     const nextKey = resolveSessionKey(rawKey);
+    const previousAgentId = state.currentAgentId;
+    const previousProvider = state.sessionInfo.modelProvider;
     updateAgentFromSessionKey(nextKey);
     state.currentSessionKey = nextKey;
     state.activeChatRunId = null;
@@ -385,6 +389,13 @@ export function createSessionActions(context: SessionActionContext) {
     updateHeader();
     updateFooter();
     await loadHistory();
+    if (
+      refreshRemoteCommands &&
+      (state.currentAgentId !== previousAgentId ||
+        state.sessionInfo.modelProvider !== previousProvider)
+    ) {
+      await refreshRemoteCommands(true);
+    }
   };
 
   const abortActive = async () => {

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../shared/assistant-error-format.js";
-import { getSlashCommands, parseCommand } from "./commands.js";
+import { getBuiltinSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
   drainAndStopTuiSafely,
@@ -65,14 +65,14 @@ describe("tui slash commands", () => {
     });
   });
 
-  it("includes gateway text commands", () => {
-    const commands = getSlashCommands({});
-    expect(commands.some((command) => command.name === "context")).toBe(true);
-    expect(commands.some((command) => command.name === "commands")).toBe(true);
+  it("keeps gateway text commands out of the static slash list", () => {
+    const commands = getBuiltinSlashCommands({});
+    expect(commands.some((command) => command.name === "context")).toBe(false);
+    expect(commands.some((command) => command.name === "commands")).toBe(false);
   });
 
   it("includes /auth in local embedded mode", () => {
-    const commands = getSlashCommands({ local: true });
+    const commands = getBuiltinSlashCommands({ local: true });
     expect(commands.some((command) => command.name === "auth")).toBe(true);
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -11,6 +11,7 @@ import {
   ProcessTerminal,
   Text,
   TUI,
+  type SlashCommand,
 } from "@mariozechner/pi-tui";
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
@@ -23,13 +24,14 @@ import {
   parseAgentSessionKey,
 } from "../routing/session-key.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
-import { getSlashCommands } from "./commands.js";
+import { getBuiltinSlashCommands } from "./commands.js";
 import { ChatLog } from "./components/chat-log.js";
 import { CustomEditor } from "./components/custom-editor.js";
 import { EmbeddedTuiBackend } from "./embedded-backend.js";
 import { GatewayChatClient } from "./gateway-chat.js";
 import { editorTheme, theme } from "./theme/theme.js";
 import type { TuiBackend } from "./tui-backend.js";
+import type { TuiCommandChoice } from "./tui-backend.js";
 import { createCommandHandlers } from "./tui-command-handlers.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
 import { formatTokens } from "./tui-formatters.js";
@@ -541,18 +543,93 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
   root.addChild(footer);
   root.addChild(editor);
 
+  let remoteCommands: TuiCommandChoice[] = [];
+  let remoteCommandsRefreshSeq = 0;
+  let remoteCommandsCacheKey = "";
+  let remoteCommandsRefreshInFlight: Promise<void> | null = null;
+
+  const dedupeSlashCommands = (commands: SlashCommand[]): SlashCommand[] => {
+    const seen = new Set<string>();
+    const deduped: SlashCommand[] = [];
+    for (const command of commands) {
+      const normalizedName = normalizeLowercaseStringOrEmpty(command.name);
+      if (!normalizedName || seen.has(normalizedName)) {
+        continue;
+      }
+      seen.add(normalizedName);
+      deduped.push({
+        ...command,
+        name: normalizedName,
+      });
+    }
+    return deduped;
+  };
+
+  const mergeAutocompleteCommands = (): SlashCommand[] => {
+    const localCommands = getBuiltinSlashCommands({
+      local: isLocalMode,
+      provider: sessionInfo.modelProvider,
+      model: sessionInfo.model,
+      thinkingLevels: sessionInfo.thinkingLevels,
+    });
+    const dynamicCommands: SlashCommand[] = remoteCommands.map((command) => ({
+      name: command.name,
+      description: command.description ?? "",
+    }));
+    // Merge remote plugin/active-memory command entries into TUI autocomplete,
+    // but keep local command argument completion behavior on name collisions.
+    return dedupeSlashCommands([...localCommands, ...dynamicCommands]);
+  };
+
+  const refreshRemoteCommands = async (force = false): Promise<void> => {
+    if (!isConnected || typeof client.listCommands !== "function") {
+      return;
+    }
+    const refreshKey = `${normalizeLowercaseStringOrEmpty(currentAgentId)}:${normalizeLowercaseStringOrEmpty(sessionInfo.modelProvider)}`;
+    if (!force && refreshKey === remoteCommandsCacheKey) {
+      return;
+    }
+    if (remoteCommandsRefreshInFlight) {
+      await remoteCommandsRefreshInFlight;
+      return;
+    }
+    const seq = ++remoteCommandsRefreshSeq;
+    remoteCommandsRefreshInFlight = (async () => {
+      try {
+        const commands = await client.listCommands?.({
+          agentId: currentAgentId,
+          provider: sessionInfo.modelProvider,
+        });
+        if (seq !== remoteCommandsRefreshSeq) {
+          return;
+        }
+        remoteCommands = Array.isArray(commands)
+          ? commands
+              .map((command) => ({
+                name: normalizeLowercaseStringOrEmpty(command.name),
+                description: command.description,
+              }))
+              .filter((command) => Boolean(command.name))
+          : [];
+        remoteCommandsCacheKey = refreshKey;
+        updateAutocompleteProvider();
+      } catch {
+        if (seq !== remoteCommandsRefreshSeq) {
+          return;
+        }
+        remoteCommands = [];
+        remoteCommandsCacheKey = "";
+        updateAutocompleteProvider();
+      } finally {
+        remoteCommandsRefreshInFlight = null;
+      }
+    })();
+    await remoteCommandsRefreshInFlight;
+  };
+
   const updateAutocompleteProvider = () => {
     editor.setAutocompleteProvider(
-      new CombinedAutocompleteProvider(
-        getSlashCommands({
-          cfg: config,
-          local: isLocalMode,
-          provider: sessionInfo.modelProvider,
-          model: sessionInfo.model,
-          thinkingLevels: sessionInfo.thinkingLevels,
-        }),
-        process.cwd(),
-      ),
+      new CombinedAutocompleteProvider(mergeAutocompleteCommands(), process.cwd()),
     );
   };
 
@@ -888,6 +965,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     updateHeader,
     updateFooter,
     updateAutocompleteProvider,
+    refreshRemoteCommands,
     setActivityStatus,
     clearLocalRunIds,
   });
@@ -959,6 +1037,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       loadHistory,
       setSession,
       refreshAgents,
+      refreshRemoteCommands,
       abortActive,
       setActivityStatus,
       formatSessionKey,
@@ -1083,6 +1162,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
       await refreshAgents();
       updateHeader();
       await loadHistory();
+      await refreshRemoteCommands(true);
       setConnectionStatus(
         isLocalMode ? "local ready" : reconnected ? "gateway reconnected" : "gateway connected",
         4000,
@@ -1102,6 +1182,10 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     wasDisconnected = true;
     historyLoaded = false;
     pauseStreamingWatchdog();
+    remoteCommands = [];
+    remoteCommandsCacheKey = "";
+    remoteCommandsRefreshSeq += 1;
+    updateAutocompleteProvider();
     const disconnectState = isLocalMode
       ? {
           connectionStatus: `local runtime stopped${reason ? `: ${reason}` : ""}`,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -585,20 +585,30 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     if (!isConnected || typeof client.listCommands !== "function") {
       return;
     }
-    const refreshKey = `${normalizeLowercaseStringOrEmpty(currentAgentId)}:${normalizeLowercaseStringOrEmpty(sessionInfo.modelProvider)}`;
+    const resolveRefreshKey = () =>
+      `${normalizeLowercaseStringOrEmpty(currentAgentId)}:${normalizeLowercaseStringOrEmpty(sessionInfo.modelProvider)}`;
+    let refreshKey = resolveRefreshKey();
     if (!force && refreshKey === remoteCommandsCacheKey) {
       return;
     }
     if (remoteCommandsRefreshInFlight) {
       await remoteCommandsRefreshInFlight;
-      return;
+      if (!isConnected || typeof client.listCommands !== "function") {
+        return;
+      }
+      refreshKey = resolveRefreshKey();
+      if (refreshKey === remoteCommandsCacheKey) {
+        return;
+      }
     }
     const seq = ++remoteCommandsRefreshSeq;
+    const requestAgentId = currentAgentId;
+    const requestProvider = sessionInfo.modelProvider;
     remoteCommandsRefreshInFlight = (async () => {
       try {
         const commands = await client.listCommands?.({
-          agentId: currentAgentId,
-          provider: sessionInfo.modelProvider,
+          agentId: requestAgentId,
+          provider: requestProvider,
         });
         if (seq !== remoteCommandsRefreshSeq) {
           return;


### PR DESCRIPTION
## Summary
- Merge remote command entries from `commands.list` into TUI slash-command autocomplete so plugin commands (for example `/active-memory`) appear in suggestions.
- Refresh remote command suggestions when command context changes (`/agent`, `/model`, and session changes that alter agent/provider), while preserving local command argument-completion behavior on name collisions.
- Align embedded and gateway command listing paths and add targeted TUI tests for command list hydration and refresh behavior.

## Test plan
- [x] `pnpm test src/tui/tui.test.ts`
- [x] `pnpm test src/tui/tui-command-handlers.test.ts`
- [x] Manual: run `pnpm tui`, switch via `/agents` to `claude-4`, type `/act`, confirm `/active-memory` appears in autocomplete.
- [x] Manual: run `/model <provider/model>` and verify autocomplete updates to the current command surface.

Made with [Cursor](https://cursor.com)