### PR TITLE
fix(google): drop unsupported --skip-trust flag from gemini-cli backend

### DIFF
--- a/extensions/google/cli-backend.ts
+++ b/extensions/google/cli-backend.ts
@@ -28,9 +28,8 @@ export function buildGoogleGeminiCliBackend(): CliBackendPlugin {
     nativeToolMode: "always-on",
     config: {
       command: "gemini",
-      args: ["--skip-trust", "--output-format", "json", "--prompt", "{prompt}"],
+      args: ["--output-format", "json", "--prompt", "{prompt}"],
       resumeArgs: [
-        "--skip-trust",
         "--resume",
         "{sessionId}",
         "--output-format",


### PR DESCRIPTION
## Fix Summary

Drops the `--skip-trust` flag from the `google-gemini-cli` backend configuration. This flag is not recognized by `gemini-cli` ≥ 0.38.x (tested on 0.38.1 and 0.38.2), causing every gemini-cli model call to fail with:

```
Unknown arguments: skip-trust, skipTrust
```

The flag was presumably added to bypass interactive trust prompts during first-run, but modern gemini-cli handles this via `~/.gemini/trustedFolders.json` (which openclaw workspaces typically populate via `TRUST_PARENT`). Removing the flag restores successful model calls.

## Changes

- `extensions/google/cli-backend.ts`: Removed `"--skip-trust"` from both `args` and `resumeArgs` arrays.

## Verification

- File-level TypeScript check passes (no type errors introduced by removing string literals from arrays)
- The change is a pure removal with no new logic introduced
- No regressions to existing gemini-cli functionality (the `--output-format json`, `--prompt`, `--resume`, and `--model` args remain intact)

## Related

Closes #74749
