### PR TITLE
Fix legacy LLM timeout diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Config/doctor: preserve legacy `agents.defaults.llm.idleTimeoutSeconds` values in `doctor --fix` output and emit a config-load warning that points users to `models.providers.<id>.timeoutSeconds`. Fixes #74910. (#74940) Thanks @chiyouYCH.
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.
 - Discord/voice: make `openclaw channels capabilities --channel discord --target channel:<id>` and `channels status --probe` audit voice-channel permissions, including auto-join targets, so missing Connect/Speak/Read Message History permissions show up before `/vc join`.
 - Docs/iMessage: deprecate BlueBubbles for new OpenClaw setups, document the upstream server-release rationale, and point new iMessage deployments toward the native `imsg` path while keeping BlueBubbles as a supported legacy fallback.

--- a/src/commands/doctor/shared/legacy-config-migrate.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.test.ts
@@ -299,20 +299,30 @@ describe("legacy migrate sandbox scope aliases", () => {
     const res = migrateLegacyConfigForTest({
       agents: {
         defaults: {
-          model: { primary: "openai/gpt-5.4" },
+          model: { primary: "mlx/slow-local" },
           llm: {
-            idleTimeoutSeconds: 120,
+            idleTimeoutSeconds: 180,
+          },
+        },
+      },
+      models: {
+        providers: {
+          mlx: {
+            baseUrl: "http://127.0.0.1:8080/v1",
+            api: "openai-completions",
+            models: [{ id: "slow-local", name: "mlx/slow-local" }],
           },
         },
       },
     });
 
     expect(res.changes).toContain(
-      "Removed agents.defaults.llm; model idle timeout now follows models.providers.<id>.timeoutSeconds.",
+      "Removed agents.defaults.llm.idleTimeoutSeconds: 180; to preserve this behavior, set models.providers.<id>.timeoutSeconds: 180 for slow providers. Configured providers: mlx.",
     );
     expect(res.config?.agents?.defaults).toEqual({
-      model: { primary: "openai/gpt-5.4" },
+      model: { primary: "mlx/slow-local" },
     });
+    expect(res.config?.models?.providers?.mlx?.timeoutSeconds).toBeUndefined();
   });
 
   it("moves legacy embeddedHarness runtime policy into agentRuntime", () => {

--- a/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.validation.test.ts
@@ -58,7 +58,7 @@ describe("legacy config migrate validation", () => {
 
     expect(res.partiallyValid).toBe(true);
     expect(res.changes).toContain(
-      "Removed agents.defaults.llm; model idle timeout now follows models.providers.<id>.timeoutSeconds.",
+      "Removed agents.defaults.llm.idleTimeoutSeconds: 120; to preserve this behavior, set models.providers.<id>.timeoutSeconds: 120 for slow providers.",
     );
     expect(res.changes).toContain(
       "Migration applied; other validation issues remain — run doctor to review.",

--- a/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
+++ b/src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts
@@ -240,6 +240,24 @@ function removeAgentRuntimeFallback(
   changes.push(`Removed ${pathLabel}.agentRuntime.fallback.`);
 }
 
+function getFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatConfiguredProvidersHint(raw: Record<string, unknown>): string {
+  const providers = getRecord(getRecord(raw.models)?.providers);
+  if (!providers) {
+    return "";
+  }
+  const providerIds = Object.keys(providers)
+    .filter((providerId) => !isBlockedObjectKey(providerId))
+    .toSorted();
+  if (providerIds.length === 0) {
+    return "";
+  }
+  return ` Configured providers: ${providerIds.join(", ")}.`;
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[] = [
   defineLegacyConfigMigration({
     id: "agents.defaults.llm->models.providers.timeoutSeconds",
@@ -247,10 +265,20 @@ export const LEGACY_CONFIG_MIGRATIONS_RUNTIME_AGENTS: LegacyConfigMigrationSpec[
     legacyRules: LEGACY_AGENT_LLM_TIMEOUT_RULES,
     apply: (raw, changes) => {
       const defaults = getRecord(getRecord(raw.agents)?.defaults);
-      if (!defaults || getRecord(defaults.llm) === null) {
+      const legacyLlm = getRecord(defaults?.llm);
+      if (!defaults || legacyLlm === null) {
         return;
       }
+      const idleTimeoutSeconds = getFiniteNumber(legacyLlm.idleTimeoutSeconds);
       delete defaults.llm;
+      if (idleTimeoutSeconds !== null) {
+        changes.push(
+          `Removed agents.defaults.llm.idleTimeoutSeconds: ${idleTimeoutSeconds}; ` +
+            `to preserve this behavior, set models.providers.<id>.timeoutSeconds: ${idleTimeoutSeconds} for slow providers.` +
+            formatConfiguredProvidersHint(raw),
+        );
+        return;
+      }
       changes.push(
         "Removed agents.defaults.llm; model idle timeout now follows models.providers.<id>.timeoutSeconds.",
       );

--- a/src/config/io.compat.test.ts
+++ b/src/config/io.compat.test.ts
@@ -109,6 +109,57 @@ describe("config io paths", () => {
     });
   });
 
+  it("logs legacy agents.defaults.llm timeout warnings at config load time", async () => {
+    await withTempHome(async (home) => {
+      const configPath = path.join(home, ".openclaw", "openclaw.json");
+      await fs.mkdir(path.dirname(configPath), { recursive: true });
+      await fs.writeFile(
+        configPath,
+        JSON.stringify(
+          {
+            agents: {
+              defaults: {
+                model: { primary: "mlx/slow-local" },
+                llm: { idleTimeoutSeconds: 180 },
+              },
+            },
+            models: {
+              providers: {
+                mlx: {
+                  baseUrl: "http://127.0.0.1:8080/v1",
+                  api: "openai-completions",
+                  models: [{ id: "slow-local", name: "mlx/slow-local" }],
+                },
+              },
+            },
+          },
+          null,
+          2,
+        ),
+      );
+      const logger = {
+        error: vi.fn(),
+        warn: vi.fn(),
+      };
+      const io = createConfigIO({
+        configPath,
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => home,
+        logger,
+      });
+
+      expect(() => io.loadConfig()).toThrow('Unrecognized key: "llm"');
+      expect(() => io.loadConfig()).toThrow('Unrecognized key: "llm"');
+
+      const legacyWarnings = logger.warn.mock.calls
+        .map(([message]) => String(message))
+        .filter((message) => message.includes("agents.defaults.llm.idleTimeoutSeconds"));
+      expect(legacyWarnings).toEqual([
+        expect.stringContaining("models.providers.<id>.timeoutSeconds: 180"),
+      ]);
+    });
+  });
+
   it("normalizes safe-bin config entries at config load time", async () => {
     const cfg = {
       tools: {

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -152,6 +152,7 @@ type ShippedPluginInstallConfigReadMigration = {
 
 const CONFIG_HEALTH_STATE_FILENAME = "config-health.json";
 const loggedInvalidConfigs = new Set<string>();
+const loggedLegacyAgentLlmTimeoutWarnings = new Set<string>();
 const warnedFutureTouchedVersions = new Set<string>();
 
 type ConfigHealthFingerprint = {
@@ -885,6 +886,69 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   }
 }
 
+function readLegacyAgentLlmIdleTimeoutSeconds(sourceRaw: unknown): number | null {
+  if (!isRecord(sourceRaw)) {
+    return null;
+  }
+  const agents = sourceRaw.agents;
+  if (!isRecord(agents)) {
+    return null;
+  }
+  const defaults = agents.defaults;
+  if (!isRecord(defaults)) {
+    return null;
+  }
+  const llm = defaults.llm;
+  if (!isRecord(llm)) {
+    return null;
+  }
+  const idleTimeoutSeconds = llm.idleTimeoutSeconds;
+  return typeof idleTimeoutSeconds === "number" && Number.isFinite(idleTimeoutSeconds)
+    ? idleTimeoutSeconds
+    : null;
+}
+
+function hasLegacyAgentLlmConfig(sourceRaw: unknown): boolean {
+  if (!isRecord(sourceRaw)) {
+    return false;
+  }
+  const agents = sourceRaw.agents;
+  if (!isRecord(agents)) {
+    return false;
+  }
+  const defaults = agents.defaults;
+  if (!isRecord(defaults)) {
+    return false;
+  }
+  return isRecord(defaults.llm);
+}
+
+function warnOnLegacyAgentLlmTimeoutConfig(params: {
+  configPath: string;
+  sourceRaw: unknown;
+  logger: Pick<typeof console, "warn">;
+}): void {
+  if (!hasLegacyAgentLlmConfig(params.sourceRaw)) {
+    return;
+  }
+  const idleTimeoutSeconds = readLegacyAgentLlmIdleTimeoutSeconds(params.sourceRaw);
+  const warningKey = `${params.configPath}:agents.defaults.llm:${idleTimeoutSeconds ?? "unknown"}`;
+  if (loggedLegacyAgentLlmTimeoutWarnings.has(warningKey)) {
+    return;
+  }
+  loggedLegacyAgentLlmTimeoutWarnings.add(warningKey);
+
+  const replacement =
+    idleTimeoutSeconds !== null
+      ? `set models.providers.<id>.timeoutSeconds: ${idleTimeoutSeconds} for slow providers`
+      : "set models.providers.<id>.timeoutSeconds for slow providers";
+  params.logger.warn(
+    `Config legacy compatibility warning:\n- agents.defaults.llm${
+      idleTimeoutSeconds !== null ? ".idleTimeoutSeconds" : ""
+    }: legacy config no longer controls model idle timeouts; ${replacement} or run "openclaw doctor --fix".`,
+  );
+}
+
 function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
   const now = new Date().toISOString();
   return {
@@ -1520,6 +1584,11 @@ export function createConfigIO(
         );
       }
       warnOnConfigMiskeys(validationConfigRaw, deps.logger);
+      warnOnLegacyAgentLlmTimeoutConfig({
+        configPath,
+        sourceRaw: validationConfigRaw,
+        logger: deps.logger,
+      });
       if (typeof validationConfigRaw !== "object" || validationConfigRaw === null) {
         observeLoadConfigSnapshot({
           ...createConfigFileSnapshot({


### PR DESCRIPTION
## Summary
- Preserve the numeric `agents.defaults.llm.idleTimeoutSeconds` value in `doctor --fix` output instead of silently dropping it.
- Add a one-shot config-load warning when `agents.defaults.llm` is still present, pointing users to `models.providers.<id>.timeoutSeconds`.
- Cover doctor migration, partial-validation migration, and config-load diagnostics with focused tests.

Fixes #74910

## Real behavior proof
**Behavior or issue addressed:** Legacy `agents.defaults.llm.idleTimeoutSeconds` was removed by `doctor --fix` with only a generic message, so users lost the old timeout value and had no actionable provider-specific migration hint.

**Real environment tested:** Local macOS OpenClaw checkout at `82e9c03`, run with isolated temporary `OPENCLAW_CONFIG_PATH` and `OPENCLAW_STATE_DIR`. The temp config contained `agents.defaults.llm.idleTimeoutSeconds: 180` and `models.providers.mlx`.

**Exact steps or command run after this patch:**
```sh
OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state pnpm openclaw health
OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state pnpm openclaw doctor --fix
```

**Evidence after fix:** Copied live terminal output from the real CLI run:
```text
$ OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state pnpm openclaw health
Config invalid
Problem:
  - agents.defaults: Unrecognized key: "llm"
Legacy config keys detected:
  - agents.defaults.llm: agents.defaults.llm is legacy; use models.providers.<id>.timeoutSeconds for slow model/provider timeouts. Run "openclaw doctor --fix".

Run: openclaw doctor --fix

$ OPENCLAW_CONFIG_PATH=<tmp>/openclaw.json OPENCLAW_STATE_DIR=<tmp>/state pnpm openclaw doctor --fix
Legacy config keys detected
  - agents.defaults.llm: agents.defaults.llm is legacy; use models.providers.<id>.timeoutSeconds for slow model/provider timeouts. Run "openclaw doctor --fix".

Doctor changes
  Removed agents.defaults.llm.idleTimeoutSeconds: 180; to preserve this behavior, set models.providers.<id>.timeoutSeconds: 180 for slow providers. Configured providers: mlx.
```

**Observed result after fix:** The real CLI now preserves the old timeout value in the doctor migration output and gives the user the exact provider-level replacement value to configure: `models.providers.<id>.timeoutSeconds: 180`. It also shows the configured provider hint: `Configured providers: mlx.`

**What was not tested:** No known gaps for this diagnostic-only change; no live LLM request was needed because the fix changes config migration and diagnostics only.

## Tests
- `pnpm test src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/config/io.compat.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/commands/doctor/shared/legacy-config-migrations.runtime.agents.ts src/commands/doctor/shared/legacy-config-migrate.test.ts src/commands/doctor/shared/legacy-config-migrate.validation.test.ts src/config/io.ts src/config/io.compat.test.ts`
