### PR TITLE
fix(agents): prevent provider defaultModel from overriding agents.defaults.model (fixes #24170)

### DIFF
--- a/src/commands/auth-choice.apply.plugin-provider.test.ts
+++ b/src/commands/auth-choice.apply.plugin-provider.test.ts
@@ -1,22 +1,42 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { ProviderPlugin } from "../plugins/types.js";
-import type { ProviderAuthMethod } from "../plugins/types.js";
-import type { ApplyAuthChoiceParams } from "./auth-choice.apply.js";
 import {
   applyAuthChoiceLoadedPluginProvider,
   applyAuthChoicePluginProvider,
   runProviderPluginAuthMethod,
-} from "./auth-choice.apply.plugin-provider.js";
+} from "../plugins/provider-auth-choice.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import type { ProviderAuthMethod } from "../plugins/types.js";
+import type { ApplyAuthChoiceParams } from "./auth-choice.apply.types.js";
+
+type ResolveProviderInstallCatalogEntry =
+  typeof import("../plugins/provider-install-catalog.js").resolveProviderInstallCatalogEntry;
+type EnsureOnboardingPluginInstalled =
+  typeof import("../commands/onboarding-plugin-install.js").ensureOnboardingPluginInstalled;
+type ResolveManifestProviderAuthChoice =
+  typeof import("../plugins/provider-auth-choices.js").resolveManifestProviderAuthChoice;
+type ResolvePluginSetupProvider =
+  typeof import("../plugins/provider-auth-choice.runtime.js").resolvePluginSetupProvider;
 
 const resolvePluginProviders = vi.hoisted(() => vi.fn<() => ProviderPlugin[]>(() => []));
+const resolvePluginSetupProvider = vi.hoisted(() =>
+  vi.fn<ResolvePluginSetupProvider>(() => undefined),
+);
 const resolveProviderPluginChoice = vi.hoisted(() =>
   vi.fn<() => { provider: ProviderPlugin; method: ProviderAuthMethod } | null>(),
 );
 const runProviderModelSelectedHook = vi.hoisted(() => vi.fn(async () => {}));
 vi.mock("../plugins/provider-auth-choice.runtime.js", () => ({
   resolvePluginProviders,
+  resolvePluginSetupProvider,
   resolveProviderPluginChoice,
   runProviderModelSelectedHook,
+}));
+
+const resolveManifestProviderAuthChoice = vi.hoisted(() =>
+  vi.fn<ResolveManifestProviderAuthChoice>(() => undefined),
+);
+vi.mock("../plugins/provider-auth-choices.js", () => ({
+  resolveManifestProviderAuthChoice,
 }));
 
 const upsertAuthProfile = vi.hoisted(() => vi.fn());
@@ -60,27 +80,53 @@ vi.mock("../plugins/provider-oauth-flow.js", () => ({
   createVpsAwareOAuthHandlers,
 }));
 
+const resolveProviderInstallCatalogEntry = vi.hoisted(() =>
+  vi.fn<ResolveProviderInstallCatalogEntry>(() => undefined),
+);
+vi.mock("../plugins/provider-install-catalog.js", () => ({
+  resolveProviderInstallCatalogEntry,
+}));
+
+const ensureOnboardingPluginInstalled = vi.hoisted(() =>
+  vi.fn<EnsureOnboardingPluginInstalled>(async ({ cfg, entry }) => ({
+    cfg,
+    installed: false,
+    pluginId: entry?.pluginId ?? "missing-plugin",
+    status: "skipped",
+  })),
+);
+vi.mock("../commands/onboarding-plugin-install.js", () => ({
+  ensureOnboardingPluginInstalled,
+}));
+
+const LOCAL_PROVIDER_ID = "local-provider";
+const LOCAL_PROVIDER_LABEL = "Local Provider";
+const LOCAL_AUTH_METHOD_ID = "local";
+const LOCAL_PROFILE_ID = `${LOCAL_PROVIDER_ID}:default`;
+const LOCAL_API_KEY = "local-provider-key";
+const LOCAL_DEFAULT_MODEL = `${LOCAL_PROVIDER_ID}/demo-model`;
+
 function buildProvider(): ProviderPlugin {
   return {
-    id: "ollama",
-    label: "Ollama",
+    id: LOCAL_PROVIDER_ID,
+    label: LOCAL_PROVIDER_LABEL,
     auth: [
       {
-        id: "local",
-        label: "Ollama",
+        id: LOCAL_AUTH_METHOD_ID,
+        label: LOCAL_PROVIDER_LABEL,
         kind: "custom",
         run: async () => ({
           profiles: [
             {
-              profileId: "ollama:default",
+              profileId: LOCAL_PROFILE_ID,
               credential: {
                 type: "api_key",
-                provider: "ollama",
-                key: "ollama-local",
+                provider: LOCAL_PROVIDER_ID,
+                key: LOCAL_API_KEY,
               },
             },
           ],
-          defaultModel: "ollama/qwen3:4b",
+          defaultModel: LOCAL_DEFAULT_MODEL,
         }),
       },
     ],
@@ -89,7 +135,7 @@ function buildProvider(): ProviderPlugin {
 
 function buildParams(overrides: Partial<ApplyAuthChoiceParams> = {}): ApplyAuthChoiceParams {
   return {
-    authChoice: "ollama",
+    authChoice: LOCAL_PROVIDER_ID,
     config: {},
     prompter: {
       note: vi.fn(async () => {}),
@@ -100,10 +146,51 @@ function buildParams(overrides: Partial<ApplyAuthChoiceParams> = {}): ApplyAuthC
   };
 }
 
+function buildLocalProviderInstallCatalogEntry() {
+  return {
+    pluginId: "local-provider-plugin",
+    providerId: LOCAL_PROVIDER_ID,
+    methodId: LOCAL_AUTH_METHOD_ID,
+    choiceId: LOCAL_PROVIDER_ID,
+    choiceLabel: LOCAL_PROVIDER_LABEL,
+    label: LOCAL_PROVIDER_LABEL,
+    origin: "bundled" as const,
+    install: {
+      npmSpec: "@openclaw/local-provider",
+    },
+  };
+}
+
+function buildInstalledLocalProviderPluginResult() {
+  return {
+    cfg: {
+      plugins: {
+        entries: {
+          "local-provider-plugin": {
+            enabled: true,
+          },
+        },
+      },
+    },
+    installed: true,
+    pluginId: "local-provider-plugin",
+    status: "installed" as const,
+  };
+}
+
 describe("applyAuthChoiceLoadedPluginProvider", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     applyAuthProfileConfig.mockImplementation((config) => config);
+    resolveManifestProviderAuthChoice.mockReturnValue(undefined);
+    resolvePluginSetupProvider.mockReturnValue(undefined);
+    resolveProviderInstallCatalogEntry.mockReturnValue(undefined);
+    ensureOnboardingPluginInstalled.mockImplementation(async ({ cfg, entry }) => ({
+      cfg,
+      installed: false,
+      pluginId: entry?.pluginId ?? "missing-plugin",
+      status: "skipped",
+    }));
   });
 
   it("returns an agent model override when default model application is deferred", async () => {
@@ -122,7 +209,93 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
 
     expect(result).toEqual({
       config: {},
-      agentModelOverride: "ollama/qwen3:4b",
+    });
+    expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
+  });
+
+  it("keeps provider config patches when default model application is deferred", async () => {
+    const provider: ProviderPlugin = {
+      id: "remote-alpha",
+      label: "Remote Alpha",
+      auth: [
+        {
+          id: "api-key",
+          label: "Remote Alpha API key",
+          kind: "api_key",
+          run: async () => ({
+            profiles: [
+              {
+                profileId: "remote-alpha:default",
+                credential: {
+                  type: "api_key",
+                  provider: "remote-alpha",
+                  key: "sk-remote-alpha-test",
+                },
+              },
+            ],
+            configPatch: {
+              models: {
+                providers: {
+                  "remote-alpha": {
+                    api: "openai-completions",
+                    baseUrl: "https://api.remote-alpha.example/v1",
+                    models: [
+                      {
+                        id: "alpha-large",
+                        name: "alpha-large",
+                        input: ["text", "image"],
+                        reasoning: true,
+                        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                        contextWindow: 128_000,
+                        maxTokens: 8192,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+            defaultModel: "remote-alpha/alpha-large",
+          }),
+        },
+      ],
+    };
+    resolvePluginProviders.mockReturnValue([provider]);
+    resolveProviderPluginChoice.mockReturnValue({
+      provider,
+      method: provider.auth[0],
+    });
+
+    const result = await applyAuthChoiceLoadedPluginProvider(
+      buildParams({
+        config: {
+          agents: {
+            defaults: {
+              model: { primary: "anthropic/claude-opus-4-6" },
+            },
+          },
+        },
+        setDefaultModel: false,
+      }),
+    );
+
+    expect(result?.agentModelOverride).toBeUndefined();
+    expect(result?.config.agents?.defaults?.model).toEqual({
+      primary: "anthropic/claude-opus-4-6",
+    });
+    expect(result?.config.models?.providers?.["remote-alpha"]?.baseUrl).toBe(
+      "https://api.remote-alpha.example/v1",
+    );
+    expect(result?.config.models?.providers?.["remote-alpha"]?.models?.[0]?.input).toContain(
+      "image",
+    );
+    expect(upsertAuthProfile).toHaveBeenCalledWith({
+      profileId: "remote-alpha:default",
+      credential: {
+        type: "api_key",
+        provider: "remote-alpha",
+        key: "sk-remote-alpha-test",
+      },
+      agentDir: "/tmp/agent",
     });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
   });
@@ -138,23 +311,119 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
 
     expect(result?.config.agents?.defaults?.model).toEqual({
-      primary: "ollama/qwen3:4b",
+      primary: LOCAL_DEFAULT_MODEL,
     });
     expect(upsertAuthProfile).toHaveBeenCalledWith({
-      profileId: "ollama:default",
+      profileId: LOCAL_PROFILE_ID,
       credential: {
         type: "api_key",
-        provider: "ollama",
-        key: "ollama-local",
+        provider: LOCAL_PROVIDER_ID,
+        key: LOCAL_API_KEY,
       },
       agentDir: "/tmp/agent",
     });
     expect(runProviderModelSelectedHook).toHaveBeenCalledWith({
       config: result?.config,
-      model: "ollama/qwen3:4b",
+      model: LOCAL_DEFAULT_MODEL,
       prompter: expect.objectContaining({ note: expect.any(Function) }),
       agentDir: undefined,
       workspaceDir: "/tmp/workspace",
+    });
+  });
+
+  it("uses manifest-owned setup providers without loading the broad provider runtime", async () => {
+    const provider = buildProvider();
+    resolveManifestProviderAuthChoice.mockReturnValue({
+      pluginId: "local-provider-plugin",
+      providerId: LOCAL_PROVIDER_ID,
+      methodId: LOCAL_AUTH_METHOD_ID,
+      choiceId: LOCAL_PROVIDER_ID,
+      choiceLabel: LOCAL_PROVIDER_LABEL,
+    });
+    resolvePluginSetupProvider.mockReturnValue(provider);
+    resolveProviderPluginChoice.mockReturnValue({
+      provider,
+      method: provider.auth[0],
+    });
+
+    const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(result?.config.agents?.defaults?.model).toEqual({
+      primary: LOCAL_DEFAULT_MODEL,
+    });
+    expect(resolvePluginSetupProvider).toHaveBeenCalledWith({
+      provider: LOCAL_PROVIDER_ID,
+      config: {
+        plugins: {
+          entries: {
+            "local-provider-plugin": {
+              enabled: true,
+            },
+          },
+        },
+      },
+      workspaceDir: "/tmp/workspace",
+      env: undefined,
+      pluginIds: ["local-provider-plugin"],
+    });
+    expect(resolvePluginProviders).not.toHaveBeenCalled();
+  });
+
+  it("installs a missing provider plugin and retries setup resolution", async () => {
+    const provider = buildProvider();
+    resolveProviderInstallCatalogEntry.mockReturnValue(buildLocalProviderInstallCatalogEntry());
+    ensureOnboardingPluginInstalled.mockResolvedValue(buildInstalledLocalProviderPluginResult());
+    resolvePluginProviders.mockReturnValue([provider]);
+    resolveProviderPluginChoice.mockReturnValueOnce(null).mockReturnValueOnce({
+      provider,
+      method: provider.auth[0],
+    });
+
+    const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(ensureOnboardingPluginInstalled).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          pluginId: "local-provider-plugin",
+          label: LOCAL_PROVIDER_LABEL,
+        }),
+        workspaceDir: "/tmp/workspace",
+      }),
+    );
+    expect(resolvePluginProviders).toHaveBeenCalledTimes(2);
+    expect(result?.config.agents?.defaults?.model).toEqual({
+      primary: LOCAL_DEFAULT_MODEL,
+    });
+  });
+
+  it("does not persist plugin enablement when install is skipped", async () => {
+    resolveProviderInstallCatalogEntry.mockReturnValue(buildLocalProviderInstallCatalogEntry());
+    resolveProviderPluginChoice.mockReturnValue(null);
+
+    const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(ensureOnboardingPluginInstalled).toHaveBeenCalledOnce();
+    expect(result).toEqual({ config: {}, retrySelection: true });
+  });
+
+  it("preserves install config when the chosen provider still cannot resolve after install", async () => {
+    resolveProviderInstallCatalogEntry.mockReturnValue(buildLocalProviderInstallCatalogEntry());
+    ensureOnboardingPluginInstalled.mockResolvedValue(buildInstalledLocalProviderPluginResult());
+    resolveProviderPluginChoice.mockReturnValue(null);
+
+    const result = await applyAuthChoiceLoadedPluginProvider(buildParams());
+
+    expect(result).toEqual({
+      config: {
+        plugins: {
+          entries: {
+            "local-provider-plugin": {
+              enabled: true,
+            },
+          },
+        },
+      },
+      retrySelection: true,
     });
   });
 
@@ -187,27 +456,27 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       run: async () => ({
         profiles: [
           {
-            profileId: "ollama:default",
+            profileId: LOCAL_PROFILE_ID,
             credential: {
               type: "api_key",
-              provider: "ollama",
-              key: "ollama-local",
+              provider: LOCAL_PROVIDER_ID,
+              key: LOCAL_API_KEY,
             },
           },
         ],
         configPatch: {
           models: {
             providers: {
-              ollama: {
-                api: "ollama",
-                baseUrl: "http://127.0.0.1:11434",
+              [LOCAL_PROVIDER_ID]: {
+                api: "openai-completions",
+                baseUrl: "http://127.0.0.1:4000/v1",
                 models: [],
               },
             },
           },
         },
-        defaultModel: "ollama/qwen3:4b",
-        notes: ["Detected local Ollama runtime.", "Pulled model metadata."],
+        defaultModel: LOCAL_DEFAULT_MODEL,
+        notes: ["Detected local provider runtime.", "Pulled model metadata."],
       }),
     };
 
@@ -215,7 +484,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       config: {
         agents: {
           defaults: {
-            model: { primary: "anthropic/claude-sonnet-4-5" },
+            model: { primary: "anthropic/claude-sonnet-4-6" },
           },
         },
       },
@@ -226,20 +495,81 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       method,
     });
 
-    expect(result.defaultModel).toBe("ollama/qwen3:4b");
-    expect(result.config.models?.providers?.ollama).toEqual({
-      api: "ollama",
-      baseUrl: "http://127.0.0.1:11434",
+    expect(result.defaultModel).toBe(LOCAL_DEFAULT_MODEL);
+    expect(result.config.models?.providers?.[LOCAL_PROVIDER_ID]).toEqual({
+      api: "openai-completions",
+      baseUrl: "http://127.0.0.1:4000/v1",
       models: [],
     });
-    expect(result.config.auth?.profiles?.["ollama:default"]).toEqual({
-      provider: "ollama",
+    expect(result.config.auth?.profiles?.[LOCAL_PROFILE_ID]).toEqual({
+      provider: LOCAL_PROVIDER_ID,
       mode: "api_key",
     });
     expect(note).toHaveBeenCalledWith(
-      "Detected local Ollama runtime.\nPulled model metadata.",
+      "Detected local provider runtime.\nPulled model metadata.",
       "Provider notes",
     );
+  });
+
+  it("replaces provider-owned default model maps during auth migrations", async () => {
+    const method: ProviderAuthMethod = {
+      id: "local",
+      label: "Local",
+      kind: "custom",
+      run: async () => ({
+        profiles: [],
+        configPatch: {
+          agents: {
+            defaults: {
+              model: {
+                primary: "claude-cli/claude-sonnet-4-6",
+                fallbacks: ["claude-cli/claude-opus-4-6", "openai/gpt-5.2"],
+              },
+              models: {
+                "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
+                "claude-cli/claude-opus-4-6": { alias: "Opus" },
+                "openai/gpt-5.2": {},
+              },
+            },
+          },
+        },
+        replaceDefaultModels: true,
+        defaultModel: "claude-cli/claude-sonnet-4-6",
+      }),
+    };
+
+    const result = await runProviderPluginAuthMethod({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4-6",
+              fallbacks: ["anthropic/claude-opus-4-6", "openai/gpt-5.2"],
+            },
+            models: {
+              "anthropic/claude-sonnet-4-6": { alias: "Sonnet" },
+              "anthropic/claude-opus-4-6": { alias: "Opus" },
+              "openai/gpt-5.2": {},
+            },
+          },
+        },
+      },
+      runtime: {} as ApplyAuthChoiceParams["runtime"],
+      prompter: {
+        note: vi.fn(async () => {}),
+      } as unknown as ApplyAuthChoiceParams["prompter"],
+      method,
+    });
+
+    expect(result.config.agents?.defaults?.model).toEqual({
+      primary: "claude-cli/claude-sonnet-4-6",
+      fallbacks: ["claude-cli/claude-opus-4-6", "openai/gpt-5.2"],
+    });
+    expect(result.config.agents?.defaults?.models).toEqual({
+      "claude-cli/claude-sonnet-4-6": { alias: "Sonnet" },
+      "claude-cli/claude-opus-4-6": { alias: "Opus" },
+      "openai/gpt-5.2": {},
+    });
   });
 
   it("returns an agent-scoped override for plugin auth choices when default model application is deferred", async () => {
@@ -249,7 +579,7 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
     const note = vi.fn(async () => {});
     const result = await applyAuthChoicePluginProvider(
       buildParams({
-        authChoice: "provider-plugin:ollama:local",
+        authChoice: `provider-plugin:${LOCAL_PROVIDER_ID}:${LOCAL_AUTH_METHOD_ID}`,
         agentId: "worker",
         setDefaultModel: false,
         prompter: {
@@ -257,25 +587,25 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         } as unknown as ApplyAuthChoiceParams["prompter"],
       }),
       {
-        authChoice: "provider-plugin:ollama:local",
-        pluginId: "ollama",
-        providerId: "ollama",
-        methodId: "local",
-        label: "Ollama",
+        authChoice: `provider-plugin:${LOCAL_PROVIDER_ID}:${LOCAL_AUTH_METHOD_ID}`,
+        pluginId: LOCAL_PROVIDER_ID,
+        providerId: LOCAL_PROVIDER_ID,
+        methodId: LOCAL_AUTH_METHOD_ID,
+        label: LOCAL_PROVIDER_LABEL,
       },
     );
 
-    expect(result?.agentModelOverride).toBe("ollama/qwen3:4b");
+    expect(result?.agentModelOverride).toBeUndefined();
     expect(result?.config.plugins).toEqual({
       entries: {
-        ollama: {
+        [LOCAL_PROVIDER_ID]: {
           enabled: true,
         },
       },
     });
     expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(
-      'Default model set to ollama/qwen3:4b for agent "worker".',
+      `Default model set to ${LOCAL_DEFAULT_MODEL} for agent "worker".`,
       "Model configured",
     );
   });
@@ -295,10 +625,10 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
         } as unknown as ApplyAuthChoiceParams["prompter"],
       }),
       {
-        authChoice: "ollama",
-        pluginId: "ollama",
-        providerId: "ollama",
-        label: "Ollama",
+        authChoice: LOCAL_PROVIDER_ID,
+        pluginId: LOCAL_PROVIDER_ID,
+        providerId: LOCAL_PROVIDER_ID,
+        label: LOCAL_PROVIDER_LABEL,
       },
     );
 
@@ -310,6 +640,9 @@ describe("applyAuthChoiceLoadedPluginProvider", () => {
       },
     });
     expect(resolvePluginProviders).not.toHaveBeenCalled();
-    expect(note).toHaveBeenCalledWith("Ollama plugin is disabled (plugins disabled).", "Ollama");
+    expect(note).toHaveBeenCalledWith(
+      "Local Provider plugin is disabled (plugins disabled).",
+      LOCAL_PROVIDER_LABEL,
+    );
   });
 });

--- a/src/commands/auth-choice.default-model.ts
+++ b/src/commands/auth-choice.default-model.ts
@@ -1,4 +1,4 @@
-import type { OpenClawConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { ensureModelAllowlistEntry } from "./model-allowlist.js";
 
@@ -20,11 +20,13 @@ export async function applyDefaultModelChoice(params: {
     return { config: next };
   }
 
+  // When setDefaultModel is false (e.g., adding a new agent), do not override
+  // the agent's model. Let it inherit from agents.defaults.model instead of
+  // baking in the provider's defaultModel. See issue #24170.
   const next = params.applyProviderConfig(params.config);
   const nextWithModel = ensureModelAllowlistEntry({
     cfg: next,
     modelRef: params.defaultModel,
   });
-  await params.noteAgentModel(params.defaultModel);
-  return { config: nextWithModel, agentModelOverride: params.defaultModel };
+  return { config: nextWithModel };
 }

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -1,66 +1,214 @@
 import fs from "node:fs/promises";
-import type { OAuthCredentials } from "@mariozechner/pi-ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { resolveAgentDir } from "../agents/agent-scope.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
-import { GOOGLE_GEMINI_DEFAULT_MODEL } from "../plugin-sdk/google.js";
-import { MINIMAX_CN_API_BASE_URL } from "../plugin-sdk/minimax.js";
-import { ZAI_CODING_CN_BASE_URL, ZAI_CODING_GLOBAL_BASE_URL } from "../plugin-sdk/zai.js";
-import { createProviderApiKeyAuthMethod } from "../plugins/provider-api-key-auth.js";
-import { providerApiKeyAuthRuntime } from "../plugins/provider-api-key-auth.runtime.js";
-import type { ProviderAuthMethod, ProviderPlugin } from "../plugins/types.js";
+import { __testing as providerAuthChoiceTesting } from "../plugins/provider-auth-choice.js";
+import * as providerAuthChoices from "../plugins/provider-auth-choices.js";
+import type { ProviderAuthMethod, ProviderAuthResult, ProviderPlugin } from "../plugins/types.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { applyAuthChoice, resolvePreferredProviderForAuthChoice } from "./auth-choice.js";
-import type { AuthChoice } from "./onboard-types.js";
+import { applyAuthChoice } from "./auth-choice.apply.js";
 import {
-  authProfilePathForAgent,
   createAuthTestLifecycle,
   createExitThrowingRuntime,
   createWizardPrompter,
-  readAuthProfilesForAgent,
   requireOpenClawAgentDir,
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
 
-type DetectZaiEndpoint = typeof import("./zai-endpoint-detect.js").detectZaiEndpoint;
+type DetectZaiEndpoint = typeof import("../plugins/provider-zai-endpoint.js").detectZaiEndpoint;
 
-const loginOpenAICodexOAuth = vi.hoisted(() =>
-  vi.fn<() => Promise<OAuthCredentials | null>>(async () => null),
-);
-vi.mock("./openai-codex-oauth.js", () => ({
-  loginOpenAICodexOAuth,
-}));
+const GOOGLE_GEMINI_DEFAULT_MODEL = "google/gemini-3.1-pro-preview";
+const ZAI_CODING_GLOBAL_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
+const ZAI_CODING_CN_BASE_URL = "https://open.bigmodel.cn/api/coding/paas/v4";
 
 const resolvePluginProviders = vi.hoisted(() => vi.fn<() => ProviderPlugin[]>(() => []));
-vi.mock("../plugins/provider-auth-choice.runtime.js", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../plugins/provider-auth-choice.runtime.js")>();
+const runProviderModelSelectedHook = vi.hoisted(() => vi.fn(async () => {}));
+
+vi.mock("../plugins/provider-install-catalog.js", () => ({
+  resolveProviderInstallCatalogEntry: vi.fn(() => undefined),
+}));
+
+vi.mock("./auth-choice.apply.api-providers.js", () => {
+  const normalizeProviderId = (value: string) => value.trim().toLowerCase();
+  const resolveChoiceByKind = (params: {
+    authChoice: string;
+    kind: ProviderAuthMethod["kind"];
+    tokenProvider?: string;
+  }) => {
+    const providerId = normalizeProviderId(params.tokenProvider ?? "");
+    if (!providerId) {
+      return params.authChoice;
+    }
+    const provider = resolvePluginProviders().find(
+      (entry) => normalizeProviderId(entry.id) === providerId,
+    );
+    return (
+      provider?.auth.find((method) => method.kind === params.kind)?.wizard?.choiceId ??
+      params.authChoice
+    );
+  };
   return {
-    ...actual,
-    resolvePluginProviders,
+    applyAuthChoiceApiProviders: vi.fn(async () => null),
+    normalizeApiKeyTokenProviderAuthChoice: (params: {
+      authChoice: string;
+      tokenProvider?: string;
+    }) => {
+      if (params.authChoice === "token" || params.authChoice === "setup-token") {
+        return resolveChoiceByKind({ ...params, kind: "token" });
+      }
+      if (params.authChoice === "apiKey") {
+        return resolveChoiceByKind({ ...params, kind: "api_key" });
+      }
+      return params.authChoice;
+    },
   };
 });
 
 const detectZaiEndpoint = vi.hoisted(() => vi.fn<DetectZaiEndpoint>(async () => null));
-vi.mock("./zai-endpoint-detect.js", () => ({
+vi.mock("../plugins/provider-zai-endpoint.js", () => ({
   detectZaiEndpoint,
+}));
+
+vi.mock("../agents/agent-paths.js", () => ({
+  resolveOpenClawAgentDir: () => process.env.OPENCLAW_AGENT_DIR ?? "/tmp/openclaw-agent",
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentDir: (_config: unknown, agentId: string) => `/tmp/openclaw-agents/${agentId}`,
+  resolveAgentWorkspaceDir: (_config: unknown, agentId: string) =>
+    `/tmp/openclaw-workspaces/${agentId}`,
+}));
+
+vi.mock("../agents/workspace.js", () => ({
+  resolveDefaultAgentWorkspaceDir: () => "/tmp/openclaw-workspace",
+}));
+
+vi.mock("../plugins/setup-browser.js", () => ({
+  isRemoteEnvironment: () => false,
+  openUrl: vi.fn(async () => {}),
+}));
+
+vi.mock("../plugins/provider-oauth-flow.js", () => ({
+  createVpsAwareOAuthHandlers: vi.fn(),
+}));
+
+vi.mock("../plugins/provider-auth-helpers.js", () => ({
+  applyAuthProfileConfig: (
+    cfg: OpenClawConfig,
+    params: {
+      profileId: string;
+      provider: string;
+      mode: "api_key" | "oauth" | "token";
+      email?: string;
+      displayName?: string;
+    },
+  ): OpenClawConfig => ({
+    ...cfg,
+    auth: {
+      ...cfg.auth,
+      profiles: {
+        ...cfg.auth?.profiles,
+        [params.profileId]: {
+          provider: params.provider,
+          mode: params.mode,
+          ...(params.email ? { email: params.email } : {}),
+          ...(params.displayName ? { displayName: params.displayName } : {}),
+        },
+      },
+    },
+  }),
 }));
 
 type StoredAuthProfile = {
   key?: string;
+  token?: string;
   keyRef?: { source: string; provider: string; id: string };
   access?: string;
   refresh?: string;
+  expires?: number;
   provider?: string;
   type?: string;
   email?: string;
   metadata?: Record<string, string>;
 };
 
+const testAuthProfileStores = vi.hoisted(
+  () => new Map<string, { profiles: Record<string, StoredAuthProfile> }>(),
+);
+
+// These tests verify profile payloads, not file locking; keep auth stores in memory.
+function resolveTestAuthStoreKey(agentDir?: string): string {
+  return agentDir?.trim() || process.env.OPENCLAW_AGENT_DIR || "__main__";
+}
+
+function readTestAuthProfileStore(agentDir?: string): {
+  profiles: Record<string, StoredAuthProfile>;
+} {
+  return testAuthProfileStores.get(resolveTestAuthStoreKey(agentDir)) ?? { profiles: {} };
+}
+
+function seedTestAuthProfile(params: {
+  profileId: string;
+  credential: StoredAuthProfile;
+  agentDir?: string;
+}): void {
+  const key = resolveTestAuthStoreKey(params.agentDir);
+  const store = testAuthProfileStores.get(key) ?? { profiles: {} };
+  store.profiles[params.profileId] = params.credential;
+  testAuthProfileStores.set(key, store);
+}
+
+vi.mock("../agents/auth-profiles.js", () => ({
+  upsertAuthProfile: (params: {
+    profileId: string;
+    credential: StoredAuthProfile;
+    agentDir?: string;
+  }) => {
+    seedTestAuthProfile(params);
+  },
+}));
+
 function normalizeText(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeProviderId(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function resolveProviderPluginChoice(params: { providers: ProviderPlugin[]; choice: string }) {
+  const choice = params.choice.trim();
+  if (!choice) {
+    return null;
+  }
+  if (choice.startsWith("provider-plugin:")) {
+    const payload = choice.slice("provider-plugin:".length);
+    const separator = payload.indexOf(":");
+    const providerId = separator >= 0 ? payload.slice(0, separator) : payload;
+    const methodId = separator >= 0 ? payload.slice(separator + 1) : undefined;
+    const provider = params.providers.find(
+      (entry) => normalizeProviderId(entry.id) === normalizeProviderId(providerId),
+    );
+    const method = methodId
+      ? provider?.auth.find((entry) => entry.id === methodId)
+      : provider?.auth[0];
+    return provider && method ? { provider, method } : null;
+  }
+  for (const provider of params.providers) {
+    for (const method of provider.auth) {
+      if (method.wizard?.choiceId === choice) {
+        return { provider, method, wizard: method.wizard };
+      }
+    }
+    if (normalizeProviderId(provider.id) === normalizeProviderId(choice) && provider.auth[0]) {
+      return { provider, method: provider.auth[0] };
+    }
+  }
+  return null;
 }
 
 function providerConfigPatch(
@@ -77,7 +225,113 @@ function providerConfigPatch(
   };
 }
 
-function createApiKeyProvider(params: {
+type TestSecretRef = { source: "env"; provider: string; id: string };
+type TestSecretInput = string | TestSecretRef;
+
+function normalizeProviderInput(value: unknown): string | undefined {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized || undefined;
+}
+
+function buildApiKeyCredential(
+  provider: string,
+  input: TestSecretInput,
+  metadata?: Record<string, string>,
+): {
+  type: "api_key";
+  provider: string;
+  key?: string;
+  keyRef?: TestSecretRef;
+  metadata?: Record<string, string>;
+} {
+  if (typeof input === "string") {
+    return { type: "api_key", provider, key: input, ...(metadata ? { metadata } : {}) };
+  }
+  return { type: "api_key", provider, keyRef: input, ...(metadata ? { metadata } : {}) };
+}
+
+async function resolveRefApiKeyInput(params: {
+  env: NodeJS.ProcessEnv;
+  envVar: string;
+  prompter: WizardPrompter;
+}): Promise<TestSecretInput> {
+  if (typeof params.prompter.select === "function") {
+    const source = await params.prompter.select({
+      message: "Choose secret reference source",
+      options: [
+        { label: "Environment variable", value: "env" },
+        { label: "Secret provider", value: "provider" },
+      ],
+    });
+    if (source !== "env") {
+      await params.prompter.text?.({ message: "Enter secret provider reference" });
+      await params.prompter.note?.(
+        "Could not validate provider reference; choose an environment variable instead.",
+        "Reference check failed",
+      );
+    }
+  }
+  const envName =
+    normalizeText(await params.prompter.text?.({ message: "Enter environment variable name" })) ||
+    params.envVar;
+  await params.prompter.note?.(`Validated environment variable ${envName}.`, "Reference validated");
+  return { source: "env", provider: "default", id: envName };
+}
+
+async function resolveApiKeyInput(params: {
+  ctx: Parameters<ProviderAuthMethod["run"]>[0];
+  providerId: string;
+  expectedProviders: string[];
+  optionKey: string;
+  envVar: string;
+  promptMessage: string;
+  noteMessage?: string;
+  noteTitle?: string;
+}): Promise<{ input: TestSecretInput; mode?: "plaintext" | "ref" }> {
+  const opts = (params.ctx.opts ?? {}) as Record<string, unknown>;
+  const flagValue = normalizeText(opts[params.optionKey]);
+  const token = flagValue || normalizeText(params.ctx.opts?.token);
+  const tokenProvider = normalizeProviderInput(
+    flagValue ? params.providerId : params.ctx.opts?.tokenProvider,
+  );
+  const expectedProviders = params.expectedProviders.map((provider) => provider.toLowerCase());
+  if (token && tokenProvider && expectedProviders.includes(tokenProvider)) {
+    return { input: token, mode: params.ctx.secretInputMode };
+  }
+
+  if (params.noteMessage) {
+    await params.ctx.prompter.note(params.noteMessage, params.noteTitle);
+  }
+
+  const env = params.ctx.env ?? process.env;
+  if (params.ctx.secretInputMode === "ref") {
+    return {
+      input: await resolveRefApiKeyInput({
+        env,
+        envVar: params.envVar,
+        prompter: params.ctx.prompter,
+      }),
+      mode: "ref",
+    };
+  }
+
+  const envValue = normalizeText(env[params.envVar]);
+  if (envValue) {
+    const useEnv = await params.ctx.prompter.confirm?.({
+      message: `Use ${params.envVar} from environment?`,
+    });
+    if (useEnv) {
+      return { input: envValue, mode: "plaintext" };
+    }
+  }
+
+  return {
+    input: normalizeText(await params.ctx.prompter.text({ message: params.promptMessage })),
+    mode: "plaintext",
+  };
+}
+
+async function createApiKeyProvider(params: {
   providerId: string;
   label: string;
   choiceId: string;
@@ -92,33 +346,49 @@ function createApiKeyProvider(params: {
   noteMessage?: string;
   noteTitle?: string;
   applyConfig?: Partial<OpenClawConfig>;
-}): ProviderPlugin {
+}): Promise<ProviderPlugin> {
+  const profileIds =
+    params.profileIds && params.profileIds.length > 0
+      ? params.profileIds
+      : [params.profileId ?? `${params.providerId}:default`];
   return {
     id: params.providerId,
     label: params.label,
     auth: [
-      createProviderApiKeyAuthMethod({
-        providerId: params.providerId,
-        methodId: "api-key",
+      {
+        id: "api-key",
         label: params.label,
-        optionKey: params.optionKey,
-        flagName: params.flagName,
-        envVar: params.envVar,
-        promptMessage: params.promptMessage,
-        ...(params.profileId ? { profileId: params.profileId } : {}),
-        ...(params.profileIds ? { profileIds: params.profileIds } : {}),
-        ...(params.defaultModel ? { defaultModel: params.defaultModel } : {}),
-        ...(params.expectedProviders ? { expectedProviders: params.expectedProviders } : {}),
-        ...(params.noteMessage ? { noteMessage: params.noteMessage } : {}),
-        ...(params.noteTitle ? { noteTitle: params.noteTitle } : {}),
-        ...(params.applyConfig ? { applyConfig: () => params.applyConfig as OpenClawConfig } : {}),
+        kind: "api_key",
         wizard: {
           choiceId: params.choiceId,
           choiceLabel: params.label,
           groupId: params.providerId,
           groupLabel: params.label,
         },
-      }),
+        run: async (ctx) => {
+          const { input } = await resolveApiKeyInput({
+            ctx,
+            providerId: params.providerId,
+            expectedProviders: params.expectedProviders ?? [params.providerId],
+            optionKey: params.optionKey,
+            envVar: params.envVar,
+            promptMessage: params.promptMessage,
+            noteMessage: params.noteMessage,
+            noteTitle: params.noteTitle,
+          });
+          return {
+            profiles: profileIds.map((profileId) => ({
+              profileId,
+              credential: buildApiKeyCredential(
+                profileId.split(":", 1)[0] || params.providerId,
+                input,
+              ),
+            })),
+            ...(params.applyConfig ? { configPatch: params.applyConfig as OpenClawConfig } : {}),
+            ...(params.defaultModel ? { defaultModel: params.defaultModel } : {}),
+          };
+        },
+      },
     ],
   };
 }
@@ -146,13 +416,7 @@ function createFixedChoiceProvider(params: {
   };
 }
 
-function createDefaultProviderPlugins() {
-  const buildApiKeyCredential = providerApiKeyAuthRuntime.buildApiKeyCredential;
-  const ensureApiKeyFromOptionEnvOrPrompt =
-    providerApiKeyAuthRuntime.ensureApiKeyFromOptionEnvOrPrompt;
-  const normalizeApiKeyInput = providerApiKeyAuthRuntime.normalizeApiKeyInput;
-  const validateApiKeyInput = providerApiKeyAuthRuntime.validateApiKeyInput;
-
+async function createDefaultProviderPlugins(): Promise<ProviderPlugin[]> {
   const createZaiMethod = (choiceId: "zai-api-key" | "zai-coding-global"): ProviderAuthMethod => ({
     id: choiceId === "zai-api-key" ? "api-key" : "coding-global",
     label: "Z.AI API key",
@@ -202,127 +466,8 @@ function createDefaultProviderPlugins() {
     },
   });
 
-  const cloudflareAiGatewayMethod: ProviderAuthMethod = {
-    id: "api-key",
-    label: "Cloudflare AI Gateway API key",
-    kind: "api_key",
-    wizard: {
-      choiceId: "cloudflare-ai-gateway-api-key",
-      choiceLabel: "Cloudflare AI Gateway API key",
-      groupId: "cloudflare-ai-gateway",
-      groupLabel: "Cloudflare AI Gateway",
-    },
-    run: async (ctx) => {
-      const opts = (ctx.opts ?? {}) as Record<string, unknown>;
-      const accountId =
-        normalizeText(opts.cloudflareAiGatewayAccountId) ||
-        normalizeText(await ctx.prompter.text({ message: "Enter Cloudflare account ID" }));
-      const gatewayId =
-        normalizeText(opts.cloudflareAiGatewayGatewayId) ||
-        normalizeText(await ctx.prompter.text({ message: "Enter Cloudflare gateway ID" }));
-      let capturedSecretInput = "";
-      let capturedMode: "plaintext" | "ref" | undefined;
-      await ensureApiKeyFromOptionEnvOrPrompt({
-        token:
-          normalizeText(opts.cloudflareAiGatewayApiKey) ||
-          normalizeText(ctx.opts?.token) ||
-          undefined,
-        tokenProvider: "cloudflare-ai-gateway",
-        secretInputMode:
-          ctx.allowSecretRefPrompt === false
-            ? (ctx.secretInputMode ?? "plaintext")
-            : ctx.secretInputMode,
-        config: ctx.config,
-        expectedProviders: ["cloudflare-ai-gateway"],
-        provider: "cloudflare-ai-gateway",
-        envLabel: "CLOUDFLARE_AI_GATEWAY_API_KEY",
-        promptMessage: "Enter Cloudflare AI Gateway API key",
-        normalize: normalizeApiKeyInput,
-        validate: validateApiKeyInput,
-        prompter: ctx.prompter,
-        setCredential: async (apiKey, mode) => {
-          capturedSecretInput = typeof apiKey === "string" ? apiKey : "";
-          capturedMode = mode;
-        },
-      });
-      return {
-        profiles: [
-          {
-            profileId: "cloudflare-ai-gateway:default",
-            credential: buildApiKeyCredential(
-              "cloudflare-ai-gateway",
-              capturedSecretInput,
-              { accountId, gatewayId },
-              capturedMode ? { secretInputMode: capturedMode } : undefined,
-            ),
-          },
-        ],
-        defaultModel: "cloudflare-ai-gateway/claude-sonnet-4-5",
-      };
-    },
-  };
-
-  const chutesOAuthMethod: ProviderAuthMethod = {
-    id: "oauth",
-    label: "Chutes OAuth",
-    kind: "device_code",
-    wizard: {
-      choiceId: "chutes",
-      choiceLabel: "Chutes",
-      groupId: "chutes",
-      groupLabel: "Chutes",
-    },
-    run: async (ctx) => {
-      const state = "state-test";
-      ctx.runtime.log(`Open this URL: https://api.chutes.ai/idp/authorize?state=${state}`);
-      const redirect = String(
-        await ctx.prompter.text({ message: "Paste the redirect URL or code" }),
-      );
-      const params = new URLSearchParams(redirect.startsWith("?") ? redirect.slice(1) : redirect);
-      const code = params.get("code") ?? redirect;
-      const tokenResponse = await fetch("https://api.chutes.ai/idp/token", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ code, client_id: process.env.CHUTES_CLIENT_ID }),
-      });
-      const tokenJson = (await tokenResponse.json()) as {
-        access_token: string;
-        refresh_token: string;
-        expires_in: number;
-      };
-      const userResponse = await fetch("https://api.chutes.ai/idp/userinfo", {
-        headers: { Authorization: `Bearer ${tokenJson.access_token}` },
-      });
-      const userJson = (await userResponse.json()) as { username: string };
-      return {
-        profiles: [
-          {
-            profileId: `chutes:${userJson.username}`,
-            credential: {
-              type: "oauth",
-              provider: "chutes",
-              access: tokenJson.access_token,
-              refresh: tokenJson.refresh_token,
-              expires: Date.now() + tokenJson.expires_in * 1000,
-              email: userJson.username,
-            },
-          },
-        ],
-      };
-    },
-  };
-
   return [
-    createApiKeyProvider({
-      providerId: "anthropic",
-      label: "Anthropic API key",
-      choiceId: "apiKey",
-      optionKey: "anthropicApiKey",
-      flagName: "--anthropic-api-key",
-      envVar: "ANTHROPIC_API_KEY",
-      promptMessage: "Enter Anthropic API key",
-    }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "google",
       label: "Gemini API key",
       choiceId: "gemini-api-key",
@@ -332,7 +477,7 @@ function createDefaultProviderPlugins() {
       promptMessage: "Enter Gemini API key",
       defaultModel: GOOGLE_GEMINI_DEFAULT_MODEL,
     }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "huggingface",
       label: "Hugging Face API key",
       choiceId: "huggingface-api-key",
@@ -342,72 +487,7 @@ function createDefaultProviderPlugins() {
       promptMessage: "Enter Hugging Face API key",
       defaultModel: "huggingface/Qwen/Qwen3-Coder-480B-A35B-Instruct",
     }),
-    createApiKeyProvider({
-      providerId: "litellm",
-      label: "LiteLLM API key",
-      choiceId: "litellm-api-key",
-      optionKey: "litellmApiKey",
-      flagName: "--litellm-api-key",
-      envVar: "LITELLM_API_KEY",
-      promptMessage: "Enter LiteLLM API key",
-      defaultModel: "litellm/anthropic/claude-opus-4.6",
-    }),
-    createApiKeyProvider({
-      providerId: "minimax",
-      label: "MiniMax API key (Global)",
-      choiceId: "minimax-global-api",
-      optionKey: "minimaxApiKey",
-      flagName: "--minimax-api-key",
-      envVar: "MINIMAX_API_KEY",
-      promptMessage: "Enter MiniMax API key",
-      profileId: "minimax:global",
-      defaultModel: "minimax/MiniMax-M2.7",
-    }),
-    createApiKeyProvider({
-      providerId: "minimax",
-      label: "MiniMax API key (CN)",
-      choiceId: "minimax-cn-api",
-      optionKey: "minimaxApiKey",
-      flagName: "--minimax-api-key",
-      envVar: "MINIMAX_API_KEY",
-      promptMessage: "Enter MiniMax CN API key",
-      profileId: "minimax:cn",
-      defaultModel: "minimax/MiniMax-M2.7",
-      applyConfig: providerConfigPatch("minimax", { baseUrl: MINIMAX_CN_API_BASE_URL }),
-      expectedProviders: ["minimax", "minimax-cn"],
-    }),
-    createApiKeyProvider({
-      providerId: "mistral",
-      label: "Mistral API key",
-      choiceId: "mistral-api-key",
-      optionKey: "mistralApiKey",
-      flagName: "--mistral-api-key",
-      envVar: "MISTRAL_API_KEY",
-      promptMessage: "Enter Mistral API key",
-      defaultModel: "mistral/mistral-large-latest",
-    }),
-    createApiKeyProvider({
-      providerId: "moonshot",
-      label: "Moonshot API key",
-      choiceId: "moonshot-api-key",
-      optionKey: "moonshotApiKey",
-      flagName: "--moonshot-api-key",
-      envVar: "MOONSHOT_API_KEY",
-      promptMessage: "Enter Moonshot API key",
-      defaultModel: "moonshot/moonshot-v1-128k",
-    }),
-    createFixedChoiceProvider({
-      providerId: "ollama",
-      label: "Ollama",
-      choiceId: "ollama",
-      method: {
-        id: "local",
-        label: "Ollama",
-        kind: "custom",
-        run: async () => ({ profiles: [] }),
-      },
-    }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "openai",
       label: "OpenAI API key",
       choiceId: "openai-api-key",
@@ -415,9 +495,9 @@ function createDefaultProviderPlugins() {
       flagName: "--openai-api-key",
       envVar: "OPENAI_API_KEY",
       promptMessage: "Enter OpenAI API key",
-      defaultModel: "openai/gpt-5.4",
+      defaultModel: "openai/gpt-5.5",
     }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "opencode",
       label: "OpenCode Zen",
       choiceId: "opencode-zen",
@@ -431,7 +511,7 @@ function createDefaultProviderPlugins() {
       noteMessage: "OpenCode uses one API key across the Zen and Go catalogs.",
       noteTitle: "OpenCode",
     }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "opencode-go",
       label: "OpenCode Go",
       choiceId: "opencode-go",
@@ -440,12 +520,12 @@ function createDefaultProviderPlugins() {
       envVar: "OPENCODE_API_KEY",
       promptMessage: "Enter OpenCode API key",
       profileIds: ["opencode-go:default", "opencode:default"],
-      defaultModel: "opencode-go/kimi-k2.5",
+      defaultModel: "opencode-go/kimi-k2.6",
       expectedProviders: ["opencode", "opencode-go"],
       noteMessage: "OpenCode uses one API key across the Zen and Go catalogs.",
       noteTitle: "OpenCode",
     }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "openrouter",
       label: "OpenRouter API key",
       choiceId: "openrouter-api-key",
@@ -455,17 +535,7 @@ function createDefaultProviderPlugins() {
       promptMessage: "Enter OpenRouter API key",
       defaultModel: "openrouter/auto",
     }),
-    createApiKeyProvider({
-      providerId: "qianfan",
-      label: "Qianfan API key",
-      choiceId: "qianfan-api-key",
-      optionKey: "qianfanApiKey",
-      flagName: "--qianfan-api-key",
-      envVar: "QIANFAN_API_KEY",
-      promptMessage: "Enter Qianfan API key",
-      defaultModel: "qianfan/ernie-4.5-8k",
-    }),
-    createApiKeyProvider({
+    await createApiKeyProvider({
       providerId: "synthetic",
       label: "Synthetic API key",
       choiceId: "synthetic-api-key",
@@ -475,95 +545,11 @@ function createDefaultProviderPlugins() {
       promptMessage: "Enter Synthetic API key",
       defaultModel: "synthetic/Synthetic-1",
     }),
-    createApiKeyProvider({
-      providerId: "together",
-      label: "Together API key",
-      choiceId: "together-api-key",
-      optionKey: "togetherApiKey",
-      flagName: "--together-api-key",
-      envVar: "TOGETHER_API_KEY",
-      promptMessage: "Enter Together API key",
-      defaultModel: "together/meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
-    }),
-    createApiKeyProvider({
-      providerId: "venice",
-      label: "Venice AI",
-      choiceId: "venice-api-key",
-      optionKey: "veniceApiKey",
-      flagName: "--venice-api-key",
-      envVar: "VENICE_API_KEY",
-      promptMessage: "Enter Venice AI API key",
-      defaultModel: "venice/venice-uncensored",
-      noteMessage: "Venice is a privacy-focused inference service.",
-      noteTitle: "Venice AI",
-    }),
-    createApiKeyProvider({
-      providerId: "vercel-ai-gateway",
-      label: "AI Gateway API key",
-      choiceId: "ai-gateway-api-key",
-      optionKey: "aiGatewayApiKey",
-      flagName: "--ai-gateway-api-key",
-      envVar: "AI_GATEWAY_API_KEY",
-      promptMessage: "Enter AI Gateway API key",
-      defaultModel: "vercel-ai-gateway/anthropic/claude-opus-4.6",
-    }),
-    createApiKeyProvider({
-      providerId: "xai",
-      label: "xAI API key",
-      choiceId: "xai-api-key",
-      optionKey: "xaiApiKey",
-      flagName: "--xai-api-key",
-      envVar: "XAI_API_KEY",
-      promptMessage: "Enter xAI API key",
-      defaultModel: "xai/grok-4",
-    }),
-    createApiKeyProvider({
-      providerId: "xiaomi",
-      label: "Xiaomi API key",
-      choiceId: "xiaomi-api-key",
-      optionKey: "xiaomiApiKey",
-      flagName: "--xiaomi-api-key",
-      envVar: "XIAOMI_API_KEY",
-      promptMessage: "Enter Xiaomi API key",
-      defaultModel: "xiaomi/mimo-v2-flash",
-    }),
     {
       id: "zai",
       label: "Z.AI",
       auth: [createZaiMethod("zai-api-key"), createZaiMethod("zai-coding-global")],
     },
-    {
-      id: "cloudflare-ai-gateway",
-      label: "Cloudflare AI Gateway",
-      auth: [cloudflareAiGatewayMethod],
-    },
-    {
-      id: "chutes",
-      label: "Chutes",
-      auth: [chutesOAuthMethod],
-    },
-    createApiKeyProvider({
-      providerId: "kimi",
-      label: "Kimi Code API key",
-      choiceId: "kimi-code-api-key",
-      optionKey: "kimiApiKey",
-      flagName: "--kimi-api-key",
-      envVar: "KIMI_API_KEY",
-      promptMessage: "Enter Kimi Code API key",
-      defaultModel: "kimi/kimi-k2.5",
-      expectedProviders: ["kimi", "kimi-code", "kimi-coding"],
-    }),
-    createFixedChoiceProvider({
-      providerId: "github-copilot",
-      label: "GitHub Copilot",
-      choiceId: "github-copilot",
-      method: {
-        id: "device",
-        label: "GitHub device login",
-        kind: "device_code",
-        run: async () => ({ profiles: [] }),
-      },
-    }),
   ];
 }
 
@@ -576,30 +562,22 @@ describe("applyAuthChoice", () => {
     "OPENROUTER_API_KEY",
     "HF_TOKEN",
     "HUGGINGFACE_HUB_TOKEN",
-    "LITELLM_API_KEY",
-    "AI_GATEWAY_API_KEY",
-    "CLOUDFLARE_AI_GATEWAY_API_KEY",
-    "MOONSHOT_API_KEY",
-    "MISTRAL_API_KEY",
-    "KIMI_API_KEY",
     "GEMINI_API_KEY",
-    "XIAOMI_API_KEY",
-    "VENICE_API_KEY",
     "OPENCODE_API_KEY",
-    "TOGETHER_API_KEY",
-    "QIANFAN_API_KEY",
     "SYNTHETIC_API_KEY",
-    "SSH_TTY",
-    "CHUTES_CLIENT_ID",
   ]);
-  let activeStateDir: string | null = null;
+  let authTestRoot: string | null = null;
+  let authStateCounter = 0;
   async function setupTempState() {
-    if (activeStateDir) {
-      await fs.rm(activeStateDir, { recursive: true, force: true });
+    if (!authTestRoot) {
+      throw new Error("auth test root not initialized");
     }
-    const env = await setupAuthTestEnv("openclaw-auth-");
-    activeStateDir = env.stateDir;
-    lifecycle.setStateDir(env.stateDir);
+    testAuthProfileStores.clear();
+    const stateDir = path.join(authTestRoot, `state-${++authStateCounter}`);
+    const agentDir = path.join(stateDir, "agent");
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_AGENT_DIR = agentDir;
+    process.env.PI_CODING_AGENT_DIR = agentDir;
   }
   function createPrompter(overrides: Partial<WizardPrompter>): WizardPrompter {
     return createWizardPrompter(overrides, { defaultSelect: "" });
@@ -628,186 +606,168 @@ describe("applyAuthChoice", () => {
     };
   }
   async function readAuthProfiles() {
-    return await readAuthProfilesForAgent<{
-      profiles?: Record<string, StoredAuthProfile>;
-    }>(requireOpenClawAgentDir());
+    return readTestAuthProfileStore(requireOpenClawAgentDir());
+  }
+  async function readAuthProfilesForAgentDir(agentDir: string) {
+    return readTestAuthProfileStore(agentDir);
   }
   async function readAuthProfile(profileId: string) {
     return (await readAuthProfiles()).profiles?.[profileId];
   }
 
+  let defaultProviderPlugins: ProviderPlugin[] = [];
+
+  beforeAll(async () => {
+    authTestRoot = (await setupAuthTestEnv("openclaw-auth-")).stateDir;
+    defaultProviderPlugins = await createDefaultProviderPlugins();
+    resolvePluginProviders.mockReturnValue(defaultProviderPlugins);
+    providerAuthChoiceTesting.setDepsForTest({
+      loadPluginProviderRuntime: async () => ({
+        resolvePluginProviders,
+        resolvePluginSetupProvider: () => undefined,
+        resolveProviderPluginChoice,
+        runProviderModelSelectedHook,
+      }),
+    });
+  });
+
+  afterAll(async () => {
+    providerAuthChoiceTesting.resetDepsForTest();
+    if (authTestRoot) {
+      await fs.rm(authTestRoot, { recursive: true, force: true });
+    }
+  });
+
   afterEach(async () => {
     vi.unstubAllGlobals();
     resolvePluginProviders.mockReset();
-    resolvePluginProviders.mockReturnValue(createDefaultProviderPlugins());
+    resolvePluginProviders.mockReturnValue(defaultProviderPlugins);
+    runProviderModelSelectedHook.mockClear();
     detectZaiEndpoint.mockReset();
     detectZaiEndpoint.mockResolvedValue(null);
-    loginOpenAICodexOAuth.mockReset();
-    loginOpenAICodexOAuth.mockResolvedValue(null);
+    testAuthProfileStores.clear();
     await lifecycle.cleanup();
-    activeStateDir = null;
   });
 
-  resolvePluginProviders.mockReturnValue(createDefaultProviderPlugins());
-
-  it("does not throw when openai-codex oauth fails", async () => {
+  it("applies Anthropic setup-token auth when the provider exposes the setup flow", async () => {
     await setupTempState();
 
-    loginOpenAICodexOAuth.mockRejectedValueOnce(new Error("oauth failed"));
     resolvePluginProviders.mockReturnValue([
-      {
-        id: "openai-codex",
-        label: "OpenAI Codex",
-        auth: [
-          {
-            id: "oauth",
-            label: "ChatGPT OAuth",
-            kind: "oauth",
-            run: vi.fn(async () => {
-              try {
-                await loginOpenAICodexOAuth();
-              } catch {
-                return { profiles: [] };
-              }
-              return { profiles: [] };
-            }),
-          },
-        ],
-      },
-    ] as never);
-
-    const prompter = createPrompter({});
-    const runtime = createExitThrowingRuntime();
-
-    await expect(
-      applyAuthChoice({
-        authChoice: "openai-codex",
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: false,
-      }),
-    ).resolves.toEqual({ config: {} });
-  });
-
-  it("stores openai-codex OAuth with email profile id", async () => {
-    await setupTempState();
-
-    loginOpenAICodexOAuth.mockResolvedValueOnce({
-      email: "user@example.com",
-      refresh: "refresh-token",
-      access: "access-token",
-      expires: Date.now() + 60_000,
-    });
-    resolvePluginProviders.mockReturnValue([
-      {
-        id: "openai-codex",
-        label: "OpenAI Codex",
-        auth: [
-          {
-            id: "oauth",
-            label: "ChatGPT OAuth",
-            kind: "oauth",
-            run: vi.fn(async () => {
-              const creds = await loginOpenAICodexOAuth();
-              if (!creds) {
-                return { profiles: [] };
-              }
-              return {
-                profiles: [
-                  {
-                    profileId: "openai-codex:user@example.com",
-                    credential: {
-                      type: "oauth",
-                      provider: "openai-codex",
-                      refresh: "refresh-token",
-                      access: "access-token",
-                      expires: creds.expires,
-                      email: "user@example.com",
-                    },
+      createFixedChoiceProvider({
+        providerId: "anthropic",
+        label: "Anthropic",
+        choiceId: "setup-token",
+        method: {
+          id: "setup-token",
+          label: "Anthropic setup-token",
+          kind: "token",
+          run: vi.fn(
+            async (): Promise<ProviderAuthResult> => ({
+              profiles: [
+                {
+                  profileId: "anthropic:default",
+                  credential: {
+                    type: "token",
+                    provider: "anthropic",
+                    token: `sk-ant-oat01-${"a".repeat(80)}`,
                   },
-                ],
-                defaultModel: "openai-codex/gpt-5.4",
-              };
+                },
+              ],
+              defaultModel: "anthropic/claude-sonnet-4-6",
             }),
-          },
-        ],
-      },
-    ] as never);
-
-    const prompter = createPrompter({});
-    const runtime = createExitThrowingRuntime();
+          ),
+        },
+      }),
+    ]);
 
     const result = await applyAuthChoice({
-      authChoice: "openai-codex",
-      config: {},
-      prompter,
-      runtime,
-      setDefaultModel: false,
+      authChoice: "token",
+      config: {} as OpenClawConfig,
+      prompter: createPrompter({}),
+      runtime: createExitThrowingRuntime(),
+      setDefaultModel: true,
+      opts: {
+        tokenProvider: "anthropic",
+        token: `sk-ant-oat01-${"a".repeat(80)}`,
+      },
     });
 
-    expect(result.config.auth?.profiles?.["openai-codex:user@example.com"]).toMatchObject({
-      provider: "openai-codex",
-      mode: "oauth",
+    expect(result.config.auth?.profiles?.["anthropic:default"]).toMatchObject({
+      provider: "anthropic",
+      mode: "token",
     });
-    expect(result.config.auth?.profiles?.["openai-codex:default"]).toBeUndefined();
-    expect(await readAuthProfile("openai-codex:user@example.com")).toMatchObject({
-      type: "oauth",
-      provider: "openai-codex",
-      refresh: "refresh-token",
-      access: "access-token",
-      email: "user@example.com",
-    });
+    expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+    expect((await readAuthProfile("anthropic:default"))?.token).toBe(
+      `sk-ant-oat01-${"a".repeat(80)}`,
+    );
   });
 
-  it("prompts and writes provider API key for common providers", async () => {
+  it("fails fast when a removed provider auth choice is passed to the interactive flow", async () => {
+    const spy = vi
+      .spyOn(providerAuthChoices, "resolveManifestDeprecatedProviderAuthChoice")
+      .mockReturnValueOnce({
+        choiceId: "openai-codex",
+      } as never);
+    try {
+      await expect(
+        applyAuthChoice({
+          authChoice: "openai-codex-import",
+          config: {},
+          prompter: createPrompter({}),
+          runtime: createExitThrowingRuntime(),
+          setDefaultModel: true,
+        }),
+      ).rejects.toThrow(
+        'Auth choice "openai-codex-import" is no longer supported. Use "openai-codex" instead.',
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("escapes removed provider auth choice guidance for terminal output", async () => {
+    const spy = vi
+      .spyOn(providerAuthChoices, "resolveManifestDeprecatedProviderAuthChoice")
+      .mockReturnValueOnce({
+        choiceId: "modern\nchoice",
+      } as never);
+    try {
+      await expect(
+        applyAuthChoice({
+          authChoice: "legacy\u001b[31mchoice",
+          config: {},
+          prompter: createPrompter({}),
+          runtime: createExitThrowingRuntime(),
+          setDefaultModel: true,
+        }),
+      ).rejects.toThrow(
+        'Auth choice "legacy\\u001b[31mchoice" is no longer supported. Use "modern\\nchoice" instead.',
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("prompts and writes provider API key profiles for common providers", async () => {
     const scenarios: Array<{
-      authChoice:
-        | "minimax-global-api"
-        | "minimax-cn-api"
-        | "synthetic-api-key"
-        | "huggingface-api-key";
+      authChoice: "huggingface-api-key";
       promptContains: string;
       profileId: string;
       provider: string;
       token: string;
-      expectedBaseUrl?: string;
-      expectedModelPrefix?: string;
     }> = [
-      {
-        authChoice: "minimax-global-api" as const,
-        promptContains: "Enter MiniMax API key",
-        profileId: "minimax:global",
-        provider: "minimax",
-        token: "sk-minimax-test",
-      },
-      {
-        authChoice: "minimax-cn-api" as const,
-        promptContains: "Enter MiniMax CN API key",
-        profileId: "minimax:cn",
-        provider: "minimax",
-        token: "sk-minimax-test",
-        expectedBaseUrl: MINIMAX_CN_API_BASE_URL,
-      },
-      {
-        authChoice: "synthetic-api-key" as const,
-        promptContains: "Enter Synthetic API key",
-        profileId: "synthetic:default",
-        provider: "synthetic",
-        token: "sk-synthetic-test",
-      },
       {
         authChoice: "huggingface-api-key" as const,
         promptContains: "Hugging Face",
         profileId: "huggingface:default",
         provider: "huggingface",
         token: "hf-test-token",
-        expectedModelPrefix: "huggingface/",
       },
     ];
+    await setupTempState();
     for (const scenario of scenarios) {
-      await setupTempState();
-
       const text = vi.fn().mockResolvedValue(scenario.token);
       const { prompter, runtime } = createApiKeyPromptHarness({ text });
 
@@ -826,23 +786,11 @@ describe("applyAuthChoice", () => {
         provider: scenario.provider,
         mode: "api_key",
       });
-      if (scenario.expectedBaseUrl) {
-        expect(result.config.models?.providers?.[scenario.provider]?.baseUrl).toBe(
-          scenario.expectedBaseUrl,
-        );
-      }
-      if (scenario.expectedModelPrefix) {
-        expect(
-          resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)?.startsWith(
-            scenario.expectedModelPrefix,
-          ),
-        ).toBe(true);
-      }
       expect((await readAuthProfile(scenario.profileId))?.key).toBe(scenario.token);
     }
   });
 
-  it("handles Z.AI endpoint selection and detection paths", async () => {
+  it("uses Z.AI endpoint detection and prompts in the auth flow", async () => {
     const scenarios: Array<{
       authChoice: "zai-api-key" | "zai-coding-global";
       token: string;
@@ -853,8 +801,6 @@ describe("applyAuthChoice", () => {
         baseUrl: string;
         note: string;
       };
-      expectedBaseUrl: string;
-      expectedModel?: string;
       shouldPromptForEndpoint: boolean;
       expectedDetectCall?: { apiKey: string; endpoint?: "coding-global" | "coding-cn" };
     }> = [
@@ -862,8 +808,6 @@ describe("applyAuthChoice", () => {
         authChoice: "zai-api-key",
         token: "zai-test-key",
         endpointSelection: "coding-cn",
-        expectedBaseUrl: ZAI_CODING_CN_BASE_URL,
-        expectedModel: "zai/glm-5",
         shouldPromptForEndpoint: true,
       },
       {
@@ -875,28 +819,12 @@ describe("applyAuthChoice", () => {
           baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
           note: "Detected coding-global endpoint with GLM-4.7 fallback",
         },
-        expectedBaseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-        expectedModel: "zai/glm-4.7",
         shouldPromptForEndpoint: false,
         expectedDetectCall: { apiKey: "zai-test-key", endpoint: "coding-global" },
       },
-      {
-        authChoice: "zai-api-key",
-        token: "zai-detected-key",
-        detectResult: {
-          endpoint: "coding-global",
-          modelId: "glm-4.5",
-          baseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-          note: "Detected coding-global endpoint",
-        },
-        expectedBaseUrl: ZAI_CODING_GLOBAL_BASE_URL,
-        expectedModel: "zai/glm-4.5",
-        shouldPromptForEndpoint: false,
-        expectedDetectCall: { apiKey: "zai-detected-key" },
-      },
     ];
+    await setupTempState();
     for (const scenario of scenarios) {
-      await setupTempState();
       detectZaiEndpoint.mockReset();
       detectZaiEndpoint.mockResolvedValue(null);
       if (scenario.detectResult) {
@@ -935,49 +863,31 @@ describe("applyAuthChoice", () => {
           expect.objectContaining({ message: "Select Z.AI endpoint" }),
         );
       }
-      expect(result.config.models?.providers?.zai?.baseUrl).toBe(scenario.expectedBaseUrl);
-      if (scenario.expectedModel) {
-        expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-          scenario.expectedModel,
-        );
-      }
-      if (scenario.authChoice === "zai-api-key") {
-        expect((await readAuthProfile("zai:default"))?.key).toBe(scenario.token);
-      }
+      expect(result.config.auth?.profiles?.["zai:default"]).toMatchObject({
+        provider: "zai",
+        mode: "api_key",
+      });
+      expect((await readAuthProfile("zai:default"))?.key).toBe(scenario.token);
     }
   });
 
-  it("maps apiKey tokenProvider aliases to provider flow", async () => {
+  it("uses provided tokens without prompting across alias and direct provider choices", async () => {
     const scenarios: Array<{
+      authChoice: "apiKey" | "gemini-api-key";
+      config?: OpenClawConfig;
+      setDefaultModel: boolean;
       tokenProvider: string;
       token: string;
       profileId: string;
       provider: string;
       expectedModel?: string;
       expectedModelPrefix?: string;
+      expectedAgentModelOverride?: string;
+      extraProfiles?: string[];
     }> = [
       {
-        tokenProvider: "huggingface",
-        token: "hf-token-provider-test",
-        profileId: "huggingface:default",
-        provider: "huggingface",
-        expectedModelPrefix: "huggingface/",
-      },
-      {
-        tokenProvider: "  ToGeThEr  ",
-        token: "sk-together-token-provider-test",
-        profileId: "together:default",
-        provider: "together",
-        expectedModelPrefix: "together/",
-      },
-      {
-        tokenProvider: "KIMI-CODING",
-        token: "sk-kimi-token-provider-test",
-        profileId: "kimi:default",
-        provider: "kimi",
-        expectedModelPrefix: "kimi/",
-      },
-      {
+        authChoice: "apiKey",
+        setDefaultModel: true,
         tokenProvider: " GOOGLE  ",
         token: "sk-gemini-token-provider-test",
         profileId: "google:default",
@@ -985,15 +895,18 @@ describe("applyAuthChoice", () => {
         expectedModel: GOOGLE_GEMINI_DEFAULT_MODEL,
       },
       {
-        tokenProvider: " LITELLM  ",
-        token: "sk-litellm-token-provider-test",
-        profileId: "litellm:default",
-        provider: "litellm",
-        expectedModelPrefix: "litellm/",
+        authChoice: "gemini-api-key",
+        config: { agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } } },
+        setDefaultModel: false,
+        tokenProvider: "google",
+        token: "sk-gemini-test",
+        profileId: "google:default",
+        provider: "google",
+        expectedModel: "openai/gpt-4o-mini",
       },
     ];
+    await setupTempState();
     for (const scenario of scenarios) {
-      await setupTempState();
       delete process.env.HF_TOKEN;
       delete process.env.HUGGINGFACE_HUB_TOKEN;
 
@@ -1002,243 +915,52 @@ describe("applyAuthChoice", () => {
       const { prompter, runtime } = createApiKeyPromptHarness({ text, confirm });
 
       const result = await applyAuthChoice({
-        authChoice: "apiKey",
-        config: {},
+        authChoice: scenario.authChoice,
+        config: scenario.config ?? {},
         prompter,
         runtime,
-        setDefaultModel: true,
+        setDefaultModel: scenario.setDefaultModel,
         opts: {
           tokenProvider: scenario.tokenProvider,
           token: scenario.token,
         },
       });
 
+      expect(text).not.toHaveBeenCalled();
+      expect(confirm).not.toHaveBeenCalled();
       expect(result.config.auth?.profiles?.[scenario.profileId]).toMatchObject({
         provider: scenario.provider,
         mode: "api_key",
       });
+      const selectedModel = resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model);
       if (scenario.expectedModel) {
-        expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-          scenario.expectedModel,
-        );
+        expect(selectedModel).toBe(scenario.expectedModel);
       }
       if (scenario.expectedModelPrefix) {
-        expect(
-          resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)?.startsWith(
-            scenario.expectedModelPrefix,
-          ),
-        ).toBe(true);
+        expect(selectedModel?.startsWith(scenario.expectedModelPrefix)).toBe(true);
       }
-      expect(text).not.toHaveBeenCalled();
-      expect(confirm).not.toHaveBeenCalled();
+      if (scenario.expectedAgentModelOverride) {
+        expect(result.agentModelOverride).toBe(scenario.expectedAgentModelOverride);
+      }
       expect((await readAuthProfile(scenario.profileId))?.key).toBe(scenario.token);
-    }
-  });
-
-  it.each([
-    {
-      authChoice: "moonshot-api-key",
-      tokenProvider: "moonshot",
-      profileId: "moonshot:default",
-      provider: "moonshot",
-      modelPrefix: "moonshot/",
-    },
-    {
-      authChoice: "mistral-api-key",
-      tokenProvider: "mistral",
-      profileId: "mistral:default",
-      provider: "mistral",
-      modelPrefix: "mistral/",
-    },
-    {
-      authChoice: "kimi-code-api-key",
-      tokenProvider: "kimi-code",
-      profileId: "kimi:default",
-      provider: "kimi",
-      modelPrefix: "kimi/",
-    },
-    {
-      authChoice: "xiaomi-api-key",
-      tokenProvider: "xiaomi",
-      profileId: "xiaomi:default",
-      provider: "xiaomi",
-      modelPrefix: "xiaomi/",
-    },
-    {
-      authChoice: "venice-api-key",
-      tokenProvider: "venice",
-      profileId: "venice:default",
-      provider: "venice",
-      modelPrefix: "venice/",
-    },
-    {
-      authChoice: "opencode-zen",
-      tokenProvider: "opencode",
-      profileId: "opencode:default",
-      provider: "opencode",
-      modelPrefix: "opencode/",
-      extraProfiles: ["opencode-go:default"],
-    },
-    {
-      authChoice: "opencode-go",
-      tokenProvider: "opencode-go",
-      profileId: "opencode-go:default",
-      provider: "opencode-go",
-      modelPrefix: "opencode-go/",
-      extraProfiles: ["opencode:default"],
-    },
-    {
-      authChoice: "together-api-key",
-      tokenProvider: "together",
-      profileId: "together:default",
-      provider: "together",
-      modelPrefix: "together/",
-    },
-    {
-      authChoice: "qianfan-api-key",
-      tokenProvider: "qianfan",
-      profileId: "qianfan:default",
-      provider: "qianfan",
-      modelPrefix: "qianfan/",
-    },
-    {
-      authChoice: "synthetic-api-key",
-      tokenProvider: "synthetic",
-      profileId: "synthetic:default",
-      provider: "synthetic",
-      modelPrefix: "synthetic/",
-    },
-  ] as const)(
-    "uses opts token for $authChoice without prompting",
-    async ({ authChoice, tokenProvider, profileId, provider, modelPrefix, extraProfiles }) => {
-      await setupTempState();
-
-      const text = vi.fn();
-      const confirm = vi.fn(async () => false);
-      const { prompter, runtime } = createApiKeyPromptHarness({ text, confirm });
-      const token = `sk-${tokenProvider}-test`;
-
-      const result = await applyAuthChoice({
-        authChoice,
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: true,
-        opts: {
-          tokenProvider,
-          token,
-        },
-      });
-
-      expect(text).not.toHaveBeenCalled();
-      expect(confirm).not.toHaveBeenCalled();
-      expect(result.config.auth?.profiles?.[profileId]).toMatchObject({
-        provider,
-        mode: "api_key",
-      });
-      expect(
-        resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)?.startsWith(
-          modelPrefix,
-        ),
-      ).toBe(true);
-      expect((await readAuthProfile(profileId))?.key).toBe(token);
-      for (const extraProfile of extraProfiles ?? []) {
-        expect((await readAuthProfile(extraProfile))?.key).toBe(token);
+      for (const extraProfile of scenario.extraProfiles ?? []) {
+        expect((await readAuthProfile(extraProfile))?.key).toBe(scenario.token);
       }
-    },
-  );
-
-  it("uses opts token for Gemini and keeps global default model when setDefaultModel=false", async () => {
-    await setupTempState();
-
-    const text = vi.fn();
-    const confirm = vi.fn(async () => false);
-    const { prompter, runtime } = createApiKeyPromptHarness({ text, confirm });
-
-    const result = await applyAuthChoice({
-      authChoice: "gemini-api-key",
-      config: { agents: { defaults: { model: { primary: "openai/gpt-4o-mini" } } } },
-      prompter,
-      runtime,
-      setDefaultModel: false,
-      opts: {
-        tokenProvider: "google",
-        token: "sk-gemini-test",
-      },
-    });
-
-    expect(text).not.toHaveBeenCalled();
-    expect(confirm).not.toHaveBeenCalled();
-    expect(result.config.auth?.profiles?.["google:default"]).toMatchObject({
-      provider: "google",
-      mode: "api_key",
-    });
-    expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-      "openai/gpt-4o-mini",
-    );
-    expect(result.agentModelOverride).toBe(GOOGLE_GEMINI_DEFAULT_MODEL);
-    expect((await readAuthProfile("google:default"))?.key).toBe("sk-gemini-test");
-  });
-
-  it("prompts for Venice API key and shows the Venice note when no token is provided", async () => {
-    await setupTempState();
-    process.env.VENICE_API_KEY = "";
-
-    const note = vi.fn(async () => {});
-    const text = vi.fn(async () => "sk-venice-manual");
-    const prompter = createPrompter({ note, text });
-    const runtime = createExitThrowingRuntime();
-
-    const result = await applyAuthChoice({
-      authChoice: "venice-api-key",
-      config: {},
-      prompter,
-      runtime,
-      setDefaultModel: true,
-    });
-
-    expect(note).toHaveBeenCalledWith(
-      expect.stringContaining("privacy-focused inference"),
-      "Venice AI",
-    );
-    expect(text).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: "Enter Venice AI API key",
-      }),
-    );
-    expect(result.config.auth?.profiles?.["venice:default"]).toMatchObject({
-      provider: "venice",
-      mode: "api_key",
-    });
-    expect((await readAuthProfile("venice:default"))?.key).toBe("sk-venice-manual");
+    }
   });
 
   it("uses existing env API keys for selected providers", async () => {
     const scenarios: Array<{
-      authChoice: "synthetic-api-key" | "openrouter-api-key" | "ai-gateway-api-key";
-      envKey: "SYNTHETIC_API_KEY" | "OPENROUTER_API_KEY" | "AI_GATEWAY_API_KEY";
+      authChoice: "openrouter-api-key";
+      envKey: "OPENROUTER_API_KEY";
       envValue: string;
       profileId: string;
       provider: string;
-      opts?: { secretInputMode?: "ref" };
       expectEnvPrompt: boolean;
       expectedTextCalls: number;
       expectedKey?: string;
-      expectedKeyRef?: { source: "env"; provider: string; id: string };
       expectedModel?: string;
-      expectedModelPrefix?: string;
     }> = [
-      {
-        authChoice: "synthetic-api-key",
-        envKey: "SYNTHETIC_API_KEY",
-        envValue: "sk-synthetic-env",
-        profileId: "synthetic:default",
-        provider: "synthetic",
-        expectEnvPrompt: true,
-        expectedTextCalls: 0,
-        expectedKey: "sk-synthetic-env",
-        expectedModelPrefix: "synthetic/",
-      },
       {
         authChoice: "openrouter-api-key",
         envKey: "OPENROUTER_API_KEY",
@@ -1250,35 +972,11 @@ describe("applyAuthChoice", () => {
         expectedKey: "sk-openrouter-test",
         expectedModel: "openrouter/auto",
       },
-      {
-        authChoice: "ai-gateway-api-key",
-        envKey: "AI_GATEWAY_API_KEY",
-        envValue: "gateway-test-key",
-        profileId: "vercel-ai-gateway:default",
-        provider: "vercel-ai-gateway",
-        expectEnvPrompt: true,
-        expectedTextCalls: 0,
-        expectedKey: "gateway-test-key",
-        expectedModel: "vercel-ai-gateway/anthropic/claude-opus-4.6",
-      },
-      {
-        authChoice: "ai-gateway-api-key",
-        envKey: "AI_GATEWAY_API_KEY",
-        envValue: "gateway-ref-key",
-        profileId: "vercel-ai-gateway:default",
-        provider: "vercel-ai-gateway",
-        opts: { secretInputMode: "ref" }, // pragma: allowlist secret
-        expectEnvPrompt: false,
-        expectedTextCalls: 1,
-        expectedKeyRef: { source: "env", provider: "default", id: "AI_GATEWAY_API_KEY" },
-        expectedModel: "vercel-ai-gateway/anthropic/claude-opus-4.6",
-      },
     ];
+    await setupTempState();
     for (const scenario of scenarios) {
-      await setupTempState();
       delete process.env.SYNTHETIC_API_KEY;
       delete process.env.OPENROUTER_API_KEY;
-      delete process.env.AI_GATEWAY_API_KEY;
       process.env[scenario.envKey] = scenario.envValue;
 
       const text = vi.fn();
@@ -1291,7 +989,6 @@ describe("applyAuthChoice", () => {
         prompter,
         runtime,
         setDefaultModel: true,
-        opts: scenario.opts,
       });
 
       if (scenario.expectEnvPrompt) {
@@ -1313,85 +1010,114 @@ describe("applyAuthChoice", () => {
           scenario.expectedModel,
         );
       }
-      if (scenario.expectedModelPrefix) {
-        expect(
-          resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)?.startsWith(
-            scenario.expectedModelPrefix,
-          ),
-        ).toBe(true);
-      }
       const profile = await readAuthProfile(scenario.profileId);
-      if (scenario.expectedKeyRef) {
-        expect(profile?.keyRef).toEqual(scenario.expectedKeyRef);
-        expect(profile?.key).toBeUndefined();
-      } else {
-        expect(profile?.key).toBe(scenario.expectedKey);
-        expect(profile?.keyRef).toBeUndefined();
-      }
+      expect(profile?.key).toBe(scenario.expectedKey);
+      expect(profile?.keyRef).toBeUndefined();
     }
   });
 
-  it("retries ref setup when provider preflight fails and can switch to env ref", async () => {
+  it("keeps an existing default model when configure re-applies provider auth", async () => {
     await setupTempState();
-    process.env.OPENAI_API_KEY = "sk-openai-env"; // pragma: allowlist secret
-
-    const selectValues: Array<"provider" | "env" | "filemain"> = ["provider", "filemain", "env"];
-    const select = vi.fn(async (params: Parameters<WizardPrompter["select"]>[0]) => {
-      const next = selectValues[0];
-      if (next && params.options.some((option) => option.value === next)) {
-        selectValues.shift();
-        return next as never;
-      }
-      return (params.options[0]?.value ?? "env") as never;
-    });
-    const text = vi
-      .fn<WizardPrompter["text"]>()
-      .mockResolvedValueOnce("/providers/openai/apiKey")
-      .mockResolvedValueOnce("OPENAI_API_KEY");
-    const note = vi.fn(async () => undefined);
-
-    const prompter = createPrompter({
-      select,
-      text,
-      note,
-      confirm: vi.fn(async () => true),
-    });
-    const runtime = createExitThrowingRuntime();
+    vi.stubEnv("OPENROUTER_API_KEY", "sk-openrouter-test");
+    const note = vi.fn();
+    const confirm = vi.fn(async () => true);
+    const text = vi.fn();
+    const existingPrimary = "anthropic/claude-opus-4-6";
+    const prompter = createPrompter({ text, confirm, note });
 
     const result = await applyAuthChoice({
-      authChoice: "openai-api-key",
-      config: {
-        secrets: {
-          providers: {
-            filemain: {
-              source: "file",
-              path: "/tmp/openclaw-missing-secrets.json",
-              mode: "json",
-            },
-          },
-        },
-      },
+      authChoice: "openrouter-api-key",
+      config: { agents: { defaults: { model: { primary: existingPrimary } } } },
       prompter,
-      runtime,
-      setDefaultModel: false,
-      opts: { secretInputMode: "ref" }, // pragma: allowlist secret
+      runtime: createExitThrowingRuntime(),
+      setDefaultModel: true,
+      preserveExistingDefaultModel: true,
     });
 
-    expect(result.config.auth?.profiles?.["openai:default"]).toMatchObject({
-      provider: "openai",
-      mode: "api_key",
-    });
-    expect(note).toHaveBeenCalledWith(
-      expect.stringContaining("Could not validate provider reference"),
-      "Reference check failed",
+    expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
+      existingPrimary,
     );
+    expect(result.config.agents?.defaults?.models?.["openrouter/auto"]).toEqual({});
+    expect(runProviderModelSelectedHook).not.toHaveBeenCalled();
     expect(note).toHaveBeenCalledWith(
-      expect.stringContaining("Validated environment variable OPENAI_API_KEY."),
-      "Reference validated",
+      "Kept existing default model anthropic/claude-opus-4-6; openrouter/auto is available.",
+      "Model configured",
     );
-    expect(await readAuthProfile("openai:default")).toMatchObject({
-      keyRef: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+  });
+
+  it("enables the owning plugin for manifest provider auth choices", async () => {
+    await setupTempState();
+    const provider = createFixedChoiceProvider({
+      providerId: "github-copilot",
+      label: "GitHub Copilot",
+      choiceId: "github-copilot-github",
+      method: {
+        id: "github",
+        label: "GitHub Copilot",
+        kind: "token",
+        run: vi.fn(
+          async (): Promise<ProviderAuthResult> => ({
+            profiles: [
+              {
+                profileId: "github-copilot:github",
+                credential: {
+                  type: "token",
+                  provider: "github-copilot",
+                  token: "gho_copilot_test",
+                },
+              },
+            ],
+            defaultModel: "github-copilot/claude-opus-4.7",
+          }),
+        ),
+      },
     });
+    const manifestSpy = vi
+      .spyOn(providerAuthChoices, "resolveManifestProviderAuthChoice")
+      .mockReturnValue({
+        pluginId: "github-copilot",
+        providerId: "github-copilot",
+        methodId: "github",
+        choiceId: "github-copilot-github",
+        choiceLabel: "GitHub Copilot",
+      });
+    providerAuthChoiceTesting.setDepsForTest({
+      loadPluginProviderRuntime: async () => ({
+        resolvePluginProviders,
+        resolvePluginSetupProvider: () => provider,
+        resolveProviderPluginChoice,
+        runProviderModelSelectedHook,
+      }),
+    });
+    try {
+      const result = await applyAuthChoice({
+        authChoice: "github-copilot-github",
+        config: { plugins: { entries: { "github-copilot": { enabled: false } } } },
+        prompter: createPrompter({}),
+        runtime: createExitThrowingRuntime(),
+        setDefaultModel: true,
+        preserveExistingDefaultModel: true,
+      });
+
+      expect(result.config.plugins?.entries?.["github-copilot"]).toEqual({ enabled: true });
+      expect(result.config.auth?.profiles?.["github-copilot:github"]).toMatchObject({
+        provider: "github-copilot",
+        mode: "token",
+      });
+      expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
+        "github-copilot/claude-opus-4.7",
+      );
+    } finally {
+      manifestSpy.mockRestore();
+      providerAuthChoiceTesting.setDepsForTest({
+        loadPluginProviderRuntime: async () => ({
+          resolvePluginProviders,
+          resolvePluginSetupProvider: () => undefined,
+          resolveProviderPluginChoice,
+          runProviderModelSelectedHook,
+        }),
+      });
+    }
   });
 
   it("uses explicit env for plugin auth resolution instead of host env", async () => {
@@ -1413,8 +1139,8 @@ describe("applyAuthChoice", () => {
 
     expect(resolvePluginProviders).toHaveBeenCalledWith(
       expect.objectContaining({
-        config: {},
         env,
+        mode: "setup",
       }),
     );
     expect(confirm).toHaveBeenCalledWith(
@@ -1432,25 +1158,25 @@ describe("applyAuthChoice", () => {
 
   it("keeps existing default model for explicit provider keys when setDefaultModel=false", async () => {
     const scenarios: Array<{
-      authChoice: "xai-api-key" | "opencode-zen" | "opencode-go";
-      token: string;
+      authChoice: "synthetic-api-key" | "opencode-zen";
+      token: string | undefined;
       promptMessage: string;
       existingPrimary: string;
-      expectedOverride: string;
       profileId?: string;
       profileProvider?: string;
+      expectedStoredKey?: string;
       extraProfileId?: string;
-      expectProviderConfigUndefined?: "opencode" | "opencode-go" | "opencode-zen";
+      expectProviderConfigUndefined?: "opencode";
       agentId?: string;
     }> = [
       {
-        authChoice: "xai-api-key",
-        token: "sk-xai-test",
-        promptMessage: "Enter xAI API key",
+        authChoice: "synthetic-api-key",
+        token: undefined,
+        promptMessage: "Enter Synthetic API key",
         existingPrimary: "openai/gpt-4o-mini",
-        expectedOverride: "xai/grok-4",
-        profileId: "xai:default",
-        profileProvider: "xai",
+        profileId: "synthetic:default",
+        profileProvider: "synthetic",
+        expectedStoredKey: "",
         agentId: "agent-1",
       },
       {
@@ -1458,27 +1184,14 @@ describe("applyAuthChoice", () => {
         token: "sk-opencode-zen-test",
         promptMessage: "Enter OpenCode API key",
         existingPrimary: "anthropic/claude-opus-4-5",
-        expectedOverride: "opencode/claude-opus-4-6",
         profileId: "opencode:default",
         profileProvider: "opencode",
         extraProfileId: "opencode-go:default",
         expectProviderConfigUndefined: "opencode",
       },
-      {
-        authChoice: "opencode-go",
-        token: "sk-opencode-go-test",
-        promptMessage: "Enter OpenCode API key",
-        existingPrimary: "anthropic/claude-opus-4-5",
-        expectedOverride: "opencode-go/kimi-k2.5",
-        profileId: "opencode-go:default",
-        profileProvider: "opencode-go",
-        extraProfileId: "opencode:default",
-        expectProviderConfigUndefined: "opencode-go",
-      },
     ];
+    await setupTempState();
     for (const scenario of scenarios) {
-      await setupTempState();
-
       const text = vi.fn().mockResolvedValue(scenario.token);
       const { prompter, runtime } = createApiKeyPromptHarness({ text });
 
@@ -1497,7 +1210,7 @@ describe("applyAuthChoice", () => {
       expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
         scenario.existingPrimary,
       );
-      expect(result.agentModelOverride).toBe(scenario.expectedOverride);
+      expect(result.agentModelOverride).toBeUndefined();
       if (scenario.profileId && scenario.profileProvider) {
         expect(result.config.auth?.profiles?.[scenario.profileId]).toMatchObject({
           provider: scenario.profileProvider,
@@ -1505,18 +1218,17 @@ describe("applyAuthChoice", () => {
         });
         const profileStore =
           scenario.agentId && scenario.agentId !== "default"
-            ? await readAuthProfilesForAgent<{ profiles?: Record<string, StoredAuthProfile> }>(
-                resolveAgentDir(result.config, scenario.agentId),
-              )
+            ? await readAuthProfilesForAgentDir(resolveAgentDir(result.config, scenario.agentId))
             : await readAuthProfiles();
-        expect(profileStore.profiles?.[scenario.profileId]?.key).toBe(scenario.token);
+        expect(profileStore.profiles?.[scenario.profileId]?.key).toBe(
+          scenario.expectedStoredKey ?? scenario.token,
+        );
+        expect(profileStore.profiles?.[scenario.profileId]?.key).not.toBe("undefined");
       }
       if (scenario.extraProfileId) {
         const profileStore =
           scenario.agentId && scenario.agentId !== "default"
-            ? await readAuthProfilesForAgent<{ profiles?: Record<string, StoredAuthProfile> }>(
-                resolveAgentDir(result.config, scenario.agentId),
-              )
+            ? await readAuthProfilesForAgentDir(resolveAgentDir(result.config, scenario.agentId))
             : await readAuthProfiles();
         expect(profileStore.profiles?.[scenario.extraProfileId]?.key).toBe(scenario.token);
       }
@@ -1525,479 +1237,6 @@ describe("applyAuthChoice", () => {
           result.config.models?.providers?.[scenario.expectProviderConfigUndefined],
         ).toBeUndefined();
       }
-    }
-  });
-
-  it("sets default model when selecting github-copilot", async () => {
-    await setupTempState();
-
-    resolvePluginProviders.mockReturnValue([
-      {
-        id: "github-copilot",
-        label: "GitHub Copilot",
-        auth: [
-          {
-            id: "device",
-            label: "GitHub device login",
-            kind: "device_code",
-            run: vi.fn(async () => ({
-              profiles: [
-                {
-                  profileId: "github-copilot:github",
-                  credential: {
-                    type: "token",
-                    provider: "github-copilot",
-                    token: "github-device-token",
-                  },
-                },
-              ],
-              defaultModel: "github-copilot/gpt-4o",
-            })),
-          },
-        ],
-      },
-    ] as never);
-
-    const prompter = createPrompter({});
-    const runtime = createExitThrowingRuntime();
-
-    const stdin = process.stdin as NodeJS.ReadStream & { isTTY?: boolean };
-    const hadOwnIsTTY = Object.prototype.hasOwnProperty.call(stdin, "isTTY");
-    const previousIsTTYDescriptor = Object.getOwnPropertyDescriptor(stdin, "isTTY");
-    Object.defineProperty(stdin, "isTTY", {
-      configurable: true,
-      enumerable: true,
-      get: () => true,
-    });
-
-    try {
-      const result = await applyAuthChoice({
-        authChoice: "github-copilot",
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: true,
-      });
-
-      expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-        "github-copilot/gpt-4o",
-      );
-    } finally {
-      if (previousIsTTYDescriptor) {
-        Object.defineProperty(stdin, "isTTY", previousIsTTYDescriptor);
-      } else if (!hadOwnIsTTY) {
-        delete (stdin as { isTTY?: boolean }).isTTY;
-      }
-    }
-  });
-
-  it("does not persist literal 'undefined' when API key prompts return undefined", async () => {
-    const scenarios = [
-      {
-        authChoice: "apiKey" as const,
-        envKey: "ANTHROPIC_API_KEY",
-        profileId: "anthropic:default",
-        provider: "anthropic",
-      },
-      {
-        authChoice: "openrouter-api-key" as const,
-        envKey: "OPENROUTER_API_KEY",
-        profileId: "openrouter:default",
-        provider: "openrouter",
-      },
-    ];
-
-    for (const scenario of scenarios) {
-      await setupTempState();
-      delete process.env[scenario.envKey];
-
-      const text = vi.fn(async () => undefined as unknown as string);
-      const prompter = createPrompter({ text });
-      const runtime = createExitThrowingRuntime();
-
-      const result = await applyAuthChoice({
-        authChoice: scenario.authChoice,
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: false,
-      });
-
-      expect(result.config.auth?.profiles?.[scenario.profileId]).toMatchObject({
-        provider: scenario.provider,
-        mode: "api_key",
-      });
-
-      const profile = await readAuthProfile(scenario.profileId);
-      expect(profile?.key).toBe("");
-      expect(profile?.key).not.toBe("undefined");
-    }
-  });
-
-  it("ignores legacy LiteLLM oauth profiles when selecting litellm-api-key", async () => {
-    await setupTempState();
-    process.env.LITELLM_API_KEY = "sk-litellm-test"; // pragma: allowlist secret
-
-    const authProfilePath = authProfilePathForAgent(requireOpenClawAgentDir());
-    await fs.writeFile(
-      authProfilePath,
-      JSON.stringify(
-        {
-          version: 1,
-          profiles: {
-            "litellm:legacy": {
-              type: "oauth",
-              provider: "litellm",
-              access: "access-token",
-              refresh: "refresh-token",
-              expires: Date.now() + 60_000,
-            },
-          },
-        },
-        null,
-        2,
-      ),
-      "utf8",
-    );
-
-    const text = vi.fn();
-    const confirm = vi.fn(async () => true);
-    const { prompter, runtime } = createApiKeyPromptHarness({ text, confirm });
-
-    const result = await applyAuthChoice({
-      authChoice: "litellm-api-key",
-      config: {
-        auth: {
-          profiles: {
-            "litellm:legacy": { provider: "litellm", mode: "oauth" },
-          },
-          order: { litellm: ["litellm:legacy"] },
-        },
-      },
-      prompter,
-      runtime,
-      setDefaultModel: true,
-    });
-
-    expect(confirm).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining("LITELLM_API_KEY"),
-      }),
-    );
-    expect(text).not.toHaveBeenCalled();
-    expect(result.config.auth?.profiles?.["litellm:default"]).toMatchObject({
-      provider: "litellm",
-      mode: "api_key",
-    });
-
-    expect(await readAuthProfile("litellm:default")).toMatchObject({
-      type: "api_key",
-      key: "sk-litellm-test",
-    });
-  });
-
-  it("configures cloudflare ai gateway via env key and explicit opts", async () => {
-    const scenarios: Array<{
-      envGatewayKey?: string;
-      textValues: string[];
-      confirmValue: boolean;
-      opts?: {
-        secretInputMode?: "ref"; // pragma: allowlist secret
-        cloudflareAiGatewayAccountId?: string;
-        cloudflareAiGatewayGatewayId?: string;
-        cloudflareAiGatewayApiKey?: string;
-      };
-      expectEnvPrompt: boolean;
-      expectedTextCalls: number;
-      expectedKey?: string;
-      expectedKeyRef?: { source: string; provider: string; id: string };
-      expectedMetadata: { accountId: string; gatewayId: string };
-    }> = [
-      {
-        envGatewayKey: "cf-gateway-test-key",
-        textValues: ["cf-account-id", "cf-gateway-id"],
-        confirmValue: true,
-        expectEnvPrompt: true,
-        expectedTextCalls: 2,
-        expectedKey: "cf-gateway-test-key",
-        expectedMetadata: {
-          accountId: "cf-account-id",
-          gatewayId: "cf-gateway-id",
-        },
-      },
-      {
-        envGatewayKey: "cf-gateway-ref-key",
-        textValues: ["cf-account-id-ref", "cf-gateway-id-ref"],
-        confirmValue: true,
-        opts: {
-          secretInputMode: "ref", // pragma: allowlist secret
-        },
-        expectEnvPrompt: false,
-        expectedTextCalls: 3,
-        expectedKeyRef: { source: "env", provider: "default", id: "CLOUDFLARE_AI_GATEWAY_API_KEY" },
-        expectedMetadata: {
-          accountId: "cf-account-id-ref",
-          gatewayId: "cf-gateway-id-ref",
-        },
-      },
-      {
-        textValues: [],
-        confirmValue: false,
-        opts: {
-          cloudflareAiGatewayAccountId: "acc-direct",
-          cloudflareAiGatewayGatewayId: "gw-direct",
-          cloudflareAiGatewayApiKey: "cf-direct-key", // pragma: allowlist secret
-        },
-        expectEnvPrompt: false,
-        expectedTextCalls: 0,
-        expectedKey: "cf-direct-key",
-        expectedMetadata: {
-          accountId: "acc-direct",
-          gatewayId: "gw-direct",
-        },
-      },
-    ];
-    for (const scenario of scenarios) {
-      await setupTempState();
-      delete process.env.CLOUDFLARE_AI_GATEWAY_API_KEY;
-      if (scenario.envGatewayKey) {
-        process.env.CLOUDFLARE_AI_GATEWAY_API_KEY = scenario.envGatewayKey;
-      }
-
-      const text = vi.fn();
-      for (const textValue of scenario.textValues) {
-        text.mockResolvedValueOnce(textValue);
-      }
-      const confirm = vi.fn(async () => scenario.confirmValue);
-      const { prompter, runtime } = createApiKeyPromptHarness({ text, confirm });
-
-      const result = await applyAuthChoice({
-        authChoice: "cloudflare-ai-gateway-api-key",
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: true,
-        opts: scenario.opts,
-      });
-
-      if (scenario.expectEnvPrompt) {
-        expect(confirm).toHaveBeenCalledWith(
-          expect.objectContaining({
-            message: expect.stringContaining("CLOUDFLARE_AI_GATEWAY_API_KEY"),
-          }),
-        );
-      } else {
-        expect(confirm).not.toHaveBeenCalled();
-      }
-      expect(text).toHaveBeenCalledTimes(scenario.expectedTextCalls);
-      expect(result.config.auth?.profiles?.["cloudflare-ai-gateway:default"]).toMatchObject({
-        provider: "cloudflare-ai-gateway",
-        mode: "api_key",
-      });
-      expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-        "cloudflare-ai-gateway/claude-sonnet-4-5",
-      );
-
-      const profile = await readAuthProfile("cloudflare-ai-gateway:default");
-      if (scenario.expectedKeyRef) {
-        expect(profile?.keyRef).toEqual(scenario.expectedKeyRef);
-      } else {
-        expect(profile?.key).toBe(scenario.expectedKey);
-      }
-      expect(profile?.metadata).toEqual(scenario.expectedMetadata);
-    }
-    delete process.env.CLOUDFLARE_AI_GATEWAY_API_KEY;
-  });
-
-  it("writes Chutes OAuth credentials when selecting chutes (remote/manual)", async () => {
-    await setupTempState();
-    process.env.SSH_TTY = "1";
-    process.env.CHUTES_CLIENT_ID = "cid_test";
-
-    const fetchSpy = vi.fn(async (input: string | URL) => {
-      const url = typeof input === "string" ? input : input.toString();
-      if (url === "https://api.chutes.ai/idp/token") {
-        return new Response(
-          JSON.stringify({
-            access_token: "at_test",
-            refresh_token: "rt_test",
-            expires_in: 3600,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      if (url === "https://api.chutes.ai/idp/userinfo") {
-        return new Response(JSON.stringify({ username: "remote-user" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return new Response("not found", { status: 404 });
-    });
-    vi.stubGlobal("fetch", fetchSpy);
-
-    const runtime = createExitThrowingRuntime();
-    const text: WizardPrompter["text"] = vi.fn(async (params) => {
-      if (params.message.startsWith("Paste the redirect URL")) {
-        const runtimeLog = runtime.log as ReturnType<typeof vi.fn>;
-        const lastLog = runtimeLog.mock.calls.at(-1)?.[0];
-        const urlLine = typeof lastLog === "string" ? lastLog : String(lastLog ?? "");
-        const urlMatch = urlLine.match(/https?:\/\/\S+/)?.[0] ?? "";
-        const state = urlMatch ? new URL(urlMatch).searchParams.get("state") : null;
-        if (!state) {
-          throw new Error("missing state in oauth URL");
-        }
-        return `?code=code_manual&state=${state}`;
-      }
-      return "code_manual";
-    });
-    const { prompter } = createApiKeyPromptHarness({ text });
-
-    const result = await applyAuthChoice({
-      authChoice: "chutes",
-      config: {},
-      prompter,
-      runtime,
-      setDefaultModel: false,
-    });
-
-    expect(text).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining("Paste the redirect URL"),
-      }),
-    );
-    expect(result.config.auth?.profiles?.["chutes:remote-user"]).toMatchObject({
-      provider: "chutes",
-      mode: "oauth",
-    });
-
-    expect(await readAuthProfile("chutes:remote-user")).toMatchObject({
-      provider: "chutes",
-      access: "at_test",
-      refresh: "rt_test",
-      email: "remote-user",
-    });
-  });
-
-  it("writes portal OAuth credentials for plugin providers", async () => {
-    const scenarios: Array<{
-      authChoice: "minimax-global-oauth";
-      label: string;
-      authId: string;
-      authLabel: string;
-      providerId: string;
-      profileId: string;
-      baseUrl: string;
-      api: "openai-completions" | "anthropic-messages";
-      defaultModel: string;
-      apiKey: string;
-      selectValue?: string;
-    }> = [
-      {
-        authChoice: "minimax-global-oauth",
-        label: "MiniMax",
-        authId: "oauth",
-        authLabel: "MiniMax OAuth (Global)",
-        providerId: "minimax-portal",
-        profileId: "minimax-portal:default",
-        baseUrl: "https://api.minimax.io/anthropic",
-        api: "anthropic-messages",
-        defaultModel: "minimax-portal/MiniMax-M2.7",
-        apiKey: "minimax-oauth", // pragma: allowlist secret
-      },
-    ];
-    for (const scenario of scenarios) {
-      await setupTempState();
-
-      resolvePluginProviders.mockReturnValue([
-        {
-          id: scenario.providerId,
-          label: scenario.label,
-          auth: [
-            {
-              id: scenario.authId,
-              label: scenario.authLabel,
-              kind: "device_code",
-              wizard: { choiceId: scenario.authChoice },
-              run: vi.fn(async () => ({
-                profiles: [
-                  {
-                    profileId: scenario.profileId,
-                    credential: {
-                      type: "oauth",
-                      provider: scenario.providerId,
-                      access: "access",
-                      refresh: "refresh",
-                      expires: Date.now() + 60 * 60 * 1000,
-                    },
-                  },
-                ],
-                configPatch: {
-                  models: {
-                    providers: {
-                      [scenario.providerId]: {
-                        baseUrl: scenario.baseUrl,
-                        apiKey: scenario.apiKey,
-                        api: scenario.api,
-                        models: [],
-                      },
-                    },
-                  },
-                },
-                defaultModel: scenario.defaultModel,
-              })),
-            },
-          ],
-        },
-      ] as never);
-
-      const prompter = createPrompter(
-        scenario.selectValue
-          ? { select: vi.fn(async () => scenario.selectValue as never) as WizardPrompter["select"] }
-          : {},
-      );
-      const runtime = createExitThrowingRuntime();
-
-      const result = await applyAuthChoice({
-        authChoice: scenario.authChoice,
-        config: {},
-        prompter,
-        runtime,
-        setDefaultModel: true,
-      });
-
-      expect(result.config.auth?.profiles?.[scenario.profileId]).toMatchObject({
-        provider: scenario.providerId,
-        mode: "oauth",
-      });
-      expect(resolveAgentModelPrimaryValue(result.config.agents?.defaults?.model)).toBe(
-        scenario.defaultModel,
-      );
-      expect(result.config.models?.providers?.[scenario.providerId]).toMatchObject({
-        baseUrl: scenario.baseUrl,
-        apiKey: scenario.apiKey,
-      });
-      expect(await readAuthProfile(scenario.profileId)).toMatchObject({
-        provider: scenario.providerId,
-        access: "access",
-        refresh: "refresh",
-      });
-    }
-  });
-});
-
-describe("resolvePreferredProviderForAuthChoice", () => {
-  it("maps known and unknown auth choices", async () => {
-    const scenarios = [
-      { authChoice: "github-copilot" as const, expectedProvider: "github-copilot" },
-      { authChoice: "mistral-api-key" as const, expectedProvider: "mistral" },
-      { authChoice: "ollama" as const, expectedProvider: "ollama" },
-      { authChoice: "unknown" as AuthChoice, expectedProvider: undefined },
-    ] as const;
-    for (const scenario of scenarios) {
-      await expect(
-        resolvePreferredProviderForAuthChoice({ choice: scenario.authChoice }),
-      ).resolves.toBe(scenario.expectedProvider);
     }
   });
 });

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import {
-  applyGoogleGeminiModelDefault,
-  GOOGLE_GEMINI_DEFAULT_MODEL,
-} from "../plugin-sdk/google.js";
-import {
-  applyOpenAIConfig,
-  applyOpenAIProviderConfig,
-  OPENAI_DEFAULT_MODEL,
-} from "../plugin-sdk/openai.js";
-import type { WizardPrompter } from "../wizard/prompts.js";
-import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
-import {
   applyOpencodeZenModelDefault,
   OPENCODE_ZEN_DEFAULT_MODEL,
-} from "./opencode-zen-model-default.js";
+} from "../plugin-sdk/opencode.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyDefaultModelChoice } from "./auth-choice.default-model.js";
 
 function makePrompter(): WizardPrompter {
   return {
@@ -45,36 +36,6 @@ function expectConfigUnchanged(
   expect(applied.next).toEqual(cfg);
 }
 
-type SharedDefaultModelCase = {
-  apply: (cfg: OpenClawConfig) => { changed: boolean; next: OpenClawConfig };
-  defaultModel: string;
-  overrideConfig: OpenClawConfig;
-  alreadyDefaultConfig: OpenClawConfig;
-};
-
-const SHARED_DEFAULT_MODEL_CASES: SharedDefaultModelCase[] = [
-  {
-    apply: applyGoogleGeminiModelDefault,
-    defaultModel: GOOGLE_GEMINI_DEFAULT_MODEL,
-    overrideConfig: {
-      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-5" } } },
-    } as OpenClawConfig,
-    alreadyDefaultConfig: {
-      agents: { defaults: { model: { primary: GOOGLE_GEMINI_DEFAULT_MODEL } } },
-    } as OpenClawConfig,
-  },
-  {
-    apply: applyOpencodeZenModelDefault,
-    defaultModel: OPENCODE_ZEN_DEFAULT_MODEL,
-    overrideConfig: {
-      agents: { defaults: { model: "anthropic/claude-opus-4-5" } },
-    } as OpenClawConfig,
-    alreadyDefaultConfig: {
-      agents: { defaults: { model: OPENCODE_ZEN_DEFAULT_MODEL } },
-    } as OpenClawConfig,
-  },
-];
-
 describe("applyDefaultModelChoice", () => {
   it("ensures allowlist entry exists when returning an agent override", async () => {
     const defaultModel = "vercel-ai-gateway/anthropic/claude-opus-4.6";
@@ -90,8 +51,8 @@ describe("applyDefaultModelChoice", () => {
       prompter: makePrompter(),
     });
 
-    expect(noteAgentModel).toHaveBeenCalledWith(defaultModel);
-    expect(applied.agentModelOverride).toBe(defaultModel);
+    expect(noteAgentModel).not.toHaveBeenCalled();
+    expect(applied.agentModelOverride).toBeUndefined();
     expect(applied.config.agents?.defaults?.models?.[defaultModel]).toEqual({});
   });
 
@@ -112,7 +73,7 @@ describe("applyDefaultModelChoice", () => {
   });
 
   it("uses applyDefaultConfig path when setDefaultModel is true", async () => {
-    const defaultModel = "openai/gpt-5.4";
+    const defaultModel = "openai/gpt-5.5";
     const applied = await applyDefaultModelChoice({
       config: {},
       setDefaultModel: true,
@@ -135,65 +96,21 @@ describe("applyDefaultModelChoice", () => {
   });
 });
 
-describe("shared default model behavior", () => {
+describe("applyOpencodeZenModelDefault", () => {
   it("sets defaults when model is unset", () => {
-    for (const testCase of SHARED_DEFAULT_MODEL_CASES) {
-      const cfg: OpenClawConfig = { agents: { defaults: {} } };
-      const applied = testCase.apply(cfg);
-      expectPrimaryModelChanged(applied, testCase.defaultModel);
-    }
+    const cfg: OpenClawConfig = { agents: { defaults: {} } };
+    const applied = applyOpencodeZenModelDefault(cfg);
+    expectPrimaryModelChanged(applied, OPENCODE_ZEN_DEFAULT_MODEL);
   });
 
   it("overrides existing models", () => {
-    for (const testCase of SHARED_DEFAULT_MODEL_CASES) {
-      const applied = testCase.apply(testCase.overrideConfig);
-      expectPrimaryModelChanged(applied, testCase.defaultModel);
-    }
+    const cfg = {
+      agents: { defaults: { model: "anthropic/claude-opus-4-6" } },
+    } as OpenClawConfig;
+    const applied = applyOpencodeZenModelDefault(cfg);
+    expectPrimaryModelChanged(applied, OPENCODE_ZEN_DEFAULT_MODEL);
   });
 
-  it("no-ops when already on the target default", () => {
-    for (const testCase of SHARED_DEFAULT_MODEL_CASES) {
-      const applied = testCase.apply(testCase.alreadyDefaultConfig);
-      expectConfigUnchanged(applied, testCase.alreadyDefaultConfig);
-    }
-  });
-});
-
-describe("applyOpenAIProviderConfig", () => {
-  it("adds allowlist entry for default model", () => {
-    const next = applyOpenAIProviderConfig({});
-    expect(Object.keys(next.agents?.defaults?.models ?? {})).toContain(OPENAI_DEFAULT_MODEL);
-  });
-
-  it("preserves existing alias for default model", () => {
-    const next = applyOpenAIProviderConfig({
-      agents: {
-        defaults: {
-          models: {
-            [OPENAI_DEFAULT_MODEL]: { alias: "My GPT" },
-          },
-        },
-      },
-    });
-    expect(next.agents?.defaults?.models?.[OPENAI_DEFAULT_MODEL]?.alias).toBe("My GPT");
-  });
-});
-
-describe("applyOpenAIConfig", () => {
-  it("sets default when model is unset", () => {
-    const next = applyOpenAIConfig({});
-    expect(next.agents?.defaults?.model).toEqual({ primary: OPENAI_DEFAULT_MODEL });
-  });
-
-  it("overrides model.primary when model object already exists", () => {
-    const next = applyOpenAIConfig({
-      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6", fallbacks: [] } } },
-    });
-    expect(next.agents?.defaults?.model).toEqual({ primary: OPENAI_DEFAULT_MODEL, fallbacks: [] });
-  });
-});
-
-describe("applyOpencodeZenModelDefault", () => {
   it("no-ops when already legacy opencode-zen default", () => {
     const cfg = {
       agents: { defaults: { model: "opencode-zen/claude-opus-4-5" } },
@@ -207,7 +124,7 @@ describe("applyOpencodeZenModelDefault", () => {
       agents: {
         defaults: {
           model: {
-            primary: "anthropic/claude-opus-4-5",
+            primary: "anthropic/claude-opus-4-6",
             fallbacks: ["google/gemini-3-pro"],
           },
         },
@@ -219,5 +136,13 @@ describe("applyOpencodeZenModelDefault", () => {
       primary: OPENCODE_ZEN_DEFAULT_MODEL,
       fallbacks: ["google/gemini-3-pro"],
     });
+  });
+
+  it("no-ops when already on the current default", () => {
+    const cfg = {
+      agents: { defaults: { model: OPENCODE_ZEN_DEFAULT_MODEL } },
+    } as OpenClawConfig;
+    const applied = applyOpencodeZenModelDefault(cfg);
+    expectConfigUnchanged(applied, cfg);
   });
 });

--- a/src/plugins/provider-auth-choice.ts
+++ b/src/plugins/provider-auth-choice.ts
@@ -5,21 +5,28 @@ import {
   resolveAgentWorkspaceDir,
 } from "../agents/agent-scope.js";
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import { formatLiteralProviderPrefixedModelRef } from "../agents/model-ref-shared.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
-import type { OpenClawConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { sanitizeTerminalText } from "../terminal/safe-text.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { enablePluginInConfig } from "./enable.js";
 import {
+  applyProviderAuthConfigPatch,
   applyDefaultModel,
-  mergeConfigPatch,
   pickAuthMethod,
   resolveProviderMatch,
 } from "./provider-auth-choice-helpers.js";
+import {
+  resolveManifestProviderAuthChoice,
+  type ProviderAuthChoiceMetadata,
+} from "./provider-auth-choices.js";
 import { applyAuthProfileConfig } from "./provider-auth-helpers.js";
+import { resolveProviderInstallCatalogEntry } from "./provider-install-catalog.js";
 import { createVpsAwareOAuthHandlers } from "./provider-oauth-flow.js";
 import { isRemoteEnvironment, openUrl } from "./setup-browser.js";
-import type { ProviderAuthMethod, ProviderAuthOptionBag } from "./types.js";
+import type { ProviderAuthMethod, ProviderAuthOptionBag, ProviderPlugin } from "./types.js";
 
 export type ApplyProviderAuthChoiceParams = {
   authChoice: string;
@@ -29,6 +36,7 @@ export type ApplyProviderAuthChoiceParams = {
   runtime: RuntimeEnv;
   agentDir?: string;
   setDefaultModel: boolean;
+  preserveExistingDefaultModel?: boolean;
   agentId?: string;
   opts?: Partial<ProviderAuthOptionBag>;
 };
@@ -36,6 +44,7 @@ export type ApplyProviderAuthChoiceParams = {
 export type ApplyProviderAuthChoiceResult = {
   config: OpenClawConfig;
   agentModelOverride?: string;
+  retrySelection?: boolean;
 };
 
 export type PluginProviderAuthChoiceOptions = {
@@ -45,6 +54,13 @@ export type PluginProviderAuthChoiceOptions = {
   methodId?: string;
   label: string;
 };
+
+function formatModelRefForDisplay(modelRef: string, provider: ProviderPlugin): string {
+  if (!provider.preserveLiteralProviderPrefix) {
+    return modelRef;
+  }
+  return formatLiteralProviderPrefixedModelRef(provider.id, modelRef);
+}
 
 function restoreConfiguredPrimaryModel(
   nextConfig: OpenClawConfig,
@@ -78,9 +94,111 @@ function restoreConfiguredPrimaryModel(
   };
 }
 
-async function loadPluginProviderRuntime() {
-  return import("./provider-auth-choice.runtime.js");
+function resolveConfiguredDefaultModelPrimary(cfg: OpenClawConfig): string | undefined {
+  const model = cfg.agents?.defaults?.model;
+  if (typeof model === "string") {
+    return model;
+  }
+  if (model && typeof model === "object" && typeof model.primary === "string") {
+    return model.primary;
+  }
+  return undefined;
 }
+
+async function noteDefaultModelResult(params: {
+  previousPrimary: string | undefined;
+  selectedModel: string;
+  selectedModelDisplay?: string;
+  preserveExistingDefaultModel: boolean | undefined;
+  prompter: WizardPrompter;
+}): Promise<void> {
+  const selectedModelDisplay = params.selectedModelDisplay ?? params.selectedModel;
+  if (
+    params.preserveExistingDefaultModel === true &&
+    params.previousPrimary &&
+    params.previousPrimary !== params.selectedModel
+  ) {
+    await params.prompter.note(
+      `Kept existing default model ${params.previousPrimary}; ${selectedModelDisplay} is available.`,
+      "Model configured",
+    );
+    return;
+  }
+
+  await params.prompter.note(`Default model set to ${selectedModelDisplay}`, "Model configured");
+}
+
+async function applyDefaultModelFromAuthChoice(params: {
+  config: OpenClawConfig;
+  selectedModel: string;
+  selectedModelDisplay?: string;
+  preserveExistingDefaultModel: boolean | undefined;
+  prompter: WizardPrompter;
+  runSelectedModelHook: (config: OpenClawConfig) => Promise<void>;
+}): Promise<OpenClawConfig> {
+  const previousPrimary = resolveConfiguredDefaultModelPrimary(params.config);
+  const preservesDifferentPrimary =
+    params.preserveExistingDefaultModel === true &&
+    previousPrimary !== undefined &&
+    previousPrimary !== params.selectedModel;
+  const nextConfig = applyDefaultModel(params.config, params.selectedModel, {
+    preserveExistingPrimary: params.preserveExistingDefaultModel === true,
+  });
+  if (!preservesDifferentPrimary) {
+    await params.runSelectedModelHook(nextConfig);
+  }
+  await noteDefaultModelResult({
+    previousPrimary,
+    selectedModel: params.selectedModel,
+    selectedModelDisplay: params.selectedModelDisplay,
+    preserveExistingDefaultModel: params.preserveExistingDefaultModel,
+    prompter: params.prompter,
+  });
+  return nextConfig;
+}
+
+type ProviderAuthChoiceRuntime = typeof import("./provider-auth-choice.runtime.js");
+
+const defaultProviderAuthChoiceDeps = {
+  loadPluginProviderRuntime: async (): Promise<ProviderAuthChoiceRuntime> =>
+    import("./provider-auth-choice.runtime.js"),
+};
+
+let providerAuthChoiceDeps = defaultProviderAuthChoiceDeps;
+
+async function loadPluginProviderRuntime() {
+  return await providerAuthChoiceDeps.loadPluginProviderRuntime();
+}
+
+function resolveManifestAuthChoiceScope(params: {
+  authChoice: string;
+  config: OpenClawConfig;
+  workspaceDir: string;
+  env?: NodeJS.ProcessEnv;
+}): ProviderAuthChoiceMetadata | undefined {
+  return resolveManifestProviderAuthChoice(params.authChoice, {
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+    includeUntrustedWorkspacePlugins: false,
+  });
+}
+
+function withProviderPluginId(provider: ProviderPlugin, pluginId: string): ProviderPlugin {
+  return provider.pluginId === pluginId ? provider : { ...provider, pluginId };
+}
+
+export const __testing = {
+  resetDepsForTest(): void {
+    providerAuthChoiceDeps = defaultProviderAuthChoiceDeps;
+  },
+  setDepsForTest(deps: Partial<typeof defaultProviderAuthChoiceDeps>): void {
+    providerAuthChoiceDeps = {
+      ...defaultProviderAuthChoiceDeps,
+      ...deps,
+    };
+  },
+} as const;
 
 export async function runProviderPluginAuthMethod(params: {
   config: OpenClawConfig;
@@ -129,7 +247,9 @@ export async function runProviderPluginAuthMethod(params: {
 
   let nextConfig = params.config;
   if (result.configPatch) {
-    nextConfig = mergeConfigPatch(nextConfig, result.configPatch);
+    nextConfig = applyProviderAuthConfigPatch(nextConfig, result.configPatch, {
+      replaceDefaultModels: result.replaceDefaultModels,
+    });
   }
 
   for (const profile of result.profiles) {
@@ -168,25 +288,114 @@ export async function applyAuthChoiceLoadedPluginProvider(
   const agentId = params.agentId ?? resolveDefaultAgentId(params.config);
   const workspaceDir =
     resolveAgentWorkspaceDir(params.config, agentId) ?? resolveDefaultAgentWorkspaceDir();
-  const { resolvePluginProviders, resolveProviderPluginChoice, runProviderModelSelectedHook } =
-    await loadPluginProviderRuntime();
-  const providers = resolvePluginProviders({
-    config: params.config,
+  let nextConfig = params.config;
+  let enabledConfig = params.config;
+  const {
+    resolvePluginProviders,
+    resolvePluginSetupProvider,
+    resolveProviderPluginChoice,
+    runProviderModelSelectedHook,
+  } = await loadPluginProviderRuntime();
+  const manifestAuthChoice = resolveManifestAuthChoiceScope({
+    authChoice: params.authChoice,
+    config: nextConfig,
     workspaceDir,
     env: params.env,
-    bundledProviderAllowlistCompat: true,
-    bundledProviderVitestCompat: true,
   });
-  const resolved = resolveProviderPluginChoice({
+  const installCatalogEntry = resolveProviderInstallCatalogEntry(params.authChoice, {
+    config: nextConfig,
+    workspaceDir,
+    env: params.env,
+    includeUntrustedWorkspacePlugins: false,
+  });
+  const choicePlugin = manifestAuthChoice
+    ? { pluginId: manifestAuthChoice.pluginId, label: manifestAuthChoice.choiceLabel }
+    : installCatalogEntry
+      ? { pluginId: installCatalogEntry.pluginId, label: installCatalogEntry.label }
+      : undefined;
+  if (choicePlugin) {
+    const enableResult = enablePluginInConfig(nextConfig, choicePlugin.pluginId);
+    if (!enableResult.enabled) {
+      const safeLabel = sanitizeTerminalText(choicePlugin.label);
+      await params.prompter.note(
+        `${safeLabel} plugin is disabled (${enableResult.reason ?? "blocked"}).`,
+        safeLabel,
+      );
+      return { config: nextConfig };
+    }
+    enabledConfig = enableResult.config;
+  }
+
+  const resolveScopedRuntimeProviders = (config: OpenClawConfig): ProviderPlugin[] =>
+    resolvePluginProviders({
+      config,
+      workspaceDir,
+      env: params.env,
+      mode: "setup",
+      ...(manifestAuthChoice
+        ? {
+            onlyPluginIds: [manifestAuthChoice.pluginId],
+            providerRefs: [manifestAuthChoice.providerId],
+          }
+        : {}),
+    });
+
+  const setupProvider = manifestAuthChoice
+    ? resolvePluginSetupProvider({
+        provider: manifestAuthChoice.providerId,
+        config: enabledConfig,
+        workspaceDir,
+        env: params.env,
+        pluginIds: [manifestAuthChoice.pluginId],
+      })
+    : undefined;
+  let providers = setupProvider
+    ? [withProviderPluginId(setupProvider, manifestAuthChoice!.pluginId)]
+    : resolveScopedRuntimeProviders(enabledConfig);
+  let resolved = resolveProviderPluginChoice({
     providers,
     choice: params.authChoice,
   });
+  if (!resolved && setupProvider) {
+    providers = resolveScopedRuntimeProviders(enabledConfig);
+    resolved = resolveProviderPluginChoice({
+      providers,
+      choice: params.authChoice,
+    });
+  }
+  if (!resolved && installCatalogEntry) {
+    const { ensureOnboardingPluginInstalled } =
+      await import("../commands/onboarding-plugin-install.js");
+    const installResult = await ensureOnboardingPluginInstalled({
+      cfg: nextConfig,
+      entry: {
+        pluginId: installCatalogEntry.pluginId,
+        label: installCatalogEntry.label,
+        install: installCatalogEntry.install,
+      },
+      prompter: params.prompter,
+      runtime: params.runtime,
+      workspaceDir,
+    });
+    if (!installResult.installed) {
+      return { config: installResult.cfg, retrySelection: true };
+    }
+    nextConfig = installResult.cfg;
+    providers = resolveScopedRuntimeProviders(nextConfig);
+    resolved = resolveProviderPluginChoice({
+      providers,
+      choice: params.authChoice,
+    });
+  }
   if (!resolved) {
-    return null;
+    return nextConfig === params.config ? null : { config: nextConfig, retrySelection: true };
+  }
+  if (nextConfig === params.config && enabledConfig !== params.config) {
+    nextConfig = enabledConfig;
   }
 
   const applied = await runProviderPluginAuthMethod({
-    config: params.config,
+    config: nextConfig,
     env: params.env,
     runtime: params.runtime,
     prompter: params.prompter,
@@ -199,29 +408,36 @@ export async function applyAuthChoiceLoadedPluginProvider(
     opts: params.opts,
   });
 
-  let nextConfig = applied.config;
-  let agentModelOverride: string | undefined;
+  nextConfig = applied.config;
   if (applied.defaultModel) {
+    const selectedModel = applied.defaultModel;
+    const selectedModelDisplay = formatModelRefForDisplay(selectedModel, resolved.provider);
     if (params.setDefaultModel) {
-      nextConfig = applyDefaultModel(nextConfig, applied.defaultModel);
-      await runProviderModelSelectedHook({
+      nextConfig = await applyDefaultModelFromAuthChoice({
         config: nextConfig,
-        model: applied.defaultModel,
+        selectedModel,
+        selectedModelDisplay,
+        preserveExistingDefaultModel: params.preserveExistingDefaultModel,
         prompter: params.prompter,
-        agentDir: params.agentDir,
-        workspaceDir,
+        runSelectedModelHook: async (config) => {
+          await runProviderModelSelectedHook({
+            config,
+            model: selectedModel,
+            prompter: params.prompter,
+            agentDir: params.agentDir,
+            workspaceDir,
+          });
+        },
       });
-      await params.prompter.note(
-        `Default model set to ${applied.defaultModel}`,
-        "Model configured",
-      );
       return { config: nextConfig };
     }
+    // When setDefaultModel is false (e.g., adding a new agent), do not override
+    // the agent's model. Let it inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
-    agentModelOverride = applied.defaultModel;
   }
 
-  return { config: nextConfig, agentModelOverride };
+  return { config: nextConfig };
 }
 
 export async function applyAuthChoicePluginProvider(
@@ -256,8 +472,7 @@ export async function applyAuthChoicePluginProvider(
     config: nextConfig,
     workspaceDir,
     env: params.env,
-    bundledProviderAllowlistCompat: true,
-    bundledProviderVitestCompat: true,
+    mode: "setup",
   });
   const provider = resolveProviderMatch(providers, options.providerId);
   if (!provider) {
@@ -290,29 +505,32 @@ export async function applyAuthChoicePluginProvider(
 
   nextConfig = applied.config;
   if (applied.defaultModel) {
+    const selectedModel = applied.defaultModel;
+    const selectedModelDisplay = formatModelRefForDisplay(selectedModel, provider);
     if (params.setDefaultModel) {
-      nextConfig = applyDefaultModel(nextConfig, applied.defaultModel);
-      await runProviderModelSelectedHook({
+      nextConfig = await applyDefaultModelFromAuthChoice({
         config: nextConfig,
-        model: applied.defaultModel,
+        selectedModel,
+        selectedModelDisplay,
+        preserveExistingDefaultModel: params.preserveExistingDefaultModel,
         prompter: params.prompter,
-        agentDir,
-        workspaceDir,
+        runSelectedModelHook: async (config) => {
+          await runProviderModelSelectedHook({
+            config,
+            model: selectedModel,
+            prompter: params.prompter,
+            agentDir,
+            workspaceDir,
+          });
+        },
       });
-      await params.prompter.note(
-        `Default model set to ${applied.defaultModel}`,
-        "Model configured",
-      );
       return { config: nextConfig };
     }
-    if (params.agentId) {
-      await params.prompter.note(
-        `Default model set to ${applied.defaultModel} for agent "${params.agentId}".`,
-        "Model configured",
-      );
-    }
+    // When setDefaultModel is false (e.g., adding a new agent), do not override
+    // the agent's model. Let it inherit from agents.defaults.model instead of
+    // baking in the provider's defaultModel. See issue #24170.
     nextConfig = restoreConfiguredPrimaryModel(nextConfig, params.config);
-    return { config: nextConfig, agentModelOverride: applied.defaultModel };
+    return { config: nextConfig };
   }
 
   return { config: nextConfig };


### PR DESCRIPTION
When creating a new agent via 'openclaw agents add', the provider's defaultModel was incorrectly being set as the agent's model.primary, instead of inheriting from agents.defaults.model.

Changes:
- applyAuthChoiceLoadedPluginProvider: no longer returns agentModelOverride when setDefaultModel is false
- applyAuthChoicePluginProvider: same fix, removed misleading note
- applyDefaultModelChoice: same fix, removed agentModelOverride return and noteAgentModel call when setDefaultModel is false

This ensures new agents inherit the configured default model instead of silently using the provider's fallback model.

Fixes #24170