### PR TITLE
feat(google): surface Gemini subscription path in onboard wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
-- Onboarding/Google: add a "Gemini subscription (no API key needed)" auth choice on the existing `google-gemini-cli` provider, surfaced ahead of the API key and OAuth paths so users with a Google subscription see the headless `gemini` CLI flow as a first-class option in `openclaw onboard`. The wizard auto-detects whether `gemini` is on PATH, offers to run `npm install -g @google/gemini-cli` after explicit confirmation, and launches the interactive `gemini` sign-in flow when the local CLI is installed but signed out. The web dashboard's chat model picker and thinking-level selector keep working with the new runtime.
+- Onboarding/Google: add a "Gemini subscription (no API key needed)" auth choice on the existing `google-gemini-cli` provider, surfaced ahead of the API key and OAuth paths so users with a Google subscription see the headless `gemini` CLI flow as a first-class option in `openclaw onboard`. The wizard auto-detects whether `gemini` is on PATH, offers to run `npm install -g @google/gemini-cli` after explicit confirmation, and launches the interactive `gemini` sign-in flow when the local CLI is installed but signed out. Onboarding seeds canonical `google/*` model refs and selects the Gemini CLI runtime through `agents.defaults.agentRuntime.id` so new configs follow the same model-ref contract as API-key and OAuth setups. The web dashboard's chat model picker and thinking-level selector keep working with the new runtime. Thanks @toto-elgringo.
 
 ## 2026.4.29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Docs: https://docs.openclaw.ai
 
+## Unreleased
+
+### Changes
+
+- Onboarding/Google: add a "Gemini subscription (no API key needed)" auth choice on the existing `google-gemini-cli` provider, surfaced ahead of the API key and OAuth paths so users with a Google subscription see the headless `gemini` CLI flow as a first-class option in `openclaw onboard`. The wizard auto-detects whether `gemini` is on PATH, offers to run `npm install -g @google/gemini-cli` after explicit confirmation, and launches the interactive `gemini` sign-in flow when the local CLI is installed but signed out. The web dashboard's chat model picker and thinking-level selector keep working with the new runtime.
+
 ## 2026.4.29
 
 ### Highlights

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -78,6 +78,7 @@ Choose your preferred auth method and follow the setup steps.
         - If `gemini` is not on PATH, OpenClaw asks for confirmation and runs `npm install -g @google/gemini-cli` for you.
         - If Gemini CLI is installed but signed out, OpenClaw launches `gemini` interactively so you can complete the Google sign-in in your browser.
         - Once signed in, the local Gemini CLI session is reused automatically — no token to copy or paste.
+
       </Step>
       <Step title="Pick a model">
         The wizard offers the Gemini model list (3 / 3.1, Pro / Flash / Flash Lite) and seeds them into your config under canonical `google/*` refs. The default is `google/gemini-3.1-pro-preview`. The Gemini CLI runtime is selected separately through `agents.defaults.agentRuntime.id: "google-gemini-cli"`.

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -80,11 +80,11 @@ Choose your preferred auth method and follow the setup steps.
         - Once signed in, the local Gemini CLI session is reused automatically — no token to copy or paste.
       </Step>
       <Step title="Pick a model">
-        The wizard offers the Gemini model list (3 / 3.1, Pro / Flash / Flash Lite) and seeds them into your config. The default is `google-gemini-cli/gemini-3-flash-preview`.
+        The wizard offers the Gemini model list (3 / 3.1, Pro / Flash / Flash Lite) and seeds them into your config under canonical `google/*` refs. The default is `google/gemini-3.1-pro-preview`. The Gemini CLI runtime is selected separately through `agents.defaults.agentRuntime.id: "google-gemini-cli"`.
       </Step>
       <Step title="Verify the model is available">
         ```bash
-        openclaw models list --provider google-gemini-cli
+        openclaw models list --provider google
         ```
       </Step>
     </Steps>

--- a/docs/providers/google.md
+++ b/docs/providers/google.md
@@ -63,6 +63,40 @@ Choose your preferred auth method and follow the setup steps.
 
   </Tab>
 
+  <Tab title="Gemini subscription (Advanced/Pro)">
+    **Best for:** running Gemini on your existing Google subscription without a separate API key. OpenClaw drives the official Gemini CLI in headless mode using your local sign-in.
+
+    <Steps>
+      <Step title="Run onboarding">
+        ```bash
+        openclaw onboard
+        # choose: Gemini subscription (no API key needed)
+        ```
+
+        The wizard handles install + login for you:
+
+        - If `gemini` is not on PATH, OpenClaw asks for confirmation and runs `npm install -g @google/gemini-cli` for you.
+        - If Gemini CLI is installed but signed out, OpenClaw launches `gemini` interactively so you can complete the Google sign-in in your browser.
+        - Once signed in, the local Gemini CLI session is reused automatically — no token to copy or paste.
+      </Step>
+      <Step title="Pick a model">
+        The wizard offers the Gemini model list (3 / 3.1, Pro / Flash / Flash Lite) and seeds them into your config. The default is `google-gemini-cli/gemini-3-flash-preview`.
+      </Step>
+      <Step title="Verify the model is available">
+        ```bash
+        openclaw models list --provider google-gemini-cli
+        ```
+      </Step>
+    </Steps>
+
+    Once configured, you can switch models live from the OpenClaw web dashboard's chat model selector. The thinking-level selector next to it is also wired up for Gemini CLI runs — pick `off` / `minimal` / `low` / `medium` / `high` per session and OpenClaw injects the directive into the system prompt for the next turn.
+
+    <Warning>
+    Gemini CLI integration is unofficial. Some users have reported Google account restrictions after using third-party CLI tools. Use a non-critical Google account if you want to be cautious, and check Google's terms of service.
+    </Warning>
+
+  </Tab>
+
   <Tab title="Gemini CLI (OAuth)">
     **Best for:** reusing an existing Gemini CLI login via PKCE OAuth instead of a separate API key.
 

--- a/extensions/google/cli-auth-seam.ts
+++ b/extensions/google/cli-auth-seam.ts
@@ -1,0 +1,9 @@
+import { readGeminiCliCredentialsCached } from "openclaw/plugin-sdk/provider-auth";
+
+export function readGeminiCliCredentialsForSetup() {
+  return readGeminiCliCredentialsCached();
+}
+
+export function readGeminiCliCredentialsForSetupNonInteractive() {
+  return readGeminiCliCredentialsCached();
+}

--- a/extensions/google/cli-install.test.ts
+++ b/extensions/google/cli-install.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  detectGeminiCli,
+  ensureGeminiCliInstalled,
+  GEMINI_CLI_NPM_PACKAGE,
+  installGeminiCliViaNpm,
+  runGeminiCliLogin,
+} from "./cli-install.js";
+
+const { createTestWizardPrompter } = await import("openclaw/plugin-sdk/plugin-test-runtime");
+
+type SpawnSyncResult = {
+  status?: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: Error;
+};
+
+function fakeSpawnSync(impl: (command: string, args: ReadonlyArray<string>) => SpawnSyncResult) {
+  return vi.fn((command: string, args: ReadonlyArray<string>) => {
+    const result = impl(command, args);
+    return {
+      pid: 0,
+      output: [],
+      stdout: result.stdout ?? "",
+      stderr: result.stderr ?? "",
+      status: result.status ?? 0,
+      signal: null,
+      ...(result.error ? { error: result.error } : {}),
+    };
+  });
+}
+
+function createTestRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+describe("detectGeminiCli", () => {
+  it("returns found with version when gemini --version exits 0", () => {
+    const spawnSync = fakeSpawnSync(() => ({ status: 0, stdout: "0.42.0\n" }));
+    const result = detectGeminiCli({ spawnSync, platform: "linux" });
+    expect(result).toEqual({ found: true, version: "0.42.0" });
+  });
+
+  it("returns not-found when binary is missing (ENOENT)", () => {
+    const error = Object.assign(new Error("spawn gemini ENOENT"), { code: "ENOENT" });
+    const spawnSync = fakeSpawnSync(() => ({ status: null, error }));
+    const result = detectGeminiCli({ spawnSync, platform: "linux" });
+    expect(result.found).toBe(false);
+    expect(result.error).toContain("ENOENT");
+  });
+});
+
+describe("installGeminiCliViaNpm", () => {
+  it("invokes npm.cmd on win32 with the global package", () => {
+    const spawnSync = fakeSpawnSync(() => ({ status: 0 }));
+    const ok = installGeminiCliViaNpm(createTestRuntime(), { spawnSync, platform: "win32" });
+    expect(ok).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "npm.cmd",
+      ["install", "-g", GEMINI_CLI_NPM_PACKAGE],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("returns false and logs an error when npm exits non-zero", () => {
+    const spawnSync = fakeSpawnSync(() => ({ status: 1 }));
+    const runtime = createTestRuntime();
+    const ok = installGeminiCliViaNpm(runtime, { spawnSync, platform: "linux" });
+    expect(ok).toBe(false);
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("exited with code 1"));
+  });
+});
+
+describe("runGeminiCliLogin", () => {
+  it("invokes the gemini binary in inherit-stdio mode", () => {
+    const spawnSync = fakeSpawnSync(() => ({ status: 0 }));
+    expect(runGeminiCliLogin(createTestRuntime(), { spawnSync, platform: "linux" })).toBe(true);
+    expect(spawnSync).toHaveBeenCalledWith(
+      "gemini",
+      [],
+      expect.objectContaining({ stdio: "inherit" }),
+    );
+  });
+
+  it("returns false when launch fails", () => {
+    const spawnSync = fakeSpawnSync(() => ({
+      status: null,
+      error: new Error("spawn gemini ENOENT"),
+    }));
+    expect(runGeminiCliLogin(createTestRuntime(), { spawnSync, platform: "linux" })).toBe(false);
+  });
+});
+
+describe("ensureGeminiCliInstalled", () => {
+  it("short-circuits when gemini is already installed", async () => {
+    const spawnSync = fakeSpawnSync(() => ({ status: 0, stdout: "9.9.9" }));
+    const result = await ensureGeminiCliInstalled({
+      prompter: createTestWizardPrompter(),
+      runtime: createTestRuntime(),
+      deps: { spawnSync, platform: "linux" },
+    });
+    expect(result).toEqual({ ok: true, version: "9.9.9" });
+  });
+
+  it("returns ok=false when the user declines auto-install", async () => {
+    const installError = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    const spawnSync = fakeSpawnSync(() => ({ status: null, error: installError }));
+    const confirm = vi.fn(async () => false);
+    const result = await ensureGeminiCliInstalled({
+      prompter: createTestWizardPrompter({ confirm }),
+      runtime: createTestRuntime(),
+      deps: { spawnSync, platform: "linux" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("declined");
+    }
+    expect(confirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-detects after a successful npm install", async () => {
+    let calls = 0;
+    const spawnSync = fakeSpawnSync((command) => {
+      calls += 1;
+      if (command === "npm" || command === "npm.cmd") {
+        return { status: 0 };
+      }
+      if (calls === 1) {
+        return { status: null, error: Object.assign(new Error("ENOENT"), { code: "ENOENT" }) };
+      }
+      return { status: 0, stdout: "1.0.0" };
+    });
+    const result = await ensureGeminiCliInstalled({
+      prompter: createTestWizardPrompter({ confirm: vi.fn(async () => true) }),
+      runtime: createTestRuntime(),
+      deps: { spawnSync, platform: "linux" },
+    });
+    expect(result).toEqual({ ok: true, version: "1.0.0" });
+  });
+
+  it("reports a clear error when install succeeds but binary is still not on PATH", async () => {
+    const spawnSync = fakeSpawnSync((command) => {
+      if (command === "npm" || command === "npm.cmd") {
+        return { status: 0 };
+      }
+      return { status: null, error: Object.assign(new Error("ENOENT"), { code: "ENOENT" }) };
+    });
+    const result = await ensureGeminiCliInstalled({
+      prompter: createTestWizardPrompter({ confirm: vi.fn(async () => true) }),
+      runtime: createTestRuntime(),
+      deps: { spawnSync, platform: "linux" },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toMatch(/not on PATH/);
+    }
+  });
+});

--- a/extensions/google/cli-install.ts
+++ b/extensions/google/cli-install.ts
@@ -1,0 +1,168 @@
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import type { WizardPrompter } from "openclaw/plugin-sdk/setup-runtime";
+
+export const GEMINI_CLI_NPM_PACKAGE = "@google/gemini-cli";
+export const GEMINI_CLI_BINARY_NAME = "gemini";
+
+const DETECT_TIMEOUT_MS = 5_000;
+
+export type GeminiCliDetectResult = {
+  found: boolean;
+  version?: string;
+  error?: string;
+};
+
+type SpawnSyncImpl = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options?: SpawnSyncOptions,
+) => ReturnType<typeof spawnSync>;
+
+export type GeminiCliInstallDeps = {
+  spawnSync: SpawnSyncImpl;
+  platform: NodeJS.Platform;
+};
+
+const defaultDeps: GeminiCliInstallDeps = {
+  spawnSync,
+  platform: process.platform,
+};
+
+function resolveNpmCommand(platform: NodeJS.Platform): string {
+  return platform === "win32" ? "npm.cmd" : "npm";
+}
+
+export function detectGeminiCli(deps: Partial<GeminiCliInstallDeps> = {}): GeminiCliDetectResult {
+  const { spawnSync: spawnImpl } = { ...defaultDeps, ...deps };
+  try {
+    const result = spawnImpl(GEMINI_CLI_BINARY_NAME, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: DETECT_TIMEOUT_MS,
+      windowsHide: true,
+      encoding: "utf8",
+    });
+    if (result.error) {
+      return { found: false, error: result.error.message };
+    }
+    if (result.status === 0) {
+      const stdout = typeof result.stdout === "string" ? result.stdout.trim() : "";
+      return { found: true, ...(stdout ? { version: stdout } : {}) };
+    }
+    const stderr = typeof result.stderr === "string" ? result.stderr.trim() : "";
+    return { found: false, error: stderr || `exit ${result.status ?? "?"}` };
+  } catch (err) {
+    return { found: false, error: (err as Error).message };
+  }
+}
+
+export function installGeminiCliViaNpm(
+  runtime: Pick<RuntimeEnv, "log" | "error">,
+  deps: Partial<GeminiCliInstallDeps> = {},
+): boolean {
+  const { spawnSync: spawnImpl, platform } = { ...defaultDeps, ...deps };
+  const npm = resolveNpmCommand(platform);
+  runtime.log(`Running: ${npm} install -g ${GEMINI_CLI_NPM_PACKAGE}`);
+  try {
+    const result = spawnImpl(npm, ["install", "-g", GEMINI_CLI_NPM_PACKAGE], {
+      stdio: "inherit",
+      windowsHide: true,
+    });
+    if (result.error) {
+      runtime.error(`Gemini CLI install failed: ${result.error.message}`);
+      return false;
+    }
+    if (result.status !== 0) {
+      runtime.error(`Gemini CLI install exited with code ${result.status ?? "?"}.`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    runtime.error(`Gemini CLI install failed: ${(err as Error).message}`);
+    return false;
+  }
+}
+
+export function runGeminiCliLogin(
+  runtime: Pick<RuntimeEnv, "log" | "error">,
+  deps: Partial<GeminiCliInstallDeps> = {},
+): boolean {
+  const { spawnSync: spawnImpl } = { ...defaultDeps, ...deps };
+  runtime.log(`Running: ${GEMINI_CLI_BINARY_NAME} (interactive sign-in flow)`);
+  try {
+    const result = spawnImpl(GEMINI_CLI_BINARY_NAME, [], {
+      stdio: "inherit",
+      windowsHide: true,
+    });
+    if (result.error) {
+      runtime.error(`Gemini CLI sign-in failed to launch: ${result.error.message}`);
+      return false;
+    }
+    return result.status === 0;
+  } catch (err) {
+    runtime.error(`Gemini CLI sign-in failed: ${(err as Error).message}`);
+    return false;
+  }
+}
+
+export type EnsureGeminiCliReadyResult =
+  | { ok: true; version?: string }
+  | { ok: false; reason: string };
+
+export async function ensureGeminiCliInstalled(params: {
+  prompter: WizardPrompter;
+  runtime: Pick<RuntimeEnv, "log" | "error">;
+  deps?: Partial<GeminiCliInstallDeps>;
+}): Promise<EnsureGeminiCliReadyResult> {
+  const initial = detectGeminiCli(params.deps);
+  if (initial.found) {
+    return { ok: true, ...(initial.version ? { version: initial.version } : {}) };
+  }
+
+  await params.prompter.note(
+    [
+      `Gemini CLI (${GEMINI_CLI_NPM_PACKAGE}) is not installed on this host.`,
+      "OpenClaw needs it to run Gemini through your subscription in headless mode.",
+    ].join("\n"),
+    "Gemini CLI",
+  );
+
+  const shouldInstall = await params.prompter.confirm({
+    message: `Install Gemini CLI now? (npm install -g ${GEMINI_CLI_NPM_PACKAGE})`,
+    initialValue: true,
+  });
+  if (!shouldInstall) {
+    return {
+      ok: false,
+      reason: [
+        "Gemini CLI install was declined.",
+        `Install it manually with: npm install -g ${GEMINI_CLI_NPM_PACKAGE}`,
+        "Then re-run this setup.",
+      ].join("\n"),
+    };
+  }
+
+  const installed = installGeminiCliViaNpm(params.runtime, params.deps);
+  if (!installed) {
+    return {
+      ok: false,
+      reason: [
+        "Gemini CLI install failed.",
+        "Check the npm output above and try again, or install manually:",
+        `  npm install -g ${GEMINI_CLI_NPM_PACKAGE}`,
+      ].join("\n"),
+    };
+  }
+
+  const verify = detectGeminiCli(params.deps);
+  if (!verify.found) {
+    return {
+      ok: false,
+      reason: [
+        "Gemini CLI install completed but the `gemini` binary is not on PATH.",
+        "Restart your terminal (so PATH refreshes) or check your npm global bin directory, then re-run this setup.",
+      ].join("\n"),
+    };
+  }
+  return { ok: true, ...(verify.version ? { version: verify.version } : {}) };
+}

--- a/extensions/google/cli-migration.test.ts
+++ b/extensions/google/cli-migration.test.ts
@@ -125,18 +125,18 @@ describe("google gemini cli migration", () => {
       },
     });
 
-    expect(result.defaultModel).toBe("google-gemini-cli/gemini-3-flash-preview");
+    expect(result.defaultModel).toBe("google/gemini-3.1-pro-preview");
     expect(result.configPatch).toMatchObject({
       agents: {
         defaults: {
           agentRuntime: { id: "google-gemini-cli" },
           models: {
             "openai/gpt-5.2": {},
-            "google-gemini-cli/gemini-3-flash-preview": {},
-            "google-gemini-cli/gemini-3-pro-preview": {},
-            "google-gemini-cli/gemini-3.1-pro-preview": {},
-            "google-gemini-cli/gemini-3.1-flash-preview": {},
-            "google-gemini-cli/gemini-3.1-flash-lite-preview": {},
+            "google/gemini-3.1-pro-preview": {},
+            "google/gemini-3.1-flash-preview": {},
+            "google/gemini-3.1-flash-lite-preview": {},
+            "google/gemini-3-pro-preview": {},
+            "google/gemini-3-flash-preview": {},
           },
         },
       },
@@ -174,7 +174,7 @@ describe("google gemini cli migration", () => {
     const result = await method.run(ctx);
 
     expect(runGeminiCliLogin).toHaveBeenCalledTimes(1);
-    expect(result.defaultModel).toBe("google-gemini-cli/gemini-3-flash-preview");
+    expect(result.defaultModel).toBe("google/gemini-3.1-pro-preview");
   });
 
   it("fails clearly when sign-in is declined", async () => {

--- a/extensions/google/cli-migration.test.ts
+++ b/extensions/google/cli-migration.test.ts
@@ -1,0 +1,202 @@
+import type {
+  ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
+} from "openclaw/plugin-sdk/plugin-entry";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  readGeminiCliCredentialsForSetup,
+  readGeminiCliCredentialsForSetupNonInteractive,
+  ensureGeminiCliInstalled,
+  runGeminiCliLogin,
+} = vi.hoisted(() => ({
+  readGeminiCliCredentialsForSetup: vi.fn(),
+  readGeminiCliCredentialsForSetupNonInteractive: vi.fn(),
+  ensureGeminiCliInstalled: vi.fn(async () => ({ ok: true as const })),
+  runGeminiCliLogin: vi.fn(() => true),
+}));
+
+vi.mock("./cli-auth-seam.js", async (importActual) => {
+  const actual = await importActual<typeof import("./cli-auth-seam.js")>();
+  return {
+    ...actual,
+    readGeminiCliCredentialsForSetup,
+    readGeminiCliCredentialsForSetupNonInteractive,
+  };
+});
+
+vi.mock("./cli-install.js", async (importActual) => {
+  const actual = await importActual<typeof import("./cli-install.js")>();
+  return {
+    ...actual,
+    ensureGeminiCliInstalled,
+    runGeminiCliLogin,
+  };
+});
+
+const { buildGoogleGeminiCliMigrationResult, hasGeminiCliAuth } = await import(
+  "./cli-migration.js"
+);
+const { createTestWizardPrompter, registerProviderPlugin, requireRegisteredProvider } =
+  await import("openclaw/plugin-sdk/plugin-test-runtime");
+const { default: googlePlugin } = await import("./index.js");
+
+async function resolveGoogleGeminiCliAuthMethod() {
+  const { providers } = await registerProviderPlugin({
+    plugin: googlePlugin,
+    id: "google",
+    name: "Google Provider",
+  });
+  const provider = requireRegisteredProvider(providers, "google-gemini-cli");
+  const method = provider.auth.find((entry) => entry.id === "cli");
+  if (!method) {
+    throw new Error("google-gemini-cli `cli` auth method missing");
+  }
+  return method;
+}
+
+function createProviderAuthContext(
+  config: ProviderAuthContext["config"] = {},
+): ProviderAuthContext {
+  return {
+    config,
+    opts: {},
+    env: {},
+    agentDir: "/tmp/openclaw/agents/main",
+    workspaceDir: "/tmp/openclaw/workspace",
+    prompter: createTestWizardPrompter(),
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
+    allowSecretRefPrompt: false,
+    isRemote: false,
+    openUrl: vi.fn(),
+    oauth: {
+      createVpsAwareHandlers: vi.fn(),
+    },
+  };
+}
+
+function createProviderAuthMethodNonInteractiveContext(
+  config: ProviderAuthMethodNonInteractiveContext["config"] = {},
+): ProviderAuthMethodNonInteractiveContext {
+  return {
+    authChoice: "google-gemini-subscription",
+    config,
+    baseConfig: config,
+    opts: {},
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn(),
+    },
+    agentDir: "/tmp/openclaw/agents/main",
+    workspaceDir: "/tmp/openclaw/workspace",
+    resolveApiKey: vi.fn(async () => null),
+    toApiKeyCredential: vi.fn(() => null),
+  };
+}
+
+describe("google gemini cli migration", () => {
+  beforeEach(() => {
+    ensureGeminiCliInstalled.mockReset();
+    ensureGeminiCliInstalled.mockResolvedValue({ ok: true });
+    runGeminiCliLogin.mockReset();
+    runGeminiCliLogin.mockReturnValue(true);
+    readGeminiCliCredentialsForSetup.mockReset();
+    readGeminiCliCredentialsForSetupNonInteractive.mockReset();
+  });
+
+  it("detects local Gemini CLI auth", () => {
+    readGeminiCliCredentialsForSetup.mockReturnValue({ type: "oauth" });
+
+    expect(hasGeminiCliAuth()).toBe(true);
+  });
+
+  it("seeds the Gemini CLI allowlist and selects the runtime", () => {
+    const result = buildGoogleGeminiCliMigrationResult({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.2" },
+          models: { "openai/gpt-5.2": {} },
+        },
+      },
+    });
+
+    expect(result.defaultModel).toBe("google-gemini-cli/gemini-3-flash-preview");
+    expect(result.configPatch).toMatchObject({
+      agents: {
+        defaults: {
+          agentRuntime: { id: "google-gemini-cli" },
+          models: {
+            "openai/gpt-5.2": {},
+            "google-gemini-cli/gemini-3-flash-preview": {},
+            "google-gemini-cli/gemini-3-pro-preview": {},
+            "google-gemini-cli/gemini-3.1-pro-preview": {},
+            "google-gemini-cli/gemini-3.1-flash-preview": {},
+            "google-gemini-cli/gemini-3.1-flash-lite-preview": {},
+          },
+        },
+      },
+    });
+  });
+
+  it("blocks setup when Gemini CLI install was declined", async () => {
+    readGeminiCliCredentialsForSetup.mockReturnValue(null);
+    ensureGeminiCliInstalled.mockResolvedValueOnce({
+      ok: false,
+      reason: "Gemini CLI install was declined.",
+    });
+    const method = await resolveGoogleGeminiCliAuthMethod();
+
+    await expect(method.run(createProviderAuthContext())).rejects.toThrow(
+      "Gemini CLI install was declined.",
+    );
+  });
+
+  it("offers to launch the gemini sign-in flow when CLI is installed but signed out", async () => {
+    readGeminiCliCredentialsForSetup.mockReturnValueOnce(null);
+    readGeminiCliCredentialsForSetup.mockReturnValueOnce({
+      type: "oauth",
+      provider: "google-gemini-cli",
+      access: "after-login-access",
+      refresh: "after-login-refresh",
+      expires: Date.now() + 60_000,
+    });
+    ensureGeminiCliInstalled.mockResolvedValueOnce({ ok: true });
+    runGeminiCliLogin.mockReturnValueOnce(true);
+    const method = await resolveGoogleGeminiCliAuthMethod();
+    const ctx = createProviderAuthContext();
+    ctx.prompter = createTestWizardPrompter({ confirm: vi.fn(async () => true) });
+
+    const result = await method.run(ctx);
+
+    expect(runGeminiCliLogin).toHaveBeenCalledTimes(1);
+    expect(result.defaultModel).toBe("google-gemini-cli/gemini-3-flash-preview");
+  });
+
+  it("fails clearly when sign-in is declined", async () => {
+    readGeminiCliCredentialsForSetup.mockReturnValue(null);
+    ensureGeminiCliInstalled.mockResolvedValueOnce({ ok: true });
+    const method = await resolveGoogleGeminiCliAuthMethod();
+    const ctx = createProviderAuthContext();
+    ctx.prompter = createTestWizardPrompter({ confirm: vi.fn(async () => false) });
+
+    await expect(method.run(ctx)).rejects.toThrow(/Gemini CLI sign-in was declined/);
+    expect(runGeminiCliLogin).not.toHaveBeenCalled();
+  });
+
+  it("non-interactive auth reports missing local auth and exits cleanly", async () => {
+    readGeminiCliCredentialsForSetupNonInteractive.mockReturnValue(null);
+    const method = await resolveGoogleGeminiCliAuthMethod();
+    const ctx = createProviderAuthMethodNonInteractiveContext();
+
+    await expect(method.runNonInteractive?.(ctx)).resolves.toBeNull();
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("requires Gemini CLI installed and signed in"),
+    );
+    expect(ctx.runtime.exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/extensions/google/cli-migration.test.ts
+++ b/extensions/google/cli-migration.test.ts
@@ -3,6 +3,7 @@ import type {
   ProviderAuthMethodNonInteractiveContext,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { EnsureGeminiCliReadyResult } from "./cli-install.js";
 
 const {
   readGeminiCliCredentialsForSetup,
@@ -12,7 +13,9 @@ const {
 } = vi.hoisted(() => ({
   readGeminiCliCredentialsForSetup: vi.fn(),
   readGeminiCliCredentialsForSetupNonInteractive: vi.fn(),
-  ensureGeminiCliInstalled: vi.fn(async () => ({ ok: true as const })),
+  ensureGeminiCliInstalled: vi.fn(
+    async (): Promise<EnsureGeminiCliReadyResult> => ({ ok: true }),
+  ),
   runGeminiCliLogin: vi.fn(() => true),
 }));
 

--- a/extensions/google/cli-migration.ts
+++ b/extensions/google/cli-migration.ts
@@ -26,7 +26,7 @@ type GeminiCliCredential = NonNullable<ReturnType<typeof readGeminiCliCredential
 function seedGeminiCliAllowlist(
   models: NonNullable<AgentDefaultsModels>,
 ): NonNullable<AgentDefaultsModels> {
-  const next = { ...models };
+  const next: NonNullable<AgentDefaultsModels> = { ...models };
   for (const ref of GEMINI_CLI_DEFAULT_ALLOWLIST_REFS) {
     next[ref] = next[ref] ?? {};
   }
@@ -54,7 +54,7 @@ export function buildGoogleGeminiCliMigrationResult(
 ): ProviderAuthResult {
   void credential;
   const defaults = config.agents?.defaults;
-  const existingModels = (defaults?.models ?? {}) as NonNullable<AgentDefaultsModels>;
+  const existingModels: NonNullable<AgentDefaultsModels> = defaults?.models ?? {};
   const nextModels = seedGeminiCliAllowlist(existingModels);
   const defaultModel = GEMINI_CLI_DEFAULT_MODEL_REF;
 

--- a/extensions/google/cli-migration.ts
+++ b/extensions/google/cli-migration.ts
@@ -1,0 +1,83 @@
+import {
+  type OpenClawConfig,
+  type ProviderAuthResult,
+} from "openclaw/plugin-sdk/provider-auth";
+import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
+import { readGeminiCliCredentialsForSetup } from "./cli-auth-seam.js";
+
+export const GEMINI_CLI_BACKEND_ID = "google-gemini-cli";
+export const GEMINI_CLI_DEFAULT_MODEL_REF = `${GEMINI_CLI_BACKEND_ID}/gemini-3-flash-preview`;
+export const GEMINI_CLI_DEFAULT_ALLOWLIST_REFS = [
+  GEMINI_CLI_DEFAULT_MODEL_REF,
+  `${GEMINI_CLI_BACKEND_ID}/gemini-3-pro-preview`,
+  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-pro-preview`,
+  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-flash-preview`,
+  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-flash-lite-preview`,
+] as const;
+
+type AgentDefaultsModels = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"];
+type AgentDefaultsRuntimePolicy = NonNullable<
+  NonNullable<OpenClawConfig["agents"]>["defaults"]
+>["agentRuntime"];
+type GeminiCliCredential = NonNullable<ReturnType<typeof readGeminiCliCredentialsForSetup>>;
+
+function seedGeminiCliAllowlist(
+  models: NonNullable<AgentDefaultsModels>,
+): NonNullable<AgentDefaultsModels> {
+  const next = { ...models };
+  for (const ref of GEMINI_CLI_DEFAULT_ALLOWLIST_REFS) {
+    next[ref] = next[ref] ?? {};
+  }
+  return next;
+}
+
+function selectGeminiCliRuntime(agentRuntime: AgentDefaultsRuntimePolicy | undefined) {
+  const currentRuntime = agentRuntime?.id?.trim();
+  if (currentRuntime && currentRuntime !== "auto") {
+    return agentRuntime;
+  }
+  return {
+    ...agentRuntime,
+    id: GEMINI_CLI_BACKEND_ID,
+  };
+}
+
+export function hasGeminiCliAuth(): boolean {
+  return Boolean(readGeminiCliCredentialsForSetup());
+}
+
+export function isGeminiCliProviderRef(ref: unknown): boolean {
+  if (typeof ref !== "string") {
+    return false;
+  }
+  const lower = normalizeLowercaseStringOrEmpty(ref);
+  return lower.startsWith(`${GEMINI_CLI_BACKEND_ID}/`);
+}
+
+export function buildGoogleGeminiCliMigrationResult(
+  config: OpenClawConfig,
+  credential?: GeminiCliCredential | null,
+): ProviderAuthResult {
+  void credential;
+  const defaults = config.agents?.defaults;
+  const existingModels = (defaults?.models ?? {}) as NonNullable<AgentDefaultsModels>;
+  const nextModels = seedGeminiCliAllowlist(existingModels);
+  const defaultModel = GEMINI_CLI_DEFAULT_MODEL_REF;
+
+  return {
+    profiles: [],
+    configPatch: {
+      agents: {
+        defaults: {
+          agentRuntime: selectGeminiCliRuntime(defaults?.agentRuntime),
+          models: nextModels,
+        },
+      },
+    },
+    defaultModel,
+    notes: [
+      "Gemini CLI auth detected; selected the local Gemini CLI runtime.",
+      "Existing Google auth profiles are kept for rollback.",
+    ],
+  };
+}

--- a/extensions/google/cli-migration.ts
+++ b/extensions/google/cli-migration.ts
@@ -2,17 +2,19 @@ import {
   type OpenClawConfig,
   type ProviderAuthResult,
 } from "openclaw/plugin-sdk/provider-auth";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/text-runtime";
 import { readGeminiCliCredentialsForSetup } from "./cli-auth-seam.js";
 
 export const GEMINI_CLI_BACKEND_ID = "google-gemini-cli";
-export const GEMINI_CLI_DEFAULT_MODEL_REF = `${GEMINI_CLI_BACKEND_ID}/gemini-3-flash-preview`;
+// Canonical `google/*` model refs. The Gemini CLI runtime is selected separately
+// through `agents.defaults.agentRuntime.id = "google-gemini-cli"` so onboarding
+// stays on the same model-ref contract as API-key and OAuth setups.
+export const GEMINI_CLI_DEFAULT_MODEL_REF = "google/gemini-3.1-pro-preview";
 export const GEMINI_CLI_DEFAULT_ALLOWLIST_REFS = [
   GEMINI_CLI_DEFAULT_MODEL_REF,
-  `${GEMINI_CLI_BACKEND_ID}/gemini-3-pro-preview`,
-  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-pro-preview`,
-  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-flash-preview`,
-  `${GEMINI_CLI_BACKEND_ID}/gemini-3.1-flash-lite-preview`,
+  "google/gemini-3.1-flash-preview",
+  "google/gemini-3.1-flash-lite-preview",
+  "google/gemini-3-pro-preview",
+  "google/gemini-3-flash-preview",
 ] as const;
 
 type AgentDefaultsModels = NonNullable<NonNullable<OpenClawConfig["agents"]>["defaults"]>["models"];
@@ -44,14 +46,6 @@ function selectGeminiCliRuntime(agentRuntime: AgentDefaultsRuntimePolicy | undef
 
 export function hasGeminiCliAuth(): boolean {
   return Boolean(readGeminiCliCredentialsForSetup());
-}
-
-export function isGeminiCliProviderRef(ref: unknown): boolean {
-  if (typeof ref !== "string") {
-    return false;
-  }
-  const lower = normalizeLowercaseStringOrEmpty(ref);
-  return lower.startsWith(`${GEMINI_CLI_BACKEND_ID}/`);
 }
 
 export function buildGoogleGeminiCliMigrationResult(

--- a/extensions/google/gemini-cli-provider.ts
+++ b/extensions/google/gemini-cli-provider.ts
@@ -1,12 +1,32 @@
+import { formatCliCommand } from "openclaw/plugin-sdk/cli-runtime";
 import type {
   OpenClawPluginApi,
   ProviderAuthContext,
+  ProviderAuthMethodNonInteractiveContext,
   ProviderFetchUsageSnapshotContext,
 } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  type OpenClawConfig as ProviderAuthConfig,
+  type ProviderAuthResult,
+} from "openclaw/plugin-sdk/provider-auth";
 import { buildOauthProviderAuthResult } from "openclaw/plugin-sdk/provider-auth-result";
 import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { buildProviderToolCompatFamilyHooks } from "openclaw/plugin-sdk/provider-tools";
 import { fetchGeminiUsage } from "openclaw/plugin-sdk/provider-usage";
+import {
+  readGeminiCliCredentialsForSetup,
+  readGeminiCliCredentialsForSetupNonInteractive,
+} from "./cli-auth-seam.js";
+import {
+  ensureGeminiCliInstalled,
+  GEMINI_CLI_NPM_PACKAGE,
+  runGeminiCliLogin,
+} from "./cli-install.js";
+import {
+  buildGoogleGeminiCliMigrationResult,
+  GEMINI_CLI_DEFAULT_ALLOWLIST_REFS,
+  GEMINI_CLI_DEFAULT_MODEL_REF,
+} from "./cli-migration.js";
 import { formatGoogleOauthApiKey, parseGoogleUsageToken } from "./oauth-token-shared.js";
 import { GOOGLE_GEMINI_PROVIDER_HOOKS } from "./provider-hooks.js";
 import { isModernGoogleModel, resolveGoogleGeminiForwardCompatModel } from "./provider-models.js";
@@ -30,6 +50,91 @@ async function fetchGeminiCliUsage(ctx: ProviderFetchUsageSnapshotContext) {
   return await fetchGeminiUsage(ctx.token, ctx.timeoutMs, ctx.fetchFn, PROVIDER_ID);
 }
 
+async function runGoogleGeminiCliSubscriptionAuth(
+  ctx: ProviderAuthContext,
+): Promise<ProviderAuthResult> {
+  const installed = await ensureGeminiCliInstalled({
+    prompter: ctx.prompter,
+    runtime: ctx.runtime,
+  });
+  if (!installed.ok) {
+    throw new Error(installed.reason);
+  }
+
+  let credential = readGeminiCliCredentialsForSetup();
+  if (!credential) {
+    await ctx.prompter.note(
+      [
+        "Gemini CLI is installed but not signed in to your Google account.",
+        "OpenClaw needs an active Gemini subscription session to run requests through your plan.",
+      ].join("\n"),
+      "Gemini CLI sign-in",
+    );
+    const shouldLogin = await ctx.prompter.confirm({
+      message: `Run ${formatCliCommand("gemini")} now to start the Google sign-in flow?`,
+      initialValue: true,
+    });
+    if (!shouldLogin) {
+      throw new Error(
+        [
+          "Gemini CLI sign-in was declined.",
+          `Run ${formatCliCommand("gemini")} manually and complete the Google sign-in, then re-run this setup.`,
+        ].join("\n"),
+      );
+    }
+    runGeminiCliLogin(ctx.runtime);
+    credential = readGeminiCliCredentialsForSetup();
+    if (!credential) {
+      throw new Error(
+        [
+          "Gemini CLI sign-in did not complete.",
+          `Run ${formatCliCommand("gemini")} again, complete the Google sign-in, then re-run this setup.`,
+        ].join("\n"),
+      );
+    }
+  }
+  return buildGoogleGeminiCliMigrationResult(ctx.config, credential);
+}
+
+async function runGoogleGeminiCliSubscriptionNonInteractive(ctx: {
+  config: ProviderAuthMethodNonInteractiveContext["config"];
+  runtime: ProviderAuthMethodNonInteractiveContext["runtime"];
+}): Promise<ProviderAuthConfig | null> {
+  const credential = readGeminiCliCredentialsForSetupNonInteractive();
+  if (!credential) {
+    ctx.runtime.error(
+      [
+        'Auth choice "google-gemini-subscription" requires Gemini CLI installed and signed in on this host.',
+        `Install Gemini CLI: npm install -g ${GEMINI_CLI_NPM_PACKAGE}`,
+        `Then sign in by running: ${formatCliCommand("gemini")} (Google sign-in opens in your browser)`,
+      ].join("\n"),
+    );
+    ctx.runtime.exit(1);
+    return null;
+  }
+
+  const result = buildGoogleGeminiCliMigrationResult(ctx.config, credential);
+  const currentDefaults = ctx.config.agents?.defaults;
+  return {
+    ...ctx.config,
+    ...result.configPatch,
+    agents: {
+      ...ctx.config.agents,
+      ...result.configPatch?.agents,
+      defaults: {
+        ...currentDefaults,
+        ...result.configPatch?.agents?.defaults,
+        model: {
+          ...(currentDefaults?.model && typeof currentDefaults.model === "object"
+            ? currentDefaults.model
+            : {}),
+          primary: result.defaultModel,
+        },
+      },
+    },
+  };
+}
+
 export function buildGoogleGeminiCliProvider(): ProviderPlugin {
   return {
     id: PROVIDER_ID,
@@ -38,6 +143,32 @@ export function buildGoogleGeminiCliProvider(): ProviderPlugin {
     aliases: ["gemini-cli"],
     envVars: [...ENV_VARS],
     auth: [
+      {
+        id: "cli",
+        label: "Gemini subscription (no API key)",
+        hint: "Use your Gemini Advanced/Pro subscription via the Gemini CLI in headless mode",
+        kind: "custom",
+        wizard: {
+          choiceId: "google-gemini-subscription",
+          choiceLabel: "Gemini subscription (no API key needed)",
+          choiceHint: "Runs Gemini through the Gemini CLI in headless mode using your Google account",
+          assistantPriority: -50,
+          groupId: "google",
+          groupLabel: "Google",
+          groupHint: "Gemini subscription + API key + OAuth",
+          modelAllowlist: {
+            allowedKeys: [...GEMINI_CLI_DEFAULT_ALLOWLIST_REFS],
+            initialSelections: [GEMINI_CLI_DEFAULT_MODEL_REF],
+            message: "Gemini models",
+          },
+        },
+        run: async (ctx: ProviderAuthContext) => await runGoogleGeminiCliSubscriptionAuth(ctx),
+        runNonInteractive: async (ctx: ProviderAuthMethodNonInteractiveContext) =>
+          await runGoogleGeminiCliSubscriptionNonInteractive({
+            config: ctx.config,
+            runtime: ctx.runtime,
+          }),
+      },
       {
         id: "oauth",
         label: "Google OAuth",

--- a/extensions/google/openclaw.plugin.json
+++ b/extensions/google/openclaw.plugin.json
@@ -100,13 +100,24 @@
   },
   "providerAuthChoices": [
     {
+      "provider": "google-gemini-cli",
+      "method": "cli",
+      "choiceId": "google-gemini-subscription",
+      "choiceLabel": "Gemini subscription (no API key needed)",
+      "choiceHint": "Runs Gemini through the Gemini CLI in headless mode using your Google account",
+      "assistantPriority": -50,
+      "groupId": "google",
+      "groupLabel": "Google",
+      "groupHint": "Gemini subscription + API key + OAuth"
+    },
+    {
       "provider": "google",
       "method": "api-key",
       "choiceId": "gemini-api-key",
       "choiceLabel": "Google Gemini API key",
       "groupId": "google",
       "groupLabel": "Google",
-      "groupHint": "Gemini API key + OAuth",
+      "groupHint": "Gemini subscription + API key + OAuth",
       "optionKey": "geminiApiKey",
       "cliFlag": "--gemini-api-key",
       "cliOption": "--gemini-api-key <key>",
@@ -120,7 +131,7 @@
       "choiceHint": "Google OAuth with project-aware token payload",
       "groupId": "google",
       "groupLabel": "Google",
-      "groupHint": "Gemini API key + OAuth"
+      "groupHint": "Gemini subscription + API key + OAuth"
     }
   ],
   "uiHints": {

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -33,7 +33,10 @@ export {
   upsertAuthProfileWithLock,
 } from "../agents/auth-profiles/profiles.js";
 export { resolveEnvApiKey } from "../agents/model-auth-env.js";
-export { readClaudeCliCredentialsCached } from "../agents/cli-credentials.js";
+export {
+  readClaudeCliCredentialsCached,
+  readGeminiCliCredentialsCached,
+} from "../agents/cli-credentials.js";
 export { suggestOAuthProfileIdForLegacyDefault } from "../agents/auth-profiles/repair.js";
 export {
   CUSTOM_LOCAL_AUTH_MARKER,


### PR DESCRIPTION
## Summary

- Adds a new `cli` auth method on the existing `google-gemini-cli` provider, surfaced as **"Gemini subscription (no API key needed)"** in `openclaw onboard` with `assistantPriority: -50` so users with a Gemini Advanced/Pro plan see the headless `gemini` CLI flow ahead of API-key and OAuth paths.
- The wizard auto-detects whether the `gemini` binary is on PATH, offers to run `npm install -g @google/gemini-cli` after an explicit confirm prompt, and launches `gemini` interactively when the CLI is installed but signed out (the binary handles Google sign-in itself).
- Web dashboard model picker and thinking-level selector keep working unchanged: the new migration seeds the canonical Gemini CLI allowlist into `agents.defaults.models` and the existing `sessions.patch { thinkingLevel }` flow injects the directive into the headless run's system prompt.

This is PR2 of a 3-PR series. PR1 (#74990) does the same for Claude. PR3 will cover dashboard polish for the thinking-level selector across both runtimes.

Why: today Gemini users with a paid Google subscription either don't notice the `google-gemini-cli` choice (its label said "Gemini CLI OAuth — Google OAuth with project-aware token payload"), or they pick the API-key path and end up on usage-based billing on top of their existing plan. After this PR the option reads as a first-class subscription path and the wizard handles install + login itself.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm test:extension google` — covers `cli-install.test.ts` (detect / install / login / ensure with deps injection) and `cli-migration.test.ts` (install declined / login OK / login refused / non-interactive error message).
- [ ] `pnpm build && pnpm check`
- [ ] Manual: run `openclaw onboard` on a fresh host without `gemini` installed → expect "Gemini subscription (no API key needed)" near the top of the Google group, then the install confirm + interactive `gemini` sign-in, then the model picker, then a working agent run.
- [ ] Manual: open the OpenClaw web dashboard, switch model and thinking level on a session backed by `google-gemini-cli`, send a message, confirm the directive lands in the next headless `gemini` turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)