### PR TITLE
fix(memory-core): use recallCount for promotion gates instead of combined signalCount

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -1252,7 +1252,7 @@ export async function rankShortTermPromotionCandidates(
     if (signalCount <= 0) {
       continue;
     }
-    if (signalCount < minRecallCount) {
+    if (recallCount < minRecallCount) {
       continue;
     }
 
@@ -1586,16 +1586,9 @@ export async function applyShortTermPromotions(
         if (candidate.score < minScore) {
           return false;
         }
-        const candidateSignalCount = Math.max(
-          0,
-          candidate.signalCount ??
-            totalSignalCountForEntry({
-              recallCount: candidate.recallCount,
-              dailyCount: candidate.dailyCount,
-              groundedCount: candidate.groundedCount,
-            }),
-        );
-        if (candidateSignalCount < minRecallCount) {
+        // Gate on real recallCount, not combined signalCount
+        const candidateRecallCount = Math.max(0, Math.floor(candidate.recallCount ?? 0));
+        if (candidateRecallCount < minRecallCount) {
           return false;
         }
         if (Math.max(candidate.uniqueQueries, candidate.recallDays.length) < minUniqueQueries) {


### PR DESCRIPTION
Closes #72021

## Summary

Short-term promotion gates on `totalSignalCountForEntry` which sums `recallCount + dailyCount + groundedCount`. Automated daily/session ingestion signals (marked as `dailyCount`) satisfy the `minRecallCount` gate even for entries with zero real user search recalls.

### Changes

- **Gate**: `minRecallCount` now checks `recallCount` alone instead of combined `signalCount`
- **avgScore/frequency**: unchanged (still uses `signalCount` as denominator) — narrow surgical fix
- **applyShortTermPromotions**: Same recallCount-only gate

Only 4 lines of logic changed. Scoring semantics preserved.