### PR TITLE
fix(cron): validate cron expression before mutating stored job on update (#74459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Cron: validate the cron expression before mutating the stored job in `cron.update`, so an invalid `--cron` expression on a disabled job is rejected without being persisted, and a `cron enable` call against a job with a corrupted schedule throws before flipping `enabled`. (#74459)
 - Dependencies: refresh workspace runtime, plugin, and tooling packages, including ACP, Pi, AWS SDK, TypeBox, pnpm, oxlint, oxfmt, jsdom, pdfjs, ciao, and tokenjuice, while keeping patched ACP behavior and lint gates current. Thanks @mariozechner.
 - Messages/queue: default active-run queueing to `steer` with a 500ms followup fallback debounce, and document the queue modes, precedence, and drop policies on the command queue page. Thanks @vincentkoc.
 - Providers/NVIDIA: add the NVIDIA provider with API-key onboarding, setup docs, static catalog metadata, and literal model-ref picker support so NVIDIA hosted models can be selected with their provider prefix intact. (#71204) Thanks @eleqtrizit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Cron: validate the cron expression before mutating the stored job in `cron.update`, so an invalid `--cron` expression on a disabled job is rejected without being persisted, and a `cron enable` call against a job with a corrupted schedule throws before flipping `enabled`. (#74459)
+- Cron: validate the cron expression before mutating the stored job in `cron.update`, so an invalid `--cron` expression on a disabled job is rejected without being persisted, and a `cron enable` call against a job with a corrupted schedule throws before flipping `enabled`. (#74459) Thanks @bittoby.
 - Dependencies: refresh workspace runtime, plugin, and tooling packages, including ACP, Pi, AWS SDK, TypeBox, pnpm, oxlint, oxfmt, jsdom, pdfjs, ciao, and tokenjuice, while keeping patched ACP behavior and lint gates current. Thanks @mariozechner.
 - Messages/queue: default active-run queueing to `steer` with a 500ms followup fallback debounce, and document the queue modes, precedence, and drop policies on the command queue page. Thanks @vincentkoc.
 - Providers/NVIDIA: add the NVIDIA provider with API-key onboarding, setup docs, static catalog metadata, and literal model-ref picker support so NVIDIA hosted models can be selected with their provider prefix intact. (#71204) Thanks @eleqtrizit.

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -165,6 +165,10 @@ export function computePreviousRunAtMs(schedule: CronSchedule, nowMs: number): n
   return previousMs;
 }
 
+export function validateCronScheduleExpr(expr: string, tz?: string): void {
+  resolveCachedCron(expr.trim(), resolveCronTimezone(tz));
+}
+
 export function clearCronScheduleCacheForTest(): void {
   cronEvalCache.clear();
 }

--- a/src/cron/service.issue-regressions.test.ts
+++ b/src/cron/service.issue-regressions.test.ts
@@ -352,4 +352,71 @@ describe("Cron issue regressions", () => {
       cron.stop();
     }
   });
+
+  it("#74459: rejects invalid cron expr on disabled job without persisting it", async () => {
+    const store = cronIssueRegressionFixtures.makeStorePath();
+    const cron = await startCronForStore({
+      storePath: store.storePath,
+      cronEnabled: false,
+    });
+
+    const job = await cron.add({
+      name: "weekly",
+      enabled: false,
+      schedule: { kind: "cron", expr: "0 9 * * 1", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    await expect(
+      cron.update(job.id, { schedule: { kind: "cron", expr: "not a cron", tz: "UTC" } }),
+    ).rejects.toThrow();
+
+    const jobs = await cron.list({ includeDisabled: true });
+    const reloaded = jobs.find((j) => j.id === job.id);
+    expect(reloaded?.schedule).toEqual({ kind: "cron", expr: "0 9 * * 1", tz: "UTC" });
+    cron.stop();
+  });
+
+  it("#74459: rejects enable when stored cron expr is invalid, does not leave job enabled", async () => {
+    const store = cronIssueRegressionFixtures.makeStorePath();
+    const cron = await startCronForStore({
+      storePath: store.storePath,
+      cronEnabled: false,
+    });
+
+    const job = await cron.add({
+      name: "broken",
+      enabled: false,
+      schedule: { kind: "cron", expr: "0 9 * * 1", tz: "UTC" },
+      sessionTarget: "main",
+      wakeMode: "next-heartbeat",
+      payload: { kind: "systemEvent", text: "tick" },
+    });
+
+    // Corrupt the stored schedule by directly writing an invalid expr to the store
+    const rawStore = JSON.parse(await fs.readFile(store.storePath, "utf-8")) as {
+      version: number;
+      jobs: Array<Record<string, unknown>>;
+    };
+    const target = rawStore.jobs.find((j) => j["id"] === job.id);
+    if (target) {
+      target["schedule"] = { kind: "cron", expr: "not a cron", tz: "UTC" };
+      target["enabled"] = false;
+    }
+    await fs.writeFile(store.storePath, JSON.stringify(rawStore), "utf-8");
+
+    const cron2 = await startCronForStore({
+      storePath: store.storePath,
+      cronEnabled: false,
+    });
+
+    await expect(cron2.update(job.id, { enabled: true })).rejects.toThrow();
+
+    const jobs2 = await cron2.list({ includeDisabled: true });
+    const reloaded = jobs2.find((j) => j.id === job.id);
+    expect(reloaded?.enabled).toBe(false);
+    cron2.stop();
+  });
 });

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -7,6 +7,7 @@ import {
   failTaskRunByRunId,
 } from "../../tasks/detached-task-runtime.js";
 import { createCronExecutionId } from "../run-id.js";
+import { validateCronScheduleExpr } from "../schedule.js";
 import type { CronJob, CronJobCreate, CronJobPatch } from "../types.js";
 import {
   applyJobPatch,
@@ -353,6 +354,14 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     await ensureLoaded(state, { skipRecompute: true });
     const job = findJobOrThrow(state, id);
     const now = state.deps.nowMs();
+    // Validate cron expression before any mutation so an invalid expr cannot
+    // be persisted on a disabled job or leave the job stuck in an enabled state
+    // after a failed enable. (#74459)
+    if (patch.schedule?.kind === "cron") {
+      validateCronScheduleExpr(patch.schedule.expr, patch.schedule.tz);
+    } else if (patch.enabled === true && job.schedule.kind === "cron") {
+      validateCronScheduleExpr(job.schedule.expr, job.schedule.tz);
+    }
     applyJobPatch(job, patch, { defaultAgentId: state.deps.defaultAgentId });
     if (job.schedule.kind === "every") {
       const anchor = job.schedule.anchorMs;

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -379,4 +379,35 @@ describe("cron method validation", () => {
     ).rejects.toThrow("DB write failed");
     expect(respond).not.toHaveBeenCalled();
   });
+
+  it("returns INVALID_REQUEST when cron.update throws a croner parse error on disabled-job schedule edit (#74459)", async () => {
+    const existingJob = createCronJob();
+    const context = createCronContext(existingJob);
+    context.cron.update.mockRejectedValueOnce(
+      new RangeError("CronPattern: Invalid expression (not a cron)"),
+    );
+    const respond = vi.fn();
+    await cronHandlers["cron.update"]({
+      req: {} as never,
+      params: {
+        id: existingJob.id,
+        patch: {
+          schedule: { kind: "cron", cron: "not a cron" },
+        },
+      } as never,
+      respond: respond as never,
+      context: context as never,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("CronPattern"),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #74459.

`cron edit <id> --cron <invalid>` on a **disabled** job silently persisted the invalid expression — the scheduler's next-run computation was skipped for disabled jobs, so the invalid cron string passed through `applyJobPatch` without error. A subsequent `cron enable` would then set `enabled = true` before Croner threw, leaving the job stuck in an enabled-but-unscheduled state.

## Fix

Two-layer guard before any mutation in `cron.update`:

1. **Schedule validation helper** — `validateCronScheduleExpr` exported from `src/cron/schedule.ts`. Calls `Croner` with the expression; throws `RangeError` on invalid input.
2. **Pre-mutation call in `ops.ts`** — validates before `applyJobPatch` when:
   - the patch supplies a new cron expression, OR
   - the patch enables a job whose existing schedule is cron-kind (catches the double-failure path)

Both paths throw before any field is mutated, so on-disk job state is never corrupted.

## Tests

- `src/cron/service.issue-regressions.test.ts`: 2 new regression tests at service level
  - disabled job: invalid `--cron` rejected before persist
  - disabled job: valid `--cron` accepted; subsequent `cron enable` with a corrupted schedule throws
- `src/gateway/server-methods/cron.validation.test.ts`: 1 gateway-level regression test

```
Tests  20 passed (20) across 2 shards
```

## Audit

- **Audit A (existing helper):** `validateCronExpression` not present; `validateCronScheduleExpr` is a new focused helper in `schedule.ts` (consistent with the module's existing `CronSchedule` type)
- **Audit B (shared callers):** `ops.ts#updateCronJob` — 1 caller path. New guard is additive (throws before mutation), no contract change for valid inputs
- **Audit C (broader rival):** PR #74068 addresses gateway-layer validation only (2 files). This fix adds service-layer validation + a shared `validateCronScheduleExpr` helper (5 files, wider coverage). Complementary rather than competing — both layers benefit.