### PR TITLE
fix(doctor): suppress false-positive embedding warning when probe skipped (#74608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 
 - Channels/Discord: keep read-only allowlist/default-target accessors from resolving SecretRef-backed bot tokens, so status and channel summaries no longer fail when tokens are only available in gateway runtime. (#74737) Thanks @eusine.
 - Agents/output: drop copied inbound metadata-only assistant replay turns before provider replay instead of synthesizing a placeholder, so Telegram and other channels cannot receive `[assistant copied inbound metadata omitted]` as model output. Fixes #74745. Thanks @adamwdear and @Marvae.
+- Doctor/memory: suppress skipped embedding-readiness warnings for key-optional providers such as Ollama and LM Studio while preserving timeout and not-ready diagnostics. Fixes #74608 and #73882. Thanks @hclsys.
 - Channels/groups: preserve observe-only turn suppression for prepared dispatch paths and restore deprecated channel turn runtime aliases, so passive observer/group flows stay silent while older plugins keep compiling. Thanks @vincentkoc.
 - Feishu/Bitable: clean up newly created placeholder rows whose fields contain only default empty values while preserving meaningful link, attachment, user, number, boolean, and location values during create-app cleanup. (#73920) Carries forward #40602. Thanks @boat2moon.
 - macOS app: keep attach-only mode and the Debug Settings launchd toggle marker-only, so launching with `--attach-only`/`--no-launchd` no longer uninstalls the Gateway LaunchAgent or drops active sessions. (#72174) Thanks @DolencLuka.

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -96,6 +96,25 @@ describe("probeGatewayMemoryStatus", () => {
     });
   });
 
+  it("propagates checked: false when gateway skipped the embedding probe", async () => {
+    // Gateway returns checked: false when called with probe: false and no cached
+    // availability data (SKIPPED_MEMORY_EMBEDDING_PROBE shape).
+    callGateway.mockResolvedValue({
+      embedding: {
+        ok: false,
+        checked: false,
+        error:
+          "memory embedding readiness not checked; run `openclaw memory status --deep` to probe",
+      },
+    });
+
+    await expect(probeGatewayMemoryStatus({ cfg })).resolves.toEqual({
+      checked: false,
+      ready: false,
+      error: expect.stringContaining("not checked"),
+    });
+  });
+
   it("keeps gateway request timeouts as explicit failures", async () => {
     callGateway.mockRejectedValue(new Error("gateway request timeout for doctor.memory.status"));
 

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -129,6 +129,7 @@ describe("probeGatewayMemoryStatus", () => {
       checked: true,
       ready: false,
       error: "gateway memory probe unavailable: gateway request timeout for doctor.memory.status",
+      skipped: false,
     });
   });
 
@@ -139,6 +140,7 @@ describe("probeGatewayMemoryStatus", () => {
       checked: true,
       ready: false,
       error: "gateway memory probe unavailable: gateway closed (1006): no close reason",
+      skipped: false,
     });
   });
 });

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -74,6 +74,7 @@ describe("probeGatewayMemoryStatus", () => {
       checked: true,
       ready: true,
       error: undefined,
+      skipped: false,
     });
 
     expect(callGateway).toHaveBeenCalledWith({
@@ -84,7 +85,9 @@ describe("probeGatewayMemoryStatus", () => {
     });
   });
 
-  it("treats outer gateway timeouts as inconclusive", async () => {
+  it("treats outer gateway timeouts as inconclusive (skipped: false)", async () => {
+    // A transport timeout must NOT be treated as a skipped probe. It is a real
+    // diagnostic signal and the renderer should warn for key-optional providers.
     callGateway.mockRejectedValue(
       new Error("gateway timeout after 8000ms\nGateway target: ws://127.0.0.1:18789"),
     );
@@ -93,12 +96,15 @@ describe("probeGatewayMemoryStatus", () => {
       checked: false,
       ready: false,
       error: expect.stringContaining("gateway memory probe timed out"),
+      skipped: false,
     });
   });
 
-  it("propagates checked: false when gateway skipped the embedding probe", async () => {
+  it("propagates checked: false and skipped: true when gateway skipped the embedding probe", async () => {
     // Gateway returns checked: false when called with probe: false and no cached
-    // availability data (SKIPPED_MEMORY_EMBEDDING_PROBE shape).
+    // availability data (SKIPPED_MEMORY_EMBEDDING_PROBE shape). The adapter must
+    // also set skipped: true so renderers can distinguish this from a transport
+    // timeout (which also returns checked: false but skipped: false).
     callGateway.mockResolvedValue({
       embedding: {
         ok: false,
@@ -112,6 +118,7 @@ describe("probeGatewayMemoryStatus", () => {
       checked: false,
       ready: false,
       error: expect.stringContaining("not checked"),
+      skipped: true,
     });
   });
 

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -86,8 +86,14 @@ export async function probeGatewayMemoryStatus(params: {
       timeoutMs,
       config: params.cfg,
     });
+    // Propagate the gateway's checked flag. When the gateway skips the embedding
+    // probe (probe: false path), it returns checked: false to signal that no
+    // readiness determination was made. Mapping that to checked: true here would
+    // cause the renderer to treat a skipped probe as a checked-but-not-ready
+    // failure and emit a false-positive warning for key-optional providers.
+    const gatewayChecked = payload.embedding.checked !== false;
     return {
-      checked: true,
+      checked: gatewayChecked,
       ready: payload.embedding.ok,
       error: payload.embedding.error,
     };

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -11,6 +11,13 @@ export type GatewayMemoryProbe = {
   checked: boolean;
   ready: boolean;
   error?: string;
+  /**
+   * True when the probe was intentionally skipped by the gateway (probe: false
+   * path). Distinct from checked: false caused by a network timeout or
+   * unavailable gateway. Renderers should suppress warnings only for skipped
+   * probes, not for transport failures.
+   */
+  skipped?: boolean;
 };
 
 function isGatewayCallTimeout(message: string): boolean {
@@ -91,11 +98,14 @@ export async function probeGatewayMemoryStatus(params: {
     // readiness determination was made. Mapping that to checked: true here would
     // cause the renderer to treat a skipped probe as a checked-but-not-ready
     // failure and emit a false-positive warning for key-optional providers.
+    // We also carry skipped: true so renderers can distinguish an intentional
+    // non-deep skip from a transport timeout (which also returns checked: false).
     const gatewayChecked = payload.embedding.checked !== false;
     return {
       checked: gatewayChecked,
       ready: payload.embedding.ok,
       error: payload.embedding.error,
+      skipped: !gatewayChecked,
     };
   } catch (err) {
     const message = formatErrorMessage(err);
@@ -104,12 +114,14 @@ export async function probeGatewayMemoryStatus(params: {
         checked: false,
         ready: false,
         error: `gateway memory probe timed out: ${message}`,
+        skipped: false,
       };
     }
     return {
       checked: true,
       ready: false,
       error: `gateway memory probe unavailable: ${message}`,
+      skipped: false,
     };
   }
 }

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -459,7 +459,11 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("embeddings are not ready");
   });
 
-  it("warns when lmstudio gateway probe is unavailable", async () => {
+  it("does not warn when key-optional provider (lmstudio) probe was skipped (checked: false)", async () => {
+    // When `openclaw doctor` runs without --deep, the probe is skipped and returns
+    // { checked: false, ready: false }. This must NOT produce a false-positive warning —
+    // it means readiness was never checked, not that embeddings are unavailable.
+    // Regression test for: https://github.com/openclaw/openclaw/issues/74608
     resolveMemorySearchConfig.mockReturnValue({
       provider: "lmstudio",
       local: {},
@@ -470,10 +474,22 @@ describe("noteMemorySearchHealth", () => {
       gatewayMemoryProbe: { checked: false, ready: false },
     });
 
-    const message = String(note.mock.calls[0]?.[0] ?? "");
-    expect(message).toContain('provider "lmstudio" is configured');
-    expect(message).toContain("could not confirm embeddings are ready");
-    expect(message).toContain("openclaw memory status --deep");
+    expect(note).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when key-optional provider (ollama) probe was skipped (checked: false)", async () => {
+    // Same guard for ollama — the most commonly reported false-positive case.
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "ollama",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: { checked: false, ready: false },
+    });
+
+    expect(note).not.toHaveBeenCalled();
   });
 
   it("notes when gateway probe reports embeddings ready and CLI API key is missing", async () => {

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -459,10 +459,11 @@ describe("noteMemorySearchHealth", () => {
     expect(message).toContain("embeddings are not ready");
   });
 
-  it("does not warn when key-optional provider (lmstudio) probe was skipped (checked: false)", async () => {
+  it("does not warn when key-optional provider (lmstudio) probe was skipped (skipped: true)", async () => {
     // When `openclaw doctor` runs without --deep, the probe is skipped and returns
-    // { checked: false, ready: false }. This must NOT produce a false-positive warning —
-    // it means readiness was never checked, not that embeddings are unavailable.
+    // { checked: false, ready: false, skipped: true }. This must NOT produce a
+    // false-positive warning — it means readiness was never checked, not that
+    // embeddings are unavailable.
     // Regression test for: https://github.com/openclaw/openclaw/issues/74608
     resolveMemorySearchConfig.mockReturnValue({
       provider: "lmstudio",
@@ -471,13 +472,13 @@ describe("noteMemorySearchHealth", () => {
     });
 
     await noteMemorySearchHealth(cfg, {
-      gatewayMemoryProbe: { checked: false, ready: false },
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
     });
 
     expect(note).not.toHaveBeenCalled();
   });
 
-  it("does not warn when key-optional provider (ollama) probe was skipped (checked: false)", async () => {
+  it("does not warn when key-optional provider (ollama) probe was skipped (skipped: true)", async () => {
     // Same guard for ollama — the most commonly reported false-positive case.
     resolveMemorySearchConfig.mockReturnValue({
       provider: "ollama",
@@ -486,10 +487,33 @@ describe("noteMemorySearchHealth", () => {
     });
 
     await noteMemorySearchHealth(cfg, {
-      gatewayMemoryProbe: { checked: false, ready: false },
+      gatewayMemoryProbe: { checked: false, ready: false, skipped: true },
     });
 
     expect(note).not.toHaveBeenCalled();
+  });
+
+  it("warns for key-optional provider (lmstudio) when gateway probe timed out", async () => {
+    // A gateway timeout sets checked: false but skipped: false/absent. This is a
+    // real diagnostic signal — embeddings may be unavailable — so we should warn.
+    // Regression guard: https://github.com/openclaw/openclaw/issues/74608
+    resolveMemorySearchConfig.mockReturnValue({
+      provider: "lmstudio",
+      local: {},
+      remote: {},
+    });
+
+    await noteMemorySearchHealth(cfg, {
+      gatewayMemoryProbe: {
+        checked: false,
+        ready: false,
+        error: "gateway memory probe timed out: gateway timeout after 8000ms",
+        skipped: false,
+      },
+    });
+
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain('provider "lmstudio" is configured');
   });
 
   it("notes when gateway probe reports embeddings ready and CLI API key is missing", async () => {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -410,6 +410,12 @@ export async function noteMemorySearchHealth(
       if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
         return;
       }
+      // When the probe was skipped (checked: false), we have no embedding status
+      // information — do not warn. A skipped probe means the user ran `openclaw doctor`
+      // without --deep; it does not mean embeddings are unavailable.
+      if (opts?.gatewayMemoryProbe && !opts.gatewayMemoryProbe.checked) {
+        return;
+      }
       const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
       note(
         [

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -316,6 +316,7 @@ export async function noteMemorySearchHealth(
       checked: boolean;
       ready: boolean;
       error?: string;
+      skipped?: boolean;
     };
   },
 ): Promise<void> {
@@ -410,10 +411,14 @@ export async function noteMemorySearchHealth(
       if (opts?.gatewayMemoryProbe?.checked && opts.gatewayMemoryProbe.ready) {
         return;
       }
-      // When the probe was skipped (checked: false), we have no embedding status
-      // information — do not warn. A skipped probe means the user ran `openclaw doctor`
-      // without --deep; it does not mean embeddings are unavailable.
-      if (opts?.gatewayMemoryProbe && !opts.gatewayMemoryProbe.checked) {
+      // When the probe was intentionally skipped (skipped: true / checked: false
+      // due to probe:false path), we have no embedding status information — do
+      // not warn. A skipped probe means the user ran `openclaw doctor` without
+      // --deep; it does not mean embeddings are unavailable.
+      // NOTE: a transport timeout also sets checked: false, but skipped stays
+      // false/absent — a timeout is a real diagnostic signal and should fall
+      // through to the warning below.
+      if (opts?.gatewayMemoryProbe?.skipped) {
         return;
       }
       const gatewayProbeWarning = buildGatewayProbeWarning(opts?.gatewayMemoryProbe);
@@ -585,6 +590,7 @@ function buildGatewayProbeWarning(
         checked: boolean;
         ready: boolean;
         error?: string;
+        skipped?: boolean;
       }
     | undefined,
 ): string | null {


### PR DESCRIPTION
## Summary

Fixes #74608.

`openclaw doctor` (without `--deep`) always passes `probe: false` to `doctor.memory.status`, causing the gateway to return `SKIPPED_MEMORY_EMBEDDING_PROBE = { ok: false, checked: false, error: "memory embedding readiness not checked..." }`.

For key-optional providers (ollama, lmstudio, local), the `noteMemorySearchHealth` rendering path fell through to a note showing:

> _Memory search provider "ollama" is configured, but the gateway could not confirm embeddings are ready. [...] Verify: openclaw memory status --deep_

This is a false positive — the warning fires not because embeddings are unavailable, but because the probe was deliberately skipped. Users with fully-functional ollama embeddings (`openclaw memory status --deep` shows green) were confused by the spurious warning.

## Fix

Guard the key-optional provider branch with `!probe.checked` early-return before the warning note. A skipped probe (`checked: false`) carries zero readiness signal — it is not a failure.

```ts
// When the probe was skipped (checked: false), we have no embedding status
// information — do not warn.
if (opts?.gatewayMemoryProbe && !opts.gatewayMemoryProbe.checked) {
  return;
}
```

## Tests

- Updated existing `lmstudio probe skipped` test to assert `note()` NOT called (was asserting warning appeared — that was the bug)
- Added new regression test for ollama + skipped probe → no warning

```
Tests  33 passed (33)
```

## Audit

- **Audit A (existing helper):** `probe?.checked` pattern already used at 4 sites in the same file — consistent with existing guard style
- **Audit B (shared callers):** `isKeyOptionalMemoryProvider` — 1 caller only (this file)
- **Audit C (broader rival):** No rival PR for #74608. PR #62338 touches the same file but for FTS5 surface (different code block, no conflict)