### PR TITLE
plugin-sdk: restore Feishu pairing facade

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-244286f93cd42484f81061b672437d7a769a61864c72eb3795f9e7abc739f60b  plugin-sdk-api-baseline.json
-5b7e45d83a0a7862f26f59a32647cdb04289609419e61473284568dd3adf9736  plugin-sdk-api-baseline.jsonl
+2f864af491af47bbfd27133885815a31964ef02e4accc0394773235ce4eea763  plugin-sdk-api-baseline.json
+201b9cbacd3c8354929d59b39d432f0e2a87cbaae0dc6f1c245cca8f755c8586  plugin-sdk-api-baseline.jsonl

--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-9a5b14ebb8d1443ebf4620a811e7de0099a71f7891de8a6a5330fd12b3417d70  plugin-sdk-api-baseline.json
-d28f0cba321bf267bfb10e4ee4d4639655dc92899b9f889b8b552397a7f01a1d  plugin-sdk-api-baseline.jsonl
+cff387f3c1527f3a3210995372b1acb20267ca860e9bd525fafe5d5445881fd6  plugin-sdk-api-baseline.json
+8e055579823fd9e0fc13a7c556532be90cd17635a2c9f23a9f8df743347fe99e  plugin-sdk-api-baseline.jsonl

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -386,6 +386,7 @@ releases.
   | `plugin-sdk/account-helpers` | Narrow account helpers | Account list/account-action helpers |
   | `plugin-sdk/channel-setup` | Setup wizard adapters | `createOptionalChannelSetupSurface`, `createOptionalChannelSetupAdapter`, `createOptionalChannelSetupWizard`, plus `DEFAULT_ACCOUNT_ID`, `createTopLevelChannelDmPolicy`, `setSetupChannelEnabled`, `splitSetupEntries` |
   | `plugin-sdk/channel-pairing` | DM pairing primitives | `createChannelPairingController` |
+  | `plugin-sdk/feishu` | Deprecated Feishu compatibility facade | Legacy `createScopedPairingAccess` export for older npm-installed Feishu packages; new channel code should use `plugin-sdk/channel-pairing` |
   | `plugin-sdk/channel-reply-pipeline` | Reply prefix, typing, and source-delivery wiring | `createChannelReplyPipeline`, `resolveChannelSourceReplyDeliveryMode` |
   | `plugin-sdk/channel-config-helpers` | Config adapter factories | `createHybridChannelConfigAdapter` |
   | `plugin-sdk/channel-config-schema` | Config schema builders | Shared channel config schema primitives and the generic builder only |
@@ -547,10 +548,11 @@ surface. The full list of 200+ entrypoints lives in
 Reserved bundled-plugin helper seams have been retired from the public SDK
 export map except for explicitly documented compatibility facades such as the
 deprecated `plugin-sdk/discord` shim retained for the published
-`@openclaw/discord@2026.3.13` package. Owner-specific helpers live inside the
-owning plugin package; shared host behavior should move through generic SDK
-contracts such as `plugin-sdk/gateway-runtime`, `plugin-sdk/security-runtime`,
-and `plugin-sdk/plugin-config-runtime`.
+`@openclaw/discord@2026.3.13` package and the deprecated `plugin-sdk/feishu`
+shim retained for older npm-installed Feishu packages. Owner-specific helpers
+live inside the owning plugin package; shared host behavior should move through
+generic SDK contracts such as `plugin-sdk/gateway-runtime`,
+`plugin-sdk/security-runtime`, and `plugin-sdk/plugin-config-runtime`.
 
 Use the narrowest import that matches the job. If you cannot find an export,
 check the source at `src/plugin-sdk/` or ask maintainers which generic contract

--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -508,6 +508,7 @@ releases.
   | `plugin-sdk/account-helpers` | Narrow account helpers | Account list/account-action helpers |
   | `plugin-sdk/channel-setup` | Setup wizard adapters | `createOptionalChannelSetupSurface`, `createOptionalChannelSetupAdapter`, `createOptionalChannelSetupWizard`, plus `DEFAULT_ACCOUNT_ID`, `createTopLevelChannelDmPolicy`, `setSetupChannelEnabled`, `splitSetupEntries` |
   | `plugin-sdk/channel-pairing` | DM pairing primitives | `createChannelPairingController` |
+  | `plugin-sdk/feishu` | Deprecated Feishu compatibility facade | Legacy `createScopedPairingAccess` export for older npm-installed Feishu packages; new channel code should use `plugin-sdk/channel-pairing` |
   | `plugin-sdk/channel-reply-pipeline` | Reply prefix, typing, and source-delivery wiring | `createChannelReplyPipeline`, `resolveChannelSourceReplyDeliveryMode` |
   | `plugin-sdk/channel-config-helpers` | Config adapter factories and DM access helpers | `createHybridChannelConfigAdapter`, `resolveChannelDmAccess`, `resolveChannelDmAllowFrom`, `resolveChannelDmPolicy`, `normalizeChannelDmPolicy`, `normalizeLegacyDmAliases` |
   | `plugin-sdk/channel-config-schema` | Config schema builders | Shared channel config schema primitives and the generic builder only |
@@ -669,10 +670,11 @@ the public subset.
 Reserved bundled-plugin helper seams have been retired from the public SDK
 export map except for explicitly documented compatibility facades such as the
 deprecated `plugin-sdk/discord` shim retained for the published
-`@openclaw/discord@2026.3.13` package. Owner-specific helpers live inside the
-owning plugin package; shared host behavior should move through generic SDK
-contracts such as `plugin-sdk/gateway-runtime`, `plugin-sdk/security-runtime`,
-and `plugin-sdk/plugin-config-runtime`.
+`@openclaw/discord@2026.3.13` package and the deprecated `plugin-sdk/feishu`
+shim retained for older npm-installed Feishu packages. Owner-specific helpers
+live inside the owning plugin package; shared host behavior should move through
+generic SDK contracts such as `plugin-sdk/gateway-runtime`,
+`plugin-sdk/security-runtime`, and `plugin-sdk/plugin-config-runtime`.
 
 Use the narrowest import that matches the job. If you cannot find an export,
 check the source at `src/plugin-sdk/` or ask maintainers which generic contract

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -85,6 +85,7 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/group-access` | Shared group-access decision helpers |
     | `plugin-sdk/direct-dm` | Shared direct-DM auth/guard helpers |
     | `plugin-sdk/discord` | Deprecated Discord compatibility facade for published `@openclaw/discord@2026.3.13` and tracked owner compatibility; new plugins should use generic channel SDK subpaths |
+    | `plugin-sdk/feishu` | Deprecated Feishu compatibility facade for legacy npm-installed Feishu packages that still import `createScopedPairingAccess`; new channel code should use `plugin-sdk/channel-pairing` |
     | `plugin-sdk/telegram-account` | Deprecated Telegram account-resolution compatibility facade for tracked owner compatibility; new plugins should use injected runtime helpers or generic channel SDK subpaths |
     | `plugin-sdk/interactive-runtime` | Semantic message presentation, delivery, and legacy interactive reply helpers. See [Message Presentation](/plugins/message-presentation) |
     | `plugin-sdk/channel-inbound` | Compatibility barrel for inbound debounce, mention matching, mention-policy helpers, and envelope helpers |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -134,6 +134,7 @@ focused channel/runtime subpaths, `config-contracts`, `string-coerce-runtime`,
     | `plugin-sdk/group-access` | Shared group-access decision helpers |
     | `plugin-sdk/direct-dm` | Shared direct-DM auth/guard helpers |
     | `plugin-sdk/discord` | Deprecated Discord compatibility facade for published `@openclaw/discord@2026.3.13` and tracked owner compatibility; new plugins should use generic channel SDK subpaths |
+    | `plugin-sdk/feishu` | Deprecated Feishu compatibility facade for legacy npm-installed Feishu packages that still import `createScopedPairingAccess`; new channel code should use `plugin-sdk/channel-pairing` |
     | `plugin-sdk/telegram-account` | Deprecated Telegram account-resolution compatibility facade for tracked owner compatibility; new plugins should use injected runtime helpers or generic channel SDK subpaths |
     | `plugin-sdk/zalouser` | Deprecated Zalo Personal compatibility facade for published Lark/Zalo packages that still import sender command authorization; new plugins should use `plugin-sdk/command-auth` |
     | `plugin-sdk/interactive-runtime` | Semantic message presentation, delivery, and legacy interactive reply helpers. See [Message Presentation](/plugins/message-presentation) |

--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -56,7 +56,7 @@ but new plugin code should use focused, actively consumed SDK subpaths instead:
 `agent-config-primitives`, `channel-config-schema-legacy`,
 `channel-reply-pipeline`, `channel-runtime`, `channel-secret-runtime`,
 `command-auth`, `compat`, `config-runtime`, `config-schema`, `discord`,
-`group-access`, `infra-runtime`, `matrix`, `mattermost`,
+`feishu`, `group-access`, `infra-runtime`, `matrix`, `mattermost`,
 `media-generation-runtime-shared`, `memory-core-engine-runtime`,
 `memory-core-host-multimodal`, `memory-core-host-query`,
 `music-generation-core`, `self-hosted-provider-setup`, `telegram-account`,

--- a/package.json
+++ b/package.json
@@ -793,6 +793,10 @@
       "types": "./dist/plugin-sdk/context-visibility-runtime.d.ts",
       "default": "./dist/plugin-sdk/context-visibility-runtime.js"
     },
+    "./plugin-sdk/feishu": {
+      "types": "./dist/plugin-sdk/feishu.d.ts",
+      "default": "./dist/plugin-sdk/feishu.js"
+    },
     "./plugin-sdk/file-lock": {
       "types": "./dist/plugin-sdk/file-lock.d.ts",
       "default": "./dist/plugin-sdk/file-lock.js"

--- a/package.json
+++ b/package.json
@@ -876,6 +876,10 @@
       "types": "./dist/plugin-sdk/context-visibility-runtime.d.ts",
       "default": "./dist/plugin-sdk/context-visibility-runtime.js"
     },
+    "./plugin-sdk/feishu": {
+      "types": "./dist/plugin-sdk/feishu.d.ts",
+      "default": "./dist/plugin-sdk/feishu.js"
+    },
     "./plugin-sdk/file-lock": {
       "types": "./dist/plugin-sdk/file-lock.d.ts",
       "default": "./dist/plugin-sdk/file-lock.js"

--- a/scripts/lib/plugin-sdk-deprecated-public-subpaths.json
+++ b/scripts/lib/plugin-sdk-deprecated-public-subpaths.json
@@ -14,6 +14,7 @@
   "config-schema",
   "config-types",
   "discord",
+  "feishu",
   "group-access",
   "infra-runtime",
   "matrix",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -181,6 +181,7 @@
   "channel-route",
   "channel-targets",
   "context-visibility-runtime",
+  "feishu",
   "file-lock",
   "fetch-runtime",
   "runtime-fetch",

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -194,6 +194,7 @@
   "channel-route",
   "channel-targets",
   "context-visibility-runtime",
+  "feishu",
   "file-lock",
   "fetch-runtime",
   "runtime-fetch",

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -12,6 +12,7 @@ export const reservedBundledPluginSdkEntrypoints = [] as const;
 // until they move to generic, plugin-neutral contracts.
 export const supportedBundledFacadeSdkEntrypoints = [
   "discord",
+  "feishu",
   "lmstudio",
   "lmstudio-runtime",
   "memory-core-engine-runtime",

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -44,6 +44,7 @@ export const reservedBundledPluginSdkEntrypoints = [
 // until they move to generic, plugin-neutral contracts.
 export const supportedBundledFacadeSdkEntrypoints = [
   "discord",
+  "feishu",
   "lmstudio",
   "lmstudio-runtime",
   "matrix",

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -3,7 +3,7 @@
 
 import type { ChannelId } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/config.js";
-import type { DmPolicy, GroupToolPolicyConfig } from "../config/types.js";
+import type { DmPolicy } from "../config/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -1,0 +1,121 @@
+// Compatibility facade for legacy npm-installed Feishu plugin packages.
+// Keep this surface scoped to the historical Feishu package imports.
+
+import type { ChannelId } from "../channels/plugins/types.public.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { DmPolicy, GroupToolPolicyConfig } from "../config/types.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+
+export type { HistoryEntry } from "../auto-reply/reply/history.js";
+export {
+  buildPendingHistoryContextFromMap,
+  clearHistoryEntriesIfEnabled,
+  DEFAULT_GROUP_HISTORY_LIMIT,
+  recordPendingHistoryEntryIfEnabled,
+} from "../auto-reply/reply/history.js";
+export type { ReplyPayload } from "./reply-payload.js";
+export { logTypingFailure } from "../channels/logging.js";
+export type { AllowlistMatch } from "../channels/allowlist-match.js";
+export {
+  buildSingleChannelSecretPromptState,
+  addWildcardAllowFrom,
+  mergeAllowFromEntries,
+  promptSingleChannelSecretInput,
+  setTopLevelChannelAllowFrom,
+  setTopLevelChannelDmPolicyWithAllowFrom,
+  setTopLevelChannelGroupPolicy,
+  splitSetupEntries as splitOnboardingEntries,
+} from "../channels/plugins/setup-wizard-helpers.js";
+export { PAIRING_APPROVED_MESSAGE } from "../channels/plugins/pairing-message.js";
+export type {
+  BaseProbeResult,
+  ChannelGroupContext,
+  ChannelMeta,
+} from "../channels/plugins/types.public.js";
+export type { ChannelOutboundAdapter } from "../channels/plugins/types.adapters.js";
+export type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+export { createReplyPrefixContext } from "../channels/reply-prefix.js";
+export { createTypingCallbacks } from "../channels/typing.js";
+export type { OpenClawConfig as ClawdbotConfig, OpenClawConfig } from "../config/config.js";
+export {
+  resolveDefaultGroupPolicy,
+  resolveOpenProviderRuntimeGroupPolicy,
+  warnMissingProviderGroupPolicyFallbackOnce,
+} from "../config/runtime-group-policy.js";
+export type { DmPolicy, GroupToolPolicyConfig } from "../config/types.js";
+export type { SecretInput } from "../config/types.secrets.js";
+export {
+  hasConfiguredSecretInput,
+  normalizeResolvedSecretInputString,
+  normalizeSecretInputString,
+} from "../config/types.secrets.js";
+export { buildSecretInputSchema } from "./secret-input-schema.js";
+export { createDedupeCache } from "../infra/dedupe.js";
+export { installRequestBodyLimitGuard, readJsonBodyWithLimit } from "../infra/http-body.js";
+export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
+export type { PluginRuntime } from "../plugins/runtime/types.js";
+export type { AnyAgentTool, OpenClawPluginApi } from "../plugins/types.js";
+export { DEFAULT_ACCOUNT_ID, normalizeAgentId } from "../routing/session-key.js";
+export type { RuntimeEnv } from "../runtime.js";
+export { formatDocsLink } from "../terminal/links.js";
+export { evaluateSenderGroupAccessForPolicy } from "./group-access.js";
+export type { WizardPrompter } from "../wizard/prompts.js";
+export { buildAgentMediaPayload } from "./agent-media-payload.js";
+export { readJsonFileWithFallback } from "./json-store.js";
+export { createScopedPairingAccess } from "./pairing-access.js";
+export { issuePairingChallenge } from "../pairing/pairing-challenge.js";
+export { createPersistentDedupe } from "./persistent-dedupe.js";
+export {
+  buildProbeChannelStatusSummary,
+  buildRuntimeAccountStatusSnapshot,
+  createDefaultChannelRuntimeState,
+} from "./status-helpers.js";
+export { withTempDownloadPath } from "./temp-path.js";
+export {
+  createFixedWindowRateLimiter,
+  createWebhookAnomalyTracker,
+  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
+  WEBHOOK_RATE_LIMIT_DEFAULTS,
+} from "./webhook-memory-guards.js";
+export { applyBasicWebhookRequestGuards } from "./webhook-request-guards.js";
+
+export type ChannelOnboardingDmPolicy = {
+  label: string;
+  channel: ChannelId;
+  policyKey: string;
+  allowFromKey: string;
+  getCurrent: (cfg: OpenClawConfig) => DmPolicy;
+  setPolicy: (cfg: OpenClawConfig, policy: DmPolicy) => OpenClawConfig;
+  promptAllowFrom?: (params: {
+    cfg: OpenClawConfig;
+    prompter: WizardPrompter;
+    accountId?: string;
+  }) => Promise<OpenClawConfig>;
+};
+
+export type ChannelOnboardingAdapter = {
+  channel: ChannelId;
+  getStatus: (ctx: {
+    cfg: OpenClawConfig;
+    options?: unknown;
+    accountOverrides: Partial<Record<ChannelId, string>>;
+  }) => Promise<{
+    channel: ChannelId;
+    configured: boolean;
+    statusLines: string[];
+    selectionHint?: string;
+    quickstartScore?: number;
+  }>;
+  configure: (ctx: {
+    cfg: OpenClawConfig;
+    runtime: RuntimeEnv;
+    prompter: WizardPrompter;
+    options?: unknown;
+    accountOverrides: Partial<Record<ChannelId, string>>;
+    shouldPromptAccountIds: boolean;
+    forceAllowFrom: boolean;
+  }) => Promise<{ cfg: OpenClawConfig; accountId?: string }>;
+  dmPolicy?: ChannelOnboardingDmPolicy;
+};

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1345,6 +1345,7 @@ describe("plugin-sdk subpath exports", () => {
       "PAIRING_APPROVED_MESSAGE",
       "WEBHOOK_ANOMALY_COUNTER_DEFAULTS",
       "WEBHOOK_RATE_LIMIT_DEFAULTS",
+      "addWildcardAllowFrom",
       "applyBasicWebhookRequestGuards",
       "buildAgentMediaPayload",
       "buildPendingHistoryContextFromMap",

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1334,6 +1334,65 @@ describe("plugin-sdk subpath exports", () => {
     }
   });
 
+  it("keeps Feishu pairing compatibility facade importable", async () => {
+    const feishuSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/feishu");
+    const channelPairingSdk = await importResolvedPluginSdkSubpath(
+      "openclaw/plugin-sdk/channel-pairing",
+    );
+    const legacyFeishuRuntimeExports = [
+      "DEFAULT_ACCOUNT_ID",
+      "DEFAULT_GROUP_HISTORY_LIMIT",
+      "PAIRING_APPROVED_MESSAGE",
+      "WEBHOOK_ANOMALY_COUNTER_DEFAULTS",
+      "WEBHOOK_RATE_LIMIT_DEFAULTS",
+      "applyBasicWebhookRequestGuards",
+      "buildAgentMediaPayload",
+      "buildPendingHistoryContextFromMap",
+      "buildProbeChannelStatusSummary",
+      "buildRuntimeAccountStatusSnapshot",
+      "buildSecretInputSchema",
+      "buildSingleChannelSecretPromptState",
+      "clearHistoryEntriesIfEnabled",
+      "createDedupeCache",
+      "createDefaultChannelRuntimeState",
+      "createFixedWindowRateLimiter",
+      "createPersistentDedupe",
+      "createReplyPrefixContext",
+      "createScopedPairingAccess",
+      "createTypingCallbacks",
+      "createWebhookAnomalyTracker",
+      "emptyPluginConfigSchema",
+      "evaluateSenderGroupAccessForPolicy",
+      "fetchWithSsrFGuard",
+      "formatDocsLink",
+      "hasConfiguredSecretInput",
+      "installRequestBodyLimitGuard",
+      "issuePairingChallenge",
+      "logTypingFailure",
+      "mergeAllowFromEntries",
+      "normalizeAgentId",
+      "normalizeResolvedSecretInputString",
+      "normalizeSecretInputString",
+      "promptSingleChannelSecretInput",
+      "readJsonBodyWithLimit",
+      "readJsonFileWithFallback",
+      "recordPendingHistoryEntryIfEnabled",
+      "resolveDefaultGroupPolicy",
+      "resolveOpenProviderRuntimeGroupPolicy",
+      "setTopLevelChannelAllowFrom",
+      "setTopLevelChannelDmPolicyWithAllowFrom",
+      "setTopLevelChannelGroupPolicy",
+      "splitOnboardingEntries",
+      "warnMissingProviderGroupPolicyFallbackOnce",
+      "withTempDownloadPath",
+    ] as const;
+
+    for (const exportName of legacyFeishuRuntimeExports) {
+      expect(feishuSdk, `legacy Feishu export ${exportName}`).toHaveProperty(exportName);
+    }
+    expect(typeof channelPairingSdk.createChannelPairingController).toBe("function");
+  });
+
   it("exports single-provider plugin entry helpers from the dedicated subpath", () => {
     expect(typeof providerEntrySdk.defineSingleProviderPluginEntry).toBe("function");
   });

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1384,6 +1384,65 @@ describe("plugin-sdk subpath exports", () => {
     );
   });
 
+  it("keeps Feishu pairing compatibility facade importable", async () => {
+    const feishuSdk = await importResolvedPluginSdkSubpath("openclaw/plugin-sdk/feishu");
+    const channelPairingSdk = await importResolvedPluginSdkSubpath(
+      "openclaw/plugin-sdk/channel-pairing",
+    );
+    const legacyFeishuRuntimeExports = [
+      "DEFAULT_ACCOUNT_ID",
+      "DEFAULT_GROUP_HISTORY_LIMIT",
+      "PAIRING_APPROVED_MESSAGE",
+      "WEBHOOK_ANOMALY_COUNTER_DEFAULTS",
+      "WEBHOOK_RATE_LIMIT_DEFAULTS",
+      "applyBasicWebhookRequestGuards",
+      "buildAgentMediaPayload",
+      "buildPendingHistoryContextFromMap",
+      "buildProbeChannelStatusSummary",
+      "buildRuntimeAccountStatusSnapshot",
+      "buildSecretInputSchema",
+      "buildSingleChannelSecretPromptState",
+      "clearHistoryEntriesIfEnabled",
+      "createDedupeCache",
+      "createDefaultChannelRuntimeState",
+      "createFixedWindowRateLimiter",
+      "createPersistentDedupe",
+      "createReplyPrefixContext",
+      "createScopedPairingAccess",
+      "createTypingCallbacks",
+      "createWebhookAnomalyTracker",
+      "emptyPluginConfigSchema",
+      "evaluateSenderGroupAccessForPolicy",
+      "fetchWithSsrFGuard",
+      "formatDocsLink",
+      "hasConfiguredSecretInput",
+      "installRequestBodyLimitGuard",
+      "issuePairingChallenge",
+      "logTypingFailure",
+      "mergeAllowFromEntries",
+      "normalizeAgentId",
+      "normalizeResolvedSecretInputString",
+      "normalizeSecretInputString",
+      "promptSingleChannelSecretInput",
+      "readJsonBodyWithLimit",
+      "readJsonFileWithFallback",
+      "recordPendingHistoryEntryIfEnabled",
+      "resolveDefaultGroupPolicy",
+      "resolveOpenProviderRuntimeGroupPolicy",
+      "setTopLevelChannelAllowFrom",
+      "setTopLevelChannelDmPolicyWithAllowFrom",
+      "setTopLevelChannelGroupPolicy",
+      "splitOnboardingEntries",
+      "warnMissingProviderGroupPolicyFallbackOnce",
+      "withTempDownloadPath",
+    ] as const;
+
+    for (const exportName of legacyFeishuRuntimeExports) {
+      expect(feishuSdk, `legacy Feishu export ${exportName}`).toHaveProperty(exportName);
+    }
+    expect(typeof channelPairingSdk.createChannelPairingController).toBe("function");
+  });
+
   it("exports single-provider plugin entry helpers from the dedicated subpath", () => {
     expect(providerEntrySdk.defineSingleProviderPluginEntry).toBe(
       providerEntryDirectSdk.defineSingleProviderPluginEntry,

--- a/src/plugins/contracts/plugin-sdk-subpaths.test.ts
+++ b/src/plugins/contracts/plugin-sdk-subpaths.test.ts
@@ -1395,6 +1395,7 @@ describe("plugin-sdk subpath exports", () => {
       "PAIRING_APPROVED_MESSAGE",
       "WEBHOOK_ANOMALY_COUNTER_DEFAULTS",
       "WEBHOOK_RATE_LIMIT_DEFAULTS",
+      "addWildcardAllowFrom",
       "applyBasicWebhookRequestGuards",
       "buildAgentMediaPayload",
       "buildPendingHistoryContextFromMap",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: npm-installed legacy Feishu plugins could import `openclaw/plugin-sdk/feishu`, but the host no longer exported that subpath.
  - Why it matters: affected Feishu/Lark installs failed during module linking before pairing or startup could run.
  - What changed: restored a scoped Feishu compatibility SDK facade, added it to SDK export wiring, updated API baseline/docs, and added a regression contract test for the legacy export surface.
  - What did NOT change (scope boundary): no Feishu runtime behavior, config format, pairing storage, auth flow, or network behavior changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74138
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: Feishu’s historical package used a Feishu-specific SDK subpath, but later SDK export cleanup removed `openclaw/plugin-sdk/feishu` without leaving a compatibility facade.
  - Missing detection / guardrail: SDK contract tests did not cover the published Feishu package’s legacy named imports from that subpath.
  - Contributing context (if known): newer bundled Feishu code had moved to focused SDK subpaths, so local/current tests missed older npm-installed package compatibility.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
  - Target test or file: `src/plugins/contracts/plugin-sdk-subpaths.test.ts`
  - Scenario the test should lock in: `openclaw/plugin-sdk/feishu` remains importable and exposes the legacy runtime names used by published Feishu packages.
  - Why this is the smallest reliable guardrail: it validates the public SDK subpath contract directly without needing to boot a full Feishu channel runtime.
  - Existing test that already covers this (if any): none before this PR.
  - If no new test is added, why not: N/A

## User-visible / Behavior Changes

  Users with older npm-installed Feishu/Lark plugin packages can start the plugin again after upgrading the host.

## Diagram (if applicable)

`N/A`.

## Security Impact (required)

  - New permissions/capabilities? (`Yes/No`) No
  - Secrets/tokens handling changed? (`Yes/No`) No
  - New/changed network calls? (`Yes/No`) No
  - Command/tool execution surface changed? (`Yes/No`) No
  - Data access scope changed? (`Yes/No`) No
  - If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

  - OS: macOS
  - Runtime/container: local repo with `pnpm`
  - Model/provider: N/A
  - Integration/channel (if any): Feishu/Lark
  - Relevant config (redacted): N/A

### Steps

  1. Install or run a legacy Feishu package that imports from `openclaw/plugin-sdk/feishu`.
  2. Start the host with that plugin available.
  3. Import/link the Feishu runtime.

### Expected

  - The Feishu SDK subpath resolves and exposes the legacy named exports required by the published plugin package.

### Actual

  - Before this PR, `openclaw/plugin-sdk/feishu` was missing or too narrow, causing ESM import/ link failures.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios:
    - `pnpm test -- src/plugins/contracts/plugin-sdk-subpaths.test.ts -t "Feishu pairing compatibility"`
    - `pnpm test -- src/plugins/contracts/plugin-sdk-subpaths.test.ts`
    - `pnpm plugin-sdk:api:check`
    - `pnpm build`
    - `pnpm check:changed`
    - `pnpm dlx codex review --base origin/main`
  - Edge cases checked: the compatibility facade includes the broader legacy Feishu named export set, not only `createScopedPairingAccess`.
  - What you did **not** verify: live Feishu/Lark API traffic with real credentials.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (`Yes/No`) Yes
  - Config/env changes? (`Yes/No`) No
  - Migration needed? (`Yes/No`) No
  - If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: the restored Feishu facade could accidentally become a new general-purpose SDK surface.
    - Mitigation: the file is documented as a legacy compatibility facade, scoped to historical Feishu package imports, and covered by a focused contract test.

### Built with Codex