### PR TITLE
fix(browser): read Chrome MCP screenshot extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -824,7 +824,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/Windows: accept drive-absolute Docker bind sources while keeping sandbox blocked-path and allowed-root policy comparisons Windows-case-insensitive. (#42174) Thanks @6607changchun.
 
 ### Fixes
-- Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. (#74685)
+- Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. (#74685) Thanks @barbarhan.
 
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -824,7 +824,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/Windows: accept drive-absolute Docker bind sources while keeping sandbox blocked-path and allowed-root policy comparisons Windows-case-insensitive. (#42174) Thanks @6607changchun.
 
 ### Fixes
-- Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. (#74685) Thanks @barbarhan.
+- Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. Fixes #77222. (#74685) Thanks @barbarhan.
 
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -824,6 +824,7 @@ Docs: https://docs.openclaw.ai
 - Sandbox/Windows: accept drive-absolute Docker bind sources while keeping sandbox blocked-path and allowed-root policy comparisons Windows-case-insensitive. (#42174) Thanks @6607changchun.
 
 ### Fixes
+- Browser/chrome-mcp: read Chrome DevTools MCP screenshot output from the extension-suffixed path, fixing ENOENT on screenshot capture. (#74685)
 
 - macOS/launchd: set generated Gateway LaunchAgent plists to `ProcessType=Interactive` so the gateway keeps timely execution during idle periods. Fixes #58061; refs #62294 and closed duplicate #66992. (#62308) Thanks @bryanpearson and @zssggle-rgb.
 - Plugins/install: honor the beta update channel for onboarding and doctor-managed plugin installs by requesting floating npm and ClawHub specs with `@beta` while keeping persistent install records on the catalog default. Thanks @vincentkoc.

--- a/extensions/browser/src/browser/chrome-mcp.test.ts
+++ b/extensions/browser/src/browser/chrome-mcp.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clickChromeMcpElement,
@@ -9,6 +10,7 @@ import {
   openChromeMcpTab,
   resetChromeMcpSessionsForTest,
   setChromeMcpSessionFactoryForTest,
+  takeChromeMcpScreenshot,
 } from "./chrome-mcp.js";
 
 type ToolCall = {
@@ -78,6 +80,15 @@ function createFakeSession(): ChromeMcpSession {
         ],
       };
     }
+    if (name === "take_screenshot") {
+      const filePath = typeof args?.filePath === "string" ? args.filePath : undefined;
+      const format = args?.format === "jpeg" ? "jpeg" : "png";
+      if (!filePath) {
+        throw new Error("missing filePath");
+      }
+      await fs.writeFile(`${filePath}.${format}`, Buffer.from(`screenshot:${format}`));
+      return { content: [{ type: "text", text: `Saved screenshot to ${filePath}.${format}.` }] };
+    }
     throw new Error(`unexpected tool ${name}`);
   });
 
@@ -125,6 +136,19 @@ describe("chrome MCP page parsing", () => {
         type: "page",
       },
     ]);
+  });
+
+  it("reads screenshot files with the extension written by chrome-devtools-mcp", async () => {
+    const factory: ChromeMcpSessionFactory = async () => createFakeSession();
+    setChromeMcpSessionFactoryForTest(factory);
+
+    await expect(
+      takeChromeMcpScreenshot({
+        profileName: "chrome-live",
+        targetId: "1",
+        format: "jpeg",
+      }),
+    ).resolves.toEqual(Buffer.from("screenshot:jpeg"));
   });
 
   it("adds --userDataDir when an explicit Chromium profile path is configured", () => {

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -919,7 +919,8 @@ export async function takeChromeMcpScreenshot(params: {
       },
       { timeoutMs: params.timeoutMs },
     );
-    return await fs.readFile(filePath);
+    const format = params.format ?? "png";
+    return await fs.readFile(`${filePath}.${format}`);
   });
 }
 

--- a/extensions/browser/src/browser/chrome-mcp.ts
+++ b/extensions/browser/src/browser/chrome-mcp.ts
@@ -906,6 +906,7 @@ export async function takeChromeMcpScreenshot(params: {
   timeoutMs?: number;
 }): Promise<Buffer> {
   return await withTempFile(async (filePath) => {
+    const format = params.format ?? "png";
     await callTool(
       params.profileName,
       chromeMcpProfileOptionsFromParams(params),
@@ -913,13 +914,12 @@ export async function takeChromeMcpScreenshot(params: {
       {
         pageId: parsePageId(params.targetId),
         filePath,
-        format: params.format ?? "png",
+        format,
         ...(params.uid ? { uid: params.uid } : {}),
         ...(params.fullPage ? { fullPage: true } : {}),
       },
       { timeoutMs: params.timeoutMs },
     );
-    const format = params.format ?? "png";
     return await fs.readFile(`${filePath}.${format}`);
   });
 }


### PR DESCRIPTION
## Summary
- read Chrome DevTools MCP screenshot output from the extension-suffixed path
- use the requested/default screenshot format when building the file path
- add a regression test covering the extension-suffixed screenshot file

## Why
`chrome-devtools-mcp` writes screenshots to `<filePath>.<format>`, but OpenClaw was reading the bare temporary `filePath`. That caused screenshot reads to fail with ENOENT even though the MCP tool had written the image successfully.

## Test
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.unit.config.ts extensions/browser/src/browser/chrome-mcp.test.ts`
