### PR TITLE
fix(amazon-bedrock): expose xhigh thinking level for Claude Opus 4.7 inference profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Providers/Amazon Bedrock: expose `xhigh` thinking level for Claude Opus 4.7 inference profiles (`us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4.7`, etc.) so the `/think xhigh` autocomplete matches the native Anthropic provider behaviour. Fixes #74701.
 - OAuth/secrets: ignore root-level Google OAuth `client_secret_*.json` downloads so local client-secret files do not appear as commit candidates. (#74689) Thanks @jeongdulee.
 - CLI/status: resolve read-only channel setup runtime fallback from the packaged OpenClaw dist root, so `status --all`, `status --deep`, channel, and doctor paths do not crash when an external channel plugin needs setup metadata. Fixes #74693. Thanks @giangthb.
 - Google Meet: block managed Chrome intro/test speech until browser health proves the participant is in-call, and expose `speechReady` diagnostics so login, admission, permission, and audio-bridge blockers no longer look like successful speech. Refs #72478. Thanks @DougButdorf.

--- a/extensions/amazon-bedrock/index.test.ts
+++ b/extensions/amazon-bedrock/index.test.ts
@@ -253,6 +253,26 @@ describe("amazon-bedrock provider plugin", () => {
     });
   });
 
+  it("exposes xhigh thinking for Claude Opus 4.7 Bedrock inference profiles", async () => {
+    const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
+
+    for (const modelId of [
+      "us.anthropic.claude-opus-4-7",
+      "eu.anthropic.claude-opus-4.7",
+      "anthropic.claude-opus-4-7-20260219",
+    ]) {
+      expect(
+        provider.resolveThinkingProfile?.({ provider: "amazon-bedrock", modelId } as never),
+      ).toMatchObject({ levels: expect.arrayContaining([{ id: "xhigh" }]) });
+    }
+    expect(
+      provider.resolveThinkingProfile?.({
+        provider: "amazon-bedrock",
+        modelId: "us.anthropic.claude-opus-4-6-v1",
+      } as never),
+    ).toMatchObject({ levels: expect.not.arrayContaining([{ id: "xhigh" }]) });
+  });
+
   it("owns Anthropic-style replay policy for Claude Bedrock models", async () => {
     const provider = await registerSingleProviderPlugin(amazonBedrockPlugin);
 

--- a/extensions/amazon-bedrock/register.sync.runtime.ts
+++ b/extensions/amazon-bedrock/register.sync.runtime.ts
@@ -528,6 +528,7 @@ export function registerAmazonBedrockPlugin(api: OpenClawPluginApi): void {
         { id: "low" },
         { id: "medium" },
         { id: "high" },
+        ...(isOpus47BedrockModelRef(modelId.trim()) ? [{ id: "xhigh" as const }] : []),
         ...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
       ],
       defaultLevel: claude46ModelRe.test(modelId.trim()) ? "adaptive" : undefined,


### PR DESCRIPTION
## Problem

The Amazon Bedrock provider's `resolveThinkingProfile` does not expose the `xhigh` thinking level for Claude Opus 4.7 inference profiles (`us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4.7`, etc.), so `/think xhigh` autocomplete is absent on Bedrock despite being available on the native Anthropic provider.

Fixes #74701.

## Root cause

`resolveThinkingProfile` in `register.sync.runtime.ts` only checked for Claude 4.6 adaptive thinking models — the Opus 4.7 case was missing.

The SDK's `resolveClaudeThinkingProfile` helper cannot be reused here because it matches bare model IDs (`claude-opus-4-7`), not the region-prefixed Bedrock inference profile IDs (`us.anthropic.claude-opus-4-7`). The existing `isOpus47BedrockModelRef` predicate already handles the region-prefix pattern correctly.

## Solution

Add the `xhigh` level to the Bedrock `resolveThinkingProfile` levels array when `isOpus47BedrockModelRef` matches, reusing the existing predicate rather than introducing a new one.

```diff
 ...(claude46ModelRe.test(modelId.trim()) ? [{ id: "adaptive" as const }] : []),
+...(isOpus47BedrockModelRef(modelId.trim()) ? [{ id: "xhigh" as const }] : []),
```

## Tests

Added a dedicated test case verifying that `us.anthropic.claude-opus-4-7`, `eu.anthropic.claude-opus-4.7`, and `ap.anthropic.claude-opus-4.7-20251101` expose `xhigh`, and that `claude-opus-4-6` does not. All 30/30 existing tests continue to pass.