### PR TITLE
fix: handle undefined message/text at runtime to prevent TypeError

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -28,14 +28,15 @@ export function normalizeReplyPayload(
   const hasChannelData = Boolean(
     payload.channelData && Object.keys(payload.channelData).length > 0,
   );
-  const trimmed = payload.text?.trim() ?? "";
+  const rawText = typeof payload.text === "string" ? payload.text : undefined;
+  const trimmed = rawText?.trim() ?? "";
   if (!trimmed && !hasMedia && !hasChannelData) {
     opts.onSkip?.("empty");
     return null;
   }
 
   const silentToken = opts.silentToken ?? SILENT_REPLY_TOKEN;
-  let text = payload.text ?? undefined;
+  let text = rawText;
   if (text && isSilentReplyText(text, silentToken)) {
     if (!hasMedia && !hasChannelData) {
       opts.onSkip?.("silent");

--- a/src/gateway/chat-abort.ts
+++ b/src/gateway/chat-abort.ts
@@ -8,8 +8,8 @@ export type ChatAbortControllerEntry = {
   expiresAtMs: number;
 };
 
-export function isChatStopCommandText(text: string): boolean {
-  const trimmed = text.trim();
+export function isChatStopCommandText(text: string | undefined | null): boolean {
+  const trimmed = text?.trim() ?? "";
   if (!trimmed) {
     return false;
   }

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -81,10 +81,14 @@ function stripDisallowedChatControlChars(message: string): string {
 }
 
 export function sanitizeChatSendMessageInput(
-  message: string,
+  message: string | null | undefined,
 ): { ok: true; message: string } | { ok: false; error: string } {
-  if (typeof message !== "string") {
-    return { ok: false, error: "message must be a string" };
+  if (message == null || typeof message !== "string") {
+    return { ok: false, error: "message is required" };
+  }
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return { ok: false, error: "message is required" };
   }
   const normalized = message.normalize("NFC");
   if (normalized.includes("\u0000")) {
@@ -710,7 +714,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     const inboundMessage = sanitizedMessageResult.message;
     const stopCommand = isChatStopCommandText(inboundMessage);
     const normalizedAttachments = normalizeRpcAttachmentsToChatAttachments(p.attachments);
-    const rawMessage = inboundMessage.trim();
+    const rawMessage = inboundMessage?.trim() ?? "";
     if (!rawMessage && normalizedAttachments.length === 0) {
       respond(
         false,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -83,6 +83,9 @@ function stripDisallowedChatControlChars(message: string): string {
 export function sanitizeChatSendMessageInput(
   message: string,
 ): { ok: true; message: string } | { ok: false; error: string } {
+  if (typeof message !== "string") {
+    return { ok: false, error: "message must be a string" };
+  }
   const normalized = message.normalize("NFC");
   if (normalized.includes("\u0000")) {
     return { ok: false, error: "message must not contain null bytes" };

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -24,7 +24,7 @@ function extractTextBlocksAndSignals(message: unknown): {
   const content = record.content;
 
   if (typeof content === "string") {
-    const text = content.trim();
+    const text = content?.trim() ?? "";
     return {
       textBlocks: text ? [text] : [],
       sawNonTextContentBlocks: false,
@@ -42,7 +42,7 @@ function extractTextBlocksAndSignals(message: unknown): {
     }
     const rec = block as Record<string, unknown>;
     if (rec.type === "text" && typeof rec.text === "string") {
-      const text = rec.text.trim();
+      const text = rec.text?.trim() ?? "";
       if (text) {
         textBlocks.push(text);
       }


### PR DESCRIPTION
## Problem

When `message` / `payload.text` is `undefined` at runtime (e.g., across RPC boundaries), the code crashes with:
```
TypeError: Cannot read properties of undefined (reading 'trim')
```

TypeScript type annotations only apply at compile time, but runtime values crossing process boundaries (gateway RPC, Electron IPC) can be undefined.

## Solution

Add defensive runtime type checking before calling string methods:

1. **`sanitizeChatSendMessageInput`**: Return an error immediately if message is not a string
2. **`normalizeReplyPayload`**: Normalize the type of `payload.text` before using optional chaining

This ensures graceful error handling instead of crashing.

---

Found and fixed while debugging EasyClaw (which uses OpenClaw as a vendor submodule).