### PR TITLE
fix(embedded): suppress aborted assistant partial payload leaks

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -121,6 +121,57 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads.some((payload) => payload.text === errorJsonPretty)).toBe(false);
   });
 
+  it("suppresses aborted assistant partial text and surfaces a clean timeout error", () => {
+    const payloads = buildPayloads({
+      assistantTexts: [
+        "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+      ],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          {
+            type: "text",
+            text: "Need answer concise mention not fully E2E tested tomorrow.\n[[reply_to_current]] Final draft",
+          },
+        ],
+      }),
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expect(payloads[0]?.text).not.toContain("Need answer concise");
+    expect(payloads[0]?.text).not.toContain("[[reply_to_current]]");
+  });
+
+  it("suppresses aborted assistant reasoning text as well as partial answer text", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["partial answer that should not leak"],
+      lastAssistant: makeAssistant({
+        stopReason: "aborted",
+        errorMessage: "request timed out",
+        content: [
+          { type: "thinking", thinking: "partial hidden reasoning" },
+          { type: "text", text: "partial answer that should not leak" },
+        ],
+      }),
+      reasoningLevel: "on",
+    });
+
+    expectSinglePayloadSummary(payloads, {
+      text: "LLM request timed out.",
+      isError: true,
+    });
+    expect(payloads.map((payload) => payload.text).join("\n")).not.toContain(
+      "partial hidden reasoning",
+    );
+    expect(payloads.map((payload) => payload.text).join("\n")).not.toContain(
+      "partial answer that should not leak",
+    );
+  });
+
   it("suppresses raw error JSON from fallback assistant text", () => {
     const payloads = buildPayloads({
       lastAssistant: makeAssistant({ content: [{ type: "text", text: errorJsonPretty }] }),

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -208,9 +208,12 @@ export function buildEmbeddedRunPayloads(params: {
 
   const useMarkdown = params.toolResultFormat === "markdown";
   const suppressAssistantArtifacts = params.didSendDeterministicApprovalPrompt === true;
-  const lastAssistantErrored = params.lastAssistant?.stopReason === "error";
+  const lastAssistantStopReason = params.lastAssistant?.stopReason;
+  const lastAssistantErrored = lastAssistantStopReason === "error";
+  const lastAssistantAborted = lastAssistantStopReason === "aborted";
+  const lastAssistantNeedsErrorSurface = lastAssistantErrored || lastAssistantAborted;
   const errorText =
-    params.lastAssistant && lastAssistantErrored
+    params.lastAssistant && lastAssistantNeedsErrorSurface
       ? suppressAssistantArtifacts
         ? undefined
         : formatAssistantErrorText(params.lastAssistant, {
@@ -220,7 +223,7 @@ export function buildEmbeddedRunPayloads(params: {
             model: params.model,
           })
       : undefined;
-  const rawErrorMessage = lastAssistantErrored
+  const rawErrorMessage = lastAssistantNeedsErrorSurface
     ? normalizeOptionalString(params.lastAssistant?.errorMessage)
     : undefined;
   const rawErrorFingerprint = rawErrorMessage
@@ -270,11 +273,12 @@ export function buildEmbeddedRunPayloads(params: {
     }
   }
 
-  const reasoningText = suppressAssistantArtifacts
-    ? ""
-    : params.lastAssistant && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
-      ? formatReasoningMessage(extractAssistantThinking(params.lastAssistant))
-      : "";
+  const reasoningText =
+    suppressAssistantArtifacts || lastAssistantAborted
+      ? ""
+      : params.lastAssistant && params.reasoningLevel === "on" && params.thinkingLevel !== "off"
+        ? formatReasoningMessage(extractAssistantThinking(params.lastAssistant))
+        : "";
   if (reasoningText) {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
@@ -284,7 +288,7 @@ export function buildEmbeddedRunPayloads(params: {
     : "";
   const fallbackRawAnswerText = resolveRawAssistantAnswerText(params.lastAssistant);
   const shouldSuppressRawErrorText = (text: string) => {
-    if (!lastAssistantErrored) {
+    if (!lastAssistantNeedsErrorSurface) {
       return false;
     }
     const trimmed = text.trim();
@@ -352,16 +356,17 @@ export function buildEmbeddedRunPayloads(params: {
         normalizedAssistantTexts.length > 0 &&
         normalizedAssistantTexts === normalizedRawAnswerText));
   const hasAssistantTextPayload = nonEmptyAssistantTexts.length > 0;
-  const answerTexts = suppressAssistantArtifacts
-    ? []
-    : (shouldPreferRawAnswerText && fallbackRawAnswerText
-        ? [fallbackRawAnswerText]
-        : hasAssistantTextPayload
-          ? nonEmptyAssistantTexts
-          : fallbackAnswerText
-            ? [fallbackAnswerText]
-            : []
-      ).filter((text) => !shouldSuppressRawErrorText(text));
+  const answerTexts =
+    suppressAssistantArtifacts || lastAssistantAborted
+      ? []
+      : (shouldPreferRawAnswerText && fallbackRawAnswerText
+          ? [fallbackRawAnswerText]
+          : hasAssistantTextPayload
+            ? nonEmptyAssistantTexts
+            : fallbackAnswerText
+              ? [fallbackAnswerText]
+              : []
+        ).filter((text) => !shouldSuppressRawErrorText(text));
 
   let hasUserFacingAssistantReply = false;
   const hasUserFacingErrorReply = replyItems.some((item) => item.isError === true);


### PR DESCRIPTION
## Summary

- Stop treating aborted assistant turns as deliverable final answer text
- Surface a clean formatted error for aborted embedded runs instead
- Suppress reasoning text when the assistant turn was aborted
- Add regression coverage for timeout/abort leakage of commentary and reply tags

## Context

Rebased from #59592 which had conflicts and a stale base. Resolved conflicts by preserving main's richer `answerTexts` selection logic (media URL preference, `shouldPreferRawAnswerText`) while adding the `lastAssistantAborted` suppression condition from the original PR.

Closes #59536

## Testing

```
pnpm test -- src/agents/pi-embedded-runner/run/payloads.errors.test.ts
pnpm test -- src/agents/pi-embedded-runner/run/payloads.ts
```

🤖 Generated with [Claude Code](https://claude.ai/claude-code)