### PR TITLE
Fix continuation-skip after assistant turns

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -302,7 +302,7 @@ describe("hasCompletedBootstrapTurn", () => {
     expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
   });
 
-  it("returns false for assistant turns without a recorded full bootstrap marker", async () => {
+  it("returns true for assistant turns without a recorded full bootstrap marker", async () => {
     const sessionFile = path.join(tmpDir, "assistant-no-marker.jsonl");
     await fs.writeFile(
       sessionFile,
@@ -313,7 +313,7 @@ describe("hasCompletedBootstrapTurn", () => {
       ].join("\n") + "\n",
       "utf8",
     );
-    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
   });
 
   it("returns true when a full bootstrap completion marker exists", async () => {
@@ -338,6 +338,7 @@ describe("hasCompletedBootstrapTurn", () => {
     await fs.writeFile(
       sessionFile,
       [
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "hi" } }),
         JSON.stringify({
           type: "custom",
           customType: FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE,
@@ -348,6 +349,21 @@ describe("hasCompletedBootstrapTurn", () => {
       "utf8",
     );
     expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(false);
+  });
+
+  it("returns true when an assistant turn happens after compaction without a marker", async () => {
+    const sessionFile = path.join(tmpDir, "assistant-after-compaction-no-marker.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      [
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "old reply" } }),
+        JSON.stringify({ type: "compaction", summary: "trimmed" }),
+        JSON.stringify({ type: "message", message: { role: "user", content: "new ask" } }),
+        JSON.stringify({ type: "message", message: { role: "assistant", content: "new reply" } }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    expect(await hasCompletedBootstrapTurn(sessionFile)).toBe(true);
   });
 
   it("returns true when a later full bootstrap marker happens after compaction", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -115,6 +115,11 @@ export async function hasCompletedBootstrapTurn(sessionFile: string): Promise<bo
         ) {
           return !compactedAfterLatestAssistant;
         }
+        // Already-configured workspaces may never write a full-bootstrap marker.
+        // A flushed assistant message is enough to prove a safe continuation turn.
+        if (record?.type === "message" && record.message?.role === "assistant") {
+          return !compactedAfterLatestAssistant;
+        }
       }
 
       return false;


### PR DESCRIPTION
## Summary
- Fixes the contextInjection: "continuation-skip" path so an already-flushed assistant message counts as a completed bootstrap/continuation turn, even when the full-bootstrap custom marker was never written.
- Preserves the compaction guard: if compaction happened after the latest assistant turn or marker, OpenClaw still re-injects bootstrap context.
- Adds regression coverage for assistant-only continuation and assistant turns after compaction.

## Why
Already-configured workspaces can skip ootstrapMode === "full", so they may never append openclaw:bootstrap-context:full. In that state, follow-up turns kept re-injecting bootstrap files even with continuation-skip, which is one of the context-bloat cases tracked in #67419.

Refs #67419.

## Validation
- Red regression first: hasCompletedBootstrapTurn returned alse for assistant turns without the marker.
- corepack pnpm exec node scripts/test-projects.mjs src/agents/bootstrap-files.test.ts -t "no assistant turn|assistant turns without|full bootstrap completion|compaction happened|assistant turn happens after compaction|later full bootstrap|malformed JSON|recent full bootstrap" -> 8 passed.
- corepack pnpm exec node scripts/test-projects.mjs src/agents/pi-embedded-runner/run/attempt.spawn-workspace.context-injection.test.ts src/agents/pi-embedded-runner/run/attempt.spawn-workspace.bootstrap-marker.test.ts -> 14 passed across 2 files.

Note: full src/agents/bootstrap-files.test.ts on this Windows workstation is blocked by the existing symlink test (EPERM: operation not permitted, symlink ...), unrelated to this change.