### PR TITLE
fix(agents): recognize params.thinking=false and "disabled"/"none" as thinking=off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/DeepSeek: treat `params.thinking: false`, `disabled`, and `none` as thinking off so DeepSeek V4 models do not fall back to provider-default reasoning. Fixes #74374. Thanks @yelog.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.
 - Infra/Windows: skip the POSIX `/tmp/openclaw` preferred path on Windows in `resolvePreferredOpenClawTmpDir` so log files, TTS temp files, and other writes land in `%TEMP%\openclaw-<uid>` instead of `C:\tmp\openclaw`. Fixes #60713. Thanks @juan-flores077.
 - Gateway/diagnostics: make stuck-session recovery outcome-driven and generation-guarded, add `diagnostics.stuckSessionAbortMs`, and emit structured recovery requested/completed events so stale or skipped recovery no longer looks like a successful abort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2645,6 +2645,7 @@ Docs: https://docs.openclaw.ai
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
+- Agents/DeepSeek: treat `params.thinking: false`, `disabled`, and `none` as thinking off so DeepSeek V4 models do not fall back to provider-default reasoning. Fixes #74374. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2645,7 +2645,6 @@ Docs: https://docs.openclaw.ai
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
 - Agents/OpenAI: honor `compat.supportsTools: false` for OpenAI Completions models so chat-only compatible endpoints do not receive `tools`, `tool_choice`, or tool-history fallback payloads. Fixes #74664. Thanks @yelog.
-- Agents/DeepSeek: treat `params.thinking: false`, `disabled`, and `none` as thinking off so DeepSeek V4 models do not fall back to provider-default reasoning. Fixes #74374. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -1651,6 +1651,72 @@ describe("model-selection", () => {
       expect(resolveAnthropicOpusThinking(cfg)).toBe("adaptive");
     });
 
+    it("treats params.thinking=false as off (#74374)", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: false },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
+    it('treats params.thinking="disabled" as off (#74374)', () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: "disabled" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
+    it('treats params.thinking="none" as off', () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: "none" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
     it("keeps thinking off by default for explicitly configured Anthropic Opus 4.7", () => {
       const cfg = {
         agents: {

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -2529,6 +2529,72 @@ describe("model-selection", () => {
       expect(resolveAnthropicOpusThinking(cfg)).toBe("adaptive");
     });
 
+    it("treats params.thinking=false as off (#74374)", () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: false },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
+    it('treats params.thinking="disabled" as off (#74374)', () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: "disabled" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
+    it('treats params.thinking="none" as off', () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            models: {
+              "deepseek/deepseek-v4-pro": {
+                params: { thinking: "none" },
+              },
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      expect(
+        resolveThinkingDefault({
+          cfg,
+          provider: "deepseek",
+          model: "deepseek-v4-pro",
+        }),
+      ).toBe("off");
+    });
+
     it("keeps thinking off by default for explicitly configured Anthropic Opus 4.7", () => {
       const cfg = {
         agents: {

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -39,6 +39,14 @@ export function resolveThinkingDefault(params: {
   const perModelThinking =
     configuredModels?.[canonicalKey]?.params?.thinking ??
     (legacyKey ? configuredModels?.[legacyKey]?.params?.thinking : undefined);
+  // Accept boolean false and common disable aliases as "off".
+  if (
+    perModelThinking === false ||
+    perModelThinking === "disabled" ||
+    perModelThinking === "none"
+  ) {
+    return "off";
+  }
   if (
     perModelThinking === "off" ||
     perModelThinking === "minimal" ||

--- a/src/agents/model-thinking-default.ts
+++ b/src/agents/model-thinking-default.ts
@@ -41,6 +41,14 @@ export function resolveThinkingDefault(params: {
   const perModelThinking =
     configuredModels?.[canonicalKey]?.params?.thinking ??
     (legacyKey ? configuredModels?.[legacyKey]?.params?.thinking : undefined);
+  // Accept boolean false and common disable aliases as "off".
+  if (
+    perModelThinking === false ||
+    perModelThinking === "disabled" ||
+    perModelThinking === "none"
+  ) {
+    return "off";
+  }
   if (
     perModelThinking === "off" ||
     perModelThinking === "minimal" ||

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -145,6 +145,43 @@ describe("createModelSelectionState catalog loading", () => {
     expect(loadModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("keeps per-model disabled params.thinking ahead of global thinkingDefault", async () => {
+    vi.mocked(loadModelCatalog).mockClear();
+    const cfg = {
+      agents: {
+        defaults: {
+          thinkingDefault: "low",
+          models: {
+            "deepseek/deepseek-v4-pro": {
+              params: { thinking: false },
+            },
+          },
+        },
+      },
+      models: {
+        providers: {
+          deepseek: {
+            baseUrl: "https://api.deepseek.com/v1",
+            models: [makeConfiguredModel({ id: "deepseek-v4-pro", name: "DeepSeek V4 Pro" })],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const state = await createModelSelectionState({
+      cfg,
+      agentCfg: cfg.agents?.defaults,
+      defaultProvider: "deepseek",
+      defaultModel: "deepseek-v4-pro",
+      provider: "deepseek",
+      model: "deepseek-v4-pro",
+      hasModelDirective: false,
+    });
+
+    await expect(state.resolveDefaultThinkingLevel()).resolves.toBe("off");
+    expect(loadModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("uses the implicit model default when no global thinking default is configured", async () => {
     vi.mocked(loadModelCatalog).mockClear();
     const cfg = {

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -470,6 +470,14 @@ export async function createModelSelectionState(params: {
       configuredModels?.[canonicalKey]?.params?.thinking ??
       (legacyKey ? configuredModels?.[legacyKey]?.params?.thinking : undefined);
     if (
+      configuredModelThinkingDefault === false ||
+      configuredModelThinkingDefault === "disabled" ||
+      configuredModelThinkingDefault === "none"
+    ) {
+      defaultThinkingLevel = "off";
+      return defaultThinkingLevel;
+    }
+    if (
       configuredModelThinkingDefault === "off" ||
       configuredModelThinkingDefault === "minimal" ||
       configuredModelThinkingDefault === "low" ||


### PR DESCRIPTION
## Summary

Fixes #74374

`resolveThinkingDefault` only recognized string values like `"off"`, `"low"`, `"high"`, etc. for per-model `params.thinking`. When a user configured `params.thinking: false` (boolean) or `params.thinking: "disabled"` — both common ways to express "no thinking" — the value fell through to the model/provider default (e.g. `"high"` for DeepSeek v4-pro).

This caused the DeepSeek thinking stream wrapper to inject `reasoning_content` into assistant messages and set `thinking: { type: "enabled" }`. If the user also configured `extra_body: { thinking: { type: "disabled" } }`, the `extra_body` wrapper then overwrote `thinking` to `disabled` — but `reasoning_content` was already in the messages. DeepSeek's API rejects this inconsistent state with:

> 400 "reasoning_content must be passed back"

## Changes

- `resolveThinkingDefault` now treats `false`, `"disabled"`, and `"none"` as `"off"`
- Added 3 tests for each alias (DeepSeek v4-pro model config)

## Root Cause

`src/agents/model-thinking-default.ts:42-52` only matched string values against the known thinking levels. Boolean `false` and aliases like `"disabled"` / `"none"` were not handled, causing them to fall through to the provider default. The DeepSeek V4 wrapper (`createDeepSeekV4OpenAICompatibleThinkingWrapper`) already handles `"none"` correctly at the stream level, but it was never reached because `thinkingLevel` was resolved to the wrong value upstream.

## Real behavior proof

Behavior addressed: DeepSeek V4 has provider default thinking `high`, but model-level disabled aliases must resolve to OpenClaw thinking `off` before request payload shaping.
Real environment tested: local OpenClaw source checkout using fork PR head `676e44b3db5b73dbd564221a2b023e708ea419a5`.
Exact steps or command run after this patch:

```text
node --import tsx -e '<script imports resolveThinkingDefault, defines a DeepSeek V4 catalog default of high, sets agents.defaults.models["deepseek/deepseek-v4-pro"].params.thinking to false/disabled/none, and prints only resolved levels>'
```

Evidence after fix:

```json
{
  "branch": "fork/fix/deepseek-v4-thinking-false-74374",
  "head": "676e44b3db5b73dbd564221a2b023e708ea419a5",
  "command": "node --import tsx resolveThinkingDefault proof",
  "providerDefault": "high",
  "cases": [
    {
      "input": false,
      "resolved": "off"
    },
    {
      "input": "disabled",
      "resolved": "off"
    },
    {
      "input": "none",
      "resolved": "off"
    }
  ]
}
```

Observed result after fix: all three disabled aliases resolve to `off` instead of falling through to the provider default `high`.
What was not tested: No live DeepSeek HTTP request was sent; this proof exercises the production thinking resolver locally and avoids printing prompts, credentials, or provider responses.
