### PR TITLE
fix(googlechat): preserve thread reply target through delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5434,6 +5434,7 @@ This audited record covers the complete v2026.5.28..v2026.5.31-beta.4 history: 4
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- Google Chat: keep assistant replies from existing Chat threads in the inbound thread for natural replies, message-tool sends, and explicit current-reply tags instead of re-rooting as new top-level messages. Thanks @jai.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,7 @@ Docs: https://docs.openclaw.ai
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- Google Chat: keep assistant replies from existing Chat threads in the inbound thread for natural replies, message-tool sends, and explicit current-reply tags instead of re-rooting as new top-level messages. Thanks @jai.
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/extensions/google/google.live.test.ts
+++ b/extensions/google/google.live.test.ts
@@ -1,5 +1,5 @@
-import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 // Google tests cover google plugin behavior.
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import {
   registerProviderPlugin,
   requireRegisteredProvider,
@@ -50,14 +50,14 @@ function isTransientGeminiSearchError(error: unknown): boolean {
   return message.includes("timeout") || message.includes("aborted");
 }
 
-function hasTrustedFfmpegForLiveVoiceNote(): boolean {
+function hasTrustedFfmpegForLiveVoiceNote(label: string): boolean {
   try {
     resolveFfmpegBin();
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("ffmpeg not found in trusted system directories")) {
-      console.warn("[google:live] skip voice-note transcode: ffmpeg unavailable");
+      console.warn(`[${label}:live] skip voice-note transcode: ffmpeg unavailable`);
       return false;
     }
     throw error;
@@ -90,7 +90,7 @@ describeLive("google plugin live", () => {
   }, 120_000);
 
   it("transcodes speech to Opus for voice-note targets", async () => {
-    if (!hasTrustedFfmpegForLiveVoiceNote()) {
+    if (!hasTrustedFfmpegForLiveVoiceNote("google")) {
       return;
     }
 

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -20,6 +20,8 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -308,6 +310,39 @@ describe("googlechat message actions", () => {
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+  });
+
+  it("ignores malformed inbound thread context when threadId/replyTo are omitted", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-5",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "root fallback",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/messages/not-a-thread" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "root fallback",
+        thread: undefined,
       }),
     );
   });

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -20,6 +20,8 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   listGoogleChatReactions,
@@ -32,6 +34,13 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./targets.js", () => ({
+  normalizeGoogleChatTarget: (raw?: string | null) => {
+    const trimmed = raw?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/^(googlechat|google-chat|gchat):/i, "");
+  },
   resolveGoogleChatOutboundSpace,
 }));
 
@@ -270,7 +279,119 @@ describe("googlechat message actions", () => {
       },
       cfg: {},
       accountId: "default",
-      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz" },
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: "spaces/AAA/threads/xyz",
+      }),
+    );
+  });
+
+  it("does not fall back to the inbound thread id when replyToMode is off", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "new root",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "off",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "new root",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("does not fall back to the inbound thread id for a different target", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/BBB");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/BBB/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/BBB",
+        message: "elsewhere",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/BBB",
+        text: "elsewhere",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("maps a Google Chat message-resource replyTo onto the inbound thread", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+        replyTo: "spaces/AAA/messages/current",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz", replyToMode: "all" },
     } as never);
 
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -247,6 +247,71 @@ describe("googlechat message actions", () => {
     });
   });
 
+  it("falls back to the inbound thread id when the agent omits threadId/replyTo", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: "spaces/AAA/threads/xyz",
+      }),
+    );
+  });
+
+  it("prefers an explicit threadId over the inbound thread id", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-4",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "explicit",
+        threadId: "spaces/AAA/threads/explicit",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/inbound" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+  });
+
   it("removes only matching app reactions on react remove", async () => {
     const account = buildAccount({
       config: { botUser: "users/app-bot" },

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -391,7 +391,11 @@ describe("googlechat message actions", () => {
       },
       cfg: {},
       accountId: "default",
-      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz", replyToMode: "all" },
+      toolContext: {
+        currentMessageId: "spaces/AAA/messages/current",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
     } as never);
 
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(
@@ -401,6 +405,96 @@ describe("googlechat message actions", () => {
         thread: "spaces/AAA/threads/xyz",
       }),
     );
+  });
+
+  it("does not map an arbitrary Google Chat message-resource replyTo onto the inbound thread", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+        replyTo: "spaces/AAA/messages/other",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentMessageId: "spaces/AAA/messages/current",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("threads only the first implicit Google Chat tool send when replyToMode is first", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+    const hasRepliedRef = { value: false };
+    const toolContext = {
+      currentChannelId: "spaces/AAA",
+      currentThreadTs: "spaces/AAA/threads/xyz",
+      replyToMode: "first",
+      hasRepliedRef,
+    };
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "first",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext,
+    } as never);
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "second",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext,
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "first", thread: "spaces/AAA/threads/xyz" }),
+    );
+    expect(sendGoogleChatMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "second", thread: undefined }),
+    );
+    expect(hasRepliedRef.value).toBe(true);
   });
 
   it("prefers an explicit threadId over the inbound thread id", async () => {

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -361,7 +361,11 @@ describe("googlechat message actions", () => {
       },
       cfg: {},
       accountId: "default",
-      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz", replyToMode: "all" },
+      toolContext: {
+        currentMessageId: "spaces/AAA/messages/current",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
     } as never);
 
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(
@@ -371,6 +375,96 @@ describe("googlechat message actions", () => {
         thread: "spaces/AAA/threads/xyz",
       }),
     );
+  });
+
+  it("does not map an arbitrary Google Chat message-resource replyTo onto the inbound thread", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+        replyTo: "spaces/AAA/messages/other",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentMessageId: "spaces/AAA/messages/current",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("threads only the first implicit Google Chat tool send when replyToMode is first", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+    const hasRepliedRef = { value: false };
+    const toolContext = {
+      currentChannelId: "spaces/AAA",
+      currentThreadTs: "spaces/AAA/threads/xyz",
+      replyToMode: "first",
+      hasRepliedRef,
+    };
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "first",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext,
+    } as never);
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "second",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext,
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ text: "first", thread: "spaces/AAA/threads/xyz" }),
+    );
+    expect(sendGoogleChatMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "second", thread: undefined }),
+    );
+    expect(hasRepliedRef.value).toBe(true);
   });
 
   it("prefers an explicit threadId over the inbound thread id", async () => {

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -19,6 +19,8 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -278,6 +280,39 @@ describe("googlechat message actions", () => {
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+  });
+
+  it("ignores malformed inbound thread context when threadId/replyTo are omitted", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-5",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "root fallback",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/messages/not-a-thread" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "root fallback",
+        thread: undefined,
       }),
     );
   });

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -217,6 +217,71 @@ describe("googlechat message actions", () => {
     });
   });
 
+  it("falls back to the inbound thread id when the agent omits threadId/replyTo", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: "spaces/AAA/threads/xyz",
+      }),
+    );
+  });
+
+  it("prefers an explicit threadId over the inbound thread id", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-4",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "explicit",
+        threadId: "spaces/AAA/threads/explicit",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/inbound" },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+  });
+
   it("removes only matching app reactions on react remove", async () => {
     resolveGoogleChatAccount.mockReturnValue({
       credentialSource: "service-account",

--- a/extensions/googlechat/src/actions.test.ts
+++ b/extensions/googlechat/src/actions.test.ts
@@ -19,6 +19,8 @@ vi.mock("./accounts.js", () => ({
 vi.mock("./api.js", () => ({
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   listGoogleChatReactions,
@@ -31,6 +33,13 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./targets.js", () => ({
+  normalizeGoogleChatTarget: (raw?: string | null) => {
+    const trimmed = raw?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/^(googlechat|google-chat|gchat):/i, "");
+  },
   resolveGoogleChatOutboundSpace,
 }));
 
@@ -240,7 +249,119 @@ describe("googlechat message actions", () => {
       },
       cfg: {},
       accountId: "default",
-      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz" },
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "follow up",
+        thread: "spaces/AAA/threads/xyz",
+      }),
+    );
+  });
+
+  it("does not fall back to the inbound thread id when replyToMode is off", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "new root",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "off",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/AAA",
+        text: "new root",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("does not fall back to the inbound thread id for a different target", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/BBB");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/BBB/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/BBB",
+        message: "elsewhere",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: {
+        currentChannelId: "spaces/AAA",
+        currentThreadTs: "spaces/AAA/threads/xyz",
+        replyToMode: "all",
+      },
+    } as never);
+
+    expect(sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        space: "spaces/BBB",
+        text: "elsewhere",
+        thread: undefined,
+      }),
+    );
+  });
+
+  it("maps a Google Chat message-resource replyTo onto the inbound thread", async () => {
+    resolveGoogleChatAccount.mockReturnValue({
+      credentialSource: "service-account",
+      config: {},
+    });
+    resolveGoogleChatOutboundSpace.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessage.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-3",
+    });
+
+    if (!googlechatMessageActions.handleAction) {
+      throw new Error("Expected googlechatMessageActions.handleAction to be defined");
+    }
+    await googlechatMessageActions.handleAction({
+      action: "send",
+      params: {
+        to: "spaces/AAA",
+        message: "follow up",
+        replyTo: "spaces/AAA/messages/current",
+      },
+      cfg: {},
+      accountId: "default",
+      toolContext: { currentThreadTs: "spaces/AAA/threads/xyz", replyToMode: "all" },
     } as never);
 
     expect(sendGoogleChatMessage).toHaveBeenCalledWith(

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -16,13 +16,14 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatMessageResourceName,
   isGoogleChatThreadResourceName,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
 import { getGoogleChatRuntime } from "./runtime.js";
-import { resolveGoogleChatOutboundSpace } from "./targets.js";
+import { normalizeGoogleChatTarget, resolveGoogleChatOutboundSpace } from "./targets.js";
 
 const providerId = "googlechat";
 
@@ -44,6 +45,48 @@ function isReactionsEnabled(accounts: Array<{ config: { actions?: unknown } }>) 
 
 function resolveAppUserNames(account: { config: { botUser?: string | null } }) {
   return new Set(["users/app", account.config.botUser?.trim()].filter(Boolean) as string[]);
+}
+
+function allowsImplicitToolThread(mode: string | undefined): boolean {
+  return mode === "first" || mode === "all";
+}
+
+function isCurrentGoogleChatTarget(params: {
+  to: string;
+  currentChannelId: string | undefined;
+}): boolean {
+  const target = normalizeGoogleChatTarget(params.to) ?? params.to.trim();
+  const current = params.currentChannelId
+    ? (normalizeGoogleChatTarget(params.currentChannelId) ?? params.currentChannelId.trim())
+    : undefined;
+  return Boolean(target && current && target === current);
+}
+
+function resolveActionThreadId(params: {
+  to: string;
+  explicitThreadId: string | undefined;
+  explicitReplyTo: string | undefined;
+  inboundThreadId: string | undefined;
+  currentChannelId: string | undefined;
+  replyToMode: string | undefined;
+}) {
+  const explicitTarget = params.explicitThreadId ?? params.explicitReplyTo;
+  if (isGoogleChatThreadResourceName(explicitTarget)) {
+    return explicitTarget;
+  }
+  if (isGoogleChatMessageResourceName(explicitTarget)) {
+    return params.inboundThreadId;
+  }
+  if (explicitTarget) {
+    return explicitTarget;
+  }
+  return allowsImplicitToolThread(params.replyToMode) &&
+    isCurrentGoogleChatTarget({
+      to: params.to,
+      currentChannelId: params.currentChannelId,
+    })
+    ? params.inboundThreadId
+    : undefined;
 }
 
 async function loadGoogleChatActionMedia(params: {
@@ -130,10 +173,17 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         isGoogleChatThreadResourceName(toolContext.currentThreadTs)
           ? toolContext.currentThreadTs
           : undefined;
-      const threadId =
-        readStringParam(params, "threadId") ??
-        readStringParam(params, "replyTo") ??
-        inboundThreadId;
+      const threadId = resolveActionThreadId({
+        to,
+        explicitThreadId: readStringParam(params, "threadId"),
+        explicitReplyTo: readStringParam(params, "replyTo"),
+        inboundThreadId,
+        currentChannelId:
+          typeof toolContext?.currentChannelId === "string"
+            ? toolContext.currentChannelId
+            : undefined,
+        replyToMode: toolContext?.replyToMode,
+      });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 
       if (mediaUrl) {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -99,6 +99,7 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    toolContext,
   }) => {
     const account = resolveGoogleChatAccount({
       cfg: cfg,
@@ -123,7 +124,12 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "media", { trim: false }) ??
         readStringParam(params, "filePath", { trim: false }) ??
         readStringParam(params, "path", { trim: false });
-      const threadId = readStringParam(params, "threadId") ?? readStringParam(params, "replyTo");
+      const inboundThreadId =
+        typeof toolContext?.currentThreadTs === "string" ? toolContext.currentThreadTs : undefined;
+      const threadId =
+        readStringParam(params, "threadId") ??
+        readStringParam(params, "replyTo") ??
+        inboundThreadId;
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 
       if (mediaUrl) {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -16,6 +16,7 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatThreadResourceName,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -125,7 +126,10 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "filePath", { trim: false }) ??
         readStringParam(params, "path", { trim: false });
       const inboundThreadId =
-        typeof toolContext?.currentThreadTs === "string" ? toolContext.currentThreadTs : undefined;
+        typeof toolContext?.currentThreadTs === "string" &&
+        isGoogleChatThreadResourceName(toolContext.currentThreadTs)
+          ? toolContext.currentThreadTs
+          : undefined;
       const threadId =
         readStringParam(params, "threadId") ??
         readStringParam(params, "replyTo") ??

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -68,25 +68,45 @@ function resolveActionThreadId(params: {
   explicitReplyTo: string | undefined;
   inboundThreadId: string | undefined;
   currentChannelId: string | undefined;
+  currentMessageId: string | number | undefined;
   replyToMode: string | undefined;
+  hasRepliedRef: { value: boolean } | undefined;
 }) {
+  const markFirstReply = () => {
+    if (params.replyToMode === "first" && params.hasRepliedRef) {
+      params.hasRepliedRef.value = true;
+    }
+  };
   const explicitTarget = params.explicitThreadId ?? params.explicitReplyTo;
   if (isGoogleChatThreadResourceName(explicitTarget)) {
+    markFirstReply();
     return explicitTarget;
   }
   if (isGoogleChatMessageResourceName(explicitTarget)) {
-    return params.inboundThreadId;
+    if (explicitTarget === params.currentMessageId) {
+      markFirstReply();
+      return params.inboundThreadId;
+    }
+    return undefined;
   }
   if (explicitTarget) {
+    markFirstReply();
     return explicitTarget;
   }
-  return allowsImplicitToolThread(params.replyToMode) &&
-    isCurrentGoogleChatTarget({
+  if (
+    !allowsImplicitToolThread(params.replyToMode) ||
+    !isCurrentGoogleChatTarget({
       to: params.to,
       currentChannelId: params.currentChannelId,
     })
-    ? params.inboundThreadId
-    : undefined;
+  ) {
+    return undefined;
+  }
+  if (params.replyToMode === "first" && params.hasRepliedRef?.value) {
+    return undefined;
+  }
+  markFirstReply();
+  return params.inboundThreadId;
 }
 
 async function loadGoogleChatActionMedia(params: {
@@ -182,7 +202,9 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           typeof toolContext?.currentChannelId === "string"
             ? toolContext.currentChannelId
             : undefined,
+        currentMessageId: toolContext?.currentMessageId,
         replyToMode: toolContext?.replyToMode,
+        hasRepliedRef: toolContext?.hasRepliedRef,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -17,13 +17,14 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatMessageResourceName,
   isGoogleChatThreadResourceName,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
 import { getGoogleChatRuntime } from "./runtime.js";
-import { resolveGoogleChatOutboundSpace } from "./targets.js";
+import { normalizeGoogleChatTarget, resolveGoogleChatOutboundSpace } from "./targets.js";
 
 const providerId = "googlechat";
 
@@ -45,6 +46,48 @@ function isReactionsEnabled(accounts: Array<{ config: { actions?: unknown } }>) 
 
 function resolveAppUserNames(account: { config: { botUser?: string | null } }) {
   return new Set(["users/app", account.config.botUser?.trim()].filter(Boolean) as string[]);
+}
+
+function allowsImplicitToolThread(mode: string | undefined): boolean {
+  return mode === "first" || mode === "all";
+}
+
+function isCurrentGoogleChatTarget(params: {
+  to: string;
+  currentChannelId: string | undefined;
+}): boolean {
+  const target = normalizeGoogleChatTarget(params.to) ?? params.to.trim();
+  const current = params.currentChannelId
+    ? (normalizeGoogleChatTarget(params.currentChannelId) ?? params.currentChannelId.trim())
+    : undefined;
+  return Boolean(target && current && target === current);
+}
+
+function resolveActionThreadId(params: {
+  to: string;
+  explicitThreadId: string | undefined;
+  explicitReplyTo: string | undefined;
+  inboundThreadId: string | undefined;
+  currentChannelId: string | undefined;
+  replyToMode: string | undefined;
+}) {
+  const explicitTarget = params.explicitThreadId ?? params.explicitReplyTo;
+  if (isGoogleChatThreadResourceName(explicitTarget)) {
+    return explicitTarget;
+  }
+  if (isGoogleChatMessageResourceName(explicitTarget)) {
+    return params.inboundThreadId;
+  }
+  if (explicitTarget) {
+    return explicitTarget;
+  }
+  return allowsImplicitToolThread(params.replyToMode) &&
+    isCurrentGoogleChatTarget({
+      to: params.to,
+      currentChannelId: params.currentChannelId,
+    })
+    ? params.inboundThreadId
+    : undefined;
 }
 
 async function loadGoogleChatActionMedia(params: {
@@ -131,10 +174,17 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         isGoogleChatThreadResourceName(toolContext.currentThreadTs)
           ? toolContext.currentThreadTs
           : undefined;
-      const threadId =
-        readStringParam(params, "threadId") ??
-        readStringParam(params, "replyTo") ??
-        inboundThreadId;
+      const threadId = resolveActionThreadId({
+        to,
+        explicitThreadId: readStringParam(params, "threadId"),
+        explicitReplyTo: readStringParam(params, "replyTo"),
+        inboundThreadId,
+        currentChannelId:
+          typeof toolContext?.currentChannelId === "string"
+            ? toolContext.currentChannelId
+            : undefined,
+        replyToMode: toolContext?.replyToMode,
+      });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 
       if (mediaUrl) {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -17,6 +17,7 @@ import { listEnabledGoogleChatAccounts, resolveGoogleChatAccount } from "./accou
 import {
   createGoogleChatReaction,
   deleteGoogleChatReaction,
+  isGoogleChatThreadResourceName,
   listGoogleChatReactions,
   sendGoogleChatMessage,
   uploadGoogleChatAttachment,
@@ -126,7 +127,10 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "filePath", { trim: false }) ??
         readStringParam(params, "path", { trim: false });
       const inboundThreadId =
-        typeof toolContext?.currentThreadTs === "string" ? toolContext.currentThreadTs : undefined;
+        typeof toolContext?.currentThreadTs === "string" &&
+        isGoogleChatThreadResourceName(toolContext.currentThreadTs)
+          ? toolContext.currentThreadTs
+          : undefined;
       const threadId =
         readStringParam(params, "threadId") ??
         readStringParam(params, "replyTo") ??

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -100,6 +100,7 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
     mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
+    toolContext,
   }) => {
     const account = resolveGoogleChatAccount({
       cfg,
@@ -124,7 +125,12 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
         readStringParam(params, "media", { trim: false }) ??
         readStringParam(params, "filePath", { trim: false }) ??
         readStringParam(params, "path", { trim: false });
-      const threadId = readStringParam(params, "threadId") ?? readStringParam(params, "replyTo");
+      const inboundThreadId =
+        typeof toolContext?.currentThreadTs === "string" ? toolContext.currentThreadTs : undefined;
+      const threadId =
+        readStringParam(params, "threadId") ??
+        readStringParam(params, "replyTo") ??
+        inboundThreadId;
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 
       if (mediaUrl) {

--- a/extensions/googlechat/src/actions.ts
+++ b/extensions/googlechat/src/actions.ts
@@ -69,25 +69,45 @@ function resolveActionThreadId(params: {
   explicitReplyTo: string | undefined;
   inboundThreadId: string | undefined;
   currentChannelId: string | undefined;
+  currentMessageId: string | number | undefined;
   replyToMode: string | undefined;
+  hasRepliedRef: { value: boolean } | undefined;
 }) {
+  const markFirstReply = () => {
+    if (params.replyToMode === "first" && params.hasRepliedRef) {
+      params.hasRepliedRef.value = true;
+    }
+  };
   const explicitTarget = params.explicitThreadId ?? params.explicitReplyTo;
   if (isGoogleChatThreadResourceName(explicitTarget)) {
+    markFirstReply();
     return explicitTarget;
   }
   if (isGoogleChatMessageResourceName(explicitTarget)) {
-    return params.inboundThreadId;
+    if (explicitTarget === params.currentMessageId) {
+      markFirstReply();
+      return params.inboundThreadId;
+    }
+    return undefined;
   }
   if (explicitTarget) {
+    markFirstReply();
     return explicitTarget;
   }
-  return allowsImplicitToolThread(params.replyToMode) &&
-    isCurrentGoogleChatTarget({
+  if (
+    !allowsImplicitToolThread(params.replyToMode) ||
+    !isCurrentGoogleChatTarget({
       to: params.to,
       currentChannelId: params.currentChannelId,
     })
-    ? params.inboundThreadId
-    : undefined;
+  ) {
+    return undefined;
+  }
+  if (params.replyToMode === "first" && params.hasRepliedRef?.value) {
+    return undefined;
+  }
+  markFirstReply();
+  return params.inboundThreadId;
 }
 
 async function loadGoogleChatActionMedia(params: {
@@ -183,7 +203,9 @@ export const googlechatMessageActions: ChannelMessageActionAdapter = {
           typeof toolContext?.currentChannelId === "string"
             ? toolContext.currentChannelId
             : undefined,
+        currentMessageId: toolContext?.currentMessageId,
         replyToMode: toolContext?.replyToMode,
+        hasRepliedRef: toolContext?.hasRepliedRef,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
 

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -6,7 +6,10 @@ import { getGoogleChatAccessToken } from "./auth.js";
 import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 import type { GoogleChatReaction } from "./types.js";
 
-export { isGoogleChatThreadResourceName } from "./thread-resource.js";
+export {
+  isGoogleChatMessageResourceName,
+  isGoogleChatThreadResourceName,
+} from "./thread-resource.js";
 
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -8,6 +8,10 @@ import type { GoogleChatReaction } from "./types.js";
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
+export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
+  return typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value);
+}
+
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>
   headers instanceof Headers
     ? Object.fromEntries(headers.entries())
@@ -151,7 +155,7 @@ export async function sendGoogleChatMessage(params: {
     body.text = text;
   }
   if (thread) {
-    if (!/^spaces\/[^/]+\/threads\/[^/]+$/.test(thread)) {
+    if (!isGoogleChatThreadResourceName(thread)) {
       throw new Error(`Google Chat thread must be a thread resource name, got ${thread}`);
     }
     body.thread = { name: thread };

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -3,14 +3,13 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { getGoogleChatAccessToken } from "./auth.js";
+import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 import type { GoogleChatReaction } from "./types.js";
+
+export { isGoogleChatThreadResourceName } from "./thread-resource.js";
 
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
-
-export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
-  return typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value);
-}
 
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>
   headers instanceof Headers

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -151,6 +151,9 @@ export async function sendGoogleChatMessage(params: {
     body.text = text;
   }
   if (thread) {
+    if (!/^spaces\/[^/]+\/threads\/[^/]+$/.test(thread)) {
+      throw new Error(`Google Chat thread must be a thread resource name, got ${thread}`);
+    }
     body.thread = { name: thread };
   }
   if (attachments && attachments.length > 0) {

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -160,6 +160,9 @@ export async function sendGoogleChatMessage(params: {
     body.cardsV2 = cardsV2;
   }
   if (thread) {
+    if (!/^spaces\/[^/]+\/threads\/[^/]+$/.test(thread)) {
+      throw new Error(`Google Chat thread must be a thread resource name, got ${thread}`);
+    }
     body.thread = { name: thread };
   }
   if (attachments && attachments.length > 0) {

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -11,17 +11,16 @@ import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import { shouldSuppressGoogleChatManualExecApprovalFollowupText } from "./approval-card-actions.js";
 import { getGoogleChatAccessToken } from "./auth.js";
+import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 import type { GoogleChatCardV2, GoogleChatReaction } from "./types.js";
+
+export { isGoogleChatThreadResourceName } from "./thread-resource.js";
 
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";
 
 async function readGoogleChatJsonResponse<T>(response: Response, label: string): Promise<T> {
   return readProviderJsonResponse<T>(response, label);
-}
-
-export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
-  return typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value);
 }
 
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -14,7 +14,10 @@ import { getGoogleChatAccessToken } from "./auth.js";
 import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 import type { GoogleChatCardV2, GoogleChatReaction } from "./types.js";
 
-export { isGoogleChatThreadResourceName } from "./thread-resource.js";
+export {
+  isGoogleChatMessageResourceName,
+  isGoogleChatThreadResourceName,
+} from "./thread-resource.js";
 
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
 const CHAT_UPLOAD_BASE = "https://chat.googleapis.com/upload/v1";

--- a/extensions/googlechat/src/api.ts
+++ b/extensions/googlechat/src/api.ts
@@ -20,6 +20,10 @@ async function readGoogleChatJsonResponse<T>(response: Response, label: string):
   return readProviderJsonResponse<T>(response, label);
 }
 
+export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
+  return typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value);
+}
+
 const headersToObject = (headers?: HeadersInit): Record<string, string> =>
   headers instanceof Headers
     ? Object.fromEntries(headers.entries())
@@ -160,7 +164,7 @@ export async function sendGoogleChatMessage(params: {
     body.cardsV2 = cardsV2;
   }
   if (thread) {
-    if (!/^spaces\/[^/]+\/threads\/[^/]+$/.test(thread)) {
+    if (!isGoogleChatThreadResourceName(thread)) {
       throw new Error(`Google Chat thread must be a thread resource name, got ${thread}`);
     }
     body.thread = { name: thread };

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -136,6 +136,19 @@ export const googlechatThreadingAdapter = {
       account.config.replyToMode,
     fallback: "off" as const,
   },
+  buildToolContext: (params: { context?: { MessageThreadId?: string | number; To?: string } }) => {
+    const threadCandidate = params.context?.MessageThreadId;
+    const currentThreadTs =
+      typeof threadCandidate === "string"
+        ? threadCandidate
+        : typeof threadCandidate === "number"
+          ? String(threadCandidate)
+          : undefined;
+    if (!currentThreadTs) {
+      return {};
+    }
+    return { currentThreadTs };
+  },
 };
 
 export const googlechatPairingTextAdapter = {

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -63,6 +63,24 @@ function createGoogleChatSendReceipt(params: {
   });
 }
 
+const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+
+function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
+  return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value)
+    ? value
+    : undefined;
+}
+
+function resolveGoogleChatOutboundThread(params: {
+  threadId?: string | number | null;
+  replyToId?: string | null;
+}): string | undefined {
+  return (
+    normalizeGoogleChatThreadResourceName(params.replyToId) ??
+    normalizeGoogleChatThreadResourceName(params.threadId)
+  );
+}
+
 export const formatAllowFromEntry = (entry: string) =>
   normalizeLowercaseStringOrEmpty(
     entry
@@ -137,17 +155,23 @@ export const googlechatThreadingAdapter = {
     fallback: "off" as const,
   },
   buildToolContext: (params: { context?: { MessageThreadId?: string | number; To?: string } }) => {
-    const threadCandidate = params.context?.MessageThreadId;
-    const currentThreadTs =
-      typeof threadCandidate === "string"
-        ? threadCandidate
-        : typeof threadCandidate === "number"
-          ? String(threadCandidate)
-          : undefined;
+    const currentThreadTs = normalizeGoogleChatThreadResourceName(params.context?.MessageThreadId);
     if (!currentThreadTs) {
       return {};
     }
     return { currentThreadTs };
+  },
+  resolveReplyTransport: ({
+    threadId,
+    replyToId,
+  }: {
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+    threadId?: string | number | null;
+    replyToId?: string | null;
+  }) => {
+    const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+    return thread ? { replyToId: thread, threadId: null } : null;
   },
 };
 
@@ -231,8 +255,7 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread =
-        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? undefined);
+      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
       const { sendGoogleChatMessage } = await loadGoogleChatChannelRuntime();
       const result = await sendGoogleChatMessage({
         account,
@@ -278,8 +301,7 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread =
-        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? undefined);
+      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg: cfg,
         resolveChannelLimitMb: ({ cfg, accountId }) =>

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -35,7 +35,10 @@ import {
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
-import { isGoogleChatThreadResourceName } from "./thread-resource.js";
+import {
+  isGoogleChatMessageResourceName,
+  isGoogleChatThreadResourceName,
+} from "./thread-resource.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -64,18 +67,61 @@ function createGoogleChatSendReceipt(params: {
   });
 }
 
+type GoogleChatToolContext = {
+  currentChannelId?: string;
+  currentThreadTs?: string;
+  replyToMode: "off" | "first" | "all" | "batched";
+};
+
 function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
   return typeof value === "string" && isGoogleChatThreadResourceName(value) ? value : undefined;
+}
+
+function normalizeGoogleChatChannelTarget(value?: string | null): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  return trimmed ? (normalizeGoogleChatTarget(trimmed) ?? trimmed) : undefined;
 }
 
 function resolveGoogleChatOutboundThread(params: {
   threadId?: string | number | null;
   replyToId?: string | null;
+  allowThreadIdOnly?: boolean;
 }): string | undefined {
-  return (
-    normalizeGoogleChatThreadResourceName(params.replyToId) ??
-    normalizeGoogleChatThreadResourceName(params.threadId)
-  );
+  const explicitThread = normalizeGoogleChatThreadResourceName(params.replyToId);
+  if (explicitThread) {
+    return explicitThread;
+  }
+  if (isGoogleChatMessageResourceName(params.replyToId)) {
+    return normalizeGoogleChatThreadResourceName(params.threadId);
+  }
+  return params.allowThreadIdOnly
+    ? normalizeGoogleChatThreadResourceName(params.threadId)
+    : undefined;
+}
+
+function resolveGoogleChatToolReplyToMode(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
+}): GoogleChatToolContext["replyToMode"] {
+  if (!params.cfg) {
+    return "off" as const;
+  }
+  const mode = resolveGoogleChatAccount({ cfg: params.cfg, accountId: params.accountId }).config
+    .replyToMode;
+  return mode === "first" || mode === "all" || mode === "batched" ? mode : "off";
+}
+
+function allowsImplicitToolThread(mode: string | undefined): boolean {
+  return mode === "first" || mode === "all";
+}
+
+function isCurrentGoogleChatTarget(params: {
+  to: string;
+  toolContext?: { currentChannelId?: string | null };
+}): boolean {
+  const target = normalizeGoogleChatChannelTarget(params.to);
+  const current = normalizeGoogleChatChannelTarget(params.toolContext?.currentChannelId);
+  return Boolean(target && current && target === current);
 }
 
 export const formatAllowFromEntry = (entry: string) =>
@@ -151,12 +197,52 @@ export const googlechatThreadingAdapter = {
       account.config.replyToMode,
     fallback: "off" as const,
   },
-  buildToolContext: (params: { context?: { MessageThreadId?: string | number; To?: string } }) => {
+  buildToolContext: (params: {
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+    context?: { MessageThreadId?: string | number; To?: string };
+  }): GoogleChatToolContext => {
+    const replyToMode = resolveGoogleChatToolReplyToMode(params);
+    const currentChannelId = normalizeGoogleChatChannelTarget(params.context?.To);
     const currentThreadTs = normalizeGoogleChatThreadResourceName(params.context?.MessageThreadId);
+    const baseContext: GoogleChatToolContext = {
+      ...(currentChannelId ? { currentChannelId } : {}),
+      replyToMode,
+    };
     if (!currentThreadTs) {
-      return {};
+      return baseContext;
     }
-    return { currentThreadTs };
+    return { ...baseContext, currentThreadTs };
+  },
+  resolveAutoThreadId: ({
+    to,
+    replyToId,
+    toolContext,
+  }: {
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+    to: string;
+    replyToId?: string | null;
+    toolContext?: {
+      currentChannelId?: string | null;
+      currentThreadTs?: string | null;
+      replyToMode?: string | null;
+    };
+  }) => {
+    if (!allowsImplicitToolThread(toolContext?.replyToMode ?? undefined)) {
+      return undefined;
+    }
+    const inboundThread = normalizeGoogleChatThreadResourceName(toolContext?.currentThreadTs);
+    if (!inboundThread) {
+      return undefined;
+    }
+    if (replyToId && !isGoogleChatMessageResourceName(replyToId)) {
+      return undefined;
+    }
+    if (!replyToId && !isCurrentGoogleChatTarget({ to, toolContext })) {
+      return undefined;
+    }
+    return inboundThread;
   },
   resolveReplyTransport: ({
     threadId,
@@ -252,7 +338,11 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+      const thread = resolveGoogleChatOutboundThread({
+        threadId,
+        replyToId,
+        allowThreadIdOnly: true,
+      });
       const { sendGoogleChatMessage } = await loadGoogleChatChannelRuntime();
       const result = await sendGoogleChatMessage({
         account,

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -35,6 +35,7 @@ import {
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
+import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -63,12 +64,8 @@ function createGoogleChatSendReceipt(params: {
   });
 }
 
-const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
-
 function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
-  return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value)
-    ? value
-    : undefined;
+  return typeof value === "string" && isGoogleChatThreadResourceName(value) ? value : undefined;
 }
 
 function resolveGoogleChatOutboundThread(params: {

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -388,7 +388,11 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+      const thread = resolveGoogleChatOutboundThread({
+        threadId,
+        replyToId,
+        allowThreadIdOnly: true,
+      });
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg: cfg,
         resolveChannelLimitMb: ({ cfg, accountId }) =>

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -70,7 +70,9 @@ function createGoogleChatSendReceipt(params: {
 type GoogleChatToolContext = {
   currentChannelId?: string;
   currentThreadTs?: string;
+  currentMessageId?: string | number;
   replyToMode: "off" | "first" | "all" | "batched";
+  hasRepliedRef?: { value: boolean };
 };
 
 function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
@@ -85,13 +87,17 @@ function normalizeGoogleChatChannelTarget(value?: string | null): string | undef
 function resolveGoogleChatOutboundThread(params: {
   threadId?: string | number | null;
   replyToId?: string | null;
+  currentMessageId?: string | number | null;
   allowThreadIdOnly?: boolean;
 }): string | undefined {
   const explicitThread = normalizeGoogleChatThreadResourceName(params.replyToId);
   if (explicitThread) {
     return explicitThread;
   }
-  if (isGoogleChatMessageResourceName(params.replyToId)) {
+  if (
+    isGoogleChatMessageResourceName(params.replyToId) &&
+    params.replyToId === params.currentMessageId
+  ) {
     return normalizeGoogleChatThreadResourceName(params.threadId);
   }
   return params.allowThreadIdOnly
@@ -201,6 +207,7 @@ export const googlechatThreadingAdapter = {
     cfg?: OpenClawConfig;
     accountId?: string | null;
     context?: { MessageThreadId?: string | number; To?: string };
+    hasRepliedRef?: { value: boolean };
   }): GoogleChatToolContext => {
     const replyToMode = resolveGoogleChatToolReplyToMode(params);
     const currentChannelId = normalizeGoogleChatChannelTarget(params.context?.To);
@@ -208,6 +215,7 @@ export const googlechatThreadingAdapter = {
     const baseContext: GoogleChatToolContext = {
       ...(currentChannelId ? { currentChannelId } : {}),
       replyToMode,
+      ...(params.hasRepliedRef ? { hasRepliedRef: params.hasRepliedRef } : {}),
     };
     if (!currentThreadTs) {
       return baseContext;
@@ -226,7 +234,9 @@ export const googlechatThreadingAdapter = {
     toolContext?: {
       currentChannelId?: string | null;
       currentThreadTs?: string | null;
+      currentMessageId?: string | number | null;
       replyToMode?: string | null;
+      hasRepliedRef?: { value: boolean };
     };
   }) => {
     if (!allowsImplicitToolThread(toolContext?.replyToMode ?? undefined)) {
@@ -240,6 +250,15 @@ export const googlechatThreadingAdapter = {
       return undefined;
     }
     if (!replyToId && !isCurrentGoogleChatTarget({ to, toolContext })) {
+      return undefined;
+    }
+    if (!replyToId && toolContext?.replyToMode === "first" && toolContext.hasRepliedRef?.value) {
+      return undefined;
+    }
+    if (
+      replyToId &&
+      (!isGoogleChatMessageResourceName(replyToId) || replyToId !== toolContext?.currentMessageId)
+    ) {
       return undefined;
     }
     return inboundThread;

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -69,6 +69,25 @@ function createGoogleChatSendReceipt(params: {
   });
 }
 
+export const formatAllowFromEntry = formatGoogleChatAllowFromEntry;
+
+const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+
+function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
+  return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value)
+    ? value
+    : undefined;
+}
+
+function resolveGoogleChatOutboundThread(params: {
+  threadId?: string | number | null;
+  replyToId?: string | null;
+}): string | undefined {
+  return (
+    normalizeGoogleChatThreadResourceName(params.replyToId) ??
+    normalizeGoogleChatThreadResourceName(params.threadId)
+  );
+}
 const collectGoogleChatGroupPolicyWarnings =
   createAllowlistProviderOpenWarningCollector<ResolvedGoogleChatAccount>({
     providerConfigPresent: (cfg) => cfg.channels?.googlechat !== undefined,
@@ -145,13 +164,7 @@ export const googlechatThreadingAdapter = {
     hasRepliedRef?: { value: boolean };
   }): ChannelThreadingToolContext => {
     const currentChannelId = normalizeGoogleChatTarget(context.To);
-    const threadCandidate = context.MessageThreadId;
-    const currentThreadTs =
-      typeof threadCandidate === "string"
-        ? normalizeOptionalString(threadCandidate)
-        : typeof threadCandidate === "number"
-          ? String(threadCandidate)
-          : undefined;
+    const currentThreadTs = normalizeGoogleChatThreadResourceName(context.MessageThreadId);
 
     return {
       currentChannelId,
@@ -160,6 +173,18 @@ export const googlechatThreadingAdapter = {
       replyToMode: resolveGoogleChatAccount({ cfg, accountId }).config.replyToMode,
       hasRepliedRef,
     };
+  },
+  resolveReplyTransport: ({
+    threadId,
+    replyToId,
+  }: {
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+    threadId?: string | number | null;
+    replyToId?: string | null;
+  }) => {
+    const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+    return thread ? { replyToId: thread, threadId: null } : null;
   },
 };
 
@@ -249,8 +274,7 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread =
-        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? undefined);
+      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
       const { sendGoogleChatMessage } = await loadGoogleChatChannelRuntime();
       const result = await sendGoogleChatMessage({
         account,
@@ -296,8 +320,7 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread =
-        typeof threadId === "number" ? String(threadId) : (threadId ?? replyToId ?? undefined);
+      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg,
         resolveChannelLimitMb: ({ cfg: cfgLocal, accountId: accountIdLocal }) =>

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -95,13 +95,17 @@ function normalizeGoogleChatChannelTarget(value?: string | null): string | undef
 function resolveGoogleChatOutboundThread(params: {
   threadId?: string | number | null;
   replyToId?: string | null;
+  currentMessageId?: string | number | null;
   allowThreadIdOnly?: boolean;
 }): string | undefined {
   const explicitThread = normalizeGoogleChatThreadResourceName(params.replyToId);
   if (explicitThread) {
     return explicitThread;
   }
-  if (isGoogleChatMessageResourceName(params.replyToId)) {
+  if (
+    isGoogleChatMessageResourceName(params.replyToId) &&
+    params.replyToId === params.currentMessageId
+  ) {
     return normalizeGoogleChatThreadResourceName(params.threadId);
   }
   return params.allowThreadIdOnly
@@ -228,7 +232,9 @@ export const googlechatThreadingAdapter = {
     toolContext?: {
       currentChannelId?: string | null;
       currentThreadTs?: string | null;
+      currentMessageId?: string | number | null;
       replyToMode?: string | null;
+      hasRepliedRef?: { value: boolean };
     };
   }) => {
     if (!allowsImplicitToolThread(toolContext?.replyToMode ?? undefined)) {
@@ -242,6 +248,15 @@ export const googlechatThreadingAdapter = {
       return undefined;
     }
     if (!replyToId && !isCurrentGoogleChatTarget({ to, toolContext })) {
+      return undefined;
+    }
+    if (!replyToId && toolContext?.replyToMode === "first" && toolContext.hasRepliedRef?.value) {
+      return undefined;
+    }
+    if (
+      replyToId &&
+      (!isGoogleChatMessageResourceName(replyToId) || replyToId !== toolContext?.currentMessageId)
+    ) {
       return undefined;
     }
     return inboundThread;

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -145,13 +145,18 @@ export const googlechatThreadingAdapter = {
     hasRepliedRef?: { value: boolean };
   }): ChannelThreadingToolContext => {
     const currentChannelId = normalizeGoogleChatTarget(context.To);
-    const replyToId =
-      normalizeOptionalString(context.ReplyToIdFull) ?? normalizeOptionalString(context.ReplyToId);
+    const threadCandidate = context.MessageThreadId;
+    const currentThreadTs =
+      typeof threadCandidate === "string"
+        ? normalizeOptionalString(threadCandidate)
+        : typeof threadCandidate === "number"
+          ? String(threadCandidate)
+          : undefined;
 
     return {
       currentChannelId,
-      currentMessageId: replyToId,
-      currentThreadTs: replyToId,
+      currentMessageId: currentThreadTs,
+      currentThreadTs,
       replyToMode: resolveGoogleChatAccount({ cfg, accountId }).config.replyToMode,
       hasRepliedRef,
     };

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -396,7 +396,11 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+      const thread = resolveGoogleChatOutboundThread({
+        threadId,
+        replyToId,
+        allowThreadIdOnly: true,
+      });
       const maxBytes = resolveChannelMediaMaxBytes({
         cfg,
         resolveChannelLimitMb: ({ cfg: cfgLocal, accountId: accountIdLocal }) =>

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -41,7 +41,10 @@ import {
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
-import { isGoogleChatThreadResourceName } from "./thread-resource.js";
+import {
+  isGoogleChatMessageResourceName,
+  isGoogleChatThreadResourceName,
+} from "./thread-resource.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -72,18 +75,63 @@ function createGoogleChatSendReceipt(params: {
 
 export const formatAllowFromEntry = formatGoogleChatAllowFromEntry;
 
+type GoogleChatToolContext = ChannelThreadingToolContext & {
+  currentChannelId?: string;
+  currentMessageId?: string;
+  currentThreadTs?: string;
+  replyToMode: "off" | "first" | "all" | "batched";
+  hasRepliedRef?: { value: boolean };
+};
+
 function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
   return typeof value === "string" && isGoogleChatThreadResourceName(value) ? value : undefined;
+}
+
+function normalizeGoogleChatChannelTarget(value?: string | null): string | undefined {
+  const trimmed = normalizeOptionalString(value);
+  return trimmed ? (normalizeGoogleChatTarget(trimmed) ?? trimmed) : undefined;
 }
 
 function resolveGoogleChatOutboundThread(params: {
   threadId?: string | number | null;
   replyToId?: string | null;
+  allowThreadIdOnly?: boolean;
 }): string | undefined {
-  return (
-    normalizeGoogleChatThreadResourceName(params.replyToId) ??
-    normalizeGoogleChatThreadResourceName(params.threadId)
-  );
+  const explicitThread = normalizeGoogleChatThreadResourceName(params.replyToId);
+  if (explicitThread) {
+    return explicitThread;
+  }
+  if (isGoogleChatMessageResourceName(params.replyToId)) {
+    return normalizeGoogleChatThreadResourceName(params.threadId);
+  }
+  return params.allowThreadIdOnly
+    ? normalizeGoogleChatThreadResourceName(params.threadId)
+    : undefined;
+}
+
+function resolveGoogleChatToolReplyToMode(params: {
+  cfg?: OpenClawConfig;
+  accountId?: string | null;
+}): GoogleChatToolContext["replyToMode"] {
+  if (!params.cfg) {
+    return "off" as const;
+  }
+  const mode = resolveGoogleChatAccount({ cfg: params.cfg, accountId: params.accountId }).config
+    .replyToMode;
+  return mode === "first" || mode === "all" || mode === "batched" ? mode : "off";
+}
+
+function allowsImplicitToolThread(mode: string | undefined): boolean {
+  return mode === "first" || mode === "all";
+}
+
+function isCurrentGoogleChatTarget(params: {
+  to: string;
+  toolContext?: { currentChannelId?: string | null };
+}): boolean {
+  const target = normalizeGoogleChatChannelTarget(params.to);
+  const current = normalizeGoogleChatChannelTarget(params.toolContext?.currentChannelId);
+  return Boolean(target && current && target === current);
 }
 const collectGoogleChatGroupPolicyWarnings =
   createAllowlistProviderOpenWarningCollector<ResolvedGoogleChatAccount>({
@@ -149,27 +197,54 @@ export const googlechatThreadingAdapter = {
       account.config.replyToMode,
     fallback: "off" as const,
   },
-  buildToolContext: ({
-    cfg,
-    accountId,
-    context,
-    hasRepliedRef,
-  }: {
-    cfg: OpenClawConfig;
+  buildToolContext: (params: {
+    cfg?: OpenClawConfig;
     accountId?: string | null;
-    context: ChannelThreadingContext;
+    context?: ChannelThreadingContext;
     hasRepliedRef?: { value: boolean };
-  }): ChannelThreadingToolContext => {
-    const currentChannelId = normalizeGoogleChatTarget(context.To);
-    const currentThreadTs = normalizeGoogleChatThreadResourceName(context.MessageThreadId);
-
-    return {
-      currentChannelId,
-      currentMessageId: currentThreadTs,
-      currentThreadTs,
-      replyToMode: resolveGoogleChatAccount({ cfg, accountId }).config.replyToMode,
-      hasRepliedRef,
+  }): GoogleChatToolContext => {
+    const replyToMode = resolveGoogleChatToolReplyToMode(params);
+    const currentChannelId = normalizeGoogleChatChannelTarget(params.context?.To);
+    const currentThreadTs = normalizeGoogleChatThreadResourceName(params.context?.MessageThreadId);
+    const baseContext: GoogleChatToolContext = {
+      ...(currentChannelId ? { currentChannelId } : {}),
+      replyToMode,
+      ...(params.hasRepliedRef ? { hasRepliedRef: params.hasRepliedRef } : {}),
     };
+    if (!currentThreadTs) {
+      return baseContext;
+    }
+    return { ...baseContext, currentMessageId: currentThreadTs, currentThreadTs };
+  },
+  resolveAutoThreadId: ({
+    to,
+    replyToId,
+    toolContext,
+  }: {
+    cfg?: OpenClawConfig;
+    accountId?: string | null;
+    to: string;
+    replyToId?: string | null;
+    toolContext?: {
+      currentChannelId?: string | null;
+      currentThreadTs?: string | null;
+      replyToMode?: string | null;
+    };
+  }) => {
+    if (!allowsImplicitToolThread(toolContext?.replyToMode ?? undefined)) {
+      return undefined;
+    }
+    const inboundThread = normalizeGoogleChatThreadResourceName(toolContext?.currentThreadTs);
+    if (!inboundThread) {
+      return undefined;
+    }
+    if (replyToId && !isGoogleChatMessageResourceName(replyToId)) {
+      return undefined;
+    }
+    if (!replyToId && !isCurrentGoogleChatTarget({ to, toolContext })) {
+      return undefined;
+    }
+    return inboundThread;
   },
   resolveReplyTransport: ({
     threadId,
@@ -271,7 +346,11 @@ export const googlechatOutboundAdapter = {
         accountId,
       });
       const space = await resolveGoogleChatOutboundSpace({ account, target: to });
-      const thread = resolveGoogleChatOutboundThread({ threadId, replyToId });
+      const thread = resolveGoogleChatOutboundThread({
+        threadId,
+        replyToId,
+        allowThreadIdOnly: true,
+      });
       const { sendGoogleChatMessage } = await loadGoogleChatChannelRuntime();
       const result = await sendGoogleChatMessage({
         account,

--- a/extensions/googlechat/src/channel.adapters.ts
+++ b/extensions/googlechat/src/channel.adapters.ts
@@ -41,6 +41,7 @@ import {
   type OpenClawConfig,
 } from "./channel.deps.runtime.js";
 import { resolveGoogleChatGroupRequireMention } from "./group-policy.js";
+import { isGoogleChatThreadResourceName } from "./thread-resource.js";
 
 const loadGoogleChatChannelRuntime = createLazyRuntimeNamedExport(
   () => import("./channel.runtime.js"),
@@ -71,12 +72,8 @@ function createGoogleChatSendReceipt(params: {
 
 export const formatAllowFromEntry = formatGoogleChatAllowFromEntry;
 
-const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
-
 function normalizeGoogleChatThreadResourceName(value?: string | number | null): string | undefined {
-  return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value)
-    ? value
-    : undefined;
+  return typeof value === "string" && isGoogleChatThreadResourceName(value) ? value : undefined;
 }
 
 function resolveGoogleChatOutboundThread(params: {

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -272,14 +272,14 @@ describe("googlechatPlugin outbound sendMedia", () => {
             cfg,
             to: "spaces/AAA",
             text: "threaded",
-            threadId: "thread-1",
+            threadId: "spaces/AAA/threads/thread-1",
           });
           const request = requireMockArg(sendGoogleChatMessageMock) as {
             space?: string;
             thread?: string;
           };
           expect(request.space).toBe("spaces/AAA");
-          expect(request.thread).toBe("thread-1");
+          expect(request.thread).toBe("spaces/AAA/threads/thread-1");
         },
         messageSendingHooks: () => {
           expect(googlechatMessageAdapter.send?.text).toBeTypeOf("function");

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -471,6 +471,28 @@ describe("googlechatPlugin threading", () => {
     });
   });
 
+  it("surfaces account reply mode in tool context", () => {
+    const hasRepliedRef = { value: false };
+    const result = googlechatThreadingAdapter.buildToolContext({
+      cfg: {
+        channels: {
+          googlechat: {
+            replyToMode: "all",
+          },
+        },
+      } as OpenClawConfig,
+      context: { MessageThreadId: "spaces/AAA/threads/xyz", To: "googlechat:spaces/AAA" },
+      hasRepliedRef,
+    });
+    expect(result).toEqual({
+      currentChannelId: "spaces/AAA",
+      currentMessageId: "spaces/AAA/threads/xyz",
+      currentThreadTs: "spaces/AAA/threads/xyz",
+      replyToMode: "all",
+      hasRepliedRef,
+    });
+  });
+
   it("does not use message resources as implicit Google Chat reply targets", () => {
     const cfg = {
       channels: {
@@ -529,10 +551,7 @@ describe("googlechatPlugin threading", () => {
         replyToId: "spaces/AAA/messages/current",
         threadId: "spaces/AAA/threads/inbound",
       }),
-    ).toEqual({
-      replyToId: "spaces/AAA/threads/inbound",
-      threadId: null,
-    });
+    ).toBeNull();
     expect(
       googlechatThreadingAdapter.resolveReplyTransport?.({
         cfg: {} as OpenClawConfig,
@@ -574,11 +593,38 @@ describe("googlechatPlugin threading", () => {
         toolContext: {
           currentChannelId: "spaces/AAA",
           currentThreadTs: "spaces/AAA/threads/inbound",
+          currentMessageId: "spaces/AAA/messages/current",
           replyToMode: "all",
         },
         replyToId: "spaces/AAA/messages/current",
       }),
     ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          currentMessageId: "spaces/AAA/messages/current",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/messages/other",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "first",
+          hasRepliedRef: { value: true },
+        },
+        replyToId: undefined,
+      }),
+    ).toBeUndefined();
     expect(
       googlechatThreadingAdapter.resolveAutoThreadId?.({
         cfg: {} as OpenClawConfig,

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -503,6 +503,7 @@ describe("googlechatPlugin threading", () => {
       cfg,
       context: { MessageThreadId: 12345 },
     });
+    expect(result.replyToMode).toBe("off");
     expect(result.currentThreadTs).toBeUndefined();
     expect(result.currentMessageId).toBeUndefined();
     expect(
@@ -516,6 +517,7 @@ describe("googlechatPlugin threading", () => {
   it("returns an empty tool context when no inbound thread is present", () => {
     const cfg = createGoogleChatCfg();
     const context = googlechatThreadingAdapter.buildToolContext({ cfg, context: {} });
+    expect(context.replyToMode).toBe("off");
     expect(context.currentThreadTs).toBeUndefined();
     expect(context.currentMessageId).toBeUndefined();
   });
@@ -548,6 +550,83 @@ describe("googlechatPlugin threading", () => {
         threadId: undefined,
       }),
     ).toBeNull();
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: undefined,
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toBeNull();
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/not-a-thread/current",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves an auto thread only when reply mode allows implicit tool threading", () => {
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/messages/current",
+      }),
+    ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "off",
+        },
+        replyToId: "spaces/AAA/messages/current",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/not-a-thread/current",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: undefined,
+      }),
+    ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/BBB",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: undefined,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -457,7 +457,7 @@ describe("googlechatPlugin threading", () => {
       context: {
         To: "googlechat:spaces/AAA",
         CurrentMessageId: "spaces/AAA/messages/msg-1",
-        ReplyToId: "spaces/AAA/threads/thread-1",
+        MessageThreadId: "spaces/AAA/threads/thread-1",
       },
       hasRepliedRef,
     });
@@ -495,6 +495,15 @@ describe("googlechatPlugin threading", () => {
     });
     expect(context.currentMessageId).toBeUndefined();
     expect(context.currentThreadTs).toBeUndefined();
+  });
+
+  it("coerces numeric MessageThreadId values to strings", () => {
+    const cfg = createGoogleChatCfg();
+    const result = googlechatThreadingAdapter.buildToolContext({
+      cfg,
+      context: { MessageThreadId: 12345 },
+    });
+    expect(result.currentThreadTs).toBe("12345");
   });
 });
 

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -946,7 +946,7 @@ describe("googlechatPlugin outbound cfg threading", () => {
       config: {},
       credentialSource: "inline" as const,
     };
-    const { fetchRemoteMedia } = setupRuntimeMediaMocks({
+    const { readRemoteMediaBuffer } = setupRuntimeMediaMocks({
       loadFileName: "unused.png",
       loadBytes: "should-not-be-used",
     });
@@ -969,7 +969,7 @@ describe("googlechatPlugin outbound cfg threading", () => {
       threadId: "spaces/AAA/threads/explicit",
     });
 
-    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+    expect(readRemoteMediaBuffer).toHaveBeenCalledWith(
       expect.objectContaining({
         url: "https://example.com/file.png",
       }),

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -893,6 +893,52 @@ describe("googlechatPlugin outbound cfg threading", () => {
     ]);
   });
 
+  it("preserves explicit thread resources on outbound media sends", async () => {
+    const cfg = createGoogleChatCfg();
+    const account = {
+      accountId: "default",
+      config: {},
+      credentialSource: "inline" as const,
+    };
+    const { fetchRemoteMedia } = setupRuntimeMediaMocks({
+      loadFileName: "unused.png",
+      loadBytes: "should-not-be-used",
+    });
+
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    uploadGoogleChatAttachmentMock.mockResolvedValue({
+      attachmentUploadToken: "token-threaded",
+    });
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-threaded-media",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      text: "photo",
+      mediaUrl: "https://example.com/file.png",
+      accountId: "default",
+      threadId: "spaces/AAA/threads/explicit",
+    });
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/file.png",
+      }),
+    );
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        space: "spaces/AAA",
+        text: "photo",
+        thread: "spaces/AAA/threads/explicit",
+        attachments: [{ attachmentUploadToken: "token-threaded", contentName: "remote.png" }],
+      }),
+    );
+  });
+
   it("sends media without requiring Google Chat runtime initialization", async () => {
     const { loadOutboundMediaFromUrl } = setupRuntimeMediaMocks({
       loadFileName: "image.png",

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -497,13 +497,57 @@ describe("googlechatPlugin threading", () => {
     expect(context.currentThreadTs).toBeUndefined();
   });
 
-  it("coerces numeric MessageThreadId values to strings", () => {
+  it("ignores non-resource MessageThreadId values in tool context", () => {
     const cfg = createGoogleChatCfg();
     const result = googlechatThreadingAdapter.buildToolContext({
       cfg,
       context: { MessageThreadId: 12345 },
     });
-    expect(result.currentThreadTs).toBe("12345");
+    expect(result.currentThreadTs).toBeUndefined();
+    expect(result.currentMessageId).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.buildToolContext({
+        cfg,
+        context: { MessageThreadId: "spaces/AAA/messages/not-a-thread" },
+      }).currentThreadTs,
+    ).toBeUndefined();
+  });
+
+  it("returns an empty tool context when no inbound thread is present", () => {
+    const cfg = createGoogleChatCfg();
+    const context = googlechatThreadingAdapter.buildToolContext({ cfg, context: {} });
+    expect(context.currentThreadTs).toBeUndefined();
+    expect(context.currentMessageId).toBeUndefined();
+  });
+
+  it("resolves reply transport to a thread-shaped reply target", () => {
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/messages/current",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toEqual({
+      replyToId: "spaces/AAA/threads/inbound",
+      threadId: null,
+    });
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/threads/explicit",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toEqual({
+      replyToId: "spaces/AAA/threads/explicit",
+      threadId: null,
+    });
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/messages/current",
+        threadId: undefined,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -651,6 +695,57 @@ describe("googlechatPlugin outbound cfg threading", () => {
     expect(request.account).toBe(account);
     expect(request.space).toBe("spaces/AAA");
     expect(request.text).toBe("hello");
+  });
+
+  it("normalizes Google Chat thread resources before outbound text sends", async () => {
+    const cfg = createGoogleChatCfg();
+    const account = {
+      accountId: "default",
+      config: {},
+      credentialSource: "inline" as const,
+    };
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-threaded",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/threads/explicit",
+      threadId: "spaces/AAA/threads/inbound",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+
+    vi.clearAllMocks();
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-unthreaded",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/messages/current",
+      threadId: undefined,
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: undefined,
+      }),
+    );
   });
 
   it("threads resolved cfg into sendMedia account and media loading path", async () => {

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -422,26 +422,48 @@ describe("googlechatPlugin threading", () => {
 
   it("surfaces the inbound thread resource as currentThreadTs in tool context", () => {
     const result = googlechatThreadingAdapter.buildToolContext({
-      context: { MessageThreadId: "spaces/AAA/threads/xyz" },
+      context: { MessageThreadId: "spaces/AAA/threads/xyz", To: "googlechat:spaces/AAA" },
     });
+    expect(result.currentChannelId).toBe("spaces/AAA");
     expect(result.currentThreadTs).toBe("spaces/AAA/threads/xyz");
+    expect(result.replyToMode).toBe("off");
+  });
+
+  it("surfaces account reply mode in tool context", () => {
+    const result = googlechatThreadingAdapter.buildToolContext({
+      cfg: {
+        channels: {
+          googlechat: {
+            replyToMode: "all",
+          },
+        },
+      } as OpenClawConfig,
+      context: { MessageThreadId: "spaces/AAA/threads/xyz", To: "googlechat:spaces/AAA" },
+    });
+    expect(result).toEqual({
+      currentChannelId: "spaces/AAA",
+      currentThreadTs: "spaces/AAA/threads/xyz",
+      replyToMode: "all",
+    });
   });
 
   it("ignores non-resource MessageThreadId values in tool context", () => {
     const result = googlechatThreadingAdapter.buildToolContext({
       context: { MessageThreadId: 12345 },
     });
-    expect(result).toEqual({});
+    expect(result).toEqual({ replyToMode: "off" });
     expect(
       googlechatThreadingAdapter.buildToolContext({
         context: { MessageThreadId: "spaces/AAA/messages/not-a-thread" },
       }),
-    ).toEqual({});
+    ).toEqual({ replyToMode: "off" });
   });
 
   it("returns an empty tool context when no inbound thread is present", () => {
-    expect(googlechatThreadingAdapter.buildToolContext({ context: {} })).toEqual({});
-    expect(googlechatThreadingAdapter.buildToolContext({})).toEqual({});
+    expect(googlechatThreadingAdapter.buildToolContext({ context: {} })).toEqual({
+      replyToMode: "off",
+    });
+    expect(googlechatThreadingAdapter.buildToolContext({})).toEqual({ replyToMode: "off" });
   });
 
   it("resolves reply transport to a thread-shaped reply target", () => {
@@ -472,6 +494,83 @@ describe("googlechatPlugin threading", () => {
         threadId: undefined,
       }),
     ).toBeNull();
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: undefined,
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toBeNull();
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/not-a-thread/current",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolves an auto thread only when reply mode allows implicit tool threading", () => {
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/messages/current",
+      }),
+    ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "off",
+        },
+        replyToId: "spaces/AAA/messages/current",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/not-a-thread/current",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: undefined,
+      }),
+    ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/BBB",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "all",
+        },
+        replyToId: undefined,
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -256,12 +256,12 @@ describe("googlechatPlugin outbound sendMedia", () => {
               cfg,
               to: "spaces/AAA",
               text: "threaded",
-              threadId: "thread-1",
+              threadId: "spaces/AAA/threads/thread-1",
             });
             expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
               expect.objectContaining({
                 space: "spaces/AAA",
-                thread: "thread-1",
+                thread: "spaces/AAA/threads/thread-1",
               }),
             );
           },

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -419,6 +419,25 @@ describe("googlechatPlugin threading", () => {
       googlechatThreadingAdapter.scopedAccountReplyToMode.resolveReplyToMode(defaultAccount),
     ).toBe("all");
   });
+
+  it("surfaces the inbound thread resource as currentThreadTs in tool context", () => {
+    const result = googlechatThreadingAdapter.buildToolContext({
+      context: { MessageThreadId: "spaces/AAA/threads/xyz" },
+    });
+    expect(result.currentThreadTs).toBe("spaces/AAA/threads/xyz");
+  });
+
+  it("coerces numeric MessageThreadId values to strings", () => {
+    const result = googlechatThreadingAdapter.buildToolContext({
+      context: { MessageThreadId: 12345 },
+    });
+    expect(result.currentThreadTs).toBe("12345");
+  });
+
+  it("returns an empty tool context when no inbound thread is present", () => {
+    expect(googlechatThreadingAdapter.buildToolContext({ context: {} })).toEqual({});
+    expect(googlechatThreadingAdapter.buildToolContext({})).toEqual({});
+  });
 });
 
 const resolveTarget = googlechatOutboundAdapter.base.resolveTarget;

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -832,6 +832,52 @@ describe("googlechatPlugin outbound cfg threading", () => {
     );
   });
 
+  it("preserves explicit thread resources on outbound media sends", async () => {
+    const cfg = createGoogleChatCfg();
+    const account = {
+      accountId: "default",
+      config: {},
+      credentialSource: "inline" as const,
+    };
+    const { fetchRemoteMedia } = setupRuntimeMediaMocks({
+      loadFileName: "unused.png",
+      loadBytes: "should-not-be-used",
+    });
+
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    uploadGoogleChatAttachmentMock.mockResolvedValue({
+      attachmentUploadToken: "token-threaded",
+    });
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-threaded-media",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendMedia({
+      cfg,
+      to: "spaces/AAA",
+      text: "photo",
+      mediaUrl: "https://example.com/file.png",
+      accountId: "default",
+      threadId: "spaces/AAA/threads/explicit",
+    });
+
+    expect(fetchRemoteMedia).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://example.com/file.png",
+      }),
+    );
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account,
+        space: "spaces/AAA",
+        text: "photo",
+        thread: "spaces/AAA/threads/explicit",
+        attachments: [{ attachmentUploadToken: "token-threaded", contentName: "remote.png" }],
+      }),
+    );
+  });
+
   it("sends media without requiring Google Chat runtime initialization", async () => {
     const { loadOutboundMediaFromUrl } = setupRuntimeMediaMocks({
       loadFileName: "image.png",

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -427,16 +427,51 @@ describe("googlechatPlugin threading", () => {
     expect(result.currentThreadTs).toBe("spaces/AAA/threads/xyz");
   });
 
-  it("coerces numeric MessageThreadId values to strings", () => {
+  it("ignores non-resource MessageThreadId values in tool context", () => {
     const result = googlechatThreadingAdapter.buildToolContext({
       context: { MessageThreadId: 12345 },
     });
-    expect(result.currentThreadTs).toBe("12345");
+    expect(result).toEqual({});
+    expect(
+      googlechatThreadingAdapter.buildToolContext({
+        context: { MessageThreadId: "spaces/AAA/messages/not-a-thread" },
+      }),
+    ).toEqual({});
   });
 
   it("returns an empty tool context when no inbound thread is present", () => {
     expect(googlechatThreadingAdapter.buildToolContext({ context: {} })).toEqual({});
     expect(googlechatThreadingAdapter.buildToolContext({})).toEqual({});
+  });
+
+  it("resolves reply transport to a thread-shaped reply target", () => {
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/messages/current",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toEqual({
+      replyToId: "spaces/AAA/threads/inbound",
+      threadId: null,
+    });
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/threads/explicit",
+        threadId: "spaces/AAA/threads/inbound",
+      }),
+    ).toEqual({
+      replyToId: "spaces/AAA/threads/explicit",
+      threadId: null,
+    });
+    expect(
+      googlechatThreadingAdapter.resolveReplyTransport?.({
+        cfg: {} as OpenClawConfig,
+        replyToId: "spaces/AAA/messages/current",
+        threadId: undefined,
+      }),
+    ).toBeNull();
   });
 });
 
@@ -580,6 +615,57 @@ describe("googlechatPlugin outbound cfg threading", () => {
         account,
         space: "spaces/AAA",
         text: "hello",
+      }),
+    );
+  });
+
+  it("normalizes Google Chat thread resources before outbound text sends", async () => {
+    const cfg = createGoogleChatCfg();
+    const account = {
+      accountId: "default",
+      config: {},
+      credentialSource: "inline" as const,
+    };
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-threaded",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/threads/explicit",
+      threadId: "spaces/AAA/threads/inbound",
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: "spaces/AAA/threads/explicit",
+      }),
+    );
+
+    vi.clearAllMocks();
+    resolveGoogleChatAccountMock.mockReturnValue(account);
+    resolveGoogleChatOutboundSpaceMock.mockResolvedValue("spaces/AAA");
+    sendGoogleChatMessageMock.mockResolvedValue({
+      messageName: "spaces/AAA/messages/msg-unthreaded",
+    });
+
+    await googlechatOutboundAdapter.attachedResults.sendText({
+      cfg,
+      to: "spaces/AAA",
+      text: "hello",
+      accountId: "default",
+      replyToId: "spaces/AAA/messages/current",
+      threadId: undefined,
+    });
+
+    expect(sendGoogleChatMessageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        thread: undefined,
       }),
     );
   });

--- a/extensions/googlechat/src/channel.test.ts
+++ b/extensions/googlechat/src/channel.test.ts
@@ -430,6 +430,7 @@ describe("googlechatPlugin threading", () => {
   });
 
   it("surfaces account reply mode in tool context", () => {
+    const hasRepliedRef = { value: false };
     const result = googlechatThreadingAdapter.buildToolContext({
       cfg: {
         channels: {
@@ -439,11 +440,13 @@ describe("googlechatPlugin threading", () => {
         },
       } as OpenClawConfig,
       context: { MessageThreadId: "spaces/AAA/threads/xyz", To: "googlechat:spaces/AAA" },
+      hasRepliedRef,
     });
     expect(result).toEqual({
       currentChannelId: "spaces/AAA",
       currentThreadTs: "spaces/AAA/threads/xyz",
       replyToMode: "all",
+      hasRepliedRef,
     });
   });
 
@@ -473,10 +476,7 @@ describe("googlechatPlugin threading", () => {
         replyToId: "spaces/AAA/messages/current",
         threadId: "spaces/AAA/threads/inbound",
       }),
-    ).toEqual({
-      replyToId: "spaces/AAA/threads/inbound",
-      threadId: null,
-    });
+    ).toBeNull();
     expect(
       googlechatThreadingAdapter.resolveReplyTransport?.({
         cfg: {} as OpenClawConfig,
@@ -518,11 +518,38 @@ describe("googlechatPlugin threading", () => {
         toolContext: {
           currentChannelId: "spaces/AAA",
           currentThreadTs: "spaces/AAA/threads/inbound",
+          currentMessageId: "spaces/AAA/messages/current",
           replyToMode: "all",
         },
         replyToId: "spaces/AAA/messages/current",
       }),
     ).toBe("spaces/AAA/threads/inbound");
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          currentMessageId: "spaces/AAA/messages/current",
+          replyToMode: "all",
+        },
+        replyToId: "spaces/AAA/messages/other",
+      }),
+    ).toBeUndefined();
+    expect(
+      googlechatThreadingAdapter.resolveAutoThreadId?.({
+        cfg: {} as OpenClawConfig,
+        to: "spaces/AAA",
+        toolContext: {
+          currentChannelId: "spaces/AAA",
+          currentThreadTs: "spaces/AAA/threads/inbound",
+          replyToMode: "first",
+          hasRepliedRef: { value: true },
+        },
+        replyToId: undefined,
+      }),
+    ).toBeUndefined();
     expect(
       googlechatThreadingAdapter.resolveAutoThreadId?.({
         cfg: {} as OpenClawConfig,

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -34,9 +34,17 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
 }));
 
-vi.mock("gaxios", () => ({
-  Gaxios: mocks.gaxiosCtor,
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: function MockGoogleAuth() {},
+  OAuth2Client: function MockOAuth2Client() {},
+  gaxios: {
+    Gaxios: mocks.gaxiosCtor,
+  },
 }));
+
+vi.mock("gaxios", () => {
+  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
+});
 
 let __testing: typeof import("./google-auth.runtime.js").__testing;
 let createGoogleAuthFetch: typeof import("./google-auth.runtime.js").createGoogleAuthFetch;

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -428,10 +428,10 @@ describe("googlechat google auth runtime", () => {
     expect(first).not.toBe(second);
     expect(mocks.gaxiosCtor).toHaveBeenCalledTimes(2);
     expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
-    expect(first.interceptors.request.add).toHaveBeenCalledOnce();
-    expect(first.interceptors.response.add).toHaveBeenCalledOnce();
-    expect(second.interceptors.request.add).toHaveBeenCalledOnce();
-    expect(second.interceptors.response.add).toHaveBeenCalledOnce();
+    expect(first.interceptors.request.add.mock.calls).toHaveLength(1);
+    expect(first.interceptors.response.add.mock.calls).toHaveLength(1);
+    expect(second.interceptors.request.add.mock.calls).toHaveLength(1);
+    expect(second.interceptors.response.add.mock.calls).toHaveLength(1);
   });
 
   it("normalizes Google auth request headers before upstream interceptors run", () => {

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     hostnameAllowlist: hosts,
   })),
   fetchWithSsrFGuard: vi.fn(),
+  directGaxiosCtor: vi.fn(),
   gaxiosCtor: vi.fn(
     function MockGaxios(
       this: {
@@ -43,9 +44,9 @@ vi.mock("google-auth-library", () => ({
   },
 }));
 
-vi.mock("gaxios", () => {
-  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
-});
+vi.mock("gaxios", () => ({
+  Gaxios: mocks.directGaxiosCtor,
+}));
 
 let testing: typeof import("./google-auth.runtime.js").testing;
 let createGoogleAuthFetch: typeof import("./google-auth.runtime.js").createGoogleAuthFetch;
@@ -65,6 +66,7 @@ beforeEach(() => {
   testing.resetGoogleAuthRuntimeForTests();
   mocks.buildHostnameAllowlistPolicyFromSuffixAllowlist.mockClear();
   mocks.fetchWithSsrFGuard.mockReset();
+  mocks.directGaxiosCtor.mockClear();
   mocks.gaxiosCtor.mockClear();
 });
 
@@ -405,6 +407,7 @@ describe("googlechat google auth runtime", () => {
         | undefined;
 
       expect(mocks.gaxiosCtor).toHaveBeenCalledOnce();
+      expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
       expect(typeof transportDefaults.fetchImplementation).toBe("function");
       expect(requestInterceptorAdd).toHaveBeenCalledOnce();
       expect(typeof requestInterceptor?.resolved).toBe("function");
@@ -424,10 +427,11 @@ describe("googlechat google auth runtime", () => {
 
     expect(first).not.toBe(second);
     expect(mocks.gaxiosCtor).toHaveBeenCalledTimes(2);
-    expect(first.interceptors.request["add"]).toHaveBeenCalledOnce();
-    expect(first.interceptors.response["add"]).toHaveBeenCalledOnce();
-    expect(second.interceptors.request["add"]).toHaveBeenCalledOnce();
-    expect(second.interceptors.response["add"]).toHaveBeenCalledOnce();
+    expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
+    expect(first.interceptors.request.add).toHaveBeenCalledOnce();
+    expect(first.interceptors.response.add).toHaveBeenCalledOnce();
+    expect(second.interceptors.request.add).toHaveBeenCalledOnce();
+    expect(second.interceptors.response.add).toHaveBeenCalledOnce();
   });
 
   it("normalizes Google auth request headers before upstream interceptors run", () => {

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -53,6 +53,13 @@ let createGoogleAuthFetch: typeof import("./google-auth.runtime.js").createGoogl
 let getGoogleAuthTransport: typeof import("./google-auth.runtime.js").getGoogleAuthTransport;
 let resolveValidatedGoogleChatCredentials: typeof import("./google-auth.runtime.js").resolveValidatedGoogleChatCredentials;
 
+type MockGoogleAuthTransport = {
+  interceptors: {
+    request: { add: ReturnType<typeof vi.fn> };
+    response: { add: ReturnType<typeof vi.fn> };
+  };
+};
+
 beforeAll(async () => {
   ({
     testing,
@@ -424,14 +431,16 @@ describe("googlechat google auth runtime", () => {
   it("keeps auth transports isolated from google-auth interceptor mutations", async () => {
     const first = await getGoogleAuthTransport();
     const second = await getGoogleAuthTransport();
+    const firstMockTransport = first as unknown as MockGoogleAuthTransport;
+    const secondMockTransport = second as unknown as MockGoogleAuthTransport;
 
     expect(first).not.toBe(second);
     expect(mocks.gaxiosCtor).toHaveBeenCalledTimes(2);
     expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
-    expect(first.interceptors.request.add.mock.calls).toHaveLength(1);
-    expect(first.interceptors.response.add.mock.calls).toHaveLength(1);
-    expect(second.interceptors.request.add.mock.calls).toHaveLength(1);
-    expect(second.interceptors.response.add.mock.calls).toHaveLength(1);
+    expect(firstMockTransport.interceptors.request.add.mock.calls).toHaveLength(1);
+    expect(firstMockTransport.interceptors.response.add.mock.calls).toHaveLength(1);
+    expect(secondMockTransport.interceptors.request.add.mock.calls).toHaveLength(1);
+    expect(secondMockTransport.interceptors.response.add.mock.calls).toHaveLength(1);
   });
 
   it("normalizes Google auth request headers before upstream interceptors run", () => {

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -35,9 +35,17 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ({
   fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
 }));
 
-vi.mock("gaxios", () => ({
-  Gaxios: mocks.gaxiosCtor,
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: function MockGoogleAuth() {},
+  OAuth2Client: function MockOAuth2Client() {},
+  gaxios: {
+    Gaxios: mocks.gaxiosCtor,
+  },
 }));
+
+vi.mock("gaxios", () => {
+  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
+});
 
 let testing: typeof import("./google-auth.runtime.js").testing;
 let createGoogleAuthFetch: typeof import("./google-auth.runtime.js").createGoogleAuthFetch;
@@ -69,6 +77,7 @@ afterEach(() => {
 afterAll(() => {
   vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
   vi.doUnmock("gaxios");
+  vi.doUnmock("google-auth-library");
   vi.resetModules();
 });
 

--- a/extensions/googlechat/src/google-auth.runtime.test.ts
+++ b/extensions/googlechat/src/google-auth.runtime.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
     hostnameAllowlist: hosts,
   })),
   fetchWithSsrFGuard: vi.fn(),
+  directGaxiosCtor: vi.fn(),
   gaxiosCtor: vi.fn(
     function MockGaxios(
       this: {
@@ -42,9 +43,9 @@ vi.mock("google-auth-library", () => ({
   },
 }));
 
-vi.mock("gaxios", () => {
-  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
-});
+vi.mock("gaxios", () => ({
+  Gaxios: mocks.directGaxiosCtor,
+}));
 
 let __testing: typeof import("./google-auth.runtime.js").__testing;
 let createGoogleAuthFetch: typeof import("./google-auth.runtime.js").createGoogleAuthFetch;
@@ -64,6 +65,7 @@ beforeEach(() => {
   __testing.resetGoogleAuthRuntimeForTests();
   mocks.buildHostnameAllowlistPolicyFromSuffixAllowlist.mockClear();
   mocks.fetchWithSsrFGuard.mockReset();
+  mocks.directGaxiosCtor.mockClear();
   mocks.gaxiosCtor.mockClear();
 });
 
@@ -368,6 +370,7 @@ describe("googlechat google auth runtime", () => {
         | undefined;
 
       expect(mocks.gaxiosCtor).toHaveBeenCalledOnce();
+      expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
       expect(typeof transportDefaults.fetchImplementation).toBe("function");
       expect(requestInterceptorAdd).toHaveBeenCalledOnce();
       expect(typeof requestInterceptor?.resolved).toBe("function");
@@ -387,6 +390,7 @@ describe("googlechat google auth runtime", () => {
 
     expect(first).not.toBe(second);
     expect(mocks.gaxiosCtor).toHaveBeenCalledTimes(2);
+    expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
     expect(first.interceptors.request.add).toHaveBeenCalledOnce();
     expect(first.interceptors.response.add).toHaveBeenCalledOnce();
     expect(second.interceptors.request.add).toHaveBeenCalledOnce();

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -13,13 +13,12 @@ type TlsCert = ConnectionOptions["cert"];
 type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthModule = typeof import("google-auth-library");
-type GaxiosModule = typeof import("gaxios");
 type GoogleAuthRuntime = {
-  Gaxios: GaxiosModule["Gaxios"];
+  Gaxios: GoogleAuthModule["gaxios"]["Gaxios"];
   GoogleAuth: GoogleAuthModule["GoogleAuth"];
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
-type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
+type GoogleAuthTransport = InstanceType<GoogleAuthModule["gaxios"]["Gaxios"]>;
 type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
   headers?: unknown;
 };
@@ -516,12 +515,9 @@ export async function loadGoogleAuthRuntime(): Promise<GoogleAuthRuntime> {
   if (!googleAuthRuntimePromise) {
     googleAuthRuntimePromise = (async () => {
       try {
-        const [googleAuthModule, gaxiosModule] = await Promise.all([
-          import("google-auth-library"),
-          import("gaxios"),
-        ]);
+        const googleAuthModule = await import("google-auth-library");
         return {
-          Gaxios: gaxiosModule.Gaxios,
+          Gaxios: googleAuthModule.gaxios.Gaxios,
           GoogleAuth: googleAuthModule.GoogleAuth,
           OAuth2Client: googleAuthModule.OAuth2Client,
         };

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -15,12 +15,13 @@ type TlsCert = ConnectionOptions["cert"];
 type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthModule = typeof import("google-auth-library");
+type GaxiosModule = typeof import("gaxios");
 type GoogleAuthRuntime = {
-  Gaxios: GoogleAuthModule["gaxios"]["Gaxios"];
+  Gaxios: GaxiosModule["Gaxios"];
   GoogleAuth: GoogleAuthModule["GoogleAuth"];
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
-type GoogleAuthTransport = InstanceType<GoogleAuthModule["gaxios"]["Gaxios"]>;
+type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
 type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
   headers?: unknown;
 };
@@ -517,9 +518,22 @@ export async function loadGoogleAuthRuntime(): Promise<GoogleAuthRuntime> {
   if (!googleAuthRuntimePromise) {
     googleAuthRuntimePromise = (async () => {
       try {
-        const googleAuthModule = await import("google-auth-library");
+        const [googleAuthModule, gaxiosModule] = await Promise.all([
+          import("google-auth-library"),
+          import("gaxios"),
+        ]);
+        const directGaxios = gaxiosModule.Gaxios;
+        const bundledGaxios = googleAuthModule.gaxios?.Gaxios as unknown as
+          | GaxiosModule["Gaxios"]
+          | undefined;
+        // Source checkouts can resolve a root gaxios version; prefer the version
+        // bundled with google-auth-library when it differs from the direct import.
+        const Gaxios =
+          bundledGaxios && (bundledGaxios as unknown) !== (directGaxios as unknown)
+            ? bundledGaxios
+            : directGaxios;
         return {
-          Gaxios: googleAuthModule.gaxios.Gaxios,
+          Gaxios,
           GoogleAuth: googleAuthModule.GoogleAuth,
           OAuth2Client: googleAuthModule.OAuth2Client,
         };

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -15,13 +15,12 @@ type TlsCert = ConnectionOptions["cert"];
 type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthModule = typeof import("google-auth-library");
-type GaxiosModule = typeof import("gaxios");
 type GoogleAuthRuntime = {
-  Gaxios: GaxiosModule["Gaxios"];
+  Gaxios: GoogleAuthModule["gaxios"]["Gaxios"];
   GoogleAuth: GoogleAuthModule["GoogleAuth"];
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
-type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
+type GoogleAuthTransport = InstanceType<GoogleAuthModule["gaxios"]["Gaxios"]>;
 type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
   headers?: unknown;
 };
@@ -518,12 +517,9 @@ export async function loadGoogleAuthRuntime(): Promise<GoogleAuthRuntime> {
   if (!googleAuthRuntimePromise) {
     googleAuthRuntimePromise = (async () => {
       try {
-        const [googleAuthModule, gaxiosModule] = await Promise.all([
-          import("google-auth-library"),
-          import("gaxios"),
-        ]);
+        const googleAuthModule = await import("google-auth-library");
         return {
-          Gaxios: gaxiosModule.Gaxios,
+          Gaxios: googleAuthModule.gaxios.Gaxios,
           GoogleAuth: googleAuthModule.GoogleAuth,
           OAuth2Client: googleAuthModule.OAuth2Client,
         };

--- a/extensions/googlechat/src/google-auth.runtime.ts
+++ b/extensions/googlechat/src/google-auth.runtime.ts
@@ -13,12 +13,13 @@ type TlsCert = ConnectionOptions["cert"];
 type TlsKey = ConnectionOptions["key"];
 type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
 type GoogleAuthModule = typeof import("google-auth-library");
+type GaxiosModule = typeof import("gaxios");
 type GoogleAuthRuntime = {
-  Gaxios: GoogleAuthModule["gaxios"]["Gaxios"];
+  Gaxios: GaxiosModule["Gaxios"];
   GoogleAuth: GoogleAuthModule["GoogleAuth"];
   OAuth2Client: GoogleAuthModule["OAuth2Client"];
 };
-type GoogleAuthTransport = InstanceType<GoogleAuthModule["gaxios"]["Gaxios"]>;
+type GoogleAuthTransport = InstanceType<GaxiosModule["Gaxios"]>;
 type GoogleAuthRequestWithUnknownHeaders = RequestInit & {
   headers?: unknown;
 };
@@ -515,9 +516,22 @@ export async function loadGoogleAuthRuntime(): Promise<GoogleAuthRuntime> {
   if (!googleAuthRuntimePromise) {
     googleAuthRuntimePromise = (async () => {
       try {
-        const googleAuthModule = await import("google-auth-library");
+        const [googleAuthModule, gaxiosModule] = await Promise.all([
+          import("google-auth-library"),
+          import("gaxios"),
+        ]);
+        const directGaxios = gaxiosModule.Gaxios;
+        const bundledGaxios = googleAuthModule.gaxios?.Gaxios as unknown as
+          | GaxiosModule["Gaxios"]
+          | undefined;
+        // Source checkouts can resolve a root gaxios version; prefer the version
+        // bundled with google-auth-library when it differs from the direct import.
+        const Gaxios =
+          bundledGaxios && (bundledGaxios as unknown) !== (directGaxios as unknown)
+            ? bundledGaxios
+            : directGaxios;
         return {
-          Gaxios: googleAuthModule.gaxios.Gaxios,
+          Gaxios,
           GoogleAuth: googleAuthModule.GoogleAuth,
           OAuth2Client: googleAuthModule.OAuth2Client,
         };

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -6,22 +6,21 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isGoogleChatThreadResourceName,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
-const GOOGLE_CHAT_THREAD_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
-
 function resolveOutboundThread(
   payloadReplyToId: string | undefined,
   inboundThreadId: string | undefined,
 ): string | undefined {
-  if (payloadReplyToId && GOOGLE_CHAT_THREAD_RE.test(payloadReplyToId)) {
+  if (isGoogleChatThreadResourceName(payloadReplyToId)) {
     return payloadReplyToId;
   }
-  return inboundThreadId;
+  return isGoogleChatThreadResourceName(inboundThreadId) ? inboundThreadId : undefined;
 }
 
 export async function deliverGoogleChatReply(params: {
@@ -33,7 +32,7 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
-  inboundThreadId?: string;
+  inboundThreadId: string | undefined;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
   const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isGoogleChatMessageResourceName,
   isGoogleChatThreadResourceName,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
@@ -20,7 +21,13 @@ function resolveOutboundThread(
   if (isGoogleChatThreadResourceName(payloadReplyToId)) {
     return payloadReplyToId;
   }
-  return isGoogleChatThreadResourceName(inboundThreadId) ? inboundThreadId : undefined;
+  if (
+    isGoogleChatMessageResourceName(payloadReplyToId) &&
+    isGoogleChatThreadResourceName(inboundThreadId)
+  ) {
+    return inboundThreadId;
+  }
+  return undefined;
 }
 
 export async function deliverGoogleChatReply(params: {

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -12,6 +12,18 @@ import {
 } from "./api.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
+const GOOGLE_CHAT_THREAD_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+
+function resolveOutboundThread(
+  payloadReplyToId: string | undefined,
+  inboundThreadId: string | undefined,
+): string | undefined {
+  if (payloadReplyToId && GOOGLE_CHAT_THREAD_RE.test(payloadReplyToId)) {
+    return payloadReplyToId;
+  }
+  return inboundThreadId;
+}
+
 export async function deliverGoogleChatReply(params: {
   payload: { text?: string; mediaUrls?: string[]; mediaUrl?: string; replyToId?: string };
   account: ResolvedGoogleChatAccount;
@@ -21,8 +33,10 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
+  inboundThreadId?: string;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
+  const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);
   // Clear this whenever the typing message is deleted or unavailable; otherwise
   // text delivery can keep retrying a dead message and drop content.
   let typingMessageName = params.typingMessageName;
@@ -70,7 +84,7 @@ export async function deliverGoogleChatReply(params: {
       account,
       space: spaceId,
       text: chunk,
-      thread: payload.replyToId,
+      thread: outboundThread,
     });
   };
   await deliverTextOrMediaReply({
@@ -125,7 +139,7 @@ export async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread: outboundThread,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -16,6 +16,7 @@ import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-type
 
 function resolveOutboundThread(
   payloadReplyToId: string | undefined,
+  inboundMessageId: string | undefined,
   inboundThreadId: string | undefined,
 ): string | undefined {
   if (isGoogleChatThreadResourceName(payloadReplyToId)) {
@@ -23,6 +24,7 @@ function resolveOutboundThread(
   }
   if (
     isGoogleChatMessageResourceName(payloadReplyToId) &&
+    payloadReplyToId === inboundMessageId &&
     isGoogleChatThreadResourceName(inboundThreadId)
   ) {
     return inboundThreadId;
@@ -39,10 +41,15 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
+  inboundMessageId: string | undefined;
   inboundThreadId: string | undefined;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
-  const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);
+  const outboundThread = resolveOutboundThread(
+    payload.replyToId,
+    params.inboundMessageId,
+    params.inboundThreadId,
+  );
   // Clear this whenever the typing message is deleted or unavailable; otherwise
   // text delivery can keep retrying a dead message and drop content.
   let typingMessageName = params.typingMessageName;

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -13,6 +13,18 @@ import {
 } from "./api.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
+const GOOGLE_CHAT_THREAD_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+
+function resolveOutboundThread(
+  payloadReplyToId: string | undefined,
+  inboundThreadId: string | undefined,
+): string | undefined {
+  if (payloadReplyToId && GOOGLE_CHAT_THREAD_RE.test(payloadReplyToId)) {
+    return payloadReplyToId;
+  }
+  return inboundThreadId;
+}
+
 export async function deliverGoogleChatReply(params: {
   payload: {
     text?: string;
@@ -27,8 +39,10 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
+  inboundThreadId?: string;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
+  const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);
   // Clear this whenever the typing message is deleted or unavailable; otherwise
   // text delivery can keep retrying a dead message and drop content.
   let typingMessageName = params.typingMessageName;
@@ -76,7 +90,7 @@ export async function deliverGoogleChatReply(params: {
       account,
       space: spaceId,
       text: chunk,
-      thread: payload.replyToId,
+      thread: outboundThread,
     });
   };
   await deliverTextOrMediaReply({
@@ -131,7 +145,7 @@ export async function deliverGoogleChatReply(params: {
           account,
           space: spaceId,
           text: caption,
-          thread: payload.replyToId,
+          thread: outboundThread,
           attachments: [
             { attachmentUploadToken: upload.attachmentUploadToken, contentName: loaded.fileName },
           ],

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -7,22 +7,21 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isGoogleChatThreadResourceName,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
   uploadGoogleChatAttachment,
 } from "./api.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
-const GOOGLE_CHAT_THREAD_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
-
 function resolveOutboundThread(
   payloadReplyToId: string | undefined,
   inboundThreadId: string | undefined,
 ): string | undefined {
-  if (payloadReplyToId && GOOGLE_CHAT_THREAD_RE.test(payloadReplyToId)) {
+  if (isGoogleChatThreadResourceName(payloadReplyToId)) {
     return payloadReplyToId;
   }
-  return inboundThreadId;
+  return isGoogleChatThreadResourceName(inboundThreadId) ? inboundThreadId : undefined;
 }
 
 export async function deliverGoogleChatReply(params: {
@@ -39,7 +38,7 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
-  inboundThreadId?: string;
+  inboundThreadId: string | undefined;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
   const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -17,6 +17,7 @@ import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-type
 
 function resolveOutboundThread(
   payloadReplyToId: string | undefined,
+  inboundMessageId: string | undefined,
   inboundThreadId: string | undefined,
 ): string | undefined {
   if (isGoogleChatThreadResourceName(payloadReplyToId)) {
@@ -24,6 +25,7 @@ function resolveOutboundThread(
   }
   if (
     isGoogleChatMessageResourceName(payloadReplyToId) &&
+    payloadReplyToId === inboundMessageId &&
     isGoogleChatThreadResourceName(inboundThreadId)
   ) {
     return inboundThreadId;
@@ -45,10 +47,15 @@ export async function deliverGoogleChatReply(params: {
   config: OpenClawConfig;
   statusSink?: (patch: { lastInboundAt?: number; lastOutboundAt?: number }) => void;
   typingMessageName?: string;
+  inboundMessageId: string | undefined;
   inboundThreadId: string | undefined;
 }): Promise<void> {
   const { payload, account, spaceId, runtime, core, config, statusSink } = params;
-  const outboundThread = resolveOutboundThread(payload.replyToId, params.inboundThreadId);
+  const outboundThread = resolveOutboundThread(
+    payload.replyToId,
+    params.inboundMessageId,
+    params.inboundThreadId,
+  );
   // Clear this whenever the typing message is deleted or unavailable; otherwise
   // text delivery can keep retrying a dead message and drop content.
   let typingMessageName = params.typingMessageName;

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -7,6 +7,7 @@ import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
 import {
   deleteGoogleChatMessage,
+  isGoogleChatMessageResourceName,
   isGoogleChatThreadResourceName,
   sendGoogleChatMessage,
   updateGoogleChatMessage,
@@ -21,7 +22,13 @@ function resolveOutboundThread(
   if (isGoogleChatThreadResourceName(payloadReplyToId)) {
     return payloadReplyToId;
   }
-  return isGoogleChatThreadResourceName(inboundThreadId) ? inboundThreadId : undefined;
+  if (
+    isGoogleChatMessageResourceName(payloadReplyToId) &&
+    isGoogleChatThreadResourceName(inboundThreadId)
+  ) {
+    return inboundThreadId;
+  }
+  return undefined;
 }
 
 export async function deliverGoogleChatReply(params: {

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
@@ -132,7 +134,7 @@ describe("Google Chat reply delivery", () => {
     });
   });
 
-  it("falls back to the inbound thread when no reply target is supplied", async () => {
+  it("does not fall back to the inbound thread when no reply target is supplied", async () => {
     const core = createCore({ chunks: ["only chunk"] });
     const runtime = createRuntime();
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
@@ -148,7 +150,27 @@ describe("Google Chat reply delivery", () => {
     });
 
     expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ thread: "spaces/AAA/threads/inbound-thread" }),
+      expect.objectContaining({ thread: undefined }),
+    );
+  });
+
+  it("does not fall back to the inbound thread for malformed reply targets", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/not-a-thread/current" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: undefined }),
     );
   });
 

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
   updateGoogleChatMessage: mocks.updateGoogleChatMessage,
   uploadGoogleChatAttachment: mocks.uploadGoogleChatAttachment,
@@ -80,6 +82,7 @@ describe("Google Chat reply delivery", () => {
       config,
       statusSink,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundThreadId: undefined,
     });
 
     expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
@@ -190,6 +193,7 @@ describe("Google Chat reply delivery", () => {
       core,
       config,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundThreadId: undefined,
     });
 
     expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
@@ -203,6 +207,29 @@ describe("Google Chat reply delivery", () => {
       text: "caption",
       thread: "spaces/AAA/threads/root",
       attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
+    });
+  });
+
+  it("drops malformed inbound thread fallbacks before the API boundary", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/inbound" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/messages/not-a-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "only chunk",
+      thread: undefined,
     });
   });
 });

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -84,6 +84,7 @@ describe("Google Chat reply delivery", () => {
       config,
       statusSink,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundMessageId: undefined,
       inboundThreadId: undefined,
     });
 
@@ -111,7 +112,7 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
-  it("uses the inbound thread when replyToId resolves to a Google Chat message resource", async () => {
+  it("uses the inbound thread when replyToId resolves to the current Google Chat message resource", async () => {
     const core = createCore({ chunks: ["only chunk"] });
     const runtime = createRuntime();
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
@@ -123,6 +124,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -132,6 +134,27 @@ describe("Google Chat reply delivery", () => {
       text: "only chunk",
       thread: "spaces/AAA/threads/inbound-thread",
     });
+  });
+
+  it("does not map an arbitrary Google Chat message-resource replyTo onto the inbound thread", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/other" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: undefined }),
+    );
   });
 
   it("does not fall back to the inbound thread when no reply target is supplied", async () => {
@@ -146,6 +169,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -166,6 +190,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -186,6 +211,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -215,6 +241,7 @@ describe("Google Chat reply delivery", () => {
       core,
       config,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundMessageId: undefined,
       inboundThreadId: undefined,
     });
 
@@ -244,6 +271,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
       inboundThreadId: "spaces/AAA/messages/not-a-thread",
     });
 

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -106,6 +106,69 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
+  it("uses the inbound thread when replyToId resolves to a Google Chat message resource", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/inbound" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "only chunk",
+      thread: "spaces/AAA/threads/inbound-thread",
+    });
+  });
+
+  it("falls back to the inbound thread when no reply target is supplied", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: "spaces/AAA/threads/inbound-thread" }),
+    );
+  });
+
+  it("preserves an explicit thread-shaped replyToId over the inbound thread", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/threads/explicit" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: "spaces/AAA/threads/explicit" }),
+    );
+  });
+
   it("does not update a deleted typing message before sending media with a caption", async () => {
     const core = createCore({
       media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -83,6 +83,7 @@ describe("Google Chat reply delivery", () => {
       config,
       statusSink,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundMessageId: undefined,
       inboundThreadId: undefined,
     });
 
@@ -110,7 +111,7 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
-  it("uses the inbound thread when replyToId resolves to a Google Chat message resource", async () => {
+  it("uses the inbound thread when replyToId resolves to the current Google Chat message resource", async () => {
     const core = createCore({ chunks: ["only chunk"] });
     const runtime = createRuntime();
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
@@ -122,6 +123,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -131,6 +133,27 @@ describe("Google Chat reply delivery", () => {
       text: "only chunk",
       thread: "spaces/AAA/threads/inbound-thread",
     });
+  });
+
+  it("does not map an arbitrary Google Chat message-resource replyTo onto the inbound thread", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/other" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: undefined }),
+    );
   });
 
   it("does not fall back to the inbound thread when no reply target is supplied", async () => {
@@ -145,6 +168,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -165,6 +189,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -185,6 +210,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: undefined,
       inboundThreadId: "spaces/AAA/threads/inbound-thread",
     });
 
@@ -214,6 +240,7 @@ describe("Google Chat reply delivery", () => {
       core,
       config,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundMessageId: undefined,
       inboundThreadId: undefined,
     });
 
@@ -243,6 +270,7 @@ describe("Google Chat reply delivery", () => {
       runtime,
       core,
       config,
+      inboundMessageId: "spaces/AAA/messages/inbound",
       inboundThreadId: "spaces/AAA/messages/not-a-thread",
     });
 

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
   updateGoogleChatMessage: mocks.updateGoogleChatMessage,
   uploadGoogleChatAttachment: mocks.uploadGoogleChatAttachment,
@@ -79,6 +81,7 @@ describe("Google Chat reply delivery", () => {
       config,
       statusSink,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundThreadId: undefined,
     });
 
     expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
@@ -189,6 +192,7 @@ describe("Google Chat reply delivery", () => {
       core,
       config,
       typingMessageName: "spaces/AAA/messages/typing",
+      inboundThreadId: undefined,
     });
 
     expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
@@ -202,6 +206,29 @@ describe("Google Chat reply delivery", () => {
       text: "caption",
       thread: "spaces/AAA/threads/root",
       attachments: [{ attachmentUploadToken: "upload-token", contentName: "reply.png" }],
+    });
+  });
+
+  it("drops malformed inbound thread fallbacks before the API boundary", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/inbound" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/messages/not-a-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "only chunk",
+      thread: undefined,
     });
   });
 });

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -105,6 +105,69 @@ describe("Google Chat reply delivery", () => {
     );
   });
 
+  it("uses the inbound thread when replyToId resolves to a Google Chat message resource", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/messages/inbound" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "only chunk",
+      thread: "spaces/AAA/threads/inbound-thread",
+    });
+  });
+
+  it("falls back to the inbound thread when no reply target is supplied", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: "spaces/AAA/threads/inbound-thread" }),
+    );
+  });
+
+  it("preserves an explicit thread-shaped replyToId over the inbound thread", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/threads/explicit" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: "spaces/AAA/threads/explicit" }),
+    );
+  });
+
   it("does not update a deleted typing message before sending media with a caption", async () => {
     const core = createCore({
       media: { buffer: Buffer.from("image"), contentType: "image/png", fileName: "reply.png" },

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("./api.js", () => ({
   deleteGoogleChatMessage: mocks.deleteGoogleChatMessage,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   sendGoogleChatMessage: mocks.sendGoogleChatMessage,
@@ -131,7 +133,7 @@ describe("Google Chat reply delivery", () => {
     });
   });
 
-  it("falls back to the inbound thread when no reply target is supplied", async () => {
+  it("does not fall back to the inbound thread when no reply target is supplied", async () => {
     const core = createCore({ chunks: ["only chunk"] });
     const runtime = createRuntime();
     mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
@@ -147,7 +149,27 @@ describe("Google Chat reply delivery", () => {
     });
 
     expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ thread: "spaces/AAA/threads/inbound-thread" }),
+      expect.objectContaining({ thread: undefined }),
+    );
+  });
+
+  it("does not fall back to the inbound thread for malformed reply targets", async () => {
+    const core = createCore({ chunks: ["only chunk"] });
+    const runtime = createRuntime();
+    mocks.sendGoogleChatMessage.mockResolvedValue({ messageName: "spaces/AAA/messages/sent" });
+
+    await deliverGoogleChatReply({
+      payload: { text: "only chunk", replyToId: "spaces/AAA/not-a-thread/current" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime,
+      core,
+      config,
+      inboundThreadId: "spaces/AAA/threads/inbound-thread",
+    });
+
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: undefined }),
     );
   });
 

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -282,6 +282,7 @@ async function processMessageWithPipeline(params: {
     }
   }
 
+  const inboundMessageId = message.name;
   const inboundThreadId = message.thread?.name;
 
   await core.channel.turn.run({
@@ -326,6 +327,7 @@ async function processMessageWithPipeline(params: {
               config,
               statusSink,
               typingMessageName,
+              inboundMessageId,
               inboundThreadId,
             });
             // Only use typing message for first delivery

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -219,6 +219,7 @@ async function processMessageWithPipeline(params: {
       originatingTo: `googlechat:${spaceId}`,
       replyToId: message.thread?.name,
       replyToIdFull: message.thread?.name,
+      messageThreadId: message.thread?.name,
     },
     message: {
       body,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -282,6 +282,8 @@ async function processMessageWithPipeline(params: {
     }
   }
 
+  const inboundThreadId = message.thread?.name;
+
   await core.channel.turn.run({
     channel: "googlechat",
     accountId: route.accountId,
@@ -324,6 +326,7 @@ async function processMessageWithPipeline(params: {
               config,
               statusSink,
               typingMessageName,
+              inboundThreadId,
             });
             // Only use typing message for first delivery
             typingMessageName = undefined;

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -326,8 +326,9 @@ async function processMessageWithPipeline(params: {
     reply: {
       to: `googlechat:${spaceId}`,
       originatingTo: `googlechat:${spaceId}`,
-      replyToId: replyThreadName,
-      replyToIdFull: replyThreadName,
+      replyToId: message.thread?.name,
+      replyToIdFull: message.thread?.name,
+      messageThreadId: message.thread?.name,
     },
     message: {
       body,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -390,6 +390,7 @@ async function processMessageWithPipeline(params: {
     }
   }
 
+  const inboundMessageId = message.name;
   const inboundThreadId = replyThreadName;
 
   await core.channel.inbound.run({
@@ -434,6 +435,7 @@ async function processMessageWithPipeline(params: {
               config,
               statusSink,
               typingMessageName,
+              inboundMessageId,
               inboundThreadId,
             });
             // Only use typing message for first delivery

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -390,6 +390,8 @@ async function processMessageWithPipeline(params: {
     }
   }
 
+  const inboundThreadId = replyThreadName;
+
   await core.channel.inbound.run({
     channel: "googlechat",
     accountId: route.accountId,
@@ -432,6 +434,7 @@ async function processMessageWithPipeline(params: {
               config,
               statusSink,
               typingMessageName,
+              inboundThreadId,
             });
             // Only use typing message for first delivery
             typingMessageName = undefined;

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -326,9 +326,9 @@ async function processMessageWithPipeline(params: {
     reply: {
       to: `googlechat:${spaceId}`,
       originatingTo: `googlechat:${spaceId}`,
-      replyToId: message.thread?.name,
-      replyToIdFull: message.thread?.name,
-      messageThreadId: message.thread?.name,
+      replyToId: replyThreadName,
+      replyToIdFull: replyThreadName,
+      messageThreadId: replyThreadName,
     },
     message: {
       body,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -387,24 +387,26 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(buildContext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "spaces/AAA/messages/123",
-          messageIdFull: "spaces/AAA/messages/123",
-          reply: expect.objectContaining({
-            messageThreadId: "spaces/AAA/threads/xyz",
-            replyToId: "spaces/AAA/threads/xyz",
-            replyToIdFull: "spaces/AAA/threads/xyz",
+      await vi.waitFor(() => {
+        expect(buildContext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: "spaces/AAA/messages/123",
+            messageIdFull: "spaces/AAA/messages/123",
+            reply: expect.objectContaining({
+              messageThreadId: "spaces/AAA/threads/xyz",
+              replyToId: "spaces/AAA/threads/xyz",
+              replyToIdFull: "spaces/AAA/threads/xyz",
+            }),
           }),
-        }),
-      );
-      expect(run).toHaveBeenCalledWith(
-        expect.objectContaining({
-          adapter: expect.objectContaining({
-            resolveTurn: expect.any(Function),
+        );
+        expect(run).toHaveBeenCalledWith(
+          expect.objectContaining({
+            adapter: expect.objectContaining({
+              resolveTurn: expect.any(Function),
+            }),
           }),
-        }),
-      );
+        );
+      });
     } finally {
       unregister();
     }
@@ -497,17 +499,19 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(buildContext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "spaces/DM/messages/789",
-          messageIdFull: "spaces/DM/messages/789",
-          reply: expect.objectContaining({
-            messageThreadId: undefined,
-            replyToId: undefined,
-            replyToIdFull: undefined,
+      await vi.waitFor(() => {
+        expect(buildContext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: "spaces/DM/messages/789",
+            messageIdFull: "spaces/DM/messages/789",
+            reply: expect.objectContaining({
+              messageThreadId: undefined,
+              replyToId: undefined,
+              replyToIdFull: undefined,
+            }),
           }),
-        }),
-      );
+        );
+      });
     } finally {
       unregister();
     }
@@ -641,10 +645,12 @@ describe("Google Chat delivery thread routing", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
-        account: expect.objectContaining({ accountId: "default" }),
-        messageName: "spaces/AAA/messages/typing",
-        text: "threaded reply",
+      await vi.waitFor(() => {
+        expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
+          account: expect.objectContaining({ accountId: "default" }),
+          messageName: "spaces/AAA/messages/typing",
+          text: "threaded reply",
+        });
       });
       expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
         1,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -284,6 +284,8 @@ const updateGoogleChatMessageMock = vi.hoisted(() => vi.fn().mockResolvedValue({
 
 vi.mock("./api.js", () => ({
   sendGoogleChatMessage: sendGoogleChatMessageMock,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   updateGoogleChatMessage: updateGoogleChatMessageMock,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -19,6 +19,11 @@ vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
 }));
 
+afterAll(() => {
+  vi.doUnmock("./auth.js");
+  vi.resetModules();
+});
+
 type GoogleChatBuildContextParams = {
   messageId?: string;
   messageIdFull?: string;
@@ -178,11 +183,6 @@ function mockSecondVerifierSuccess() {
 describe("Google Chat webhook routing", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
-  });
-
-  afterAll(() => {
-    vi.doUnmock("./auth.js");
-    vi.resetModules();
   });
 
   it("rejects ambiguous routing when multiple targets on the same path verify successfully", async () => {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -257,8 +257,16 @@ describe("Google Chat webhook routing", () => {
   });
 });
 
+const sendGoogleChatMessageMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+);
+const updateGoogleChatMessageMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
 vi.mock("./api.js", () => ({
-  sendGoogleChatMessage: vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+  sendGoogleChatMessage: sendGoogleChatMessageMock,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
+  updateGoogleChatMessage: updateGoogleChatMessageMock,
   downloadGoogleChatMedia: vi.fn(),
 }));
 
@@ -282,7 +290,11 @@ describe("Google Chat monitor inbound context", () => {
           shouldHandleTextCommands: () => false,
           isControlCommandMessage: () => false,
         },
-        text: { hasControlCommand: () => false },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
         routing: {
           resolveAgentRoute: () => ({
             agentId: "finn",
@@ -387,7 +399,11 @@ describe("Google Chat monitor inbound context", () => {
           shouldHandleTextCommands: () => false,
           isControlCommandMessage: () => false,
         },
-        text: { hasControlCommand: () => false },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
         routing: {
           resolveAgentRoute: () => ({
             agentId: "finn",
@@ -460,6 +476,146 @@ describe("Google Chat monitor inbound context", () => {
           MessageThreadId: undefined,
           ReplyToId: undefined,
           ReplyToIdFull: undefined,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});
+
+describe("Google Chat delivery thread routing", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    sendGoogleChatMessageMock.mockClear();
+    updateGoogleChatMessageMock.mockClear();
+  });
+
+  function createPluginRuntime(
+    dispatchReplyWithBufferedBlockDispatcher: ReturnType<typeof vi.fn>,
+  ): PluginRuntime {
+    return {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:group:spaces/AAA",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext: vi.fn((ctx) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+  }
+
+  const inboundPayload = {
+    type: "MESSAGE",
+    eventTime: "2026-04-28T00:00:00.000Z",
+    space: { name: "spaces/AAA", displayName: "Team Room", type: "ROOM" },
+    message: {
+      name: "spaces/AAA/messages/123",
+      text: "hello",
+      sender: { name: "users/alice", displayName: "Alice" },
+      thread: { name: "spaces/AAA/threads/xyz" },
+      annotations: [],
+    },
+  };
+
+  const accountConfig = {
+    accountId: "default",
+    enabled: true,
+    credentialSource: "none",
+    config: {
+      allowBots: true,
+      groups: {
+        "spaces/AAA": { users: ["users/alice"], requireMention: false },
+      },
+    },
+  } as ResolvedGoogleChatAccount;
+
+  it("threads delivered replies through the inbound thread when replyToId is a message resource", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    updateGoogleChatMessageMock.mockRejectedValueOnce(new Error("typing message disappeared"));
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(
+      async (params: {
+        dispatcherOptions: {
+          deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+        };
+      }) => {
+        await params.dispatcherOptions.deliver({
+          text: "threaded reply",
+          replyToId: "spaces/AAA/messages/123",
+        });
+      },
+    );
+    const core = createPluginRuntime(dispatchReplyWithBufferedBlockDispatcher);
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: accountConfig,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-delivery-thread",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-delivery-thread",
+          payload: inboundPayload,
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
+        account: expect.objectContaining({ accountId: "default" }),
+        messageName: "spaces/AAA/messages/typing",
+        text: "threaded reply",
+      });
+      expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          text: expect.stringContaining("is typing"),
+          thread: "spaces/AAA/threads/xyz",
+        }),
+      );
+      expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          text: "threaded reply",
+          thread: "spaces/AAA/threads/xyz",
         }),
       );
     } finally {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -19,6 +19,26 @@ vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
 }));
 
+type GoogleChatBuildContextParams = {
+  messageId?: string;
+  messageIdFull?: string;
+  reply: {
+    messageThreadId?: string;
+    replyToId?: string;
+    replyToIdFull?: string;
+  };
+};
+
+function createGoogleChatBuildContextMock() {
+  return vi.fn((params: GoogleChatBuildContextParams) => ({
+    MessageSid: params.messageId,
+    MessageSidFull: params.messageIdFull,
+    MessageThreadId: params.reply.messageThreadId,
+    ReplyToId: params.reply.replyToId,
+    ReplyToIdFull: params.reply.replyToIdFull,
+  }));
+}
+
 function createWebhookRequest(params: {
   authorization?: string;
   payload: unknown;
@@ -279,8 +299,8 @@ describe("Google Chat monitor inbound context", () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
     await import("./monitor.js");
 
-    const finalizeInboundContext = vi.fn((ctx) => ctx);
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -310,8 +330,10 @@ describe("Google Chat monitor inbound context", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext,
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -363,20 +385,20 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect(buildContext).toHaveBeenCalledWith(
         expect.objectContaining({
-          MessageSid: "spaces/AAA/messages/123",
-          MessageSidFull: "spaces/AAA/messages/123",
-          MessageThreadId: "spaces/AAA/threads/xyz",
-          ReplyToId: "spaces/AAA/threads/xyz",
-          ReplyToIdFull: "spaces/AAA/threads/xyz",
+          messageId: "spaces/AAA/messages/123",
+          messageIdFull: "spaces/AAA/messages/123",
+          reply: expect.objectContaining({
+            messageThreadId: "spaces/AAA/threads/xyz",
+            replyToId: "spaces/AAA/threads/xyz",
+            replyToIdFull: "spaces/AAA/threads/xyz",
+          }),
         }),
       );
-      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect(runResolved).toHaveBeenCalledWith(
         expect.objectContaining({
-          ctx: expect.objectContaining({
-            MessageThreadId: "spaces/AAA/threads/xyz",
-          }),
+          resolveTurn: expect.any(Function),
         }),
       );
     } finally {
@@ -388,8 +410,8 @@ describe("Google Chat monitor inbound context", () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
     await import("./monitor.js");
 
-    const finalizeInboundContext = vi.fn((ctx) => ctx);
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -419,8 +441,10 @@ describe("Google Chat monitor inbound context", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext,
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -469,13 +493,15 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect(buildContext).toHaveBeenCalledWith(
         expect.objectContaining({
-          MessageSid: "spaces/DM/messages/789",
-          MessageSidFull: "spaces/DM/messages/789",
-          MessageThreadId: undefined,
-          ReplyToId: undefined,
-          ReplyToIdFull: undefined,
+          messageId: "spaces/DM/messages/789",
+          messageIdFull: "spaces/DM/messages/789",
+          reply: expect.objectContaining({
+            messageThreadId: undefined,
+            replyToId: undefined,
+            replyToIdFull: undefined,
+          }),
         }),
       );
     } finally {
@@ -491,9 +517,26 @@ describe("Google Chat delivery thread routing", () => {
     updateGoogleChatMessageMock.mockClear();
   });
 
-  function createPluginRuntime(
-    dispatchReplyWithBufferedBlockDispatcher: ReturnType<typeof vi.fn>,
-  ): PluginRuntime {
+  function createPluginRuntime(deliverPayload?: {
+    text: string;
+    replyToId: string;
+  }): PluginRuntime {
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(
+      async (params: {
+        resolveTurn: () => {
+          delivery: {
+            deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+          };
+        };
+      }) => {
+        if (deliverPayload) {
+          await params.resolveTurn().delivery.deliver(deliverPayload);
+        }
+        return {};
+      },
+    );
+
     return {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -523,8 +566,10 @@ describe("Google Chat delivery thread routing", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext: vi.fn((ctx) => ctx),
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -563,19 +608,10 @@ describe("Google Chat delivery thread routing", () => {
     await import("./monitor.js");
 
     updateGoogleChatMessageMock.mockRejectedValueOnce(new Error("typing message disappeared"));
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(
-      async (params: {
-        dispatcherOptions: {
-          deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
-        };
-      }) => {
-        await params.dispatcherOptions.deliver({
-          text: "threaded reply",
-          replyToId: "spaces/AAA/messages/123",
-        });
-      },
-    );
-    const core = createPluginRuntime(dispatchReplyWithBufferedBlockDispatcher);
+    const core = createPluginRuntime({
+      text: "threaded reply",
+      replyToId: "spaces/AAA/messages/123",
+    });
 
     const unregister = registerGoogleChatWebhookTarget({
       account: accountConfig,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -420,7 +420,7 @@ describe("Google Chat monitor inbound context", () => {
         config: {
           allowBots: true,
           typingIndicator: "none",
-          dm: { policy: "open" },
+          dm: { policy: "allowlist", allowFrom: ["users/alice"] },
         },
       } as ResolvedGoogleChatAccount,
       config: {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -300,7 +300,7 @@ describe("Google Chat monitor inbound context", () => {
     await import("./monitor.js");
 
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(async () => ({}));
+    const run = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -333,7 +333,7 @@ describe("Google Chat monitor inbound context", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -396,9 +396,11 @@ describe("Google Chat monitor inbound context", () => {
           }),
         }),
       );
-      expect(runResolved).toHaveBeenCalledWith(
+      expect(run).toHaveBeenCalledWith(
         expect.objectContaining({
-          resolveTurn: expect.any(Function),
+          adapter: expect.objectContaining({
+            resolveTurn: expect.any(Function),
+          }),
         }),
       );
     } finally {
@@ -411,7 +413,7 @@ describe("Google Chat monitor inbound context", () => {
     await import("./monitor.js");
 
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(async () => ({}));
+    const run = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -444,7 +446,7 @@ describe("Google Chat monitor inbound context", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -522,16 +524,18 @@ describe("Google Chat delivery thread routing", () => {
     replyToId: string;
   }): PluginRuntime {
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(
+    const run = vi.fn(
       async (params: {
-        resolveTurn: () => {
-          delivery: {
-            deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+        adapter: {
+          resolveTurn: () => {
+            delivery: {
+              deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+            };
           };
         };
       }) => {
         if (deliverPayload) {
-          await params.resolveTurn().delivery.deliver(deliverPayload);
+          await params.adapter.resolveTurn().delivery.deliver(deliverPayload);
         }
         return {};
       },
@@ -569,7 +573,7 @@ describe("Google Chat delivery thread routing", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -256,3 +256,119 @@ describe("Google Chat webhook routing", () => {
     }
   });
 });
+
+vi.mock("./api.js", () => ({
+  sendGoogleChatMessage: vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+  downloadGoogleChatMedia: vi.fn(),
+}));
+
+describe("Google Chat monitor inbound context", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("preserves the Google Chat thread resource separately from the message id", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: { hasControlCommand: () => false },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:group:spaces/AAA",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: {
+        accountId: "default",
+        enabled: true,
+        credentialSource: "none",
+        config: {
+          allowBots: true,
+          typingIndicator: "none",
+          groups: {
+            "spaces/AAA": { users: ["users/alice"], requireMention: false },
+          },
+        },
+      } as ResolvedGoogleChatAccount,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-context",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-context",
+          payload: {
+            type: "MESSAGE",
+            eventTime: "2026-04-28T00:00:00.000Z",
+            space: { name: "spaces/AAA", displayName: "Team Room", type: "ROOM" },
+            message: {
+              name: "spaces/AAA/messages/123",
+              text: "hello thread",
+              sender: { name: "users/alice", displayName: "Alice" },
+              thread: { name: "spaces/AAA/threads/xyz" },
+              annotations: [],
+            },
+          },
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(finalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MessageSid: "spaces/AAA/messages/123",
+          MessageSidFull: "spaces/AAA/messages/123",
+          MessageThreadId: "spaces/AAA/threads/xyz",
+          ReplyToId: "spaces/AAA/threads/xyz",
+          ReplyToIdFull: "spaces/AAA/threads/xyz",
+        }),
+      );
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            MessageThreadId: "spaces/AAA/threads/xyz",
+          }),
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -371,4 +371,99 @@ describe("Google Chat monitor inbound context", () => {
       unregister();
     }
   });
+
+  it("leaves MessageThreadId unset when the inbound message has no thread", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: { hasControlCommand: () => false },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:dm:spaces/DM",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: {
+        accountId: "default",
+        enabled: true,
+        credentialSource: "none",
+        config: {
+          allowBots: true,
+          typingIndicator: "none",
+          dm: { policy: "open" },
+        },
+      } as ResolvedGoogleChatAccount,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-context-dm",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-context-dm",
+          payload: {
+            type: "MESSAGE",
+            eventTime: "2026-04-28T00:00:00.000Z",
+            space: { name: "spaces/DM", type: "DM" },
+            message: {
+              name: "spaces/DM/messages/789",
+              text: "hi",
+              sender: { name: "users/alice", displayName: "Alice" },
+              annotations: [],
+            },
+          },
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(finalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MessageSid: "spaces/DM/messages/789",
+          MessageSidFull: "spaces/DM/messages/789",
+          MessageThreadId: undefined,
+          ReplyToId: undefined,
+          ReplyToIdFull: undefined,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
 });

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -333,7 +333,7 @@ describe("Google Chat monitor inbound context", () => {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
         },
-        turn: {
+        inbound: {
           buildContext,
           run,
         },
@@ -448,7 +448,7 @@ describe("Google Chat monitor inbound context", () => {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
         },
-        turn: {
+        inbound: {
           buildContext,
           run,
         },
@@ -577,7 +577,7 @@ describe("Google Chat delivery thread routing", () => {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
         },
-        turn: {
+        inbound: {
           buildContext,
           run,
         },

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -255,3 +255,119 @@ describe("Google Chat webhook routing", () => {
     }
   });
 });
+
+vi.mock("./api.js", () => ({
+  sendGoogleChatMessage: vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+  downloadGoogleChatMedia: vi.fn(),
+}));
+
+describe("Google Chat monitor inbound context", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("preserves the Google Chat thread resource separately from the message id", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: { hasControlCommand: () => false },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:group:spaces/AAA",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: {
+        accountId: "default",
+        enabled: true,
+        credentialSource: "none",
+        config: {
+          allowBots: true,
+          typingIndicator: "none",
+          groups: {
+            "spaces/AAA": { users: ["users/alice"], requireMention: false },
+          },
+        },
+      } as ResolvedGoogleChatAccount,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-context",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-context",
+          payload: {
+            type: "MESSAGE",
+            eventTime: "2026-04-28T00:00:00.000Z",
+            space: { name: "spaces/AAA", displayName: "Team Room", type: "ROOM" },
+            message: {
+              name: "spaces/AAA/messages/123",
+              text: "hello thread",
+              sender: { name: "users/alice", displayName: "Alice" },
+              thread: { name: "spaces/AAA/threads/xyz" },
+              annotations: [],
+            },
+          },
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(finalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MessageSid: "spaces/AAA/messages/123",
+          MessageSidFull: "spaces/AAA/messages/123",
+          MessageThreadId: "spaces/AAA/threads/xyz",
+          ReplyToId: "spaces/AAA/threads/xyz",
+          ReplyToIdFull: "spaces/AAA/threads/xyz",
+        }),
+      );
+      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ctx: expect.objectContaining({
+            MessageThreadId: "spaces/AAA/threads/xyz",
+          }),
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -386,24 +386,26 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(buildContext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "spaces/AAA/messages/123",
-          messageIdFull: "spaces/AAA/messages/123",
-          reply: expect.objectContaining({
-            messageThreadId: "spaces/AAA/threads/xyz",
-            replyToId: "spaces/AAA/threads/xyz",
-            replyToIdFull: "spaces/AAA/threads/xyz",
+      await vi.waitFor(() => {
+        expect(buildContext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: "spaces/AAA/messages/123",
+            messageIdFull: "spaces/AAA/messages/123",
+            reply: expect.objectContaining({
+              messageThreadId: "spaces/AAA/threads/xyz",
+              replyToId: "spaces/AAA/threads/xyz",
+              replyToIdFull: "spaces/AAA/threads/xyz",
+            }),
           }),
-        }),
-      );
-      expect(run).toHaveBeenCalledWith(
-        expect.objectContaining({
-          adapter: expect.objectContaining({
-            resolveTurn: expect.any(Function),
+        );
+        expect(run).toHaveBeenCalledWith(
+          expect.objectContaining({
+            adapter: expect.objectContaining({
+              resolveTurn: expect.any(Function),
+            }),
           }),
-        }),
-      );
+        );
+      });
     } finally {
       unregister();
     }
@@ -496,17 +498,19 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(buildContext).toHaveBeenCalledWith(
-        expect.objectContaining({
-          messageId: "spaces/DM/messages/789",
-          messageIdFull: "spaces/DM/messages/789",
-          reply: expect.objectContaining({
-            messageThreadId: undefined,
-            replyToId: undefined,
-            replyToIdFull: undefined,
+      await vi.waitFor(() => {
+        expect(buildContext).toHaveBeenCalledWith(
+          expect.objectContaining({
+            messageId: "spaces/DM/messages/789",
+            messageIdFull: "spaces/DM/messages/789",
+            reply: expect.objectContaining({
+              messageThreadId: undefined,
+              replyToId: undefined,
+              replyToIdFull: undefined,
+            }),
           }),
-        }),
-      );
+        );
+      });
     } finally {
       unregister();
     }
@@ -640,10 +644,12 @@ describe("Google Chat delivery thread routing", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
-        account: expect.objectContaining({ accountId: "default" }),
-        messageName: "spaces/AAA/messages/typing",
-        text: "threaded reply",
+      await vi.waitFor(() => {
+        expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
+          account: expect.objectContaining({ accountId: "default" }),
+          messageName: "spaces/AAA/messages/typing",
+          text: "threaded reply",
+        });
       });
       expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
         1,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -299,7 +299,7 @@ describe("Google Chat monitor inbound context", () => {
     await import("./monitor.js");
 
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(async () => ({}));
+    const run = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -332,7 +332,7 @@ describe("Google Chat monitor inbound context", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -395,9 +395,11 @@ describe("Google Chat monitor inbound context", () => {
           }),
         }),
       );
-      expect(runResolved).toHaveBeenCalledWith(
+      expect(run).toHaveBeenCalledWith(
         expect.objectContaining({
-          resolveTurn: expect.any(Function),
+          adapter: expect.objectContaining({
+            resolveTurn: expect.any(Function),
+          }),
         }),
       );
     } finally {
@@ -410,7 +412,7 @@ describe("Google Chat monitor inbound context", () => {
     await import("./monitor.js");
 
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(async () => ({}));
+    const run = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -443,7 +445,7 @@ describe("Google Chat monitor inbound context", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -521,16 +523,18 @@ describe("Google Chat delivery thread routing", () => {
     replyToId: string;
   }): PluginRuntime {
     const buildContext = createGoogleChatBuildContextMock();
-    const runResolved = vi.fn(
+    const run = vi.fn(
       async (params: {
-        resolveTurn: () => {
-          delivery: {
-            deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+        adapter: {
+          resolveTurn: () => {
+            delivery: {
+              deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+            };
           };
         };
       }) => {
         if (deliverPayload) {
-          await params.resolveTurn().delivery.deliver(deliverPayload);
+          await params.adapter.resolveTurn().delivery.deliver(deliverPayload);
         }
         return {};
       },
@@ -568,7 +572,7 @@ describe("Google Chat delivery thread routing", () => {
         },
         turn: {
           buildContext,
-          runResolved,
+          run,
         },
         media: {
           saveMediaBuffer: vi.fn(),

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -18,6 +18,26 @@ vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
 }));
 
+type GoogleChatBuildContextParams = {
+  messageId?: string;
+  messageIdFull?: string;
+  reply: {
+    messageThreadId?: string;
+    replyToId?: string;
+    replyToIdFull?: string;
+  };
+};
+
+function createGoogleChatBuildContextMock() {
+  return vi.fn((params: GoogleChatBuildContextParams) => ({
+    MessageSid: params.messageId,
+    MessageSidFull: params.messageIdFull,
+    MessageThreadId: params.reply.messageThreadId,
+    ReplyToId: params.reply.replyToId,
+    ReplyToIdFull: params.reply.replyToIdFull,
+  }));
+}
+
 function createWebhookRequest(params: {
   authorization?: string;
   payload: unknown;
@@ -278,8 +298,8 @@ describe("Google Chat monitor inbound context", () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
     await import("./monitor.js");
 
-    const finalizeInboundContext = vi.fn((ctx) => ctx);
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -309,8 +329,10 @@ describe("Google Chat monitor inbound context", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext,
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -362,20 +384,20 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect(buildContext).toHaveBeenCalledWith(
         expect.objectContaining({
-          MessageSid: "spaces/AAA/messages/123",
-          MessageSidFull: "spaces/AAA/messages/123",
-          MessageThreadId: "spaces/AAA/threads/xyz",
-          ReplyToId: "spaces/AAA/threads/xyz",
-          ReplyToIdFull: "spaces/AAA/threads/xyz",
+          messageId: "spaces/AAA/messages/123",
+          messageIdFull: "spaces/AAA/messages/123",
+          reply: expect.objectContaining({
+            messageThreadId: "spaces/AAA/threads/xyz",
+            replyToId: "spaces/AAA/threads/xyz",
+            replyToIdFull: "spaces/AAA/threads/xyz",
+          }),
         }),
       );
-      expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect(runResolved).toHaveBeenCalledWith(
         expect.objectContaining({
-          ctx: expect.objectContaining({
-            MessageThreadId: "spaces/AAA/threads/xyz",
-          }),
+          resolveTurn: expect.any(Function),
         }),
       );
     } finally {
@@ -387,8 +409,8 @@ describe("Google Chat monitor inbound context", () => {
     vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
     await import("./monitor.js");
 
-    const finalizeInboundContext = vi.fn((ctx) => ctx);
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(async () => ({}));
     const core = {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -418,8 +440,10 @@ describe("Google Chat monitor inbound context", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext,
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -468,13 +492,15 @@ describe("Google Chat monitor inbound context", () => {
       );
 
       expect(res.statusCode).toBe(200);
-      expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect(buildContext).toHaveBeenCalledWith(
         expect.objectContaining({
-          MessageSid: "spaces/DM/messages/789",
-          MessageSidFull: "spaces/DM/messages/789",
-          MessageThreadId: undefined,
-          ReplyToId: undefined,
-          ReplyToIdFull: undefined,
+          messageId: "spaces/DM/messages/789",
+          messageIdFull: "spaces/DM/messages/789",
+          reply: expect.objectContaining({
+            messageThreadId: undefined,
+            replyToId: undefined,
+            replyToIdFull: undefined,
+          }),
         }),
       );
     } finally {
@@ -490,9 +516,26 @@ describe("Google Chat delivery thread routing", () => {
     updateGoogleChatMessageMock.mockClear();
   });
 
-  function createPluginRuntime(
-    dispatchReplyWithBufferedBlockDispatcher: ReturnType<typeof vi.fn>,
-  ): PluginRuntime {
+  function createPluginRuntime(deliverPayload?: {
+    text: string;
+    replyToId: string;
+  }): PluginRuntime {
+    const buildContext = createGoogleChatBuildContextMock();
+    const runResolved = vi.fn(
+      async (params: {
+        resolveTurn: () => {
+          delivery: {
+            deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+          };
+        };
+      }) => {
+        if (deliverPayload) {
+          await params.resolveTurn().delivery.deliver(deliverPayload);
+        }
+        return {};
+      },
+    );
+
     return {
       logging: { shouldLogVerbose: () => false },
       channel: {
@@ -522,8 +565,10 @@ describe("Google Chat delivery thread routing", () => {
         reply: {
           resolveEnvelopeFormatOptions: () => ({}),
           formatAgentEnvelope: ({ body }: { body: string }) => body,
-          finalizeInboundContext: vi.fn((ctx) => ctx),
-          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        turn: {
+          buildContext,
+          runResolved,
         },
         media: {
           saveMediaBuffer: vi.fn(),
@@ -562,19 +607,10 @@ describe("Google Chat delivery thread routing", () => {
     await import("./monitor.js");
 
     updateGoogleChatMessageMock.mockRejectedValueOnce(new Error("typing message disappeared"));
-    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(
-      async (params: {
-        dispatcherOptions: {
-          deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
-        };
-      }) => {
-        await params.dispatcherOptions.deliver({
-          text: "threaded reply",
-          replyToId: "spaces/AAA/messages/123",
-        });
-      },
-    );
-    const core = createPluginRuntime(dispatchReplyWithBufferedBlockDispatcher);
+    const core = createPluginRuntime({
+      text: "threaded reply",
+      replyToId: "spaces/AAA/messages/123",
+    });
 
     const unregister = registerGoogleChatWebhookTarget({
       account: accountConfig,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -419,7 +419,7 @@ describe("Google Chat monitor inbound context", () => {
         config: {
           allowBots: true,
           typingIndicator: "none",
-          dm: { policy: "open" },
+          dm: { policy: "allowlist", allowFrom: ["users/alice"] },
         },
       } as ResolvedGoogleChatAccount,
       config: {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -256,8 +256,16 @@ describe("Google Chat webhook routing", () => {
   });
 });
 
+const sendGoogleChatMessageMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+);
+const updateGoogleChatMessageMock = vi.hoisted(() => vi.fn().mockResolvedValue({}));
+
 vi.mock("./api.js", () => ({
-  sendGoogleChatMessage: vi.fn().mockResolvedValue({ messageName: "spaces/AAA/messages/typing" }),
+  sendGoogleChatMessage: sendGoogleChatMessageMock,
+  isGoogleChatThreadResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
+  updateGoogleChatMessage: updateGoogleChatMessageMock,
   downloadGoogleChatMedia: vi.fn(),
 }));
 
@@ -281,7 +289,11 @@ describe("Google Chat monitor inbound context", () => {
           shouldHandleTextCommands: () => false,
           isControlCommandMessage: () => false,
         },
-        text: { hasControlCommand: () => false },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
         routing: {
           resolveAgentRoute: () => ({
             agentId: "finn",
@@ -386,7 +398,11 @@ describe("Google Chat monitor inbound context", () => {
           shouldHandleTextCommands: () => false,
           isControlCommandMessage: () => false,
         },
-        text: { hasControlCommand: () => false },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
         routing: {
           resolveAgentRoute: () => ({
             agentId: "finn",
@@ -459,6 +475,146 @@ describe("Google Chat monitor inbound context", () => {
           MessageThreadId: undefined,
           ReplyToId: undefined,
           ReplyToIdFull: undefined,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
+});
+
+describe("Google Chat delivery thread routing", () => {
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    sendGoogleChatMessageMock.mockClear();
+    updateGoogleChatMessageMock.mockClear();
+  });
+
+  function createPluginRuntime(
+    dispatchReplyWithBufferedBlockDispatcher: ReturnType<typeof vi.fn>,
+  ): PluginRuntime {
+    return {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: {
+          hasControlCommand: () => false,
+          resolveChunkMode: () => "markdown",
+          chunkMarkdownTextWithMode: (text: string) => [text],
+        },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:group:spaces/AAA",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext: vi.fn((ctx) => ctx),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+  }
+
+  const inboundPayload = {
+    type: "MESSAGE",
+    eventTime: "2026-04-28T00:00:00.000Z",
+    space: { name: "spaces/AAA", displayName: "Team Room", type: "ROOM" },
+    message: {
+      name: "spaces/AAA/messages/123",
+      text: "hello",
+      sender: { name: "users/alice", displayName: "Alice" },
+      thread: { name: "spaces/AAA/threads/xyz" },
+      annotations: [],
+    },
+  };
+
+  const accountConfig = {
+    accountId: "default",
+    enabled: true,
+    credentialSource: "none",
+    config: {
+      allowBots: true,
+      groups: {
+        "spaces/AAA": { users: ["users/alice"], requireMention: false },
+      },
+    },
+  } as ResolvedGoogleChatAccount;
+
+  it("threads delivered replies through the inbound thread when replyToId is a message resource", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    updateGoogleChatMessageMock.mockRejectedValueOnce(new Error("typing message disappeared"));
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(
+      async (params: {
+        dispatcherOptions: {
+          deliver: (payload: { text: string; replyToId: string }) => Promise<void>;
+        };
+      }) => {
+        await params.dispatcherOptions.deliver({
+          text: "threaded reply",
+          replyToId: "spaces/AAA/messages/123",
+        });
+      },
+    );
+    const core = createPluginRuntime(dispatchReplyWithBufferedBlockDispatcher);
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: accountConfig,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-delivery-thread",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-delivery-thread",
+          payload: inboundPayload,
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(updateGoogleChatMessageMock).toHaveBeenCalledWith({
+        account: expect.objectContaining({ accountId: "default" }),
+        messageName: "spaces/AAA/messages/typing",
+        text: "threaded reply",
+      });
+      expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          text: expect.stringContaining("is typing"),
+          thread: "spaces/AAA/threads/xyz",
+        }),
+      );
+      expect(sendGoogleChatMessageMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          text: "threaded reply",
+          thread: "spaces/AAA/threads/xyz",
         }),
       );
     } finally {

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -370,4 +370,99 @@ describe("Google Chat monitor inbound context", () => {
       unregister();
     }
   });
+
+  it("leaves MessageThreadId unset when the inbound message has no thread", async () => {
+    vi.mocked(verifyGoogleChatRequest).mockResolvedValue({ ok: true });
+    await import("./monitor.js");
+
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn(async () => {});
+    const core = {
+      logging: { shouldLogVerbose: () => false },
+      channel: {
+        commands: {
+          shouldComputeCommandAuthorized: () => false,
+          resolveCommandAuthorizedFromAuthorizers: () => false,
+          shouldHandleTextCommands: () => false,
+          isControlCommandMessage: () => false,
+        },
+        text: { hasControlCommand: () => false },
+        routing: {
+          resolveAgentRoute: () => ({
+            agentId: "finn",
+            accountId: "default",
+            sessionKey: "agent:finn:googlechat:dm:spaces/DM",
+          }),
+        },
+        session: {
+          resolveStorePath: () => "/tmp/openclaw-test-store",
+          readSessionUpdatedAt: () => undefined,
+          recordSessionMetaFromInbound: vi.fn(async () => {}),
+        },
+        reply: {
+          resolveEnvelopeFormatOptions: () => ({}),
+          formatAgentEnvelope: ({ body }: { body: string }) => body,
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+        media: {
+          saveMediaBuffer: vi.fn(),
+        },
+      },
+    } as unknown as PluginRuntime;
+
+    const unregister = registerGoogleChatWebhookTarget({
+      account: {
+        accountId: "default",
+        enabled: true,
+        credentialSource: "none",
+        config: {
+          allowBots: true,
+          typingIndicator: "none",
+          dm: { policy: "open" },
+        },
+      } as ResolvedGoogleChatAccount,
+      config: {
+        agents: { list: [{ id: "finn", name: "Cosmo" }] },
+        channels: { googlechat: {} },
+      } as OpenClawConfig,
+      runtime: {},
+      core,
+      path: "/googlechat-context-dm",
+      mediaMaxMb: 5,
+    });
+
+    try {
+      const res = await dispatchWebhookRequest(
+        createWebhookRequest({
+          authorization: "Bearer test-token",
+          path: "/googlechat-context-dm",
+          payload: {
+            type: "MESSAGE",
+            eventTime: "2026-04-28T00:00:00.000Z",
+            space: { name: "spaces/DM", type: "DM" },
+            message: {
+              name: "spaces/DM/messages/789",
+              text: "hi",
+              sender: { name: "users/alice", displayName: "Alice" },
+              annotations: [],
+            },
+          },
+        }),
+      );
+
+      expect(res.statusCode).toBe(200);
+      expect(finalizeInboundContext).toHaveBeenCalledWith(
+        expect.objectContaining({
+          MessageSid: "spaces/DM/messages/789",
+          MessageSidFull: "spaces/DM/messages/789",
+          MessageThreadId: undefined,
+          ReplyToId: undefined,
+          ReplyToIdFull: undefined,
+        }),
+      );
+    } finally {
+      unregister();
+    }
+  });
 });

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -283,6 +283,8 @@ const updateGoogleChatMessageMock = vi.hoisted(() => vi.fn().mockResolvedValue({
 
 vi.mock("./api.js", () => ({
   sendGoogleChatMessage: sendGoogleChatMessageMock,
+  isGoogleChatMessageResourceName: (value: string | undefined) =>
+    typeof value === "string" && /^spaces\/[^/]+\/messages\/[^/]+$/.test(value),
   isGoogleChatThreadResourceName: (value: string | undefined) =>
     typeof value === "string" && /^spaces\/[^/]+\/threads\/[^/]+$/.test(value),
   updateGoogleChatMessage: updateGoogleChatMessageMock,

--- a/extensions/googlechat/src/monitor.webhook-routing.test.ts
+++ b/extensions/googlechat/src/monitor.webhook-routing.test.ts
@@ -18,6 +18,11 @@ vi.mock("./auth.js", () => ({
   verifyGoogleChatRequest: vi.fn(),
 }));
 
+afterAll(() => {
+  vi.doUnmock("./auth.js");
+  vi.resetModules();
+});
+
 type GoogleChatBuildContextParams = {
   messageId?: string;
   messageIdFull?: string;
@@ -177,11 +182,6 @@ function mockSecondVerifierSuccess() {
 describe("Google Chat webhook routing", () => {
   afterEach(() => {
     setActivePluginRegistry(createEmptyPluginRegistry());
-  });
-
-  afterAll(() => {
-    vi.doUnmock("./auth.js");
-    vi.resetModules();
   });
 
   it("rejects ambiguous routing when multiple targets on the same path verify successfully", async () => {

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -34,22 +34,25 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => {
   };
 });
 
-vi.mock("gaxios", () => ({
-  Gaxios: class {
-    defaults: unknown;
-    interceptors = {
-      request: { add: vi.fn() },
-      response: { add: vi.fn() },
-    };
-
-    constructor(defaults?: unknown) {
-      this.defaults = defaults;
-      mocks.gaxiosCtor(defaults);
-    }
-  },
-}));
+vi.mock("gaxios", () => {
+  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
+});
 
 vi.mock("google-auth-library", () => ({
+  gaxios: {
+    Gaxios: class {
+      defaults: unknown;
+      interceptors = {
+        request: { add: vi.fn() },
+        response: { add: vi.fn() },
+      };
+
+      constructor(defaults?: unknown) {
+        this.defaults = defaults;
+        mocks.gaxiosCtor(defaults);
+      }
+    },
+  },
   GoogleAuth: class {
     constructor(options?: unknown) {
       mocks.googleAuthCtor(options);

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -38,22 +38,25 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => {
   };
 });
 
-vi.mock("gaxios", () => ({
-  Gaxios: class {
-    defaults: unknown;
-    interceptors = {
-      request: { add: vi.fn() },
-      response: { add: vi.fn() },
-    };
-
-    constructor(defaults?: unknown) {
-      this.defaults = defaults;
-      mocks.gaxiosCtor(defaults);
-    }
-  },
-}));
+vi.mock("gaxios", () => {
+  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
+});
 
 vi.mock("google-auth-library", () => ({
+  gaxios: {
+    Gaxios: class {
+      defaults: unknown;
+      interceptors = {
+        request: { add: vi.fn() },
+        response: { add: vi.fn() },
+      };
+
+      constructor(defaults?: unknown) {
+        this.defaults = defaults;
+        mocks.gaxiosCtor(defaults);
+      }
+    },
+  },
   GoogleAuth: class {
     constructor(options?: unknown) {
       mocks.googleAuthCtor(options);

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -348,6 +348,27 @@ describe("sendGoogleChatMessage", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["space resource without /threads/", "spaces/AAA"],
+    ["thread name with empty thread id", "spaces/AAA/threads/"],
+    ["thread name with empty space id", "spaces//threads/xyz"],
+    ["thread name with extra path segments", "spaces/AAA/threads/xyz/messages/abc"],
+    ["bare thread id without resource path", "xyz"],
+  ])("rejects %s before sending", async (_label, badThread) => {
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/126");
+
+    await expect(
+      sendGoogleChatMessage({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+        thread: badThread,
+      }),
+    ).rejects.toThrow(`Google Chat thread must be a thread resource name, got ${badThread}`);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("reports malformed send JSON with a stable API error", async () => {
     vi.stubGlobal(
       "fetch",

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -331,6 +331,23 @@ describe("sendGoogleChatMessage", () => {
     expect(mocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
   });
 
+  it("rejects message resources passed as thread names", async () => {
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/125");
+
+    await expect(
+      sendGoogleChatMessage({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+        thread: "spaces/AAA/messages/123",
+      }),
+    ).rejects.toThrow(
+      "Google Chat thread must be a thread resource name, got spaces/AAA/messages/123",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("reports malformed send JSON with a stable API error", async () => {
     vi.stubGlobal(
       "fetch",

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
     response: await fetch(params.url, params.init),
     release: async () => {},
   })),
+  directGaxiosCtor: vi.fn(),
   googleAuthCtor: vi.fn(),
   gaxiosCtor: vi.fn(),
   getAccessToken: vi.fn().mockResolvedValue({ token: "access-token" }),
@@ -38,9 +39,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => {
   };
 });
 
-vi.mock("gaxios", () => {
-  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
-});
+vi.mock("gaxios", () => ({
+  Gaxios: function MockDirectGaxios(defaults?: unknown) {
+    mocks.directGaxiosCtor(defaults);
+  },
+}));
 
 vi.mock("google-auth-library", () => ({
   gaxios: {
@@ -439,6 +442,7 @@ function mockTicket(payload: Record<string, unknown>) {
 describe("verifyGoogleChatRequest", () => {
   afterEach(() => {
     authTesting.resetGoogleChatAuthForTests();
+    mocks.directGaxiosCtor.mockClear();
     mocks.getAccessToken.mockClear();
     mocks.gaxiosCtor.mockClear();
     mocks.googleAuthCtor.mockClear();
@@ -467,8 +471,13 @@ describe("verifyGoogleChatRequest", () => {
     };
 
     expect(mocks.gaxiosCtor).toHaveBeenCalledOnce();
-    expect(googleAuthOptions.credentials?.client_email).toBe("bot@example.iam.gserviceaccount.com");
-    expect(googleAuthOptions.credentials?.token_uri).toBe("https://oauth2.googleapis.com/token");
+    expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
+    expect(googleAuthOptions).toMatchObject({
+      credentials: {
+        client_email: "bot@example.iam.gserviceaccount.com",
+        token_uri: "https://oauth2.googleapis.com/token",
+      },
+    });
     expect(typeof googleAuthOptions.clientOptions?.transporter?.defaults?.fetchImplementation).toBe(
       "function",
     );

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -276,6 +276,27 @@ describe("sendGoogleChatMessage", () => {
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["space resource without /threads/", "spaces/AAA"],
+    ["thread name with empty thread id", "spaces/AAA/threads/"],
+    ["thread name with empty space id", "spaces//threads/xyz"],
+    ["thread name with extra path segments", "spaces/AAA/threads/xyz/messages/abc"],
+    ["bare thread id without resource path", "xyz"],
+  ])("rejects %s before sending", async (_label, badThread) => {
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/126");
+
+    await expect(
+      sendGoogleChatMessage({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+        thread: badThread,
+      }),
+    ).rejects.toThrow(`Google Chat thread must be a thread resource name, got ${badThread}`);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 function mockTicket(payload: Record<string, unknown>) {

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -259,6 +259,23 @@ describe("sendGoogleChatMessage", () => {
     const [url] = fetchMock.mock.calls[0] ?? [];
     expect(String(url)).not.toContain("messageReplyOption=");
   });
+
+  it("rejects message resources passed as thread names", async () => {
+    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/125");
+
+    await expect(
+      sendGoogleChatMessage({
+        account,
+        space: "spaces/AAA",
+        text: "hello",
+        thread: "spaces/AAA/messages/123",
+      }),
+    ).rejects.toThrow(
+      "Google Chat thread must be a thread resource name, got spaces/AAA/messages/123",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });
 
 function mockTicket(payload: Record<string, unknown>) {

--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => ({
     response: await fetch(params.url, params.init),
     release: async () => {},
   })),
+  directGaxiosCtor: vi.fn(),
   googleAuthCtor: vi.fn(),
   gaxiosCtor: vi.fn(),
   getAccessToken: vi.fn().mockResolvedValue({ token: "access-token" }),
@@ -34,9 +35,11 @@ vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => {
   };
 });
 
-vi.mock("gaxios", () => {
-  throw new Error("Google Chat auth must use google-auth-library's bundled gaxios.");
-});
+vi.mock("gaxios", () => ({
+  Gaxios: function MockDirectGaxios(defaults?: unknown) {
+    mocks.directGaxiosCtor(defaults);
+  },
+}));
 
 vi.mock("google-auth-library", () => ({
   gaxios: {
@@ -311,6 +314,7 @@ function mockTicket(payload: Record<string, unknown>) {
 describe("verifyGoogleChatRequest", () => {
   afterEach(() => {
     authTesting.resetGoogleChatAuthForTests();
+    mocks.directGaxiosCtor.mockClear();
     mocks.getAccessToken.mockClear();
     mocks.gaxiosCtor.mockClear();
     mocks.googleAuthCtor.mockClear();
@@ -339,6 +343,7 @@ describe("verifyGoogleChatRequest", () => {
     };
 
     expect(mocks.gaxiosCtor).toHaveBeenCalledOnce();
+    expect(mocks.directGaxiosCtor).not.toHaveBeenCalled();
     expect(googleAuthOptions).toMatchObject({
       credentials: {
         client_email: "bot@example.iam.gserviceaccount.com",

--- a/extensions/googlechat/src/thread-resource.ts
+++ b/extensions/googlechat/src/thread-resource.ts
@@ -1,5 +1,10 @@
 export const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+export const GOOGLE_CHAT_MESSAGE_RESOURCE_RE = /^spaces\/[^/]+\/messages\/[^/]+$/;
 
-export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
+export function isGoogleChatThreadResourceName(value: string | null | undefined): boolean {
   return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value);
+}
+
+export function isGoogleChatMessageResourceName(value: string | null | undefined): boolean {
+  return typeof value === "string" && GOOGLE_CHAT_MESSAGE_RESOURCE_RE.test(value);
 }

--- a/extensions/googlechat/src/thread-resource.ts
+++ b/extensions/googlechat/src/thread-resource.ts
@@ -1,0 +1,5 @@
+export const GOOGLE_CHAT_THREAD_RESOURCE_RE = /^spaces\/[^/]+\/threads\/[^/]+$/;
+
+export function isGoogleChatThreadResourceName(value: string | undefined): boolean {
+  return typeof value === "string" && GOOGLE_CHAT_THREAD_RESOURCE_RE.test(value);
+}

--- a/extensions/minimax/minimax.live.test.ts
+++ b/extensions/minimax/minimax.live.test.ts
@@ -1,5 +1,5 @@
-import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 // Minimax tests cover minimax plugin behavior.
+import { resolveFfmpegBin } from "openclaw/plugin-sdk/media-runtime";
 import {
   registerProviderPlugin,
   requireRegisteredProvider,
@@ -36,14 +36,14 @@ const registerMinimaxPlugin = () =>
     name: "MiniMax Provider",
   });
 
-function hasTrustedFfmpegForLiveVoiceNote(): boolean {
+function hasTrustedFfmpegForLiveVoiceNote(label: string): boolean {
   try {
     resolveFfmpegBin();
     return true;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (message.includes("ffmpeg not found in trusted system directories")) {
-      console.warn("[minimax:live] skip voice-note transcode: ffmpeg unavailable");
+      console.warn(`[${label}:live] skip voice-note transcode: ffmpeg unavailable`);
       return false;
     }
     throw error;
@@ -85,7 +85,7 @@ describeTtsLive("minimax tts live", () => {
   }, 120_000);
 
   it("synthesizes MiniMax TTS as an Opus voice note", async () => {
-    if (!hasTrustedFfmpegForLiveVoiceNote()) {
+    if (!hasTrustedFfmpegForLiveVoiceNote("minimax")) {
       return;
     }
 

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -154,10 +154,6 @@ function requireRegexMatch(value: string, pattern: RegExp): RegExpExecArray {
   return match;
 }
 
-async function expectPathMissing(targetPath: string): Promise<void> {
-  await expect(fs.access(targetPath)).rejects.toMatchObject({ code: "ENOENT" });
-}
-
 describe("runCliAgent spawn path", () => {
   it("formats redacted CLI resume diagnostics without exposing raw session ids", () => {
     const logLine = buildCliExecLogLine({

--- a/src/agents/cli-runner.spawn.test.ts
+++ b/src/agents/cli-runner.spawn.test.ts
@@ -455,7 +455,7 @@ describe("runCliAgent spawn path", () => {
           },
         }),
       );
-      await expectPathMissing(pluginDir);
+      await expect(fs.access(pluginDir)).rejects.toMatchObject({ code: "ENOENT" });
     } finally {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     }

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -154,6 +154,10 @@ vi.mock("./agent-runner-utils.js", () => ({
   }),
   resolveQueuedReplyRuntimeConfig: <T>(config: T) => config,
   resolveModelFallbackOptions: vi.fn(() => ({})),
+  resolveAutoThreadingTargets: (sessionCtx: { MessageSid?: string; MessageSidFull?: string }) => {
+    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    return { currentMessageId, implicitReplyToId: currentMessageId };
+  },
 }));
 
 vi.mock("./reply-delivery.js", () => ({

--- a/src/auto-reply/reply/agent-runner-execution.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test.ts
@@ -293,6 +293,10 @@ vi.mock("./agent-runner-utils.js", () => ({
     fastMode: params.run.fastMode,
     fastModeAutoOnSeconds: params.run.fastModeAutoOnSeconds,
   }),
+  resolveAutoThreadingTargets: (sessionCtx: { MessageSid?: string; MessageSidFull?: string }) => {
+    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    return { currentMessageId, implicitReplyToId: currentMessageId };
+  },
 }));
 
 vi.mock("./reply-delivery.js", () => ({

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1797,6 +1797,8 @@ async function runAgentTurnWithFallbackInternal(
     });
   };
   const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
+  const implicitReplyToId =
+    normalizeOptionalString(params.sessionCtx.MessageThreadId) ?? currentMessageId;
   const notifyUserAboutCompaction = shouldNotifyUserAboutCompaction(runtimeConfig);
   const deliverCompactionNoticePayload = async (noticePayload: ReplyPayload, label: string) => {
     try {
@@ -1815,7 +1817,7 @@ async function runAgentTurnWithFallbackInternal(
     await deliverCompactionNoticePayload(
       createCompactionNoticePayload({
         phase,
-        currentMessageId,
+        currentMessageId: implicitReplyToId,
         applyReplyToMode: params.applyReplyToMode,
       }),
       phase,
@@ -2128,7 +2130,8 @@ async function runAgentTurnWithFallbackInternal(
       const blockReplyHandler = params.opts?.onBlockReply
         ? createBlockReplyDeliveryHandler({
             onBlockReply: params.opts.onBlockReply,
-            currentMessageId: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+            currentMessageId,
+            implicitReplyToId,
             replyThreading: params.replyThreading,
             normalizeStreamingText,
             applyReplyToMode: params.applyReplyToMode,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -128,6 +128,7 @@ import {
 } from "./agent-runner-failure-copy.js";
 import {
   buildEmbeddedRunExecutionParams,
+  resolveAutoThreadingTargets,
   resolveQueuedReplyRuntimeConfig,
   resolveModelFallbackOptions,
   resolveRunFastModeForFallbackCandidate,
@@ -1777,6 +1778,7 @@ async function runAgentTurnWithFallbackInternal(
     didNotifyAgentRunStart = true;
     params.opts?.onAgentRunStart?.(runId);
   };
+  const { currentMessageId, implicitReplyToId } = resolveAutoThreadingTargets(params.sessionCtx);
   const signalExecutionPhaseForTyping = (
     info: Parameters<NonNullable<RunEmbeddedAgentParams["onExecutionPhase"]>>[0],
   ) => {
@@ -1796,9 +1798,6 @@ async function runAgentTurnWithFallbackInternal(
       logVerbose(`execution phase typing signal failed: ${String(err)}`);
     });
   };
-  const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
-  const implicitReplyToId =
-    normalizeOptionalString(params.sessionCtx.MessageThreadId) ?? currentMessageId;
   const notifyUserAboutCompaction = shouldNotifyUserAboutCompaction(runtimeConfig);
   const deliverCompactionNoticePayload = async (noticePayload: ReplyPayload, label: string) => {
     try {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -73,6 +73,7 @@ import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { resolveRunAuthProfile } from "./agent-runner-auth-profile.js";
 import {
   buildEmbeddedRunExecutionParams,
+  resolveAutoThreadingTargets,
   resolveQueuedReplyRuntimeConfig,
   resolveModelFallbackOptions,
 } from "./agent-runner-utils.js";
@@ -1083,9 +1084,7 @@ export async function runAgentTurnWithFallback(params: {
     didNotifyAgentRunStart = true;
     params.opts?.onAgentRunStart?.(runId);
   };
-  const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
-  const implicitReplyToId =
-    normalizeOptionalString(params.sessionCtx.MessageThreadId) ?? currentMessageId;
+  const { currentMessageId, implicitReplyToId } = resolveAutoThreadingTargets(params.sessionCtx);
   const shouldNotifyUserAboutCompaction =
     runtimeConfig?.agents?.defaults?.compaction?.notifyUser === true;
   const sendCompactionNotice = async (phase: "start" | "end" | "incomplete") => {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1084,6 +1084,8 @@ export async function runAgentTurnWithFallback(params: {
     params.opts?.onAgentRunStart?.(runId);
   };
   const currentMessageId = params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid;
+  const implicitReplyToId =
+    normalizeOptionalString(params.sessionCtx.MessageThreadId) ?? currentMessageId;
   const shouldNotifyUserAboutCompaction =
     runtimeConfig?.agents?.defaults?.compaction?.notifyUser === true;
   const sendCompactionNotice = async (phase: "start" | "end" | "incomplete") => {
@@ -1098,7 +1100,7 @@ export async function runAgentTurnWithFallback(params: {
           : "🧹 Compaction incomplete";
     const noticePayload = params.applyReplyToMode({
       text,
-      replyToId: currentMessageId,
+      replyToId: implicitReplyToId,
       replyToCurrent: true,
       isCompactionNotice: true,
     });
@@ -1343,7 +1345,8 @@ export async function runAgentTurnWithFallback(params: {
       const blockReplyHandler = params.opts?.onBlockReply
         ? createBlockReplyDeliveryHandler({
             onBlockReply: params.opts.onBlockReply,
-            currentMessageId: params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+            currentMessageId,
+            implicitReplyToId,
             replyThreading: params.replyThreading,
             normalizeStreamingText,
             applyReplyToMode: params.applyReplyToMode,

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -448,6 +448,19 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("uses an alternate implicit reply target for final payload threading", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "hello" }],
+      replyToMode: "first",
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0].replyToId).toBe("spaces/AAA/threads/xyz");
+  });
+
   it("drops all final payloads when block pipeline streamed successfully", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -898,6 +898,19 @@ describe("buildReplyPayloads media filter integration", () => {
     expect(replyPayloads).toHaveLength(0);
   });
 
+  it("uses an alternate implicit reply target for final payload threading", async () => {
+    const { replyPayloads } = await buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "hello" }],
+      replyToMode: "first",
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0].replyToId).toBe("spaces/AAA/threads/xyz");
+  });
+
   it("preserves unsent text-only final payloads after block pipeline streamed partial content", async () => {
     const pipeline: Parameters<typeof buildReplyPayloads>[0]["blockReplyPipeline"] = {
       didStream: () => true,

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -178,6 +178,7 @@ export async function buildReplyPayloads(params: {
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
   messageProvider?: string;
   messagingToolSentTexts?: string[];
@@ -242,6 +243,7 @@ export async function buildReplyPayloads(params: {
       replyToMode: params.replyToMode,
       replyToChannel: params.replyToChannel,
       currentMessageId: params.currentMessageId,
+      implicitReplyToId: params.implicitReplyToId,
       replyThreading: params.replyThreading,
     }).map(async (payload) => {
       const parsed = normalizeReplyPayloadDirectives({

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -119,6 +119,7 @@ export async function buildReplyPayloads(params: {
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
   messageProvider?: string;
   messagingToolSentTexts?: string[];
@@ -169,6 +170,7 @@ export async function buildReplyPayloads(params: {
       replyToMode: params.replyToMode,
       replyToChannel: params.replyToChannel,
       currentMessageId: params.currentMessageId,
+      implicitReplyToId: params.implicitReplyToId,
       replyThreading: params.replyThreading,
     }).map(async (payload) => {
       const parsed = normalizeReplyPayloadDirectives({

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -25,6 +25,7 @@ const {
   buildThreadingToolContext,
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
+  resolveAutoThreadingTargets,
   resolveModelFallbackOptions,
   resolveEnforceFinalTag,
   resolveProviderScopedAuthProfile,
@@ -239,6 +240,65 @@ describe("agent-runner-utils", () => {
       currentChannelId: "telegram:-1003841603622",
       currentThreadTs: "928",
       currentMessageId: "2284",
+    });
+  });
+
+  it("resolves implicit reply target from MessageThreadId when present", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "spaces/AAA/messages/123",
+      MessageSid: "spaces/AAA/messages/123",
+      MessageThreadId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+  });
+
+  it("falls back to currentMessageId when MessageThreadId is missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "msg-full-1",
+      MessageSid: "msg-1",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-full-1",
+      implicitReplyToId: "msg-full-1",
+    });
+  });
+
+  it("falls back to MessageSid when MessageSidFull is missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSid: "msg-7",
+      MessageThreadId: "thread-7",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-7",
+      implicitReplyToId: "thread-7",
+    });
+  });
+
+  it("treats blank MessageThreadId as missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "msg-full-2",
+      MessageSid: "msg-2",
+      MessageThreadId: "   ",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-full-2",
+      implicitReplyToId: "msg-full-2",
+    });
+  });
+
+  it("returns undefined targets when neither sid nor thread is present", () => {
+    const targets = resolveAutoThreadingTargets({});
+
+    expect(targets).toEqual({
+      currentMessageId: undefined,
+      implicitReplyToId: undefined,
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -243,7 +243,7 @@ describe("agent-runner-utils", () => {
     });
   });
 
-  it("resolves implicit reply target from MessageThreadId when present", () => {
+  it("keeps implicit reply target on currentMessageId when MessageThreadId is present", () => {
     const targets = resolveAutoThreadingTargets({
       MessageSidFull: "spaces/AAA/messages/123",
       MessageSid: "spaces/AAA/messages/123",
@@ -252,7 +252,7 @@ describe("agent-runner-utils", () => {
 
     expect(targets).toEqual({
       currentMessageId: "spaces/AAA/messages/123",
-      implicitReplyToId: "spaces/AAA/threads/xyz",
+      implicitReplyToId: "spaces/AAA/messages/123",
     });
   });
 
@@ -276,7 +276,7 @@ describe("agent-runner-utils", () => {
 
     expect(targets).toEqual({
       currentMessageId: "msg-7",
-      implicitReplyToId: "thread-7",
+      implicitReplyToId: "msg-7",
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -26,6 +26,7 @@ const {
   buildThreadingToolContext,
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunExecutionParams,
+  resolveAutoThreadingTargets,
   resolveModelFallbackOptions,
   resolveProviderScopedAuthProfile,
 } = await import("./agent-runner-utils.js");
@@ -424,6 +425,65 @@ describe("agent-runner-utils", () => {
     expect(context.currentChannelId).toBe("telegram:-1003841603622");
     expect(context.currentThreadTs).toBe("928");
     expect(context.currentMessageId).toBe("2284");
+  });
+
+  it("resolves implicit reply target from MessageThreadId when present", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "spaces/AAA/messages/123",
+      MessageSid: "spaces/AAA/messages/123",
+      MessageThreadId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+  });
+
+  it("falls back to currentMessageId when MessageThreadId is missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "msg-full-1",
+      MessageSid: "msg-1",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-full-1",
+      implicitReplyToId: "msg-full-1",
+    });
+  });
+
+  it("falls back to MessageSid when MessageSidFull is missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSid: "msg-7",
+      MessageThreadId: "thread-7",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-7",
+      implicitReplyToId: "thread-7",
+    });
+  });
+
+  it("treats blank MessageThreadId as missing", () => {
+    const targets = resolveAutoThreadingTargets({
+      MessageSidFull: "msg-full-2",
+      MessageSid: "msg-2",
+      MessageThreadId: "   ",
+    });
+
+    expect(targets).toEqual({
+      currentMessageId: "msg-full-2",
+      implicitReplyToId: "msg-full-2",
+    });
+  });
+
+  it("returns undefined targets when neither sid nor thread is present", () => {
+    const targets = resolveAutoThreadingTargets({});
+
+    expect(targets).toEqual({
+      currentMessageId: undefined,
+      implicitReplyToId: undefined,
+    });
   });
 
   it("uses OriginatingTo for threading tool context on discord native commands", () => {

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -427,7 +427,7 @@ describe("agent-runner-utils", () => {
     expect(context.currentMessageId).toBe("2284");
   });
 
-  it("resolves implicit reply target from MessageThreadId when present", () => {
+  it("keeps implicit reply target on currentMessageId when MessageThreadId is present", () => {
     const targets = resolveAutoThreadingTargets({
       MessageSidFull: "spaces/AAA/messages/123",
       MessageSid: "spaces/AAA/messages/123",
@@ -436,7 +436,7 @@ describe("agent-runner-utils", () => {
 
     expect(targets).toEqual({
       currentMessageId: "spaces/AAA/messages/123",
-      implicitReplyToId: "spaces/AAA/threads/xyz",
+      implicitReplyToId: "spaces/AAA/messages/123",
     });
   });
 
@@ -460,7 +460,7 @@ describe("agent-runner-utils", () => {
 
     expect(targets).toEqual({
       currentMessageId: "msg-7",
-      implicitReplyToId: "thread-7",
+      implicitReplyToId: "msg-7",
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -161,6 +161,15 @@ export function buildThreadingToolContext(params: {
   };
 }
 
+export function resolveAutoThreadingTargets(sessionCtx: TemplateContext): {
+  currentMessageId: string | undefined;
+  implicitReplyToId: string | undefined;
+} {
+  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  const implicitReplyToId = normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+  return { currentMessageId, implicitReplyToId };
+}
+
 export const isBunFetchSocketError = (message?: string) =>
   message ? BUN_FETCH_SOCKET_ERROR_RE.test(message) : false;
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -166,7 +166,7 @@ export function resolveAutoThreadingTargets(sessionCtx: TemplateContext): {
   implicitReplyToId: string | undefined;
 } {
   const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-  const implicitReplyToId = normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+  const implicitReplyToId = currentMessageId;
   return { currentMessageId, implicitReplyToId };
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -190,7 +190,7 @@ export function resolveAutoThreadingTargets(sessionCtx: TemplateContext): {
   implicitReplyToId: string | undefined;
 } {
   const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-  const implicitReplyToId = normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+  const implicitReplyToId = currentMessageId;
   return { currentMessageId, implicitReplyToId };
 }
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -185,6 +185,15 @@ export function buildThreadingToolContext(params: {
   };
 }
 
+export function resolveAutoThreadingTargets(sessionCtx: TemplateContext): {
+  currentMessageId: string | undefined;
+  implicitReplyToId: string | undefined;
+} {
+  const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+  const implicitReplyToId = normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+  return { currentMessageId, implicitReplyToId };
+}
+
 /** Detects Bun socket-close errors that should be formatted more clearly. */
 export const isBunFetchSocketError = (message?: string) =>
   message ? BUN_FETCH_SOCKET_ERROR_RE.test(message) : false;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -2100,6 +2100,8 @@ export async function runReplyAgent(params: {
     }
 
     const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    const implicitReplyToId =
+      normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
     const payloadResult = await buildReplyPayloads({
       config: cfg,
       payloads:
@@ -2116,6 +2118,7 @@ export async function runReplyAgent(params: {
       replyToMode,
       replyToChannel,
       currentMessageId,
+      implicitReplyToId,
       replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
       messageProvider: followupRun.run.messageProvider,
       messagingToolSentTexts: runResult.messagingToolSentTexts,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -66,7 +66,10 @@ import {
 } from "./agent-runner-reminder-guard.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
-import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
+import {
+  resolveAutoThreadingTargets,
+  resolveQueuedReplyExecutionConfig,
+} from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
@@ -1461,9 +1464,7 @@ export async function runReplyAgent(params: {
       return returnWithQueuedFollowupDrain(undefined);
     }
 
-    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-    const implicitReplyToId =
-      normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+    const { currentMessageId, implicitReplyToId } = resolveAutoThreadingTargets(sessionCtx);
     const payloadResult = await buildReplyPayloads({
       payloads: payloadArray,
       isHeartbeat,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1462,6 +1462,8 @@ export async function runReplyAgent(params: {
     }
 
     const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
+    const implicitReplyToId =
+      normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
     const payloadResult = await buildReplyPayloads({
       payloads: payloadArray,
       isHeartbeat,
@@ -1473,6 +1475,7 @@ export async function runReplyAgent(params: {
       replyToMode,
       replyToChannel,
       currentMessageId,
+      implicitReplyToId,
       replyThreading: replyThreadingOverride ?? sessionCtx.ReplyThreading,
       messageProvider: followupRun.run.messageProvider,
       messagingToolSentTexts: runResult.messagingToolSentTexts,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -84,8 +84,11 @@ import {
   hasUnbackedReminderCommitment,
 } from "./agent-runner-reminder-guard.js";
 import { resetReplyRunSession } from "./agent-runner-session-reset.js";
-import { appendUsageLine, resolveResponseUsageLine } from "./agent-runner-usage-line.js";
-import { resolveQueuedReplyExecutionConfig } from "./agent-runner-utils.js";
+import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-usage-line.js";
+import {
+  resolveAutoThreadingTargets,
+  resolveQueuedReplyExecutionConfig,
+} from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import {
@@ -2099,9 +2102,7 @@ export async function runReplyAgent(params: {
       return returnWithQueuedFollowupDrain(undefined);
     }
 
-    const currentMessageId = sessionCtx.MessageSidFull ?? sessionCtx.MessageSid;
-    const implicitReplyToId =
-      normalizeOptionalString(sessionCtx.MessageThreadId) ?? currentMessageId;
+    const { currentMessageId, implicitReplyToId } = resolveAutoThreadingTargets(sessionCtx);
     const payloadResult = await buildReplyPayloads({
       config: cfg,
       payloads:

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -181,6 +181,38 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("uses an alternate implicit reply target for block-streamed replies", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "threaded stream" });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith({
+      text: "threaded stream",
+      mediaUrl: undefined,
+      replyToId: "spaces/AAA/threads/xyz",
+      replyToCurrent: undefined,
+      replyToTag: undefined,
+      audioAsVoice: false,
+      mediaUrls: undefined,
+    });
+  });
+
   it("suppresses implicit current-message threading for block replies when reply threading denies it", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -213,6 +213,37 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("falls back to currentMessageId when no implicit reply target is supplied", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      currentMessageId: "msg-only",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "fallback stream" });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith({
+      text: "fallback stream",
+      mediaUrl: undefined,
+      replyToId: "msg-only",
+      replyToCurrent: undefined,
+      replyToTag: undefined,
+      audioAsVoice: false,
+      mediaUrls: undefined,
+    });
+  });
+
   it("suppresses implicit current-message threading for block replies when reply threading denies it", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -224,6 +224,38 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("uses an alternate implicit reply target for block-streamed replies", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "threaded stream" });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith({
+      text: "threaded stream",
+      mediaUrl: undefined,
+      replyToId: "spaces/AAA/threads/xyz",
+      replyToCurrent: undefined,
+      replyToTag: undefined,
+      audioAsVoice: false,
+      mediaUrls: undefined,
+    });
+  });
+
   it("suppresses implicit current-message threading for block replies when reply threading denies it", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -256,6 +256,37 @@ describe("createBlockReplyDeliveryHandler", () => {
     });
   });
 
+  it("falls back to currentMessageId when no implicit reply target is supplied", async () => {
+    const blockReplyPipeline = {
+      enqueue: vi.fn(),
+    } as unknown as BlockReplyPipelineLike;
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply: vi.fn(async () => {}),
+      currentMessageId: "msg-only",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        signalTextDelta: vi.fn(async () => {}),
+      } as unknown as TypingSignaler,
+      blockStreamingEnabled: true,
+      blockReplyPipeline,
+      directlySentBlockKeys: new Set(),
+    });
+
+    await handler({ text: "fallback stream" });
+
+    expect(blockReplyPipeline.enqueue).toHaveBeenCalledWith({
+      text: "fallback stream",
+      mediaUrl: undefined,
+      replyToId: "msg-only",
+      replyToCurrent: undefined,
+      replyToTag: undefined,
+      audioAsVoice: false,
+      mediaUrls: undefined,
+    });
+  });
+
   it("suppresses implicit current-message threading for block replies when reply threading denies it", async () => {
     const blockReplyPipeline = {
       enqueue: vi.fn(),

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -241,6 +241,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
+      directlySentBlockPayloads: [],
     });
 
     await handler({ text: "threaded stream" });
@@ -272,6 +273,7 @@ describe("createBlockReplyDeliveryHandler", () => {
       blockStreamingEnabled: true,
       blockReplyPipeline,
       directlySentBlockKeys: new Set(),
+      directlySentBlockPayloads: [],
     });
 
     await handler({ text: "fallback stream" });

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -75,6 +75,7 @@ async function sendDirectBlockReply(params: {
 export function createBlockReplyDeliveryHandler(params: {
   onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
   normalizeStreamingText: (payload: ReplyPayload) => { text?: string; skip: boolean };
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;
@@ -104,9 +105,12 @@ export function createBlockReplyDeliveryHandler(params: {
         mediaUrl: payload.mediaUrl ?? payload.mediaUrls?.[0],
         replyToId:
           payload.replyToId ??
-          (implicitCurrentMessageAllowed ? params.currentMessageId : undefined),
+          (implicitCurrentMessageAllowed
+            ? (params.implicitReplyToId ?? params.currentMessageId)
+            : undefined),
       },
       params.currentMessageId,
+      params.implicitReplyToId,
     );
 
     // Let through payloads with audioAsVoice flag even if empty (need to track it).

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -91,6 +91,7 @@ async function sendDirectBlockReply(params: {
 export function createBlockReplyDeliveryHandler(params: {
   onBlockReply: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
   normalizeStreamingText: (payload: ReplyPayload) => { text?: string; skip: boolean };
   applyReplyToMode: (payload: ReplyPayload) => ReplyPayload;
@@ -122,9 +123,12 @@ export function createBlockReplyDeliveryHandler(params: {
         mediaUrl: payload.mediaUrl ?? payload.mediaUrls?.[0],
         replyToId:
           payload.replyToId ??
-          (implicitCurrentMessageAllowed ? params.currentMessageId : undefined),
+          (implicitCurrentMessageAllowed
+            ? (params.implicitReplyToId ?? params.currentMessageId)
+            : undefined),
       },
       params.currentMessageId,
+      params.implicitReplyToId,
     );
 
     // Let through payloads with audioAsVoice flag even if empty (need to track it).

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -75,8 +75,9 @@ function resolveReplyThreadingForPayload(params: {
 export function applyReplyTagsToPayload(
   payload: ReplyPayload,
   currentMessageId?: string,
+  implicitReplyToId?: string,
 ): ReplyPayload {
-  return resolveReplyThreadingForPayload({ payload, currentMessageId });
+  return resolveReplyThreadingForPayload({ payload, currentMessageId, implicitReplyToId });
 }
 
 export function isRenderablePayload(payload: ReplyPayload): boolean {
@@ -92,11 +93,19 @@ export function applyReplyThreading(params: {
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
 }): ReplyPayload[] {
-  const { payloads, replyToMode, replyToChannel, currentMessageId, replyThreading } = params;
+  const {
+    payloads,
+    replyToMode,
+    replyToChannel,
+    currentMessageId,
+    implicitReplyToId: requestedImplicitReplyToId,
+    replyThreading,
+  } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
-  const implicitReplyToId = normalizeOptionalString(currentMessageId);
+  const implicitReplyToId = normalizeOptionalString(requestedImplicitReplyToId ?? currentMessageId);
   return payloads
     .map((payload) =>
       resolveReplyThreadingForPayload({

--- a/src/auto-reply/reply/reply-payloads-base.ts
+++ b/src/auto-reply/reply/reply-payloads-base.ts
@@ -84,8 +84,9 @@ function resolveReplyThreadingForPayload(params: {
 export function applyReplyTagsToPayload(
   payload: ReplyPayload,
   currentMessageId?: string,
+  implicitReplyToId?: string,
 ): ReplyPayload {
-  return resolveReplyThreadingForPayload({ payload, currentMessageId });
+  return resolveReplyThreadingForPayload({ payload, currentMessageId, implicitReplyToId });
 }
 
 /** True when a payload has visible or playable content for delivery. */
@@ -104,11 +105,19 @@ export function applyReplyThreading(params: {
   replyToMode: ReplyToMode;
   replyToChannel?: OriginatingChannelType;
   currentMessageId?: string;
+  implicitReplyToId?: string;
   replyThreading?: ReplyThreadingPolicy;
 }): ReplyPayload[] {
-  const { payloads, replyToMode, replyToChannel, currentMessageId, replyThreading } = params;
+  const {
+    payloads,
+    replyToMode,
+    replyToChannel,
+    currentMessageId,
+    implicitReplyToId: requestedImplicitReplyToId,
+    replyThreading,
+  } = params;
   const applyReplyToMode = createReplyToModeFilterForChannel(replyToMode, replyToChannel);
-  const implicitReplyToId = normalizeOptionalString(currentMessageId);
+  const implicitReplyToId = normalizeOptionalString(requestedImplicitReplyToId ?? currentMessageId);
   return payloads
     .map((payload) =>
       resolveReplyThreadingForPayload({

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -219,6 +219,21 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[1].replyToId).toBeUndefined();
   });
 
+  it("uses a supplied implicit reply target only for auto-threading", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "Hello" }, { text: "[[reply_to_current]]Explicit" }],
+      replyToMode: "all",
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("spaces/AAA/threads/xyz");
+    expect(result[0].replyToTag).toBeUndefined();
+    expect(result[1].replyToId).toBe("spaces/AAA/messages/123");
+    expect(result[1].replyToTag).toBe(true);
+  });
+
   it("threads only first payload when mode is 'batched' and the turn is batched", () => {
     const result = applyReplyThreading({
       payloads: [{ text: "A" }, { text: "B" }],

--- a/src/auto-reply/reply/reply-plumbing.test.ts
+++ b/src/auto-reply/reply/reply-plumbing.test.ts
@@ -278,6 +278,21 @@ describe("applyReplyThreading auto-threading", () => {
     expect(result[1].replyToId).toBeUndefined();
   });
 
+  it("uses a supplied implicit reply target only for auto-threading", () => {
+    const result = applyReplyThreading({
+      payloads: [{ text: "Hello" }, { text: "[[reply_to_current]]Explicit" }],
+      replyToMode: "all",
+      currentMessageId: "spaces/AAA/messages/123",
+      implicitReplyToId: "spaces/AAA/threads/xyz",
+    });
+
+    expect(result).toHaveLength(2);
+    expect(result[0].replyToId).toBe("spaces/AAA/threads/xyz");
+    expect(result[0].replyToTag).toBeUndefined();
+    expect(result[1].replyToId).toBe("spaces/AAA/messages/123");
+    expect(result[1].replyToTag).toBe(true);
+  });
+
   it("threads only first payload when mode is 'batched' and the turn is batched", () => {
     const result = applyReplyThreading({
       payloads: [{ text: "A" }, { text: "B" }],


### PR DESCRIPTION
## Summary

- **Problem:** Google Chat replies could leave the inbound Chat thread and appear as new top-level messages.
- **Why it matters:** delayed or tool-driven assistant replies break group-thread UX when they detach from the conversation the user spoke into.
- **What changed:** preserve `message.thread.name` as `MessageThreadId`, expose it to reply/message-tool threading, and normalize Google Chat outbound thread targets before they reach `thread.name`.
- **What did NOT change:** no Google Chat per-thread OpenClaw session isolation; core reply plumbing remains channel-agnostic and Google Chat resource-name handling stays behind the Google Chat boundary.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #69422
- Related #39554
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: Google Chat assistant replies from existing Chat threads should remain in the inbound thread.
- Real environment tested: Linux VPS-hosted OpenClaw Google Chat runtime with service-account auth and a real Google Chat space.
- Exact steps or command run after this patch: Jai sent real Google Chat threaded messages and confirmed assistant replies stayed in-thread before this PR was marked ready.
- Evidence after fix: screenshot evidence is attached below:
  - Before: Google Chat reply appeared outside the inbound thread.
  - After: Google Chat reply stayed inside the inbound thread.
  - Scope note: typing-placeholder editing is separate follow-up behavior; this PR fixes thread placement.
- Observed result after fix: live Google Chat replies stayed in-thread; local seam tests also verified natural replies, message-tool sends, and current-reply behavior use the inbound Google Chat thread resource.
- What was not tested: every Google Chat account/space policy combination; typing-placeholder edit/cleanup for message-tool sends; Google Chat per-thread OpenClaw session isolation, which is out of scope.
- Before evidence: prior behavior re-rooted replies as new top-level Chat messages.

## Root Cause (if applicable)

- Root cause: Google Chat exposes different resource shapes for messages (`spaces/.../messages/...`) and threads (`spaces/.../threads/...`), and OpenClaw previously let message-shaped values flow into thread-routing seams.
- Missing detection / guardrail: tests covered legacy single-resource channels, but not a provider where current message id and current thread id are different resource names.
- Contributing context:
  - Inbound webhook context did not populate generic `MessageThreadId` from `message.thread.name`.
  - The message-tool path had no inbound-thread default when the agent omitted `threadId`.
  - `[[reply_to_current]]` resolves to the current message id; for Google Chat that value must be converted to the inbound thread before delivery.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/auto-reply/reply/reply-plumbing.test.ts`
  - `src/auto-reply/reply/agent-runner-payloads.test.ts`
  - `src/auto-reply/reply/agent-runner-utils.test.ts`
  - `src/auto-reply/reply/reply-delivery.test.ts`
  - `extensions/googlechat/src/monitor.webhook-routing.test.ts`
  - `extensions/googlechat/src/monitor.reply-delivery.test.ts`
  - `extensions/googlechat/src/channel.test.ts`
  - `extensions/googlechat/src/actions.test.ts`
  - `extensions/googlechat/src/targets.test.ts`
- Scenario the test should lock in: Google Chat has a current message resource and a distinct current thread resource; implicit replies and message-tool sends use the thread resource, while message-shaped reply ids are rewritten or rejected before reaching the Chat API.
- Why this is the smallest reliable guardrail: it covers webhook ingress, core reply seams, message-tool routing, channel delivery, and the API boundary without requiring live Google Chat in CI.
- Existing test that already covers this (if any): none.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

Google Chat assistant replies from an existing Chat thread now stay in that thread instead of creating a new top-level message.

## Diagram (if applicable)

```text
Before:
Google Chat webhook -> currentMessageId=spaces/.../messages/...
                    -> delivery sends that as thread.name
                    -> Chat API rejects/falls back -> new top-level thread

After:
Google Chat webhook -> MessageThreadId=spaces/.../threads/...
                    -> reply/tool delivery resolves outbound thread
                    -> Chat API receives thread.name=spaces/.../threads/...
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout; Linux VPS-hosted runtime for real Chat verification
- Runtime/container: OpenClaw source checkout; local verification on exact rebased head `a617644c81dd43bb7285d3001ca6d19750e62e68`; live Google Chat verification on a Linux VPS-hosted runtime with the thread-placement patch applied
- Model/provider: N/A
- Integration/channel (if any): Google Chat service-account auth
- Relevant config (redacted): Google Chat enabled with group mention policy; no secret/config changes required

### Steps

1. Send a threaded Google Chat message that mentions the bot.
2. Let the assistant produce a normal final reply.
3. Exercise message-tool sends without explicit `threadId`.
4. Exercise `[[reply_to_current]]` behavior where the core seam supplies the current message id.

### Expected

- Replies and message-tool sends stay in the original Google Chat thread.
- Explicit thread-shaped ids are preserved.
- Message-shaped or malformed thread targets never reach `thread.name` as-is.

### Actual

- Before this patch: replies could re-root as new top-level Chat messages.
- After this patch: live verification and local seam coverage keep replies in the inbound thread.
- Scope note: typing-placeholder editing is separate follow-up behavior and is not fixed by this PR.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

Screenshot evidence attached below:

- Before screenshot: Google Chat reply escaped the inbound thread and appeared outside the original conversation thread.
- After screenshot: Google Chat reply stayed inside the inbound thread.
- Scope note: the after screenshot may still show a stale typing placeholder when the message-tool path is used; typing-placeholder edit/cleanup is not part of this PR.

Verification commands run on exact rebased head `a617644c81dd43bb7285d3001ca6d19750e62e68` after the May 26 rebase:

```bash
mise exec node@22.22.2 -- node scripts/docs-list.js
# passed

mise exec node@22.22.2 -- ./node_modules/.bin/oxfmt --check --threads=1 CHANGELOG.md extensions/googlechat/src/actions.test.ts extensions/googlechat/src/actions.ts extensions/googlechat/src/api.ts extensions/googlechat/src/channel.adapters.ts extensions/googlechat/src/channel.test.ts extensions/googlechat/src/google-auth.runtime.test.ts extensions/googlechat/src/google-auth.runtime.ts extensions/googlechat/src/monitor-reply-delivery.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.ts extensions/googlechat/src/monitor.webhook-routing.test.ts extensions/googlechat/src/targets.test.ts extensions/googlechat/src/thread-resource.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-execution.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/agent-runner-payloads.ts src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/agent-runner-utils.ts src/auto-reply/reply/agent-runner.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/reply-delivery.ts src/auto-reply/reply/reply-payloads-base.ts src/auto-reply/reply/reply-plumbing.test.ts
# All matched files use the correct format.

mise exec node@22.22.2 -- node scripts/test-projects.mjs extensions/googlechat/src/actions.test.ts extensions/googlechat/src/channel.test.ts extensions/googlechat/src/google-auth.runtime.test.ts extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.webhook-routing.test.ts extensions/googlechat/src/targets.test.ts src/auto-reply/reply/agent-runner-execution.test.ts src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/agent-runner-utils.test.ts src/auto-reply/reply/reply-delivery.test.ts src/auto-reply/reply/reply-plumbing.test.ts
# 2 Vitest shards passed; 330 tests passed

mise exec node@22.22.2 -- node scripts/changed-lanes.mjs --json
# lanes=core, coreTests, extensions, extensionTests, docs
```

Additional broad test signal from pre-ready validation on a prior PR head:

```bash
pnpm test src/auto-reply/reply extensions/googlechat extensions/telegram
# auto-reply: 113 files, 1508 tests passed
# telegram: 106 files, 1483 tests passed
# googlechat shard was rerun after fixture alignment: 15 files, 141 tests passed
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Jai verified live Google Chat thread placement on a real Google Chat runtime and attached before/after screenshots below.
  - I verified the exact rebased code locally with the commands listed above.
- Edge cases checked:
  - `[[reply_to_current]]` can still resolve to the core current message id; Google Chat rewrites message-shaped values at the channel boundary.
  - Explicit thread-shaped `replyToId` wins over the inbound thread.
  - Malformed thread values are rejected before reaching the Google Chat send API.
  - Message-tool sends without `threadId` use the inbound thread only when the current target matches and reply mode allows implicit threading.
- What you did **not** verify:
  - Every Google Chat account/space policy combination.
  - Per-thread OpenClaw session isolation for Google Chat; this PR does not implement it.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers that accidentally pass a Google Chat message resource as `thread` now fail loudly instead of silently falling back.
  - Mitigation: channel delivery rewrites known message-resource reply targets to the inbound thread; the API guard reports invalid values before sending.
- Risk: a future non-message, non-thread Google Chat resource shape could appear in `replyToId`.
  - Mitigation: only `spaces/.../threads/...` passes as `thread.name`; everything else is dropped or falls back to the inbound thread.

---

## Screenshots (Bad, Good)

### Bad (before patch)

<img width="1876" height="738" alt="openclaw-google-chat-bad" src="https://github.com/user-attachments/assets/7dc6fe6c-aa34-4acb-8c83-7ab5e905f8b6" />

### Good (after patch)

<img width="784" height="1204" alt="openclaw-google-chat-good" src="https://github.com/user-attachments/assets/22160bbb-3c00-432f-af9d-eaaf64462452" />