### PR TITLE
fix(agents): detect media:// URIs before sandbox bridge path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/media: resolve validated `media://inbound/<file>` sandbox fallback files before bridge path normalization while leaving malformed, nested, or unsupported media URIs to downstream media validation. Fixes #74123. Thanks @yelog.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.
 - Infra/Windows: skip the POSIX `/tmp/openclaw` preferred path on Windows in `resolvePreferredOpenClawTmpDir` so log files, TTS temp files, and other writes land in `%TEMP%\openclaw-<uid>` instead of `C:\tmp\openclaw`. Fixes #60713. Thanks @juan-flores077.
 - Gateway/diagnostics: make stuck-session recovery outcome-driven and generation-guarded, add `diagnostics.stuckSessionAbortMs`, and emit structured recovery requested/completed events so stale or skipped recovery no longer looks like a successful abort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -829,6 +829,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
+- Agents/media: resolve validated `media://inbound/<file>` sandbox fallback files before bridge path normalization while leaving malformed, nested, or unsupported media URIs to downstream media validation. Fixes #74123. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   createSandboxBridgeReadFile,
   resolveSandboxedBridgeMediaPath,
 } from "./sandbox-media-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+
+const assertSandboxPath = vi.hoisted(() => vi.fn());
+
+vi.mock("./sandbox-paths.js", async () => {
+  const actual = await vi.importActual<typeof import("./sandbox-paths.js")>("./sandbox-paths.js");
+  return { ...actual, assertSandboxPath };
+});
 
 describe("createSandboxBridgeReadFile", () => {
   it("delegates reads through the sandbox bridge with sandbox root cwd", async () => {
@@ -45,6 +52,9 @@ describe("createSandboxBridgeReadFile", () => {
 });
 
 describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
+  beforeEach(() => {
+    assertSandboxPath.mockReset();
+  });
   it("resolves media://inbound URI via fallback dir instead of mangling through bridge", async () => {
     const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
       relativePath: filePath,
@@ -129,5 +139,56 @@ describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
       filePath: "images/photo.png",
       cwd: "/workspace",
     });
+  });
+
+  it("enforces workspace boundary on media:// fallback when workspaceOnly is true", async () => {
+    assertSandboxPath.mockRejectedValueOnce(new Error("path escapes sandbox root"));
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      hostPath: `/host/${filePath}`,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    await expect(
+      resolveSandboxedBridgeMediaPath({
+        sandbox: {
+          root: "/workspace",
+          workspaceOnly: true,
+          bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+        },
+        mediaPath: "media://inbound/../../../etc/passwd",
+        inboundFallbackDir: "media/inbound",
+      }),
+    ).rejects.toThrow("path escapes sandbox root");
+
+    expect(assertSandboxPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: expect.any(String),
+        cwd: "/workspace",
+        root: "/workspace",
+      }),
+    );
+  });
+
+  it("skips workspace boundary on media:// fallback when workspaceOnly is falsy", async () => {
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      hostPath: `/host/${filePath}`,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/test.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved.resolved).toBe("/host/media/inbound/test.png");
+    expect(assertSandboxPath).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -141,7 +141,7 @@ describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
     });
   });
 
-  it("enforces workspace boundary on media:// fallback when workspaceOnly is true", async () => {
+  it("enforces workspace boundary on valid media:// fallback when workspaceOnly is true", async () => {
     assertSandboxPath.mockRejectedValueOnce(new Error("path escapes sandbox root"));
     const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
       relativePath: filePath,
@@ -157,7 +157,7 @@ describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
           workspaceOnly: true,
           bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
         },
-        mediaPath: "media://inbound/../../../etc/passwd",
+        mediaPath: "media://inbound/test.png",
         inboundFallbackDir: "media/inbound",
       }),
     ).rejects.toThrow("path escapes sandbox root");
@@ -169,6 +169,60 @@ describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
         root: "/workspace",
       }),
     );
+  });
+
+  it("returns raw unsupported media:// URI without probing fallback", async () => {
+    const resolvePath = vi.fn();
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://other/test.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved).toEqual({ resolved: "media://other/test.png" });
+    expect(stat).not.toHaveBeenCalled();
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("returns raw nested media://inbound URI without probing fallback", async () => {
+    const resolvePath = vi.fn();
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/nested/test.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved).toEqual({ resolved: "media://inbound/nested/test.png" });
+    expect(stat).not.toHaveBeenCalled();
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("returns raw encoded path separator media://inbound URI without probing fallback", async () => {
+    const resolvePath = vi.fn();
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/nested%2Ftest.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    expect(resolved).toEqual({ resolved: "media://inbound/nested%2Ftest.png" });
+    expect(stat).not.toHaveBeenCalled();
+    expect(resolvePath).not.toHaveBeenCalled();
   });
 
   it("skips workspace boundary on media:// fallback when workspaceOnly is falsy", async () => {

--- a/src/agents/sandbox-media-paths.test.ts
+++ b/src/agents/sandbox-media-paths.test.ts
@@ -43,3 +43,91 @@ describe("createSandboxBridgeReadFile", () => {
     expect(stat).not.toHaveBeenCalled();
   });
 });
+
+describe("resolveSandboxedBridgeMediaPath media:// URIs", () => {
+  it("resolves media://inbound URI via fallback dir instead of mangling through bridge", async () => {
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      hostPath: `/host/${filePath}`,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+    const stat = vi.fn(async () => ({ type: "file" as const, size: 100, mtimeMs: 1 }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/claim-check-test.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    // Should rewrite to fallback path and resolve through bridge
+    expect(resolved.rewrittenFrom).toBe("media://inbound/claim-check-test.png");
+    expect(resolved.resolved).toBe("/host/media/inbound/claim-check-test.png");
+    // resolvePath should be called with the fallback path, not the raw URI
+    expect(resolvePath).toHaveBeenCalledWith({
+      filePath: "media/inbound/claim-check-test.png",
+      cwd: "/workspace",
+    });
+  });
+
+  it("returns raw media:// URI when inbound fallback stat fails", async () => {
+    const resolvePath = vi.fn();
+    const stat = vi.fn(async () => null);
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath, stat } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/missing.png",
+      inboundFallbackDir: "media/inbound",
+    });
+
+    // Should return the raw URI so loadWebMedia can resolve it
+    expect(resolved.resolved).toBe("media://inbound/missing.png");
+    expect(resolved.rewrittenFrom).toBeUndefined();
+    // resolvePath should NOT have been called with the mangled URI
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("returns raw media:// URI when no inbound fallback dir is provided", async () => {
+    const resolvePath = vi.fn();
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "media://inbound/test.png",
+    });
+
+    expect(resolved.resolved).toBe("media://inbound/test.png");
+    // Bridge resolvePath should never be called for media:// URIs
+    expect(resolvePath).not.toHaveBeenCalled();
+  });
+
+  it("does not intercept non-media:// paths", async () => {
+    const resolvePath = vi.fn(({ filePath }: { filePath: string }) => ({
+      relativePath: filePath,
+      hostPath: `/host/${filePath}`,
+      containerPath: `/sandbox/${filePath}`,
+    }));
+
+    const resolved = await resolveSandboxedBridgeMediaPath({
+      sandbox: {
+        root: "/workspace",
+        bridge: { resolvePath } as unknown as SandboxFsBridge,
+      },
+      mediaPath: "images/photo.png",
+    });
+
+    expect(resolved.resolved).toBe("/host/images/photo.png");
+    // Normal paths still go through bridge resolution
+    expect(resolvePath).toHaveBeenCalledWith({
+      filePath: "images/photo.png",
+      cwd: "/workspace",
+    });
+  });
+});

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -18,6 +18,38 @@ export function createSandboxBridgeReadFile(params: {
     });
 }
 
+function parseInboundMediaFallbackName(rawPath: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(rawPath);
+  } catch {
+    return null;
+  }
+  if (url.protocol.toLowerCase() !== "media:" || url.hostname !== "inbound") {
+    return null;
+  }
+  const rawName = url.pathname.startsWith("/") ? url.pathname.slice(1) : url.pathname;
+  if (!rawName || rawName.includes("/")) {
+    return null;
+  }
+  let decodedName: string;
+  try {
+    decodedName = decodeURIComponent(rawName);
+  } catch {
+    return null;
+  }
+  if (
+    !decodedName ||
+    decodedName === "." ||
+    decodedName === ".." ||
+    decodedName.includes("/") ||
+    decodedName.includes("\\")
+  ) {
+    return null;
+  }
+  return decodedName;
+}
+
 export async function resolveSandboxedBridgeMediaPath(params: {
   sandbox: SandboxedBridgeMediaPathConfig;
   mediaPath: string;
@@ -42,9 +74,9 @@ export async function resolveSandboxedBridgeMediaPath(params: {
   // by POSIX path.resolve (which turns media://inbound/x into workspace/media:/inbound/x).
   if (/^media:\/\//i.test(filePath)) {
     const fallbackDir = params.inboundFallbackDir?.trim();
-    if (fallbackDir) {
-      const basename = path.basename(new URL(filePath).pathname);
-      const fallbackPath = path.join(fallbackDir, basename);
+    const inboundName = parseInboundMediaFallbackName(filePath);
+    if (fallbackDir && inboundName) {
+      const fallbackPath = path.join(fallbackDir, inboundName);
       let fallbackStat: Awaited<ReturnType<SandboxFsBridge["stat"]>> | null = null;
       try {
         fallbackStat = await params.sandbox.bridge.stat({

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -26,6 +26,38 @@ export async function resolveSandboxedBridgeMediaPath(params: {
   const normalizeFileUrl = (rawPath: string) =>
     rawPath.startsWith("file://") ? rawPath.slice("file://".length) : rawPath;
   const filePath = normalizeFileUrl(params.mediaPath);
+
+  // Detect media:// URIs before bridge resolution so they are not mangled
+  // by POSIX path.resolve (which turns media://inbound/x into workspace/media:/inbound/x).
+  if (/^media:\/\//i.test(filePath)) {
+    const fallbackDir = params.inboundFallbackDir?.trim();
+    if (fallbackDir) {
+      const basename = path.basename(new URL(filePath).pathname);
+      const fallbackPath = path.join(fallbackDir, basename);
+      try {
+        const stat = await params.sandbox.bridge.stat({
+          filePath: fallbackPath,
+          cwd: params.sandbox.root,
+        });
+        if (stat) {
+          const resolvedFallback = params.sandbox.bridge.resolvePath({
+            filePath: fallbackPath,
+            cwd: params.sandbox.root,
+          });
+          return {
+            resolved: resolvedFallback.hostPath ?? resolvedFallback.containerPath,
+            rewrittenFrom: filePath,
+          };
+        }
+      } catch {
+        // stat or resolve failed — fall through to return the raw URI
+      }
+    }
+    // Return the raw media:// URI so downstream loadWebMedia can resolve it
+    // through resolveMediaStoreUriToPath.
+    return { resolved: filePath };
+  }
+
   const enforceWorkspaceBoundary = async (hostPath: string) => {
     if (!params.sandbox.workspaceOnly) {
       return;

--- a/src/agents/sandbox-media-paths.ts
+++ b/src/agents/sandbox-media-paths.ts
@@ -27,37 +27,6 @@ export async function resolveSandboxedBridgeMediaPath(params: {
     rawPath.startsWith("file://") ? rawPath.slice("file://".length) : rawPath;
   const filePath = normalizeFileUrl(params.mediaPath);
 
-  // Detect media:// URIs before bridge resolution so they are not mangled
-  // by POSIX path.resolve (which turns media://inbound/x into workspace/media:/inbound/x).
-  if (/^media:\/\//i.test(filePath)) {
-    const fallbackDir = params.inboundFallbackDir?.trim();
-    if (fallbackDir) {
-      const basename = path.basename(new URL(filePath).pathname);
-      const fallbackPath = path.join(fallbackDir, basename);
-      try {
-        const stat = await params.sandbox.bridge.stat({
-          filePath: fallbackPath,
-          cwd: params.sandbox.root,
-        });
-        if (stat) {
-          const resolvedFallback = params.sandbox.bridge.resolvePath({
-            filePath: fallbackPath,
-            cwd: params.sandbox.root,
-          });
-          return {
-            resolved: resolvedFallback.hostPath ?? resolvedFallback.containerPath,
-            rewrittenFrom: filePath,
-          };
-        }
-      } catch {
-        // stat or resolve failed — fall through to return the raw URI
-      }
-    }
-    // Return the raw media:// URI so downstream loadWebMedia can resolve it
-    // through resolveMediaStoreUriToPath.
-    return { resolved: filePath };
-  }
-
   const enforceWorkspaceBoundary = async (hostPath: string) => {
     if (!params.sandbox.workspaceOnly) {
       return;
@@ -68,6 +37,41 @@ export async function resolveSandboxedBridgeMediaPath(params: {
       root: params.sandbox.root,
     });
   };
+
+  // Detect media:// URIs before bridge resolution so they are not mangled
+  // by POSIX path.resolve (which turns media://inbound/x into workspace/media:/inbound/x).
+  if (/^media:\/\//i.test(filePath)) {
+    const fallbackDir = params.inboundFallbackDir?.trim();
+    if (fallbackDir) {
+      const basename = path.basename(new URL(filePath).pathname);
+      const fallbackPath = path.join(fallbackDir, basename);
+      let fallbackStat: Awaited<ReturnType<SandboxFsBridge["stat"]>> | null = null;
+      try {
+        fallbackStat = await params.sandbox.bridge.stat({
+          filePath: fallbackPath,
+          cwd: params.sandbox.root,
+        });
+      } catch {
+        // stat failed — fall through to return the raw URI
+      }
+      if (fallbackStat) {
+        const resolvedFallback = params.sandbox.bridge.resolvePath({
+          filePath: fallbackPath,
+          cwd: params.sandbox.root,
+        });
+        if (resolvedFallback.hostPath) {
+          await enforceWorkspaceBoundary(resolvedFallback.hostPath);
+        }
+        return {
+          resolved: resolvedFallback.hostPath ?? resolvedFallback.containerPath,
+          rewrittenFrom: filePath,
+        };
+      }
+    }
+    // Return the raw media:// URI so downstream loadWebMedia can resolve it
+    // through resolveMediaStoreUriToPath.
+    return { resolved: filePath };
+  }
 
   const resolveDirect = () =>
     params.sandbox.bridge.resolvePath({


### PR DESCRIPTION
## Summary
- Detects `media://` URIs early in `resolveSandboxedBridgeMediaPath` before they reach the sandbox bridge resolver
- When an inbound fallback dir is configured, resolves `media://inbound/<id>` to `media/inbound/<basename>` via the bridge
- When no fallback dir or stat fails, passes the raw `media://` URI through so downstream `loadWebMedia` can resolve it via `resolveMediaStoreUriToPath`

## Problem
Passing `media://inbound/xxx.png` to the image tool in a sandboxed context fails because the sandbox bridge resolver applies POSIX `path.resolve(cwd, "media://inbound/xxx.png")` which produces `/workspace/media:/inbound/xxx.png` — an invalid path. The `resolveDirect()` call does not throw (the path is syntactically valid), so the inbound fallback branch is never reached. The downstream `loadWebMedia` receives the corrupted path instead of the original `media://` URI.

## Changes

### `src/agents/sandbox-media-paths.ts`
- Added early detection of `media://` URIs (regex `^media:\/\//i`) before the `resolveDirect()` call
- For `media://inbound/<id>`, extracts basename from URL pathname and tries the inbound fallback path via bridge stat/resolve
- Falls back to returning the raw `media://` URI when no fallback dir or stat fails, so `loadWebMedia` can resolve it normally
- Non-`media://` paths continue through the existing bridge resolution path unchanged

### `src/agents/sandbox-media-paths.test.ts`
- Added 4 new tests covering:
  - `media://inbound` URI resolved via fallback dir
  - Raw URI returned when fallback stat fails
  - Raw URI returned when no fallback dir configured
  - Non-`media://` paths still go through bridge resolution

## Note
This is complementary to PR #63497 which fixes `media://inbound` handling in the non-sandbox image tool path. This PR fixes the sandbox resolver path which is a separate bug surface.

Fixes #74123