### PR TITLE
fix(security): block untrusted workspace providers in startup discovery

### DIFF
--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -111,6 +111,7 @@ describe("resolveImplicitProviders startup discovery scope", () => {
     expect(mocks.resolveRuntimePluginDiscoveryProviders).toHaveBeenCalledWith(
       expect.objectContaining({
         discoveryEntriesOnly: true,
+        includeUntrustedWorkspacePlugins: false,
       }),
     );
   });

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -484,7 +484,9 @@ export async function resolveImplicitProviders(
     ...(params.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: params.pluginMetadataSnapshot }
       : {}),
-    ...(params.providerDiscoveryEntriesOnly === true ? { discoveryEntriesOnly: true } : {}),
+    ...(params.providerDiscoveryEntriesOnly === true
+      ? { discoveryEntriesOnly: true, includeUntrustedWorkspacePlugins: false }
+      : {}),
   });
 
   for (const order of PLUGIN_DISCOVERY_ORDERS) {


### PR DESCRIPTION
### Motivation

- Prevent untrusted workspace plugin discovery entries from being imported/executed during startup prewarm when `providerDiscoveryEntriesOnly` is enabled, closing a path that could run workspace code without explicit trust.

### Description

- When `providerDiscoveryEntriesOnly` is true, forward `includeUntrustedWorkspacePlugins: false` into `resolveRuntimePluginDiscoveryProviders` in `resolveImplicitProviders` (`src/agents/models-config.providers.implicit.ts`) to block workspace-origin plugins from being considered. 
- Add/adjust a unit expectation to assert the entries-only startup discovery call includes `includeUntrustedWorkspacePlugins: false` in `src/agents/models-config.providers.implicit.discovery-scope.test.ts`.

### Testing

- Ran `pnpm test src/agents/models-config.providers.implicit.discovery-scope.test.ts`, which passed. 
- The new/updated test verifies the entries-only startup discovery flow sets the untrusted-workspace guard and the assertion passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ba0fdaa48320baad6d0a69fd59e9)