### PR TITLE
perf(routing): reuse evaluated bindings cache when cfg is rebuilt wit…

### DIFF
--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1246,3 +1246,103 @@ describe("binding evaluation cache scalability", () => {
     expect(defaultRoute.matchedBy).toBe("default");
   });
 });
+
+describe("binding evaluation cache fingerprint fallback", () => {
+  test("reuses cached bindings when cfg object is rebuilt with identical bindings content", () => {
+    const makeCfg = (): OpenClawConfig => ({
+      bindings: [
+        {
+          agentId: "agent-a",
+          match: {
+            channel: "dingtalk",
+            accountId: "acct-a",
+            peer: { kind: "direct", id: "user-a" },
+          },
+        },
+        {
+          agentId: "agent-b",
+          match: {
+            channel: "dingtalk",
+            accountId: "acct-b",
+            peer: { kind: "direct", id: "user-b" },
+          },
+        },
+      ],
+    });
+
+    // Warm cache with cfg #1.
+    resolveAgentRoute({
+      cfg: makeCfg(),
+      channel: "dingtalk",
+      accountId: "acct-a",
+      peer: { kind: "direct", id: "user-a" },
+    });
+
+    const listBindingsSpy = vi.spyOn(routingBindings, "listBindings");
+    try {
+      // cfg #2: same content, fresh object + fresh bindings array. Without the
+      // fingerprint fallback cache this would trigger another full scan via
+      // listBindings → buildEvaluatedBindingsByChannel.
+      for (let i = 0; i < 10; i += 1) {
+        const route = resolveAgentRoute({
+          cfg: makeCfg(),
+          channel: "dingtalk",
+          accountId: "acct-a",
+          peer: { kind: "direct", id: "user-a" },
+        });
+        expect(route.agentId).toBe("agent-a");
+        expect(route.matchedBy).toBe("binding.peer");
+      }
+      expect(listBindingsSpy).not.toHaveBeenCalled();
+    } finally {
+      listBindingsSpy.mockRestore();
+    }
+  });
+
+  test("still rebuilds when bindings content changes", () => {
+    const warmCfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "agent-warm",
+          match: {
+            channel: "dingtalk",
+            accountId: "acct-warm",
+            peer: { kind: "direct", id: "user-warm" },
+          },
+        },
+      ],
+    };
+    resolveAgentRoute({
+      cfg: warmCfg,
+      channel: "dingtalk",
+      accountId: "acct-warm",
+      peer: { kind: "direct", id: "user-warm" },
+    });
+
+    const changedCfg: OpenClawConfig = {
+      bindings: [
+        {
+          agentId: "agent-changed",
+          match: {
+            channel: "dingtalk",
+            accountId: "acct-changed",
+            peer: { kind: "direct", id: "user-changed" },
+          },
+        },
+      ],
+    };
+    const listBindingsSpy = vi.spyOn(routingBindings, "listBindings");
+    try {
+      const route = resolveAgentRoute({
+        cfg: changedCfg,
+        channel: "dingtalk",
+        accountId: "acct-changed",
+        peer: { kind: "direct", id: "user-changed" },
+      });
+      expect(route.agentId).toBe("agent-changed");
+      expect(listBindingsSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      listBindingsSpy.mockRestore();
+    }
+  });
+});

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
@@ -203,6 +204,93 @@ type EvaluatedBindingsCache = {
 
 const evaluatedBindingsCacheByCfg = new WeakMap<OpenClawConfig, EvaluatedBindingsCache>();
 const MAX_EVALUATED_BINDINGS_CACHE_KEYS = 2000;
+
+// Secondary cache keyed by the `bindings` array identity (and its content fingerprint).
+// The primary WeakMap<OpenClawConfig, EvaluatedBindingsCache> misses whenever callers
+// rebuild a fresh cfg object on every resolve call — even if the underlying bindings
+// array is identical. We catch two increasingly expensive cases here:
+//   1. Same bindings array reference reused across cfg objects (O(1) lookup).
+//   2. Same bindings content but a new array instance (O(N) SHA-256 fingerprint once,
+//      then O(1) lookups for subsequent identical payloads).
+// Both layers are bounded so long-running processes cannot grow them unboundedly.
+const evaluatedBindingsCacheByBindingsRef = new WeakMap<object, EvaluatedBindingsCache>();
+const evaluatedBindingsCacheByFingerprint = new Map<string, EvaluatedBindingsCache>();
+const MAX_EVALUATED_BINDINGS_FINGERPRINT_KEYS = 64;
+
+function computeBindingsFingerprint(bindings: OpenClawConfig["bindings"]): string | null {
+  if (!Array.isArray(bindings) || bindings.length === 0) {
+    // For empty/undefined bindings the cheap WeakMap path is sufficient; skip hashing.
+    return null;
+  }
+  try {
+    return createHash("sha256").update(JSON.stringify(bindings)).digest("hex");
+  } catch {
+    // JSON.stringify can throw on circular structures. Fall back to no fingerprint;
+    // the primary WeakMap path still works, we just lose the cross-cfg fast path.
+    return null;
+  }
+}
+
+function rememberEvaluatedBindingsCache(
+  cfg: OpenClawConfig,
+  cache: EvaluatedBindingsCache,
+  fingerprint: string | null,
+): void {
+  evaluatedBindingsCacheByCfg.set(cfg, cache);
+  if (cache.bindingsRef && typeof cache.bindingsRef === "object") {
+    evaluatedBindingsCacheByBindingsRef.set(cache.bindingsRef as object, cache);
+  }
+  if (fingerprint) {
+    if (
+      !evaluatedBindingsCacheByFingerprint.has(fingerprint) &&
+      evaluatedBindingsCacheByFingerprint.size >= MAX_EVALUATED_BINDINGS_FINGERPRINT_KEYS
+    ) {
+      // Simple LRU-ish eviction: drop the oldest insertion.
+      const oldest = evaluatedBindingsCacheByFingerprint.keys().next().value;
+      if (oldest !== undefined) {
+        evaluatedBindingsCacheByFingerprint.delete(oldest);
+      }
+    }
+    evaluatedBindingsCacheByFingerprint.set(fingerprint, cache);
+  }
+}
+
+function lookupEvaluatedBindingsCache(cfg: OpenClawConfig): {
+  cache: EvaluatedBindingsCache | undefined;
+  fingerprint: string | null;
+} {
+  const bindingsRef = cfg.bindings;
+  const byCfg = evaluatedBindingsCacheByCfg.get(cfg);
+  if (byCfg && byCfg.bindingsRef === bindingsRef) {
+    return { cache: byCfg, fingerprint: null };
+  }
+
+  // Same bindings array referenced via a freshly built cfg object.
+  if (bindingsRef && typeof bindingsRef === "object") {
+    const byRef = evaluatedBindingsCacheByBindingsRef.get(bindingsRef as object);
+    if (byRef) {
+      evaluatedBindingsCacheByCfg.set(cfg, byRef);
+      return { cache: byRef, fingerprint: null };
+    }
+  }
+
+  // Different bindings array but potentially identical content — only hash on miss.
+  const fingerprint = computeBindingsFingerprint(bindingsRef);
+  if (fingerprint) {
+    const byFingerprint = evaluatedBindingsCacheByFingerprint.get(fingerprint);
+    if (byFingerprint) {
+      // Re-bind to the new cfg/bindingsRef for cheap hits next time.
+      evaluatedBindingsCacheByCfg.set(cfg, byFingerprint);
+      if (bindingsRef && typeof bindingsRef === "object") {
+        evaluatedBindingsCacheByBindingsRef.set(bindingsRef as object, byFingerprint);
+      }
+      return { cache: byFingerprint, fingerprint };
+    }
+  }
+
+  return { cache: undefined, fingerprint };
+}
+
 const resolvedRouteCacheByCfg = new WeakMap<
   OpenClawConfig,
   {
@@ -425,19 +513,18 @@ function getEvaluatedBindingsForChannelAccount(
   channel: string,
   accountId: string,
 ): EvaluatedBinding[] {
-  const bindingsRef = cfg.bindings;
-  const existing = evaluatedBindingsCacheByCfg.get(cfg);
-  const cache =
-    existing && existing.bindingsRef === bindingsRef
-      ? existing
-      : {
-          bindingsRef,
-          byChannel: buildEvaluatedBindingsByChannel(cfg),
-          byChannelAccount: new Map<string, EvaluatedBinding[]>(),
-          byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
-        };
-  if (cache !== existing) {
-    evaluatedBindingsCacheByCfg.set(cfg, cache);
+  const { cache: existingCache, fingerprint } = lookupEvaluatedBindingsCache(cfg);
+  let cache: EvaluatedBindingsCache;
+  if (existingCache) {
+    cache = existingCache;
+  } else {
+    cache = {
+      bindingsRef: cfg.bindings,
+      byChannel: buildEvaluatedBindingsByChannel(cfg),
+      byChannelAccount: new Map<string, EvaluatedBinding[]>(),
+      byChannelAccountIndex: new Map<string, EvaluatedBindingsIndex>(),
+    };
+    rememberEvaluatedBindingsCache(cfg, cache, fingerprint);
   }
 
   const cacheKey = `${channel}\t${accountId}`;


### PR DESCRIPTION
…h identical bindings

## Summary



- Problem:
What: Add two layers of fallback (WeakMap<bindings, cache> + Map<sha256-fingerprint, cache>) to getEvaluatedBindingsForChannelAccount.
Why: The current cache upstream is only keyed by the reference of the cfg object; each time a new cfg is created (such as a per-request configuration clone), the entire byChannel index is rebuilt, which is O(N bindings).
Evidence: The newly added test uses a spy to prove that when the same content cfg is rebuilt 10 times, listBindings is called 0 times; different contents are still correctly rebuilt.
Risk: Medium-low. Both layers of cache have caps (WeakMap is naturally GC, and the fingerprint map has an upper limit of 64 LRU); the fingerprint is only calculated when it misses, and there is a short-circuit exit.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
