### PR TITLE
fix(control-ui): clear live stream artifacts on final chat events

### DIFF
--- a/ui/src/ui/chat/build-chat-items.test.ts
+++ b/ui/src/ui/chat/build-chat-items.test.ts
@@ -24,7 +24,51 @@ function firstMessageContent(group: MessageGroup): unknown[] {
   return Array.isArray(message.content) ? message.content : [];
 }
 
+function streamItems(props: Partial<BuildChatItemsProps>) {
+  return buildChatItems(createProps(props)).filter((item) => item.kind === "stream");
+}
+
 describe("buildChatItems", () => {
+  it("subtracts committed pre-tool stream segments from cumulative live stream text", () => {
+    const streams = streamItems({
+      toolMessages: [
+        {
+          role: "assistant",
+          toolCallId: "call-1",
+          content: [{ type: "toolcall", name: "exec", arguments: {} }],
+          timestamp: 2,
+        },
+      ],
+      streamSegments: [{ text: "Pre-tool narration.", ts: 1 }],
+      stream: "Pre-tool narration.\nFinal answer.",
+      streamStartedAt: 3,
+    });
+
+    expect(streams).toHaveLength(2);
+    expect(streams[0]).toMatchObject({ text: "Pre-tool narration." });
+    expect(streams[1]).toMatchObject({ text: "Final answer." });
+  });
+
+  it("keeps live stream text intact when it is not cumulative", () => {
+    const streams = streamItems({
+      toolMessages: [
+        {
+          role: "assistant",
+          toolCallId: "call-1",
+          content: [{ type: "toolcall", name: "exec", arguments: {} }],
+          timestamp: 2,
+        },
+      ],
+      streamSegments: [{ text: "Pre-tool narration.", ts: 1 }],
+      stream: "Final answer.",
+      streamStartedAt: 3,
+    });
+
+    expect(streams).toHaveLength(2);
+    expect(streams[0]).toMatchObject({ text: "Pre-tool narration." });
+    expect(streams[1]).toMatchObject({ text: "Final answer." });
+  });
+
   it("keeps consecutive user messages from different senders in separate groups", () => {
     const groups = messageGroups({
       messages: [

--- a/ui/src/ui/chat/build-chat-items.ts
+++ b/ui/src/ui/chat/build-chat-items.ts
@@ -148,6 +148,26 @@ function findNearestAssistantMessageIndex(
   return assistantEntries[assistantEntries.length - 1]?.index ?? null;
 }
 
+function trimCommittedStreamPrefix(
+  stream: string | null,
+  segments: Array<{ text: string; ts: number }>,
+): string | null {
+  if (stream === null) {
+    return null;
+  }
+  let remaining = stream;
+  for (const segment of segments) {
+    if (!segment.text.trim()) {
+      continue;
+    }
+    if (!remaining.startsWith(segment.text)) {
+      break;
+    }
+    remaining = remaining.slice(segment.text.length).replace(/^\n{1,2}/, "");
+  }
+  return remaining;
+}
+
 function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup> {
   const result: Array<ChatItem | MessageGroup> = [];
   let currentGroup: MessageGroup | null = null;
@@ -291,14 +311,15 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
 
   if (props.stream !== null) {
     const key = `stream:${props.sessionKey}:${props.streamStartedAt ?? "live"}`;
-    if (props.stream.trim().length > 0) {
+    const visibleStream = trimCommittedStreamPrefix(props.stream, segments);
+    if (visibleStream?.trim().length) {
       items.push({
         kind: "stream",
         key,
-        text: props.stream,
+        text: visibleStream,
         startedAt: props.streamStartedAt ?? Date.now(),
       });
-    } else {
+    } else if (props.stream.trim().length === 0) {
       items.push({ kind: "reading-indicator", key });
     }
   }

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -361,6 +361,105 @@ describe("handleChatEvent", () => {
     expect(state.chatStreamStartedAt).toBe(null);
   });
 
+  it("clears live tool stream artifacts after final payload is committed", () => {
+    const state = Object.assign(
+      createState({
+        sessionKey: "main",
+        chatRunId: "run-1",
+        chatStream: "Complete reply",
+        chatStreamStartedAt: 100,
+      }),
+      {
+        toolStreamById: new Map([["call-1", { toolCallId: "call-1" }]]),
+        toolStreamOrder: ["call-1"],
+        chatToolMessages: [{ role: "tool", toolCallId: "call-1" }],
+        chatStreamSegments: [{ text: "Pre-tool narration", ts: 99 }],
+      },
+    );
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "final",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Complete reply" }],
+        timestamp: 101,
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("final");
+    expect(state.chatMessages).toEqual([payload.message]);
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    // Preserve stream bookkeeping so app-gateway can still detect tool usage
+    // and replace live artifacts with persisted history after final events.
+    expect(state.toolStreamOrder).toEqual(["call-1"]);
+    expect(state.toolStreamById.size).toBe(1);
+  });
+
+  it("clears live tool stream artifacts after aborted payload is committed", () => {
+    const state = Object.assign(
+      createState({
+        sessionKey: "main",
+        chatRunId: "run-1",
+        chatStream: "Partial reply",
+        chatStreamStartedAt: 100,
+      }),
+      {
+        toolStreamById: new Map([["call-1", { toolCallId: "call-1" }]]),
+        toolStreamOrder: ["call-1"],
+        chatToolMessages: [{ role: "tool", toolCallId: "call-1" }],
+        chatStreamSegments: [{ text: "Pre-tool narration", ts: 99 }],
+      },
+    );
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "aborted",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Partial reply" }],
+        timestamp: 101,
+      },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("aborted");
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamOrder).toEqual(["call-1"]);
+    expect(state.toolStreamById.size).toBe(1);
+  });
+
+  it("clears live tool stream artifacts after error payload", () => {
+    const state = Object.assign(
+      createState({
+        sessionKey: "main",
+        chatRunId: "run-1",
+        chatStream: "Working",
+        chatStreamStartedAt: 100,
+      }),
+      {
+        toolStreamById: new Map([["call-1", { toolCallId: "call-1" }]]),
+        toolStreamOrder: ["call-1"],
+        chatToolMessages: [{ role: "tool", toolCallId: "call-1" }],
+        chatStreamSegments: [{ text: "Pre-tool narration", ts: 99 }],
+      },
+    );
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "error",
+      errorMessage: "boom",
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("error");
+    expect(state.chatToolMessages).toEqual([]);
+    expect(state.chatStreamSegments).toEqual([]);
+    expect(state.toolStreamOrder).toEqual(["call-1"]);
+    expect(state.toolStreamById.size).toBe(1);
+    expect(state.lastError).toBe("boom");
+  });
+
   it("processes aborted from own run and keeps partial assistant message", () => {
     const existingMessage = {
       role: "user",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -383,6 +383,19 @@ function maybeResetToolStream(state: ChatState) {
   }
 }
 
+function maybeClearLiveToolStreamArtifacts(state: ChatState) {
+  const toolHost = state as ChatState & {
+    chatToolMessages?: unknown[];
+    chatStreamSegments?: Array<{ text: string; ts: number }>;
+  };
+  if (Array.isArray(toolHost.chatToolMessages)) {
+    toolHost.chatToolMessages = [];
+  }
+  if (Array.isArray(toolHost.chatStreamSegments)) {
+    toolHost.chatStreamSegments = [];
+  }
+}
+
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
@@ -752,6 +765,7 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         },
       ];
     }
+    maybeClearLiveToolStreamArtifacts(state);
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
@@ -772,10 +786,12 @@ export function handleChatEvent(state: ChatState, payload?: ChatEventPayload) {
         ];
       }
     }
+    maybeClearLiveToolStreamArtifacts(state);
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;
   } else if (payload.state === "error") {
+    maybeClearLiveToolStreamArtifacts(state);
     state.chatStream = null;
     state.chatRunId = null;
     state.chatStreamStartedAt = null;


### PR DESCRIPTION
## Summary
- clear live tool stream artifacts when an owned chat run reaches `final`, `aborted`, or `error`
- prevents stale pre-tool streamed text/tool cards from rendering alongside the committed final assistant payload
- adds a regression test for the final-event duplicate bubble case reported in #72341

Fixes #72341.

## Tests
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit-ui.config.ts ui/src/ui/controllers/chat.test.ts`
- `pnpm lint:core -- ui/src/ui/controllers/chat.ts ui/src/ui/controllers/chat.test.ts`
