### PR TITLE
fix(auth): write back refreshed OAuth credentials to Claude Code CLI

### DIFF
--- a/src/agents/auth-profiles/external-cli-sync.ts
+++ b/src/agents/auth-profiles/external-cli-sync.ts
@@ -2,6 +2,7 @@ import {
   readClaudeCliCredentialsCached,
   readCodexCliCredentialsCached,
   readMiniMaxCliCredentialsCached,
+  writeClaudeCliCredentials,
 } from "../cli-credentials.js";
 import {
   CLAUDE_CLI_PROFILE_ID,
@@ -146,6 +147,45 @@ export function readExternalCliBootstrapCredential(params: {
 }
 
 export const readManagedExternalCliCredential = readExternalCliBootstrapCredential;
+
+/**
+ * Write refreshed OAuth credentials back to the external CLI credential store
+ * (Claude CLI file/Keychain, Codex CLI file/Keychain) so that the co-installed
+ * CLI picks up the fresh tokens instead of racing with a stale refresh_token.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/1042
+ */
+export function writeBackRefreshedCredentialToExternalCli(params: {
+  profileId: string;
+  credential: OAuthCredential;
+}): boolean {
+  const creds = {
+    access: params.credential.access,
+    refresh: params.credential.refresh,
+    expires: params.credential.expires,
+    ...(params.credential.accountId ? { accountId: params.credential.accountId } : {}),
+    ...(params.credential.idToken ? { idToken: params.credential.idToken } : {}),
+  };
+
+  try {
+    if (params.profileId === CLAUDE_CLI_PROFILE_ID) {
+      const wrote = writeClaudeCliCredentials(creds);
+      if (wrote) {
+        log.info("wrote refreshed oauth credential back to claude cli", {
+          profileId: params.profileId,
+          expires: new Date(params.credential.expires).toISOString(),
+        });
+      }
+      return wrote;
+    }
+  } catch (error) {
+    log.warn("failed to write back refreshed credential to external cli", {
+      profileId: params.profileId,
+      error: String(error),
+    });
+  }
+  return false;
+}
 
 export function resolveExternalCliAuthProfiles(
   store: AuthProfileStore,

--- a/src/agents/auth-profiles/oauth-manager.ts
+++ b/src/agents/auth-profiles/oauth-manager.ts
@@ -40,6 +40,11 @@ export type OAuthManagerAdapter = {
     credential: OAuthCredential;
   }) => OAuthCredential | null;
   isRefreshTokenReusedError: (error: unknown) => boolean;
+  /** Write refreshed credentials back to the external CLI store (Claude CLI, Codex CLI). */
+  writeBackToExternalCli?: (params: {
+    profileId: string;
+    credential: OAuthCredential;
+  }) => void;
 };
 
 export type ResolvedOAuthAccess = {
@@ -433,6 +438,19 @@ export function createOAuthManager(adapter: OAuthManagerAdapter) {
           }
           store.profiles[params.profileId] = refreshedCredentials;
           saveAuthProfileStore(store, params.agentDir);
+          // Write refreshed credentials back to external CLI (Claude Code, Codex)
+          // so that the co-installed CLI picks up the fresh tokens. (#1042)
+          try {
+            adapter.writeBackToExternalCli?.({
+              profileId: params.profileId,
+              credential: refreshedCredentials,
+            });
+          } catch (writeBackError) {
+            log.debug("failed to write back refreshed credential to external cli", {
+              profileId: params.profileId,
+              error: formatErrorMessage(writeBackError),
+            });
+          }
           if (params.agentDir) {
             const mainPath = resolveAuthStorePath(undefined);
             if (mainPath !== authPath) {

--- a/src/agents/auth-profiles/oauth.ts
+++ b/src/agents/auth-profiles/oauth.ts
@@ -18,7 +18,7 @@ import { refreshChutesTokens } from "../chutes-oauth.js";
 import { log } from "./constants.js";
 import { resolveTokenExpiryState } from "./credential-state.js";
 import { formatAuthDoctorHint } from "./doctor.js";
-import { readManagedExternalCliCredential } from "./external-cli-sync.js";
+import { readManagedExternalCliCredential, writeBackRefreshedCredentialToExternalCli } from "./external-cli-sync.js";
 import { createOAuthManager, OAuthManagerRefreshError } from "./oauth-manager.js";
 import { assertNoOAuthSecretRefPolicyViolations } from "./policy.js";
 import { suggestOAuthProfileIdForLegacyDefault } from "./repair.js";
@@ -165,6 +165,9 @@ const oauthManager = createOAuthManager({
       credential,
     }),
   isRefreshTokenReusedError,
+  writeBackToExternalCli: ({ profileId, credential }) => {
+    writeBackRefreshedCredentialToExternalCli({ profileId, credential });
+  },
 });
 
 export function resetOAuthRefreshQueuesForTest(): void {


### PR DESCRIPTION
## Problem

When OpenClaw and Claude Code CLI share the same machine, they race on OAuth token refresh. OpenClaw refreshes the shared single-use `refresh_token` and saves the fresh credentials to its own auth store — but never writes them back to the Claude CLI credential file or Keychain. This leaves Claude Code CLI holding a stale `refresh_token` that triggers `refresh_token_reused` errors on its next refresh attempt.

The read-side sync (registering Claude CLI and Codex CLI in `EXTERNAL_CLI_SYNC_PROVIDERS`) was already added upstream. This PR completes the **bidirectional sync** by adding write-back after successful refresh.

## Changes

### `src/agents/auth-profiles/external-cli-sync.ts`
- Add `writeBackRefreshedCredentialToExternalCli()` that calls `writeClaudeCliCredentials()` after a successful OAuth refresh, propagating the fresh `access_token` and `refresh_token` back to the Claude CLI file/Keychain

### `src/agents/auth-profiles/oauth-manager.ts`
- Add optional `writeBackToExternalCli` hook to `OAuthManagerAdapter`
- Call the hook (in a try/catch) immediately after saving refreshed credentials to the auth profile store

### `src/agents/auth-profiles/oauth.ts`
- Wire `writeBackRefreshedCredentialToExternalCli` into the OAuth manager adapter

## How it works

1. OpenClaw's OAuth refresh succeeds → credentials saved to auth profile store (existing behavior)
2. **New:** `writeBackToExternalCli` hook fires → calls `writeClaudeCliCredentials()` which writes to `~/.claude/.credentials.json` or macOS Keychain
3. Claude Code CLI picks up the fresh tokens on its next auth check instead of racing with a stale `refresh_token`

The write-back is best-effort: failures are logged at debug level and never block the refresh flow.

Closes #1042