### PR TITLE
fix(agents): preserve seeded Anthropic text blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Anthropic/Meridian: preserve text and thinking content seeded on `content_block_start` in anthropic-messages streams, so `[thinking, text]` replies no longer persist as empty turns or trigger empty-response fallbacks. Fixes #74410. Thanks @vyctorbrzezowski.
 - Media: include redacted per-attempt resize failures and resolved model input capabilities in vision-pipeline errors so ARM64 image failures are diagnosable without closing the remaining routing investigation. Refs #74552. Thanks @1yihui.
 - Auto-reply: honor explicit `silentReply.direct: "allow"` for clean empty or reasoning-only direct chat turns while keeping the default direct-chat empty-response guard conservative. Fixes #74409. Thanks @jesuskannolis.
 - OpenAI Codex: send a non-empty Responses input item when a Codex turn only has systemPrompt-backed instructions, avoiding ChatGPT backend 400s from `input: []`. Fixes #73820. Thanks @woodhouse-bot.

--- a/src/agents/anthropic-transport-stream.test.ts
+++ b/src/agents/anthropic-transport-stream.test.ts
@@ -457,6 +457,82 @@ describe("anthropic transport stream", () => {
     );
   });
 
+  it("preserves text seeded on a text block after a thinking block", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        {
+          type: "message_start",
+          message: { id: "msg_1", usage: { input_tokens: 6, output_tokens: 0 } },
+        },
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "thinking", thinking: "checking", signature: "sig_1" },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "signature_delta", signature: "sig_2" },
+        },
+        {
+          type: "content_block_stop",
+          index: 0,
+        },
+        {
+          type: "content_block_start",
+          index: 1,
+          content_block: { type: "text", text: "NO_REPLY" },
+        },
+        {
+          type: "content_block_stop",
+          index: 1,
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 6, output_tokens: 9 },
+        },
+      ]),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        makeAnthropicTransportModel({ provider: "meridian", baseUrl: "http://127.0.0.1:3456" }),
+        {
+          messages: [{ role: "user", content: "heartbeat" }],
+        } as Parameters<typeof streamFn>[1],
+        {
+          apiKey: "meridian-key",
+        } as Parameters<typeof streamFn>[2],
+      ),
+    );
+    const events: Array<{ type?: string; delta?: string; content?: string }> = [];
+    for await (const event of stream as AsyncIterable<{
+      type?: string;
+      delta?: string;
+      content?: string;
+    }>) {
+      events.push(event);
+    }
+    const result = await stream.result();
+
+    expect(result.content).toEqual([
+      expect.objectContaining({
+        type: "thinking",
+        thinking: "checking",
+        thinkingSignature: "sig_2",
+      }),
+      { type: "text", text: "NO_REPLY" },
+    ]);
+    expect(events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: "text_delta", delta: "NO_REPLY" }),
+        expect.objectContaining({ type: "text_end", content: "NO_REPLY" }),
+      ]),
+    );
+    expect(result.usage.output).toBe(9);
+  });
+
   it("skips malformed tools when building Anthropic payloads", async () => {
     await runTransportStream(
       makeAnthropicTransportModel(),

--- a/src/agents/anthropic-transport-stream.ts
+++ b/src/agents/anthropic-transport-stream.ts
@@ -924,28 +924,55 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
             const contentBlock = event.content_block as Record<string, unknown> | undefined;
             const index = typeof event.index === "number" ? event.index : -1;
             if (contentBlock?.type === "text") {
-              const block: TransportContentBlock = { type: "text", text: "", index };
+              const text =
+                typeof contentBlock.text === "string"
+                  ? sanitizeTransportPayloadText(contentBlock.text)
+                  : "";
+              const block: TransportContentBlock = { type: "text", text, index };
               output.content.push(block);
+              const contentIndex = output.content.length - 1;
               stream.push({
                 type: "text_start",
-                contentIndex: output.content.length - 1,
+                contentIndex,
                 partial: output as never,
               });
+              if (text.length > 0) {
+                stream.push({
+                  type: "text_delta",
+                  contentIndex,
+                  delta: text,
+                  partial: output as never,
+                });
+              }
               continue;
             }
             if (contentBlock?.type === "thinking") {
+              const thinking =
+                typeof contentBlock.thinking === "string"
+                  ? sanitizeTransportPayloadText(contentBlock.thinking)
+                  : "";
               const block: TransportContentBlock = {
                 type: "thinking",
-                thinking: "",
-                thinkingSignature: "",
+                thinking,
+                thinkingSignature:
+                  typeof contentBlock.signature === "string" ? contentBlock.signature : "",
                 index,
               };
               output.content.push(block);
+              const contentIndex = output.content.length - 1;
               stream.push({
                 type: "thinking_start",
-                contentIndex: output.content.length - 1,
+                contentIndex,
                 partial: output as never,
               });
+              if (thinking.length > 0) {
+                stream.push({
+                  type: "thinking_delta",
+                  contentIndex,
+                  delta: thinking,
+                  partial: output as never,
+                });
+              }
               continue;
             }
             if (contentBlock?.type === "redacted_thinking") {
@@ -1042,7 +1069,7 @@ export function createAnthropicMessagesTransportStreamFn(): StreamFn {
               delta?.type === "signature_delta" &&
               typeof delta.signature === "string"
             ) {
-              block.thinkingSignature = `${block.thinkingSignature ?? ""}${delta.signature}`;
+              block.thinkingSignature = delta.signature;
             }
             continue;
           }


### PR DESCRIPTION
## Summary

- Problem: Anthropic-compatible `anthropic-messages` streams can seed text/thinking content on `content_block_start`; the transport only applied later deltas, so a `[thinking, text]` response could persist empty blocks.
- Why it matters: Meridian/Anthropic responses with visible text could be treated as empty assistant turns, triggering empty-response fallback behavior despite upstream output.
- What changed: Seeded `text` and `thinking` content is now copied into the mutable assistant output and emitted as matching stream deltas; `signature_delta` replaces the seeded thinking signature instead of concatenating it.
- What did NOT change (scope boundary): No fallback policy, replay policy, provider selection, or non-Anthropic transport behavior changed.

AI-assisted: yes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74410
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The Anthropic stream parser initialized `text` and `thinking` blocks with empty strings on `content_block_start` and only appended later `content_block_delta` payloads. Some compatible streams include non-empty content in the start block itself.
- Missing detection / guardrail: There was no unit coverage for a `thinking` block followed by a `text` block where the visible text is seeded on `content_block_start`.
- Contributing context (if known): Meridian and Anthropic-compatible Messages streams can produce `[thinking, text]` content where the start event carries the initial block payload.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/anthropic-transport-stream.test.ts`
- Scenario the test should lock in: A Meridian-style Anthropic Messages SSE response starts a `thinking` block and then a `text` block with seeded `NO_REPLY`; the final assistant content and stream events preserve the text.
- Why this is the smallest reliable guardrail: The bug is in the transport parser, so a mocked SSE unit test exercises the exact event shape without live Anthropic/Meridian credentials.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Anthropic-compatible streamed replies that include visible text in `content_block_start` are no longer treated as empty assistant turns.

## Diagram (if applicable)

```text
Before:
[thinking start with content] -> [text start with content] -> persisted empty blocks

After:
[thinking start with content] -> [text start with content] -> persisted thinking + text
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local Node/pnpm checkout
- Model/provider: mocked `meridian` model with `api: "anthropic-messages"`
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Stream Anthropic Messages SSE events with `content_block_start` index 0 containing `{ type: "thinking", thinking: "checking", signature: "sig_1" }`.
2. Emit a `signature_delta` for index 0.
3. Stream `content_block_start` index 1 containing `{ type: "text", text: "NO_REPLY" }`.
4. Complete the message with non-zero `output_tokens`.

### Expected

- The assistant message contains both the thinking block and `{ type: "text", text: "NO_REPLY" }`.
- The stream emits `text_delta` and `text_end` for `NO_REPLY`.
- The thinking signature is the final `signature_delta` value.

### Actual

- Before this patch, the seeded start-block content was ignored and the assistant content could persist as empty blocks.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: targeted Anthropic transport stream unit test; changed-gate for core/coreTests; local Codex review.
- Edge cases checked: seeded text after thinking; seeded thinking with later `signature_delta` replacement.
- What you did **not** verify: Live Anthropic or Meridian API traffic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Some providers may emit both seeded start content and later deltas for the same text/thinking block.
  - Mitigation: The transport appends later deltas after the seeded content, matching Anthropic SDK snapshot behavior for text/thinking accumulation; signature deltas replace the seeded signature.
