### PR TITLE
fix(exec): reject invalid host targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00.
 - Build/Gateway: route restart, shutdown, respawn, diagnostics, command-queue cleanup, and runtime cleanup through one stable gateway lifecycle runtime entry so rebuilt packages do not strand long-running gateways on stale hashed chunks. Carries forward #73964. Thanks @pashpashpash.
 - Memory/wiki: keep broad shared-source and generated related-link blocks from turning every page into a search hit, cap noisy backlinks, support all-term searches such as people-routing queries, and prefer readable page body snippets over generated metadata. Thanks @vincentkoc.
 - Cron/Gateway: abort and bounded-clean up timed-out isolated agent turns before recording the timeout, so stale cron sessions cannot leave Discord or other chat lanes stuck in `processing` after a timeout. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00.
+- Exec: reject invalid per-call `host` values instead of silently falling back to the default target, so hostname-like values fail before commands run. Fixes #74426. Thanks @scr00ge-00 and @vyctorbrzezowski.
 - Build/Gateway: route restart, shutdown, respawn, diagnostics, command-queue cleanup, and runtime cleanup through one stable gateway lifecycle runtime entry so rebuilt packages do not strand long-running gateways on stale hashed chunks. Carries forward #73964. Thanks @pashpashpash.
 - Memory/wiki: keep broad shared-source and generated related-link blocks from turning every page into a search hit, cap noisy backlinks, support all-term searches such as people-routing queries, and prefer readable page body snippets over generated metadata. Thanks @vincentkoc.
 - Cron/Gateway: abort and bounded-clean up timed-out isolated agent turns before recording the timeout, so stale cron sessions cannot leave Discord or other chat lanes stuck in `processing` after a timeout. Thanks @vincentkoc.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -63,6 +63,7 @@ Request elevated mode — escape the sandbox onto the configured host path. `sec
 Notes:
 
 - `host` defaults to `auto`: sandbox when sandbox runtime is active for the session, otherwise gateway.
+- `host` only accepts `auto`, `sandbox`, `gateway`, or `node`. It is not a hostname selector; hostname-like values are rejected before the command runs.
 - `auto` is the default routing strategy, not a wildcard. Per-call `host=node` is allowed from `auto`; per-call `host=gateway` is only allowed when no sandbox runtime is active.
 - With no extra config, `host=auto` still "just works": no sandbox means it resolves to `gateway`; a live sandbox means it stays in the sandbox.
 - `elevated` escapes the sandbox onto the configured host path: `gateway` by default, or `node` when `tools.exec.host=node` (or the session default is `host=node`). It is only available when elevated access is enabled for the current session/provider.

--- a/src/agents/bash-tools.exec-foreground-failures.test.ts
+++ b/src/agents/bash-tools.exec-foreground-failures.test.ts
@@ -50,4 +50,32 @@ describe("exec foreground failures", () => {
     });
     expect((result.details as { durationMs?: number }).durationMs).toEqual(expect.any(Number));
   });
+
+  it("rejects invalid host values before launching a command", async () => {
+    const tool = createExecTool({
+      security: "full",
+      ask: "off",
+      allowBackground: false,
+    });
+    for (const testCase of [
+      {
+        host: "spark-ff13",
+        message: 'Invalid exec host "spark-ff13". Allowed values: auto, sandbox, gateway, node.',
+      },
+      {
+        host: 42,
+        message:
+          "Invalid exec host value type number. Allowed values: auto, sandbox, gateway, node.",
+      },
+    ]) {
+      const malformedArgs = {
+        command: "echo should-not-run",
+        host: testCase.host,
+      } as unknown as Parameters<typeof tool.execute>[1];
+
+      await expect(tool.execute("call-invalid-host", malformedArgs)).rejects.toThrow(
+        testCase.message,
+      );
+    }
+  });
 });

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -8,6 +8,7 @@ import {
   loadExecApprovals,
   maxAsk,
   minSecurity,
+  requireValidExecTarget,
 } from "../infra/exec-approvals.js";
 import { resolveExecSafeBinRuntimePolicy } from "../infra/exec-safe-bin-runtime-policy.js";
 import { sanitizeHostExecEnvWithDiagnostics } from "../infra/host-env-security.js";
@@ -38,7 +39,6 @@ import {
   applyShellPath,
   normalizeExecAsk,
   normalizeExecSecurity,
-  normalizeExecTarget,
   normalizePathPrepend,
   resolveExecTarget,
   resolveApprovalRunningNoticeMs,
@@ -1543,9 +1543,10 @@ export function createExecTool(
       if (elevatedRequested) {
         logInfo(`exec: elevated command ${truncateMiddle(params.command, 120)}`);
       }
+      const requestedTarget = requireValidExecTarget(params.host);
       const target = resolveExecTarget({
         configuredTarget: defaults?.host,
-        requestedTarget: normalizeExecTarget(params.host),
+        requestedTarget,
         elevatedRequested,
         sandboxAvailable: Boolean(defaults?.sandbox),
       });

--- a/src/agents/bash-tools.schemas.ts
+++ b/src/agents/bash-tools.schemas.ts
@@ -1,4 +1,7 @@
 import { Type } from "typebox";
+import { optionalStringEnum } from "./schema/typebox.js";
+
+const EXEC_TOOL_HOST_VALUES = ["auto", "sandbox", "gateway", "node"] as const;
 
 export const execSchema = Type.Object({
   command: Type.String({ description: "Shell command to execute" }),
@@ -26,11 +29,9 @@ export const execSchema = Type.Object({
       description: "Run on the host with elevated permissions (if allowed)",
     }),
   ),
-  host: Type.Optional(
-    Type.String({
-      description: "Exec host/target (auto|sandbox|gateway|node).",
-    }),
-  ),
+  host: optionalStringEnum(EXEC_TOOL_HOST_VALUES, {
+    description: "Exec host/target (auto|sandbox|gateway|node).",
+  }),
   security: Type.Optional(
     Type.String({
       description: "Exec security mode (deny|allowlist|full).",

--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -14,6 +14,7 @@ import {
   hasDurableExecApproval,
   maxAsk,
   minSecurity,
+  requireValidExecTarget,
   type ExecApprovalsFile,
   normalizeExecAsk,
   normalizeExecHost,
@@ -71,6 +72,18 @@ describe("exec approvals policy helpers", () => {
     { raw: "ssh", expected: null },
   ])("normalizes exec target value %j", ({ raw, expected }) => {
     expect(normalizeExecTarget(raw)).toBe(expected);
+  });
+
+  it("requires direct exec target requests to use the closed host set", () => {
+    expect(requireValidExecTarget(" gateway ")).toBe("gateway");
+    expect(requireValidExecTarget("")).toBe(null);
+    expect(requireValidExecTarget(undefined)).toBe(null);
+    expect(() => requireValidExecTarget("spark-ff13")).toThrow(
+      'Invalid exec host "spark-ff13". Allowed values: auto, sandbox, gateway, node.',
+    );
+    expect(() => requireValidExecTarget(42)).toThrow(
+      "Invalid exec host value type number. Allowed values: auto, sandbox, gateway, node.",
+    );
   });
 
   it.each([

--- a/src/infra/exec-approvals.ts
+++ b/src/infra/exec-approvals.ts
@@ -22,6 +22,8 @@ export type ExecTarget = "auto" | ExecHost;
 export type ExecSecurity = "deny" | "allowlist" | "full";
 export type ExecAsk = "off" | "on-miss" | "always";
 
+export const EXEC_TARGET_VALUES: readonly ExecTarget[] = ["auto", "sandbox", "gateway", "node"];
+
 export function normalizeExecHost(value?: string | null): ExecHost | null {
   const normalized = normalizeOptionalLowercaseString(value);
   if (normalized === "sandbox" || normalized === "gateway" || normalized === "node") {
@@ -36,6 +38,30 @@ export function normalizeExecTarget(value?: string | null): ExecTarget | null {
     return normalized;
   }
   return normalizeExecHost(normalized);
+}
+
+export function requireValidExecTarget(value?: unknown): ExecTarget | null {
+  if (value == null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(
+      `Invalid exec host value type ${typeof value}. Allowed values: ${EXEC_TARGET_VALUES.join(
+        ", ",
+      )}.`,
+    );
+  }
+  const normalized = normalizeOptionalLowercaseString(value);
+  if (!normalized) {
+    return null;
+  }
+  const target = normalizeExecTarget(normalized);
+  if (target) {
+    return target;
+  }
+  throw new Error(
+    `Invalid exec host "${value}". Allowed values: ${EXEC_TARGET_VALUES.join(", ")}.`,
+  );
 }
 
 /** Coerce a raw JSON field to string, returning undefined for non-string types. */


### PR DESCRIPTION
## Summary

- Problem: per-call exec `host` values outside `auto`, `sandbox`, `gateway`, and `node` were normalized away, so hostname-like input could silently fall back to the default target.
- Why it matters: a malformed direct exec request should fail closed before any command launches instead of relying on fallback routing.
- What changed: validate per-call exec host values before target resolution, tighten the exec tool schema enum, add regression coverage for invalid string and non-string host values, and document the allowed host set.
- What did NOT change (scope boundary): no new config keys, no approval/elevated routing changes, and no change to default `host=auto` behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #74426
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: direct exec calls used the permissive target normalizer, which returned `null` for unknown host values and allowed target resolution to fall back to the configured/default target.
- Missing detection / guardrail: regression coverage did not assert that malformed per-call `host` input fails before command launch.
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/infra/exec-approvals-policy.test.ts`, `src/agents/bash-tools.exec-foreground-failures.test.ts`
- Scenario the test should lock in: invalid string and non-string per-call `host` values throw before the exec command can launch.
- Why this is the smallest reliable guardrail: one policy helper test locks the closed host set, and one exec tool test verifies runtime behavior at the command boundary.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Direct exec calls with malformed `host` values now fail with an explicit validation error instead of falling back to the configured/default exec target. Valid `auto`, `sandbox`, `gateway`, and `node` behavior is unchanged.

## Diagram (if applicable)

```text
Before:
exec({ command, host: "spark-ff13" }) -> invalid host normalizes to null -> default target runs command

After:
exec({ command, host: "spark-ff13" }) -> validation error -> command is not launched
```

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? Yes
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: command execution input validation is stricter; malformed per-call host values now fail closed before launch.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node.js v24.14.0, pnpm
- Model/provider: N/A
- Integration/channel (if any): exec tool
- Relevant config (redacted): N/A

### Steps

1. Call the exec tool with `host: "spark-ff13"` and a command.
2. Call the exec tool with a non-string `host` value.

### Expected

- The exec tool rejects the malformed `host` before launching the command.

### Actual

- Before this change, invalid host-like values could be treated like no per-call host override and fall back to the default target.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New regression tests cover invalid string and non-string host values, and the focused test lane passes.

## Human Verification (required)

What I personally verified (not just CI), and how:

- Verified scenarios: invalid string host, non-string host, blank/undefined host, valid trimmed host, existing exec target runtime tests.
- Edge cases checked: blank host remains equivalent to no override; `gateway` with whitespace still normalizes correctly; non-string input fails explicitly.
- What I did **not** verify: full `pnpm build && pnpm check && pnpm test`; this PR was validated with focused tests plus `check:changed` for the touched surface.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: callers relying on malformed host values silently falling back will now get an error.
  - Mitigation: documented the allowed host set and preserved fallback behavior for missing/blank host values.

## AI-assisted disclosure

This PR was AI-assisted. I reviewed the diff, understand the changed exec validation path, and ran the validation listed above, including local `codex review --base origin/main`.
