### PR TITLE
fix(cron): infer delivery.to when only delivery.channel is set on ann…

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -891,6 +891,59 @@ describe("cron tool", () => {
     });
   });
 
+  it("infers delivery.to when the caller set delivery.channel but left delivery.to empty", async () => {
+    // Regression: when the model emits `{ mode: "announce", channel: "slack" }`
+    // with no `to`, the inference gate must still populate `to` from the
+    // session key. Previously `hasTarget = channel || to` treated the channel
+    // as a complete target and skipped inference, leaving `to` unset and
+    // forcing downstream delivery to fall back to the session store's
+    // `lastTo` — which routes the announce to whichever peer the host last
+    // spoke with, often the wrong one.
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const delivery = await executeAddAndReadDelivery({
+      callId: "call-channel-only",
+      agentSessionKey: "agent:main:slack:channel:general",
+      delivery: { mode: "announce", channel: "slack" },
+    });
+    expect(delivery).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "general",
+    });
+  });
+
+  it("keeps caller-provided delivery.to when it is set, even if channel is also set", async () => {
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const delivery = await executeAddAndReadDelivery({
+      callId: "call-explicit-to",
+      agentSessionKey: "agent:main:slack:channel:general",
+      delivery: { mode: "announce", channel: "slack", to: "random" },
+    });
+    // to="random" is explicit — inference must not overwrite it.
+    expect(delivery).toEqual({
+      mode: "announce",
+      channel: "slack",
+      to: "random",
+    });
+  });
+
+  it("infers delivery.to when the caller sets only channel with no mode", async () => {
+    // Some models emit bare `{ channel: "..." }` without a mode. The default
+    // gate accepts that as announce-mode (mode === ""), so inference should
+    // still run and fill in `to`.
+    callGatewayMock.mockResolvedValueOnce({ ok: true });
+    const delivery = await executeAddAndReadDelivery({
+      callId: "call-bare-channel",
+      agentSessionKey: "agent:main:discord:dm:buddy",
+      delivery: { channel: "discord" },
+    });
+    expect(delivery).toEqual({
+      mode: "announce",
+      channel: "discord",
+      to: "buddy",
+    });
+  });
+
   it("fails fast when webhook mode is missing delivery.to", async () => {
     const tool = createTestCronTool({ agentSessionKey: "agent:main:discord:dm:buddy" });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -724,21 +724,31 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
               }
             }
 
-            const hasTarget =
-              (typeof delivery?.channel === "string" && delivery.channel.trim()) ||
-              (typeof delivery?.to === "string" && delivery.to.trim());
+            // Inference gates on whether `to` was explicitly set. Treating
+            // `channel` alone as "has target" skips inference for calls like
+            // `{ mode: "announce", channel: "wea" }` and the downstream
+            // delivery resolver then falls back to the session store's stale
+            // `lastTo`, mis-routing the message to whichever peer the host
+            // last spoke with. See the inferDeliveryFrom* helpers below for
+            // how the correct `to` is derived.
+            const hasExplicitTo = typeof delivery?.to === "string" && delivery.to.trim().length > 0;
             const shouldInfer =
               (deliveryValue == null || delivery) &&
               (mode === "" || mode === "announce") &&
-              !hasTarget;
+              !hasExplicitTo;
             if (shouldInfer) {
               const inferred =
                 inferDeliveryFromContext(opts.currentDeliveryContext) ??
                 inferDeliveryFromSessionKey(opts.agentSessionKey);
               if (inferred) {
+                // Start from the inferred delivery so the caller's partial
+                // object (mode/channel/etc.) is preserved on top of it, then
+                // re-assert `to` from the inferred result since the caller
+                // did not provide one.
                 (job as { delivery?: unknown }).delivery = {
                   ...inferred,
                   ...delivery,
+                  to: inferred.to,
                 } satisfies CronDelivery;
               }
             }


### PR DESCRIPTION
…ounce jobs

Cron jobs created with `delivery: { mode: "announce", channel: "..." }` (no `to`) were never getting their target populated. The inference gate treated `channel || to` as "target already resolved", skipped the inferDeliveryFrom{Context,SessionKey} helpers, and handed a `to`-less delivery object to the scheduler. Downstream, `resolveDeliveryTarget` then fell back to the session store's last-seen peer, so the announce was dispatched to whichever peer the host had most recently spoken with — which in practice meant cron jobs created from one context (for example, a group chat) silently leaked their output into another (the user's DM with the bot).

Narrow the gate to `hasExplicitTo`: only skip inference when the caller actually supplied `to`. A caller-provided `channel` is an intent signal about the delivery surface, not a substitute for the target, so it must not suppress inference.

On the injection side, the previous spread order (`{...inferred, ...delivery}`) meant a partial caller object without `to` still overrode the inferred `to` with `undefined`. Re-assert `to: inferred.to` at the tail to restore the intended fallback.

Adds three regression tests in the existing announce-inference suite:

- `delivery: { mode: "announce", channel: "slack" }` gets `to` inferred from `agent:main:slack:channel:general`.
- Explicit `delivery.to` set by the caller is preserved verbatim even when `channel` is also set.
- `delivery: { channel: "discord" }` (no mode) still triggers announce-mode inference.

Existing tests that covered `to`-only and `no-delivery` cases remain untouched and continue to pass (67/67 in cron-tool.test.ts).

## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause:
- Missing detection / guardrail:
- Contributing context (if known):

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file:
- Scenario the test should lock in:
- Why this is the smallest reliable guardrail:
- Existing test that already covers this (if any):
- If no new test is added, why not:

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
Before:
[user action] -> [old state]

After:
[user action] -> [new state] -> [result]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
