### PR TITLE
fix(telegram): avoid resolving secrets for status accessors

### DIFF
--- a/extensions/telegram/src/shared.test.ts
+++ b/extensions/telegram/src/shared.test.ts
@@ -166,4 +166,49 @@ describe("createTelegramPluginBase config duplicate token guard", () => {
     expect(await telegramPluginBase.config.isConfigured!(account, cfg)).toBe(false);
     expect(telegramPluginBase.config.unconfiguredReason?.(account, cfg)).toContain("unavailable");
   });
+
+  it("resolves allowFrom without dereferencing SecretRef bot tokens", () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          filemain: { source: "file", path: "/tmp/openclaw-test-secrets.json" },
+        },
+      },
+      channels: {
+        telegram: {
+          botToken: { source: "file", provider: "filemain", id: "/telegram/botToken" },
+          allowFrom: ["8197233951"],
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(telegramPluginBase.config.resolveAllowFrom?.({ cfg, accountId: "default" })).toEqual([
+      "8197233951",
+    ]);
+  });
+
+  it("resolves named account allowFrom without dereferencing SecretRef bot tokens", () => {
+    const cfg = {
+      secrets: {
+        providers: {
+          filemain: { source: "file", path: "/tmp/openclaw-test-secrets.json" },
+        },
+      },
+      channels: {
+        telegram: {
+          allowFrom: ["top"],
+          accounts: {
+            ops: {
+              botToken: { source: "file", provider: "filemain", id: "/telegram/opsToken" },
+              allowFrom: ["ops"],
+            },
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    expect(telegramPluginBase.config.resolveAllowFrom?.({ cfg, accountId: "ops" })).toEqual([
+      "ops",
+    ]);
+  });
 });

--- a/extensions/telegram/src/shared.ts
+++ b/extensions/telegram/src/shared.ts
@@ -8,9 +8,13 @@ import {
 import { createChannelPluginBase, type ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
 import { getChatChannelMeta } from "openclaw/plugin-sdk/channel-plugin-common";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId as normalizeRoutingAccountId,
+} from "openclaw/plugin-sdk/routing";
 import { inspectTelegramAccount } from "./account-inspect.js";
 import {
+  mergeTelegramAccountConfig,
   listTelegramAccountIds,
   resolveDefaultTelegramAccountId,
   resolveTelegramAccount,
@@ -99,17 +103,40 @@ function isBlockedByMultiBotGuard(cfg: OpenClawConfig, accountId: string): boole
   return !resolveNormalizedAccountEntry(accounts, accountId, normalizeAccountId);
 }
 
-export const telegramConfigAdapter = createScopedChannelConfigAdapter<ResolvedTelegramAccount>({
+type TelegramConfigAccessorAccount = {
+  allowFrom: Array<string | number> | undefined;
+  defaultTo: string | number | null | undefined;
+};
+
+function resolveTelegramConfigAccessorAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): TelegramConfigAccessorAccount {
+  const accountId = normalizeRoutingAccountId(
+    params.accountId ?? resolveDefaultTelegramAccountId(params.cfg),
+  );
+  const config = mergeTelegramAccountConfig(params.cfg, accountId);
+  return {
+    allowFrom: config.allowFrom,
+    defaultTo: config.defaultTo,
+  };
+}
+
+export const telegramConfigAdapter = createScopedChannelConfigAdapter<
+  ResolvedTelegramAccount,
+  TelegramConfigAccessorAccount
+>({
   sectionKey: TELEGRAM_CHANNEL,
   listAccountIds: listTelegramAccountIds,
   resolveAccount: adaptScopedAccountAccessor(resolveTelegramAccount),
+  resolveAccessorAccount: resolveTelegramConfigAccessorAccount,
   inspectAccount: adaptScopedAccountAccessor(inspectTelegramAccount),
   defaultAccountId: resolveDefaultTelegramAccountId,
   clearBaseFields: ["botToken", "tokenFile", "name"],
-  resolveAllowFrom: (account: ResolvedTelegramAccount) => account.config.allowFrom,
+  resolveAllowFrom: (account) => account.allowFrom,
   formatAllowFrom: (allowFrom) =>
     formatAllowFromLowercase({ allowFrom, stripPrefixRe: /^(telegram|tg):/i }),
-  resolveDefaultTo: (account: ResolvedTelegramAccount) => account.config.defaultTo,
+  resolveDefaultTo: (account) => account.defaultTo,
 });
 
 export function createTelegramPluginBase(params: {


### PR DESCRIPTION
## Summary

Fix Telegram config/status accessors so read-only metadata paths (`allowFrom`, `defaultTo`) do not strict-resolve `botToken` SecretRefs.

`openclaw status` can currently fail when Telegram uses a valid file-backed SecretRef:

```text
channels.telegram.botToken: unresolved SecretRef "file:filemain:/telegram/botToken". Resolve this command against an active gateway runtime snapshot before reading it.
```

The runtime account resolver should still resolve tokens strictly. This PR only adds a config-only accessor account for status/allowlist/default-target metadata, using `mergeTelegramAccountConfig` instead of `resolveTelegramAccount`.

Fixes #74832.

## Testing

```bash
pnpm exec vitest run extensions/telegram/src/shared.test.ts extensions/telegram/src/account-inspect.test.ts --config test/vitest/vitest.extension-telegram.config.ts
# 2 files, 15 tests passed

NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc -p tsconfig.extensions.test.json --noEmit --pretty false
# passed
```
