### PR TITLE
fix(onboard): clarify keyed vs keyless skill setup prompts

### DIFF
--- a/extensions/discord/api.ts
+++ b/extensions/discord/api.ts
@@ -15,7 +15,6 @@ export {
   resolveDiscordGroupRequireMention,
   resolveDiscordGroupToolPolicy,
 } from "./src/group-policy.js";
-export { resolveDiscordRuntimeGroupPolicy } from "./src/runtime-group-policy.js";
 export {
   looksLikeDiscordTargetId,
   normalizeDiscordMessagingTarget,

--- a/extensions/discord/api.ts
+++ b/extensions/discord/api.ts
@@ -15,6 +15,7 @@ export {
   resolveDiscordGroupRequireMention,
   resolveDiscordGroupToolPolicy,
 } from "./src/group-policy.js";
+export { resolveDiscordRuntimeGroupPolicy } from "./src/runtime-group-policy.js";
 export {
   looksLikeDiscordTargetId,
   normalizeDiscordMessagingTarget,

--- a/src/commands/onboard-skills.test.ts
+++ b/src/commands/onboard-skills.test.ts
@@ -186,4 +186,107 @@ describe("setupSkills", () => {
     const brewNote = notes.find((n) => n.title === "Homebrew recommended");
     expect(brewNote).toBeDefined();
   });
+
+  it("separates keyless dependency installs from keyed credential prompts", async () => {
+    mocks.detectBinary.mockResolvedValue(true);
+    mocks.installSkill.mockResolvedValue({
+      ok: true,
+      message: "Installed",
+      stdout: "",
+      stderr: "",
+      code: 0,
+    });
+    mocks.buildWorkspaceSkillStatus.mockReturnValue({
+      workspaceDir: "/tmp/ws",
+      managedSkillsDir: "/tmp/managed",
+      skills: [
+        {
+          ...createBundledSkill({
+            name: "openai-whisper",
+            description: "Local Whisper transcription (no API key required)",
+            bins: ["whisper"],
+            installLabel: "Install whisper",
+          }),
+          skillKey: "openai-whisper",
+          primaryEnv: undefined,
+          missing: { bins: ["whisper"], anyBins: [], env: [], config: [], os: [] },
+        },
+        {
+          ...createBundledSkill({
+            name: "openai-whisper-api",
+            description: "Cloud Whisper API",
+            bins: ["curl"],
+            installLabel: "Install curl",
+          }),
+          skillKey: "openai-whisper-api",
+          primaryEnv: "OPENAI_API_KEY",
+          missing: {
+            bins: ["curl"],
+            anyBins: [],
+            env: ["OPENAI_API_KEY"],
+            config: [],
+            os: [],
+          },
+        },
+        {
+          ...createBundledSkill({
+            name: "sag",
+            description: "Speech generation",
+            bins: ["ffmpeg"],
+            installLabel: "Install ffmpeg",
+          }),
+          skillKey: "sag",
+          primaryEnv: "ELEVENLABS_API_KEY",
+          missing: {
+            bins: ["ffmpeg"],
+            anyBins: [],
+            env: ["ELEVENLABS_API_KEY"],
+            config: [],
+            os: [],
+          },
+        },
+      ],
+    } as never);
+
+    const notes: Array<{ title?: string; message: string }> = [];
+    const confirmMessages: string[] = [];
+    const promptTexts: string[] = [];
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async (message: string, title?: string) => {
+        notes.push({ title, message });
+      }),
+      select: vi.fn(async () => "npm") as unknown as WizardPrompter["select"],
+      multiselect: vi.fn(async () => ["__skip__"]) as unknown as WizardPrompter["multiselect"],
+      text: vi.fn(async ({ message }: { message: string }) => {
+        promptTexts.push(message);
+        return "secret";
+      }) as unknown as WizardPrompter["text"],
+      confirm: vi.fn(async ({ message }: { message: string }) => {
+        confirmMessages.push(message);
+        if (message === "Configure skills now? (recommended)") {
+          return true;
+        }
+        if (message.startsWith("Set OPENAI_API_KEY")) {
+          return true;
+        }
+        return false;
+      }) as unknown as WizardPrompter["confirm"],
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    await setupSkills({} as OpenClawConfig, "/tmp/ws", runtime, prompter);
+
+    const credentialNote = notes.find((entry) => entry.title === "Skill credentials");
+    expect(credentialNote?.message).toContain("openai-whisper-api: OPENAI_API_KEY");
+    expect(credentialNote?.message).toContain("sag: ELEVENLABS_API_KEY");
+    expect(credentialNote?.message).not.toContain("openai-whisper:");
+
+    expect(confirmMessages).toContain("Set OPENAI_API_KEY for openai-whisper-api?");
+    expect(confirmMessages).toContain("Set ELEVENLABS_API_KEY for sag?");
+    expect(confirmMessages).not.toContain("Set OPENAI_API_KEY for openai-whisper?");
+    expect(promptTexts).toContain("Enter OPENAI_API_KEY");
+    expect(promptTexts).not.toContain("Enter ELEVENLABS_API_KEY");
+  });
 });

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -47,10 +47,6 @@ function upsertSkillEntry(
   };
 }
 
-function formatCredentialSetupMessage(skill: { name: string; primaryEnv: string }): string {
-  return `Set ${skill.primaryEnv} for ${skill.name}?`;
-}
-
 export async function setupSkills(
   cfg: OpenClawConfig,
   workspaceDir: string,
@@ -220,10 +216,7 @@ export async function setupSkills(
 
   for (const skill of missingCredentialSkills) {
     const wantsKey = await prompter.confirm({
-      message: formatCredentialSetupMessage({
-        name: skill.name,
-        primaryEnv: skill.primaryEnv as string,
-      }),
+      message: `Set ${skill.primaryEnv} for ${skill.name}?`,
       initialValue: false,
     });
     if (!wantsKey) {

--- a/src/commands/onboard-skills.ts
+++ b/src/commands/onboard-skills.ts
@@ -47,6 +47,10 @@ function upsertSkillEntry(
   };
 }
 
+function formatCredentialSetupMessage(skill: { name: string; primaryEnv: string }): string {
+  return `Set ${skill.primaryEnv} for ${skill.name}?`;
+}
+
 export async function setupSkills(
   cfg: OpenClawConfig,
   workspaceDir: string,
@@ -198,12 +202,28 @@ export async function setupSkills(
     }
   }
 
-  for (const skill of missing) {
-    if (!skill.primaryEnv || skill.missing.env.length === 0) {
-      continue;
-    }
+  const missingCredentialSkills = missing.filter(
+    (skill) => Boolean(skill.primaryEnv) && skill.missing.env.length > 0,
+  );
+  if (missingCredentialSkills.length > 0) {
+    await prompter.note(
+      [
+        "Credential setup is separate from dependency installation.",
+        "You'll only be prompted for skills that explicitly require environment secrets:",
+        ...missingCredentialSkills.map(
+          (skill) => `- ${skill.name}: ${skill.primaryEnv ?? skill.missing.env[0] ?? "secret"}`,
+        ),
+      ].join("\n"),
+      "Skill credentials",
+    );
+  }
+
+  for (const skill of missingCredentialSkills) {
     const wantsKey = await prompter.confirm({
-      message: `Set ${skill.primaryEnv} for ${skill.name}?`,
+      message: formatCredentialSetupMessage({
+        name: skill.name,
+        primaryEnv: skill.primaryEnv as string,
+      }),
       initialValue: false,
     });
     if (!wantsKey) {


### PR DESCRIPTION
Made-with: Cursor

## Summary

- Problem: `openclaw onboard` can show keyless skill dependency install options (for example local `openai-whisper`) and later ask for API keys for different keyed skills, which is easy to misread as contradictory.
- Why it matters: Users may think onboarding is requesting unnecessary secrets, reducing trust and increasing setup friction.
- What changed: Added a dedicated "Skill credentials" note that explicitly separates dependency installation from credential setup, and lists only skills that actually require env secrets.
- What did NOT change: No skill capability semantics changed; no security ACL logic changed; no install backend behavior changed.

## Linked Issue/PR

- Closes #74382
- Related #74382
- [x] This PR fixes a bug or regression

## Root Cause

- Root cause: Onboarding mixed install and credential steps without an explicit transition note, so keyless/keyed skills appeared conflated in the user flow.
- Missing guardrail: No regression test covered a mixed keyless (`openai-whisper`) + keyed (`openai-whisper-api`, `sag`) scenario.

## Regression Test Plan

- Coverage: Unit test
- Target: `src/commands/onboard-skills.test.ts`
- Scenario: Mixed keyless + keyed skills only prompts for keyed env vars and shows a credentials summary note.

## User-visible / Behavior Changes

- Onboarding now shows a "Skill credentials" note before secret prompts.
- Secret prompts only target skills with missing required env vars.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No (prompt clarity only)
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No