### PR TITLE
fix(infra): guard all startup process.cwd() callers against deleted CWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Fixes
+
+- CLI/TUI: handle deleted working directory (uv_cwd ENOENT) during startup — dotenv probing, PATH bootstrap, TUI workspace inference, autocomplete setup, and local auth spawn no longer crash when cwd is removed; falls back to `os.tmpdir()` as a last resort. (#73676) Thanks @sumaiazaman.
+
 ### Changes
 
 - Telegram: treat successful same-chat `message` tool outbound sends during an inbound telegram turn as delivered when deciding whether to emit the rewritten silent reply fallback (#78685). Thanks @neeravmakwana.

--- a/src/cli/dotenv.ts
+++ b/src/cli/dotenv.ts
@@ -1,11 +1,14 @@
 import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadGlobalRuntimeDotEnvFiles, loadWorkspaceDotEnvFile } from "../infra/dotenv.js";
+import { safeCwd } from "../infra/home-dir.js";
 
 export function loadCliDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
-  loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
+  const cwd = safeCwd();
+  if (cwd != null) {
+    loadWorkspaceDotEnvFile(path.join(cwd, ".env"), { quiet });
+  }
 
   // Then load the global fallback set without overriding any env vars that
   // were already set or loaded from CWD. This includes the Ubuntu fresh-install

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue, normalizeEnv } from "../infra/env.js";
+import { safeCwd } from "../infra/home-dir.js";
 import { isMainModule } from "../infra/is-main.js";
 import type { ProxyHandle } from "../infra/net/proxy/proxy-lifecycle.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
@@ -232,7 +233,8 @@ export function resolveMissingPluginCommandMessage(
 }
 
 function shouldLoadCliDotEnv(env: NodeJS.ProcessEnv = process.env): boolean {
-  if (existsSync(path.join(process.cwd(), ".env"))) {
+  const cwd = safeCwd();
+  if (cwd != null && existsSync(path.join(cwd, ".env"))) {
     return true;
   }
   return existsSync(path.join(resolveStateDir(env), ".env"));

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveConfigDir } from "../utils.js";
-import { resolveRequiredHomeDir } from "./home-dir.js";
+import { resolveRequiredHomeDir, safeCwd } from "./home-dir.js";
 import {
   isDangerousHostEnvOverrideVarName,
   isDangerousHostEnvVarName,
@@ -278,8 +278,10 @@ export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvP
 
 export function loadDotEnv(opts?: { quiet?: boolean }) {
   const quiet = opts?.quiet ?? true;
-  const cwdEnvPath = path.join(process.cwd(), ".env");
-  loadWorkspaceDotEnvFile(cwdEnvPath, { quiet });
+  const cwd = safeCwd();
+  if (cwd != null) {
+    loadWorkspaceDotEnvFile(path.join(cwd, ".env"), { quiet });
+  }
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.

--- a/src/infra/home-dir.test.ts
+++ b/src/infra/home-dir.test.ts
@@ -1,5 +1,6 @@
+import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   expandHomePrefix,
   resolveEffectiveHomeDir,
@@ -7,6 +8,8 @@ import {
   resolveOsHomeDir,
   resolveOsHomeRelativePath,
   resolveRequiredHomeDir,
+  resolveRequiredOsHomeDir,
+  safeCwd,
 } from "./home-dir.js";
 
 describe("resolveEffectiveHomeDir", () => {
@@ -210,5 +213,56 @@ describe("resolveOsHomeRelativePath", () => {
         } as NodeJS.ProcessEnv,
       }),
     ).toBe(path.resolve("/home/alice/docs"));
+  });
+});
+
+describe("safeCwd", () => {
+  it("returns the current working directory normally", () => {
+    expect(safeCwd()).toBe(process.cwd());
+  });
+
+  it("returns undefined when process.cwd() throws (deleted directory)", () => {
+    const spy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory, uv_cwd");
+    });
+    try {
+      expect(safeCwd()).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("resolveRequiredHomeDir — deleted-cwd fallback", () => {
+  it("falls back to os.tmpdir when no home source exists and cwd is deleted", () => {
+    const spy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory, uv_cwd");
+    });
+    try {
+      expect(
+        resolveRequiredHomeDir({} as NodeJS.ProcessEnv, () => {
+          throw new Error("no home");
+        }),
+      ).toBe(path.resolve(os.tmpdir()));
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("resolveRequiredOsHomeDir — deleted-cwd fallback", () => {
+  it("falls back to os.tmpdir when no home source exists and cwd is deleted", () => {
+    const spy = vi.spyOn(process, "cwd").mockImplementation(() => {
+      throw new Error("ENOENT: no such file or directory, uv_cwd");
+    });
+    try {
+      expect(
+        resolveRequiredOsHomeDir({} as NodeJS.ProcessEnv, () => {
+          throw new Error("no home");
+        }),
+      ).toBe(path.resolve(os.tmpdir()));
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/src/infra/home-dir.ts
+++ b/src/infra/home-dir.ts
@@ -33,6 +33,14 @@ function resolveRawHomeDir(env: NodeJS.ProcessEnv, homedir: () => string): strin
   return explicitHome;
 }
 
+export function safeCwd(): string | undefined {
+  try {
+    return process.cwd();
+  } catch {
+    return undefined;
+  }
+}
+
 export function resolveEffectiveHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
@@ -53,14 +61,14 @@ export function resolveRequiredHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  return resolveEffectiveHomeDir(env, homedir) ?? path.resolve(process.cwd());
+  return resolveEffectiveHomeDir(env, homedir) ?? path.resolve(safeCwd() ?? os.tmpdir());
 }
 
 export function resolveRequiredOsHomeDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = os.homedir,
 ): string {
-  return resolveOsHomeDir(env, homedir) ?? path.resolve(process.cwd());
+  return resolveOsHomeDir(env, homedir) ?? path.resolve(safeCwd() ?? os.tmpdir());
 }
 
 export function expandHomePrefix(

--- a/src/infra/is-main.ts
+++ b/src/infra/is-main.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { safeCwd } from "./home-dir.js";
 
 type IsMainModuleOptions = {
   currentFile: string;
@@ -29,11 +31,12 @@ export function isMainModule({
   currentFile,
   argv = process.argv,
   env = process.env,
-  cwd = process.cwd(),
+  cwd,
   wrapperEntryPairs = [],
 }: IsMainModuleOptions): boolean {
-  const normalizedCurrent = normalizePathCandidate(currentFile, cwd);
-  const normalizedArgv1 = normalizePathCandidate(argv[1], cwd);
+  const resolvedCwd: string = cwd ?? safeCwd() ?? os.tmpdir();
+  const normalizedCurrent = normalizePathCandidate(currentFile, resolvedCwd);
+  const normalizedArgv1 = normalizePathCandidate(argv[1], resolvedCwd);
 
   if (normalizedCurrent && normalizedArgv1 && normalizedCurrent === normalizedArgv1) {
     return true;
@@ -41,7 +44,7 @@ export function isMainModule({
 
   // PM2 runs the script via an internal wrapper; `argv[1]` points at the wrapper.
   // PM2 exposes the actual script path in `pm_exec_path`.
-  const normalizedPmExecPath = normalizePathCandidate(env.pm_exec_path, cwd);
+  const normalizedPmExecPath = normalizePathCandidate(env.pm_exec_path, resolvedCwd);
   if (normalizedCurrent && normalizedPmExecPath && normalizedCurrent === normalizedPmExecPath) {
     return true;
   }

--- a/src/infra/path-env.ts
+++ b/src/infra/path-env.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { resolveBrewPathDirs } from "./brew.js";
 import { isTruthyEnvValue } from "./env.js";
+import { safeCwd } from "./home-dir.js";
 
 type EnsureOpenClawPathOpts = {
   execPath?: string;
@@ -51,7 +52,7 @@ function mergePath(params: { existing: string; prepend?: string[]; append?: stri
 
 function candidateBinDirs(opts: EnsureOpenClawPathOpts): { prepend: string[]; append: string[] } {
   const execPath = opts.execPath ?? process.execPath;
-  const cwd = opts.cwd ?? process.cwd();
+  const cwd = opts.cwd ?? safeCwd() ?? os.tmpdir();
   const homeDir = opts.homeDir ?? os.homedir();
   const platform = opts.platform ?? process.platform;
 

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -1,5 +1,6 @@
 import { execFileSync, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -14,6 +15,7 @@ import {
 } from "@mariozechner/pi-tui";
 import { resolveAgentIdByWorkspacePath, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getRuntimeConfig, type OpenClawConfig } from "../config/config.js";
+import { safeCwd } from "../infra/home-dir.js";
 import { registerUncaughtExceptionHandler } from "../infra/unhandled-rejections.js";
 import { setConsoleSubsystemFilter } from "../logging/console.js";
 import { loggingState } from "../logging/state.js";
@@ -129,7 +131,7 @@ export function resolveLocalAuthSpawnOptions(params: {
 }
 
 export function resolveLocalAuthSpawnCwd(params: { args: string[]; defaultCwd?: string }): string {
-  const defaultCwd = params.defaultCwd ?? process.cwd();
+  const defaultCwd = params.defaultCwd ?? safeCwd() ?? os.tmpdir();
   const entryArg = params.args[0]?.trim();
   if (!entryArg) {
     return defaultCwd;
@@ -182,7 +184,7 @@ export function resolveInitialTuiAgentId(params: {
 
   const inferredFromWorkspace = resolveAgentIdByWorkspacePath(
     params.cfg,
-    params.cwd ?? process.cwd(),
+    params.cwd ?? safeCwd() ?? os.tmpdir(),
   );
   if (inferredFromWorkspace) {
     return inferredFromWorkspace;
@@ -392,7 +394,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
     cfg: config,
     fallbackAgentId: agentDefaultId,
     initialSessionInput,
-    cwd: process.cwd(),
+    cwd: safeCwd() ?? os.tmpdir(),
   });
   let agents: AgentSummary[] = [];
   const agentNames = new Map<string, string>();
@@ -650,7 +652,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
           model: sessionInfo.model,
           thinkingLevels: sessionInfo.thinkingLevels,
         }),
-        process.cwd(),
+        safeCwd() ?? os.tmpdir(),
       ),
     );
   };
@@ -971,7 +973,7 @@ export async function runTui(opts: RunTuiOptions): Promise<TuiResult> {
                 }
 
                 const child = spawn(command, args, {
-                  cwd: resolveLocalAuthSpawnCwd({ args, defaultCwd: process.cwd() }),
+                  cwd: resolveLocalAuthSpawnCwd({ args, defaultCwd: safeCwd() ?? os.tmpdir() }),
                   env: process.env,
                   stdio: "inherit",
                   ...resolveLocalAuthSpawnOptions({ command }),


### PR DESCRIPTION
Fixes #73676

## Problem

When the process working directory is deleted after startup (common in CI, container teardown, or test environments), any bare `process.cwd()` call throws `ENOENT: no such file or directory, uv_cwd`. Four call sites in the startup path were unguarded:

- `resolveRequiredHomeDir` / `resolveRequiredOsHomeDir` in `src/infra/home-dir.ts`
- The `cwd` default parameter of `isMainModule` in `src/infra/is-main.ts`
- `loadDotEnv` / `loadCliDotEnv` in `src/infra/dotenv.ts` and `src/cli/dotenv.ts`
- `shouldLoadCliDotEnv` / `candidateBinDirs` / TUI startup in `src/cli/run-main.ts`, `src/infra/path-env.ts`, `src/tui/tui.ts`

## Solution

Export a `safeCwd()` helper from `home-dir.ts` that catches the ENOENT and returns `undefined`, then route all call sites through it. Falls back to `os.tmpdir()` as last resort; workspace `.env` probe is skipped entirely when cwd is unavailable.

## Real behavior proof

Reproduced with Node.js 22 on macOS — create a directory, `cd` into it, delete it, then run the affected code paths:

```
$ mkdir /tmp/test-dir && cd /tmp/test-dir && rm -rf /tmp/test-dir

=== Before fix (bare process.cwd()) ===
Error: ENOENT: no such file or directory, uv_cwd

=== After fix (safeCwd()) ===
safeCwd() returned: undefined

=== resolveRequiredHomeDir fallback ===
result: /var/folders/c2/qd5dslc953b2wm85wq0vkc0m0000gp/T
os.tmpdir(): /var/folders/c2/qd5dslc953b2wm85wq0vkc0m0000gp/T
match: true

=== loadDotEnv skips workspace .env ===
cwd unavailable — workspace .env probe skipped (no crash)
```

Before the fix: `process.cwd()` throws `ENOENT: no such file or directory, uv_cwd` and crashes startup.
After the fix: `safeCwd()` returns `undefined`, `resolveRequiredHomeDir` falls back to `os.tmpdir()`, and all dotenv probes are skipped without error.

## Tests

Added to `src/infra/home-dir.test.ts`:
- `safeCwd()` — returns the real cwd normally, returns `undefined` when `process.cwd()` throws
- `resolveRequiredHomeDir` deleted-cwd case — falls back to `os.tmpdir()`
- `resolveRequiredOsHomeDir` deleted-cwd case — falls back to `os.tmpdir()`