### PR TITLE
fix(media): allow explicit synthetic auth for media providers

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -610,6 +610,24 @@ API key auth, and dynamic model resolution.
           transcribeAudio: async (req) => ({ text: "Transcript..." }),
         });
         ```
+
+        Local or self-hosted media providers that intentionally do not require
+        credentials can expose `resolveSyntheticAuth` and return a non-secret
+        marker. OpenClaw still keeps the normal auth gate for providers that do
+        not explicitly opt in.
+
+        ```typescript
+        api.registerMediaUnderstandingProvider({
+          id: "local-audio",
+          capabilities: ["audio"],
+          resolveSyntheticAuth: () => ({
+            apiKey: "custom-local",
+            source: "local-audio plugin synthetic auth",
+            mode: "api-key",
+          }),
+          transcribeAudio: async (req) => ({ text: "Transcript..." }),
+        });
+        ```
       </Tab>
       <Tab title="Image and video generation">
         Video capabilities use a **mode-aware** shape: `generate`,

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -660,6 +660,24 @@ API key auth, and dynamic model resolution.
           transcribeAudio: async (req) => ({ text: "Transcript..." }),
         });
         ```
+
+        Local or self-hosted media providers that intentionally do not require
+        credentials can expose `resolveSyntheticAuth` and return a non-secret
+        marker. OpenClaw still keeps the normal auth gate for providers that do
+        not explicitly opt in.
+
+        ```typescript
+        api.registerMediaUnderstandingProvider({
+          id: "local-audio",
+          capabilities: ["audio"],
+          resolveSyntheticAuth: () => ({
+            apiKey: "custom-local",
+            source: "local-audio plugin synthetic auth",
+            mode: "api-key",
+          }),
+          transcribeAudio: async (req) => ({ text: "Transcript..." }),
+        });
+        ```
       </Tab>
       <Tab title="Embeddings">
         ```typescript

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -406,12 +406,22 @@ function resolveMediaRequestOverrides(config: MediaUnderstandingConfig | undefin
   };
 }
 
+function isMissingProviderApiKeyError(err: unknown, providerId: string): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes(`No API key found for provider "${providerId}"`) ||
+    message.includes(`No API key resolved for provider "${providerId}"`)
+  );
+}
+
 async function resolveProviderExecutionAuth(params: {
   providerId: string;
+  provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   agentDir?: string;
 }) {
+  const providerConfig = params.cfg.models?.providers?.[params.providerId];
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,
     providerId: params.providerId,
@@ -422,28 +432,66 @@ async function resolveProviderExecutionAuth(params: {
         provider: params.providerId,
         primaryApiKey: literalApiKey,
       }),
-      providerConfig: params.cfg.models?.providers?.[params.providerId],
+      providerConfig,
     };
   }
-  const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
-  const auth = await resolveApiKeyForProvider({
-    provider: params.providerId,
-    cfg: params.cfg,
-    profileId: params.entry.profile,
-    preferredProfile: params.entry.preferredProfile,
-    agentDir: params.agentDir,
-  });
-  return {
-    apiKeys: collectProviderApiKeysForExecution({
+  const resolveMediaProviderSyntheticAuth = () => {
+    const syntheticAuth = params.provider?.resolveSyntheticAuth?.({
+      config: params.cfg,
       provider: params.providerId,
-      primaryApiKey: requireApiKey(auth, params.providerId),
-    }),
-    providerConfig: params.cfg.models?.providers?.[params.providerId],
+      providerConfig,
+    });
+    return syntheticAuth?.apiKey?.trim() || undefined;
   };
+  if (!providerConfig) {
+    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
+    if (syntheticApiKey) {
+      return {
+        apiKeys: collectProviderApiKeysForExecution({
+          provider: params.providerId,
+          primaryApiKey: syntheticApiKey,
+        }),
+        providerConfig,
+      };
+    }
+  }
+  const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
+  try {
+    const auth = await resolveApiKeyForProvider({
+      provider: params.providerId,
+      cfg: params.cfg,
+      profileId: params.entry.profile,
+      preferredProfile: params.entry.preferredProfile,
+      agentDir: params.agentDir,
+    });
+    return {
+      apiKeys: collectProviderApiKeysForExecution({
+        provider: params.providerId,
+        primaryApiKey: requireApiKey(auth, params.providerId),
+      }),
+      providerConfig,
+    };
+  } catch (err) {
+    if (!isMissingProviderApiKeyError(err, params.providerId)) {
+      throw err;
+    }
+    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
+    if (syntheticApiKey) {
+      return {
+        apiKeys: collectProviderApiKeysForExecution({
+          provider: params.providerId,
+          primaryApiKey: syntheticApiKey,
+        }),
+        providerConfig,
+      };
+    }
+    throw err;
+  }
 }
 
 async function resolveProviderExecutionContext(params: {
   providerId: string;
+  provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   config?: MediaUnderstandingConfig;
@@ -451,6 +499,7 @@ async function resolveProviderExecutionContext(params: {
 }) {
   const { apiKeys, providerConfig } = await resolveProviderExecutionAuth({
     providerId: params.providerId,
+    provider: params.provider,
     cfg: params.cfg,
     entry: params.entry,
     agentDir: params.agentDir,
@@ -619,6 +668,7 @@ export async function runProviderEntry(params: {
     assertMinAudioSize({ size: media.size, attachmentIndex: params.attachmentIndex });
     const { apiKeys, baseUrl, headers, request } = await resolveProviderExecutionContext({
       providerId,
+      provider,
       cfg,
       entry,
       config: params.config,
@@ -689,6 +739,7 @@ export async function runProviderEntry(params: {
   }
   const { apiKeys, baseUrl, headers, request } = await resolveProviderExecutionContext({
     providerId,
+    provider,
     cfg,
     entry,
     config: params.config,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -443,7 +443,8 @@ async function resolveProviderExecutionAuth(params: {
     });
     return syntheticAuth?.apiKey?.trim() || undefined;
   };
-  if (!providerConfig) {
+  const hasProfileSelection = Boolean(params.entry.profile || params.entry.preferredProfile);
+  if (!providerConfig && !hasProfileSelection) {
     const syntheticApiKey = resolveMediaProviderSyntheticAuth();
     if (syntheticApiKey) {
       return {

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -443,19 +443,6 @@ async function resolveProviderExecutionAuth(params: {
     });
     return syntheticAuth?.apiKey?.trim() || undefined;
   };
-  const hasProfileSelection = Boolean(params.entry.profile || params.entry.preferredProfile);
-  if (!providerConfig && !hasProfileSelection) {
-    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
-    if (syntheticApiKey) {
-      return {
-        apiKeys: collectProviderApiKeysForExecution({
-          provider: params.providerId,
-          primaryApiKey: syntheticApiKey,
-        }),
-        providerConfig,
-      };
-    }
-  }
   const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
   try {
     const auth = await resolveApiKeyForProvider({

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -463,19 +463,6 @@ async function resolveProviderExecutionAuth(params: {
     });
     return syntheticAuth?.apiKey?.trim() || undefined;
   };
-  const hasProfileSelection = Boolean(params.entry.profile || params.entry.preferredProfile);
-  if (!providerConfig && !hasProfileSelection) {
-    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
-    if (syntheticApiKey) {
-      return {
-        apiKeys: collectProviderApiKeysForExecution({
-          provider: params.providerId,
-          primaryApiKey: syntheticApiKey,
-        }),
-        providerConfig,
-      };
-    }
-  }
   const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
   try {
     const auth = await resolveApiKeyForProvider({

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -425,13 +425,23 @@ function resolveMediaRequestOverrides(config: MediaUnderstandingConfig | undefin
   };
 }
 
+function isMissingProviderApiKeyError(err: unknown, providerId: string): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes(`No API key found for provider "${providerId}"`) ||
+    message.includes(`No API key resolved for provider "${providerId}"`)
+  );
+}
+
 async function resolveProviderExecutionAuth(params: {
   providerId: string;
+  provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   agentDir?: string;
   workspaceDir?: string;
 }) {
+  const providerConfig = params.cfg.models?.providers?.[params.providerId];
   const literalApiKey = resolveLiteralProviderApiKey({
     cfg: params.cfg,
     providerId: params.providerId,
@@ -442,29 +452,67 @@ async function resolveProviderExecutionAuth(params: {
         provider: params.providerId,
         primaryApiKey: literalApiKey,
       }),
-      providerConfig: params.cfg.models?.providers?.[params.providerId],
+      providerConfig,
     };
   }
-  const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
-  const auth = await resolveApiKeyForProvider({
-    provider: params.providerId,
-    cfg: params.cfg,
-    profileId: params.entry.profile,
-    preferredProfile: params.entry.preferredProfile,
-    agentDir: params.agentDir,
-    workspaceDir: params.workspaceDir,
-  });
-  return {
-    apiKeys: collectProviderApiKeysForExecution({
+  const resolveMediaProviderSyntheticAuth = () => {
+    const syntheticAuth = params.provider?.resolveSyntheticAuth?.({
+      config: params.cfg,
       provider: params.providerId,
-      primaryApiKey: requireApiKey(auth, params.providerId),
-    }),
-    providerConfig: params.cfg.models?.providers?.[params.providerId],
+      providerConfig,
+    });
+    return syntheticAuth?.apiKey?.trim() || undefined;
   };
+  if (!providerConfig) {
+    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
+    if (syntheticApiKey) {
+      return {
+        apiKeys: collectProviderApiKeysForExecution({
+          provider: params.providerId,
+          primaryApiKey: syntheticApiKey,
+        }),
+        providerConfig,
+      };
+    }
+  }
+  const { requireApiKey, resolveApiKeyForProvider } = await loadModelAuth();
+  try {
+    const auth = await resolveApiKeyForProvider({
+      provider: params.providerId,
+      cfg: params.cfg,
+      profileId: params.entry.profile,
+      preferredProfile: params.entry.preferredProfile,
+      agentDir: params.agentDir,
+      workspaceDir: params.workspaceDir,
+    });
+    return {
+      apiKeys: collectProviderApiKeysForExecution({
+        provider: params.providerId,
+        primaryApiKey: requireApiKey(auth, params.providerId),
+      }),
+      providerConfig,
+    };
+  } catch (err) {
+    if (!isMissingProviderApiKeyError(err, params.providerId)) {
+      throw err;
+    }
+    const syntheticApiKey = resolveMediaProviderSyntheticAuth();
+    if (syntheticApiKey) {
+      return {
+        apiKeys: collectProviderApiKeysForExecution({
+          provider: params.providerId,
+          primaryApiKey: syntheticApiKey,
+        }),
+        providerConfig,
+      };
+    }
+    throw err;
+  }
 }
 
 async function resolveProviderExecutionContext(params: {
   providerId: string;
+  provider?: MediaUnderstandingProvider;
   cfg: OpenClawConfig;
   entry: MediaUnderstandingModelConfig;
   config?: MediaUnderstandingConfig;
@@ -473,6 +521,7 @@ async function resolveProviderExecutionContext(params: {
 }) {
   const { apiKeys, providerConfig } = await resolveProviderExecutionAuth({
     providerId: params.providerId,
+    provider: params.provider,
     cfg: params.cfg,
     entry: params.entry,
     agentDir: params.agentDir,
@@ -651,6 +700,7 @@ export async function runProviderEntry(params: {
     assertMinAudioSize({ size: media.size, attachmentIndex: params.attachmentIndex });
     const { apiKeys, baseUrl, headers, request } = await resolveProviderExecutionContext({
       providerId,
+      provider,
       cfg,
       entry,
       config: params.config,
@@ -724,6 +774,7 @@ export async function runProviderEntry(params: {
   }
   const { apiKeys, baseUrl, headers, request } = await resolveProviderExecutionContext({
     providerId,
+    provider,
     cfg,
     entry,
     config: params.config,

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -463,7 +463,8 @@ async function resolveProviderExecutionAuth(params: {
     });
     return syntheticAuth?.apiKey?.trim() || undefined;
   };
-  if (!providerConfig) {
+  const hasProfileSelection = Boolean(params.entry.profile || params.entry.preferredProfile);
+  if (!providerConfig && !hasProfileSelection) {
     const syntheticApiKey = resolveMediaProviderSyntheticAuth();
     if (syntheticApiKey) {
       return {

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -1,0 +1,436 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { CUSTOM_LOCAL_AUTH_MARKER } from "../agents/model-auth-markers.js";
+import type { OpenClawConfig } from "../config/types.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { buildProviderRegistry, runCapability } from "./runner.js";
+import { withAudioFixture, withVideoFixture } from "./runner.test-utils.js";
+import type {
+  AudioTranscriptionRequest,
+  MediaUnderstandingProvider,
+  VideoDescriptionRequest,
+} from "./types.js";
+
+vi.mock("../plugins/capability-provider-runtime.js", async () => {
+  const { createEmptyCapabilityProviderMockModule } = await import("./runner.test-mocks.js");
+  return createEmptyCapabilityProviderMockModule();
+});
+
+vi.mock("../plugins/providers.js", async (importOriginal) => ({
+  ...((await importOriginal()) as typeof import("../plugins/providers.js")),
+  resolveOwningPluginIdsForProvider: () => [],
+}));
+
+const AUTH_ENV = {
+  LOCAL_AUDIO_API_KEY: undefined,
+  REMOTE_AUDIO_API_KEY: undefined,
+  OPENCLAW_AGENT_DIR: undefined,
+} satisfies Record<string, string | undefined>;
+
+function createAudioProvider(
+  id: string,
+  transcribeAudio: (req: AudioTranscriptionRequest) => Promise<{ text: string; model?: string }>,
+  extra?: Partial<MediaUnderstandingProvider>,
+): MediaUnderstandingProvider {
+  return {
+    id,
+    capabilities: ["audio"],
+    transcribeAudio,
+    ...extra,
+  };
+}
+
+function createVideoProvider(
+  id: string,
+  describeVideo: (req: VideoDescriptionRequest) => Promise<{ text: string; model?: string }>,
+  extra?: Partial<MediaUnderstandingProvider>,
+): MediaUnderstandingProvider {
+  return {
+    id,
+    capabilities: ["video"],
+    describeVideo,
+    ...extra,
+  };
+}
+
+async function withIsolatedAgentDir<T>(run: (agentDir: string) => Promise<T>): Promise<T> {
+  const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-local-audio-auth-"));
+  try {
+    return await run(agentDir);
+  } finally {
+    await fs.rm(agentDir, { recursive: true, force: true });
+  }
+}
+
+function createAudioCfg(params: {
+  provider: string;
+  model: string;
+  providerConfig?: Record<string, unknown>;
+  entry?: Record<string, unknown>;
+}): OpenClawConfig {
+  return {
+    ...(params.providerConfig
+      ? {
+          models: {
+            providers: {
+              [params.provider]: params.providerConfig,
+            },
+          },
+        }
+      : {}),
+    tools: {
+      media: {
+        audio: {
+          enabled: true,
+          models: [
+            { type: "provider", provider: params.provider, model: params.model, ...params.entry },
+          ],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+function createVideoCfg(params: { provider: string; model: string }): OpenClawConfig {
+  return {
+    tools: {
+      media: {
+        video: {
+          enabled: true,
+          models: [{ type: "provider", provider: params.provider, model: params.model }],
+        },
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("runCapability local no-auth audio providers", () => {
+  it("allows a local no-auth audio provider when configured as a local models provider", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture("openclaw-local-audio-configured", async ({ ctx, media, cache }) => {
+          const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+            text: `ok:${req.apiKey}`,
+            model: req.model,
+          }));
+          const cfg = createAudioCfg({
+            provider: "local-audio",
+            model: "whisper-local",
+            providerConfig: {
+              api: "openai-completions",
+              baseUrl: "http://127.0.0.1:43111/v1",
+              models: [{ id: "whisper-local", input: ["audio"] }],
+            },
+          });
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir,
+            providerRegistry: buildProviderRegistry({
+              "local-audio": createAudioProvider("local-audio", transcribeAudio),
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("success");
+          expect(result.outputs[0]?.text).toBe(`ok:${CUSTOM_LOCAL_AUTH_MARKER}`);
+          expect(transcribeAudio).toHaveBeenCalledTimes(1);
+          expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe(CUSTOM_LOCAL_AUTH_MARKER);
+        });
+      });
+    });
+  });
+
+  it("regression #74644: plugin-only local no-auth audio provider can use synthetic auth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture(
+          "openclaw-local-audio-plugin-only",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: "plugin local ok",
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({ provider: "local-audio", model: "whisper-local" });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-audio plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            if (result.decision.outcome !== "success") {
+              throw new Error(
+                result.decision.attachments[0]?.attempts[0]?.reason ??
+                  `expected success, got ${result.decision.outcome}`,
+              );
+            }
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("plugin local ok");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe(CUSTOM_LOCAL_AUTH_MARKER);
+          },
+        );
+      });
+    });
+  });
+
+  it("still rejects a remote audio provider without credentials", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture("openclaw-remote-audio-no-auth", async ({ ctx, media, cache }) => {
+          const transcribeAudio = vi.fn(async () => ({
+            text: "should not run",
+            model: "remote-whisper",
+          }));
+          const cfg = createAudioCfg({
+            provider: "remote-audio",
+            model: "remote-whisper",
+            providerConfig: {
+              api: "openai-completions",
+              baseUrl: "https://example.invalid/v1",
+              models: [{ id: "remote-whisper", input: ["audio"] }],
+            },
+          });
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir,
+            providerRegistry: buildProviderRegistry({
+              "remote-audio": createAudioProvider("remote-audio", transcribeAudio),
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("failed");
+          expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+            'No API key found for provider "remote-audio"',
+          );
+          expect(transcribeAudio).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  it("prefers literal configured provider apiKey over media synthetic auth hook", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture(
+          "openclaw-local-audio-literal-key",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `literal:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({
+              provider: "local-audio",
+              model: "whisper-local",
+              providerConfig: {
+                apiKey: "real-key",
+                models: [],
+              },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-audio plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("literal:real-key");
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("real-key");
+          },
+        );
+      });
+    });
+  });
+
+  it("does not allow plugin-only media provider without explicit synthetic auth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture("openclaw-local-audio-no-hook", async ({ ctx, media, cache }) => {
+          const transcribeAudio = vi.fn(async () => ({
+            text: "should not run",
+            model: "whisper-local",
+          }));
+          const cfg = createAudioCfg({ provider: "local-audio", model: "whisper-local" });
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir,
+            providerRegistry: buildProviderRegistry({
+              "local-audio": createAudioProvider("local-audio", transcribeAudio),
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("failed");
+          expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+            'No API key found for provider "local-audio"',
+          );
+          expect(transcribeAudio).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  it("does not allow plugin-only media provider when synthetic auth hook returns null", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture("openclaw-local-audio-null-hook", async ({ ctx, media, cache }) => {
+          const transcribeAudio = vi.fn(async () => ({
+            text: "should not run",
+            model: "whisper-local",
+          }));
+          const cfg = createAudioCfg({ provider: "local-audio", model: "whisper-local" });
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir,
+            providerRegistry: buildProviderRegistry({
+              "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                resolveSyntheticAuth: () => null,
+              }),
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("failed");
+          expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+            'No API key found for provider "local-audio"',
+          );
+          expect(transcribeAudio).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  it("does not let media synthetic auth override an explicit missing profile", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture(
+          "openclaw-local-audio-missing-profile",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async () => ({
+              text: "should not run",
+              model: "whisper-local",
+            }));
+            const cfg = createAudioCfg({
+              provider: "local-audio",
+              model: "whisper-local",
+              entry: { profile: "missing-profile" },
+              providerConfig: {
+                api: "openai-completions",
+                baseUrl: "https://example.invalid/v1",
+                models: [{ id: "whisper-local", input: ["audio"] }],
+              },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-audio plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("failed");
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+              'No credentials found for profile "missing-profile"',
+            );
+            expect(transcribeAudio).not.toHaveBeenCalled();
+          },
+        );
+      });
+    });
+  });
+
+  it("allows explicit synthetic auth for plugin-only no-auth video provider", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withVideoFixture(
+          "openclaw-local-video-plugin-only",
+          async ({ ctx, media, cache }) => {
+            const describeVideo = vi.fn(async (req: VideoDescriptionRequest) => ({
+              text: `video:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createVideoCfg({ provider: "local-video", model: "video-local" });
+
+            const result = await runCapability({
+              capability: "video",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-video": createVideoProvider("local-video", describeVideo, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-video plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe(`video:${CUSTOM_LOCAL_AUTH_MARKER}`);
+            expect(describeVideo).toHaveBeenCalledTimes(1);
+            expect(describeVideo.mock.calls[0]?.[0].apiKey).toBe(CUSTOM_LOCAL_AUTH_MARKER);
+          },
+        );
+      });
+    });
+  });
+});

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -344,6 +344,51 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
+  it("does not let plugin-only synthetic auth override an explicit missing profile", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await withAudioFixture(
+          "openclaw-local-audio-plugin-missing-profile",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async () => ({
+              text: "should not run",
+              model: "whisper-local",
+            }));
+            const cfg = createAudioCfg({
+              provider: "local-audio",
+              model: "whisper-local",
+              entry: { profile: "missing-profile" },
+            });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-audio plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("failed");
+            expect(result.decision.attachments[0]?.attempts[0]?.reason).toContain(
+              'No credentials found for profile "missing-profile"',
+            );
+            expect(transcribeAudio).not.toHaveBeenCalled();
+          },
+        );
+      });
+    });
+  });
+
   it("does not let media synthetic auth override an explicit missing profile", async () => {
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync(AUTH_ENV, async () => {

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -19,7 +19,7 @@ vi.mock("../plugins/capability-provider-runtime.js", async () => {
 });
 
 vi.mock("../plugins/providers.js", async (importOriginal) => ({
-  ...((await importOriginal()) as typeof import("../plugins/providers.js")),
+  ...(await importOriginal()),
   resolveOwningPluginIdsForProvider: () => [],
 }));
 

--- a/src/media-understanding/runner.local-no-auth.test.ts
+++ b/src/media-understanding/runner.local-no-auth.test.ts
@@ -192,6 +192,96 @@ describe("runCapability local no-auth audio providers", () => {
     });
   });
 
+  it("prefers resolver env credentials over plugin-only media synthetic auth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync({ ...AUTH_ENV, OPENAI_API_KEY: "env-openai-audio-key" }, async () => {
+        await withAudioFixture("openclaw-openai-audio-env-key", async ({ ctx, media, cache }) => {
+          const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+            text: `env:${req.apiKey}`,
+            model: req.model,
+          }));
+          const cfg = createAudioCfg({ provider: "openai", model: "whisper-1" });
+
+          const result = await runCapability({
+            capability: "audio",
+            cfg,
+            ctx,
+            attachments: cache,
+            media,
+            agentDir,
+            providerRegistry: buildProviderRegistry({
+              openai: createAudioProvider("openai", transcribeAudio, {
+                resolveSyntheticAuth: () => ({
+                  apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                  source: "openai plugin synthetic auth",
+                  mode: "api-key",
+                }),
+              }),
+            }),
+          });
+
+          expect(result.decision.outcome).toBe("success");
+          expect(result.outputs[0]?.text).toBe("env:env-openai-audio-key");
+          expect(transcribeAudio).toHaveBeenCalledTimes(1);
+          expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("env-openai-audio-key");
+        });
+      });
+    });
+  });
+
+  it("prefers stored auth profile credentials over plugin-only media synthetic auth", async () => {
+    await withIsolatedAgentDir(async (agentDir) => {
+      await withEnvAsync(AUTH_ENV, async () => {
+        await fs.writeFile(
+          path.join(agentDir, "auth-profiles.json"),
+          JSON.stringify({
+            version: 1,
+            profiles: {
+              "local-audio:default": {
+                type: "api_key",
+                provider: "local-audio",
+                key: "stored-local-audio-key",
+              },
+            },
+          }),
+        );
+        await withAudioFixture(
+          "openclaw-local-audio-stored-profile",
+          async ({ ctx, media, cache }) => {
+            const transcribeAudio = vi.fn(async (req: AudioTranscriptionRequest) => ({
+              text: `profile:${req.apiKey}`,
+              model: req.model,
+            }));
+            const cfg = createAudioCfg({ provider: "local-audio", model: "whisper-local" });
+
+            const result = await runCapability({
+              capability: "audio",
+              cfg,
+              ctx,
+              attachments: cache,
+              media,
+              agentDir,
+              providerRegistry: buildProviderRegistry({
+                "local-audio": createAudioProvider("local-audio", transcribeAudio, {
+                  resolveSyntheticAuth: () => ({
+                    apiKey: CUSTOM_LOCAL_AUTH_MARKER,
+                    source: "local-audio plugin synthetic auth",
+                    mode: "api-key",
+                  }),
+                }),
+              }),
+            });
+
+            expect(result.decision.outcome).toBe("success");
+            expect(result.outputs[0]?.text).toBe("profile:stored-local-audio-key");
+            expect(transcribeAudio).toHaveBeenCalledTimes(1);
+            expect(transcribeAudio.mock.calls[0]?.[0].apiKey).toBe("stored-local-audio-key");
+          },
+        );
+      });
+    });
+  });
+
   it("still rejects a remote audio provider without credentials", async () => {
     await withIsolatedAgentDir(async (agentDir) => {
       await withEnvAsync(AUTH_ENV, async () => {

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -1,4 +1,5 @@
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 export type MediaUnderstandingKind =
@@ -174,12 +175,27 @@ export type ImagesDescriptionResult = {
   model?: string;
 };
 
+export type MediaUnderstandingProviderSyntheticAuthContext = {
+  config?: OpenClawConfig;
+  provider: string;
+  providerConfig?: ModelProviderConfig;
+};
+
+export type MediaUnderstandingProviderSyntheticAuthResult = {
+  apiKey: string;
+  source: string;
+  mode: "api-key";
+};
+
 export type MediaUnderstandingProvider = {
   id: string;
   capabilities?: MediaUnderstandingCapability[];
   defaultModels?: Partial<Record<MediaUnderstandingCapability, string>>;
   autoPriority?: Partial<Record<MediaUnderstandingCapability, number>>;
   nativeDocumentInputs?: Array<"pdf">;
+  resolveSyntheticAuth?: (
+    ctx: MediaUnderstandingProviderSyntheticAuthContext,
+  ) => MediaUnderstandingProviderSyntheticAuthResult | null | undefined;
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;

--- a/src/media-understanding/types.ts
+++ b/src/media-understanding/types.ts
@@ -1,4 +1,5 @@
 import type { AuthProfileStore } from "../agents/auth-profiles/types.js";
+import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 
 type MediaUnderstandingKind = "audio.transcription" | "video.description" | "image.description";
@@ -217,6 +218,18 @@ export type MediaUnderstandingDocumentModelDefaults = {
   image?: string | false;
 };
 
+export type MediaUnderstandingProviderSyntheticAuthContext = {
+  config?: OpenClawConfig;
+  provider: string;
+  providerConfig?: ModelProviderConfig;
+};
+
+export type MediaUnderstandingProviderSyntheticAuthResult = {
+  apiKey: string;
+  source: string;
+  mode: "api-key";
+};
+
 export type MediaUnderstandingProvider = {
   id: string;
   capabilities?: MediaUnderstandingCapability[];
@@ -224,6 +237,9 @@ export type MediaUnderstandingProvider = {
   autoPriority?: Partial<Record<MediaUnderstandingCapability, number>>;
   nativeDocumentInputs?: Array<"pdf">;
   documentModels?: Partial<Record<"pdf", MediaUnderstandingDocumentModelDefaults>>;
+  resolveSyntheticAuth?: (
+    ctx: MediaUnderstandingProviderSyntheticAuthContext,
+  ) => MediaUnderstandingProviderSyntheticAuthResult | null | undefined;
   transcribeAudio?: (req: AudioTranscriptionRequest) => Promise<AudioTranscriptionResult>;
   describeVideo?: (req: VideoDescriptionRequest) => Promise<VideoDescriptionResult>;
   describeImage?: (req: ImageDescriptionRequest) => Promise<ImageDescriptionResult>;


### PR DESCRIPTION
## Summary

- add an explicit synthetic auth hook for media understanding providers
- allow plugin-only local/no-auth audio and video providers to opt into non-secret auth
- preserve existing model-provider auth resolution and fail-closed behavior for unmarked providers
- document the hook for local/self-hosted media provider plugins

## Why

Fixes #74644.

`mediaUnderstandingProviders` can register audio/video providers, but provider execution still goes through model-provider auth resolution before calling `transcribeAudio` or `describeVideo`. Plugin-only local STT providers that do not need credentials were therefore rejected with missing API key errors before their provider implementation could run.

This keeps the media provider auth gate in place. It only lets a media provider explicitly opt into synthetic, non-secret auth for local/no-auth execution, while preserving configured API keys, existing model-auth resolution, explicit profile errors, and fail-closed behavior for unmarked remote providers.

## Real behavior proof

- **Behavior or issue addressed:** Plugin-only local/no-auth media providers can run after this patch without `models.providers`, env API keys, or auth profiles. The provider still receives an explicit synthetic non-secret auth marker, while ordinary unmarked providers remain fail-closed.
- **Real environment tested:** Local OpenClaw checkout on macOS, PR head `108628d8d86d`, rebased onto `main` `4305fb7cdf2c`, running repository TypeScript through `node --import tsx`.
- **Exact steps or command run after this patch:** `env OPENCLAW_PROOF_COMMIT=108628d8d86d node --import tsx /private/tmp/openclaw-pr75005-proof.mts`
- **Evidence after fix:** Copied terminal output from the local OpenClaw smoke:

  ```text
  OpenClaw PR #75005 local/no-auth media provider smoke
  commit=108628d8d86d
  provider=local-audio-proof
  model=proof-whisper-local
  outputKind=audio.transcription
  output=proof transcript from proof-whisper-local
  providerCalled=yes
  audioBytes=16044
  syntheticAuthMarkerReceived=yes
  apiKey=REDACTED_SYNTHETIC_LOCAL_MARKER
  ```

- **Observed result after fix:** The media provider entry completed successfully with no configured model provider, no env API key, and no auth profile. `transcribeAudio` ran and received the redacted synthetic local auth marker, confirming the no-auth local provider path executes instead of failing at model-provider auth resolution.
- **What was not tested:** Full packaged plugin loading through a user-installed plugin was not exercised in this smoke; this proof directly runs the media provider entry with a plugin-shaped provider registered in the provider registry.

## Validation

Latest post-rebase validation on PR head `108628d8d86d`:

- `git diff --check`
- `node scripts/check-no-raw-channel-fetch.mjs`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.media-understanding.config.ts src/media-understanding/runner.local-no-auth.test.ts`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `node node_modules/@typescript/native-preview/bin/tsgo.js -p test/tsconfig/tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo --declaration false --singleThreaded --checkers 1`
- `env OPENCLAW_PROOF_COMMIT=108628d8d86d node --import tsx /private/tmp/openclaw-pr75005-proof.mts`

Earlier validation on the same patch series before the latest rebase:

- `node scripts/test-projects.mjs src/agents/model-auth.test.ts src/agents/model-auth.profiles.test.ts src/agents/model-auth.workspace-plugin.test.ts`
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.media-understanding.config.ts`

## Notes

The hook is intended for local, self-hosted, or otherwise explicit no-auth media providers. Ordinary remote providers without credentials continue to fail closed unless their provider implementation explicitly opts into synthetic auth.
