### PR TITLE
fix(deepseek): strip reasoning_content when extra_body disables thinking

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -946,6 +946,42 @@ describe("applyExtraParamsToAgent", () => {
     expect(payload).not.toHaveProperty("store");
   });
 
+  it("strips reasoning_content when extra_body sets thinking to disabled (#74374)", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "deepseek",
+      applyModelId: "deepseek-v4-pro",
+      cfg: {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: {
+                  extra_body: { thinking: { type: "disabled" } },
+                },
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-completions",
+        provider: "deepseek",
+        id: "deepseek-v4-pro",
+        baseUrl: "https://api.deepseek.com",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi", reasoning_content: "let me think" },
+        ],
+      },
+    });
+
+    expect(payload.thinking).toEqual({ type: "disabled" });
+    const messages = payload.messages as Record<string, unknown>[];
+    expect(messages[1]).not.toHaveProperty("reasoning_content");
+  });
+
   it("forwards chat_template_kwargs params as top-level openai-completions payload fields", () => {
     const payload = runResponsesPayloadMutationCase({
       applyProvider: "vllm",

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -504,6 +504,23 @@ function createOpenAICompletionsExtraBodyWrapper(
         log.warn(`extra_body overwriting request payload keys: ${collisions.join(", ")}`);
       }
       Object.assign(payloadObj, extraBody);
+
+      // When extra_body sets thinking to disabled after a provider wrapper may have
+      // backfilled reasoning_content, strip it to avoid DeepSeek 400 errors.
+      // See: https://github.com/openclaw/openclaw/issues/74374
+      const thinking = payloadObj.thinking;
+      if (
+        thinking &&
+        typeof thinking === "object" &&
+        (thinking as Record<string, unknown>).type === "disabled" &&
+        Array.isArray(payloadObj.messages)
+      ) {
+        for (const message of payloadObj.messages) {
+          if (message && typeof message === "object") {
+            delete (message as Record<string, unknown>).reasoning_content;
+          }
+        }
+      }
     });
   };
 }


### PR DESCRIPTION
## Root Cause

The `extra_body` wrapper (`createOpenAICompletionsExtraBodyWrapper`) runs **after** the DeepSeek V4 provider wrapper. When `thinkingLevel` is not explicitly `off`/`none` (e.g. user sets `params.thinking: false` which isn't recognized as a string level), the provider wrapper backfills `reasoning_content: ""` on assistant messages and sets `thinking: { type: "enabled" }`. Then `extra_body` overwrites `thinking` to `{ type: "disabled" }`, leaving stale `reasoning_content` on messages — causing DeepSeek to reject with 400.

## Fix

After applying `extra_body` to the payload, check if the resulting `thinking.type === "disabled"`. If so, strip `reasoning_content` from all messages in the payload. This ensures no provider-wrapper backfill or model-response remnant leaks into a disabled-thinking request.

## Changed Files

- `src/agents/pi-embedded-runner/extra-params.ts` — strip logic after `Object.assign(payloadObj, extraBody)`
- `src/agents/pi-embedded-runner-extraparams.test.ts` — regression test

Fixes #74374