### PR TITLE
[docs][plugin sdk] Split host-hook recipes from workflow follow-ups

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -516,6 +516,14 @@
     "target": "插件钩子"
   },
   {
+    "source": "Host-hook examples and recipes",
+    "target": "宿主钩子示例与配方"
+  },
+  {
+    "source": "Host-hook examples",
+    "target": "宿主钩子示例"
+  },
+  {
     "source": "Internal hooks",
     "target": "内部钩子"
   },

--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -744,6 +744,14 @@
     "target": "插件钩子"
   },
   {
+    "source": "Host-hook examples and recipes",
+    "target": "宿主钩子示例与配方"
+  },
+  {
+    "source": "Host-hook examples",
+    "target": "宿主钩子示例"
+  },
+  {
     "source": "Internal hooks",
     "target": "内部钩子"
   },
@@ -998,5 +1006,89 @@
   {
     "source": "ds4 (local DeepSeek V4)",
     "target": "ds4（本地 DeepSeek V4）"
+  },
+  {
+    "source": "Ambient room events",
+    "target": "环境房间事件"
+  },
+  {
+    "source": "Groups",
+    "target": "群组"
+  },
+  {
+    "source": "Channel troubleshooting",
+    "target": "频道故障排除"
+  },
+  {
+    "source": "Channel configuration reference",
+    "target": "频道配置参考"
+  },
+  {
+    "source": "Bot loop protection",
+    "target": "机器人循环保护"
+  },
+  {
+    "source": "TaskFlow",
+    "target": "TaskFlow"
+  },
+  {
+    "source": "Onboarding (CLI)",
+    "target": "Onboarding (CLI)"
+  },
+  {
+    "source": "Gmail Pub/Sub",
+    "target": "Gmail Pub/Sub"
+  },
+  {
+    "source": "Personal agent benchmark pack",
+    "target": "个人 Agent 基准包"
+  },
+  {
+    "source": "Local model services",
+    "target": "本地模型服务"
+  },
+  {
+    "source": "Camera nodes",
+    "target": "摄像头节点"
+  },
+  {
+    "source": "Location command",
+    "target": "位置命令"
+  },
+  {
+    "source": "Gateway pairing",
+    "target": "Gateway 配对"
+  },
+  {
+    "source": "Admin HTTP RPC plugin",
+    "target": "Admin HTTP RPC 插件"
+  },
+  {
+    "source": "Operator scopes",
+    "target": "操作员作用域"
+  },
+  {
+    "source": "Gateway security",
+    "target": "Gateway 安全"
+  },
+  {
+    "source": "Remote access",
+    "target": "远程访问"
+  },
+  {
+    "source": "SDK subpaths",
+    "target": "SDK 子路径"
+  },
+  {
+    "source": "Admin Http Rpc plugin",
+    "target": "Admin Http Rpc 插件"
+  },
+  {
+    "source": "admin-http-rpc",
+    "target": "admin-http-rpc"
+  },
+  {
+    "source": "ds4",
+    "target": "ds4"
   }
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1203,6 +1203,7 @@
                     "pages": [
                       "plugins/building-plugins",
                       "plugins/hooks",
+                      "plugins/host-hooks-examples",
                       "plugins/sdk-channel-plugins",
                       "plugins/sdk-provider-plugins",
                       "plugins/compatibility",

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1225,6 +1225,7 @@
                   "plugins/sdk-provider-plugins",
                   "plugins/cli-backend-plugins",
                   "plugins/hooks",
+                  "plugins/host-hooks-examples",
                   "plugins/adding-capabilities"
                 ]
               },

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -289,27 +289,27 @@ with `plugins.entries.<id>.hooks.allowPromptInjection=false`.
 Workflow plugins can persist small JSON-compatible session state with
 `api.registerSessionExtension(...)` and update it through the Gateway
 `sessions.pluginPatch` method. Session rows project registered extension state
-through `pluginExtensions`, letting Control UI and other clients render
+through the `GatewaySessionRow.pluginExtensions` array of `{ pluginId,
+namespace, value }` entries, letting Control UI and other clients render
 plugin-owned status without learning plugin internals.
 
 When a generic session reader needs a stable top-level field, a session
-extension may also declare `sessionEntrySlotKey`. After every successful
-`sessions.pluginPatch`, OpenClaw mirrors the projected value into
+extension may also declare `sessionEntrySlotKey` in companion PR #75609. After
+every successful `sessions.pluginPatch`, OpenClaw mirrors the projected value into
 `SessionEntry[sessionEntrySlotKey]`. The mirror uses the same projection source
-as `pluginExtensions`: the synchronous `project()` result when present, or the
-raw JSON-compatible state otherwise. The slot is mirror-only: clients still
+as `pluginExtensions[]`: the synchronous `project()` result when present, or
+the raw JSON-compatible state otherwise. The slot is mirror-only: clients still
 write through `sessions.pluginPatch`, the host overwrites the slot on later
-patches, and `unset: true` clears both the namespace state and the mirror. If
-the projector returns `undefined`, throws, returns a promise, or returns a
-non-JSON value, the host keeps the plugin namespace state and clears the mirror
-to avoid stale top-level data.
+patches, and `unset: true` clears both the namespace state and the mirror.
+Until companion #75609 merges, plugin-aware clients should consume the
+`pluginExtensions[]` projection array directly.
 
 Slot keys must be identifier-style names, must not collide with current
 `SessionEntry` fields or prototype keys, and must be unique across registered
 session extensions. Use ordinary `pluginExtensions` for plugin-aware clients
 or plugin-local UI state. Use `sessionEntrySlotKey` only for small, non-secret
 summaries that generic session consumers need without parsing
-`pluginExtensions[pluginId][namespace]`. `sessionEntrySlotSchema` can describe
+the `pluginExtensions[]` entries. `sessionEntrySlotSchema` can describe
 the projected slot shape in registration metadata; it is informational, not a
 replacement for JSON-compatible state validation.
 
@@ -325,8 +325,9 @@ runtime lifecycle cleanup callbacks receive `reset`, `delete`, `disable`, or
 `restart`. The host removes the owning plugin's persistent session extension
 state, pending next-turn injections, and promoted `SessionEntry` slots for
 reset/delete/disable; restart keeps durable session state while cleanup
-callbacks let plugins release scheduler jobs, run context, and other
-out-of-band resources for the old runtime generation.
+callbacks let plugins release runtime resources for the old generation. Run
+context is per-run scratch state and is cleared on terminal/restart cleanup;
+restart-preserved scheduler jobs skip scheduler cleanup callbacks.
 
 ## Message hooks
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -292,6 +292,27 @@ Workflow plugins can persist small JSON-compatible session state with
 through `pluginExtensions`, letting Control UI and other clients render
 plugin-owned status without learning plugin internals.
 
+When a generic session reader needs a stable top-level field, a session
+extension may also declare `sessionEntrySlotKey`. After every successful
+`sessions.pluginPatch`, OpenClaw mirrors the projected value into
+`SessionEntry[sessionEntrySlotKey]`. The mirror uses the same projection source
+as `pluginExtensions`: the synchronous `project()` result when present, or the
+raw JSON-compatible state otherwise. The slot is mirror-only: clients still
+write through `sessions.pluginPatch`, the host overwrites the slot on later
+patches, and `unset: true` clears both the namespace state and the mirror. If
+the projector returns `undefined`, throws, returns a promise, or returns a
+non-JSON value, the host keeps the plugin namespace state and clears the mirror
+to avoid stale top-level data.
+
+Slot keys must be identifier-style names, must not collide with current
+`SessionEntry` fields or prototype keys, and must be unique across registered
+session extensions. Use ordinary `pluginExtensions` for plugin-aware clients
+or plugin-local UI state. Use `sessionEntrySlotKey` only for small, non-secret
+summaries that generic session consumers need without parsing
+`pluginExtensions[pluginId][namespace]`. `sessionEntrySlotSchema` can describe
+the projected slot shape in registration metadata; it is informational, not a
+replacement for JSON-compatible state validation.
+
 Use `api.enqueueNextTurnInjection(...)` when a plugin needs durable context to
 reach the next model turn exactly once. OpenClaw drains queued injections before
 prompt hooks, drops expired injections, and deduplicates by `idempotencyKey`
@@ -302,10 +323,10 @@ the model on the next turn but should not become permanent system prompt text.
 Cleanup semantics are part of the contract. Session extension cleanup and
 runtime lifecycle cleanup callbacks receive `reset`, `delete`, `disable`, or
 `restart`. The host removes the owning plugin's persistent session extension
-state and pending next-turn injections for reset/delete/disable; restart keeps
-durable session state while cleanup callbacks let plugins release scheduler
-jobs, run context, and other out-of-band resources for the old runtime
-generation.
+state, pending next-turn injections, and promoted `SessionEntry` slots for
+reset/delete/disable; restart keeps durable session state while cleanup
+callbacks let plugins release scheduler jobs, run context, and other
+out-of-band resources for the old runtime generation.
 
 ## Message hooks
 

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -342,17 +342,19 @@ with `plugins.entries.<id>.hooks.allowPromptInjection=false`.
 ### Session extensions and next-turn injections
 
 Workflow plugins can persist small JSON-compatible session state with
-`api.registerSessionExtension(...)` and update it through the Gateway
-`sessions.pluginPatch` method. Session rows project registered extension state
-through `pluginExtensions`, letting Control UI and other clients render
-plugin-owned status without learning plugin internals.
+`api.session.state.registerSessionExtension(...)` and update it through the
+Gateway `sessions.pluginPatch` method. Session rows project registered
+extension state through `pluginExtensions`, letting Control UI and other clients
+render plugin-owned status without learning plugin internals.
 
-Use `api.enqueueNextTurnInjection(...)` when a plugin needs durable context to
-reach the next model turn exactly once. OpenClaw drains queued injections before
-prompt hooks, drops expired injections, and deduplicates by `idempotencyKey`
-per plugin. This is the right seam for approval resumes, policy summaries,
-background monitor deltas, and command continuations that should be visible to
-the model on the next turn but should not become permanent system prompt text.
+Use `api.session.workflow.enqueueNextTurnInjection(...)` when a plugin needs
+durable context to reach the next model turn exactly once. OpenClaw drains
+queued injections before prompt hooks, drops expired injections, and deduplicates
+by `idempotencyKey` per plugin. This is the right seam for approval resumes,
+policy summaries, background monitor deltas, and command continuations that
+should be visible to the model on the next turn but should not become permanent
+system prompt text. See [Host-hook examples](/plugins/host-hooks-examples) for
+worked workflow recipes.
 
 Cleanup semantics are part of the contract. Session extension cleanup and
 runtime lifecycle cleanup callbacks receive `reset`, `delete`, `disable`, or
@@ -454,6 +456,7 @@ accessors, and the `command-auth` → `command-status` rename - see
 - [Plugin SDK migration](/plugins/sdk-migration) - active deprecations and removal timeline
 - [Building plugins](/plugins/building-plugins)
 - [Plugin SDK overview](/plugins/sdk-overview)
+- [Host-hook examples](/plugins/host-hooks-examples)
 - [Plugin entry points](/plugins/sdk-entrypoints)
 - [Internal hooks](/automation/hooks)
 - [Plugin architecture internals](/plugins/architecture-internals)

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -1,0 +1,2680 @@
+---
+summary: "Host-hook recipes: worked examples, composition patterns, and plugin archetypes for the generic plugin host-hook contracts"
+title: "Host-hook examples and recipes"
+sidebarTitle: "Host-hook examples"
+read_when:
+  - You are building a plugin that participates in the host lifecycle (approval flow, policy gate, monitor, wizard, dashboard)
+  - You want a worked example of a specific host-hook contract
+  - You are choosing which hooks to compose for a workflow plugin archetype
+  - You want a starting skeleton for a workflow-style plugin without writing core
+---
+
+This doc is a recipe book. It does not re-document the API surface — that is the
+job of [Plugin SDK overview](/plugins/sdk-overview)
+and [Plugin hooks](/plugins/hooks). Instead, every section here answers a single
+question: _"if I want my plugin to do **X**, which host-hook contracts do I
+compose, and what does that look like end-to-end?"_
+
+Examples here are deliberately **product-neutral**. A planning workflow is one
+tenant of the host-hook contract — not a privileged one. Approval flows,
+workspace policy gates, background monitors, setup wizards, review assistants,
+and release workflows can all be built as plugins through the same seams.
+
+<Note>
+  The generic foundation for these recipes landed in #72287. The workflow
+  seams and advanced fixture proofs are implemented in the companion
+  host-hook follow-up PRs; this docs PR is the recipe map for those additive
+  SDK seams. In the companion implementation PRs, the contract coverage in
+  `src/plugins/contracts/host-hooks.contract.test.ts`, together with the
+  supporting fixture in `src/plugins/contracts/host-hook-fixture.ts`, is the
+  executable spec for these recipes.
+</Note>
+
+```mermaid
+flowchart LR
+  A["#72287 generic host hooks (merged)"] --> B["Consolidated follow-up PR"]
+  B --> C["Workflow action, outbound, scheduler, and retry seams"]
+  B --> D["Advanced contract fixture proofs"]
+  B --> E["Docs recipes PR"]
+  A --> D
+  C --> E
+  D --> E
+```
+
+## How to read this doc
+
+Each recipe has the same six parts:
+
+1. **What it does** — the one-line behavior.
+2. **Contract** — a source-oriented TypeScript excerpt from the companion
+   implementation PRs. Some excerpts omit nearby helper type declarations for
+   readability; the implementation PR source remains authoritative.
+3. **Minimal example** — the smallest plugin that exercises the contract.
+4. **Diagram** — a sequence or flow diagram of the runtime path.
+5. **Real-world example** — a complete plugin entry that's representative of
+   how you'd actually ship the contract in production.
+6. **Common pitfalls** — the failure modes worth knowing before you ship.
+
+Where two contracts compose naturally (e.g. session extension + command
+continuation), the recipe links forward to the full archetype recipe at the
+bottom of the doc.
+
+## Quick start
+
+Every plugin entry follows the same shape. The host-hook contracts add
+methods to the existing `OpenClawPluginApi` you already get inside `register`:
+
+```typescript
+// my-plugin/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  description: "What it does in one sentence",
+  register(api) {
+    // Existing surfaces you already know:
+    //   api.registerTool(...), api.registerCommand(...), api.on(...)
+    //
+    // Host-hook surfaces introduced by the host-hook contract PRs:
+    //   api.registerSessionExtension(...)
+    //   api.enqueueNextTurnInjection(...)
+    //   api.registerTrustedToolPolicy(...)        // bundled-only
+    //   api.registerToolMetadata(...)
+    //   api.registerControlUiDescriptor(...)
+    //   api.registerRuntimeLifecycle(...)
+    //   api.registerAgentEventSubscription(...)
+    //   api.setRunContext(...) / getRunContext(...) / clearRunContext(...)
+    //   api.registerSessionSchedulerJob(...)
+    //   api.registerSessionAction(...)
+    //   api.sendSessionAttachment(...)
+    //   api.scheduleSessionTurn(...)
+    //   api.emitAgentEvent(...)
+    //
+    // And new typed hook names for api.on(...):
+    //   "agent_turn_prepare"
+    //   "heartbeat_prompt_contribution"
+  },
+});
+```
+
+If you only need one host-hook surface, you can ignore the others. Composition
+is opt-in and lazy — registering nothing in a category means the plugin does
+not participate in that category.
+
+---
+
+## Recipe gallery (one section per contract)
+
+### 1. Plugin-owned session state: `api.registerSessionExtension(...)`
+
+**What it does**
+
+Persists small JSON-compatible plugin state alongside the session row, with
+optional projection into Gateway clients under `pluginExtensions`. Two plugins
+can ship two unrelated extensions and never collide because the namespace and
+plugin id key the storage.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginSessionExtensionRegistration = {
+  namespace: string;
+  description: string;
+  project?: (ctx: PluginSessionExtensionProjectionContext) => PluginJsonValue | undefined;
+  cleanup?: (ctx: { reason: PluginHostCleanupReason; sessionKey?: string }) => void | Promise<void>;
+};
+
+export type PluginSessionExtensionProjectionContext = {
+  sessionKey: string;
+  sessionId?: string;
+  state: PluginJsonValue | undefined;
+};
+
+// PluginHostCleanupReason = "disable" | "reset" | "delete" | "restart"
+```
+
+`project()` is optional — if you don't pass one, the host returns the raw
+stored state under `pluginExtensions[<pluginId>][<namespace>]`. Pass `project()`
+when you want to _transform_ what clients see (for example, hide secrets, or
+return a different shape than what you persist).
+
+**Minimal example**
+
+```typescript
+// my-plugin/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "review-status",
+  name: "Review Status",
+  description: "Tracks per-session code-review state",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "review-status",
+      description: "Per-session review state: pending | in_review | approved",
+      project: ({ state }) => {
+        // Show a friendly summary; persist the raw record
+        if (!state || typeof state !== "object" || Array.isArray(state)) {
+          return undefined;
+        }
+        return { status: state.status ?? "pending" };
+      },
+    });
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin as Review Status
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+  participant GW as Gateway
+  participant UI as Control UI
+
+  Plugin->>Reg: registerSessionExtension({namespace, project, cleanup})
+  Note over Reg,Store: namespace + pluginId now valid for sessions.pluginPatch
+
+  UI->>GW: sessions.pluginPatch({pluginId, namespace, value: {...}})
+  GW->>Reg: lookup (pluginId, namespace) — reject if unknown
+  Reg->>Store: write namespaced state
+  Store->>Plugin: invoke project({sessionKey, sessionId, state})
+  Plugin-->>Store: projection JSON
+  Store-->>GW: session row with pluginExtensions[pluginId][namespace] = projection
+  GW-->>UI: live row update
+```
+
+**Real-world example: Review Concierge session state**
+
+A code-review plugin that tracks which files an operator has approved per
+session. The persisted state is the full file list; the projection returns
+only counts so the row stays small for clients that only need a meter.
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
+
+type ReviewStatePersisted = {
+  approvedFiles: string[];
+  rejectedFiles: string[];
+  updatedAt: number;
+};
+
+type ReviewStateProjection = {
+  approvedCount: number;
+  rejectedCount: number;
+  totalReviewed: number;
+};
+
+function isReviewState(value: PluginJsonValue | undefined): value is ReviewStatePersisted {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, PluginJsonValue>;
+  return Array.isArray(obj.approvedFiles) && Array.isArray(obj.rejectedFiles);
+}
+
+export default definePluginEntry({
+  id: "review-concierge",
+  name: "Review Concierge",
+  description: "Per-session code-review tracking and projection",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "review-state",
+      description: "Files approved or rejected for code review during this session",
+      project: ({ state }): ReviewStateProjection | undefined => {
+        if (!isReviewState(state)) return undefined;
+        return {
+          approvedCount: state.approvedFiles.length,
+          rejectedCount: state.rejectedFiles.length,
+          totalReviewed: state.approvedFiles.length + state.rejectedFiles.length,
+        };
+      },
+      cleanup: async ({ reason, sessionKey }) => {
+        api.logger.info(`review-state cleanup reason=${reason} sessionKey=${sessionKey ?? "*"}`);
+        // Host already removes the persisted state — this callback is for
+        // plugin-owned out-of-band resources (caches, WebSocket handles, etc.)
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't put secrets in the projected value.** Anything you return from
+  `project()` ends up on session rows that Gateway hands to mobile/desktop
+  clients. Persist secrets only if your plugin renders them itself.
+- **Validate JSON shape inside `project()`.** The host stores whatever
+  `sessions.pluginPatch` writes (it's checked via `isPluginJsonValue`); your
+  projection should still defend against shape drift across schema versions.
+- **Cleanup is host-driven for the persisted state.** You don't need to clear
+  the namespace from `cleanup()`. Use `cleanup()` for _plugin-owned_
+  out-of-band resources only (timers, caches, file watchers).
+
+---
+
+### 2. Patching session state from clients: `sessions.pluginPatch`
+
+**What it does**
+
+Lets Control UI / mobile / desktop / internal clients update plugin-owned
+session state through the Gateway, with namespace-and-plugin-id validation
+at the wire.
+
+**Contract**
+
+```typescript
+// Wire-level params for sessions.pluginPatch
+type PluginSessionExtensionPatchParams = {
+  key: string; // sessionKey
+  pluginId: string;
+  namespace: string;
+  value?: PluginJsonValue;
+  unset?: boolean; // pass true to remove the namespace entirely
+};
+```
+
+**Minimal example**
+
+A Control UI calling `sessions.pluginPatch` to mark a session's approval flow
+approved:
+
+```jsonc
+// JSON-RPC request from Control UI
+{
+  "method": "sessions.pluginPatch",
+  "params": {
+    "key": "agent-default:demo",
+    "pluginId": "deploy-approver",
+    "namespace": "deploy-approver",
+    "value": { "state": "approved", "approvedAt": 1745000000000 },
+  },
+}
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant UI as Control UI / mobile / etc.
+  participant GW as Gateway
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+
+  UI->>GW: sessions.pluginPatch(params)
+  GW->>GW: validate params shape
+  GW->>Reg: lookup (pluginId, namespace) — must be registered
+  alt unknown plugin or namespace
+    Reg-->>GW: 404 unknown plugin session extension
+    GW-->>UI: error: unknown plugin session extension: id/namespace
+  else registered
+    Reg->>Store: write patched value (or unset)
+    Store->>Reg: invoke project() callback
+    Reg-->>GW: updated session row
+    GW-->>UI: { ok: true, key, value }
+  end
+```
+
+**Real-world example: operator approval card**
+
+The Control UI approval card binds approve/deny buttons to `sessions.pluginPatch`
+calls. The plugin doesn't need a custom Gateway method; the patch protocol is
+generic.
+
+```typescript
+// Control UI side (sketch)
+async function approveDeploy(sessionKey: string, version: string) {
+  return await gatewayClient.call("sessions.pluginPatch", {
+    key: sessionKey,
+    pluginId: "deploy-approver",
+    namespace: "deploy-approver",
+    value: { state: "approved", version, approvedAt: Date.now() },
+  });
+}
+
+async function denyDeploy(sessionKey: string, reason: string) {
+  return await gatewayClient.call("sessions.pluginPatch", {
+    key: sessionKey,
+    pluginId: "deploy-approver",
+    namespace: "deploy-approver",
+    value: { state: "denied", reason, deniedAt: Date.now() },
+  });
+}
+```
+
+**Common pitfalls**
+
+- **Patches are atomic per call, not transactional across plugins.** If your
+  workflow needs cross-plugin atomicity, model it as a single state machine in
+  one plugin's namespace.
+- **`unset: true` removes the entire namespace for the session.** Use it for
+  reset-style operations; use `value: <new state>` for partial updates.
+
+---
+
+### 3. Durable next-turn context: `api.enqueueNextTurnInjection(...)`
+
+**What it does**
+
+Reaches the next agent turn for a session **exactly once**, with TTL,
+idempotency, and chronological cross-plugin drain ordering. The right seam
+for "the model should know X on its very next turn, but not as permanent
+system prompt text."
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginNextTurnInjectionPlacement =
+  | "prepend_context"
+  | "append_context";
+
+export type PluginNextTurnInjection = {
+  sessionKey: string;
+  text: string;
+  idempotencyKey?: string;
+  placement?: PluginNextTurnInjectionPlacement;
+  ttlMs?: number;
+  priority?: number;
+  metadata?: PluginJsonValue;
+};
+
+api.enqueueNextTurnInjection(
+  injection: PluginNextTurnInjection,
+): Promise<{ enqueued: boolean; id: string; sessionKey: string }>;
+```
+
+`enqueued: false` means the call was a duplicate (same `idempotencyKey` for
+the same plugin in the same session). The returned `id` is the canonical
+record id either way.
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "note-save",
+  description: "Save the current model output as a note and inject a summary on the next turn",
+  acceptsArgs: false,
+  handler: async (ctx) => {
+    if (!ctx.sessionKey) {
+      return { text: "This command must run inside a bound session." };
+    }
+    await api.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      text: `[note saved] previous answer captured at ${new Date().toISOString()}`,
+      placement: "prepend_context",
+      idempotencyKey: `note-save:${ctx.sessionKey}`,
+      ttlMs: 5 * 60_000, // 5 min
+    });
+    return { text: "Saved.", continueAgent: false };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin
+  participant Q as Next-turn Queue
+  participant Runner as Agent Runner
+  participant Hook as agent_turn_prepare
+  participant Model
+
+  Plugin->>Q: enqueueNextTurnInjection({sessionKey, text, idempotencyKey, ttlMs})
+  Q-->>Plugin: { enqueued: true, id, sessionKey }
+  Note over Q: same idempotencyKey before drain → enqueued: false
+
+  Note over Runner: next agent turn starts
+  Runner->>Q: drain(sessionKey)
+  Q-->>Runner: queuedInjections (sorted by createdAt, expired dropped)
+  Runner->>Hook: agent_turn_prepare({prompt, messages, queuedInjections})
+  Hook-->>Runner: { prependContext?, appendContext? }
+  Runner->>Model: prompt + drained context
+```
+
+**Real-world example: Code Review Concierge auto-retry**
+
+When a tool call fails, the plugin queues a one-shot diagnosis for the next
+turn so the model retries with full context:
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "review-concierge",
+  name: "Review Concierge",
+  description: "Inject failing-test context on the next turn after a test fails",
+  register(api) {
+    api.registerAgentEventSubscription({
+      id: "review-concierge.tool-fail-watcher",
+      streams: ["tool"],
+      handle: async (event) => {
+        const toolName = String(event.data.name ?? "");
+        if (
+          event.stream !== "tool" ||
+          event.data.phase !== "result" ||
+          event.data.isError !== true
+        ) {
+          return;
+        }
+        if (toolName !== "run_tests") return;
+        const sessionKey = event.sessionKey;
+        if (!sessionKey) return;
+
+        const summary = formatTestFailure(event.data.result); // your own helper
+        const toolCallId = String(event.data.toolCallId ?? "unknown");
+        await api.enqueueNextTurnInjection({
+          sessionKey,
+          text: `Previous test run failed:\n\n${summary}\n\nThe model should diagnose and propose a focused fix.`,
+          placement: "prepend_context",
+          idempotencyKey: `tool-fail-${event.runId}-${toolCallId}`,
+          ttlMs: 10 * 60_000,
+          metadata: { source: "review-concierge", kind: "tool-fail-summary" },
+        });
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't use this for permanent context.** It's exactly-once-per-drain by
+  design. Use `before_prompt_build` for context that should appear on every
+  turn.
+- **`idempotencyKey` is plugin-scoped per session.** If two plugins both
+  enqueue with the same key, both fire. The dedup is `(pluginId, sessionKey,
+idempotencyKey)`.
+- **A drain consumes all of this session's queue, including from
+  transiently-inactive plugins.** This is intentional (the drain is the
+  consume boundary). If you need to reschedule across registry hot-reload,
+  re-enqueue from your reload hook.
+
+---
+
+### 4. Same-turn context from drained injections: `agent_turn_prepare`
+
+**What it does**
+
+Receives the drained next-turn injections and lets you fold them into prompt
+context **before** the ordinary `before_prompt_build` hook fires. Use this
+when the queued context needs plugin-side shaping before it becomes part of
+the prompt. If no plugin handles `agent_turn_prepare`, the host applies the
+default fold for queued injections: `prepend_context` items go before the
+turn prompt, `append_context` items go after it, and priority decides ordering
+within each placement.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginAgentTurnPrepareEvent = {
+  prompt: string;
+  messages: AgentMessage[] | unknown[];
+  queuedInjections: PluginNextTurnInjectionRecord[];
+};
+
+export type PluginAgentTurnPrepareResult = {
+  prependContext?: string;
+  appendContext?: string;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.on("agent_turn_prepare", (event) => {
+  const reviewInjections = event.queuedInjections.filter((entry) => entry.pluginId === api.id);
+  if (reviewInjections.length === 0) return;
+
+  const summary = reviewInjections.map((entry) => entry.text).join("\n\n");
+  return { prependContext: `[review-concierge] notes:\n\n${summary}` };
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Drain["drainPluginNextTurnInjections(sessionKey)"]
+  Drain --> Sort["sort by createdAt"]
+  Sort --> ATP["agent_turn_prepare hooks (priority order)"]
+  ATP --> Defaults["host default fold\nfor queued injections"]
+  ATP --> Custom["plugin-custom fold"]
+  Defaults --> PB["before_prompt_build"]
+  Custom --> PB
+  PB --> Build["prompt build"]
+```
+
+**Real-world example: multi-plugin draft for a meeting summarizer**
+
+```typescript
+api.on(
+  "agent_turn_prepare",
+  (event) => {
+    const my = event.queuedInjections.filter((e) => e.pluginId === api.id);
+    if (my.length === 0) return;
+
+    // Group by metadata.kind, render with our own headers
+    const groups = new Map<string, string[]>();
+    for (const entry of my) {
+      const kind =
+        (entry.metadata && typeof entry.metadata === "object" && !Array.isArray(entry.metadata)
+          ? (entry.metadata as { kind?: string }).kind
+          : undefined) ?? "note";
+      const bucket = groups.get(kind) ?? [];
+      bucket.push(entry.text);
+      groups.set(kind, bucket);
+    }
+
+    const sections: string[] = [];
+    for (const [kind, items] of groups.entries()) {
+      sections.push(`### ${kind}\n\n${items.map((t) => `- ${t}`).join("\n")}`);
+    }
+    return { prependContext: `## meeting-summarizer queued\n\n${sections.join("\n\n")}` };
+  },
+  { priority: 60 },
+);
+```
+
+**Common pitfalls**
+
+- **Don't drop other plugins' injections.** Filter to your own `pluginId`
+  before consuming. The host defaults already handle every plugin's items —
+  if you replace the default, do it for _your_ injections only.
+- **`agent_turn_prepare` runs only on user-initiated turns.** For
+  background-only context use `heartbeat_prompt_contribution` instead.
+- **`allowPromptInjection=false` disables this hook per-plugin.** Operators
+  can opt out of any prompt-mutating plugin individually.
+
+---
+
+### 5. Heartbeat-only prompt context: `heartbeat_prompt_contribution`
+
+**What it does**
+
+Returns prompt context that fires **only** on heartbeat turns, never on
+user-initiated turns. The right seam for SLA timers, long-job progress
+deltas, and incident timers — context the model should notice in the
+background without polluting interactive prompts.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginHeartbeatPromptContributionEvent = {
+  sessionKey?: string;
+  agentId?: string;
+  heartbeatName?: string;
+};
+
+export type PluginHeartbeatPromptContributionResult = {
+  prependContext?: string;
+  appendContext?: string;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.on("heartbeat_prompt_contribution", (event) => {
+  if (!event.sessionKey) return;
+  const elapsed = getElapsedMinutes(event.sessionKey); // your own helper
+  if (elapsed < 10) return;
+  return { appendContext: `⏱ Long-running session: ${elapsed}m elapsed.` };
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Sched as Heartbeat Scheduler
+  participant Runner
+  participant Plugin
+  participant Model
+  participant User
+
+  Sched->>Runner: heartbeat fires (heartbeatName)
+  Runner->>Plugin: heartbeat_prompt_contribution({sessionKey, agentId, heartbeatName})
+  Plugin-->>Runner: { appendContext: "..." }
+  Runner->>Model: heartbeat prompt + appended context
+  Model-->>Runner: condensed status
+
+  Note over User,Runner: User types a question
+  User->>Runner: prompt
+  Runner->>Model: user prompt (NO heartbeat note)
+```
+
+**Real-world example: SLA Watcher**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const SLA_BY_AGENT: Record<string, number> = {
+  default: 15 * 60_000,
+  "release-bot": 30 * 60_000,
+};
+
+export default definePluginEntry({
+  id: "sla-watcher",
+  name: "SLA Watcher",
+  description: "Surfaces SLA elapsed/remaining only on heartbeat turns",
+  register(api) {
+    const startedAt = new Map<string, number>();
+
+    api.registerAgentEventSubscription({
+      id: "sla-watcher.run-tracker",
+      streams: ["lifecycle"],
+      handle: (event, ctx) => {
+        if (event.data.phase === "start" && event.sessionKey) {
+          startedAt.set(event.sessionKey, Date.now());
+          ctx.setRunContext("sla", { startedAt: Date.now() });
+        } else if (
+          (event.data.phase === "end" || event.data.phase === "error") &&
+          event.sessionKey
+        ) {
+          startedAt.delete(event.sessionKey);
+        }
+      },
+    });
+
+    api.on("heartbeat_prompt_contribution", (event) => {
+      if (!event.sessionKey || !event.agentId) return;
+      const sla = SLA_BY_AGENT[event.agentId] ?? SLA_BY_AGENT.default;
+      const start = startedAt.get(event.sessionKey);
+      if (!start) return;
+      const elapsed = Date.now() - start;
+      const remaining = sla - elapsed;
+      if (remaining > 60_000) return; // only nudge inside the last minute
+      const human = remaining > 0 ? `${Math.ceil(remaining / 60_000)}m` : "exceeded";
+      return {
+        appendContext: `⏱ SLA budget: ${human}. Wrap up if possible.`,
+      };
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Heartbeat handlers must be cheap.** They run on a timer; an expensive
+  handler will slow heartbeat cadence for the whole agent.
+- **Empty returns are fine.** If you don't have anything to say this tick,
+  return nothing — don't fall through to a generic "no update" string.
+- **`allowPromptInjection=false` disables this hook per-plugin** (same as
+  `agent_turn_prepare` and `before_prompt_build`).
+
+---
+
+### 6. Bundled-only pre-plugin policy: `api.registerTrustedToolPolicy(...)`
+
+**What it does**
+
+Runs **before** any `before_tool_call` hook. Bundled plugins only. The right
+home for compliance, workspace-policy, budget, and other host-trusted gates
+that must fire before any third-party plugin can see a tool call.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginToolPolicyDecision =
+  | PluginHookBeforeToolCallResult
+  | { allow?: boolean; reason?: string };
+
+export type PluginTrustedToolPolicyRegistration = {
+  id: string;
+  description: string;
+  evaluate: (
+    event: PluginHookBeforeToolCallEvent,
+    ctx: PluginHookToolContext,
+  ) => PluginToolPolicyDecision | void | Promise<PluginToolPolicyDecision | void>;
+};
+```
+
+`{ allow: false, reason }` becomes `{ block: true, blockReason }` downstream.
+You can also return any `BeforeToolCallResult` directly: `{block, blockReason,
+params, requireApproval}`.
+
+**Minimal example**
+
+```typescript
+import fs from "node:fs/promises";
+import path from "node:path";
+
+api.registerTrustedToolPolicy({
+  id: "workspace-policy",
+  description: "Block writes outside the configured workspace root",
+  evaluate: async (event) => {
+    if (event.toolName !== "write_file") return;
+    const configuredRoot = process.env.OPENCLAW_WORKSPACE_ROOT;
+    if (!configuredRoot) {
+      return { allow: false, reason: "workspace root is not configured" };
+    }
+    let workspaceRoot: string;
+    try {
+      workspaceRoot = await fs.realpath(configuredRoot);
+    } catch {
+      return { allow: false, reason: "workspace root is not readable" };
+    }
+    let targetPath: string;
+    try {
+      targetPath = await fs.realpath(String(event.params?.path ?? ""));
+    } catch {
+      return { allow: false, reason: "path is not readable" };
+    }
+    const relative = path.relative(workspaceRoot, targetPath);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      return { allow: false, reason: "path outside workspace root" };
+    }
+    return undefined;
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant TP as Trusted Tool Policy
+  participant Hooks as before_tool_call (external plugins)
+  participant Approval
+  participant Tool
+
+  Agent->>TP: tool call (name, params)
+  alt allow:false / block:true
+    TP-->>Agent: { block: true, blockReason }
+    Note over Hooks: never runs — blocked at policy tier
+  else requireApproval
+    TP-->>Approval: requireApproval
+    Approval-->>TP: decision (allow-once / allow-always / deny / timeout / cancelled)
+    TP->>Hooks: pass on if allowed
+  else params rewrite
+    TP->>Hooks: forward policyAdjustedParams
+    Hooks-->>TP: ok / block / approval / params
+    TP->>Tool: execute(adjustedParams)
+  else no decision
+    TP->>Hooks: forward original params
+    Hooks-->>TP: ok / block / approval / params
+    TP->>Tool: execute(adjustedParams)
+  end
+```
+
+**Real-world example: Budget Guard**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const TOOL_COST_USD: Record<string, number> = {
+  llm_call: 0.02,
+  search: 0.001,
+  expensive_analysis: 0.5,
+};
+
+export default definePluginEntry({
+  id: "budget-guard",
+  name: "Budget Guard",
+  description: "Blocks tools whose estimated cost would exceed the session budget",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "budget",
+      description: "Budget tracking: spent (USD), capUsd",
+    });
+
+    api.registerTrustedToolPolicy({
+      id: "budget-guard.cost-cap",
+      description: "Require approval when tool cost would exceed session cap",
+      evaluate: async (event, ctx) => {
+        if (!ctx.sessionKey) return;
+        const cost = TOOL_COST_USD[event.toolName] ?? 0;
+        if (cost <= 0) return;
+
+        const budget = await getBudgetState(ctx.sessionKey); // your own helper
+        const projected = budget.spent + cost;
+        if (projected > budget.capUsd) {
+          return {
+            requireApproval: {
+              title: "Budget cap exceeded",
+              description: `${event.toolName} (~$${cost.toFixed(2)}) would push session spend to $${projected.toFixed(2)} (cap: $${budget.capUsd.toFixed(2)})`,
+              severity: "warning",
+              timeoutBehavior: "deny",
+              timeoutMs: 60_000,
+            },
+          };
+        }
+        return undefined;
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Bundled-only.** External plugins should use `before_tool_call` instead.
+  The host enforces this at registration.
+- **Trusted policy adjustments propagate as `policyAdjustedParams`.**
+  Downstream `before_tool_call` hooks see the adjusted params and can rewrite
+  them again. The execution-time params are the final merge.
+- **Your `evaluate` runs on every tool call.** Filter by `event.toolName` early
+  and return `undefined` fast for tools you don't care about.
+
+---
+
+### 7. Tool catalog and inventory metadata: `api.registerToolMetadata(...)`
+
+**What it does**
+
+Adds display and policy metadata (risk, tags, label) for tools without
+forking or wrapping the tool implementation. Projects into the tool catalog
+and the effective-inventory view.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginToolMetadataRegistration = {
+  toolName: string;
+  displayName?: string;
+  description?: string;
+  risk?: "low" | "medium" | "high";
+  tags?: string[];
+};
+```
+
+**Minimal example**
+
+```typescript
+api.registerToolMetadata({
+  toolName: "s3_export",
+  displayName: "Export to S3",
+  description: "Writes data to a configured S3 bucket",
+  risk: "high",
+  tags: ["data-egress", "compliance"],
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Plugin["Plugin"] -->|registerToolMetadata| Reg[Registry]
+  Reg --> Catalog[Tool catalog]
+  Reg --> Inventory[Effective inventory]
+  Catalog --> UI[Control UI]
+  Inventory --> UI
+  UI --> FilterByRisk[Filter: risk=high]
+  UI --> FilterByTag[Filter: tag=compliance]
+  Inventory --> Audit[Audit log row \n with risk + tags]
+```
+
+**Real-world example: Compliance Vault**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const HIGH_RISK_TOOLS = [
+  { name: "s3_export", display: "Export to S3" },
+  { name: "db_dump", display: "Database dump" },
+  { name: "bigquery_export", display: "Export to BigQuery" },
+];
+
+const PII_TOOLS = ["read_user_record", "lookup_email", "read_address_book"];
+
+export default definePluginEntry({
+  id: "compliance-vault",
+  name: "Compliance Vault",
+  description: "Tags export/PII tools for catalog filtering and audit",
+  register(api) {
+    for (const { name, display } of HIGH_RISK_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        displayName: display,
+        risk: "high",
+        tags: ["data-egress", "compliance"],
+      });
+    }
+    for (const name of PII_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        risk: "medium",
+        tags: ["pii", "compliance"],
+      });
+    }
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Metadata is additive within a plugin's own tool registrations.**
+  Uniqueness is enforced per `(pluginId, toolName)`, so different plugins
+  can use the same `toolName` without colliding. A plugin also can't
+  decorate or override core or another plugin's tools at projection time.
+- **`risk` is enum.** Only `"low" | "medium" | "high"` are valid. Don't
+  pass arbitrary strings.
+
+---
+
+### 8. Scoped commands with continuation: `api.registerCommand(...)`
+
+**What it does**
+
+Adds two new fields to the existing command-registration shape: `requiredScopes`
+(Gateway-enforced operator scopes) and `ownership` (bundled-only escape for
+reserved names). Plus, command results can carry `continueAgent: true` to wake
+the agent immediately after the command's state mutation.
+
+**Contract**
+
+```typescript
+// from src/plugins/types.ts
+export type PluginCommandResult = ReplyPayload & { continueAgent?: boolean };
+
+export type OpenClawPluginCommandDefinition = {
+  name: string;
+  nativeNames?: { default?: string } & Partial<Record<string, string>>;
+  nativeProgressMessages?: Partial<Record<string, string>> & { default?: string };
+  description: string;
+  agentPromptGuidance?: readonly string[];
+  acceptsArgs?: boolean;
+  requireAuth?: boolean;
+  requiredScopes?: OperatorScope[];
+  ownership?: "plugin" | "reserved";
+  handler: PluginCommandHandler;
+};
+```
+
+The authoritative reserved-command check lives in
+`src/plugins/command-registration.ts` inside `validateCommandName`, which
+builds its reserved `Set` from names such as `help, commands, status, whoami,
+context, btw, stop, restart, reset, new, compact, config, debug, allowlist,
+activation, skill, subagents, kill, steer, tell, model, models, queue, send,
+bash, exec, think, verbose, reasoning, elevated, usage`. External plugins are
+rejected at registration if they try to claim those; only
+`ownership: "reserved"` on a bundled plugin can override.
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "release",
+  description: "Release management",
+  acceptsArgs: true,
+  requiredScopes: ["operator.approvals"],
+  handler: async (ctx) => {
+    return { text: `release: ${ctx.args ?? "(no args)"}`, continueAgent: false };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Op as Operator
+  participant GW as Gateway
+  participant Router as Command Router
+  participant Plugin
+  participant Runner as Agent Runner
+
+  Op->>GW: /release approve v1.4.2
+  GW->>GW: enforce requiredScopes against operator scopes
+  alt missing scope
+    GW-->>Op: 403 — missing scope: operator.approvals
+  else has scope
+    GW->>Router: dispatch
+    Router->>Plugin: handler(ctx)
+    Plugin-->>Router: PluginCommandResult { content, continueAgent }
+    alt continueAgent: true
+      Router->>Runner: start next turn
+    end
+    Router-->>Op: result
+  end
+```
+
+**Real-world example: Release Train Conductor**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "release-conductor",
+  name: "Release Train Conductor",
+  description: "/release plan / approve / rollback with operator scopes",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "release",
+      description: "Per-session release state: stage, version, approvedBy",
+    });
+
+    api.registerCommand({
+      name: "release-plan",
+      description: "Print the release plan for a version",
+      acceptsArgs: true,
+      requiredScopes: ["operator.read"],
+      handler: async (ctx) => {
+        const plan = await loadReleasePlan(ctx.args ?? "");
+        return { text: renderPlan(plan), continueAgent: false };
+      },
+    });
+
+    api.registerCommand({
+      name: "release-approve",
+      description: "Approve a release for deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        const version = (ctx.args ?? "").trim();
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        if (!version) {
+          return { text: "Usage: /release-approve <version>", continueAgent: false };
+        }
+        await api.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator approved release of ${version}.`,
+          placement: "prepend_context",
+          idempotencyKey: `release-approve-${version}`,
+        });
+        return { text: `Approved ${version}.`, continueAgent: true };
+      },
+    });
+
+    api.registerCommand({
+      name: "release-rollback",
+      description: "Roll back the most recent release",
+      acceptsArgs: false,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator initiated release rollback.`,
+          placement: "prepend_context",
+        });
+        return { text: "Rollback queued.", continueAgent: true };
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't forget `requiredScopes` for write commands.** The Gateway enforces
+  scopes only when you declare them. A command without scopes is callable by
+  any authenticated client.
+- **`ownership: "reserved"` is bundled-only.** External plugins are rejected
+  at registration. If you're a third-party plugin, pick a non-reserved name
+  or use `nativeNames` to alias to one of yours.
+
+---
+
+### 9. Command-then-continue: `PluginCommandResult.continueAgent`
+
+**What it does**
+
+Lets a command result wake the agent immediately for one more turn after the
+command's state mutation. The classic pattern is: operator clicks Approve,
+plugin updates session state and queues a next-turn injection, returns
+`continueAgent: true`, agent immediately resumes with the new context.
+
+**Contract**
+
+```typescript
+export type PluginCommandResult = ReplyPayload & { continueAgent?: boolean };
+```
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "deploy-approve",
+  description: "Approve a pending deployment",
+  acceptsArgs: false,
+  requiredScopes: ["operator.approvals"],
+  handler: async (ctx) => {
+    if (!ctx.sessionKey) {
+      return { text: "This command must run inside a bound session.", continueAgent: false };
+    }
+    await applyApprovalState(ctx.sessionKey, "approved"); // your helper
+    await api.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      text: "Deployment approved. Proceed.",
+      placement: "prepend_context",
+    });
+    return { text: "Approved.", continueAgent: true };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Op as Operator
+  participant Router
+  participant Plugin
+  participant Q as Next-turn Queue
+  participant Runner
+  participant Model
+
+  Op->>Router: /deploy-approve
+  Router->>Plugin: handler
+  Plugin->>Plugin: update session state
+  Plugin->>Q: enqueueNextTurnInjection
+  Plugin-->>Router: { content, continueAgent: true }
+  Router->>Runner: start next turn
+  Runner->>Q: drain
+  Runner->>Model: prompt + drained context
+  Model-->>Op: agent reply post-approval
+```
+
+**Common pitfalls**
+
+- **Pair with `enqueueNextTurnInjection` whenever the agent needs to know
+  why it was woken.** Without an injection, the agent restarts with no
+  visible cause; the model has to infer.
+- **Don't use `continueAgent: true` for commands that don't change state.**
+  The agent will just spin its wheels.
+
+---
+
+### 10. Data-only Control UI surfaces: `api.registerControlUiDescriptor(...)`
+
+**What it does**
+
+Lets a plugin contribute Control UI surfaces (session, tool, run, settings
+panels) by shipping a JSON descriptor. The host renders. **No plugin-shipped
+JavaScript reaches client surfaces.**
+
+**Contract**
+
+This excerpt is the descriptor shape from the companion implementation PR. If
+you read this docs PR before the implementation PRs have landed, bare `main`
+will still show the older descriptor subset.
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginControlUiDescriptor = {
+  id: string;
+  surface: "session" | "tool" | "run" | "settings";
+  label: string;
+  description?: string;
+  placement?: string;
+  renderer?: "approval-card" | "mode-switcher" | "sidebar-panel" | "input-guard" | (string & {});
+  stateNamespace?: string;
+  actionIds?: string[];
+  schema?: PluginJsonValue;
+  requiredScopes?: OperatorScope[];
+};
+```
+
+The descriptor is exposed via the new Gateway method `plugins.uiDescriptors`,
+which returns each descriptor with `pluginId` and `pluginName` injected by the
+host.
+
+**Minimal example**
+
+```typescript
+api.registerControlUiDescriptor({
+  id: "review-status-panel",
+  surface: "session",
+  label: "Review Status",
+  description: "Shows code-review approval/rejection counts for this session",
+  placement: "sidebar",
+  schema: {
+    kind: "review-counts-card",
+    fields: ["approvedCount", "rejectedCount", "totalReviewed"],
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Plugin -->|registerControlUiDescriptor| Reg[Registry]
+  Reg --> GW[Gateway: plugins.uiDescriptors]
+  GW --> Web[Control UI \n web]
+  GW --> Mac[macOS \n native]
+  GW --> iOS[iOS \n native]
+  Web --> Render[Renders schema with web component]
+  Mac --> Render2[Renders schema with SwiftUI component]
+  iOS --> Render3[Renders schema with SwiftUI component]
+```
+
+**Real-world example: Budget Meter card**
+
+```typescript
+api.registerControlUiDescriptor({
+  id: "budget-meter",
+  surface: "session",
+  label: "Budget",
+  description: "Per-session spend tracker",
+  placement: "header",
+  schema: {
+    kind: "meter",
+    valuePath: "pluginExtensions.budget-guard.budget.spent",
+    capPath: "pluginExtensions.budget-guard.budget.capUsd",
+    format: "usd",
+    warningRatio: 0.8,
+    criticalRatio: 1.0,
+  },
+});
+```
+
+The web Control UI, the macOS app, and the iOS app each ship a `meter`
+renderer that knows how to read `valuePath` and `capPath` from the session
+row. The plugin only ships data — never UI code.
+
+**Common pitfalls**
+
+- **The `schema` shape is plugin-and-renderer-defined.** Pick a clear
+  `kind` field (or any naming convention you like) so renderers can switch.
+  The host doesn't validate the shape beyond JSON-compatibility.
+- **No XSS surface, but no client-side compute either.** If your plugin
+  needs to do anything dynamic in the client (formatting, animations,
+  conditional rendering beyond what the schema supports), build a richer
+  generic renderer in clients first; don't try to ship JS through `schema`.
+
+---
+
+### 11. Host-mediated session actions: `api.registerSessionAction(...)`
+
+**What it does**
+
+Registers a typed action that trusted clients can invoke through the host. The
+host owns scope checks, payload validation, and response shape; the plugin owns
+only the domain action.
+
+**Minimal example**
+
+```typescript
+api.registerSessionAction({
+  id: "approve-deploy",
+  description: "Approve or deny a queued deployment",
+  requiredScopes: ["operator.approvals"],
+  schema: {
+    type: "object",
+    properties: {
+      decision: { enum: ["approved", "denied"] },
+      reason: { type: "string" },
+    },
+    required: ["decision"],
+  },
+  async handler(ctx) {
+    if (!ctx.sessionKey) {
+      return { ok: false, error: "approve-deploy requires a bound session" };
+    }
+    if (!ctx.payload || typeof ctx.payload !== "object" || Array.isArray(ctx.payload)) {
+      return { ok: false, error: "approve-deploy payload must be an object" };
+    }
+    const decision = (ctx.payload as { decision?: unknown }).decision;
+    if (decision !== "approved" && decision !== "denied") {
+      return { ok: false, error: "decision must be approved or denied" };
+    }
+    await api.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      placement: "prepend_context",
+      text: `Deployment decision: ${decision}`,
+      priority: 100,
+      idempotencyKey: `deploy:${decision}`,
+    });
+    return { data: { decision }, continueAgent: true };
+  },
+});
+```
+
+Use this for approval cards, review triage buttons, incident escalation forms,
+or admin-only maintenance actions. Use command hooks when a human types a
+command; use session actions when a client or UI surface invokes a structured
+operation.
+
+---
+
+### 12. Host-mediated attachments: `api.sendSessionAttachment(...)`
+
+**What it does**
+
+Lets bundled plugins send generated artifacts through the session's existing
+delivery route. The host validates file entries, count, total size, and route
+availability so plugins do not bypass channel policy.
+
+**Minimal example**
+
+```typescript
+const result = await api.sendSessionAttachment({
+  sessionKey: ctx.sessionKey,
+  files: [{ path: reportPath }],
+  text: "Review report is ready.",
+  maxBytes: 5 * 1024 * 1024,
+});
+
+if (!result.ok) {
+  api.logger.warn(`report delivery skipped: ${result.error}`);
+}
+```
+
+Use this for report generators, screenshot collectors, transcript exporters,
+and artifact-producing test plugins. Workspace plugins should return a link or
+structured result instead; attachment delivery is bundled-only.
+
+---
+
+### 13. Scheduled follow-up turns: `api.scheduleSessionTurn(...)`
+
+**What it does**
+
+Registers a plugin-owned follow-up turn through the host scheduler. The host
+tracks ownership so disabling, resetting, or deleting the plugin cleans pending
+jobs instead of leaving orphan wakes behind.
+
+**Minimal example**
+
+```typescript
+const job = await api.scheduleSessionTurn({
+  sessionKey,
+  message: "Recheck the unresolved SLA queue.",
+  delayMs: 15 * 60 * 1000,
+  deleteAfterRun: true,
+  deliveryMode: "none",
+  name: "SLA recheck",
+});
+```
+
+Use this for SLA watchers, budget threshold rechecks, background review
+summaries, or delayed approval reminders. Keep product-specific wake logic in
+the plugin; the host seam only owns scheduling, validation, and cleanup.
+
+---
+
+### 14. Plugin-owned event emission: `api.emitAgentEvent(...)`
+
+**What it does**
+
+Lets plugins emit their own agent-event stream entries without impersonating
+host streams like `tool`, `assistant`, `approval`, or `lifecycle`. Plugin
+emissions must use a `plugin.*` stream name and carry JSON-compatible data; the
+host injects `pluginId` and `pluginName` into the payload.
+
+**Minimal example**
+
+```typescript
+api.emitAgentEvent({
+  runId,
+  sessionKey,
+  stream: "plugin.review",
+  data: {
+    phase: "summary-ready",
+    filesReviewed: 12,
+  },
+});
+```
+
+Use this for plugin-specific progress, workflow milestones, review summaries,
+or background monitor status. Subscribe to host streams with
+`registerAgentEventSubscription`; emit only plugin-namespaced streams from
+plugin code.
+
+---
+
+### 15. Sanitized event subscriptions: `api.registerAgentEventSubscription(...)`
+
+**What it does**
+
+Subscribes to host-owned, sanitized agent events (run lifecycle, tool calls,
+turn boundaries) with plugin lifecycle ownership. The subscription is torn
+down when the plugin is disabled, restarted, deleted, or reset.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginAgentEventSubscriptionRegistration = {
+  id: string;
+  description?: string;
+  streams?: AgentEventStream[];
+  handle: (
+    event: AgentEventPayload,
+    ctx: {
+      // run-scoped — runId is implied by the firing event
+      getRunContext: <T extends PluginJsonValue = PluginJsonValue>(
+        namespace: string,
+      ) => T | undefined;
+      setRunContext: (namespace: string, value: PluginJsonValue) => void;
+      clearRunContext: (namespace?: string) => void;
+    },
+  ) => void | Promise<void>;
+};
+```
+
+Inside `handle`, the run-context API is **scoped to the firing event** — you
+don't pass `runId` explicitly. Use the top-level `api.setRunContext({runId,
+namespace, ...})` if you need to write context outside an event handler.
+
+**Minimal example**
+
+```typescript
+api.registerAgentEventSubscription({
+  id: "incident-watcher.run-watcher",
+  description: "Open an incident timeline on run start",
+  streams: ["lifecycle"],
+  handle: (event, ctx) => {
+    if (event.data.phase === "start") {
+      ctx.setRunContext("incident", { startedAt: Date.now() });
+    }
+    if (event.data.phase === "error" || event.data.phase === "end") {
+      const incident = ctx.getRunContext<{ startedAt: number }>("incident");
+      if (incident) {
+        api.logger.info(`incident closed after ${Date.now() - incident.startedAt}ms`);
+      }
+    }
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Runner
+  participant Bus as Sanitized Event Bus
+  participant Plugin
+  participant Sink as External sink \n (PagerDuty, Datadog, etc.)
+
+  Plugin->>Bus: registerAgentEventSubscription({streams, handle})
+  Runner-->>Bus: agent event
+  Bus->>Plugin: handle(event, ctx)
+  Plugin->>Sink: forward sanitized event
+
+  Note over Plugin,Bus: operator disables plugin
+  Bus-->>Plugin: subscription torn down by host
+  Runner-->>Bus: more events (NOT delivered)
+```
+
+**Real-world example: Pager Bridge**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "pager-bridge",
+  name: "Pager Bridge",
+  description: "Forward sanitized run-failure events to PagerDuty",
+  register(api) {
+    let pagerClient = createPagerClient(api.pluginConfig); // your helper
+
+    api.registerAgentEventSubscription({
+      id: "pager-bridge.failures",
+      description: "Run lifecycle failures forwarded to PagerDuty",
+      streams: ["lifecycle", "tool"],
+      handle: async (event) => {
+        if (event.stream === "lifecycle" && event.data.phase === "error") {
+          await pagerClient.trigger({
+            severity: "critical",
+            summary: `Run ${event.runId} failed: ${String(event.data.error ?? "unknown")}`,
+          });
+          return;
+        }
+        if (
+          event.stream === "tool" &&
+          event.data.phase === "result" &&
+          event.data.isError === true
+        ) {
+          const toolName = String(event.data.name ?? "unknown");
+          await pagerClient.trigger({
+            severity: "warning",
+            summary: `Tool ${toolName} failed`,
+          });
+        }
+      },
+    });
+
+    api.registerRuntimeLifecycle({
+      id: "pager-bridge.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`pager-bridge cleanup reason=${reason}`);
+        await pagerClient.close();
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Events are sanitized.** You don't see raw prompts, tool params with
+  secrets, or provider request bodies. Use this for telemetry and routing,
+  not deep introspection.
+- **`handle` must be idempotent.** Restart-preserved subscriptions may see
+  the same event class on restart depending on stream semantics.
+- **Pair every long-lived resource with a `registerRuntimeLifecycle`.**
+  Event subscription teardown is automatic; sockets/timers you opened are
+  not.
+
+---
+
+### 16. Per-run plugin context: `setRunContext` / `getRunContext` / `clearRunContext`
+
+**What it does**
+
+Stores namespaced JSON-compatible per-run state. Cleared on terminal run
+events. Two flavors — top-level on `api`, or run-scoped inside an event
+handler.
+
+**Contract**
+
+```typescript
+// Top-level on api — needs explicit runId
+api.setRunContext(patch: PluginRunContextPatch): boolean;
+api.getRunContext<T>(params: PluginRunContextGetParams): T | undefined;
+api.clearRunContext(params: { runId: string; namespace?: string }): void;
+
+type PluginRunContextPatch = {
+  runId: string;
+  namespace: string;
+  value?: PluginJsonValue;
+  unset?: boolean;
+};
+type PluginRunContextGetParams = { runId: string; namespace: string };
+
+// Inside an agent-event-subscription handler ctx — runId is implied
+ctx.setRunContext(namespace: string, value: PluginJsonValue): void;
+ctx.getRunContext<T>(namespace: string): T | undefined;
+ctx.clearRunContext(namespace?: string): void;
+```
+
+`setRunContext` returns `true` on success; `false` typically means there is
+no active run for the supplied `runId` (already terminal, never started, or
+garbage-collected).
+
+**Minimal example (in-handler form)**
+
+```typescript
+api.registerAgentEventSubscription({
+  id: "billing.tagger",
+  streams: ["lifecycle", "tool"],
+  handle: (event, ctx) => {
+    if (event.stream === "lifecycle" && event.data.phase === "start") {
+      const tenantId = inferTenantFromSession(event.sessionKey); // your helper
+      ctx.setRunContext("billing", { tenantId });
+      return;
+    }
+    if (event.stream === "tool" && event.data.phase === "result" && event.data.name) {
+      const billing = ctx.getRunContext<{ tenantId: string }>("billing");
+      if (!billing) return;
+      emitBillingRow({ tenantId: billing.tenantId, tool: String(event.data.name) });
+    }
+  },
+});
+```
+
+**Minimal example (top-level form)**
+
+```typescript
+api.on("agent_end", (event, ctx) => {
+  if (!event.runId || !ctx.runId) return;
+  const summary = api.getRunContext<{ steps: number }>({
+    runId: event.runId,
+    namespace: "review",
+  });
+  api.logger.info(`run ${event.runId} ended, steps=${summary?.steps ?? 0}`);
+  api.clearRunContext({ runId: event.runId, namespace: "review" });
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Runner
+  participant Plugin
+  participant Ctx as Run Context
+  participant Sink
+
+  Runner->>Plugin: handle({stream:"lifecycle", data:{phase:"start"}}, ctx)
+  Plugin->>Ctx: ctx.setRunContext("billing", {tenantId})
+
+  loop tool events during run
+    Runner-->>Plugin: handle({stream:"tool", data:{phase:"result"}}, ctx)
+    Plugin->>Ctx: ctx.getRunContext("billing")
+    Ctx-->>Plugin: {tenantId}
+    Plugin->>Sink: emit row(tenantId, tool, cost)
+  end
+
+  Runner->>Plugin: handle({stream:"lifecycle", data:{phase:"end"}}, ctx)
+  Plugin->>Ctx: (host) clears all namespaces for runId
+```
+
+**Common pitfalls**
+
+- **Don't roll your own global maps keyed by `runId`.** That's exactly what
+  this contract is for. The host clears it deterministically; your map will
+  leak if you forget a cleanup edge case.
+- **Don't store cross-run state here.** Use `registerSessionExtension` for
+  session-lifetime state.
+- **In top-level form, check the `boolean` return.** If `false`, the run
+  is gone — your write was a no-op. Common during reload or terminal
+  races.
+
+---
+
+### 17. Session scheduler jobs: `api.registerSessionSchedulerJob(...)`
+
+**What it does**
+
+Plugin-owned scheduled work scoped to a session. Cleanup is host-driven on
+disable / reset / delete / restart, with restart-preserved jobs skipping
+teardown callbacks (so jobs aren't double-run after a host restart).
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginSessionSchedulerJobRegistration = {
+  id: string;
+  sessionKey: string;
+  kind: string;
+  description?: string;
+  cleanup?: (ctx: {
+    reason: PluginHostCleanupReason;
+    sessionKey: string;
+    jobId: string;
+  }) => void | Promise<void>;
+};
+
+export type PluginSessionSchedulerJobHandle = {
+  id: string;
+  pluginId: string;
+  sessionKey: string;
+  kind: string;
+};
+
+api.registerSessionSchedulerJob(
+  job: PluginSessionSchedulerJobRegistration,
+): PluginSessionSchedulerJobHandle | undefined;
+```
+
+Returns `undefined` if registration fails (for example, duplicate job id for
+this plugin). The job ownership key is `(pluginId, jobId)`; `sessionKey` is
+stored on the job for cleanup filtering.
+
+**Minimal example**
+
+```typescript
+const sessionKey = "agent:main:main"; // from the command/event handler context
+const handle = api.registerSessionSchedulerJob({
+  id: "follow-up-9am",
+  sessionKey,
+  kind: "follow-up",
+  description: "Wake the agent at 9am with a follow-up summary",
+  cleanup: async ({ reason, jobId }) => {
+    api.logger.info(`scheduler cleanup job=${jobId} reason=${reason}`);
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin
+  participant Sched as Session Scheduler
+  participant Host
+
+  Plugin->>Sched: registerSessionSchedulerJob({id, sessionKey, kind, cleanup})
+  Sched-->>Plugin: PluginSessionSchedulerJobHandle
+
+  Note over Plugin,Host: operator disables plugin
+  Host->>Sched: dispose plugin jobs, reason="disable"
+  Sched-->>Sched: drop jobs, run cleanup callbacks
+  Note over Sched: scheduled fire never happens
+
+  Note over Host: alternative: host restart
+  Host->>Sched: dispose, reason="restart"
+  Sched-->>Sched: keep restart-preserved jobs,\nskip cleanup callbacks
+```
+
+**Real-world example: Quiet Hours**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "quiet-hours",
+  name: "Quiet Hours",
+  description: "Suppress heartbeat nudges during configured quiet hours",
+  register(api) {
+    api.registerAgentEventSubscription({
+      id: "quiet-hours.session-watcher",
+      streams: ["session"],
+      handle: (event) => {
+        if (event.stream !== "session" || event.data.kind !== "start" || !event.sessionKey) {
+          return;
+        }
+
+        // Schedule a "resume nudges" job for the next non-quiet hour.
+        const resumeAt = computeNextResumeTime(api.pluginConfig.quietWindow);
+        api.registerSessionSchedulerJob({
+          id: `resume-nudges-${event.sessionKey}`,
+          sessionKey: event.sessionKey,
+          kind: "resume-nudges",
+          description: `Re-enable heartbeat nudges at ${new Date(resumeAt).toISOString()}`,
+        });
+      },
+    });
+
+    api.registerRuntimeLifecycle({
+      id: "quiet-hours.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`quiet-hours runtime cleanup reason=${reason}`);
+        // Scheduler jobs are cleaned up by the host already; this is for
+        // plugin-owned timers/state if any.
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Pick stable, scoped `id`s.** Job ownership is `(pluginId, jobId)`;
+  include the session key in the job id when a plugin needs one scheduled job
+  per session. Duplicate job ids for the same plugin are rejected even when
+  their payloads target different sessions.
+- **Don't assume the cleanup callback fires on restart.**
+  Restart-preserved jobs deliberately skip teardown. If you need
+  deterministic teardown on restart, use `registerRuntimeLifecycle` with
+  `reason === "restart"`.
+- **Cleanup is best-effort.** If your callback throws, the host keeps the
+  record retryable. Don't rely on cleanup for critical state — write
+  through to durable storage from the job firing path itself.
+
+---
+
+### 18. Runtime lifecycle cleanup: `api.registerRuntimeLifecycle(...)`
+
+**What it does**
+
+Lets the plugin clean up out-of-band resources (sockets, polling timers,
+file watchers, telemetry buffers) when the plugin is disabled, reset,
+deleted, or restarted. The quiet feature that makes every other contract
+safe to ship.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginRuntimeLifecycleRegistration = {
+  id: string;
+  description?: string;
+  cleanup?: (ctx: {
+    reason: PluginHostCleanupReason; // "disable" | "reset" | "delete" | "restart"
+    sessionKey?: string;
+    runId?: string;
+  }) => void | Promise<void>;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.registerRuntimeLifecycle({
+  id: "my-plugin.lifecycle",
+  description: "Close webhook subscriptions on plugin teardown",
+  cleanup: async ({ reason }) => {
+    await myWebhookClient.close();
+    api.logger.info(`my-plugin lifecycle cleanup reason=${reason}`);
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart TD
+  Trigger["Operator: disable plugin"] --> Host
+  Host --> RemoveExt["Remove plugin session extensions"]
+  Host --> RemoveInj["Remove pending next-turn injections"]
+  Host --> ClearCtx["Clear plugin run context"]
+  Host --> SchedClean["Cleanup scheduler jobs \n (retryable records kept on failure)"]
+  Host --> Lifecycle["Invoke registerRuntimeLifecycle cleanup({reason:'disable'})"]
+  Lifecycle --> Plugin["Plugin closes sockets, timers, watchers"]
+  Plugin --> Done["Plugin fully torn down \n No zombie state, no leaked resources"]
+```
+
+**Common pitfalls**
+
+- **Make `cleanup` idempotent.** It can be called more than once across the
+  plugin's lifetime; design it to be a no-op when there's nothing left to
+  clean.
+- **Don't block on long teardown.** The host awaits your callback but
+  long-running cleanup makes operator UX bad. Push slow work to fire-and-
+  forget queues if necessary.
+- **Restart vs. delete are different reasons.** `restart` preserves the
+  plugin's installation; `delete` removes it entirely. Use the `reason`
+  field to decide whether to keep on-disk caches or wipe them.
+
+---
+
+### 19. The cleanup matrix at a glance
+
+The four `PluginHostCleanupReason` values fire different combinations of
+host-driven cleanup. This table is the contract:
+
+| Reason    | Persistent extensions  | Pending injections | Run context | Scheduler jobs                            | Lifecycle callback             |
+| --------- | ---------------------- | ------------------ | ----------- | ----------------------------------------- | ------------------------------ |
+| `restart` | preserved              | preserved          | preserved   | preserved (cleanup callbacks **skipped**) | called with `reason:"restart"` |
+| `disable` | removed                | removed            | cleared     | removed                                   | called with `reason:"disable"` |
+| `reset`   | removed (for session)  | removed (session)  | cleared     | removed (session)                         | called with `reason:"reset"`   |
+| `delete`  | removed (all sessions) | removed (all)      | cleared     | removed (all)                             | called with `reason:"delete"`  |
+
+> **Why restart is special.** Restart is the only reason where scheduler
+> jobs survive but cleanup callbacks are _skipped_. The reason: cleanup
+> callbacks for scheduled jobs typically free resources the job needs to
+> fire. If you call them on restart, the surviving job has nothing left to
+> do when it fires. So the host preserves both the job and its underlying
+> resources, and the cleanup callback runs only when the job actually
+> stops being preserved (disable / reset / delete).
+
+---
+
+## Composition recipes
+
+The single-hook recipes above show how each contract behaves alone. Real
+plugins compose 2–6 hooks. Here are the canonical archetypes, fully
+worked.
+
+### Recipe A: Approval workflow plugin
+
+**Goal.** Operator runs a sensitive command (deploy, release, escalation).
+The plugin pauses execution, opens an approval card in Control UI, and
+resumes the agent on approve / deny.
+
+**Composes:** session extension + UI descriptor + scoped command +
+`continueAgent` + next-turn injection + cleanup.
+
+**Architecture**
+
+```mermaid
+flowchart TD
+  Op[Operator] --> Cmd[/deploy v1.4.2/]
+  Cmd --> BTH[before_tool_call]
+  BTH --> SE[Session extension: 'deploy-approver']
+  SE --> UI[Control UI \n approval card]
+  UI --> Patch[sessions.pluginPatch]
+  Patch --> SE
+  Op --> Approve[/deploy-approve/]
+  Approve --> Plugin
+  Plugin --> Q[Next-turn queue]
+  Plugin --> Cont[continueAgent: true]
+  Q --> Runner[Agent Runner]
+  Cont --> Runner
+  Runner --> Model
+```
+
+**End-to-end sequence**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant UI as Control UI
+  participant GW as Gateway
+  participant Cmd as Command Router
+  participant Plugin as Deploy Approver
+  participant Q as Next-turn Queue
+  participant R as Runner
+  participant M as Model
+
+  Op->>R: "deploy v1.4.2"
+  R->>M: turn
+  M-->>R: tool_call("deploy", {version:"v1.4.2"})
+  Note over R,Plugin: api.on("before_tool_call") intercepts
+
+  Plugin->>Plugin: sessionExt.deploy-approver = pending
+  Plugin->>UI: (projection) approval card visible
+  Plugin-->>R: short-circuit reply: "awaiting approval"
+
+  Op->>UI: clicks Approve
+  UI->>GW: sessions.pluginPatch(deploy-approver, {state:"approved"})
+  GW->>Plugin: validate + write
+  Op->>Cmd: /deploy-approve v1.4.2
+  Cmd->>Plugin: handler, requiredScopes ok
+  Plugin->>Q: enqueueNextTurnInjection
+  Plugin-->>Cmd: { ...reply, continueAgent: true }
+  Cmd->>R: start next turn
+  R->>Q: drain
+  R->>M: prompt + drained context
+  M-->>Op: "deploying v1.4.2 now…"
+```
+
+**Code**
+
+```typescript
+// deploy-approver/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type DeployApproverState = {
+  state: "pending" | "approved" | "denied";
+  version?: string;
+  approvedBy?: string;
+  reason?: string;
+  updatedAt: number;
+};
+
+export default definePluginEntry({
+  id: "deploy-approver",
+  name: "Deploy Approver",
+  description: "Pause deploys for human approval; resume agent on decision",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "deploy-approver",
+      description: "Per-session deploy approval state",
+    });
+
+    api.registerControlUiDescriptor({
+      id: "deploy-approver-card",
+      surface: "session",
+      label: "Deploy approval",
+      placement: "sidebar",
+      schema: {
+        kind: "approval-card",
+        valuePath: "pluginExtensions.deploy-approver.deploy-approver",
+        actions: [
+          { kind: "approve", label: "Approve", command: "/deploy-approve" },
+          { kind: "deny", label: "Deny", command: "/deploy-deny" },
+        ],
+      },
+    });
+
+    api.on("before_tool_call", async (event, ctx) => {
+      if (event.toolName !== "deploy") return;
+      if (!ctx.sessionKey) return;
+      // Mark pending and short-circuit; the operator will run /deploy-approve next.
+      await markPending(ctx.sessionKey, String(event.params.version ?? ""));
+      return {
+        block: true,
+        blockReason: "Deploy paused; awaiting operator approval. Use /deploy-approve to continue.",
+      };
+    });
+
+    api.registerCommand({
+      name: "deploy-approve",
+      description: "Approve the pending deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        const version = (ctx.args ?? "").trim();
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator approved deployment of ${version || "the pending version"}.`,
+          placement: "prepend_context",
+          idempotencyKey: `approve-${version || ctx.sessionKey}`,
+        });
+        return { text: "Approved.", continueAgent: true };
+      },
+    });
+
+    api.registerCommand({
+      name: "deploy-deny",
+      description: "Deny the pending deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator denied deployment. Cancel and explain to user.`,
+          placement: "prepend_context",
+        });
+        return { text: "Denied.", continueAgent: true };
+      },
+    });
+
+    api.registerRuntimeLifecycle({
+      id: "deploy-approver.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`deploy-approver cleanup reason=${reason}`);
+      },
+    });
+  },
+});
+
+async function markPending(_sessionKey: string, _version: string): Promise<void> {
+  // Patch in via sessions.pluginPatch from a host RPC, or from a co-registered
+  // gateway method. Sketch only; production code lives in your plugin.
+}
+```
+
+---
+
+### Recipe B: Workspace policy gate
+
+**Goal.** Bundled-only host policy. Block any tool call whose path argument
+escapes the configured workspace root, before any third-party plugin can
+intervene.
+
+**Composes:** trusted tool policy.
+
+**Architecture**
+
+```mermaid
+flowchart LR
+  Agent --> Trusted[Trusted policy]
+  Trusted -->|block / approve / rewrite| Tool
+  Trusted --> Hooks[external before_tool_call]
+  Hooks --> Tool
+  Trusted --> Audit[Policy diagnostics]
+```
+
+**Code**
+
+```typescript
+// workspace-policy/index.ts (BUNDLED-ONLY plugin)
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const PATH_TOOL_NAMES = new Set(["write_file", "delete_file", "rename_file", "exec_in_dir"]);
+
+export default definePluginEntry({
+  id: "workspace-policy",
+  name: "Workspace Policy",
+  description: "Block writes outside the configured workspace root",
+  register(api) {
+    const workspaceRoot = String(api.pluginConfig.root ?? "");
+
+    api.registerTrustedToolPolicy({
+      id: "workspace-policy.path-confinement",
+      description: "Reject path-bearing tool calls outside workspace root",
+      evaluate: (event) => {
+        if (!PATH_TOOL_NAMES.has(event.toolName)) return;
+        const raw = String(event.params?.path ?? "");
+        const normalized = normalize(raw); // your helper
+        if (!normalized.startsWith(workspaceRoot + "/")) {
+          return {
+            allow: false,
+            reason: `path "${raw}" is outside workspace root`,
+          };
+        }
+        // Rewrite to canonical form so downstream hooks see consistent params.
+        if (normalized !== raw) {
+          return { params: { ...event.params, path: normalized } };
+        }
+        return undefined;
+      },
+    });
+
+    // Tool metadata is intentionally omitted here: metadata projection applies
+    // to plugin-owned tools, while this policy gates core tools owned by the
+    // host. Use registerToolMetadata in plugins that register their own tools.
+  },
+});
+
+function normalize(p: string): string {
+  // Resolve to absolute path, collapse "..", reject symlink escapes, etc.
+  return p; // sketch
+}
+```
+
+---
+
+### Recipe C: Background lifecycle monitor
+
+**Goal.** Watch long-running runs. Open an incident timeline, schedule
+periodic ticks, surface elapsed time only on heartbeats, clean up on
+disable.
+
+**Composes:** event subscription + run context + scheduler job + heartbeat
+contribution + UI descriptor + runtime lifecycle.
+
+**Architecture**
+
+```mermaid
+flowchart TD
+  RunStart["lifecycle:start"] --> Sub[Event Subscription]
+  Sub --> Ctx[Run Context]
+  Sub --> Sched[Session Scheduler Job]
+  Sub --> UI[Control UI: incident timeline]
+
+  Tick[Scheduler tick] --> UpdateUI[Update timeline]
+
+  HB[Heartbeat] --> Contrib[heartbeat_prompt_contribution]
+  Contrib --> Ctx
+  Contrib --> Prompt[Heartbeat prompt context]
+
+  RunEnd["lifecycle:end"] --> Cleanup[Host cleanup]
+  Disable[Operator disable] --> RTL[Runtime lifecycle: close webhook]
+```
+
+**End-to-end sequence**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Run as Long-running run
+  participant Ev as Sanitized Event Bus
+  participant IC as Incident Commander
+  participant Ctx as Run Context
+  participant Sched as Scheduler
+  participant HB as Heartbeat
+  participant UI as Control UI
+  participant Op as Operator
+
+  Run-->>Ev: stream=lifecycle, data.phase=start, runId=42
+  Ev->>IC: handle(event, ctx)
+  IC->>Ctx: ctx.setRunContext("incident", {startedAt, sla:15m})
+  IC->>Sched: registerSessionSchedulerJob
+  IC->>UI: registerControlUiDescriptor (timeline empty)
+
+  loop heartbeat ticks
+    HB->>IC: heartbeat_prompt_contribution
+    IC->>Ctx: api.getRunContext({runId, namespace:"incident"})
+    IC-->>HB: { appendContext: "elapsed 7m / SLA 15m" }
+  end
+
+  Sched->>IC: tick fired
+  IC->>UI: descriptor update: "tick at 8m"
+
+  Run-->>Ev: stream=tool, data.phase=result, data.isError=true
+  Ev->>IC: handle
+  IC->>UI: descriptor update: red marker
+
+  Run-->>Ev: stream=lifecycle, data.phase=end
+  Ev->>IC: handle
+  IC->>Sched: (host) cleanup
+  IC->>Ctx: (host) clearRunContext
+  Note over Op: operator disables plugin
+  IC->>IC: registerRuntimeLifecycle.cleanup → close webhook
+```
+
+**Code**
+
+```typescript
+// incident-commander/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type IncidentState = { startedAt: number; slaMs: number };
+
+const SLA_BY_AGENT: Record<string, number> = {
+  default: 15 * 60_000,
+  "release-bot": 30 * 60_000,
+};
+
+export default definePluginEntry({
+  id: "incident-commander",
+  name: "Incident Commander",
+  description: "Track long-running runs with timeline + heartbeat-only nudges",
+  register(api) {
+    api.registerControlUiDescriptor({
+      id: "incident-timeline",
+      surface: "run",
+      label: "Incident timeline",
+      placement: "footer",
+      schema: { kind: "timeline", source: "incident-commander" },
+    });
+
+    api.registerAgentEventSubscription({
+      id: "incident-commander.run-watcher",
+      streams: ["lifecycle", "tool"],
+      handle: async (event, ctx) => {
+        if (event.stream === "lifecycle" && event.data.phase === "start") {
+          const agentId = String(event.data.agentId ?? "");
+          const sla = SLA_BY_AGENT[agentId] ?? SLA_BY_AGENT.default;
+          ctx.setRunContext("incident", { startedAt: Date.now(), slaMs: sla });
+          if (event.sessionKey) {
+            api.registerSessionSchedulerJob({
+              id: `incident-tick-${event.runId}`,
+              sessionKey: event.sessionKey,
+              kind: "incident-tick",
+            });
+          }
+        }
+        if (
+          event.stream === "tool" &&
+          event.data.phase === "result" &&
+          event.data.isError === true
+        ) {
+          const toolName = String(event.data.name ?? "unknown");
+          api.logger.warn(`incident-commander tool fail in run=${event.runId} tool=${toolName}`);
+        }
+        if (event.stream === "lifecycle" && event.data.phase === "end") {
+          ctx.clearRunContext("incident");
+        }
+      },
+    });
+
+    api.on("heartbeat_prompt_contribution", (event) => {
+      if (!event.sessionKey || !event.agentId) return;
+      // Look up the latest run context the heartbeat path knows about.
+      // (In production, snapshot the runId in your run-watcher and read from there.)
+      return undefined; // sketch — replace with elapsed/remaining computation
+    });
+
+    api.registerRuntimeLifecycle({
+      id: "incident-commander.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`incident-commander cleanup reason=${reason}`);
+        // Close any external webhooks, flush incident store, etc.
+      },
+    });
+  },
+});
+```
+
+---
+
+### Recipe D: Setup / onboarding wizard
+
+**Goal.** First-run onboarding flow that walks the operator through provider
+auth, workspace selection, and a smoke test. Each step persists progress so
+operators can resume across reloads.
+
+**Composes:** session extension + scoped commands + UI descriptor.
+
+**Architecture**
+
+```mermaid
+flowchart LR
+  Op[Operator] --> Card[UI: setup card]
+  Card --> Cmd1[/setup-step provider/]
+  Card --> Cmd2[/setup-step workspace/]
+  Card --> Cmd3[/setup-step smoke-test/]
+  Cmd1 --> SE[Session extension: 'setup']
+  Cmd2 --> SE
+  Cmd3 --> SE
+  SE --> Card
+```
+
+**Code**
+
+```typescript
+// setup-wizard/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type SetupStep = "provider" | "workspace" | "smoke-test";
+type SetupState = {
+  completed: SetupStep[];
+  current: SetupStep | "done";
+};
+
+export default definePluginEntry({
+  id: "setup-wizard",
+  name: "Setup Wizard",
+  description: "Multi-step first-run onboarding",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "setup",
+      description: "First-run onboarding progress",
+    });
+
+    api.registerControlUiDescriptor({
+      id: "setup-card",
+      surface: "session",
+      label: "Setup",
+      placement: "header",
+      schema: {
+        kind: "wizard-card",
+        valuePath: "pluginExtensions.setup-wizard.setup",
+        steps: [
+          { id: "provider", label: "Choose a provider" },
+          { id: "workspace", label: "Pick your workspace" },
+          { id: "smoke-test", label: "Run a smoke test" },
+        ],
+      },
+    });
+
+    api.registerCommand({
+      name: "setup-advance",
+      description: "Mark the current onboarding step complete",
+      acceptsArgs: true,
+      requiredScopes: ["operator.write"],
+      handler: async (ctx) => {
+        const step = (ctx.args ?? "").trim() as SetupStep;
+        if (!step) {
+          return { text: "Usage: /setup-advance <provider|workspace|smoke-test>" };
+        }
+        // In production: read state, append, write back via sessions.pluginPatch
+        return { text: `Marked ${step} complete.`, continueAgent: false };
+      },
+    });
+  },
+});
+```
+
+---
+
+### Recipe E: Review assistant
+
+**Goal.** Watch tool failures, queue diagnostic context for the next turn,
+tag review-relevant tools in the catalog, surface session review status.
+
+**Composes:** event subscription + next-turn injection + tool metadata + UI
+descriptor.
+
+```typescript
+// review-assistant/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const REVIEW_TOOLS = ["run_tests", "lint", "typecheck", "build"];
+
+export default definePluginEntry({
+  id: "review-assistant",
+  name: "Review Assistant",
+  description: "Auto-diagnose test/build failures and resurface them next turn",
+  register(api) {
+    api.registerSessionExtension({
+      namespace: "review",
+      description: "Per-session review summary: lastFailure, lastDiagnosis",
+    });
+
+    api.registerControlUiDescriptor({
+      id: "review-summary-card",
+      surface: "session",
+      label: "Review",
+      placement: "sidebar",
+      schema: {
+        kind: "review-summary",
+        valuePath: "pluginExtensions.review-assistant.review",
+      },
+    });
+
+    for (const name of REVIEW_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        tags: ["review"],
+      });
+    }
+
+    api.registerAgentEventSubscription({
+      id: "review-assistant.failure-watcher",
+      streams: ["tool"],
+      handle: async (event) => {
+        if (
+          event.stream !== "tool" ||
+          event.data.phase !== "result" ||
+          event.data.isError !== true
+        ) {
+          return;
+        }
+        const toolName = String(event.data.name ?? "");
+        if (!event.sessionKey || !toolName) return;
+        if (!REVIEW_TOOLS.includes(toolName)) return;
+
+        const summary = await summarizeFailure(event.data.result); // your helper
+        const toolCallId = String(event.data.toolCallId ?? "unknown");
+        await api.enqueueNextTurnInjection({
+          sessionKey: event.sessionKey,
+          text: `Review notes for ${toolName} failure:\n\n${summary}`,
+          placement: "prepend_context",
+          idempotencyKey: `review-fail-${event.runId}-${toolCallId}`,
+          ttlMs: 10 * 60_000,
+        });
+      },
+    });
+
+    api.registerRuntimeLifecycle({
+      id: "review-assistant.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`review-assistant cleanup reason=${reason}`);
+      },
+    });
+  },
+});
+
+async function summarizeFailure(_event: unknown): Promise<string> {
+  return "(failure summary placeholder)";
+}
+```
+
+---
+
+## Patterns and pitfalls
+
+## Compose, do not subclass
+
+Each contract is independent. Don't try to wrap `registerSessionExtension`
+or `registerCommand` into a higher-level abstraction inside your plugin —
+the SDK already provides the right granularity. Two contracts that always
+appear together (session extension + UI descriptor) are still better as
+two separate registrations than one fused helper.
+
+## Keep handlers cheap
+
+`heartbeat_prompt_contribution`, `agent_turn_prepare`, and event-subscription
+`handle` callbacks all run on hot paths. Cache pre-computed values in
+your closure or in run/session context; avoid synchronous I/O.
+
+## Prefer projection over duplication
+
+If clients need to read plugin state, use `registerSessionExtension({project})`
+rather than copying the same data into a custom Gateway method. Two
+plugins reading the same row see the same projection; clients only need to
+learn `pluginExtensions[<id>][<namespace>]`.
+
+## Prefer next-turn injection over `before_prompt_build`
+
+For one-shot context (post-approval continuation, post-failure diagnosis,
+operator-triggered events), use `enqueueNextTurnInjection`. Reserve
+`before_prompt_build` for context that genuinely belongs in **every**
+turn (memory adjuncts, capability hints, tool documentation).
+
+## Pair every `register*` that opens a resource with a `registerRuntimeLifecycle`
+
+Event subscriptions, session extensions, and scheduler jobs are torn down by
+the host. Sockets, polling timers, file watchers, telemetry buffers, and
+external clients **are not**. If you opened it, register a lifecycle
+cleanup for it. The host calls cleanup on disable / reset / delete /
+restart — write idempotently.
+
+## Test against the contract suite
+
+`src/plugins/contracts/host-hooks.contract.test.ts` is the authoritative
+behavior spec. When you add a new plugin that exercises a host-hook surface,
+mirror its assertions in your own tests:
+
+- For session extensions: assert that a patch round-trips through
+  `sessions.pluginPatch` and your `project()` callback.
+- For next-turn injections: assert that two enqueues with the same
+  idempotency key produce one delivered injection.
+- For trusted tool policy: assert that `allow:false` becomes
+  `block: true, blockReason` downstream.
+- For commands: assert that `requiredScopes` is enforced for both
+  permitted and rejected callers.
+- For UI descriptors: assert the `plugins.uiDescriptors` Gateway response
+  includes your descriptor with `pluginId` injected.
+- For event subscriptions: assert that disable tears the subscription
+  down and post-disable events are not delivered.
+- For run context: assert that terminal run events clear all
+  namespaces.
+- For scheduler jobs: assert that each cleanup reason produces the
+  documented behavior (especially that `restart` skips teardown
+  callbacks).
+
+---
+
+## Cleanup matrix end-to-end
+
+This sequence is the canonical "operator disables a plugin that uses every
+host-hook contract":
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant Host
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+  participant Q as Next-turn Queue
+  participant Ctx as Run Context
+  participant Sched as Scheduler
+  participant Plug as Plugin
+
+  Op->>Host: disable plugin "incident-commander"
+  Host->>Reg: deregister all surfaces
+  Host->>Store: remove pluginExtensions[incident-commander][*]
+  Host->>Q: drop queued injections for plugin
+  Host->>Ctx: clear run-context namespaces for plugin
+  Host->>Sched: dispose plugin scheduler jobs (call cleanup callbacks)
+  Host->>Plug: registerRuntimeLifecycle.cleanup({reason:"disable"})
+  Plug->>Plug: close webhooks, timers, watchers, flush telemetry
+  Plug-->>Host: cleanup resolved
+  Host-->>Op: plugin disabled — no zombie state, no leaked resources
+```
+
+Compare to **restart** (host preserves jobs, skips teardown callbacks, but
+still calls runtime lifecycle for resource cleanup):
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant Host
+  participant Sched as Scheduler
+  participant Plug as Plugin
+
+  Op->>Host: restart plugin "incident-commander"
+  Host->>Sched: dispose, reason="restart"
+  Sched-->>Sched: keep restart-preserved jobs, SKIP cleanup callbacks
+  Host->>Plug: registerRuntimeLifecycle.cleanup({reason:"restart"})
+  Plug->>Plug: close webhooks, timers (will reopen on re-register)
+  Note over Sched: jobs survive — fire normally after restart
+```
+
+---
+
+## Testing your plugin against host hooks
+
+The contract test file (`src/plugins/contracts/host-hooks.contract.test.ts`)
+is 1,637 lines of executable spec. Every plugin that touches a host-hook
+contract should have its own coverage that mirrors the relevant subset.
+
+A reasonable pattern:
+
+```typescript
+// my-plugin/host-hooks.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import myPlugin from "./index";
+
+describe("my-plugin host hooks", () => {
+  it("registers session extension and projects state", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        myPlugin.register?.(api);
+      },
+    });
+
+    expect(registry.registry.sessionExtensions).toEqual([
+      expect.objectContaining({
+        pluginId: "my-plugin",
+        extension: expect.objectContaining({ namespace: "my-namespace" }),
+      }),
+    ]);
+  });
+
+  it("queues exactly-once injections by idempotency key", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    const results: unknown[] = [];
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        results.push(
+          api.enqueueNextTurnInjection({
+            sessionKey: "agent:main:main",
+            text: "hello",
+            idempotencyKey: "k1",
+          }),
+        );
+      },
+    });
+
+    await expect(results[0]).resolves.toMatchObject({ enqueued: true });
+  });
+
+  it("registers event subscriptions with a stable plugin owner", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        api.registerAgentEventSubscription({
+          id: "test.recorder",
+          streams: ["lifecycle"],
+          handle: () => undefined,
+        });
+      },
+    });
+
+    expect(registry.registry.agentEventSubscriptions).toEqual([
+      expect.objectContaining({
+        pluginId: "my-plugin",
+        subscription: expect.objectContaining({ id: "test.recorder" }),
+      }),
+    ]);
+  });
+});
+```
+
+The exported helpers in `openclaw/plugin-sdk/plugin-test-contracts` expose
+enough host fixtures to exercise every contract above.
+
+---
+
+## Closing
+
+If you've made it this far, you have the full picture: 17 host-hook
+contracts, 5 composition recipes, the cleanup matrix, and a testing
+pattern. The host-hook contract is small on purpose — every surface here
+solves one problem cleanly, composes with the others, and cleans up after
+itself.
+
+If you're building a plugin and a contract above doesn't fit your need,
+that's worth opening an issue or RFC discussion before working around it.
+The right answer is usually a small new contract; the wrong answer is
+patching core. Planning workflows are one tenant. Yours can be the next.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Plugin SDK overview" icon="book" href="/plugins/sdk-overview">
+    Reference for every registration method on `OpenClawPluginApi`.
+  </Card>
+  <Card title="Plugin hooks" icon="bolt" href="/plugins/hooks">
+    The full hook catalog (agent turn, tools, messages, sessions, lifecycle).
+  </Card>
+  <Card title="Building plugins" icon="cube" href="/plugins/building-plugins">
+    Step-by-step guide to scaffolding a new plugin.
+  </Card>
+  <Card title="Plugin internals" icon="diagram-project" href="/plugins/architecture-internals">
+    Deep architecture and capability model.
+  </Card>
+</CardGroup>

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -197,13 +197,6 @@ export default definePluginEntry({
     api.registerSessionExtension({
       namespace: "review-status",
       description: "Per-session review state: pending | in_review | approved",
-      sessionEntrySlotKey: "reviewStatus",
-      sessionEntrySlotSchema: {
-        type: "object",
-        properties: {
-          status: { type: "string" },
-        },
-      },
       project: ({ state }) => {
         // Show a friendly summary; persist the raw record
         if (!state || typeof state !== "object" || Array.isArray(state)) {
@@ -1352,10 +1345,11 @@ api.registerControlUiDescriptor({
 });
 ```
 
-The web Control UI, the macOS app, and the iOS app each ship a `meter`
-renderer that knows how to find the matching `pluginExtensions[]` entry by
-`pluginId` and `namespace`, then read `valuePath` and `capPath` relative to
-that entry. The plugin only ships data — never UI code.
+This descriptor is a companion-implementation contract, not a stable-client
+promise. A client that implements a `meter` renderer can find the matching
+`pluginExtensions[]` entry by `pluginId` and `namespace`, then read `valuePath`
+and `capPath` relative to that entry. The plugin only ships data — never UI
+code.
 
 **Common pitfalls**
 

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -86,10 +86,6 @@ export default definePluginEntry({
     //   api.registerAgentEventSubscription(...)
     //   api.setRunContext(...) / getRunContext(...) / clearRunContext(...)
     //   api.registerSessionSchedulerJob(...)
-    //   api.registerSessionAction(...)
-    //   api.sendSessionAttachment(...)
-    //   api.scheduleSessionTurn(...)
-    //   api.emitAgentEvent(...)
     //
     // And new typed hook names for api.on(...):
     //   "agent_turn_prepare"

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -94,6 +94,11 @@ export default definePluginEntry({
 });
 ```
 
+Companion PRs add additional SDK surfaces that are referenced later in this
+recipe guide but are not available on current stable `main` until those PRs
+merge: session actions (#75578), host-mediated attachments (#75581), scheduled
+turn helpers (#75588), and guarded `SessionEntry` slot mirrors (#75609).
+
 If you only need one host-hook surface, you can ignore the others. Composition
 is opt-in and lazy — registering nothing in a category means the plugin does
 not participate in that category.
@@ -115,6 +120,7 @@ plugin id key the storage.
 
 ```typescript
 // from src/plugins/host-hooks.ts
+// sessionEntrySlotKey/sessionEntrySlotSchema are companion #75609 fields.
 export type PluginSessionExtensionRegistration = {
   namespace: string;
   description: string;
@@ -137,6 +143,16 @@ export type PluginSessionExtensionProjectionContext = {
 stored value as a `pluginExtensions` row entry with `{ pluginId, namespace,
 value }`. Pass `project()` when you want to _transform_ what clients see (for
 example, hide secrets, or return a different shape than what you persist).
+
+`GatewaySessionRow.pluginExtensions` is an array of projection entries, not a
+nested object. Clients may derive a convenience map like
+`pluginExtensionsByPlugin[pluginId][namespace]`, but that map is client-owned.
+
+<Note>
+  `sessionEntrySlotKey` and `sessionEntrySlotSchema` are companion #75609
+  additions. Until #75609 merges, use the `pluginExtensions[]` projection array
+  for Gateway session rows.
+</Note>
 
 You can also set `sessionEntrySlotKey` when one non-plugin reader needs a
 stable top-level `SessionEntry` field instead of a `pluginExtensions[]`
@@ -216,11 +232,13 @@ sequenceDiagram
   UI->>GW: sessions.pluginPatch({pluginId, namespace, value: {...}})
   GW->>Reg: lookup (pluginId, namespace) — reject if unknown
   Reg->>Store: write namespaced state
-  Store-->>GW: raw state saved
-  GW->>Plugin: build session row, invoke project({sessionKey, sessionId, state})
+  Store-->>GW: { ok, key, value }
+  GW-->>UI: { ok, key, value }
+  GW-->>UI: sessions.changed notification
+  UI->>GW: refresh session row
+  GW->>Plugin: build row projection with project({sessionKey, sessionId, state})
   Plugin-->>GW: pluginExtensions[] projection entry
-  GW->>Store: mirror projected value to SessionEntry.reviewStatus
-  GW-->>UI: live row update
+  GW-->>UI: refreshed row (and #75609 slot mirror when enabled)
 ```
 
 **Real-world example: Review Concierge session state**
@@ -313,6 +331,8 @@ export default definePluginEntry({
 Lets privileged Control UI / mobile / desktop / internal clients update
 plugin-owned session state through the Gateway, with namespace-and-plugin-id
 validation at the wire. The Gateway method requires `operator.admin` scope.
+The RPC returns `{ ok, key, value }`; session-row projection happens on the
+subsequent session refresh, not as a nested object in the patch response.
 
 **Contract**
 
@@ -355,16 +375,18 @@ sequenceDiagram
   participant Store as Session Store
 
   UI->>GW: sessions.pluginPatch(params)
-  GW->>GW: validate params shape
+  GW->>GW: validate params shape and operator.admin scope
   GW->>Reg: lookup (pluginId, namespace) — must be registered
   alt unknown plugin or namespace
-    Reg-->>GW: 404 unknown plugin session extension
-    GW-->>UI: error: unknown plugin session extension: id/namespace
+    Reg-->>GW: unknown plugin session extension
+    GW-->>UI: JSON-RPC INVALID_REQUEST error: "unknown plugin session extension: id/namespace"
   else registered
-    Reg->>Store: write patched value (or unset)
-    Store->>Reg: invoke project() callback
-    Reg-->>GW: updated session row
+    GW->>Store: write patched value (or unset)
+    Store-->>GW: persisted namespace value
     GW-->>UI: { ok: true, key, value }
+    GW-->>UI: sessions.changed notification
+    UI->>GW: sessions.list/detail refresh
+    GW->>Reg: project pluginExtensions[] for session row
   end
 ```
 
@@ -538,10 +560,10 @@ export default definePluginEntry({
 - **`idempotencyKey` is plugin-scoped per session.** If two plugins both
   enqueue with the same key, both fire. The dedup is `(pluginId, sessionKey,
 idempotencyKey)`.
-- **A drain consumes all of this session's queue, including from
-  transiently-inactive plugins.** This is intentional (the drain is the
-  consume boundary). If you need to reschedule across registry hot-reload,
-  re-enqueue from your reload hook.
+- **A drain only delivers active loaded plugins with prompt injection enabled.**
+  Records for inactive or disabled plugins are discarded when any drain happens
+  for that session. If you need to survive a registry hot-reload, re-enqueue
+  from your reload hook.
 
 ---
 
@@ -1343,6 +1365,11 @@ row. The plugin only ships data — never UI code.
 
 ### 11. Host-mediated session actions: `api.registerSessionAction(...)`
 
+<Note>
+  Companion implementation: #75578. `api.registerSessionAction(...)` is not
+  available on current stable `main` until that PR merges.
+</Note>
+
 **What it does**
 
 Registers a typed action that trusted clients can invoke through the host. The
@@ -1379,7 +1406,6 @@ api.registerSessionAction({
       sessionKey: ctx.sessionKey,
       placement: "prepend_context",
       text: `Deployment decision: ${decision}`,
-      priority: 100,
       idempotencyKey: `deploy:${decision}`,
     });
     return { data: { decision }, continueAgent: true };
@@ -1395,6 +1421,11 @@ operation.
 ---
 
 ### 12. Host-mediated attachments: `api.sendSessionAttachment(...)`
+
+<Note>
+  Companion implementation: #75581. `api.sendSessionAttachment(...)` is not
+  available on current stable `main` until that PR merges.
+</Note>
 
 **What it does**
 
@@ -1425,6 +1456,11 @@ structured result instead; attachment delivery is bundled-only.
 
 ### 13. Scheduled follow-up turns: `api.scheduleSessionTurn(...)`
 
+<Note>
+  Companion implementation: #75588. `api.scheduleSessionTurn(...)` is not
+  available on current stable `main` until that PR merges.
+</Note>
+
 **What it does**
 
 Registers a plugin-owned follow-up turn through the host scheduler. The host
@@ -1451,6 +1487,14 @@ the plugin; the host seam only owns scheduling, validation, and cleanup.
 ---
 
 ### 14. Plugin-owned event emission: `api.emitAgentEvent(...)`
+
+<Note>
+  This recipe is a future/candidate plugin-facing event-emission seam. There is
+  no `api.emitAgentEvent(...)` method on current stable `OpenClawPluginApi`;
+  do not implement against this name until a companion implementation PR adds
+  it. Current plugins can subscribe to sanitized host streams with
+  `api.registerAgentEventSubscription(...)`.
+</Note>
 
 **What it does**
 
@@ -1926,7 +1970,7 @@ host-driven cleanup. This table is the contract:
 
 | Reason    | Persistent extensions  | Pending injections | Run context | Scheduler jobs                            | Lifecycle callback             |
 | --------- | ---------------------- | ------------------ | ----------- | ----------------------------------------- | ------------------------------ |
-| `restart` | preserved              | preserved          | preserved   | preserved (cleanup callbacks **skipped**) | called with `reason:"restart"` |
+| `restart` | preserved              | preserved          | cleared     | preserved (cleanup callbacks **skipped**) | called with `reason:"restart"` |
 | `disable` | removed                | removed            | cleared     | removed                                   | called with `reason:"disable"` |
 | `reset`   | removed (for session)  | removed (session)  | cleared     | removed (session)                         | called with `reason:"reset"`   |
 | `delete`  | removed (all sessions) | removed (all)      | cleared     | removed (all)                             | called with `reason:"delete"`  |
@@ -1937,7 +1981,9 @@ host-driven cleanup. This table is the contract:
 > fire. If you call them on restart, the surviving job has nothing left to
 > do when it fires. So the host preserves both the job and its underlying
 > resources, and the cleanup callback runs only when the job actually
-> stops being preserved (disable / reset / delete).
+> stops being preserved (disable / reset / delete). Run context is still
+> cleared on restart because it is per-run scratch state, not durable plugin
+> session state.
 
 ---
 

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -1338,8 +1338,13 @@ api.registerControlUiDescriptor({
   placement: "header",
   schema: {
     kind: "meter",
-    valuePath: "pluginExtensions.budget-guard.budget.spent",
-    capPath: "pluginExtensions.budget-guard.budget.capUsd",
+    source: {
+      kind: "pluginExtension",
+      pluginId: "budget-guard",
+      namespace: "budget",
+    },
+    valuePath: "value.spent",
+    capPath: "value.capUsd",
     format: "usd",
     warningRatio: 0.8,
     criticalRatio: 1.0,
@@ -1348,8 +1353,9 @@ api.registerControlUiDescriptor({
 ```
 
 The web Control UI, the macOS app, and the iOS app each ship a `meter`
-renderer that knows how to read `valuePath` and `capPath` from the session
-row. The plugin only ships data — never UI code.
+renderer that knows how to find the matching `pluginExtensions[]` entry by
+`pluginId` and `namespace`, then read `valuePath` and `capPath` relative to
+that entry. The plugin only ships data — never UI code.
 
 **Common pitfalls**
 
@@ -2088,7 +2094,12 @@ export default definePluginEntry({
       placement: "sidebar",
       schema: {
         kind: "approval-card",
-        valuePath: "pluginExtensions.deploy-approver.deploy-approver",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "deploy-approver",
+          namespace: "deploy-approver",
+        },
+        valuePath: "value",
         actions: [
           { kind: "approve", label: "Approve", command: "/deploy-approve" },
           { kind: "deny", label: "Deny", command: "/deploy-deny" },
@@ -2427,7 +2438,12 @@ export default definePluginEntry({
       placement: "header",
       schema: {
         kind: "wizard-card",
-        valuePath: "pluginExtensions.setup-wizard.setup",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "setup-wizard",
+          namespace: "setup",
+        },
+        valuePath: "value",
         steps: [
           { id: "provider", label: "Choose a provider" },
           { id: "workspace", label: "Pick your workspace" },
@@ -2487,7 +2503,12 @@ export default definePluginEntry({
       placement: "sidebar",
       schema: {
         kind: "review-summary",
-        valuePath: "pluginExtensions.review-assistant.review",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "review-assistant",
+          namespace: "review",
+        },
+        valuePath: "value",
       },
     });
 

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -120,6 +120,8 @@ export type PluginSessionExtensionRegistration = {
   description: string;
   project?: (ctx: PluginSessionExtensionProjectionContext) => PluginJsonValue | undefined;
   cleanup?: (ctx: { reason: PluginHostCleanupReason; sessionKey?: string }) => void | Promise<void>;
+  sessionEntrySlotKey?: string;
+  sessionEntrySlotSchema?: PluginJsonValue;
 };
 
 export type PluginSessionExtensionProjectionContext = {
@@ -136,6 +138,35 @@ stored value as a `pluginExtensions` row entry with `{ pluginId, namespace,
 value }`. Pass `project()` when you want to _transform_ what clients see (for
 example, hide secrets, or return a different shape than what you persist).
 
+You can also set `sessionEntrySlotKey` when one non-plugin reader needs a
+stable top-level `SessionEntry` field instead of a `pluginExtensions[]`
+projection entry. The host mirrors the projected value into
+`SessionEntry[sessionEntrySlotKey]` after each successful
+`sessions.pluginPatch` call, using the same projection source as
+`pluginExtensions[]`: `project({ sessionKey, sessionId, state })` when present,
+or the raw JSON-compatible state when no projector is registered. The mirror is
+read-only: clients still write through `sessions.pluginPatch`, and the host
+overwrites the slot on the next patch. `sessionEntrySlotSchema` is optional
+JSON-compatible registration metadata describing the projected slot shape; it
+does not replace the patch path's JSON-compatible state validation.
+
+Slot keys are intentionally narrow. They must be identifier-style names, cannot
+collide with current `SessionEntry` fields, cannot use prototype keys such as
+`__proto__`, `constructor`, `prototype`, `toString`, or `hasOwnProperty`, and
+must be unique across all registered session extensions. If `project()` returns
+`undefined`, throws, returns a promise, or returns a non-JSON value, the host
+keeps the namespaced plugin state but clears the top-level mirror so stale
+slot data is not exposed. `unset: true` removes both the namespace state and
+the promoted slot. Reset/delete/disable cleanup clears the owning plugin's
+session extensions, pending next-turn injections, and promoted slots; restart
+cleanup keeps durable session state.
+
+Use ordinary `pluginExtensions[]` when plugin-aware clients can read by
+`pluginId` and `namespace`, when several plugins may expose similar state, or
+when the state is only for your own UI. Use `sessionEntrySlotKey` only for a
+small, non-secret, stable summary that a generic session reader needs without
+knowing your plugin namespace.
+
 **Minimal example**
 
 ```typescript
@@ -150,6 +181,13 @@ export default definePluginEntry({
     api.registerSessionExtension({
       namespace: "review-status",
       description: "Per-session review state: pending | in_review | approved",
+      sessionEntrySlotKey: "reviewStatus",
+      sessionEntrySlotSchema: {
+        type: "object",
+        properties: {
+          status: { type: "string" },
+        },
+      },
       project: ({ state }) => {
         // Show a friendly summary; persist the raw record
         if (!state || typeof state !== "object" || Array.isArray(state)) {
@@ -181,6 +219,7 @@ sequenceDiagram
   Store-->>GW: raw state saved
   GW->>Plugin: build session row, invoke project({sessionKey, sessionId, state})
   Plugin-->>GW: pluginExtensions[] projection entry
+  GW->>Store: mirror projected value to SessionEntry.reviewStatus
   GW-->>UI: live row update
 ```
 
@@ -220,6 +259,15 @@ export default definePluginEntry({
     api.registerSessionExtension({
       namespace: "review-state",
       description: "Files approved or rejected for code review during this session",
+      sessionEntrySlotKey: "reviewSummary",
+      sessionEntrySlotSchema: {
+        type: "object",
+        properties: {
+          approvedCount: { type: "number" },
+          rejectedCount: { type: "number" },
+          totalReviewed: { type: "number" },
+        },
+      },
       project: ({ state }): ReviewStateProjection | undefined => {
         if (!isReviewState(state)) return undefined;
         return {
@@ -249,6 +297,12 @@ export default definePluginEntry({
 - **Cleanup is host-driven for the persisted state.** You don't need to clear
   the namespace from `cleanup()`. Use `cleanup()` for _plugin-owned_
   out-of-band resources only (timers, caches, file watchers).
+- **Promoted slots are not a write API.** `sessionEntrySlotKey` mirrors the
+  projected value into a top-level `SessionEntry` field for readers. Clients
+  still mutate the plugin namespace through `sessions.pluginPatch`.
+- **Reserve promoted slots for stable generic readers.** If the consumer is
+  already plugin-aware, keep the default `pluginExtensions[]` projection and
+  avoid adding a top-level field.
 
 ---
 

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -135,10 +135,10 @@ export type PluginSessionExtensionProjectionContext = {
 // PluginHostCleanupReason = "disable" | "reset" | "delete" | "restart"
 ```
 
-`project()` is optional — if you don't pass one, the host returns the raw
-stored state under `pluginExtensions[<pluginId>][<namespace>]`. Pass `project()`
-when you want to _transform_ what clients see (for example, hide secrets, or
-return a different shape than what you persist).
+`project()` is optional — if you don't pass one, the host projects the raw
+stored value as a `pluginExtensions` row entry with `{ pluginId, namespace,
+value }`. Pass `project()` when you want to _transform_ what clients see (for
+example, hide secrets, or return a different shape than what you persist).
 
 **Minimal example**
 
@@ -182,9 +182,9 @@ sequenceDiagram
   UI->>GW: sessions.pluginPatch({pluginId, namespace, value: {...}})
   GW->>Reg: lookup (pluginId, namespace) — reject if unknown
   Reg->>Store: write namespaced state
-  Store->>Plugin: invoke project({sessionKey, sessionId, state})
-  Plugin-->>Store: projection JSON
-  Store-->>GW: session row with pluginExtensions[pluginId][namespace] = projection
+  Store-->>GW: raw state saved
+  GW->>Plugin: build session row, invoke project({sessionKey, sessionId, state})
+  Plugin-->>GW: pluginExtensions[] projection entry
   GW-->>UI: live row update
 ```
 
@@ -260,9 +260,9 @@ export default definePluginEntry({
 
 **What it does**
 
-Lets Control UI / mobile / desktop / internal clients update plugin-owned
-session state through the Gateway, with namespace-and-plugin-id validation
-at the wire.
+Lets privileged Control UI / mobile / desktop / internal clients update
+plugin-owned session state through the Gateway, with namespace-and-plugin-id
+validation at the wire. The Gateway method requires `operator.admin` scope.
 
 **Contract**
 
@@ -378,7 +378,6 @@ export type PluginNextTurnInjection = {
   idempotencyKey?: string;
   placement?: PluginNextTurnInjectionPlacement;
   ttlMs?: number;
-  priority?: number;
   metadata?: PluginJsonValue;
 };
 
@@ -503,10 +502,10 @@ idempotencyKey)`.
 Receives the drained next-turn injections and lets you fold them into prompt
 context **before** the ordinary `before_prompt_build` hook fires. Use this
 when the queued context needs plugin-side shaping before it becomes part of
-the prompt. If no plugin handles `agent_turn_prepare`, the host applies the
-default fold for queued injections: `prepend_context` items go before the
-turn prompt, `append_context` items go after it, and priority decides ordering
-within each placement.
+the prompt. The host always applies the default fold for queued injections:
+`prepend_context` items go before the turn prompt, `append_context` items go
+after it, and drained records keep chronological ordering. `agent_turn_prepare`
+handlers can add plugin-shaped context alongside that default fold.
 
 **Contract**
 
@@ -541,12 +540,13 @@ api.on("agent_turn_prepare", (event) => {
 ```mermaid
 flowchart LR
   Drain["drainPluginNextTurnInjections(sessionKey)"]
-  Drain --> Sort["sort by createdAt"]
+  Drain --> Sort["sort chronologically by createdAt"]
   Sort --> ATP["agent_turn_prepare hooks (priority order)"]
-  ATP --> Defaults["host default fold\nfor queued injections"]
-  ATP --> Custom["plugin-custom fold"]
-  Defaults --> PB["before_prompt_build"]
-  Custom --> PB
+  Sort --> Defaults["host default fold\nfor queued injections"]
+  ATP --> Custom["plugin-added context"]
+  Defaults --> Merge["merge prompt context"]
+  Custom --> Merge
+  Merge --> PB["before_prompt_build"]
   PB --> Build["prompt build"]
 ```
 
@@ -586,8 +586,9 @@ api.on(
 - **Don't drop other plugins' injections.** Filter to your own `pluginId`
   before consuming. The host defaults already handle every plugin's items —
   if you replace the default, do it for _your_ injections only.
-- **`agent_turn_prepare` runs only on user-initiated turns.** For
-  background-only context use `heartbeat_prompt_contribution` instead.
+- **`agent_turn_prepare` runs during prompt builds, including heartbeat runs.**
+  Use `heartbeat_prompt_contribution` for context that should apply only to
+  heartbeat-triggered turns.
 - **`allowPromptInjection=false` disables this hook per-plugin.** Operators
   can opt out of any prompt-mutating plugin individually.
 
@@ -2446,7 +2447,7 @@ async function summarizeFailure(_event: unknown): Promise<string> {
 
 ## Patterns and pitfalls
 
-## Compose, do not subclass
+### Compose, do not subclass
 
 Each contract is independent. Don't try to wrap `registerSessionExtension`
 or `registerCommand` into a higher-level abstraction inside your plugin —
@@ -2454,27 +2455,27 @@ the SDK already provides the right granularity. Two contracts that always
 appear together (session extension + UI descriptor) are still better as
 two separate registrations than one fused helper.
 
-## Keep handlers cheap
+### Keep handlers cheap
 
 `heartbeat_prompt_contribution`, `agent_turn_prepare`, and event-subscription
 `handle` callbacks all run on hot paths. Cache pre-computed values in
 your closure or in run/session context; avoid synchronous I/O.
 
-## Prefer projection over duplication
+### Prefer projection over duplication
 
 If clients need to read plugin state, use `registerSessionExtension({project})`
 rather than copying the same data into a custom Gateway method. Two
 plugins reading the same row see the same projection; clients only need to
-learn `pluginExtensions[<id>][<namespace>]`.
+learn the `pluginExtensions[]` projection entries.
 
-## Prefer next-turn injection over `before_prompt_build`
+### Prefer next-turn injection over `before_prompt_build`
 
 For one-shot context (post-approval continuation, post-failure diagnosis,
 operator-triggered events), use `enqueueNextTurnInjection`. Reserve
 `before_prompt_build` for context that genuinely belongs in **every**
 turn (memory adjuncts, capability hints, tool documentation).
 
-## Pair every `register*` that opens a resource with a `registerRuntimeLifecycle`
+### Pair every `register*` that opens a resource with a `registerRuntimeLifecycle`
 
 Event subscriptions, session extensions, and scheduler jobs are torn down by
 the host. Sockets, polling timers, file watchers, telemetry buffers, and
@@ -2482,7 +2483,7 @@ external clients **are not**. If you opened it, register a lifecycle
 cleanup for it. The host calls cleanup on disable / reset / delete /
 restart — write idempotently.
 
-## Test against the contract suite
+### Test against the contract suite
 
 `src/plugins/contracts/host-hooks.contract.test.ts` is the authoritative
 behavior spec. When you add a new plugin that exercises a host-hook surface,

--- a/docs/plugins/host-hooks-examples.md
+++ b/docs/plugins/host-hooks-examples.md
@@ -1,0 +1,2819 @@
+---
+summary: "Host-hook recipes: worked examples, composition patterns, and plugin archetypes for the generic plugin host-hook contracts"
+title: "Host-hook examples and recipes"
+sidebarTitle: "Host-hook examples"
+read_when:
+  - You are building a plugin that participates in the host lifecycle (approval flow, policy gate, monitor, wizard, dashboard)
+  - You want a worked example of a specific host-hook contract
+  - You are choosing which hooks to compose for a workflow plugin archetype
+  - You want a starting skeleton for a workflow-style plugin without writing core
+---
+
+This doc is a recipe book. It does not re-document the API surface — that is the
+job of [Plugin SDK overview](/plugins/sdk-overview)
+and [Plugin hooks](/plugins/hooks). Instead, every section here answers a single
+question: _"if I want my plugin to do **X**, which host-hook contracts do I
+compose, and what does that look like end-to-end?"_
+
+Examples here are deliberately **product-neutral**. A planning workflow is one
+tenant of the host-hook contract — not a privileged one. Approval flows,
+workspace policy gates, background monitors, setup wizards, review assistants,
+and release workflows can all be built as plugins through the same seams.
+
+<Note>
+  This page targets the grouped Plugin SDK host-hook surface shipped in the
+  2026.5.12 line. The contract coverage in
+  `src/plugins/contracts/host-hooks.contract.test.ts`,
+  `src/plugins/contracts/session-actions.contract.test.ts`,
+  `src/plugins/contracts/session-attachments.contract.test.ts`,
+  `src/plugins/contracts/scheduled-turns.contract.test.ts`, and
+  `src/plugins/contracts/session-entry-projection.contract.test.ts` is the
+  executable spec for these recipes.
+</Note>
+
+```mermaid
+flowchart LR
+  A["Plugin entry: definePluginEntry"] --> B["Grouped host-hook APIs"]
+  B --> C["Session state, actions, UI descriptors"]
+  B --> D["Next-turn injection, schedules, attachments"]
+  B --> E["Agent events, run context, lifecycle cleanup"]
+  C --> F["Workflow plugin recipes"]
+  D --> F
+  E --> F
+```
+
+## How to read this doc
+
+Each recipe has the same six parts:
+
+1. **What it does** — the one-line behavior.
+2. **Contract** — a source-oriented TypeScript excerpt from the current SDK.
+   Some excerpts omit nearby helper type declarations for readability; the
+   implementation source remains authoritative.
+3. **Minimal example** — the smallest plugin that exercises the contract.
+4. **Diagram** — a sequence or flow diagram of the runtime path.
+5. **Real-world example** — a complete plugin entry that's representative of
+   how you'd actually ship the contract in production.
+6. **Common pitfalls** — the failure modes worth knowing before you ship.
+
+Where two contracts compose naturally (e.g. session extension + command
+continuation), the recipe links forward to the full archetype recipe at the
+bottom of the doc.
+
+## Quick start
+
+Every plugin entry follows the same shape. The host-hook contracts add
+methods to the existing `OpenClawPluginApi` you already get inside `register`:
+
+```typescript
+// my-plugin/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "my-plugin",
+  name: "My Plugin",
+  description: "What it does in one sentence",
+  register(api) {
+    // Existing surfaces you already know:
+    //   api.registerTool(...), api.registerCommand(...), api.on(...)
+    //
+    // Current grouped host-hook surfaces:
+    //   api.session.state.registerSessionExtension(...)
+    //   api.session.workflow.enqueueNextTurnInjection(...)
+    //   api.session.workflow.registerSessionSchedulerJob(...)
+    //   api.session.workflow.sendSessionAttachment(...)        // bundled-only
+    //   api.session.workflow.scheduleSessionTurn(...)          // bundled-only
+    //   api.session.workflow.unscheduleSessionTurnsByTag(...)  // bundled-only
+    //   api.session.controls.registerSessionAction(...)
+    //   api.session.controls.registerControlUiDescriptor(...)
+    //   api.agent.events.registerAgentEventSubscription(...)
+    //   api.agent.events.emitAgentEvent(...)
+    //   api.runContext.setRunContext(...) / getRunContext(...) / clearRunContext(...)
+    //   api.lifecycle.registerRuntimeLifecycle(...)
+    //
+    // Adjacent flat surfaces:
+    //   api.registerTrustedToolPolicy(...)        // bundled-only
+    //   api.registerToolMetadata(...)
+    //
+    // Typed hook names for api.on(...):
+    //   "agent_turn_prepare"
+    //   "heartbeat_prompt_contribution"
+  },
+});
+```
+
+The older flat methods remain available as compatibility aliases, but new
+plugin code should prefer the grouped namespaces. The group names are useful to
+both humans and agents: they say whether a method belongs to session state,
+workflow continuation, UI controls, agent events, run-scoped scratch state, or
+lifecycle cleanup.
+
+This page covers workflow-style host hooks. If you only need static agent
+tools, use [Tool Plugins](/plugins/tool-plugins). For provider auth, OAuth
+refresh, external credential overlays, or model-runtime hooks, use
+[Provider Plugins](/plugins/sdk-provider-plugins) and
+[Plugin architecture internals](/plugins/architecture-internals#provider-runtime-hooks).
+For host-owned model calls from a plugin, use
+[Runtime helpers](/plugins/sdk-runtime).
+
+If you only need one host-hook surface, you can ignore the others. Composition
+is opt-in and lazy — registering nothing in a category means the plugin does
+not participate in that category.
+
+---
+
+## Recipe gallery (one section per contract)
+
+### 1. Plugin-owned session state: `api.session.state.registerSessionExtension(...)`
+
+**What it does**
+
+Persists small JSON-compatible plugin state alongside the session row, with
+optional projection into Gateway clients under `pluginExtensions`. Two plugins
+can ship two unrelated extensions and never collide because the namespace and
+plugin id key the storage.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginSessionExtensionRegistration = {
+  namespace: string;
+  description: string;
+  project?: (ctx: PluginSessionExtensionProjectionContext) => PluginJsonValue | undefined;
+  cleanup?: (ctx: { reason: PluginHostCleanupReason; sessionKey?: string }) => void | Promise<void>;
+  sessionEntrySlotKey?: string;
+  sessionEntrySlotSchema?: PluginJsonValue;
+};
+
+export type PluginSessionExtensionProjectionContext = {
+  sessionKey: string;
+  sessionId?: string;
+  state: PluginJsonValue | undefined;
+};
+
+// PluginHostCleanupReason = "disable" | "reset" | "delete" | "restart"
+```
+
+`project()` is optional — if you don't pass one, the host projects the raw
+stored value as a `pluginExtensions` row entry with `{ pluginId, namespace,
+value }`. Pass `project()` when you want to _transform_ what clients see (for
+example, hide secrets, or return a different shape than what you persist).
+
+`GatewaySessionRow.pluginExtensions` is an array of projection entries, not a
+nested object. Clients may derive a convenience map like
+`pluginExtensionsByPlugin[pluginId][namespace]`, but that map is client-owned.
+
+<Note>
+  `pluginExtensions[]` is the default projection for plugin-aware clients. Use
+  `sessionEntrySlotKey` only when a small, stable, non-secret summary also needs
+  to appear on the top-level `SessionEntry` shape for generic readers.
+</Note>
+
+You can also set `sessionEntrySlotKey` when one non-plugin reader needs a
+stable top-level `SessionEntry` field instead of a `pluginExtensions[]`
+projection entry. The host mirrors the projected value into
+`SessionEntry[sessionEntrySlotKey]` after each successful
+`sessions.pluginPatch` call, using the same projection source as
+`pluginExtensions[]`: `project({ sessionKey, sessionId, state })` when present,
+or the raw JSON-compatible state when no projector is registered. The mirror is
+read-only: clients still write through `sessions.pluginPatch`, and the host
+overwrites the slot on the next patch. `sessionEntrySlotSchema` is optional
+JSON-compatible registration metadata describing the projected slot shape; it
+does not replace the patch path's JSON-compatible state validation.
+
+Slot keys are intentionally narrow. They must be identifier-style names, cannot
+collide with current `SessionEntry` fields, cannot use prototype keys such as
+`__proto__`, `constructor`, `prototype`, `toString`, or `hasOwnProperty`, and
+must be unique across all registered session extensions. If `project()` returns
+`undefined`, throws, returns a promise, or returns a non-JSON value, the host
+keeps the namespaced plugin state but clears the top-level mirror so stale
+slot data is not exposed. `unset: true` removes both the namespace state and
+the promoted slot. Reset/delete/disable cleanup clears the owning plugin's
+session extensions, pending next-turn injections, and promoted slots; restart
+cleanup keeps durable session state.
+
+Use ordinary `pluginExtensions[]` when plugin-aware clients can read by
+`pluginId` and `namespace`, when several plugins may expose similar state, or
+when the state is only for your own UI. Use `sessionEntrySlotKey` only for a
+small, non-secret, stable summary that a generic session reader needs without
+knowing your plugin namespace.
+
+**Minimal example**
+
+```typescript
+// my-plugin/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "review-status",
+  name: "Review Status",
+  description: "Tracks per-session code-review state",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "review-status",
+      description: "Per-session review state: pending | in_review | approved",
+      project: ({ state }) => {
+        // Show a friendly summary; persist the raw record
+        if (!state || typeof state !== "object" || Array.isArray(state)) {
+          return undefined;
+        }
+        return { status: state.status ?? "pending" };
+      },
+    });
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin as Review Status
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+  participant GW as Gateway
+  participant UI as Control UI
+
+  Plugin->>Reg: registerSessionExtension({namespace, project, cleanup})
+  Note over Reg,Store: namespace + pluginId now valid for sessions.pluginPatch
+
+  UI->>GW: sessions.pluginPatch({pluginId, namespace, value: {...}})
+  GW->>Reg: lookup (pluginId, namespace) — reject if unknown
+  Reg->>Store: write namespaced state
+  Store-->>GW: { ok, key, value }
+  GW-->>UI: { ok, key, value }
+  GW-->>UI: sessions.changed notification
+  UI->>GW: refresh session row
+  GW->>Plugin: build row projection with project({sessionKey, sessionId, state})
+  Plugin-->>GW: pluginExtensions[] projection entry
+  GW-->>UI: refreshed row (and declared slot mirror when enabled)
+```
+
+**Real-world example: Review Concierge session state**
+
+A code-review plugin that tracks which files an operator has approved per
+session. The persisted state is the full file list; the projection returns
+only counts so the row stays small for clients that only need a meter.
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import type { PluginJsonValue } from "openclaw/plugin-sdk/plugin-entry";
+
+type ReviewStatePersisted = {
+  approvedFiles: string[];
+  rejectedFiles: string[];
+  updatedAt: number;
+};
+
+type ReviewStateProjection = {
+  approvedCount: number;
+  rejectedCount: number;
+  totalReviewed: number;
+};
+
+function isReviewState(value: PluginJsonValue | undefined): value is ReviewStatePersisted {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, PluginJsonValue>;
+  return Array.isArray(obj.approvedFiles) && Array.isArray(obj.rejectedFiles);
+}
+
+export default definePluginEntry({
+  id: "review-concierge",
+  name: "Review Concierge",
+  description: "Per-session code-review tracking and projection",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "review-state",
+      description: "Files approved or rejected for code review during this session",
+      sessionEntrySlotKey: "reviewSummary",
+      sessionEntrySlotSchema: {
+        type: "object",
+        properties: {
+          approvedCount: { type: "number" },
+          rejectedCount: { type: "number" },
+          totalReviewed: { type: "number" },
+        },
+      },
+      project: ({ state }): ReviewStateProjection | undefined => {
+        if (!isReviewState(state)) return undefined;
+        return {
+          approvedCount: state.approvedFiles.length,
+          rejectedCount: state.rejectedFiles.length,
+          totalReviewed: state.approvedFiles.length + state.rejectedFiles.length,
+        };
+      },
+      cleanup: async ({ reason, sessionKey }) => {
+        api.logger.info(`review-state cleanup reason=${reason} sessionKey=${sessionKey ?? "*"}`);
+        // Host already removes the persisted state — this callback is for
+        // plugin-owned out-of-band resources (caches, WebSocket handles, etc.)
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't put secrets in the projected value.** Anything you return from
+  `project()` ends up on session rows that Gateway hands to mobile/desktop
+  clients. Persist secrets only if your plugin renders them itself.
+- **Validate JSON shape inside `project()`.** The host stores whatever
+  `sessions.pluginPatch` writes (it's checked via `isPluginJsonValue`); your
+  projection should still defend against shape drift across schema versions.
+- **Cleanup is host-driven for the persisted state.** You don't need to clear
+  the namespace from `cleanup()`. Use `cleanup()` for _plugin-owned_
+  out-of-band resources only (timers, caches, file watchers).
+- **Promoted slots are not a write API.** `sessionEntrySlotKey` mirrors the
+  projected value into a top-level `SessionEntry` field for readers. Clients
+  still mutate the plugin namespace through `sessions.pluginPatch`.
+- **Reserve promoted slots for stable generic readers.** If the consumer is
+  already plugin-aware, keep the default `pluginExtensions[]` projection and
+  avoid adding a top-level field.
+
+---
+
+### 2. Patching session state from clients: `sessions.pluginPatch`
+
+**What it does**
+
+Lets privileged Control UI / mobile / desktop / internal clients update
+plugin-owned session state through the Gateway, with namespace-and-plugin-id
+validation at the wire. The Gateway method requires `operator.admin` scope.
+The RPC returns `{ ok, key, value }`; session-row projection happens on the
+subsequent session refresh, not as a nested object in the patch response.
+
+**Contract**
+
+```typescript
+// Wire-level params for sessions.pluginPatch
+type PluginSessionExtensionPatchParams = {
+  key: string; // sessionKey
+  pluginId: string;
+  namespace: string;
+  value?: PluginJsonValue;
+  unset?: boolean; // pass true to remove the namespace entirely
+};
+```
+
+**Minimal example**
+
+A Control UI calling `sessions.pluginPatch` to mark a session's approval flow
+approved:
+
+```jsonc
+// JSON-RPC request from Control UI
+{
+  "method": "sessions.pluginPatch",
+  "params": {
+    "key": "agent-default:demo",
+    "pluginId": "deploy-approver",
+    "namespace": "deploy-approver",
+    "value": { "state": "approved", "approvedAt": 1745000000000 },
+  },
+}
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant UI as Control UI / mobile / etc.
+  participant GW as Gateway
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+
+  UI->>GW: sessions.pluginPatch(params)
+  GW->>GW: validate params shape and operator.admin scope
+  GW->>Reg: lookup (pluginId, namespace) — must be registered
+  alt unknown plugin or namespace
+    Reg-->>GW: unknown plugin session extension
+    GW-->>UI: JSON-RPC INVALID_REQUEST error: "unknown plugin session extension: id/namespace"
+  else registered
+    GW->>Store: write patched value (or unset)
+    Store-->>GW: persisted namespace value
+    GW-->>UI: { ok: true, key, value }
+    GW-->>UI: sessions.changed notification
+    UI->>GW: sessions.list/detail refresh
+    GW->>Reg: project pluginExtensions[] for session row
+  end
+```
+
+**Real-world example: operator approval card**
+
+The Control UI approval card binds approve/deny buttons to `sessions.pluginPatch`
+calls. The plugin doesn't need a custom Gateway method; the patch protocol is
+generic.
+
+```typescript
+// Control UI side (sketch)
+async function approveDeploy(sessionKey: string, version: string) {
+  return await gatewayClient.call("sessions.pluginPatch", {
+    key: sessionKey,
+    pluginId: "deploy-approver",
+    namespace: "deploy-approver",
+    value: { state: "approved", version, approvedAt: Date.now() },
+  });
+}
+
+async function denyDeploy(sessionKey: string, reason: string) {
+  return await gatewayClient.call("sessions.pluginPatch", {
+    key: sessionKey,
+    pluginId: "deploy-approver",
+    namespace: "deploy-approver",
+    value: { state: "denied", reason, deniedAt: Date.now() },
+  });
+}
+```
+
+**Common pitfalls**
+
+- **Patches are atomic per call, not transactional across plugins.** If your
+  workflow needs cross-plugin atomicity, model it as a single state machine in
+  one plugin's namespace.
+- **`unset: true` removes the entire namespace for the session.** Use it for
+  reset-style operations; use `value: <new state>` for partial updates.
+
+---
+
+### 3. Durable next-turn context: `api.session.workflow.enqueueNextTurnInjection(...)`
+
+**What it does**
+
+Reaches the next agent turn for a session **exactly once**, with TTL,
+idempotency, and chronological cross-plugin drain ordering. The right seam
+for "the model should know X on its very next turn, but not as permanent
+system prompt text."
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginNextTurnInjectionPlacement =
+  | "prepend_context"
+  | "append_context";
+
+export type PluginNextTurnInjection = {
+  sessionKey: string;
+  text: string;
+  idempotencyKey?: string;
+  placement?: PluginNextTurnInjectionPlacement;
+  ttlMs?: number;
+  metadata?: PluginJsonValue;
+};
+
+api.session.workflow.enqueueNextTurnInjection(
+  injection: PluginNextTurnInjection,
+): Promise<{ enqueued: boolean; id: string; sessionKey: string }>;
+```
+
+`enqueued: false` means the call was a duplicate (same `idempotencyKey` for
+the same plugin in the same session). The returned `id` is the canonical
+record id either way.
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "note-save",
+  description: "Save the current model output as a note and inject a summary on the next turn",
+  acceptsArgs: false,
+  handler: async (ctx) => {
+    if (!ctx.sessionKey) {
+      return { text: "This command must run inside a bound session." };
+    }
+    await api.session.workflow.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      text: `[note saved] previous answer captured at ${new Date().toISOString()}`,
+      placement: "prepend_context",
+      idempotencyKey: `note-save:${ctx.sessionKey}`,
+      ttlMs: 5 * 60_000, // 5 min
+    });
+    return { text: "Saved.", continueAgent: false };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin
+  participant Q as Next-turn Queue
+  participant Runner as Agent Runner
+  participant Hook as agent_turn_prepare
+  participant Model
+
+  Plugin->>Q: enqueueNextTurnInjection({sessionKey, text, idempotencyKey, ttlMs})
+  Q-->>Plugin: { enqueued: true, id, sessionKey }
+  Note over Q: same idempotencyKey before drain → enqueued: false
+
+  Note over Runner: next agent turn starts
+  Runner->>Q: drain(sessionKey)
+  Q-->>Runner: queuedInjections (sorted by createdAt, expired dropped)
+  Runner->>Hook: agent_turn_prepare({prompt, messages, queuedInjections})
+  Hook-->>Runner: { prependContext?, appendContext? }
+  Runner->>Model: prompt + drained context
+```
+
+**Real-world example: Code Review Concierge auto-retry**
+
+When a tool call fails, the plugin queues a one-shot diagnosis for the next
+turn so the model retries with full context:
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "review-concierge",
+  name: "Review Concierge",
+  description: "Inject failing-test context on the next turn after a test fails",
+  register(api) {
+    api.agent.events.registerAgentEventSubscription({
+      id: "review-concierge.tool-fail-watcher",
+      streams: ["tool"],
+      handle: async (event) => {
+        const toolName = String(event.data.name ?? "");
+        if (
+          event.stream !== "tool" ||
+          event.data.phase !== "result" ||
+          event.data.isError !== true
+        ) {
+          return;
+        }
+        if (toolName !== "run_tests") return;
+        const sessionKey = event.sessionKey;
+        if (!sessionKey) return;
+
+        const summary = formatTestFailure(event.data.result); // your own helper
+        const toolCallId = String(event.data.toolCallId ?? "unknown");
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey,
+          text: `Previous test run failed:\n\n${summary}\n\nThe model should diagnose and propose a focused fix.`,
+          placement: "prepend_context",
+          idempotencyKey: `tool-fail-${event.runId}-${toolCallId}`,
+          ttlMs: 10 * 60_000,
+          metadata: { source: "review-concierge", kind: "tool-fail-summary" },
+        });
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't use this for permanent context.** It's exactly-once-per-drain by
+  design. Use `before_prompt_build` for context that should appear on every
+  turn.
+- **`idempotencyKey` is plugin-scoped per session.** If two plugins both
+  enqueue with the same key, both fire. The dedup is `(pluginId, sessionKey,
+idempotencyKey)`.
+- **A drain only delivers active loaded plugins with prompt injection enabled.**
+  Records for inactive or disabled plugins are discarded when any drain happens
+  for that session. If you need to survive a registry hot-reload, re-enqueue
+  from your reload hook.
+
+---
+
+### 4. Same-turn context from drained injections: `agent_turn_prepare`
+
+**What it does**
+
+Receives the drained next-turn injections and lets you fold them into prompt
+context **before** the ordinary `before_prompt_build` hook fires. Use this
+when the queued context needs plugin-side shaping before it becomes part of
+the prompt. The host always applies the default fold for queued injections:
+`prepend_context` items go before the turn prompt, `append_context` items go
+after it, and drained records keep chronological ordering. `agent_turn_prepare`
+handlers can add plugin-shaped context alongside that default fold.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginAgentTurnPrepareEvent = {
+  prompt: string;
+  messages: AgentMessage[] | unknown[];
+  queuedInjections: PluginNextTurnInjectionRecord[];
+};
+
+export type PluginAgentTurnPrepareResult = {
+  prependContext?: string;
+  appendContext?: string;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.on("agent_turn_prepare", (event) => {
+  const reviewInjections = event.queuedInjections.filter((entry) => entry.pluginId === api.id);
+  if (reviewInjections.length === 0) return;
+
+  const summary = reviewInjections.map((entry) => entry.text).join("\n\n");
+  return { prependContext: `[review-concierge] notes:\n\n${summary}` };
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Drain["drainPluginNextTurnInjections(sessionKey)"]
+  Drain --> Sort["sort chronologically by createdAt"]
+  Sort --> ATP["agent_turn_prepare hooks (priority order)"]
+  Sort --> Defaults["host default fold\nfor queued injections"]
+  ATP --> Custom["plugin-added context"]
+  Defaults --> Merge["merge prompt context"]
+  Custom --> Merge
+  Merge --> PB["before_prompt_build"]
+  PB --> Build["prompt build"]
+```
+
+**Real-world example: multi-plugin draft for a meeting summarizer**
+
+```typescript
+api.on(
+  "agent_turn_prepare",
+  (event) => {
+    const my = event.queuedInjections.filter((e) => e.pluginId === api.id);
+    if (my.length === 0) return;
+
+    // Group by metadata.kind, render with our own headers
+    const groups = new Map<string, string[]>();
+    for (const entry of my) {
+      const kind =
+        (entry.metadata && typeof entry.metadata === "object" && !Array.isArray(entry.metadata)
+          ? (entry.metadata as { kind?: string }).kind
+          : undefined) ?? "note";
+      const bucket = groups.get(kind) ?? [];
+      bucket.push(entry.text);
+      groups.set(kind, bucket);
+    }
+
+    const sections: string[] = [];
+    for (const [kind, items] of groups.entries()) {
+      sections.push(`### ${kind}\n\n${items.map((t) => `- ${t}`).join("\n")}`);
+    }
+    return { prependContext: `## meeting-summarizer queued\n\n${sections.join("\n\n")}` };
+  },
+  { priority: 60 },
+);
+```
+
+**Common pitfalls**
+
+- **Don't drop other plugins' injections.** Filter to your own `pluginId`
+  before consuming. The host defaults already handle every plugin's items —
+  if you replace the default, do it for _your_ injections only.
+- **`agent_turn_prepare` runs during prompt builds, including heartbeat runs.**
+  Use `heartbeat_prompt_contribution` for context that should apply only to
+  heartbeat-triggered turns.
+- **`allowPromptInjection=false` disables this hook per-plugin.** Operators
+  can opt out of any prompt-mutating plugin individually.
+
+---
+
+### 5. Heartbeat-only prompt context: `heartbeat_prompt_contribution`
+
+**What it does**
+
+Returns prompt context that fires **only** on heartbeat turns, never on
+user-initiated turns. The right seam for SLA timers, long-job progress
+deltas, and incident timers — context the model should notice in the
+background without polluting interactive prompts.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hook-turn-types.ts
+export type PluginHeartbeatPromptContributionEvent = {
+  sessionKey?: string;
+  agentId?: string;
+  heartbeatName?: string;
+};
+
+export type PluginHeartbeatPromptContributionResult = {
+  prependContext?: string;
+  appendContext?: string;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.on("heartbeat_prompt_contribution", (event) => {
+  if (!event.sessionKey) return;
+  const elapsed = getElapsedMinutes(event.sessionKey); // your own helper
+  if (elapsed < 10) return;
+  return { appendContext: `⏱ Long-running session: ${elapsed}m elapsed.` };
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Sched as Heartbeat Scheduler
+  participant Runner
+  participant Plugin
+  participant Model
+  participant User
+
+  Sched->>Runner: heartbeat fires (heartbeatName)
+  Runner->>Plugin: heartbeat_prompt_contribution({sessionKey, agentId, heartbeatName})
+  Plugin-->>Runner: { appendContext: "..." }
+  Runner->>Model: heartbeat prompt + appended context
+  Model-->>Runner: condensed status
+
+  Note over User,Runner: User types a question
+  User->>Runner: prompt
+  Runner->>Model: user prompt (NO heartbeat note)
+```
+
+**Real-world example: SLA Watcher**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const SLA_BY_AGENT: Record<string, number> = {
+  default: 15 * 60_000,
+  "release-bot": 30 * 60_000,
+};
+
+export default definePluginEntry({
+  id: "sla-watcher",
+  name: "SLA Watcher",
+  description: "Surfaces SLA elapsed/remaining only on heartbeat turns",
+  register(api) {
+    const startedAt = new Map<string, number>();
+
+    api.agent.events.registerAgentEventSubscription({
+      id: "sla-watcher.run-tracker",
+      streams: ["lifecycle"],
+      handle: (event, ctx) => {
+        if (event.data.phase === "start" && event.sessionKey) {
+          startedAt.set(event.sessionKey, Date.now());
+          ctx.setRunContext("sla", { startedAt: Date.now() });
+        } else if (
+          (event.data.phase === "end" || event.data.phase === "error") &&
+          event.sessionKey
+        ) {
+          startedAt.delete(event.sessionKey);
+        }
+      },
+    });
+
+    api.on("heartbeat_prompt_contribution", (event) => {
+      if (!event.sessionKey || !event.agentId) return;
+      const sla = SLA_BY_AGENT[event.agentId] ?? SLA_BY_AGENT.default;
+      const start = startedAt.get(event.sessionKey);
+      if (!start) return;
+      const elapsed = Date.now() - start;
+      const remaining = sla - elapsed;
+      if (remaining > 60_000) return; // only nudge inside the last minute
+      const human = remaining > 0 ? `${Math.ceil(remaining / 60_000)}m` : "exceeded";
+      return {
+        appendContext: `⏱ SLA budget: ${human}. Wrap up if possible.`,
+      };
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Heartbeat handlers must be cheap.** They run on a timer; an expensive
+  handler will slow heartbeat cadence for the whole agent.
+- **Empty returns are fine.** If you don't have anything to say this tick,
+  return nothing — don't fall through to a generic "no update" string.
+- **`allowPromptInjection=false` disables this hook per-plugin** (same as
+  `agent_turn_prepare` and `before_prompt_build`).
+
+---
+
+### 6. Bundled-only pre-plugin policy: `api.registerTrustedToolPolicy(...)`
+
+**What it does**
+
+Runs **before** any `before_tool_call` hook. Bundled plugins only. The right
+home for compliance, workspace-policy, budget, and other host-trusted gates
+that must fire before any third-party plugin can see a tool call.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginToolPolicyDecision =
+  | PluginHookBeforeToolCallResult
+  | { allow?: boolean; reason?: string };
+
+export type PluginTrustedToolPolicyRegistration = {
+  id: string;
+  description: string;
+  evaluate: (
+    event: PluginHookBeforeToolCallEvent,
+    ctx: PluginHookToolContext,
+  ) => PluginToolPolicyDecision | void | Promise<PluginToolPolicyDecision | void>;
+};
+```
+
+`{ allow: false, reason }` becomes `{ block: true, blockReason }` downstream.
+You can also return any `BeforeToolCallResult` directly: `{block, blockReason,
+params, requireApproval}`.
+
+**Minimal example**
+
+```typescript
+import fs from "node:fs/promises";
+import path from "node:path";
+
+api.registerTrustedToolPolicy({
+  id: "workspace-policy",
+  description: "Block writes outside the configured workspace root",
+  evaluate: async (event) => {
+    if (event.toolName !== "write_file") return;
+    const configuredRoot = process.env.OPENCLAW_WORKSPACE_ROOT;
+    if (!configuredRoot) {
+      return { allow: false, reason: "workspace root is not configured" };
+    }
+    let workspaceRoot: string;
+    try {
+      workspaceRoot = await fs.realpath(configuredRoot);
+    } catch {
+      return { allow: false, reason: "workspace root is not readable" };
+    }
+    let targetPath: string;
+    try {
+      targetPath = await fs.realpath(String(event.params?.path ?? ""));
+    } catch {
+      return { allow: false, reason: "path is not readable" };
+    }
+    const relative = path.relative(workspaceRoot, targetPath);
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      return { allow: false, reason: "path outside workspace root" };
+    }
+    return undefined;
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Agent
+  participant TP as Trusted Tool Policy
+  participant Hooks as before_tool_call (external plugins)
+  participant Approval
+  participant Tool
+
+  Agent->>TP: tool call (name, params)
+  alt allow:false / block:true
+    TP-->>Agent: { block: true, blockReason }
+    Note over Hooks: never runs — blocked at policy tier
+  else requireApproval
+    TP-->>Approval: requireApproval
+    Approval-->>TP: decision (allow-once / allow-always / deny / timeout / cancelled)
+    TP->>Hooks: pass on if allowed
+  else params rewrite
+    TP->>Hooks: forward policyAdjustedParams
+    Hooks-->>TP: ok / block / approval / params
+    TP->>Tool: execute(adjustedParams)
+  else no decision
+    TP->>Hooks: forward original params
+    Hooks-->>TP: ok / block / approval / params
+    TP->>Tool: execute(adjustedParams)
+  end
+```
+
+**Real-world example: Budget Guard**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const TOOL_COST_USD: Record<string, number> = {
+  llm_call: 0.02,
+  search: 0.001,
+  expensive_analysis: 0.5,
+};
+
+export default definePluginEntry({
+  id: "budget-guard",
+  name: "Budget Guard",
+  description: "Blocks tools whose estimated cost would exceed the session budget",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "budget",
+      description: "Budget tracking: spent (USD), capUsd",
+    });
+
+    api.registerTrustedToolPolicy({
+      id: "budget-guard.cost-cap",
+      description: "Require approval when tool cost would exceed session cap",
+      evaluate: async (event, ctx) => {
+        if (!ctx.sessionKey) return;
+        const cost = TOOL_COST_USD[event.toolName] ?? 0;
+        if (cost <= 0) return;
+
+        const budget = await getBudgetState(ctx.sessionKey); // your own helper
+        const projected = budget.spent + cost;
+        if (projected > budget.capUsd) {
+          return {
+            requireApproval: {
+              title: "Budget cap exceeded",
+              description: `${event.toolName} (~$${cost.toFixed(2)}) would push session spend to $${projected.toFixed(2)} (cap: $${budget.capUsd.toFixed(2)})`,
+              severity: "warning",
+              timeoutBehavior: "deny",
+              timeoutMs: 60_000,
+            },
+          };
+        }
+        return undefined;
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Bundled-only.** External plugins should use `before_tool_call` instead.
+  The host enforces this at registration.
+- **Trusted policy adjustments propagate as `policyAdjustedParams`.**
+  Downstream `before_tool_call` hooks see the adjusted params and can rewrite
+  them again. The execution-time params are the final merge.
+- **Your `evaluate` runs on every tool call.** Filter by `event.toolName` early
+  and return `undefined` fast for tools you don't care about.
+
+---
+
+### 7. Tool catalog and inventory metadata: `api.registerToolMetadata(...)`
+
+**What it does**
+
+Adds display and policy metadata (risk, tags, label) for tools without
+forking or wrapping the tool implementation. Projects into the tool catalog
+and the effective-inventory view.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginToolMetadataRegistration = {
+  toolName: string;
+  displayName?: string;
+  description?: string;
+  risk?: "low" | "medium" | "high";
+  tags?: string[];
+};
+```
+
+**Minimal example**
+
+```typescript
+api.registerToolMetadata({
+  toolName: "s3_export",
+  displayName: "Export to S3",
+  description: "Writes data to a configured S3 bucket",
+  risk: "high",
+  tags: ["data-egress", "compliance"],
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Plugin["Plugin"] -->|registerToolMetadata| Reg[Registry]
+  Reg --> Catalog[Tool catalog]
+  Reg --> Inventory[Effective inventory]
+  Catalog --> UI[Control UI]
+  Inventory --> UI
+  UI --> FilterByRisk[Filter: risk=high]
+  UI --> FilterByTag[Filter: tag=compliance]
+  Inventory --> Audit[Audit log row \n with risk + tags]
+```
+
+**Real-world example: Compliance Vault**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const HIGH_RISK_TOOLS = [
+  { name: "s3_export", display: "Export to S3" },
+  { name: "db_dump", display: "Database dump" },
+  { name: "bigquery_export", display: "Export to BigQuery" },
+];
+
+const PII_TOOLS = ["read_user_record", "lookup_email", "read_address_book"];
+
+export default definePluginEntry({
+  id: "compliance-vault",
+  name: "Compliance Vault",
+  description: "Tags export/PII tools for catalog filtering and audit",
+  register(api) {
+    for (const { name, display } of HIGH_RISK_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        displayName: display,
+        risk: "high",
+        tags: ["data-egress", "compliance"],
+      });
+    }
+    for (const name of PII_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        risk: "medium",
+        tags: ["pii", "compliance"],
+      });
+    }
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Metadata is additive within a plugin's own tool registrations.**
+  Uniqueness is enforced per `(pluginId, toolName)`, so different plugins
+  can use the same `toolName` without colliding. A plugin also can't
+  decorate or override core or another plugin's tools at projection time.
+- **`risk` is enum.** Only `"low" | "medium" | "high"` are valid. Don't
+  pass arbitrary strings.
+
+---
+
+### 8. Scoped commands with continuation: `api.registerCommand(...)`
+
+**What it does**
+
+Adds two new fields to the existing command-registration shape: `requiredScopes`
+(Gateway-enforced operator scopes) and `ownership` (bundled-only escape for
+reserved names). Plus, command results can carry `continueAgent: true` to wake
+the agent immediately after the command's state mutation.
+
+**Contract**
+
+```typescript
+// from src/plugins/types.ts
+export type PluginCommandResult = ReplyPayload & { continueAgent?: boolean };
+
+export type OpenClawPluginCommandDefinition = {
+  name: string;
+  nativeNames?: { default?: string } & Partial<Record<string, string>>;
+  nativeProgressMessages?: Partial<Record<string, string>> & { default?: string };
+  description: string;
+  agentPromptGuidance?: readonly string[];
+  acceptsArgs?: boolean;
+  requireAuth?: boolean;
+  requiredScopes?: OperatorScope[];
+  ownership?: "plugin" | "reserved";
+  handler: PluginCommandHandler;
+};
+```
+
+The authoritative reserved-command check lives in
+`src/plugins/command-registration.ts` inside `validateCommandName`, which
+builds its reserved `Set` from names such as `help, commands, status, whoami,
+context, btw, stop, restart, reset, new, compact, config, debug, allowlist,
+activation, skill, subagents, kill, steer, tell, model, models, queue, send,
+bash, exec, think, verbose, reasoning, elevated, usage`. External plugins are
+rejected at registration if they try to claim those; only
+`ownership: "reserved"` on a bundled plugin can override.
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "release",
+  description: "Release management",
+  acceptsArgs: true,
+  requiredScopes: ["operator.approvals"],
+  handler: async (ctx) => {
+    return { text: `release: ${ctx.args ?? "(no args)"}`, continueAgent: false };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Op as Operator
+  participant GW as Gateway
+  participant Router as Command Router
+  participant Plugin
+  participant Runner as Agent Runner
+
+  Op->>GW: /release approve v1.4.2
+  GW->>GW: enforce requiredScopes against operator scopes
+  alt missing scope
+    GW-->>Op: 403 — missing scope: operator.approvals
+  else has scope
+    GW->>Router: dispatch
+    Router->>Plugin: handler(ctx)
+    Plugin-->>Router: PluginCommandResult { content, continueAgent }
+    alt continueAgent: true
+      Router->>Runner: start next turn
+    end
+    Router-->>Op: result
+  end
+```
+
+**Real-world example: Release Train Conductor**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "release-conductor",
+  name: "Release Train Conductor",
+  description: "/release plan / approve / rollback with operator scopes",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "release",
+      description: "Per-session release state: stage, version, approvedBy",
+    });
+
+    api.registerCommand({
+      name: "release-plan",
+      description: "Print the release plan for a version",
+      acceptsArgs: true,
+      requiredScopes: ["operator.read"],
+      handler: async (ctx) => {
+        const plan = await loadReleasePlan(ctx.args ?? "");
+        return { text: renderPlan(plan), continueAgent: false };
+      },
+    });
+
+    api.registerCommand({
+      name: "release-approve",
+      description: "Approve a release for deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        const version = (ctx.args ?? "").trim();
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        if (!version) {
+          return { text: "Usage: /release-approve <version>", continueAgent: false };
+        }
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator approved release of ${version}.`,
+          placement: "prepend_context",
+          idempotencyKey: `release-approve-${version}`,
+        });
+        return { text: `Approved ${version}.`, continueAgent: true };
+      },
+    });
+
+    api.registerCommand({
+      name: "release-rollback",
+      description: "Roll back the most recent release",
+      acceptsArgs: false,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator initiated release rollback.`,
+          placement: "prepend_context",
+        });
+        return { text: "Rollback queued.", continueAgent: true };
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Don't forget `requiredScopes` for write commands.** The Gateway enforces
+  scopes only when you declare them. A command without scopes is callable by
+  any authenticated client.
+- **`ownership: "reserved"` is bundled-only.** External plugins are rejected
+  at registration. If you're a third-party plugin, pick a non-reserved name
+  or use `nativeNames` to alias to one of yours.
+
+---
+
+### 9. Command-then-continue: `PluginCommandResult.continueAgent`
+
+**What it does**
+
+Lets a command result wake the agent immediately for one more turn after the
+command's state mutation. The classic pattern is: operator clicks Approve,
+plugin updates session state and queues a next-turn injection, returns
+`continueAgent: true`, agent immediately resumes with the new context.
+
+**Contract**
+
+```typescript
+export type PluginCommandResult = ReplyPayload & { continueAgent?: boolean };
+```
+
+**Minimal example**
+
+```typescript
+api.registerCommand({
+  name: "deploy-approve",
+  description: "Approve a pending deployment",
+  acceptsArgs: false,
+  requiredScopes: ["operator.approvals"],
+  handler: async (ctx) => {
+    if (!ctx.sessionKey) {
+      return { text: "This command must run inside a bound session.", continueAgent: false };
+    }
+    await applyApprovalState(ctx.sessionKey, "approved"); // your helper
+    await api.session.workflow.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      text: "Deployment approved. Proceed.",
+      placement: "prepend_context",
+    });
+    return { text: "Approved.", continueAgent: true };
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Op as Operator
+  participant Router
+  participant Plugin
+  participant Q as Next-turn Queue
+  participant Runner
+  participant Model
+
+  Op->>Router: /deploy-approve
+  Router->>Plugin: handler
+  Plugin->>Plugin: update session state
+  Plugin->>Q: enqueueNextTurnInjection
+  Plugin-->>Router: { content, continueAgent: true }
+  Router->>Runner: start next turn
+  Runner->>Q: drain
+  Runner->>Model: prompt + drained context
+  Model-->>Op: agent reply post-approval
+```
+
+**Common pitfalls**
+
+- **Pair with `enqueueNextTurnInjection` whenever the agent needs to know
+  why it was woken.** Without an injection, the agent restarts with no
+  visible cause; the model has to infer.
+- **Don't use `continueAgent: true` for commands that don't change state.**
+  The agent will just spin its wheels.
+
+---
+
+### 10. Data-only Control UI surfaces: `api.session.controls.registerControlUiDescriptor(...)`
+
+**What it does**
+
+Lets a plugin contribute Control UI surfaces (session, tool, run, settings
+panels) by shipping a JSON descriptor. The host renders. **No plugin-shipped
+JavaScript reaches client surfaces.**
+
+**Contract**
+
+This is the data-only descriptor shape from `src/plugins/host-hooks.ts`.
+Clients own renderer implementations; plugins only contribute JSON-compatible
+metadata and schema.
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginControlUiDescriptor = {
+  id: string;
+  surface: "session" | "tool" | "run" | "settings";
+  label: string;
+  description?: string;
+  placement?: string;
+  schema?: PluginJsonValue;
+  requiredScopes?: OperatorScope[];
+};
+```
+
+The descriptor is exposed via Gateway method `plugins.uiDescriptors`, which
+returns each descriptor with `pluginId` and `pluginName` injected by the host.
+
+**Minimal example**
+
+```typescript
+api.session.controls.registerControlUiDescriptor({
+  id: "review-status-panel",
+  surface: "session",
+  label: "Review Status",
+  description: "Shows code-review approval/rejection counts for this session",
+  placement: "sidebar",
+  schema: {
+    kind: "review-counts-card",
+    fields: ["approvedCount", "rejectedCount", "totalReviewed"],
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart LR
+  Plugin -->|registerControlUiDescriptor| Reg[Registry]
+  Reg --> GW[Gateway: plugins.uiDescriptors]
+  GW --> Web[Control UI \n web]
+  GW --> Mac[macOS \n native]
+  GW --> iOS[iOS \n native]
+  Web --> Render[Renders schema with web component]
+  Mac --> Render2[Renders schema with SwiftUI component]
+  iOS --> Render3[Renders schema with SwiftUI component]
+```
+
+**Real-world example: Budget Meter card**
+
+```typescript
+api.session.controls.registerControlUiDescriptor({
+  id: "budget-meter",
+  surface: "session",
+  label: "Budget",
+  description: "Per-session spend tracker",
+  placement: "header",
+  schema: {
+    kind: "meter",
+    source: {
+      kind: "pluginExtension",
+      pluginId: "budget-guard",
+      namespace: "budget",
+    },
+    valuePath: "value.spent",
+    capPath: "value.capUsd",
+    format: "usd",
+    warningRatio: 0.8,
+    criticalRatio: 1.0,
+  },
+});
+```
+
+A client that implements a `meter` renderer can find the matching
+`pluginExtensions[]` entry by `pluginId` and `namespace`, then read `valuePath`
+and `capPath` relative to that entry. The plugin only ships data — never UI
+code.
+
+**Common pitfalls**
+
+- **The `schema` shape is plugin-and-renderer-defined.** Pick a clear
+  `kind` field (or any naming convention you like) so renderers can switch.
+  The host doesn't validate the shape beyond JSON-compatibility.
+- **No XSS surface, but no client-side compute either.** If your plugin
+  needs to do anything dynamic in the client (formatting, animations,
+  conditional rendering beyond what the schema supports), build a richer
+  generic renderer in clients first; don't try to ship JS through `schema`.
+
+---
+
+### 11. Host-mediated session actions: `api.session.controls.registerSessionAction(...)`
+
+<Note>
+  Session actions are invoked through the Gateway method
+  `plugins.sessionAction`. The Gateway resolves the registered action's
+  `requiredScopes`, validates JSON-compatible payloads and results, and then
+  calls the plugin handler.
+</Note>
+
+**What it does**
+
+Registers a typed action that trusted clients can invoke through the host. The
+host owns scope checks, payload validation, and response shape; the plugin owns
+only the domain action.
+
+**Minimal example**
+
+```typescript
+api.session.controls.registerSessionAction({
+  id: "approve-deploy",
+  description: "Approve or deny a queued deployment",
+  requiredScopes: ["operator.approvals"],
+  schema: {
+    type: "object",
+    properties: {
+      decision: { enum: ["approved", "denied"] },
+      reason: { type: "string" },
+    },
+    required: ["decision"],
+  },
+  async handler(ctx) {
+    if (!ctx.sessionKey) {
+      return { ok: false, error: "approve-deploy requires a bound session" };
+    }
+    if (!ctx.payload || typeof ctx.payload !== "object" || Array.isArray(ctx.payload)) {
+      return { ok: false, error: "approve-deploy payload must be an object" };
+    }
+    const decision = (ctx.payload as { decision?: unknown }).decision;
+    if (decision !== "approved" && decision !== "denied") {
+      return { ok: false, error: "decision must be approved or denied" };
+    }
+    await api.session.workflow.enqueueNextTurnInjection({
+      sessionKey: ctx.sessionKey,
+      placement: "prepend_context",
+      text: `Deployment decision: ${decision}`,
+      idempotencyKey: `deploy:${decision}`,
+    });
+    return { result: { decision }, continueAgent: true };
+  },
+});
+```
+
+Use this for approval cards, review triage buttons, incident escalation forms,
+or admin-only maintenance actions. Use command hooks when a human types a
+command; use session actions when a client or UI surface invokes a structured
+operation.
+
+---
+
+### 12. Host-mediated attachments: `api.session.workflow.sendSessionAttachment(...)`
+
+<Note>
+  Attachment delivery is host-trusted and bundled-only. Workspace plugins should
+  usually return a structured result or link instead of trying to send files
+  through the session route directly.
+</Note>
+
+**What it does**
+
+Lets bundled plugins send generated artifacts through the session's existing
+delivery route. The host validates file entries, count, total size, and route
+availability so plugins do not bypass channel policy.
+
+**Minimal example**
+
+```typescript
+const result = await api.session.workflow.sendSessionAttachment({
+  sessionKey: ctx.sessionKey,
+  files: [{ path: reportPath }],
+  text: "Review report is ready.",
+  maxBytes: 5 * 1024 * 1024,
+});
+
+if (!result.ok) {
+  api.logger.warn(`report delivery skipped: ${result.error}`);
+}
+```
+
+Use this for report generators, screenshot collectors, transcript exporters,
+and artifact-producing test plugins. Workspace plugins should return a link or
+structured result instead; attachment delivery is bundled-only.
+
+---
+
+### 13. Scheduled follow-up turns: `api.session.workflow.scheduleSessionTurn(...)`
+
+<Note>
+  Scheduled turns are host-trusted and bundled-only because they create future
+  session work through Cron. Workspace plugins should request this through a
+  reviewed host integration rather than owning wakeups directly.
+</Note>
+
+**What it does**
+
+Registers a plugin-owned follow-up turn through the host scheduler. The host
+tracks ownership so disabling, resetting, or deleting the plugin cleans pending
+jobs instead of leaving orphan wakes behind.
+
+**Minimal example**
+
+```typescript
+const job = await api.session.workflow.scheduleSessionTurn({
+  sessionKey,
+  message: "Recheck the unresolved SLA queue.",
+  delayMs: 15 * 60 * 1000,
+  deleteAfterRun: true,
+  deliveryMode: "none",
+  name: "SLA recheck",
+});
+```
+
+Use this for SLA watchers, budget threshold rechecks, background review
+summaries, or delayed approval reminders. Keep product-specific wake logic in
+the plugin; the host seam only owns scheduling, validation, and cleanup.
+
+---
+
+### 14. Plugin-owned event emission: `api.agent.events.emitAgentEvent(...)`
+
+<Note>
+  Plugin event emission is paired with sanitized subscriptions. External plugins
+  must emit streams scoped to their own plugin id, either exactly `pluginId` or
+  prefixed as `${pluginId}.*`. Host-reserved streams such as `lifecycle`,
+  `assistant`, `tool`, and `approval` are bundled-only.
+</Note>
+
+**What it does**
+
+Lets plugins emit their own agent-event stream entries without impersonating
+host streams like `tool`, `assistant`, `approval`, or `lifecycle`. Workspace
+plugin emissions must use a stream name scoped to the plugin id and carry
+JSON-compatible data; the host injects `pluginId` and `pluginName` into the
+payload.
+
+**Minimal example**
+
+```typescript
+api.agent.events.emitAgentEvent({
+  runId,
+  sessionKey,
+  stream: "review-concierge.review",
+  data: {
+    phase: "summary-ready",
+    filesReviewed: 12,
+  },
+});
+```
+
+Use this for plugin-specific progress, workflow milestones, review summaries,
+or background monitor status. Subscribe to host streams with
+`registerAgentEventSubscription`; emit only plugin-id-scoped streams from
+plugin code.
+
+---
+
+### 15. Sanitized event subscriptions: `api.agent.events.registerAgentEventSubscription(...)`
+
+**What it does**
+
+Subscribes to host-owned, sanitized agent events (run lifecycle, tool calls,
+turn boundaries) with plugin lifecycle ownership. The subscription is torn
+down when the plugin is disabled, restarted, deleted, or reset.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginAgentEventSubscriptionRegistration = {
+  id: string;
+  description?: string;
+  streams?: AgentEventStream[];
+  handle: (
+    event: AgentEventPayload,
+    ctx: {
+      // run-scoped — runId is implied by the firing event
+      getRunContext: <T extends PluginJsonValue = PluginJsonValue>(
+        namespace: string,
+      ) => T | undefined;
+      setRunContext: (namespace: string, value: PluginJsonValue) => void;
+      clearRunContext: (namespace?: string) => void;
+    },
+  ) => void | Promise<void>;
+};
+```
+
+Inside `handle`, the run-context API is **scoped to the firing event** — you
+don't pass `runId` explicitly. Use the top-level `api.runContext.setRunContext({runId,
+namespace, ...})` if you need to write context outside an event handler.
+
+**Minimal example**
+
+```typescript
+api.agent.events.registerAgentEventSubscription({
+  id: "incident-watcher.run-watcher",
+  description: "Open an incident timeline on run start",
+  streams: ["lifecycle"],
+  handle: (event, ctx) => {
+    if (event.data.phase === "start") {
+      ctx.setRunContext("incident", { startedAt: Date.now() });
+    }
+    if (event.data.phase === "error" || event.data.phase === "end") {
+      const incident = ctx.getRunContext<{ startedAt: number }>("incident");
+      if (incident) {
+        api.logger.info(`incident closed after ${Date.now() - incident.startedAt}ms`);
+      }
+    }
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Runner
+  participant Bus as Sanitized Event Bus
+  participant Plugin
+  participant Sink as External sink \n (PagerDuty, Datadog, etc.)
+
+  Plugin->>Bus: registerAgentEventSubscription({streams, handle})
+  Runner-->>Bus: agent event
+  Bus->>Plugin: handle(event, ctx)
+  Plugin->>Sink: forward sanitized event
+
+  Note over Plugin,Bus: operator disables plugin
+  Bus-->>Plugin: subscription torn down by host
+  Runner-->>Bus: more events (NOT delivered)
+```
+
+**Real-world example: Pager Bridge**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "pager-bridge",
+  name: "Pager Bridge",
+  description: "Forward sanitized run-failure events to PagerDuty",
+  register(api) {
+    let pagerClient = createPagerClient(api.pluginConfig); // your helper
+
+    api.agent.events.registerAgentEventSubscription({
+      id: "pager-bridge.failures",
+      description: "Run lifecycle failures forwarded to PagerDuty",
+      streams: ["lifecycle", "tool"],
+      handle: async (event) => {
+        if (event.stream === "lifecycle" && event.data.phase === "error") {
+          await pagerClient.trigger({
+            severity: "critical",
+            summary: `Run ${event.runId} failed: ${String(event.data.error ?? "unknown")}`,
+          });
+          return;
+        }
+        if (
+          event.stream === "tool" &&
+          event.data.phase === "result" &&
+          event.data.isError === true
+        ) {
+          const toolName = String(event.data.name ?? "unknown");
+          await pagerClient.trigger({
+            severity: "warning",
+            summary: `Tool ${toolName} failed`,
+          });
+        }
+      },
+    });
+
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "pager-bridge.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`pager-bridge cleanup reason=${reason}`);
+        await pagerClient.close();
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Events are sanitized.** You don't see raw prompts, tool params with
+  secrets, or provider request bodies. Use this for telemetry and routing,
+  not deep introspection.
+- **`handle` must be idempotent.** Restart-preserved subscriptions may see
+  the same event class on restart depending on stream semantics.
+- **Pair every long-lived resource with a `registerRuntimeLifecycle`.**
+  Event subscription teardown is automatic; sockets/timers you opened are
+  not.
+
+---
+
+### 16. Per-run plugin context: `api.runContext.setRunContext(...)` / `getRunContext(...)` / `clearRunContext(...)`
+
+**What it does**
+
+Stores namespaced JSON-compatible per-run state. Cleared on terminal run
+events. Two flavors: explicit `api.runContext.*` calls that include a `runId`,
+or run-scoped helpers inside an event handler.
+
+**Contract**
+
+```typescript
+// Top-level on api — needs explicit runId
+api.runContext.setRunContext(patch: PluginRunContextPatch): boolean;
+api.runContext.getRunContext<T>(params: PluginRunContextGetParams): T | undefined;
+api.runContext.clearRunContext(params: { runId: string; namespace?: string }): void;
+
+type PluginRunContextPatch = {
+  runId: string;
+  namespace: string;
+  value?: PluginJsonValue;
+  unset?: boolean;
+};
+type PluginRunContextGetParams = { runId: string; namespace: string };
+
+// Inside an agent-event-subscription handler ctx — runId is implied
+ctx.setRunContext(namespace: string, value: PluginJsonValue): void;
+ctx.getRunContext<T>(namespace: string): T | undefined;
+ctx.clearRunContext(namespace?: string): void;
+```
+
+`setRunContext` returns `true` on success; `false` typically means there is
+no active run for the supplied `runId` (already terminal, never started, or
+garbage-collected).
+
+**Minimal example (in-handler form)**
+
+```typescript
+api.agent.events.registerAgentEventSubscription({
+  id: "billing.tagger",
+  streams: ["lifecycle", "tool"],
+  handle: (event, ctx) => {
+    if (event.stream === "lifecycle" && event.data.phase === "start") {
+      const tenantId = inferTenantFromSession(event.sessionKey); // your helper
+      ctx.setRunContext("billing", { tenantId });
+      return;
+    }
+    if (event.stream === "tool" && event.data.phase === "result" && event.data.name) {
+      const billing = ctx.getRunContext<{ tenantId: string }>("billing");
+      if (!billing) return;
+      emitBillingRow({ tenantId: billing.tenantId, tool: String(event.data.name) });
+    }
+  },
+});
+```
+
+**Minimal example (top-level form)**
+
+```typescript
+api.on("agent_end", (event, ctx) => {
+  if (!event.runId || !ctx.runId) return;
+  const summary = api.runContext.getRunContext<{ steps: number }>({
+    runId: event.runId,
+    namespace: "review",
+  });
+  api.logger.info(`run ${event.runId} ended, steps=${summary?.steps ?? 0}`);
+  api.runContext.clearRunContext({ runId: event.runId, namespace: "review" });
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Runner
+  participant Plugin
+  participant Ctx as Run Context
+  participant Sink
+
+  Runner->>Plugin: handle({stream:"lifecycle", data:{phase:"start"}}, ctx)
+  Plugin->>Ctx: ctx.setRunContext("billing", {tenantId})
+
+  loop tool events during run
+    Runner-->>Plugin: handle({stream:"tool", data:{phase:"result"}}, ctx)
+    Plugin->>Ctx: ctx.getRunContext("billing")
+    Ctx-->>Plugin: {tenantId}
+    Plugin->>Sink: emit row(tenantId, tool, cost)
+  end
+
+  Runner->>Plugin: handle({stream:"lifecycle", data:{phase:"end"}}, ctx)
+  Plugin->>Ctx: (host) clears all namespaces for runId
+```
+
+**Common pitfalls**
+
+- **Don't roll your own global maps keyed by `runId`.** That's exactly what
+  this contract is for. The host clears it deterministically; your map will
+  leak if you forget a cleanup edge case.
+- **Don't store cross-run state here.** Use `registerSessionExtension` for
+  session-lifetime state.
+- **In top-level form, check the `boolean` return.** If `false`, the run
+  is gone — your write was a no-op. Common during reload or terminal
+  races.
+
+---
+
+### 17. Session scheduler jobs: `api.session.workflow.registerSessionSchedulerJob(...)`
+
+**What it does**
+
+Plugin-owned scheduled work scoped to a session. Cleanup is host-driven on
+disable / reset / delete / restart, with restart-preserved jobs skipping
+teardown callbacks (so jobs aren't double-run after a host restart).
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginSessionSchedulerJobRegistration = {
+  id: string;
+  sessionKey: string;
+  kind: string;
+  description?: string;
+  cleanup?: (ctx: {
+    reason: PluginHostCleanupReason;
+    sessionKey: string;
+    jobId: string;
+  }) => void | Promise<void>;
+};
+
+export type PluginSessionSchedulerJobHandle = {
+  id: string;
+  pluginId: string;
+  sessionKey: string;
+  kind: string;
+};
+
+api.session.workflow.registerSessionSchedulerJob(
+  job: PluginSessionSchedulerJobRegistration,
+): PluginSessionSchedulerJobHandle | undefined;
+```
+
+Returns `undefined` if registration fails (for example, duplicate job id for
+this plugin). The job ownership key is `(pluginId, jobId)`; `sessionKey` is
+stored on the job for cleanup filtering.
+
+**Minimal example**
+
+```typescript
+const sessionKey = "agent:main:main"; // from the command/event handler context
+const handle = api.session.workflow.registerSessionSchedulerJob({
+  id: "follow-up-9am",
+  sessionKey,
+  kind: "follow-up",
+  description: "Wake the agent at 9am with a follow-up summary",
+  cleanup: async ({ reason, jobId }) => {
+    api.logger.info(`scheduler cleanup job=${jobId} reason=${reason}`);
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+sequenceDiagram
+  participant Plugin
+  participant Sched as Session Scheduler
+  participant Host
+
+  Plugin->>Sched: registerSessionSchedulerJob({id, sessionKey, kind, cleanup})
+  Sched-->>Plugin: PluginSessionSchedulerJobHandle
+
+  Note over Plugin,Host: operator disables plugin
+  Host->>Sched: dispose plugin jobs, reason="disable"
+  Sched-->>Sched: drop jobs, run cleanup callbacks
+  Note over Sched: scheduled fire never happens
+
+  Note over Host: alternative: host restart
+  Host->>Sched: dispose, reason="restart"
+  Sched-->>Sched: keep restart-preserved jobs,\nskip cleanup callbacks
+```
+
+**Real-world example: Quiet Hours**
+
+```typescript
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+export default definePluginEntry({
+  id: "quiet-hours",
+  name: "Quiet Hours",
+  description: "Suppress heartbeat nudges during configured quiet hours",
+  register(api) {
+    api.agent.events.registerAgentEventSubscription({
+      id: "quiet-hours.session-watcher",
+      streams: ["session"],
+      handle: (event) => {
+        if (event.stream !== "session" || event.data.kind !== "start" || !event.sessionKey) {
+          return;
+        }
+
+        // Schedule a "resume nudges" job for the next non-quiet hour.
+        const resumeAt = computeNextResumeTime(api.pluginConfig.quietWindow);
+        api.session.workflow.registerSessionSchedulerJob({
+          id: `resume-nudges-${event.sessionKey}`,
+          sessionKey: event.sessionKey,
+          kind: "resume-nudges",
+          description: `Re-enable heartbeat nudges at ${new Date(resumeAt).toISOString()}`,
+        });
+      },
+    });
+
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "quiet-hours.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`quiet-hours runtime cleanup reason=${reason}`);
+        // Scheduler jobs are cleaned up by the host already; this is for
+        // plugin-owned timers/state if any.
+      },
+    });
+  },
+});
+```
+
+**Common pitfalls**
+
+- **Pick stable, scoped `id`s.** Job ownership is `(pluginId, jobId)`;
+  include the session key in the job id when a plugin needs one scheduled job
+  per session. Duplicate job ids for the same plugin are rejected even when
+  their payloads target different sessions.
+- **Don't assume the cleanup callback fires on restart.**
+  Restart-preserved jobs deliberately skip teardown. If you need
+  deterministic teardown on restart, use `registerRuntimeLifecycle` with
+  `reason === "restart"`.
+- **Cleanup is best-effort.** If your callback throws, the host keeps the
+  record retryable. Don't rely on cleanup for critical state — write
+  through to durable storage from the job firing path itself.
+
+---
+
+### 18. Runtime lifecycle cleanup: `api.lifecycle.registerRuntimeLifecycle(...)`
+
+**What it does**
+
+Lets the plugin clean up out-of-band resources (sockets, polling timers,
+file watchers, telemetry buffers) when the plugin is disabled, reset,
+deleted, or restarted. The quiet feature that makes every other contract
+safe to ship.
+
+**Contract**
+
+```typescript
+// from src/plugins/host-hooks.ts
+export type PluginRuntimeLifecycleRegistration = {
+  id: string;
+  description?: string;
+  cleanup?: (ctx: {
+    reason: PluginHostCleanupReason; // "disable" | "reset" | "delete" | "restart"
+    sessionKey?: string;
+    runId?: string;
+  }) => void | Promise<void>;
+};
+```
+
+**Minimal example**
+
+```typescript
+api.lifecycle.registerRuntimeLifecycle({
+  id: "my-plugin.lifecycle",
+  description: "Close webhook subscriptions on plugin teardown",
+  cleanup: async ({ reason }) => {
+    await myWebhookClient.close();
+    api.logger.info(`my-plugin lifecycle cleanup reason=${reason}`);
+  },
+});
+```
+
+**Diagram**
+
+```mermaid
+flowchart TD
+  Trigger["Operator: disable plugin"] --> Host
+  Host --> RemoveExt["Remove plugin session extensions"]
+  Host --> RemoveInj["Remove pending next-turn injections"]
+  Host --> ClearCtx["Clear plugin run context"]
+  Host --> SchedClean["Cleanup scheduler jobs \n (retryable records kept on failure)"]
+  Host --> Lifecycle["Invoke registerRuntimeLifecycle cleanup({reason:'disable'})"]
+  Lifecycle --> Plugin["Plugin closes sockets, timers, watchers"]
+  Plugin --> Done["Plugin fully torn down \n No zombie state, no leaked resources"]
+```
+
+**Common pitfalls**
+
+- **Make `cleanup` idempotent.** It can be called more than once across the
+  plugin's lifetime; design it to be a no-op when there's nothing left to
+  clean.
+- **Don't block on long teardown.** The host awaits your callback but
+  long-running cleanup makes operator UX bad. Push slow work to fire-and-
+  forget queues if necessary.
+- **Restart vs. delete are different reasons.** `restart` preserves the
+  plugin's installation; `delete` removes it entirely. Use the `reason`
+  field to decide whether to keep on-disk caches or wipe them.
+
+---
+
+### 19. The cleanup matrix at a glance
+
+The four `PluginHostCleanupReason` values fire different combinations of
+host-driven cleanup. This table is the contract:
+
+| Reason    | Persistent extensions  | Pending injections | Run context | Scheduler jobs                            | Lifecycle callback             |
+| --------- | ---------------------- | ------------------ | ----------- | ----------------------------------------- | ------------------------------ |
+| `restart` | preserved              | preserved          | cleared     | preserved (cleanup callbacks **skipped**) | called with `reason:"restart"` |
+| `disable` | removed                | removed            | cleared     | removed                                   | called with `reason:"disable"` |
+| `reset`   | removed (for session)  | removed (session)  | cleared     | removed (session)                         | called with `reason:"reset"`   |
+| `delete`  | removed (all sessions) | removed (all)      | cleared     | removed (all)                             | called with `reason:"delete"`  |
+
+> **Why restart is special.** Restart is the only reason where scheduler
+> jobs survive but cleanup callbacks are _skipped_. The reason: cleanup
+> callbacks for scheduled jobs typically free resources the job needs to
+> fire. If you call them on restart, the surviving job has nothing left to
+> do when it fires. So the host preserves both the job and its underlying
+> resources, and the cleanup callback runs only when the job actually
+> stops being preserved (disable / reset / delete). Run context is still
+> cleared on restart because it is per-run scratch state, not durable plugin
+> session state.
+
+---
+
+## Composition recipes
+
+The single-hook recipes above show how each contract behaves alone. Real
+plugins compose 2–6 hooks. Here are the canonical archetypes, fully
+worked.
+
+### Recipe A: Approval workflow plugin
+
+**Goal.** Operator runs a sensitive command (deploy, release, escalation).
+The plugin pauses execution, opens an approval card in Control UI, and
+resumes the agent on approve / deny.
+
+**Composes:** session extension + UI descriptor + scoped command +
+`continueAgent` + next-turn injection + cleanup.
+
+**Architecture**
+
+```mermaid
+flowchart TD
+  Op[Operator] --> Cmd[/deploy v1.4.2/]
+  Cmd --> BTH[before_tool_call]
+  BTH --> SE[Session extension: 'deploy-approver']
+  SE --> UI[Control UI \n approval card]
+  UI --> Patch[sessions.pluginPatch]
+  Patch --> SE
+  Op --> Approve[/deploy-approve/]
+  Approve --> Plugin
+  Plugin --> Q[Next-turn queue]
+  Plugin --> Cont[continueAgent: true]
+  Q --> Runner[Agent Runner]
+  Cont --> Runner
+  Runner --> Model
+```
+
+**End-to-end sequence**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant UI as Control UI
+  participant GW as Gateway
+  participant Cmd as Command Router
+  participant Plugin as Deploy Approver
+  participant Q as Next-turn Queue
+  participant R as Runner
+  participant M as Model
+
+  Op->>R: "deploy v1.4.2"
+  R->>M: turn
+  M-->>R: tool_call("deploy", {version:"v1.4.2"})
+  Note over R,Plugin: api.on("before_tool_call") intercepts
+
+  Plugin->>Plugin: sessionExt.deploy-approver = pending
+  Plugin->>UI: (projection) approval card visible
+  Plugin-->>R: short-circuit reply: "awaiting approval"
+
+  Op->>UI: clicks Approve
+  UI->>GW: sessions.pluginPatch(deploy-approver, {state:"approved"})
+  GW->>Plugin: validate + write
+  Op->>Cmd: /deploy-approve v1.4.2
+  Cmd->>Plugin: handler, requiredScopes ok
+  Plugin->>Q: enqueueNextTurnInjection
+  Plugin-->>Cmd: { ...reply, continueAgent: true }
+  Cmd->>R: start next turn
+  R->>Q: drain
+  R->>M: prompt + drained context
+  M-->>Op: "deploying v1.4.2 now…"
+```
+
+**Code**
+
+```typescript
+// deploy-approver/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type DeployApproverState = {
+  state: "pending" | "approved" | "denied";
+  version?: string;
+  approvedBy?: string;
+  reason?: string;
+  updatedAt: number;
+};
+
+export default definePluginEntry({
+  id: "deploy-approver",
+  name: "Deploy Approver",
+  description: "Pause deploys for human approval; resume agent on decision",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "deploy-approver",
+      description: "Per-session deploy approval state",
+    });
+
+    api.session.controls.registerControlUiDescriptor({
+      id: "deploy-approver-card",
+      surface: "session",
+      label: "Deploy approval",
+      placement: "sidebar",
+      schema: {
+        kind: "approval-card",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "deploy-approver",
+          namespace: "deploy-approver",
+        },
+        valuePath: "value",
+        actions: [
+          { kind: "approve", label: "Approve", command: "/deploy-approve" },
+          { kind: "deny", label: "Deny", command: "/deploy-deny" },
+        ],
+      },
+    });
+
+    api.on("before_tool_call", async (event, ctx) => {
+      if (event.toolName !== "deploy") return;
+      if (!ctx.sessionKey) return;
+      // Mark pending and short-circuit; the operator will run /deploy-approve next.
+      await markPending(ctx.sessionKey, String(event.params.version ?? ""));
+      return {
+        block: true,
+        blockReason: "Deploy paused; awaiting operator approval. Use /deploy-approve to continue.",
+      };
+    });
+
+    api.registerCommand({
+      name: "deploy-approve",
+      description: "Approve the pending deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        const version = (ctx.args ?? "").trim();
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator approved deployment of ${version || "the pending version"}.`,
+          placement: "prepend_context",
+          idempotencyKey: `approve-${version || ctx.sessionKey}`,
+        });
+        return { text: "Approved.", continueAgent: true };
+      },
+    });
+
+    api.registerCommand({
+      name: "deploy-deny",
+      description: "Deny the pending deployment",
+      acceptsArgs: true,
+      requiredScopes: ["operator.approvals"],
+      handler: async (ctx) => {
+        if (!ctx.sessionKey) {
+          return { text: "This command must run inside a bound session.", continueAgent: false };
+        }
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey: ctx.sessionKey,
+          text: `Operator denied deployment. Cancel and explain to user.`,
+          placement: "prepend_context",
+        });
+        return { text: "Denied.", continueAgent: true };
+      },
+    });
+
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "deploy-approver.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`deploy-approver cleanup reason=${reason}`);
+      },
+    });
+  },
+});
+
+async function markPending(_sessionKey: string, _version: string): Promise<void> {
+  // Patch in via sessions.pluginPatch from a host RPC, or from a co-registered
+  // gateway method. Sketch only; production code lives in your plugin.
+}
+```
+
+---
+
+### Recipe B: Workspace policy gate
+
+**Goal.** Bundled-only host policy. Block any tool call whose path argument
+escapes the configured workspace root, before any third-party plugin can
+intervene.
+
+**Composes:** trusted tool policy.
+
+**Architecture**
+
+```mermaid
+flowchart LR
+  Agent --> Trusted[Trusted policy]
+  Trusted -->|block / approve / rewrite| Tool
+  Trusted --> Hooks[external before_tool_call]
+  Hooks --> Tool
+  Trusted --> Audit[Policy diagnostics]
+```
+
+**Code**
+
+```typescript
+// workspace-policy/index.ts (BUNDLED-ONLY plugin)
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const PATH_TOOL_NAMES = new Set(["write_file", "delete_file", "rename_file", "exec_in_dir"]);
+
+export default definePluginEntry({
+  id: "workspace-policy",
+  name: "Workspace Policy",
+  description: "Block writes outside the configured workspace root",
+  register(api) {
+    const workspaceRoot = String(api.pluginConfig.root ?? "");
+
+    api.registerTrustedToolPolicy({
+      id: "workspace-policy.path-confinement",
+      description: "Reject path-bearing tool calls outside workspace root",
+      evaluate: (event) => {
+        if (!PATH_TOOL_NAMES.has(event.toolName)) return;
+        const raw = String(event.params?.path ?? "");
+        const normalized = normalize(raw); // your helper
+        if (!normalized.startsWith(workspaceRoot + "/")) {
+          return {
+            allow: false,
+            reason: `path "${raw}" is outside workspace root`,
+          };
+        }
+        // Rewrite to canonical form so downstream hooks see consistent params.
+        if (normalized !== raw) {
+          return { params: { ...event.params, path: normalized } };
+        }
+        return undefined;
+      },
+    });
+
+    // Tool metadata is intentionally omitted here: metadata projection applies
+    // to plugin-owned tools, while this policy gates core tools owned by the
+    // host. Use registerToolMetadata in plugins that register their own tools.
+  },
+});
+
+function normalize(p: string): string {
+  // Resolve to absolute path, collapse "..", reject symlink escapes, etc.
+  return p; // sketch
+}
+```
+
+---
+
+### Recipe C: Background lifecycle monitor
+
+**Goal.** Watch long-running runs. Open an incident timeline, schedule
+periodic ticks, surface elapsed time only on heartbeats, clean up on
+disable.
+
+**Composes:** event subscription + run context + scheduler job + heartbeat
+contribution + UI descriptor + runtime lifecycle.
+
+**Architecture**
+
+```mermaid
+flowchart TD
+  RunStart["lifecycle:start"] --> Sub[Event Subscription]
+  Sub --> Ctx[Run Context]
+  Sub --> Sched[Session Scheduler Job]
+  Sub --> UI[Control UI: incident timeline]
+
+  Tick[Scheduler tick] --> UpdateUI[Update timeline]
+
+  HB[Heartbeat] --> Contrib[heartbeat_prompt_contribution]
+  Contrib --> Ctx
+  Contrib --> Prompt[Heartbeat prompt context]
+
+  RunEnd["lifecycle:end"] --> Cleanup[Host cleanup]
+  Disable[Operator disable] --> RTL[Runtime lifecycle: close webhook]
+```
+
+**End-to-end sequence**
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Run as Long-running run
+  participant Ev as Sanitized Event Bus
+  participant IC as Incident Commander
+  participant Ctx as Run Context
+  participant Sched as Scheduler
+  participant HB as Heartbeat
+  participant UI as Control UI
+  participant Op as Operator
+
+  Run-->>Ev: stream=lifecycle, data.phase=start, runId=42
+  Ev->>IC: handle(event, ctx)
+  IC->>Ctx: ctx.setRunContext("incident", {startedAt, sla:15m})
+  IC->>Sched: registerSessionSchedulerJob
+  IC->>UI: registerControlUiDescriptor (timeline empty)
+
+  loop heartbeat ticks
+    HB->>IC: heartbeat_prompt_contribution
+    IC->>Ctx: api.runContext.getRunContext({runId, namespace:"incident"})
+    IC-->>HB: { appendContext: "elapsed 7m / SLA 15m" }
+  end
+
+  Sched->>IC: tick fired
+  IC->>UI: descriptor update: "tick at 8m"
+
+  Run-->>Ev: stream=tool, data.phase=result, data.isError=true
+  Ev->>IC: handle
+  IC->>UI: descriptor update: red marker
+
+  Run-->>Ev: stream=lifecycle, data.phase=end
+  Ev->>IC: handle
+  IC->>Sched: (host) cleanup
+  IC->>Ctx: (host) clearRunContext
+  Note over Op: operator disables plugin
+  IC->>IC: registerRuntimeLifecycle.cleanup → close webhook
+```
+
+**Code**
+
+```typescript
+// incident-commander/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type IncidentState = { startedAt: number; slaMs: number };
+
+const SLA_BY_AGENT: Record<string, number> = {
+  default: 15 * 60_000,
+  "release-bot": 30 * 60_000,
+};
+
+export default definePluginEntry({
+  id: "incident-commander",
+  name: "Incident Commander",
+  description: "Track long-running runs with timeline + heartbeat-only nudges",
+  register(api) {
+    api.session.controls.registerControlUiDescriptor({
+      id: "incident-timeline",
+      surface: "run",
+      label: "Incident timeline",
+      placement: "footer",
+      schema: { kind: "timeline", source: "incident-commander" },
+    });
+
+    api.agent.events.registerAgentEventSubscription({
+      id: "incident-commander.run-watcher",
+      streams: ["lifecycle", "tool"],
+      handle: async (event, ctx) => {
+        if (event.stream === "lifecycle" && event.data.phase === "start") {
+          const agentId = String(event.data.agentId ?? "");
+          const sla = SLA_BY_AGENT[agentId] ?? SLA_BY_AGENT.default;
+          ctx.setRunContext("incident", { startedAt: Date.now(), slaMs: sla });
+          if (event.sessionKey) {
+            api.session.workflow.registerSessionSchedulerJob({
+              id: `incident-tick-${event.runId}`,
+              sessionKey: event.sessionKey,
+              kind: "incident-tick",
+            });
+          }
+        }
+        if (
+          event.stream === "tool" &&
+          event.data.phase === "result" &&
+          event.data.isError === true
+        ) {
+          const toolName = String(event.data.name ?? "unknown");
+          api.logger.warn(`incident-commander tool fail in run=${event.runId} tool=${toolName}`);
+        }
+        if (event.stream === "lifecycle" && event.data.phase === "end") {
+          ctx.clearRunContext("incident");
+        }
+      },
+    });
+
+    api.on("heartbeat_prompt_contribution", (event) => {
+      if (!event.sessionKey || !event.agentId) return;
+      // Look up the latest run context the heartbeat path knows about.
+      // (In production, snapshot the runId in your run-watcher and read from there.)
+      return undefined; // sketch — replace with elapsed/remaining computation
+    });
+
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "incident-commander.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`incident-commander cleanup reason=${reason}`);
+        // Close any external webhooks, flush incident store, etc.
+      },
+    });
+  },
+});
+```
+
+---
+
+### Recipe D: Setup / onboarding wizard
+
+**Goal.** First-run onboarding flow that walks the operator through provider
+auth, workspace selection, and a smoke test. Each step persists progress so
+operators can resume across reloads.
+
+**Composes:** session extension + scoped commands + UI descriptor.
+
+**Architecture**
+
+```mermaid
+flowchart LR
+  Op[Operator] --> Card[UI: setup card]
+  Card --> Cmd1[/setup-step provider/]
+  Card --> Cmd2[/setup-step workspace/]
+  Card --> Cmd3[/setup-step smoke-test/]
+  Cmd1 --> SE[Session extension: 'setup']
+  Cmd2 --> SE
+  Cmd3 --> SE
+  SE --> Card
+```
+
+**Code**
+
+```typescript
+// setup-wizard/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+type SetupStep = "provider" | "workspace" | "smoke-test";
+type SetupState = {
+  completed: SetupStep[];
+  current: SetupStep | "done";
+};
+
+export default definePluginEntry({
+  id: "setup-wizard",
+  name: "Setup Wizard",
+  description: "Multi-step first-run onboarding",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "setup",
+      description: "First-run onboarding progress",
+    });
+
+    api.session.controls.registerControlUiDescriptor({
+      id: "setup-card",
+      surface: "session",
+      label: "Setup",
+      placement: "header",
+      schema: {
+        kind: "wizard-card",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "setup-wizard",
+          namespace: "setup",
+        },
+        valuePath: "value",
+        steps: [
+          { id: "provider", label: "Choose a provider" },
+          { id: "workspace", label: "Pick your workspace" },
+          { id: "smoke-test", label: "Run a smoke test" },
+        ],
+      },
+    });
+
+    api.registerCommand({
+      name: "setup-advance",
+      description: "Mark the current onboarding step complete",
+      acceptsArgs: true,
+      requiredScopes: ["operator.write"],
+      handler: async (ctx) => {
+        const step = (ctx.args ?? "").trim() as SetupStep;
+        if (!step) {
+          return { text: "Usage: /setup-advance <provider|workspace|smoke-test>" };
+        }
+        // In production: read state, append, write back via sessions.pluginPatch
+        return { text: `Marked ${step} complete.`, continueAgent: false };
+      },
+    });
+  },
+});
+```
+
+---
+
+### Recipe E: Review assistant
+
+**Goal.** Watch tool failures, queue diagnostic context for the next turn,
+tag review-relevant tools in the catalog, surface session review status.
+
+**Composes:** event subscription + next-turn injection + tool metadata + UI
+descriptor.
+
+```typescript
+// review-assistant/index.ts
+import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+
+const REVIEW_TOOLS = ["run_tests", "lint", "typecheck", "build"];
+
+export default definePluginEntry({
+  id: "review-assistant",
+  name: "Review Assistant",
+  description: "Auto-diagnose test/build failures and resurface them next turn",
+  register(api) {
+    api.session.state.registerSessionExtension({
+      namespace: "review",
+      description: "Per-session review summary: lastFailure, lastDiagnosis",
+    });
+
+    api.session.controls.registerControlUiDescriptor({
+      id: "review-summary-card",
+      surface: "session",
+      label: "Review",
+      placement: "sidebar",
+      schema: {
+        kind: "review-summary",
+        source: {
+          kind: "pluginExtension",
+          pluginId: "review-assistant",
+          namespace: "review",
+        },
+        valuePath: "value",
+      },
+    });
+
+    for (const name of REVIEW_TOOLS) {
+      api.registerToolMetadata({
+        toolName: name,
+        tags: ["review"],
+      });
+    }
+
+    api.agent.events.registerAgentEventSubscription({
+      id: "review-assistant.failure-watcher",
+      streams: ["tool"],
+      handle: async (event) => {
+        if (
+          event.stream !== "tool" ||
+          event.data.phase !== "result" ||
+          event.data.isError !== true
+        ) {
+          return;
+        }
+        const toolName = String(event.data.name ?? "");
+        if (!event.sessionKey || !toolName) return;
+        if (!REVIEW_TOOLS.includes(toolName)) return;
+
+        const summary = await summarizeFailure(event.data.result); // your helper
+        const toolCallId = String(event.data.toolCallId ?? "unknown");
+        await api.session.workflow.enqueueNextTurnInjection({
+          sessionKey: event.sessionKey,
+          text: `Review notes for ${toolName} failure:\n\n${summary}`,
+          placement: "prepend_context",
+          idempotencyKey: `review-fail-${event.runId}-${toolCallId}`,
+          ttlMs: 10 * 60_000,
+        });
+      },
+    });
+
+    api.lifecycle.registerRuntimeLifecycle({
+      id: "review-assistant.lifecycle",
+      cleanup: async ({ reason }) => {
+        api.logger.info(`review-assistant cleanup reason=${reason}`);
+      },
+    });
+  },
+});
+
+async function summarizeFailure(_event: unknown): Promise<string> {
+  return "(failure summary placeholder)";
+}
+```
+
+---
+
+## Patterns and pitfalls
+
+### Compose, do not subclass
+
+Each contract is independent. Don't try to wrap
+`api.session.state.registerSessionExtension(...)` or `api.registerCommand(...)`
+into a higher-level abstraction inside your plugin —
+the SDK already provides the right granularity. Two contracts that always
+appear together (session extension + UI descriptor) are still better as
+two separate registrations than one fused helper.
+
+### Keep handlers cheap
+
+`heartbeat_prompt_contribution`, `agent_turn_prepare`, and event-subscription
+`handle` callbacks all run on hot paths. Cache pre-computed values in
+your closure or in run/session context; avoid synchronous I/O.
+
+### Prefer projection over duplication
+
+If clients need to read plugin state, use
+`api.session.state.registerSessionExtension({ project })` rather than copying
+the same data into a custom Gateway method. Two
+plugins reading the same row see the same projection; clients only need to
+learn the `pluginExtensions[]` projection entries.
+
+### Prefer next-turn injection over `before_prompt_build`
+
+For one-shot context (post-approval continuation, post-failure diagnosis,
+operator-triggered events), use
+`api.session.workflow.enqueueNextTurnInjection(...)`. Reserve
+`before_prompt_build` for context that genuinely belongs in **every**
+turn (memory adjuncts, capability hints, tool documentation).
+
+### Pair every `register*` that opens a resource with `api.lifecycle.registerRuntimeLifecycle(...)`
+
+Event subscriptions, session extensions, and scheduler jobs are torn down by
+the host. Sockets, polling timers, file watchers, telemetry buffers, and
+external clients **are not**. If you opened it, register a lifecycle
+cleanup for it. The host calls cleanup on disable / reset / delete /
+restart — write idempotently.
+
+### Test against the contract suite
+
+`src/plugins/contracts/host-hooks.contract.test.ts` is the authoritative
+behavior spec. When you add a new plugin that exercises a host-hook surface,
+mirror its assertions in your own tests:
+
+- For session extensions: assert that a patch round-trips through
+  `sessions.pluginPatch` and your `project()` callback.
+- For next-turn injections: assert that two enqueues with the same
+  idempotency key produce one delivered injection.
+- For trusted tool policy: assert that `allow:false` becomes
+  `block: true, blockReason` downstream.
+- For commands: assert that `requiredScopes` is enforced for both
+  permitted and rejected callers.
+- For UI descriptors: assert the `plugins.uiDescriptors` Gateway response
+  includes your descriptor with `pluginId` injected.
+- For event subscriptions: assert that disable tears the subscription
+  down and post-disable events are not delivered.
+- For run context: assert that terminal run events clear all
+  namespaces.
+- For scheduler jobs: assert that each cleanup reason produces the
+  documented behavior (especially that `restart` skips teardown
+  callbacks).
+
+---
+
+## Cleanup matrix end-to-end
+
+This sequence is the canonical "operator disables a plugin that uses every
+host-hook contract":
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant Host
+  participant Reg as Plugin Registry
+  participant Store as Session Store
+  participant Q as Next-turn Queue
+  participant Ctx as Run Context
+  participant Sched as Scheduler
+  participant Plug as Plugin
+
+  Op->>Host: disable plugin "incident-commander"
+  Host->>Reg: deregister all surfaces
+  Host->>Store: remove pluginExtensions[] entries for incident-commander
+  Host->>Q: drop queued injections for plugin
+  Host->>Ctx: clear run-context namespaces for plugin
+  Host->>Sched: dispose plugin scheduler jobs (call cleanup callbacks)
+  Host->>Plug: registerRuntimeLifecycle.cleanup({reason:"disable"})
+  Plug->>Plug: close webhooks, timers, watchers, flush telemetry
+  Plug-->>Host: cleanup resolved
+  Host-->>Op: plugin disabled — no zombie state, no leaked resources
+```
+
+Compare to **restart** (host preserves jobs, skips teardown callbacks, but
+still calls runtime lifecycle for resource cleanup):
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Op as Operator
+  participant Host
+  participant Sched as Scheduler
+  participant Plug as Plugin
+
+  Op->>Host: restart plugin "incident-commander"
+  Host->>Sched: dispose, reason="restart"
+  Sched-->>Sched: keep restart-preserved jobs, SKIP cleanup callbacks
+  Host->>Plug: registerRuntimeLifecycle.cleanup({reason:"restart"})
+  Plug->>Plug: close webhooks, timers (will reopen on re-register)
+  Note over Sched: jobs survive — fire normally after restart
+```
+
+---
+
+## Testing your plugin against host hooks
+
+The contract files under `src/plugins/contracts/` are the executable spec.
+Every plugin that touches a host-hook contract should have its own coverage that
+mirrors the relevant subset.
+
+A reasonable pattern:
+
+```typescript
+// my-plugin/host-hooks.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  createPluginRegistryFixture,
+  registerVirtualTestPlugin,
+} from "openclaw/plugin-sdk/plugin-test-contracts";
+import myPlugin from "./index";
+
+describe("my-plugin host hooks", () => {
+  it("registers session extension and projects state", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        myPlugin.register?.(api);
+      },
+    });
+
+    expect(registry.registry.sessionExtensions).toEqual([
+      expect.objectContaining({
+        pluginId: "my-plugin",
+        extension: expect.objectContaining({ namespace: "my-namespace" }),
+      }),
+    ]);
+  });
+
+  it("queues exactly-once injections by idempotency key", async () => {
+    const { config, registry } = createPluginRegistryFixture();
+    const results: unknown[] = [];
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        results.push(
+          api.session.workflow.enqueueNextTurnInjection({
+            sessionKey: "agent:main:main",
+            text: "hello",
+            idempotencyKey: "k1",
+          }),
+        );
+      },
+    });
+
+    await expect(results[0]).resolves.toMatchObject({ enqueued: true });
+  });
+
+  it("registers event subscriptions with a stable plugin owner", () => {
+    const { config, registry } = createPluginRegistryFixture();
+    registerVirtualTestPlugin({
+      registry,
+      config,
+      id: "my-plugin",
+      name: "My Plugin",
+      register(api) {
+        api.agent.events.registerAgentEventSubscription({
+          id: "test.recorder",
+          streams: ["lifecycle"],
+          handle: () => undefined,
+        });
+      },
+    });
+
+    expect(registry.registry.agentEventSubscriptions).toEqual([
+      expect.objectContaining({
+        pluginId: "my-plugin",
+        subscription: expect.objectContaining({ id: "test.recorder" }),
+      }),
+    ]);
+  });
+});
+```
+
+The exported helpers in `openclaw/plugin-sdk/plugin-test-contracts` expose
+enough host fixtures to exercise every contract above.
+
+---
+
+## Closing
+
+If you've made it this far, you have the full picture: 18 host-hook
+contracts, 5 composition recipes, the cleanup matrix, and a testing
+pattern. The host-hook contract is small on purpose — every surface here
+solves one problem cleanly, composes with the others, and cleans up after
+itself.
+
+If you're building a plugin and a contract above doesn't fit your need,
+that's worth opening an issue or RFC discussion before working around it.
+The right answer is usually a small new contract; the wrong answer is
+patching core. Planning workflows are one tenant. Yours can be the next.
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Plugin SDK overview" icon="book" href="/plugins/sdk-overview">
+    Reference for every registration method on `OpenClawPluginApi`.
+  </Card>
+  <Card title="Plugin hooks" icon="bolt" href="/plugins/hooks">
+    The full hook catalog (agent turn, tools, messages, sessions, lifecycle).
+  </Card>
+  <Card title="Building plugins" icon="cube" href="/plugins/building-plugins">
+    Step-by-step guide to scaffolding a new plugin.
+  </Card>
+  <Card title="Tool plugins" icon="wrench" href="/plugins/tool-plugins">
+    Simple typed agent tools with static metadata and generated manifests.
+  </Card>
+  <Card title="Provider plugins" icon="key" href="/plugins/sdk-provider-plugins">
+    Provider auth, OAuth refresh, usage, and runtime-auth hooks.
+  </Card>
+  <Card title="Runtime helpers" icon="gears" href="/plugins/sdk-runtime">
+    Host-owned model calls, task flows, media understanding, and runtime utilities.
+  </Card>
+  <Card title="Plugin internals" icon="diagram-project" href="/plugins/architecture-internals">
+    Deep architecture and capability model.
+  </Card>
+</CardGroup>

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -133,16 +133,16 @@ plugins.
 
 | Method                                                                   | Contract it owns                                                                                                                  |
 | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| `api.registerSessionExtension(...)`                                      | Plugin-owned, JSON-compatible session state projected through Gateway sessions                                                    |
+| `api.registerSessionExtension(...)`                                      | Plugin-owned, JSON-compatible session state projected through Gateway sessions; guarded `SessionEntry` slot mirrors are in #75609 |
 | `api.enqueueNextTurnInjection(...)`                                      | Durable exactly-once context injected into the next agent turn for one session                                                    |
 | `api.registerTrustedToolPolicy(...)`                                     | Bundled/trusted pre-plugin tool policy that can block or rewrite tool params                                                      |
 | `api.registerToolMetadata(...)`                                          | Tool catalog display metadata without changing the tool implementation                                                            |
-| `api.registerCommand(...)`                                               | Scoped plugin commands; command results can set `continueAgent: true`; Discord native commands support `descriptionLocalizations` |
+| `api.registerCommand(...)`                                               | Scoped plugin commands; command continuation helpers are in #75578; Discord native commands support `descriptionLocalizations`    |
 | `api.registerControlUiDescriptor(...)`                                   | Control UI contribution descriptors for session, tool, run, or settings surfaces                                                  |
 | `api.registerRuntimeLifecycle(...)`                                      | Cleanup callbacks for plugin-owned runtime resources on reset/delete/reload paths                                                 |
 | `api.registerAgentEventSubscription(...)`                                | Sanitized event subscriptions for workflow state and monitors                                                                     |
 | `api.setRunContext(...)` / `getRunContext(...)` / `clearRunContext(...)` | Per-run plugin scratch state cleared on terminal run lifecycle                                                                    |
-| `api.registerSessionSchedulerJob(...)`                                   | Plugin-owned session scheduler job records with deterministic cleanup                                                             |
+| `api.registerSessionSchedulerJob(...)`                                   | Plugin-owned session scheduler job records with deterministic cleanup; scheduler tag cleanup is in #75588                         |
 
 The contracts intentionally split authority:
 

--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -20,7 +20,7 @@ reference for **what to import** and **what you can register**.
 </Note>
 
 <Tip>
-Looking for a how-to guide instead? Start with [Building plugins](/plugins/building-plugins), use [Channel plugins](/plugins/sdk-channel-plugins) for channel plugins, [Provider plugins](/plugins/sdk-provider-plugins) for provider plugins, [CLI backend plugins](/plugins/cli-backend-plugins) for local AI CLI backends, and [Plugin hooks](/plugins/hooks) for tool or lifecycle hook plugins.
+Looking for a how-to guide instead? Start with [Building plugins](/plugins/building-plugins), use [Channel plugins](/plugins/sdk-channel-plugins) for channel plugins, [Provider plugins](/plugins/sdk-provider-plugins) for provider plugins, [CLI backend plugins](/plugins/cli-backend-plugins) for local AI CLI backends, [Plugin hooks](/plugins/hooks) for tool or lifecycle hook plugins, and [Host-hook examples](/plugins/host-hooks-examples) for workflow-style recipes.
 </Tip>
 
 ## Import convention
@@ -465,6 +465,9 @@ subpath yet. Bundled examples:
   </Card>
   <Card title="Runtime helpers" icon="gears" href="/plugins/sdk-runtime">
     Full `api.runtime` namespace reference.
+  </Card>
+  <Card title="Host-hook examples" icon="puzzle-piece" href="/plugins/host-hooks-examples">
+    Worked recipes for approval flows, policy gates, monitors, wizards, and review assistants.
   </Card>
   <Card title="Setup and config" icon="sliders" href="/plugins/sdk-setup">
     Packaging, manifests, and config schemas.


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2-5 bullets:

- Problem: OpenClaw's Plugin SDK now has many useful host/workflow seams, but the docs did not give plugin authors or AI agents a single product-neutral recipe map for composing them safely.
- Why it matters: without a concrete recipe guide, authors either overfit on Plan Mode, miss the grouped SDK namespaces, or try to patch core for workflows that can now be built as plugins.
- What changed: this PR adds a long-form host-hook recipe page, wires it into docs navigation, links it from the Plugin SDK overview/hooks docs, and refreshes glossary coverage required by docs CI.
- What did NOT change (scope boundary): this is docs-only. It does not change runtime behavior, plugin permissions, Gateway methods, SDK exports, auth/OAuth provider hooks, or any build/package surface.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #71731, #71732, #71733, #71734, #71735, #71736, #71737, #72287
- [ ] This PR fixes a bug or regression

## Why this PR exists

The SDK surface is no longer just a flat `registerTool(...)` story. Current OpenClaw has grouped host-hook families for session state, workflow continuation, session controls, agent events, per-run context, and runtime lifecycle cleanup. That is powerful, but it is also easy to misread if the docs only expose API tables.

This PR turns that surface into a recipe book. The new page answers the author-facing question directly:

> If I want my plugin to do X, which host-hook contracts do I compose, and what does that look like end-to-end?

The examples are intentionally product-neutral. Plan Mode is one tenant of these seams, not the privileged one. The same contracts can support approval workflows, workspace policy gates, background monitors, setup wizards, review assistants, release workflows, and future bundled plugins.

## Reviewer guide

### Changed files

| File | Purpose |
| --- | --- |
| `docs/plugins/host-hooks-examples.md` | New recipe guide with 18 host-hook recipes, diagrams, examples, pitfalls, cleanup behavior, and test guidance. |
| `docs/plugins/sdk-overview.md` | Links the overview page to the new workflow-recipes page and keeps grouped SDK guidance discoverable. |
| `docs/plugins/hooks.md` | Updates session-extension/next-turn injection examples to grouped namespaces and links to the recipes. |
| `docs/docs.json` | Adds the new page to the plugin docs navigation. |
| `docs/.i18n/glossary.zh-CN.json` | Adds required glossary labels, including current-main labels needed for `docs:check-i18n-glossary`. |

### How the recipe page is structured

The new page deliberately uses the same structure for every recipe:

1. What it does
2. Contract excerpt
3. Minimal example
4. Diagram
5. Real-world example
6. Common pitfalls

This makes the page usable both for humans and for AI agents that need a stable pattern to follow.

### System flow

```mermaid
flowchart LR
  A[Plugin entry: definePluginEntry] --> B[Grouped host-hook APIs]
  B --> C[Session state, actions, UI descriptors]
  B --> D[Next-turn injection, schedules, attachments]
  B --> E[Agent events, run context, lifecycle cleanup]
  C --> F[Workflow plugin recipes]
  D --> F
  E --> F
```

### Documentation routing

```mermaid
flowchart TD
  Start[Plugin author asks: what can I build?]
  Start --> Tools{Only static agent tools?}
  Tools -->|yes| ToolDocs[Tool Plugins]
  Tools -->|no| Provider{Provider auth, OAuth, runtime auth, model catalog?}
  Provider -->|yes| ProviderDocs[Provider Plugins + Architecture Internals]
  Provider -->|no| Runtime{Host-owned model calls or runtime utilities?}
  Runtime -->|yes| RuntimeDocs[Runtime helpers]
  Runtime -->|no| Hooks[Host-hook examples and recipes]
  Hooks --> Workflow[Approval flows, policy gates, monitors, wizards, review assistants]
```

### Current grouped host-hook surface covered

| Group | Authoring surface | What the recipe teaches |
| --- | --- | --- |
| Session state | `api.session.state.registerSessionExtension(...)` | JSON-compatible plugin state, Gateway row projection, optional `SessionEntry` slot mirrors. |
| Workflow continuation | `api.session.workflow.enqueueNextTurnInjection(...)` | Exactly-once next-turn context for approvals, policy summaries, and command continuations. |
| Workflow jobs | `api.session.workflow.registerSessionSchedulerJob(...)` | Cleanup ownership for plugin-owned scheduler jobs. |
| Bundled workflow helpers | `sendSessionAttachment(...)`, `scheduleSessionTurn(...)`, `unscheduleSessionTurnsByTag(...)` | Host-mediated attachments and Cron-backed scheduled turns, clearly marked bundled-only. |
| Session controls | `api.session.controls.registerSessionAction(...)` | Gateway-mediated action dispatch with scopes, schema validation, and structured results. |
| Control UI descriptors | `api.session.controls.registerControlUiDescriptor(...)` | Data-only UI contribution descriptors; clients own rendering. |
| Agent events | `api.agent.events.registerAgentEventSubscription(...)`, `emitAgentEvent(...)` | Sanitized subscriptions and plugin-id-scoped event emission. |
| Run context | `api.runContext.setRunContext(...)`, `getRunContext(...)`, `clearRunContext(...)` | Per-run JSON-compatible scratch state cleared on terminal lifecycle. |
| Lifecycle cleanup | `api.lifecycle.registerRuntimeLifecycle(...)` | Idempotent cleanup for sockets, timers, watchers, buffers, and external clients. |
| Adjacent host policy | `api.registerTrustedToolPolicy(...)`, `api.registerToolMetadata(...)`, `api.registerCommand(...)` | Trusted policy, inventory metadata, scoped commands, and command continuation patterns. |

## Pulling directly from the docs

The opening of the new page frames the work this way:

```text
This doc is a recipe book. It does not re-document the API surface; that is the
job of Plugin SDK overview and Plugin hooks. Instead, every section here answers
a single question: if I want my plugin to do X, which host-hook contracts do I
compose, and what does that look like end-to-end?
```

The quick-start block then gives authors the current grouped API map:

```typescript
register(api) {
  // Existing surfaces you already know:
  //   api.registerTool(...), api.registerCommand(...), api.on(...)
  //
  // Current grouped host-hook surfaces:
  //   api.session.state.registerSessionExtension(...)
  //   api.session.workflow.enqueueNextTurnInjection(...)
  //   api.session.workflow.registerSessionSchedulerJob(...)
  //   api.session.workflow.sendSessionAttachment(...)        // bundled-only
  //   api.session.workflow.scheduleSessionTurn(...)          // bundled-only
  //   api.session.workflow.unscheduleSessionTurnsByTag(...)  // bundled-only
  //   api.session.controls.registerSessionAction(...)
  //   api.session.controls.registerControlUiDescriptor(...)
  //   api.agent.events.registerAgentEventSubscription(...)
  //   api.agent.events.emitAgentEvent(...)
  //   api.runContext.setRunContext(...) / getRunContext(...) / clearRunContext(...)
  //   api.lifecycle.registerRuntimeLifecycle(...)
}
```

Two important examples of source-aligned polish in this PR:

- `GatewaySessionRow.pluginExtensions` is described as an array of `{ pluginId, namespace, value }` entries, not a nested object. Any nested lookup map is explicitly client-derived.
- External plugin event emission now uses plugin-id-scoped streams (`pluginId` or `${pluginId}.*`) and calls out that host-reserved streams like `lifecycle`, `assistant`, `tool`, and `approval` are bundled-only.

## How selected recipes work

### Session state projection

```mermaid
sequenceDiagram
  autonumber
  participant Plugin
  participant Reg as Registry
  participant Store as Session Store
  participant GW as Gateway
  participant UI as Control UI

  Plugin->>Reg: registerSessionExtension({namespace, project, cleanup})
  Note over Reg,Store: namespace + pluginId now valid for sessions.pluginPatch
  UI->>GW: sessions.pluginPatch({pluginId, namespace, value})
  GW->>Reg: validate pluginId, namespace, and operator.admin scope
  Reg->>Store: write namespaced state
  Store-->>GW: { ok, key, value }
  GW-->>UI: { ok, key, value }
  GW-->>UI: sessions.changed notification
  UI->>GW: refresh session row
  GW->>Plugin: build row projection with project({sessionKey, sessionId, state})
  Plugin-->>GW: pluginExtensions[] projection entry
  GW-->>UI: refreshed row and declared slot mirror when enabled
```

### Control UI descriptors

Control UI contributions are data-only. The plugin supplies a JSON descriptor; clients own rendering. That keeps plugin code out of client surfaces while still letting plugins expose review cards, budget meters, status panels, settings panels, and action-driven UX.

```typescript
api.session.controls.registerControlUiDescriptor({
  id: "budget-meter",
  surface: "session",
  label: "Budget",
  description: "Per-session spend tracker",
  placement: "header",
  schema: {
    kind: "meter",
    source: {
      kind: "pluginExtension",
      pluginId: "budget-guard",
      namespace: "budget",
    },
    valuePath: "value.spent",
    capPath: "value.capUsd",
    format: "usd",
    warningRatio: 0.8,
    criticalRatio: 1.0,
  },
});
```

### Session action dispatch

```mermaid
sequenceDiagram
  autonumber
  participant Client
  participant Gateway
  participant Registry
  participant Plugin
  participant Agent

  Client->>Gateway: plugins.sessionAction({pluginId, actionId, sessionKey, payload})
  Gateway->>Registry: find action and requiredScopes
  Gateway->>Gateway: validate caller scopes + JSON schema
  Gateway->>Plugin: handler({pluginId, actionId, sessionKey, payload, client})
  Plugin->>Gateway: { result, continueAgent }
  Gateway-->>Client: { ok:true, result, continueAgent }
  Gateway->>Agent: optional continuation path via next-turn injection
```

### Event emission contract

The event-emission recipe was tightened after review. External plugins must use plugin-id-scoped streams:

```typescript
api.agent.events.emitAgentEvent({
  runId,
  sessionKey,
  stream: "review-concierge.review",
  data: {
    phase: "summary-ready",
    filesReviewed: 12,
  },
});
```

That matches `src/plugins/agent-event-emission.ts`: external plugins cannot emit host-reserved streams and cannot emit streams owned by another plugin id.

## Scope boundaries and non-goals

- Provider auth, OAuth refresh, external credential overlays, provider usage hooks, and runtime-auth hooks are intentionally routed to `sdk-provider-plugins` and `architecture-internals`; this page does not duplicate that provider catalog.
- Simple static tools are routed to `tool-plugins`; this page focuses on workflow-style host hooks.
- Host-owned model calls and runtime utilities are routed to `sdk-runtime`; this page only points authors there.
- Open/future follow-up seams such as chat-stream renderers, structured-complete helpers, or compaction interception are not documented as shipped APIs here.
- The PR does not change TypeScript declarations or runtime semantics. It is a documentation and discoverability PR over current source.

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: The Plugin SDK docs now expose the current grouped host-hook APIs, correct plugin event stream scoping, and point authors toward the right adjacent docs for tool plugins, provider/OAuth hooks, and runtime helpers instead of stale companion-PR guidance.
- Real environment tested: Real OpenClaw checkout at `/Volumes/LEXAR/repos/openclaw-host-hook-docs` on branch `docs/plugin-sdk-host-hook-recipes-split-refresh`, plus GitHub Actions docs CI for commit `3465338a09`.
- Exact steps or command run after this patch:

```text
pwd
node scripts/check-docs-mdx.mjs docs/plugins/host-hooks-examples.md docs/plugins/hooks.md docs/plugins/sdk-overview.md
node scripts/format-docs.mjs --check
node scripts/check-docs-i18n-glossary.mjs
node scripts/docs-link-audit.mjs
jq empty docs/docs.json && jq empty docs/.i18n/glossary.zh-CN.json && git diff --check
gh pr checks 74853 -R openclaw/openclaw --watch --interval 10
```

- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
$ pwd
/Volumes/LEXAR/repos/openclaw-host-hook-docs

$ node scripts/check-docs-mdx.mjs docs/plugins/host-hooks-examples.md docs/plugins/hooks.md docs/plugins/sdk-overview.md
Docs MDX check passed (3 files, 176ms).

$ node scripts/format-docs.mjs --check
Docs formatting clean (632 files).

$ node scripts/docs-link-audit.mjs
checked_internal_links=4425
broken_links=0

$ node scripts/check-docs-i18n-glossary.mjs
exited 0
```

- Observed result after fix: The changed docs pass MDX parsing, docs formatting, i18n glossary validation, JSON parsing, whitespace validation, and internal link audit locally. GitHub checks for commit `3465338a09` passed after the event-stream wording correction and final docs-consistency polish, including `check-docs` and Real behavior proof.
- What was not tested: No browser screenshot of the rendered Mintlify page was captured in this pass; this is docs-only and the repository MDX/link/i18n checks cover the changed docs surface.
- Before evidence (optional but encouraged): Earlier review identified the old event-emission example as wrong because it used `plugin.review`; current docs now use `review-concierge.review`, matching plugin-id-scoped stream policy.

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

- Root cause: N/A for runtime behavior. Documentation drift came from carrying an older host-hook recipe page across a fast-moving SDK stack and then rebasing it after the grouped host-hook APIs landed.
- Missing detection / guardrail: Bot review correctly caught one remaining source/doc mismatch around plugin event stream scoping; the updated page now matches `emitPluginAgentEvent(...)` and the contract tests.
- Contributing context (if known): The Plugin SDK moved from older flat/companion-PR language to grouped namespaces and shipped workflow seams. The PR body and docs now reflect current source instead of old stack-order assumptions.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [ ] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [x] Existing coverage already sufficient
- Target test or file: `src/plugins/contracts/session-actions.contract.test.ts` already covers plugin-id-scoped event emission; docs checks cover the changed Markdown/links/navigation.
- Scenario the test should lock in: workspace plugin event streams must be scoped to the plugin id or rejected; docs examples should not recommend rejected stream names.
- Why this is the smallest reliable guardrail: the behavior is already locked by the SDK contract test; the PR only needed doc alignment.
- Existing test that already covers this (if any): `session-actions.contract.test.ts` accepts `workspace-event-plugin.workflow` and rejects `other-plugin.workflow` for the workspace plugin.
- If no new test is added, why not: docs-only PR; no runtime behavior changed.

## User-visible / Behavior Changes

Plugin authors now get a navigable recipe guide for workflow-style host hooks, linked from Plugin SDK overview, Plugin hooks, and the docs sidebar. Runtime users see no behavior change.

## Diagram (if applicable)

```text
Before:
[plugin author] -> [SDK overview table + hook catalog] -> [manual inference / stale stack context]

After:
[plugin author] -> [Host-hook examples] -> [recipe by use case]
                -> [current grouped API] -> [pitfalls + tests + cleanup semantics]
```

Additional system diagram:

```mermaid
flowchart LR
  Author[Plugin author or AI agent] --> Recipe[Host-hook recipe guide]
  Recipe --> State[Session state + projections]
  Recipe --> Workflow[Next-turn context + scheduler ownership]
  Recipe --> Controls[Actions + Control UI descriptors]
  Recipe --> Events[Agent events + run context]
  Recipe --> Cleanup[Lifecycle cleanup matrix]
  Cleanup --> Tests[Contract-test guidance]
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS local checkout under `/Volumes/LEXAR/repos/openclaw-host-hook-docs`; GitHub Actions Ubuntu runner for docs CI.
- Runtime/container: Node scripts from the existing OpenClaw repo checkout; no new install was performed.
- Model/provider: N/A
- Integration/channel (if any): GitHub PR #74853 and docs CI.
- Relevant config (redacted): N/A

### Steps

1. Verify working directory is on Lexar.
2. Run focused docs MDX, formatting, i18n glossary, and link checks.
3. Inspect current source/contract tests for event-stream scoping.
4. Update PR body and comments with reviewer-facing docs excerpts and diagrams.
5. Push commit `3465338a09` and wait for PR checks.

### Expected

- Docs checks pass locally and in GitHub.
- PR remains mergeable.
- Real behavior proof gate passes.
- PR body follows the repository template and contains enough architecture context for reviewers unfamiliar with the stack.

### Actual

- Local docs checks passed.
- PR branch updated to `3465338a09`.
- GitHub checks on `3465338a09` passed, including `check-docs` and Real behavior proof.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence is embedded above under Real behavior proof and includes copied terminal output plus the current GitHub `check-docs` and Real behavior proof checks for `3465338a09`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: docs syntax, docs formatting, docs link integrity, i18n glossary coverage, JSON validity, whitespace diff check, PR template completeness, review-thread status, maintainer edit setting.
- Edge cases checked: stale companion-PR language, non-existent descriptor fields, nested `pluginExtensions` wording, event stream scoping, non-current API caveats, `SessionEntry` slot mirror wording, bundled-only helper labeling.
- What you did **not** verify: rendered Mintlify screenshot; full local test suite; runtime plugin execution. These were intentionally skipped because this PR is docs-only and local heavyweight suites are discouraged for this workspace.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

The latest ClawSweeper issue-comment finding about `plugin.*` event streams is addressed in commit `3465338a09`: the recipe now uses plugin-id-scoped streams and explains the bundled-only reserved-stream exception.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: A docs recipe could drift from source and teach a non-existent or rejected SDK call.
  - Mitigation: the page now points at the current contract test files, uses grouped APIs from `src/plugins/types.ts`, and was checked against the event-emission source/contract test after bot review.
- Risk: The page could blur boundaries between workflow hooks, provider/OAuth hooks, static tool plugins, and runtime helpers.
  - Mitigation: the quick-start and related links explicitly route provider auth/OAuth to provider docs, static tools to Tool Plugins, and host-owned model calls to Runtime helpers.
- Risk: The docs-only branch could be mistaken for a runtime SDK change.
  - Mitigation: the PR body marks this as docs-only, all security-impact answers are No, and the changed-file list is limited to docs/nav/glossary.


