### PR TITLE
refactor(gateway): consolidate lifecycle lazy boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Build/Gateway: route restart, shutdown, respawn, diagnostics, command-queue cleanup, and runtime cleanup through one stable gateway lifecycle runtime entry so rebuilt packages do not strand long-running gateways on stale hashed chunks. Carries forward #73964. Thanks @pashpashpash.
 - Agents/errors: suppress malformed streaming tool-call JSON fragments before they reach chat surfaces while preserving provider request-validation diagnostics. Fixes #59076; keeps #59080 as duplicate coverage. (#59118) Thanks @singleGanghood.
 - CLI/models: restore provider-filtered `models list --all --provider <id>` rows for providers without manifest/static catalog coverage, including Anthropic and Amazon Bedrock, while keeping the compatibility fallback off expensive availability and resolver paths. Thanks @shakkernerd.
 - CLI/models: move the OpenAI listable catalog into the plugin manifest so `models list --all --provider openai` uses the manifest fast path instead of loading provider runtime normalization hooks. Thanks @shakkernerd.

--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -1,0 +1,34 @@
+export {
+  abortEmbeddedPiRun,
+  getActiveEmbeddedRunCount,
+  waitForActiveEmbeddedRuns,
+} from "../../agents/pi-embedded-runner/runs.js";
+export { getRuntimeConfig } from "../../config/config.js";
+export {
+  respawnGatewayProcessForUpdate,
+  restartGatewayProcessWithFreshPid,
+} from "../../infra/process-respawn.js";
+export {
+  resolveGatewayRestartDeferralTimeoutMs,
+  consumeGatewayRestartIntentSync,
+  consumeGatewaySigusr1RestartAuthorization,
+  isGatewaySigusr1RestartExternallyAllowed,
+  markGatewaySigusr1RestartHandled,
+  peekGatewaySigusr1RestartReason,
+  resetGatewayRestartStateForInProcessRestart,
+  scheduleGatewaySigusr1Restart,
+} from "../../infra/restart.js";
+export { markUpdateRestartSentinelFailure } from "../../infra/restart-sentinel.js";
+export { detectRespawnSupervisor } from "../../infra/supervisor-markers.js";
+export { writeDiagnosticStabilityBundleForFailureSync } from "../../logging/diagnostic-stability-bundle.js";
+export {
+  getActiveBundledRuntimeDepsInstallCount,
+  waitForBundledRuntimeDepsInstallIdle,
+} from "../../plugins/bundled-runtime-deps-activity.js";
+export {
+  getActiveTaskCount,
+  markGatewayDraining,
+  resetAllLanes,
+  waitForActiveTasks,
+} from "../../process/command-queue.js";
+export { reloadTaskRegistryFromStore } from "../../tasks/runtime-internal.js";

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -15,48 +15,12 @@ const UPDATE_RESPAWN_HEALTH_POLL_MS = 200;
 type GatewayRunSignalAction = "stop" | "restart";
 type RestartDrainTimeoutMs = number | undefined;
 
-type EmbeddedRunsModule = typeof import("../../agents/pi-embedded-runner/runs.js");
-type RuntimeConfigModule = typeof import("../../config/config.js");
-type ProcessRespawnModule = typeof import("../../infra/process-respawn.js");
-type RestartSentinelModule = typeof import("../../infra/restart-sentinel.js");
-type RestartModule = typeof import("../../infra/restart.js");
-type SupervisorMarkersModule = typeof import("../../infra/supervisor-markers.js");
-type DiagnosticStabilityBundleModule =
-  typeof import("../../logging/diagnostic-stability-bundle.js");
-type BundledRuntimeDepsActivityModule =
-  typeof import("../../plugins/bundled-runtime-deps-activity.js");
-type CommandQueueModule = typeof import("../../process/command-queue.js");
-type RuntimeInternalModule = typeof import("../../tasks/runtime-internal.js");
+type GatewayLifecycleRuntimeModule = typeof import("./lifecycle.runtime.js");
 
-let embeddedRunsModule: Promise<EmbeddedRunsModule> | undefined;
-let runtimeConfigModule: Promise<RuntimeConfigModule> | undefined;
-let processRespawnModule: Promise<ProcessRespawnModule> | undefined;
-let restartSentinelModule: Promise<RestartSentinelModule> | undefined;
-let restartModule: Promise<RestartModule> | undefined;
-let supervisorMarkersModule: Promise<SupervisorMarkersModule> | undefined;
-let diagnosticStabilityBundleModule: Promise<DiagnosticStabilityBundleModule> | undefined;
-let bundledRuntimeDepsActivityModule: Promise<BundledRuntimeDepsActivityModule> | undefined;
-let commandQueueModule: Promise<CommandQueueModule> | undefined;
-let runtimeInternalModule: Promise<RuntimeInternalModule> | undefined;
+let gatewayLifecycleRuntimeModule: Promise<GatewayLifecycleRuntimeModule> | undefined;
 
-const loadEmbeddedRunsModule = () =>
-  (embeddedRunsModule ??= import("../../agents/pi-embedded-runner/runs.js"));
-const loadRuntimeConfigModule = () => (runtimeConfigModule ??= import("../../config/config.js"));
-const loadProcessRespawnModule = () =>
-  (processRespawnModule ??= import("../../infra/process-respawn.js"));
-const loadRestartSentinelModule = () =>
-  (restartSentinelModule ??= import("../../infra/restart-sentinel.js"));
-const loadRestartModule = () => (restartModule ??= import("../../infra/restart.js"));
-const loadSupervisorMarkersModule = () =>
-  (supervisorMarkersModule ??= import("../../infra/supervisor-markers.js"));
-const loadDiagnosticStabilityBundleModule = () =>
-  (diagnosticStabilityBundleModule ??= import("../../logging/diagnostic-stability-bundle.js"));
-const loadBundledRuntimeDepsActivityModule = () =>
-  (bundledRuntimeDepsActivityModule ??= import("../../plugins/bundled-runtime-deps-activity.js"));
-const loadCommandQueueModule = () =>
-  (commandQueueModule ??= import("../../process/command-queue.js"));
-const loadRuntimeInternalModule = () =>
-  (runtimeInternalModule ??= import("../../tasks/runtime-internal.js"));
+const loadGatewayLifecycleRuntimeModule = () =>
+  (gatewayLifecycleRuntimeModule ??= import("./lifecycle.runtime.js"));
 
 function createRestartIterationHook(onRestart: () => Promise<void> | void): () => Promise<boolean> {
   let isFirstIteration = true;
@@ -137,7 +101,7 @@ export async function runGatewayLoop(params: {
   };
   const writeStabilityBundle = async (reason: string, error?: unknown) => {
     const { writeDiagnosticStabilityBundleForFailureSync } =
-      await loadDiagnosticStabilityBundleModule();
+      await loadGatewayLifecycleRuntimeModule();
     const result = writeDiagnosticStabilityBundleForFailureSync(reason, error);
     if ("message" in result) {
       gatewayLog.warn(result.message);
@@ -165,10 +129,12 @@ export async function runGatewayLoop(params: {
   const handleRestartAfterServerClose = async (restartReason?: string) => {
     const hadLock = await releaseLockIfHeld();
     const isUpdateRestart = restartReason === "update.run";
-    const { respawnGatewayProcessForUpdate, restartGatewayProcessWithFreshPid } =
-      await loadProcessRespawnModule();
-    const { detectRespawnSupervisor } = await loadSupervisorMarkersModule();
-    const { markUpdateRestartSentinelFailure } = await loadRestartSentinelModule();
+    const {
+      detectRespawnSupervisor,
+      markUpdateRestartSentinelFailure,
+      respawnGatewayProcessForUpdate,
+      restartGatewayProcessWithFreshPid,
+    } = await loadGatewayLifecycleRuntimeModule();
 
     if (isUpdateRestart) {
       const respawn = respawnGatewayProcessForUpdate();
@@ -279,10 +245,8 @@ export async function runGatewayLoop(params: {
   const SHUTDOWN_TIMEOUT_MS = SUPERVISOR_STOP_TIMEOUT_MS - 5_000;
   const resolveRestartDrainTimeoutMs = async (): Promise<RestartDrainTimeoutMs> => {
     try {
-      const [{ getRuntimeConfig }, { resolveGatewayRestartDeferralTimeoutMs }] = await Promise.all([
-        loadRuntimeConfigModule(),
-        loadRestartModule(),
-      ]);
+      const { getRuntimeConfig, resolveGatewayRestartDeferralTimeoutMs } =
+        await loadGatewayLifecycleRuntimeModule();
       const timeoutMs = getRuntimeConfig().gateway?.reload?.deferralTimeoutMs;
       return resolveGatewayRestartDeferralTimeoutMs(timeoutMs);
     } catch {
@@ -351,15 +315,16 @@ export async function runGatewayLoop(params: {
         // On restart, wait for in-flight agent turns to finish before
         // tearing down the server so buffered messages are delivered.
         if (isRestart) {
-          const [
-            { abortEmbeddedPiRun, getActiveEmbeddedRunCount, waitForActiveEmbeddedRuns },
-            { getActiveBundledRuntimeDepsInstallCount, waitForBundledRuntimeDepsInstallIdle },
-            { getActiveTaskCount, markGatewayDraining, waitForActiveTasks },
-          ] = await Promise.all([
-            loadEmbeddedRunsModule(),
-            loadBundledRuntimeDepsActivityModule(),
-            loadCommandQueueModule(),
-          ]);
+          const {
+            abortEmbeddedPiRun,
+            getActiveBundledRuntimeDepsInstallCount,
+            getActiveEmbeddedRunCount,
+            getActiveTaskCount,
+            markGatewayDraining,
+            waitForActiveEmbeddedRuns,
+            waitForActiveTasks,
+            waitForBundledRuntimeDepsInstallIdle,
+          } = await loadGatewayLifecycleRuntimeModule();
           const createStillPendingDrainLogger = () =>
             setInterval(() => {
               gatewayLog.warn(
@@ -429,7 +394,7 @@ export async function runGatewayLoop(params: {
   const onSigterm = () => {
     gatewayLog.info("signal SIGTERM received");
     void (async () => {
-      const { consumeGatewayRestartIntentSync } = await loadRestartModule();
+      const { consumeGatewayRestartIntentSync } = await loadGatewayLifecycleRuntimeModule();
       request(consumeGatewayRestartIntentSync() ? "restart" : "stop", "SIGTERM");
     })();
   };
@@ -446,7 +411,7 @@ export async function runGatewayLoop(params: {
         markGatewaySigusr1RestartHandled,
         peekGatewaySigusr1RestartReason,
         scheduleGatewaySigusr1Restart,
-      } = await loadRestartModule();
+      } = await loadGatewayLifecycleRuntimeModule();
       const authorized = consumeGatewaySigusr1RestartAuthorization();
       if (!authorized) {
         if (!isGatewaySigusr1RestartExternallyAllowed()) {
@@ -482,15 +447,11 @@ export async function runGatewayLoop(params: {
       // new work from draining. The same boundary also discards stale restart
       // deferral timers and reloads the task registry from durable state so
       // cancelled/completed work is not kept alive by old in-memory maps.
-      const [
-        { resetAllLanes },
-        { resetGatewayRestartStateForInProcessRestart },
-        { reloadTaskRegistryFromStore },
-      ] = await Promise.all([
-        loadCommandQueueModule(),
-        loadRestartModule(),
-        loadRuntimeInternalModule(),
-      ]);
+      const {
+        reloadTaskRegistryFromStore,
+        resetAllLanes,
+        resetGatewayRestartStateForInProcessRestart,
+      } = await loadGatewayLifecycleRuntimeModule();
       resetAllLanes();
       resetGatewayRestartStateForInProcessRestart();
       reloadTaskRegistryFromStore();

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
 import tsdownConfig from "../../tsdown.config.ts";
@@ -41,6 +42,13 @@ function entryKeys(config: TsdownConfigEntry): string[] {
   return Object.keys(config.entry);
 }
 
+function entrySources(config: TsdownConfigEntry): Record<string, string> {
+  if (!config.entry || Array.isArray(config.entry)) {
+    return {};
+  }
+  return config.entry;
+}
+
 function hasBundledPluginRuntimeEntry(config: TsdownConfigEntry): boolean {
   const keys = entryKeys(config);
   return keys.includes("index") || keys.includes("runtime-api");
@@ -56,6 +64,10 @@ function unifiedDistGraph(): TsdownConfigEntry | undefined {
   );
 }
 
+function readGatewayRunLoopSource(): string {
+  return readFileSync(new URL("../cli/gateway-cli/run-loop.ts", import.meta.url), "utf8");
+}
+
 describe("tsdown config", () => {
   it("keeps core, plugin runtime, plugin-sdk, bundled root plugins, and bundled hooks in one dist graph", () => {
     const distGraph = unifiedDistGraph();
@@ -66,6 +78,7 @@ describe("tsdown config", () => {
         "agents/auth-profiles.runtime",
         "agents/model-catalog.runtime",
         "agents/models-config.runtime",
+        "cli/gateway-lifecycle.runtime",
         "plugins/memory-state",
         "subagent-registry.runtime",
         "task-registry-control.runtime",
@@ -83,6 +96,24 @@ describe("tsdown config", () => {
         "bundled/boot-md/handler",
       ]),
     );
+  });
+
+  it("keeps gateway lifecycle lazy runtime behind one stable dist entry", () => {
+    const distGraph = unifiedDistGraph();
+
+    expect(entrySources(distGraph as TsdownConfigEntry)).toEqual(
+      expect.objectContaining({
+        "cli/gateway-lifecycle.runtime": "src/cli/gateway-cli/lifecycle.runtime.ts",
+      }),
+    );
+  });
+
+  it("routes gateway run-loop lifecycle imports through the stable runtime boundary", () => {
+    const importSpecifiers = [...readGatewayRunLoopSource().matchAll(/import\("([^"]+)"\)/gu)].map(
+      (match) => match[1],
+    );
+
+    expect(new Set(importSpecifiers)).toEqual(new Set(["./lifecycle.runtime.js"]));
   });
 
   it("emits staged bundled plugins as separate extension graphs", () => {

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -109,9 +109,9 @@ describe("tsdown config", () => {
   });
 
   it("routes gateway run-loop lifecycle imports through the stable runtime boundary", () => {
-    const importSpecifiers = [...readGatewayRunLoopSource().matchAll(/import\("([^"]+)"\)/gu)].map(
-      (match) => match[1],
-    );
+    const importSpecifiers = [
+      ...readGatewayRunLoopSource().matchAll(/import\(["']([^"']+)["']\)/gu),
+    ].map((match) => match[1]);
 
     expect(new Set(importSpecifiers)).toEqual(new Set(["./lifecycle.runtime.js"]));
   });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -212,6 +212,7 @@ function buildCoreDistEntries(): Record<string, string> {
     "agents/auth-profiles.runtime": "src/agents/auth-profiles.runtime.ts",
     "agents/model-catalog.runtime": "src/agents/model-catalog.runtime.ts",
     "agents/models-config.runtime": "src/agents/models-config.runtime.ts",
+    "cli/gateway-lifecycle.runtime": "src/cli/gateway-cli/lifecycle.runtime.ts",
     "plugins/memory-state": "src/plugins/memory-state.ts",
     "subagent-registry.runtime": "src/agents/subagent-registry.runtime.ts",
     "task-registry-control.runtime": "src/tasks/task-registry-control.runtime.ts",


### PR DESCRIPTION
## Summary

- Problem: gateway lifecycle restart/shutdown paths lazily import hashed chunks from a long-running process, so a rebuilt `dist/` can remove chunks that the live gateway imports during update, restart, or shutdown cleanup.
- Why it matters: the existing #74075 fix stabilized every current lifecycle import individually, but it left a hand-maintained list that would drift as more lifecycle helpers move behind lazy imports.
- What changed: added one gateway lifecycle runtime boundary and made `run-loop.ts` lazy-load that stable entry instead of ten separate implementation modules.
- What did NOT change (scope boundary): no restart semantics, config defaults, gateway protocol, or plugin behavior changes.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [x] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [x] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Supersedes #74075
- Carries forward #73964
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `src/cli/gateway-cli/run-loop.ts` was intentionally lazy-loading lifecycle helpers directly from implementation modules that tsdown emits as hashed chunks unless each module is promoted to a stable entry.
- Missing detection / guardrail: the tsdown config test covered existing stable entries but did not assert that gateway lifecycle lazy imports go through a single stable boundary.
- Contributing context (if known): #74075 fixed the immediate missing chunks by listing every current lifecycle module as a stable entry, but that makes future lifecycle imports easy to miss.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/tsdown-config.test.ts`
- Scenario the test should lock in: the unified dist graph contains the stable gateway lifecycle runtime entry, and `run-loop.ts` imports only that lifecycle runtime boundary.
- Why this is the smallest reliable guardrail: it checks the build-entry contract and the source import shape that would otherwise drift independently.
- Existing test that already covers this (if any): the existing unified dist graph test now includes the lifecycle runtime key.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
run-loop restart/shutdown -> lazy import many implementation chunks -> stale hashed chunk risk after rebuild

After:
run-loop restart/shutdown -> lazy import stable lifecycle runtime entry -> lifecycle helpers loaded behind one build boundary
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local maintainer checkout
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway lifecycle/build config
- Relevant config (redacted): N/A

### Steps

1. Inspect #74075 and current `run-loop.ts` lazy imports.
2. Replace per-module lifecycle lazy imports with a single stable lifecycle runtime boundary.
3. Verify tsdown config and import-shape guardrails.

### Expected

- Gateway lifecycle lazy imports are reachable through one stable dist entry.
- Future direct lifecycle imports in `run-loop.ts` fail the tsdown config test.

### Actual

- `run-loop.ts` imports only `./lifecycle.runtime.js` for lifecycle helpers.
- `tsdown.config.ts` emits `cli/gateway-lifecycle.runtime` as a stable core dist entry.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Focused/local verification:

- `pnpm test src/infra/tsdown-config.test.ts`
- `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/cli/gateway-cli/lifecycle.runtime.ts src/cli/gateway-cli/run-loop.ts src/infra/tsdown-config.test.ts tsdown.config.ts`
- `pnpm check:changelog-attributions`
- `pnpm build`
- `OPENCLAW_LOCAL_CHECK=1 OPENCLAW_LOCAL_CHECK_MODE=throttled pnpm check:changed`
- `pnpm lint:tmp:dynamic-import-warts` (advisory-only; no new `run-loop.ts` advisory)

Testbox note: attempted `blacksmith testbox run --id tbx_01kqbtr2qyhwavtspead9m6vs6 "pnpm build"` and `pnpm check:changed`, but the client stalled in the sync phase while reporting only 4 changed tracked files plus 1 untracked file. The created box was stopped.

## Human Verification (required)

- Verified scenarios: build entry exists, run-loop import shape is guarded, focused tsdown config test passes, local build passes, broad changed gate passes locally in throttled mode.
- Edge cases checked: post-rebase changelog conflict resolved against current `origin/main`; reran focused test, formatter, attribution check, and `git diff --check` after rebase.
- What you did **not** verify: live gateway update/restart against a real installed package.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: the lifecycle runtime boundary pulls several lifecycle helpers together on first lifecycle import instead of loading each helper separately.
  - Mitigation: it remains lazy from startup, and the grouped helpers are all restart/shutdown/update lifecycle code paths already loaded in the same long-running process phase.
