### PR TITLE
docs: Document oMLX (Apple Silicon MLX) as memorySearch embedding provider

### DIFF
--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -41,18 +41,58 @@ Some OpenAI-compatible embedding endpoints require asymmetric labels such as
 for indexed chunks. Configure those with `memorySearch.queryInputType` and
 `memorySearch.documentInputType`; see the [Memory configuration reference](/reference/memory-config#provider-specific-config).
 
+### Using oMLX (Apple Silicon, MLX-native)
+
+[oMLX](https://github.com/jundot/omlx) is a local inference server optimized
+for Apple Silicon. It auto-discovers embedding models in its model directory
+and serves them via an OpenAI-compatible API on `http://localhost:8000/v1`,
+making it a strong Ollama alternative for Mac users on M-series chips.
+
+To use an oMLX-hosted embedding model (e.g.
+`jina-embeddings-v5-text-small-retrieval-mlx`):
+
+```json5
+{
+  agents: {
+    defaults: {
+      memorySearch: {
+        enabled: true,
+        provider: "openai",
+        model: "jina-embeddings-v5-text-small-retrieval-mlx",
+        remote: {
+          baseUrl: "http://127.0.0.1:8000/v1",
+          apiKey: "<your-omlx-api-key>",
+        },
+      },
+    },
+  },
+}
+```
+
+<Tip>
+Use `provider: "openai"` (not `"ollama"`) for oMLX. Although oMLX is
+positionally similar to Ollama as a local runtime, it speaks the OpenAI
+protocol, not Ollama's `/api/embeddings` protocol. The OpenAI adapter handles
+any OpenAI-compatible endpoint, including local oMLX.
+</Tip>
+
+After switching providers or models, run `openclaw memory index --force` to
+re-embed existing notes in the new vector space — embeddings from different
+models are not interchangeable.
+
 ## Supported providers
 
-| Provider       | ID               | Needs API key | Notes                                                |
-| -------------- | ---------------- | ------------- | ---------------------------------------------------- |
-| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves |
-| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                        |
-| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription             |
-| Local          | `local`          | No            | GGUF model, ~0.6 GB download                         |
-| Mistral        | `mistral`        | Yes           | Auto-detected                                        |
-| Ollama         | `ollama`         | No            | Local, must set explicitly                           |
-| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                  |
-| Voyage         | `voyage`         | Yes           | Auto-detected                                        |
+| Provider       | ID               | Needs API key | Notes                                                       |
+| -------------- | ---------------- | ------------- | ----------------------------------------------------------- |
+| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves        |
+| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                               |
+| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription                    |
+| Local          | `local`          | No            | GGUF model, ~0.6 GB download                                |
+| Mistral        | `mistral`        | Yes           | Auto-detected                                               |
+| Ollama         | `ollama`         | No            | Local, must set explicitly                                  |
+| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                         |
+| oMLX           | `openai`         | Local key     | Apple Silicon MLX server; use `openai` adapter with custom `baseUrl` |
+| Voyage         | `voyage`         | Yes           | Auto-detected                                               |
 
 ## How search works
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -82,17 +82,17 @@ models are not interchangeable.
 
 ## Supported providers
 
-| Provider       | ID               | Needs API key | Notes                                                             |
-| -------------- | ---------------- | ------------- | ----------------------------------------------------------------- |
-| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves              |
-| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                                     |
-| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription                          |
-| Local          | `local`          | No            | GGUF model, ~0.6 GB download                                      |
-| Mistral        | `mistral`        | Yes           | Auto-detected                                                     |
-| Ollama         | `ollama`         | No            | Local, must set explicitly                                        |
-| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                               |
-| oMLX           | `openai`         | Local key     | Apple Silicon MLX server; use `openai` adapter with custom baseUrl|
-| Voyage         | `voyage`         | Yes           | Auto-detected                                                     |
+| Provider       | ID               | Needs API key | Notes                                                              |
+| -------------- | ---------------- | ------------- | ------------------------------------------------------------------ |
+| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves               |
+| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                                      |
+| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription                           |
+| Local          | `local`          | No            | GGUF model, ~0.6 GB download                                       |
+| Mistral        | `mistral`        | Yes           | Auto-detected                                                      |
+| Ollama         | `ollama`         | No            | Local, must set explicitly                                         |
+| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                                |
+| oMLX           | `openai`         | Local key     | Apple Silicon MLX server; use `openai` adapter with custom baseUrl |
+| Voyage         | `voyage`         | Yes           | Auto-detected                                                      |
 
 ## How search works
 

--- a/docs/concepts/memory-search.md
+++ b/docs/concepts/memory-search.md
@@ -82,17 +82,17 @@ models are not interchangeable.
 
 ## Supported providers
 
-| Provider       | ID               | Needs API key | Notes                                                       |
-| -------------- | ---------------- | ------------- | ----------------------------------------------------------- |
-| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves        |
-| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                               |
-| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription                    |
-| Local          | `local`          | No            | GGUF model, ~0.6 GB download                                |
-| Mistral        | `mistral`        | Yes           | Auto-detected                                               |
-| Ollama         | `ollama`         | No            | Local, must set explicitly                                  |
-| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                         |
-| oMLX           | `openai`         | Local key     | Apple Silicon MLX server; use `openai` adapter with custom `baseUrl` |
-| Voyage         | `voyage`         | Yes           | Auto-detected                                               |
+| Provider       | ID               | Needs API key | Notes                                                             |
+| -------------- | ---------------- | ------------- | ----------------------------------------------------------------- |
+| Bedrock        | `bedrock`        | No            | Auto-detected when the AWS credential chain resolves              |
+| Gemini         | `gemini`         | Yes           | Supports image/audio indexing                                     |
+| GitHub Copilot | `github-copilot` | No            | Auto-detected, uses Copilot subscription                          |
+| Local          | `local`          | No            | GGUF model, ~0.6 GB download                                      |
+| Mistral        | `mistral`        | Yes           | Auto-detected                                                     |
+| Ollama         | `ollama`         | No            | Local, must set explicitly                                        |
+| OpenAI         | `openai`         | Yes           | Auto-detected, fast                                               |
+| oMLX           | `openai`         | Local key     | Apple Silicon MLX server; use `openai` adapter with custom baseUrl|
+| Voyage         | `voyage`         | Yes           | Auto-detected                                                     |
 
 ## How search works
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -110,6 +110,36 @@ those as provider-specific `input_type` request fields: query embeddings use
 `queryInputType`; indexed memory chunks and batch indexing use
 `documentInputType`. See the [Memory configuration reference](/reference/memory-config#provider-specific-config) for the full example.
 
+### Local OpenAI-compatible servers (e.g. oMLX)
+
+The `openai` embedding adapter also works with local OpenAI-compatible
+inference servers. The most notable example on Apple Silicon is
+[oMLX](https://github.com/jundot/omlx), which serves MLX-native embedding
+models like `jina-embeddings-v5-text-small-retrieval-mlx` on
+`http://localhost:8000/v1`:
+
+```json5
+{
+  agents: {
+    defaults: {
+      memorySearch: {
+        provider: "openai",
+        model: "jina-embeddings-v5-text-small-retrieval-mlx",
+        remote: {
+          baseUrl: "http://127.0.0.1:8000/v1",
+          apiKey: "<your-omlx-api-key>",
+        },
+      },
+    },
+  },
+}
+```
+
+Use `provider: "openai"` rather than a runtime-specific id — OpenClaw's
+OpenAI adapter handles any OpenAI-compatible `/v1/embeddings` endpoint. See
+the [Memory configuration reference](/reference/memory-config#remote-endpoint-config)
+for full `remote.*` options.
+
 ## Getting started
 
 Choose your preferred auth method and follow the setup steps.

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -165,6 +165,39 @@ For custom OpenAI-compatible endpoints or overriding provider defaults:
 }
 ```
 
+### Example: oMLX (Apple Silicon, MLX-native)
+
+[oMLX](https://github.com/jundot/omlx) is a local MLX inference server for
+Apple Silicon that exposes an OpenAI-compatible API on
+`http://localhost:8000/v1`. Configure it as an OpenAI-compatible endpoint:
+
+```json5
+{
+  agents: {
+    defaults: {
+      memorySearch: {
+        provider: "openai",
+        model: "jina-embeddings-v5-text-small-retrieval-mlx",
+        remote: {
+          baseUrl: "http://127.0.0.1:8000/v1",
+          apiKey: "<your-omlx-api-key>",
+        },
+      },
+    },
+  },
+}
+```
+
+<Warning>
+Use `provider: "openai"` (not `"ollama"`) for oMLX. oMLX speaks the OpenAI
+protocol, not Ollama's `/api/embeddings` protocol — pointing the `ollama`
+adapter at oMLX's port will fail with confusing errors.
+</Warning>
+
+After switching providers or models, run `openclaw memory index --force` to
+re-embed existing notes; embeddings from different models live in incompatible
+vector spaces.
+
 ---
 
 ## Provider-specific config


### PR DESCRIPTION
## Summary

Resolves the documentation gap identified in #74732. Adds focused recipes
for using oMLX (Apple Silicon MLX inference server) as a memorySearch
embedding provider via the existing OpenAI-compatible adapter.

## Changes

- `docs/concepts/memory-search.md`: New "Using oMLX" subsection under
  Quick start, plus an oMLX row in the Supported providers table.
- `docs/reference/memory-config.md`: New oMLX example under Remote
  endpoint config, with a warning against the common `provider: "ollama"`
  mistake.
- `docs/providers/openai.md`: New "Local OpenAI-compatible servers"
  subsection under Memory embeddings, surfacing oMLX as a notable
  Apple Silicon use case.

## What this addresses

Per the Codex review on #74732, this is the **narrow docs-only fix**:

> Add a focused docs recipe for oMLX that uses the existing OpenAI-compatible
> embedding path, warns users not to configure oMLX as Ollama, includes the
> local /v1 base URL and model example from the report, and tells users to
> reindex after changing embedding models or vector spaces.

All three points are covered. No core behavior change; no new provider
adapter introduced. The first-class `omlx` adapter discussion (Option B in
#74732) remains separate and is **not** part of this PR.

## Verification

The configuration shipped in this PR was verified end-to-end on:

| Component | Version |
|---|---|
| OpenClaw | 2026.4.26 |
| oMLX | v1.3.6 |
| Embedding model | jina-embeddings-v5-text-small-retrieval-mlx (1024 dims) |
| OS | macOS, Apple Silicon |

`openclaw memory status --deep` after migration:

- Provider: `openai (requested: openai)`
- Model: `jina-embeddings-v5-text-small-retrieval-mlx`
- Vector dims: `1024`
- Indexed: `150/150 files · 946 chunks`
- Batch failures: `0/2`

## Related

Closes #74732 (docs portion).

cc @jundot — oMLX maintainer, in case the oMLX side wants to cross-link.