### PR TITLE
fix(agents): disable pi-coding-agent auto-retry to prevent tool call replay loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. Thanks @yelog.
 - Slack/subagents: keep resumed parent `message.send` calls in the originating Slack thread when ambient session thread context is present, and suppress successful silent child completion rows from follow-up findings. Thanks @bek91.
 - Infra/Windows: skip the POSIX `/tmp/openclaw` preferred path on Windows in `resolvePreferredOpenClawTmpDir` so log files, TTS temp files, and other writes land in `%TEMP%\openclaw-<uid>` instead of `C:\tmp\openclaw`. Fixes #60713. Thanks @juan-flores077.
 - Gateway/diagnostics: make stuck-session recovery outcome-driven and generation-guarded, add `diagnostics.stuckSessionAbortMs`, and emit structured recovery requested/completed events so stale or skipped recovery no longer looks like a successful abort.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -829,6 +829,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 - Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
+- Agents/Pi: disable the embedded pi-coding-agent runtime auto-retry so OpenClaw's own retry and failover loop does not replay failed tool calls through a nested SDK retry. Fixes #73781. Thanks @yelog.
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.
 - WhatsApp/onboarding: canonicalize setup and pairing allowlist entries to WhatsApp's digit-only phone ids while still accepting E.164, JID, and `whatsapp:` inputs, so personal-phone allowlists match WhatsApp Web sender ids after setup. Thanks @vincentkoc.

--- a/src/agents/pi-project-settings.test.ts
+++ b/src/agents/pi-project-settings.test.ts
@@ -161,9 +161,8 @@ describe("createPreparedEmbeddedPiSettingsManager", () => {
       });
 
       expect(settingsManager.getShellCommandPrefix()).toBe("echo trusted &&");
-      expect(settingsManager.getRetryEnabled()).toBe(true);
+      expect(settingsManager.getRetryEnabled()).toBe(false);
 
-      settingsManager.setRetryEnabled(false);
       await settingsManager.flush();
 
       const diskSettings = JSON.parse(await fs.readFile(agentSettingsPath, "utf8")) as {

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -57,5 +57,10 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     cfg: params.cfg,
     contextTokenBudget: params.contextTokenBudget,
   });
+  // Disable the pi-coding-agent auto-retry. OpenClaw has its own comprehensive
+  // retry layer (failover rotation, auth profile rotation, empty-error retry,
+  // thinking-level fallback) in run.ts. Having both layers active creates a
+  // double-retry that can replay failed tool calls in an unbounded loop (#73781).
+  settingsManager.setRetryEnabled(false);
   return settingsManager;
 }

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -61,5 +61,10 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     cfg: params.cfg,
     contextTokenBudget: params.contextTokenBudget,
   });
+  // Disable the pi-coding-agent auto-retry. OpenClaw has its own comprehensive
+  // retry layer (failover rotation, auth profile rotation, empty-error retry,
+  // thinking-level fallback) in run.ts. Having both layers active creates a
+  // double-retry that can replay failed tool calls in an unbounded loop (#73781).
+  settingsManager.setRetryEnabled(false);
   return settingsManager;
 }


### PR DESCRIPTION
## Summary

Fixes #73781

The pi-coding-agent SDK has auto-retry enabled by default (`retry.enabled ?? true`, up to 3 retries). When a tool call fails, the SDK strips the error assistant message from history and calls `agent.continue()`, which causes the LLM to re-issue the same tool calls — since it never sees the previous failure reasoning.

OpenClaw has its own comprehensive retry layer in `run.ts` (failover rotation, auth profile rotation, empty-error retry, thinking-level fallback). Having both layers active creates a double-retry that replays failed tool calls in an unbounded loop: up to 3 SDK retries x 32-160 outer iterations = 96-480 total LLM calls.

## Changes

- `createPreparedEmbeddedPiSettingsManager` now calls `settingsManager.setRetryEnabled(false)` to disable the SDK auto-retry
- OpenClaw's own retry layer (failover, auth rotation, empty-error retry) continues to handle all error recovery
- Added test verifying auto-retry is disabled

## Root Cause

Two nested retry layers both strip the error context and re-submit:
1. pi-coding-agent `_handleRetryableError()` strips the error assistant message and calls `agent.continue()`
2. OpenClaw `run.ts` outer loop detects `stopReason="error"` and creates a new attempt

The LLM never sees the failure reasoning after stripping, so it naturally re-issues the same tool calls. Disabling the inner layer eliminates the compounding without affecting OpenClaw's own recovery paths.