### PR TITLE
fix(memory): keep daily signals out of recall gates

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -87,12 +87,12 @@ openclaw memory promote [--apply] [--limit <n>] [--include-promoted]
 Full options:
 
 - Ranks short-term candidates from `memory/YYYY-MM-DD.md` using weighted promotion signals (`frequency`, `relevance`, `query diversity`, `recency`, `consolidation`, `conceptual richness`).
-- Uses short-term signals from both memory recalls and daily-ingestion passes, plus light/REM phase reinforcement signals.
+- Uses short-term signals from both memory recalls and daily-ingestion passes, plus light/REM phase reinforcement signals. Daily-ingestion signals can affect scoring, but only recall or grounded evidence satisfies the recall-count gate.
 - When dreaming is enabled, `memory-core` auto-manages one cron job that runs a full sweep (`light -> REM -> deep`) in the background (no manual `openclaw cron add` required).
 - `--agent <id>`: scope to a single agent (default: the default agent).
 - `--limit <n>`: max candidates to return/apply.
 - `--min-score <n>`: minimum weighted promotion score.
-- `--min-recall-count <n>`: minimum recall count required for a candidate.
+- `--min-recall-count <n>`: minimum recall or grounded evidence count required for a candidate.
 - `--min-unique-queries <n>`: minimum distinct query count required for a candidate.
 - `--apply`: append selected candidates into `MEMORY.md` and mark them promoted.
 - `--include-promoted`: include already promoted candidates in output.

--- a/docs/concepts/dreaming.md
+++ b/docs/concepts/dreaming.md
@@ -49,7 +49,7 @@ These phases are internal implementation details, not separate user-configured "
     Deep phase decides what becomes long-term memory.
 
     - Ranks candidates using weighted scoring and threshold gates.
-    - Requires `minScore`, `minRecallCount`, and `minUniqueQueries` to pass.
+    - Requires `minScore`, `minUniqueQueries`, and `minRecallCount` from recall or grounded evidence to pass. Daily-ingestion-only signals do not satisfy the recall gate.
     - Rehydrates snippets from live daily files before writing, so stale/deleted snippets are skipped.
     - Appends promoted entries to `MEMORY.md`.
     - Writes a `## Deep Sleep` summary into `DREAMS.md` and optionally writes `memory/dreaming/deep/YYYY-MM-DD.md`.
@@ -106,6 +106,7 @@ Deep ranking uses six weighted base signals plus phase reinforcement:
 | Conceptual richness | 0.06   | Concept-tag density from snippet/path             |
 
 Light and REM phase hits add a small recency-decayed boost from `memory/.dreams/phase-signals.json`.
+Daily-ingestion signals can still contribute to frequency and scoring, but they do not satisfy the deep phase `minRecallCount` gate without recall or grounded evidence.
 
 ## Scheduling
 

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -606,6 +606,96 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
+  it("prioritizes recalled entries over newer daily-only entries in light sleep", async () => {
+    const workspaceDir = await createDreamingWorkspace();
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-03.md"),
+      "Recalled router backup rotation.\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", "2026-04-05.md"),
+      ["Daily-only note 1.", "Daily-only note 2.", "Daily-only note 3."].join("\n"),
+      "utf-8",
+    );
+    const recalledAt = Date.parse("2026-04-03T10:00:00.000Z");
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "router backup rotation",
+      nowMs: recalledAt,
+      results: [
+        {
+          path: "memory/2026-04-03.md",
+          startLine: 1,
+          endLine: 1,
+          score: 0.92,
+          snippet: "Recalled router backup rotation.",
+          source: "memory",
+        },
+      ],
+    });
+
+    for (const index of [1, 2, 3]) {
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: `__dreaming_daily__:2026-04-05:${index}`,
+        signalType: "daily",
+        dayBucket: "2026-04-05",
+        nowMs: Date.parse("2026-04-05T10:00:00.000Z") + index,
+        results: [
+          {
+            path: "memory/2026-04-05.md",
+            startLine: index,
+            endLine: index,
+            score: 0.74,
+            snippet: `Daily-only note ${index}.`,
+            source: "memory",
+          },
+        ],
+      });
+    }
+
+    const { beforeAgentReply } = createHarness(
+      {
+        plugins: {
+          entries: {
+            "memory-core": {
+              config: {
+                dreaming: {
+                  enabled: true,
+                  timezone: "UTC",
+                  storage: { mode: "inline", separateReports: false },
+                  phases: {
+                    light: {
+                      enabled: true,
+                      limit: 2,
+                      lookbackDays: 7,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      workspaceDir,
+    );
+
+    await withDreamingTestClock(async () => {
+      await triggerLightDreaming(beforeAgentReply, workspaceDir, 5);
+    });
+
+    const dailyContent = await fs.readFile(
+      path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
+      "utf-8",
+    );
+    const recalledIndex = dailyContent.indexOf("- Candidate: Recalled router backup rotation.");
+    const dailyIndex = dailyContent.indexOf("- Candidate: Daily-only note");
+    expect(recalledIndex).toBeGreaterThanOrEqual(0);
+    expect(dailyIndex).toBeGreaterThanOrEqual(0);
+    expect(recalledIndex).toBeLessThan(dailyIndex);
+  });
+
   it("checkpoints session transcript ingestion and skips unchanged transcripts", async () => {
     const workspaceDir = await createDreamingWorkspace();
     vi.stubEnv("OPENCLAW_TEST_FAST", "1");

--- a/extensions/memory-core/src/dreaming-phases.test.ts
+++ b/extensions/memory-core/src/dreaming-phases.test.ts
@@ -606,11 +606,19 @@ describe("memory-core dreaming phases", () => {
     });
   });
 
-  it("prioritizes recalled entries over newer daily-only entries in light sleep", async () => {
+  it("prioritizes fresh recalled entries over stale recalled and daily-only entries in light sleep", async () => {
     const workspaceDir = await createDreamingWorkspace();
+    await fs.mkdir(path.join(workspaceDir, "memory", ".dreams", "session-corpus"), {
+      recursive: true,
+    });
     await fs.writeFile(
-      path.join(workspaceDir, "memory", "2026-04-03.md"),
-      "Recalled router backup rotation.\n",
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-03.txt"),
+      "Stale recalled router backup rotation.\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(workspaceDir, "memory", ".dreams", "session-corpus", "2026-04-04.txt"),
+      "Fresh recalled router backup check.\n",
       "utf-8",
     );
     await fs.writeFile(
@@ -625,11 +633,41 @@ describe("memory-core dreaming phases", () => {
       nowMs: recalledAt,
       results: [
         {
-          path: "memory/2026-04-03.md",
+          path: "memory/.dreams/session-corpus/2026-04-03.txt",
           startLine: 1,
           endLine: 1,
           score: 0.92,
-          snippet: "Recalled router backup rotation.",
+          snippet: "Stale recalled router backup rotation.",
+          source: "memory",
+        },
+      ],
+    });
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "router backup retention",
+      nowMs: recalledAt + 1_000,
+      results: [
+        {
+          path: "memory/.dreams/session-corpus/2026-04-03.txt",
+          startLine: 1,
+          endLine: 1,
+          score: 0.91,
+          snippet: "Stale recalled router backup rotation.",
+          source: "memory",
+        },
+      ],
+    });
+    await recordShortTermRecalls({
+      workspaceDir,
+      query: "fresh router backup check",
+      nowMs: Date.parse("2026-04-04T10:00:00.000Z"),
+      results: [
+        {
+          path: "memory/.dreams/session-corpus/2026-04-04.txt",
+          startLine: 1,
+          endLine: 1,
+          score: 0.9,
+          snippet: "Fresh recalled router backup check.",
           source: "memory",
         },
       ],
@@ -668,7 +706,7 @@ describe("memory-core dreaming phases", () => {
                   phases: {
                     light: {
                       enabled: true,
-                      limit: 2,
+                      limit: 3,
                       lookbackDays: 7,
                     },
                   },
@@ -689,11 +727,18 @@ describe("memory-core dreaming phases", () => {
       path.join(workspaceDir, "memory", `${DREAMING_TEST_DAY}.md`),
       "utf-8",
     );
-    const recalledIndex = dailyContent.indexOf("- Candidate: Recalled router backup rotation.");
+    const freshRecalledIndex = dailyContent.indexOf(
+      "- Candidate: Fresh recalled router backup check.",
+    );
+    const staleRecalledIndex = dailyContent.indexOf(
+      "- Candidate: Stale recalled router backup rotation.",
+    );
     const dailyIndex = dailyContent.indexOf("- Candidate: Daily-only note");
-    expect(recalledIndex).toBeGreaterThanOrEqual(0);
+    expect(freshRecalledIndex).toBeGreaterThanOrEqual(0);
+    expect(staleRecalledIndex).toBeGreaterThanOrEqual(0);
     expect(dailyIndex).toBeGreaterThanOrEqual(0);
-    expect(recalledIndex).toBeLessThan(dailyIndex);
+    expect(freshRecalledIndex).toBeLessThan(staleRecalledIndex);
+    expect(staleRecalledIndex).toBeLessThan(dailyIndex);
   });
 
   it("checkpoints session transcript ingestion and skips unchanged transcripts", async () => {

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1587,11 +1587,15 @@ async function runLightDreaming(params: {
   const entries = dedupeEntries(
     recentEntries
       .toSorted((a, b) => {
+        const byRecall = b.recallCount - a.recallCount;
+        if (byRecall !== 0) {
+          return byRecall;
+        }
         const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
         if (byTime !== 0) {
           return byTime;
         }
-        return b.recallCount - a.recallCount;
+        return a.path.localeCompare(b.path);
       })
       .slice(0, params.config.limit),
     params.config.dedupeSimilarity,

--- a/extensions/memory-core/src/dreaming-phases.ts
+++ b/extensions/memory-core/src/dreaming-phases.ts
@@ -1587,13 +1587,17 @@ async function runLightDreaming(params: {
   const entries = dedupeEntries(
     recentEntries
       .toSorted((a, b) => {
-        const byRecall = b.recallCount - a.recallCount;
-        if (byRecall !== 0) {
-          return byRecall;
+        const byRecallPresence = Number(b.recallCount > 0) - Number(a.recallCount > 0);
+        if (byRecallPresence !== 0) {
+          return byRecallPresence;
         }
         const byTime = Date.parse(b.lastRecalledAt) - Date.parse(a.lastRecalledAt);
         if (byTime !== 0) {
           return byTime;
+        }
+        const byRecall = b.recallCount - a.recallCount;
+        if (byRecall !== 0) {
+          return byRecall;
         }
         return a.path.localeCompare(b.path);
       })

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1527,6 +1527,59 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps nearby containment matches ahead of tighter distant repeats", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "intro",
+        "summary",
+        "daily note churn",
+        "another inserted line",
+        "Move backups to S3",
+        "Glacier. Nearby suffix.",
+        "gap",
+        "gap",
+        "gap",
+        "Far prefix Move backups to S3 Glacier. Far suffix.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier nearby repeated",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 5,
+            endLine: 6,
+            score: 0.94,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(5);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(6);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-04-01.md:5-6");
+      expect(memoryText).toContain("Glacier. Nearby suffix.");
+      expect(memoryText).not.toContain("Far prefix Move backups");
+    });
+  });
+
   it("prefers the nearest matching snippet when the same text appears multiple times", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1580,6 +1580,57 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("does not ratchet containment matches away from the nearest range", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "intro",
+        "summary",
+        "daily note churn",
+        "another inserted line",
+        "nearest envelope before repeated target",
+        "",
+        "",
+        "",
+        "",
+        "Far prefix Move backups to S3 Glacier. Far suffix.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier ratchet repeated",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 5,
+            endLine: 10,
+            score: 0.94,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBeLessThanOrEqual(6);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(10);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).not.toContain("memory/2026-04-01.md:10-10");
+    });
+  });
+
   it("prefers the nearest matching snippet when the same text appears multiple times", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1527,59 +1527,6 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("keeps nearby containment matches ahead of tighter distant repeats", async () => {
-    await withTempWorkspace(async (workspaceDir) => {
-      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
-        "intro",
-        "summary",
-        "daily note churn",
-        "another inserted line",
-        "Move backups to S3",
-        "Glacier. Nearby suffix.",
-        "gap",
-        "gap",
-        "gap",
-        "Far prefix Move backups to S3 Glacier. Far suffix.",
-      ]);
-      await recordShortTermRecalls({
-        workspaceDir,
-        query: "glacier nearby repeated",
-        results: [
-          {
-            path: "memory/2026-04-01.md",
-            startLine: 5,
-            endLine: 6,
-            score: 0.94,
-            snippet: "Move backups to S3 Glacier.",
-            source: "memory",
-          },
-        ],
-      });
-
-      const ranked = await rankShortTermPromotionCandidates({
-        workspaceDir,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-      });
-      const applied = await applyShortTermPromotions({
-        workspaceDir,
-        candidates: ranked,
-        minScore: 0,
-        minRecallCount: 0,
-        minUniqueQueries: 0,
-      });
-
-      expect(applied.applied).toBe(1);
-      expect(applied.appliedCandidates[0]?.startLine).toBe(5);
-      expect(applied.appliedCandidates[0]?.endLine).toBe(6);
-      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).toContain("memory/2026-04-01.md:5-6");
-      expect(memoryText).toContain("Glacier. Nearby suffix.");
-      expect(memoryText).not.toContain("Far prefix Move backups");
-    });
-  });
-
   it("keeps nearby wider containment matches ahead of distant tight repeats", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -428,7 +428,7 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("lets repeated dreaming-only daily signals clear the default promotion gates", async () => {
+  it("does not let repeated dreaming-only daily signals clear the default promotion gates", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       const queryDays = ["2026-04-01", "2026-04-02", "2026-04-03"];
       let candidateKey = "";
@@ -490,14 +490,29 @@ describe("short-term promotion", () => {
         nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
       });
 
-      expect(ranked).toHaveLength(1);
-      expect(ranked[0]).toMatchObject({
+      expect(ranked).toHaveLength(0);
+
+      const staged = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+        nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+      });
+      expect(staged).toHaveLength(1);
+      expect(staged[0]).toMatchObject({
         recallCount: 0,
         dailyCount: 3,
         uniqueQueries: 3,
       });
-      expect(ranked[0]?.recallDays).toEqual(queryDays);
-      expect(ranked[0]?.score).toBeGreaterThanOrEqual(0.75);
+      expect(staged[0]?.recallDays).toEqual(queryDays);
+
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: staged,
+        nowMs: Date.parse("2026-04-03T10:01:00.000Z"),
+      });
+      expect(applied.applied).toBe(0);
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1580,7 +1580,7 @@ describe("short-term promotion", () => {
     });
   });
 
-  it("does not ratchet containment matches away from the nearest range", async () => {
+  it("uses nested tight containment instead of broad stale ranges", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
         "intro",
@@ -1591,12 +1591,12 @@ describe("short-term promotion", () => {
         "",
         "",
         "",
-        "",
+        "Unrelated account note should stay local.",
         "Far prefix Move backups to S3 Glacier. Far suffix.",
       ]);
       await recordShortTermRecalls({
         workspaceDir,
-        query: "glacier ratchet repeated",
+        query: "glacier broad stale range",
         results: [
           {
             path: "memory/2026-04-01.md",
@@ -1624,10 +1624,12 @@ describe("short-term promotion", () => {
       });
 
       expect(applied.applied).toBe(1);
-      expect(applied.appliedCandidates[0]?.startLine).toBeLessThanOrEqual(6);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(10);
       expect(applied.appliedCandidates[0]?.endLine).toBe(10);
       const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
-      expect(memoryText).not.toContain("memory/2026-04-01.md:10-10");
+      expect(memoryText).toContain("memory/2026-04-01.md:10-10");
+      expect(memoryText).not.toContain("nearest envelope before repeated target");
+      expect(memoryText).not.toContain("Unrelated account note should stay local.");
     });
   });
 

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1477,6 +1477,56 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("uses the tightest containing range for embedded moved snippets", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "Do not promote this adjacent planning line.",
+        "Context prefix Move backups to S3 Glacier. Context suffix.",
+        "Do not promote this adjacent security line.",
+        "Keep the unrelated account note local.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier embedded",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 4,
+            score: 0.94,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(2);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(2);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(
+        "Context prefix Move backups to S3 Glacier. Context suffix.",
+      );
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-04-01.md:2-2");
+      expect(memoryText).not.toContain("Do not promote this adjacent planning line.");
+      expect(memoryText).not.toContain("Do not promote this adjacent security line.");
+    });
+  });
+
   it("prefers the nearest matching snippet when the same text appears multiple times", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1416,6 +1416,67 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("rehydrates broad moved snippets beyond the original short range", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      const movedLines = [
+        "Moved backups to S3 Glacier.",
+        "Keep cold storage retention at 365 days.",
+        "Expire restore manifests after quarterly verification.",
+        "Mirror billing reports into the archive bucket.",
+        "Tag storage objects with owner and purpose.",
+        "Keep recovery runbooks beside the archive index.",
+        "Rotate the restore test sample every month.",
+        "Alert if retrieval failures exceed one per week.",
+        "Preserve a local checksum manifest for audits.",
+        "Document the next cold-storage review date.",
+      ];
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "intro",
+        "summary",
+        "daily note churn",
+        "another inserted line",
+        ...movedLines,
+        "afterward",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier broad retention",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 1,
+            endLine: 2,
+            score: 0.94,
+            snippet: movedLines.join("\n"),
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(5);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(14);
+      expect(applied.appliedCandidates[0]?.snippet).toBe(movedLines.join(" "));
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-04-01.md:5-14");
+      expect(memoryText).toContain("Document the next cold-storage review date.");
+    });
+  });
+
   it("prefers the nearest matching snippet when the same text appears multiple times", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1580,6 +1580,59 @@ describe("short-term promotion", () => {
     });
   });
 
+  it("keeps nearby wider containment matches ahead of distant tight repeats", async () => {
+    await withTempWorkspace(async (workspaceDir) => {
+      await writeDailyMemoryNote(workspaceDir, "2026-04-01", [
+        "intro",
+        "summary",
+        "daily note churn",
+        "another inserted line",
+        "Move backups",
+        "to S3",
+        "Glacier. Nearby suffix.",
+        "gap",
+        "gap",
+        "Far prefix Move backups to S3 Glacier. Far suffix.",
+      ]);
+      await recordShortTermRecalls({
+        workspaceDir,
+        query: "glacier nearby wrapped repeated",
+        results: [
+          {
+            path: "memory/2026-04-01.md",
+            startLine: 5,
+            endLine: 7,
+            score: 0.94,
+            snippet: "Move backups to S3 Glacier.",
+            source: "memory",
+          },
+        ],
+      });
+
+      const ranked = await rankShortTermPromotionCandidates({
+        workspaceDir,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+      const applied = await applyShortTermPromotions({
+        workspaceDir,
+        candidates: ranked,
+        minScore: 0,
+        minRecallCount: 0,
+        minUniqueQueries: 0,
+      });
+
+      expect(applied.applied).toBe(1);
+      expect(applied.appliedCandidates[0]?.startLine).toBe(5);
+      expect(applied.appliedCandidates[0]?.endLine).toBe(7);
+      const memoryText = await fs.readFile(path.join(workspaceDir, "MEMORY.md"), "utf-8");
+      expect(memoryText).toContain("memory/2026-04-01.md:5-7");
+      expect(memoryText).toContain("Glacier. Nearby suffix.");
+      expect(memoryText).not.toContain("Far prefix Move backups");
+    });
+  });
+
   it("uses nested tight containment instead of broad stale ranges", async () => {
     await withTempWorkspace(async (workspaceDir) => {
       await writeDailyMemoryNote(workspaceDir, "2026-04-01", [

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -400,6 +400,16 @@ function totalSignalCountForEntry(entry: {
   );
 }
 
+function promotionGateSignalCountForEntry(entry: {
+  recallCount?: number;
+  groundedCount?: number;
+}): number {
+  return (
+    Math.max(0, Math.floor(entry.recallCount ?? 0)) +
+    Math.max(0, Math.floor(entry.groundedCount ?? 0))
+  );
+}
+
 function calculateConsolidationComponent(recallDays: string[]): number {
   if (recallDays.length === 0) {
     return 0;
@@ -1248,7 +1258,11 @@ export async function rankShortTermPromotionCandidates(
     if (signalCount <= 0) {
       continue;
     }
-    if (signalCount < minRecallCount) {
+    const promotionGateSignalCount = promotionGateSignalCountForEntry({
+      recallCount,
+      groundedCount,
+    });
+    if (promotionGateSignalCount < minRecallCount) {
       continue;
     }
 
@@ -1582,16 +1596,11 @@ export async function applyShortTermPromotions(
         if (candidate.score < minScore) {
           return false;
         }
-        const candidateSignalCount = Math.max(
-          0,
-          candidate.signalCount ??
-            totalSignalCountForEntry({
-              recallCount: candidate.recallCount,
-              dailyCount: candidate.dailyCount,
-              groundedCount: candidate.groundedCount,
-            }),
-        );
-        if (candidateSignalCount < minRecallCount) {
+        const candidatePromotionGateSignalCount = promotionGateSignalCountForEntry({
+          recallCount: candidate.recallCount,
+          groundedCount: candidate.groundedCount,
+        });
+        if (candidatePromotionGateSignalCount < minRecallCount) {
           return false;
         }
         if (Math.max(candidate.uniqueQueries, candidate.recallDays.length) < minUniqueQueries) {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1468,13 +1468,16 @@ function relocateCandidateRange(
         shouldReplace = true;
       } else if (comparison.quality === bestMatch.quality) {
         const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
-        const compareDistance = comparison.quality !== 2 || span === bestSpan;
-        shouldReplace =
-          (comparison.quality === 2 && span < bestSpan) ||
-          (compareDistance && distance < bestMatch.distance) ||
-          (compareDistance &&
-            distance === bestMatch.distance &&
-            Math.abs(span - preferredSpan) < Math.abs(bestSpan - preferredSpan));
+        if (comparison.quality === 2) {
+          shouldReplace =
+            distance < bestMatch.distance ||
+            (span < bestSpan && distance <= bestMatch.distance + 1);
+        } else {
+          shouldReplace =
+            distance < bestMatch.distance ||
+            (distance === bestMatch.distance &&
+              Math.abs(span - preferredSpan) < Math.abs(bestSpan - preferredSpan));
+        }
       }
       if (shouldReplace) {
         bestMatch = {

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1447,7 +1447,7 @@ function relocateCandidateRange(
     };
   }
 
-  const maxSpan = Math.min(lines.length, Math.max(preferredSpan + 3, 8));
+  const maxSpan = Math.min(lines.length, Math.max(preferredSpan + 15, 20));
   let bestMatch:
     | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
     | undefined;

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1461,15 +1461,22 @@ function relocateCandidateRange(
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
-      if (
-        !bestMatch ||
-        comparison.quality > bestMatch.quality ||
-        (comparison.quality === bestMatch.quality && distance < bestMatch.distance) ||
-        (comparison.quality === bestMatch.quality &&
-          distance === bestMatch.distance &&
-          Math.abs(span - preferredSpan) <
-            Math.abs(bestMatch.endLine - bestMatch.startLine + 1 - preferredSpan))
-      ) {
+      let shouldReplace = false;
+      if (!bestMatch) {
+        shouldReplace = true;
+      } else if (comparison.quality > bestMatch.quality) {
+        shouldReplace = true;
+      } else if (comparison.quality === bestMatch.quality) {
+        const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
+        const compareDistance = comparison.quality !== 2 || span === bestSpan;
+        shouldReplace =
+          (comparison.quality === 2 && span < bestSpan) ||
+          (compareDistance && distance < bestMatch.distance) ||
+          (compareDistance &&
+            distance === bestMatch.distance &&
+            Math.abs(span - preferredSpan) < Math.abs(bestSpan - preferredSpan));
+      }
+      if (shouldReplace) {
         bestMatch = {
           startLine,
           endLine,

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1451,6 +1451,7 @@ function relocateCandidateRange(
   let bestMatch:
     | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
     | undefined;
+  let nearestContainingDistance: number | undefined;
   for (let startIndex = 0; startIndex < lines.length; startIndex += 1) {
     for (let span = 1; span <= maxSpan && startIndex + span <= lines.length; span += 1) {
       const startLine = startIndex + 1;
@@ -1461,6 +1462,12 @@ function relocateCandidateRange(
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
+      if (
+        comparison.quality === 2 &&
+        (nearestContainingDistance === undefined || distance < nearestContainingDistance)
+      ) {
+        nearestContainingDistance = distance;
+      }
       let shouldReplace = false;
       if (!bestMatch) {
         shouldReplace = true;
@@ -1469,9 +1476,10 @@ function relocateCandidateRange(
       } else if (comparison.quality === bestMatch.quality) {
         const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
         if (comparison.quality === 2) {
+          const containingDistanceLimit = (nearestContainingDistance ?? distance) + 1;
           shouldReplace =
             distance < bestMatch.distance ||
-            (span < bestSpan && distance <= bestMatch.distance + 1);
+            (span < bestSpan && distance <= containingDistanceLimit);
         } else {
           shouldReplace =
             distance < bestMatch.distance ||

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1420,6 +1420,15 @@ function compareCandidateWindow(
   return { matched: false, quality: 0 };
 }
 
+function rangesOverlap(
+  firstStartLine: number,
+  firstEndLine: number,
+  secondStartLine: number,
+  secondEndLine: number,
+): boolean {
+  return firstStartLine <= secondEndLine && secondStartLine <= firstEndLine;
+}
+
 function relocateCandidateRange(
   lines: string[],
   candidate: PromotionCandidate,
@@ -1448,10 +1457,15 @@ function relocateCandidateRange(
   }
 
   const maxSpan = Math.min(lines.length, Math.max(preferredSpan + 15, 20));
-  let bestMatch:
-    | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
-    | undefined;
-  let nearestContainingDistance: number | undefined;
+  const matches: Array<{
+    startLine: number;
+    endLine: number;
+    span: number;
+    snippet: string;
+    quality: number;
+    distance: number;
+  }> = [];
+  let smallestContainingSpan: number | undefined;
   for (let startIndex = 0; startIndex < lines.length; startIndex += 1) {
     for (let span = 1; span <= maxSpan && startIndex + span <= lines.length; span += 1) {
       const startLine = startIndex + 1;
@@ -1462,40 +1476,67 @@ function relocateCandidateRange(
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
-      if (
-        comparison.quality === 2 &&
-        (nearestContainingDistance === undefined || distance < nearestContainingDistance)
-      ) {
-        nearestContainingDistance = distance;
+      if (comparison.quality === 2) {
+        smallestContainingSpan =
+          smallestContainingSpan === undefined ? span : Math.min(smallestContainingSpan, span);
       }
-      let shouldReplace = false;
-      if (!bestMatch) {
-        shouldReplace = true;
-      } else if (comparison.quality > bestMatch.quality) {
-        shouldReplace = true;
-      } else if (comparison.quality === bestMatch.quality) {
-        const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
-        if (comparison.quality === 2) {
-          const containingDistanceLimit = (nearestContainingDistance ?? distance) + 1;
-          shouldReplace =
-            distance < bestMatch.distance ||
-            (span < bestSpan && distance <= containingDistanceLimit);
-        } else {
-          shouldReplace =
-            distance < bestMatch.distance ||
-            (distance === bestMatch.distance &&
-              Math.abs(span - preferredSpan) < Math.abs(bestSpan - preferredSpan));
-        }
+      matches.push({
+        startLine,
+        endLine,
+        span,
+        snippet,
+        quality: comparison.quality,
+        distance,
+      });
+    }
+  }
+
+  const containingSpanLimit =
+    smallestContainingSpan === undefined ? undefined : smallestContainingSpan + 1;
+  let bestMatch:
+    | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
+    | undefined;
+  for (const match of matches) {
+    if (
+      match.quality === 2 &&
+      containingSpanLimit !== undefined &&
+      match.span > containingSpanLimit
+    ) {
+      continue;
+    }
+    let shouldReplace = false;
+    if (!bestMatch) {
+      shouldReplace = true;
+    } else if (match.quality > bestMatch.quality) {
+      shouldReplace = true;
+    } else if (match.quality === bestMatch.quality) {
+      const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
+      if (match.quality === 2) {
+        const overlapsBest = rangesOverlap(
+          match.startLine,
+          match.endLine,
+          bestMatch.startLine,
+          bestMatch.endLine,
+        );
+        shouldReplace =
+          (overlapsBest && match.span < bestSpan) ||
+          match.distance < bestMatch.distance ||
+          (match.distance === bestMatch.distance && match.span < bestSpan);
+      } else {
+        shouldReplace =
+          match.distance < bestMatch.distance ||
+          (match.distance === bestMatch.distance &&
+            Math.abs(match.span - preferredSpan) < Math.abs(bestSpan - preferredSpan));
       }
-      if (shouldReplace) {
-        bestMatch = {
-          startLine,
-          endLine,
-          snippet,
-          quality: comparison.quality,
-          distance,
-        };
-      }
+    }
+    if (shouldReplace) {
+      bestMatch = {
+        startLine: match.startLine,
+        endLine: match.endLine,
+        snippet: match.snippet,
+        quality: match.quality,
+        distance: match.distance,
+      };
     }
   }
 

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1465,7 +1465,6 @@ function relocateCandidateRange(
     quality: number;
     distance: number;
   }> = [];
-  let smallestContainingSpan: number | undefined;
   for (let startIndex = 0; startIndex < lines.length; startIndex += 1) {
     for (let span = 1; span <= maxSpan && startIndex + span <= lines.length; span += 1) {
       const startLine = startIndex + 1;
@@ -1476,10 +1475,6 @@ function relocateCandidateRange(
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
-      if (comparison.quality === 2) {
-        smallestContainingSpan =
-          smallestContainingSpan === undefined ? span : Math.min(smallestContainingSpan, span);
-      }
       matches.push({
         startLine,
         endLine,
@@ -1491,16 +1486,31 @@ function relocateCandidateRange(
     }
   }
 
-  const containingSpanLimit =
-    smallestContainingSpan === undefined ? undefined : smallestContainingSpan + 1;
+  const containingAnchor = matches.reduce<(typeof matches)[number] | undefined>((best, match) => {
+    if (match.quality !== 2) {
+      return best;
+    }
+    if (!best || match.distance < best.distance) {
+      return match;
+    }
+    if (match.distance === best.distance && match.span < best.span) {
+      return match;
+    }
+    return best;
+  }, undefined);
   let bestMatch:
     | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
     | undefined;
   for (const match of matches) {
     if (
       match.quality === 2 &&
-      containingSpanLimit !== undefined &&
-      match.span > containingSpanLimit
+      containingAnchor &&
+      !rangesOverlap(
+        match.startLine,
+        match.endLine,
+        containingAnchor.startLine,
+        containingAnchor.endLine,
+      )
     ) {
       continue;
     }

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1429,6 +1429,15 @@ function rangesOverlap(
   return firstStartLine <= secondEndLine && secondStartLine <= firstEndLine;
 }
 
+type RelocationMatch = {
+  startLine: number;
+  endLine: number;
+  span: number;
+  snippet: string;
+  quality: number;
+  distance: number;
+};
+
 function relocateCandidateRange(
   lines: string[],
   candidate: PromotionCandidate,
@@ -1457,14 +1466,8 @@ function relocateCandidateRange(
   }
 
   const maxSpan = Math.min(lines.length, Math.max(preferredSpan + 15, 20));
-  const matches: Array<{
-    startLine: number;
-    endLine: number;
-    span: number;
-    snippet: string;
-    quality: number;
-    distance: number;
-  }> = [];
+  const matches: RelocationMatch[] = [];
+  let containingAnchor: RelocationMatch | undefined;
   for (let startIndex = 0; startIndex < lines.length; startIndex += 1) {
     for (let span = 1; span <= maxSpan && startIndex + span <= lines.length; span += 1) {
       const startLine = startIndex + 1;
@@ -1475,29 +1478,26 @@ function relocateCandidateRange(
         continue;
       }
       const distance = Math.abs(startLine - candidate.startLine);
-      matches.push({
+      const match = {
         startLine,
         endLine,
         span,
         snippet,
         quality: comparison.quality,
         distance,
-      });
+      };
+      if (
+        match.quality === 2 &&
+        (!containingAnchor ||
+          match.distance < containingAnchor.distance ||
+          (match.distance === containingAnchor.distance && match.span < containingAnchor.span))
+      ) {
+        containingAnchor = match;
+      }
+      matches.push(match);
     }
   }
 
-  const containingAnchor = matches.reduce<(typeof matches)[number] | undefined>((best, match) => {
-    if (match.quality !== 2) {
-      return best;
-    }
-    if (!best || match.distance < best.distance) {
-      return match;
-    }
-    if (match.distance === best.distance && match.span < best.span) {
-      return match;
-    }
-    return best;
-  }, undefined);
   let bestMatch:
     | { startLine: number; endLine: number; snippet: string; quality: number; distance: number }
     | undefined;
@@ -1522,16 +1522,8 @@ function relocateCandidateRange(
     } else if (match.quality === bestMatch.quality) {
       const bestSpan = bestMatch.endLine - bestMatch.startLine + 1;
       if (match.quality === 2) {
-        const overlapsBest = rangesOverlap(
-          match.startLine,
-          match.endLine,
-          bestMatch.startLine,
-          bestMatch.endLine,
-        );
         shouldReplace =
-          (overlapsBest && match.span < bestSpan) ||
-          match.distance < bestMatch.distance ||
-          (match.distance === bestMatch.distance && match.span < bestSpan);
+          match.span < bestSpan || (match.span === bestSpan && match.distance < bestMatch.distance);
       } else {
         shouldReplace =
           match.distance < bestMatch.distance ||


### PR DESCRIPTION
## Summary
- prioritize real recalled short-term entries before newer daily-only entries in Light dreaming output
- keep daily-only dreaming signals out of default promotion/apply `minRecallCount` gates while preserving grounded evidence
- widen live-note rehydration so moved broad snippets can be relocated before promotion
- constrain containment relocation to the tightest matching range so adjacent daily-note lines are not promoted
- document that daily-ingestion signals can affect scoring but do not satisfy the recall-count gate

Fixes #71976

## Tests
- `pnpm test extensions/memory-core/src/dreaming-phases.test.ts extensions/memory-core/src/short-term-promotion.test.ts`
- `pnpm exec oxfmt --check --threads=1 extensions/memory-core/src/short-term-promotion.ts extensions/memory-core/src/short-term-promotion.test.ts extensions/memory-core/src/dreaming-phases.test.ts docs/concepts/dreaming.md docs/cli/memory.md`
- `pnpm check:docs`
- `git diff --check origin/main...HEAD`

## Notes
- `pnpm changed:lanes --json` selects extension production, extension test, and docs lanes.
- Testbox `pnpm check:changed` was not run because `blacksmith` is not installed and no `OPENCLAW_TESTBOX`/`BLACKSMITH_ORG` configuration is present in this shell.
