### PR TITLE
feat: add Gradium realtime speech-to-text provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Gradium: add a bundled realtime speech-to-text provider for Voice Call streaming STT, using the Gradium ASR WebSocket with PCM, WAV, Opus, μ-law, and A-law input formats. Thanks @timpratim.
 - Agents/commitments: add opt-in inferred follow-up commitments with hidden batched extraction, per-agent/per-channel scoping, heartbeat delivery, CLI management, a simple `commitments.enabled`/`commitments.maxPerDay` config, and heartbeat-interval due-time clamping so magical check-ins do not echo immediately. (#74189) Thanks @vignesh07.
 - Messages/queue: make `steer` drain all pending Pi steering messages at the next model boundary, keep legacy one-at-a-time steering as `queue`, and add a dedicated steering queue docs page. Thanks @vincentkoc.
 - Messages/queue: default active-run queueing to `steer` with a 500ms followup fallback debounce, and document the queue modes, precedence, and drop policies on the command queue page. Thanks @vincentkoc.

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -295,7 +295,7 @@ options.
 Current runtime behavior:
 
 - `streaming.provider` is optional. If unset, Voice Call uses the first registered realtime transcription provider.
-- Bundled realtime transcription providers: Deepgram (`deepgram`), ElevenLabs (`elevenlabs`), Mistral (`mistral`), OpenAI (`openai`), and xAI (`xai`), registered by their provider plugins.
+- Bundled realtime transcription providers: Deepgram (`deepgram`), ElevenLabs (`elevenlabs`), Gradium (`gradium`), Mistral (`mistral`), OpenAI (`openai`), and xAI (`xai`), registered by their provider plugins.
 - Provider-owned raw config lives under `streaming.providers.<providerId>`.
 - If `streaming.provider` points at an unregistered provider, or none is registered, Voice Call logs a warning and skips media streaming instead of failing the whole plugin.
 

--- a/docs/providers/gradium.md
+++ b/docs/providers/gradium.md
@@ -1,12 +1,13 @@
 ---
-summary: "Use Gradium text-to-speech in OpenClaw"
+summary: "Use Gradium text-to-speech and realtime speech-to-text in OpenClaw"
 read_when:
   - You want Gradium for text-to-speech
+  - You want Gradium for realtime speech-to-text on Voice Call
   - You need Gradium API key or voice configuration
 title: "Gradium"
 ---
 
-Gradium is a bundled text-to-speech provider for OpenClaw. It can generate normal audio replies, voice-note-compatible Opus output, and 8 kHz u-law audio for telephony surfaces.
+Gradium is a bundled speech provider for OpenClaw. It generates normal audio replies, voice-note-compatible Opus output, and 8 kHz u-law audio for telephony surfaces, and it streams Voice Call audio through its realtime ASR WebSocket for live transcription.
 
 ## Setup
 
@@ -57,6 +58,36 @@ Default voice: Emma.
 - Audio-file replies use WAV.
 - Voice-note replies use Opus and are marked voice-compatible.
 - Telephony synthesis uses `ulaw_8000` at 8 kHz.
+
+## Realtime speech-to-text
+
+Gradium's realtime ASR WebSocket (`wss://api.gradium.ai/api/speech/asr`) is registered as a Voice Call streaming STT provider. Configure it under the voice-call plugin:
+
+```json5
+{
+  plugins: {
+    entries: {
+      "voice-call": {
+        config: {
+          streaming: {
+            provider: "gradium",
+            providers: {
+              gradium: {
+                // apiKey: "${GRADIUM_API_KEY}",
+                modelName: "default",
+                inputFormat: "ulaw_8000",
+                language: "en",
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Supported `inputFormat` values: `pcm` (24 kHz 16-bit mono), `wav`, `opus`, `ulaw_8000`, `alaw_8000`. The default is `ulaw_8000`, which matches the audio format Voice Call telephony bridges send.
 
 ## Related
 

--- a/docs/tools/media-overview.md
+++ b/docs/tools/media-overview.md
@@ -55,7 +55,7 @@ provider is configured.
 | ElevenLabs  |       |       |       |  ✓  |  ✓  |                |                     |
 | fal         |   ✓   |   ✓   |       |     |     |                |                     |
 | Google      |   ✓   |   ✓   |   ✓   |  ✓  |     |       ✓        |          ✓          |
-| Gradium     |       |       |       |  ✓  |     |                |                     |
+| Gradium     |       |       |       |  ✓  |  ✓  |                |                     |
 | Local CLI   |       |       |       |  ✓  |     |                |                     |
 | Microsoft   |       |       |       |  ✓  |     |                |                     |
 | MiniMax     |   ✓   |   ✓   |   ✓   |  ✓  |     |                |                     |
@@ -103,9 +103,9 @@ parsing mark the transcribed attachment on the inbound context, so the shared
 media-understanding pass reuses that transcript instead of making a second
 STT call for the same audio.
 
-Deepgram, ElevenLabs, Mistral, OpenAI, and xAI also register Voice Call
-streaming STT providers, so live phone audio can be forwarded to the selected
-vendor without waiting for a completed recording.
+Deepgram, ElevenLabs, Gradium, Mistral, OpenAI, and xAI also register Voice
+Call streaming STT providers, so live phone audio can be forwarded to the
+selected vendor without waiting for a completed recording.
 
 ## Provider mappings (how vendors split across surfaces)
 

--- a/extensions/gradium/gradium.live.test.ts
+++ b/extensions/gradium/gradium.live.test.ts
@@ -5,9 +5,13 @@ import {
   registerProviderPlugin,
   requireRegisteredProvider,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { runRealtimeSttLiveTest } from "openclaw/plugin-sdk/provider-test-contracts";
 import { isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
 import plugin from "./index.js";
+import { buildGradiumRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
+import { DEFAULT_GRADIUM_BASE_URL, DEFAULT_GRADIUM_VOICE_ID } from "./shared.js";
+import { gradiumTTS } from "./tts.js";
 
 const LIVE = isLiveTestEnabled();
 const GRADIUM_API_KEY = process.env.GRADIUM_API_KEY?.trim() ?? "";
@@ -39,4 +43,27 @@ describe.skipIf(!LIVE || !GRADIUM_API_KEY)("gradium live", () => {
     writeFileSync(outPath, result.audioBuffer);
     console.log(`Audio written to ${outPath}`);
   }, 60_000);
+
+  it("streams realtime STT through the registered transcription provider", async () => {
+    const provider = buildGradiumRealtimeTranscriptionProvider();
+    const phrase = "Testing OpenClaw Gradium realtime transcription integration OK.";
+    const speech = await gradiumTTS({
+      text: phrase,
+      apiKey: GRADIUM_API_KEY,
+      baseUrl: DEFAULT_GRADIUM_BASE_URL,
+      voiceId: DEFAULT_GRADIUM_VOICE_ID,
+      outputFormat: "ulaw_8000",
+      timeoutMs: 30_000,
+    });
+
+    await runRealtimeSttLiveTest({
+      provider,
+      providerConfig: {
+        apiKey: GRADIUM_API_KEY,
+        inputFormat: "ulaw_8000",
+        language: "en",
+      },
+      audio: Buffer.concat([Buffer.alloc(4000, 0xff), speech, Buffer.alloc(8000, 0xff)]),
+    });
+  }, 90_000);
 });

--- a/extensions/gradium/index.ts
+++ b/extensions/gradium/index.ts
@@ -1,4 +1,5 @@
 import { definePluginEntry } from "openclaw/plugin-sdk/plugin-entry";
+import { buildGradiumRealtimeTranscriptionProvider } from "./realtime-transcription-provider.js";
 import { buildGradiumSpeechProvider } from "./speech-provider.js";
 
 export default definePluginEntry({
@@ -7,5 +8,6 @@ export default definePluginEntry({
   description: "Bundled Gradium speech provider",
   register(api) {
     api.registerSpeechProvider(buildGradiumSpeechProvider());
+    api.registerRealtimeTranscriptionProvider(buildGradiumRealtimeTranscriptionProvider());
   },
 });

--- a/extensions/gradium/openclaw.plugin.json
+++ b/extensions/gradium/openclaw.plugin.json
@@ -7,7 +7,8 @@
     "gradium": ["GRADIUM_API_KEY"]
   },
   "contracts": {
-    "speechProviders": ["gradium"]
+    "speechProviders": ["gradium"],
+    "realtimeTranscriptionProviders": ["gradium"]
   },
   "configSchema": {
     "type": "object",

--- a/extensions/gradium/plugin-registration.contract.test.ts
+++ b/extensions/gradium/plugin-registration.contract.test.ts
@@ -3,4 +3,5 @@ import { describePluginRegistrationContract } from "openclaw/plugin-sdk/plugin-t
 describePluginRegistrationContract({
   pluginId: "gradium",
   speechProviderIds: ["gradium"],
+  realtimeTranscriptionProviderIds: ["gradium"],
 });

--- a/extensions/gradium/realtime-transcription-provider.test.ts
+++ b/extensions/gradium/realtime-transcription-provider.test.ts
@@ -1,0 +1,82 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-types";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __testing,
+  buildGradiumRealtimeTranscriptionProvider,
+} from "./realtime-transcription-provider.js";
+
+describe("buildGradiumRealtimeTranscriptionProvider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("normalizes nested provider config", () => {
+    const provider = buildGradiumRealtimeTranscriptionProvider();
+    const resolved = provider.resolveConfig?.({
+      cfg: {} as OpenClawConfig,
+      rawConfig: {
+        providers: {
+          gradium: {
+            apiKey: "gsk_test",
+            model_name: "default",
+            input_format: "pcm",
+            language: "en",
+          },
+        },
+      },
+    });
+
+    expect(resolved).toMatchObject({
+      apiKey: "gsk_test",
+      modelName: "default",
+      inputFormat: "pcm",
+      language: "en",
+    });
+  });
+
+  it("rejects unknown input formats", () => {
+    const provider = buildGradiumRealtimeTranscriptionProvider();
+    expect(() =>
+      provider.resolveConfig?.({
+        cfg: {} as OpenClawConfig,
+        rawConfig: { providers: { gradium: { input_format: "mp3" } } },
+      }),
+    ).toThrow("Invalid Gradium realtime transcription input format: mp3");
+  });
+
+  it("builds a Gradium ASR websocket URL", () => {
+    const url = __testing.toGradiumRealtimeWsUrl({
+      apiKey: "gsk_test",
+      baseUrl: "https://api.gradium.ai",
+      providerConfig: {},
+      modelName: "default",
+      inputFormat: "ulaw_8000",
+    });
+
+    expect(url).toBe("wss://api.gradium.ai/api/speech/asr");
+  });
+
+  it("includes language in the setup payload when configured", () => {
+    const setup = __testing.buildSetupPayload({
+      apiKey: "gsk_test",
+      baseUrl: "https://api.gradium.ai",
+      providerConfig: {},
+      modelName: "default",
+      inputFormat: "pcm",
+      language: "en",
+    });
+
+    expect(setup).toEqual({
+      type: "setup",
+      model_name: "default",
+      input_format: "pcm",
+      json_config: { language: "en" },
+    });
+  });
+
+  it("requires an API key when creating sessions", () => {
+    vi.stubEnv("GRADIUM_API_KEY", "");
+    const provider = buildGradiumRealtimeTranscriptionProvider();
+    expect(() => provider.createSession({ providerConfig: {} })).toThrow("Gradium API key missing");
+  });
+});

--- a/extensions/gradium/realtime-transcription-provider.ts
+++ b/extensions/gradium/realtime-transcription-provider.ts
@@ -1,0 +1,221 @@
+import {
+  createRealtimeTranscriptionWebSocketSession,
+  type RealtimeTranscriptionProviderConfig,
+  type RealtimeTranscriptionProviderPlugin,
+  type RealtimeTranscriptionSession,
+  type RealtimeTranscriptionSessionCreateRequest,
+  type RealtimeTranscriptionWebSocketTransport,
+} from "openclaw/plugin-sdk/realtime-transcription";
+import { normalizeResolvedSecretInputString } from "openclaw/plugin-sdk/secret-input";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
+import { DEFAULT_GRADIUM_BASE_URL, normalizeGradiumBaseUrl } from "./shared.js";
+
+type GradiumRealtimeInputFormat = "pcm" | "wav" | "opus" | "ulaw_8000" | "alaw_8000";
+
+type GradiumRealtimeProviderConfig = {
+  apiKey?: string;
+  baseUrl?: string;
+  modelName?: string;
+  inputFormat?: GradiumRealtimeInputFormat;
+  language?: string;
+};
+
+type GradiumRealtimeSessionConfig = RealtimeTranscriptionSessionCreateRequest & {
+  apiKey: string;
+  baseUrl: string;
+  modelName: string;
+  inputFormat: GradiumRealtimeInputFormat;
+  language?: string;
+};
+
+type GradiumRealtimeEvent = {
+  type?: string;
+  text?: string;
+  message?: string;
+  error?: string;
+};
+
+const GRADIUM_REALTIME_DEFAULT_MODEL = "default";
+const GRADIUM_REALTIME_DEFAULT_INPUT_FORMAT: GradiumRealtimeInputFormat = "ulaw_8000";
+const GRADIUM_REALTIME_CONNECT_TIMEOUT_MS = 10_000;
+const GRADIUM_REALTIME_CLOSE_TIMEOUT_MS = 5_000;
+const GRADIUM_REALTIME_MAX_RECONNECT_ATTEMPTS = 5;
+const GRADIUM_REALTIME_RECONNECT_DELAY_MS = 1000;
+const GRADIUM_REALTIME_MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+
+const VALID_INPUT_FORMATS: ReadonlySet<GradiumRealtimeInputFormat> = new Set([
+  "pcm",
+  "wav",
+  "opus",
+  "ulaw_8000",
+  "alaw_8000",
+]);
+
+function readRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function readNestedGradiumConfig(rawConfig: RealtimeTranscriptionProviderConfig) {
+  const raw = readRecord(rawConfig);
+  const providers = readRecord(raw?.providers);
+  return readRecord(providers?.gradium ?? raw?.gradium ?? raw) ?? {};
+}
+
+function normalizeInputFormat(value: unknown): GradiumRealtimeInputFormat | undefined {
+  const normalized = normalizeOptionalString(value)?.toLowerCase();
+  if (!normalized) {
+    return undefined;
+  }
+  if (VALID_INPUT_FORMATS.has(normalized as GradiumRealtimeInputFormat)) {
+    return normalized as GradiumRealtimeInputFormat;
+  }
+  throw new Error(`Invalid Gradium realtime transcription input format: ${normalized}`);
+}
+
+function normalizeProviderConfig(
+  config: RealtimeTranscriptionProviderConfig,
+): GradiumRealtimeProviderConfig {
+  const raw = readNestedGradiumConfig(config);
+  return {
+    apiKey: normalizeResolvedSecretInputString({
+      value: raw.apiKey,
+      path: "plugins.entries.voice-call.config.streaming.providers.gradium.apiKey",
+    }),
+    baseUrl: normalizeOptionalString(raw.baseUrl),
+    modelName: normalizeOptionalString(raw.modelName ?? raw.model_name ?? raw.model),
+    inputFormat: normalizeInputFormat(raw.inputFormat ?? raw.input_format ?? raw.encoding),
+    language: normalizeOptionalString(raw.language),
+  };
+}
+
+function normalizeGradiumRealtimeBaseUrl(value?: string): string {
+  return normalizeGradiumBaseUrl(value ?? process.env.GRADIUM_BASE_URL);
+}
+
+function toGradiumRealtimeWsUrl(config: GradiumRealtimeSessionConfig): string {
+  const url = new URL(`${normalizeGradiumRealtimeBaseUrl(config.baseUrl)}/api/speech/asr`);
+  url.protocol = url.protocol === "http:" ? "ws:" : "wss:";
+  return url.toString();
+}
+
+function readErrorDetail(event: GradiumRealtimeEvent): string {
+  return (
+    normalizeOptionalString(event.message) ??
+    normalizeOptionalString(event.error) ??
+    "Gradium realtime transcription error"
+  );
+}
+
+function buildSetupPayload(config: GradiumRealtimeSessionConfig) {
+  const payload: Record<string, unknown> = {
+    type: "setup",
+    model_name: config.modelName,
+    input_format: config.inputFormat,
+  };
+  if (config.language) {
+    payload.json_config = { language: config.language };
+  }
+  return payload;
+}
+
+function createGradiumRealtimeTranscriptionSession(
+  config: GradiumRealtimeSessionConfig,
+): RealtimeTranscriptionSession {
+  let speechStarted = false;
+
+  const sendAudioChunk = (
+    audio: Buffer,
+    transport: RealtimeTranscriptionWebSocketTransport,
+  ): void => {
+    transport.sendJson({ type: "audio", audio: audio.toString("base64") });
+  };
+
+  const handleEvent = (
+    event: GradiumRealtimeEvent,
+    transport: RealtimeTranscriptionWebSocketTransport,
+  ) => {
+    switch (event.type) {
+      case "ready":
+        transport.markReady();
+        return;
+      case "text": {
+        const text = normalizeOptionalString(event.text);
+        if (!text) {
+          return;
+        }
+        if (!speechStarted) {
+          speechStarted = true;
+          config.onSpeechStart?.();
+        }
+        config.onTranscript?.(text);
+        return;
+      }
+      case "error":
+        if (!transport.isReady()) {
+          transport.failConnect(new Error(readErrorDetail(event)));
+          return;
+        }
+        config.onError?.(new Error(readErrorDetail(event)));
+        return;
+      default:
+        return;
+    }
+  };
+
+  return createRealtimeTranscriptionWebSocketSession<GradiumRealtimeEvent>({
+    providerId: "gradium",
+    callbacks: config,
+    url: () => toGradiumRealtimeWsUrl(config),
+    headers: { "x-api-key": config.apiKey },
+    connectTimeoutMs: GRADIUM_REALTIME_CONNECT_TIMEOUT_MS,
+    closeTimeoutMs: GRADIUM_REALTIME_CLOSE_TIMEOUT_MS,
+    maxReconnectAttempts: GRADIUM_REALTIME_MAX_RECONNECT_ATTEMPTS,
+    reconnectDelayMs: GRADIUM_REALTIME_RECONNECT_DELAY_MS,
+    maxQueuedBytes: GRADIUM_REALTIME_MAX_QUEUED_BYTES,
+    connectTimeoutMessage: "Gradium realtime transcription connection timeout",
+    reconnectLimitMessage: "Gradium realtime transcription reconnect limit reached",
+    sendAudio: sendAudioChunk,
+    onOpen: (transport) => {
+      transport.sendJson(buildSetupPayload(config));
+    },
+    onClose: (transport) => {
+      transport.sendJson({ type: "end_of_stream" });
+    },
+    onMessage: handleEvent,
+  });
+}
+
+export function buildGradiumRealtimeTranscriptionProvider(): RealtimeTranscriptionProviderPlugin {
+  return {
+    id: "gradium",
+    label: "Gradium Realtime Transcription",
+    aliases: ["gradium-realtime", "gradium-asr"],
+    autoSelectOrder: 50,
+    resolveConfig: ({ rawConfig }) => normalizeProviderConfig(rawConfig),
+    isConfigured: ({ providerConfig }) =>
+      Boolean(normalizeProviderConfig(providerConfig).apiKey || process.env.GRADIUM_API_KEY),
+    createSession: (req) => {
+      const config = normalizeProviderConfig(req.providerConfig);
+      const apiKey = config.apiKey || process.env.GRADIUM_API_KEY;
+      if (!apiKey) {
+        throw new Error("Gradium API key missing");
+      }
+      return createGradiumRealtimeTranscriptionSession({
+        ...req,
+        apiKey,
+        baseUrl: normalizeGradiumRealtimeBaseUrl(config.baseUrl) || DEFAULT_GRADIUM_BASE_URL,
+        modelName: config.modelName ?? GRADIUM_REALTIME_DEFAULT_MODEL,
+        inputFormat: config.inputFormat ?? GRADIUM_REALTIME_DEFAULT_INPUT_FORMAT,
+        language: config.language,
+      });
+    },
+  };
+}
+
+export const __testing = {
+  normalizeProviderConfig,
+  toGradiumRealtimeWsUrl,
+  buildSetupPayload,
+};


### PR DESCRIPTION
## Summary

  - **Problem:** PR #64958 added Gradium TTS but no matching STT, so Gradium-only voice deployments still had to bring in a second vendor for inbound transcription on Voice Call.
  - **Why it matters:** Lets operators run end-to-end speech (in and out) on a single Gradium account, simplifying credential and billing setup.
  - **What changed:** New `extensions/gradium/realtime-transcription-provider.ts` registers a `RealtimeTranscriptionProviderPlugin` that opens a WebSocket to
  `wss://api.gradium.ai/api/speech/asr`, performs the setup handshake, base64-encodes inbound audio frames, and surfaces `text` events as transcripts. Plugin manifest now declares
  `realtimeTranscriptionProviders: ["gradium"]`. Docs updated for `voice-call`, `media-overview`, and the Gradium provider page.
  - **What did NOT change (scope boundary):** TTS provider (shipped in #64958), other transcription providers, voice-call core wiring, batch/HTTP STT path (Gradium only exposes streaming),
   Gradium TTS PR's `shared.ts` defaults (we reuse them).

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor required for the fix
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #
  - Related #64958
  - [ ] This PR fixes a bug or regression

  ## Root Cause (if applicable)

  N/A — feature addition, not a fix.

  ## Regression Test Plan (if applicable)

  N/A — feature addition. New unit + live tests cover the new code path.

  ## User-visible / Behavior Changes

  - New `gradium` value for `plugins.entries.voice-call.config.streaming.provider`.
  - New `plugins.entries.voice-call.config.streaming.providers.gradium` config block (`apiKey`, `baseUrl`, `modelName`, `inputFormat`, `language`).
  - API key resolves from the existing `GRADIUM_API_KEY` env var (already declared by the TTS PR's manifest).
  - Default `inputFormat` is `ulaw_8000` so it works out of the box with Twilio media streams.

  ## Diagram (if applicable)

  ```
  Voice Call (Twilio media stream)
         |  ulaw_8000 audio frames
         v
  RealtimeTranscriptionSession (gradium)
         |  WebSocket: wss://api.gradium.ai/api/speech/asr
         |  -> {"type":"setup","model_name":"default","input_format":"ulaw_8000"}
         |  <- {"type":"ready"}                      (markReady)
         |  -> {"type":"audio","audio":"<base64>"}   (per frame)
         |  <- {"type":"text","text":"..."}          (onTranscript)
         |  -> {"type":"end_of_stream"}              (on close)
         v
  Voice Call agent loop
  ```

  ## Security Impact (required)

  - New permissions/capabilities? **No** (reuses `GRADIUM_API_KEY` already declared by the TTS PR).
  - Secrets/tokens handling changed? **No** (resolved via the standard `normalizeResolvedSecretInputString` path).
  - New/changed network calls? **Yes** — outbound WebSocket to `wss://api.gradium.ai/api/speech/asr` when configured.
  - Command/tool execution surface changed? **No.**
  - Data access scope changed? **No.**

  Risk + mitigation: when configured, live call audio is forwarded to Gradium. Mitigation: provider only activates when an operator opts in via `streaming.provider: "gradium"`;
  default-disabled, no auto-selection over existing providers.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Node 22, local pnpm dev tree
  - Model/provider: Gradium (TTS to generate test audio + STT to transcribe)
  - Integration/channel (if any): Voice Call streaming-STT contract, no Twilio in this verification
  - Relevant config (redacted): `GRADIUM_API_KEY`

  ### Steps

  1. `export GRADIUM_API_KEY=...`
  2. `pnpm install && pnpm build`
  3. `pnpm test extensions/gradium` → 17/17 pass
  4. `OPENCLAW_LIVE_TEST=1 pnpm test:live -- extensions/gradium/gradium.live.test.ts` → 2/2 pass

  ### Expected

  - Live test synthesizes a marker phrase via Gradium TTS, streams μ-law frames into the new STT provider, and the returned transcript matches the marker.

  ### Actual

  - Both live tests pass; STT round-trip completes in ~4s; transcript matches.

  ## Evidence

  - [x] Failing test/log before + passing after — new tests pass; no behavior was previously asserted for this provider since it didn't exist.
  - [x] Trace/log snippets — live test output:

  ```
  [live] loaded 4 env vars from ~/.profile
  Audio written to /var/folders/.../gradium-live-test.wav
   ✓ extensions/gradium/gradium.live.test.ts (2 tests) 5507ms
       ✓ synthesizes speech through the registered provider  1448ms
       ✓ streams realtime STT through the registered transcription provider  4058ms

   Test Files  1 passed (1)
        Tests  2 passed (2)
  ```

  ## Human Verification (required)

  What I personally verified (not just CI), and how:

  - **Verified scenarios:**
    - End-to-end Gradium round-trip on live API: TTS → STT, transcript matches the phrase.
    - `pnpm test extensions/gradium` (17/17), `pnpm test src/plugins/contracts/registry.contract.test.ts` (19/19), `pnpm check:changed` (clean), `pnpm test:changed` (clean).
    - Manifest contract picks up `realtimeTranscriptionProviders: ["gradium"]` automatically (capability snapshot is dynamic, no manual regen needed).
  - **Edge cases checked:**
    - Missing `GRADIUM_API_KEY` raises `"Gradium API key missing"` from `createSession`.
    - Invalid `inputFormat` rejected at config-resolution time.
    - WebSocket setup payload only includes `json_config.language` when configured.

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need a reviewer or maintainer judgment.

  ## Compatibility / Migration

  - Backward compatible? **Yes** — purely additive provider registration; no existing config keys touched.
  - Config/env changes? **No** new env vars (`GRADIUM_API_KEY` already declared by #64958).
  - Migration needed? **No.**

  ## Risks and Mitigations

  - **Risk:** Gradium ASR endpoint outage causes streaming STT failures for opted-in operators.
  - **Mitigation:** Voice-call streaming providers fail open (log a warning and skip media streaming rather than failing the call); operators can fall back to a different
  `streaming.provider` without code changes.