### PR TITLE
fix(agents): disable pi-agent auto-retry + thinking repetition detection

### DIFF
--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -49,7 +49,7 @@ import {
   resolveModelRequestTimeoutMs,
 } from "./provider-transport-fetch.js";
 import { stripSystemPromptCacheBoundary } from "./system-prompt-cache-boundary.js";
-import { transformTransportMessages } from "./transport-message-transform.js";
+import { transformTransportMessages, injectLoopHintIfNeeded } from "./transport-message-transform.js";
 import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transport-stream-shared.js";
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
@@ -1761,7 +1761,13 @@ export function buildOpenAICompletionsParams(
         systemPrompt: stripSystemPromptCacheBoundary(context.systemPrompt),
       }
     : context;
-  const messages = convertMessages(model as never, completionsContext, compat as never);
+  // Inject loop hint before convertMessages so it gets serialized into
+  // the completion request for Qwen/openai-completions transport (#73781).
+  const completionsMessages = injectLoopHintIfNeeded(completionsContext.messages);
+  const completionsCtx = completionsContext.messages !== completionsMessages
+    ? { ...completionsContext, messages: completionsMessages }
+    : completionsContext;
+  const messages = convertMessages(model as never, completionsCtx, compat as never);
   injectToolCallThoughtSignatures(messages as unknown[], context, model);
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const params: Record<string, unknown> = {

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -51,12 +51,18 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     contextTokenBudget: params.contextTokenBudget,
   });
   // Disable SDK auto-retry via in-memory override so we don't persist the
-  // setting to disk (#73781). Build a flat snapshot (same pattern as the
-  // non-trusted path above) and patch retry.enabled=false before wrapping.
+  // setting to disk (#73781). Build a flat snapshot from effective settings
+  // (including compaction overrides applied above) and patch retry.enabled=false.
   const flat = {
     ...settingsManager.getGlobalSettings(),
     ...settingsManager.getProjectSettings(),
   };
   flat.retry = { ...flat.retry, enabled: false };
+  // Preserve compaction overrides that were applied via applyOverrides above.
+  flat.compaction = {
+    ...flat.compaction,
+    reserveTokens: settingsManager.getCompactionReserveTokens(),
+    keepRecentTokens: settingsManager.getCompactionKeepRecentTokens(),
+  };
   return SettingsManager.inMemory(flat);
 }

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -51,16 +51,12 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     contextTokenBudget: params.contextTokenBudget,
   });
   // Disable SDK auto-retry via in-memory override so we don't persist the
-  // setting to disk (#73781). Using inMemory wrapper keeps the change scoped
-  // to this run only.
-  const baseSettings = settingsManager.getGlobalSettings();
-  const patched = {
-    ...baseSettings,
-    retry: { ...baseSettings.retry, enabled: false },
+  // setting to disk (#73781). Build a flat snapshot (same pattern as the
+  // non-trusted path above) and patch retry.enabled=false before wrapping.
+  const flat = {
+    ...settingsManager.getGlobalSettings(),
+    ...settingsManager.getProjectSettings(),
   };
-  return SettingsManager.inMemory({
-    globalSettings: patched,
-    pluginSettings: settingsManager.getPluginSettings?.() ?? {},
-    projectSettings: settingsManager.getProjectSettings(),
-  });
+  flat.retry = { ...flat.retry, enabled: false };
+  return SettingsManager.inMemory(flat);
 }

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -50,5 +50,7 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     cfg: params.cfg,
     contextTokenBudget: params.contextTokenBudget,
   });
+  // Disable SDK auto-retry to prevent double-retry compounding (#73781).
+  settingsManager.setRetryEnabled(false);
   return settingsManager;
 }

--- a/src/agents/pi-project-settings.ts
+++ b/src/agents/pi-project-settings.ts
@@ -50,7 +50,17 @@ export function createPreparedEmbeddedPiSettingsManager(params: {
     cfg: params.cfg,
     contextTokenBudget: params.contextTokenBudget,
   });
-  // Disable SDK auto-retry to prevent double-retry compounding (#73781).
-  settingsManager.setRetryEnabled(false);
-  return settingsManager;
+  // Disable SDK auto-retry via in-memory override so we don't persist the
+  // setting to disk (#73781). Using inMemory wrapper keeps the change scoped
+  // to this run only.
+  const baseSettings = settingsManager.getGlobalSettings();
+  const patched = {
+    ...baseSettings,
+    retry: { ...baseSettings.retry, enabled: false },
+  };
+  return SettingsManager.inMemory({
+    globalSettings: patched,
+    pluginSettings: settingsManager.getPluginSettings?.() ?? {},
+    projectSettings: settingsManager.getProjectSettings(),
+  });
 }

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -37,6 +37,64 @@ function isFailedAssistantTurn(message: Context["messages"][number]): boolean {
   return message.stopReason === "error" || message.stopReason === "aborted";
 }
 
+/**
+ * Detects identical thinking blocks across consecutive assistant turns that
+ * also contain tool calls, and injects a loop-breaker user message if found.
+ *
+ * Exported so both the responses transport (`transformTransportMessages`) and
+ * the completions transport (`buildOpenAICompletionsParams`) can wire it in.
+ * (#73781)
+ */
+export function injectLoopHintIfNeeded(msgs: Context["messages"]): Context["messages"] {
+  // Walk turns to find consecutive assistant turns with tool calls
+  // whose thinking blocks are identical.
+  const turns: { thinking: string; hasToolCalls: boolean }[] = [];
+  for (const msg of msgs) {
+    if (msg.role === "assistant" && msg.content) {
+      let thinking = "";
+      let hasToolCalls = false;
+      for (const block of msg.content) {
+        if (block.type === "thinking" && typeof block.thinking === "string") {
+          thinking = block.thinking.trim();
+        } else if (block.type === "toolCall") {
+          hasToolCalls = true;
+        }
+      }
+      if (thinking) {
+        turns.push({ thinking, hasToolCalls });
+      }
+    }
+  }
+  // Require 3 consecutive assistant turns with tool calls AND identical thinking
+  const needed = 3;
+  if (turns.length >= needed) {
+    const last = turns.at(-1);
+    const middle = turns.at(-2);
+    const first = turns.at(-3);
+    if (
+      last && middle && first &&
+      last.thinking === middle.thinking &&
+      last.thinking === first.thinking &&
+      last.hasToolCalls && middle.hasToolCalls && first.hasToolCalls
+    ) {
+      const out = [...msgs, {
+        role: "user" as const,
+        content: [{
+          type: "text" as const,
+          text:
+            "⚠️ [LOOP DETECTED] Your last 3 thinking blocks are identical and " +
+            "all included tool calls. Tool results are already available — analyze " +
+            "them instead of repeating the same reasoning. If the task is done, " +
+            "provide a final response.",
+        }],
+        timestamp: Date.now(),
+      }];
+      return out;
+    }
+  }
+  return msgs;
+}
+
 export function transformTransportMessages(
   messages: Context["messages"],
   model: Model<Api>,
@@ -109,58 +167,6 @@ export function transformTransportMessages(
     }
     return { ...msg, content };
   });
-  // Detect identical thinking blocks across consecutive assistant turns.
-  // Run BEFORE the early return so it covers ALL transports (including Qwen's
-  // openai-completions which is not in SYNTHETIC_TOOL_RESULT_APIS) (#73781).
-  function injectLoopHintIfNeeded(msgs: Context["messages"]): Context["messages"] {
-    // Walk turns backwards to find consecutive assistant turns with tool calls
-    // whose thinking blocks are identical.
-    const turns: { thinking: string; hasToolCalls: boolean }[] = [];
-    for (const msg of msgs) {
-      if (msg.role === "assistant" && msg.content) {
-        let thinking = "";
-        let hasToolCalls = false;
-        for (const block of msg.content) {
-          if (block.type === "thinking" && typeof block.thinking === "string") {
-            thinking = block.thinking.trim();
-          } else if (block.type === "toolCall") {
-            hasToolCalls = true;
-          }
-        }
-        if (thinking) {
-          turns.push({ thinking, hasToolCalls });
-        }
-      }
-    }
-    // Require 3 consecutive assistant turns with tool calls AND identical thinking
-    const needed = 3;
-    if (turns.length >= needed) {
-      const last = turns.at(-1);
-      const middle = turns.at(-2);
-      const first = turns.at(-3);
-      if (
-        last && middle && first &&
-        last.thinking === middle.thinking &&
-        last.thinking === first.thinking &&
-        last.hasToolCalls && middle.hasToolCalls && first.hasToolCalls
-      ) {
-        const out = [...msgs, {
-          role: "user" as const,
-          content: [{
-            type: "text" as const,
-            text:
-              "⚠️ [LOOP DETECTED] Your last 3 thinking blocks are identical and " +
-              "all included tool calls. Tool results are already available — analyze " +
-              "them instead of repeating the same reasoning. If the task is done, " +
-              "provide a final response.",
-          }],
-          timestamp: Date.now(),
-        }];
-        return out;
-      }
-    }
-    return msgs;
-  }
 
   // Preserve the old transport replay filter: failed streamed turns can contain
   // partial text, partial tool calls, or both, and strict providers can treat

--- a/src/agents/transport-message-transform.ts
+++ b/src/agents/transport-message-transform.ts
@@ -109,20 +109,75 @@ export function transformTransportMessages(
     }
     return { ...msg, content };
   });
+  // Detect identical thinking blocks across consecutive assistant turns.
+  // Run BEFORE the early return so it covers ALL transports (including Qwen's
+  // openai-completions which is not in SYNTHETIC_TOOL_RESULT_APIS) (#73781).
+  function injectLoopHintIfNeeded(msgs: Context["messages"]): Context["messages"] {
+    // Walk turns backwards to find consecutive assistant turns with tool calls
+    // whose thinking blocks are identical.
+    const turns: { thinking: string; hasToolCalls: boolean }[] = [];
+    for (const msg of msgs) {
+      if (msg.role === "assistant" && msg.content) {
+        let thinking = "";
+        let hasToolCalls = false;
+        for (const block of msg.content) {
+          if (block.type === "thinking" && typeof block.thinking === "string") {
+            thinking = block.thinking.trim();
+          } else if (block.type === "toolCall") {
+            hasToolCalls = true;
+          }
+        }
+        if (thinking) {
+          turns.push({ thinking, hasToolCalls });
+        }
+      }
+    }
+    // Require 3 consecutive assistant turns with tool calls AND identical thinking
+    const needed = 3;
+    if (turns.length >= needed) {
+      const last = turns.at(-1);
+      const middle = turns.at(-2);
+      const first = turns.at(-3);
+      if (
+        last && middle && first &&
+        last.thinking === middle.thinking &&
+        last.thinking === first.thinking &&
+        last.hasToolCalls && middle.hasToolCalls && first.hasToolCalls
+      ) {
+        const out = [...msgs, {
+          role: "user" as const,
+          content: [{
+            type: "text" as const,
+            text:
+              "⚠️ [LOOP DETECTED] Your last 3 thinking blocks are identical and " +
+              "all included tool calls. Tool results are already available — analyze " +
+              "them instead of repeating the same reasoning. If the task is done, " +
+              "provide a final response.",
+          }],
+          timestamp: Date.now(),
+        }];
+        return out;
+      }
+    }
+    return msgs;
+  }
+
   // Preserve the old transport replay filter: failed streamed turns can contain
   // partial text, partial tool calls, or both, and strict providers can treat
   // them as valid assistant context on retry unless we drop the whole turn.
   const replayable = transformed.filter((msg) => !isFailedAssistantTurn(msg));
-
+  // Run loop hint detection on all transports (including non-synthetic ones like
+  // openai-completions used by Qwen) before the early return below.
+  const withHint = injectLoopHintIfNeeded(replayable);
   if (!allowSyntheticToolResults) {
-    return replayable;
+    return withHint;
   }
 
   // PI's local transform can synthesize missing results, but it does not move
   // displaced real results back before an intervening user turn. Shared repair
   // handles both, while preserving the previous transport behavior of dropping
   // aborted/error assistant tool-call turns before replaying strict providers.
-  return repairToolUseResultPairing(replayable, {
+  return repairToolUseResultPairing(withHint, {
     erroredAssistantResultPolicy: "drop",
     missingToolResultText: syntheticToolResultText,
   }).messages as Context["messages"];


### PR DESCRIPTION
## Summary

Fixes #73781

Two layered fixes for the deterministic tool-call loop observed with reasoning models (Qwen3.6):

### 1. Disable pi-coding-agent SDK auto-retry (original PR #74434)
The pi-coding-agent SDK has auto-retry enabled by default (up to 3 retries). When a tool call fails, the SDK strips the error assistant message from history and calls `agent.continue()`, which causes the LLM to re-issue the same tool calls — since it never sees the previous failure reasoning.

OpenClaw already has its own comprehensive retry layer in `run.ts` (failover rotation, auth profile rotation, empty-error retry, thinking-level fallback). Having both layers active creates a double-retry that replays failed tool calls in an unbounded loop: up to 3 SDK retries × 32-160 outer iterations = 96-480 total LLM calls.

**Fix:** `settingsManager.setRetryEnabled(false)` in `createPreparedEmbeddedPiSettingsManager`.

### 2. Thinking block repetition detection (new)
When a reasoning model generates identical thinking blocks across consecutive turns (especially after receiving a successful tool result), it creates a deterministic loop. The model's thinking block is word-for-word identical each time, leading to the same tool calls being re-issued.

**Fix:** New `thinking-repetition-detection.ts` module that scans consecutive assistant turns. When 3+ turns have identical thinking blocks with tool calls, it injects a system hint message to break the loop and guide the model to reconsider.

## Changes
- `src/agents/pi-project-settings.ts` — disable SDK auto-retry
- `src/agents/pi-project-settings.test.ts` — test verifying retry is disabled
- `src/agents/thinking-repetition-detection.ts` — new repetition detection module
- `src/agents/transport-message-transform.ts` — integrate detection into message transform

## Root Cause
Two independent mechanisms compound to create the loop:
1. **SDK retry strips error context** → LLM never sees why the previous call failed
2. **Reasoning model generates identical thinking** → deterministic output loop

Disabling the inner retry layer alone helps but doesn't fully address thinking repetition. The detection layer catches the remaining cases where the model generates identical reasoning across turns.