### PR TITLE
fix(agents): accept multi-line ANNOUNCE_SKIP on final line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/subagents: suppress announce delivery when a sub-agent emits `ANNOUNCE_SKIP` on its own final line after a multi-line summary, while keeping embedded or non-final tokens visible. Fixes #74071. Thanks @yelog.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.
 - Infra/Windows: skip the POSIX `/tmp/openclaw` preferred path on Windows in `resolvePreferredOpenClawTmpDir` so log files, TTS temp files, and other writes land in `%TEMP%\openclaw-<uid>` instead of `C:\tmp\openclaw`. Fixes #60713. Thanks @juan-flores077.
 - Gateway/diagnostics: make stuck-session recovery outcome-driven and generation-guarded, add `diagnostics.stuckSessionAbortMs`, and emit structured recovery requested/completed events so stale or skipped recovery no longer looks like a successful abort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2492,7 +2492,6 @@ Docs: https://docs.openclaw.ai
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
-- Agents/subagents: suppress announce delivery when a sub-agent emits `ANNOUNCE_SKIP` on its own final line after a multi-line summary, while keeping embedded or non-final tokens visible. Fixes #74071. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2492,6 +2492,7 @@ Docs: https://docs.openclaw.ai
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
+- Agents/subagents: suppress announce delivery when a sub-agent emits `ANNOUNCE_SKIP` on its own final line after a multi-line summary, while keeping embedded or non-final tokens visible. Fixes #74071. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -373,7 +373,7 @@ fallbacks. Fully isolated auth per agent is not supported yet.
 Sub-agents report back via an announce step:
 
 - The announce step runs inside the sub-agent session (not the requester session).
-- If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
+- If the sub-agent replies exactly `ANNOUNCE_SKIP`, or puts `ANNOUNCE_SKIP` on its own final line after a summary block, nothing is posted.
 - If the latest assistant text is the exact silent token `NO_REPLY` / `no_reply`, announce output is suppressed even if earlier visible progress existed.
 
 Delivery depends on requester depth:

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -465,7 +465,7 @@ fallbacks. Fully isolated auth per agent is not supported yet.
 Sub-agents report back via an announce step:
 
 - The announce step runs inside the sub-agent session (not the requester session).
-- If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
+- If the sub-agent replies exactly `ANNOUNCE_SKIP`, or puts `ANNOUNCE_SKIP` on its own final line after a summary block, nothing is posted.
 - If the latest assistant text is the exact silent token `NO_REPLY` / `no_reply`, announce output is suppressed even if earlier visible progress existed.
 
 Delivery depends on requester depth:

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -796,6 +796,23 @@ describe("subagent announce formatting", () => {
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses announce flow for multi-line text ending with ANNOUNCE_SKIP (#74071)", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-multiline-skip",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "DM summary block\nANNOUNCE_SKIP",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
   it("suppresses completion delivery when subagent reply is NO_REPLY", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -868,6 +868,23 @@ describe("subagent announce formatting", () => {
     expect(sessionsDeleteSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses announce flow for multi-line text ending with ANNOUNCE_SKIP (#74071)", async () => {
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-multiline-skip",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "DM summary block\nANNOUNCE_SKIP",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(agentSpy).not.toHaveBeenCalled();
+  });
+
   it("suppresses completion delivery when subagent reply is NO_REPLY", async () => {
     const didAnnounce = await runSubagentAnnounceFlow({
       childSessionKey: "agent:main:subagent:test",

--- a/src/agents/tools/sessions-send-tokens.test.ts
+++ b/src/agents/tools/sessions-send-tokens.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAnnounceSkip,
+  isReplySkip,
+  ANNOUNCE_SKIP_TOKEN,
+  REPLY_SKIP_TOKEN,
+} from "./sessions-send-tokens.js";
+
+describe("isAnnounceSkip", () => {
+  it("matches the exact token", () => {
+    expect(isAnnounceSkip(ANNOUNCE_SKIP_TOKEN)).toBe(true);
+  });
+
+  it("matches with surrounding whitespace", () => {
+    expect(isAnnounceSkip("  ANNOUNCE_SKIP  ")).toBe(true);
+  });
+
+  it("matches with leading/trailing newlines", () => {
+    expect(isAnnounceSkip("\nANNOUNCE_SKIP\n")).toBe(true);
+  });
+
+  it("matches multi-line text ending with the token on its own line", () => {
+    expect(isAnnounceSkip("DM summary block\nANNOUNCE_SKIP")).toBe(true);
+  });
+
+  it("matches multi-line text with whitespace-padded final token line", () => {
+    expect(isAnnounceSkip("Some summary\n  ANNOUNCE_SKIP  ")).toBe(true);
+  });
+
+  it("matches multi-line text with multiple preceding lines", () => {
+    expect(isAnnounceSkip("Line 1\nLine 2\nLine 3\nANNOUNCE_SKIP")).toBe(true);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isAnnounceSkip(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isAnnounceSkip("")).toBe(false);
+  });
+
+  it("returns false for substantive text without the token", () => {
+    expect(isAnnounceSkip("Hello world")).toBe(false);
+  });
+
+  it("returns false when the token is embedded mid-text", () => {
+    expect(isAnnounceSkip("Please ANNOUNCE_SKIP this")).toBe(false);
+  });
+
+  it("returns false when the token is on the first line with trailing content", () => {
+    expect(isAnnounceSkip("ANNOUNCE_SKIP\nMore text after")).toBe(false);
+  });
+
+  it("returns false for a partial token on the last line", () => {
+    expect(isAnnounceSkip("summary\nANNOUNCE_SKI")).toBe(false);
+  });
+});
+
+describe("isReplySkip", () => {
+  it("matches the exact token", () => {
+    expect(isReplySkip(REPLY_SKIP_TOKEN)).toBe(true);
+  });
+
+  it("matches with surrounding whitespace", () => {
+    expect(isReplySkip("  REPLY_SKIP  ")).toBe(true);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isReplySkip(undefined)).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isReplySkip("")).toBe(false);
+  });
+});

--- a/src/agents/tools/sessions-send-tokens.ts
+++ b/src/agents/tools/sessions-send-tokens.ts
@@ -11,7 +11,16 @@ const NON_DELIVERABLE_REPLY_TOKENS = [
 ] as const;
 
 export function isAnnounceSkip(text?: string) {
-  return (text ?? "").trim() === ANNOUNCE_SKIP_TOKEN;
+  const t = (text ?? "").trim();
+  if (t === ANNOUNCE_SKIP_TOKEN) {
+    return true;
+  }
+  // Accept multi-line output where the final line is the token (#74071).
+  // Sub-agents may emit a DM summary block followed by ANNOUNCE_SKIP on its
+  // own line; strict equality misses that and leaks the summary as an
+  // announcement.
+  const lastNewline = t.lastIndexOf("\n");
+  return lastNewline >= 0 && t.slice(lastNewline + 1).trim() === ANNOUNCE_SKIP_TOKEN;
 }
 
 export function isReplySkip(text?: string) {


### PR DESCRIPTION
## Summary

- Fix `isAnnounceSkip()` to also accept multi-line sub-agent output where `ANNOUNCE_SKIP` appears as the final line after a newline, not just as the sole content.
- Add focused unit tests for `sessions-send-tokens.ts` covering exact, whitespace-padded, multi-line, and negative cases.
- Add an e2e regression test for the multi-line announce-skip scenario.

Closes #74071

## Problem

Sub-agents that produce a DM summary block followed by `ANNOUNCE_SKIP` on the final line had their entire summary leak into the parent session as an announcement. The strict equality check `(text ?? "").trim() === ANNOUNCE_SKIP_TOKEN` only matched when the model emitted *just* the token, but real sub-agent outputs typically end with the token after a summary block.

## Fix

`isAnnounceSkip()` now checks two conditions:
1. **Exact match** (existing): trimmed text equals the token
2. **Final-line match** (new): trimmed text ends with the token on its own line (after the last `\n`), with the final line also trimmed to handle whitespace

This preserves all existing behavior (exact and whitespace-padded) and adds the realistic multi-line case reported in the issue. The reporter had been running this patch locally since 2026-04-14 with no regressions.

## Test plan

- `pnpm test src/agents/tools/sessions-send-tokens.test.ts` — 16 new focused unit tests (all pass)
- `pnpm test src/agents/subagent-announce.test.ts` — 9 existing tests (all pass)
- `pnpm test src/agents/subagent-announce-output.test.ts` — 3 existing tests (all pass)
- `pnpm test src/agents/openclaw-tools.sessions.test.ts` — 15 existing tests (all pass)

## Real behavior proof

Behavior addressed: sub-agent output ending with a final-line `ANNOUNCE_SKIP` should suppress completion announcement delivery, while `ANNOUNCE_SKIP` followed by more text should not be treated as a silent sentinel.
Real environment tested: local OpenClaw source checkout using fork PR head `6440ea6b4f`, plus reporter production confirmation on issue #74071's canonical sub-agent workflow.
Exact steps or command run after this patch:

```text
node --import tsx -e '<script imports isAnnounceSkip, checks single-line sentinel, multiline text ending with ANNOUNCE_SKIP, and ANNOUNCE_SKIP followed by more text>'
```

Evidence after fix:

```json
{
  "branch": "fork/fix/announce-skip-multiline-74071",
  "head": "6440ea6b4f",
  "command": "node --import tsx isAnnounceSkip proof",
  "cases": [
    {
      "name": "single-line sentinel",
      "lineCount": 1,
      "result": true
    },
    {
      "name": "multiline final-line sentinel",
      "lineCount": 3,
      "result": true
    },
    {
      "name": "sentinel not final",
      "lineCount": 2,
      "result": false
    }
  ]
}
```

Observed result after fix: a final-line `ANNOUNCE_SKIP` suppresses announcement, including after a summary block; a non-final sentinel does not suppress announcement. The reporter also confirmed an equivalent local patch has run for about 5 weeks across about 5,000+ sub-agent completions with zero observed regressions.
What was not tested: This proof exercises the production sentinel parser locally rather than sending a live sub-agent completion through an external channel.

## Notes

- `isReplySkip()` has the same strict-equality pattern but is not changed here since there is no reported issue for it in the A2A ping-pong flow. It could receive the same treatment in a follow-up if needed.
- Docs currently describe exact-token suppression (`docs/tools/subagents.md`); consider aligning docs if final-line token support becomes the intended contract.
