### PR TITLE
fix(anthropic): honor ANTHROPIC_BASE_URL when no baseUrl is configured

### DIFF
--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -118,6 +118,55 @@ async function runTransportStream(
   return stream.result();
 }
 
+describe("resolveAnthropicMessagesUrl", () => {
+  let resolveAnthropicMessagesUrl: typeof import("./anthropic-transport-stream.js").resolveAnthropicMessagesUrl;
+
+  beforeAll(async () => {
+    ({ resolveAnthropicMessagesUrl } = await import("./anthropic-transport-stream.js"));
+  });
+
+  it("uses the explicit baseUrl when provided", () => {
+    expect(resolveAnthropicMessagesUrl("https://proxy.example.com", {})).toBe(
+      "https://proxy.example.com/v1/messages",
+    );
+    expect(resolveAnthropicMessagesUrl("https://proxy.example.com/v1", {})).toBe(
+      "https://proxy.example.com/v1/messages",
+    );
+  });
+
+  it("prefers explicit baseUrl over ANTHROPIC_BASE_URL", () => {
+    expect(
+      resolveAnthropicMessagesUrl("https://explicit.example.com", {
+        ANTHROPIC_BASE_URL: "https://env.example.com",
+      }),
+    ).toBe("https://explicit.example.com/v1/messages");
+  });
+
+  it("falls back to ANTHROPIC_BASE_URL when baseUrl is empty", () => {
+    expect(
+      resolveAnthropicMessagesUrl(undefined, { ANTHROPIC_BASE_URL: "https://env.example.com" }),
+    ).toBe("https://env.example.com/v1/messages");
+    expect(resolveAnthropicMessagesUrl("", { ANTHROPIC_BASE_URL: "https://env.example.com" })).toBe(
+      "https://env.example.com/v1/messages",
+    );
+    expect(
+      resolveAnthropicMessagesUrl("   ", { ANTHROPIC_BASE_URL: "https://env.example.com" }),
+    ).toBe("https://env.example.com/v1/messages");
+  });
+
+  it("falls back to api.anthropic.com when neither baseUrl nor env is set", () => {
+    expect(resolveAnthropicMessagesUrl(undefined, {})).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+    expect(resolveAnthropicMessagesUrl(undefined, { ANTHROPIC_BASE_URL: "" })).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+    expect(resolveAnthropicMessagesUrl(undefined, { ANTHROPIC_BASE_URL: "   " })).toBe(
+      "https://api.anthropic.com/v1/messages",
+    );
+  });
+});
+
 describe("anthropic transport stream", () => {
   beforeAll(async () => {
     ({ createAnthropicMessagesTransportStreamFn } =

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -470,8 +470,23 @@ function mapStopReason(reason: string | undefined): string {
   }
 }
 
-function resolveAnthropicMessagesUrl(baseUrl?: string): string {
-  const normalized = (baseUrl?.trim() || "https://api.anthropic.com").replace(/\/+$/, "");
+/**
+ * Resolve the URL for an Anthropic /v1/messages call.
+ *
+ * Precedence: explicit baseUrl > ANTHROPIC_BASE_URL env var > hardcoded default.
+ * Honoring the env var here matches what the Anthropic Node SDK does and
+ * unblocks running OpenClaw behind an Anthropic-compatible proxy (LiteLLM,
+ * vLLM, local gateway) without forcing users to mirror the URL into config.
+ *
+ * @internal Exported for tests.
+ */
+export function resolveAnthropicMessagesUrl(
+  baseUrl?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicit = baseUrl?.trim();
+  const fromEnv = env.ANTHROPIC_BASE_URL?.trim();
+  const normalized = (explicit || fromEnv || "https://api.anthropic.com").replace(/\/+$/, "");
   return normalized.endsWith("/v1") ? `${normalized}/messages` : `${normalized}/v1/messages`;
 }
 

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -6,6 +6,7 @@
 import { normalizeProviderTransportWithPlugin } from "../../plugins/provider-runtime.js";
 import { isRecord } from "../../utils.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
+import { resolveAnthropicMessagesUrl } from "../anthropic-transport-stream.js";
 
 type PdfInput = {
   base64: string;
@@ -62,12 +63,8 @@ export async function anthropicAnalyzePdf(params: {
   }
   content.push({ type: "text", text: params.prompt });
 
-  const baseUrl = (
-    params.baseUrl ??
-    process.env.ANTHROPIC_BASE_URL?.trim() ??
-    "https://api.anthropic.com"
-  ).replace(/\/+$/, "");
-  const res = await fetch(`${baseUrl}/v1/messages`, {
+  const url = resolveAnthropicMessagesUrl(params.baseUrl);
+  const res = await fetch(url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -62,7 +62,11 @@ export async function anthropicAnalyzePdf(params: {
   }
   content.push({ type: "text", text: params.prompt });
 
-  const baseUrl = (params.baseUrl ?? "https://api.anthropic.com").replace(/\/+$/, "");
+  const baseUrl = (
+    params.baseUrl ??
+    process.env.ANTHROPIC_BASE_URL?.trim() ??
+    "https://api.anthropic.com"
+  ).replace(/\/+$/, "");
   const res = await fetch(`${baseUrl}/v1/messages`, {
     method: "POST",
     headers: {


### PR DESCRIPTION
## Summary

Two helpers in `src/agents` fall back to a hardcoded `https://api.anthropic.com` when no `baseUrl` is supplied:

- `resolveAnthropicMessagesUrl` in `src/agents/anthropic-transport-stream.ts:474` — used by every streaming Anthropic call
- The native-PDF tool in `src/agents/tools/pdf-native-providers.ts:65` — used by Anthropic's PDF document tool

Both silently ignore `ANTHROPIC_BASE_URL`, so users running OpenClaw behind an Anthropic-compatible proxy (LiteLLM, vLLM, local gateway) see calls hit `api.anthropic.com` directly even when the env var is set.

The fix adds `ANTHROPIC_BASE_URL` to the existing precedence chain:

> explicit `baseUrl` → `ANTHROPIC_BASE_URL` → `https://api.anthropic.com`

This mirrors what the Anthropic Node SDK already does and matches the OpenAI counterpart PR (#74427) and the merged whisper precedent (#55597).

## Backwards compatibility

Explicit `baseUrl` still takes precedence:

| User has | Before | After |
|---|---|---|
| Nothing | api.anthropic.com | api.anthropic.com (unchanged) |
| `model.baseUrl` set (e.g. via provider config) | their value | their value (unchanged) |
| Only `ANTHROPIC_BASE_URL` env var | api.anthropic.com (silent ignore) | env var honored |
| Both env var and explicit baseUrl | explicit | explicit (unchanged) |

## Test plan

- [x] Exported `resolveAnthropicMessagesUrl` so the precedence chain is unit-testable.
- [x] Added 4 new test cases in `anthropic-transport-stream.test.ts` covering: explicit wins over env, env fallback for empty/whitespace baseUrl, default fallback when neither is set.
- [x] `pnpm test -- src/agents/anthropic-transport-stream.test.ts` → 25/25 pass (21 existing + 4 new).
- [ ] CI run on upstream main.

## Related

- Companion PR for OpenAI provider: #74427