### PR TITLE
fix(auto-reply): honor direct silent empty replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply: honor explicit `silentReply.direct: "allow"` for clean empty or reasoning-only direct chat turns while keeping the default direct-chat empty-response guard conservative. Fixes #74409. Thanks @jesuskannolis.
 - Ollama: normalize provider-prefixed tool-call names at the native stream boundary so Kimi/Ollama calls such as `functions.exec` dispatch as `exec` instead of missing configured tools. Fixes #74487. Thanks @afurm and @carreipeia.
 - Security/audit: resolve configured model aliases before model-tier and small-parameter checks, so alias-based GPT-5/Codex configs no longer report false weak-model warnings. Fixes #74455. Thanks @blaspat.
 - CLI/agent: isolate Gateway-timeout embedded fallback runs under explicit `gateway-fallback-*` sessions so accepted Gateway runs cannot race transcript locks or replace the routed conversation session. Fixes #62981. Thanks @HemantSudarshan.

--- a/docs/channels/groups.md
+++ b/docs/channels/groups.md
@@ -329,7 +329,7 @@ Replying to a bot message counts as an implicit mention when the channel support
     - Per-agent override: `agents.list[].groupChat.mentionPatterns` (useful when multiple agents share a group).
     - Mention gating is only enforced when mention detection is possible (native mentions or `mentionPatterns` are configured).
     - Group chat prompt context carries the resolved silent-reply instruction every turn; workspace files should not duplicate `NO_REPLY` mechanics.
-    - Groups where silent replies are allowed treat clean empty or reasoning-only model turns as silent, equivalent to `NO_REPLY`. Direct chats still treat empty replies as a failed agent turn.
+    - Groups where silent replies are allowed treat clean empty or reasoning-only model turns as silent, equivalent to `NO_REPLY`. Direct chats do the same only when direct silent replies are explicitly allowed; otherwise empty replies remain failed agent turns.
     - Discord defaults live in `channels.discord.guilds."*"` (overridable per guild/channel).
     - Group history context is wrapped uniformly across channels and is **pending-only** (messages skipped due to mention gating); use `messages.groupChat.historyLimit` for the global default and `channels.<channel>.historyLimit` (or `channels.<channel>.accounts.*.historyLimit`) for overrides. Set `0` to disable.
 

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -374,6 +374,42 @@ describe("runPreparedReply media-only handling", () => {
     },
   );
 
+  it("does not borrow target-session silence for native commands sent from direct chats", async () => {
+    await runPreparedReply(
+      baseParams({
+        sessionKey: "agent:main:telegram:group:target",
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+          ThreadHistoryBody: "Earlier direct message",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "D123",
+          ChatType: "direct",
+          CommandSource: "native",
+          SessionKey: "agent:main:telegram:direct:source",
+          CommandTargetSessionKey: "agent:main:telegram:group:target",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          ThreadHistoryBody: "Earlier direct message",
+          MediaPath: "/tmp/input.png",
+          Provider: "telegram",
+          ChatType: "direct",
+          OriginatingChannel: "telegram",
+          OriginatingTo: "D123",
+          CommandSource: "native",
+          SessionKey: "agent:main:telegram:direct:source",
+          CommandTargetSessionKey: "agent:main:telegram:group:target",
+        },
+      }),
+    );
+
+    const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+    expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(false);
+  });
+
   it("allows media-only prompts and preserves thread context in queued followups", async () => {
     const result = await runPreparedReply(baseParams());
     expect(result).toEqual({ text: "ok" });

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -302,7 +302,7 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
   });
 
-  it("does not propagate empty-assistant silence for direct runs", async () => {
+  it("keeps empty-assistant silence disabled for direct runs by default", async () => {
     await runPreparedReply(
       baseParams({
         ctx: {
@@ -330,6 +330,49 @@ describe("runPreparedReply media-only handling", () => {
     const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
     expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(false);
   });
+
+  it.each(["direct", "dm"] as const)(
+    "propagates empty-assistant silence for %s runs with explicit direct silent replies",
+    async (chatType) => {
+      await runPreparedReply(
+        baseParams({
+          ctx: {
+            Body: "",
+            RawBody: "",
+            CommandBody: "",
+            ThreadHistoryBody: "Earlier direct message",
+            OriginatingChannel: "slack",
+            OriginatingTo: "D123",
+            ChatType: chatType,
+          },
+          sessionCtx: {
+            Body: "",
+            BodyStripped: "",
+            ThreadHistoryBody: "Earlier direct message",
+            MediaPath: "/tmp/input.png",
+            Provider: "slack",
+            ChatType: chatType,
+            OriginatingChannel: "slack",
+            OriginatingTo: "D123",
+          },
+          cfg: {
+            session: {},
+            channels: {},
+            agents: {
+              defaults: {
+                silentReply: {
+                  direct: "allow",
+                },
+              },
+            },
+          },
+        }),
+      );
+
+      const call = vi.mocked(runReplyAgent).mock.calls.at(-1)?.[0];
+      expect(call?.followupRun.run.allowEmptyAssistantReplyAsSilent).toBe(true);
+    },
+  );
 
   it("allows media-only prompts and preserves thread context in queued followups", async () => {
     const result = await runPreparedReply(baseParams());

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -425,6 +425,7 @@ export async function runPreparedReply(
   const isFirstTurnInSession = isNewSession || !currentSystemSent;
   const isGroupChat =
     promptSessionCtx.ChatType === "group" || promptSessionCtx.ChatType === "channel";
+  const isDirectChat = promptSessionCtx.ChatType === "direct" || promptSessionCtx.ChatType === "dm";
   const wasMentioned = ctx.WasMentioned === true;
   const { typingPolicy, suppressTyping } = resolveRunTypingPolicy({
     requestedPolicy: opts?.typingPolicy,
@@ -444,15 +445,14 @@ export async function runPreparedReply(
   const shouldInjectGroupIntro = Boolean(
     isGroupChat && (isFirstTurnInSession || sessionEntry?.groupActivationNeedsSystemIntro),
   );
-  const directChatContext =
-    promptSessionCtx.ChatType === "direct" || promptSessionCtx.ChatType === "dm"
-      ? buildDirectChatContext({
-          sessionCtx: promptSessionCtx,
-          silentReplyPolicy: silentReplySettings.policy,
-          silentReplyRewrite: silentReplySettings.rewrite,
-          silentToken: SILENT_REPLY_TOKEN,
-        })
-      : "";
+  const directChatContext = isDirectChat
+    ? buildDirectChatContext({
+        sessionCtx: promptSessionCtx,
+        silentReplyPolicy: silentReplySettings.policy,
+        silentReplyRewrite: silentReplySettings.rewrite,
+        silentToken: SILENT_REPLY_TOKEN,
+      })
+    : "";
   // Always include persistent group chat context (provider + reply guidance).
   const groupChatContext = isGroupChat
     ? buildGroupChatContext({
@@ -476,13 +476,14 @@ export async function runPreparedReply(
       })
     : "";
   const allowEmptyAssistantReplyAsSilent =
-    isGroupChat &&
-    resolveGroupSilentReplyBehavior({
-      sessionEntry,
-      defaultActivation,
-      silentReplyPolicy: silentReplySettings.policy,
-      silentReplyRewrite: silentReplySettings.rewrite,
-    }).allowEmptyAssistantReplyAsSilent;
+    (isDirectChat && silentReplySettings.policy === "allow") ||
+    (isGroupChat &&
+      resolveGroupSilentReplyBehavior({
+        sessionEntry,
+        defaultActivation,
+        silentReplyPolicy: silentReplySettings.policy,
+        silentReplyRewrite: silentReplySettings.rewrite,
+      }).allowEmptyAssistantReplyAsSilent);
   const groupSystemPrompt = normalizeOptionalString(promptSessionCtx.GroupSystemPrompt) ?? "";
   const inboundMetaPrompt = buildInboundMetaSystemPrompt(
     isNewSession ? sessionCtx : { ...sessionCtx, ThreadStarterBody: undefined },

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -400,14 +400,15 @@ export async function runPreparedReply(
     ctx,
     isHeartbeat,
   });
+  const silentReplyConversationType = resolvePromptSilentReplyConversationType({
+    ctx: promptSessionCtx,
+    inboundSessionKey: ctx.SessionKey,
+  });
   const silentReplySettings = resolveSilentReplySettings({
     cfg,
     sessionKey: runtimePolicySessionKey,
     surface: promptSessionCtx.Surface ?? promptSessionCtx.Provider,
-    conversationType: resolvePromptSilentReplyConversationType({
-      ctx: promptSessionCtx,
-      inboundSessionKey: ctx.SessionKey,
-    }),
+    conversationType: silentReplyConversationType,
   });
   const useFastReplyRuntime = shouldUseReplyFastTestRuntime({
     cfg,
@@ -476,7 +477,9 @@ export async function runPreparedReply(
       })
     : "";
   const allowEmptyAssistantReplyAsSilent =
-    (isDirectChat && silentReplySettings.policy === "allow") ||
+    (isDirectChat &&
+      silentReplyConversationType === "direct" &&
+      silentReplySettings.policy === "allow") ||
     (isGroupChat &&
       resolveGroupSilentReplyBehavior({
         sessionEntry,


### PR DESCRIPTION
## Summary

- Problem: `silentReply.direct: "allow"` told direct-chat prompts to use `NO_REPLY`, but empty or reasoning-only direct turns were still treated as failed empty responses.
- Why it matters: operators who explicitly opt direct chats into silence should get the same intentional-silence handling as `NO_REPLY`, without changing conservative direct-chat defaults.
- What changed: direct/dm runs now pass `allowEmptyAssistantReplyAsSilent` only when the resolved prompt-policy context is direct and `silentReply.direct` resolves to `allow`.
- What did NOT change (scope boundary): group/channel behavior, default direct-chat behavior, silent rewrite behavior, and cross-session native command targeting remain conservative.

AI-assisted: yes. I understand what the code changes do.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74409
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: the prompt path resolved direct silent-reply policy, but `allowEmptyAssistantReplyAsSilent` was gated behind `isGroupChat` only.
- Missing detection / guardrail: coverage checked group empty/reasoning-only silence and direct prompt text, but not direct runner propagation for explicit `silentReply.direct: "allow"`.
- Contributing context (if known): direct chats intentionally default to `disallow`, so the fix must only apply to explicit direct policy context.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/get-reply-run.media-only.test.ts`
- Scenario the test should lock in: direct and dm runs propagate empty-assistant silence only when direct silent replies are explicitly allowed; native commands sent from direct chats do not borrow target-session silence.
- Why this is the smallest reliable guardrail: `runPreparedReply` is the seam that computes and forwards `allowEmptyAssistantReplyAsSilent` into the runner.
- Existing test that already covers this (if any): runner behavior for the flag itself is covered in `src/agents/pi-embedded-runner/run.incomplete-turn.test.ts`.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Operators who explicitly configure `silentReply.direct: "allow"` can now have clean empty or reasoning-only direct/dm model turns treated as intentional silence. Direct chats still disallow this by default.

## Diagram (if applicable)

N/A

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node/pnpm local checkout
- Model/provider: N/A
- Integration/channel (if any): direct/dm auto-reply runner
- Relevant config (redacted): `agents.defaults.silentReply.direct = "allow"`

### Steps

1. Configure direct silent replies with `silentReply.direct: "allow"`.
2. Run a direct/dm turn where the assistant produces no visible text or only reasoning.
3. Compare with a default direct/dm config and with a native direct command targeting a different session.

### Expected

- Explicit direct allow treats clean empty/reasoning-only as intentional silence.
- Default direct config keeps empty-response retry/fallback behavior.
- Targeted native commands do not inherit target-session silence for direct requester delivery.

### Actual

- Before this change, direct/dm runs never enabled empty-assistant silence because the flag was gated on `isGroupChat`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: explicit direct/dm allow, default direct disallow, targeted native direct command guard, existing runner handling for empty/reasoning-only silence.
- Edge cases checked: group/channel behavior remains routed through `resolveGroupSilentReplyBehavior`; direct allow requires direct prompt-policy context.
- What you did **not** verify: live messaging-channel delivery.

Commands run:

```text
pnpm docs:list
pnpm test src/auto-reply/reply/get-reply-run.media-only.test.ts src/agents/pi-embedded-runner/run.incomplete-turn.test.ts
pnpm exec oxfmt --check --threads=1 src/auto-reply/reply/get-reply-run.ts src/auto-reply/reply/get-reply-run.media-only.test.ts CHANGELOG.md docs/channels/groups.md
git diff --check
pnpm changed:lanes --json
pnpm check:changed
/Users/vyctor/.codex/skills/oss-pr-contributions/scripts/public_pr_preflight.sh /Users/vyctor/Documents/Codex/2026-04-29/quero-trabalhar-na-issue-74409-do/openclaw
```

`codex review --base origin/main` initially found one P2 around native direct commands targeting another session. That finding was fixed and covered with a regression test. A final retry completed successfully with no remaining findings.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: direct chats could accidentally suppress empty failed turns.
  - Mitigation: the direct branch requires direct prompt-policy context plus explicit `silentReply.direct: "allow"`; defaults remain conservative and targeted native commands are covered.

