### PR TITLE
Group namespaced models in /models

### DIFF
--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -297,6 +297,83 @@ describe("handleModelsCommand", () => {
     expect(result?.reply?.text).toContain("Switch: /model <provider/model>");
   });
 
+  it("groups namespaced models for aggregator providers", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "litellm"]);
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "litellm", id: "anthropic/claude-sonnet-4-5", name: "Claude Sonnet" },
+      { provider: "litellm", id: "deepseek/deepseek-chat", name: "DeepSeek Chat" },
+      { provider: "litellm", id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner" },
+      { provider: "litellm", id: "openai/gpt-4.1", name: "GPT-4.1" },
+      { provider: "litellm", id: "openai/gpt-4.1-mini", name: "GPT-4.1 Mini" },
+      { provider: "litellm", id: "mistral-small", name: "Mistral Small" },
+    ]);
+
+    const result = await handleModelsCommand(buildParams("/models litellm"), true);
+
+    expect(result?.reply?.text).toContain(
+      "Model groups (litellm) — showing 1-3 of 3 groups (6 models, page 1/1)",
+    );
+    expect(result?.reply?.text).toContain("- /models litellm/anthropic (1)");
+    expect(result?.reply?.text).toContain("- /models litellm/deepseek (2)");
+    expect(result?.reply?.text).toContain("- /models litellm/openai (2)");
+    expect(result?.reply?.text).toContain("Ungrouped models: 1");
+    expect(result?.reply?.text).not.toContain("- litellm/deepseek/deepseek-chat");
+  });
+
+  it("lists a selected aggregator model group without changing /model refs", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "litellm"]);
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "litellm", id: "deepseek/deepseek-chat", name: "DeepSeek Chat" },
+      { provider: "litellm", id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner" },
+      { provider: "litellm", id: "openai/gpt-4.1", name: "GPT-4.1" },
+    ]);
+
+    const result = await handleModelsCommand(buildParams("/models litellm/deepseek"), true);
+
+    expect(result?.reply?.text).toContain(
+      "Models (litellm/deepseek) — showing 1-2 of 2 (page 1/1)",
+    );
+    expect(result?.reply?.text).toContain("- litellm/deepseek/deepseek-chat");
+    expect(result?.reply?.text).toContain("- litellm/deepseek/deepseek-reasoner");
+    expect(result?.reply?.text).toContain("Switch: /model <provider/model>");
+    expect(result?.reply?.text).not.toContain("- litellm/openai/gpt-4.1");
+  });
+
+  it("does not add a grouping layer when a provider has only one namespaced group", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set(["anthropic", "litellm"]);
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "anthropic", id: "claude-opus-4-5", name: "Claude Opus" },
+      { provider: "litellm", id: "deepseek/deepseek-chat", name: "DeepSeek Chat" },
+      { provider: "litellm", id: "deepseek/deepseek-reasoner", name: "DeepSeek Reasoner" },
+    ]);
+
+    const result = await handleModelsCommand(buildParams("/models litellm"), true);
+
+    expect(result?.reply?.text).toContain("Models (litellm) — showing 1-2 of 2 (page 1/1)");
+    expect(result?.reply?.text).toContain("- litellm/deepseek/deepseek-chat");
+    expect(result?.reply?.text).toContain("- litellm/deepseek/deepseek-reasoner");
+    expect(result?.reply?.text).not.toContain("Model groups (litellm)");
+  });
+
+  it("does not group mostly direct local model namespaces", async () => {
+    modelProviderAuthMocks.authenticatedProviders = new Set(["ollama"]);
+    modelCatalogMocks.loadModelCatalog.mockResolvedValue([
+      { provider: "ollama", id: "llama3.2:latest", name: "Llama 3.2" },
+      { provider: "ollama", id: "qwen3:latest", name: "Qwen 3" },
+      { provider: "ollama", id: "huihui_ai/deepseek-r1-abliterated:8b", name: "DeepSeek R1" },
+      { provider: "ollama", id: "ALIENTELLIGENCE/triangular:latest", name: "Triangular" },
+    ]);
+
+    const result = await handleModelsCommand(buildParams("/models ollama"), true);
+
+    expect(result?.reply?.text).toContain("Models (ollama) — showing 1-4 of 4 (page 1/1)");
+    expect(result?.reply?.text).toContain("- ollama/llama3.2:latest");
+    expect(result?.reply?.text).toContain("- ollama/huihui_ai/deepseek-r1-abliterated:8b");
+    expect(result?.reply?.text).not.toContain("Model groups (ollama)");
+  });
+
   it("does not list bare fallback models under the default provider when catalog ownership is unique", async () => {
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "openai-codex", id: "gpt-5.4", name: "GPT-5.4" },

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -55,6 +55,7 @@ type ParsedModelsCommand =
   | {
       action: "list";
       provider?: string;
+      modelPrefix?: string;
       page: number;
       pageSize: number;
       all: boolean;
@@ -198,8 +199,28 @@ function formatProviderLine(params: { provider: string; count: number }): string
   return `- ${params.provider} (${params.count})`;
 }
 
+function parseProviderModelPath(raw?: string): { provider?: string; modelPrefix?: string } {
+  const trimmed = normalizeOptionalString(raw);
+  if (!trimmed) {
+    return {};
+  }
+  const slash = trimmed.indexOf("/");
+  if (slash === -1) {
+    return { provider: normalizeProviderId(trimmed) };
+  }
+  const provider = normalizeProviderId(trimmed.slice(0, slash));
+  const modelPrefix = trimmed
+    .slice(slash + 1)
+    .replace(/^\/+|\/+$/g, "")
+    .trim();
+  return {
+    provider,
+    ...(modelPrefix ? { modelPrefix } : {}),
+  };
+}
+
 function parseListArgs(tokens: string[]): Extract<ParsedModelsCommand, { action: "list" }> {
-  const provider = normalizeOptionalString(tokens[0]);
+  const providerPath = parseProviderModelPath(tokens[0]);
 
   let page = 1;
   let all = false;
@@ -238,7 +259,8 @@ function parseListArgs(tokens: string[]): Extract<ParsedModelsCommand, { action:
 
   return {
     action: "list",
-    provider: provider ? normalizeProviderId(provider) : undefined,
+    provider: providerPath.provider,
+    modelPrefix: providerPath.modelPrefix,
     page,
     pageSize,
     all,
@@ -269,13 +291,17 @@ function parseModelsArgs(raw: string): ParsedModelsCommand {
   }
 }
 
-function resolveProviderLabel(params: {
+function resolveProviderScopeLabel(params: {
   provider: string;
+  modelPrefix?: string;
   cfg: OpenClawConfig;
   agentDir?: string;
   workspaceDir?: string;
   sessionEntry?: ModelsCommandSessionEntry;
 }): string {
+  const scopedProvider = params.modelPrefix
+    ? `${params.provider}/${params.modelPrefix}`
+    : params.provider;
   const authLabel = resolveModelAuthLabel({
     provider: params.provider,
     cfg: params.cfg,
@@ -284,9 +310,19 @@ function resolveProviderLabel(params: {
     workspaceDir: params.workspaceDir,
   });
   if (!authLabel || authLabel === "unknown") {
-    return params.provider;
+    return scopedProvider;
   }
-  return `${params.provider} · 🔑 ${authLabel}`;
+  return `${scopedProvider} · 🔑 ${authLabel}`;
+}
+
+function resolveProviderLabel(params: {
+  provider: string;
+  cfg: OpenClawConfig;
+  agentDir?: string;
+  workspaceDir?: string;
+  sessionEntry?: ModelsCommandSessionEntry;
+}): string {
+  return resolveProviderScopeLabel(params);
 }
 
 export function formatModelsAvailableHeader(params: {
@@ -333,6 +369,101 @@ function buildProviderInfos(params: {
     id: provider,
     count: params.byProvider.get(provider)?.size ?? 0,
   }));
+}
+
+function scopedModelsForPrefix(models: readonly string[], modelPrefix?: string): string[] {
+  if (!modelPrefix) {
+    return [...models];
+  }
+  const prefixWithSlash = `${modelPrefix}/`;
+  return models.filter((model) => model === modelPrefix || model.startsWith(prefixWithSlash));
+}
+
+function buildModelGroupCounts(
+  models: readonly string[],
+  modelPrefix?: string,
+): { groups: Array<{ id: string; count: number }>; directCount: number } {
+  const prefixWithSlash = modelPrefix ? `${modelPrefix}/` : "";
+  const counts = new Map<string, number>();
+  let directCount = 0;
+  for (const model of models) {
+    const remainder = modelPrefix
+      ? model === modelPrefix
+        ? ""
+        : model.startsWith(prefixWithSlash)
+          ? model.slice(prefixWithSlash.length)
+          : undefined
+      : model;
+    if (remainder === undefined) {
+      continue;
+    }
+    const slash = remainder.indexOf("/");
+    if (slash <= 0) {
+      directCount += 1;
+      continue;
+    }
+    const group = remainder.slice(0, slash);
+    counts.set(group, (counts.get(group) ?? 0) + 1);
+  }
+  return {
+    groups: [...counts.entries()]
+      .map(([id, count]) => ({ id, count }))
+      .toSorted((left, right) => left.id.localeCompare(right.id)),
+    directCount,
+  };
+}
+
+function buildScopedModelPath(
+  provider: string,
+  modelPrefix: string | undefined,
+  child: string,
+): string {
+  return `${provider}/${modelPrefix ? `${modelPrefix}/` : ""}${child}`;
+}
+
+function buildModelGroupsText(params: {
+  provider: string;
+  providerLabel: string;
+  modelPrefix?: string;
+  groups: Array<{ id: string; count: number }>;
+  directCount: number;
+  total: number;
+  page: number;
+  pageSize: number;
+}): string | undefined {
+  if (params.groups.length <= 1) {
+    return;
+  }
+  const groupedCount = params.groups.reduce((sum, group) => sum + group.count, 0);
+  if (groupedCount <= params.directCount) {
+    return;
+  }
+  const pageCount = Math.max(1, Math.ceil(params.groups.length / params.pageSize));
+  const safePage = Math.max(1, Math.min(params.page, pageCount));
+  const startIndex = (safePage - 1) * params.pageSize;
+  const endIndexExclusive = Math.min(params.groups.length, startIndex + params.pageSize);
+  const pageGroups = params.groups.slice(startIndex, endIndexExclusive);
+  const lines = [
+    `Model groups (${params.providerLabel}) — showing ${startIndex + 1}-${endIndexExclusive} of ${params.groups.length} groups (${params.total} models, page ${safePage}/${pageCount})`,
+  ];
+  for (const group of pageGroups) {
+    lines.push(
+      `- /models ${buildScopedModelPath(params.provider, params.modelPrefix, group.id)} (${group.count})`,
+    );
+  }
+  if (params.directCount > 0) {
+    lines.push(
+      "",
+      `Ungrouped models: ${params.directCount}. Use /models ${params.provider} all to list every model.`,
+    );
+  }
+  lines.push("", "Open group: /models <provider/group>", "Switch: /model <provider/model>");
+  if (safePage < pageCount) {
+    lines.push(
+      `More: /models list ${params.modelPrefix ? `${params.provider}/${params.modelPrefix}` : params.provider} ${safePage + 1}`,
+    );
+  }
+  return lines.join("\n");
 }
 
 export async function resolveModelsCommandReply(params: {
@@ -387,7 +518,7 @@ export async function resolveModelsCommandReply(params: {
     return { text: MODELS_ADD_DEPRECATED_TEXT };
   }
 
-  const { provider, page, pageSize, all } = parsed;
+  const { provider, modelPrefix, page, pageSize, all } = parsed;
 
   if (!provider) {
     const channelData = commandPlugin?.commands?.buildModelsProviderChannelData?.({
@@ -417,12 +548,14 @@ export async function resolveModelsCommandReply(params: {
     };
   }
 
-  const models = [...(byProvider.get(provider) ?? new Set<string>())].toSorted();
+  const allProviderModels = [...(byProvider.get(provider) ?? new Set<string>())].toSorted();
+  const models = scopedModelsForPrefix(allProviderModels, modelPrefix).toSorted();
   const total = models.length;
 
   if (total === 0) {
-    const emptyProviderLabel = resolveProviderLabel({
+    const emptyProviderLabel = resolveProviderScopeLabel({
       provider,
+      modelPrefix,
       cfg: params.cfg,
       agentDir: params.agentDir,
       workspaceDir: params.workspaceDir,
@@ -464,6 +597,31 @@ export async function resolveModelsCommandReply(params: {
     };
   }
 
+  const providerLabel = resolveProviderScopeLabel({
+    provider,
+    modelPrefix,
+    cfg: params.cfg,
+    agentDir: params.agentDir,
+    workspaceDir: params.workspaceDir,
+    sessionEntry: params.sessionEntry,
+  });
+  if (!all) {
+    const groupInfo = buildModelGroupCounts(models, modelPrefix);
+    const groupText = buildModelGroupsText({
+      provider,
+      providerLabel,
+      modelPrefix,
+      groups: groupInfo.groups,
+      directCount: groupInfo.directCount,
+      total,
+      page,
+      pageSize,
+    });
+    if (groupText) {
+      return { text: groupText };
+    }
+  }
+
   const effectivePageSize = all ? total : pageSize;
   const pageCount = effectivePageSize > 0 ? Math.ceil(total / effectivePageSize) : 1;
   const safePage = all ? 1 : Math.max(1, Math.min(page, pageCount));
@@ -473,8 +631,8 @@ export async function resolveModelsCommandReply(params: {
       text: [
         `Page out of range: ${page} (valid: 1-${pageCount})`,
         "",
-        `Try: /models list ${provider} ${safePage}`,
-        `All: /models list ${provider} all`,
+        `Try: /models list ${modelPrefix ? `${provider}/${modelPrefix}` : provider} ${safePage}`,
+        `All: /models list ${modelPrefix ? `${provider}/${modelPrefix}` : provider} all`,
       ].join("\n"),
     };
   }
@@ -482,13 +640,6 @@ export async function resolveModelsCommandReply(params: {
   const startIndex = (safePage - 1) * effectivePageSize;
   const endIndexExclusive = Math.min(total, startIndex + effectivePageSize);
   const pageModels = models.slice(startIndex, endIndexExclusive);
-  const providerLabel = resolveProviderLabel({
-    provider,
-    cfg: params.cfg,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-    sessionEntry: params.sessionEntry,
-  });
   const lines = [
     `Models (${providerLabel}) — showing ${startIndex + 1}-${endIndexExclusive} of ${total} (page ${safePage}/${pageCount})`,
   ];
@@ -497,10 +648,12 @@ export async function resolveModelsCommandReply(params: {
   }
   lines.push("", "Switch: /model <provider/model>");
   if (!all && safePage < pageCount) {
-    lines.push(`More: /models list ${provider} ${safePage + 1}`);
+    lines.push(
+      `More: /models list ${modelPrefix ? `${provider}/${modelPrefix}` : provider} ${safePage + 1}`,
+    );
   }
   if (!all) {
-    lines.push(`All: /models list ${provider} all`);
+    lines.push(`All: /models list ${modelPrefix ? `${provider}/${modelPrefix}` : provider} all`);
   }
   return { text: lines.join("\n") };
 }

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -432,11 +432,11 @@ function buildModelGroupsText(params: {
   pageSize: number;
 }): string | undefined {
   if (params.groups.length <= 1) {
-    return;
+    return undefined;
   }
   const groupedCount = params.groups.reduce((sum, group) => sum + group.count, 0);
   if (groupedCount <= params.directCount) {
-    return;
+    return undefined;
   }
   const pageCount = Math.max(1, Math.ceil(params.groups.length / params.pageSize));
   const safePage = Math.max(1, Math.min(params.page, pageCount));


### PR DESCRIPTION
## Summary
- add generic namespace drilldown for `/models <provider>/<group>`
- group namespaced aggregator catalogs when grouped models dominate direct models
- keep `/model <provider/model>` unchanged and preserve `/models <provider> all` as a flat escape hatch

## Tests
- `pnpm exec oxfmt --check src/auto-reply/reply/commands-models.ts src/auto-reply/reply/commands-models.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.auto-reply-reply.config.ts src/auto-reply/reply/commands-models.test.ts`
- `pnpm exec tsc --noEmit --pretty false --project tsconfig.core.json`
- `git diff --check`