### PR TITLE
fix(doctor): don't flag the live compatibility agent dir as orphan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Doctor: stop flagging the live compatibility agent directory as orphaned when the configured default agent is not `main`. Fixes #74313. (#74438) Thanks @carlos4s.
 - Codex app-server: report Codex-native tool execution to diagnostics so long-running native `bash`, web, file, and MCP tools no longer look like stale embedded runs to the watchdog. (#80217)
 - Telegram: preserve blank lines between manually indented bullet blocks and following numbered sections in rendered replies. Fixes #76998. Thanks @evgyur.
 - Slack: pass configured agent identity through draft preview sends so partial streaming replies keep custom username/avatar on the initial Slack message. Fixes #38235. (#38237) Thanks @lacymorrow.

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -33,6 +33,8 @@ type EnvSnapshot = {
   OPENCLAW_HOME?: string;
   OPENCLAW_STATE_DIR?: string;
   OPENCLAW_OAUTH_DIR?: string;
+  OPENCLAW_AGENT_DIR?: string;
+  PI_CODING_AGENT_DIR?: string;
 };
 
 function captureEnv(): EnvSnapshot {
@@ -41,6 +43,8 @@ function captureEnv(): EnvSnapshot {
     OPENCLAW_HOME: process.env.OPENCLAW_HOME,
     OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
     OPENCLAW_OAUTH_DIR: process.env.OPENCLAW_OAUTH_DIR,
+    OPENCLAW_AGENT_DIR: process.env.OPENCLAW_AGENT_DIR,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
   };
 }
 
@@ -156,6 +160,8 @@ describe("doctor state integrity oauth dir checks", () => {
     process.env.OPENCLAW_HOME = tempHome;
     process.env.OPENCLAW_STATE_DIR = path.join(tempHome, ".openclaw");
     delete process.env.OPENCLAW_OAUTH_DIR;
+    delete process.env.OPENCLAW_AGENT_DIR;
+    delete process.env.PI_CODING_AGENT_DIR;
     fs.mkdirSync(process.env.OPENCLAW_STATE_DIR, { recursive: true, mode: 0o700 });
     noteMock.mockClear();
   });
@@ -242,6 +248,40 @@ describe("doctor state integrity oauth dir checks", () => {
     const text = await runStateIntegrityText({
       agents: {
         list: [{ id: "main", default: true }, { id: "ops" }],
+      },
+    });
+
+    expect(text).not.toContain("without a matching agents.list entry");
+    expect(text).not.toContain("Examples:");
+  });
+
+  it("does not warn when the live compatibility main agent dir is missing from agents.list", async () => {
+    createAgentDir("main");
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "jeremiah", default: true }],
+      },
+    });
+
+    expect(text).not.toContain("without a matching agents.list entry");
+    expect(text).not.toContain("Examples:");
+  });
+
+  it("does not warn when OPENCLAW_AGENT_DIR points at the live compatibility agent dir", async () => {
+    createAgentDir("legacy");
+    const legacyAgentDir = path.join(
+      process.env.OPENCLAW_STATE_DIR ?? "",
+      "agents",
+      "legacy",
+      "agent",
+    );
+    process.env.OPENCLAW_AGENT_DIR = legacyAgentDir;
+    process.env.PI_CODING_AGENT_DIR = legacyAgentDir;
+
+    const text = await runStateIntegrityText({
+      agents: {
+        list: [{ id: "main", default: true }],
       },
     });
 

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -25,6 +25,7 @@ import { updateSessionStore } from "../config/sessions/store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { resolveMemoryBackendConfig } from "../memory-host-sdk/engine-storage.js";
+import { resolveOpenClawAgentDir } from "../plugin-sdk/agent-dir-compat.js";
 import { listConfiguredChannelIdsForReadOnlyScope } from "../plugins/channel-plugin-ids.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
@@ -90,6 +91,12 @@ function resolveComparableTranscriptPath(filePath: string): string {
   return tryResolveNativeRealPath(filePath) ?? path.resolve(filePath);
 }
 
+function areComparablePathsEqual(leftPath: string, rightPath: string): boolean {
+  const leftRealPath = tryResolveNativeRealPath(leftPath);
+  const rightRealPath = tryResolveNativeRealPath(rightPath);
+  return leftRealPath !== null && leftRealPath === rightRealPath;
+}
+
 function isReachableConfiguredAgentDir(params: {
   agentsRoot: string;
   dirName: string;
@@ -126,6 +133,7 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgent
   }
 
   const agentsRoot = path.join(stateDir, "agents");
+  const liveCompatibilityAgentDir = resolveOpenClawAgentDir();
   try {
     const entries = fs.readdirSync(agentsRoot, { withFileTypes: true });
     return entries
@@ -135,8 +143,12 @@ function listOrphanAgentDirs(cfg: OpenClawConfig, stateDir: string): OrphanAgent
         agentId: normalizeAgentId(entry.name),
       }))
       .filter(({ dirName, agentId }) => {
-        const hasNestedAgentDir = existsDir(path.join(agentsRoot, dirName, "agent"));
+        const nestedAgentDir = path.join(agentsRoot, dirName, "agent");
+        const hasNestedAgentDir = existsDir(nestedAgentDir);
         if (!hasNestedAgentDir) {
+          return false;
+        }
+        if (areComparablePathsEqual(nestedAgentDir, liveCompatibilityAgentDir)) {
           return false;
         }
         if (!configuredIds.has(agentId)) {


### PR DESCRIPTION
# Description

Closes #74313

## Summary

`openclaw doctor` could report the live legacy compatibility agent dir as an orphan when the configured default agent was not `main`. This PR exempts only the realpath-matching live compatibility store while preserving warnings for genuine orphan agent dirs.

## Root Cause

`listOrphanAgentDirs` built its configured id set from `resolveDefaultAgentId(cfg)` plus `agents.list[].id`. When `agents.list` used a non-`main` default and `~/.openclaw/agents/main/agent` still existed as the legacy compatibility store, `main` was treated like stale state because the orphan scan never compared it with `resolveOpenClawAgentDir()`.

## What Changed

- Add a strict realpath comparison helper for agent-dir equality.
- Skip the on-disk nested `agent/` dir whose realpath matches `resolveOpenClawAgentDir()`.
- Add regression coverage for the non-main default-agent case and `OPENCLAW_AGENT_DIR` compatibility override.

## What This Does Not Fix

A separate gateway write-side issue can recreate `agents/main/{models.json,sessions.json}` even after the directory is archived. This PR only fixes the doctor read-side warning so users are not guided toward deleting live compatibility state.

## Real behavior proof

- **Behavior or issue addressed:** `openclaw doctor` no longer reports the live legacy compatibility agent dir as orphaned when the configured default agent is not `main`; genuine orphan dirs are still reported.
- **Real environment tested:** Linux x86_64, kernel 6.8.0-111-generic, Node v24.11.0, OpenClaw built from this branch at `a296a342a8`, isolated state under `/tmp/openclaw-real-test/`.
- **Exact steps or command run after this patch:** Created `/tmp/openclaw-real-test/openclaw.json` with default agent `alfred`, created `agents/{alfred,main,zzz-stale}/agent`, then ran `OPENCLAW_STATE_DIR=/tmp/openclaw-real-test OPENCLAW_HOME=/tmp/openclaw-real-test OPENCLAW_CONFIG=/tmp/openclaw-real-test/openclaw.json pnpm openclaw doctor`.
- **Evidence after fix:** Terminal output from the real command showed doctor reporting only `zzz-stale`:

```text
◇  State integrity ────────────────────────────────────────────────────────╮
│  - Found 1 agent directory on disk without a matching agents.list        │
│    Examples: zzz-stale                                                   │
│    Restore the missing agents.list entries or remove stale dirs after    │
│    confirming they are no longer needed: …/agents                        │
```

- **Observed result after fix:** `main` was exempted because its realpath matched `resolveOpenClawAgentDir()`, while `zzz-stale` was still flagged as a real orphan. Additional live checks covered `OPENCLAW_AGENT_DIR` pointing at `legacy/agent`, a non-existent override path, and mixed env override plus non-main default.
- **What was not tested:** The separate gateway write-side recreation behavior was not tested or fixed here.

## Tests

- `pnpm test src/commands/doctor-state-integrity.test.ts`
- Contributor also reported `pnpm tsgo:core`, `pnpm tsgo:test`, and `pnpm check:changed` clean on the branch.

## Security Impact

No new permissions, secrets handling, network calls, or data access scope. Doctor only reads local filesystem state and suppresses one unsafe false-positive warning.
