### PR TITLE
fix(heartbeat): derive ctx.To from delivery target, not sender sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Heartbeat/runner: derive `ctx.To` from the resolved delivery target instead of mirroring the `sender` identifier, so the literal `"heartbeat"` sentinel returned by `resolveHeartbeatSenderId` when no candidates resolve cannot leak through `resolveLastToRaw` into the session's persisted `lastTo` and poison every later `delivery.channel: "last"` dispatch with a bogus `@heartbeat` recipient. Thanks @dangngo-tech.
 - Docs/Hetzner: clarify that SSH tunnel access requires `AllowTcpForwarding local` before running `ssh -L`, so hardened VPS sshd configs do not block loopback Gateway access. Fixes #54557; carries forward #54564; refs #54954. Thanks @satishkc7, @blackstrype, and @Aftabbs.
 - Gateway/shutdown: report structured shutdown warnings and HTTP close timeout warnings through `ShutdownResult` while preserving lifecycle hook hardening. Carries forward #41296. Thanks @edenfunf.
 - Plugins/QA: prebuild the private QA channel runtime before plugin gauntlet source runs so wrapper CPU/RSS measurements are not polluted by private QA dist rebuild work. Thanks @vincentkoc.

--- a/src/infra/heartbeat-runner.does-not-leak-sender-into-to.test.ts
+++ b/src/infra/heartbeat-runner.does-not-leak-sender-into-to.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveMainSessionKey } from "../config/sessions.js";
+import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { installHeartbeatRunnerTestRuntime } from "./heartbeat-runner.test-harness.js";
+import { withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
+import { enqueueSystemEvent, resetSystemEventsForTest } from "./system-events.js";
+
+installHeartbeatRunnerTestRuntime();
+
+// Regression: when no real delivery target resolves, `resolveHeartbeatSenderId`
+// returns the literal "heartbeat" sentinel as the From identifier. ctx.To used
+// to mirror that, which then propagated into the session's persisted lastTo via
+// `resolveLastToRaw` (originatingTo || toRaw fallback) whenever the session was
+// next written. The corruption made every later `delivery.channel: "last"`
+// dispatch from that session try to deliver to a username @heartbeat.
+describe("runHeartbeatOnce ctx.To", () => {
+  it("does not echo the sender sentinel into ctx.To when no delivery target resolves", async () => {
+    await withTempHeartbeatSandbox(
+      async ({ tmpDir, storePath, replySpy }) => {
+        resetSystemEventsForTest();
+
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: {
+              workspace: tmpDir,
+              heartbeat: { every: "5m", target: "none" },
+            },
+          },
+          channels: { telegram: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+
+        const sessionKey = resolveMainSessionKey(cfg);
+        // Pre-existing session with a real lastTo. The fix preserves it.
+        const realLastTo = "telegram:6704095127";
+        await fs.writeFile(
+          storePath,
+          JSON.stringify({
+            [sessionKey]: {
+              sessionId: "sid",
+              updatedAt: Date.now(),
+              lastChannel: "telegram",
+              lastTo: realLastTo,
+            },
+          }),
+        );
+
+        // Force the heartbeat runner to actually invoke replySpy by enqueuing an
+        // actionable system event for the session.
+        enqueueSystemEvent("Reminder: probe ctx.To shape", { sessionKey });
+
+        let capturedTo: unknown = "<not-captured>";
+        let capturedFrom: unknown = "<not-captured>";
+        replySpy.mockImplementation(async (ctx: { To?: unknown; From?: unknown }) => {
+          capturedTo = ctx.To;
+          capturedFrom = ctx.From;
+          return [{ text: "ok" }];
+        });
+
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: {
+            getReplyFromConfig: replySpy,
+            getQueueSize: () => 0,
+            nowMs: () => 0,
+          },
+        });
+
+        expect(result.status).toBe("ran");
+        // From may legitimately carry the "heartbeat" sentinel — that's the
+        // documented self-event identity for the LLM prompt.
+        expect(capturedFrom).toBeDefined();
+        // To must NOT carry the sentinel; otherwise it leaks into lastTo.
+        expect(capturedTo).not.toBe("heartbeat");
+
+        // The session's persisted lastTo should be untouched after a heartbeat
+        // turn that had no real recipient — the previously-saved real recipient
+        // must survive.
+        const persisted = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+          string,
+          { lastTo?: string }
+        >;
+        expect(persisted[sessionKey]?.lastTo).toBe(realLastTo);
+      },
+      { prefix: "openclaw-hb-no-leak-" },
+    );
+  });
+});

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -972,7 +972,12 @@ export async function runHeartbeatOnce(opts: {
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
-    To: sender,
+    // Use the resolved delivery target rather than `sender`. When sender falls
+    // back to the literal "heartbeat" sentinel (no candidates resolved), echoing
+    // it into ctx.To causes resolveLastToRaw to write "heartbeat" into the
+    // session's persisted lastTo, which then poisons every later
+    // `delivery.channel: "last"` dispatch from that session.
+    To: delivery.to,
     OriginatingChannel:
       !suppressOriginatingContext && delivery.channel !== "none" ? delivery.channel : undefined,
     OriginatingTo: !suppressOriginatingContext ? delivery.to : undefined,


### PR DESCRIPTION
## What

In `src/infra/heartbeat-runner.ts`, the heartbeat turn's runtime context sets both `From` and `To` to the resolved `sender`. When `sender` falls back to the literal `"heartbeat"` sentinel (the documented default in `resolveHeartbeatSenderId`, returned when no candidates resolve), `ctx.To = "heartbeat"` then propagates into the persisted session's `lastTo` via `resolveLastToRaw` in `src/auto-reply/reply/session-delivery.ts`:

```ts
return params.originatingToRaw || params.toRaw || params.persistedLastTo;
```

When `originatingToRaw` (= `delivery.to`) is empty (e.g. crons with `delivery.mode: "none"`), the fallback returns `toRaw` = `ctx.To` = `"heartbeat"`, which is then written into the session's `lastTo` and `deliveryContext.to`. From that point, every later message dispatched from that session with `delivery.channel: "last"` resolves the recipient to the literal string `"heartbeat"`, which Telegram rejects with `getChat 400 Bad Request: chat not found`. The failed payloads pile up in `delivery-queue/failed/` indefinitely until a human edits the session store.

This was diagnosed in production after `agent:main:main` accumulated 3+ phantom `@heartbeat` deliveries across days; manually resetting `sessions.json` worked until the next heartbeat path ran without a real recipient and re-corrupted it.

## Fix

Derive `ctx.To` from the resolved delivery target rather than mirroring `sender`:

```diff
   const ctx = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
-    To: sender,
+    To: delivery.to,
     OriginatingChannel:
       !suppressOriginatingContext && delivery.channel !== "none" ? delivery.channel : undefined,
     OriginatingTo: !suppressOriginatingContext ? delivery.to : undefined,
```

When `delivery.to` is set (the case existing tests exercise), `sender` already equals `delivery.to`, so `ctx.To` is unchanged. When `delivery.to` is undefined (the bug case), `ctx.To` is now undefined and `resolveLastToRaw` correctly falls through to `persistedLastTo`, preserving the real recipient already on the session.

`From: sender` is left alone — the `"heartbeat"` sentinel as a synthetic identifier is still useful in the LLM prompt to label self-events.

## Tests

Existing tests still pass (`heartbeat-runner.sender-prefers-delivery-target.test.ts`, `heartbeat-runner.returns-default-unset.test.ts`) — they assert `ctx.To === delivery.to` in scenarios where sender resolves to the same value, which still holds.

New regression test `heartbeat-runner.does-not-leak-sender-into-to.test.ts`:

- Configures `heartbeat.target: "none"` with a session that already has a real `lastTo`
- Enqueues an actionable system event so `runHeartbeatOnce` actually invokes the reply spy
- Asserts `ctx.To !== "heartbeat"` (the sentinel)
- Asserts the session's persisted `lastTo` is preserved across the heartbeat turn

## Why this matters

This is a delivery-routing data-corruption bug with privacy implications: once a session's `lastTo` is corrupted, subsequent operator-authored messages routed through `delivery.channel: "last"` from that session can mis-deliver, and (in the steady-state Telegram failure mode) leak proactive reminder content into the failed-queue file on disk where it sits visible to anyone with filesystem access. In production the failed queue accumulated reminders containing dependents' names and schedules.

## Related

- #73900 — different heartbeat routing leak (global `heartbeat.to` overriding session `last`); same area of code, distinct fix.
- #63733, #65693, #21235 — historical poisoned-deliveryContext bugs in the heartbeat path.

## Checklist

- [x] Fix applied to `src/infra/heartbeat-runner.ts`
- [x] Regression test added
- [x] Existing related tests pass
- [x] CHANGELOG entry added under `Unreleased / Fixes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
