### PR TITLE
fix(ui): show Communication Notifications tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - Gateway: avoid synchronous restart-sentinel state probes during post-attach startup, preventing slow Windows or redirected state directories from blocking channel turns. Fixes #79264. Thanks @liyi58.
 - Agents/image: honor explicit `image` tool model overrides even when `agents.defaults.imageModel` is unset, restoring one-off vision calls for configured multimodal providers. Fixes #79341. Thanks @haumanto.
 - Codex app-server: preserve prompt-local current-turn context through context-engine prompt projection, so replied-to Telegram messages stay visible to the Codex model input.
+- Control UI: show the Communication Notifications tab for Web Push settings even when the settings section is virtual. Thanks @VladyslavLevchuk.
 - Telegram: pass agent-scoped media roots through gateway message actions so workspace-local media from the active agent is not rejected as cross-agent access. Thanks @frankekn.
 - CLI/gateway: keep `gateway status --deep` plugin-aware so configured plugin manifest warnings, including missing channel config metadata, stay visible during install and update smoke checks.
 - Feishu: fall back to a top-level group send when normal group quoted replies target a withdrawn or missing message, preventing replies from disappearing silently while preserving native topic safety. Fixes #79349. Thanks @arlen8411.

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -350,6 +350,43 @@ describe("config view", () => {
     expect(onSectionChange).toHaveBeenCalledWith("gateway");
   });
 
+  it("renders the virtual Notifications tab in Communication settings", () => {
+    const onSectionChange = vi.fn();
+    const { container } = renderConfigView({
+      navRootLabel: "Communication",
+      includeSections: ["channels", "messages", "broadcast", "__notifications__", "talk", "audio"],
+      includeVirtualSections: true,
+      onSectionChange,
+      schema: {
+        type: "object",
+        properties: {
+          channels: { type: "object", properties: {} },
+          messages: { type: "object", properties: {} },
+        },
+      },
+      formValue: { channels: {}, messages: {} },
+      originalValue: { channels: {}, messages: {} },
+      webPush: {
+        supported: true,
+        permission: "default",
+        subscribed: false,
+        loading: false,
+      },
+    });
+
+    const tabs = Array.from(container.querySelectorAll(".config-top-tabs__tab")).map((tab) =>
+      tab.textContent?.trim(),
+    );
+    expect(tabs).toContain("Notifications");
+
+    const btn = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.trim() === "Notifications",
+    );
+    expect(btn).toBeTruthy();
+    btn?.click();
+    expect(onSectionChange).toHaveBeenCalledWith("__notifications__");
+  });
+
   it("resets config content scroll when switching top-tab sections", async () => {
     const { container } = renderConfigView({
       activeSection: "channels",

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -370,6 +370,12 @@ const sidebarIcons = {
       <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
     </svg>
   `,
+  __notifications__: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"></path>
+      <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+    </svg>
+  `,
   default: html`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -419,6 +425,7 @@ const SECTION_CATEGORIES: SectionCategory[] = [
       { key: "channels", label: "Channels" },
       { key: "messages", label: "Messages" },
       { key: "broadcast", label: "Broadcast" },
+      { key: "__notifications__", label: "Notifications" },
       { key: "talk", label: "Talk" },
       { key: "audio", label: "Audio" },
     ],

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1218,11 +1218,15 @@ export function renderConfig(props: ConfigProps) {
   const schemaProps = analysis.schema?.properties ?? {};
 
   const VIRTUAL_SECTIONS = new Set(["__appearance__", "__notifications__"]);
+  const isVisibleVirtualSection = (key: string) =>
+    includeVirtualSections &&
+    VIRTUAL_SECTIONS.has(key) &&
+    (key === "__appearance__" || include?.has(key) === true);
   const visibleCategories = SECTION_CATEGORIES.map((cat) =>
     Object.assign({}, cat, {
       sections: cat.sections.filter(
         (s) =>
-          ((includeVirtualSections && VIRTUAL_SECTIONS.has(s.key)) || s.key in schemaProps) &&
+          (isVisibleVirtualSection(s.key) || s.key in schemaProps) &&
           (!include || include.has(s.key)) &&
           (!exclude || !exclude.has(s.key)),
       ),

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -386,6 +386,12 @@ const sidebarIcons = {
       <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
     </svg>
   `,
+  __notifications__: html`
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M18 8a6 6 0 0 0-12 0c0 7-3 7-3 9h18c0-2-3-2-3-9"></path>
+      <path d="M13.73 21a2 2 0 0 1-3.46 0"></path>
+    </svg>
+  `,
   default: html`
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
@@ -435,6 +441,7 @@ const SECTION_CATEGORIES: SectionCategory[] = [
       { key: "channels", label: "Channels" },
       { key: "messages", label: "Messages" },
       { key: "broadcast", label: "Broadcast" },
+      { key: "__notifications__", label: "Notifications" },
       { key: "talk", label: "Talk" },
       { key: "audio", label: "Audio" },
     ],


### PR DESCRIPTION
## Summary

- expose the virtual Notifications section in the Communication settings navigation
- add a bell icon for the Notifications entry
- add a browser-view regression test so virtual Communication sections remain reachable even when they are not present in the config schema

## Issue check

I checked existing notification-related issues/PRs before patching. The closest open items are broader notification work (#20237, #53228) and PR #73894, but this PR is intentionally the narrow PWA/mobile UI fix for the missing Communication -> Notifications tab.

## AI assistance

Prepared with Codex assistance. I reviewed the diff, understand the change, and kept the PR scoped to the existing virtual Notifications settings path.

## Real behavior proof

- Behavior or issue addressed: Communication settings omitted the virtual Notifications tab even though the notifications section renderer already existed.
- Real environment tested: Local OpenClaw Control UI served by Vite from this PR branch on macOS, rendered in headless Chromium via Playwright.
- Exact steps or command run after this patch: `pnpm --dir ui exec vite --host 127.0.0.1 --port 4178 --strictPort`, then a Playwright-driven Chromium render of `renderConfig` with Communication sections including `__notifications__`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
REAL_BROWSER_PROOF {"renderedTabs":["Communication","Channels","Messages","Notifications"],"notificationsButtonFound":true,"sectionChanges":["__notifications__"],"chromiumUserAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/147.0.7727.15 Safari/537.36"}
```

- Observed result after fix: Chromium rendered the Notifications tab in the Communication settings tab list, found the Notifications button, and clicking it emitted `__notifications__`.
- What was not tested: Installed PWA/service-worker cache refresh on a phone.
- Before evidence (optional but encouraged): Before this change, the Communication section category list did not include `__notifications__`, so the existing virtual notifications renderer was unreachable from the settings navigation.

## Test plan

- `git diff --check origin/main...HEAD`
- `pnpm test ui/src/ui/views/config.browser.test.ts`
- `pnpm exec oxfmt --check CHANGELOG.md ui/src/ui/views/config.ts ui/src/ui/views/config.browser.test.ts`
- `pnpm exec oxlint ui/src/ui/views/config.ts ui/src/ui/views/config.browser.test.ts`
- `pnpm check:test-types`
- `pnpm check:changed`
- `pnpm test:changed:max`
- `pnpm --dir ui build`
- `codex review --base origin/main`
