### PR TITLE
fix(control-ui): download assistant markdown attachments

### DIFF
--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -332,6 +332,49 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("serves markdown assistant media as a download", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-md-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "notes.md");
+        await fs.writeFile(filePath, "# Notes\n");
+        const { res, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "text/markdown");
+        expect(res.setHeader).toHaveBeenCalledWith(
+          "Content-Disposition",
+          'attachment; filename="notes.md"',
+        );
+      },
+    });
+  });
+
+  it("serves requested assistant media downloads with an attachment disposition", async () => {
+    await withAllowedAssistantMediaRoot({
+      prefix: "ui-media-download-",
+      fn: async (tmpRoot) => {
+        const filePath = path.join(tmpRoot, "report.pdf");
+        await fs.writeFile(filePath, "%PDF-1.4\n");
+        const { res, handled } = await runAssistantMediaRequest({
+          url: `/__openclaw__/assistant-media?source=${encodeURIComponent(filePath)}&download=1&token=test-token`,
+          method: "GET",
+          auth: { mode: "token", token: "test-token", allowTailscale: false },
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(res.setHeader).toHaveBeenCalledWith(
+          "Content-Disposition",
+          'attachment; filename="report.pdf"',
+        );
+      },
+    });
+  });
+
   it("serves assistant media from canonical inbound media refs", async () => {
     const stateDir = resolveStateDir();
     const id = `ui-media-ref-${Date.now()}-${Math.random().toString(36).slice(2)}.png`;

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -511,10 +511,15 @@ export async function handleControlUiAssistantMediaRequest(
       buffer: sniffBuffer?.subarray(0, bytesRead),
       filePath: localPath,
     });
-    if (mime) {
-      res.setHeader("Content-Type", mime);
-    } else {
-      res.setHeader("Content-Type", "application/octet-stream");
+    const contentType = mime ?? "application/octet-stream";
+    res.setHeader("Content-Type", contentType);
+    if (
+      url.searchParams.get("download") === "1" ||
+      contentType === "text/markdown" ||
+      /\.md$/i.test(localPath)
+    ) {
+      const fileName = path.basename(localPath).replace(/["\r\n]/g, "_") || "download";
+      res.setHeader("Content-Disposition", `attachment; filename="${fileName}"`);
     }
     res.setHeader("Cache-Control", "no-cache");
     res.setHeader("Content-Length", String(opened.stat.size));

--- a/ui/src/ui/chat/grouped-render.test.ts
+++ b/ui/src/ui/chat/grouped-render.test.ts
@@ -736,7 +736,10 @@ describe("grouped chat rendering", () => {
       ".chat-assistant-attachment-card__link",
     );
     expect(documentLink?.textContent).toContain("user-upload.pdf");
-    expect(documentLink?.getAttribute("href")).toBe("/__openclaw__/media/user-upload.pdf");
+    expect(documentLink?.getAttribute("href")).toBe(
+      "/__openclaw__/media/user-upload.pdf?download=1",
+    );
+    expect(documentLink?.getAttribute("download")).toBe("user-upload.pdf");
   });
 
   it("fetches managed chat images with auth and renders blob previews", async () => {
@@ -944,8 +947,9 @@ describe("grouped chat rendering", () => {
       "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest+image.png&token=session-token",
     );
     expect(docLink?.getAttribute("href")).toBe(
-      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest-doc.pdf&token=session-token",
+      "/openclaw/__openclaw__/assistant-media?source=%2Ftmp%2Fopenclaw%2Ftest-doc.pdf&token=session-token&download=1",
     );
+    expect(docLink?.getAttribute("download")).toBe("test-doc.pdf");
     expect(container.textContent).not.toContain("test image.png");
     vi.unstubAllGlobals();
   });
@@ -1029,7 +1033,8 @@ describe("grouped chat rendering", () => {
       ".chat-assistant-attachment-card__link",
     );
     expect(image?.getAttribute("src")).toBe("/media/inbound/test-image.png");
-    expect(docLink?.getAttribute("href")).toBe("/__openclaw__/media/test-doc.pdf");
+    expect(docLink?.getAttribute("href")).toBe("/__openclaw__/media/test-doc.pdf?download=1");
+    expect(docLink?.getAttribute("download")).toBe("test-doc.pdf");
     expect(container.textContent).not.toContain("Unavailable");
   });
 

--- a/ui/src/ui/chat/grouped-render.ts
+++ b/ui/src/ui/chat/grouped-render.ts
@@ -947,13 +947,21 @@ async function resolveManagedOutgoingImageBlobUrl(
   return pending;
 }
 
+function appendAssistantAttachmentQueryParam(url: string, key: string, value: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}${new URLSearchParams({ [key]: value }).toString()}`;
+}
+
 function buildAssistantAttachmentMetaUrl(
   source: string,
   basePath?: string,
   authToken?: string | null,
 ): string {
   const attachmentUrl = buildAssistantAttachmentUrl(source, basePath, authToken);
-  return `${attachmentUrl}${attachmentUrl.includes("?") ? "&" : "?"}meta=1`;
+  return appendAssistantAttachmentQueryParam(attachmentUrl, "meta", "1");
+}
+
+function buildAssistantAttachmentDownloadUrl(url: string): string {
+  return appendAssistantAttachmentQueryParam(url, "download", "1");
 }
 
 function resolveAssistantAttachmentAvailability(
@@ -1072,6 +1080,9 @@ function renderAssistantAttachments(
           availability.status === "available"
             ? buildAssistantAttachmentUrl(attachment.url, basePath, authToken)
             : null;
+        const attachmentDownloadUrl = attachmentUrl
+          ? buildAssistantAttachmentDownloadUrl(attachmentUrl)
+          : null;
         if (attachment.kind === "image") {
           if (!attachmentUrl) {
             return renderAssistantAttachmentStatusCard({
@@ -1105,7 +1116,14 @@ function renderAssistantAttachments(
                     : nothing}
               </div>
               ${attachmentUrl
-                ? html`<audio controls preload="metadata" src=${attachmentUrl}></audio>`
+                ? html`<audio controls preload="metadata" src=${attachmentUrl}></audio>
+                    <a
+                      class="chat-assistant-attachment-card__link"
+                      href=${attachmentDownloadUrl}
+                      download=${attachment.label}
+                      rel="noreferrer"
+                      >Download</a
+                    >`
                 : availability.status === "unavailable"
                   ? html`<div class="chat-assistant-attachment-card__reason">
                       ${availability.reason}
@@ -1128,8 +1146,8 @@ function renderAssistantAttachments(
               <video controls preload="metadata" src=${attachmentUrl}></video>
               <a
                 class="chat-assistant-attachment-card__link"
-                href=${attachmentUrl}
-                target="_blank"
+                href=${attachmentDownloadUrl}
+                download=${attachment.label}
                 rel="noreferrer"
                 >${attachment.label}</a
               >
@@ -1149,8 +1167,8 @@ function renderAssistantAttachments(
             <span class="chat-assistant-attachment-card__icon">${icons.paperclip}</span>
             <a
               class="chat-assistant-attachment-card__link"
-              href=${attachmentUrl}
-              target="_blank"
+              href=${attachmentDownloadUrl}
+              download=${attachment.label}
               rel="noreferrer"
               >${attachment.label}</a
             >

--- a/ui/src/ui/chat/message-normalizer.test.ts
+++ b/ui/src/ui/chat/message-normalizer.test.ts
@@ -250,6 +250,57 @@ describe("message-normalizer", () => {
       expect(result.content).toEqual([]);
     });
 
+    it("renders top-level mediaUrls as assistant attachments", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: "Here is the file",
+        mediaUrls: ["/tmp/openclaw/notes.md"],
+      });
+
+      expect(result.content).toEqual([
+        { type: "text", text: "Here is the file" },
+        {
+          type: "attachment",
+          attachment: {
+            url: "/tmp/openclaw/notes.md",
+            kind: "document",
+            label: "notes.md",
+            mimeType: "text/markdown",
+          },
+        },
+      ]);
+    });
+
+    it("ignores top-level mediaUrls on non-assistant messages", () => {
+      const result = normalizeMessage({
+        role: "user",
+        content: "Here is the file",
+        mediaUrls: ["/tmp/openclaw/notes.md"],
+      });
+
+      expect(result.content).toEqual([{ type: "text", text: "Here is the file" }]);
+    });
+
+    it("deduplicates top-level mediaUrls already present in assistant content", () => {
+      const result = normalizeMessage({
+        role: "assistant",
+        content: "MEDIA:/tmp/openclaw/notes.md",
+        mediaUrls: ["/tmp/openclaw/notes.md"],
+      });
+
+      expect(result.content).toEqual([
+        {
+          type: "attachment",
+          attachment: {
+            url: "/tmp/openclaw/notes.md",
+            kind: "document",
+            label: "notes.md",
+            mimeType: "text/markdown",
+          },
+        },
+      ]);
+    });
+
     it("preserves relative MEDIA references as visible text instead of dropping the assistant turn", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/ui/chat/message-normalizer.ts
+++ b/ui/src/ui/chat/message-normalizer.ts
@@ -365,6 +365,48 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     }
   }
 
+  const topLevelMediaUrls = [
+    ...(Array.isArray(m.mediaUrls) ? m.mediaUrls : []),
+    ...(typeof m.mediaUrl === "string" ? [m.mediaUrl] : []),
+  ].filter((url, index, urls): url is string => {
+    return typeof url === "string" && url.trim().length > 0 && urls.indexOf(url) === index;
+  });
+  if (isAssistantMessage && topLevelMediaUrls.length > 0) {
+    const existingAttachmentUrls = new Set(
+      content
+        .filter((item): item is Extract<MessageContentItem, { type: "attachment" }> => {
+          return item.type === "attachment";
+        })
+        .map((item) => item.attachment.url),
+    );
+    content = mergeAdjacentTextItems([
+      ...content,
+      ...topLevelMediaUrls.flatMap((url): MessageContentItem[] => {
+        if (existingAttachmentUrls.has(url)) {
+          return [];
+        }
+        existingAttachmentUrls.add(url);
+        if (!isRenderableAssistantAttachment(url)) {
+          return shouldPreserveRelativeAssistantAttachment(url)
+            ? [{ type: "text", text: `MEDIA:${url}` }]
+            : [];
+        }
+        const inferred = inferAttachmentKind(url);
+        return [
+          {
+            type: "attachment",
+            attachment: {
+              url,
+              kind: inferred.kind,
+              label: inferred.label,
+              mimeType: inferred.mimeType,
+            },
+          },
+        ];
+      }),
+    ]);
+  }
+
   const timestamp = typeof m.timestamp === "number" ? m.timestamp : Date.now();
   const id = typeof m.id === "string" ? m.id : undefined;
   const senderLabel =


### PR DESCRIPTION
## Summary
- render assistant `mediaUrl` / `mediaUrls` payload fields as attachment cards in the Control UI
- add download links for non-image assistant attachments instead of opening them inline
- force `Content-Disposition: attachment` for local markdown files served by `assistant-media`

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/control-ui.http.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/grouped-render.test.ts`
- `pnpm lint:core -- src/gateway/control-ui.ts src/gateway/control-ui.http.test.ts ui/src/ui/chat/message-normalizer.ts ui/src/ui/chat/message-normalizer.test.ts ui/src/ui/chat/grouped-render.ts ui/src/ui/chat/grouped-render.test.ts`

Note: a full `pnpm exec tsc --noEmit --pretty false -p tsconfig.json` attempt exceeded the local Node heap / was killed; targeted tests and lint passed.
