### PR TITLE
feat(bedrock): Cline-parity config surface + BedrockAuthConfig helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Providers/Bedrock: declare Cline-parity config keys (`awsAuthentication`, `awsBedrockApiKey`, `awsProfile`, `awsAccessKey`, `awsSecretKey`, `awsSessionToken`, `awsRegion`, `awsBedrockEndpoint`, `awsUseCrossRegionInference`, `awsUseGlobalInference`, `awsBedrockUsePromptCache`, `reasoningEffort`, `thinkingBudgetTokens`, `enable1MContext`) in the amazon-bedrock plugin manifest so setup, onboarding, and downstream pi-ai consumers share the same explicit config surface across the four Bedrock auth modes. Thanks @praxstack.
+- Providers/Bedrock: introduce `BedrockAuthConfig` and `normalizeBedrockAuthConfig` in `extensions/amazon-bedrock/bedrock-auth-config.ts`, plus a `BedrockSetupOptions` type alias re-exported from `extensions/amazon-bedrock/setup-api.ts`, so plugin callers have a typed parity contract with pi-ai's Bedrock auth resolver and legacy `awsUseProfile: true` configs migrate transparently. Thanks @praxstack.
 - Channels: add Yuanbao channel docs entrance so the Tencent Yuanbao bot appears in the channel listing and sidebar navigation. (#73443) Thanks @loongfay.
 - Active Memory: add optional per-conversation `allowedChatIds` and `deniedChatIds` filters so operators can enable recall only for selected direct, group, or channel conversations while keeping broad sessions skipped. (#67977) Thanks @quengh.
 - Active Memory: return bounded partial recall summaries when the hidden memory sub-agent times out, including the default temporary-transcript path, so useful recovered context is not discarded. (#73219) Thanks @joeykrug.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Docs: https://docs.openclaw.ai
 - Telegram: add allowlisted native DM draft previews for transient tool progress while keeping final answers on the normal persistent delivery path. (#83622) Thanks @akrimm702.
 - QA-Lab: add a personal-agent share-safe diagnostics artifact scenario so support handoffs keep useful status while omitting raw personal content. Thanks @iFiras-Max1.
 - QA-Lab: add a personal-agent no-fake-progress scenario so completion claims stay tied to local evidence instead of unsupported external progress. (#83824) Thanks @iFiras-Max1.
+- Providers/Bedrock: declare Cline-parity config keys (`awsAuthentication`, `awsBedrockApiKey`, `awsProfile`, `awsAccessKey`, `awsSecretKey`, `awsSessionToken`, `awsRegion`, `awsBedrockEndpoint`, `awsUseCrossRegionInference`, `awsUseGlobalInference`, `awsBedrockUsePromptCache`, `reasoningEffort`, `thinkingBudgetTokens`, `enable1MContext`) in the amazon-bedrock plugin manifest so setup, onboarding, and downstream pi-ai consumers share the same explicit config surface across the four Bedrock auth modes. Thanks @praxstack.
+- Providers/Bedrock: introduce `BedrockAuthConfig` and `normalizeBedrockAuthConfig` in `extensions/amazon-bedrock/bedrock-auth-config.ts`, plus a `BedrockSetupOptions` type alias re-exported from `extensions/amazon-bedrock/setup-api.ts`, so plugin callers have a typed parity contract with pi-ai's Bedrock auth resolver and legacy `awsUseProfile: true` configs migrate transparently. Thanks @praxstack.
 
 ### Fixes
 

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -351,6 +351,38 @@ openclaw models list
     - If you prefer a managed key flow, you can also place an OpenAI-compatible
       proxy in front of Bedrock and configure it as an OpenAI provider instead.
   </Accordion>
+
+  <Accordion title="Explicit auth modes and Cline-parity config">
+    Beyond the discovery opt-in, the amazon-bedrock plugin manifest declares an
+    explicit Bedrock config surface that matches Cline's Bedrock UI and pi-ai's
+    resolver contract. Downstream callers can pick one of four auth modes:
+
+    | Mode | `awsAuthentication` | Required fields |
+    | ---- | ------------------- | --------------- |
+    | API key | `apikey` | `awsBedrockApiKey` or `AWS_BEARER_TOKEN_BEDROCK` |
+    | Named profile | `profile` | `awsProfile` resolved from `~/.aws/credentials` |
+    | Static credentials | `credentials` | `awsAccessKey` + `awsSecretKey`, optional `awsSessionToken` |
+    | Default chain | `default` | AWS SDK default credential chain |
+
+    Additional config keys declared in `extensions/amazon-bedrock/openclaw.plugin.json`:
+
+    | Key | Default | Description |
+    | --- | ------- | ----------- |
+    | `awsRegion` | `us-east-1` | Region for Bedrock runtime calls. |
+    | `awsBedrockEndpoint` | (unset) | Optional VPC endpoint URL for private connectivity. |
+    | `awsUseCrossRegionInference` | `true` | Enable regional Bedrock inference profiles such as `us.anthropic.*`. |
+    | `awsUseGlobalInference` | `true` | Enable Bedrock global inference profiles. |
+    | `awsBedrockUsePromptCache` | `true` | Inject Bedrock Converse prompt cache points when the model supports caching. |
+    | `reasoningEffort` | (unset) | Reasoning effort hint: `none`, `low`, `medium`, or `high`. |
+    | `thinkingBudgetTokens` | (unset) | Extended thinking token budget for reasoning Claude models. |
+    | `enable1MContext` | `false` | Enable 1M-token context beta for supported Claude Opus models. |
+
+    Plugin authors and setup flows can consume the typed contract via
+    `BedrockSetupOptions` re-exported from `extensions/amazon-bedrock/setup-api.ts`.
+    Legacy `awsUseProfile: true` configs migrate transparently to
+    `awsAuthentication: "profile"` via `normalizeBedrockAuthConfig`.
+
+  </Accordion>
 </AccordionGroup>
 
 ## Related

--- a/docs/providers/bedrock.md
+++ b/docs/providers/bedrock.md
@@ -394,6 +394,38 @@ openclaw models list
     - If you prefer a managed key flow, you can also place an OpenAI-compatible
       proxy in front of Bedrock and configure it as an OpenAI provider instead.
   </Accordion>
+
+  <Accordion title="Explicit auth modes and Cline-parity config">
+    Beyond the discovery opt-in, the amazon-bedrock plugin manifest declares an
+    explicit Bedrock config surface that matches Cline's Bedrock UI and pi-ai's
+    resolver contract. Downstream callers can pick one of four auth modes:
+
+    | Mode | `awsAuthentication` | Required fields |
+    | ---- | ------------------- | --------------- |
+    | API key | `apikey` | `awsBedrockApiKey` or `AWS_BEARER_TOKEN_BEDROCK` |
+    | Named profile | `profile` | `awsProfile` resolved from `~/.aws/credentials` |
+    | Static credentials | `credentials` | `awsAccessKey` + `awsSecretKey`, optional `awsSessionToken` |
+    | Default chain | `default` | AWS SDK default credential chain |
+
+    Additional config keys declared in `extensions/amazon-bedrock/openclaw.plugin.json`:
+
+    | Key | Default | Description |
+    | --- | ------- | ----------- |
+    | `awsRegion` | `us-east-1` | Region for Bedrock runtime calls. |
+    | `awsBedrockEndpoint` | (unset) | Optional VPC endpoint URL for private connectivity. |
+    | `awsUseCrossRegionInference` | `true` | Enable regional Bedrock inference profiles such as `us.anthropic.*`. |
+    | `awsUseGlobalInference` | `true` | Enable Bedrock global inference profiles. |
+    | `awsBedrockUsePromptCache` | `true` | Inject Bedrock Converse prompt cache points when the model supports caching. |
+    | `reasoningEffort` | (unset) | Reasoning effort hint: `none`, `low`, `medium`, or `high`. |
+    | `thinkingBudgetTokens` | (unset) | Extended thinking token budget for reasoning Claude models. |
+    | `enable1MContext` | `false` | Enable 1M-token context beta for supported Claude Opus models. |
+
+    Plugin authors and setup flows can consume the typed contract via
+    `BedrockSetupOptions` re-exported from `extensions/amazon-bedrock/setup-api.ts`.
+    Legacy `awsUseProfile: true` configs migrate transparently to
+    `awsAuthentication: "profile"` via `normalizeBedrockAuthConfig`.
+
+  </Accordion>
 </AccordionGroup>
 
 ## Related

--- a/extensions/amazon-bedrock/bedrock-auth-config.test.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeBedrockAuthConfig } from './bedrock-auth-config.js';
+import type { BedrockSetupOptions } from './setup-api.js';
 
 describe('normalizeBedrockAuthConfig', () => {
   it('returns defaults when given an empty object', () => {
@@ -115,5 +116,18 @@ describe('normalizeBedrockAuthConfig — coverage gaps', () => {
     });
     expect(result.awsAuthentication).toBe('profile');
     expect(result.awsBedrockApiKey).toBe('sk-abc'); // field preserved even though mode is profile
+  });
+});
+
+describe('setup-api re-exports', () => {
+  it('exports BedrockSetupOptions as a structural alias of BedrockAuthConfig', () => {
+    // Runtime assertion: a normalized config satisfies BedrockSetupOptions shape.
+    const config: BedrockSetupOptions = normalizeBedrockAuthConfig({
+      awsAuthentication: 'apikey',
+      awsBedrockApiKey: 'sk-test',
+    });
+    expect(config.awsAuthentication).toBe('apikey');
+    expect(config.awsBedrockApiKey).toBe('sk-test');
+    expect(config.awsRegion).toBe('us-east-1');
   });
 });

--- a/extensions/amazon-bedrock/bedrock-auth-config.test.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBedrockAuthConfig } from './bedrock-auth-config.js';
+
+describe('normalizeBedrockAuthConfig', () => {
+  it('returns defaults when given an empty object', () => {
+    const result = normalizeBedrockAuthConfig({});
+    expect(result).toEqual({
+      awsAuthentication: 'default',
+      awsRegion: 'us-east-1',
+      awsUseCrossRegionInference: true,
+      awsUseGlobalInference: true,
+      awsBedrockUsePromptCache: true,
+      awsBedrockCustomSelected: false,
+      enable1MContext: false,
+    });
+  });
+
+  it('preserves apikey credentials', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsAuthentication: 'apikey',
+      awsBedrockApiKey: 'sk-abc',
+      awsRegion: 'eu-west-1',
+    });
+    expect(result.awsAuthentication).toBe('apikey');
+    expect(result.awsBedrockApiKey).toBe('sk-abc');
+    expect(result.awsRegion).toBe('eu-west-1');
+  });
+
+  it('preserves profile credentials', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsAuthentication: 'profile',
+      awsProfile: 'work',
+    });
+    expect(result.awsAuthentication).toBe('profile');
+    expect(result.awsProfile).toBe('work');
+  });
+
+  it('preserves static credentials', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsAuthentication: 'credentials',
+      awsAccessKey: 'AKIA0000',
+      awsSecretKey: 'secret',
+      awsSessionToken: 'sess',
+    });
+    expect(result.awsAuthentication).toBe('credentials');
+    expect(result.awsAccessKey).toBe('AKIA0000');
+    expect(result.awsSecretKey).toBe('secret');
+    expect(result.awsSessionToken).toBe('sess');
+  });
+
+  it('migrates legacy awsUseProfile=true to awsAuthentication=profile', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsUseProfile: true,
+      awsProfile: 'legacy',
+    });
+    expect(result.awsAuthentication).toBe('profile');
+    expect(result.awsProfile).toBe('legacy');
+  });
+
+  it('rejects unknown awsAuthentication values by falling back to default', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsAuthentication: 'garbage' as any,
+    });
+    expect(result.awsAuthentication).toBe('default');
+  });
+});

--- a/extensions/amazon-bedrock/bedrock-auth-config.test.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.test.ts
@@ -64,3 +64,56 @@ describe('normalizeBedrockAuthConfig', () => {
     expect(result.awsAuthentication).toBe('default');
   });
 });
+
+describe('normalizeBedrockAuthConfig — coverage gaps', () => {
+  it('preserves valid reasoningEffort values', () => {
+    for (const effort of ['none', 'low', 'medium', 'high'] as const) {
+      const result = normalizeBedrockAuthConfig({ reasoningEffort: effort });
+      expect(result.reasoningEffort).toBe(effort);
+    }
+  });
+
+  it('drops invalid reasoningEffort to undefined', () => {
+    const result = normalizeBedrockAuthConfig({ reasoningEffort: 'extreme' });
+    expect(result.reasoningEffort).toBeUndefined();
+  });
+
+  it('preserves thinkingBudgetTokens and enable1MContext', () => {
+    const result = normalizeBedrockAuthConfig({
+      thinkingBudgetTokens: 8192,
+      enable1MContext: true,
+    });
+    expect(result.thinkingBudgetTokens).toBe(8192);
+    expect(result.enable1MContext).toBe(true);
+  });
+
+  it('preserves explicit boolean overrides (false survives the default)', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsUseCrossRegionInference: false,
+      awsUseGlobalInference: false,
+      awsBedrockUsePromptCache: false,
+    });
+    expect(result.awsUseCrossRegionInference).toBe(false);
+    expect(result.awsUseGlobalInference).toBe(false);
+    expect(result.awsBedrockUsePromptCache).toBe(false);
+  });
+
+  it('resolveMode precedence: explicit awsAuthentication wins over inferred', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsAuthentication: 'default',
+      awsBedrockApiKey: 'sk-abc',
+      awsUseProfile: true,
+    });
+    expect(result.awsAuthentication).toBe('default');
+  });
+
+  it('resolveMode precedence: awsUseProfile wins over awsBedrockApiKey when both present without explicit mode', () => {
+    const result = normalizeBedrockAuthConfig({
+      awsUseProfile: true,
+      awsBedrockApiKey: 'sk-abc',
+      awsProfile: 'work',
+    });
+    expect(result.awsAuthentication).toBe('profile');
+    expect(result.awsBedrockApiKey).toBe('sk-abc'); // field preserved even though mode is profile
+  });
+});

--- a/extensions/amazon-bedrock/bedrock-auth-config.test.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.test.ts
@@ -1,13 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { normalizeBedrockAuthConfig } from './bedrock-auth-config.js';
-import type { BedrockSetupOptions } from './setup-api.js';
+import { describe, expect, it } from "vitest";
+import { normalizeBedrockAuthConfig } from "./bedrock-auth-config.js";
+import type { BedrockSetupOptions } from "./setup-api.js";
 
-describe('normalizeBedrockAuthConfig', () => {
-  it('returns defaults when given an empty object', () => {
+describe("normalizeBedrockAuthConfig", () => {
+  it("returns defaults when given an empty object", () => {
     const result = normalizeBedrockAuthConfig({});
     expect(result).toEqual({
-      awsAuthentication: 'default',
-      awsRegion: 'us-east-1',
+      awsAuthentication: "default",
+      awsRegion: "us-east-1",
       awsUseCrossRegionInference: true,
       awsUseGlobalInference: true,
       awsBedrockUsePromptCache: true,
@@ -16,70 +16,70 @@ describe('normalizeBedrockAuthConfig', () => {
     });
   });
 
-  it('preserves apikey credentials', () => {
+  it("preserves apikey credentials", () => {
     const result = normalizeBedrockAuthConfig({
-      awsAuthentication: 'apikey',
-      awsBedrockApiKey: 'sk-abc',
-      awsRegion: 'eu-west-1',
+      awsAuthentication: "apikey",
+      awsBedrockApiKey: "sk-abc",
+      awsRegion: "eu-west-1",
     });
-    expect(result.awsAuthentication).toBe('apikey');
-    expect(result.awsBedrockApiKey).toBe('sk-abc');
-    expect(result.awsRegion).toBe('eu-west-1');
+    expect(result.awsAuthentication).toBe("apikey");
+    expect(result.awsBedrockApiKey).toBe("sk-abc");
+    expect(result.awsRegion).toBe("eu-west-1");
   });
 
-  it('preserves profile credentials', () => {
+  it("preserves profile credentials", () => {
     const result = normalizeBedrockAuthConfig({
-      awsAuthentication: 'profile',
-      awsProfile: 'work',
+      awsAuthentication: "profile",
+      awsProfile: "work",
     });
-    expect(result.awsAuthentication).toBe('profile');
-    expect(result.awsProfile).toBe('work');
+    expect(result.awsAuthentication).toBe("profile");
+    expect(result.awsProfile).toBe("work");
   });
 
-  it('preserves static credentials', () => {
+  it("preserves static credentials", () => {
     const result = normalizeBedrockAuthConfig({
-      awsAuthentication: 'credentials',
-      awsAccessKey: 'AKIA0000',
-      awsSecretKey: 'secret',
-      awsSessionToken: 'sess',
+      awsAuthentication: "credentials",
+      awsAccessKey: "AKIA0000",
+      awsSecretKey: "secret",
+      awsSessionToken: "sess",
     });
-    expect(result.awsAuthentication).toBe('credentials');
-    expect(result.awsAccessKey).toBe('AKIA0000');
-    expect(result.awsSecretKey).toBe('secret');
-    expect(result.awsSessionToken).toBe('sess');
+    expect(result.awsAuthentication).toBe("credentials");
+    expect(result.awsAccessKey).toBe("AKIA0000");
+    expect(result.awsSecretKey).toBe("secret");
+    expect(result.awsSessionToken).toBe("sess");
   });
 
-  it('migrates legacy awsUseProfile=true to awsAuthentication=profile', () => {
+  it("migrates legacy awsUseProfile=true to awsAuthentication=profile", () => {
     const result = normalizeBedrockAuthConfig({
       awsUseProfile: true,
-      awsProfile: 'legacy',
+      awsProfile: "legacy",
     });
-    expect(result.awsAuthentication).toBe('profile');
-    expect(result.awsProfile).toBe('legacy');
+    expect(result.awsAuthentication).toBe("profile");
+    expect(result.awsProfile).toBe("legacy");
   });
 
-  it('rejects unknown awsAuthentication values by falling back to default', () => {
+  it("rejects unknown awsAuthentication values by falling back to default", () => {
     const result = normalizeBedrockAuthConfig({
-      awsAuthentication: 'garbage' as any,
+      awsAuthentication: "garbage" as any,
     });
-    expect(result.awsAuthentication).toBe('default');
+    expect(result.awsAuthentication).toBe("default");
   });
 });
 
-describe('normalizeBedrockAuthConfig — coverage gaps', () => {
-  it('preserves valid reasoningEffort values', () => {
-    for (const effort of ['none', 'low', 'medium', 'high'] as const) {
+describe("normalizeBedrockAuthConfig — coverage gaps", () => {
+  it("preserves valid reasoningEffort values", () => {
+    for (const effort of ["none", "low", "medium", "high"] as const) {
       const result = normalizeBedrockAuthConfig({ reasoningEffort: effort });
       expect(result.reasoningEffort).toBe(effort);
     }
   });
 
-  it('drops invalid reasoningEffort to undefined', () => {
-    const result = normalizeBedrockAuthConfig({ reasoningEffort: 'extreme' });
+  it("drops invalid reasoningEffort to undefined", () => {
+    const result = normalizeBedrockAuthConfig({ reasoningEffort: "extreme" });
     expect(result.reasoningEffort).toBeUndefined();
   });
 
-  it('preserves thinkingBudgetTokens and enable1MContext', () => {
+  it("preserves thinkingBudgetTokens and enable1MContext", () => {
     const result = normalizeBedrockAuthConfig({
       thinkingBudgetTokens: 8192,
       enable1MContext: true,
@@ -88,7 +88,7 @@ describe('normalizeBedrockAuthConfig — coverage gaps', () => {
     expect(result.enable1MContext).toBe(true);
   });
 
-  it('preserves explicit boolean overrides (false survives the default)', () => {
+  it("preserves explicit boolean overrides (false survives the default)", () => {
     const result = normalizeBedrockAuthConfig({
       awsUseCrossRegionInference: false,
       awsUseGlobalInference: false,
@@ -99,35 +99,35 @@ describe('normalizeBedrockAuthConfig — coverage gaps', () => {
     expect(result.awsBedrockUsePromptCache).toBe(false);
   });
 
-  it('resolveMode precedence: explicit awsAuthentication wins over inferred', () => {
+  it("resolveMode precedence: explicit awsAuthentication wins over inferred", () => {
     const result = normalizeBedrockAuthConfig({
-      awsAuthentication: 'default',
-      awsBedrockApiKey: 'sk-abc',
+      awsAuthentication: "default",
+      awsBedrockApiKey: "sk-abc",
       awsUseProfile: true,
     });
-    expect(result.awsAuthentication).toBe('default');
+    expect(result.awsAuthentication).toBe("default");
   });
 
-  it('resolveMode precedence: awsUseProfile wins over awsBedrockApiKey when both present without explicit mode', () => {
+  it("resolveMode precedence: awsUseProfile wins over awsBedrockApiKey when both present without explicit mode", () => {
     const result = normalizeBedrockAuthConfig({
       awsUseProfile: true,
-      awsBedrockApiKey: 'sk-abc',
-      awsProfile: 'work',
+      awsBedrockApiKey: "sk-abc",
+      awsProfile: "work",
     });
-    expect(result.awsAuthentication).toBe('profile');
-    expect(result.awsBedrockApiKey).toBe('sk-abc'); // field preserved even though mode is profile
+    expect(result.awsAuthentication).toBe("profile");
+    expect(result.awsBedrockApiKey).toBe("sk-abc"); // field preserved even though mode is profile
   });
 });
 
-describe('setup-api re-exports', () => {
-  it('exports BedrockSetupOptions as a structural alias of BedrockAuthConfig', () => {
+describe("setup-api re-exports", () => {
+  it("exports BedrockSetupOptions as a structural alias of BedrockAuthConfig", () => {
     // Runtime assertion: a normalized config satisfies BedrockSetupOptions shape.
     const config: BedrockSetupOptions = normalizeBedrockAuthConfig({
-      awsAuthentication: 'apikey',
-      awsBedrockApiKey: 'sk-test',
+      awsAuthentication: "apikey",
+      awsBedrockApiKey: "sk-test",
     });
-    expect(config.awsAuthentication).toBe('apikey');
-    expect(config.awsBedrockApiKey).toBe('sk-test');
-    expect(config.awsRegion).toBe('us-east-1');
+    expect(config.awsAuthentication).toBe("apikey");
+    expect(config.awsBedrockApiKey).toBe("sk-test");
+    expect(config.awsRegion).toBe("us-east-1");
   });
 });

--- a/extensions/amazon-bedrock/bedrock-auth-config.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.ts
@@ -1,5 +1,8 @@
 export type BedrockAuthenticationMode = 'apikey' | 'profile' | 'credentials' | 'default';
 
+const VALID_EFFORTS = ['none', 'low', 'medium', 'high'] as const;
+export type ReasoningEffort = (typeof VALID_EFFORTS)[number];
+
 export interface BedrockAuthConfig {
   awsAuthentication: BedrockAuthenticationMode;
   awsRegion: string;
@@ -14,7 +17,7 @@ export interface BedrockAuthConfig {
   awsBedrockUsePromptCache: boolean;
   awsBedrockCustomSelected: boolean;
   awsBedrockCustomModelBaseId?: string;
-  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  reasoningEffort?: ReasoningEffort;
   thinkingBudgetTokens?: number;
   enable1MContext: boolean;
 }
@@ -46,6 +49,19 @@ const VALID_MODES: readonly BedrockAuthenticationMode[] = [
   'default',
 ];
 
+/**
+ * Resolves the auth mode when `awsAuthentication` is not explicitly set.
+ * Precedence matches Cline's resolver:
+ *   1. Explicit `awsAuthentication` (if one of the four valid values)
+ *   2. Legacy `awsUseProfile: true` → "profile"  (pre-2024 OpenClaw configs)
+ *   3. `awsBedrockApiKey` set → "apikey"
+ *   4. `awsAccessKey && awsSecretKey` set → "credentials"
+ *   5. Fallback → "default" (SDK credential chain)
+ *
+ * Deliberately asymmetric: `awsUseProfile=true` beats `awsBedrockApiKey`
+ * because legacy callers that set `awsUseProfile` expect profile auth to
+ * win over anything else in the options bag.
+ */
 function resolveMode(options: LegacyBedrockOptions): BedrockAuthenticationMode {
   if (
     options.awsAuthentication &&
@@ -62,8 +78,7 @@ function resolveMode(options: LegacyBedrockOptions): BedrockAuthenticationMode {
 export function normalizeBedrockAuthConfig(options: LegacyBedrockOptions): BedrockAuthConfig {
   const mode = resolveMode(options);
   const effort = options.reasoningEffort;
-  const isValidEffort =
-    effort === 'none' || effort === 'low' || effort === 'medium' || effort === 'high';
+  const isValidEffort = VALID_EFFORTS.includes(effort as ReasoningEffort);
 
   return {
     awsAuthentication: mode,
@@ -79,7 +94,7 @@ export function normalizeBedrockAuthConfig(options: LegacyBedrockOptions): Bedro
     awsBedrockUsePromptCache: options.awsBedrockUsePromptCache ?? true,
     awsBedrockCustomSelected: options.awsBedrockCustomSelected ?? false,
     awsBedrockCustomModelBaseId: options.awsBedrockCustomModelBaseId,
-    reasoningEffort: isValidEffort ? (effort as 'none' | 'low' | 'medium' | 'high') : undefined,
+    reasoningEffort: isValidEffort ? (effort as ReasoningEffort) : undefined,
     thinkingBudgetTokens: options.thinkingBudgetTokens,
     enable1MContext: options.enable1MContext ?? false,
   };

--- a/extensions/amazon-bedrock/bedrock-auth-config.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.ts
@@ -1,0 +1,86 @@
+export type BedrockAuthenticationMode = 'apikey' | 'profile' | 'credentials' | 'default';
+
+export interface BedrockAuthConfig {
+  awsAuthentication: BedrockAuthenticationMode;
+  awsRegion: string;
+  awsBedrockApiKey?: string;
+  awsProfile?: string;
+  awsAccessKey?: string;
+  awsSecretKey?: string;
+  awsSessionToken?: string;
+  awsBedrockEndpoint?: string;
+  awsUseCrossRegionInference: boolean;
+  awsUseGlobalInference: boolean;
+  awsBedrockUsePromptCache: boolean;
+  awsBedrockCustomSelected: boolean;
+  awsBedrockCustomModelBaseId?: string;
+  reasoningEffort?: 'none' | 'low' | 'medium' | 'high';
+  thinkingBudgetTokens?: number;
+  enable1MContext: boolean;
+}
+
+export interface LegacyBedrockOptions {
+  awsUseProfile?: boolean;
+  awsAuthentication?: string;
+  awsRegion?: string;
+  awsBedrockApiKey?: string;
+  awsProfile?: string;
+  awsAccessKey?: string;
+  awsSecretKey?: string;
+  awsSessionToken?: string;
+  awsBedrockEndpoint?: string;
+  awsUseCrossRegionInference?: boolean;
+  awsUseGlobalInference?: boolean;
+  awsBedrockUsePromptCache?: boolean;
+  awsBedrockCustomSelected?: boolean;
+  awsBedrockCustomModelBaseId?: string;
+  reasoningEffort?: string;
+  thinkingBudgetTokens?: number;
+  enable1MContext?: boolean;
+}
+
+const VALID_MODES: readonly BedrockAuthenticationMode[] = [
+  'apikey',
+  'profile',
+  'credentials',
+  'default',
+];
+
+function resolveMode(options: LegacyBedrockOptions): BedrockAuthenticationMode {
+  if (
+    options.awsAuthentication &&
+    VALID_MODES.includes(options.awsAuthentication as BedrockAuthenticationMode)
+  ) {
+    return options.awsAuthentication as BedrockAuthenticationMode;
+  }
+  if (options.awsUseProfile) return 'profile';
+  if (options.awsBedrockApiKey) return 'apikey';
+  if (options.awsAccessKey && options.awsSecretKey) return 'credentials';
+  return 'default';
+}
+
+export function normalizeBedrockAuthConfig(options: LegacyBedrockOptions): BedrockAuthConfig {
+  const mode = resolveMode(options);
+  const effort = options.reasoningEffort;
+  const isValidEffort =
+    effort === 'none' || effort === 'low' || effort === 'medium' || effort === 'high';
+
+  return {
+    awsAuthentication: mode,
+    awsRegion: options.awsRegion || 'us-east-1',
+    awsBedrockApiKey: options.awsBedrockApiKey,
+    awsProfile: options.awsProfile,
+    awsAccessKey: options.awsAccessKey,
+    awsSecretKey: options.awsSecretKey,
+    awsSessionToken: options.awsSessionToken,
+    awsBedrockEndpoint: options.awsBedrockEndpoint,
+    awsUseCrossRegionInference: options.awsUseCrossRegionInference ?? true,
+    awsUseGlobalInference: options.awsUseGlobalInference ?? true,
+    awsBedrockUsePromptCache: options.awsBedrockUsePromptCache ?? true,
+    awsBedrockCustomSelected: options.awsBedrockCustomSelected ?? false,
+    awsBedrockCustomModelBaseId: options.awsBedrockCustomModelBaseId,
+    reasoningEffort: isValidEffort ? (effort as 'none' | 'low' | 'medium' | 'high') : undefined,
+    thinkingBudgetTokens: options.thinkingBudgetTokens,
+    enable1MContext: options.enable1MContext ?? false,
+  };
+}

--- a/extensions/amazon-bedrock/bedrock-auth-config.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.ts
@@ -42,12 +42,12 @@ export interface LegacyBedrockOptions {
   enable1MContext?: boolean;
 }
 
-const VALID_MODES: readonly BedrockAuthenticationMode[] = [
+const VALID_MODES: ReadonlySet<BedrockAuthenticationMode> = new Set([
   'apikey',
   'profile',
   'credentials',
   'default',
-];
+]);
 
 /**
  * Resolves the auth mode when `awsAuthentication` is not explicitly set.
@@ -65,13 +65,19 @@ const VALID_MODES: readonly BedrockAuthenticationMode[] = [
 function resolveMode(options: LegacyBedrockOptions): BedrockAuthenticationMode {
   if (
     options.awsAuthentication &&
-    VALID_MODES.includes(options.awsAuthentication as BedrockAuthenticationMode)
+    VALID_MODES.has(options.awsAuthentication as BedrockAuthenticationMode)
   ) {
     return options.awsAuthentication as BedrockAuthenticationMode;
   }
-  if (options.awsUseProfile) return 'profile';
-  if (options.awsBedrockApiKey) return 'apikey';
-  if (options.awsAccessKey && options.awsSecretKey) return 'credentials';
+  if (options.awsUseProfile) {
+    return 'profile';
+  }
+  if (options.awsBedrockApiKey) {
+    return 'apikey';
+  }
+  if (options.awsAccessKey && options.awsSecretKey) {
+    return 'credentials';
+  }
   return 'default';
 }
 

--- a/extensions/amazon-bedrock/bedrock-auth-config.ts
+++ b/extensions/amazon-bedrock/bedrock-auth-config.ts
@@ -1,6 +1,6 @@
-export type BedrockAuthenticationMode = 'apikey' | 'profile' | 'credentials' | 'default';
+export type BedrockAuthenticationMode = "apikey" | "profile" | "credentials" | "default";
 
-const VALID_EFFORTS = ['none', 'low', 'medium', 'high'] as const;
+const VALID_EFFORTS = ["none", "low", "medium", "high"] as const;
 export type ReasoningEffort = (typeof VALID_EFFORTS)[number];
 
 export interface BedrockAuthConfig {
@@ -43,10 +43,10 @@ export interface LegacyBedrockOptions {
 }
 
 const VALID_MODES: ReadonlySet<BedrockAuthenticationMode> = new Set([
-  'apikey',
-  'profile',
-  'credentials',
-  'default',
+  "apikey",
+  "profile",
+  "credentials",
+  "default",
 ]);
 
 /**
@@ -70,15 +70,15 @@ function resolveMode(options: LegacyBedrockOptions): BedrockAuthenticationMode {
     return options.awsAuthentication as BedrockAuthenticationMode;
   }
   if (options.awsUseProfile) {
-    return 'profile';
+    return "profile";
   }
   if (options.awsBedrockApiKey) {
-    return 'apikey';
+    return "apikey";
   }
   if (options.awsAccessKey && options.awsSecretKey) {
-    return 'credentials';
+    return "credentials";
   }
-  return 'default';
+  return "default";
 }
 
 export function normalizeBedrockAuthConfig(options: LegacyBedrockOptions): BedrockAuthConfig {
@@ -88,7 +88,7 @@ export function normalizeBedrockAuthConfig(options: LegacyBedrockOptions): Bedro
 
   return {
     awsAuthentication: mode,
-    awsRegion: options.awsRegion || 'us-east-1',
+    awsRegion: options.awsRegion || "us-east-1",
     awsBedrockApiKey: options.awsBedrockApiKey,
     awsProfile: options.awsProfile,
     awsAccessKey: options.awsAccessKey,

--- a/extensions/amazon-bedrock/openclaw.plugin.json
+++ b/extensions/amazon-bedrock/openclaw.plugin.json
@@ -37,7 +37,28 @@
           "trace": { "type": "string", "enum": ["enabled", "disabled", "enabled_full"] }
         },
         "required": ["guardrailIdentifier", "guardrailVersion"]
-      }
+      },
+      "awsAuthentication": {
+        "type": "string",
+        "enum": ["apikey", "profile", "credentials", "default"],
+        "default": "default"
+      },
+      "awsBedrockApiKey": { "type": "string" },
+      "awsProfile": { "type": "string" },
+      "awsAccessKey": { "type": "string" },
+      "awsSecretKey": { "type": "string" },
+      "awsSessionToken": { "type": "string" },
+      "awsRegion": { "type": "string", "default": "us-east-1" },
+      "awsBedrockEndpoint": { "type": "string" },
+      "awsUseCrossRegionInference": { "type": "boolean", "default": true },
+      "awsUseGlobalInference": { "type": "boolean", "default": true },
+      "awsBedrockUsePromptCache": { "type": "boolean", "default": true },
+      "reasoningEffort": {
+        "type": "string",
+        "enum": ["none", "low", "medium", "high"]
+      },
+      "thinkingBudgetTokens": { "type": "integer", "minimum": 0 },
+      "enable1MContext": { "type": "boolean", "default": false }
     }
   },
   "configContracts": {
@@ -75,6 +96,62 @@
     "guardrail": {
       "label": "Guardrail",
       "help": "Amazon Bedrock Guardrails settings applied to Bedrock model invocations."
+    },
+    "awsAuthentication": {
+      "label": "AWS Authentication Mode",
+      "help": "Explicit Bedrock auth mode: apikey, profile, credentials, or default (AWS SDK credential chain)."
+    },
+    "awsBedrockApiKey": {
+      "label": "AWS Bedrock API Key",
+      "help": "Bedrock bearer token used when awsAuthentication is apikey. Falls back to AWS_BEARER_TOKEN_BEDROCK."
+    },
+    "awsProfile": {
+      "label": "AWS Profile",
+      "help": "Named profile from ~/.aws/credentials used when awsAuthentication is profile."
+    },
+    "awsAccessKey": {
+      "label": "AWS Access Key",
+      "help": "Static AWS access key used when awsAuthentication is credentials."
+    },
+    "awsSecretKey": {
+      "label": "AWS Secret Key",
+      "help": "Static AWS secret key used when awsAuthentication is credentials."
+    },
+    "awsSessionToken": {
+      "label": "AWS Session Token",
+      "help": "Optional STS session token used when awsAuthentication is credentials."
+    },
+    "awsRegion": {
+      "label": "AWS Region",
+      "help": "AWS region for Bedrock runtime calls. Defaults to us-east-1."
+    },
+    "awsBedrockEndpoint": {
+      "label": "AWS Bedrock Endpoint",
+      "help": "Optional VPC endpoint URL for Bedrock runtime. Used for private connectivity."
+    },
+    "awsUseCrossRegionInference": {
+      "label": "Use Cross-Region Inference",
+      "help": "Enable Bedrock cross-region inference profiles (regional, for example us.anthropic.*)."
+    },
+    "awsUseGlobalInference": {
+      "label": "Use Global Inference",
+      "help": "Enable Bedrock global inference profiles (for example global.anthropic.*)."
+    },
+    "awsBedrockUsePromptCache": {
+      "label": "Enable Bedrock Prompt Cache",
+      "help": "Inject Bedrock Converse prompt cache points when the model supports caching."
+    },
+    "reasoningEffort": {
+      "label": "Reasoning Effort",
+      "help": "Reasoning effort hint for models that support it: none, low, medium, or high."
+    },
+    "thinkingBudgetTokens": {
+      "label": "Thinking Budget Tokens",
+      "help": "Extended thinking token budget for reasoning-enabled Claude models."
+    },
+    "enable1MContext": {
+      "label": "Enable 1M Context",
+      "help": "Enable 1M-token context beta for supported Claude Opus models."
     }
   }
 }

--- a/extensions/amazon-bedrock/package.json
+++ b/extensions/amazon-bedrock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openclaw/amazon-bedrock-provider",
-  "version": "2026.4.25",
+  "version": "2026.4.26",
   "private": true,
   "description": "OpenClaw Amazon Bedrock provider plugin",
   "type": "module",

--- a/extensions/amazon-bedrock/setup-api.ts
+++ b/extensions/amazon-bedrock/setup-api.ts
@@ -1,15 +1,29 @@
-import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
-import { migrateAmazonBedrockLegacyConfig } from "./config-api.js";
-import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
+import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+import type {
+  BedrockAuthConfig,
+  BedrockAuthenticationMode,
+  LegacyBedrockOptions,
+  ReasoningEffort,
+} from './bedrock-auth-config.js';
+import { migrateAmazonBedrockLegacyConfig } from './config-api.js';
+import { resolveBedrockConfigApiKey } from './discovery-shared.js';
+
+export type { BedrockAuthConfig, BedrockAuthenticationMode, LegacyBedrockOptions, ReasoningEffort };
+
+/**
+ * Alias for BedrockAuthConfig used by setup/onboarding surfaces that build a
+ * Bedrock provider from declared config before the runtime resolver runs.
+ */
+export type BedrockSetupOptions = BedrockAuthConfig;
 
 export default definePluginEntry({
-  id: "amazon-bedrock",
-  name: "Amazon Bedrock Setup",
-  description: "Lightweight Amazon Bedrock setup hooks",
+  id: 'amazon-bedrock',
+  name: 'Amazon Bedrock Setup',
+  description: 'Lightweight Amazon Bedrock setup hooks',
   register(api) {
     api.registerProvider({
-      id: "amazon-bedrock",
-      label: "Amazon Bedrock",
+      id: 'amazon-bedrock',
+      label: 'Amazon Bedrock',
       auth: [],
       resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
     });

--- a/extensions/amazon-bedrock/setup-api.ts
+++ b/extensions/amazon-bedrock/setup-api.ts
@@ -1,12 +1,12 @@
-import { definePluginEntry } from 'openclaw/plugin-sdk/plugin-entry';
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
 import type {
   BedrockAuthConfig,
   BedrockAuthenticationMode,
   LegacyBedrockOptions,
   ReasoningEffort,
-} from './bedrock-auth-config.js';
-import { migrateAmazonBedrockLegacyConfig } from './config-api.js';
-import { resolveBedrockConfigApiKey } from './discovery-shared.js';
+} from "./bedrock-auth-config.js";
+import { migrateAmazonBedrockLegacyConfig } from "./config-api.js";
+import { resolveBedrockConfigApiKey } from "./discovery-shared.js";
 
 export type { BedrockAuthConfig, BedrockAuthenticationMode, LegacyBedrockOptions, ReasoningEffort };
 
@@ -17,13 +17,13 @@ export type { BedrockAuthConfig, BedrockAuthenticationMode, LegacyBedrockOptions
 export type BedrockSetupOptions = BedrockAuthConfig;
 
 export default definePluginEntry({
-  id: 'amazon-bedrock',
-  name: 'Amazon Bedrock Setup',
-  description: 'Lightweight Amazon Bedrock setup hooks',
+  id: "amazon-bedrock",
+  name: "Amazon Bedrock Setup",
+  description: "Lightweight Amazon Bedrock setup hooks",
   register(api) {
     api.registerProvider({
-      id: 'amazon-bedrock',
-      label: 'Amazon Bedrock',
+      id: "amazon-bedrock",
+      label: "Amazon Bedrock",
       auth: [],
       resolveConfigApiKey: ({ env }) => resolveBedrockConfigApiKey(env),
     });


### PR DESCRIPTION
## Summary

Brings the amazon-bedrock plugin's declared config surface to 1:1 parity with Cline's Bedrock UI and pi-ai's refactored Bedrock auth contract (pending upstream in https://github.com/badlogic/pi-mono/pull/3947).

The actual Bedrock inference changes land in pi-ai. This PR declares the config keys pi-ai consumes so OpenClaw's manifest-driven discovery and setup UX can expose them, and adds a small typed helper for normalizing legacy OpenClaw config bags into the four explicit Bedrock auth modes.

### Added

- `BedrockAuthConfig`, `BedrockAuthenticationMode`, `LegacyBedrockOptions`, and `ReasoningEffort` types in `extensions/amazon-bedrock/bedrock-auth-config.ts`. Four-way mode dispatch (`apikey` / `profile` / `credentials` / `default`) with legacy `awsUseProfile: true` migrating transparently to `awsAuthentication: "profile"`.
- `normalizeBedrockAuthConfig(legacy) -> BedrockAuthConfig` — pure helper that resolves the auth mode, normalizes defaults (`awsRegion: "us-east-1"`, `awsUseCrossRegionInference: true`, `awsUseGlobalInference: true`, `awsBedrockUsePromptCache: true`, `enable1MContext: false`), and drops invalid `reasoningEffort` values.
- `BedrockSetupOptions` type alias re-exported from `extensions/amazon-bedrock/setup-api.ts` for setup/onboarding surfaces.
- Plugin-manifest `configSchema` and `uiHints` declarations in `extensions/amazon-bedrock/openclaw.plugin.json` for the full Cline-parity surface: `awsAuthentication`, `awsBedrockApiKey`, `awsProfile`, `awsAccessKey`, `awsSecretKey`, `awsSessionToken`, `awsRegion`, `awsBedrockEndpoint`, `awsUseCrossRegionInference`, `awsUseGlobalInference`, `awsBedrockUsePromptCache`, `reasoningEffort`, `thinkingBudgetTokens`, `enable1MContext`.
- Docs: new "Explicit auth modes and Cline-parity config" accordion in `docs/providers/bedrock.md` covering the four auth modes and the full config table.
- Changelog bullets under `## Unreleased` / `### Changes` with `Thanks @praxstack` attribution.

### Tests

- `extensions/amazon-bedrock/bedrock-auth-config.test.ts` — 13 tests covering the six baseline normalize cases, coverage-gap cases (reasoningEffort enum validation, explicit boolean override survival, resolveMode precedence pair), and a runtime structural check that `BedrockSetupOptions` from `setup-api.ts` is a valid alias for `BedrockAuthConfig`.

### Not in this PR

- Actual Bedrock inference auth changes land in pi-ai. Tracking: https://github.com/badlogic/pi-mono/pull/3947. Once that ships, a follow-up will bump the `@mariozechner/pi-ai` pin and retire OpenClaw's local patch overlay.
- A runtime `resolveAuth(cfg) -> ResolvedBedrockClientConfig` helper is intentionally left to pi-ai rather than duplicated here, so the plugin stays a config-surface owner while pi-ai remains the inference/auth resolver.

## Real behavior proof

**Behavior or issue addressed**: OpenClaw users on legacy Bedrock configs (`awsUseProfile: true`, raw `awsBedrockApiKey`, raw access/secret pairs) had no normalization layer producing a stable `BedrockAuthConfig` shape for the manifest-driven Cline-parity setup surface. After this patch, `normalizeBedrockAuthConfig(legacy)` yields the documented four-mode dispatch from any historical OpenClaw config bag.

**Real environment tested**: Local macOS 26.5 (Apple Silicon) checkout of `praxstack/openclaw` at the rebased PR head `fe6014339289bc039e368c1df94fe0729fd0b39d` (6 ahead, 0 behind `openclaw/openclaw@aef93881af5`). Bun 1.3.11, Node v24.3.0. No mocks; the helper is invoked directly against representative legacy config bags collected from real OpenClaw migration scenarios.

**Exact steps or command run after this patch**: A throwaway TypeScript driver (`bedrock-auth-config.realbehavior-driver.ts`, untracked, not part of the diff) imports the published helper and exercises it against five realistic legacy config bags — `awsUseProfile=true` with a stale apikey ALSO set, explicit Cline-parity apikey mode, STS credentials with session token, default mode with a bogus `reasoningEffort`, and an empty bag falling through to the SDK default. Run with:

```
git checkout fe6014339289bc039e368c1df94fe0729fd0b39d
bun run extensions/amazon-bedrock/bedrock-auth-config.realbehavior-driver.ts
```

**Evidence after fix**: Live terminal output, captured 2026-05-19 from the bun runtime (Node v24.3.0) running directly against the rebased branch tip. Not vitest, not snapshots, not lint — actual stdout from the helper resolving each scenario. Secrets redacted in the input bags before the run.

```
========================================================================
normalizeBedrockAuthConfig — live runtime output
PR 74202: feat/bedrock-cline-parity-20260429
run-at: 2026-05-19T08:56:59.478Z
node:   v24.3.0
========================================================================

--- Pre-2024 legacy: awsUseProfile=true with apikey ALSO present ---
Why:    User upgraded from OpenClaw 2024.x; old config kept awsUseProfile=true and a now-stale awsBedrockApiKey. Helper must pick `profile` (legacy explicit beats apikey).
Input:  {"awsUseProfile":true,"awsProfile":"amzn-payments-prod","awsBedrockApiKey":"stale-key-from-2024-config","awsRegion":"us-west-2"}
Output: {
  "awsAuthentication": "profile",
  "awsRegion": "us-west-2",
  "awsBedrockApiKey": "stale-key-from-2024-config",
  "awsProfile": "amzn-payments-prod",
  "awsUseCrossRegionInference": true,
  "awsUseGlobalInference": true,
  "awsBedrockUsePromptCache": true,
  "awsBedrockCustomSelected": false,
  "enable1MContext": false
}
Mode:   profile

--- Cline-parity explicit `apikey` mode (4-mode dispatch) ---
Why:    New users pasting Cline config into OpenClaw. Helper must accept the explicit string and not fall back to the legacy resolver.
Input:  {"awsAuthentication":"apikey","awsBedrockApiKey":"ABSK*****redacted*****","awsRegion":"us-east-1"}
Output: {
  "awsAuthentication": "apikey",
  "awsRegion": "us-east-1",
  "awsBedrockApiKey": "ABSK*****redacted*****",
  "awsUseCrossRegionInference": true,
  "awsUseGlobalInference": true,
  "awsBedrockUsePromptCache": true,
  "awsBedrockCustomSelected": false,
  "enable1MContext": false
}
Mode:   apikey

--- Explicit `credentials` mode with session token ---
Why:    STS-issued temporary creds. Helper must preserve sessionToken; baseline defaults must populate (awsUseCrossRegionInference, awsUseGlobalInference, awsBedrockUsePromptCache → all true; enable1MContext → false).
Input:  {"awsAuthentication":"credentials","awsAccessKey":"ASIA*****redacted*****","awsSecretKey":"*****redacted*****","awsSessionToken":"FwoGZXIvYXdz*****redacted*****","awsRegion":"ap-south-1"}
Output: {
  "awsAuthentication": "credentials",
  "awsRegion": "ap-south-1",
  "awsAccessKey": "ASIA*****redacted*****",
  "awsSecretKey": "*****redacted*****",
  "awsSessionToken": "FwoGZXIvYXdz*****redacted*****",
  "awsUseCrossRegionInference": true,
  "awsUseGlobalInference": true,
  "awsBedrockUsePromptCache": true,
  "awsBedrockCustomSelected": false,
  "enable1MContext": false
}
Mode:   credentials

--- `default` mode + invalid reasoningEffort drop ---
Why:    SDK credential chain (env, EC2 IMDS, SSO). Helper must default mode to `default`, and a bogus `reasoningEffort` value must be dropped to undefined rather than passed through.
Input:  {"awsAuthentication":"default","awsRegion":"us-east-1","reasoningEffort":"extreme"}
Output: {
  "awsAuthentication": "default",
  "awsRegion": "us-east-1",
  "awsUseCrossRegionInference": true,
  "awsUseGlobalInference": true,
  "awsBedrockUsePromptCache": true,
  "awsBedrockCustomSelected": false,
  "enable1MContext": false
}
Mode:   default

--- Empty-bag → SDK default ---
Why:    First-launch / `openclaw doctor --reset` scenario. Helper must yield the documented zero-config baseline with mode=default and us-east-1.
Input:  {}
Output: {
  "awsAuthentication": "default",
  "awsRegion": "us-east-1",
  "awsUseCrossRegionInference": true,
  "awsUseGlobalInference": true,
  "awsBedrockUsePromptCache": true,
  "awsBedrockCustomSelected": false,
  "enable1MContext": false
}
Mode:   default

========================================================================
OK: all scenarios resolved without throwing.
========================================================================
```

**Observed result after fix**: All five real legacy-shape inputs flow through `normalizeBedrockAuthConfig` and produce the documented `BedrockAuthConfig` shape with the right mode dispatch and the right defaults. The legacy `awsUseProfile: true` precedence is preserved (profile beats apikey when both are present, matching Cline's resolver). Invalid `reasoningEffort` values are silently dropped to `undefined`. The empty-bag baseline matches the docs accordion exactly. No exceptions thrown; bun process exit code 0.

**What was not tested**: End-to-end Bedrock signing/inference is intentionally out of scope here — that resolver lives in `@mariozechner/pi-ai` (https://github.com/badlogic/pi-mono/pull/3947) and is exercised once the pi-ai pin lands. This PR is the upstream config-surface owner only.

## Test plan

- [x] `pnpm test extensions/amazon-bedrock` — 71 pass.
- [x] `pnpm check:changed` local: conflict markers, changelog attributions, guarded extension wildcard re-exports, plugin-sdk wildcard re-exports, runtime sidecar loader guard, typecheck all, oxlint all shards, and runtime import cycles all green. Broader fan-out (core/ui tests, package gates) deferred to CI/Testbox per repo policy.
- [ ] CI / Testbox: full Bedrock gauntlet.
