### PR TITLE
[codex] fix(mcp): restrict serve scope selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/memory: add a read-only `doctor.memory.remHarness` RPC so operator clients can preview bounded REM dreaming output without running mutation paths. (#66673) Thanks @samzong.
 - Gateway/events: surface `spawnedBy` on subagent chat and agent broadcast payloads so clients can route child session events without an extra session lookup. (#63244) Thanks @samzong.
 - Security policy: classify media/base64 decode and format-conversion overhead after configured acceptance limits as performance-only for GHSA triage unless a report demonstrates a limit bypass, crash, exhaustion, data exposure, or another boundary bypass. (#74311)
+- MCP: add a repeatable `openclaw mcp serve --scope` selector for least-privilege bridge profiles, limited to `operator.read`, `operator.write`, and `operator.approvals`, while preserving the existing default scope request when omitted. (#74428) Thanks @mstr-six.
 
 ### Fixes
 

--- a/docs/cli/mcp.md
+++ b/docs/cli/mcp.md
@@ -261,6 +261,16 @@ Example stdio client config:
 
 For most generic MCP clients, start with the standard tool surface and ignore Claude mode. Turn Claude mode on only for clients that actually understand the Claude-specific notification methods.
 
+For least-privilege MCP bridge identities, pass `--scope` once for each bridge capability that profile needs:
+
+```bash
+openclaw mcp serve --scope operator.read
+openclaw mcp serve --scope operator.read --scope operator.write
+openclaw mcp serve --scope operator.read --scope operator.approvals
+```
+
+When `--scope` is omitted, the bridge keeps the default request of `operator.read`, `operator.write`, and `operator.approvals`. `openclaw mcp serve` only accepts those three MCP bridge scopes; broader operator scopes such as admin or pairing are not valid for this flag.
+
 ### Options
 
 `openclaw mcp serve` supports:
@@ -279,6 +289,9 @@ For most generic MCP clients, start with the standard tool surface and ignore Cl
 </ParamField>
 <ParamField path="--password-file" type="string">
   Read password from file.
+</ParamField>
+<ParamField path="--scope" type='"operator.read" | "operator.write" | "operator.approvals"'>
+  Operator scope to request. Repeat for multiple scopes.
 </ParamField>
 <ParamField path="--claude-channel-mode" type='"auto" | "on" | "off"'>
   Claude notification mode.

--- a/src/cli/mcp-cli.test.ts
+++ b/src/cli/mcp-cli.test.ts
@@ -117,9 +117,62 @@ describe("mcp cli", () => {
         gatewayUrl: "ws://127.0.0.1:18789",
         gatewayToken: "secret-token",
         gatewayPassword: undefined,
+        operatorScopes: undefined,
         claudeChannelMode: "on",
         verbose: true,
       });
+    });
+  });
+
+  it("starts the channel bridge with explicit operator scopes", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await runMcpCommand([
+        "mcp",
+        "serve",
+        "--scope",
+        "operator.read",
+        "--scope",
+        "operator.approvals",
+      ]);
+
+      expect(serveOpenClawChannelMcp).toHaveBeenCalledWith(
+        expect.objectContaining({
+          operatorScopes: ["operator.read", "operator.approvals"],
+        }),
+      );
+    });
+  });
+
+  it("rejects unknown operator scopes", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(runMcpCommand(["mcp", "serve", "--scope", "operator.nope"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(mockError).toHaveBeenCalledWith(expect.stringContaining("Invalid --scope value"));
+      expect(serveOpenClawChannelMcp).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects operator scopes outside the MCP bridge surface", async () => {
+    await withTempHome("openclaw-cli-mcp-home-", async () => {
+      const workspaceDir = await createWorkspace();
+      vi.spyOn(process, "cwd").mockReturnValue(workspaceDir);
+
+      await expect(runMcpCommand(["mcp", "serve", "--scope", "operator.admin"])).rejects.toThrow(
+        "__exit__:1",
+      );
+
+      expect(mockError).toHaveBeenCalledWith(
+        expect.stringContaining("Use one of: operator.read, operator.write, operator.approvals"),
+      );
+      expect(serveOpenClawChannelMcp).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cli/mcp-cli.ts
+++ b/src/cli/mcp-cli.ts
@@ -5,6 +5,12 @@ import {
   setConfiguredMcpServer,
   unsetConfiguredMcpServer,
 } from "../config/mcp-config.js";
+import {
+  APPROVALS_SCOPE,
+  READ_SCOPE,
+  WRITE_SCOPE,
+  type OperatorScope,
+} from "../gateway/operator-scopes.js";
 import { serveOpenClawChannelMcp } from "../mcp/channel-server.js";
 import { defaultRuntime } from "../runtime.js";
 import {
@@ -24,6 +30,41 @@ function printJson(value: unknown): void {
   defaultRuntime.writeJson(value);
 }
 
+const MCP_SERVE_OPERATOR_SCOPE_VALUES: readonly OperatorScope[] = [
+  READ_SCOPE,
+  WRITE_SCOPE,
+  APPROVALS_SCOPE,
+];
+const MCP_SERVE_OPERATOR_SCOPES: ReadonlySet<OperatorScope> = new Set<OperatorScope>(
+  MCP_SERVE_OPERATOR_SCOPE_VALUES,
+);
+
+function collectScopeOption(value: string | string[], previous: string[] = []): string[] {
+  return [...previous, ...(Array.isArray(value) ? value : [value])];
+}
+
+function parseOperatorScopes(values: unknown): OperatorScope[] | undefined {
+  if (values === undefined) {
+    return undefined;
+  }
+  const rawValues = Array.isArray(values) ? values : [values];
+  const scopes: OperatorScope[] = [];
+  for (const raw of rawValues) {
+    const scope = String(raw).trim();
+    if (!MCP_SERVE_OPERATOR_SCOPES.has(scope as OperatorScope)) {
+      throw new Error(
+        `Invalid --scope value "${scope}". Use one of: ${MCP_SERVE_OPERATOR_SCOPE_VALUES.join(
+          ", ",
+        )}.`,
+      );
+    }
+    if (!scopes.includes(scope as OperatorScope)) {
+      scopes.push(scope as OperatorScope);
+    }
+  }
+  return scopes.length > 0 ? scopes : undefined;
+}
+
 export function registerMcpCli(program: Command) {
   const mcp = program.command("mcp").description("Manage OpenClaw MCP config and channel bridge");
 
@@ -35,6 +76,7 @@ export function registerMcpCli(program: Command) {
     .option("--token-file <path>", "Read gateway token from file")
     .option("--password <password>", "Gateway password (if required)")
     .option("--password-file <path>", "Read gateway password from file")
+    .option("--scope <scope...>", "Operator scope to request (repeatable)", collectScopeOption)
     .option(
       "--claude-channel-mode <mode>",
       "Claude channel notification mode: auto, on, or off",
@@ -58,6 +100,7 @@ export function registerMcpCli(program: Command) {
           gatewayUrl: opts.url as string | undefined,
           gatewayToken,
           gatewayPassword,
+          operatorScopes: parseOperatorScopes(opts.scope),
           claudeChannelMode,
           verbose: Boolean(opts.verbose),
         });

--- a/src/mcp/channel-bridge.ts
+++ b/src/mcp/channel-bridge.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GatewayClient } from "../gateway/client.js";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import type { EventFrame } from "../gateway/protocol/index.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
 import {
@@ -63,6 +64,7 @@ export class OpenClawChannelBridge {
       gatewayUrl?: string;
       gatewayToken?: string;
       gatewayPassword?: string;
+      operatorScopes?: OperatorScope[];
       claudeChannelMode: ClaudeChannelMode;
       verbose: boolean;
     },
@@ -121,7 +123,7 @@ export class OpenClawChannelBridge {
       clientDisplayName: "OpenClaw MCP",
       clientVersion: VERSION,
       mode: GATEWAY_CLIENT_MODES.CLI,
-      scopes: [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
+      scopes: this.params.operatorScopes ?? [READ_SCOPE, WRITE_SCOPE, APPROVALS_SCOPE],
       requestTimeoutMs: 180_000,
       onEvent: (event) => {
         void this.handleGatewayEvent(event);

--- a/src/mcp/channel-server.test.ts
+++ b/src/mcp/channel-server.test.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, test, vi } from "vitest";
 import { z } from "zod";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import { shouldRetryInitialMcpGatewayConnect } from "./channel-bridge.js";
 import { createOpenClawChannelMcpServer, OpenClawChannelBridge } from "./channel-server.js";
 import { extractAttachmentsFromMessage } from "./channel-shared.js";
@@ -81,6 +82,70 @@ function gatewayRequestError(retryable: boolean): Error {
   });
 }
 
+async function captureGatewayClientScopes(operatorScopes?: OperatorScope[]): Promise<unknown> {
+  let capturedScopes: unknown;
+
+  vi.resetModules();
+  vi.doMock("../gateway/client-bootstrap.js", () => ({
+    resolveGatewayClientBootstrap: vi.fn(async () => ({
+      url: "ws://127.0.0.1:18888",
+      auth: {},
+    })),
+  }));
+  vi.doMock("../gateway/client.js", () => ({
+    GatewayClient: class {
+      private readonly opts: {
+        scopes?: unknown;
+        onHelloOk?: () => void;
+      };
+
+      constructor(opts: { scopes?: unknown; onHelloOk?: () => void }) {
+        this.opts = opts;
+        capturedScopes = opts.scopes;
+      }
+
+      start(): void {
+        this.opts.onHelloOk?.();
+      }
+
+      async request(): Promise<Record<string, never>> {
+        return {};
+      }
+
+      async stopAndWait(): Promise<void> {
+        return undefined;
+      }
+    },
+  }));
+  vi.doMock("../gateway/method-scopes.js", () => ({
+    APPROVALS_SCOPE: "operator.approvals",
+    READ_SCOPE: "operator.read",
+    WRITE_SCOPE: "operator.write",
+  }));
+  vi.doMock("../gateway/protocol/client-info.js", () => ({
+    GATEWAY_CLIENT_MODES: { CLI: "cli" },
+    GATEWAY_CLIENT_NAMES: { CLI: "cli" },
+  }));
+
+  const bridge = new OpenClawChannelBridge({} as never, {
+    operatorScopes,
+    claudeChannelMode: "off",
+    verbose: false,
+  });
+  try {
+    await bridge.start();
+  } finally {
+    await bridge.close();
+    vi.doUnmock("../gateway/client-bootstrap.js");
+    vi.doUnmock("../gateway/client.js");
+    vi.doUnmock("../gateway/method-scopes.js");
+    vi.doUnmock("../gateway/protocol/client-info.js");
+    vi.resetModules();
+  }
+
+  return capturedScopes;
+}
+
 describe("openclaw channel mcp server", () => {
   test("keeps initial MCP gateway connection alive through transient connect errors", () => {
     expect(
@@ -88,6 +153,18 @@ describe("openclaw channel mcp server", () => {
     ).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(true))).toBe(true);
     expect(shouldRetryInitialMcpGatewayConnect(gatewayRequestError(false))).toBe(false);
+  });
+
+  test("passes configured operator scopes to the gateway client", async () => {
+    await expect(captureGatewayClientScopes(["operator.read"])).resolves.toEqual(["operator.read"]);
+  });
+
+  test("defaults gateway client scopes for mcp serve", async () => {
+    await expect(captureGatewayClientScopes()).resolves.toEqual([
+      "operator.read",
+      "operator.write",
+      "operator.approvals",
+    ]);
   });
 
   describe("gateway-backed flows", () => {

--- a/src/mcp/channel-server.ts
+++ b/src/mcp/channel-server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OperatorScope } from "../gateway/operator-scopes.js";
 import { VERSION } from "../version.js";
 import { OpenClawChannelBridge } from "./channel-bridge.js";
 import { ClaudePermissionRequestSchema, type ClaudeChannelMode } from "./channel-shared.js";
@@ -12,6 +13,7 @@ export type OpenClawMcpServeOptions = {
   gatewayUrl?: string;
   gatewayToken?: string;
   gatewayPassword?: string;
+  operatorScopes?: OperatorScope[];
   config?: OpenClawConfig;
   claudeChannelMode?: ClaudeChannelMode;
   verbose?: boolean;
@@ -42,6 +44,7 @@ export async function createOpenClawChannelMcpServer(opts: OpenClawMcpServeOptio
     gatewayUrl: opts.gatewayUrl,
     gatewayToken: opts.gatewayToken,
     gatewayPassword: opts.gatewayPassword,
+    operatorScopes: opts.operatorScopes,
     claudeChannelMode,
     verbose: opts.verbose ?? false,
   });


### PR DESCRIPTION
## Summary

This is a narrow replacement for #74030 that keeps the useful MCP bridge scope plumbing while limiting `openclaw mcp serve --scope` to the three scopes needed for least-privilege Agent-stack bridge profiles:

- `operator.read`
- `operator.write`
- `operator.approvals`

The default behavior is unchanged when `--scope` is omitted: MCP serve still requests read, write, and approvals.

## Why

The Agent stack needs separate MCP bridge identities for read-only inspection, send-capable workflows, and approval handling. It does not need MCP serve to request broader operator scopes such as admin or pairing.

## Attribution

This PR is derived from the implementation approach in #74030 by @brokemac79. I reused the MCP scope plumbing shape from that PR, then narrowed the accepted scope set to the MCP bridge least-privilege scopes and added docs/changelog coverage.

I reviewed the borrowed diff before adapting it, as normal diligence for code coming from another branch.

## Validation

- `node scripts/test-projects.mjs src/cli/mcp-cli.test.ts src/mcp/channel-server.test.ts`
- `pnpm exec oxlint src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts src/mcp/channel-bridge.ts src/mcp/channel-server.ts src/mcp/channel-server.test.ts`
- `pnpm exec oxfmt --check src/cli/mcp-cli.ts src/cli/mcp-cli.test.ts src/mcp/channel-bridge.ts src/mcp/channel-server.ts src/mcp/channel-server.test.ts CHANGELOG.md`
- `pnpm check:changelog-attributions`
- `pnpm tsgo:core`
- `git diff --check`

## CI note

After rebasing onto current `origin/main` (`8935dd154a`), I reproduced the remaining built-artifact failure locally with `node scripts/test-projects.mjs test/scripts/package-acceptance-workflow.test.ts`. It is the current-main release workflow assertion expecting `artifact_run_id: ${{ github.run_id }}` after the release workflow switched package acceptance to current-run artifact download, and is unrelated to this MCP scope diff.
