### PR TITLE
Skip auto-update on Homebrew installs with clear hint (#74754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+- Auto-update: detect Homebrew-managed installs and skip the npm-based auto-update path (which silently fails to update brew-installed binaries). Log a clear `auto-update skipped: Homebrew-managed install (run: brew upgrade openclaw)` hint with the detected Cellar version so users on `brew install openclaw` see why no install ran. (#74754) Thanks @Sanjays2402.
+
 ## 2026.4.29
 
 ### Highlights

--- a/src/infra/homebrew-install.test.ts
+++ b/src/infra/homebrew-install.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { withTempDir } from "../test-helpers/temp-dir.js";
+import {
+  detectHomebrewInstall,
+  extractHomebrewCellarVersion,
+  isHomebrewManagedRootPath,
+} from "./homebrew-install.js";
+
+describe("homebrew-install", () => {
+  describe("isHomebrewManagedRootPath", () => {
+    it("matches a macOS Cellar-style openclaw root", () => {
+      expect(
+        isHomebrewManagedRootPath(
+          "/opt/homebrew/Cellar/openclaw/2026.4.25/libexec/lib/node_modules/openclaw",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches an Intel /usr/local Cellar-style openclaw root", () => {
+      expect(
+        isHomebrewManagedRootPath(
+          "/usr/local/Cellar/openclaw/2026.4.25/libexec/lib/node_modules/openclaw",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches a Linuxbrew Cellar-style openclaw root", () => {
+      expect(
+        isHomebrewManagedRootPath(
+          "/home/linuxbrew/.linuxbrew/Cellar/openclaw/2026.4.25/libexec/lib/node_modules/openclaw",
+        ),
+      ).toBe(true);
+    });
+
+    it("matches the opt symlink layout", () => {
+      expect(
+        isHomebrewManagedRootPath("/opt/homebrew/opt/openclaw/libexec/lib/node_modules/openclaw"),
+      ).toBe(true);
+    });
+
+    it("rejects a vanilla npm global install", () => {
+      expect(isHomebrewManagedRootPath("/opt/homebrew/lib/node_modules/openclaw")).toBe(false);
+      expect(isHomebrewManagedRootPath("/usr/lib/node_modules/openclaw")).toBe(false);
+      expect(isHomebrewManagedRootPath("/Users/sanjay/.npm-global/lib/node_modules/openclaw")).toBe(
+        false,
+      );
+    });
+
+    it("rejects empty input", () => {
+      expect(isHomebrewManagedRootPath("")).toBe(false);
+    });
+
+    it("matches Windows-style Cellar paths", () => {
+      expect(
+        isHomebrewManagedRootPath(
+          "C:\\opt\\homebrew\\Cellar\\openclaw\\2026.4.25\\libexec\\lib\\node_modules\\openclaw",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("extractHomebrewCellarVersion", () => {
+    it("extracts the version segment from Cellar paths", () => {
+      expect(
+        extractHomebrewCellarVersion(
+          "/opt/homebrew/Cellar/openclaw/2026.4.25/libexec/lib/node_modules/openclaw",
+        ),
+      ).toBe("2026.4.25");
+    });
+
+    it("returns undefined for non-Cellar paths", () => {
+      expect(
+        extractHomebrewCellarVersion(
+          "/opt/homebrew/opt/openclaw/libexec/lib/node_modules/openclaw",
+        ),
+      ).toBeUndefined();
+      expect(
+        extractHomebrewCellarVersion("/opt/homebrew/lib/node_modules/openclaw"),
+      ).toBeUndefined();
+      expect(extractHomebrewCellarVersion("")).toBeUndefined();
+    });
+  });
+
+  describe("detectHomebrewInstall", () => {
+    it("returns null for empty input", async () => {
+      await expect(detectHomebrewInstall({ packageRoot: null })).resolves.toBeNull();
+      await expect(detectHomebrewInstall({ packageRoot: "" })).resolves.toBeNull();
+    });
+
+    it("matches a Cellar-style realpath and returns the version", async () => {
+      await withTempDir({ prefix: "openclaw-brew-detect-" }, async (tmp) => {
+        const cellarRoot = path.join(
+          tmp,
+          "Cellar",
+          "openclaw",
+          "2026.4.25",
+          "libexec",
+          "lib",
+          "node_modules",
+          "openclaw",
+        );
+        await fs.mkdir(cellarRoot, { recursive: true });
+        const info = await detectHomebrewInstall({ packageRoot: cellarRoot, env: {} });
+        expect(info).not.toBeNull();
+        expect(info?.cellarVersion).toBe("2026.4.25");
+        expect(info?.resolvedRoot).toContain("Cellar");
+      });
+    });
+
+    it("matches via the opt symlink even when realpath resolves into Cellar", async () => {
+      await withTempDir({ prefix: "openclaw-brew-detect-" }, async (tmp) => {
+        const cellarRoot = path.join(
+          tmp,
+          "Cellar",
+          "openclaw",
+          "2026.4.25",
+          "libexec",
+          "lib",
+          "node_modules",
+          "openclaw",
+        );
+        await fs.mkdir(cellarRoot, { recursive: true });
+        const optDir = path.join(tmp, "opt");
+        await fs.mkdir(optDir, { recursive: true });
+        const optLink = path.join(optDir, "openclaw");
+        await fs.symlink(path.join(tmp, "Cellar", "openclaw", "2026.4.25"), optLink);
+        const optRoot = path.join(optLink, "libexec", "lib", "node_modules", "openclaw");
+        const info = await detectHomebrewInstall({ packageRoot: optRoot, env: {} });
+        expect(info).not.toBeNull();
+        // We follow realpath so cellarVersion is populated even when the input
+        // was the opt symlink.
+        expect(info?.cellarVersion).toBe("2026.4.25");
+      });
+    });
+
+    it("returns null for a vanilla npm global install", async () => {
+      await withTempDir({ prefix: "openclaw-brew-detect-" }, async (tmp) => {
+        const npmRoot = path.join(tmp, "lib", "node_modules", "openclaw");
+        await fs.mkdir(npmRoot, { recursive: true });
+        await expect(detectHomebrewInstall({ packageRoot: npmRoot, env: {} })).resolves.toBeNull();
+      });
+    });
+
+    it("does not throw if the root does not exist on disk", async () => {
+      const ghost = "/opt/homebrew/Cellar/openclaw/0.0.0/libexec/lib/node_modules/openclaw";
+      const info = await detectHomebrewInstall({ packageRoot: ghost, env: {} });
+      // Even when realpath fails, the literal Cellar path should still match.
+      expect(info).not.toBeNull();
+      expect(info?.cellarVersion).toBe("0.0.0");
+    });
+  });
+});

--- a/src/infra/homebrew-install.ts
+++ b/src/infra/homebrew-install.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveBrewExecutable } from "./brew.js";
+
+/**
+ * Detects whether an OpenClaw installation is managed by Homebrew.
+ *
+ * Homebrew-managed installations live under one of:
+ *   - <HOMEBREW_PREFIX>/Cellar/openclaw/<version>/...        (versioned keg)
+ *   - <HOMEBREW_PREFIX>/opt/openclaw/...                      (stable opt symlink)
+ *
+ * On macOS the default prefix is `/opt/homebrew` (Apple Silicon) or `/usr/local`
+ * (Intel). On Linux it's `/home/linuxbrew/.linuxbrew` or `~/.linuxbrew`.
+ *
+ * Detection runs against the package root path itself and its realpath, so a
+ * symlinked entrypoint (e.g. `/opt/homebrew/bin/openclaw`) still resolves to a
+ * Homebrew install when followed back to a Cellar location.
+ */
+
+const CELLAR_OPENCLAW_RE = /[\\/]Cellar[\\/]openclaw[\\/]([^\\/]+)[\\/]/;
+const OPT_OPENCLAW_RE = /[\\/]opt[\\/]openclaw[\\/]/;
+
+export type HomebrewInstallInfo = {
+  /** Cellar version segment (e.g. "2026.4.25") when matched via Cellar layout. */
+  cellarVersion?: string;
+  /** Realpath of the package root used for detection. */
+  resolvedRoot: string;
+  /** Brew executable path on PATH (best-effort, may be undefined). */
+  brewPath?: string;
+};
+
+export function isHomebrewManagedRootPath(rootPath: string): boolean {
+  if (!rootPath) {
+    return false;
+  }
+  return CELLAR_OPENCLAW_RE.test(rootPath) || OPT_OPENCLAW_RE.test(rootPath);
+}
+
+export function extractHomebrewCellarVersion(rootPath: string): string | undefined {
+  const match = rootPath.match(CELLAR_OPENCLAW_RE);
+  return match?.[1] ?? undefined;
+}
+
+/**
+ * Detects whether the resolved OpenClaw package root is a Homebrew-managed
+ * install. Returns metadata when matched, otherwise null.
+ *
+ * Resolves the realpath of the supplied root before matching so symlinked
+ * entrypoints (Homebrew/Linuxbrew opt symlinks) are recognized.
+ */
+export async function detectHomebrewInstall(opts: {
+  packageRoot: string | null;
+  homeDir?: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<HomebrewInstallInfo | null> {
+  const root = opts.packageRoot?.trim();
+  if (!root) {
+    return null;
+  }
+
+  let resolved = root;
+  try {
+    resolved = await fs.realpath(root);
+  } catch {
+    // Keep the supplied path; some Homebrew layouts may not be readable here.
+  }
+
+  // Match against the realpath first (Cellar) and fall back to the original
+  // input (opt symlink path that we deliberately did not resolve).
+  const candidatePaths = [resolved, root].map((p) => path.resolve(p));
+
+  let matched = false;
+  let cellarVersion: string | undefined;
+  for (const candidate of candidatePaths) {
+    if (CELLAR_OPENCLAW_RE.test(candidate)) {
+      matched = true;
+      cellarVersion ??= extractHomebrewCellarVersion(candidate);
+    } else if (OPT_OPENCLAW_RE.test(candidate)) {
+      matched = true;
+    }
+  }
+
+  if (!matched) {
+    return null;
+  }
+
+  return {
+    cellarVersion,
+    resolvedRoot: resolved,
+    brewPath: resolveBrewExecutable({
+      homeDir: opts.homeDir,
+      env: opts.env ?? process.env,
+    }),
+  };
+}

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -488,6 +488,90 @@ describe("update-startup", () => {
     );
   });
 
+  it("persists Homebrew skip notification state when checkOnStart is disabled", async () => {
+    const cellarRoot = path.join(
+      tempDir,
+      "Cellar",
+      "openclaw",
+      "2026.4.25",
+      "libexec",
+      "lib",
+      "node_modules",
+      "openclaw",
+    );
+    await fs.mkdir(cellarRoot, { recursive: true });
+
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(cellarRoot);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: cellarRoot,
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    mockNpmChannelTag("latest", "2.0.0");
+
+    const log = { info: vi.fn() };
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+
+    // First run with checkOnStart: false — startup hint path is skipped, so
+    // lastNotifiedVersion/Tag must be populated by the Homebrew skip branch
+    // itself or the hint will repeat on every eligible check.
+    await runGatewayUpdateCheck({
+      cfg: {
+        update: {
+          checkOnStart: false,
+          channel: "stable",
+          auto: {
+            enabled: true,
+            stableDelayHours: 0,
+            stableJitterHours: 0,
+          },
+        },
+      },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+      runAutoUpdate,
+    });
+
+    const statePath = path.join(tempDir, "update-check.json");
+    const parsed = JSON.parse(await fs.readFile(statePath, "utf-8")) as {
+      lastNotifiedVersion?: string;
+      lastNotifiedTag?: string;
+    };
+    expect(parsed.lastNotifiedVersion).toBe("2.0.0");
+    expect(parsed.lastNotifiedTag).toBe("latest");
+    expect(runAutoUpdate).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("auto-update skipped: Homebrew-managed install"),
+      expect.objectContaining({ version: "2.0.0", tag: "latest" }),
+    );
+
+    // Second run for the same version/tag should not re-log the hint.
+    log.info.mockClear();
+    await runGatewayUpdateCheck({
+      cfg: {
+        update: {
+          checkOnStart: false,
+          channel: "stable",
+          auto: {
+            enabled: true,
+            stableDelayHours: 0,
+            stableJitterHours: 0,
+          },
+        },
+      },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+      runAutoUpdate,
+    });
+
+    expect(log.info).not.toHaveBeenCalledWith(
+      expect.stringContaining("auto-update skipped: Homebrew-managed install"),
+      expect.anything(),
+    );
+  });
+
   it("scheduleGatewayUpdateCheck returns a cleanup function", async () => {
     mockPackageUpdateStatus("latest", "2.0.0");
 

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -436,6 +436,58 @@ describe("update-startup", () => {
     );
   });
 
+  it("skips auto-update on Homebrew-managed installs and logs a brew upgrade hint", async () => {
+    const cellarRoot = path.join(
+      tempDir,
+      "Cellar",
+      "openclaw",
+      "2026.4.25",
+      "libexec",
+      "lib",
+      "node_modules",
+      "openclaw",
+    );
+    await fs.mkdir(cellarRoot, { recursive: true });
+
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(cellarRoot);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: cellarRoot,
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    mockNpmChannelTag("latest", "2.0.0");
+
+    const log = { info: vi.fn() };
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+
+    await runGatewayUpdateCheck({
+      cfg: {
+        update: {
+          channel: "stable",
+          auto: {
+            enabled: true,
+            stableDelayHours: 0,
+            stableJitterHours: 0,
+          },
+        },
+      },
+      log,
+      isNixMode: false,
+      allowInTests: true,
+      runAutoUpdate,
+    });
+
+    expect(runAutoUpdate).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining("auto-update skipped: Homebrew-managed install"),
+      expect.objectContaining({
+        version: "2.0.0",
+        tag: "latest",
+        cellarVersion: "2026.4.25",
+      }),
+    );
+  });
+
   it("scheduleGatewayUpdateCheck returns a cleanup function", async () => {
     mockPackageUpdateStatus("latest", "2.0.0");
 

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -437,6 +437,11 @@ export async function runGatewayUpdateCheck(params: {
             },
           );
         }
+        // Persist notification state so the Homebrew hint is one-shot per
+        // version/tag, even when `update.checkOnStart` is false (in which
+        // case the regular startup-hint path never populates these fields).
+        nextState.lastNotifiedVersion = resolved.version;
+        nextState.lastNotifiedTag = tag;
         await writeState(statePath, nextState);
         return;
       }

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -8,6 +8,7 @@ import { runCommandWithTimeout } from "../process/exec.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 import { VERSION } from "../version.js";
 import { isTruthyEnvValue } from "./env.js";
+import { detectHomebrewInstall } from "./homebrew-install.js";
 import { writeJsonAtomic } from "./json-files.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
@@ -420,6 +421,25 @@ export async function runGatewayUpdateCheck(params: {
     }
 
     if (shouldRunAutoUpdate && (channel === "stable" || channel === "beta")) {
+      const homebrewInstall = await detectHomebrewInstall({
+        packageRoot: root,
+      });
+      if (homebrewInstall) {
+        const shouldNotifyHomebrew =
+          state.lastNotifiedVersion !== resolved.version || state.lastNotifiedTag !== tag;
+        if (shouldNotifyHomebrew) {
+          params.log.info(
+            "auto-update skipped: Homebrew-managed install (run: brew upgrade openclaw)",
+            {
+              version: resolved.version,
+              tag,
+              cellarVersion: homebrewInstall.cellarVersion,
+            },
+          );
+        }
+        await writeState(statePath, nextState);
+        return;
+      }
       const runAuto = params.runAutoUpdate ?? runAutoUpdateCommand;
       const attemptIntervalMs =
         channel === "beta"


### PR DESCRIPTION
Closes #74754

## Problem

The auto-update path runs `openclaw update --yes --channel <channel> --json` after the daily check. That command uses npm internally and cannot update a Homebrew-installed binary. On Homebrew installs (`brew install openclaw` or the tap formula), the daily auto-update either silently no-ops or runs an npm install against a directory the brew node wrapper does not see, so users on Homebrew never get auto-updated and have no clue why.

Reproduced with `brew install openclaw` on Apple Silicon: `update.json` records `hasUpdate: true` for weeks, but `autoFirstSeenAt` resets every restart and no install ever runs.

## Fix

Detect Homebrew-managed installs before spawning the auto-update child:

- New `src/infra/homebrew-install.ts` matches the package root (and its realpath) against the canonical Homebrew layouts:
  - `<HOMEBREW_PREFIX>/Cellar/openclaw/<version>/...` (versioned keg)
  - `<HOMEBREW_PREFIX>/opt/openclaw/...` (stable opt symlink)
  - Works for `/opt/homebrew` (Apple Silicon), `/usr/local` (Intel), and `/home/linuxbrew/.linuxbrew` (Linuxbrew).
- `update-startup.ts` calls the helper before invoking `runAutoUpdateCommand`. When matched it:
  - Skips the doomed npm invocation entirely.
  - Logs `auto-update skipped: Homebrew-managed install (run: brew upgrade openclaw)` with the detected Cellar version and channel tag so the user understands why no install ran and what to do next.
  - Reuses the existing `lastNotifiedVersion`/`lastNotifiedTag` persistence so the hint fires once per (version, tag) pair rather than every heartbeat.

The explicit `openclaw update` CLI is intentionally untouched - the issue is about the silent auto-update path. CLI-side parity can land separately if desired.

## Tests

- `src/infra/homebrew-install.test.ts` (14 cases): pure-string detection across Apple Silicon, Intel, Linuxbrew, opt-symlink and Cellar layouts; rejects vanilla npm globals; realpath-based detection across symlinked opt directories; ghost paths.
- `src/infra/update-startup.test.ts`: new case asserts the auto-update child is **not** invoked and the brew-upgrade hint is logged with the right metadata when the resolved root sits inside Cellar.

```
✓ infra ../../src/infra/update-startup.test.ts (12 tests)
✓ infra ../../src/infra/homebrew-install.test.ts (14 tests)

 Test Files  2 passed (2)
      Tests  26 passed (26)
```

## Risk

Low. The helper is read-only path matching plus a realpath() lookup. Fall-through behaviour for non-Homebrew installs is unchanged. Worst case a misdetection skips one auto-update cycle and the next `openclaw update` invocation still works.