### PR TITLE
feat(openai): dynamic model catalog discovery from upstream /v1/models

### DIFF
--- a/extensions/openai/api.ts
+++ b/extensions/openai/api.ts
@@ -9,6 +9,7 @@ export {
   OPENAI_DEFAULT_TTS_MODEL,
   OPENAI_DEFAULT_TTS_VOICE,
 } from "./default-models.js";
+export { discoverOpenAIModels, resetOpenAIDiscoveryCacheForTest } from "./discovery.js";
 export { buildOpenAICodexProvider } from "./openai-codex-catalog.js";
 export { buildOpenAICodexProviderPlugin } from "./openai-codex-provider.js";
 export { buildOpenAIProvider } from "./openai-provider.js";

--- a/extensions/openai/discovery.test.ts
+++ b/extensions/openai/discovery.test.ts
@@ -1,0 +1,235 @@
+// extensions/openai/discovery.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { discoverOpenAIModels, resetOpenAIDiscoveryCacheForTest } from "./discovery.js";
+
+afterEach(() => {
+  resetOpenAIDiscoveryCacheForTest();
+  vi.restoreAllMocks();
+});
+
+function buildResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("discoverOpenAIModels", () => {
+  it("returns [] when baseUrl or apiKey is missing", async () => {
+    const fetchFn = vi.fn();
+    expect(await discoverOpenAIModels({ baseUrl: "", apiKey: "k", fetchFn })).toEqual([]);
+    expect(
+      await discoverOpenAIModels({
+        baseUrl: "https://x.example.com/v1",
+        apiKey: "",
+        fetchFn,
+      }),
+    ).toEqual([]);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("calls <baseUrl>/models with Authorization Bearer", async () => {
+    const fetchFn = vi.fn(async () => buildResponse({ object: "list", data: [] }));
+    await discoverOpenAIModels({
+      baseUrl: "https://aceteam.ai/api/gateway/v1",
+      apiKey: "act_secret_key_12345678",
+      fetchFn,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchFn.mock.calls[0]!;
+    expect(endpoint).toBe("https://aceteam.ai/api/gateway/v1/models");
+    expect((init as RequestInit).method).toBe("GET");
+    expect((init as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer act_secret_key_12345678",
+      Accept: "application/json",
+    });
+  });
+
+  it("strips trailing slashes from baseUrl", async () => {
+    const fetchFn = vi.fn(async () => buildResponse({ object: "list", data: [] }));
+    await discoverOpenAIModels({
+      baseUrl: "https://aceteam.ai/api/gateway/v1///",
+      apiKey: "k",
+      fetchFn,
+    });
+    expect(fetchFn.mock.calls[0]![0]).toBe("https://aceteam.ai/api/gateway/v1/models");
+  });
+
+  it("maps OpenAI-spec entries to ModelDefinitionConfig with sane defaults", async () => {
+    const fetchFn = vi.fn(async () =>
+      buildResponse({
+        object: "list",
+        data: [{ id: "gpt-4o", object: "model", created: 1, owned_by: "openai" }],
+      }),
+    );
+    const models = await discoverOpenAIModels({
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-xxx",
+      fetchFn,
+    });
+    expect(models).toHaveLength(1);
+    expect(models[0]).toMatchObject({
+      id: "gpt-4o",
+      name: "gpt-4o",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 16384,
+    });
+  });
+
+  it("honors AceTeam superset fields when present", async () => {
+    const fetchFn = vi.fn(async () =>
+      buildResponse({
+        object: "list",
+        data: [
+          {
+            id: "gpt-4o",
+            object: "model",
+            created: 1715126400,
+            owned_by: "openai",
+            context_window: 128000,
+            max_output_tokens: 16384,
+            modalities: ["text", "image"],
+            cost_per_million_tokens: {
+              input: 2.5,
+              output: 10,
+              cache_read: 1.25,
+              cache_write: 0,
+            },
+          },
+        ],
+      }),
+    );
+    const [model] = await discoverOpenAIModels({
+      baseUrl: "https://aceteam.ai/api/gateway/v1",
+      apiKey: "act_xxx",
+      fetchFn,
+    });
+    expect(model).toMatchObject({
+      id: "gpt-4o",
+      input: ["text", "image"],
+      cost: { input: 2.5, output: 10, cacheRead: 1.25, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 16384,
+    });
+  });
+
+  it("infers reasoning support from model id family", async () => {
+    const fetchFn = vi.fn(async () =>
+      buildResponse({
+        object: "list",
+        data: [
+          { id: "gpt-5.5", object: "model" },
+          { id: "o3-mini", object: "model" },
+          { id: "gpt-4o", object: "model" },
+          { id: "claude-3-5-sonnet-20241022", object: "model" },
+        ],
+      }),
+    );
+    const models = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+    });
+    const reasoning = Object.fromEntries(models.map((m) => [m.id, m.reasoning]));
+    expect(reasoning).toEqual({
+      "gpt-5.5": true,
+      "o3-mini": true,
+      "gpt-4o": false,
+      "claude-3-5-sonnet-20241022": false,
+    });
+  });
+
+  it("skips entries without an id and sorts the rest", async () => {
+    const fetchFn = vi.fn(async () =>
+      buildResponse({
+        object: "list",
+        data: [{ id: "" }, { object: "model" }, { id: "gpt-4o" }, { id: "claude-3-5-sonnet" }],
+      }),
+    );
+    const models = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+    });
+    expect(models.map((m) => m.id)).toEqual(["claude-3-5-sonnet", "gpt-4o"]);
+  });
+
+  it("caches per (baseUrl, last-8-of-apiKey) for DEFAULT_REFRESH_INTERVAL_SECONDS", async () => {
+    const fetchFn = vi.fn(async () => buildResponse({ object: "list", data: [{ id: "gpt-4o" }] }));
+    const args = {
+      baseUrl: "https://x/v1",
+      apiKey: "k1234567890",
+      fetchFn,
+      now: () => 1000,
+    };
+    await discoverOpenAIModels(args);
+    await discoverOpenAIModels({ ...args, now: () => 1000 + 30 * 60 * 1000 });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches once the TTL expires", async () => {
+    const fetchFn = vi.fn(async () => buildResponse({ object: "list", data: [{ id: "gpt-4o" }] }));
+    const args = { baseUrl: "https://x/v1", apiKey: "k", fetchFn };
+    await discoverOpenAIModels({ ...args, now: () => 1000 });
+    await discoverOpenAIModels({ ...args, now: () => 1000 + 3601 * 1000 });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns last-known-good on transient failure", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(buildResponse({ object: "list", data: [{ id: "gpt-4o" }] }))
+      .mockResolvedValueOnce(buildResponse("Internal Server Error", 500));
+
+    const first = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+      now: () => 1000,
+    });
+    expect(first.map((m) => m.id)).toEqual(["gpt-4o"]);
+
+    const second = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+      now: () => 1000 + 3601 * 1000,
+    });
+    expect(second.map((m) => m.id)).toEqual(["gpt-4o"]);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns [] when there's no cache and the fetch fails", async () => {
+    const fetchFn = vi.fn(async () => buildResponse("nope", 401));
+    const models = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+    });
+    expect(models).toEqual([]);
+  });
+
+  it("swallows network errors and returns last-known-good", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(buildResponse({ object: "list", data: [{ id: "gpt-4o" }] }))
+      .mockRejectedValueOnce(new Error("network down"));
+
+    await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+      now: () => 1000,
+    });
+    const second = await discoverOpenAIModels({
+      baseUrl: "https://x/v1",
+      apiKey: "k",
+      fetchFn,
+      now: () => 1000 + 3601 * 1000,
+    });
+    expect(second.map((m) => m.id)).toEqual(["gpt-4o"]);
+  });
+});

--- a/extensions/openai/discovery.ts
+++ b/extensions/openai/discovery.ts
@@ -1,0 +1,215 @@
+// extensions/openai/discovery.ts
+//
+// Dynamic catalog discovery for the OpenAI provider.
+//
+// When users run OpenClaw against an OpenAI-compatible upstream (LiteLLM,
+// vLLM, AceTeam gateway, local proxy, etc.) the bundled catalog in
+// `openai-provider.ts` doesn't reflect what the upstream actually accepts —
+// users see picker options like `gpt-5.5` that the upstream may 404 on, and
+// don't see custom models the upstream offers.
+//
+// This module fetches `<baseUrl>/models` with the configured `apiKey` and
+// maps the response (strict superset of OpenAI's `/v1/models` shape — extra
+// fields like `context_window`, `cost_per_million_tokens`, `modalities` from
+// gateways like AceTeam are honored when present, otherwise we fall back to
+// per-id heuristics shared with the static catalog).
+//
+// Mirrors `extensions/amazon-bedrock-mantle/discovery.ts` — same caching
+// strategy (per-key, 1h TTL), same failure mode (return last-known-good or
+// empty array; never throw at the caller).
+
+import { createSubsystemLogger } from "openclaw/plugin-sdk/core";
+import { formatErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+
+const log = createSubsystemLogger("openai-discovery");
+
+const DEFAULT_REFRESH_INTERVAL_SECONDS = 3600; // 1 hour, matches Mantle.
+const DEFAULT_CONTEXT_WINDOW = 128_000;
+const DEFAULT_MAX_TOKENS = 16_384;
+const DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+// ---------------------------------------------------------------------------
+// Response shapes — superset of OpenAI's /v1/models
+// ---------------------------------------------------------------------------
+
+interface OpenAIModelEntry {
+  id: string;
+  object?: string;
+  created?: number;
+  owned_by?: string;
+  // AceTeam gateway and similar upstreams add these alongside the spec fields.
+  context_window?: number;
+  max_output_tokens?: number;
+  modalities?: string[];
+  cost_per_million_tokens?: {
+    input?: number;
+    output?: number;
+    cache_read?: number;
+    cache_write?: number;
+  };
+}
+
+interface OpenAIModelsResponse {
+  object?: string;
+  data?: OpenAIModelEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+interface DiscoveryCacheEntry {
+  models: ModelDefinitionConfig[];
+  fetchedAt: number;
+}
+
+const discoveryCache = new Map<string, DiscoveryCacheEntry>();
+
+/** Test-only: clear the in-memory discovery cache. */
+export function resetOpenAIDiscoveryCacheForTest(): void {
+  discoveryCache.clear();
+}
+
+// Cache key collapses the secret part of the auth token so two callers using
+// the same key share a cache entry, but rotating a key invalidates.
+function cacheKey(baseUrl: string, apiKey: string): string {
+  // We only need a stable identifier — full key isn't logged anywhere from
+  // the cache key, but hashing avoids holding raw secrets in memory map keys
+  // beyond what's already in the request flow.
+  return `${baseUrl}::${apiKey.slice(-8)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+const TEXT_MODALITY_NAMES = new Set(["text", "input_text", "output_text"]);
+const IMAGE_MODALITY_NAMES = new Set(["image", "input_image", "vision"]);
+const AUDIO_MODALITY_NAMES = new Set(["audio", "input_audio", "output_audio"]);
+const VIDEO_MODALITY_NAMES = new Set(["video", "input_video"]);
+
+function mapModalities(raw: string[] | undefined): Array<"text" | "image" | "video" | "audio"> {
+  // OpenAI's spec doesn't define a `modalities` field; gateways that ship one
+  // use a mix of conventions. Fall back to text-only when nothing is supplied.
+  if (!raw || raw.length === 0) return ["text"];
+  const out = new Set<"text" | "image" | "video" | "audio">();
+  for (const m of raw) {
+    const lower = m.toLowerCase();
+    if (TEXT_MODALITY_NAMES.has(lower)) out.add("text");
+    else if (IMAGE_MODALITY_NAMES.has(lower)) out.add("image");
+    else if (AUDIO_MODALITY_NAMES.has(lower)) out.add("audio");
+    else if (VIDEO_MODALITY_NAMES.has(lower)) out.add("video");
+  }
+  if (out.size === 0) out.add("text");
+  return Array.from(out);
+}
+
+function inferReasoningSupport(modelId: string): boolean {
+  // Heuristic: GPT-5.x family and the o-series reasoning models all support
+  // `reasoning_effort`. Lower-case match — gateways sometimes uppercase IDs.
+  const id = modelId.toLowerCase();
+  if (id.startsWith("gpt-5") || id.startsWith("o1") || id.startsWith("o3") || id.startsWith("o4")) {
+    return true;
+  }
+  return false;
+}
+
+function toModelDefinition(entry: OpenAIModelEntry): ModelDefinitionConfig | null {
+  const id = entry.id?.trim();
+  if (!id) return null;
+  const cost = entry.cost_per_million_tokens;
+  return {
+    id,
+    name: id,
+    reasoning: inferReasoningSupport(id),
+    input: mapModalities(entry.modalities),
+    cost: {
+      input: typeof cost?.input === "number" ? cost.input : DEFAULT_COST.input,
+      output: typeof cost?.output === "number" ? cost.output : DEFAULT_COST.output,
+      cacheRead: typeof cost?.cache_read === "number" ? cost.cache_read : DEFAULT_COST.cacheRead,
+      cacheWrite:
+        typeof cost?.cache_write === "number" ? cost.cache_write : DEFAULT_COST.cacheWrite,
+    },
+    contextWindow:
+      typeof entry.context_window === "number" && entry.context_window > 0
+        ? entry.context_window
+        : DEFAULT_CONTEXT_WINDOW,
+    maxTokens:
+      typeof entry.max_output_tokens === "number" && entry.max_output_tokens > 0
+        ? entry.max_output_tokens
+        : DEFAULT_MAX_TOKENS,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the list of available models from an OpenAI-compatible upstream.
+ *
+ * Sample request:
+ * ```
+ * GET https://aceteam.ai/api/gateway/v1/models
+ * Authorization: Bearer <apiKey>
+ * ```
+ *
+ * Cached per `(baseUrl, last-8-of-apiKey)` for `DEFAULT_REFRESH_INTERVAL_SECONDS`.
+ * Returns the cached result on transient failure; returns `[]` if there's no
+ * cache and the fetch fails.
+ */
+export async function discoverOpenAIModels(params: {
+  baseUrl: string;
+  apiKey: string;
+  fetchFn?: typeof fetch;
+  now?: () => number;
+}): Promise<ModelDefinitionConfig[]> {
+  const { baseUrl, apiKey, fetchFn = fetch, now = Date.now } = params;
+  if (!baseUrl || !apiKey) return [];
+
+  const key = cacheKey(baseUrl, apiKey);
+  const cached = discoveryCache.get(key);
+  if (cached && now() - cached.fetchedAt < DEFAULT_REFRESH_INTERVAL_SECONDS * 1000) {
+    return cached.models;
+  }
+
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  const endpoint = `${trimmed}/models`;
+
+  try {
+    const response = await fetchFn(endpoint, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      log.debug?.("OpenAI model discovery failed", {
+        endpoint,
+        status: response.status,
+        statusText: response.statusText,
+      });
+      return cached?.models ?? [];
+    }
+
+    const body = (await response.json()) as OpenAIModelsResponse;
+    const rawModels = body.data ?? [];
+
+    const models = rawModels
+      .map(toModelDefinition)
+      .filter((m): m is ModelDefinitionConfig => m !== null)
+      .toSorted((a, b) => a.id.localeCompare(b.id));
+
+    discoveryCache.set(key, { models, fetchedAt: now() });
+    return models;
+  } catch (error) {
+    log.debug?.("OpenAI model discovery error", {
+      endpoint,
+      error: formatErrorMessage(error),
+    });
+    return cached?.models ?? [];
+  }
+}


### PR DESCRIPTION
First slice of the design proposed in #74481 — adds the discovery primitive without yet wiring it into catalog resolution. Keeping infrastructure and integration in separate PRs so the cache strategy / response mapping can be reviewed independently of the bigger plumbing question (where in the model-resolution path discovery should be invoked, merge-vs-replace semantics, Control UI refresh trigger).

## What this PR does

Adds `extensions/openai/discovery.ts` exposing `discoverOpenAIModels({baseUrl, apiKey, fetchFn?, now?})`:

- Fetches `${baseUrl}/models` with `Authorization: Bearer ${apiKey}`.
- Maps the response (strict superset of OpenAI's `/v1/models` envelope — gateways like AceTeam ship extra fields like `context_window`, `max_output_tokens`, `modalities`, `cost_per_million_tokens` and we honor them when present).
- Falls back to per-id heuristics (default 128k context, 16k max output, text-only, zero cost; `reasoning=true` for `gpt-5.x` / `o[1,3,4]` families).
- Caches per `(baseUrl, last-8-of-apiKey)` for 1h. Rotating the key invalidates.
- Fail-soft: returns last-known-good on transient failure, returns `[]` when there's no cache and the fetch fails. Never throws at the caller.

## Mirrors existing precedent

This is the same shape as `extensions/amazon-bedrock-mantle/discovery.ts:265` — same TTL, same cache-on-success / cache-on-failure semantics, same `ModelDefinitionConfig[]` return type. Makes it familiar to anyone who has read that file.

## What this PR does NOT do (intentionally)

- **Doesn't wire discovery into catalog resolution.** The static catalog in `openai-provider.ts` is unchanged. To exercise the discovered list you'd call `discoverOpenAIModels()` from your own integration today; a follow-up PR will plumb it into the dynamic-model resolution path.
- **Doesn't touch the `ProviderPlugin` interface.** The proposed `resolveDynamicCatalog` hook in #74481 needs maintainer agreement on shape before it lands. If reviewers prefer that path, this discovery function is what the OpenAI plugin's `resolveDynamicCatalog` would call.
- **Doesn't address Anthropic.** Anthropic's `/v1/models` shape and auth header conventions differ; that's a separate PR mirroring this one.

## Test plan

- [x] `pnpm test extensions/openai/discovery.test.ts` → 12/12 pass.
- [x] Coverage: missing inputs, header/URL shape, trailing-slash normalization, AceTeam superset fields, modality/cost/reasoning mapping, sort, cache hit, TTL expiry, transient-failure fallback, network-error fallback, no-cache failure path.
- [ ] Integration: hit a real `/v1/models` endpoint and confirm the mapped output is sensible.

## Discussion

Design questions (from #74481) still open:
1. Hook name/shape for plumbing into catalog resolution.
2. Merge-vs-replace semantics — does dynamic discovery need its own setting, or does `models.modelCatalogMode` cover it?
3. Cache scoping for multi-tenant gateways where the same `baseUrl` returns different lists per org.

Happy to revise this PR or split further once those land.

## Forks affected

`aceteam-ai/safeclaw` (OpenClaw + AEP safety-proxy fork) needs this for its model picker to reflect what its proxy actually accepts. Will consume the same discovery function.