### PR TITLE
fix(agents): route async media completions through wake media

### DIFF
--- a/src/agents/tools/media-generate-background-shared.ts
+++ b/src/agents/tools/media-generate-background-shared.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
-import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearAgentRunContext, registerAgentRunContext } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
@@ -230,8 +229,8 @@ function buildMediaGenerationReplyInstruction(params: {
   if (params.status === "ok") {
     return [
       `A completed ${params.completionLabel} generation task is ready for user delivery.`,
-      `Prefer the message tool for delivery: use action="send" to the current/original chat, put your user-facing caption in message, attach each generated file with path/filePath using the exact path from the result, then reply ONLY: ${SILENT_REPLY_TOKEN}.`,
-      `If you cannot use the message tool, reply in your normal assistant voice and include the exact MEDIA: lines from the result so OpenClaw attaches the finished ${params.completionLabel}.`,
+      "Reply in your normal assistant voice with a short caption; do not call the message tool for this completion.",
+      `OpenClaw already carries the generated ${params.completionLabel} as structured media for this wake. If structured media is unavailable on this surface, include the exact MEDIA: lines from the result as a fallback.`,
       "Keep internal task/session details private and do not copy the internal event text verbatim.",
     ].join(" ");
   }

--- a/src/agents/tools/media-generate-background.test-support.ts
+++ b/src/agents/tools/media-generate-background.test-support.ts
@@ -191,9 +191,18 @@ export function expectFallbackMediaAnnouncement({
           status: "ok",
           result: expect.stringContaining(resultMediaPath),
           mediaUrls,
-          replyInstruction: expect.stringContaining("Prefer the message tool for delivery"),
+          replyInstruction: expect.stringContaining(
+            "do not call the message tool for this completion",
+          ),
         }),
       ]),
     }),
   );
+
+  const call = (deliverAnnouncementMock as { mock: { calls: unknown[][] } }).mock.calls[0]?.[0] as
+    | { internalEvents?: Array<{ replyInstruction?: string }> }
+    | undefined;
+  const replyInstruction = call?.internalEvents?.[0]?.replyInstruction ?? "";
+  expect(replyInstruction).not.toContain("Prefer the message tool");
+  expect(replyInstruction).not.toContain("NO_REPLY");
 }


### PR DESCRIPTION
## Summary
- stop async media completion wakes from instructing the parent to call the message tool
- rely on structured media carried by the wake, with MEDIA lines only as fallback
- assert fallback instructions no longer mention message-tool delivery or NO_REPLY

## Tests
- pnpm vitest run src/agents/tools/music-generate-background.test.ts src/agents/tools/video-generate-background.test.ts
- pnpm vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts -t "attaches media from internal completion events"