### PR TITLE
fix(moonshot): ensure reasoning_content on assistant tool call messages

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams-moonshot.test.ts
@@ -171,4 +171,73 @@ describe("applyExtraParamsToAgent Moonshot", () => {
 
     expect(payload.thinking).toEqual({ type: "disabled" });
   });
+
+  it("injects reasoning_content on assistant messages with tool_calls when thinking is enabled", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "low",
+      payload: {
+        messages: [
+          { role: "user", content: "search" },
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "search", arguments: "{}" } },
+            ],
+          },
+          { role: "tool", tool_call_id: "call_1", content: "result" },
+        ],
+      },
+    });
+
+    const assistantMsg = (payload.messages as Array<Record<string, unknown>>)?.[1];
+    expect(assistantMsg?.reasoning_content).toBe("");
+  });
+
+  it("does not inject reasoning_content when thinking is disabled", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.5",
+      thinkingLevel: "off",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "search", arguments: "{}" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMsg = (payload.messages as Array<Record<string, unknown>>)?.[0];
+    expect(assistantMsg?.reasoning_content).toBeUndefined();
+  });
+
+  it("preserves existing reasoning_content on assistant tool call messages", () => {
+    const payload = runExtraParamsPayloadCase({
+      provider: "moonshot",
+      modelId: "kimi-k2.6",
+      thinkingLevel: "low",
+      payload: {
+        messages: [
+          {
+            role: "assistant",
+            content: "",
+            reasoning_content: "original reasoning",
+            tool_calls: [
+              { id: "call_1", type: "function", function: { name: "search", arguments: "{}" } },
+            ],
+          },
+        ],
+      },
+    });
+
+    const assistantMsg = (payload.messages as Array<Record<string, unknown>>)?.[0];
+    expect(assistantMsg?.reasoning_content).toBe("original reasoning");
+  });
 });

--- a/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
+++ b/src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts
@@ -67,6 +67,30 @@ function isPinnedToolChoice(toolChoice: unknown): boolean {
   return typeValue === "tool" || typeValue === "function";
 }
 
+/**
+ * Ensures assistant messages with tool_calls have reasoning_content when
+ * thinking is enabled. Moonshot's API requires this field on replayed
+ * assistant messages that contain tool calls, otherwise it returns:
+ * "thinking is enabled but reasoning_content is missing in assistant tool call message"
+ */
+function ensureMoonshotToolCallReasoningContent(payload: Record<string, unknown>): void {
+  if (!Array.isArray(payload.messages)) {
+    return;
+  }
+  for (const message of payload.messages) {
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+    const record = message as Record<string, unknown>;
+    if (record.role !== "assistant" || !Array.isArray(record.tool_calls)) {
+      continue;
+    }
+    if (!("reasoning_content" in record)) {
+      record.reasoning_content = "";
+    }
+  }
+}
+
 export function resolveMoonshotThinkingType(params: {
   configuredThinking: unknown;
   thinkingLevel?: ThinkLevel;
@@ -124,6 +148,12 @@ export function createMoonshotThinkingWrapper(
         } else if ("keep" in thinkingObj) {
           delete thinkingObj.keep;
         }
+      }
+
+      // Moonshot requires reasoning_content on assistant messages with tool_calls
+      // when thinking is enabled. Inject empty string if missing to avoid 400 errors.
+      if (effectiveThinkingType === "enabled") {
+        ensureMoonshotToolCallReasoningContent(payloadObj);
       }
     });
   };


### PR DESCRIPTION
## Summary

Fixes the "thinking is enabled but reasoning_content is missing in assistant tool call message" error when using Moonshot Kimi models (kimi-k2.5, kimi-k2.6) with tool calls in multi-turn conversations.

## Problem

When thinking mode is enabled for Moonshot models and the assistant produces tool_calls, the API requires `reasoning_content` to be present on replayed assistant messages. Without it, Moonshot returns a 400 error:

> thinking is enabled but reasoning_content is missing in assistant tool call message at index N

This breaks multi-turn tool-use conversations with Kimi models.

## Solution

Mirror the existing DeepSeek V4 compatibility approach by injecting an empty `reasoning_content` string on assistant messages with `tool_calls` when Moonshot thinking is enabled.

### Changes

- **src/agents/pi-embedded-runner/moonshot-thinking-stream-wrappers.ts**
  - Added `ensureMoonshotToolCallReasoningContent()` helper
  - Calls it when `effectiveThinkingType === 'enabled'`
  - Preserves existing `reasoning_content` if already present

- **src/agents/pi-embedded-runner-extraparams-moonshot.test.ts**
  - Added 3 test cases:
    - Injects `reasoning_content` when thinking enabled
    - Does not inject when thinking disabled
    - Preserves existing `reasoning_content`

## Testing

- [x] Added unit tests for the new behavior
- [x] Tested locally with Kimi k2.6
- Tests follow existing Moonshot test patterns

## Related Issues

This addresses the root cause of errors reported in downstream projects using Moonshot models through OpenClaw.

## Checklist

- [x] PR is focused (single concern)
- [x] Added tests for new behavior
- [x] Follows existing code patterns (mirrors DeepSeek V4 approach)
- [x] Marked as AI-assisted
- [x] Uses American English

## AI-Assisted

This PR was prepared with assistance from an LLM coding agent.
