### PR TITLE
docs(sdk): clarify app and plugin sdk boundary

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -622,5 +622,45 @@
   {
     "source": "/cli/config",
     "target": "/cli/config"
+  },
+  {
+    "source": "Media understanding pipeline",
+    "target": "媒体理解管线"
+  },
+  {
+    "source": "PDF tool",
+    "target": "PDF 工具"
+  },
+  {
+    "source": "Background tasks",
+    "target": "后台任务"
+  },
+  {
+    "source": "ACP agents",
+    "target": "ACP agents"
+  },
+  {
+    "source": "Command queue",
+    "target": "命令队列"
+  },
+  {
+    "source": "Messages",
+    "target": "消息"
+  },
+  {
+    "source": "Channel turn kernel",
+    "target": "渠道回合内核"
+  },
+  {
+    "source": "Building channel plugins",
+    "target": "构建渠道插件"
+  },
+  {
+    "source": "Plugin runtime helpers",
+    "target": "插件运行时辅助工具"
+  },
+  {
+    "source": "Plugin internals",
+    "target": "插件内部机制"
   }
 ]

--- a/docs/concepts/openclaw-sdk.md
+++ b/docs/concepts/openclaw-sdk.md
@@ -21,6 +21,27 @@ resources.
   register providers, channels, tools, hooks, or trusted runtimes.
 </Note>
 
+## Boundary Checklist
+
+Use `@openclaw/sdk` when the code is an external client of a running Gateway.
+That includes apps, scripts, dashboards, CI jobs, IDE extensions, and
+OpenMeow/OpenCoven-style dogfood clients.
+
+External App SDK examples should:
+
+- Import from `@openclaw/sdk`
+- Connect through Gateway URL, token, password, or a custom transport
+- Use Gateway-backed namespaces such as `oc.agents`, `oc.sessions`, `oc.runs`,
+  `oc.models`, `oc.tools`, and `oc.approvals`
+- Treat raw Gateway events as an advanced escape hatch and prefer normalized
+  SDK events for UI state
+- Avoid `openclaw/plugin-sdk/*`, `src/**`, plugin runtime APIs, and bundled
+  plugin internals
+
+Use the [Plugin SDK](/plugins/sdk-overview) only when the code is loaded by
+OpenClaw as trusted in-process plugin code that registers providers, channels,
+tools, hooks, services, or runtimes.
+
 ## What Ships Today
 
 `@openclaw/sdk` ships with:
@@ -88,7 +109,9 @@ const oc = new OpenClaw({
 ## Run An Agent
 
 Use `oc.agents.get(id)` when the app wants an agent handle, then call
-`agent.run()`.
+`agent.run()`. This is the correct pattern for external clients such as
+OpenMeow, OpenCoven examples, local scripts, or CI jobs; those clients should
+not import Plugin SDK subpaths or OpenClaw core internals.
 
 ```typescript
 const agent = await oc.agents.get("main");

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -19,6 +19,27 @@ reference for **what to import** and **what you can register**.
   instead.
 </Note>
 
+## Where Plugin SDK Code Runs
+
+Plugin SDK code runs inside OpenClaw's trusted plugin runtime. Use it when the
+code must extend OpenClaw by registering providers, channels, tools, hooks,
+services, Gateway plugin methods, or trusted runtime helpers.
+
+Do not use the Plugin SDK for an external app that only needs to control or
+observe OpenClaw. OpenMeow/OpenCoven-style desktop apps, dashboards, IDE
+extensions, CI automation, and standalone scripts should import
+`@openclaw/sdk`, connect to the Gateway, and use the public App SDK contract
+documented in [OpenClaw App SDK](/concepts/openclaw-sdk).
+
+Boundary summary:
+
+| Code location                              | Correct SDK             | Why                                                        |
+| ------------------------------------------ | ----------------------- | ---------------------------------------------------------- |
+| Outside OpenClaw: app, script, dashboard   | `@openclaw/sdk`         | Talks to Gateway RPCs and normalized events                |
+| Inside OpenClaw: plugin runtime            | `openclaw/plugin-sdk/*` | Registers trusted capabilities with the host               |
+| Docs or examples for OpenMeow/OpenCoven UI | `@openclaw/sdk`         | These are external app clients, not in-process plugins     |
+| Provider, channel, tool, hook, or harness  | `openclaw/plugin-sdk/*` | These extend OpenClaw from inside the trusted plugin layer |
+
 <Tip>
 Looking for a how-to guide instead? Start with [Building plugins](/plugins/building-plugins), use [Channel plugins](/plugins/sdk-channel-plugins) for channel plugins, [Provider plugins](/plugins/sdk-provider-plugins) for provider plugins, and [Plugin hooks](/plugins/hooks) for tool or lifecycle hook plugins.
 </Tip>

--- a/docs/reference/openclaw-sdk-api-design.md
+++ b/docs/reference/openclaw-sdk-api-design.md
@@ -24,6 +24,12 @@ The public app SDK should be built in two layers:
 2. A high-level ergonomic wrapper with `OpenClaw`, `Agent`, `Session`, `Run`,
    `Task`, `Artifact`, `Approval`, and `Environment` objects.
 
+All App SDK examples should preserve the external-client boundary:
+`@openclaw/sdk` calls Gateway RPCs, and Gateway owns access to the OpenClaw
+runtime. OpenMeow/OpenCoven examples belong on this side of the boundary. They
+should not import `openclaw/plugin-sdk/*`, `src/**`, plugin runtime APIs, or
+other in-process implementation seams.
+
 ## Namespace design
 
 The low-level namespaces should closely follow Gateway resources:


### PR DESCRIPTION
## Summary

- Problem: the App SDK and Plugin SDK docs already mention the split, but the boundary is easy to miss when writing quickstarts or OpenMeow/OpenCoven-style examples.
- Why it matters: external apps should talk to Gateway through `@openclaw/sdk`, while trusted in-process plugins should use `openclaw/plugin-sdk/*`; mixing these contracts leaks internals into public examples.
- What changed: added an App SDK boundary checklist, a Plugin SDK runtime/boundary table, and API-design guidance that keeps OpenMeow/OpenCoven examples on the external client side.
- What did NOT change (scope boundary): no SDK code, Gateway behavior, plugin contracts, or generated API surfaces changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #74709
- Related #
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A

- Root cause: N/A
- Missing detection / guardrail: N/A
- Contributing context (if known): N/A

## Regression Test Plan (if applicable)

N/A

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: docs checks only.
- Scenario the test should lock in: docs formatting, linting, MDX validity, i18n glossary coverage, and internal links remain valid.
- Why this is the smallest reliable guardrail: the change is documentation-only.
- Existing test that already covers this (if any): `pnpm check:docs`.
- If no new test is added, why not: docs-only clarification.

## User-visible / Behavior Changes

Docs now explicitly state that external apps, dashboards, scripts, IDE extensions, and OpenMeow/OpenCoven-style examples use `@openclaw/sdk` over Gateway, while provider/channel/tool/hook/runtime extensions use `openclaw/plugin-sdk/*` inside OpenClaw.

## Diagram (if applicable)

```text
External app/docs example -> @openclaw/sdk -> Gateway RPC/events -> OpenClaw runtime
Trusted plugin code       -> openclaw/plugin-sdk/* -> host registration APIs
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / pnpm repo scripts
- Model/provider: N/A
- Integration/channel (if any): docs
- Relevant config (redacted): N/A

### Steps

1. Read `docs/concepts/openclaw-sdk.md`.
2. Read `docs/plugins/sdk-overview.md`.
3. Read `docs/reference/openclaw-sdk-api-design.md`.

### Expected

- App SDK docs clearly say `@openclaw/sdk` is for outside-process clients.
- Plugin SDK docs clearly say `openclaw/plugin-sdk/*` is for trusted in-process plugin runtime code.
- Cross-links and OpenMeow/OpenCoven guidance keep future examples on the correct side of the boundary.

### Actual

- Before this PR, the boundary existed but was less explicit in quickstart/example guidance.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm check:docs`; `git diff --check upstream/main..HEAD`.
- Edge cases checked: docs formatter, markdown lint, MDX validation, zh-CN glossary entries required by the docs gate, and internal link audit.
- What you did **not** verify: rendered Mintlify preview.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

None.
