### PR TITLE
fix(browser): give upload hooks enough client timeout

### DIFF
--- a/extensions/browser/src/browser/client-actions-core.ts
+++ b/extensions/browser/src/browser/client-actions-core.ts
@@ -121,6 +121,11 @@ export async function browserArmFileChooser(
   },
 ): Promise<BrowserActionOk> {
   const q = buildProfileQuery(opts.profile);
+  const explicitTimeout = normalizePositiveTimeoutMs(opts.timeoutMs);
+  const clientTimeoutMs =
+    explicitTimeout === undefined
+      ? DEFAULT_BROWSER_ACTION_TIMEOUT_MS
+      : explicitTimeout + BROWSER_ACT_REQUEST_TIMEOUT_SLACK_MS;
   return await fetchBrowserJson<BrowserActionOk>(withBaseUrl(baseUrl, `/hooks/file-chooser${q}`), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -132,7 +137,7 @@ export async function browserArmFileChooser(
       targetId: opts.targetId,
       timeoutMs: opts.timeoutMs,
     }),
-    timeoutMs: 20000,
+    timeoutMs: clientTimeoutMs,
   });
 }
 

--- a/extensions/browser/src/browser/client.test.ts
+++ b/extensions/browser/src/browser/client.test.ts
@@ -298,6 +298,12 @@ describe("browser client", () => {
       }),
     ).resolves.toMatchObject({ ok: true });
     await expect(
+      browserArmFileChooser("http://127.0.0.1:18791", {
+        paths: ["/tmp/b.txt"],
+        timeoutMs: 70_000,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
       browserArmDialog("http://127.0.0.1:18791", { accept: true }),
     ).resolves.toMatchObject({ ok: true });
     await expect(
@@ -319,6 +325,9 @@ describe("browser client", () => {
     expect(calls.some((c) => c.url.endsWith("/doctor?profile=openclaw&deep=true"))).toBe(true);
     const open = calls.find((c) => c.url.endsWith("/tabs/open"));
     expect(open?.init?.method).toBe("POST");
+
+    const fileChooserCalls = calls.filter((c) => c.url.endsWith("/hooks/file-chooser"));
+    expect(fileChooserCalls.map((c) => c.init?.timeoutMs)).toEqual([60_000, 75_000]);
 
     const screenshotCalls = calls.filter((c) => c.url.endsWith("/screenshot"));
     const screenshot = screenshotCalls[0];

--- a/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
+++ b/extensions/browser/src/cli/browser-cli-actions-input/register.files-downloads.ts
@@ -116,7 +116,7 @@ export function registerBrowserFilesAndDownloadsCommands(
           targetId,
           timeoutMs,
         },
-        timeoutMs: timeoutMs ?? 20000,
+        timeoutMs: timeoutMs ?? 60000,
         describeSuccess: () => `upload armed for ${paths.length} file(s)`,
       });
     });


### PR DESCRIPTION
## Summary

- Problem: browser file-upload arming used a fixed 20s client transport timeout even though the upload route may need extra time to resolve the tab and attach Playwright before it can return.
- Why it matters: real agent-driven browser uploads can fail with gateway timeout before the file chooser hook is armed, even when staging is correct and the browser itself is healthy.
- What changed: aligned browser upload hook client timeout with the browser action timeout model, and added coverage that locks in the request timeout sent for file chooser arming.
- What did NOT change (scope boundary): no changes to upload path guardrails, Playwright upload semantics, product app upload behavior, or browser server-side route contracts.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the browser upload arm client used a hardcoded 20s transport timeout on `/hooks/file-chooser`, unlike browser actions that already scale their client timeout to match the requested operation. In real runs, the upload hook can spend meaningful time in tab resolution and Playwright/CDP attach before the arm returns `{ ok: true }`.
- Missing detection / guardrail: client-side coverage did not assert that file-chooser arming received the longer action-style timeout budget, and the CLI upload command kept the same 20s assumption.
- Contributing context (if known): real QA runs against a live localhost app showed upload timeout even after staging files into the required temp uploads directory, while browser status/snapshot remained healthy.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/browser/src/browser/client.test.ts`
- Scenario the test should lock in: browser file-chooser arming uses `DEFAULT_BROWSER_ACTION_TIMEOUT_MS` by default, and `opts.timeoutMs + slack` when an explicit chooser timeout is provided.
- Why this is the smallest reliable guardrail: the failure surface is the client transport timeout budget sent to the browser control service, so the client request test is the narrowest place that directly protects the regression.
- Existing test that already covers this (if any): none for file-chooser timeout propagation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

- Agent-driven browser uploads now have a longer client timeout budget before surfacing browser-control timeout errors.
- CLI `openclaw browser upload` also uses a 60s default request timeout instead of 20s.

## Diagram (if applicable)

```text
Before:
agent upload -> /hooks/file-chooser client timeout fixed at 20s -> timeout before arm completes

After:
agent upload -> /hooks/file-chooser client timeout follows browser action budget -> arm completes more reliably
```

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS arm64
- Runtime/container: local OpenClaw gateway + local managed browser profile
- Model/provider: N/A
- Integration/channel (if any): browser tool against localhost app
- Relevant config (redacted): default local managed `openclaw` browser profile

### Steps

1. Stage upload files into `/tmp/openclaw/uploads`.
2. Use agent/browser upload flow against a live page that requires Playwright/CDP attach before arming upload.
3. Observe browser upload timeout despite browser status/snapshot remaining healthy.

### Expected

- File chooser hook arms successfully unless the underlying browser attach path is genuinely unavailable.

### Actual

- Client transport can time out at 20s before upload arming completes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - reproduced the upload timeout symptom in a real local QA flow after correctly staging files
  - verified browser status, tabs, and snapshot still worked while upload failed
  - verified updated timeout expectations in `client.test.ts`
  - ran focused browser extension tests covering upload and connection behavior
  - ran `pnpm build` and `pnpm check`
- Edge cases checked:
  - explicit upload timeout still adds slack instead of using a bare raw value
  - CLI upload default now matches the longer browser action-style budget
- What you did **not** verify:
  - a full end-to-end live browser upload success after this exact patch on the same environment

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Risks and Mitigations

- Risk: longer client timeout can delay surfacing some real browser-control failures.
  - Mitigation: timeout now matches existing browser action behavior instead of a unique shorter path; error handling remains unchanged.
