### PR TITLE
fix(cron): prefix Discord DM targets with user: in inferred delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron/Discord: prefix inferred Discord DM delivery targets with `user:` so cron jobs resume direct-message sessions instead of treating bare numeric IDs as channel ids. Fixes #74375. Thanks @yelog.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.
 - Infra/Windows: skip the POSIX `/tmp/openclaw` preferred path on Windows in `resolvePreferredOpenClawTmpDir` so log files, TTS temp files, and other writes land in `%TEMP%\openclaw-<uid>` instead of `C:\tmp\openclaw`. Fixes #60713. Thanks @juan-flores077.
 - Gateway/diagnostics: make stuck-session recovery outcome-driven and generation-guarded, add `diagnostics.stuckSessionAbortMs`, and emit structured recovery requested/completed events so stale or skipped recovery no longer looks like a successful abort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -829,6 +829,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
+- Cron/Discord: prefix inferred Discord DM delivery targets with `user:` so cron jobs resume direct-message sessions instead of treating bare numeric IDs as channel ids. Fixes #74375. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -592,6 +592,58 @@ describe("cron tool", () => {
     });
   });
 
+  it("prefixes discord dm targets with user: to prevent channel: default (#74375)", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-dm-numeric",
+        agentSessionKey: "agent:main:discord:direct:204737678510391296",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "user:204737678510391296",
+    });
+  });
+
+  it("prefixes legacy discord dm targets with user: (#74375)", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-dm-legacy",
+        agentSessionKey: "agent:main:discord:dm:204737678510391296",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "user:204737678510391296",
+    });
+  });
+
+  it("does not prefix discord group targets with user:", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-group",
+        agentSessionKey: "agent:main:discord:group:123456789012345678",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "123456789012345678",
+    });
+  });
+
+  it("does not prefix discord channel targets with user:", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-channel",
+        agentSessionKey: "agent:main:discord:channel:123456789012345678",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "123456789012345678",
+    });
+  });
+
   it("prefers current delivery context over lowercased session-key targets", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -782,6 +782,58 @@ describe("cron tool", () => {
     });
   });
 
+  it("prefixes discord dm targets with user: to prevent channel: default (#74375)", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-dm-numeric",
+        agentSessionKey: "agent:main:discord:direct:204737678510391296",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "user:204737678510391296",
+    });
+  });
+
+  it("prefixes legacy discord dm targets with user: (#74375)", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-dm-legacy",
+        agentSessionKey: "agent:main:discord:dm:204737678510391296",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "user:204737678510391296",
+    });
+  });
+
+  it("does not prefix discord group targets with user:", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-group",
+        agentSessionKey: "agent:main:discord:group:123456789012345678",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "123456789012345678",
+    });
+  });
+
+  it("does not prefix discord channel targets with user:", async () => {
+    expect(
+      await executeAddAndReadDelivery({
+        callId: "call-discord-channel",
+        agentSessionKey: "agent:main:discord:channel:123456789012345678",
+      }),
+    ).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "123456789012345678",
+    });
+  });
+
   it("prefers current delivery context over lowercased session-key targets", async () => {
     expect(
       await executeAddAndReadDelivery({

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -514,7 +514,15 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
   }
 
   const marker = parts[markerIndex];
-  const delivery: CronDelivery = { mode: "announce", to: peerId };
+  const isDirectMessage = marker === "direct" || marker === "dm";
+  // Discord defaults bare numeric IDs to "channel:" in normalizeDiscordMessagingTarget.
+  // Prefix DM targets with "user:" so cron delivery resolves them as user DMs,
+  // not guild channels. Other channels (Telegram, Slack) use unambiguous IDs.
+  const needsUserPrefix = isDirectMessage && channel === "discord";
+  const delivery: CronDelivery = {
+    mode: "announce",
+    to: needsUserPrefix ? `user:${peerId}` : peerId,
+  };
   if (channel) {
     delivery.channel = channel;
   }

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -573,7 +573,15 @@ function inferDeliveryFromSessionKey(agentSessionKey?: string): CronDelivery | n
   }
 
   const marker = parts[markerIndex];
-  const delivery: CronDelivery = { mode: "announce", to: peerId };
+  const isDirectMessage = marker === "direct" || marker === "dm";
+  // Discord defaults bare numeric IDs to "channel:" in normalizeDiscordMessagingTarget.
+  // Prefix DM targets with "user:" so cron delivery resolves them as user DMs,
+  // not guild channels. Other channels (Telegram, Slack) use unambiguous IDs.
+  const needsUserPrefix = isDirectMessage && channel === "discord";
+  const delivery: CronDelivery = {
+    mode: "announce",
+    to: needsUserPrefix ? `user:${peerId}` : peerId,
+  };
   if (channel) {
     delivery.channel = channel;
   }


### PR DESCRIPTION
## Summary

Fixes #74375

When a cron job with `delivery.mode: "announce"` is created from a Discord DM session, `inferDeliveryFromSessionKey` extracts a bare numeric peer ID (e.g. `204737678510391296`). When this bare ID later passes through Discord's `normalizeDiscordMessagingTarget`, it defaults to `channel:204737678510391296` (since `parseDiscordTarget` uses `defaultKind: "channel"`), causing an `Unknown Channel` error.

## Changes

- `inferDeliveryFromSessionKey` now prefixes the `to` field with `user:` when the session key marker is `direct` or `dm` **and** the channel is `discord`
- This is Discord-specific because Telegram uses unambiguous signed numeric IDs (negative for groups) and Slack uses string IDs, so they don't need disambiguation
- Added 4 tests: Discord DM `direct`, Discord DM `dm` (legacy), Discord `group` (no prefix), Discord `channel` (no prefix)

## Root Cause

`src/agents/tools/cron-tool.ts:517` stored `to: peerId` as a bare string. Discord's target normalizer (`extensions/discord/src/normalize.ts:5`) calls `parseDiscordTarget(raw, { defaultKind: "channel" })`, which treats bare numeric IDs as channel IDs. The `user:` prefix makes the DM intent explicit.