### PR TITLE
docs(cli): add agent selector to CLI backend quick start

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -29,8 +29,11 @@ You can use Codex CLI **without any config** (the bundled OpenAI plugin
 registers a default backend):
 
 ```bash
-openclaw agent --message "hi" --model codex-cli/gpt-5.5
+openclaw agent --agent main --message "hi" --model codex-cli/gpt-5.5
 ```
+
+`main` is the default agent id when no explicit agent list is configured. If
+you use multiple agents, replace it with the agent id you want to run.
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
 command path:

--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -35,8 +35,11 @@ You can use Claude Code CLI **without any config** (the bundled Anthropic plugin
 registers a default backend):
 
 ```bash
-openclaw agent --message "hi" --model claude-cli/claude-sonnet-4-6
+openclaw agent --agent main --message "hi" --model claude-cli/claude-sonnet-4-6
 ```
+
+`main` is the default agent id when no explicit agent list is configured. If
+you use multiple agents, replace it with the agent id you want to run.
 
 If your gateway runs under launchd/systemd and PATH is minimal, add just the
 command path:


### PR DESCRIPTION
## Summary

- Fixes #68940.
- Updates the CLI Backends quick start to keep the current Claude CLI backend example while adding the required `--agent main` selector.
- Explains that `main` is the default agent id when no explicit agent list is configured.
- No CLI, gateway, plugin backend, model default, or runtime behavior changes.

## Real behavior proof

Behavior addressed: The CLI Backends quick-start docs now include a valid agent selector for the documented `openclaw agent --model ...` command shape.

Real environment tested: Local OpenClaw source checkout at PR head on macOS, after rebasing onto current `origin/main`.

Exact steps or command run after this patch: Read the updated quick-start snippet from `docs/gateway/cli-backends.md` and checked the changed Markdown formatting.

Evidence after fix: Terminal output from the updated docs snippet:

````text
$ sed -n '35,43p' docs/gateway/cli-backends.md
registers a default backend):

```bash
openclaw agent --agent main --message "hi" --model claude-cli/claude-sonnet-4-6
```

`main` is the default agent id when no explicit agent list is configured. If
````

Observed result after fix: The quick-start command now includes `--agent main` and keeps the current `claude-cli/claude-sonnet-4-6` backend wording from main.

What was not tested: I did not run a live Claude CLI model invocation; this PR changes only documentation text.

## Verification

- `pnpm exec oxfmt --check --threads=1 docs/gateway/cli-backends.md`
- `git diff --check`
- `pnpm docs:list` was attempted after updating main, but pnpm dependency status reconciliation hit local `ERR_PNPM_ENOSPC`; no docs code or navigation files were changed.
