### PR TITLE
feat(telegram): support mini app URL buttons

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -436,6 +436,15 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
     Legacy `capabilities: ["inlineButtons"]` maps to `inlineButtons: "all"`.
 
+    URL buttons in shared presentations are supported. In direct Telegram chats, HTTPS URL
+    buttons render as Telegram Mini App `web_app` buttons so canvas-style views open inside
+    Telegram. In groups, supergroups, channels, username targets, and non-HTTPS URLs, they render
+    as regular URL buttons because Bot API Mini App inline buttons are limited to private chats
+    between the user and bot and require HTTPS.
+
+    Mini App payloads must validate `Telegram.WebApp.initData` server-side before trusting user or
+    session data. Do not use `initDataUnsafe` for authorization decisions.
+
     Message action example:
 
 ```json5

--- a/extensions/telegram/src/button-types.test-helpers.ts
+++ b/extensions/telegram/src/button-types.test-helpers.ts
@@ -32,6 +32,53 @@ export function describeTelegramInteractiveButtonBehavior(): void {
         [{ text: "Alpha", callback_data: "alpha", style: undefined }],
       ]);
     });
+
+    it("maps URL buttons to Telegram URL buttons by default", () => {
+      expect(
+        buildTelegramInteractiveButtons({
+          blocks: [
+            {
+              type: "buttons",
+              buttons: [{ label: "Open", url: "https://example.com/app" }],
+            },
+          ],
+        }),
+      ).toEqual([[{ text: "Open", url: "https://example.com/app", style: undefined }]]);
+    });
+
+    it("maps HTTPS URL buttons to Mini App buttons when requested", () => {
+      expect(
+        buildTelegramInteractiveButtons(
+          {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Open", url: "https://example.com/app" }],
+              },
+            ],
+          },
+          { urlButtonMode: "web_app" },
+        ),
+      ).toEqual([
+        [{ text: "Open", web_app: { url: "https://example.com/app" }, style: undefined }],
+      ]);
+    });
+
+    it("keeps non-HTTPS URL buttons as regular URL buttons for Mini App mode", () => {
+      expect(
+        buildTelegramInteractiveButtons(
+          {
+            blocks: [
+              {
+                type: "buttons",
+                buttons: [{ label: "Open", url: "http://example.test/app" }],
+              },
+            ],
+          },
+          { urlButtonMode: "web_app" },
+        ),
+      ).toEqual([[{ text: "Open", url: "http://example.test/app", style: undefined }]]);
+    });
   });
 
   describe("resolveTelegramInlineButtons", () => {

--- a/extensions/telegram/src/button-types.ts
+++ b/extensions/telegram/src/button-types.ts
@@ -8,13 +8,26 @@ import { sanitizeTelegramCallbackData } from "./approval-callback-data.js";
 
 export type TelegramButtonStyle = "danger" | "success" | "primary";
 
-export type TelegramInlineButton = {
+export type TelegramInlineButtonBase = {
   text: string;
-  callback_data: string;
   style?: TelegramButtonStyle;
 };
 
+export type TelegramInlineButton =
+  | (TelegramInlineButtonBase & {
+      callback_data: string;
+    })
+  | (TelegramInlineButtonBase & {
+      url: string;
+    })
+  | (TelegramInlineButtonBase & {
+      web_app: {
+        url: string;
+      };
+    });
+
 export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineButton>>;
+export type TelegramUrlButtonMode = "url" | "web_app";
 
 const TELEGRAM_INTERACTIVE_ROW_SIZE = 3;
 
@@ -24,26 +37,53 @@ function toTelegramButtonStyle(
   return style === "danger" || style === "success" || style === "primary" ? style : undefined;
 }
 
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function buildTelegramInteractiveButton(
+  button: InteractiveReplyButton,
+  urlButtonMode: TelegramUrlButtonMode,
+): TelegramInlineButton | undefined {
+  if (button.url) {
+    return urlButtonMode === "web_app" && isHttpsUrl(button.url)
+      ? {
+          text: button.label,
+          web_app: { url: button.url },
+          style: toTelegramButtonStyle(button.style),
+        }
+      : {
+          text: button.label,
+          url: button.url,
+          style: toTelegramButtonStyle(button.style),
+        };
+  }
+  if (!button.value) {
+    return undefined;
+  }
+  const callbackData = sanitizeTelegramCallbackData(button.value);
+  return callbackData
+    ? {
+        text: button.label,
+        callback_data: callbackData,
+        style: toTelegramButtonStyle(button.style),
+      }
+    : undefined;
+}
+
 function chunkInteractiveButtons(
   buttons: readonly InteractiveReplyButton[],
   rows: TelegramInlineButton[][],
+  urlButtonMode: TelegramUrlButtonMode,
 ) {
   for (let i = 0; i < buttons.length; i += TELEGRAM_INTERACTIVE_ROW_SIZE) {
     const row = buttons.slice(i, i + TELEGRAM_INTERACTIVE_ROW_SIZE).flatMap((button) => {
-      if (!button.value) {
-        return [];
-      }
-      const callbackData = sanitizeTelegramCallbackData(button.value);
-      if (!callbackData) {
-        return [];
-      }
-      return [
-        {
-          text: button.label,
-          callback_data: callbackData,
-          style: toTelegramButtonStyle(button.style),
-        },
-      ];
+      const telegramButton = buildTelegramInteractiveButton(button, urlButtonMode);
+      return telegramButton ? [telegramButton] : [];
     });
     if (row.length > 0) {
       rows.push(row);
@@ -53,13 +93,15 @@ function chunkInteractiveButtons(
 
 export function buildTelegramInteractiveButtons(
   interactive?: InteractiveReply,
+  opts?: { urlButtonMode?: TelegramUrlButtonMode },
 ): TelegramInlineButtons | undefined {
+  const urlButtonMode = opts?.urlButtonMode ?? "url";
   const rows = reduceInteractiveReply(
     interactive,
     [] as TelegramInlineButton[][],
     (state, block) => {
       if (block.type === "buttons") {
-        chunkInteractiveButtons(block.buttons, state);
+        chunkInteractiveButtons(block.buttons, state, urlButtonMode);
         return state;
       }
       if (block.type === "select") {
@@ -69,6 +111,7 @@ export function buildTelegramInteractiveButtons(
             value: option.value,
           })),
           state,
+          urlButtonMode,
         );
       }
       return state;
@@ -80,8 +123,12 @@ export function buildTelegramInteractiveButtons(
 export function resolveTelegramInlineButtons(params: {
   buttons?: TelegramInlineButtons;
   interactive?: unknown;
+  urlButtonMode?: TelegramUrlButtonMode;
 }): TelegramInlineButtons | undefined {
   return (
-    params.buttons ?? buildTelegramInteractiveButtons(normalizeInteractiveReply(params.interactive))
+    params.buttons ??
+    buildTelegramInteractiveButtons(normalizeInteractiveReply(params.interactive), {
+      urlButtonMode: params.urlButtonMode,
+    })
   );
 }

--- a/extensions/telegram/src/inline-keyboard.test.ts
+++ b/extensions/telegram/src/inline-keyboard.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildInlineKeyboard } from "./inline-keyboard.js";
+
+describe("buildInlineKeyboard", () => {
+  it("builds callback, URL, and Mini App buttons", () => {
+    expect(
+      buildInlineKeyboard([
+        [
+          { text: "Approve", callback_data: "approve", style: "success" },
+          { text: "Docs", url: "https://example.com/docs" },
+          { text: "Canvas", web_app: { url: "https://example.com/canvas" } },
+        ],
+      ]),
+    ).toEqual({
+      inline_keyboard: [
+        [
+          { text: "Approve", callback_data: "approve", style: "success" },
+          { text: "Docs", url: "https://example.com/docs" },
+          { text: "Canvas", web_app: { url: "https://example.com/canvas" } },
+        ],
+      ],
+    });
+  });
+});

--- a/extensions/telegram/src/inline-keyboard.ts
+++ b/extensions/telegram/src/inline-keyboard.ts
@@ -1,6 +1,31 @@
 import type { InlineKeyboardButton, InlineKeyboardMarkup } from "@grammyjs/types";
 import type { TelegramInlineButtons } from "./button-types.js";
 
+function isInlineKeyboardButton(
+  value: InlineKeyboardButton | undefined,
+): value is InlineKeyboardButton {
+  return value !== undefined;
+}
+
+function buildInlineKeyboardButton(
+  button: TelegramInlineButtons[number][number],
+): InlineKeyboardButton | undefined {
+  if (!button?.text) {
+    return undefined;
+  }
+  const base = Object.assign({ text: button.text }, button.style ? { style: button.style } : {});
+  if ("callback_data" in button && button.callback_data) {
+    return { ...base, callback_data: button.callback_data };
+  }
+  if ("web_app" in button && button.web_app.url) {
+    return { ...base, web_app: { url: button.web_app.url } };
+  }
+  if ("url" in button && button.url) {
+    return { ...base, url: button.url };
+  }
+  return undefined;
+}
+
 export function buildInlineKeyboard(
   buttons?: TelegramInlineButtons,
 ): InlineKeyboardMarkup | undefined {
@@ -9,15 +34,7 @@ export function buildInlineKeyboard(
   }
   const rows = buttons
     .map((row) =>
-      row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton =>
-            Object.assign(
-              { text: button.text, callback_data: button.callback_data },
-              button.style ? { style: button.style } : {},
-            ),
-        ),
+      row.map((button) => buildInlineKeyboardButton(button)).filter(isInlineKeyboardButton),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -98,6 +98,76 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "12345" });
   });
 
+  it("renders direct-chat HTTPS presentation URL buttons as Mini App buttons", async () => {
+    const payload = telegramOutbound.renderPresentation?.({
+      payload: { text: "hello" },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Open canvas", url: "https://example.com/canvas" }],
+          },
+        ],
+      },
+      ctx: {
+        cfg: {},
+        to: "12345",
+        text: "",
+        payload: { text: "hello" },
+      },
+    });
+
+    expect(payload).toMatchObject({
+      channelData: {
+        telegram: {
+          buttons: [
+            [
+              {
+                text: "Open canvas",
+                web_app: { url: "https://example.com/canvas" },
+              },
+            ],
+          ],
+        },
+      },
+    });
+  });
+
+  it("renders group presentation URL buttons as regular URL buttons", async () => {
+    const payload = telegramOutbound.renderPresentation?.({
+      payload: { text: "hello" },
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [{ label: "Open canvas", url: "https://example.com/canvas" }],
+          },
+        ],
+      },
+      ctx: {
+        cfg: {},
+        to: "-1001234567890",
+        text: "",
+        payload: { text: "hello" },
+      },
+    });
+
+    expect(payload).toMatchObject({
+      channelData: {
+        telegram: {
+          buttons: [
+            [
+              {
+                text: "Open canvas",
+                url: "https://example.com/canvas",
+              },
+            ],
+          ],
+        },
+      },
+    });
+  });
+
   it("passes delivery pin notify requests to Telegram pinning", async () => {
     pinMessageTelegramMock.mockResolvedValueOnce({ ok: true, messageId: "tg-1", chatId: "12345" });
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -21,6 +21,7 @@ import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import type { TelegramInlineButtons } from "./button-types.js";
 import { resolveTelegramInlineButtons } from "./button-types.js";
 import { markdownToTelegramHtmlChunks } from "./format.js";
+import { resolveTelegramTargetChatType } from "./inline-buttons.js";
 import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
 import { pinMessageTelegram } from "./send.js";
 
@@ -70,6 +71,14 @@ async function resolveTelegramSendContext(params: {
       gatewayClientScopes: params.gatewayClientScopes,
     },
   };
+}
+
+function resolveTelegramPresentationUrlButtonMode(to: string): "url" | "web_app" {
+  return resolveTelegramTargetChatType(to) === "direct" ? "web_app" : "url";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
 
 export async function sendTelegramPayloadMessages(params: {
@@ -135,11 +144,29 @@ export const telegramOutbound: ChannelOutboundAdapter = {
   deliveryCapabilities: {
     pin: true,
   },
-  renderPresentation: ({ payload, presentation }) => ({
-    ...payload,
-    text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
-    interactive: presentationToInteractiveReply(presentation),
-  }),
+  renderPresentation: ({ payload, presentation, ctx }) => {
+    const interactive = presentationToInteractiveReply(presentation);
+    const buttons = resolveTelegramInlineButtons({
+      interactive,
+      urlButtonMode: resolveTelegramPresentationUrlButtonMode(ctx.to),
+    });
+    return {
+      ...payload,
+      text: renderMessagePresentationFallbackText({ text: payload.text, presentation }),
+      interactive,
+      ...(buttons
+        ? {
+            channelData: {
+              ...payload.channelData,
+              telegram: {
+                ...(isRecord(payload.channelData?.telegram) ? payload.channelData.telegram : {}),
+                buttons,
+              },
+            },
+          }
+        : {}),
+    };
+  },
   pinDeliveredMessage: async ({ cfg, target, messageId, pin }) => {
     await pinMessageTelegram(target.to, messageId, {
       cfg,


### PR DESCRIPTION
## Summary
- Reuse shared presentation URL buttons in Telegram inline keyboards.
- Render direct-chat HTTPS presentation buttons as Telegram Mini App web_app buttons.
- Document the Telegram HTTPS, private-chat, and initData constraints.

## Validation
- pnpm test extensions/telegram/src/button-types.test.ts extensions/telegram/src/inline-buttons.test.ts extensions/telegram/src/inline-keyboard.test.ts extensions/telegram/src/outbound-adapter.test.ts
- pnpm check:changed
