### PR TITLE
fix(cron): keep recurring backoff stable after reload

### DIFF
--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -732,4 +732,36 @@ describe("recomputeNextRuns", () => {
     }
     expect(job.state.nextRunAtMs).toBe(now);
   });
+
+  it("uses recurring error backoff instead of one-shot retry config during recompute", () => {
+    const lastRunAtMs = Date.parse("2026-03-01T12:00:00.000Z");
+    const now = lastRunAtMs + 1_000;
+    const job: CronJob = {
+      id: "recurring-error",
+      name: "recurring-error",
+      enabled: true,
+      createdAtMs: lastRunAtMs - 120_000,
+      updatedAtMs: lastRunAtMs,
+      schedule: { kind: "every", everyMs: 10_000 },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {
+        lastStatus: "error",
+        lastRunAtMs,
+        consecutiveErrors: 1,
+      },
+    };
+    const state = {
+      ...createMockState(now),
+      deps: {
+        ...createMockState(now).deps,
+        cronConfig: { retry: { backoffMs: [60 * 60_000], maxAttempts: 1 } },
+      },
+      store: { version: 1 as const, jobs: [job] },
+    } as CronServiceState;
+
+    expect(recomputeNextRuns(state)).toBe(true);
+    expect(job.state.nextRunAtMs).toBe(lastRunAtMs + 30_000);
+  });
 });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -452,12 +452,7 @@ function recomputeJobNextRunAtMs(params: { state: CronServiceState; job: CronJob
         typeof consecutiveErrorsRaw === "number" && Number.isFinite(consecutiveErrorsRaw)
           ? Math.max(1, Math.floor(consecutiveErrorsRaw))
           : 1;
-      const backoffFloor =
-        params.job.state.lastRunAtMs +
-        errorBackoffMs(
-          consecutiveErrors,
-          params.state.deps.cronConfig?.retry?.backoffMs ?? DEFAULT_ERROR_BACKOFF_SCHEDULE_MS,
-        );
+      const backoffFloor = params.job.state.lastRunAtMs + errorBackoffMs(consecutiveErrors);
       if (newNext !== undefined) {
         newNext = Math.max(newNext, backoffFloor);
       }


### PR DESCRIPTION
## Summary
- keep recurring cron error backoff on the fixed recurring schedule during reload/recompute
- stop applying one-shot `cron.retry.backoffMs` to recurring jobs after reload
- add regression coverage for an errored recurring job with custom one-shot retry backoff

## Verification
- pnpm test src/cron/service.jobs.test.ts -- --reporter=verbose
- git diff --check
- pnpm check:changed --base openclaw/main
  - passed through core/core-test typecheck
  - stopped at lint:core because oxlint config reports: Rule 'no-underscore-dangle' not found in plugin 'eslint'
