### PR TITLE
fix(skills): never wipe target skills dir on sync to prevent data los…

### DIFF
--- a/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
+++ b/src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.test.ts
@@ -358,3 +358,117 @@ describe("buildWorkspaceSkillsPrompt", () => {
     );
   });
 });
+
+describe("syncSkillsToWorkspace non-destructive sync", () => {
+  const syncSkills = async (sourceWorkspace: string, targetWorkspace: string) =>
+    withEnv({ HOME: sourceWorkspace }, () =>
+      syncSkillsToWorkspace({
+        sourceWorkspaceDir: sourceWorkspace,
+        targetWorkspaceDir: targetWorkspace,
+        bundledSkillsDir: path.join(sourceWorkspace, ".bundled"),
+        managedSkillsDir: path.join(sourceWorkspace, ".managed"),
+      }),
+    );
+
+  it("does not wipe previously synced skills when the source load returns empty", async () => {
+    const sourceWorkspace = await createCaseDir("src-full");
+    const targetWorkspace = await createCaseDir("target-existing");
+
+    // First sync: source has two skills. Target should receive both.
+    await writeSkill({
+      dir: path.join(sourceWorkspace, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+    await writeSkill({
+      dir: path.join(sourceWorkspace, "skills", "beta"),
+      name: "beta",
+      description: "Beta skill",
+    });
+    await syncSkills(sourceWorkspace, targetWorkspace);
+    expect(await pathExists(path.join(targetWorkspace, "skills", "alpha", "SKILL.md"))).toBe(true);
+    expect(await pathExists(path.join(targetWorkspace, "skills", "beta", "SKILL.md"))).toBe(true);
+
+    // Second sync with a completely empty source skills dir (simulating a
+    // transient load failure where loadWorkspaceSkillEntries returns []).
+    // Previously the implementation would wipe the entire target skills
+    // directory — now it must keep both existing skill directories intact.
+    const emptySource = await createCaseDir("src-empty");
+    await syncSkills(emptySource, targetWorkspace);
+    expect(await pathExists(path.join(targetWorkspace, "skills", "alpha", "SKILL.md"))).toBe(true);
+    expect(await pathExists(path.join(targetWorkspace, "skills", "beta", "SKILL.md"))).toBe(true);
+  });
+
+  it("preserves unrelated user-created directories in the target skills dir", async () => {
+    const sourceWorkspace = await createCaseDir("src-one");
+    const targetWorkspace = await createCaseDir("target-mixed");
+    await writeSkill({
+      dir: path.join(sourceWorkspace, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+
+    // Simulate a skill that was installed directly inside the sandbox by
+    // the user/agent and is not part of the source manifest.
+    await writeSkill({
+      dir: path.join(targetWorkspace, "skills", "user-made"),
+      name: "user-made",
+      description: "User-installed skill",
+    });
+
+    await syncSkills(sourceWorkspace, targetWorkspace);
+
+    expect(await pathExists(path.join(targetWorkspace, "skills", "alpha", "SKILL.md"))).toBe(true);
+    // The user-installed skill must not be touched.
+    expect(await pathExists(path.join(targetWorkspace, "skills", "user-made", "SKILL.md"))).toBe(
+      true,
+    );
+  });
+
+  it("skips re-copying when the destination is already up to date", async () => {
+    const sourceWorkspace = await createCaseDir("src-mtime");
+    const targetWorkspace = await createCaseDir("target-mtime");
+    await writeSkill({
+      dir: path.join(sourceWorkspace, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+    await syncSkills(sourceWorkspace, targetWorkspace);
+
+    const destSkillMd = path.join(targetWorkspace, "skills", "alpha", "SKILL.md");
+    const firstMtime = (await fs.stat(destSkillMd)).mtimeMs;
+
+    // Second sync with no source changes: destination mtime should stay
+    // unchanged because the incremental skip path avoids re-copying.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await syncSkills(sourceWorkspace, targetWorkspace);
+    const secondMtime = (await fs.stat(destSkillMd)).mtimeMs;
+    expect(secondMtime).toBe(firstMtime);
+  });
+
+  it("re-copies a skill when the source has been modified after the previous sync", async () => {
+    const sourceWorkspace = await createCaseDir("src-change");
+    const targetWorkspace = await createCaseDir("target-change");
+    const sourceSkillDir = path.join(sourceWorkspace, "skills", "alpha");
+    await writeSkill({
+      dir: sourceSkillDir,
+      name: "alpha",
+      description: "Original",
+    });
+    await syncSkills(sourceWorkspace, targetWorkspace);
+
+    const destSkillMd = path.join(targetWorkspace, "skills", "alpha", "SKILL.md");
+    expect((await fs.readFile(destSkillMd, "utf-8")).includes("Original")).toBe(true);
+
+    // Wait past filesystem mtime resolution, then modify source.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await writeSkill({
+      dir: sourceSkillDir,
+      name: "alpha",
+      description: "Updated",
+    });
+
+    await syncSkills(sourceWorkspace, targetWorkspace);
+    expect((await fs.readFile(destSkillMd, "utf-8")).includes("Updated")).toBe(true);
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -907,6 +907,39 @@ function resolveSyncedSkillDestinationPath(params: {
   }).resolved;
 }
 
+/**
+ * Walk a directory up to 2 levels deep and return the newest file mtime
+ * found. Returns 0 if the directory does not exist, is empty, or is
+ * unreadable. Used to detect whether a skill's source tree has changed
+ * since the last sync so we can skip re-copying unchanged skills.
+ */
+async function getNewestMtime(dir: string, depth = 0): Promise<number> {
+  const MAX_DEPTH = 2;
+  let newest = 0;
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory() && depth < MAX_DEPTH) {
+        const sub = await getNewestMtime(fullPath, depth + 1);
+        if (sub > newest) newest = sub;
+      } else if (entry.isFile()) {
+        const stat = await fsp.stat(fullPath);
+        if (stat.mtimeMs > newest) newest = stat.mtimeMs;
+      }
+    } catch {
+      // Skip unreadable entries — a best-effort freshness check does not
+      // need perfect coverage.
+    }
+  }
+  return newest;
+}
+
 export async function syncSkillsToWorkspace(params: {
   sourceWorkspaceDir: string;
   targetWorkspaceDir: string;
@@ -935,10 +968,20 @@ export async function syncSkillsToWorkspace(params: {
       bundledSkillsDir: params.bundledSkillsDir,
     });
 
-    await fsp.rm(targetSkillsDir, { recursive: true, force: true });
+    // Ensure the target directory exists, but never wipe it wholesale.
+    // Wiping before copy is unsafe: when `loadWorkspaceSkillEntries`
+    // returns a partial result due to a transient config parse error or
+    // filesystem hiccup, `rm -rf` destroys skills that should have been
+    // preserved and the recopy step can't restore them. A non-destructive
+    // sync is strictly safer — at worst the sandbox carries a few stale
+    // directories, which is cheap because sandboxes are ephemeral.
     await fsp.mkdir(targetSkillsDir, { recursive: true });
 
+    // Build a manifest of destination directory → source entry. We resolve
+    // each destination up front so duplicate source basenames get distinct
+    // target names consistent with the previous behavior.
     const usedDirNames = new Set<string>();
+    const sourceManifest: { entry: SkillEntry; destDir: string }[] = [];
     for (const entry of entries) {
       let dest: string | null = null;
       try {
@@ -958,8 +1001,29 @@ export async function syncSkillsToWorkspace(params: {
         );
         continue;
       }
+      sourceManifest.push({ entry, destDir: dest });
+    }
+
+    // Incremental per-skill copy. For each entry: if the destination is
+    // already at least as new as the source, skip. Otherwise remove only
+    // that one destination directory and re-copy. We never touch
+    // destination directories that aren't in the manifest.
+    let copiedCount = 0;
+    let skippedCount = 0;
+    let failedCount = 0;
+    for (const { entry, destDir } of sourceManifest) {
+      const srcMtime = await getNewestMtime(entry.skill.baseDir);
+      const destMtime = await getNewestMtime(destDir);
+      if (srcMtime > 0 && destMtime >= srcMtime) {
+        skippedCount++;
+        continue;
+      }
+
       try {
-        await fsp.cp(entry.skill.baseDir, dest, {
+        // Scoped removal: only the target directory for this specific
+        // skill, so stale files inside it do not leak into the new copy.
+        await fsp.rm(destDir, { recursive: true, force: true });
+        await fsp.cp(entry.skill.baseDir, destDir, {
           recursive: true,
           force: true,
           filter: (src) => {
@@ -967,11 +1031,17 @@ export async function syncSkillsToWorkspace(params: {
             return !(name === ".git" || name === "node_modules");
           },
         });
+        copiedCount++;
       } catch (error) {
         const message = error instanceof Error ? error.message : JSON.stringify(error);
         skillsLogger.warn(`Failed to copy ${entry.skill.name} to sandbox: ${message}`);
+        failedCount++;
       }
     }
+
+    skillsLogger.debug(
+      `syncSkillsToWorkspace: manifest=${sourceManifest.length} copied=${copiedCount} skipped=${skippedCount} failed=${failedCount}`,
+    );
   });
 }
 


### PR DESCRIPTION
…s on partial load

`syncSkillsToWorkspace` used to call `fsp.rm(targetSkillsDir)` before recopying every skill. Any transient failure inside `loadWorkspaceSkillEntries` (a filesystem hiccup, a config parse error, an agent-filter edge case) returns fewer entries than expected and the wipe step destroys skills that the recopy step cannot restore. Users report their entire skills directory disappearing after a single bad load.

Switch to a non-destructive, per-skill incremental sync:

- Only `mkdir` the target skills dir, never wipe it wholesale.
- Build a manifest of (destination dir, source entry) pairs up front, preserving the existing duplicate-basename disambiguation.
- For each entry compare source vs destination mtime via a small 2-level `getNewestMtime` helper; skip re-copying when the destination is already at least as new.
- When a copy is needed, scope the `rm` to that single destination dir so stale files inside it cannot leak into the new copy, then `cp`.
- Emit a debug summary (`manifest/copied/skipped/failed`) to make post-sync diagnostics possible without reconstructing state.

Target directories that are not part of the source manifest — for example skills the user installed directly inside a sandbox — are left untouched. Sandboxes are ephemeral, so a few leftover directories are cheap; losing real user data is not.

Add four regression tests in the existing sync suite:

- Second sync with an empty source no longer wipes previously synced skills.
- User-created skill directories survive an unrelated source sync.
- Unchanged skills are not re-copied (destination mtime preserved).
- Modified source skills are picked up and re-copied.

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
