### PR TITLE
feat(bootstrap): support session-scoped extra files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Hooks: add exact-session `bootstrap-extra-files.sessions` config entries that can include custom bootstrap filenames while global extra-file globs keep the recognized basename allowlist. Thanks @presidenzo.
+
 ### Fixes
 
 - Feishu: auto-thread `message(action="send")` replies inside the topic when the active session is group_topic or group_topic_sender, and propagate `replyInThread` through text, card, and media outbound adapters so topic-scoped sessions no longer post at the group root. Fixes #74903. (#77151) Thanks @ai-hpc.

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -191,7 +191,10 @@ Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YY
       "entries": {
         "bootstrap-extra-files": {
           "enabled": true,
-          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md"]
+          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md"],
+          "sessions": {
+            "agent:main:whatsapp:group:123": ["sessions/zeus-dev/BOOTSTRAP-ZEUS.md"]
+          }
         }
       }
     }
@@ -199,7 +202,9 @@ Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YY
 }
 ```
 
-Paths resolve relative to workspace. Only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+Paths resolve relative to workspace. Matching files are loaded even when their basename is not one of the default workspace bootstrap filenames.
+
+Use `sessions` to add extra bootstrap files only for an exact `sessionKey`. Session-specific paths are combined with the global `paths`/`patterns`/`files` list and then filtered through the normal session bootstrap allowlist.
 
 <a id="command-logger"></a>
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -202,9 +202,9 @@ Extracts the last 15 user/assistant messages and saves to `<workspace>/memory/YY
 }
 ```
 
-Paths resolve relative to workspace. Matching files are loaded even when their basename is not one of the default workspace bootstrap filenames.
+Paths resolve relative to workspace. Global `paths`/`patterns`/`files` keep the default bootstrap filename allowlist, so broad globs do not inject arbitrary workspace files.
 
-Use `sessions` to add extra bootstrap files only for an exact `sessionKey`. Session-specific paths are combined with the global `paths`/`patterns`/`files` list and then filtered through the normal session bootstrap allowlist.
+Use `sessions` to add extra bootstrap files only for an exact `sessionKey`. Session-specific paths may use custom filenames, are loaded in addition to the global list, and are then filtered through the normal session bootstrap allowlist.
 
 <a id="command-logger"></a>
 

--- a/docs/cli/hooks.md
+++ b/docs/cli/hooks.md
@@ -288,7 +288,7 @@ openclaw hooks enable session-memory
 
 ### bootstrap-extra-files
 
-Injects additional bootstrap files (for example monorepo-local `AGENTS.md` / `TOOLS.md`) during `agent:bootstrap`.
+Injects additional workspace files (for example monorepo-local `AGENTS.md` / `PROJECT.md`) during `agent:bootstrap`.
 
 **Enable:**
 

--- a/src/agents/bootstrap-cache.test.ts
+++ b/src/agents/bootstrap-cache.test.ts
@@ -14,7 +14,7 @@ import { loadWorkspaceBootstrapFiles } from "./workspace.js";
 
 function makeFile(name: string, content: string): WorkspaceBootstrapFile {
   return {
-    name: name as WorkspaceBootstrapFile["name"],
+    name,
     path: `/ws/${name}`,
     content,
     missing: false,

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -25,32 +25,35 @@ describe("loadExtraBootstrapFiles", () => {
     }
   });
 
-  it("loads matching extra files from glob patterns regardless of basename", async () => {
+  it("loads recognized bootstrap files from glob patterns", async () => {
     const workspaceDir = await createWorkspaceDir("glob");
     const packageDir = path.join(workspaceDir, "packages", "core");
     await fs.mkdir(packageDir, { recursive: true });
     await fs.writeFile(path.join(packageDir, "TOOLS.md"), "tools", "utf-8");
-    await fs.writeFile(path.join(packageDir, "BOOTSTRAP-EUROTRIP.md"), "eurotrip", "utf-8");
+    await fs.writeFile(path.join(packageDir, "README.md"), "not bootstrap", "utf-8");
 
     const files = await loadExtraBootstrapFiles(workspaceDir, ["packages/*/*"]);
 
-    expect(files.map((file) => file.name)).toEqual(["BOOTSTRAP-EUROTRIP.md", "TOOLS.md"]);
-    expect(files.map((file) => file.content)).toEqual(["eurotrip", "tools"]);
+    expect(files).toHaveLength(1);
+    expect(files[0]?.name).toBe("TOOLS.md");
+    expect(files[0]?.content).toBe("tools");
   });
 
   it("preserves Node glob character class matching for extra file patterns", async () => {
     const workspaceDir = await createWorkspaceDir("glob-classes");
     const docsDir = path.join(workspaceDir, "docs");
-    await fs.mkdir(docsDir, { recursive: true });
-    await fs.writeFile(path.join(docsDir, "a.md"), "a", "utf-8");
-    await fs.writeFile(path.join(docsDir, "b.md"), "b", "utf-8");
-    await fs.writeFile(path.join(docsDir, "c.md"), "c", "utf-8");
+    await fs.mkdir(path.join(docsDir, "a"), { recursive: true });
+    await fs.mkdir(path.join(docsDir, "b"), { recursive: true });
+    await fs.mkdir(path.join(docsDir, "c"), { recursive: true });
+    await fs.writeFile(path.join(docsDir, "a", "TOOLS.md"), "a", "utf-8");
+    await fs.writeFile(path.join(docsDir, "b", "TOOLS.md"), "b", "utf-8");
+    await fs.writeFile(path.join(docsDir, "c", "TOOLS.md"), "c", "utf-8");
 
-    const files = await loadExtraBootstrapFiles(workspaceDir, ["docs/[ab]*.md"]);
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["docs/[ab]/TOOLS.md"]);
 
     expect(files.map((file) => path.relative(workspaceDir, file.path))).toEqual([
-      path.join("docs", "a.md"),
-      path.join("docs", "b.md"),
+      path.join("docs", "a", "TOOLS.md"),
+      path.join("docs", "b", "TOOLS.md"),
     ]);
     expect(files.map((file) => file.content)).toEqual(["a", "b"]);
   });
@@ -59,16 +62,19 @@ describe("loadExtraBootstrapFiles", () => {
     const workspaceDir = await createWorkspaceDir("literal-order");
     const notesDir = path.join(workspaceDir, "notes");
     await fs.mkdir(notesDir, { recursive: true });
-    await fs.writeFile(path.join(notesDir, "z.md"), "z", "utf-8");
-    await fs.writeFile(path.join(notesDir, "a.md"), "a", "utf-8");
+    await fs.writeFile(path.join(notesDir, "TOOLS.md"), "tools", "utf-8");
+    await fs.writeFile(path.join(notesDir, "AGENTS.md"), "agents", "utf-8");
 
-    const files = await loadExtraBootstrapFiles(workspaceDir, ["notes/z.md", "notes/a.md"]);
+    const files = await loadExtraBootstrapFiles(workspaceDir, [
+      "notes/TOOLS.md",
+      "notes/AGENTS.md",
+    ]);
 
     expect(files.map((file) => path.relative(workspaceDir, file.path))).toEqual([
-      path.join("notes", "z.md"),
-      path.join("notes", "a.md"),
+      path.join("notes", "TOOLS.md"),
+      path.join("notes", "AGENTS.md"),
     ]);
-    expect(files.map((file) => file.content)).toEqual(["z", "a"]);
+    expect(files.map((file) => file.content)).toEqual(["tools", "agents"]);
   });
 
   it("keeps path-traversal attempts outside workspace excluded", async () => {
@@ -84,20 +90,41 @@ describe("loadExtraBootstrapFiles", () => {
     expect(files).toHaveLength(0);
   });
 
-  it("reports missing arbitrary files without adding placeholders", async () => {
+  it("reports missing recognized files without adding placeholders", async () => {
     const workspaceDir = await createWorkspaceDir("missing");
 
     const { files, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
-      "docs/PROJECT.md",
+      "docs/TOOLS.md",
     ]);
 
     expect(files).toHaveLength(0);
     expect(diagnostics).toEqual([
       expect.objectContaining({
-        path: path.join(workspaceDir, "docs", "PROJECT.md"),
+        path: path.join(workspaceDir, "docs", "TOOLS.md"),
         reason: "missing",
       }),
     ]);
+  });
+
+  it("allows arbitrary basenames only when explicitly requested", async () => {
+    const workspaceDir = await createWorkspaceDir("arbitrary");
+    await fs.writeFile(path.join(workspaceDir, "PROJECT.md"), "project", "utf-8");
+
+    const defaultResult = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
+      "PROJECT.md",
+    ]);
+    const arbitraryResult = await loadExtraBootstrapFilesWithDiagnostics(
+      workspaceDir,
+      ["PROJECT.md"],
+      { allowArbitraryBasenames: true },
+    );
+
+    expect(defaultResult.files).toHaveLength(0);
+    expect(defaultResult.diagnostics).toEqual([
+      expect.objectContaining({ reason: "invalid-bootstrap-filename" }),
+    ]);
+    expect(arbitraryResult.files.map((file) => file.content)).toEqual(["project"]);
+    expect(arbitraryResult.diagnostics).toHaveLength(0);
   });
 
   it("supports symlinked workspace roots with realpath checks", async () => {
@@ -162,10 +189,11 @@ describe("loadExtraBootstrapFiles", () => {
     const workspaceDir = await createWorkspaceDir("budget");
     await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP-EUROTRIP.md"), "a".repeat(200), "utf-8");
     await fs.writeFile(path.join(workspaceDir, "PROJECT.md"), "b".repeat(200), "utf-8");
-    const files = await loadExtraBootstrapFiles(workspaceDir, [
-      "BOOTSTRAP-EUROTRIP.md",
-      "PROJECT.md",
-    ]);
+    const { files } = await loadExtraBootstrapFilesWithDiagnostics(
+      workspaceDir,
+      ["BOOTSTRAP-EUROTRIP.md", "PROJECT.md"],
+      { allowArbitraryBasenames: true },
+    );
     const warnings: string[] = [];
 
     const embedded = buildBootstrapContextFiles(files, {

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -24,18 +24,22 @@ describe("loadExtraBootstrapFiles", () => {
     }
   });
 
-  it("loads recognized bootstrap files from glob patterns", async () => {
+  it("loads matching extra files from glob patterns regardless of basename", async () => {
     const workspaceDir = await createWorkspaceDir("glob");
     const packageDir = path.join(workspaceDir, "packages", "core");
     await fs.mkdir(packageDir, { recursive: true });
     await fs.writeFile(path.join(packageDir, "TOOLS.md"), "tools", "utf-8");
-    await fs.writeFile(path.join(packageDir, "README.md"), "not bootstrap", "utf-8");
+    await fs.writeFile(path.join(packageDir, "BOOTSTRAP-EUROTRIP.md"), "eurotrip", "utf-8");
 
     const files = await loadExtraBootstrapFiles(workspaceDir, ["packages/*/*"]);
 
-    expect(files).toHaveLength(1);
-    expect(files[0]?.name).toBe("TOOLS.md");
-    expect(files[0]?.content).toBe("tools");
+    expect(files.map((file) => file.name).toSorted()).toEqual([
+      "BOOTSTRAP-EUROTRIP.md",
+      "TOOLS.md",
+    ]);
+    expect(files.map((file) => file.content)).toEqual(
+      expect.arrayContaining(["eurotrip", "tools"]),
+    );
   });
 
   it("keeps path-traversal attempts outside workspace excluded", async () => {

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -55,7 +55,7 @@ describe("loadExtraBootstrapFiles", () => {
     expect(files.map((file) => file.content)).toEqual(["a", "b"]);
   });
 
-  it("sorts literal paths deterministically before loading", async () => {
+  it("preserves configured literal path order before loading", async () => {
     const workspaceDir = await createWorkspaceDir("literal-order");
     const notesDir = path.join(workspaceDir, "notes");
     await fs.mkdir(notesDir, { recursive: true });
@@ -65,10 +65,10 @@ describe("loadExtraBootstrapFiles", () => {
     const files = await loadExtraBootstrapFiles(workspaceDir, ["notes/z.md", "notes/a.md"]);
 
     expect(files.map((file) => path.relative(workspaceDir, file.path))).toEqual([
-      path.join("notes", "a.md"),
       path.join("notes", "z.md"),
+      path.join("notes", "a.md"),
     ]);
-    expect(files.map((file) => file.content)).toEqual(["a", "z"]);
+    expect(files.map((file) => file.content)).toEqual(["z", "a"]);
   });
 
   it("keeps path-traversal attempts outside workspace excluded", async () => {

--- a/src/agents/workspace.load-extra-bootstrap-files.test.ts
+++ b/src/agents/workspace.load-extra-bootstrap-files.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { buildBootstrapContextFiles } from "./pi-embedded-helpers.js";
 import { loadExtraBootstrapFiles, loadExtraBootstrapFilesWithDiagnostics } from "./workspace.js";
 
 describe("loadExtraBootstrapFiles", () => {
@@ -33,13 +34,41 @@ describe("loadExtraBootstrapFiles", () => {
 
     const files = await loadExtraBootstrapFiles(workspaceDir, ["packages/*/*"]);
 
-    expect(files.map((file) => file.name).toSorted()).toEqual([
-      "BOOTSTRAP-EUROTRIP.md",
-      "TOOLS.md",
+    expect(files.map((file) => file.name)).toEqual(["BOOTSTRAP-EUROTRIP.md", "TOOLS.md"]);
+    expect(files.map((file) => file.content)).toEqual(["eurotrip", "tools"]);
+  });
+
+  it("preserves Node glob character class matching for extra file patterns", async () => {
+    const workspaceDir = await createWorkspaceDir("glob-classes");
+    const docsDir = path.join(workspaceDir, "docs");
+    await fs.mkdir(docsDir, { recursive: true });
+    await fs.writeFile(path.join(docsDir, "a.md"), "a", "utf-8");
+    await fs.writeFile(path.join(docsDir, "b.md"), "b", "utf-8");
+    await fs.writeFile(path.join(docsDir, "c.md"), "c", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["docs/[ab]*.md"]);
+
+    expect(files.map((file) => path.relative(workspaceDir, file.path))).toEqual([
+      path.join("docs", "a.md"),
+      path.join("docs", "b.md"),
     ]);
-    expect(files.map((file) => file.content)).toEqual(
-      expect.arrayContaining(["eurotrip", "tools"]),
-    );
+    expect(files.map((file) => file.content)).toEqual(["a", "b"]);
+  });
+
+  it("sorts literal paths deterministically before loading", async () => {
+    const workspaceDir = await createWorkspaceDir("literal-order");
+    const notesDir = path.join(workspaceDir, "notes");
+    await fs.mkdir(notesDir, { recursive: true });
+    await fs.writeFile(path.join(notesDir, "z.md"), "z", "utf-8");
+    await fs.writeFile(path.join(notesDir, "a.md"), "a", "utf-8");
+
+    const files = await loadExtraBootstrapFiles(workspaceDir, ["notes/z.md", "notes/a.md"]);
+
+    expect(files.map((file) => path.relative(workspaceDir, file.path))).toEqual([
+      path.join("notes", "a.md"),
+      path.join("notes", "z.md"),
+    ]);
+    expect(files.map((file) => file.content)).toEqual(["a", "z"]);
   });
 
   it("keeps path-traversal attempts outside workspace excluded", async () => {
@@ -53,6 +82,22 @@ describe("loadExtraBootstrapFiles", () => {
     const files = await loadExtraBootstrapFiles(workspaceDir, ["../outside/AGENTS.md"]);
 
     expect(files).toHaveLength(0);
+  });
+
+  it("reports missing arbitrary files without adding placeholders", async () => {
+    const workspaceDir = await createWorkspaceDir("missing");
+
+    const { files, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
+      "docs/PROJECT.md",
+    ]);
+
+    expect(files).toHaveLength(0);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        path: path.join(workspaceDir, "docs", "PROJECT.md"),
+        reason: "missing",
+      }),
+    ]);
   });
 
   it("supports symlinked workspace roots with realpath checks", async () => {
@@ -111,5 +156,27 @@ describe("loadExtraBootstrapFiles", () => {
 
     expect(files).toHaveLength(0);
     expect(diagnostics.map((diagnostic) => diagnostic.reason)).toContain("security");
+  });
+
+  it("passes arbitrary extra files through existing per-file and total bootstrap budgets", async () => {
+    const workspaceDir = await createWorkspaceDir("budget");
+    await fs.writeFile(path.join(workspaceDir, "BOOTSTRAP-EUROTRIP.md"), "a".repeat(200), "utf-8");
+    await fs.writeFile(path.join(workspaceDir, "PROJECT.md"), "b".repeat(200), "utf-8");
+    const files = await loadExtraBootstrapFiles(workspaceDir, [
+      "BOOTSTRAP-EUROTRIP.md",
+      "PROJECT.md",
+    ]);
+    const warnings: string[] = [];
+
+    const embedded = buildBootstrapContextFiles(files, {
+      maxChars: 80,
+      totalMaxChars: 120,
+      warn: (message) => warnings.push(message),
+    });
+
+    expect(embedded.reduce((sum, entry) => sum + entry.content.length, 0)).toBeLessThanOrEqual(120);
+    expect(embedded[0]?.content.length).toBeLessThanOrEqual(80);
+    expect(embedded[0]?.content).toContain("truncated");
+    expect(warnings.some((warning) => warning.includes("BOOTSTRAP-EUROTRIP.md"))).toBe(true);
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -713,8 +713,17 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   }
   const resolvedDir = resolveUserPath(dir);
 
-  // Resolve glob patterns into concrete file paths
-  const resolvedPaths = new Set<string>();
+  // Resolve glob patterns into concrete file paths. Keep configured pattern order
+  // while sorting each glob expansion for deterministic results.
+  const resolvedPaths: string[] = [];
+  const seenPaths = new Set<string>();
+  const addResolvedPath = (candidate: string) => {
+    if (seenPaths.has(candidate)) {
+      return;
+    }
+    seenPaths.add(candidate);
+    resolvedPaths.push(candidate);
+  };
   for (const pattern of extraPatterns) {
     if (
       pattern.includes("*") ||
@@ -723,22 +732,26 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
       pattern.includes("[")
     ) {
       try {
-        const matches = fs.glob(pattern, { cwd: resolvedDir });
-        for await (const m of matches) {
-          resolvedPaths.add(m);
+        const matches: string[] = [];
+        const globMatches = fs.glob(pattern, { cwd: resolvedDir });
+        for await (const m of globMatches) {
+          matches.push(m);
+        }
+        for (const match of matches.toSorted((a, b) => a.localeCompare(b))) {
+          addResolvedPath(match);
         }
       } catch {
         // glob not available or pattern error — fall back to literal
-        resolvedPaths.add(pattern);
+        addResolvedPath(pattern);
       }
     } else {
-      resolvedPaths.add(pattern);
+      addResolvedPath(pattern);
     }
   }
 
   const files: WorkspaceBootstrapFile[] = [];
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
-  for (const relPath of [...resolvedPaths].toSorted((a, b) => a.localeCompare(b))) {
+  for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
     const baseName = path.basename(relPath);
     const loaded = await readWorkspaceFileWithGuards({

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -129,15 +129,7 @@ async function loadTemplate(name: string): Promise<string> {
   }
 }
 
-export type WorkspaceBootstrapFileName =
-  | typeof DEFAULT_AGENTS_FILENAME
-  | typeof DEFAULT_SOUL_FILENAME
-  | typeof DEFAULT_TOOLS_FILENAME
-  | typeof DEFAULT_IDENTITY_FILENAME
-  | typeof DEFAULT_USER_FILENAME
-  | typeof DEFAULT_HEARTBEAT_FILENAME
-  | typeof DEFAULT_BOOTSTRAP_FILENAME
-  | typeof DEFAULT_MEMORY_FILENAME;
+export type WorkspaceBootstrapFileName = string;
 
 export type WorkspaceBootstrapFile = {
   name: WorkspaceBootstrapFileName;
@@ -146,11 +138,7 @@ export type WorkspaceBootstrapFile = {
   missing: boolean;
 };
 
-export type ExtraBootstrapLoadDiagnosticCode =
-  | "invalid-bootstrap-filename"
-  | "missing"
-  | "security"
-  | "io";
+export type ExtraBootstrapLoadDiagnosticCode = "missing" | "security" | "io";
 
 export type ExtraBootstrapLoadDiagnostic = {
   path: string;
@@ -739,23 +727,14 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
-    // Only load files whose basename is a recognized bootstrap filename
     const baseName = path.basename(relPath);
-    if (!VALID_BOOTSTRAP_NAMES.has(baseName)) {
-      diagnostics.push({
-        path: filePath,
-        reason: "invalid-bootstrap-filename",
-        detail: `unsupported bootstrap basename: ${baseName}`,
-      });
-      continue;
-    }
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
       workspaceDir: resolvedDir,
     });
     if (loaded.ok) {
       files.push({
-        name: baseName as WorkspaceBootstrapFileName,
+        name: baseName,
         path: filePath,
         content: loaded.content,
         missing: false,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -146,7 +146,11 @@ export type WorkspaceBootstrapFile = {
   missing: boolean;
 };
 
-export type ExtraBootstrapLoadDiagnosticCode = "missing" | "security" | "io";
+export type ExtraBootstrapLoadDiagnosticCode =
+  | "invalid-bootstrap-filename"
+  | "missing"
+  | "security"
+  | "io";
 
 export type ExtraBootstrapLoadDiagnostic = {
   path: string;
@@ -704,6 +708,7 @@ export async function loadExtraBootstrapFiles(
 export async function loadExtraBootstrapFilesWithDiagnostics(
   dir: string,
   extraPatterns: string[],
+  options: { allowArbitraryBasenames?: boolean } = {},
 ): Promise<{
   files: WorkspaceBootstrapFile[];
   diagnostics: ExtraBootstrapLoadDiagnostic[];
@@ -754,6 +759,14 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   for (const relPath of resolvedPaths) {
     const filePath = path.resolve(resolvedDir, relPath);
     const baseName = path.basename(relPath);
+    if (!options.allowArbitraryBasenames && !VALID_BOOTSTRAP_NAMES.has(baseName)) {
+      diagnostics.push({
+        path: filePath,
+        reason: "invalid-bootstrap-filename",
+        detail: `unsupported bootstrap basename: ${baseName}`,
+      });
+      continue;
+    }
     const loaded = await readWorkspaceFileWithGuards({
       filePath,
       workspaceDir: resolvedDir,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -129,10 +129,18 @@ async function loadTemplate(name: string): Promise<string> {
   }
 }
 
-export type WorkspaceBootstrapFileName = string;
+export type WorkspaceBootstrapFileName =
+  | typeof DEFAULT_AGENTS_FILENAME
+  | typeof DEFAULT_SOUL_FILENAME
+  | typeof DEFAULT_TOOLS_FILENAME
+  | typeof DEFAULT_IDENTITY_FILENAME
+  | typeof DEFAULT_USER_FILENAME
+  | typeof DEFAULT_HEARTBEAT_FILENAME
+  | typeof DEFAULT_BOOTSTRAP_FILENAME
+  | typeof DEFAULT_MEMORY_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: string;
   path: string;
   content?: string;
   missing: boolean;
@@ -708,7 +716,12 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
   // Resolve glob patterns into concrete file paths
   const resolvedPaths = new Set<string>();
   for (const pattern of extraPatterns) {
-    if (pattern.includes("*") || pattern.includes("?") || pattern.includes("{")) {
+    if (
+      pattern.includes("*") ||
+      pattern.includes("?") ||
+      pattern.includes("{") ||
+      pattern.includes("[")
+    ) {
       try {
         const matches = fs.glob(pattern, { cwd: resolvedDir });
         for await (const m of matches) {
@@ -725,7 +738,7 @@ export async function loadExtraBootstrapFilesWithDiagnostics(
 
   const files: WorkspaceBootstrapFile[] = [];
   const diagnostics: ExtraBootstrapLoadDiagnostic[] = [];
-  for (const relPath of resolvedPaths) {
+  for (const relPath of [...resolvedPaths].toSorted((a, b) => a.localeCompare(b))) {
     const filePath = path.resolve(resolvedDir, relPath);
     const baseName = path.basename(relPath);
     const loaded = await readWorkspaceFileWithGuards({

--- a/src/hooks/bundled/README.md
+++ b/src/hooks/bundled/README.md
@@ -20,7 +20,7 @@ openclaw hooks enable session-memory
 
 ### 📎 bootstrap-extra-files
 
-Injects extra bootstrap files (for example monorepo `AGENTS.md`/`TOOLS.md`) during prompt assembly.
+Injects extra workspace files (for example monorepo `AGENTS.md`/`PROJECT.md`) during prompt assembly.
 
 **Events**: `agent:bootstrap`
 **What it does**: Expands configured workspace glob/path patterns and appends matching bootstrap files to injected context.

--- a/src/hooks/bundled/bootstrap-extra-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-extra-files/HOOK.md
@@ -53,5 +53,5 @@ workspace root.
 - `sessions` (object): exact `sessionKey` to extra path list map. Matching session paths are loaded in addition to the global list.
 
 All paths are resolved from the workspace and must stay inside it (including realpath checks).
-Matching files are loaded even when their basename is not one of the default workspace
-bootstrap filenames.
+Global `paths`/`patterns`/`files` keep the default bootstrap filename allowlist.
+Matching `sessions` entries may use custom filenames for the exact session they target.

--- a/src/hooks/bundled/bootstrap-extra-files/HOOK.md
+++ b/src/hooks/bundled/bootstrap-extra-files/HOOK.md
@@ -34,7 +34,10 @@ workspace root.
       "entries": {
         "bootstrap-extra-files": {
           "enabled": true,
-          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md"]
+          "paths": ["packages/*/AGENTS.md", "packages/*/TOOLS.md"],
+          "sessions": {
+            "agent:main:whatsapp:group:123": ["sessions/zeus-dev/BOOTSTRAP-ZEUS.md"]
+          }
         }
       }
     }
@@ -47,7 +50,8 @@ workspace root.
 - `paths` (string[]): preferred list of glob/path patterns.
 - `patterns` (string[]): alias of `paths`.
 - `files` (string[]): alias of `paths`.
+- `sessions` (object): exact `sessionKey` to extra path list map. Matching session paths are loaded in addition to the global list.
 
 All paths are resolved from the workspace and must stay inside it (including realpath checks).
-Only recognized bootstrap basenames are loaded (`AGENTS.md`, `SOUL.md`, `TOOLS.md`,
-`IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`, `MEMORY.md`).
+Matching files are loaded even when their basename is not one of the default workspace
+bootstrap filenames.

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -146,10 +146,11 @@ describe("bootstrap-extra-files hook", () => {
         [sessionKey]: ["sessions/zeus-dev/ZEUS.md"],
       },
     });
+    const nonMatchingSessionKey = "agent:main:whatsapp:group:456";
     const nonMatchingContext = await createBootstrapContext({
       workspaceDir: tempDir,
       cfg,
-      sessionKey: "agent:main:whatsapp:group:456",
+      sessionKey: nonMatchingSessionKey,
       rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
     });
     const matchingContext = await createBootstrapContext({
@@ -162,7 +163,7 @@ describe("bootstrap-extra-files hook", () => {
     const nonMatchingEvent = createHookEvent(
       "agent",
       "bootstrap",
-      nonMatchingContext.sessionKey,
+      nonMatchingSessionKey,
       nonMatchingContext,
     );
     const matchingEvent = createHookEvent("agent", "bootstrap", sessionKey, matchingContext);

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -133,6 +133,48 @@ describe("bootstrap-extra-files hook", () => {
     expect(context.bootstrapFiles.map((file) => file.content)).not.toContain("main bootstrap");
   });
 
+  it("keeps arbitrary basenames scoped to matching session entries", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-session-custom-");
+    const sessionDir = path.join(tempDir, "sessions", "zeus-dev");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(path.join(sessionDir, "ZEUS.md"), "zeus custom", "utf-8");
+
+    const sessionKey = "agent:main:whatsapp:group:123";
+    const cfg = createBootstrapExtraConfig({
+      paths: ["sessions/zeus-dev/ZEUS.md"],
+      sessions: {
+        [sessionKey]: ["sessions/zeus-dev/ZEUS.md"],
+      },
+    });
+    const nonMatchingContext = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey: "agent:main:whatsapp:group:456",
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+    const matchingContext = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey,
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const nonMatchingEvent = createHookEvent(
+      "agent",
+      "bootstrap",
+      nonMatchingContext.sessionKey,
+      nonMatchingContext,
+    );
+    const matchingEvent = createHookEvent("agent", "bootstrap", sessionKey, matchingContext);
+    await handler(nonMatchingEvent);
+    await handler(matchingEvent);
+
+    expect(nonMatchingContext.bootstrapFiles.map((file) => file.content)).not.toContain(
+      "zeus custom",
+    );
+    expect(matchingContext.bootstrapFiles.map((file) => file.content)).toContain("zeus custom");
+  });
+
   it("combines and deduplicates global and session-specific patterns", async () => {
     const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-session-dedupe-");
     const sessionDir = path.join(tempDir, "sessions", "zeus-dev");

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -7,14 +7,18 @@ import type { AgentBootstrapHookContext } from "../../hooks.js";
 import { createHookEvent } from "../../hooks.js";
 import handler from "./handler.js";
 
-function createBootstrapExtraConfig(paths: string[]): OpenClawConfig {
+function createBootstrapExtraConfig(params: {
+  paths?: string[];
+  sessions?: Record<string, string[]>;
+}): OpenClawConfig {
   return {
     hooks: {
       internal: {
         entries: {
           "bootstrap-extra-files": {
             enabled: true,
-            paths,
+            paths: params.paths,
+            sessions: params.sessions,
           },
         },
       },
@@ -55,7 +59,7 @@ describe("bootstrap-extra-files hook", () => {
     await fs.mkdir(extraDir, { recursive: true });
     await fs.writeFile(path.join(extraDir, "AGENTS.md"), "extra agents", "utf-8");
 
-    const cfg = createBootstrapExtraConfig(["packages/*/AGENTS.md"]);
+    const cfg = createBootstrapExtraConfig({ paths: ["packages/*/AGENTS.md"] });
     const context = await createBootstrapContext({
       workspaceDir: tempDir,
       cfg,
@@ -79,7 +83,7 @@ describe("bootstrap-extra-files hook", () => {
     await fs.mkdir(extraDir, { recursive: true });
     await fs.writeFile(path.join(extraDir, "SOUL.md"), "evil", "utf-8");
 
-    const cfg = createBootstrapExtraConfig(["packages/*/SOUL.md"]);
+    const cfg = createBootstrapExtraConfig({ paths: ["packages/*/SOUL.md"] });
     const context = await createBootstrapContext({
       workspaceDir: tempDir,
       cfg,
@@ -97,5 +101,90 @@ describe("bootstrap-extra-files hook", () => {
       "SOUL.md",
       "TOOLS.md",
     ]);
+  });
+
+  it("adds session-specific bootstrap files only for the exact session key", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-session-");
+    const sessionDir = path.join(tempDir, "sessions", "zeus-dev");
+    const otherDir = path.join(tempDir, "sessions", "main");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.mkdir(otherDir, { recursive: true });
+    await fs.writeFile(path.join(sessionDir, "BOOTSTRAP-ZEUS.md"), "zeus bootstrap", "utf-8");
+    await fs.writeFile(path.join(otherDir, "BOOTSTRAP-MAIN.md"), "main bootstrap", "utf-8");
+
+    const sessionKey = "agent:main:whatsapp:group:123";
+    const cfg = createBootstrapExtraConfig({
+      sessions: {
+        [sessionKey]: ["sessions/zeus-dev/BOOTSTRAP-ZEUS.md"],
+        "agent:main:whatsapp:group:456": ["sessions/main/BOOTSTRAP-MAIN.md"],
+      },
+    });
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey,
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", sessionKey, context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.map((file) => file.content)).toContain("zeus bootstrap");
+    expect(context.bootstrapFiles.map((file) => file.content)).not.toContain("main bootstrap");
+  });
+
+  it("combines and deduplicates global and session-specific patterns", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-session-dedupe-");
+    const sessionDir = path.join(tempDir, "sessions", "zeus-dev");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(path.join(sessionDir, "BOOTSTRAP-ZEUS.md"), "zeus bootstrap", "utf-8");
+    await fs.writeFile(path.join(sessionDir, "TOOLS.md"), "zeus tools", "utf-8");
+
+    const sessionKey = "agent:main:whatsapp:group:123";
+    const cfg = createBootstrapExtraConfig({
+      paths: ["sessions/zeus-dev/BOOTSTRAP-ZEUS.md"],
+      sessions: {
+        [sessionKey]: ["sessions/zeus-dev/BOOTSTRAP-ZEUS.md", "sessions/zeus-dev/TOOLS.md"],
+      },
+    });
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey,
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", sessionKey, context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.filter((file) => file.content === "zeus bootstrap")).toHaveLength(
+      1,
+    );
+    expect(context.bootstrapFiles.map((file) => file.content)).toContain("zeus tools");
+  });
+
+  it("keeps session-specific paths inside the workspace boundary", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-bootstrap-extra-session-boundary-");
+    const outsideDir = path.join(path.dirname(tempDir), `${path.basename(tempDir)}-outside`);
+    await fs.mkdir(outsideDir, { recursive: true });
+    await fs.writeFile(path.join(outsideDir, "BOOTSTRAP.md"), "outside bootstrap", "utf-8");
+
+    const sessionKey = "agent:main:whatsapp:group:123";
+    const cfg = createBootstrapExtraConfig({
+      sessions: {
+        [sessionKey]: [path.relative(tempDir, path.join(outsideDir, "BOOTSTRAP.md"))],
+      },
+    });
+    const context = await createBootstrapContext({
+      workspaceDir: tempDir,
+      cfg,
+      sessionKey,
+      rootFiles: [{ name: "AGENTS.md", content: "root agents" }],
+    });
+
+    const event = createHookEvent("agent", "bootstrap", sessionKey, context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.map((file) => file.content)).not.toContain("outside bootstrap");
   });
 });

--- a/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.test.ts
@@ -157,10 +157,14 @@ describe("bootstrap-extra-files hook", () => {
     const event = createHookEvent("agent", "bootstrap", sessionKey, context);
     await handler(event);
 
+    expect(context.bootstrapFiles.map((file) => file.content)).toEqual([
+      "root agents",
+      "zeus bootstrap",
+      "zeus tools",
+    ]);
     expect(context.bootstrapFiles.filter((file) => file.content === "zeus bootstrap")).toHaveLength(
       1,
     );
-    expect(context.bootstrapFiles.map((file) => file.content)).toContain("zeus tools");
   });
 
   it("keeps session-specific paths inside the workspace boundary", async () => {

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -48,21 +48,31 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
   }
 
   const typedConfig = hookConfig as Record<string, unknown>;
-  const patterns = [
-    ...new Set([
-      ...resolveExtraBootstrapPatterns(typedConfig),
-      ...resolveSessionBootstrapPatterns(typedConfig, context.sessionKey),
-    ]),
-  ];
-  if (patterns.length === 0) {
+  const globalPatterns = resolveExtraBootstrapPatterns(typedConfig);
+  const sessionPatterns = resolveSessionBootstrapPatterns(typedConfig, context.sessionKey);
+  if (globalPatterns.length === 0 && sessionPatterns.length === 0) {
     return;
   }
 
   try {
-    const { files: extras, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(
+    const globalResult = await loadExtraBootstrapFilesWithDiagnostics(
       context.workspaceDir,
-      patterns,
+      globalPatterns,
     );
+    const sessionResult = await loadExtraBootstrapFilesWithDiagnostics(
+      context.workspaceDir,
+      sessionPatterns,
+      { allowArbitraryBasenames: true },
+    );
+    const seenExtraPaths = new Set<string>();
+    const extras = [...globalResult.files, ...sessionResult.files].filter((file) => {
+      if (seenExtraPaths.has(file.path)) {
+        return false;
+      }
+      seenExtraPaths.add(file.path);
+      return true;
+    });
+    const diagnostics = [...globalResult.diagnostics, ...sessionResult.diagnostics];
     if (diagnostics.length > 0) {
       log.debug("skipped extra bootstrap candidates", {
         skipped: diagnostics.length,

--- a/src/hooks/bundled/bootstrap-extra-files/handler.ts
+++ b/src/hooks/bundled/bootstrap-extra-files/handler.ts
@@ -22,6 +22,20 @@ function resolveExtraBootstrapPatterns(hookConfig: Record<string, unknown>): str
   return normalizeTrimmedStringList(hookConfig.files);
 }
 
+function resolveSessionBootstrapPatterns(
+  hookConfig: Record<string, unknown>,
+  sessionKey?: string,
+): string[] {
+  if (!sessionKey) {
+    return [];
+  }
+  const sessions = hookConfig.sessions;
+  if (!sessions || typeof sessions !== "object" || Array.isArray(sessions)) {
+    return [];
+  }
+  return normalizeTrimmedStringList((sessions as Record<string, unknown>)[sessionKey]);
+}
+
 const bootstrapExtraFilesHook: HookHandler = async (event) => {
   if (!isAgentBootstrapEvent(event)) {
     return;
@@ -33,7 +47,13 @@ const bootstrapExtraFilesHook: HookHandler = async (event) => {
     return;
   }
 
-  const patterns = resolveExtraBootstrapPatterns(hookConfig as Record<string, unknown>);
+  const typedConfig = hookConfig as Record<string, unknown>;
+  const patterns = [
+    ...new Set([
+      ...resolveExtraBootstrapPatterns(typedConfig),
+      ...resolveSessionBootstrapPatterns(typedConfig, context.sessionKey),
+    ]),
+  ];
   if (patterns.length === 0) {
     return;
   }


### PR DESCRIPTION
## Summary

- Problem: `bootstrap-extra-files` could only apply one global extra file set, and explicitly configured extra files were still constrained by the default bootstrap basename list.
- Why it matters: operators with long-lived group/session workflows need deterministic session-specific context without renaming files to generic `BOOTSTRAP.md` or mixing unrelated domain context into shared bootstrap files.
- What changed: `bootstrap-extra-files` now supports exact `sessions[sessionKey]` path lists, combines them with global `paths`/`patterns`/`files`, deduplicates while preserving configured order, and loads explicitly configured workspace files with custom basenames through the existing workspace guards and budgets.
- What did NOT change (scope boundary): this does not add channel-wide selectors, session-type selectors, tiered bootstrap policy, symlink expansion beyond existing boundary checks, or a new global `agents.defaults` schema.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39120
- Related #73917
- Related #50876
- Related #61001
- Related #22438
- Related #22439
- Related #54315
- Related #62110
- Related #73401
- Related #73988
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): Existing `bootstrap-extra-files` already resolved configured workspace paths, but the public contract only supported one global list. The basename allowlist also made explicit custom files such as `BOOTSTRAP-SUPPORT.md` unusable even when the path was intentionally configured and still passed workspace boundary checks.

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
  - `src/hooks/bundled/bootstrap-extra-files/handler.test.ts`
  - `src/agents/workspace.load-extra-bootstrap-files.test.ts`
- Scenario the test should lock in:
  - exact `sessionKey` paths are loaded only for the matching session;
  - global paths and session paths combine in deterministic configured order;
  - duplicate global/session paths are injected once;
  - explicitly configured custom basenames load normally;
  - workspace boundary and bootstrap budget checks still apply.
- Why this is the smallest reliable guardrail: the hook test covers config/session composition, while the workspace loader test covers file resolution, custom basename loading, ordering, and guard behavior without starting a gateway.
- Existing test that already covers this (if any): existing hook tests covered global extra file injection and subagent filtering; this PR extends that coverage for session-scoped paths.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

`bootstrap-extra-files` accepts an optional `sessions` object mapping exact session keys to additional workspace-relative path lists:

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "bootstrap-extra-files": {
          "enabled": true,
          "paths": ["shared/BOOTSTRAP.md"],
          "sessions": {
            "agent:main:whatsapp:group:123": [
              "groups/support/BOOTSTRAP-SUPPORT.md"
            ]
          }
        }
      }
    }
  }
}
```

Global `paths` / `patterns` / `files` remain backward compatible. Matching files are loaded even when their basename is not one of the default workspace bootstrap filenames, as long as they pass the existing workspace path and size guards.

If the same file is present in both the global list and the matching session list, it is injected once, preserving the first configured occurrence.

## Diagram (if applicable)

```text
Before:
[agent:bootstrap] -> [global bootstrap-extra-files paths only] -> [same extras in every session]

After:
[agent:bootstrap]
  -> [global bootstrap-extra-files paths]
  -> [exact sessions[sessionKey] paths when configured]
  -> [dedupe + workspace guards + session bootstrap filter]
  -> [session-specific context]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

Configured extra files are still constrained to the workspace by the existing path, realpath, and file-size guards. This PR does not add external path access or expand tool execution.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / local pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted):

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "bootstrap-extra-files": {
          "enabled": true,
          "paths": ["shared/BOOTSTRAP.md"],
          "sessions": {
            "agent:main:whatsapp:group:123": [
              "groups/support/BOOTSTRAP-SUPPORT.md"
            ]
          }
        }
      }
    }
  }
}
```

### Steps

1. Configure `bootstrap-extra-files.paths` with a global extra file.
2. Configure `bootstrap-extra-files.sessions["agent:main:whatsapp:group:123"]` with a matching session-specific custom basename file.
3. Trigger the hook with the matching session key.
4. Trigger the hook with a different session key.
5. Try a session-specific path that resolves outside the workspace.

### Expected

- Matching session receives root bootstrap context, global extras, and session-specific extras in deterministic configured order.
- Duplicate global/session paths are injected once.
- Non-matching sessions do not receive the other session's extra files.
- Custom basenames such as `BOOTSTRAP-SUPPORT.md` load when explicitly configured.
- Outside-workspace paths are rejected.

### Actual

- Matches expected behavior in focused tests.

## Real behavior proof

- **Behavior or issue addressed:** exact-session `bootstrap-extra-files.sessions[sessionKey]` entries inject matching session extras while global extra-file paths keep the recognized bootstrap basename allowlist.
- **Real setup tested:** local OpenClaw pnpm workspace on macOS, running the actual bundled `bootstrap-extra-files` hook handler against a temporary workspace with real files on disk.
- **Exact steps or command run after this patch:** `node --import tsx -e '<runs the bundled bootstrap-extra-files hook against a temp workspace with matching and non-matching session keys>'`.
- **Evidence after fix:** terminal output from that command:

```text
workspace=/var/folders/3w/hh0mlt3n7p91vspj8jc_nfs00000gn/T/openclaw-real-bootstrap-dBsTbc
matching=["AGENTS.md","shared/BOOTSTRAP.md","sessions/support/BOOTSTRAP-SUPPORT.md"]
nonMatching=["AGENTS.md","shared/BOOTSTRAP.md"]
customBasenameScoped=true
globalRecognizedOnly=true
```

- **Observed result after fix:** the matching session received the custom-basename `sessions/support/BOOTSTRAP-SUPPORT.md` file, the non-matching session did not, and the same custom basename was not injected through the global `paths` list.
- **What was not tested:** live gateway/channel E2E; no symlink policy changes beyond the existing workspace guard behavior.

## Evidence

Local validation:

```bash
pnpm test src/hooks/bundled/bootstrap-extra-files/handler.test.ts src/agents/workspace.load-extra-bootstrap-files.test.ts
pnpm check:changed
git diff --check
```

All passed locally. `pnpm check:changed` selected a broad scope because the branch is currently behind `upstream/main`, but completed successfully.

Stable release reference checked before PR prep:

```text
latest stable: v2026.4.27
published: 2026-04-29T22:12:19Z
tag object: 89159965a186b8fa94475dc7b2d5e1703206f368
peeled commit: cbc2ba0931468259f26a7c547131a06e03ca6c6c
```

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - session-specific paths are applied only for exact `sessionKey`;
  - global and session-specific paths combine and dedupe;
  - literal path ordering follows configured order;
  - glob matches remain deterministic within each glob expansion;
  - custom basenames load when explicitly configured;
  - outside-workspace session paths remain excluded;
  - arbitrary extra files still pass through per-file and total bootstrap budgets.
- Edge cases checked:
  - duplicate path in global and session lists;
  - non-matching session key;
  - custom file basename;
  - path traversal outside workspace;
  - missing arbitrary file diagnostics;
  - oversized file diagnostics/budget behavior.
- What you did **not** verify:
  - no live gateway/channel E2E run;
  - no symlink policy changes beyond existing workspace guard coverage;
  - no broad performance benchmark, because this is a small config/file-resolution path change.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

No upstream review conversations exist for this PR yet.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

Existing `bootstrap-extra-files.paths`, `patterns`, and `files` configs continue to work. Operators can optionally add `sessions` entries keyed by exact session key. No migration is required.

## Risks and Mitigations

- Risk: Custom basenames could make it less obvious which files are injected.
  - Mitigation: files must be explicitly configured and still pass existing workspace boundary and size guards; docs call out the behavior.

- Risk: Session-specific config could be mistaken for channel/type matching.
  - Mitigation: the contract is exact `sessionKey` matching only; broader session-type policy remains separate and related to #61001.

- Risk: Large session-specific files could increase prompt size.
  - Mitigation: existing `bootstrapMaxChars` and `bootstrapTotalMaxChars` budgets still apply, with truncation diagnostics.

