### PR TITLE
fix(cron): mirror direct cron deliveries into destination sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -952,6 +952,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Cron: mirror direct cron deliveries into destination sessions only after the full best-effort payload set succeeds, so retries cannot silently drop failed payloads behind a mirrored transcript entry. Fixes #74743. Thanks @yfge.
 - Agents/tools: skip unavailable media generation and PDF tool factories from the live reply path when Gateway metadata and the active auth store prove no configured provider can back them, while keeping explicit config and auth-backed providers on the normal factory path. Thanks @shakkernerd.
 - Agents/runtime: reuse the Gateway metadata startup plan when ensuring reply runtime plugins are loaded, so live agent turns do not broad-load plugin runtimes after the Gateway already scoped startup activation. Thanks @shakkernerd.
 - Agents/runtime: delegate scoped reply runtime registry reuse to the plugin loader cache-key compatibility checks, so config changes with the same startup plugin ids cannot keep stale runtime hooks or tools active. Thanks @shakkernerd.

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -22,6 +22,10 @@ const { countActiveDescendantRunsMock, maybeApplyTtsToPayloadMock, retireSession
     retireSessionMcpRuntimeMock: vi.fn().mockResolvedValue(true),
   }));
 
+vi.mock("../../config/sessions/transcript.runtime.js", () => ({
+  appendAssistantMessageToSessionTranscript: vi.fn().mockResolvedValue({ ok: true }),
+}));
+
 vi.mock("../../config/sessions/main-session.js", () => ({
   resolveAgentMainSessionKey: vi.fn(({ agentId }: { agentId: string }) => `agent:${agentId}:main`),
   resolveMainSessionKey: vi.fn(() => "global"),
@@ -86,6 +90,7 @@ import { retireSessionMcpRuntime } from "../../agents/pi-bundle-mcp-tools.js";
 // Import after mocks
 import { countActiveDescendantRuns } from "../../agents/subagent-registry-read.js";
 import { callGateway } from "../../gateway/call.runtime.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.runtime.js";
 import { deliverOutboundPayloads } from "../../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
@@ -788,6 +793,7 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(first.delivered).toBe(false);
     expect(second.delivered).toBe(false);
     expect(deliverOutboundPayloads).toHaveBeenCalledTimes(2);
+    expect(appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
   });
 
   it("prunes the completed-delivery cache back to the entry cap", async () => {
@@ -1072,15 +1078,15 @@ describe("dispatchCronDelivery — double-announce guard", () => {
       sessionKey: "agent:main:session:dest-session-id",
     });
     expect(deliverOutboundPayloads).toHaveBeenCalledWith(
-      expect.objectContaining({
-        mirror: {
-          sessionKey: "agent:main:session:dest-session-id",
-          agentId: "main",
-          text: "hello from cron",
-          idempotencyKey: expect.stringContaining("test-job"),
-        },
-      }),
+      expect.not.objectContaining({ mirror: expect.anything() }),
     );
+    expect(appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      sessionKey: "agent:main:session:dest-session-id",
+      agentId: "main",
+      text: "hello from cron",
+      mediaUrls: undefined,
+      idempotencyKey: expect.stringContaining("test-job"),
+    });
   });
 
   it("mirrors the filtered direct-delivery payload projection including media", async () => {
@@ -1111,15 +1117,15 @@ describe("dispatchCronDelivery — double-announce guard", () => {
             mediaUrls: ["https://example.com/report.pdf"],
           },
         ],
-        mirror: {
-          sessionKey: "agent:main:session:dest-session-id",
-          agentId: "main",
-          text: undefined,
-          mediaUrls: ["https://example.com/report.pdf"],
-          idempotencyKey: expect.stringContaining("test-job"),
-        },
       }),
     );
+    expect(appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith({
+      sessionKey: "agent:main:session:dest-session-id",
+      agentId: "main",
+      text: undefined,
+      mediaUrls: ["https://example.com/report.pdf"],
+      idempotencyKey: expect.stringContaining("test-job"),
+    });
   });
 
   it("passes threaded telegram delivery through to the outbound adapter", async () => {

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1069,14 +1069,53 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     expect(buildOutboundSessionContext).toHaveBeenCalledWith({
       cfg: params.cfgWithAgentDefaults,
       agentId: "main",
-      sessionKey: "dest-session-id",
+      sessionKey: "agent:main:session:dest-session-id",
     });
     expect(deliverOutboundPayloads).toHaveBeenCalledWith(
       expect.objectContaining({
         mirror: {
-          sessionKey: "dest-session-id",
+          sessionKey: "agent:main:session:dest-session-id",
           agentId: "main",
           text: "hello from cron",
+          idempotencyKey: expect.stringContaining("test-job"),
+        },
+      }),
+    );
+  });
+
+  it("mirrors the filtered direct-delivery payload projection including media", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: undefined });
+    params.job.sessionTarget = "session:dest-session-id";
+    params.agentSessionKey = "agent:main:session:dest-session-id";
+    params.deliveryPayloads = [
+      {
+        text: "NO_REPLY",
+        mediaUrls: ["https://example.com/report.pdf"],
+      },
+    ];
+    params.outputText = "NO_REPLY";
+    params.summary = "Report attached.";
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payloads: [
+          {
+            text: undefined,
+            mediaUrls: ["https://example.com/report.pdf"],
+          },
+        ],
+        mirror: {
+          sessionKey: "agent:main:session:dest-session-id",
+          agentId: "main",
+          text: undefined,
+          mediaUrls: ["https://example.com/report.pdf"],
           idempotencyKey: expect.stringContaining("test-job"),
         },
       }),

--- a/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts
@@ -1054,6 +1054,35 @@ describe("dispatchCronDelivery — double-announce guard", () => {
     });
   });
 
+  it("mirrors custom-session cron deliveries into the destination session transcript", async () => {
+    vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
+    vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);
+
+    const params = makeBaseParams({ synthesizedText: "hello from cron" });
+    params.job.sessionTarget = "session:dest-session-id";
+    params.agentSessionKey = "agent:main:session:dest-session-id";
+
+    const state = await dispatchCronDelivery(params);
+
+    expect(state.result).toBeUndefined();
+    expect(state.delivered).toBe(true);
+    expect(buildOutboundSessionContext).toHaveBeenCalledWith({
+      cfg: params.cfgWithAgentDefaults,
+      agentId: "main",
+      sessionKey: "dest-session-id",
+    });
+    expect(deliverOutboundPayloads).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mirror: {
+          sessionKey: "dest-session-id",
+          agentId: "main",
+          text: "hello from cron",
+          idempotencyKey: expect.stringContaining("test-job"),
+        },
+      }),
+    );
+  });
+
   it("passes threaded telegram delivery through to the outbound adapter", async () => {
     vi.mocked(countActiveDescendantRuns).mockReturnValue(0);
     vi.mocked(isLikelyInterimCronMessage).mockReturnValue(false);

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -39,6 +39,15 @@ import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpe
 import type { RunCronAgentTurnResult } from "./run.types.js";
 import { expectsSubagentFollowup, isLikelyInterimCronMessage } from "./subagent-followup-hints.js";
 
+let transcriptRuntimePromise:
+  | Promise<typeof import("../../config/sessions/transcript.runtime.js")>
+  | undefined;
+
+async function loadTranscriptRuntime() {
+  transcriptRuntimePromise ??= import("../../config/sessions/transcript.runtime.js");
+  return await transcriptRuntimePromise;
+}
+
 function normalizeDeliveryTarget(channel: string, to: string): string {
   const toTrimmed = to.trim();
   return normalizeTargetForProvider(channel, toTrimmed) ?? toTrimmed;
@@ -655,6 +664,13 @@ export async function dispatchCronDelivery(
       const mirrorProjection = projectOutboundPayloadPlanForMirror(
         createOutboundPayloadPlan(payloadsForDelivery),
       );
+      const transcriptMirror = {
+        sessionKey: deliverySessionKey,
+        agentId: params.agentId,
+        text: mirrorProjection.text || undefined,
+        mediaUrls: mirrorProjection.mediaUrls.length ? mirrorProjection.mediaUrls : undefined,
+        idempotencyKey: deliveryIdempotencyKey,
+      };
 
       // Track bestEffort partial failures so we can log them and avoid
       // marking the job as delivered when payloads were silently dropped.
@@ -677,13 +693,6 @@ export async function dispatchCronDelivery(
           threadId: delivery.threadId,
           payloads: payloadsForDelivery,
           session: deliverySession,
-          mirror: {
-            sessionKey: deliverySessionKey,
-            agentId: params.agentId,
-            text: mirrorProjection.text || undefined,
-            mediaUrls: mirrorProjection.mediaUrls.length ? mirrorProjection.mediaUrls : undefined,
-            idempotencyKey: deliveryIdempotencyKey,
-          },
           identity,
           bestEffort: params.deliveryBestEffort,
           deps: createOutboundSendDeps(params.deps),
@@ -708,6 +717,10 @@ export async function dispatchCronDelivery(
       // Intentionally leave partial success uncached: replay may duplicate the
       // successful subset, but caching it here would permanently drop the
       // failed payloads by converting the replay into delivered=true.
+      if (delivered) {
+        const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
+        await appendAssistantMessageToSessionTranscript(transcriptMirror);
+      }
       if (
         delivered &&
         shouldQueueCronAwareness({

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -29,6 +29,7 @@ import {
 import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 import { createCronExecutionId } from "../run-id.js";
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";
+import { resolveCronDeliverySessionKey } from "../session-target.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpers.js";
@@ -642,10 +643,12 @@ export async function dispatchCronDelivery(
         delivered = true;
         return null;
       }
+      const deliverySessionKey =
+        resolveCronDeliverySessionKey(params.job) ?? params.agentSessionKey;
       const deliverySession = buildOutboundSessionContext({
         cfg: params.cfgWithAgentDefaults,
         agentId: params.agentId,
-        sessionKey: params.agentSessionKey,
+        sessionKey: deliverySessionKey,
       });
 
       // Track bestEffort partial failures so we can log them and avoid
@@ -669,6 +672,12 @@ export async function dispatchCronDelivery(
           threadId: delivery.threadId,
           payloads: payloadsForDelivery,
           session: deliverySession,
+          mirror: {
+            sessionKey: deliverySessionKey,
+            agentId: params.agentId,
+            text: outputText || synthesizedText || undefined,
+            idempotencyKey: deliveryIdempotencyKey,
+          },
           identity,
           bestEffort: params.deliveryBestEffort,
           deps: createOutboundSendDeps(params.deps),

--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -17,6 +17,10 @@ import type { TtsAutoMode } from "../../config/types.tts.js";
 import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import type { OutboundDeliveryResult } from "../../infra/outbound/deliver.js";
+import {
+  createOutboundPayloadPlan,
+  projectOutboundPayloadPlanForMirror,
+} from "../../infra/outbound/payloads.js";
 import { normalizeTargetForProvider } from "../../infra/outbound/target-normalization.js";
 import { hasReplyPayloadContent } from "../../interactive/payload.js";
 import { stringifyRouteThreadId } from "../../plugin-sdk/channel-route.js";
@@ -29,7 +33,6 @@ import {
 import { shouldAttemptTtsPayload } from "../../tts/tts-config.js";
 import { createCronExecutionId } from "../run-id.js";
 import { hasScheduledNextRunAtMs } from "../service/jobs.js";
-import { resolveCronDeliverySessionKey } from "../session-target.js";
 import type { CronJob, CronRunTelemetry } from "../types.js";
 import type { DeliveryTargetResolution } from "./delivery-target.js";
 import { pickLastNonEmptyTextFromPayloads, pickSummaryFromOutput } from "./helpers.js";
@@ -643,13 +646,15 @@ export async function dispatchCronDelivery(
         delivered = true;
         return null;
       }
-      const deliverySessionKey =
-        resolveCronDeliverySessionKey(params.job) ?? params.agentSessionKey;
+      const deliverySessionKey = params.agentSessionKey;
       const deliverySession = buildOutboundSessionContext({
         cfg: params.cfgWithAgentDefaults,
         agentId: params.agentId,
         sessionKey: deliverySessionKey,
       });
+      const mirrorProjection = projectOutboundPayloadPlanForMirror(
+        createOutboundPayloadPlan(payloadsForDelivery),
+      );
 
       // Track bestEffort partial failures so we can log them and avoid
       // marking the job as delivered when payloads were silently dropped.
@@ -675,7 +680,8 @@ export async function dispatchCronDelivery(
           mirror: {
             sessionKey: deliverySessionKey,
             agentId: params.agentId,
-            text: outputText || synthesizedText || undefined,
+            text: mirrorProjection.text || undefined,
+            mediaUrls: mirrorProjection.mediaUrls.length ? mirrorProjection.mediaUrls : undefined,
             idempotencyKey: deliveryIdempotencyKey,
           },
           identity,


### PR DESCRIPTION
## Summary

### Background
- Fixes https://github.com/openclaw/openclaw/issues/74743.
- `openclaw cron run` could announce into the requested external channel while skipping the destination `session:<id>` transcript mirror, so the agent forgot the message it had just sent.

### Changes
- Resolve the cron delivery session key before direct outbound delivery instead of always reusing the agent-store session key.
- Mirror direct cron delivery text back into that destination session transcript with the direct-delivery idempotency key.
- Add a regression test covering `session:<id>` cron delivery so the outbound context and mirror both point at the destination session.

### Validation
- `pnpm exec oxfmt --check --threads=1 src/cron/isolated-agent/delivery-dispatch.ts src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`
- `pnpm test src/cron/isolated-agent/delivery-dispatch.double-announce.test.ts`

### Impact
- Cron jobs pinned to `--session session:<id>` now leave the delivered assistant reply in the same persistent session transcript that users inspect later.
- This keeps follow-up turns grounded in the actual last sent cron message instead of stale pre-cron transcript state.
