### PR TITLE
fix(logs): only report rotation when the log file actually shrank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,8 @@ Docs: https://docs.openclaw.ai
 - Web fetch: bound guarded dispatcher cleanup after request timeouts so timed-out fetches return tool errors instead of leaving Gateway tool lanes active. (#78439) Thanks @obviyus.
 - Mattermost/setup: prompt for and persist the server base URL after the bot token in `openclaw setup --wizard`, instead of failing validation before `--http-url` is collected. Fixes #76670. Thanks @jacobtomlinson.
 - Gate Slack startup user allowlist resolution [AI]. (#77898) Thanks @pgondhi987.
+- Logs/follow: only emit `Log cursor reset (file rotated).` when the log file actually shrank below the previous cursor; fast-growth bursts that exceed `--max-bytes` now show only the existing `Log tail truncated` notice. (#74252) Thanks @BSG2000.
+
 - OpenAI/Codex: suppress stale `openai-codex` GPT-5.1/5.2/5.3 model refs that ChatGPT/Codex OAuth accounts now reject, keeping model lists, config validation, and forward-compat resolution on current 5.4/5.5 routes. Fixes #67158. Thanks @drpau.
 - CLI/update: keep pnpm package updates on the running custom global install root and pass pnpm's `--global-dir` so `openclaw update` does not create a second default-prefix install when `OPENCLAW_HOME` or the shell points at a custom OpenClaw directory. Fixes #78377. Thanks @amknight.
 - Google Meet/Voice Call: wait longer before playing PIN-derived Twilio DTMF for Meet dial-in prompts and retire stale delegated phone sessions instead of reusing completed calls.

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -17355,6 +17355,7 @@ public struct LogsTailResult: Codable, Sendable {
     public let lines: [String]
     public let truncated: Bool?
     public let reset: Bool?
+    public let skippedbytes: Int?
 
     public init(
         file: String,
@@ -17362,7 +17363,8 @@ public struct LogsTailResult: Codable, Sendable {
         size: Int,
         lines: [String],
         truncated: Bool? = nil,
-        reset: Bool? = nil)
+        reset: Bool? = nil,
+        skippedbytes: Int? = nil)
     {
         self.file = file
         self.cursor = cursor
@@ -17370,6 +17372,17 @@ public struct LogsTailResult: Codable, Sendable {
         self.lines = lines
         self.truncated = truncated
         self.reset = reset
+        self.skippedbytes = skippedbytes
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case file
+        case cursor
+        case size
+        case lines
+        case truncated
+        case reset
+        case skippedbytes = "skippedBytes"
     }
 }
 

--- a/packages/gateway-protocol/src/schema/logs-chat.ts
+++ b/packages/gateway-protocol/src/schema/logs-chat.ts
@@ -20,6 +20,7 @@ export const LogsTailResultSchema = closedObject({
   lines: Type.Array(Type.String()),
   truncated: Type.Optional(Type.Boolean()),
   reset: Type.Optional(Type.Boolean()),
+  skippedBytes: Type.Optional(Type.Integer({ minimum: 0 })),
 });
 
 /** Session-scoped history request used by WebChat and native WebSocket clients. */

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -214,6 +214,30 @@ describe("logs cli", () => {
     expect(stderrWrites.join("")).toContain("Log cursor reset");
   });
 
+  it.each(["plain", "json"])(
+    "reports a byte-budget re-anchor without claiming rotation in %s output",
+    async (mode) => {
+      callGatewayFromCli.mockResolvedValueOnce({
+        file: "/tmp/openclaw.log",
+        cursor: 8192,
+        size: 8192,
+        lines: ["line after skipped burst"],
+        truncated: true,
+        reset: true,
+        skippedBytes: 4096,
+      });
+
+      const stdoutWrites = captureStdoutWrites();
+      const stderrWrites = captureStderrWrites();
+
+      await runLogsCli(["logs", mode === "json" ? "--json" : "--plain"]);
+
+      const output = `${stdoutWrites.join("")}\n${stderrWrites.join("")}`;
+      expect(output).toContain("re-anchored (skipped 4096 bytes)");
+      expect(output).not.toContain("file rotated");
+    },
+  );
+
   it("uses the passive local Gateway client for implicit loopback log reads", async () => {
     callGatewayFromCli.mockResolvedValueOnce({
       file: "/tmp/openclaw.log",

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -52,6 +52,7 @@ type LogsTailPayload = {
   lines?: string[];
   truncated?: boolean;
   reset?: boolean;
+  skippedBytes?: number;
   localFallback?: boolean;
 };
 
@@ -336,6 +337,12 @@ function normalizeTailText(text: string, truncated: boolean): { text: string; tr
     return { text: "", truncated };
   }
   return { text: text.slice(firstNewline + 1), truncated };
+}
+
+function formatLogResetNotice(skippedBytes: number | undefined): string {
+  return skippedBytes !== undefined && skippedBytes > 0
+    ? `Log cursor re-anchored (skipped ${skippedBytes} bytes).`
+    : "Log cursor reset (file rotated).";
 }
 
 function parseJournalctlOutput(output: string): { lines: string[]; cursor?: string } {
@@ -735,7 +742,7 @@ export function registerLogsCli(program: Command) {
           if (
             !emitJsonLine({
               type: "notice",
-              message: "Log cursor reset (file rotated).",
+              message: formatLogResetNotice(payload.skippedBytes),
             })
           ) {
             return;
@@ -790,7 +797,7 @@ export function registerLogsCli(program: Command) {
           }
         }
         if (payload.reset) {
-          if (!errorLine("Log cursor reset (file rotated).")) {
+          if (!errorLine(formatLogResetNotice(payload.skippedBytes))) {
             return;
           }
         }

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -53,4 +53,52 @@ describe("readConfiguredLogTail", () => {
 
     await fs.rm(tempDir, { recursive: true, force: true });
   });
+
+  it("reports truncated without reset when the file grew faster than --max-bytes between polls", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-log-tail-"));
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+
+    await fs.writeFile(file, "first line\n");
+    setLoggerOverride({ file });
+    const initial = await readConfiguredLogTail();
+
+    // The file grows by far more than maxBytes between polls (e.g. a burst of
+    // log activity). The cursor is still valid — readConfiguredLogTail should
+    // fast-forward and report `truncated: true` so callers know lines were
+    // skipped, but `reset` must stay false because the log was not rotated.
+    const burst = `${"x".repeat(40)}\n`.repeat(200);
+    await fs.appendFile(file, burst);
+
+    const result = await readConfiguredLogTail({
+      cursor: initial.cursor,
+      maxBytes: 500,
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.reset).toBe(false);
+    expect(result.lines.length).toBeGreaterThan(0);
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("reports reset when the file shrank below the previous cursor (rotation)", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-log-tail-"));
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+
+    await fs.writeFile(file, "old line one\nold line two\nold line three\n");
+    setLoggerOverride({ file });
+    const initial = await readConfiguredLogTail();
+
+    // Simulate rotation: replace the file with shorter content so that the
+    // previous cursor is now past EOF.
+    await fs.writeFile(file, "fresh\n");
+
+    const result = await readConfiguredLogTail({ cursor: initial.cursor });
+
+    expect(result.reset).toBe(true);
+
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
 });

--- a/src/logging/log-tail.test.ts
+++ b/src/logging/log-tail.test.ts
@@ -139,6 +139,28 @@ describe("readConfiguredLogTail", () => {
     });
   });
 
+  it("distinguishes a byte-budget re-anchor from file shrink", async () => {
+    const { readConfiguredLogTail } = await import("./log-tail.js");
+    const tempDir = tempDirs.make("openclaw-log-tail-");
+    const file = path.join(tempDir, "openclaw-2026-01-22.log");
+
+    await fs.writeFile(file, "first line\n");
+    setLoggerOverride({ file });
+    const initial = await readConfiguredLogTail();
+
+    await fs.appendFile(file, `${"x".repeat(40)}\n`.repeat(200));
+    const byteBudget = await readConfiguredLogTail({ cursor: initial.cursor, maxBytes: 500 });
+
+    expect(byteBudget).toMatchObject({ truncated: true, reset: true });
+    expect(byteBudget.skippedBytes).toBeGreaterThan(0);
+
+    await fs.writeFile(file, "fresh\n");
+    const fileShrink = await readConfiguredLogTail({ cursor: byteBudget.cursor, maxBytes: 500 });
+
+    expect(fileShrink).toMatchObject({ reset: true });
+    expect(fileShrink.skippedBytes).toBeUndefined();
+  });
+
   it("keeps the first line when the byte window starts exactly after a newline", async () => {
     const { readConfiguredLogTail } = await import("./log-tail.js");
     const tempDir = tempDirs.make("openclaw-log-tail-");

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -83,13 +83,18 @@ async function readLogSlice(params: {
 
   if (cursor != null) {
     if (cursor > size) {
+      // The file shrank below the previously-returned cursor, so the log was
+      // rotated or truncated and the cursor is no longer meaningful.
       reset = true;
       start = Math.max(0, size - maxBytes);
       truncated = start > 0;
     } else {
       start = cursor;
       if (size - start > maxBytes) {
-        reset = true;
+        // The file grew faster than --max-bytes between polls. The cursor is
+        // still valid (we are reading forward from it), but we have to skip
+        // bytes to fit the budget; the caller should report this as a tail
+        // truncation, not a rotation.
         truncated = true;
         start = Math.max(0, size - maxBytes);
       }

--- a/src/logging/log-tail.ts
+++ b/src/logging/log-tail.ts
@@ -31,6 +31,7 @@ export type LogTailPayload = {
   lines: string[];
   truncated: boolean;
   reset: boolean;
+  skippedBytes?: number;
 };
 
 /** Redacted configured log tail with only parseable structured records. */
@@ -95,6 +96,7 @@ async function readLogSlice(params: {
       ? Math.max(0, Math.floor(params.cursor))
       : undefined;
   let reset = false;
+  let skippedBytes: number | undefined;
   let truncated = false;
   let start;
 
@@ -107,10 +109,13 @@ async function readLogSlice(params: {
     } else {
       start = cursor;
       if (size - start > maxBytes) {
-        // Cursor is valid but too stale; cap reads and tell the caller state was reset.
+        // Keep reset as the re-anchor signal for existing clients. The skipped byte count
+        // lets current clients distinguish this valid-cursor fast-forward from file shrink.
         reset = true;
         truncated = true;
-        start = Math.max(0, size - maxBytes);
+        const boundedStart = Math.max(0, size - maxBytes);
+        skippedBytes = boundedStart - start;
+        start = boundedStart;
       }
     }
   } else {
@@ -125,6 +130,7 @@ async function readLogSlice(params: {
       lines: [],
       truncated,
       reset,
+      skippedBytes,
     };
   }
 
@@ -166,6 +172,7 @@ async function readLogSlice(params: {
       lines,
       truncated,
       reset,
+      skippedBytes,
     };
   } finally {
     await handle.close();


### PR DESCRIPTION
## What Problem This Solves

`openclaw logs --follow` called a byte-budget fast-forward a file rotation. A configured log that grew from a valid cursor to 8,211 bytes with `--max-bytes 500` printed both the truncation notice and `Log cursor reset (file rotated).`

## Root cause

`logs.tail.reset` is the compatibility signal that tells clients to replace their retained window. The reader used the same Boolean for file shrink and byte-budget fast-forward, while the CLI treated every reset as proof of rotation.

## Fix

- Record the skipped byte count at the log-tail reader when a valid cursor must fast-forward.
- Keep `reset: true` so existing clients still re-anchor instead of appending across omitted data.
- Use `skippedBytes` in both plain and JSON CLI output to report a byte-budget re-anchor without claiming rotation.
- Keep file shrink on the existing rotation notice.
- Add the optional field to the Gateway schema and generated Swift model.

## Evidence

Built Gateway-to-CLI runs used the same configured-log follow flow and byte limit.

| Revision | Scenario | Result |
| --- | --- | --- |
| Current main `98fe750bd25887fa516cf184943577bba2c5ecd9` | Valid cursor, log grows to 8,211 bytes, `--max-bytes 500` | Printed truncation and the false `file rotated` notice |
| Head `67eae075355cee37e9d676b7fcf68de7a330f9f6` | Same plain flow | Printed truncation and `re-anchored (skipped 7581 bytes)`; no rotation claim |
| Head `67eae075355cee37e9d676b7fcf68de7a330f9f6` | Same JSON flow | Emitted a re-anchor notice with the skipped byte count; no rotation claim |
| Head `67eae075355cee37e9d676b7fcf68de7a330f9f6` | File replaced by a shorter file | Kept `Log cursor reset (file rotated).` |

## Validation

- `node scripts/run-vitest.mjs run src/logging/log-tail.test.ts src/cli/logs-cli.test.ts src/gateway/server-methods/server-methods.test.ts ui/src/pages/logs/logs-page.test.ts`
- `pnpm protocol:check`
- Focused Oxfmt and Oxlint checks
- Repository max-lines, assertion-safety, dead-code, protocol, dependency, boundary, and storage ratchets

Production TypeScript is +15 lines. Tests are +46 lines. Generated Swift is +13 lines. The production growth carries one new additive protocol fact that existing fields cannot express.
