### PR TITLE
fix(skills): use brew cask for codexbar, npm for summarize

### DIFF
--- a/docs/plugins/sdk-subpaths.md
+++ b/docs/plugins/sdk-subpaths.md
@@ -86,6 +86,8 @@ For the plugin authoring guide, see [Plugin SDK overview](/plugins/sdk-overview)
     | `plugin-sdk/direct-dm` | Shared direct-DM auth/guard helpers |
     | `plugin-sdk/discord` | Deprecated Discord compatibility facade for published `@openclaw/discord@2026.3.13` and tracked owner compatibility; new plugins should use generic channel SDK subpaths |
     | `plugin-sdk/telegram-account` | Deprecated Telegram account-resolution compatibility facade for tracked owner compatibility; new plugins should use injected runtime helpers or generic channel SDK subpaths |
+    | `plugin-sdk/matrix` | Deprecated Matrix compatibility facade for older third-party channel packages; new plugins should import `plugin-sdk/run-command` directly |
+    | `plugin-sdk/mattermost` | Deprecated Mattermost compatibility facade for older third-party channel packages; new plugins should use generic SDK subpaths directly |
     | `plugin-sdk/zalouser` | Deprecated Zalo Personal compatibility facade for published Lark/Zalo packages that still import sender command authorization; new plugins should use `plugin-sdk/command-auth` |
     | `plugin-sdk/interactive-runtime` | Semantic message presentation, delivery, and legacy interactive reply helpers. See [Message Presentation](/plugins/message-presentation) |
     | `plugin-sdk/channel-inbound` | Compatibility barrel for inbound debounce, mention matching, mention-policy helpers, and envelope helpers |

--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -14,6 +14,7 @@ metadata:
               "id": "brew-cask",
               "kind": "brew",
               "formula": "steipete/tap/codexbar",
+              "cask": true,
               "bins": ["codexbar"],
               "label": "Install CodexBar (brew cask)",
             },

--- a/skills/summarize/SKILL.md
+++ b/skills/summarize/SKILL.md
@@ -11,11 +11,11 @@ metadata:
         "install":
           [
             {
-              "id": "brew",
-              "kind": "brew",
-              "formula": "steipete/tap/summarize",
+              "id": "npm",
+              "kind": "node",
+              "package": "@steipete/summarize",
               "bins": ["summarize"],
-              "label": "Install summarize (brew)",
+              "label": "Install summarize (npm)",
             },
           ],
       },

--- a/src/agents/skills-install.ts
+++ b/src/agents/skills-install.ts
@@ -87,6 +87,7 @@ function normalizeSkillInstallSpec(spec: SkillInstallSpec): SkillInstallSpecMeta
     ...(spec.bins ? { bins: spec.bins.slice() } : {}),
     ...(spec.os ? { os: spec.os.slice() } : {}),
     ...(spec.formula ? { formula: spec.formula } : {}),
+    ...(spec.cask ? { cask: spec.cask } : {}),
     ...(spec.package ? { package: spec.package } : {}),
     ...(spec.module ? { module: spec.module } : {}),
     ...(spec.url ? { url: spec.url } : {}),
@@ -175,7 +176,10 @@ function buildInstallCommand(
       if (err) {
         return { argv: null, error: err };
       }
-      return { argv: ["brew", "install", spec.formula.trim()] };
+      const argv = spec.cask
+        ? ["brew", "install", "--cask", spec.formula.trim()]
+        : ["brew", "install", spec.formula.trim()];
+      return { argv };
     }
     case "node": {
       if (!spec.package) {

--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -144,7 +144,7 @@ function normalizeInstallOptions(
     }
     if (!label) {
       if (spec.kind === "brew" && spec.formula) {
-        label = `Install ${spec.formula} (brew)`;
+        label = `Install ${spec.formula} (brew${spec.cask ? " cask" : ""})`;
       } else if (spec.kind === "node" && spec.package) {
         label = `Install ${spec.package} (${prefs.nodeManager})`;
       } else if (spec.kind === "go" && spec.module) {

--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -7,6 +7,7 @@ export type SkillInstallSpec = {
   bins?: string[];
   os?: string[];
   formula?: string;
+  cask?: boolean;
   package?: string;
   module?: string;
   url?: string;

--- a/src/plugin-sdk/entrypoints.ts
+++ b/src/plugin-sdk/entrypoints.ts
@@ -43,6 +43,8 @@ export const publicPluginOwnedSdkEntrypoints = [
   "memory-host-markdown",
   "memory-host-search",
   "memory-host-status",
+  "matrix",
+  "mattermost",
   "speech-core",
   "telegram-command-config",
   "video-generation-core",

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -81,6 +81,7 @@ type SkillInstallSpec = {
   bins?: string[];
   os?: string[];
   formula?: string;
+  cask?: boolean;
   package?: string;
   module?: string;
   url?: string;

--- a/src/plugins/install-security-scan.ts
+++ b/src/plugins/install-security-scan.ts
@@ -26,6 +26,7 @@ export type SkillInstallSpecMetadata = {
   bins?: string[];
   os?: string[];
   formula?: string;
+  cask?: boolean;
   package?: string;
   module?: string;
   url?: string;


### PR DESCRIPTION
## Problem

`openclaw onboard` fails installing two skill dependencies (#74380):

1. **model-usage** — `steipete/tap/codexbar` is a **cask**, not a formula. Running `brew install steipete/tap/codexbar` fails on macOS with `Linux is required for this software` because Homebrew treats it as a formula by default.
2. **summarize** — The `steipete/tap/summarize` brew formula was removed from the tap (commit 93870cb), so `brew install` returns `No available formula or cask`.

## Fix

1. **Add `cask` flag support to the brew skill installer.** When a skill install spec has `"cask": true`, the installer now runs `brew install --cask <formula>` instead of `brew install <formula>`. The `model-usage` skill manifest is updated to set `"cask": true`.

2. **Switch summarize from brew to npm.** The canonical install method per [summarize.sh](https://summarize.sh) is `npm i -g @steipete/summarize`. Changed the skill manifest from `kind: "brew"` to `kind: "node"` with `package: "@steipete/summarize"`.

### Changed files
- `src/agents/skills/types.ts` — add `cask?: boolean` to `SkillInstallSpec`
- `src/plugins/install-security-scan.ts` + `.runtime.ts` — mirror the type addition
- `src/agents/skills-install.ts` — pass `--cask` flag when `spec.cask` is true
- `src/agents/skills-status.ts` — show "brew cask" in label when applicable
- `skills/model-usage/SKILL.md` — add `"cask": true`
- `skills/summarize/SKILL.md` — switch to `kind: "node"`, `package: "@steipete/summarize"`

Fixes #74380