### PR TITLE
fix: log and inject synthetic error results for unknown tool calls

### DIFF
--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -385,8 +385,8 @@ describe("installSessionToolResultGuard", () => {
     appendAssistantToolCall(sm, { id: "call_2", name: "read", withArguments: false });
 
     // call_1: valid → persisted as assistant message, pending toolResult
-    // call_2: malformed (missing input) → dropped, synthetic error result injected,
-    // then pending flush triggers synthetic result for call_1
+    // call_2: entirely dropped (all tool calls invalid) → synthetic error result
+    //   injected for call_2, then pending flush triggers synthetic result for call_1
     const messages = getPersistedMessages(sm);
     const roles = messages.map((m) => m.role);
     expect(roles).toContain("assistant");
@@ -403,12 +403,12 @@ describe("installSessionToolResultGuard", () => {
     appendAssistantToolCall(sm, { id: "call_1", name: "read" });
     appendAssistantToolCall(sm, { id: "call_2", name: "write" });
 
-    // call_1 persisted as assistant, call_2 dropped with an error toolResult injected.
-    // When synthetic results are disabled, pending flush only clears state (no synthetic for call_1).
+    // call_1 persisted as assistant with pending toolResult.
+    // call_2 entirely dropped (all tool calls invalid) → synthetic error result
+    //   injected for call_2. Pending flush only clears state (no synthetic for call_1).
     const messages = getPersistedMessages(sm);
     const roles = messages.map((m) => m.role);
     expect(roles).toContain("assistant");
-    // The error result for the unknown "write" tool is still injected
     const errorResults = messages.filter(
       (m) =>
         m.role === "toolResult" &&
@@ -632,7 +632,7 @@ describe("installSessionToolResultGuard", () => {
     expect(toolResult.content?.[0]?.text).toContain("malformed");
   });
 
-  it("injects error result for unknown tool and keeps valid tool calls in mixed message", () => {
+  it("drops unknown tool call but keeps valid tool call in mixed message without injecting synthetic error", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {
       allowedToolNames: ["read"],
@@ -649,25 +649,14 @@ describe("installSessionToolResultGuard", () => {
     );
 
     const messages = getPersistedMessages(sm);
-    // Should have: synthetic error result for unknown_tool + remaining assistant with "read"
-    const roles = messages.map((m) => m.role);
-    expect(roles).toContain("toolResult");
-    expect(roles).toContain("assistant");
+    // Only the sanitized assistant message with valid tool call should be persisted.
+    // No synthetic error result is injected for partially-dropped messages to avoid
+    // protocol ordering violations (toolResult before its originating assistant turn).
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("assistant");
 
-    // Verify the synthetic error result is for the unknown tool
-    const errorResult = messages.find((m) => m.role === "toolResult") as {
-      toolCallId?: string;
-      toolName?: string;
-      isError?: boolean;
-      content?: Array<{ type: string; text: string }>;
-    };
-    expect(errorResult.toolCallId).toBe("call_bad");
-    expect(errorResult.toolName).toBe("unknown_tool");
-    expect(errorResult.isError).toBe(true);
-    expect(errorResult.content?.[0]?.text).toContain("not available");
-
-    // Verify the valid tool call is preserved in the assistant message
-    const assistantMsg = messages.find((m) => m.role === "assistant") as {
+    // Verify the valid tool call is preserved and the invalid one is removed
+    const assistantMsg = messages[0] as {
       content: Array<{ id?: string; name?: string }>;
     };
     expect(assistantMsg.content).toHaveLength(1);

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -290,7 +290,7 @@ describe("installSessionToolResultGuard", () => {
     expectPersistedRoles(sm, ["assistant", "toolResult"]);
   });
 
-  it("drops malformed tool calls missing input before persistence", () => {
+  it("drops malformed tool calls missing input and injects synthetic error result", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);
 
@@ -302,10 +302,20 @@ describe("installSessionToolResultGuard", () => {
     );
 
     const messages = getPersistedMessages(sm);
-    expect(messages).toHaveLength(0);
+    // A synthetic error toolResult is persisted for the malformed call.
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("toolResult");
+    const toolResult = messages[0] as {
+      toolCallId?: string;
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    expect(toolResult.toolCallId).toBe("call_1");
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content?.[0]?.text).toContain("malformed");
   });
 
-  it("drops malformed tool calls with invalid name tokens before persistence", () => {
+  it("drops malformed tool calls with invalid name tokens and injects synthetic error result", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm);
 
@@ -323,10 +333,21 @@ describe("installSessionToolResultGuard", () => {
       }),
     );
 
-    expect(getPersistedMessages(sm)).toHaveLength(0);
+    const messages = getPersistedMessages(sm);
+    // A synthetic error toolResult is persisted for the malformed call.
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("toolResult");
+    const toolResult = messages[0] as {
+      toolCallId?: string;
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    expect(toolResult.toolCallId).toBe("call_bad_name");
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content?.[0]?.text).toContain("malformed");
   });
 
-  it("drops tool calls not present in allowedToolNames", () => {
+  it("drops tool calls not present in allowedToolNames and injects synthetic error result", () => {
     const sm = SessionManager.inMemory();
     installSessionToolResultGuard(sm, {
       allowedToolNames: ["read"],
@@ -339,7 +360,21 @@ describe("installSessionToolResultGuard", () => {
       }),
     );
 
-    expect(getPersistedMessages(sm)).toHaveLength(0);
+    // The assistant message itself is dropped, but a synthetic error toolResult is persisted
+    // to give the model feedback that the tool is unavailable.
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("toolResult");
+    const toolResult = messages[0] as {
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    expect(toolResult.toolCallId).toBe("call_1");
+    expect(toolResult.toolName).toBe("write");
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content?.[0]?.text).toContain("not available");
   });
 
   it("flushes pending tool results when a sanitized assistant message is dropped", () => {
@@ -349,7 +384,13 @@ describe("installSessionToolResultGuard", () => {
     appendAssistantToolCall(sm, { id: "call_1", name: "read" });
     appendAssistantToolCall(sm, { id: "call_2", name: "read", withArguments: false });
 
-    expectPersistedRoles(sm, ["assistant", "toolResult"]);
+    // call_1: valid → persisted as assistant message, pending toolResult
+    // call_2: malformed (missing input) → dropped, synthetic error result injected,
+    // then pending flush triggers synthetic result for call_1
+    const messages = getPersistedMessages(sm);
+    const roles = messages.map((m) => m.role);
+    expect(roles).toContain("assistant");
+    expect(roles.filter((r) => r === "toolResult").length).toBeGreaterThanOrEqual(2);
   });
 
   it("clears pending when a sanitized assistant message is dropped and synthetic results are disabled", () => {
@@ -362,7 +403,18 @@ describe("installSessionToolResultGuard", () => {
     appendAssistantToolCall(sm, { id: "call_1", name: "read" });
     appendAssistantToolCall(sm, { id: "call_2", name: "write" });
 
-    expectPersistedRoles(sm, ["assistant"]);
+    // call_1 persisted as assistant, call_2 dropped with an error toolResult injected.
+    // When synthetic results are disabled, pending flush only clears state (no synthetic for call_1).
+    const messages = getPersistedMessages(sm);
+    const roles = messages.map((m) => m.role);
+    expect(roles).toContain("assistant");
+    // The error result for the unknown "write" tool is still injected
+    const errorResults = messages.filter(
+      (m) =>
+        m.role === "toolResult" &&
+        (m as { toolCallId?: string }).toolCallId === "call_2",
+    );
+    expect(errorResults).toHaveLength(1);
     expect(guard.getPendingIds()).toEqual([]);
   });
 
@@ -553,5 +605,72 @@ describe("installSessionToolResultGuard", () => {
       (m) => (m as { toolCallId?: string }).toolCallId === "call_error",
     );
     expect(syntheticForError).toHaveLength(0);
+  });
+
+  it("injects synthetic error results for malformed tool calls (missing input)", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm);
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_no_input", name: "read" }],
+      }),
+    );
+
+    // A synthetic error toolResult should be persisted for the malformed call.
+    const messages = getPersistedMessages(sm);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].role).toBe("toolResult");
+    const toolResult = messages[0] as {
+      toolCallId?: string;
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    expect(toolResult.toolCallId).toBe("call_no_input");
+    expect(toolResult.isError).toBe(true);
+    expect(toolResult.content?.[0]?.text).toContain("malformed");
+  });
+
+  it("injects error result for unknown tool and keeps valid tool calls in mixed message", () => {
+    const sm = SessionManager.inMemory();
+    installSessionToolResultGuard(sm, {
+      allowedToolNames: ["read"],
+    });
+
+    sm.appendMessage(
+      asAppendMessage({
+        role: "assistant",
+        content: [
+          { type: "toolCall", id: "call_good", name: "read", arguments: {} },
+          { type: "toolCall", id: "call_bad", name: "unknown_tool", arguments: {} },
+        ],
+      }),
+    );
+
+    const messages = getPersistedMessages(sm);
+    // Should have: synthetic error result for unknown_tool + remaining assistant with "read"
+    const roles = messages.map((m) => m.role);
+    expect(roles).toContain("toolResult");
+    expect(roles).toContain("assistant");
+
+    // Verify the synthetic error result is for the unknown tool
+    const errorResult = messages.find((m) => m.role === "toolResult") as {
+      toolCallId?: string;
+      toolName?: string;
+      isError?: boolean;
+      content?: Array<{ type: string; text: string }>;
+    };
+    expect(errorResult.toolCallId).toBe("call_bad");
+    expect(errorResult.toolName).toBe("unknown_tool");
+    expect(errorResult.isError).toBe(true);
+    expect(errorResult.content?.[0]?.text).toContain("not available");
+
+    // Verify the valid tool call is preserved in the assistant message
+    const assistantMsg = messages.find((m) => m.role === "assistant") as {
+      content: Array<{ id?: string; name?: string }>;
+    };
+    expect(assistantMsg.content).toHaveLength(1);
+    expect(assistantMsg.content[0].name).toBe("read");
   });
 });

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -411,8 +411,8 @@ export function installSessionToolResultGuard(
         allowedToolNames: opts?.allowedToolNames,
       });
 
-      // Log and provide feedback for dropped tool calls.
-      if (report.droppedToolCalls > 0) {
+      // Log dropped tool calls for observability.
+      if (report.droppedToolCalls > 0 && report.droppedToolCallDetails.length > 0) {
         const droppedNames = report.droppedToolCallDetails
           .map((d) => `${d.name} (${d.reason})`)
           .join(", ");
@@ -424,9 +424,12 @@ export function installSessionToolResultGuard(
             sessionKey: opts?.sessionKey,
           },
         );
+      }
 
-        // Inject synthetic error results so the model learns the tool is unavailable
-        // and can self-correct on the next turn instead of repeating the same call.
+      if (report.messages.length === 0) {
+        // Entire assistant message was dropped — safe to inject synthetic error
+        // results because there is no surviving assistant turn whose tool_use
+        // ordering would be violated.
         for (const detail of report.droppedToolCallDetails) {
           if (detail.id) {
             const errorResult = makeUnknownToolErrorResult(detail);
@@ -444,9 +447,6 @@ export function installSessionToolResultGuard(
             }
           }
         }
-      }
-
-      if (report.messages.length === 0) {
         if (pendingState.shouldFlushForSanitizedDrop()) {
           flushPendingToolResults();
         }

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -11,6 +11,7 @@ import type {
   PluginHookBeforeMessageWriteResult,
 } from "../plugins/types.js";
 import { emitSessionTranscriptUpdate } from "../sessions/transcript-events.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeOptionalString } from "../shared/string-coerce.js";
 import { formatContextLimitTruncationNotice } from "./pi-embedded-runner/tool-result-context-guard.js";
 import {
@@ -22,8 +23,33 @@ import {
   setRawSessionAppendMessage,
 } from "./session-raw-append-message.js";
 import { createPendingToolCallState } from "./session-tool-result-state.js";
-import { makeMissingToolResult, sanitizeToolCallInputs } from "./session-transcript-repair.js";
+import {
+  makeMissingToolResult,
+  sanitizeToolCallInputsWithReport,
+  type DroppedToolCallInfo,
+} from "./session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-id.js";
+
+const log = createSubsystemLogger("session/tool-guard");
+
+/**
+ * Build a synthetic error tool result that informs the model a tool is not available.
+ * This gives the model a chance to self-correct instead of silently dropping the call.
+ */
+function makeUnknownToolErrorResult(detail: DroppedToolCallInfo): AgentMessage {
+  const reasonText =
+    detail.reason === "not_in_allowlist"
+      ? `Tool "${detail.name}" is not available. Use only the tools listed in your system prompt.`
+      : `Tool call for "${detail.name}" was malformed (${detail.reason}). Use only the tools listed in your system prompt.`;
+  return {
+    role: "toolResult",
+    toolCallId: detail.id,
+    toolName: detail.name,
+    content: [{ type: "text", text: `[openclaw] ${reasonText}` }],
+    isError: true,
+    timestamp: Date.now(),
+  } as Extract<AgentMessage, { role: "toolResult" }>;
+}
 
 /**
  * Truncate oversized text content blocks in a tool result message.
@@ -381,16 +407,52 @@ export function installSessionToolResultGuard(
     let nextMessage = message;
     const role = (message as { role?: unknown }).role;
     if (role === "assistant") {
-      const sanitized = sanitizeToolCallInputs([message], {
+      const report = sanitizeToolCallInputsWithReport([message], {
         allowedToolNames: opts?.allowedToolNames,
       });
-      if (sanitized.length === 0) {
+
+      // Log and provide feedback for dropped tool calls.
+      if (report.droppedToolCalls > 0) {
+        const droppedNames = report.droppedToolCallDetails
+          .map((d) => `${d.name} (${d.reason})`)
+          .join(", ");
+        log.warn(
+          `[tool-call-dropped] Dropped ${report.droppedToolCalls} unknown/invalid tool call(s): ${droppedNames}`,
+          {
+            droppedToolCalls: report.droppedToolCalls,
+            details: report.droppedToolCallDetails,
+            sessionKey: opts?.sessionKey,
+          },
+        );
+
+        // Inject synthetic error results so the model learns the tool is unavailable
+        // and can self-correct on the next turn instead of repeating the same call.
+        for (const detail of report.droppedToolCallDetails) {
+          if (detail.id) {
+            const errorResult = makeUnknownToolErrorResult(detail);
+            const persisted = applyBeforeWriteHook(
+              persistToolResult(persistMessage(errorResult), {
+                toolCallId: detail.id,
+                toolName: detail.name,
+                isSynthetic: true,
+              }),
+            );
+            if (persisted) {
+              originalAppend(
+                capToolResultForPersistence(persisted, maxToolResultChars) as never,
+              );
+            }
+          }
+        }
+      }
+
+      if (report.messages.length === 0) {
         if (pendingState.shouldFlushForSanitizedDrop()) {
           flushPendingToolResults();
         }
         return undefined;
       }
-      nextMessage = sanitized[0];
+      nextMessage = report.messages[0];
     }
     const nextRole = (nextMessage as { role?: unknown }).role;
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -8,6 +8,8 @@ import { extractToolCallsFromAssistant, extractToolResultId } from "./tool-call-
 import {
   REDACTED_SESSIONS_SPAWN_ATTACHMENT_CONTENT,
   SESSIONS_SPAWN_ATTACHMENT_METADATA_KEYS,
+  TOOL_CALL_NAME_MAX_CHARS,
+  TOOL_CALL_NAME_RE,
   isAllowedToolCallName,
   isRedactedSessionsSpawnAttachment,
   normalizeAllowedToolNames,
@@ -247,10 +249,18 @@ function normalizeToolResultName(
 
 export { makeMissingToolResult };
 
+export type DroppedToolCallInfo = {
+  id: string;
+  name: string;
+  reason: "missing_input" | "missing_id" | "invalid_name" | "not_in_allowlist";
+};
+
 export type ToolCallInputRepairReport = {
   messages: AgentMessage[];
   droppedToolCalls: number;
   droppedAssistantMessages: number;
+  /** Details about each dropped tool call for diagnostics/logging. */
+  droppedToolCallDetails: DroppedToolCallInfo[];
 };
 
 export type ToolCallInputRepairOptions = {
@@ -293,6 +303,7 @@ export function repairToolCallInputs(
   let droppedAssistantMessages = 0;
   let changed = false;
   const out: AgentMessage[] = [];
+  const droppedToolCallDetails: DroppedToolCallInfo[] = [];
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
   const allowProviderOwnedThinkingReplay = options?.allowProviderOwnedThinkingReplay === true;
   const claimedReplaySafeToolCallIds = new Set<string>();
@@ -349,6 +360,27 @@ export function repairToolCallInputs(
         droppedInMessage += 1;
         changed = true;
         messageChanged = true;
+        // Collect diagnostic details about why this tool call was dropped.
+        const rawId = typeof block.id === "string" ? block.id : "";
+        const rawName =
+          typeof (block as { name?: unknown }).name === "string"
+            ? ((block as { name: string }).name).trim()
+            : "";
+        let reason: DroppedToolCallInfo["reason"];
+        if (!hasToolCallInput(block)) {
+          reason = "missing_input";
+        } else if (!hasToolCallId(block)) {
+          reason = "missing_id";
+        } else if (
+          !rawName ||
+          rawName.length > TOOL_CALL_NAME_MAX_CHARS ||
+          !TOOL_CALL_NAME_RE.test(rawName)
+        ) {
+          reason = "invalid_name";
+        } else {
+          reason = "not_in_allowlist";
+        }
+        droppedToolCallDetails.push({ id: rawId, name: rawName || "(empty)", reason });
         continue;
       }
       if (isRawToolCallBlock(block)) {
@@ -415,6 +447,7 @@ export function repairToolCallInputs(
     messages: changed ? out : messages,
     droppedToolCalls,
     droppedAssistantMessages,
+    droppedToolCallDetails,
   };
 }
 
@@ -423,6 +456,17 @@ export function sanitizeToolCallInputs(
   options?: ToolCallInputRepairOptions,
 ): AgentMessage[] {
   return repairToolCallInputs(messages, options).messages;
+}
+
+/**
+ * Like {@link sanitizeToolCallInputs} but returns the full repair report,
+ * including details about which tool calls were dropped and why.
+ */
+export function sanitizeToolCallInputsWithReport(
+  messages: AgentMessage[],
+  options?: ToolCallInputRepairOptions,
+): ToolCallInputRepairReport {
+  return repairToolCallInputs(messages, options);
 }
 
 export function sanitizeToolUseResultPairing(

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -338,6 +338,21 @@ export function repairToolCallInputs(
         }
         out.push(msg);
       } else {
+        // Collect diagnostic details for the dropped thinking-replay turn so that
+        // callers logging `droppedToolCallDetails` do not see an empty list when
+        // `droppedToolCalls > 0`.
+        for (const block of msg.content) {
+          if (isRawToolCallBlock(block)) {
+            const rawBlock = block as RawToolCallBlock;
+            const rawId = typeof rawBlock.id === "string" ? rawBlock.id : "";
+            const rawName = typeof rawBlock.name === "string" ? (rawBlock.name as string).trim() : "";
+            droppedToolCallDetails.push({
+              id: rawId,
+              name: rawName || "(empty)",
+              reason: "not_in_allowlist",
+            });
+          }
+        }
         droppedToolCalls += countRawToolCallBlocks(msg.content);
         droppedAssistantMessages += 1;
         changed = true;

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -345,7 +345,7 @@ export function repairToolCallInputs(
           if (isRawToolCallBlock(block)) {
             const rawBlock = block as RawToolCallBlock;
             const rawId = typeof rawBlock.id === "string" ? rawBlock.id : "";
-            const rawName = typeof rawBlock.name === "string" ? (rawBlock.name as string).trim() : "";
+            const rawName = typeof rawBlock.name === "string" ? rawBlock.name.trim() : "";
             droppedToolCallDetails.push({
               id: rawId,
               name: rawName || "(empty)",
@@ -379,7 +379,7 @@ export function repairToolCallInputs(
         const rawBlock = block as RawToolCallBlock;
         const rawId = typeof rawBlock.id === "string" ? rawBlock.id : "";
         const rawName =
-          typeof rawBlock.name === "string" ? (rawBlock.name as string).trim() : "";
+          typeof rawBlock.name === "string" ? rawBlock.name.trim() : "";
         let reason: DroppedToolCallInfo["reason"];
         if (!hasToolCallInput(block)) {
           reason = "missing_input";

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -361,11 +361,10 @@ export function repairToolCallInputs(
         changed = true;
         messageChanged = true;
         // Collect diagnostic details about why this tool call was dropped.
-        const rawId = typeof block.id === "string" ? block.id : "";
+        const rawBlock = block as RawToolCallBlock;
+        const rawId = typeof rawBlock.id === "string" ? rawBlock.id : "";
         const rawName =
-          typeof (block as { name?: unknown }).name === "string"
-            ? ((block as { name: string }).name).trim()
-            : "";
+          typeof rawBlock.name === "string" ? (rawBlock.name as string).trim() : "";
         let reason: DroppedToolCallInfo["reason"];
         if (!hasToolCallInput(block)) {
           reason = "missing_input";


### PR DESCRIPTION
## Summary

  - Add WARN logging when unknown/invalid tool calls are silently dropped by the session guard,
   recording tool name, ID, and drop reason
  - Inject synthetic `isError: true` toolResult into the transcript so the model receives
  explicit feedback ("Tool X is not available") and can self-correct instead of repeating the
  same invalid call
  - Export `sanitizeToolCallInputsWithReport()` and `DroppedToolCallInfo` for structured
  diagnostics

  ## Problem

  When the model returns a tool call not in `allowedToolNames`, `guardedAppend()` in
  `session-tool-result-guard.ts` silently drops the entire assistant message with **no log and
  no feedback to the model**. This causes:

  1. **No observability** — operators have no way to detect misconfigured tool lists or model
  hallucinations
  2. **Repeated API waste** — the model never learns the tool is unavailable and may repeat the
   same call
  3. **Cost risk** — worst case up to `MAX_RUN_LOOP_ITERATIONS` (32–160) wasted API calls per
  request


  ## Changes

  | File | What changed |
  |------|-------------|
  | `src/agents/session-transcript-repair.ts` | `repairToolCallInputs()` now collects
  `DroppedToolCallInfo[]` with per-call drop reason; new `sanitizeToolCallInputsWithReport()`
  export |
  | `src/agents/session-tool-result-guard.ts` | `guardedAppend()` calls
  `sanitizeToolCallInputsWithReport()`, emits WARN log on drops, injects synthetic error
  toolResult per dropped call via `makeUnknownToolErrorResult()` |
  | `src/agents/session-tool-result-guard.test.ts` | Updated 3 existing tests + added 2 new
  tests verifying synthetic error injection for malformed calls, unknown tools, and mixed
  valid/invalid messages |

  ## Test plan

  - [x] Existing tests updated: malformed (missing input), invalid name tokens,
  not-in-allowlist now assert synthetic error result
  - [x] New test: mixed message with valid `read` + unknown `unknown_tool` — valid call
  preserved, error injected for unknown
  - [x] New test: standalone malformed call (missing input) gets synthetic error
  - [ ] `pnpm test src/agents/session-tool-result-guard.test.ts`
  - [ ] `pnpm check:changed`