### PR TITLE
fix(channels): strip <relevant-memories> from outbound assistant text

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -456,6 +456,52 @@ describe("sanitizeUserFacingText", () => {
     expect(sanitizeUserFacingText(undefined as unknown as string)).toBe("");
     expect(sanitizeUserFacingText(42 as unknown as string)).toBe("42");
   });
+
+  it("strips reflected <relevant-memories> blocks injected by the memory plugin (#74364)", () => {
+    const input = [
+      "<relevant-memories>",
+      'The following are stored memories for user "kevin". Use them to personalize your response:',
+      "- Kevin prefers operator mode with verification discipline",
+      "- VEDA uses Opus 4.6 as main model",
+      "</relevant-memories>",
+      "",
+      "Here is the actual reply.",
+    ].join("\n");
+    const result = sanitizeUserFacingText(input);
+    expect(result).not.toContain("<relevant-memories>");
+    expect(result).not.toContain("</relevant-memories>");
+    expect(result).not.toContain("stored memories for user");
+    expect(result).toContain("Here is the actual reply.");
+  });
+
+  it("preserves <relevant-memories> inside fenced code blocks (developer is teaching about the tag)", () => {
+    const input = [
+      "Here is how the memory tag works:",
+      "",
+      "```",
+      "<relevant-memories>",
+      "example content",
+      "</relevant-memories>",
+      "```",
+      "",
+      "End of explanation.",
+    ].join("\n");
+    const result = sanitizeUserFacingText(input);
+    expect(result).toContain("<relevant-memories>");
+    expect(result).toContain("</relevant-memories>");
+    expect(result).toContain("example content");
+    expect(result).toContain("End of explanation.");
+  });
+
+  it("strips <relevant-memories> blocks interleaved with normal prose", () => {
+    const input =
+      "Reply intro. <relevant-memories>internal scaffolding</relevant-memories> Reply continues.";
+    const result = sanitizeUserFacingText(input);
+    expect(result).not.toContain("<relevant-memories>");
+    expect(result).not.toContain("internal scaffolding");
+    expect(result).toContain("Reply intro.");
+    expect(result).toContain("Reply continues.");
+  });
 });
 
 describe("stripThoughtSignatures", () => {

--- a/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
+++ b/src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts
@@ -15,6 +15,7 @@ import {
 import {
   stripLegacyBracketToolCallBlocks,
   stripMinimaxToolCallXml,
+  stripRelevantMemoriesTags,
   stripToolCallXmlTags,
 } from "../../shared/text/assistant-visible-text.js";
 import { formatExecDeniedUserMessage } from "../exec-approval-result.js";
@@ -404,7 +405,9 @@ export function sanitizeUserFacingText(text: unknown, opts?: { errorContext?: bo
     return raw;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw)));
+  const stripped = stripRelevantMemoriesTags(
+    stripInboundMetadata(stripInternalRuntimeContext(stripFinalTagsFromText(raw))),
+  );
   const withoutToolCallXml = stripToolCallXmlTags(stripMinimaxToolCallXml(stripped), {
     stripFunctionCallsXmlPayloads: true,
   });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -586,7 +586,7 @@ export function stripDowngradedToolCallText(text: string): string {
   return cleaned.trim();
 }
 
-function stripRelevantMemoriesTags(text: string): string {
+export function stripRelevantMemoriesTags(text: string): string {
   if (!text || !MEMORY_TAG_QUICK_RE.test(text)) {
     return text;
   }


### PR DESCRIPTION
## Summary

Fixes #74364. When the memory plugin injects `<relevant-memories>` context via `prependContext` and the LLM echoes the block, the raw markup is delivered verbatim to messaging channels (Telegram, Discord, etc.).

The shared `stripRelevantMemoriesTags` (`src/shared/text/assistant-visible-text.ts:517`) already strips these blocks with code-fence-aware preservation, but `sanitizeUserFacingText` (`src/agents/pi-embedded-helpers/sanitize-user-facing-text.ts`) — the canonical outbound text sanitizer used by `bash-tools.exec-approval-followup.ts`, `auto-reply/reply/normalize-reply.ts`, and `auto-reply/reply/agent-runner-execution.ts` — doesn't call into it.

## Change

- Export `stripRelevantMemoriesTags`.
- Wrap the existing strip chain in `sanitizeUserFacingText` so it lands on the same boundary that already strips inbound metadata, internal runtime context, and final tags.
- Three regression tests in `pi-embedded-helpers.sanitizeuserfacingtext.test.ts`: reflected block stripped, code-fence preservation, interleaved-with-prose strip.

## Testing

```
pnpm test src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
# 89/89 passing
pnpm exec oxfmt --check --threads=1 <touched files>
# green
```

## Out of scope

- This fix does not cover the partial-preview/streaming paths (`pi-embedded-subscribe.ts` text_end, `pi-embedded-subscribe.handlers.messages.ts` partial preview), which use a different sanitizer and may require a separate fix if the leak is confirmed there.
- Provider-side fix to prevent the LLM from echoing memory tags (out of scope per existing pattern of sanitizing at the delivery boundary).

### Suggested release note

Outbound channel messages no longer leak `<relevant-memories>` scaffolding when the memory plugin's context is reflected back by the LLM.
