### PR TITLE
fix(agents): strip metadata for openai-codex Responses to avoid ChatGPT 400 (#73963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/OpenAI Codex: drop the top-level `metadata` field for `openai-codex-responses` requests so the ChatGPT codex backend at `https://chatgpt.com/backend-api/codex/responses` no longer rejects them with HTTP 400 `Unsupported parameter: metadata` (surfaced as the misleading `400 status code (no body)` because the SDK error parser expects an `{"error":{"message":...}}` envelope). Non-Codex `openai-responses` and `azure-openai-responses` paths still attach metadata as before. Fixes #73963. Thanks @kasanuowa.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.
 - Gateway/reload: bound default restart deferral and SIGUSR1 restart drain to five minutes while preserving explicit `deferralTimeoutMs: 0` indefinite waits, so stale active work accounting cannot block config reloads forever. Thanks @vincentkoc.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -955,14 +955,76 @@ describe("openai transport stream", () => {
     );
     expect(params.prompt_cache_key).toBe("session-123");
     expect(params.prompt_cache_retention).toBeUndefined();
-    expect(params.metadata).toEqual({
-      openclaw_session_id: "session-123",
-      openclaw_turn_id: "turn-123",
-    });
+    // ChatGPT codex backend rejects requests with a top-level `metadata`
+    // field as `Unsupported parameter: metadata` — see #73963. Even though
+    // the caller passed turn metadata, the Codex Responses params must drop
+    // it before send.
+    expect(params.metadata).toBeUndefined();
     expect(params.store).toBe(false);
     expect(params.max_output_tokens).toBe(1024);
     expect(params.temperature).toBe(0.2);
     expect(params.service_tier).toBe("auto");
+  });
+
+  it("strips top-level metadata for openai-codex-responses to avoid ChatGPT 400 (regression for #73963)", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4-mini",
+        name: "GPT-5.4-mini",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: "system",
+        messages: [{ role: "user", content: "ping", timestamp: 1 }],
+        tools: [],
+      } as never,
+      { sessionId: "s-codex" },
+      {
+        openclaw_session_id: "s-codex",
+        openclaw_turn_id: "t-codex",
+      },
+    ) as Record<string, unknown> & { metadata?: Record<string, string> };
+
+    expect(params).not.toHaveProperty("metadata");
+  });
+
+  it("keeps top-level metadata for non-Codex openai-responses (regression for #73963)", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-responses",
+        provider: "openai",
+        baseUrl: "https://api.openai.com/v1",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-responses">,
+      {
+        systemPrompt: "system",
+        messages: [{ role: "user", content: "ping", timestamp: 1 }],
+        tools: [],
+      } as never,
+      { sessionId: "s-openai" },
+      {
+        openclaw_session_id: "s-openai",
+        openclaw_turn_id: "t-openai",
+      },
+    ) as Record<string, unknown> & { metadata?: Record<string, string> };
+
+    expect(params.metadata).toEqual({
+      openclaw_session_id: "s-openai",
+      openclaw_turn_id: "t-openai",
+    });
   });
 
   it("does not infer high reasoning when Pi passes thinking off", () => {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -897,7 +897,14 @@ export function buildOpenAIResponsesParams(
     prompt_cache_key: cacheRetention === "none" ? undefined : options?.sessionId,
     prompt_cache_retention: getPromptCacheRetention(model.baseUrl, cacheRetention),
     ...(isCodexResponses ? { instructions: buildOpenAICodexResponsesInstructions(context) } : {}),
-    ...(metadata ? { metadata } : {}),
+    // ChatGPT codex backend at https://chatgpt.com/backend-api/codex/responses
+    // rejects requests carrying a top-level `metadata` field with HTTP 400
+    // `Unsupported parameter: metadata`. The error is surfaced to the user as
+    // the misleading `400 status code (no body)` because the SDK error parser
+    // expects an `{"error":{"message":...}}` envelope. Strip metadata for
+    // Codex-Responses requests; keep it for the regular openai-responses /
+    // azure-openai-responses paths where the field is honored. See #73963.
+    ...(metadata && !isCodexResponses ? { metadata } : {}),
   };
   if (options?.maxTokens) {
     params.max_output_tokens = options.maxTokens;


### PR DESCRIPTION
Fixes #73963.

## Problem

The ChatGPT codex backend at \`https://chatgpt.com/backend-api/codex/responses\` rejects every request that carries a top-level \`metadata\` field with HTTP 400:

\`\`\`
{\"detail\":\"Unsupported parameter: metadata\"}
\`\`\`

OpenClaw 2026.4.26 attaches \`metadata\` (turn/session ids) unconditionally in \`buildOpenAIResponsesParams\`. The SDK error parser expects an \`{\"error\":{\"message\":...}}\` envelope and falls through, surfacing the backend rejection to the user as the misleading string \`400 status code (no body)\`. **All \`openai-codex/*\` models on the ChatGPT subscription path are unusable** until the provider stops attaching \`metadata\`.

## Fix

Strip \`metadata\` for \`isCodexResponses\` requests; keep it for \`openai-responses\` and \`azure-openai-responses\` where the field is honored. One-line conditional:

\`\`\`ts
...(metadata && !isCodexResponses ? { metadata } : {}),
\`\`\`

Confirmed via curl in #73963: the same payload without \`metadata\` returns the assistant message normally on the same OAuth token.

## What changed

| File | Change | LOC |
|---|---|---|
| \`openai-transport-stream.ts\` | Strip metadata for isCodexResponses | +9 |
| \`openai-transport-stream.test.ts\` | Update existing Codex test + 2 new regression tests | +60 |
| \`CHANGELOG.md\` | Unreleased Fixes line | +1 |

The pre-existing test \`\"uses top-level instructions for Codex responses without dropping parity fields\"\` was asserting \`params.metadata\` IS attached for Codex Responses. **That test was actually capturing the bug** (codified the broken behavior). Updated it to assert metadata is now \`undefined\` for Codex Responses, with a comment citing #73963.

## Tests

\`\`\`
pnpm vitest run src/agents/openai-transport-stream.test.ts
→ 92 passed (90 existing + 2 new regression tests, +1 existing test updated to assert new contract)
\`\`\`

## Coordination with #73930

This PR touches the same file as my open #73930 (codex empty-input fail-fast). The two fixes are at different lines — #73930 adds a guard before \`convertResponsesMessages\`, this PR conditionally spreads \`metadata\` later in the params object. Both can land independently or together; if Pete prefers one squashed PR I can rebase #73930 into this one.

🦞 lobster-biscuit

---
Sign-Off: hclsys