### PR TITLE
fix(pi-embedded-runner): only cooldown auth profile on real auth signals

### DIFF
--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts
@@ -39,4 +39,29 @@ describe("resolveAuthProfileFailureReason", () => {
       }),
     ).toBeNull();
   });
+
+  it("does not punish profile for client-side / non-auth failure reasons", () => {
+    // Regression: a single Anthropic 400 "assistant message prefill" 400 from
+    // one model used to mark the only github-copilot profile failed, cascading
+    // into "all profiles unavailable" across every fallback model.
+    for (const reason of ["format", "overloaded", "model_not_found", "unknown"] as const) {
+      expect(
+        resolveAuthProfileFailureReason({
+          failoverReason: reason,
+          policy: "shared",
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("records genuine auth-health signals", () => {
+    for (const reason of ["auth", "auth_permanent", "session_expired"] as const) {
+      expect(
+        resolveAuthProfileFailureReason({
+          failoverReason: reason,
+          policy: "shared",
+        }),
+      ).toBe(reason);
+    }
+  });
 });

--- a/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
+++ b/src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts
@@ -6,9 +6,44 @@ export function resolveAuthProfileFailureReason(params: {
   failoverReason: FailoverReason | null;
   policy?: AuthProfileFailurePolicy;
 }): AuthProfileFailureReason | null {
-  // Helper-local runs and transport timeouts should not poison shared provider auth health.
-  if (params.policy === "local" || !params.failoverReason || params.failoverReason === "timeout") {
+  // Only signals that genuinely reflect auth-profile health should put a
+  // profile into cooldown. Transport/payload/model-path failures are not
+  // auth signals and must not punish the profile (otherwise a single
+  // request-side bug — e.g. an Anthropic 400 "assistant message prefill"
+  // schema rejection from one model — cascades into "all profiles
+  // unavailable" across every fallback model on the same provider).
+  if (params.policy === "local" || !params.failoverReason) {
     return null;
   }
-  return params.failoverReason;
+  switch (params.failoverReason) {
+    case "auth":
+    case "auth_permanent":
+    case "billing":
+    case "rate_limit":
+    case "session_expired":
+      return params.failoverReason;
+    // format          → client-side payload/schema bug, not profile fault
+    // overloaded      → provider-wide capacity, not profile fault
+    // timeout         → transport, not auth health signal
+    // model_not_found → catalog/model issue, not profile fault
+    // empty_response  → provider returned nothing usable, not auth fault
+    // no_error_details → opaque server failure, ambiguous
+    // unclassified    → couldn't classify, ambiguous
+    // unknown         → too risky to penalize profile on ambiguous errors
+    case "format":
+    case "overloaded":
+    case "timeout":
+    case "model_not_found":
+    case "empty_response":
+    case "no_error_details":
+    case "unclassified":
+    case "unknown":
+      return null;
+    default: {
+      // Exhaustiveness guard — fail closed (don't mark) for new reasons.
+      const _exhaustive: never = params.failoverReason;
+      void _exhaustive;
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Currently `resolveAuthProfileFailureReason` in `src/agents/pi-embedded-runner/run/auth-profile-failure-policy.ts` returns the `FailoverReason` for **every** non-`timeout`, non-`local` failure. That value flows directly into `markAuthProfileFailure` and puts the profile into cooldown. The result: any client-side payload/schema bug, provider overload, or unclassified error pollutes shared auth health and cascades across every fallback model on the same provider.

## Repro

Send a request to `github-copilot/claude-opus-4.7` ending in an assistant message:

```
400 invalid_request_error: This model does not support assistant message prefill.
The conversation must end with a user message.
```

This is classified as `format` → marks the only `github-copilot` profile failed → all 8 fallback models (`gpt-5.4`, `gemini-3.1-pro-preview`, `claude-sonnet-4.6`, …) immediately fail with `No available auth profile for github-copilot (all in cooldown or unavailable)`. Entire chain exhausted; user sees `All models failed (8): …`.

Real-world log excerpt:

```
warn agent/embedded auth_profile_failure_state_updated reason=format errorCount=1 cooldownUntil=...
error Embedded agent failed before reply: All models failed (8): ...: No available auth profile (all in cooldown or unavailable). (format) | ... (format) | ...
```

## Fix

Restrict `resolveAuthProfileFailureReason` to only the `FailoverReason` values that genuinely reflect profile health:

- `auth`
- `auth_permanent`
- `billing`
- `rate_limit`
- `session_expired`

Everything else (`format`, `overloaded`, `timeout`, `model_not_found`, `empty_response`, `no_error_details`, `unclassified`, `unknown`) is request/transport/model-side and must not punish the profile.

Adds an exhaustiveness guard via a `never` binding so any future `FailoverReason` addition fails closed (does not mark the profile) until the policy is explicitly extended.

## Tests

Extends `auth-profile-failure-policy.test.ts`:

- New regression test asserting `format`, `overloaded`, `model_not_found`, `unknown` all return `null`.
- New positive test asserting `auth`, `auth_permanent`, `session_expired` are still recorded.
- Existing tests (`billing`, `rate_limit`, `local` policy, `timeout`) continue to pass.

```
✓ unit-fast  src/agents/pi-embedded-runner/run/auth-profile-failure-policy.test.ts (5 tests) 3ms
```

`pnpm build` passes locally.