### PR TITLE
fix(WebUI): remove duplicate headers, move i18n descriptions to bread…crumb

### DIFF
--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -168,6 +168,11 @@
   text-overflow: ellipsis;
 }
 
+.topnav-shell .dashboard-header__breadcrumb-desc {
+  color: var(--muted);
+  font-weight: normal;
+}
+
 .topbar-status {
   display: flex;
   align-items: center;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1297,11 +1297,11 @@ export function renderApp(state: AppViewState) {
       },
     })}
     <div
-      class="shell ${isChat ? "shell--chat" : ""} ${chatFocus
-        ? "shell--chat-focus"
-        : ""} ${navCollapsed ? "shell--nav-collapsed" : ""} ${navDrawerOpen
-        ? "shell--nav-drawer-open"
-        : ""} ${state.onboarding ? "shell--onboarding" : ""}"
+      class="shell ${isChat ? "shell--chat" : ""} ${
+        chatFocus ? "shell--chat-focus" : ""
+      } ${navCollapsed ? "shell--nav-collapsed" : ""} ${
+        navDrawerOpen ? "shell--nav-drawer-open" : ""
+      } ${state.onboarding ? "shell--onboarding" : ""}"
     >
       <button
         type="button"
@@ -1352,9 +1352,10 @@ export function renderApp(state: AppViewState) {
           <div class="sidebar-shell">
             <div class="sidebar-shell__header">
               <div class="sidebar-brand">
-                ${navCollapsed
-                  ? nothing
-                  : html`
+                ${
+                  navCollapsed
+                    ? nothing
+                    : html`
                       <img
                         class="sidebar-brand__logo"
                         src="${agentLogoUrl(basePath)}"
@@ -1364,7 +1365,8 @@ export function renderApp(state: AppViewState) {
                         <span class="sidebar-brand__eyebrow">${t("nav.control")}</span>
                         <span class="sidebar-brand__title">OpenClaw</span>
                       </span>
-                    `}
+                    `
+                }
               </div>
               <button
                 type="button"
@@ -1391,8 +1393,9 @@ export function renderApp(state: AppViewState) {
 
                   return html`
                     <section class="nav-section ${!showItems ? "nav-section--collapsed" : ""}">
-                      ${!navCollapsed
-                        ? html`
+                      ${
+                        !navCollapsed
+                          ? html`
                             <button
                               class="nav-section__label"
                               @click=${() => {
@@ -1411,7 +1414,8 @@ export function renderApp(state: AppViewState) {
                               <span class="nav-section__chevron"> ${icons.chevronDown} </span>
                             </button>
                           `
-                        : nothing}
+                          : nothing
+                      }
                       <div class="nav-section__items">
                         ${group.tabs.map((tab) =>
                           renderTab(state, tab, { collapsed: navCollapsed }),
@@ -1432,12 +1436,14 @@ export function renderApp(state: AppViewState) {
                   title="${t("common.docs")} (opens in new tab)"
                 >
                   <span class="nav-item__icon" aria-hidden="true">${icons.book}</span>
-                  ${!navCollapsed
-                    ? html`
+                  ${
+                    !navCollapsed
+                      ? html`
                         <span class="nav-item__text">${t("common.docs")}</span>
                         <span class="nav-item__external-icon">${icons.externalLink}</span>
                       `
-                    : nothing}
+                      : nothing
+                  }
                 </a>
                 <div class="sidebar-mode-switch">${renderTopbarThemeModeToggle(state)}</div>
                 ${(() => {
@@ -1445,13 +1451,15 @@ export function renderApp(state: AppViewState) {
                   return version
                     ? html`
                         <div class="sidebar-version" title=${`v${version}`}>
-                          ${!navCollapsed
-                            ? html`
+                          ${
+                            !navCollapsed
+                              ? html`
                                 <span class="sidebar-version__label">${t("common.version")}</span>
                                 <span class="sidebar-version__text">v${version}</span>
                                 ${renderSidebarConnectionStatus(state)}
                               `
-                            : html` ${renderSidebarConnectionStatus(state)} `}
+                              : html` ${renderSidebarConnectionStatus(state)} `
+                          }
                         </div>
                       `
                     : nothing;
@@ -1462,15 +1470,18 @@ export function renderApp(state: AppViewState) {
         </aside>
       </div>
       <main class="content ${isChat ? "content--chat" : ""}">
-        ${state.updateStatusBanner
-          ? html`<div class="callout ${state.updateStatusBanner.tone}" role="alert">
+        ${
+          state.updateStatusBanner
+            ? html`<div class="callout ${state.updateStatusBanner.tone}" role="alert">
               ${state.updateStatusBanner.text}
             </div>`
-          : nothing}
-        ${state.updateAvailable &&
-        state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
-        !isUpdateBannerDismissed(state.updateAvailable)
-          ? html`<div class="update-banner callout danger" role="alert">
+            : nothing
+        }
+        ${
+          state.updateAvailable &&
+          state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
+          !isUpdateBannerDismissed(state.updateAvailable)
+            ? html`<div class="update-banner callout danger" role="alert">
               <strong>Update available:</strong> v${state.updateAvailable.latestVersion} (running
               v${state.updateAvailable.currentVersion}).
               <button
@@ -1493,33 +1504,35 @@ export function renderApp(state: AppViewState) {
                 ${icons.x}
               </button>
             </div>`
-          : nothing}
-        ${state.tab === "config"
-          ? nothing
-          : html`<section class="content-header">
+            : nothing
+        }
+        ${
+          state.tab === "config"
+            ? nothing
+            : html`<section class="content-header">
               <div>
-                ${isChat
-                  ? renderChatSessionSelect(state)
-                  : html`<div class="page-title">${titleForTab(state.tab)}</div>`}
-                ${isChat ? nothing : html`<div class="page-sub">${subtitleForTab(state.tab)}</div>`}
+                ${isChat ? renderChatSessionSelect(state) : nothing}
               </div>
               <div class="page-meta">
-                ${state.tab === "dreams"
-                  ? html`
+                ${
+                  state.tab === "dreams"
+                    ? html`
                       <div class="dreaming-header-controls">
                         <button
                           class="btn btn--subtle btn--sm"
                           ?disabled=${dreamingLoading || state.dreamDiaryLoading}
                           @click=${refreshDreaming}
                         >
-                          ${dreamingRefreshLoading
-                            ? t("dreaming.header.refreshing")
-                            : t("dreaming.header.refresh")}
+                          ${
+                            dreamingRefreshLoading
+                              ? t("dreaming.header.refreshing")
+                              : t("dreaming.header.refresh")
+                          }
                         </button>
                         <button
-                          class="dreams__phase-toggle ${dreamingOn
-                            ? "dreams__phase-toggle--on"
-                            : ""}"
+                          class="dreams__phase-toggle ${
+                            dreamingOn ? "dreams__phase-toggle--on" : ""
+                          }"
                           ?disabled=${dreamingLoading}
                           @click=${() => applyDreamingEnabled(!dreamingOn)}
                         >
@@ -1530,989 +1543,1018 @@ export function renderApp(state: AppViewState) {
                         </button>
                       </div>
                     `
-                  : nothing}
-                ${state.lastError
-                  ? html`<div class="pill danger">${state.lastError}</div>`
-                  : nothing}
+                    : nothing
+                }
+                ${
+                  state.lastError
+                    ? html`<div class="pill danger">${state.lastError}</div>`
+                    : nothing
+                }
                 ${isChat ? renderChatControls(state) : nothing}
               </div>
-            </section>`}
-        ${state.tab === "overview"
-          ? renderOverview({
-              connected: state.connected,
-              hello: state.hello,
-              settings: state.settings,
-              password: state.password,
-              lastError: state.lastError,
-              lastErrorCode: state.lastErrorCode,
-              presenceCount,
-              sessionsCount,
-              cronEnabled: state.cronStatus?.enabled ?? null,
-              cronNext,
-              lastChannelsRefresh: state.channelsLastSuccess,
-              warnQueryToken,
-              modelAuthStatus: state.modelAuthStatusResult,
-              usageResult: state.usageResult,
-              sessionsResult: state.sessionsResult,
-              skillsReport: state.skillsReport,
-              cronJobs: state.cronJobs,
-              cronStatus: state.cronStatus,
-              attentionItems: state.attentionItems,
-              eventLog: state.eventLog,
-              overviewLogLines: state.overviewLogLines,
-              showGatewayToken: state.overviewShowGatewayToken,
-              showGatewayPassword: state.overviewShowGatewayPassword,
-              onSettingsChange: (next) => state.applySettings(next),
-              onPasswordChange: (next) => (state.password = next),
-              onSessionKeyChange: (next) => {
-                state.sessionKey = next;
-                state.chatMessage = "";
-                state.resetChatInputHistoryNavigation();
-                state.chatMessages = [];
-                state.chatToolMessages = [];
-                state.chatStream = null;
-                state.chatRunId = null;
-                state.chatQueue = [];
-                state.resetToolStream();
-                state.applySettings({
-                  ...state.settings,
-                  sessionKey: next,
-                  lastActiveSessionKey: next,
-                });
-              },
-              onToggleGatewayTokenVisibility: () => {
-                state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
-              },
-              onToggleGatewayPasswordVisibility: () => {
-                state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
-              },
-              onConnect: () => state.connect(),
-              onRefresh: () => state.loadOverview({ refresh: true }),
-              onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
-              onRefreshLogs: () => state.loadOverview({ refresh: true }),
-            })
-          : nothing}
-        ${state.tab === "channels"
-          ? renderLazyView(lazyChannels, (m) =>
-              m.renderChannels({
+            </section>`
+        }
+        ${
+          state.tab === "overview"
+            ? renderOverview({
                 connected: state.connected,
-                loading: state.channelsLoading,
-                snapshot: state.channelsSnapshot,
-                lastError: state.channelsError,
-                lastSuccessAt: state.channelsLastSuccess,
-                whatsappMessage: state.whatsappLoginMessage,
-                whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
-                whatsappConnected: state.whatsappLoginConnected,
-                whatsappBusy: state.whatsappBusy,
-                configSchema: state.configSchema,
-                configSchemaLoading: state.configSchemaLoading,
-                configForm: state.configForm,
-                configUiHints: state.configUiHints,
-                configSaving: state.configSaving,
-                configFormDirty: state.configFormDirty,
-                nostrProfileFormState: state.nostrProfileFormState,
-                nostrProfileAccountId: state.nostrProfileAccountId,
-                onRefresh: (probe) => loadChannels(state, probe),
-                onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
-                onWhatsAppWait: () => state.handleWhatsAppWait(),
-                onWhatsAppLogout: () => state.handleWhatsAppLogout(),
-                onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
-                onConfigSave: () => state.handleChannelConfigSave(),
-                onConfigReload: () => state.handleChannelConfigReload(),
-                onNostrProfileEdit: (accountId, profile) =>
-                  state.handleNostrProfileEdit(accountId, profile),
-                onNostrProfileCancel: () => state.handleNostrProfileCancel(),
-                onNostrProfileFieldChange: (field, value) =>
-                  state.handleNostrProfileFieldChange(field, value),
-                onNostrProfileSave: () => state.handleNostrProfileSave(),
-                onNostrProfileImport: () => state.handleNostrProfileImport(),
-                onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
-              }),
-            )
-          : nothing}
-        ${state.tab === "instances"
-          ? renderLazyView(lazyInstances, (m) =>
-              m.renderInstances({
-                loading: state.presenceLoading,
-                entries: state.presenceEntries,
-                lastError: state.presenceError,
-                statusMessage: state.presenceStatus,
-                onRefresh: () => loadPresence(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "sessions"
-          ? renderLazyView(lazySessions, (m) =>
-              m.renderSessions({
-                loading: state.sessionsLoading,
-                result: state.sessionsResult,
-                error: state.sessionsError,
-                activeMinutes: state.sessionsFilterActive,
-                limit: state.sessionsFilterLimit,
-                includeGlobal: state.sessionsIncludeGlobal,
-                includeUnknown: state.sessionsIncludeUnknown,
-                basePath: state.basePath,
-                searchQuery: state.sessionsSearchQuery,
-                agentIdentityById: state.agentIdentityById,
-                sortColumn: state.sessionsSortColumn,
-                sortDir: state.sessionsSortDir,
-                page: state.sessionsPage,
-                pageSize: state.sessionsPageSize,
-                selectedKeys: state.sessionsSelectedKeys,
-                expandedCheckpointKey: state.sessionsExpandedCheckpointKey,
-                checkpointItemsByKey: state.sessionsCheckpointItemsByKey,
-                checkpointLoadingKey: state.sessionsCheckpointLoadingKey,
-                checkpointBusyKey: state.sessionsCheckpointBusyKey,
-                checkpointErrorByKey: state.sessionsCheckpointErrorByKey,
-                onFiltersChange: (next) => {
-                  state.sessionsFilterActive = next.activeMinutes;
-                  state.sessionsFilterLimit = next.limit;
-                  state.sessionsIncludeGlobal = next.includeGlobal;
-                  state.sessionsIncludeUnknown = next.includeUnknown;
+                hello: state.hello,
+                settings: state.settings,
+                password: state.password,
+                lastError: state.lastError,
+                lastErrorCode: state.lastErrorCode,
+                presenceCount,
+                sessionsCount,
+                cronEnabled: state.cronStatus?.enabled ?? null,
+                cronNext,
+                lastChannelsRefresh: state.channelsLastSuccess,
+                warnQueryToken,
+                modelAuthStatus: state.modelAuthStatusResult,
+                usageResult: state.usageResult,
+                sessionsResult: state.sessionsResult,
+                skillsReport: state.skillsReport,
+                cronJobs: state.cronJobs,
+                cronStatus: state.cronStatus,
+                attentionItems: state.attentionItems,
+                eventLog: state.eventLog,
+                overviewLogLines: state.overviewLogLines,
+                showGatewayToken: state.overviewShowGatewayToken,
+                showGatewayPassword: state.overviewShowGatewayPassword,
+                onSettingsChange: (next) => state.applySettings(next),
+                onPasswordChange: (next) => (state.password = next),
+                onSessionKeyChange: (next) => {
+                  state.sessionKey = next;
+                  state.chatMessage = "";
+                  state.resetChatInputHistoryNavigation();
+                  state.chatMessages = [];
+                  state.chatToolMessages = [];
+                  state.chatStream = null;
+                  state.chatRunId = null;
+                  state.chatQueue = [];
+                  state.resetToolStream();
+                  state.applySettings({
+                    ...state.settings,
+                    sessionKey: next,
+                    lastActiveSessionKey: next,
+                  });
                 },
-                onSearchChange: (q) => {
-                  state.sessionsSearchQuery = q;
-                  state.sessionsPage = 0;
+                onToggleGatewayTokenVisibility: () => {
+                  state.overviewShowGatewayToken = !state.overviewShowGatewayToken;
                 },
-                onSortChange: (col, dir) => {
-                  state.sessionsSortColumn = col;
-                  state.sessionsSortDir = dir;
-                  state.sessionsPage = 0;
+                onToggleGatewayPasswordVisibility: () => {
+                  state.overviewShowGatewayPassword = !state.overviewShowGatewayPassword;
                 },
-                onPageChange: (p) => {
-                  state.sessionsPage = p;
-                },
-                onPageSizeChange: (s) => {
-                  state.sessionsPageSize = s;
-                  state.sessionsPage = 0;
-                },
-                onRefresh: () => loadSessions(state),
-                onPatch: (key, patch) => patchSession(state, key, patch),
-                onToggleSelect: (key) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  if (next.has(key)) {
-                    next.delete(key);
-                  } else {
-                    next.add(key);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onSelectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.add(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectPage: (keys) => {
-                  const next = new Set(state.sessionsSelectedKeys);
-                  for (const k of keys) {
-                    next.delete(k);
-                  }
-                  state.sessionsSelectedKeys = next;
-                },
-                onDeselectAll: () => {
-                  state.sessionsSelectedKeys = new Set();
-                },
-                onDeleteSelected: async () => {
-                  const keys = [...state.sessionsSelectedKeys];
-                  const deleted = await deleteSessionsAndRefresh(state, keys);
-                  if (deleted.length > 0) {
+                onConnect: () => state.connect(),
+                onRefresh: () => state.loadOverview({ refresh: true }),
+                onNavigate: (tab) => state.setTab(tab as import("./navigation.ts").Tab),
+                onRefreshLogs: () => state.loadOverview({ refresh: true }),
+              })
+            : nothing
+        }
+        ${
+          state.tab === "channels"
+            ? renderLazyView(lazyChannels, (m) =>
+                m.renderChannels({
+                  connected: state.connected,
+                  loading: state.channelsLoading,
+                  snapshot: state.channelsSnapshot,
+                  lastError: state.channelsError,
+                  lastSuccessAt: state.channelsLastSuccess,
+                  whatsappMessage: state.whatsappLoginMessage,
+                  whatsappQrDataUrl: state.whatsappLoginQrDataUrl,
+                  whatsappConnected: state.whatsappLoginConnected,
+                  whatsappBusy: state.whatsappBusy,
+                  configSchema: state.configSchema,
+                  configSchemaLoading: state.configSchemaLoading,
+                  configForm: state.configForm,
+                  configUiHints: state.configUiHints,
+                  configSaving: state.configSaving,
+                  configFormDirty: state.configFormDirty,
+                  nostrProfileFormState: state.nostrProfileFormState,
+                  nostrProfileAccountId: state.nostrProfileAccountId,
+                  onRefresh: (probe) => loadChannels(state, probe),
+                  onWhatsAppStart: (force) => state.handleWhatsAppStart(force),
+                  onWhatsAppWait: () => state.handleWhatsAppWait(),
+                  onWhatsAppLogout: () => state.handleWhatsAppLogout(),
+                  onConfigPatch: (path, value) => updateConfigFormValue(state, path, value),
+                  onConfigSave: () => state.handleChannelConfigSave(),
+                  onConfigReload: () => state.handleChannelConfigReload(),
+                  onNostrProfileEdit: (accountId, profile) =>
+                    state.handleNostrProfileEdit(accountId, profile),
+                  onNostrProfileCancel: () => state.handleNostrProfileCancel(),
+                  onNostrProfileFieldChange: (field, value) =>
+                    state.handleNostrProfileFieldChange(field, value),
+                  onNostrProfileSave: () => state.handleNostrProfileSave(),
+                  onNostrProfileImport: () => state.handleNostrProfileImport(),
+                  onNostrProfileToggleAdvanced: () => state.handleNostrProfileToggleAdvanced(),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "instances"
+            ? renderLazyView(lazyInstances, (m) =>
+                m.renderInstances({
+                  loading: state.presenceLoading,
+                  entries: state.presenceEntries,
+                  lastError: state.presenceError,
+                  statusMessage: state.presenceStatus,
+                  onRefresh: () => loadPresence(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "sessions"
+            ? renderLazyView(lazySessions, (m) =>
+                m.renderSessions({
+                  loading: state.sessionsLoading,
+                  result: state.sessionsResult,
+                  error: state.sessionsError,
+                  activeMinutes: state.sessionsFilterActive,
+                  limit: state.sessionsFilterLimit,
+                  includeGlobal: state.sessionsIncludeGlobal,
+                  includeUnknown: state.sessionsIncludeUnknown,
+                  basePath: state.basePath,
+                  searchQuery: state.sessionsSearchQuery,
+                  agentIdentityById: state.agentIdentityById,
+                  sortColumn: state.sessionsSortColumn,
+                  sortDir: state.sessionsSortDir,
+                  page: state.sessionsPage,
+                  pageSize: state.sessionsPageSize,
+                  selectedKeys: state.sessionsSelectedKeys,
+                  expandedCheckpointKey: state.sessionsExpandedCheckpointKey,
+                  checkpointItemsByKey: state.sessionsCheckpointItemsByKey,
+                  checkpointLoadingKey: state.sessionsCheckpointLoadingKey,
+                  checkpointBusyKey: state.sessionsCheckpointBusyKey,
+                  checkpointErrorByKey: state.sessionsCheckpointErrorByKey,
+                  onFiltersChange: (next) => {
+                    state.sessionsFilterActive = next.activeMinutes;
+                    state.sessionsFilterLimit = next.limit;
+                    state.sessionsIncludeGlobal = next.includeGlobal;
+                    state.sessionsIncludeUnknown = next.includeUnknown;
+                  },
+                  onSearchChange: (q) => {
+                    state.sessionsSearchQuery = q;
+                    state.sessionsPage = 0;
+                  },
+                  onSortChange: (col, dir) => {
+                    state.sessionsSortColumn = col;
+                    state.sessionsSortDir = dir;
+                    state.sessionsPage = 0;
+                  },
+                  onPageChange: (p) => {
+                    state.sessionsPage = p;
+                  },
+                  onPageSizeChange: (s) => {
+                    state.sessionsPageSize = s;
+                    state.sessionsPage = 0;
+                  },
+                  onRefresh: () => loadSessions(state),
+                  onPatch: (key, patch) => patchSession(state, key, patch),
+                  onToggleSelect: (key) => {
                     const next = new Set(state.sessionsSelectedKeys);
-                    for (const k of deleted) {
+                    if (next.has(key)) {
+                      next.delete(key);
+                    } else {
+                      next.add(key);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onSelectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
+                      next.add(k);
+                    }
+                    state.sessionsSelectedKeys = next;
+                  },
+                  onDeselectPage: (keys) => {
+                    const next = new Set(state.sessionsSelectedKeys);
+                    for (const k of keys) {
                       next.delete(k);
                     }
                     state.sessionsSelectedKeys = next;
-                  }
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-                onToggleCheckpointDetails: (sessionKey) =>
-                  toggleSessionCompactionCheckpoints(state, sessionKey),
-                onBranchFromCheckpoint: async (sessionKey, checkpointId) => {
-                  const nextKey = await branchSessionFromCheckpoint(
-                    state,
-                    sessionKey,
-                    checkpointId,
-                  );
-                  if (nextKey) {
-                    switchChatSession(state, nextKey);
+                  },
+                  onDeselectAll: () => {
+                    state.sessionsSelectedKeys = new Set();
+                  },
+                  onDeleteSelected: async () => {
+                    const keys = [...state.sessionsSelectedKeys];
+                    const deleted = await deleteSessionsAndRefresh(state, keys);
+                    if (deleted.length > 0) {
+                      const next = new Set(state.sessionsSelectedKeys);
+                      for (const k of deleted) {
+                        next.delete(k);
+                      }
+                      state.sessionsSelectedKeys = next;
+                    }
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
                     state.setTab("chat" as import("./navigation.ts").Tab);
-                  }
-                },
-                onRestoreCheckpoint: (sessionKey, checkpointId) =>
-                  restoreSessionFromCheckpoint(state, sessionKey, checkpointId),
-              }),
-            )
-          : nothing}
+                  },
+                  onToggleCheckpointDetails: (sessionKey) =>
+                    toggleSessionCompactionCheckpoints(state, sessionKey),
+                  onBranchFromCheckpoint: async (sessionKey, checkpointId) => {
+                    const nextKey = await branchSessionFromCheckpoint(
+                      state,
+                      sessionKey,
+                      checkpointId,
+                    );
+                    if (nextKey) {
+                      switchChatSession(state, nextKey);
+                      state.setTab("chat" as import("./navigation.ts").Tab);
+                    }
+                  },
+                  onRestoreCheckpoint: (sessionKey, checkpointId) =>
+                    restoreSessionFromCheckpoint(state, sessionKey, checkpointId),
+                }),
+              )
+            : nothing
+        }
         ${renderUsageTab(state)}
         ${state.tab === "cron" ? renderCronQuickCreateForTab(state, requestHostUpdate) : nothing}
-        ${state.tab === "cron"
-          ? renderLazyView(lazyCron, (m) =>
-              m.renderCron({
-                basePath: state.basePath,
-                loading: state.cronLoading,
-                status: state.cronStatus,
-                jobs: visibleCronJobs,
-                jobsLoadingMore: state.cronJobsLoadingMore,
-                jobsTotal: state.cronJobsTotal,
-                jobsHasMore: state.cronJobsHasMore,
-                jobsQuery: state.cronJobsQuery,
-                jobsEnabledFilter: state.cronJobsEnabledFilter,
-                jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
-                jobsLastStatusFilter: state.cronJobsLastStatusFilter,
-                jobsSortBy: state.cronJobsSortBy,
-                jobsSortDir: state.cronJobsSortDir,
-                editingJobId: state.cronEditingJobId,
-                error: state.cronError,
-                busy: state.cronBusy,
-                form: state.cronForm,
-                channels: state.channelsSnapshot?.channelMeta?.length
-                  ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
-                  : (state.channelsSnapshot?.channelOrder ?? []),
-                channelLabels: state.channelsSnapshot?.channelLabels ?? {},
-                channelMeta: state.channelsSnapshot?.channelMeta ?? [],
-                runsJobId: state.cronRunsJobId,
-                runs: state.cronRuns,
-                runsTotal: state.cronRunsTotal,
-                runsHasMore: state.cronRunsHasMore,
-                runsLoadingMore: state.cronRunsLoadingMore,
-                runsScope: state.cronRunsScope,
-                runsStatuses: state.cronRunsStatuses,
-                runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
-                runsStatusFilter: state.cronRunsStatusFilter,
-                runsQuery: state.cronRunsQuery,
-                runsSortDir: state.cronRunsSortDir,
-                fieldErrors: state.cronFieldErrors,
-                canSubmit: !hasCronFormErrors(state.cronFieldErrors),
-                agentSuggestions: cronAgentSuggestions,
-                modelSuggestions: cronModelSuggestions,
-                thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
-                timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
-                deliveryToSuggestions,
-                accountSuggestions,
-                onFormChange: (patch) => {
-                  state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
-                  state.cronFieldErrors = validateCronForm(state.cronForm);
-                },
-                onRefresh: () => state.loadCron(),
-                onAdd: () => addCronJob(state),
-                onEdit: (job) => startCronEdit(state, job),
-                onClone: (job) => startCronClone(state, job),
-                onCancelEdit: () => cancelCronEdit(state),
-                onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
-                onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
-                onRemove: (job) => removeCronJob(state, job),
-                onQuickCreate: () => {
-                  state.cronQuickCreateOpen = true;
-                  state.cronQuickCreateStep = "what";
-                  state.cronQuickCreateDraft = createDefaultDraft();
-                  requestHostUpdate?.();
-                },
-                onLoadRuns: async (jobId) => {
-                  updateCronRunsFilter(state, { cronRunsScope: "job" });
-                  await loadCronRuns(state, jobId);
-                },
-                onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
-                onJobsFiltersChange: async (patch) => {
-                  updateCronJobsFilter(state, patch);
-                  const shouldReload =
-                    typeof patch.cronJobsQuery === "string" ||
-                    Boolean(patch.cronJobsEnabledFilter) ||
-                    Boolean(patch.cronJobsSortBy) ||
-                    Boolean(patch.cronJobsSortDir);
-                  if (shouldReload) {
-                    await loadCronJobsPage(state, { append: false });
-                  }
-                },
-                onJobsFiltersReset: async () => {
-                  updateCronJobsFilter(state, {
-                    cronJobsQuery: "",
-                    cronJobsEnabledFilter: "all",
-                    cronJobsScheduleKindFilter: "all",
-                    cronJobsLastStatusFilter: "all",
-                    cronJobsSortBy: "nextRunAtMs",
-                    cronJobsSortDir: "asc",
-                  });
-                  await loadCronJobsPage(state, { append: false });
-                },
-                onLoadMoreRuns: () => loadMoreCronRuns(state),
-                onRunsFiltersChange: async (patch) => {
-                  updateCronRunsFilter(state, patch);
-                  if (state.cronRunsScope === "all") {
-                    await loadCronRuns(state, null);
-                    return;
-                  }
-                  await loadCronRuns(state, state.cronRunsJobId);
-                },
-                onNavigateToChat: (sessionKey) => {
-                  switchChatSession(state, sessionKey);
-                  state.setTab("chat" as import("./navigation.ts").Tab);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "agents"
-          ? renderLazyView(lazyAgents, (m) =>
-              m.renderAgents({
-                basePath: state.basePath ?? "",
-                loading: state.agentsLoading,
-                error: state.agentsError,
-                agentsList: state.agentsList,
-                selectedAgentId: resolvedAgentId,
-                activePanel: state.agentsPanel,
-                config: {
-                  form: configValue,
-                  loading: state.configLoading,
-                  saving: state.configSaving,
-                  dirty: state.configFormDirty,
-                },
-                channels: {
-                  snapshot: state.channelsSnapshot,
-                  loading: state.channelsLoading,
-                  error: state.channelsError,
-                  lastSuccess: state.channelsLastSuccess,
-                },
-                cron: {
-                  status: state.cronStatus,
-                  jobs: state.cronJobs,
+        ${
+          state.tab === "cron"
+            ? renderLazyView(lazyCron, (m) =>
+                m.renderCron({
+                  basePath: state.basePath,
                   loading: state.cronLoading,
+                  status: state.cronStatus,
+                  jobs: visibleCronJobs,
+                  jobsLoadingMore: state.cronJobsLoadingMore,
+                  jobsTotal: state.cronJobsTotal,
+                  jobsHasMore: state.cronJobsHasMore,
+                  jobsQuery: state.cronJobsQuery,
+                  jobsEnabledFilter: state.cronJobsEnabledFilter,
+                  jobsScheduleKindFilter: state.cronJobsScheduleKindFilter,
+                  jobsLastStatusFilter: state.cronJobsLastStatusFilter,
+                  jobsSortBy: state.cronJobsSortBy,
+                  jobsSortDir: state.cronJobsSortDir,
+                  editingJobId: state.cronEditingJobId,
                   error: state.cronError,
-                },
-                agentFiles: {
-                  list: state.agentFilesList,
-                  loading: state.agentFilesLoading,
-                  error: state.agentFilesError,
-                  active: state.agentFileActive,
-                  contents: state.agentFileContents,
-                  drafts: state.agentFileDrafts,
-                  saving: state.agentFileSaving,
-                },
-                agentIdentityLoading: state.agentIdentityLoading,
-                agentIdentityError: state.agentIdentityError,
-                agentIdentityById: state.agentIdentityById,
-                agentSkills: {
-                  report: state.agentSkillsReport,
-                  loading: state.agentSkillsLoading,
-                  error: state.agentSkillsError,
-                  agentId: state.agentSkillsAgentId,
-                  filter: state.skillsFilter,
-                },
-                toolsCatalog: {
-                  loading: state.toolsCatalogLoading,
-                  error: state.toolsCatalogError,
-                  result: state.toolsCatalogResult,
-                },
-                toolsEffective: {
-                  loading: state.toolsEffectiveLoading,
-                  error: state.toolsEffectiveError,
-                  result: state.toolsEffectiveResult,
-                },
-                runtimeSessionKey: state.sessionKey,
-                runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
-                modelCatalog: state.chatModelCatalog ?? [],
-                onRefresh: async () => {
-                  await loadAgents(state);
-                  const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
-                  if (agentIds.length > 0) {
-                    void loadAgentIdentities(state, agentIds);
-                  }
-                  loadAgentPanelDataForSelectedAgent(resolveSelectedAgentId());
-                  refreshAgentsPanelSupplementalData(state.agentsPanel);
-                },
-                onSelectAgent: (agentId) => {
-                  if (state.agentsSelectedId === agentId) {
-                    return;
-                  }
-                  state.agentsSelectedId = agentId;
-                  resetAgentSelectionPanelState();
-                  void loadAgentIdentity(state, agentId);
-                  loadAgentPanelDataForSelectedAgent(agentId);
-                },
-                onSelectPanel: (panel) => {
-                  state.agentsPanel = panel;
-                  if (
-                    panel === "files" &&
-                    resolvedAgentId &&
-                    state.agentFilesList?.agentId !== resolvedAgentId
-                  ) {
-                    resetAgentFilesState();
-                    void loadAgentFiles(state, resolvedAgentId);
-                  }
-                  if (panel === "skills" && resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                  if (panel === "tools" && resolvedAgentId) {
-                    if (
-                      state.toolsCatalogResult?.agentId !== resolvedAgentId ||
-                      state.toolsCatalogError
-                    ) {
-                      void loadToolsCatalog(state, resolvedAgentId);
+                  busy: state.cronBusy,
+                  form: state.cronForm,
+                  channels: state.channelsSnapshot?.channelMeta?.length
+                    ? state.channelsSnapshot.channelMeta.map((entry) => entry.id)
+                    : (state.channelsSnapshot?.channelOrder ?? []),
+                  channelLabels: state.channelsSnapshot?.channelLabels ?? {},
+                  channelMeta: state.channelsSnapshot?.channelMeta ?? [],
+                  runsJobId: state.cronRunsJobId,
+                  runs: state.cronRuns,
+                  runsTotal: state.cronRunsTotal,
+                  runsHasMore: state.cronRunsHasMore,
+                  runsLoadingMore: state.cronRunsLoadingMore,
+                  runsScope: state.cronRunsScope,
+                  runsStatuses: state.cronRunsStatuses,
+                  runsDeliveryStatuses: state.cronRunsDeliveryStatuses,
+                  runsStatusFilter: state.cronRunsStatusFilter,
+                  runsQuery: state.cronRunsQuery,
+                  runsSortDir: state.cronRunsSortDir,
+                  fieldErrors: state.cronFieldErrors,
+                  canSubmit: !hasCronFormErrors(state.cronFieldErrors),
+                  agentSuggestions: cronAgentSuggestions,
+                  modelSuggestions: cronModelSuggestions,
+                  thinkingSuggestions: CRON_THINKING_SUGGESTIONS,
+                  timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
+                  deliveryToSuggestions,
+                  accountSuggestions,
+                  onFormChange: (patch) => {
+                    state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
+                    state.cronFieldErrors = validateCronForm(state.cronForm);
+                  },
+                  onRefresh: () => state.loadCron(),
+                  onAdd: () => addCronJob(state),
+                  onEdit: (job) => startCronEdit(state, job),
+                  onClone: (job) => startCronClone(state, job),
+                  onCancelEdit: () => cancelCronEdit(state),
+                  onToggle: (job, enabled) => toggleCronJob(state, job, enabled),
+                  onRun: (job, mode) => runCronJob(state, job, mode ?? "force"),
+                  onRemove: (job) => removeCronJob(state, job),
+                  onQuickCreate: () => {
+                    state.cronQuickCreateOpen = true;
+                    state.cronQuickCreateStep = "what";
+                    state.cronQuickCreateDraft = createDefaultDraft();
+                    requestHostUpdate?.();
+                  },
+                  onLoadRuns: async (jobId) => {
+                    updateCronRunsFilter(state, { cronRunsScope: "job" });
+                    await loadCronRuns(state, jobId);
+                  },
+                  onLoadMoreJobs: () => loadCronJobsPage(state, { append: true }),
+                  onJobsFiltersChange: async (patch) => {
+                    updateCronJobsFilter(state, patch);
+                    const shouldReload =
+                      typeof patch.cronJobsQuery === "string" ||
+                      Boolean(patch.cronJobsEnabledFilter) ||
+                      Boolean(patch.cronJobsSortBy) ||
+                      Boolean(patch.cronJobsSortDir);
+                    if (shouldReload) {
+                      await loadCronJobsPage(state, { append: false });
                     }
-                    if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
-                      const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
-                        agentId: resolvedAgentId,
-                        sessionKey: state.sessionKey,
-                      });
+                  },
+                  onJobsFiltersReset: async () => {
+                    updateCronJobsFilter(state, {
+                      cronJobsQuery: "",
+                      cronJobsEnabledFilter: "all",
+                      cronJobsScheduleKindFilter: "all",
+                      cronJobsLastStatusFilter: "all",
+                      cronJobsSortBy: "nextRunAtMs",
+                      cronJobsSortDir: "asc",
+                    });
+                    await loadCronJobsPage(state, { append: false });
+                  },
+                  onLoadMoreRuns: () => loadMoreCronRuns(state),
+                  onRunsFiltersChange: async (patch) => {
+                    updateCronRunsFilter(state, patch);
+                    if (state.cronRunsScope === "all") {
+                      await loadCronRuns(state, null);
+                      return;
+                    }
+                    await loadCronRuns(state, state.cronRunsJobId);
+                  },
+                  onNavigateToChat: (sessionKey) => {
+                    switchChatSession(state, sessionKey);
+                    state.setTab("chat" as import("./navigation.ts").Tab);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "agents"
+            ? renderLazyView(lazyAgents, (m) =>
+                m.renderAgents({
+                  basePath: state.basePath ?? "",
+                  loading: state.agentsLoading,
+                  error: state.agentsError,
+                  agentsList: state.agentsList,
+                  selectedAgentId: resolvedAgentId,
+                  activePanel: state.agentsPanel,
+                  config: {
+                    form: configValue,
+                    loading: state.configLoading,
+                    saving: state.configSaving,
+                    dirty: state.configFormDirty,
+                  },
+                  channels: {
+                    snapshot: state.channelsSnapshot,
+                    loading: state.channelsLoading,
+                    error: state.channelsError,
+                    lastSuccess: state.channelsLastSuccess,
+                  },
+                  cron: {
+                    status: state.cronStatus,
+                    jobs: state.cronJobs,
+                    loading: state.cronLoading,
+                    error: state.cronError,
+                  },
+                  agentFiles: {
+                    list: state.agentFilesList,
+                    loading: state.agentFilesLoading,
+                    error: state.agentFilesError,
+                    active: state.agentFileActive,
+                    contents: state.agentFileContents,
+                    drafts: state.agentFileDrafts,
+                    saving: state.agentFileSaving,
+                  },
+                  agentIdentityLoading: state.agentIdentityLoading,
+                  agentIdentityError: state.agentIdentityError,
+                  agentIdentityById: state.agentIdentityById,
+                  agentSkills: {
+                    report: state.agentSkillsReport,
+                    loading: state.agentSkillsLoading,
+                    error: state.agentSkillsError,
+                    agentId: state.agentSkillsAgentId,
+                    filter: state.skillsFilter,
+                  },
+                  toolsCatalog: {
+                    loading: state.toolsCatalogLoading,
+                    error: state.toolsCatalogError,
+                    result: state.toolsCatalogResult,
+                  },
+                  toolsEffective: {
+                    loading: state.toolsEffectiveLoading,
+                    error: state.toolsEffectiveError,
+                    result: state.toolsEffectiveResult,
+                  },
+                  runtimeSessionKey: state.sessionKey,
+                  runtimeSessionMatchesSelectedAgent: toolsPanelUsesActiveSession,
+                  modelCatalog: state.chatModelCatalog ?? [],
+                  onRefresh: async () => {
+                    await loadAgents(state);
+                    const agentIds = state.agentsList?.agents?.map((entry) => entry.id) ?? [];
+                    if (agentIds.length > 0) {
+                      void loadAgentIdentities(state, agentIds);
+                    }
+                    loadAgentPanelDataForSelectedAgent(resolveSelectedAgentId());
+                    refreshAgentsPanelSupplementalData(state.agentsPanel);
+                  },
+                  onSelectAgent: (agentId) => {
+                    if (state.agentsSelectedId === agentId) {
+                      return;
+                    }
+                    state.agentsSelectedId = agentId;
+                    resetAgentSelectionPanelState();
+                    void loadAgentIdentity(state, agentId);
+                    loadAgentPanelDataForSelectedAgent(agentId);
+                  },
+                  onSelectPanel: (panel) => {
+                    state.agentsPanel = panel;
+                    if (
+                      panel === "files" &&
+                      resolvedAgentId &&
+                      state.agentFilesList?.agentId !== resolvedAgentId
+                    ) {
+                      resetAgentFilesState();
+                      void loadAgentFiles(state, resolvedAgentId);
+                    }
+                    if (panel === "skills" && resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
+                    if (panel === "tools" && resolvedAgentId) {
                       if (
-                        state.toolsEffectiveResultKey !== toolsRequestKey ||
-                        state.toolsEffectiveError
+                        state.toolsCatalogResult?.agentId !== resolvedAgentId ||
+                        state.toolsCatalogError
                       ) {
-                        void loadToolsEffective(state, {
+                        void loadToolsCatalog(state, resolvedAgentId);
+                      }
+                      if (resolvedAgentId === resolveAgentIdFromSessionKey(state.sessionKey)) {
+                        const toolsRequestKey = buildToolsEffectiveRequestKey(state, {
                           agentId: resolvedAgentId,
                           sessionKey: state.sessionKey,
                         });
-                      }
-                    } else {
-                      resetToolsEffectiveState(state);
-                    }
-                  }
-                  refreshAgentsPanelSupplementalData(panel);
-                },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
-                onSelectFile: (name) => {
-                  state.agentFileActive = name;
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  void loadAgentFileContent(state, resolvedAgentId, name);
-                },
-                onFileDraftChange: (name, content) => {
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
-                },
-                onFileReset: (name) => {
-                  const base = state.agentFileContents[name] ?? "";
-                  state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
-                },
-                onFileSave: (name) => {
-                  if (!resolvedAgentId) {
-                    return;
-                  }
-                  const content =
-                    state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
-                  void saveAgentFile(state, resolvedAgentId, name, content);
-                },
-                onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  const basePath = resolveAgentToolsPath(agentId, Boolean(profile || clearAllow));
-                  if (!basePath) {
-                    return;
-                  }
-                  if (profile) {
-                    updateConfigFormValue(state, [...basePath, "profile"], profile);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "profile"]);
-                  }
-                  if (clearAllow) {
-                    removeConfigFormValue(state, [...basePath, "allow"]);
-                  }
-                },
-                onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  const basePath = resolveAgentToolsPath(
-                    agentId,
-                    alsoAllow.length > 0 || deny.length > 0,
-                  );
-                  if (!basePath) {
-                    return;
-                  }
-                  if (alsoAllow.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "alsoAllow"]);
-                  }
-                  if (deny.length > 0) {
-                    updateConfigFormValue(state, [...basePath, "deny"], deny);
-                  } else {
-                    removeConfigFormValue(state, [...basePath, "deny"]);
-                  }
-                },
-                onConfigReload: () => loadConfig(state, { discardPendingChanges: true }),
-                onConfigSave: () => saveAgentsConfig(state),
-                onChannelsRefresh: () => loadChannels(state, false),
-                onCronRefresh: () => state.loadCron(),
-                onCronRunNow: (jobId) => {
-                  const job = state.cronJobs.find((entry) => entry.id === jobId);
-                  if (!job) {
-                    return;
-                  }
-                  void runCronJob(state, job, "force");
-                },
-                onSkillsFilterChange: (next) => (state.skillsFilter = next),
-                onSkillsRefresh: () => {
-                  if (resolvedAgentId) {
-                    void loadAgentSkills(state, resolvedAgentId);
-                  }
-                },
-                onAgentSkillToggle: (agentId, skillName, enabled) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const list = (getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null)
-                    ?.agents?.list;
-                  const entry = Array.isArray(list)
-                    ? (list[index] as { skills?: unknown })
-                    : undefined;
-                  const normalizedSkill = skillName.trim();
-                  if (!normalizedSkill) {
-                    return;
-                  }
-                  const allSkills =
-                    state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-                    [];
-                  const existing = Array.isArray(entry?.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
-                    : undefined;
-                  const base = existing ?? allSkills;
-                  const next = new Set(base);
-                  if (enabled) {
-                    next.add(normalizedSkill);
-                  } else {
-                    next.delete(normalizedSkill);
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
-                },
-                onAgentSkillsClear: (agentId) => {
-                  const index = findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  removeConfigFormValue(state, ["agents", "list", index, "skills"]);
-                },
-                onAgentSkillsDisableAll: (agentId) => {
-                  const index = ensureAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
-                },
-                onModelChange: (agentId, modelId) => {
-                  const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
-                  if (index < 0) {
-                    return;
-                  }
-                  const modelEntry = resolveAgentModelFormEntry(index);
-                  const { basePath, existing } = modelEntry;
-                  if (!modelId) {
-                    removeConfigFormValue(state, basePath);
-                  } else {
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
-                      const next = {
-                        primary: modelId,
-                        ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
-                      };
-                      updateConfigFormValue(state, basePath, next);
-                    } else {
-                      updateConfigFormValue(state, basePath, modelId);
-                    }
-                  }
-                  void refreshVisibleToolsEffectiveForCurrentSession(state);
-                },
-                onModelFallbacksChange: (agentId, fallbacks) => {
-                  const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const currentConfig = getCurrentConfigValue();
-                  const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
-                  const effectivePrimary =
-                    resolveModelPrimary(resolvedConfig.entry?.model) ??
-                    resolveModelPrimary(resolvedConfig.defaults?.model);
-                  const effectiveFallbacks = resolveEffectiveModelFallbacks(
-                    resolvedConfig.entry?.model,
-                    resolvedConfig.defaults?.model,
-                  );
-                  const index =
-                    normalized.length > 0
-                      ? effectivePrimary
-                        ? ensureAgentIndex(agentId)
-                        : -1
-                      : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
-                        ? ensureAgentIndex(agentId)
-                        : -1;
-                  if (index < 0) {
-                    return;
-                  }
-                  const { basePath, existing } = resolveAgentModelFormEntry(index);
-                  const resolvePrimary = () => {
-                    if (typeof existing === "string") {
-                      return existing.trim() || null;
-                    }
-                    if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-                      const primary = (existing as { primary?: unknown }).primary;
-                      if (typeof primary === "string") {
-                        const trimmed = primary.trim();
-                        return trimmed || null;
+                        if (
+                          state.toolsEffectiveResultKey !== toolsRequestKey ||
+                          state.toolsEffectiveError
+                        ) {
+                          void loadToolsEffective(state, {
+                            agentId: resolvedAgentId,
+                            sessionKey: state.sessionKey,
+                          });
+                        }
+                      } else {
+                        resetToolsEffectiveState(state);
                       }
                     }
-                    return null;
-                  };
-                  const primary = resolvePrimary() ?? effectivePrimary;
-                  if (normalized.length === 0) {
-                    if (primary) {
-                      updateConfigFormValue(state, basePath, primary);
+                    refreshAgentsPanelSupplementalData(panel);
+                  },
+                  onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                  onSelectFile: (name) => {
+                    state.agentFileActive = name;
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    void loadAgentFileContent(state, resolvedAgentId, name);
+                  },
+                  onFileDraftChange: (name, content) => {
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: content };
+                  },
+                  onFileReset: (name) => {
+                    const base = state.agentFileContents[name] ?? "";
+                    state.agentFileDrafts = { ...state.agentFileDrafts, [name]: base };
+                  },
+                  onFileSave: (name) => {
+                    if (!resolvedAgentId) {
+                      return;
+                    }
+                    const content =
+                      state.agentFileDrafts[name] ?? state.agentFileContents[name] ?? "";
+                    void saveAgentFile(state, resolvedAgentId, name, content);
+                  },
+                  onToolsProfileChange: (agentId, profile, clearAllow) => {
+                    const basePath = resolveAgentToolsPath(agentId, Boolean(profile || clearAllow));
+                    if (!basePath) {
+                      return;
+                    }
+                    if (profile) {
+                      updateConfigFormValue(state, [...basePath, "profile"], profile);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "profile"]);
+                    }
+                    if (clearAllow) {
+                      removeConfigFormValue(state, [...basePath, "allow"]);
+                    }
+                  },
+                  onToolsOverridesChange: (agentId, alsoAllow, deny) => {
+                    const basePath = resolveAgentToolsPath(
+                      agentId,
+                      alsoAllow.length > 0 || deny.length > 0,
+                    );
+                    if (!basePath) {
+                      return;
+                    }
+                    if (alsoAllow.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "alsoAllow"]);
+                    }
+                    if (deny.length > 0) {
+                      updateConfigFormValue(state, [...basePath, "deny"], deny);
+                    } else {
+                      removeConfigFormValue(state, [...basePath, "deny"]);
+                    }
+                  },
+                  onConfigReload: () => loadConfig(state, { discardPendingChanges: true }),
+                  onConfigSave: () => saveAgentsConfig(state),
+                  onChannelsRefresh: () => loadChannels(state, false),
+                  onCronRefresh: () => state.loadCron(),
+                  onCronRunNow: (jobId) => {
+                    const job = state.cronJobs.find((entry) => entry.id === jobId);
+                    if (!job) {
+                      return;
+                    }
+                    void runCronJob(state, job, "force");
+                  },
+                  onSkillsFilterChange: (next) => (state.skillsFilter = next),
+                  onSkillsRefresh: () => {
+                    if (resolvedAgentId) {
+                      void loadAgentSkills(state, resolvedAgentId);
+                    }
+                  },
+                  onAgentSkillToggle: (agentId, skillName, enabled) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const list = (
+                      getCurrentConfigValue() as { agents?: { list?: unknown[] } } | null
+                    )?.agents?.list;
+                    const entry = Array.isArray(list)
+                      ? (list[index] as { skills?: unknown })
+                      : undefined;
+                    const normalizedSkill = skillName.trim();
+                    if (!normalizedSkill) {
+                      return;
+                    }
+                    const allSkills =
+                      state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
+                      [];
+                    const existing = Array.isArray(entry?.skills)
+                      ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
+                      : undefined;
+                    const base = existing ?? allSkills;
+                    const next = new Set(base);
+                    if (enabled) {
+                      next.add(normalizedSkill);
+                    } else {
+                      next.delete(normalizedSkill);
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], [...next]);
+                  },
+                  onAgentSkillsClear: (agentId) => {
+                    const index = findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    removeConfigFormValue(state, ["agents", "list", index, "skills"]);
+                  },
+                  onAgentSkillsDisableAll: (agentId) => {
+                    const index = ensureAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
+                  },
+                  onModelChange: (agentId, modelId) => {
+                    const index = modelId ? ensureAgentIndex(agentId) : findAgentIndex(agentId);
+                    if (index < 0) {
+                      return;
+                    }
+                    const modelEntry = resolveAgentModelFormEntry(index);
+                    const { basePath, existing } = modelEntry;
+                    if (!modelId) {
+                      removeConfigFormValue(state, basePath);
+                    } else {
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const fallbacks = (existing as { fallbacks?: unknown }).fallbacks;
+                        const next = {
+                          primary: modelId,
+                          ...(Array.isArray(fallbacks) ? { fallbacks } : {}),
+                        };
+                        updateConfigFormValue(state, basePath, next);
+                      } else {
+                        updateConfigFormValue(state, basePath, modelId);
+                      }
+                    }
+                    void refreshVisibleToolsEffectiveForCurrentSession(state);
+                  },
+                  onModelFallbacksChange: (agentId, fallbacks) => {
+                    const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
+                    const currentConfig = getCurrentConfigValue();
+                    const resolvedConfig = resolveAgentConfig(currentConfig, agentId);
+                    const effectivePrimary =
+                      resolveModelPrimary(resolvedConfig.entry?.model) ??
+                      resolveModelPrimary(resolvedConfig.defaults?.model);
+                    const effectiveFallbacks = resolveEffectiveModelFallbacks(
+                      resolvedConfig.entry?.model,
+                      resolvedConfig.defaults?.model,
+                    );
+                    const index =
+                      normalized.length > 0
+                        ? effectivePrimary
+                          ? ensureAgentIndex(agentId)
+                          : -1
+                        : (effectiveFallbacks?.length ?? 0) > 0 || findAgentIndex(agentId) >= 0
+                          ? ensureAgentIndex(agentId)
+                          : -1;
+                    if (index < 0) {
+                      return;
+                    }
+                    const { basePath, existing } = resolveAgentModelFormEntry(index);
+                    const resolvePrimary = () => {
+                      if (typeof existing === "string") {
+                        return existing.trim() || null;
+                      }
+                      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+                        const primary = (existing as { primary?: unknown }).primary;
+                        if (typeof primary === "string") {
+                          const trimmed = primary.trim();
+                          return trimmed || null;
+                        }
+                      }
+                      return null;
+                    };
+                    const primary = resolvePrimary() ?? effectivePrimary;
+                    if (normalized.length === 0) {
+                      if (primary) {
+                        updateConfigFormValue(state, basePath, primary);
+                      } else {
+                        removeConfigFormValue(state, basePath);
+                      }
+                      return;
+                    }
+                    if (!primary) {
+                      return;
+                    }
+                    updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSetDefault: (agentId) => {
+                    if (!configValue) {
+                      return;
+                    }
+                    updateConfigFormValue(state, ["agents", "defaultId"], agentId);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "skills"
+            ? renderLazyView(lazySkills, (m) =>
+                m.renderSkills({
+                  connected: state.connected,
+                  loading: state.skillsLoading,
+                  report: state.skillsReport,
+                  error: state.skillsError,
+                  filter: state.skillsFilter,
+                  statusFilter: state.skillsStatusFilter,
+                  edits: state.skillEdits,
+                  messages: state.skillMessages,
+                  busyKey: state.skillsBusyKey,
+                  detailKey: state.skillsDetailKey,
+                  clawhubQuery: state.clawhubSearchQuery,
+                  clawhubResults: state.clawhubSearchResults,
+                  clawhubSearchLoading: state.clawhubSearchLoading,
+                  clawhubSearchError: state.clawhubSearchError,
+                  clawhubDetail: state.clawhubDetail,
+                  clawhubDetailSlug: state.clawhubDetailSlug,
+                  clawhubDetailLoading: state.clawhubDetailLoading,
+                  clawhubDetailError: state.clawhubDetailError,
+                  clawhubInstallSlug: state.clawhubInstallSlug,
+                  clawhubInstallMessage: state.clawhubInstallMessage,
+                  onFilterChange: (next) => (state.skillsFilter = next),
+                  onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
+                  onRefresh: () => loadSkills(state, { clearMessages: true }),
+                  onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
+                  onEdit: (key, value) => updateSkillEdit(state, key, value),
+                  onSaveKey: (key) => saveSkillApiKey(state, key),
+                  onInstall: (skillKey, name, installId) =>
+                    installSkill(state, skillKey, name, installId),
+                  onDetailOpen: (key) => (state.skillsDetailKey = key),
+                  onDetailClose: () => (state.skillsDetailKey = null),
+                  onClawHubQueryChange: (query) => {
+                    setClawHubSearchQuery(state, query);
+                    if (clawhubSearchTimer) {
+                      clearTimeout(clawhubSearchTimer);
+                    }
+                    clawhubSearchTimer = setTimeout(() => searchClawHub(state, query), 300);
+                  },
+                  onClawHubDetailOpen: (slug) => loadClawHubDetail(state, slug),
+                  onClawHubDetailClose: () => closeClawHubDetail(state),
+                  onClawHubInstall: (slug) => installFromClawHub(state, slug),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "nodes"
+            ? renderLazyView(lazyNodes, (m) =>
+                m.renderNodes({
+                  loading: state.nodesLoading,
+                  nodes: state.nodes,
+                  devicesLoading: state.devicesLoading,
+                  devicesError: state.devicesError,
+                  devicesList: state.devicesList,
+                  configForm:
+                    state.configForm ??
+                    (state.configSnapshot?.config as Record<string, unknown> | null),
+                  configLoading: state.configLoading,
+                  configSaving: state.configSaving,
+                  configDirty: state.configFormDirty,
+                  configFormMode: state.configFormMode,
+                  execApprovalsLoading: state.execApprovalsLoading,
+                  execApprovalsSaving: state.execApprovalsSaving,
+                  execApprovalsDirty: state.execApprovalsDirty,
+                  execApprovalsSnapshot: state.execApprovalsSnapshot,
+                  execApprovalsForm: state.execApprovalsForm,
+                  execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
+                  execApprovalsTarget: state.execApprovalsTarget,
+                  execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
+                  onRefresh: () => loadNodes(state),
+                  onDevicesRefresh: () => loadDevices(state),
+                  onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
+                  onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
+                  onDeviceRotate: (deviceId, role, scopes) =>
+                    rotateDeviceToken(state, { deviceId, role, scopes }),
+                  onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
+                  onLoadConfig: () => loadConfig(state, { discardPendingChanges: true }),
+                  onLoadExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return loadExecApprovals(state, target);
+                  },
+                  onBindDefault: (nodeId) => {
+                    if (nodeId) {
+                      updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
+                    } else {
+                      removeConfigFormValue(state, ["tools", "exec", "node"]);
+                    }
+                  },
+                  onBindAgent: (agentIndex, nodeId) => {
+                    const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
+                    if (nodeId) {
+                      updateConfigFormValue(state, basePath, nodeId);
                     } else {
                       removeConfigFormValue(state, basePath);
                     }
-                    return;
-                  }
-                  if (!primary) {
-                    return;
-                  }
-                  updateConfigFormValue(state, basePath, { primary, fallbacks: normalized });
+                  },
+                  onSaveBindings: () => saveConfig(state),
+                  onExecApprovalsTargetChange: (kind, nodeId) => {
+                    state.execApprovalsTarget = kind;
+                    state.execApprovalsTargetNodeId = nodeId;
+                    state.execApprovalsSnapshot = null;
+                    state.execApprovalsForm = null;
+                    state.execApprovalsDirty = false;
+                    state.execApprovalsSelectedAgent = null;
+                  },
+                  onExecApprovalsSelectAgent: (agentId) => {
+                    state.execApprovalsSelectedAgent = agentId;
+                  },
+                  onExecApprovalsPatch: (path, value) =>
+                    updateExecApprovalsFormValue(state, path, value),
+                  onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
+                  onSaveExecApprovals: () => {
+                    const target =
+                      state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
+                        ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
+                        : { kind: "gateway" as const };
+                    return saveExecApprovals(state, target);
+                  },
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "chat"
+            ? renderChat({
+                sessionKey: state.sessionKey,
+                onSessionKeyChange: (next) => {
+                  switchChatSession(state, next);
                 },
-                onSetDefault: (agentId) => {
-                  if (!configValue) {
-                    return;
-                  }
-                  updateConfigFormValue(state, ["agents", "defaultId"], agentId);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "skills"
-          ? renderLazyView(lazySkills, (m) =>
-              m.renderSkills({
+                thinkingLevel: state.chatThinkingLevel,
+                showThinking,
+                showToolCalls,
+                loading: state.chatLoading,
+                sending: state.chatSending,
+                compactionStatus: state.compactionStatus,
+                fallbackStatus: state.fallbackStatus,
+                assistantAvatarUrl: chatAvatarUrl,
+                messages: state.chatMessages,
+                sideResult: state.chatSideResult,
+                toolMessages: state.chatToolMessages,
+                streamSegments: state.chatStreamSegments,
+                stream: state.chatStream,
+                streamStartedAt: state.chatStreamStartedAt,
+                draft: state.chatMessage,
+                queue: state.chatQueue,
+                realtimeTalkActive: state.realtimeTalkActive,
+                realtimeTalkStatus: state.realtimeTalkStatus,
+                realtimeTalkDetail: state.realtimeTalkDetail,
+                realtimeTalkTranscript: state.realtimeTalkTranscript,
                 connected: state.connected,
-                loading: state.skillsLoading,
-                report: state.skillsReport,
-                error: state.skillsError,
-                filter: state.skillsFilter,
-                statusFilter: state.skillsStatusFilter,
-                edits: state.skillEdits,
-                messages: state.skillMessages,
-                busyKey: state.skillsBusyKey,
-                detailKey: state.skillsDetailKey,
-                clawhubQuery: state.clawhubSearchQuery,
-                clawhubResults: state.clawhubSearchResults,
-                clawhubSearchLoading: state.clawhubSearchLoading,
-                clawhubSearchError: state.clawhubSearchError,
-                clawhubDetail: state.clawhubDetail,
-                clawhubDetailSlug: state.clawhubDetailSlug,
-                clawhubDetailLoading: state.clawhubDetailLoading,
-                clawhubDetailError: state.clawhubDetailError,
-                clawhubInstallSlug: state.clawhubInstallSlug,
-                clawhubInstallMessage: state.clawhubInstallMessage,
-                onFilterChange: (next) => (state.skillsFilter = next),
-                onStatusFilterChange: (next) => (state.skillsStatusFilter = next),
-                onRefresh: () => loadSkills(state, { clearMessages: true }),
-                onToggle: (key, enabled) => updateSkillEnabled(state, key, enabled),
-                onEdit: (key, value) => updateSkillEdit(state, key, value),
-                onSaveKey: (key) => saveSkillApiKey(state, key),
-                onInstall: (skillKey, name, installId) =>
-                  installSkill(state, skillKey, name, installId),
-                onDetailOpen: (key) => (state.skillsDetailKey = key),
-                onDetailClose: () => (state.skillsDetailKey = null),
-                onClawHubQueryChange: (query) => {
-                  setClawHubSearchQuery(state, query);
-                  if (clawhubSearchTimer) {
-                    clearTimeout(clawhubSearchTimer);
-                  }
-                  clawhubSearchTimer = setTimeout(() => searchClawHub(state, query), 300);
-                },
-                onClawHubDetailOpen: (slug) => loadClawHubDetail(state, slug),
-                onClawHubDetailClose: () => closeClawHubDetail(state),
-                onClawHubInstall: (slug) => installFromClawHub(state, slug),
-              }),
-            )
-          : nothing}
-        ${state.tab === "nodes"
-          ? renderLazyView(lazyNodes, (m) =>
-              m.renderNodes({
-                loading: state.nodesLoading,
-                nodes: state.nodes,
-                devicesLoading: state.devicesLoading,
-                devicesError: state.devicesError,
-                devicesList: state.devicesList,
-                configForm:
-                  state.configForm ??
-                  (state.configSnapshot?.config as Record<string, unknown> | null),
-                configLoading: state.configLoading,
-                configSaving: state.configSaving,
-                configDirty: state.configFormDirty,
-                configFormMode: state.configFormMode,
-                execApprovalsLoading: state.execApprovalsLoading,
-                execApprovalsSaving: state.execApprovalsSaving,
-                execApprovalsDirty: state.execApprovalsDirty,
-                execApprovalsSnapshot: state.execApprovalsSnapshot,
-                execApprovalsForm: state.execApprovalsForm,
-                execApprovalsSelectedAgent: state.execApprovalsSelectedAgent,
-                execApprovalsTarget: state.execApprovalsTarget,
-                execApprovalsTargetNodeId: state.execApprovalsTargetNodeId,
-                onRefresh: () => loadNodes(state),
-                onDevicesRefresh: () => loadDevices(state),
-                onDeviceApprove: (requestId) => approveDevicePairing(state, requestId),
-                onDeviceReject: (requestId) => rejectDevicePairing(state, requestId),
-                onDeviceRotate: (deviceId, role, scopes) =>
-                  rotateDeviceToken(state, { deviceId, role, scopes }),
-                onDeviceRevoke: (deviceId, role) => revokeDeviceToken(state, { deviceId, role }),
-                onLoadConfig: () => loadConfig(state, { discardPendingChanges: true }),
-                onLoadExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return loadExecApprovals(state, target);
-                },
-                onBindDefault: (nodeId) => {
-                  if (nodeId) {
-                    updateConfigFormValue(state, ["tools", "exec", "node"], nodeId);
-                  } else {
-                    removeConfigFormValue(state, ["tools", "exec", "node"]);
-                  }
-                },
-                onBindAgent: (agentIndex, nodeId) => {
-                  const basePath = ["agents", "list", agentIndex, "tools", "exec", "node"];
-                  if (nodeId) {
-                    updateConfigFormValue(state, basePath, nodeId);
-                  } else {
-                    removeConfigFormValue(state, basePath);
-                  }
-                },
-                onSaveBindings: () => saveConfig(state),
-                onExecApprovalsTargetChange: (kind, nodeId) => {
-                  state.execApprovalsTarget = kind;
-                  state.execApprovalsTargetNodeId = nodeId;
-                  state.execApprovalsSnapshot = null;
-                  state.execApprovalsForm = null;
-                  state.execApprovalsDirty = false;
-                  state.execApprovalsSelectedAgent = null;
-                },
-                onExecApprovalsSelectAgent: (agentId) => {
-                  state.execApprovalsSelectedAgent = agentId;
-                },
-                onExecApprovalsPatch: (path, value) =>
-                  updateExecApprovalsFormValue(state, path, value),
-                onExecApprovalsRemove: (path) => removeExecApprovalsFormValue(state, path),
-                onSaveExecApprovals: () => {
-                  const target =
-                    state.execApprovalsTarget === "node" && state.execApprovalsTargetNodeId
-                      ? { kind: "node" as const, nodeId: state.execApprovalsTargetNodeId }
-                      : { kind: "gateway" as const };
-                  return saveExecApprovals(state, target);
-                },
-              }),
-            )
-          : nothing}
-        ${state.tab === "chat"
-          ? renderChat({
-              sessionKey: state.sessionKey,
-              onSessionKeyChange: (next) => {
-                switchChatSession(state, next);
-              },
-              thinkingLevel: state.chatThinkingLevel,
-              showThinking,
-              showToolCalls,
-              loading: state.chatLoading,
-              sending: state.chatSending,
-              compactionStatus: state.compactionStatus,
-              fallbackStatus: state.fallbackStatus,
-              assistantAvatarUrl: chatAvatarUrl,
-              messages: state.chatMessages,
-              sideResult: state.chatSideResult,
-              toolMessages: state.chatToolMessages,
-              streamSegments: state.chatStreamSegments,
-              stream: state.chatStream,
-              streamStartedAt: state.chatStreamStartedAt,
-              draft: state.chatMessage,
-              queue: state.chatQueue,
-              realtimeTalkActive: state.realtimeTalkActive,
-              realtimeTalkStatus: state.realtimeTalkStatus,
-              realtimeTalkDetail: state.realtimeTalkDetail,
-              realtimeTalkTranscript: state.realtimeTalkTranscript,
-              connected: state.connected,
-              canSend: state.connected,
-              disabledReason: chatDisabledReason,
-              error: state.lastError,
-              sessions: state.sessionsResult,
-              focusMode: chatFocus,
-              autoExpandToolCalls: false,
-              onRefresh: () => {
-                state.chatSideResult = null;
-                state.resetToolStream();
-                return refreshChat(state, { scheduleScroll: false });
-              },
-              onToggleFocusMode: () => {
-                if (state.onboarding) {
-                  return;
-                }
-                state.applySettings({
-                  ...state.settings,
-                  chatFocusMode: !state.settings.chatFocusMode,
-                });
-              },
-              onChatScroll: (event) => state.handleChatScroll(event),
-              getDraft: () => state.chatMessage,
-              onDraftChange: (next) => state.handleChatDraftChange(next),
-              onRequestUpdate: requestHostUpdate,
-              onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
-              attachments: state.chatAttachments,
-              onAttachmentsChange: (next) => (state.chatAttachments = next),
-              onSend: () => state.handleSendChat(),
-              onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
-              onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
-              canAbort: Boolean(state.chatRunId),
-              onAbort: () => void state.handleAbortChat(),
-              onQueueRemove: (id) => state.removeQueuedMessage(id),
-              onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
-              onDismissSideResult: () => {
-                state.chatSideResult = null;
-              },
-              onNewSession: () =>
-                state.handleSendChat("/new", { confirmReset: true, restoreDraft: true }),
-              onClearHistory: async () => {
-                if (!state.client || !state.connected) {
-                  return;
-                }
-                try {
-                  await state.client.request("sessions.reset", { key: state.sessionKey });
-                  state.chatMessages = [];
+                canSend: state.connected,
+                disabledReason: chatDisabledReason,
+                error: state.lastError,
+                sessions: state.sessionsResult,
+                focusMode: chatFocus,
+                autoExpandToolCalls: false,
+                onRefresh: () => {
                   state.chatSideResult = null;
-                  state.chatStream = null;
-                  state.chatRunId = null;
-                  await loadChatHistory(state);
-                } catch (err) {
-                  state.lastError = String(err);
-                }
-              },
-              agentsList: state.agentsList,
-              currentAgentId: resolvedAgentId ?? "main",
-              onAgentChange: (agentId: string) => {
-                switchChatSession(state, buildAgentMainSessionKey({ agentId }));
-              },
-              onNavigateToAgent: () => {
-                state.agentsSelectedId = resolvedAgentId;
-                state.setTab("agents" as import("./navigation.ts").Tab);
-              },
-              onSessionSelect: (key: string) => {
-                switchChatSession(state, key);
-              },
-              showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
-              onScrollToBottom: () => state.scrollToBottom(),
-              // Sidebar props for tool output viewing
-              sidebarOpen: state.sidebarOpen,
-              sidebarContent: state.sidebarContent,
-              sidebarError: state.sidebarError,
-              splitRatio: state.splitRatio,
-              canvasHostUrl: state.hello?.canvasHostUrl ?? null,
-              onOpenSidebar: (content) => state.handleOpenSidebar(content),
-              onCloseSidebar: () => state.handleCloseSidebar(),
-              onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
-              assistantName: state.assistantName,
-              assistantAvatar: effectiveAssistantAvatar,
-              userName: state.userName ?? null,
-              userAvatar: state.userAvatar ?? null,
-              localMediaPreviewRoots: state.localMediaPreviewRoots,
-              embedSandboxMode: state.embedSandboxMode,
-              allowExternalEmbedUrls: state.allowExternalEmbedUrls,
-              assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
-              basePath: state.basePath ?? "",
-            })
-          : nothing}
-        ${renderConfigTabForActiveTab()}
-        ${state.tab === "debug"
-          ? renderLazyView(lazyDebug, (m) =>
-              m.renderDebug({
-                loading: state.debugLoading,
-                status: state.debugStatus,
-                health: state.debugHealth,
-                models: state.debugModels,
-                heartbeat: state.debugHeartbeat,
-                eventLog: state.eventLog,
-                methods: (state.hello?.features?.methods ?? []).toSorted(),
-                callMethod: state.debugCallMethod,
-                callParams: state.debugCallParams,
-                callResult: state.debugCallResult,
-                callError: state.debugCallError,
-                onCallMethodChange: (next) => (state.debugCallMethod = next),
-                onCallParamsChange: (next) => (state.debugCallParams = next),
-                onRefresh: () => loadDebug(state),
-                onCall: () => callDebugMethod(state),
-              }),
-            )
-          : nothing}
-        ${state.tab === "logs"
-          ? renderLazyView(lazyLogs, (m) =>
-              m.renderLogs({
-                loading: state.logsLoading,
-                error: state.logsError,
-                file: state.logsFile,
-                entries: state.logsEntries,
-                filterText: state.logsFilterText,
-                levelFilters: state.logsLevelFilters,
-                autoFollow: state.logsAutoFollow,
-                truncated: state.logsTruncated,
-                onFilterTextChange: (next) => (state.logsFilterText = next),
-                onLevelToggle: (level, enabled) => {
-                  state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  state.resetToolStream();
+                  return refreshChat(state, { scheduleScroll: false });
                 },
-                onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
-                onRefresh: () => loadLogs(state, { reset: true }),
-                onExport: (lines, label) => state.exportLogs(lines, label),
-                onScroll: (event) => state.handleLogsScroll(event),
-              }),
-            )
-          : nothing}
-        ${state.tab === "dreams"
-          ? renderDreaming({
-              active: dreamingOn,
-              shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
-              groundedSignalCount: state.dreamingStatus?.groundedSignalCount ?? 0,
-              totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
-              promotedCount: state.dreamingStatus?.promotedToday ?? 0,
-              phases: state.dreamingStatus?.phases ?? undefined,
-              shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
-              promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
-              dreamingOf: null,
-              nextCycle: dreamingNextCycle,
-              timezone: state.dreamingStatus?.timezone ?? null,
-              statusLoading: state.dreamingStatusLoading,
-              statusError: state.dreamingStatusError,
-              modeSaving: state.dreamingModeSaving,
-              dreamDiaryLoading: state.dreamDiaryLoading,
-              dreamDiaryActionLoading: state.dreamDiaryActionLoading,
-              dreamDiaryActionMessage: state.dreamDiaryActionMessage,
-              dreamDiaryActionArchivePath: state.dreamDiaryActionArchivePath,
-              dreamDiaryError: state.dreamDiaryError,
-              dreamDiaryPath: state.dreamDiaryPath,
-              dreamDiaryContent: state.dreamDiaryContent,
-              memoryWikiEnabled: isPluginEnabledInConfigSnapshot(
-                state.configSnapshot,
-                "memory-wiki",
-                { enabledByDefault: false },
-              ),
-              wikiImportInsightsLoading: state.wikiImportInsightsLoading,
-              wikiImportInsightsError: state.wikiImportInsightsError,
-              wikiImportInsights: state.wikiImportInsights,
-              wikiMemoryPalaceLoading: state.wikiMemoryPalaceLoading,
-              wikiMemoryPalaceError: state.wikiMemoryPalaceError,
-              wikiMemoryPalace: state.wikiMemoryPalace,
-              onRefresh: refreshDreaming,
-              onRefreshDiary: () => loadDreamDiary(state),
-              onRefreshImports: () => {
-                void (async () => {
-                  await loadConfig(state);
-                  await loadWikiImportInsights(state);
-                })();
-              },
-              onRefreshMemoryPalace: () => {
-                void (async () => {
-                  await loadConfig(state);
-                  await loadWikiMemoryPalace(state);
-                })();
-              },
-              onOpenConfig: () => openConfigFile(state),
-              onOpenWikiPage: (lookup: string) => openWikiPage(lookup),
-              onBackfillDiary: () => backfillDreamDiary(state),
-              onCopyDreamingArchivePath: () => {
-                void copyDreamingArchivePath(state);
-              },
-              onDedupeDreamDiary: () => dedupeDreamDiary(state),
-              onResetDiary: () => resetDreamDiary(state),
-              onResetGroundedShortTerm: () => resetGroundedShortTerm(state),
-              onRepairDreamingArtifacts: () => repairDreamingArtifacts(state),
-              onRequestUpdate: requestHostUpdate,
-            })
-          : nothing}
+                onToggleFocusMode: () => {
+                  if (state.onboarding) {
+                    return;
+                  }
+                  state.applySettings({
+                    ...state.settings,
+                    chatFocusMode: !state.settings.chatFocusMode,
+                  });
+                },
+                onChatScroll: (event) => state.handleChatScroll(event),
+                getDraft: () => state.chatMessage,
+                onDraftChange: (next) => state.handleChatDraftChange(next),
+                onRequestUpdate: requestHostUpdate,
+                onHistoryKeydown: (input) => state.handleChatInputHistoryKey(input),
+                attachments: state.chatAttachments,
+                onAttachmentsChange: (next) => (state.chatAttachments = next),
+                onSend: () => state.handleSendChat(),
+                onCompact: () => state.handleSendChat("/compact", { restoreDraft: true }),
+                onToggleRealtimeTalk: () => state.toggleRealtimeTalk(),
+                canAbort: Boolean(state.chatRunId),
+                onAbort: () => void state.handleAbortChat(),
+                onQueueRemove: (id) => state.removeQueuedMessage(id),
+                onQueueSteer: (id) => void state.steerQueuedChatMessage(id),
+                onDismissSideResult: () => {
+                  state.chatSideResult = null;
+                },
+                onNewSession: () =>
+                  state.handleSendChat("/new", { confirmReset: true, restoreDraft: true }),
+                onClearHistory: async () => {
+                  if (!state.client || !state.connected) {
+                    return;
+                  }
+                  try {
+                    await state.client.request("sessions.reset", { key: state.sessionKey });
+                    state.chatMessages = [];
+                    state.chatSideResult = null;
+                    state.chatStream = null;
+                    state.chatRunId = null;
+                    await loadChatHistory(state);
+                  } catch (err) {
+                    state.lastError = String(err);
+                  }
+                },
+                agentsList: state.agentsList,
+                currentAgentId: resolvedAgentId ?? "main",
+                onAgentChange: (agentId: string) => {
+                  switchChatSession(state, buildAgentMainSessionKey({ agentId }));
+                },
+                onNavigateToAgent: () => {
+                  state.agentsSelectedId = resolvedAgentId;
+                  state.setTab("agents" as import("./navigation.ts").Tab);
+                },
+                onSessionSelect: (key: string) => {
+                  switchChatSession(state, key);
+                },
+                showNewMessages: state.chatNewMessagesBelow && !state.chatManualRefreshInFlight,
+                onScrollToBottom: () => state.scrollToBottom(),
+                // Sidebar props for tool output viewing
+                sidebarOpen: state.sidebarOpen,
+                sidebarContent: state.sidebarContent,
+                sidebarError: state.sidebarError,
+                splitRatio: state.splitRatio,
+                canvasHostUrl: state.hello?.canvasHostUrl ?? null,
+                onOpenSidebar: (content) => state.handleOpenSidebar(content),
+                onCloseSidebar: () => state.handleCloseSidebar(),
+                onSplitRatioChange: (ratio: number) => state.handleSplitRatioChange(ratio),
+                assistantName: state.assistantName,
+                assistantAvatar: effectiveAssistantAvatar,
+                userName: state.userName ?? null,
+                userAvatar: state.userAvatar ?? null,
+                localMediaPreviewRoots: state.localMediaPreviewRoots,
+                embedSandboxMode: state.embedSandboxMode,
+                allowExternalEmbedUrls: state.allowExternalEmbedUrls,
+                assistantAttachmentAuthToken: resolveAssistantAttachmentAuthToken(state),
+                basePath: state.basePath ?? "",
+              })
+            : nothing
+        }
+        ${renderConfigTabForActiveTab()}
+        ${
+          state.tab === "debug"
+            ? renderLazyView(lazyDebug, (m) =>
+                m.renderDebug({
+                  loading: state.debugLoading,
+                  status: state.debugStatus,
+                  health: state.debugHealth,
+                  models: state.debugModels,
+                  heartbeat: state.debugHeartbeat,
+                  eventLog: state.eventLog,
+                  methods: (state.hello?.features?.methods ?? []).toSorted(),
+                  callMethod: state.debugCallMethod,
+                  callParams: state.debugCallParams,
+                  callResult: state.debugCallResult,
+                  callError: state.debugCallError,
+                  onCallMethodChange: (next) => (state.debugCallMethod = next),
+                  onCallParamsChange: (next) => (state.debugCallParams = next),
+                  onRefresh: () => loadDebug(state),
+                  onCall: () => callDebugMethod(state),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "logs"
+            ? renderLazyView(lazyLogs, (m) =>
+                m.renderLogs({
+                  loading: state.logsLoading,
+                  error: state.logsError,
+                  file: state.logsFile,
+                  entries: state.logsEntries,
+                  filterText: state.logsFilterText,
+                  levelFilters: state.logsLevelFilters,
+                  autoFollow: state.logsAutoFollow,
+                  truncated: state.logsTruncated,
+                  onFilterTextChange: (next) => (state.logsFilterText = next),
+                  onLevelToggle: (level, enabled) => {
+                    state.logsLevelFilters = { ...state.logsLevelFilters, [level]: enabled };
+                  },
+                  onToggleAutoFollow: (next) => (state.logsAutoFollow = next),
+                  onRefresh: () => loadLogs(state, { reset: true }),
+                  onExport: (lines, label) => state.exportLogs(lines, label),
+                  onScroll: (event) => state.handleLogsScroll(event),
+                }),
+              )
+            : nothing
+        }
+        ${
+          state.tab === "dreams"
+            ? renderDreaming({
+                active: dreamingOn,
+                shortTermCount: state.dreamingStatus?.shortTermCount ?? 0,
+                groundedSignalCount: state.dreamingStatus?.groundedSignalCount ?? 0,
+                totalSignalCount: state.dreamingStatus?.totalSignalCount ?? 0,
+                promotedCount: state.dreamingStatus?.promotedToday ?? 0,
+                phases: state.dreamingStatus?.phases ?? undefined,
+                shortTermEntries: state.dreamingStatus?.shortTermEntries ?? [],
+                promotedEntries: state.dreamingStatus?.promotedEntries ?? [],
+                dreamingOf: null,
+                nextCycle: dreamingNextCycle,
+                timezone: state.dreamingStatus?.timezone ?? null,
+                statusLoading: state.dreamingStatusLoading,
+                statusError: state.dreamingStatusError,
+                modeSaving: state.dreamingModeSaving,
+                dreamDiaryLoading: state.dreamDiaryLoading,
+                dreamDiaryActionLoading: state.dreamDiaryActionLoading,
+                dreamDiaryActionMessage: state.dreamDiaryActionMessage,
+                dreamDiaryActionArchivePath: state.dreamDiaryActionArchivePath,
+                dreamDiaryError: state.dreamDiaryError,
+                dreamDiaryPath: state.dreamDiaryPath,
+                dreamDiaryContent: state.dreamDiaryContent,
+                memoryWikiEnabled: isPluginEnabledInConfigSnapshot(
+                  state.configSnapshot,
+                  "memory-wiki",
+                  { enabledByDefault: false },
+                ),
+                wikiImportInsightsLoading: state.wikiImportInsightsLoading,
+                wikiImportInsightsError: state.wikiImportInsightsError,
+                wikiImportInsights: state.wikiImportInsights,
+                wikiMemoryPalaceLoading: state.wikiMemoryPalaceLoading,
+                wikiMemoryPalaceError: state.wikiMemoryPalaceError,
+                wikiMemoryPalace: state.wikiMemoryPalace,
+                onRefresh: refreshDreaming,
+                onRefreshDiary: () => loadDreamDiary(state),
+                onRefreshImports: () => {
+                  void (async () => {
+                    await loadConfig(state);
+                    await loadWikiImportInsights(state);
+                  })();
+                },
+                onRefreshMemoryPalace: () => {
+                  void (async () => {
+                    await loadConfig(state);
+                    await loadWikiMemoryPalace(state);
+                  })();
+                },
+                onOpenConfig: () => openConfigFile(state),
+                onOpenWikiPage: (lookup: string) => openWikiPage(lookup),
+                onBackfillDiary: () => backfillDreamDiary(state),
+                onCopyDreamingArchivePath: () => {
+                  void copyDreamingArchivePath(state);
+                },
+                onDedupeDreamDiary: () => dedupeDreamDiary(state),
+                onResetDiary: () => resetDreamDiary(state),
+                onResetGroundedShortTerm: () => resetGroundedShortTerm(state),
+                onRepairDreamingArtifacts: () => repairDreamingArtifacts(state),
+                onRequestUpdate: requestHostUpdate,
+              })
+            : nothing
+        }
       </main>
       ${renderExecApprovalPrompt(state)} ${renderGatewayUrlConfirmation(state)}
       ${renderDreamingRestartConfirmation({

--- a/ui/src/ui/components/dashboard-header.ts
+++ b/ui/src/ui/components/dashboard-header.ts
@@ -1,6 +1,6 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
-import { titleForTab, type Tab } from "../navigation.js";
+import { subtitleForTab, titleForTab, type Tab } from "../navigation.js";
 
 export class DashboardHeader extends LitElement {
   override createRenderRoot() {
@@ -11,6 +11,7 @@ export class DashboardHeader extends LitElement {
 
   override render() {
     const label = titleForTab(this.tab);
+    const subtitle = subtitleForTab(this.tab);
 
     return html`
       <div class="dashboard-header">
@@ -26,6 +27,11 @@ export class DashboardHeader extends LitElement {
           </span>
           <span class="dashboard-header__breadcrumb-sep">›</span>
           <span class="dashboard-header__breadcrumb-current">${label}</span>
+          ${
+            subtitle
+              ? html`<span class="dashboard-header__breadcrumb-sep">—</span><span class="dashboard-header__breadcrumb-desc">${subtitle}</span>`
+              : nothing
+          }
         </div>
         <div class="dashboard-header__actions">
           <slot></slot>

--- a/ui/src/ui/views/channels.ts
+++ b/ui/src/ui/views/channels.ts
@@ -75,17 +75,16 @@ export function renderChannels(props: ChannelsProps) {
 
     <section class="card" style="margin-top: 18px;">
       <div class="row" style="justify-content: space-between;">
-        <div>
-          <div class="card-title">${t("channels.health.title")}</div>
-          <div class="card-sub">${t("channels.health.subtitle")}</div>
-        </div>
+        <div></div>
         <div class="muted">
           ${props.lastSuccessAt ? formatRelativeTimestamp(props.lastSuccessAt) : t("common.na")}
         </div>
       </div>
-      ${props.lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
-        : nothing}
+      ${
+        props.lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
+          : nothing
+      }
       <pre class="code-block" style="margin-top: 12px;">
 ${props.snapshot ? JSON.stringify(props.snapshot, null, 2) : t("channels.health.noSnapshotYet")}
       </pre
@@ -199,13 +198,14 @@ function renderGenericChannelCard(
       <div class="card-title">${label}</div>
       <div class="card-sub">${t("channels.generic.subtitle")}</div>
       ${accountCountLabel}
-      ${accounts.length > 0
-        ? html`
+      ${
+        accounts.length > 0
+          ? html`
             <div class="account-card-list">
               ${accounts.map((account) => renderGenericAccount(account))}
             </div>
           `
-        : html`
+          : html`
             <div class="status-list" style="margin-top: 16px;">
               <div>
                 <span class="label">${t("common.configured")}</span>
@@ -220,10 +220,13 @@ function renderGenericChannelCard(
                 <span>${formatNullableBoolean(displayState.connected)}</span>
               </div>
             </div>
-          `}
-      ${lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${lastError}</div>`
-        : nothing}
+          `
+      }
+      ${
+        lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${lastError}</div>`
+          : nothing
+      }
       ${renderChannelConfigSection({ channelId: key, props })}
     </div>
   `;
@@ -303,14 +306,18 @@ function renderGenericAccount(account: ChannelAccountSnapshot) {
         <div>
           <span class="label">${t("common.lastInbound")}</span>
           <span
-            >${account.lastInboundAt
-              ? formatRelativeTimestamp(account.lastInboundAt)
-              : t("common.na")}</span
+            >${
+              account.lastInboundAt
+                ? formatRelativeTimestamp(account.lastInboundAt)
+                : t("common.na")
+            }</span
           >
         </div>
-        ${account.lastError
-          ? html` <div class="account-card-error">${account.lastError}</div> `
-          : nothing}
+        ${
+          account.lastError
+            ? html` <div class="account-card-error">${account.lastError}</div> `
+            : nothing
+        }
       </div>
     </div>
   `;

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -226,9 +226,7 @@ describe("cron view", () => {
     expect(container.textContent).toContain("Latest runs for Daily ping.");
 
     const cards = Array.from(container.querySelectorAll(".card"));
-    const runHistoryCard = cards.find(
-      (card) => card.querySelector(".card-title")?.textContent?.trim() === "Run history",
-    );
+    const runHistoryCard = cards.find((card) => card.querySelector(".cron-run-filters") !== null);
     expect(runHistoryCard).not.toBeUndefined();
 
     const summaries = Array.from(

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -345,12 +345,14 @@ function focusFormField(id: string) {
 function renderFieldLabel(text: string, required = false) {
   return html`<span>
     ${text}
-    ${required
-      ? html`
+    ${
+      required
+        ? html`
           <span class="cron-required-marker" aria-hidden="true">*</span>
           <span class="cron-required-sr">${t("cron.form.requiredSr")}</span>
         `
-      : nothing}
+        : nothing
+    }
   </span>`;
 }
 
@@ -404,11 +406,13 @@ export function renderCron(props: CronProps) {
           <div class="cron-summary-label">${t("cron.summary.enabled")}</div>
           <div class="cron-summary-value">
             <span class=${`chip ${props.status?.enabled ? "chip-ok" : "chip-danger"}`}>
-              ${props.status
-                ? props.status.enabled
-                  ? t("cron.summary.yes")
-                  : t("cron.summary.no")
-                : t("common.na")}
+              ${
+                props.status
+                  ? props.status.enabled
+                    ? t("cron.summary.yes")
+                    : t("cron.summary.no")
+                  : t("common.na")
+              }
             </span>
           </div>
         </div>
@@ -422,9 +426,11 @@ export function renderCron(props: CronProps) {
         </div>
       </div>
       <div class="cron-summary-strip__actions">
-        ${props.onQuickCreate
-          ? html` <button class="btn btn--primary" @click=${props.onQuickCreate}>+ New</button> `
-          : nothing}
+        ${
+          props.onQuickCreate
+            ? html` <button class="btn btn--primary" @click=${props.onQuickCreate}>+ New</button> `
+            : nothing
+        }
         <button
           class=${props.loading ? "btn cron-refresh-btn--loading" : "btn"}
           ?disabled=${props.loading}
@@ -438,22 +444,19 @@ export function renderCron(props: CronProps) {
 
     <section class="cron-workspace">
       <div class="cron-workspace-main">
-        <section class="card">
-          <div
-            class="row"
-            style="justify-content: space-between; align-items: flex-start; gap: 12px;"
-          >
-            <div>
-              <div class="card-title">${t("cron.jobs.title")}</div>
-              <div class="card-sub">${t("cron.jobs.subtitle")}</div>
-            </div>
-            <div class="muted">
-              ${t("cron.jobs.shownOf", {
-                shown: String(props.jobs.length),
-                total: String(props.jobsTotal),
-              })}
-            </div>
+      <section class="card">
+        <div
+          class="row"
+          style="justify-content: space-between; align-items: flex-start; gap: 12px;"
+        >
+          <div></div>
+          <div class="muted">
+            ${t("cron.jobs.shownOf", {
+              shown: String(props.jobs.length),
+              total: String(props.jobsTotal),
+            })}
           </div>
+        </div>
           <div class="filters" style="margin-top: 12px;">
             <label class="field cron-filter-search">
               <span>${t("cron.jobs.searchJobs")}</span>
@@ -554,15 +557,18 @@ export function renderCron(props: CronProps) {
               </button>
             </label>
           </div>
-          ${props.jobs.length === 0
-            ? html` <div class="muted" style="margin-top: 12px">${t("cron.jobs.noMatching")}</div> `
-            : html`
+          ${
+            props.jobs.length === 0
+              ? html` <div class="muted" style="margin-top: 12px">${t("cron.jobs.noMatching")}</div> `
+              : html`
                 <div class="list" style="margin-top: 12px;">
                   ${props.jobs.map((job) => renderJob(job, props))}
                 </div>
-              `}
-          ${props.jobsHasMore
-            ? html`
+              `
+          }
+          ${
+            props.jobsHasMore
+              ? html`
                 <div class="row" style="margin-top: 12px">
                   <button
                     class="btn"
@@ -573,7 +579,8 @@ export function renderCron(props: CronProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </section>
 
         <section class="card">
@@ -581,14 +588,7 @@ export function renderCron(props: CronProps) {
             class="row"
             style="justify-content: space-between; align-items: flex-start; gap: 12px;"
           >
-            <div>
-              <div class="card-title">${t("cron.runs.title")}</div>
-              <div class="card-sub">
-                ${props.runsScope === "all"
-                  ? t("cron.runs.subtitleAll")
-                  : t("cron.runs.subtitleJob", { title: selectedRunTitle })}
-              </div>
-            </div>
+            <div></div>
             <div class="muted">
               ${t("cron.jobs.shownOf", {
                 shown: String(runs.length),
@@ -677,21 +677,24 @@ export function renderCron(props: CronProps) {
               })}
             </div>
           </div>
-          ${props.runsScope === "job" && props.runsJobId == null
-            ? html`
+          ${
+            props.runsScope === "job" && props.runsJobId == null
+              ? html`
                 <div class="muted" style="margin-top: 12px">${t("cron.runs.selectJobHint")}</div>
               `
-            : runs.length === 0
-              ? html`
+              : runs.length === 0
+                ? html`
                   <div class="muted" style="margin-top: 12px">${t("cron.runs.noMatching")}</div>
                 `
-              : html`
+                : html`
                   <div class="list" style="margin-top: 12px;">
                     ${runs.map((entry) => renderRun(entry, props.basePath, props.onNavigateToChat))}
                   </div>
-                `}
-          ${(props.runsScope === "all" || props.runsJobId != null) && props.runsHasMore
-            ? html`
+                `
+          }
+          ${
+            (props.runsScope === "all" || props.runsJobId != null) && props.runsHasMore
+              ? html`
                 <div class="row" style="margin-top: 12px">
                   <button
                     class="btn"
@@ -702,15 +705,13 @@ export function renderCron(props: CronProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </section>
       </div>
 
       <section class="card cron-workspace-form">
-        <div class="card-title">${isEditing ? t("cron.form.editJob") : t("cron.form.newJob")}</div>
-        <div class="card-sub">
-          ${isEditing ? t("cron.form.updateSubtitle") : t("cron.form.createSubtitle")}
-        </div>
+        <div></div>
         <div class="cron-form">
           <div class="cron-required-legend">
             <span class="cron-required-marker" aria-hidden="true">*</span> ${t(
@@ -844,13 +845,16 @@ export function renderCron(props: CronProps) {
                   <option value="agentTurn">${t("cron.form.agentTurn")}</option>
                 </select>
                 <div class="cron-help">
-                  ${props.form.payloadKind === "systemEvent"
-                    ? t("cron.form.systemEventHelp")
-                    : t("cron.form.agentTurnHelp")}
+                  ${
+                    props.form.payloadKind === "systemEvent"
+                      ? t("cron.form.systemEventHelp")
+                      : t("cron.form.agentTurnHelp")
+                  }
                 </div>
               </label>
-              ${isAgentTurn
-                ? html`
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field">
                       ${renderFieldLabel(t("cron.form.timeoutSeconds"))}
                       <input
@@ -875,7 +879,8 @@ export function renderCron(props: CronProps) {
                       )}
                     </label>
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
             <label class="field cron-span-2">
               ${renderFieldLabel(
@@ -916,16 +921,19 @@ export function renderCron(props: CronProps) {
                         .value as CronFormState["deliveryMode"],
                     })}
                 >
-                  ${supportsAnnounce
-                    ? html` <option value="announce">${t("cron.form.announceDefault")}</option> `
-                    : nothing}
+                  ${
+                    supportsAnnounce
+                      ? html` <option value="announce">${t("cron.form.announceDefault")}</option> `
+                      : nothing
+                  }
                   <option value="webhook">${t("cron.form.webhookPost")}</option>
                   <option value="none">${t("cron.form.noneInternal")}</option>
                 </select>
                 <div class="cron-help">${t("cron.form.deliveryHelp")}</div>
               </label>
-              ${selectedDeliveryMode !== "none"
-                ? html`
+              ${
+                selectedDeliveryMode !== "none"
+                  ? html`
                     <label class="field ${selectedDeliveryMode === "webhook" ? "cron-span-2" : ""}">
                       ${renderFieldLabel(
                         selectedDeliveryMode === "webhook"
@@ -933,8 +941,9 @@ export function renderCron(props: CronProps) {
                           : t("cron.form.channel"),
                         selectedDeliveryMode === "webhook",
                       )}
-                      ${selectedDeliveryMode === "webhook"
-                        ? html`
+                      ${
+                        selectedDeliveryMode === "webhook"
+                          ? html`
                             <input
                               id="cron-delivery-to"
                               .value=${props.form.deliveryTo}
@@ -952,7 +961,7 @@ export function renderCron(props: CronProps) {
                               placeholder=${t("cron.form.webhookPlaceholder")}
                             />
                           `
-                        : html`
+                          : html`
                             <select
                               id="cron-delivery-channel"
                               .value=${props.form.deliveryChannel || "last"}
@@ -968,13 +977,17 @@ export function renderCron(props: CronProps) {
                                   </option>`,
                               )}
                             </select>
-                          `}
-                      ${selectedDeliveryMode === "announce"
-                        ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
-                        : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `}
+                          `
+                      }
+                      ${
+                        selectedDeliveryMode === "announce"
+                          ? html` <div class="cron-help">${t("cron.form.channelHelp")}</div> `
+                          : html` <div class="cron-help">${t("cron.form.webhookHelp")}</div> `
+                      }
                     </label>
-                    ${selectedDeliveryMode === "announce"
-                      ? html`
+                    ${
+                      selectedDeliveryMode === "announce"
+                        ? html`
                           <label class="field cron-span-2">
                             ${renderFieldLabel(t("cron.form.to"))}
                             <input
@@ -990,15 +1003,19 @@ export function renderCron(props: CronProps) {
                             <div class="cron-help">${t("cron.form.toHelp")}</div>
                           </label>
                         `
-                      : nothing}
-                    ${selectedDeliveryMode === "webhook"
-                      ? renderFieldError(
-                          props.fieldErrors.deliveryTo,
-                          errorIdForField("deliveryTo"),
-                        )
-                      : nothing}
+                        : nothing
+                    }
+                    ${
+                      selectedDeliveryMode === "webhook"
+                        ? renderFieldError(
+                            props.fieldErrors.deliveryTo,
+                            errorIdForField("deliveryTo"),
+                          )
+                        : nothing
+                    }
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
           </section>
 
@@ -1043,8 +1060,9 @@ export function renderCron(props: CronProps) {
                 />
                 <div class="cron-help">Optional routing key for job delivery and wake routing.</div>
               </label>
-              ${isCronSchedule
-                ? html`
+              ${
+                isCronSchedule
+                  ? html`
                     <label class="field checkbox cron-checkbox cron-span-2">
                       <input
                         type="checkbox"
@@ -1098,9 +1116,11 @@ export function renderCron(props: CronProps) {
                       </label>
                     </div>
                   `
-                : nothing}
-              ${isAgentTurn
-                ? html`
+                  : nothing
+              }
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field cron-span-2">
                       ${renderFieldLabel("Account ID")}
                       <input
@@ -1161,9 +1181,11 @@ export function renderCron(props: CronProps) {
                       <div class="cron-help">${t("cron.form.thinkingHelp")}</div>
                     </label>
                   `
-                : nothing}
-              ${isAgentTurn
-                ? html`
+                  : nothing
+              }
+              ${
+                isAgentTurn
+                  ? html`
                     <label class="field cron-span-2">
                       ${renderFieldLabel("Failure alerts")}
                       <select
@@ -1182,8 +1204,9 @@ export function renderCron(props: CronProps) {
                         Control when this job sends repeated-failure alerts.
                       </div>
                     </label>
-                    ${props.form.failureAlertMode === "custom"
-                      ? html`
+                    ${
+                      props.form.failureAlertMode === "custom"
+                        ? html`
                           <label class="field">
                             ${renderFieldLabel("Alert after")}
                             <input
@@ -1212,9 +1235,9 @@ export function renderCron(props: CronProps) {
                             <input
                               id="cron-failure-alert-cooldown-seconds"
                               .value=${props.form.failureAlertCooldownSeconds}
-                              aria-invalid=${props.fieldErrors.failureAlertCooldownSeconds
-                                ? "true"
-                                : "false"}
+                              aria-invalid=${
+                                props.fieldErrors.failureAlertCooldownSeconds ? "true" : "false"
+                              }
                               aria-describedby=${ifDefined(
                                 props.fieldErrors.failureAlertCooldownSeconds
                                   ? errorIdForField("failureAlertCooldownSeconds")
@@ -1290,11 +1313,14 @@ export function renderCron(props: CronProps) {
                             />
                           </label>
                         `
-                      : nothing}
+                        : nothing
+                    }
                   `
-                : nothing}
-              ${selectedDeliveryMode !== "none"
-                ? html`
+                  : nothing
+              }
+              ${
+                selectedDeliveryMode !== "none"
+                  ? html`
                     <label class="field checkbox cron-checkbox cron-span-2">
                       <input
                         type="checkbox"
@@ -1310,12 +1336,14 @@ export function renderCron(props: CronProps) {
                       <div class="cron-help">${t("cron.form.bestEffortHelp")}</div>
                     </label>
                   `
-                : nothing}
+                  : nothing
+              }
             </div>
           </details>
         </div>
-        ${blockedByValidation
-          ? html`
+        ${
+          blockedByValidation
+            ? html`
               <div class="cron-form-status" role="status" aria-live="polite">
                 <div class="cron-form-status__title">${t("cron.form.cantAddYet")}</div>
                 <div class="cron-help">${t("cron.form.fillRequired")}</div>
@@ -1336,29 +1364,36 @@ export function renderCron(props: CronProps) {
                 </ul>
               </div>
             `
-          : nothing}
+            : nothing
+        }
         <div class="row cron-form-actions">
           <button
             class="btn primary"
             ?disabled=${props.busy || !props.canSubmit}
             @click=${props.onAdd}
           >
-            ${props.busy
-              ? t("cron.form.saving")
-              : isEditing
-                ? t("cron.form.saveChanges")
-                : t("cron.form.addJob")}
+            ${
+              props.busy
+                ? t("cron.form.saving")
+                : isEditing
+                  ? t("cron.form.saveChanges")
+                  : t("cron.form.addJob")
+            }
           </button>
-          ${submitDisabledReason
-            ? html`<div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div>`
-            : nothing}
-          ${isEditing
-            ? html`
+          ${
+            submitDisabledReason
+              ? html`<div class="cron-submit-reason" aria-live="polite">${submitDisabledReason}</div>`
+              : nothing
+          }
+          ${
+            isEditing
+              ? html`
                 <button class="btn" ?disabled=${props.busy} @click=${props.onCancelEdit}>
                   ${t("cron.form.cancel")}
                 </button>
               `
-            : nothing}
+              : nothing
+          }
         </div>
       </section>
     </section>
@@ -1485,11 +1520,13 @@ function renderJob(job: CronJob, props: CronProps) {
         <div class="list-main">
           <div class="list-title">${job.name}</div>
           <div class="list-sub">${formatCronSchedule(job)}</div>
-          ${job.agentId
-            ? html`<div class="muted cron-job-agent">
+          ${
+            job.agentId
+              ? html`<div class="muted cron-job-agent">
                 ${t("cron.jobDetail.agent")}: ${job.agentId}
               </div>`
-            : nothing}
+              : nothing
+          }
         </div>
         <div class="list-meta">${renderJobState(job)}</div>
       </div>
@@ -1605,12 +1642,14 @@ function renderJobPayload(job: CronJob) {
           ${unsafeHTML(toSanitizedMarkdownHtml(job.payload.message))}
         </div>
       </div>
-      ${delivery
-        ? html`<div class="cron-job-detail-section">
+      ${
+        delivery
+          ? html`<div class="cron-job-detail-section">
             <span class="cron-job-detail-label">${t("cron.jobDetail.delivery")}</span>
             <span class="muted cron-job-detail-value">${delivery.mode}${deliveryTarget}</span>
           </div>`
-        : nothing}
+          : nothing
+      }
     </div>
   `;
 }
@@ -1742,15 +1781,20 @@ function renderRun(
         </div>
         <div class="list-meta cron-run-entry__meta">
           <div>${formatMs(entry.ts)}</div>
-          ${typeof entry.runAtMs === "number"
-            ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
-            : nothing}
+          ${
+            typeof entry.runAtMs === "number"
+              ? html`<div class="muted">${t("cron.runEntry.runAt")} ${formatMs(entry.runAtMs)}</div>`
+              : nothing
+          }
           <div class="muted">${entry.durationMs ?? 0}ms</div>
-          ${typeof entry.nextRunAtMs === "number"
-            ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
-            : nothing}
-          ${chatUrl
-            ? html`<div>
+          ${
+            typeof entry.nextRunAtMs === "number"
+              ? html`<div class="muted">${formatRunNextLabel(entry.nextRunAtMs)}</div>`
+              : nothing
+          }
+          ${
+            chatUrl
+              ? html`<div>
                 <a
                   class="session-link"
                   href=${chatUrl}
@@ -1773,7 +1817,8 @@ function renderRun(
                   >${t("cron.runEntry.openRunChat")}</a
                 >
               </div>`
-            : nothing}
+              : nothing
+          }
           ${showErrorInMeta ? html`<div class="muted">${entry.error}</div>` : nothing}
           ${entry.deliveryError ? html`<div class="muted">${entry.deliveryError}</div>` : nothing}
         </div>

--- a/ui/src/ui/views/debug.ts
+++ b/ui/src/ui/views/debug.ts
@@ -38,10 +38,7 @@ export function renderDebug(props: DebugProps) {
     <section class="grid">
       <div class="card">
         <div class="row" style="justify-content: space-between;">
-          <div>
-            <div class="card-title">Snapshots</div>
-            <div class="card-sub">Status, health, and heartbeat data.</div>
-          </div>
+          <div></div>
           <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
             ${props.loading ? t("common.refreshing") : t("common.refresh")}
           </button>
@@ -49,12 +46,14 @@ export function renderDebug(props: DebugProps) {
         <div class="stack" style="margin-top: 12px;">
           <div>
             <div class="muted">Status</div>
-            ${securitySummary
-              ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">
+            ${
+              securitySummary
+                ? html`<div class="callout ${securityTone}" style="margin-top: 8px;">
                   Security audit: ${securityLabel}${info > 0 ? ` · ${info} info` : ""}. Run
                   <span class="mono">openclaw security audit --deep</span> for details.
                 </div>`
-              : nothing}
+                : nothing
+            }
             <pre class="code-block">${JSON.stringify(props.status ?? {}, null, 2)}</pre>
           </div>
           <div>
@@ -69,8 +68,10 @@ export function renderDebug(props: DebugProps) {
       </div>
 
       <div class="card">
-        <div class="card-title">Manual RPC</div>
-        <div class="card-sub">Send a raw gateway method with JSON params.</div>
+        <div class="row" style="justify-content: space-between;">
+          <div></div>
+          <div></div>
+        </div>
         <div class="stack" style="margin-top: 16px;">
           <label class="field">
             <span>Method</span>
@@ -79,9 +80,13 @@ export function renderDebug(props: DebugProps) {
               @change=${(e: Event) =>
                 props.onCallMethodChange((e.target as HTMLSelectElement).value)}
             >
-              ${!props.callMethod
-                ? html` <option value="" disabled>Select a method…</option> `
-                : nothing}
+              ${
+                !props.callMethod
+                  ? html`
+                      <option value="" disabled>Select a method…</option>
+                    `
+                  : nothing
+              }
               ${props.methods.map((m) => html`<option value=${m}>${m}</option>`)}
             </select>
           </label>
@@ -98,29 +103,33 @@ export function renderDebug(props: DebugProps) {
         <div class="row" style="margin-top: 12px;">
           <button class="btn primary" @click=${props.onCall}>${t("common.call")}</button>
         </div>
-        ${props.callError
-          ? html`<div class="callout danger" style="margin-top: 12px;">${props.callError}</div>`
-          : nothing}
-        ${props.callResult
-          ? html`<pre class="code-block" style="margin-top: 12px;">${props.callResult}</pre>`
-          : nothing}
+        ${
+          props.callError
+            ? html`<div class="callout danger" style="margin-top: 12px;">${props.callError}</div>`
+            : nothing
+        }
+        ${
+          props.callResult
+            ? html`<pre class="code-block" style="margin-top: 12px;">${props.callResult}</pre>`
+            : nothing
+        }
       </div>
     </section>
 
     <section class="card" style="margin-top: 18px;">
-      <div class="card-title">Models</div>
-      <div class="card-sub">Catalog from models.list.</div>
+      <div class="muted">Models</div>
       <pre class="code-block" style="margin-top: 12px;">
-${JSON.stringify(props.models ?? [], null, 2)}</pre
-      >
+${JSON.stringify(props.models ?? [], null, 2)}</pre>
     </section>
 
     <section class="card" style="margin-top: 18px;">
-      <div class="card-title">Event Log</div>
-      <div class="card-sub">Latest gateway events.</div>
-      ${props.eventLog.length === 0
-        ? html` <div class="muted" style="margin-top: 12px">No events yet.</div> `
-        : html`
+      <div class="muted">Event Log</div>
+      ${
+        props.eventLog.length === 0
+          ? html`
+              <div class="muted" style="margin-top: 12px">No events yet.</div>
+            `
+          : html`
             <div class="list debug-event-log" style="margin-top: 12px;">
               ${props.eventLog.map(
                 (evt) => html`
@@ -131,14 +140,14 @@ ${JSON.stringify(props.models ?? [], null, 2)}</pre
                     </div>
                     <div class="list-meta debug-event-log__meta">
                       <pre class="code-block debug-event-log__payload">
-${formatEventPayload(evt.payload)}</pre
-                      >
+${formatEventPayload(evt.payload)}</pre>
                     </div>
                   </div>
                 `,
               )}
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }

--- a/ui/src/ui/views/instances.ts
+++ b/ui/src/ui/views/instances.ts
@@ -20,10 +20,7 @@ export function renderInstances(props: InstancesProps) {
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between;">
-        <div>
-          <div class="card-title">${t("instances.title")}</div>
-          <div class="card-sub">${t("instances.subtitle")}</div>
-        </div>
+        <div></div>
         <div class="row" style="gap: 8px;">
           <button
             class="btn btn--icon ${masked ? "" : "active"}"
@@ -43,16 +40,22 @@ export function renderInstances(props: InstancesProps) {
           </button>
         </div>
       </div>
-      ${props.lastError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
-        : nothing}
-      ${props.statusMessage
-        ? html`<div class="callout" style="margin-top: 12px;">${props.statusMessage}</div>`
-        : nothing}
+      ${
+        props.lastError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.lastError}</div>`
+          : nothing
+      }
+      ${
+        props.statusMessage
+          ? html`<div class="callout" style="margin-top: 12px;">${props.statusMessage}</div>`
+          : nothing
+      }
       <div class="list" style="margin-top: 16px;">
-        ${props.entries.length === 0
-          ? html` <div class="muted">${t("instances.noInstances")}</div> `
-          : props.entries.map((entry) => renderEntry(entry, masked))}
+        ${
+          props.entries.length === 0
+            ? html` <div class="muted">${t("instances.noInstances")}</div> `
+            : props.entries.map((entry) => renderEntry(entry, masked))
+        }
       </div>
     </section>
   `;
@@ -90,9 +93,11 @@ function renderEntry(entry: PresenceEntry, masked: boolean) {
           ${scopesLabel ? html`<span class="chip">${scopesLabel}</span>` : nothing}
           ${entry.platform ? html`<span class="chip">${entry.platform}</span>` : nothing}
           ${entry.deviceFamily ? html`<span class="chip">${entry.deviceFamily}</span>` : nothing}
-          ${entry.modelIdentifier
-            ? html`<span class="chip">${entry.modelIdentifier}</span>`
-            : nothing}
+          ${
+            entry.modelIdentifier
+              ? html`<span class="chip">${entry.modelIdentifier}</span>`
+              : nothing
+          }
           ${entry.version ? html`<span class="chip">${entry.version}</span>` : nothing}
         </div>
       </div>

--- a/ui/src/ui/views/logs.ts
+++ b/ui/src/ui/views/logs.ts
@@ -57,10 +57,7 @@ export function renderLogs(props: LogsProps) {
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between;">
-        <div>
-          <div class="card-title">Logs</div>
-          <div class="card-sub">Gateway file logs (JSONL).</div>
-        </div>
+        <div></div>
         <div class="row" style="gap: 8px;">
           <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
             ${props.loading ? t("common.loading") : t("common.refresh")}
@@ -115,25 +112,32 @@ export function renderLogs(props: LogsProps) {
         )}
       </div>
 
-      ${props.file
-        ? html`<div class="muted" style="margin-top: 10px;">File: ${props.file}</div>`
-        : nothing}
-      ${props.truncated
-        ? html`
-            <div class="callout" style="margin-top: 10px">
-              Log output truncated; showing latest chunk.
-            </div>
-          `
-        : nothing}
-      ${props.error
-        ? html`<div class="callout danger" style="margin-top: 10px;">${props.error}</div>`
-        : nothing}
+      ${
+        props.file
+          ? html`<div class="muted" style="margin-top: 10px;">File: ${props.file}</div>`
+          : nothing
+      }
+      ${
+        props.truncated
+          ? html`
+              <div class="callout" style="margin-top: 10px">Log output truncated; showing latest chunk.</div>
+            `
+          : nothing
+      }
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 10px;">${props.error}</div>`
+          : nothing
+      }
 
       <div class="log-stream" style="margin-top: 12px;" @scroll=${props.onScroll}>
-        ${filtered.length === 0
-          ? html` <div class="muted" style="padding: 12px">No log entries.</div> `
-          : filtered.map(
-              (entry) => html`
+        ${
+          filtered.length === 0
+            ? html`
+                <div class="muted" style="padding: 12px">No log entries.</div>
+              `
+            : filtered.map(
+                (entry) => html`
                 <div class="log-row">
                   <div class="log-time mono">${formatTime(entry.time)}</div>
                   <div class="log-level ${entry.level ?? ""}">${entry.level ?? ""}</div>
@@ -141,7 +145,8 @@ export function renderLogs(props: LogsProps) {
                   <div class="log-message mono">${entry.message ?? entry.raw}</div>
                 </div>
               `,
-            )}
+              )
+        }
       </div>
     </section>
   `;

--- a/ui/src/ui/views/nodes.ts
+++ b/ui/src/ui/views/nodes.ts
@@ -20,18 +20,19 @@ export function renderNodes(props: NodesProps) {
     ${renderExecApprovals(approvalsState)} ${renderBindings(bindingState)} ${renderDevices(props)}
     <section class="card">
       <div class="row" style="justify-content: space-between;">
-        <div>
-          <div class="card-title">Nodes</div>
-          <div class="card-sub">Paired devices and live links.</div>
-        </div>
+        <div></div>
         <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
           ${props.loading ? t("common.loading") : t("common.refresh")}
         </button>
       </div>
       <div class="list" style="margin-top: 16px;">
-        ${props.nodes.length === 0
-          ? html` <div class="muted">No nodes found.</div> `
-          : props.nodes.map((n) => renderNode(n))}
+        ${
+          props.nodes.length === 0
+            ? html`
+                <div class="muted">No nodes found.</div>
+              `
+            : props.nodes.map((n) => renderNode(n))
+        }
       </div>
     </section>
   `;
@@ -57,27 +58,37 @@ function renderDevices(props: NodesProps) {
           ${props.devicesLoading ? t("common.loading") : t("common.refresh")}
         </button>
       </div>
-      ${props.devicesError
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.devicesError}</div>`
-        : nothing}
+      ${
+        props.devicesError
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.devicesError}</div>`
+          : nothing
+      }
       <div class="list" style="margin-top: 16px;">
-        ${pending.length > 0
-          ? html`
+        ${
+          pending.length > 0
+            ? html`
               <div class="muted" style="margin-bottom: 8px;">Pending</div>
               ${pending.map((req) =>
                 renderPendingDevice(req, props, lookupPairedDevice(pairedByDeviceId, req)),
               )}
             `
-          : nothing}
-        ${paired.length > 0
-          ? html`
+            : nothing
+        }
+        ${
+          paired.length > 0
+            ? html`
               <div class="muted" style="margin-top: 12px; margin-bottom: 8px;">Paired</div>
               ${paired.map((device) => renderPairedDevice(device, props))}
             `
-          : nothing}
-        ${pending.length === 0 && paired.length === 0
-          ? html` <div class="muted">No paired devices.</div> `
-          : nothing}
+            : nothing
+        }
+        ${
+          pending.length === 0 && paired.length === 0
+            ? html`
+                <div class="muted">No paired devices.</div>
+              `
+            : nothing
+        }
       </div>
     </section>
   `;
@@ -143,13 +154,15 @@ function renderPendingDevice(req: PendingDevice, props: NodesProps, paired?: Pai
         <div class="muted" style="margin-top: 6px;">
           requested: ${formatAccessSummary(approval.requested)}
         </div>
-        ${approval.approved
-          ? html`
+        ${
+          approval.approved
+            ? html`
               <div class="muted" style="margin-top: 6px;">
                 approved now: ${formatAccessSummary(approval.approved)}
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
       <div class="list-meta">
         <div class="row" style="justify-content: flex-end; gap: 8px; flex-wrap: wrap;">
@@ -177,14 +190,18 @@ function renderPairedDevice(device: PairedDevice, props: NodesProps) {
         <div class="list-title">${name}</div>
         <div class="list-sub">${device.deviceId}${ip}</div>
         <div class="muted" style="margin-top: 6px;">${roles} · ${scopes}</div>
-        ${tokens.length === 0
-          ? html` <div class="muted" style="margin-top: 6px">Tokens: none</div> `
-          : html`
+        ${
+          tokens.length === 0
+            ? html`
+                <div class="muted" style="margin-top: 6px">Tokens: none</div>
+              `
+            : html`
               <div class="muted" style="margin-top: 10px;">Tokens</div>
               <div style="display: flex; flex-direction: column; gap: 8px; margin-top: 6px;">
                 ${tokens.map((token) => renderTokenRow(device.deviceId, token, props))}
               </div>
-            `}
+            `
+        }
       </div>
     </div>
   `;
@@ -206,16 +223,18 @@ function renderTokenRow(deviceId: string, token: DeviceTokenSummary, props: Node
         >
           Rotate
         </button>
-        ${token.revokedAtMs
-          ? nothing
-          : html`
+        ${
+          token.revokedAtMs
+            ? nothing
+            : html`
               <button
                 class="btn btn--sm danger"
                 @click=${() => props.onDeviceRevoke(deviceId, token.role)}
               >
                 Revoke
               </button>
-            `}
+            `
+        }
       </div>
     </div>
   `;
@@ -289,21 +308,24 @@ function renderBindings(state: BindingState) {
         </button>
       </div>
 
-      ${state.formMode === "raw"
-        ? html`
+      ${
+        state.formMode === "raw"
+          ? html`
             <div class="callout warn" style="margin-top: 12px">
               ${t("nodes.binding.formModeHint")}
             </div>
           `
-        : nothing}
-      ${!state.ready
-        ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
+          : nothing
+      }
+      ${
+        !state.ready
+          ? html`<div class="row" style="margin-top: 12px; gap: 12px;">
             <div class="muted">${t("nodes.binding.loadConfigHint")}</div>
             <button class="btn" ?disabled=${state.configLoading} @click=${state.onLoadConfig}>
               ${state.configLoading ? t("common.loading") : t("common.loadConfig")}
             </button>
           </div>`
-        : html`
+          : html`
             <div class="list" style="margin-top: 16px;">
               <div class="list-item">
                 <div class="list-main">
@@ -330,17 +352,26 @@ function renderBindings(state: BindingState) {
                       )}
                     </select>
                   </label>
-                  ${!supportsBinding
-                    ? html` <div class="muted">No nodes with system.run available.</div> `
-                    : nothing}
+                  ${
+                    !supportsBinding
+                      ? html`
+                          <div class="muted">No nodes with system.run available.</div>
+                        `
+                      : nothing
+                  }
                 </div>
               </div>
 
-              ${state.agents.length === 0
-                ? html` <div class="muted">No agents found.</div> `
-                : state.agents.map((agent) => renderAgentBinding(agent, state))}
+              ${
+                state.agents.length === 0
+                  ? html`
+                      <div class="muted">No agents found.</div>
+                    `
+                  : state.agents.map((agent) => renderAgentBinding(agent, state))
+              }
             </div>
-          `}
+          `
+      }
     </section>
   `;
 }
@@ -355,9 +386,11 @@ function renderAgentBinding(agent: BindingAgent, state: BindingState) {
         <div class="list-title">${label}</div>
         <div class="list-sub">
           ${agent.isDefault ? "default agent" : "agent"} ·
-          ${bindingValue === "__default__"
-            ? `uses default (${state.defaultBinding ?? "any"})`
-            : `override: ${agent.binding}`}
+          ${
+            bindingValue === "__default__"
+              ? `uses default (${state.defaultBinding ?? "any"})`
+              : `override: ${agent.binding}`
+          }
         </div>
       </div>
       <div class="list-meta">

--- a/ui/src/ui/views/sessions.ts
+++ b/ui/src/ui/views/sessions.ts
@@ -268,14 +268,7 @@ export function renderSessions(props: SessionsProps) {
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between; margin-bottom: 12px;">
-        <div>
-          <div class="card-title">Sessions</div>
-          <div class="card-sub">
-            ${props.result
-              ? `Store: ${props.result.path}`
-              : "Active session keys and per-session overrides."}
-          </div>
-        </div>
+        <div></div>
         <button class="btn" ?disabled=${props.loading} @click=${props.onRefresh}>
           ${props.loading ? t("common.loading") : t("common.refresh")}
         </button>
@@ -341,9 +334,11 @@ export function renderSessions(props: SessionsProps) {
         </label>
       </div>
 
-      ${props.error
-        ? html`<div class="callout danger" style="margin-bottom: 12px;">${props.error}</div>`
-        : nothing}
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-bottom: 12px;">${props.error}</div>`
+          : nothing
+      }
 
       <div class="data-table-wrapper">
         <div class="data-table-toolbar">
@@ -357,8 +352,9 @@ export function renderSessions(props: SessionsProps) {
           </div>
         </div>
 
-        ${props.selectedKeys.size > 0
-          ? html`
+        ${
+          props.selectedKeys.size > 0
+            ? html`
               <div class="data-table-bulk-bar">
                 <span>${props.selectedKeys.size} selected</span>
                 <button class="btn btn--sm" @click=${props.onDeselectAll}>
@@ -373,20 +369,26 @@ export function renderSessions(props: SessionsProps) {
                 </button>
               </div>
             `
-          : nothing}
+            : nothing
+        }
 
         <div class="data-table-container">
           <table class="data-table">
             <thead>
               <tr>
                 <th class="data-table-checkbox-col">
-                  ${paginated.length > 0
-                    ? html`<input
+                  ${
+                    paginated.length > 0
+                      ? html`<input
                         type="checkbox"
-                        .checked=${paginated.length > 0 &&
-                        paginated.every((r) => props.selectedKeys.has(r.key))}
-                        .indeterminate=${paginated.some((r) => props.selectedKeys.has(r.key)) &&
-                        !paginated.every((r) => props.selectedKeys.has(r.key))}
+                        .checked=${
+                          paginated.length > 0 &&
+                          paginated.every((r) => props.selectedKeys.has(r.key))
+                        }
+                        .indeterminate=${
+                          paginated.some((r) => props.selectedKeys.has(r.key)) &&
+                          !paginated.every((r) => props.selectedKeys.has(r.key))
+                        }
                         @change=${() => {
                           const allSelected = paginated.every((r) => props.selectedKeys.has(r.key));
                           if (allSelected) {
@@ -397,7 +399,8 @@ export function renderSessions(props: SessionsProps) {
                         }}
                         aria-label="Select all on page"
                       />`
-                    : nothing}
+                      : nothing
+                  }
                 </th>
                 ${sortHeader("key", "Key", "data-table-key-col")}
                 <th>Label</th>
@@ -411,24 +414,24 @@ export function renderSessions(props: SessionsProps) {
               </tr>
             </thead>
             <tbody>
-              ${paginated.length === 0
-                ? html`
-                    <tr>
-                      <td
-                        colspan="11"
-                        style="text-align: center; padding: 48px 16px; color: var(--muted)"
-                      >
-                        No sessions found.
-                      </td>
-                    </tr>
-                  `
-                : paginated.flatMap((row) => renderRows(row, props))}
+              ${
+                paginated.length === 0
+                  ? html`
+                      <tr>
+                        <td colspan="11" style="text-align: center; padding: 48px 16px; color: var(--muted)">
+                          No sessions found.
+                        </td>
+                      </tr>
+                    `
+                  : paginated.flatMap((row) => renderRows(row, props))
+              }
             </tbody>
           </table>
         </div>
 
-        ${totalRows > 0
-          ? html`
+        ${
+          totalRows > 0
+            ? html`
               <div class="data-table-pagination">
                 <div class="data-table-pagination__info">
                   ${page * props.pageSize + 1}-${Math.min((page + 1) * props.pageSize, totalRows)}
@@ -455,7 +458,8 @@ export function renderSessions(props: SessionsProps) {
                 </div>
               </div>
             `
-          : nothing}
+            : nothing
+        }
       </div>
     </section>
   `;
@@ -521,8 +525,9 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
           class=${friendlyKeyLabel ? "session-key-cell" : "mono session-key-cell"}
           title=${keyCellTitle}
         >
-          ${canLink
-            ? html`<a
+          ${
+            canLink
+              ? html`<a
                 href=${chatUrl}
                 class="session-link"
                 @click=${(e: MouseEvent) => {
@@ -543,10 +548,13 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
                 }}
                 >${friendlyKeyLabel ?? row.key}</a
               >`
-            : (friendlyKeyLabel ?? row.key)}
-          ${showDisplayName
-            ? html`<span class="muted session-key-display-name">${displayName}</span>`
-            : nothing}
+              : (friendlyKeyLabel ?? row.key)
+          }
+          ${
+            showDisplayName
+              ? html`<span class="muted session-key-display-name">${displayName}</span>`
+              : nothing
+          }
         </div>
       </td>
       <td>
@@ -569,18 +577,22 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
       <td>
         <div style="display: grid; gap: 6px;">
           <span class="muted" style="font-size: 12px;">
-            ${checkpointCount > 0
-              ? `${checkpointCount} checkpoint${checkpointCount === 1 ? "" : "s"}`
-              : "none"}
+            ${
+              checkpointCount > 0
+                ? `${checkpointCount} checkpoint${checkpointCount === 1 ? "" : "s"}`
+                : "none"
+            }
           </span>
-          ${latestCheckpoint
-            ? html`
+          ${
+            latestCheckpoint
+              ? html`
                 <span style="font-size: 12px;">
                   ${formatCheckpointReason(latestCheckpoint.reason)} ·
                   ${formatRelativeTimestamp(latestCheckpoint.createdAt)}
                 </span>
               `
-            : nothing}
+              : nothing
+          }
           <button
             class="btn btn--sm"
             ?disabled=${props.checkpointLoadingKey === row.key}
@@ -668,15 +680,18 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
               <div
                 style="padding: 14px 16px; border-top: 1px solid var(--border); background: var(--surface-2, rgba(127, 127, 127, 0.05));"
               >
-                ${props.checkpointLoadingKey === row.key
-                  ? html`<div class="muted">Loading checkpoints…</div>`
-                  : checkpointError
-                    ? html`<div class="callout danger">${checkpointError}</div>`
-                    : checkpointItems.length === 0
-                      ? html`<div class="muted">
-                          No compaction checkpoints recorded for this session.
-                        </div>`
-                      : html`
+                ${
+                  props.checkpointLoadingKey === row.key
+                    ? html`
+                        <div class="muted">Loading checkpoints…</div>
+                      `
+                    : checkpointError
+                      ? html`<div class="callout danger">${checkpointError}</div>`
+                      : checkpointItems.length === 0
+                        ? html`
+                            <div class="muted">No compaction checkpoints recorded for this session.</div>
+                          `
+                        : html`
                           <div style="display: grid; gap: 10px;">
                             ${checkpointItems.map(
                               (checkpoint) => html`
@@ -694,16 +709,21 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
                                       ${formatCheckpointDelta(checkpoint)}
                                     </span>
                                   </div>
-                                  ${checkpoint.summary
-                                    ? html`<div style="white-space: pre-wrap;">
+                                  ${
+                                    checkpoint.summary
+                                      ? html`<div style="white-space: pre-wrap;">
                                         ${checkpoint.summary}
                                       </div>`
-                                    : html`<div class="muted">No summary captured.</div>`}
+                                      : html`
+                                          <div class="muted">No summary captured.</div>
+                                        `
+                                  }
                                   <div style="display: flex; gap: 8px; flex-wrap: wrap;">
                                     <button
                                       class="btn btn--sm"
-                                      ?disabled=${props.checkpointBusyKey ===
-                                      checkpoint.checkpointId}
+                                      ?disabled=${
+                                        props.checkpointBusyKey === checkpoint.checkpointId
+                                      }
                                       @click=${() =>
                                         props.onBranchFromCheckpoint(
                                           row.key,
@@ -714,8 +734,9 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
                                     </button>
                                     <button
                                       class="btn btn--sm"
-                                      ?disabled=${props.checkpointBusyKey ===
-                                      checkpoint.checkpointId}
+                                      ?disabled=${
+                                        props.checkpointBusyKey === checkpoint.checkpointId
+                                      }
                                       @click=${() =>
                                         props.onRestoreCheckpoint(row.key, checkpoint.checkpointId)}
                                     >
@@ -726,7 +747,8 @@ function renderRows(row: GatewaySessionRow, props: SessionsProps) {
                               `,
                             )}
                           </div>
-                        `}
+                        `
+                }
               </div>
             </td>
           </tr>`,

--- a/ui/src/ui/views/skills.ts
+++ b/ui/src/ui/views/skills.ts
@@ -140,10 +140,7 @@ export function renderSkills(props: SkillsProps) {
   return html`
     <section class="card">
       <div class="row" style="justify-content: space-between;">
-        <div>
-          <div class="card-title">Skills</div>
-          <div class="card-sub">Installed skills and their status.</div>
-        </div>
+        <div></div>
         <button
           class="btn"
           ?disabled=${props.loading || !props.connected}
@@ -200,36 +197,49 @@ export function renderSkills(props: SkillsProps) {
               name="clawhub-search"
             />
           </label>
-          ${props.clawhubSearchLoading ? html`<span class="muted">Searching…</span>` : nothing}
+          ${
+            props.clawhubSearchLoading
+              ? html`
+                  <span class="muted">Searching…</span>
+                `
+              : nothing
+          }
         </div>
-        ${props.clawhubSearchError
-          ? html`<div class="callout danger" style="margin-top: 8px;">
+        ${
+          props.clawhubSearchError
+            ? html`<div class="callout danger" style="margin-top: 8px;">
               ${props.clawhubSearchError}
             </div>`
-          : nothing}
-        ${props.clawhubInstallMessage
-          ? html`<div
+            : nothing
+        }
+        ${
+          props.clawhubInstallMessage
+            ? html`<div
               class="callout ${props.clawhubInstallMessage.kind === "error" ? "danger" : "success"}"
               style="margin-top: 8px;"
             >
               ${props.clawhubInstallMessage.text}
             </div>`
-          : nothing}
+            : nothing
+        }
         ${renderClawHubResults(props)}
       </div>
 
-      ${props.error
-        ? html`<div class="callout danger" style="margin-top: 12px;">${props.error}</div>`
-        : nothing}
-      ${filtered.length === 0
-        ? html`
+      ${
+        props.error
+          ? html`<div class="callout danger" style="margin-top: 12px;">${props.error}</div>`
+          : nothing
+      }
+      ${
+        filtered.length === 0
+          ? html`
             <div class="muted" style="margin-top: 16px">
-              ${!props.connected && !props.report
-                ? "Not connected to gateway."
-                : "No skills found."}
+              ${
+                !props.connected && !props.report ? "Not connected to gateway." : "No skills found."
+              }
             </div>
           `
-        : html`
+          : html`
             <div class="agent-skills-groups" style="margin-top: 16px;">
               ${groups.map((group) => {
                 return html`
@@ -245,7 +255,8 @@ export function renderSkills(props: SkillsProps) {
                 `;
               })}
             </div>
-          `}
+          `
+      }
     </section>
 
     ${detailSkill ? renderSkillDetail(detailSkill, props) : nothing}
@@ -259,7 +270,9 @@ function renderClawHubResults(props: SkillsProps) {
     return nothing;
   }
   if (results.length === 0) {
-    return html`<div class="muted" style="margin-top: 8px;">No skills found on ClawHub.</div>`;
+    return html`
+      <div class="muted" style="margin-top: 8px">No skills found on ClawHub.</div>
+    `;
   }
   return html`
     <div class="list" style="margin-top: 8px;">
@@ -274,9 +287,11 @@ function renderClawHubResults(props: SkillsProps) {
               <div class="list-sub">${r.summary ? clampText(r.summary, 120) : r.slug}</div>
             </div>
             <div class="list-meta" style="display: flex; align-items: center; gap: 8px;">
-              ${r.version
-                ? html`<span class="muted" style="font-size: 12px;">v${r.version}</span>`
-                : nothing}
+              ${
+                r.version
+                  ? html`<span class="muted" style="font-size: 12px;">v${r.version}</span>`
+                  : nothing
+              }
               <button
                 class="btn btn--sm"
                 ?disabled=${props.clawhubInstallSlug !== null}
@@ -325,40 +340,49 @@ function renderClawHubDetailDialog(props: SkillsProps) {
           </button>
         </div>
         <div class="md-preview-dialog__body" style="display: grid; gap: 16px;">
-          ${props.clawhubDetailLoading
-            ? html`<div class="muted">${t("common.loading")}</div>`
-            : props.clawhubDetailError
-              ? html`<div class="callout danger">${props.clawhubDetailError}</div>`
-              : detail?.skill
-                ? html`
+          ${
+            props.clawhubDetailLoading
+              ? html`<div class="muted">${t("common.loading")}</div>`
+              : props.clawhubDetailError
+                ? html`<div class="callout danger">${props.clawhubDetailError}</div>`
+                : detail?.skill
+                  ? html`
                     <div style="font-size: 14px; line-height: 1.5;">
                       ${detail.skill.summary ?? ""}
                     </div>
-                    ${detail.owner?.displayName
-                      ? html`<div class="muted" style="font-size: 13px;">
+                    ${
+                      detail.owner?.displayName
+                        ? html`<div class="muted" style="font-size: 13px;">
                           By
-                          ${detail.owner.displayName}${detail.owner.handle
-                            ? html` (@${detail.owner.handle})`
-                            : nothing}
+                          ${detail.owner.displayName}${
+                            detail.owner.handle ? html` (@${detail.owner.handle})` : nothing
+                          }
                         </div>`
-                      : nothing}
-                    ${detail.latestVersion
-                      ? html`<div class="muted" style="font-size: 13px;">
+                        : nothing
+                    }
+                    ${
+                      detail.latestVersion
+                        ? html`<div class="muted" style="font-size: 13px;">
                           Latest: v${detail.latestVersion.version}
                         </div>`
-                      : nothing}
-                    ${detail.latestVersion?.changelog
-                      ? html`<div
+                        : nothing
+                    }
+                    ${
+                      detail.latestVersion?.changelog
+                        ? html`<div
                           style="font-size: 13px; border-top: 1px solid var(--border); padding-top: 12px; white-space: pre-wrap;"
                         >
                           ${detail.latestVersion.changelog}
                         </div>`
-                      : nothing}
-                    ${detail.metadata?.os
-                      ? html`<div class="muted" style="font-size: 12px;">
+                        : nothing
+                    }
+                    ${
+                      detail.metadata?.os
+                        ? html`<div class="muted" style="font-size: 12px;">
                           Platforms: ${detail.metadata.os.join(", ")}
                         </div>`
-                      : nothing}
+                        : nothing
+                    }
                     <button
                       class="btn primary"
                       ?disabled=${props.clawhubInstallSlug !== null}
@@ -368,12 +392,17 @@ function renderClawHubDetailDialog(props: SkillsProps) {
                         }
                       }}
                     >
-                      ${props.clawhubInstallSlug === props.clawhubDetailSlug
-                        ? "Installing\u2026"
-                        : `Install ${detail.skill.displayName}`}
+                      ${
+                        props.clawhubInstallSlug === props.clawhubDetailSlug
+                          ? "Installing\u2026"
+                          : `Install ${detail.skill.displayName}`
+                      }
                     </button>
                   `
-                : html`<div class="muted">Skill not found.</div>`}
+                  : html`
+                      <div class="muted">Skill not found.</div>
+                    `
+          }
         </div>
       </div>
     </dialog>
@@ -463,8 +492,9 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             ${renderSkillStatusChips({ skill, showBundledBadge })}
           </div>
 
-          ${missing.length > 0
-            ? html`
+          ${
+            missing.length > 0
+              ? html`
                 <div
                   class="callout"
                   style="border-color: var(--warn-subtle); background: var(--warn-subtle); color: var(--warn);"
@@ -473,12 +503,15 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   <div>${missing.join(", ")}</div>
                 </div>
               `
-            : nothing}
-          ${reasons.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            reasons.length > 0
+              ? html`
                 <div class="muted" style="font-size: 13px;">Reason: ${reasons.join(", ")}</div>
               `
-            : nothing}
+              : nothing
+          }
 
           <div style="display: flex; align-items: center; gap: 12px;">
             <label class="skill-toggle-wrap">
@@ -493,24 +526,29 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
             <span style="font-size: 13px; font-weight: 500;">
               ${skill.disabled ? "Disabled" : "Enabled"}
             </span>
-            ${canInstall
-              ? html`<button
+            ${
+              canInstall
+                ? html`<button
                   class="btn"
                   ?disabled=${busy}
                   @click=${() => props.onInstall(skill.skillKey, skill.name, skill.install[0].id)}
                 >
                   ${busy ? "Installing\u2026" : skill.install[0].label}
                 </button>`
-              : nothing}
+                : nothing
+            }
           </div>
 
-          ${message
-            ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
+          ${
+            message
+              ? html`<div class="callout ${message.kind === "error" ? "danger" : "success"}">
                 ${message.message}
               </div>`
-            : nothing}
-          ${skill.primaryEnv
-            ? html`
+              : nothing
+          }
+          ${
+            skill.primaryEnv
+              ? html`
                 <div style="display: grid; gap: 8px;">
                   <div class="field">
                     <span
@@ -546,7 +584,8 @@ function renderSkillDetail(skill: SkillStatusEntry, props: SkillsProps) {
                   </button>
                 </div>
               `
-            : nothing}
+              : nothing
+          }
 
           <div
             style="border-top: 1px solid var(--border); padding-top: 12px; display: grid; gap: 6px; font-size: 12px; color: var(--muted);"

--- a/ui/src/ui/views/usage.ts
+++ b/ui/src/ui/views/usage.ts
@@ -376,9 +376,11 @@ export function renderUsage(props: UsageProps) {
       >
         <summary>
           <span>${label}</span>
-          ${selectedCount > 0
-            ? html`<span class="usage-filter-badge">${selectedCount}</span>`
-            : html` <span class="usage-filter-badge">${t("usage.filters.all")}</span> `}
+          ${
+            selectedCount > 0
+              ? html`<span class="usage-filter-badge">${selectedCount}</span>`
+              : html` <span class="usage-filter-badge">${t("usage.filters.all")}</span> `
+          }
         </summary>
         <div class="usage-filter-popover">
           <div class="usage-filter-actions">
@@ -438,25 +440,25 @@ export function renderUsage(props: UsageProps) {
 
   return html`
     <div class="usage-page">
-      <section class="usage-page-header">
-        <div class="usage-page-title">${t("tabs.usage")}</div>
-        <div class="usage-page-subtitle">${t("usage.page.subtitle")}</div>
-      </section>
-
       <section class="card usage-header ${display.headerPinned ? "pinned" : ""}">
         <div class="usage-header-row">
           <div class="usage-header-title">
             <div class="card-title usage-section-title">${t("usage.filters.title")}</div>
-            ${data.loading
-              ? html`<span class="usage-refresh-indicator">${t("usage.loading.badge")}</span>`
-              : nothing}
-            ${isEmpty
-              ? html`<span class="usage-query-hint">${t("usage.empty.hint")}</span>`
-              : nothing}
+            ${
+              data.loading
+                ? html`<span class="usage-refresh-indicator">${t("usage.loading.badge")}</span>`
+                : nothing
+            }
+            ${
+              isEmpty
+                ? html`<span class="usage-query-hint">${t("usage.empty.hint")}</span>`
+                : nothing
+            }
           </div>
           <div class="usage-header-metrics">
-            ${displayTotals
-              ? html`
+            ${
+              displayTotals
+                ? html`
                   <span class="usage-metric-badge">
                     <strong>${formatTokens(displayTotals.totalTokens)}</strong>
                     ${t("usage.metrics.tokens")}
@@ -467,12 +469,15 @@ export function renderUsage(props: UsageProps) {
                   </span>
                   <span class="usage-metric-badge">
                     <strong>${displaySessionCount}</strong>
-                    ${displaySessionCount === 1
-                      ? t("usage.metrics.session")
-                      : t("usage.metrics.sessions")}
+                    ${
+                      displaySessionCount === 1
+                        ? t("usage.metrics.session")
+                        : t("usage.metrics.sessions")
+                    }
                   </span>
                 `
-              : nothing}
+                : nothing
+            }
             <button
               class="btn btn--sm usage-pin-btn ${display.headerPinned ? "active" : ""}"
               title=${display.headerPinned ? t("usage.filters.unpin") : t("usage.filters.pin")}
@@ -654,20 +659,24 @@ export function renderUsage(props: UsageProps) {
               >
                 ${t("usage.query.apply")}
               </button>
-              ${hasDraftQuery || hasQuery
-                ? html`
+              ${
+                hasDraftQuery || hasQuery
+                  ? html`
                     <button class="btn btn--sm" @click=${filterActions.onClearQuery}>
                       ${t("usage.filters.clear")}
                     </button>
                   `
-                : nothing}
+                  : nothing
+              }
               <span class="usage-query-hint">
-                ${hasQuery
-                  ? t("usage.query.matching", {
-                      shown: String(filteredSessions.length),
-                      total: String(totalSessions),
-                    })
-                  : t("usage.query.inRange", { total: String(totalSessions) })}
+                ${
+                  hasQuery
+                    ? t("usage.query.matching", {
+                        shown: String(filteredSessions.length),
+                        total: String(totalSessions),
+                      })
+                    : t("usage.query.inRange", { total: String(totalSessions) })
+                }
               </span>
             </div>
           </div>
@@ -679,8 +688,9 @@ export function renderUsage(props: UsageProps) {
             ${renderFilterSelect("tool", t("usage.filters.tool"), toolOptions)}
             <span class="usage-query-hint">${t("usage.query.tip")}</span>
           </div>
-          ${queryTerms.length > 0
-            ? html`
+          ${
+            queryTerms.length > 0
+              ? html`
                 <div class="usage-query-chips">
                   ${queryTerms.map((term) => {
                     const label = term.raw;
@@ -701,9 +711,11 @@ export function renderUsage(props: UsageProps) {
                   })}
                 </div>
               `
-            : nothing}
-          ${querySuggestions.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            querySuggestions.length > 0
+              ? html`
                 <div class="usage-query-suggestions">
                   ${querySuggestions.map(
                     (suggestion) => html`
@@ -720,29 +732,35 @@ export function renderUsage(props: UsageProps) {
                   )}
                 </div>
               `
-            : nothing}
-          ${queryWarnings.length > 0
-            ? html`
+              : nothing
+          }
+          ${
+            queryWarnings.length > 0
+              ? html`
                 <div class="callout warning usage-callout usage-callout--tight">
                   ${queryWarnings.join(" · ")}
                 </div>
               `
-            : nothing}
+              : nothing
+          }
         </div>
 
-        ${data.error
-          ? html`<div class="callout danger usage-callout">${data.error}</div>`
-          : nothing}
-        ${data.sessionsLimitReached
-          ? html`
+        ${
+          data.error ? html`<div class="callout danger usage-callout">${data.error}</div>` : nothing
+        }
+        ${
+          data.sessionsLimitReached
+            ? html`
               <div class="callout warning usage-callout">${t("usage.sessions.limitReached")}</div>
             `
-          : nothing}
+            : nothing
+        }
       </section>
 
-      ${isEmpty
-        ? renderUsageEmptyState(filterActions.onRefresh)
-        : html`
+      ${
+        isEmpty
+          ? renderUsageEmptyState(filterActions.onRefresh)
+          : html`
             ${renderUsageInsights(
               displayTotals,
               activeAggregates,
@@ -770,9 +788,11 @@ export function renderUsage(props: UsageProps) {
                     displayActions.onDailyChartModeChange,
                     filterActions.onSelectDay,
                   )}
-                  ${displayTotals
-                    ? renderCostBreakdownCompact(displayTotals, display.chartMode)
-                    : nothing}
+                  ${
+                    displayTotals
+                      ? renderCostBreakdownCompact(displayTotals, display.chartMode)
+                      : nothing
+                  }
                 </div>
                 ${renderSessionsCard(
                   filteredSessions,
@@ -792,8 +812,9 @@ export function renderUsage(props: UsageProps) {
                   filterActions.onClearSessions,
                 )}
               </div>
-              ${primarySelectedEntry
-                ? html`<div class="usage-grid-column">
+              ${
+                primarySelectedEntry
+                  ? html`<div class="usage-grid-column">
                     ${renderSessionDetailPanel(
                       primarySelectedEntry,
                       detail.timeSeries,
@@ -823,9 +844,11 @@ export function renderUsage(props: UsageProps) {
                       filterActions.onClearSessions,
                     )}
                   </div>`
-                : nothing}
+                  : nothing
+              }
             </div>
-          `}
+          `
+      }
     </div>
   `;
 }


### PR DESCRIPTION
Remove duplicate page headers across the web UI, consolidating all navigation context into a single topbar with breadcrumb navigation.

Summary
 - Problem: Every page had duplicate headers - topbar showed "OpenClaw" branding, then a separate
       content-header below showed "OpenClaw › {Page} • {subtitle}" again. Additionally, pages showed
       hardcoded subtitles that duplicated (with different wording) the i18n subtitles already in the topbar.

 Why it matters: Visual clutter, wasted vertical space, inconsistent UX, and confusion from seeing the
       same information twice with different wording.
 - What changed: Consolidated all navigation into a single topbar with inline breadcrumb + subtitle.
       Removed duplicate content-header sections and hardcoded page subtitles. Chat tab retains a dedicated
       content-header for necessary controls (session/model dropdowns, chat action buttons).
- What did NOT change (scope boundary): No backend changes, no API changes, no config schema changes, no
       behavior changes to chat functionality or config diff logic - purely visual/UI cleanup.

Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [X] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

User-visible / Behavior Changes

- Topbar now shows: "OpenClaw › {Page} • {subtitle}" on all pages (single source of truth for navigation
       context)
- Pages no longer show: Duplicate page title + subtitle below topbar
- Chat tab exception: Retains content-header with session dropdown, model dropdown, and action buttons
       (Refresh, Thinking, Tool calls, Focus, Cron sessions)
- Config page: Removed "No changes" / "X unsaved changes" badge; kept only expandable "View X pending
       changes" diff panel (now positioned at top of page)
- Mobile: Subtitle hidden on small screens to keep topbar compact

Security Impact (required)

- No impact on security, just UI changes.

Repro + Verification

Environment

- OS: Linux (development)
- Runtime/container: Node 22, pnpm
- Model/provider: N/A (UI only)
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

Steps

1. Start dev server: pnpm dev (from ui/ directory)
2. Navigate to each page: Sessions, Usage, Skills, Logs, Config, Chat
3. Verify topbar shows breadcrumb + subtitle
4. Verify no duplicate title/subtitle below topbar
5. Verify Chat tab has session/model dropdowns and action buttons
6. Verify Config page shows diff panel at top when changes exist

Expected

- Single topbar header with "OpenClaw › {Page} • {subtitle}"
- No duplicate page headers below topbar
- Chat controls visible and functional
- Config diff panel at top when changes exist

Actual

- Matches expected (verified locally)

Evidence

- [X] Screenshot/recording


     
<img width="705" height="813" alt="Screenshot from 2026-03-19 15-12-13" src="https://github.com/user-attachments/assets/ae841576-1a54-4f85-a6ad-f1e0a52318ce" />
Duplicate title before(top), fixed UI (bottom) 

<img width="705" height="813" alt="Screenshot from 2026-03-19 14-18-50" src="https://github.com/user-attachments/assets/a0b8930f-f405-460b-abdf-917440d79c38" />
Duplicate Diff panel and change status (before), fixed UI (bottom)


Human Verification (required)

What you personally verified (not just CI), and how:

 Verified scenarios:
- All pages render without duplicate headers
- Topbar breadcrumb + subtitle displays correctly
- Chat tab controls (dropdowns + buttons) functional
- Config diff panel appears at top when changes exist
- Mobile layout hides subtitle appropriately
- Edge cases checked:
- Sessions page with/without store path
- Config page with no changes (clean UI)
- Config page with pending changes (diff panel visible)
- Chat tab with controls expanded
- What you did not verify:
- All i18n translations (only English verified)
- Tablet breakpoint layouts
- Screen reader accessibility


Compatibility / Migration

- Backward compatible? Yes (visual only, no API/config changes)
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit or restore previous CSS + view files
- Files/config to restore: ui/src/ui/app-render.ts, ui/src/ui/components/dashboard-header.ts,
       ui/src/ui/views/*.ts, ui/src/styles/*.css
- Known bad symptoms reviewers should watch for: Missing page titles, missing chat controls, broken
       config diff panel

Risks and Mitigations

- Risk: Chat controls may not render correctly if session/model data is unavailable
- Mitigation: Existing disabled state logic preserved; controls gracefully disable when disconnected
- Risk: Config diff panel positioning may conflict with future layout changes
- Mitigation: Uses existing CSS classes; positioned at top of main content area (standard location)
- Risk: Mobile subtitle hiding may affect accessibility
- Mitigation: Subtitle still present in DOM (hidden via CSS); screen readers can access it