### PR TITLE
fix(subagent-announce): unified post-compaction retry before finalizing output

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -44,6 +44,7 @@ import {
 } from "./subagent-announce.runtime.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import type { SpawnSubagentMode } from "./subagent-spawn.types.js";
+import { readLatestAssistantReply } from "./tools/agent-step.js";
 import { isAnnounceSkip } from "./tools/sessions-send-tokens.js";
 
 type SubagentAnnounceDeps = {
@@ -449,6 +450,28 @@ export async function runSubagentAnnounceFlow(params: {
 
     if (!outcome) {
       outcome = { status: "unknown" };
+    }
+
+    // Unified post-compaction retry: after both branches have resolved,
+    // check once for post-compaction assistant output before finalizing.
+    // This catches the case where auto-compaction ran mid-turn and the
+    // real assistant reply is not yet in the session history.
+    if (reply && !isAnnounceSkip(reply) && !isSilentReplyText(reply, SILENT_REPLY_TOKEN)) {
+      try {
+        const latestReply = await readLatestAssistantReply({
+          sessionKey: params.childSessionKey,
+          limit: 100,
+        });
+        if (latestReply?.trim() && latestReply !== reply) {
+          // Assistant has produced newer output after compaction
+          const cleaned = latestReply.trim();
+          if (!isAnnounceSkip(cleaned) && !isSilentReplyText(cleaned, SILENT_REPLY_TOKEN)) {
+            reply = cleaned;
+          }
+        }
+      } catch {
+        // Best-effort; keep existing reply on failure
+      }
     }
 
     // Build status label


### PR DESCRIPTION
Fix #74073\n\nWhen a sub-agent uses tools that trigger auto-compaction mid-turn (e.g. Grok/DeepSeek + web_search returning a large Tavily JSON), the announce flow resolves before the post-compaction assistant message is produced.  returns stale tool JSON, which then leaks into the parent session as the announcement.\n\nThis PR adds a unified retry after both the  and fallback branches resolve:\n1. After both branches complete, call  once\n2. If the assistant has produced newer output (different from captured reply) and it's not a silent/announce-skip token, use it instead\n\nThis mirrors the approach described in the issue's suggested fix without modifying the core retry loop structure.