### PR TITLE
fix(openai): honor OPENAI_BASE_URL when no provider config sets a baseUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- OpenAI: honor `OPENAI_BASE_URL` environment variable for GPT forward-compatible dynamic model fallbacks when no explicit provider `baseUrl` is configured. Thanks @sunapi386.
 - gateway: pass Talk session scope to resolver [AI]. (#81379) Thanks @pgondhi987.
 - Gateway protocol: require v4 clients and stream explicit chat `deltaText`/`replace` frames so SDK clients can consume assistant updates without local diffing. (#80725) Thanks @samzong.
 - OpenAI plugin: clarify remote Codex OAuth login copy so tunneled users know sign-in may finish automatically before they paste the redirect URL. (#81301) Thanks @rubencu.

--- a/extensions/openai/base-url.test.ts
+++ b/extensions/openai/base-url.test.ts
@@ -4,6 +4,8 @@ import {
   isOpenAIApiBaseUrl,
   isOpenAICodexBaseUrl,
   OPENAI_CODEX_RESPONSES_BASE_URL,
+  OPENAI_DEFAULT_BASE_URL,
+  resolveOpenAIDefaultBaseUrl,
 } from "./base-url.js";
 
 describe("openai base URL helpers", () => {
@@ -40,6 +42,15 @@ describe("openai base URL helpers", () => {
     expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/v2")).toBe(false);
     expect(isOpenAICodexBaseUrl("https://chatgpt.com/backend-api/codex/v2")).toBe(false);
     expect(isOpenAICodexBaseUrl(undefined)).toBe(false);
+  });
+
+  it("resolves the default OpenAI base URL", () => {
+    expect(resolveOpenAIDefaultBaseUrl({})).toBe(OPENAI_DEFAULT_BASE_URL);
+    expect(resolveOpenAIDefaultBaseUrl({ OPENAI_BASE_URL: "" })).toBe(OPENAI_DEFAULT_BASE_URL);
+    expect(resolveOpenAIDefaultBaseUrl({ OPENAI_BASE_URL: "   " })).toBe(OPENAI_DEFAULT_BASE_URL);
+    expect(resolveOpenAIDefaultBaseUrl({ OPENAI_BASE_URL: "https://proxy.example.com/v1" })).toBe(
+      "https://proxy.example.com/v1",
+    );
   });
 
   it("canonicalizes legacy Codex Responses base URLs", () => {

--- a/extensions/openai/base-url.ts
+++ b/extensions/openai/base-url.ts
@@ -1,6 +1,22 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 
+export const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 export const OPENAI_CODEX_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/codex";
+
+/**
+ * Resolve the default OpenAI base URL for the dynamic-model registry.
+ * Honors OPENAI_BASE_URL when no provider config sets a baseUrl, mirroring
+ * the OpenAI Node SDK's own env-var precedence so users running OpenClaw
+ * behind an OpenAI-compatible proxy (LiteLLM, vLLM, AEP, etc.) only need to
+ * set the env var instead of duplicating it in models.providers.openai.baseUrl.
+ *
+ * Provider-config baseUrl still wins over the env var because the resolver
+ * (src/agents/pi-embedded-runner/model.ts) prefers providerConfig.baseUrl
+ * before consulting discoveredModel.baseUrl.
+ */
+export function resolveOpenAIDefaultBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeOptionalString(env.OPENAI_BASE_URL) ?? OPENAI_DEFAULT_BASE_URL;
+}
 
 export function isOpenAIApiBaseUrl(baseUrl?: string): boolean {
   const trimmed = normalizeOptionalString(baseUrl);

--- a/extensions/openai/base-url.ts
+++ b/extensions/openai/base-url.ts
@@ -1,6 +1,22 @@
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 
+export const OPENAI_DEFAULT_BASE_URL = "https://api.openai.com/v1";
 export const OPENAI_CODEX_RESPONSES_BASE_URL = "https://chatgpt.com/backend-api/codex";
+
+/**
+ * Resolve the default OpenAI base URL for the dynamic-model registry.
+ * Honors OPENAI_BASE_URL when no provider config sets a baseUrl, mirroring
+ * the OpenAI Node SDK's own env-var precedence so users running OpenClaw
+ * behind an OpenAI-compatible proxy (LiteLLM, vLLM, AEP, etc.) only need to
+ * set the env var instead of duplicating it in models.providers.openai.baseUrl.
+ *
+ * Provider-config baseUrl still wins over the env var because the resolver
+ * (src/agents/pi-embedded-runner/model.ts) prefers providerConfig.baseUrl
+ * before consulting discoveredModel.baseUrl.
+ */
+export function resolveOpenAIDefaultBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  return normalizeOptionalString(env.OPENAI_BASE_URL) ?? OPENAI_DEFAULT_BASE_URL;
+}
 
 export function isOpenAIApiBaseUrl(baseUrl?: string): boolean {
   const trimmed = normalizeOptionalString(baseUrl);

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -11,7 +11,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { OPENAI_API_KEY_LABEL, OPENAI_API_KEY_WIZARD_GROUP } from "./auth-choice-copy.js";
-import { isOpenAIApiBaseUrl } from "./base-url.js";
+import { isOpenAIApiBaseUrl, resolveOpenAIDefaultBaseUrl } from "./base-url.js";
 import { applyOpenAIConfig, OPENAI_DEFAULT_MODEL } from "./default-models.js";
 import {
   buildOpenAIResponsesProviderHooks,
@@ -119,7 +119,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_55_PRO_COST,
@@ -131,7 +131,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_COST,
@@ -143,7 +143,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_PRO_COST,
@@ -155,7 +155,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_MINI_COST,
@@ -167,7 +167,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_NANO_COST,

--- a/extensions/openai/openai-provider.ts
+++ b/extensions/openai/openai-provider.ts
@@ -11,7 +11,7 @@ import {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { OPENAI_ACCOUNT_WIZARD_GROUP, OPENAI_API_KEY_LABEL } from "./auth-choice-copy.js";
-import { isOpenAIApiBaseUrl } from "./base-url.js";
+import { isOpenAIApiBaseUrl, resolveOpenAIDefaultBaseUrl } from "./base-url.js";
 import { applyOpenAIConfig, OPENAI_DEFAULT_MODEL } from "./default-models.js";
 import {
   buildOpenAIResponsesProviderHooks,
@@ -132,7 +132,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_55_PRO_COST,
@@ -144,7 +144,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_COST,
@@ -156,7 +156,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_PRO_COST,
@@ -168,7 +168,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_MINI_COST,
@@ -180,7 +180,7 @@ function resolveOpenAIGptForwardCompatModel(ctx: ProviderResolveDynamicModelCont
     patch = {
       api: "openai-responses",
       provider: PROVIDER_ID,
-      baseUrl: "https://api.openai.com/v1",
+      baseUrl: resolveOpenAIDefaultBaseUrl(),
       reasoning: true,
       input: ["text", "image"],
       cost: OPENAI_GPT_54_NANO_COST,


### PR DESCRIPTION
## Summary

The dynamic-model resolver in `extensions/openai/openai-provider.ts` hardcodes `baseUrl: \"https://api.openai.com/v1\"` for every default GPT entry. This silently overrides `OPENAI_BASE_URL`, so users running OpenClaw behind a LiteLLM/vLLM/local proxy get a 401 from `api.openai.com` even when the env var is set correctly — the discovered baseUrl wins via `?? discoveredModel.baseUrl` in `src/agents/pi-embedded-runner/model.ts:530`.

The fix introduces `resolveOpenAIDefaultBaseUrl()` in `extensions/openai/base-url.ts` that returns `process.env.OPENAI_BASE_URL` (when non-empty) and falls back to `https://api.openai.com/v1`. The 5 hardcoded literals in the registry are replaced with the helper.

This mirrors the precedent of #55597 (\"honor OPENAI_BASE_URL in whisper api skill\") and matches what the OpenAI Node SDK already does — its constructor falls back to `process.env.OPENAI_BASE_URL` when `baseURL` is `undefined`.

## Backwards compatibility

Provider-config baseUrl still takes precedence (the resolver consults `providerConfig.baseUrl` before `discoveredModel.baseUrl` at `model.ts:530`):

| User has | Before | After |
|---|---|---|
| Nothing (default) | api.openai.com | api.openai.com (unchanged) |
| `models.providers.openai.baseUrl` in config | their config | their config (unchanged) |
| Only `OPENAI_BASE_URL` env var | api.openai.com (silent ignore) | env var honored |
| Both env var and config | config | config (unchanged) |

No existing user is broken. Users who set the env var expecting it to work — like the OpenAI Node SDK's own behavior — now get the routing they expected.

## Why not anthropic too

Anthropic's hardcoded fallback is in `src/agents/anthropic-transport-stream.ts:474` rather than a model registry, and the discovery flow is shaped differently. Keeping this PR scoped to OpenAI to mirror the #55597 precedent and make review easy. Happy to follow up with an analogous Anthropic PR if this lands.

## Test plan

- [x] Added unit coverage in `extensions/openai/base-url.test.ts` (env unset, empty, whitespace, custom URL).
- [x] `pnpm test -- extensions/openai/base-url.test.ts` passes (6 tests).
- [ ] CI run on upstream main.