### PR TITLE
fix(exec): keep long commands from blocking agent turns

### DIFF
--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -6,8 +6,9 @@ read_when:
 title: "Exec tool"
 ---
 
-Run shell commands in the workspace. Supports foreground + background execution via `process`.
-If `process` is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
+Run shell commands in the workspace. Supports foreground + background execution.
+When `process` is available, background sessions can be managed with `process`.
+If `process` is disallowed, `exec` can still background long commands, but follow-up is limited to completion wake notifications and the command timeout.
 Background sessions are scoped per agent; `process` only sees sessions from the same agent.
 
 ## Parameters
@@ -88,7 +89,7 @@ Notes:
   that file.
 - For long-running work that starts now, start it once and rely on automatic
   completion wake when it is enabled and the command emits output or fails.
-  Use `process` for logs, status, input, or intervention; do not emulate
+  Use `process` when available for logs, status, input, or intervention; do not emulate
   scheduling with sleep loops, timeout loops, or repeated polling.
 - For work that should happen later or on a schedule, use cron instead of
   `exec` sleep/delay patterns.

--- a/docs/tools/exec.md
+++ b/docs/tools/exec.md
@@ -8,7 +8,7 @@ title: "Exec tool"
 
 Run shell commands in the workspace. `exec` is a mutating shell surface: commands can create, edit, or delete files wherever the selected host or sandbox filesystem permits. Disabling OpenClaw filesystem tools such as `write`, `edit`, or `apply_patch` does not make `exec` read-only.
 
-Supports foreground + background execution via `process`. If `process` is disallowed, `exec` runs synchronously and ignores `yieldMs`/`background`.
+Supports foreground + background execution. When `process` is available, background sessions can be managed with `process`. If `process` is disallowed, `exec` can still background long commands with a finite timeout, but follow-up is limited to completion wake notifications and the command timeout. Timeoutless backgrounding is rejected because there is no `process` tool available to inspect or stop the session.
 Background sessions are scoped per agent; `process` only sees sessions from the same agent.
 
 ## Parameters
@@ -91,7 +91,7 @@ Notes:
   that file.
 - For long-running work that starts now, start it once and rely on automatic
   completion wake when it is enabled and the command emits output or fails.
-  Use `process` for logs, status, input, or intervention; do not emulate
+  Use `process` when available for logs, status, input, or intervention; do not emulate
   scheduling with sleep loops, timeout loops, or repeated polling.
 - For work that should happen later or on a schedule, use cron instead of
   `exec` sleep/delay patterns.

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -27,6 +27,7 @@ export type ExecToolDefaults = {
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
+  processToolAvailable?: boolean;
   scopeKey?: string;
   sessionKey?: string;
   messageProvider?: string;

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -28,6 +28,7 @@ export type ExecToolDefaults = {
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;
+  processToolAvailable?: boolean;
   scopeKey?: string;
   sessionKey?: string;
   /** `session.mainKey` from the runtime config; passed through into

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1386,6 +1386,7 @@ export function createExecTool(
     120_000,
   );
   const allowBackground = defaults?.allowBackground ?? true;
+  const processToolAvailable = defaults?.processToolAvailable ?? true;
   const defaultTimeoutSec =
     typeof defaults?.timeoutSec === "number" && defaults.timeoutSec > 0
       ? defaults.timeoutSec
@@ -1817,7 +1818,11 @@ export function createExecTool(
                 type: "text",
                 text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
                   run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/kill/clear/remove) for follow-up.`,
+                }). ${
+                  processToolAvailable
+                    ? "Use process (list/poll/log/write/kill/clear/remove) for follow-up."
+                    : "The process tool is unavailable; rely on completion wake notifications or the command timeout for follow-up."
+                }`,
               },
             ],
             details: {

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -1228,6 +1228,7 @@ export function createExecTool(
     120_000,
   );
   const allowBackground = defaults?.allowBackground ?? true;
+  const processToolAvailable = defaults?.processToolAvailable ?? true;
   const defaultTimeoutSec =
     typeof defaults?.timeoutSec === "number" && defaults.timeoutSec > 0
       ? defaults.timeoutSec
@@ -1600,6 +1601,16 @@ export function createExecTool(
 
       const explicitTimeoutSec = typeof params.timeout === "number" ? params.timeout : null;
       const effectiveTimeout = explicitTimeoutSec ?? defaultTimeoutSec;
+      if (
+        !processToolAvailable &&
+        allowBackground &&
+        yieldWindow !== null &&
+        effectiveTimeout <= 0
+      ) {
+        throw new Error(
+          "exec cannot background a timeoutless command while the process tool is unavailable. Set timeout to a positive number or enable process for follow-up.",
+        );
+      }
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
 
@@ -1664,7 +1675,11 @@ export function createExecTool(
                 type: "text",
                 text: `${getWarningText()}Command still running (session ${run.session.id}, pid ${
                   run.session.pid ?? "n/a"
-                }). Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up.`,
+                }). ${
+                  processToolAvailable
+                    ? "Use process (list/poll/log/write/send-keys/submit/paste/kill/clear/remove) for follow-up."
+                    : "The process tool is unavailable; rely on completion wake notifications or the command timeout for follow-up."
+                }`,
               },
             ],
             details: {

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -104,6 +104,9 @@ describe("Agent-specific exec tool defaults", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("running");
+    const resultText = result?.content?.find((item) => item.type === "text")?.text ?? "";
+    expect(resultText).not.toContain("Use process");
+    expect(resultText).toContain("completion wake");
   });
 
   it("routes implicit auto exec to gateway without a sandbox runtime", async () => {

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
 
 function createExecHostDefaultsConfig(
@@ -39,6 +40,10 @@ describe("Agent-specific exec tool defaults", () => {
     setActivePluginRegistry(createSessionConversationTestRegistry());
   });
 
+  afterEach(() => {
+    resetProcessRegistryForTests();
+  });
+
   it("should run exec synchronously when process is denied", async () => {
     const cfg: OpenClawConfig = {
       tools: {
@@ -67,6 +72,38 @@ describe("Agent-specific exec tool defaults", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("completed");
+  });
+
+  it("auto-backgrounds long exec commands even when process is denied", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        deny: ["process"],
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+        },
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp/test-main",
+      agentDir: "/tmp/agent-main",
+    });
+    expect(tools.some((tool) => tool.name === "process")).toBe(false);
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    const result = await execTool?.execute("call-long", {
+      command: `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 250)"`,
+      yieldMs: 10,
+      timeout: 1,
+    });
+
+    const resultDetails = result?.details as { status?: string } | undefined;
+    expect(resultDetails?.status).toBe("running");
   });
 
   it("routes implicit auto exec to gateway without a sandbox runtime", async () => {

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -74,7 +74,7 @@ describe("Agent-specific exec tool defaults", () => {
 
     const result = await execTool.execute("call1", {
       command: "echo done",
-      yieldMs: 10,
+      yieldMs: 5_000,
     });
 
     const resultDetails = result?.details as { status?: string } | undefined;

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -111,6 +111,9 @@ describe("Agent-specific exec tool defaults", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("running");
+    const resultText = result?.content?.find((item) => item.type === "text")?.text ?? "";
+    expect(resultText).not.toContain("Use process");
+    expect(resultText).toContain("completion wake");
   });
 
   it("routes implicit auto exec to gateway without a sandbox runtime", async () => {

--- a/src/agents/pi-tools-agent-config.exec.test.ts
+++ b/src/agents/pi-tools-agent-config.exec.test.ts
@@ -1,9 +1,10 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import "./test-helpers/fast-coding-tools.js";
 import "./test-helpers/fast-openclaw-tools.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createSessionConversationTestRegistry } from "../test-utils/session-conversation-registry.js";
+import { resetProcessRegistryForTests } from "./bash-process-registry.js";
 import { createOpenClawCodingTools } from "./pi-tools.js";
 
 function createExecHostDefaultsConfig(
@@ -47,6 +48,10 @@ describe("Agent-specific exec tool defaults", () => {
     setActivePluginRegistry(createSessionConversationTestRegistry());
   });
 
+  afterEach(() => {
+    resetProcessRegistryForTests();
+  });
+
   it("should run exec synchronously when process is denied", async () => {
     const cfg: OpenClawConfig = {
       tools: {
@@ -74,6 +79,38 @@ describe("Agent-specific exec tool defaults", () => {
 
     const resultDetails = result?.details as { status?: string } | undefined;
     expect(resultDetails?.status).toBe("completed");
+  });
+
+  it("auto-backgrounds long exec commands even when process is denied", async () => {
+    const cfg: OpenClawConfig = {
+      tools: {
+        deny: ["process"],
+        exec: {
+          host: "gateway",
+          security: "full",
+          ask: "off",
+        },
+      },
+    };
+
+    const tools = createOpenClawCodingTools({
+      config: cfg,
+      sessionKey: "agent:main:main",
+      workspaceDir: "/tmp/test-main",
+      agentDir: "/tmp/agent-main",
+    });
+    expect(tools.some((tool) => tool.name === "process")).toBe(false);
+    const execTool = tools.find((tool) => tool.name === "exec");
+    expect(execTool).toBeDefined();
+
+    const result = await execTool?.execute("call-long", {
+      command: `${JSON.stringify(process.execPath)} -e "setTimeout(() => {}, 250)"`,
+      yieldMs: 10,
+      timeout: 1,
+    });
+
+    const resultDetails = result?.details as { status?: string } | undefined;
+    expect(resultDetails?.status).toBe("running");
   });
 
   it("routes implicit auto exec to gateway without a sandbox runtime", async () => {

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -27,7 +27,6 @@ import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
 import {
-  isToolAllowedByPolicies,
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -27,6 +27,7 @@ import { wrapToolWithBeforeToolCallHook } from "./pi-tools.before-tool-call.js";
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
 import {
+  isToolAllowedByPolicies,
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveSubagentToolPolicyForSession,
@@ -427,6 +428,17 @@ export function createOpenClawCodingTools(options?: {
           store: subagentStore,
         })
       : undefined;
+  const processToolAvailable = isToolAllowedByPolicies("process", [
+    profilePolicyWithAlsoAllow,
+    providerProfilePolicyWithAlsoAllow,
+    globalPolicy,
+    globalProviderPolicy,
+    agentPolicy,
+    agentProviderPolicy,
+    groupPolicy,
+    sandboxToolPolicy,
+    subagentPolicy,
+  ]);
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const fsPolicy = createToolFsPolicy({
@@ -517,6 +529,7 @@ export function createOpenClawCodingTools(options?: {
     // even when the separate process follow-up tool is hidden, so long-running
     // commands cannot pin the agent turn indefinitely.
     allowBackground: true,
+    processToolAvailable,
     scopeKey,
     sessionKey: options?.sessionKey,
     messageProvider: options?.messageProvider,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -428,17 +428,6 @@ export function createOpenClawCodingTools(options?: {
           store: subagentStore,
         })
       : undefined;
-  const allowBackground = isToolAllowedByPolicies("process", [
-    profilePolicyWithAlsoAllow,
-    providerProfilePolicyWithAlsoAllow,
-    globalPolicy,
-    globalProviderPolicy,
-    agentPolicy,
-    agentProviderPolicy,
-    groupPolicy,
-    sandboxToolPolicy,
-    subagentPolicy,
-  ]);
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
   const fsPolicy = createToolFsPolicy({
@@ -525,7 +514,10 @@ export function createOpenClawCodingTools(options?: {
     safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
     agentId,
     cwd: workspaceRoot,
-    allowBackground,
+    // Exec owns process lifetime and timeout. Keep auto-backgrounding available
+    // even when the separate process follow-up tool is hidden, so long-running
+    // commands cannot pin the agent turn indefinitely.
+    allowBackground: true,
     scopeKey,
     sessionKey: options?.sessionKey,
     messageProvider: options?.messageProvider,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -37,7 +37,6 @@ import {
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
 import {
-  isToolAllowedByPolicies,
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveInheritedToolPolicyForSession,
@@ -607,19 +606,6 @@ export function createOpenClawCodingTools(options?: {
   const sandboxToolPolicyWithToolSearchControls =
     mergeToolSearchControlAllowlist(sandboxToolPolicy);
   const subagentPolicyWithToolSearchControls = mergeToolSearchControlAllowlist(subagentPolicy);
-  const allowBackground = isToolAllowedByPolicies("process", [
-    profilePolicyWithAlsoAllow,
-    providerProfilePolicyWithAlsoAllow,
-    globalPolicyWithToolSearchControls,
-    globalProviderPolicyWithToolSearchControls,
-    agentPolicyWithToolSearchControls,
-    agentProviderPolicyWithToolSearchControls,
-    groupPolicyWithToolSearchControls,
-    senderPolicyWithToolSearchControls,
-    sandboxToolPolicyWithToolSearchControls,
-    subagentPolicyWithToolSearchControls,
-    inheritedToolPolicy,
-  ]);
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
@@ -739,7 +725,10 @@ export function createOpenClawCodingTools(options?: {
         safeBinProfiles: options?.exec?.safeBinProfiles ?? execConfig.safeBinProfiles,
         agentId,
         cwd: workspaceRoot,
-        allowBackground,
+        // Exec owns process lifetime and timeout. Keep auto-backgrounding available
+        // even when the separate process follow-up tool is hidden, so long-running
+        // commands cannot pin the agent turn indefinitely.
+        allowBackground: true,
         scopeKey,
         sessionKey: options?.sessionKey,
         mainKey: options?.config?.session?.mainKey,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -37,6 +37,7 @@ import {
 import { applyDeferredFollowupToolDescriptions } from "./pi-tools.deferred-followup.js";
 import { filterToolsByMessageProvider } from "./pi-tools.message-provider-policy.js";
 import {
+  isToolAllowedByPolicies,
   resolveEffectiveToolPolicy,
   resolveGroupToolPolicy,
   resolveInheritedToolPolicyForSession,
@@ -606,6 +607,19 @@ export function createOpenClawCodingTools(options?: {
   const sandboxToolPolicyWithToolSearchControls =
     mergeToolSearchControlAllowlist(sandboxToolPolicy);
   const subagentPolicyWithToolSearchControls = mergeToolSearchControlAllowlist(subagentPolicy);
+  const processToolAvailable = isToolAllowedByPolicies("process", [
+    profilePolicyWithAlsoAllow,
+    providerProfilePolicyWithAlsoAllow,
+    globalPolicyWithToolSearchControls,
+    globalProviderPolicyWithToolSearchControls,
+    agentPolicyWithToolSearchControls,
+    agentProviderPolicyWithToolSearchControls,
+    groupPolicyWithToolSearchControls,
+    senderPolicyWithToolSearchControls,
+    sandboxToolPolicyWithToolSearchControls,
+    subagentPolicyWithToolSearchControls,
+    inheritedToolPolicy,
+  ]);
   options?.recordToolPrepStage?.("tool-policy");
   const execConfig = resolveExecConfig({ cfg: options?.config, agentId });
   const fsConfig = resolveToolFsConfig({ cfg: options?.config, agentId });
@@ -729,6 +743,7 @@ export function createOpenClawCodingTools(options?: {
         // even when the separate process follow-up tool is hidden, so long-running
         // commands cannot pin the agent turn indefinitely.
         allowBackground: true,
+        processToolAvailable,
         scopeKey,
         sessionKey: options?.sessionKey,
         mainKey: options?.config?.session?.mainKey,


### PR DESCRIPTION
## Summary

- Problem: long-running `exec` calls could pin an agent turn when `process` was hidden by policy because `exec` disabled background continuation with `process`.
- Why it matters: provider/tool policies can hide `process`; in that setup a finite-timeout command should still be able to yield instead of blocking the model turn.
- What changed: `exec` now keeps finite-timeout backgrounding available even when `process` is unavailable, changes follow-up wording for that case, and rejects timeoutless backgrounding without `process`.
- What did NOT change: `process` remains hidden when policy denies it, and timeoutless detached follow-up still requires `process`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #79283
- Related #82178
- [x] This PR fixes a bug or regression

## Real behavior proof (required for external PRs)

- Behavior or issue addressed: with `tools.deny: ["process"]`, `exec` still auto-backgrounds a finite-timeout long command after `yieldMs` and does not instruct the model to use the unavailable `process` tool; timeoutless backgrounding is rejected.
- Real environment tested: local OpenClaw source checkout on macOS after building the PR head with `pnpm openclaw --help`; runtime command imported the built `dist/plugin-sdk/agent-harness.js` from commit `b5c1604` and used the actual `exec` tool implementation with a policy that denies `process`.
- Exact steps or command run after this patch: `node --input-type=module -e '<script importing createOpenClawCodingTools from ./dist/plugin-sdk/agent-harness.js, denying process, invoking exec with yieldMs: 10 and timeout: 1, then invoking timeout: 0>'`; supplemental checks: `node scripts/run-vitest.mjs src/agents/pi-tools-agent-config.exec.test.ts`, `pnpm check:changed`, `git diff --check`, `pnpm exec oxfmt --check --threads=1 src/agents/bash-tools.exec.ts src/agents/bash-tools.exec-types.ts src/agents/pi-tools.ts src/agents/pi-tools-agent-config.exec.test.ts`, `node scripts/format-docs.mjs --check docs/tools/exec.md docs/gateway/background-process.md`.
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output): copied terminal output from the built OpenClaw runtime smoke:

```json
{
  "hasProcess": false,
  "runningStatus": "running",
  "runningText": "Command still running (session young-shore, pid 69828). The process tool is unavailable; rely on completion wake notifications or the command timeout for follow-up.",
  "timeoutlessError": "exec cannot background a timeoutless command while the process tool is unavailable. Set timeout to a positive number or enable process for follow-up."
}
```

- Observed result after fix: the tool catalog omitted `process`, the finite-timeout long `exec` call returned `details.status: "running"`, the user-visible follow-up text referenced completion wake/timeout instead of `process`, and the timeoutless background attempt failed before creating an unmanaged session.
- What was not tested: WSL2/webchat live end-to-end reproduction for issue #79283; true timeoutless detached process follow-up with `process` disabled, because this PR intentionally rejects that unsupported path.

## Root Cause (if applicable)

- Root cause: `createOpenClawCodingTools` reused the `process` policy decision as `exec`'s `allowBackground` flag, so denying the separate follow-up tool also disabled `exec`'s own finite-timeout yielding path.
- Missing detection / guardrail: coverage checked synchronous execution when `process` was denied, but did not cover long-running finite-timeout commands with `yieldMs` under the same policy.
- Contributing context (if known): the old docs also stated that `exec` would ignore `yieldMs`/`background` whenever `process` was disallowed.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/pi-tools-agent-config.exec.test.ts`
- Scenario the test should lock in: with `tools.deny: ["process"]`, finite-timeout `exec` auto-backgrounding returns `running` and timeoutless backgrounding rejects.
- Why this is the smallest reliable guardrail: the bug is in tool construction/default propagation from policy to `createExecTool`, so the focused agent tool config test covers the failing seam directly.
- Existing test that already covers this (if any): existing synchronous denied-process coverage remained, but did not cover long command yielding.
