### PR TITLE
fix(feishu): repair stale channel state in doctor

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -62,6 +62,7 @@ import {
   parseFeishuTargetId,
 } from "./conversation-id.js";
 import { listFeishuDirectoryGroups, listFeishuDirectoryPeers } from "./directory.static.js";
+import { feishuDoctor } from "./doctor.js";
 import { messageActionTargetAliases } from "./message-action-contract.js";
 import { resolveFeishuGroupToolPolicy } from "./policy.js";
 import { collectRuntimeConfigAssignments, secretTargetRegistryEntries } from "./secret-contract.js";
@@ -617,6 +618,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount, FeishuProbeResul
         stripPatterns: () => ['<at user_id="[^"]*">[^<]*</at>'],
       },
       reload: { configPrefixes: ["channels.feishu"] },
+      doctor: feishuDoctor,
       configSchema: buildChannelConfigSchema(FeishuConfigSchema),
       config: {
         ...feishuConfigAdapter,

--- a/extensions/feishu/src/doctor.test.ts
+++ b/extensions/feishu/src/doctor.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { loadSessionStore } from "openclaw/plugin-sdk/config-runtime";
+import { loadSessionStore } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import { isFeishuSessionStoreKey, runFeishuDoctorSequence } from "./doctor.js";

--- a/extensions/feishu/src/doctor.test.ts
+++ b/extensions/feishu/src/doctor.test.ts
@@ -1,0 +1,237 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadSessionStore } from "openclaw/plugin-sdk/config-runtime";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../runtime-api.js";
+import { isFeishuSessionStoreKey, runFeishuDoctorSequence } from "./doctor.js";
+
+type EnvSnapshot = {
+  HOME?: string;
+  OPENCLAW_HOME?: string;
+  OPENCLAW_STATE_DIR?: string;
+};
+
+function captureEnv(): EnvSnapshot {
+  return {
+    HOME: process.env.HOME,
+    OPENCLAW_HOME: process.env.OPENCLAW_HOME,
+    OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+  };
+}
+
+function restoreEnv(snapshot: EnvSnapshot) {
+  for (const key of Object.keys(snapshot) as Array<keyof EnvSnapshot>) {
+    const value = snapshot[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function feishuConfig(): OpenClawConfig {
+  return {
+    channels: {
+      feishu: {
+        appId: "cli_xxx",
+        appSecret: "secret_xxx",
+      },
+    },
+  } as OpenClawConfig;
+}
+
+function stateDir(): string {
+  const dir = process.env.OPENCLAW_STATE_DIR;
+  if (!dir) {
+    throw new Error("OPENCLAW_STATE_DIR is not set");
+  }
+  return dir;
+}
+
+function sessionsDir(agentId = "main"): string {
+  return path.join(stateDir(), "agents", agentId, "sessions");
+}
+
+function storePath(agentId = "main"): string {
+  return path.join(sessionsDir(agentId), "sessions.json");
+}
+
+function writeStore(entries: Record<string, unknown>, agentId = "main"): string {
+  const target = storePath(agentId);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, JSON.stringify(entries, null, 2));
+  return target;
+}
+
+function writeTranscript(sessionId: string, lines: unknown[], agentId = "main"): string {
+  const target = path.join(sessionsDir(agentId), `${sessionId}.jsonl`);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`);
+  return target;
+}
+
+function sessionHeader(sessionId: string) {
+  return {
+    type: "session",
+    id: sessionId,
+    version: 7,
+    timestamp: new Date(0).toISOString(),
+    cwd: "/tmp",
+  };
+}
+
+function userMessage(content: string) {
+  return {
+    type: "message",
+    id: `msg-${content || "blank"}-${Math.random().toString(36).slice(2)}`,
+    parentId: null,
+    timestamp: new Date(0).toISOString(),
+    message: { role: "user", content },
+  };
+}
+
+function listBackupDirs(): string[] {
+  const backupsDir = path.join(stateDir(), "backups");
+  return fs.existsSync(backupsDir)
+    ? fs.readdirSync(backupsDir).filter((name) => name.startsWith("feishu-state-repair-"))
+    : [];
+}
+
+describe("Feishu doctor state repair", () => {
+  let envSnapshot: EnvSnapshot;
+  let tempHome = "";
+
+  beforeEach(() => {
+    envSnapshot = captureEnv();
+    tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-feishu-doctor-"));
+    process.env.HOME = tempHome;
+    process.env.OPENCLAW_HOME = tempHome;
+    process.env.OPENCLAW_STATE_DIR = path.join(tempHome, ".openclaw");
+    fs.mkdirSync(process.env.OPENCLAW_STATE_DIR, { recursive: true, mode: 0o700 });
+  });
+
+  afterEach(() => {
+    restoreEnv(envSnapshot);
+    fs.rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("matches only Feishu channel session keys", () => {
+    expect(isFeishuSessionStoreKey("agent:main:feishu:direct:ou_user")).toBe(true);
+    expect(isFeishuSessionStoreKey("feishu:direct:ou_user")).toBe(true);
+    expect(isFeishuSessionStoreKey("agent:codex:acp:binding:feishu:default:abc123")).toBe(false);
+    expect(isFeishuSessionStoreKey("agent:main:discord:direct:user")).toBe(false);
+  });
+
+  it("stays quiet for healthy Feishu state and transcripts", async () => {
+    const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
+    fs.mkdirSync(feishuDedupDir, { recursive: true });
+    fs.writeFileSync(path.join(feishuDedupDir, "default.json"), JSON.stringify({ msg1: 1 }));
+
+    writeTranscript("sess-ok", [sessionHeader("sess-ok"), userMessage("hello")]);
+    writeStore({
+      "agent:main:feishu:direct:ou_user": {
+        sessionId: "sess-ok",
+        sessionFile: "sess-ok.jsonl",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const result = await runFeishuDoctorSequence({
+      cfg: feishuConfig(),
+      env: process.env,
+      shouldRepair: false,
+    });
+
+    expect(result).toEqual({ changeNotes: [], warningNotes: [] });
+  });
+
+  it("warns before repair when Feishu local state is corrupt", async () => {
+    const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
+    fs.mkdirSync(feishuDedupDir, { recursive: true });
+    fs.writeFileSync(path.join(feishuDedupDir, "default.json"), "{");
+
+    const result = await runFeishuDoctorSequence({
+      cfg: feishuConfig(),
+      env: process.env,
+      shouldRepair: false,
+    });
+
+    expect(result.changeNotes).toEqual([]);
+    expect(result.warningNotes.join("\n")).toContain("Feishu local channel state may need repair");
+    expect(result.warningNotes.join("\n")).toContain("preserving Feishu App ID/secret config");
+    expect(result.warningNotes.join("\n")).toContain("openclaw doctor --fix");
+  });
+
+  it("archives Feishu state and direct Feishu sessions while preserving config and other sessions", async () => {
+    const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
+    fs.mkdirSync(feishuDedupDir, { recursive: true });
+    fs.writeFileSync(path.join(feishuDedupDir, "default.json"), JSON.stringify({ msg1: 1 }));
+
+    const transcriptPath = writeTranscript("sess-bad", [
+      sessionHeader("sess-bad"),
+      userMessage(""),
+      userMessage(""),
+      userMessage(""),
+    ]);
+    const trajectoryPath = path.join(sessionsDir(), "sess-bad.trajectory.jsonl");
+    const trajectoryIndexPath = path.join(sessionsDir(), "sess-bad.trajectory-path.json");
+    fs.writeFileSync(trajectoryPath, "{}\n");
+    fs.writeFileSync(trajectoryIndexPath, "{}\n");
+
+    const targetStorePath = writeStore({
+      "agent:main:feishu:direct:ou_user": {
+        sessionId: "sess-bad",
+        sessionFile: "sess-bad.jsonl",
+        updatedAt: Date.now(),
+      },
+      "agent:codex:acp:binding:feishu:default:abc123": {
+        sessionId: "sess-acp",
+        updatedAt: Date.now(),
+      },
+      "agent:main:discord:direct:user": {
+        sessionId: "sess-discord",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const result = await runFeishuDoctorSequence({
+      cfg: feishuConfig(),
+      env: process.env,
+      shouldRepair: true,
+    });
+
+    expect(result.warningNotes).toEqual([]);
+    expect(result.changeNotes.join("\n")).toContain("Feishu local state repaired");
+    expect(result.changeNotes.join("\n")).toContain("Preserved Feishu App ID/secret config");
+
+    expect(fs.existsSync(path.join(stateDir(), "feishu"))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir(), "feishu", "dedup", "default.json"))).toBe(false);
+
+    const backups = listBackupDirs();
+    expect(backups).toHaveLength(1);
+    const backupDir = path.join(stateDir(), "backups", backups[0] ?? "");
+    expect(fs.existsSync(path.join(backupDir, "feishu", "dedup", "default.json"))).toBe(true);
+    expect(fs.existsSync(path.join(backupDir, "session-stores", "main", "sessions.json"))).toBe(
+      true,
+    );
+
+    const store = loadSessionStore(targetStorePath, { skipCache: true });
+    expect(store["agent:main:feishu:direct:ou_user"]).toBeUndefined();
+    expect(store["agent:codex:acp:binding:feishu:default:abc123"]).toBeDefined();
+    expect(store["agent:main:discord:direct:user"]).toBeDefined();
+
+    expect(fs.existsSync(transcriptPath)).toBe(false);
+    expect(fs.existsSync(trajectoryPath)).toBe(false);
+    expect(fs.existsSync(trajectoryIndexPath)).toBe(false);
+    const archivedNames = fs.readdirSync(sessionsDir());
+    expect(archivedNames.some((name) => name.startsWith("sess-bad.jsonl.deleted."))).toBe(true);
+    expect(
+      archivedNames.some((name) => name.startsWith("sess-bad.trajectory.jsonl.deleted.")),
+    ).toBe(true);
+    expect(
+      archivedNames.some((name) => name.startsWith("sess-bad.trajectory-path.json.deleted.")),
+    ).toBe(true);
+  });
+});

--- a/extensions/feishu/src/doctor.test.ts
+++ b/extensions/feishu/src/doctor.test.ts
@@ -164,7 +164,50 @@ describe("Feishu doctor state repair", () => {
     expect(result.warningNotes.join("\n")).toContain("openclaw doctor --fix");
   });
 
-  it("archives Feishu state and direct Feishu sessions while preserving config and other sessions", async () => {
+  it("rebuilds corrupt Feishu state without deleting healthy Feishu sessions", async () => {
+    const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
+    fs.mkdirSync(feishuDedupDir, { recursive: true });
+    fs.writeFileSync(path.join(feishuDedupDir, "default.json"), "{");
+
+    const transcriptPath = writeTranscript("sess-ok", [
+      sessionHeader("sess-ok"),
+      userMessage("hello"),
+    ]);
+    const targetStorePath = writeStore({
+      "agent:main:feishu:direct:ou_user": {
+        sessionId: "sess-ok",
+        sessionFile: "sess-ok.jsonl",
+        updatedAt: Date.now(),
+      },
+    });
+
+    const result = await runFeishuDoctorSequence({
+      cfg: feishuConfig(),
+      env: process.env,
+      shouldRepair: true,
+    });
+
+    expect(result.warningNotes).toEqual([]);
+    expect(result.changeNotes.join("\n")).toContain("Rebuilt Feishu runtime state: yes");
+    expect(result.changeNotes.join("\n")).toContain("Removed 0 Feishu-scoped session entries");
+
+    const store = loadSessionStore(targetStorePath, { skipCache: true });
+    expect(store["agent:main:feishu:direct:ou_user"]).toBeDefined();
+    expect(fs.existsSync(transcriptPath)).toBe(true);
+
+    expect(fs.existsSync(path.join(stateDir(), "feishu"))).toBe(true);
+    expect(fs.existsSync(path.join(stateDir(), "feishu", "dedup", "default.json"))).toBe(false);
+
+    const backups = listBackupDirs();
+    expect(backups).toHaveLength(1);
+    const backupDir = path.join(stateDir(), "backups", backups[0] ?? "");
+    expect(fs.existsSync(path.join(backupDir, "feishu", "dedup", "default.json"))).toBe(true);
+    expect(fs.existsSync(path.join(backupDir, "session-stores", "main", "sessions.json"))).toBe(
+      false,
+    );
+  });
+
+  it("archives only unhealthy Feishu direct sessions while preserving state, config, and other sessions", async () => {
     const feishuDedupDir = path.join(stateDir(), "feishu", "dedup");
     fs.mkdirSync(feishuDedupDir, { recursive: true });
     fs.writeFileSync(path.join(feishuDedupDir, "default.json"), JSON.stringify({ msg1: 1 }));
@@ -204,15 +247,16 @@ describe("Feishu doctor state repair", () => {
 
     expect(result.warningNotes).toEqual([]);
     expect(result.changeNotes.join("\n")).toContain("Feishu local state repaired");
+    expect(result.changeNotes.join("\n")).toContain("Rebuilt Feishu runtime state: not needed");
     expect(result.changeNotes.join("\n")).toContain("Preserved Feishu App ID/secret config");
 
     expect(fs.existsSync(path.join(stateDir(), "feishu"))).toBe(true);
-    expect(fs.existsSync(path.join(stateDir(), "feishu", "dedup", "default.json"))).toBe(false);
+    expect(fs.existsSync(path.join(stateDir(), "feishu", "dedup", "default.json"))).toBe(true);
 
     const backups = listBackupDirs();
     expect(backups).toHaveLength(1);
     const backupDir = path.join(stateDir(), "backups", backups[0] ?? "");
-    expect(fs.existsSync(path.join(backupDir, "feishu", "dedup", "default.json"))).toBe(true);
+    expect(fs.existsSync(path.join(backupDir, "feishu", "dedup", "default.json"))).toBe(false);
     expect(fs.existsSync(path.join(backupDir, "session-stores", "main", "sessions.json"))).toBe(
       true,
     );

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -5,14 +5,13 @@ import type {
   ChannelDoctorAdapter,
   ChannelDoctorSequenceResult,
 } from "openclaw/plugin-sdk/channel-contract";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import {
   loadSessionStore,
-  resolveDefaultAgentId,
   resolveStorePath,
   updateSessionStore,
-  type OpenClawConfig,
-} from "openclaw/plugin-sdk/config-runtime";
-import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+} from "openclaw/plugin-sdk/session-store-runtime";
 import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
 
 const FEISHU_STATE_DIR = "feishu";
@@ -144,6 +143,8 @@ function formatFinding(finding: FeishuDoctorFinding): string {
         finding.path,
       )}`;
   }
+  const exhaustive: never = finding;
+  return exhaustive;
 }
 
 export function isFeishuSessionStoreKey(key: string): boolean {
@@ -153,13 +154,19 @@ export function isFeishuSessionStoreKey(key: string): boolean {
 
 function collectConfiguredAgentIds(cfg: OpenClawConfig): string[] {
   const ids = new Set<string>();
-  ids.add(normalizeAgentId(resolveDefaultAgentId(cfg)));
+  ids.add(resolveConfiguredDefaultAgentId(cfg));
   for (const agent of cfg.agents?.list ?? []) {
     if (typeof agent.id === "string" && agent.id.trim()) {
       ids.add(normalizeAgentId(agent.id));
     }
   }
   return [...ids].toSorted();
+}
+
+function resolveConfiguredDefaultAgentId(cfg: OpenClawConfig): string {
+  const agents = cfg.agents?.list ?? [];
+  const chosen = agents.find((agent) => agent?.default) ?? agents[0];
+  return normalizeAgentId(typeof chosen?.id === "string" && chosen.id.trim() ? chosen.id : "main");
 }
 
 function collectFeishuSessionTargets(params: {
@@ -545,14 +552,15 @@ function archiveSessionArtifacts(params: {
   return archived;
 }
 
-export async function repairFeishuDoctorState(params: {
+async function repairFeishuDoctorState(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
   now?: Date;
+  inspection?: FeishuDoctorInspection;
 }): Promise<FeishuDoctorRepairReport> {
   const env = params.env ?? process.env;
   const now = params.now ?? new Date();
-  const inspection = inspectFeishuDoctorState({ cfg: params.cfg, env });
+  const inspection = params.inspection ?? inspectFeishuDoctorState({ cfg: params.cfg, env });
   const backupDir = ensureBackupDir(inspection.stateDir, now);
   const archiveTimestamp = timestampForPath(now);
   const warnings: string[] = [];
@@ -696,7 +704,11 @@ export async function runFeishuDoctorSequence(params: {
     };
   }
 
-  const report = await repairFeishuDoctorState({ cfg: params.cfg, env: params.env });
+  const report = await repairFeishuDoctorState({
+    cfg: params.cfg,
+    env: params.env,
+    inspection,
+  });
   return {
     changeNotes: [formatRepairChange(report)],
     warningNotes: report.warnings,

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -54,20 +54,23 @@ type FeishuSessionEntry = {
   sessionFile?: unknown;
 };
 
+type FeishuDoctorSessionEntry = {
+  key: string;
+  storePath: string;
+  agentId: string;
+  entry: FeishuSessionEntry;
+};
+
 export type FeishuDoctorInspection = {
   stateDir: string;
   feishuStateDir: string;
   findings: FeishuDoctorFinding[];
-  sessionEntries: Array<{
-    key: string;
-    storePath: string;
-    agentId: string;
-    entry: FeishuSessionEntry;
-  }>;
+  sessionEntries: FeishuDoctorSessionEntry[];
 };
 
 export type FeishuDoctorRepairReport = {
   backupDir: string;
+  stateDirRepairAttempted: boolean;
   rebuiltStateDir: boolean;
   removedSessionEntries: number;
   touchedSessionStores: number;
@@ -81,6 +84,16 @@ function timestampForPath(now = new Date()): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function toFeishuSessionEntry(value: unknown): FeishuSessionEntry {
+  if (!isRecord(value)) {
+    return {};
+  }
+  return {
+    sessionId: value.sessionId,
+    sessionFile: value.sessionFile,
+  };
 }
 
 function countLabel(count: number, singular: string, plural = `${singular}s`): string {
@@ -418,6 +431,46 @@ function collectFeishuSessionFindings(params: {
   return findings;
 }
 
+function hasCorruptFeishuStateJsonFinding(inspection: FeishuDoctorInspection): boolean {
+  return inspection.findings.some((finding) => finding.kind === "corrupt-state-json");
+}
+
+function sessionEntryId(storePath: string, key: string): string {
+  return `${path.resolve(storePath)}\0${key}`;
+}
+
+function collectRepairSessionEntries(
+  inspection: FeishuDoctorInspection,
+): FeishuDoctorSessionEntry[] {
+  const entriesById = new Map<string, FeishuDoctorSessionEntry>();
+  for (const entry of inspection.sessionEntries) {
+    entriesById.set(sessionEntryId(entry.storePath, entry.key), entry);
+  }
+
+  const repairEntries: FeishuDoctorSessionEntry[] = [];
+  const seen = new Set<string>();
+  for (const finding of inspection.findings) {
+    if (finding.kind === "corrupt-state-json") {
+      continue;
+    }
+
+    const id = sessionEntryId(finding.storePath, finding.sessionKey);
+    if (seen.has(id)) {
+      continue;
+    }
+    const entry = entriesById.get(id);
+    if (entry) {
+      repairEntries.push(entry);
+      seen.add(id);
+    }
+  }
+
+  return repairEntries.toSorted(
+    (left, right) =>
+      left.storePath.localeCompare(right.storePath) || left.key.localeCompare(right.key),
+  );
+}
+
 export function inspectFeishuDoctorState(params: {
   cfg: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
@@ -436,17 +489,18 @@ export function inspectFeishuDoctorState(params: {
       if (!isFeishuSessionStoreKey(key)) {
         continue;
       }
+      const sessionEntry = toFeishuSessionEntry(entry);
       sessionEntries.push({
         key,
         storePath: target.storePath,
         agentId: target.agentId,
-        entry,
+        entry: sessionEntry,
       });
       findings.push(
         ...collectFeishuSessionFindings({
           sessionKey: key,
           storePath: target.storePath,
-          entry,
+          entry: sessionEntry,
         }),
       );
     }
@@ -564,17 +618,20 @@ async function repairFeishuDoctorState(params: {
   const backupDir = ensureBackupDir(inspection.stateDir, now);
   const archiveTimestamp = timestampForPath(now);
   const warnings: string[] = [];
+  const stateDirRepairAttempted = hasCorruptFeishuStateJsonFinding(inspection);
 
   let rebuiltStateDir = false;
-  try {
-    rebuiltStateDir = movePathToBackup({
-      sourcePath: inspection.feishuStateDir,
-      backupDir,
-      relativeTarget: FEISHU_STATE_DIR,
-    });
-    fs.mkdirSync(inspection.feishuStateDir, { recursive: true, mode: 0o700 });
-  } catch (error) {
-    warnings.push(`- Failed to rebuild Feishu local state: ${String(error)}`);
+  if (stateDirRepairAttempted) {
+    try {
+      rebuiltStateDir = movePathToBackup({
+        sourcePath: inspection.feishuStateDir,
+        backupDir,
+        relativeTarget: FEISHU_STATE_DIR,
+      });
+      fs.mkdirSync(inspection.feishuStateDir, { recursive: true, mode: 0o700 });
+    } catch (error) {
+      warnings.push(`- Failed to rebuild Feishu local state: ${String(error)}`);
+    }
   }
 
   const entriesByStore = new Map<
@@ -584,7 +641,7 @@ async function repairFeishuDoctorState(params: {
       entries: Array<{ key: string; entry: FeishuSessionEntry }>;
     }
   >();
-  for (const entry of inspection.sessionEntries) {
+  for (const entry of collectRepairSessionEntries(inspection)) {
     const existing = entriesByStore.get(entry.storePath);
     if (existing) {
       existing.entries.push({ key: entry.key, entry: entry.entry });
@@ -640,6 +697,7 @@ async function repairFeishuDoctorState(params: {
 
   return {
     backupDir,
+    stateDirRepairAttempted,
     rebuiltStateDir,
     removedSessionEntries,
     touchedSessionStores,
@@ -651,24 +709,41 @@ async function repairFeishuDoctorState(params: {
 function formatPreviewWarning(inspection: FeishuDoctorInspection): string {
   const previewFindings = inspection.findings.slice(0, 5).map(formatFinding);
   const remaining = inspection.findings.length - previewFindings.length;
+  const repairActions: string[] = [];
+  if (hasCorruptFeishuStateJsonFinding(inspection)) {
+    repairActions.push(`archive ${formatDisplayPath(inspection.feishuStateDir)}`);
+  }
+  const repairSessionEntries = collectRepairSessionEntries(inspection);
+  if (repairSessionEntries.length > 0) {
+    repairActions.push(
+      `archive artifacts and remove ${countLabel(
+        repairSessionEntries.length,
+        "flagged Feishu-scoped session entry",
+        "flagged Feishu-scoped session entries",
+      )}`,
+    );
+  }
+  const repairSummary =
+    repairActions.length > 0 ? repairActions.join(" and ") : "apply targeted Feishu state cleanup";
   return [
     "- Feishu local channel state may need repair.",
     ...previewFindings,
     ...(remaining > 0 ? [`- ...and ${remaining} more Feishu state finding(s).`] : []),
-    `- Repair will archive ${formatDisplayPath(inspection.feishuStateDir)} and ${countLabel(
-      inspection.sessionEntries.length,
-      "Feishu-scoped session entry",
-      "Feishu-scoped session entries",
-    )}, while preserving Feishu App ID/secret config.`,
+    `- Repair will ${repairSummary}, while preserving Feishu App ID/secret config and healthy session entries.`,
     '- Run "openclaw doctor --fix" to rebuild Feishu local state.',
   ].join("\n");
 }
 
 function formatRepairChange(report: FeishuDoctorRepairReport): string {
+  const stateRepairStatus = report.stateDirRepairAttempted
+    ? report.rebuiltStateDir
+      ? "yes"
+      : "no existing state"
+    : "not needed";
   return [
     "Feishu local state repaired.",
     `- Backup dir: ${formatDisplayPath(report.backupDir)}`,
-    `- Rebuilt Feishu runtime state: ${report.rebuiltStateDir ? "yes" : "no existing state"}`,
+    `- Rebuilt Feishu runtime state: ${stateRepairStatus}`,
     `- Removed ${countLabel(
       report.removedSessionEntries,
       "Feishu-scoped session entry",

--- a/extensions/feishu/src/doctor.ts
+++ b/extensions/feishu/src/doctor.ts
@@ -1,0 +1,709 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  ChannelDoctorAdapter,
+  ChannelDoctorSequenceResult,
+} from "openclaw/plugin-sdk/channel-contract";
+import {
+  loadSessionStore,
+  resolveDefaultAgentId,
+  resolveStorePath,
+  updateSessionStore,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/config-runtime";
+import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
+import { resolveStateDir } from "openclaw/plugin-sdk/state-paths";
+
+const FEISHU_STATE_DIR = "feishu";
+const BACKUP_PREFIX = "feishu-state-repair";
+const BLANK_USER_MESSAGE_REPAIR_THRESHOLD = 3;
+const SESSION_FILE_INSPECTION_MAX_BYTES = 16 * 1024 * 1024;
+
+type FeishuDoctorFinding =
+  | {
+      kind: "corrupt-state-json";
+      path: string;
+    }
+  | {
+      kind: "missing-session-transcript";
+      sessionKey: string;
+      storePath: string;
+    }
+  | {
+      kind: "invalid-session-transcript";
+      sessionKey: string;
+      storePath: string;
+      path: string;
+      reason: string;
+    }
+  | {
+      kind: "blank-user-message-run";
+      sessionKey: string;
+      storePath: string;
+      path: string;
+      count: number;
+    };
+
+type FeishuSessionTarget = {
+  agentId: string;
+  storePath: string;
+};
+
+type FeishuSessionEntry = {
+  sessionId?: unknown;
+  sessionFile?: unknown;
+};
+
+export type FeishuDoctorInspection = {
+  stateDir: string;
+  feishuStateDir: string;
+  findings: FeishuDoctorFinding[];
+  sessionEntries: Array<{
+    key: string;
+    storePath: string;
+    agentId: string;
+    entry: FeishuSessionEntry;
+  }>;
+};
+
+export type FeishuDoctorRepairReport = {
+  backupDir: string;
+  rebuiltStateDir: boolean;
+  removedSessionEntries: number;
+  touchedSessionStores: number;
+  archivedSessionArtifacts: number;
+  warnings: string[];
+};
+
+function timestampForPath(now = new Date()): string {
+  return now.toISOString().replaceAll(":", "-");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function countLabel(count: number, singular: string, plural = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : plural}`;
+}
+
+function existsDir(dir: string): boolean {
+  try {
+    return fs.statSync(dir).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function existsFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function safeReadDir(dir: string): fs.Dirent[] {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+}
+
+function isPathWithinRoot(targetPath: string, rootPath: string): boolean {
+  const resolvedTarget = path.resolve(targetPath);
+  const resolvedRoot = path.resolve(rootPath);
+  const relative = path.relative(resolvedRoot, resolvedTarget);
+  return Boolean(relative) && !relative.startsWith("..") && !path.isAbsolute(relative);
+}
+
+function formatDisplayPath(filePath: string): string {
+  const home = os.homedir();
+  const resolved = path.resolve(filePath);
+  return resolved === home || resolved.startsWith(`${home}${path.sep}`)
+    ? `~${resolved.slice(home.length)}`
+    : resolved;
+}
+
+function formatFinding(finding: FeishuDoctorFinding): string {
+  switch (finding.kind) {
+    case "corrupt-state-json":
+      return `- Feishu local JSON state is corrupt: ${formatDisplayPath(finding.path)}`;
+    case "missing-session-transcript":
+      return `- Feishu session ${finding.sessionKey} points to a missing transcript in ${formatDisplayPath(
+        finding.storePath,
+      )}`;
+    case "invalid-session-transcript":
+      return `- Feishu session ${finding.sessionKey} has an invalid transcript (${finding.reason}): ${formatDisplayPath(
+        finding.path,
+      )}`;
+    case "blank-user-message-run":
+      return `- Feishu session ${finding.sessionKey} contains ${finding.count} blank user messages: ${formatDisplayPath(
+        finding.path,
+      )}`;
+  }
+}
+
+export function isFeishuSessionStoreKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return /^agent:[^:]+:feishu(?::|$)/.test(normalized) || /^feishu(?::|$)/.test(normalized);
+}
+
+function collectConfiguredAgentIds(cfg: OpenClawConfig): string[] {
+  const ids = new Set<string>();
+  ids.add(normalizeAgentId(resolveDefaultAgentId(cfg)));
+  for (const agent of cfg.agents?.list ?? []) {
+    if (typeof agent.id === "string" && agent.id.trim()) {
+      ids.add(normalizeAgentId(agent.id));
+    }
+  }
+  return [...ids].toSorted();
+}
+
+function collectFeishuSessionTargets(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  stateDir: string;
+}): FeishuSessionTarget[] {
+  const byStorePath = new Map<string, FeishuSessionTarget>();
+  const addTarget = (target: FeishuSessionTarget) => {
+    byStorePath.set(path.resolve(target.storePath), {
+      ...target,
+      storePath: path.resolve(target.storePath),
+    });
+  };
+
+  for (const agentId of collectConfiguredAgentIds(params.cfg)) {
+    addTarget({
+      agentId,
+      storePath: resolveStorePath(params.cfg.session?.store, { agentId, env: params.env }),
+    });
+  }
+
+  const agentsDir = path.join(params.stateDir, "agents");
+  for (const agentDir of safeReadDir(agentsDir)) {
+    if (!agentDir.isDirectory()) {
+      continue;
+    }
+    const agentId = normalizeAgentId(agentDir.name);
+    const storePath = path.join(agentsDir, agentDir.name, "sessions", "sessions.json");
+    if (existsFile(storePath)) {
+      addTarget({ agentId, storePath });
+    }
+  }
+
+  return [...byStorePath.values()].toSorted((left, right) =>
+    left.storePath.localeCompare(right.storePath),
+  );
+}
+
+function collectJsonFiles(rootDir: string, limit = 200): string[] {
+  const files: string[] = [];
+  const visit = (dir: string) => {
+    if (files.length >= limit) {
+      return;
+    }
+    for (const entry of safeReadDir(dir).toSorted((left, right) =>
+      left.name.localeCompare(right.name),
+    )) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        files.push(fullPath);
+      }
+      if (files.length >= limit) {
+        return;
+      }
+    }
+  };
+  if (existsDir(rootDir)) {
+    visit(rootDir);
+  }
+  return files;
+}
+
+function collectCorruptFeishuStateJsonFindings(feishuStateDir: string): FeishuDoctorFinding[] {
+  const findings: FeishuDoctorFinding[] = [];
+  for (const filePath of collectJsonFiles(feishuStateDir)) {
+    try {
+      JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    } catch {
+      findings.push({ kind: "corrupt-state-json", path: filePath });
+    }
+  }
+  return findings;
+}
+
+function resolveSessionTranscriptCandidates(params: {
+  storePath: string;
+  entry: FeishuSessionEntry;
+}): string[] {
+  const candidates = new Set<string>();
+  const sessionsDir = path.dirname(params.storePath);
+  const addSafeCandidate = (candidate: string) => {
+    const resolved = path.isAbsolute(candidate)
+      ? path.resolve(candidate)
+      : path.resolve(sessionsDir, candidate);
+    if (resolved === sessionsDir || !isPathWithinRoot(resolved, sessionsDir)) {
+      return;
+    }
+    candidates.add(resolved);
+  };
+
+  if (typeof params.entry.sessionFile === "string" && params.entry.sessionFile.trim()) {
+    addSafeCandidate(params.entry.sessionFile.trim());
+  }
+  if (
+    typeof params.entry.sessionId === "string" &&
+    /^[a-z0-9][a-z0-9._-]{0,127}$/i.test(params.entry.sessionId)
+  ) {
+    addSafeCandidate(`${params.entry.sessionId}.jsonl`);
+  }
+
+  return [...candidates].toSorted();
+}
+
+function isSessionHeader(value: unknown): boolean {
+  return isRecord(value) && value.type === "session" && typeof value.id === "string";
+}
+
+function isBlankUserMessage(value: unknown): boolean {
+  if (!isRecord(value) || value.type !== "message" || !isRecord(value.message)) {
+    return false;
+  }
+  if (value.message.role !== "user") {
+    return false;
+  }
+  const content = value.message.content;
+  if (typeof content === "string") {
+    return content.trim().length === 0;
+  }
+  return Array.isArray(content) && content.length === 0;
+}
+
+function inspectSessionTranscript(params: {
+  sessionKey: string;
+  storePath: string;
+  transcriptPath: string;
+}): FeishuDoctorFinding | null {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(params.transcriptPath);
+  } catch {
+    return null;
+  }
+  if (!stat.isFile()) {
+    return {
+      kind: "invalid-session-transcript",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      reason: "not a file",
+    };
+  }
+  if (stat.size > SESSION_FILE_INSPECTION_MAX_BYTES) {
+    return null;
+  }
+
+  let raw = "";
+  try {
+    raw = fs.readFileSync(params.transcriptPath, "utf-8");
+  } catch {
+    return {
+      kind: "invalid-session-transcript",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      reason: "unreadable",
+    };
+  }
+
+  const entries: unknown[] = [];
+  let malformedLines = 0;
+  let blankUserMessages = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim()) {
+      continue;
+    }
+    try {
+      const entry = JSON.parse(line);
+      entries.push(entry);
+      if (isBlankUserMessage(entry)) {
+        blankUserMessages += 1;
+      }
+    } catch {
+      malformedLines += 1;
+    }
+  }
+
+  if (entries.length === 0) {
+    return {
+      kind: "invalid-session-transcript",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      reason: "empty transcript",
+    };
+  }
+  if (!isSessionHeader(entries[0])) {
+    return {
+      kind: "invalid-session-transcript",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      reason: "invalid session header",
+    };
+  }
+  if (malformedLines > 0) {
+    return {
+      kind: "invalid-session-transcript",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      reason: `${malformedLines} malformed JSONL line(s)`,
+    };
+  }
+  if (blankUserMessages >= BLANK_USER_MESSAGE_REPAIR_THRESHOLD) {
+    return {
+      kind: "blank-user-message-run",
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      path: params.transcriptPath,
+      count: blankUserMessages,
+    };
+  }
+  return null;
+}
+
+function collectFeishuSessionFindings(params: {
+  sessionKey: string;
+  storePath: string;
+  entry: FeishuSessionEntry;
+}): FeishuDoctorFinding[] {
+  const transcriptCandidates = resolveSessionTranscriptCandidates(params);
+  const existing = transcriptCandidates.filter(existsFile);
+  if (transcriptCandidates.length > 0 && existing.length === 0) {
+    return [
+      {
+        kind: "missing-session-transcript",
+        sessionKey: params.sessionKey,
+        storePath: params.storePath,
+      },
+    ];
+  }
+
+  const findings: FeishuDoctorFinding[] = [];
+  for (const transcriptPath of existing) {
+    const finding = inspectSessionTranscript({
+      sessionKey: params.sessionKey,
+      storePath: params.storePath,
+      transcriptPath,
+    });
+    if (finding) {
+      findings.push(finding);
+    }
+  }
+  return findings;
+}
+
+export function inspectFeishuDoctorState(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): FeishuDoctorInspection {
+  const env = params.env ?? process.env;
+  const stateDir = resolveStateDir(env, os.homedir);
+  const feishuStateDir = path.join(stateDir, FEISHU_STATE_DIR);
+  const findings: FeishuDoctorFinding[] = collectCorruptFeishuStateJsonFindings(feishuStateDir);
+  const sessionEntries: FeishuDoctorInspection["sessionEntries"] = [];
+
+  for (const target of collectFeishuSessionTargets({ cfg: params.cfg, env, stateDir })) {
+    const store = loadSessionStore(target.storePath, { skipCache: true });
+    for (const [key, entry] of Object.entries(store).toSorted(([left], [right]) =>
+      left.localeCompare(right),
+    )) {
+      if (!isFeishuSessionStoreKey(key)) {
+        continue;
+      }
+      sessionEntries.push({
+        key,
+        storePath: target.storePath,
+        agentId: target.agentId,
+        entry,
+      });
+      findings.push(
+        ...collectFeishuSessionFindings({
+          sessionKey: key,
+          storePath: target.storePath,
+          entry,
+        }),
+      );
+    }
+  }
+
+  return {
+    stateDir,
+    feishuStateDir,
+    findings,
+    sessionEntries,
+  };
+}
+
+function ensureBackupDir(stateDir: string, now: Date): string {
+  const backupDir = path.join(stateDir, "backups", `${BACKUP_PREFIX}-${timestampForPath(now)}`);
+  fs.mkdirSync(backupDir, { recursive: true, mode: 0o700 });
+  return backupDir;
+}
+
+function resolveUniquePath(candidate: string): string {
+  if (!fs.existsSync(candidate)) {
+    return candidate;
+  }
+  for (let index = 1; index < 1000; index += 1) {
+    const next = `${candidate}.${index}`;
+    if (!fs.existsSync(next)) {
+      return next;
+    }
+  }
+  throw new Error(`Unable to resolve unique path for ${candidate}`);
+}
+
+function movePathToBackup(params: {
+  sourcePath: string;
+  backupDir: string;
+  relativeTarget: string;
+}): boolean {
+  if (!fs.existsSync(params.sourcePath)) {
+    return false;
+  }
+  const targetPath = resolveUniquePath(path.join(params.backupDir, params.relativeTarget));
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: 0o700 });
+  fs.renameSync(params.sourcePath, targetPath);
+  return true;
+}
+
+function copyStoreBackup(params: { storePath: string; backupDir: string; agentId: string }) {
+  if (!existsFile(params.storePath)) {
+    return;
+  }
+  const targetPath = path.join(
+    params.backupDir,
+    "session-stores",
+    params.agentId,
+    path.basename(params.storePath),
+  );
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true, mode: 0o700 });
+  fs.copyFileSync(params.storePath, resolveUniquePath(targetPath));
+}
+
+function collectSessionArtifactPaths(params: {
+  storePath: string;
+  entry: FeishuSessionEntry;
+}): string[] {
+  const artifacts = new Set<string>();
+  for (const transcriptPath of resolveSessionTranscriptCandidates(params)) {
+    artifacts.add(transcriptPath);
+    if (transcriptPath.endsWith(".jsonl")) {
+      const base = transcriptPath.slice(0, -".jsonl".length);
+      artifacts.add(`${base}.trajectory.jsonl`);
+      artifacts.add(`${base}.trajectory-path.json`);
+    }
+  }
+  return [...artifacts].toSorted();
+}
+
+function archiveSessionArtifacts(params: {
+  storePath: string;
+  entries: FeishuSessionEntry[];
+  archiveTimestamp: string;
+}): number {
+  const storeDir = path.dirname(params.storePath);
+  const seen = new Set<string>();
+  let archived = 0;
+  for (const entry of params.entries) {
+    for (const artifactPath of collectSessionArtifactPaths({
+      storePath: params.storePath,
+      entry,
+    })) {
+      if (
+        seen.has(artifactPath) ||
+        !isPathWithinRoot(artifactPath, storeDir) ||
+        !existsFile(artifactPath)
+      ) {
+        continue;
+      }
+      seen.add(artifactPath);
+      const archivedPath = resolveUniquePath(`${artifactPath}.deleted.${params.archiveTimestamp}`);
+      fs.renameSync(artifactPath, archivedPath);
+      archived += 1;
+    }
+  }
+  return archived;
+}
+
+export async function repairFeishuDoctorState(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+}): Promise<FeishuDoctorRepairReport> {
+  const env = params.env ?? process.env;
+  const now = params.now ?? new Date();
+  const inspection = inspectFeishuDoctorState({ cfg: params.cfg, env });
+  const backupDir = ensureBackupDir(inspection.stateDir, now);
+  const archiveTimestamp = timestampForPath(now);
+  const warnings: string[] = [];
+
+  let rebuiltStateDir = false;
+  try {
+    rebuiltStateDir = movePathToBackup({
+      sourcePath: inspection.feishuStateDir,
+      backupDir,
+      relativeTarget: FEISHU_STATE_DIR,
+    });
+    fs.mkdirSync(inspection.feishuStateDir, { recursive: true, mode: 0o700 });
+  } catch (error) {
+    warnings.push(`- Failed to rebuild Feishu local state: ${String(error)}`);
+  }
+
+  const entriesByStore = new Map<
+    string,
+    {
+      agentId: string;
+      entries: Array<{ key: string; entry: FeishuSessionEntry }>;
+    }
+  >();
+  for (const entry of inspection.sessionEntries) {
+    const existing = entriesByStore.get(entry.storePath);
+    if (existing) {
+      existing.entries.push({ key: entry.key, entry: entry.entry });
+    } else {
+      entriesByStore.set(entry.storePath, {
+        agentId: entry.agentId,
+        entries: [{ key: entry.key, entry: entry.entry }],
+      });
+    }
+  }
+
+  let removedSessionEntries = 0;
+  let touchedSessionStores = 0;
+  let archivedSessionArtifacts = 0;
+  for (const [storePath, group] of [...entriesByStore.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    try {
+      copyStoreBackup({ storePath, backupDir, agentId: group.agentId });
+      archivedSessionArtifacts += archiveSessionArtifacts({
+        storePath,
+        entries: group.entries.map((entry) => entry.entry),
+        archiveTimestamp,
+      });
+      const keys = new Set(group.entries.map((entry) => entry.key));
+      const removed = await updateSessionStore(
+        storePath,
+        (store) => {
+          let count = 0;
+          for (const key of keys) {
+            if (Object.prototype.hasOwnProperty.call(store, key)) {
+              delete store[key];
+              count += 1;
+            }
+          }
+          return count;
+        },
+        {
+          skipMaintenance: true,
+          allowDropAcpMetaSessionKeys: [...keys],
+        },
+      );
+      removedSessionEntries += removed;
+      if (removed > 0) {
+        touchedSessionStores += 1;
+      }
+    } catch (error) {
+      warnings.push(
+        `- Failed to archive Feishu sessions in ${formatDisplayPath(storePath)}: ${String(error)}`,
+      );
+    }
+  }
+
+  return {
+    backupDir,
+    rebuiltStateDir,
+    removedSessionEntries,
+    touchedSessionStores,
+    archivedSessionArtifacts,
+    warnings,
+  };
+}
+
+function formatPreviewWarning(inspection: FeishuDoctorInspection): string {
+  const previewFindings = inspection.findings.slice(0, 5).map(formatFinding);
+  const remaining = inspection.findings.length - previewFindings.length;
+  return [
+    "- Feishu local channel state may need repair.",
+    ...previewFindings,
+    ...(remaining > 0 ? [`- ...and ${remaining} more Feishu state finding(s).`] : []),
+    `- Repair will archive ${formatDisplayPath(inspection.feishuStateDir)} and ${countLabel(
+      inspection.sessionEntries.length,
+      "Feishu-scoped session entry",
+      "Feishu-scoped session entries",
+    )}, while preserving Feishu App ID/secret config.`,
+    '- Run "openclaw doctor --fix" to rebuild Feishu local state.',
+  ].join("\n");
+}
+
+function formatRepairChange(report: FeishuDoctorRepairReport): string {
+  return [
+    "Feishu local state repaired.",
+    `- Backup dir: ${formatDisplayPath(report.backupDir)}`,
+    `- Rebuilt Feishu runtime state: ${report.rebuiltStateDir ? "yes" : "no existing state"}`,
+    `- Removed ${countLabel(
+      report.removedSessionEntries,
+      "Feishu-scoped session entry",
+      "Feishu-scoped session entries",
+    )} from ${countLabel(report.touchedSessionStores, "session store")}.`,
+    `- Archived ${countLabel(report.archivedSessionArtifacts, "session artifact file")}.`,
+    "- Preserved Feishu App ID/secret config.",
+  ].join("\n");
+}
+
+function hasConfiguredFeishuChannel(cfg: OpenClawConfig): boolean {
+  return Boolean(cfg.channels?.feishu);
+}
+
+export async function runFeishuDoctorSequence(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  shouldRepair: boolean;
+}): Promise<ChannelDoctorSequenceResult> {
+  if (!hasConfiguredFeishuChannel(params.cfg)) {
+    return { changeNotes: [], warningNotes: [] };
+  }
+
+  const inspection = inspectFeishuDoctorState({ cfg: params.cfg, env: params.env });
+  if (inspection.findings.length === 0) {
+    return { changeNotes: [], warningNotes: [] };
+  }
+
+  if (!params.shouldRepair) {
+    return {
+      changeNotes: [],
+      warningNotes: [formatPreviewWarning(inspection)],
+    };
+  }
+
+  const report = await repairFeishuDoctorState({ cfg: params.cfg, env: params.env });
+  return {
+    changeNotes: [formatRepairChange(report)],
+    warningNotes: report.warnings,
+  };
+}
+
+export const feishuDoctor: ChannelDoctorAdapter = {
+  runConfigSequence: async ({ cfg, env, shouldRepair }) =>
+    await runFeishuDoctorSequence({ cfg, env, shouldRepair }),
+};


### PR DESCRIPTION
## Summary

- Problem: Feishu can keep reprocessing stale/corrupt local channel state or direct channel session entries, which can leave the gateway hot-looping after startup.
- Why it matters: Reinstalling the plugin or re-entering Feishu App ID/secret does not clear these local runtime/session files, so users can remain stuck with high CPU even when credentials are valid.
- What changed: Added a Feishu-owned doctor sequence that detects corrupt Feishu JSON state and suspicious Feishu direct session transcripts, then `openclaw doctor --fix` archives/rebuilds only Feishu local state and Feishu-scoped direct session entries.
- What did NOT change (scope boundary): This does not change Feishu credentials, App ID/secret config, network behavior, message handling, or ACP binding session entries.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74237
- Related #74237
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Feishu had persistent local runtime/session state that could become stale or corrupt independently from plugin installation and credentials. The channel did not have a doctor-owned repair path to rebuild that channel-local state while preserving configured App ID/secret values.
- Missing detection / guardrail: `openclaw doctor` did not inspect Feishu local state JSON or Feishu direct channel session transcript integrity, so the recovery step was manual and easy to over-delete.
- Contributing context (if known): A fresh plugin reinstall can still reuse existing `~/.openclaw/feishu` files and agent session store entries, so the problem is not solved by reinstalling the Feishu plugin alone.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `extensions/feishu/src/doctor.test.ts`
- Scenario the test should lock in: Feishu doctor stays quiet for healthy state, warns before repair for corrupt Feishu local JSON, and `--fix` archives Feishu local state plus direct Feishu session entries while preserving non-Feishu sessions and ACP binding session entries.
- Why this is the smallest reliable guardrail: The bug is in channel-local state repair behavior, so the test can cover the doctor sequence directly without requiring a live Feishu tenant.
- Existing test that already covers this (if any): None.
- If no new test is added, why not: N/A.

## User-visible / Behavior Changes

`openclaw doctor` can now warn when Feishu local channel state appears repairable. `openclaw doctor --fix` can archive/rebuild Feishu local runtime state and Feishu-scoped direct session entries while preserving Feishu App ID/secret config.

## Diagram (if applicable)

```text
Before:
[stale Feishu local state] -> [gateway restart] -> [same bad state reused]

After:
[openclaw doctor --fix] -> [archive Feishu state/session entries] -> [gateway rebuilds clean Feishu local state]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) Yes
- If any `Yes`, explain risk + mitigation: Feishu doctor now reads Feishu local state JSON and configured/discovered session stores under the OpenClaw state directory, and repair mode renames/removes only Feishu-scoped direct channel state. It creates timestamped backups and intentionally preserves Feishu App ID/secret config, non-Feishu sessions, and ACP binding session entries.

## Repro + Verification

### Environment

- OS: Linux VM observed during debugging; local tests run on macOS
- Runtime/container: OpenClaw CLI/gateway local mode
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): Feishu channel configured with App ID/secret; local Feishu state/session data present

### Steps

1. Configure Feishu and start the gateway.
2. Leave stale/corrupt Feishu local state or Feishu direct session entries on disk.
3. Restart the gateway.
4. Run `openclaw doctor` and then `openclaw doctor --fix`.

### Expected

- Doctor identifies Feishu-local repairable state.
- Repair archives Feishu-local state and Feishu-scoped direct session entries.
- Feishu App ID/secret config remains intact.
- Non-Feishu sessions and ACP binding session entries remain intact.

### Actual

- Before this PR, users had to manually delete Feishu local state/session files to recover.
- After this PR, doctor provides a scoped repair path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local verification:

```text
node --no-maglev node_modules/vitest/vitest.mjs run --config test/vitest/vitest.extension-feishu.config.ts extensions/feishu/src/doctor.test.ts
Test Files  1 passed (1)
Tests       4 passed (4)
```

```text
node_modules/.bin/oxfmt --check extensions/feishu/src/doctor.ts extensions/feishu/src/doctor.test.ts extensions/feishu/src/channel.ts
All matched files use the correct format.
```

```text
node_modules/.bin/oxlint extensions/feishu/src/doctor.ts extensions/feishu/src/doctor.test.ts extensions/feishu/src/channel.ts
Found 0 warnings and 0 errors.
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Healthy Feishu state is quiet; corrupt Feishu local JSON warns before repair; repair archives Feishu local state and direct Feishu sessions while preserving App ID/secret config, non-Feishu sessions, and ACP binding session entries.
- Edge cases checked: Legacy `feishu:*` session keys, `agent:<id>:feishu:*` session keys, ACP binding keys containing `feishu`, missing transcript paths, blank user message transcripts, local JSON parse failures.
- What you did **not** verify: Full `pnpm check` / `pnpm test`; this local checkout does not currently have `pnpm`/`corepack` available, and the broader Feishu channel test import path is missing `typebox` in `node_modules`.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A. Users affected by stale Feishu local state can run `openclaw doctor --fix`.

## Risks and Mitigations

- Risk: Repair could remove more Feishu session state than intended.
  - Mitigation: The repair only targets direct Feishu channel session keys (`feishu:*` and `agent:<id>:feishu:*`), explicitly preserves ACP binding Feishu session keys, backs up session stores, and archives transcript artifacts by renaming them instead of deleting them.
