### PR TITLE
fix(agents): avoid empty Codex Responses input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Auto-reply: honor explicit `silentReply.direct: "allow"` for clean empty or reasoning-only direct chat turns while keeping the default direct-chat empty-response guard conservative. Fixes #74409. Thanks @jesuskannolis.
+- OpenAI Codex: send a non-empty Responses input item when a Codex turn only has systemPrompt-backed instructions, avoiding ChatGPT backend 400s from `input: []`. Fixes #73820. Thanks @woodhouse-bot.
 - Ollama: normalize provider-prefixed tool-call names at the native stream boundary so Kimi/Ollama calls such as `functions.exec` dispatch as `exec` instead of missing configured tools. Fixes #74487. Thanks @afurm and @carreipeia.
 - Security/audit: resolve configured model aliases before model-tier and small-parameter checks, so alias-based GPT-5/Codex configs no longer report false weak-model warnings. Fixes #74455. Thanks @blaspat.
 - CLI/agent: isolate Gateway-timeout embedded fallback runs under explicit `gateway-fallback-*` sessions so accepted Gateway runs cannot race transcript locks or replace the routed conversation session. Fixes #62981. Thanks @HemantSudarshan.

--- a/src/agents/openai-transport-stream.test.ts
+++ b/src/agents/openai-transport-stream.test.ts
@@ -1031,6 +1031,40 @@ describe("openai transport stream", () => {
     expect(params.service_tier).toBe("auto");
   });
 
+  it("adds minimal user input for Codex responses when only the system prompt is present", () => {
+    const params = buildOpenAIResponsesParams(
+      {
+        id: "gpt-5.4",
+        name: "GPT-5.4",
+        api: "openai-codex-responses",
+        provider: "openai-codex",
+        baseUrl: "https://chatgpt.com/backend-api",
+        reasoning: true,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 200000,
+        maxTokens: 8192,
+      } satisfies Model<"openai-codex-responses">,
+      {
+        systemPrompt: `Stable prefix${SYSTEM_PROMPT_CACHE_BOUNDARY}Dynamic suffix`,
+        messages: [],
+        tools: [],
+      } as never,
+      undefined,
+    ) as {
+      input?: Array<{ role?: string; content?: Array<{ type?: string; text?: string }> }>;
+      instructions?: string;
+    };
+
+    expect(params.instructions).toBe("Stable prefix\nDynamic suffix");
+    expect(params.input).toEqual([
+      {
+        role: "user",
+        content: [{ type: "input_text", text: " " }],
+      },
+    ]);
+  });
+
   it("does not infer high reasoning when Pi passes thinking off", () => {
     const params = buildOpenAIResponsesParams(
       {

--- a/src/agents/openai-transport-stream.ts
+++ b/src/agents/openai-transport-stream.ts
@@ -53,6 +53,7 @@ import { transformTransportMessages } from "./transport-message-transform.js";
 import { mergeTransportMetadata, sanitizeTransportPayloadText } from "./transport-stream-shared.js";
 
 const DEFAULT_AZURE_OPENAI_API_VERSION = "2024-12-01-preview";
+const OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT = " ";
 const log = createSubsystemLogger("openai-transport");
 
 type BaseStreamOptions = {
@@ -876,6 +877,22 @@ function buildOpenAICodexResponsesInstructions(context: Context): string | undef
   return sanitizeTransportPayloadText(stripSystemPromptCacheBoundary(context.systemPrompt));
 }
 
+function ensureOpenAICodexResponsesInput(messages: ResponseInput, context: Context): void {
+  if (messages.length > 0 || !context.systemPrompt) {
+    return;
+  }
+  const text = buildOpenAICodexResponsesInstructions(context);
+  if (!text) {
+    throw new Error(
+      "OpenAI Codex Responses requires non-empty input when only systemPrompt is provided.",
+    );
+  }
+  messages.push({
+    role: "user",
+    content: [{ type: "input_text", text: OPENAI_CODEX_RESPONSES_EMPTY_INPUT_TEXT }],
+  });
+}
+
 export function buildOpenAIResponsesParams(
   model: Model<Api>,
   context: Context,
@@ -892,6 +909,9 @@ export function buildOpenAIResponsesParams(
     new Set(["openai", "openai-codex", "opencode", "azure-openai-responses"]),
     { includeSystemPrompt: !isCodexResponses, supportsDeveloperRole },
   );
+  if (isCodexResponses) {
+    ensureOpenAICodexResponsesInput(messages, context);
+  }
   const cacheRetention = resolveCacheRetention(options?.cacheRetention);
   const payloadPolicy = resolveOpenAIResponsesPayloadPolicy(model, {
     storeMode: "disable",


### PR DESCRIPTION
## Summary

- Problem: `openai-codex` models using `openai-codex-responses` could build a request with `input: []` when the context only had a `systemPrompt`.
- Why it matters: ChatGPT's Codex backend rejects that shape with a 400 before the stream can complete.
- What changed: Codex Responses payloads now keep system prompt text in top-level `instructions` and add a minimal sentinel user input item when there are no converted messages.
- What did NOT change (scope boundary): Other OpenAI Responses providers, auth, model catalog, and tool conversion behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Fixes #73820
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: Codex Responses moved the system prompt to top-level `instructions`, but still sent the converted message array as `input`; with no user/assistant/tool history, that array was empty.
- Missing detection / guardrail: No focused test covered the `openai-codex-responses` system-prompt-only payload shape.
- Contributing context (if known): The Codex backend requires one of `input`, `previous_response_id`, `prompt`, or `conversation_id`; an empty `input` array is treated as missing.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/openai-transport-stream.test.ts`
- Scenario the test should lock in: `openai-codex-responses` with `systemPrompt` and `messages: []` produces non-empty sentinel `input` while preserving top-level `instructions`.
- Why this is the smallest reliable guardrail: The bug is in `buildOpenAIResponsesParams`, so direct builder coverage catches the rejected payload shape without live Codex calls.
- Existing test that already covers this (if any): N/A
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

OpenAI Codex provider turns that only have system-prompt-backed instructions no longer send `input: []` to the ChatGPT Codex backend.

## Diagram (if applicable)

```text
Before:
systemPrompt only -> instructions set + input: [] -> backend 400

After:
systemPrompt only -> instructions set + one sentinel input_text item -> request is non-empty
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node v24.14.0, pnpm 10.33.0
- Model/provider: `openai-codex` / `openai-codex-responses`
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Build OpenAI Responses params for an `openai-codex` model with API `openai-codex-responses`.
2. Pass a context with `systemPrompt` set and `messages: []`.
3. Inspect the request payload.

### Expected

- `instructions` contains the sanitized system prompt.
- `input` is non-empty.

### Actual

- Before this fix, `input` was `[]`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: focused unit coverage for system-prompt-only Codex Responses payloads; focused transport test suite; changed-file format; changed-lane gate.
- Edge cases checked: system prompt cache boundary stripping is preserved in `instructions`; fallback input stays a small sentinel; non-Codex providers are not routed through the new fallback.
- What you did **not** verify: no live ChatGPT/Codex backend call was made.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: The sentinel input adds a tiny user item to otherwise empty Codex requests.
  - Mitigation: The behavior is limited to `openai-codex` + `openai-codex-responses` and only when the converted input would otherwise be empty; the system prompt remains in `instructions`.

## AI-Assisted Disclosure

- AI-assisted: Yes
- Testing degree: Focused local validation plus `pnpm check:changed`.
- I confirm I reviewed the diff and understand the code change.
