### PR TITLE
ci: add local shell CodeQL security shard

### DIFF
--- a/.github/codeql/codeql-local-shell-runtime-boundary-critical-security.yml
+++ b/.github/codeql/codeql-local-shell-runtime-boundary-critical-security.yml
@@ -1,0 +1,42 @@
+name: openclaw-codeql-local-shell-runtime-boundary-critical-security
+
+disable-default-queries: true
+
+queries:
+  - uses: security-extended
+
+query-filters:
+  - include:
+      precision:
+        - high
+        - very-high
+  - exclude:
+      problem.severity:
+        - recommendation
+        - warning
+
+paths:
+  - src/tui/tui-local-shell.ts
+  - src/tui/tui.ts
+  - src/process/exec.ts
+  - packages/memory-host-sdk/src/host/windows-spawn.ts
+  - packages/memory-host-sdk/src/host/qmd-process.ts
+  - extensions/bonjour/src/advertiser.ts
+
+paths-ignore:
+  - "**/node_modules"
+  - "**/coverage"
+  - "**/*.generated.ts"
+  - "**/*.bundle.js"
+  - "**/*-runtime.js"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/*.e2e.test.ts"
+  - "**/*.e2e.test.tsx"
+  - "**/*test-support*"
+  - "**/*test-helper*"
+  - "**/*mock*"
+  - "**/*fixture*"
+  - "**/*bench*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,6 +11,7 @@ on:
         options:
           - all
           - security
+          - local-shell
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
@@ -90,3 +91,25 @@ jobs:
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           category: "/codeql-security-high/${{ matrix.category }}"
+
+  local-shell-runtime-boundary:
+    name: Security High (local-shell-runtime-boundary)
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.profile == 'all' || inputs.profile == 'local-shell') }}
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          languages: javascript-typescript
+          config-file: ./.github/codeql/codeql-local-shell-runtime-boundary-critical-security.yml
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+        with:
+          category: "/codeql-security-high/local-shell-runtime-boundary"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -316,6 +316,8 @@ Do not put the PR landing path behind `Parity gate` unless the change actually t
 
 The `CodeQL` workflow is intentionally a narrow first-pass security scanner, not the full repository sweep. Daily, manual, and non-draft pull request guard runs scan Actions workflow code plus the highest-risk JavaScript/TypeScript surfaces with high-confidence security queries filtered to high/critical `security-severity`.
 
+Manual dispatch accepts `profile=all|security|local-shell`. The `local-shell` profile is a manual-only teaching and validation shard for shell/command-exec boundaries that is not yet part of the scheduled or pull request baseline.
+
 The pull request guard stays light: it only starts for changes under `.github/actions`, `.github/codeql`, `.github/workflows`, `packages`, or `src`, and it runs the same high-confidence security matrix as the scheduled workflow. Android and macOS CodeQL stay out of PR defaults.
 
 ### Security categories
@@ -327,6 +329,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 | `/codeql-security-high/network-ssrf-boundary`     | Core SSRF, IP parsing, network guard, web-fetch, and Plugin SDK SSRF policy surfaces                                                   |
 | `/codeql-security-high/mcp-process-tool-boundary` | MCP servers, process execution helpers, outbound delivery, and agent tool-execution gates                                              |
 | `/codeql-security-high/plugin-trust-boundary`     | Plugin install, loader, manifest, registry, runtime-dependency staging, source-loading, and Plugin SDK package contract trust surfaces |
+| `/codeql-security-high/local-shell-runtime-boundary` | Local TUI shell runner, Windows spawn fallback helpers, qmd spawn wrappers, and the Bonjour Windows shell bridge                         |
 
 ### Platform-specific security shards
 


### PR DESCRIPTION
## Summary
- add a manual-only `local-shell` CodeQL security profile
- add a narrow `/codeql-critical-security/local-shell-runtime-boundary` shard
- document the manual profile and shard purpose in CI docs

## Why
- continue the small-slice CodeQL rollout pattern
- create a branch-dispatchable shard that is more likely to exercise real JS/TS security findings on exec-heavy code
- validate that branch-triggered CodeQL uploads still flow into code scanning for a new category

## Validation
- `pnpm check:workflows`
- `git diff --check`
- manual dispatch: `gh workflow run codeql.yml --ref mason/codeql-matrix-transport-shard -f profile=local-shell`
