### PR TITLE
fix(config): migrate legacy ACP stream keys on load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Config/ACP: migrate legacy `acp.stream.maxTurnChars` and `acp.stream.maxToolSummaryChars` during runtime config loading, while dropping retired ACP stream keys, so older ACP stream configs keep starting after the key rename. Fixes #35957. Thanks @BlueBirdBack.
 - CLI/status: resolve read-only channel setup runtime fallback from the packaged OpenClaw dist root, so `status --all`, `status --deep`, channel, and doctor paths do not crash when an external channel plugin needs setup metadata. Fixes #74693. Thanks @giangthb.
 - CLI/update: scope packaged Node compile caches by OpenClaw version and install metadata, so global installs no longer reuse stale compiled chunks after package updates. Thanks @pashpashpash.
 - Channels/Voice call: keep pre-auth webhook in-flight limiting active when socket remote address metadata is missing, so slow-body requests from stripped-IP proxy paths still share the fallback bucket. (#74453) Thanks @davidangularme.

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.js";
+import { validateConfigObjectRaw } from "../../../config/validation.js";
 import { LEGACY_CONFIG_MIGRATIONS } from "./legacy-config-migrations.js";
 
 function migrateLegacyConfigForTest(raw: unknown): {
@@ -18,6 +19,132 @@ function migrateLegacyConfigForTest(raw: unknown): {
     ? { config: null, changes }
     : { config: next as OpenClawConfig, changes };
 }
+
+const LEGACY_ACP_STREAM_FIXTURE = {
+  acp: {
+    stream: {
+      maxTurnChars: 5000,
+      maxToolSummaryChars: 1000,
+      maxStatusChars: 400,
+      maxMetaEventsPerTurn: 6,
+      metaMode: "full",
+      showUsage: true,
+    },
+  },
+};
+
+describe("legacy acp.stream migrate", () => {
+  it("flags old acp.stream keys during raw validation", () => {
+    const result = validateConfigObjectRaw(LEGACY_ACP_STREAM_FIXTURE);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        "acp.stream.maxTurnChars",
+        "acp.stream.maxToolSummaryChars",
+        "acp.stream.maxStatusChars",
+        "acp.stream.maxMetaEventsPerTurn",
+        "acp.stream.metaMode",
+        "acp.stream.showUsage",
+      ]),
+    );
+  });
+
+  it("migrates old acp.stream keys to supported config", () => {
+    const result = migrateLegacyConfigForTest(LEGACY_ACP_STREAM_FIXTURE);
+
+    expect(result.config?.acp?.stream).toEqual({
+      maxOutputChars: 5000,
+      maxSessionUpdateChars: 1000,
+    });
+    expect(validateConfigObjectRaw(result.config).ok).toBe(true);
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        "Moved acp.stream.maxTurnChars → acp.stream.maxOutputChars.",
+        "Moved acp.stream.maxToolSummaryChars → acp.stream.maxSessionUpdateChars.",
+        "Removed acp.stream.maxStatusChars (no replacement).",
+        "Removed acp.stream.maxMetaEventsPerTurn (no replacement).",
+        "Removed acp.stream.metaMode (no replacement).",
+        "Removed acp.stream.showUsage (no replacement).",
+      ]),
+    );
+  });
+
+  it("does not overwrite new keys that are already set", () => {
+    const result = migrateLegacyConfigForTest({
+      acp: {
+        stream: {
+          maxTurnChars: 5000,
+          maxToolSummaryChars: 1000,
+          maxOutputChars: 9000,
+          maxSessionUpdateChars: 300,
+        },
+      },
+    });
+
+    expect(result.config?.acp?.stream).toEqual({
+      maxOutputChars: 9000,
+      maxSessionUpdateChars: 300,
+    });
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        "Removed acp.stream.maxTurnChars (acp.stream.maxOutputChars already set).",
+        "Removed acp.stream.maxToolSummaryChars (acp.stream.maxSessionUpdateChars already set).",
+      ]),
+    );
+  });
+
+  it("removes no-replacement legacy keys even when their values have wrong types", () => {
+    const result = migrateLegacyConfigForTest({
+      acp: {
+        stream: {
+          maxOutputChars: 9000,
+          maxSessionUpdateChars: 300,
+          maxStatusChars: "400",
+          maxMetaEventsPerTurn: "6",
+          metaMode: 1,
+          showUsage: "true",
+        },
+      },
+    });
+
+    expect(result.config?.acp?.stream).toEqual({
+      maxOutputChars: 9000,
+      maxSessionUpdateChars: 300,
+    });
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        "Removed acp.stream.maxStatusChars (no replacement).",
+        "Removed acp.stream.maxMetaEventsPerTurn (no replacement).",
+        "Removed acp.stream.metaMode (no replacement).",
+        "Removed acp.stream.showUsage (no replacement).",
+      ]),
+    );
+  });
+
+  it("removes invalid renamed legacy keys instead of leaving validation errors", () => {
+    const result = migrateLegacyConfigForTest({
+      acp: {
+        stream: {
+          maxTurnChars: "5000",
+          maxToolSummaryChars: "1000",
+        },
+      },
+    });
+
+    expect(result.config?.acp?.stream).toEqual({});
+    expect(validateConfigObjectRaw(result.config).ok).toBe(true);
+    expect(result.changes).toEqual(
+      expect.arrayContaining([
+        "Removed acp.stream.maxTurnChars (legacy value was not a positive integer).",
+        "Removed acp.stream.maxToolSummaryChars (legacy value was not a positive integer).",
+      ]),
+    );
+  });
+});
 
 describe("legacy session maintenance migrate", () => {
   it("removes deprecated session.maintenance.rotateBytes", () => {

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.acp.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.acp.ts
@@ -1,0 +1,101 @@
+import {
+  defineLegacyConfigMigration,
+  getRecord,
+  type LegacyConfigMigrationSpec,
+  type LegacyConfigRule,
+} from "../../../config/legacy.shared.js";
+
+const LEGACY_ACP_STREAM_RULES: LegacyConfigRule[] = [
+  {
+    path: ["acp", "stream", "maxTurnChars"],
+    message:
+      "acp.stream.maxTurnChars was renamed; use acp.stream.maxOutputChars instead (auto-migrated or removed on load).",
+  },
+  {
+    path: ["acp", "stream", "maxToolSummaryChars"],
+    message:
+      "acp.stream.maxToolSummaryChars was renamed; use acp.stream.maxSessionUpdateChars instead (auto-migrated or removed on load).",
+  },
+  {
+    path: ["acp", "stream", "maxStatusChars"],
+    message: "acp.stream.maxStatusChars was removed with no replacement (auto-removed on load).",
+  },
+  {
+    path: ["acp", "stream", "maxMetaEventsPerTurn"],
+    message:
+      "acp.stream.maxMetaEventsPerTurn was removed with no replacement (auto-removed on load).",
+  },
+  {
+    path: ["acp", "stream", "metaMode"],
+    message: "acp.stream.metaMode was removed with no replacement (auto-removed on load).",
+  },
+  {
+    path: ["acp", "stream", "showUsage"],
+    message: "acp.stream.showUsage was removed with no replacement (auto-removed on load).",
+  },
+];
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+function migrateLegacyAcpStream(stream: Record<string, unknown>, changes: string[]): void {
+  if (hasOwn(stream, "maxTurnChars")) {
+    if (isPositiveInteger(stream.maxTurnChars) && stream.maxOutputChars === undefined) {
+      stream.maxOutputChars = stream.maxTurnChars;
+      changes.push("Moved acp.stream.maxTurnChars → acp.stream.maxOutputChars.");
+    } else if (stream.maxOutputChars !== undefined) {
+      changes.push("Removed acp.stream.maxTurnChars (acp.stream.maxOutputChars already set).");
+    } else {
+      changes.push("Removed acp.stream.maxTurnChars (legacy value was not a positive integer).");
+    }
+    delete stream.maxTurnChars;
+  }
+
+  if (hasOwn(stream, "maxToolSummaryChars")) {
+    if (
+      isPositiveInteger(stream.maxToolSummaryChars) &&
+      stream.maxSessionUpdateChars === undefined
+    ) {
+      stream.maxSessionUpdateChars = stream.maxToolSummaryChars;
+      changes.push("Moved acp.stream.maxToolSummaryChars → acp.stream.maxSessionUpdateChars.");
+    } else if (stream.maxSessionUpdateChars !== undefined) {
+      changes.push(
+        "Removed acp.stream.maxToolSummaryChars (acp.stream.maxSessionUpdateChars already set).",
+      );
+    } else {
+      changes.push(
+        "Removed acp.stream.maxToolSummaryChars (legacy value was not a positive integer).",
+      );
+    }
+    delete stream.maxToolSummaryChars;
+  }
+
+  for (const key of ["maxStatusChars", "maxMetaEventsPerTurn", "metaMode", "showUsage"] as const) {
+    if (!hasOwn(stream, key)) {
+      continue;
+    }
+    delete stream[key];
+    changes.push(`Removed acp.stream.${key} (no replacement).`);
+  }
+}
+
+export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_ACP: LegacyConfigMigrationSpec[] = [
+  defineLegacyConfigMigration({
+    id: "acp.stream-v2026.3.2-keys",
+    describe: "Migrate removed ACP stream keys from v2026.3.2 to supported config",
+    legacyRules: LEGACY_ACP_STREAM_RULES,
+    apply: (raw, changes) => {
+      const acp = getRecord(raw.acp);
+      const stream = getRecord(acp?.stream);
+      if (!stream) {
+        return;
+      }
+      migrateLegacyAcpStream(stream, changes);
+    },
+  }),
+];

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.ts
@@ -1,4 +1,5 @@
 import type { LegacyConfigMigrationSpec } from "../../../config/legacy.shared.js";
+import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_ACP } from "./legacy-config-migrations.runtime.acp.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS } from "./legacy-config-migrations.runtime.agents.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY } from "./legacy-config-migrations.runtime.gateway.js";
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP } from "./legacy-config-migrations.runtime.mcp.js";
@@ -7,6 +8,7 @@ import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_SESSION } from "./legacy-config-migrat
 import { LEGACY_CONFIG_MIGRATIONS_RUNTIME_TTS } from "./legacy-config-migrations.runtime.tts.js";
 
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME: LegacyConfigMigrationSpec[] = [
+  ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_ACP,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_GATEWAY,
   ...LEGACY_CONFIG_MIGRATIONS_RUNTIME_MCP,

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -6,6 +6,7 @@ import { applyRuntimeLegacyConfigMigrations } from "../commands/doctor/shared/ru
 import { createConfigIO } from "./io.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
+import { validateConfigObjectRaw } from "./validation.js";
 
 async function withTempHome(run: (home: string) => Promise<void>): Promise<void> {
   const home = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-"));
@@ -152,6 +153,38 @@ describe("config io paths", () => {
       },
     });
     expect(cfg.agents?.list?.[0]?.tools?.exec?.safeBinTrustedDirs).toEqual(["/ops/bin"]);
+  });
+
+  it("migrates legacy acp.stream keys during runtime compat", () => {
+    const migrated = applyRuntimeLegacyConfigMigrations({
+      acp: {
+        stream: {
+          maxTurnChars: 5000,
+          maxToolSummaryChars: 1000,
+          maxStatusChars: "400",
+          maxMetaEventsPerTurn: 6,
+          metaMode: "full",
+          showUsage: true,
+        },
+      },
+    });
+
+    const next = migrated.next as OpenClawConfig | null;
+    expect(next?.acp?.stream).toEqual({
+      maxOutputChars: 5000,
+      maxSessionUpdateChars: 1000,
+    });
+    expect(validateConfigObjectRaw(next).ok).toBe(true);
+    expect(migrated.changes).toEqual(
+      expect.arrayContaining([
+        "Moved acp.stream.maxTurnChars → acp.stream.maxOutputChars.",
+        "Moved acp.stream.maxToolSummaryChars → acp.stream.maxSessionUpdateChars.",
+        "Removed acp.stream.maxStatusChars (no replacement).",
+        "Removed acp.stream.maxMetaEventsPerTurn (no replacement).",
+        "Removed acp.stream.metaMode (no replacement).",
+        "Removed acp.stream.showUsage (no replacement).",
+      ]),
+    );
   });
 
   it("moves WhatsApp shared access defaults into accounts.default during runtime compat", () => {


### PR DESCRIPTION
## Summary

Fixes #35957 by porting the stale ACP stream legacy-config migration into the current modular runtime migration registry.

Migrated:
- `acp.stream.maxTurnChars` → `acp.stream.maxOutputChars`
- `acp.stream.maxToolSummaryChars` → `acp.stream.maxSessionUpdateChars`

Removed as legacy keys with no replacement:
- `acp.stream.maxStatusChars`
- `acp.stream.maxMetaEventsPerTurn`
- `acp.stream.metaMode`
- `acp.stream.showUsage`

Also preserves explicitly set replacement keys and removes invalid legacy renamed values instead of leaving validation errors.

Supersedes #60824, which targets the old monolithic runtime migration file that no longer exists on current `main`.

## Verification

- `pnpm exec oxfmt --check src/commands/doctor/shared/legacy-config-migrations.runtime.acp.ts src/commands/doctor/shared/legacy-config-migrations.runtime.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/config/io.compat.test.ts`
- `node scripts/test-projects.mjs src/commands/doctor/shared/legacy-config-migrate.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.runtime-config.config.ts src/config/io.compat.test.ts -t 'migrates legacy acp.stream keys during runtime compat'`
- `pnpm tsgo:test:src`

Note: the full targeted two-file run also hit an unrelated ambient failure in the pre-existing `io.compat.test.ts` warning-format case caused by current ClawHub plugin config validation (`anima-mirror` missing required fields). The new runtime compat test passed in isolation.
