### PR TITLE
fix(infer): load model catalog metadata-only for list/inspect/providers

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -200,6 +200,174 @@ describe("loadModelCatalog", () => {
     expect(discoverAuthStorage).toHaveBeenCalledWith("/tmp/openclaw", { readOnly: true });
   });
 
+  it("skips provider plugin augmentation when skipProviderPluginAugmentation is true", async () => {
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+    augmentCatalogMock.mockClear();
+    augmentCatalogMock.mockResolvedValueOnce([
+      { id: "ollama-live-only", name: "Ollama Live Only", provider: "ollama" },
+    ]);
+
+    const result = await loadModelCatalog({
+      config: {} as OpenClawConfig,
+      readOnly: true,
+      skipProviderPluginAugmentation: true,
+    });
+
+    // The pi SDK static row is included but the provider-plugin supplemental
+    // entry is NOT, because plugin runtime catalog hooks are bypassed.
+    expect(result).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
+    expect(augmentCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("reuses the read-only catalog cache for repeated loadModelCatalog({ readOnly: true }) calls", async () => {
+    let registryCalls = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryCalls += 1;
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+    augmentCatalogMock.mockReset().mockResolvedValue([]);
+
+    const first = await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+    const second = await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+
+    expect(first).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
+    expect(second).toBe(first);
+    expect(registryCalls).toBe(1);
+  });
+
+  it("does not cache read-only metadata-only loads so later non-skip callers stay correct", async () => {
+    let registryCalls = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryCalls += 1;
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+    augmentCatalogMock
+      .mockReset()
+      .mockResolvedValue([
+        { id: "ollama-live-only", name: "Ollama Live Only", provider: "ollama" },
+      ]);
+
+    // Metadata-only call (skip=true): registry read once, no augmentation row.
+    const metadataOnly = await loadModelCatalog({
+      config: {} as OpenClawConfig,
+      readOnly: true,
+      skipProviderPluginAugmentation: true,
+    });
+    expect(metadataOnly).toEqual([{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }]);
+    expect(registryCalls).toBe(1);
+
+    // Subsequent non-skip readOnly call MUST rebuild (the metadata-only result
+    // is a strict subset and must not be served as the with-augmentation cache)
+    // and MUST include the augmented row.
+    const withAugmentation = await loadModelCatalog({
+      config: {} as OpenClawConfig,
+      readOnly: true,
+    });
+    expect(registryCalls).toBe(2);
+    expect(withAugmentation).toContainEqual(
+      expect.objectContaining({ id: "ollama-live-only", provider: "ollama" }),
+    );
+  });
+
+  it("invalidates the read-only catalog cache when useCache:false is passed", async () => {
+    let registryCalls = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryCalls += 1;
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+    augmentCatalogMock.mockReset().mockResolvedValue([]);
+
+    // Prime the read-only cache slot.
+    await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+    expect(registryCalls).toBe(1);
+
+    // Repeat without invalidation — cache hit, registry not re-queried.
+    await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+    expect(registryCalls).toBe(1);
+
+    // useCache:false MUST invalidate the read-only slot and force a rebuild,
+    // even though readOnly is also true (freshness is symmetric).
+    await loadModelCatalog({
+      config: {} as OpenClawConfig,
+      readOnly: true,
+      useCache: false,
+    });
+    expect(registryCalls).toBe(2);
+  });
+
+  it("invalidates the read-only catalog cache when useCache:false is passed without readOnly", async () => {
+    let registryCalls = 0;
+    __setModelCatalogImportForTest(
+      async () =>
+        ({
+          discoverAuthStorage: () => ({}),
+          AuthStorage: function AuthStorage() {},
+          ModelRegistry: class {
+            getAll() {
+              registryCalls += 1;
+              return [{ id: "gpt-4.1", name: "GPT-4.1", provider: "openai" }];
+            }
+          },
+        }) as unknown as PiSdkModule,
+    );
+    augmentCatalogMock.mockReset().mockResolvedValue([]);
+
+    // Prime the read-only cache slot.
+    await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+    expect(registryCalls).toBe(1);
+
+    // Write-path call with useCache:false and no readOnly mirrors the
+    // production caller in src/commands/auth-choice.model-check.ts. The
+    // freshness contract requires this to invalidate the read-only slot
+    // too, not just the read-write slot: otherwise a write-path refresh
+    // would leave a stale read-only cache visible to subsequent
+    // inspection callers.
+    await loadModelCatalog({ config: {} as OpenClawConfig, useCache: false });
+
+    // The next readOnly call MUST rebuild because the read-only slot was
+    // cleared by the cross-slot invalidation above.
+    await loadModelCatalog({ config: {} as OpenClawConfig, readOnly: true });
+    expect(registryCalls).toBe(3);
+  });
+
   it("does not synthesize stale openai-codex/gpt-5.3-codex-spark entries from gpt-5.4", async () => {
     mockPiDiscoveryModels([
       {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -45,6 +45,16 @@ type PiRegistryClassLike = {
 };
 
 let modelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
+// Separate slot for read-only catalog reads with full provider plugin
+// augmentation. Long-running hosts that invoke the read-only path repeatedly
+// should not rebuild from scratch each time. Skip-augmentation callers
+// deliberately stay uncached: their result is a strict subset of rows and must
+// not be served the with-augmentation cache, and the path is intended for
+// one-shot CLI inspection — a long-lived host that opts into skip-augmentation
+// would silently rebuild on every call (the rebuild still pays for pi-sdk
+// import, auth-storage discovery, registry instantiation, and configured-row
+// assembly; only the provider-runtime fan-out is bypassed).
+let readOnlyModelCatalogPromise: Promise<ModelCatalogEntry[]> | null = null;
 let hasLoggedModelCatalogError = false;
 const defaultImportPiSdk = () => import("./pi-model-discovery-runtime.js");
 let importPiSdk = defaultImportPiSdk;
@@ -61,6 +71,7 @@ function loadModelSuppression() {
 
 export function resetModelCatalogCache() {
   modelCatalogPromise = null;
+  readOnlyModelCatalogPromise = null;
   hasLoggedModelCatalogError = false;
 }
 
@@ -109,13 +120,28 @@ export async function loadModelCatalog(params?: {
   config?: OpenClawConfig;
   useCache?: boolean;
   readOnly?: boolean;
+  // Skip the `augmentModelCatalogWithProviderPlugins` step, which is the last
+  // path inside `loadModelCatalog` that loads provider plugin runtime to invoke
+  // each provider's `augmentModelCatalog` hook. Read-only inspection callers
+  // (e.g. `infer model list`) opt in to keep the load fully metadata-only.
+  // Pi SDK static, manifest, and configured catalog rows are still returned —
+  // only live plugin-derived supplements are suppressed.
+  skipProviderPluginAugmentation?: boolean;
 }): Promise<ModelCatalogEntry[]> {
   const readOnly = params?.readOnly === true;
-  if (!readOnly && params?.useCache === false) {
+  const skipProviderPluginAugmentation = params?.skipProviderPluginAugmentation === true;
+  if (params?.useCache === false) {
+    // useCache:false invalidates both slots regardless of readOnly — the flag
+    // means "don't reuse any cached promise for this call", and freshness is
+    // symmetric across the read-write and read-only halves of the cache.
     modelCatalogPromise = null;
+    readOnlyModelCatalogPromise = null;
   }
   if (!readOnly && modelCatalogPromise) {
     return modelCatalogPromise;
+  }
+  if (readOnly && !skipProviderPluginAugmentation && readOnlyModelCatalogPromise) {
+    return readOnlyModelCatalogPromise;
   }
 
   const loadCatalog = async () => {
@@ -191,20 +217,24 @@ export async function loadModelCatalog(params?: {
         const compat = entry?.compat && typeof entry.compat === "object" ? entry.compat : undefined;
         models.push({ id, name, provider, contextWindow, reasoning, input, compat });
       }
-      const supplemental = await augmentModelCatalogWithProviderPlugins({
-        config: cfg,
-        env: process.env,
-        context: {
+      if (!skipProviderPluginAugmentation) {
+        const supplemental = await augmentModelCatalogWithProviderPlugins({
           config: cfg,
-          agentDir,
           env: process.env,
-          entries: [...models],
-        },
-      });
-      if (supplemental.length > 0) {
-        appendCatalogEntriesIfAbsent(models, supplemental);
+          context: {
+            config: cfg,
+            agentDir,
+            env: process.env,
+            entries: [...models],
+          },
+        });
+        if (supplemental.length > 0) {
+          appendCatalogEntriesIfAbsent(models, supplemental);
+        }
+        logStage("plugin-models-merged", `entries=${models.length}`);
+      } else {
+        logStage("plugin-models-skipped", `entries=${models.length}`);
       }
-      logStage("plugin-models-merged", `entries=${models.length}`);
 
       const configuredModels = buildConfiguredModelCatalog({ cfg });
       if (configuredModels.length > 0) {
@@ -216,6 +246,8 @@ export async function loadModelCatalog(params?: {
         // If we found nothing, don't cache this result so we can try again.
         if (!readOnly) {
           modelCatalogPromise = null;
+        } else if (!skipProviderPluginAugmentation) {
+          readOnlyModelCatalogPromise = null;
         }
       }
 
@@ -230,6 +262,8 @@ export async function loadModelCatalog(params?: {
       // Don't poison the cache on transient dependency/filesystem issues.
       if (!readOnly) {
         modelCatalogPromise = null;
+      } else if (!skipProviderPluginAugmentation) {
+        readOnlyModelCatalogPromise = null;
       }
       if (models.length > 0) {
         return sortModels(models);
@@ -239,7 +273,11 @@ export async function loadModelCatalog(params?: {
   };
 
   if (readOnly) {
-    return loadCatalog();
+    if (skipProviderPluginAugmentation) {
+      return loadCatalog();
+    }
+    readOnlyModelCatalogPromise = loadCatalog();
+    return readOnlyModelCatalogPromise;
   }
 
   modelCatalogPromise = loadCatalog();

--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -374,6 +374,60 @@ describe("capability cli", () => {
     expect(payload.some((entry) => entry.id === "image.describe")).toBe(true);
   });
 
+  it("loads the catalog metadata-only for infer model list", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { id: "gpt-5.4", provider: "openai", name: "GPT-5.4" },
+    ] as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "list", "--json"],
+    });
+
+    expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readOnly: true,
+        skipProviderPluginAugmentation: true,
+      }),
+    );
+  });
+
+  it("loads the catalog metadata-only for infer model inspect", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { id: "gpt-5.4", provider: "openai", name: "GPT-5.4" },
+    ] as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "inspect", "--model", "openai/gpt-5.4", "--json"],
+    });
+
+    expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readOnly: true,
+        skipProviderPluginAugmentation: true,
+      }),
+    );
+  });
+
+  it("loads the catalog metadata-only for infer model providers", async () => {
+    mocks.loadModelCatalog.mockResolvedValueOnce([
+      { id: "gpt-5.4", provider: "openai", name: "GPT-5.4" },
+    ] as never);
+
+    await runRegisteredCli({
+      register: registerCapabilityCli as (program: Command) => void,
+      argv: ["capability", "model", "providers", "--json"],
+    });
+
+    expect(mocks.loadModelCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readOnly: true,
+        skipProviderPluginAugmentation: true,
+      }),
+    );
+  });
+
   it("defaults model run to local transport", async () => {
     await runRegisteredCli({
       register: registerCapabilityCli as (program: Command) => void,

--- a/src/cli/capability-cli.ts
+++ b/src/cli/capability-cli.ts
@@ -764,7 +764,14 @@ async function runModelRun(params: {
 
 async function buildModelProviders() {
   const cfg = getRuntimeConfig();
-  const catalog = await loadModelCatalog({ config: cfg });
+  // Read-only inspection: load the catalog without refreshing models.json
+  // and without invoking provider plugin runtime catalog hooks, so listing
+  // never blocks on plugin-runtime fan-out.
+  const catalog = await loadModelCatalog({
+    config: cfg,
+    readOnly: true,
+    skipProviderPluginAugmentation: true,
+  });
   const selectedProvider = resolveSelectedProviderFromModelRef(
     resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model),
   );
@@ -1601,24 +1608,36 @@ export function registerCapabilityCli(program: Command) {
 
   model
     .command("list")
-    .description("List known models")
+    .description(
+      "List known models (catalog metadata; use `openclaw models list --all` for live provider-discovered models)",
+    )
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        const result = await loadModelCatalog({ config: getRuntimeConfig() });
+        const result = await loadModelCatalog({
+          config: getRuntimeConfig(),
+          readOnly: true,
+          skipProviderPluginAugmentation: true,
+        });
         emitJsonOrText(defaultRuntime, Boolean(opts.json), result, providerSummaryText);
       });
     });
 
   model
     .command("inspect")
-    .description("Inspect one model catalog entry")
+    .description(
+      "Inspect one model catalog entry (catalog metadata; use `openclaw models list --all` for live provider-discovered models)",
+    )
     .requiredOption("--model <provider/model>", "Model id")
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const target = normalizeStringifiedOptionalString(opts.model) ?? "";
-        const catalog = await loadModelCatalog({ config: getRuntimeConfig() });
+        const catalog = await loadModelCatalog({
+          config: getRuntimeConfig(),
+          readOnly: true,
+          skipProviderPluginAugmentation: true,
+        });
         const entry =
           catalog.find((candidate) => `${candidate.provider}/${candidate.id}` === target) ??
           catalog.find((candidate) => candidate.id === target);
@@ -1633,7 +1652,9 @@ export function registerCapabilityCli(program: Command) {
 
   model
     .command("providers")
-    .description("List model providers from the catalog")
+    .description(
+      "List model providers from the catalog (catalog metadata; use `openclaw models list --all` for live provider-discovered models)",
+    )
     .option("--json", "Output JSON", false)
     .action(async (opts) => {
       await runCommandWithRuntime(defaultRuntime, async () => {


### PR DESCRIPTION
### Summary

- **Problem**: `openclaw infer model list`, `openclaw infer model inspect`, and `openclaw infer model providers` hang indefinitely on 2026.4.27. The grandchild Node process spins at 100% CPU, opens zero TCP connections, and writes nothing to stdout/stderr until the timeout fires. Reported in #74986; `--version`, `--help`, and `gateway status` work.
- **Root cause (catalog-inspection slice)**: All three handlers funnel into `loadModelCatalog(...)` in `src/agents/model-catalog.ts`. Even on the read-only path, the function unconditionally calls `augmentModelCatalogWithProviderPlugins(...)` at the call site formerly on line 194, which threads through `src/plugins/provider-runtime.ts:resolveProviderPluginsForCatalogHooks` → `src/plugins/provider-hook-runtime.ts:resolveProviderPluginsForHooks` → `src/plugins/providers.runtime.ts:resolvePluginProviders` → `src/plugins/loader.ts:resolveRuntimePluginRegistry`. On a CLI cold start with no active registry, `resolveRuntimePluginRegistry` falls through to `loadOpenClawPlugins(...)`, which since `b7a1bfd2` ("fix(plugins): cache installed manifest registry") builds an installed-manifest cache key via `safeFileSignature` (`fs.statSync` per plugin) + `hashJson(...)` over the index — exactly the synchronous CPU work the reporter's `lsof`/`ps` evidence points at (100% CPU, zero TCP, zero stdout). The `agents list` 2026.4.29 fixes (`8fe449c8`, `d5eae0d9`) addressed the same regression class on a different code path by routing channel queries through `listReadOnlyChannelPluginsForConfig` — i.e. "no plugin runtime on read-only metadata paths."
- **Fix**: Add an opt-in `skipProviderPluginAugmentation?: boolean` option to `loadModelCatalog`. When `true`, the function returns the catalog assembled from PI SDK static rows + manifest static rows + `cfg.models.providers` configured rows, and skips the `augmentModelCatalogWithProviderPlugins(...)` call entirely. The three CLI inspection commands — `infer model list`, `infer model inspect`, and `infer model providers` (`buildModelProviders`) — pass `readOnly: true` *and* `skipProviderPluginAugmentation: true`. The flag is opt-in so existing `readOnly: true` callers (the only one outside this PR is `appendCatalogSupplementRows` in `src/commands/models/list.rows.ts:347`, used by `models list --all`) keep their dynamic plugin-derived rows.
- **What changed**:
  - `src/agents/model-catalog.ts`:
    - Add `skipProviderPluginAugmentation?: boolean` to `loadModelCatalog`'s param type with a doc comment that names the contract.
    - Gate the `augmentModelCatalogWithProviderPlugins(...)` call behind the new flag; emit `plugin-models-skipped` instead of `plugin-models-merged` when bypassed.
    - Add a parallel `readOnlyModelCatalogPromise` cache slot for `readOnly: true` callers that *do* want augmentation, so long-running hosts (`appendCatalogSupplementRows`) don't rebuild from scratch on every call. Skip-augmentation callers deliberately stay uncached: their result is a strict subset of rows and must not be served the with-augmentation cache. `useCache: false` and `resetModelCatalogCache()` symmetrically invalidate both slots; the empty-result branch and the `catch` handler null the matching slot to avoid cache poisoning.
  - `src/cli/capability-cli.ts`: `buildModelProviders` (used by `infer model providers`), `infer model list`, and `infer model inspect` pass `readOnly: true, skipProviderPluginAugmentation: true`. Command `--description` text now points users to `openclaw models list --all` for live provider-discovered models.
  - `src/cli/capability-cli.test.ts`: three tests assert the flag combination per command.
  - `src/agents/model-catalog.test.ts`: five tests lock the new contract — augmentation actually skipped when the flag is set, read-only cache reuse for non-skip callers, metadata-only result must not be served as the with-augmentation cache, `useCache: false` paired with `readOnly: true` invalidates the read-only slot, and `useCache: false` *without* `readOnly` also invalidates the read-only slot (cross-slot freshness from the write-path caller in `src/commands/auth-choice.model-check.ts`).
- **What did NOT change (scope boundary)**:
  - `CHANGELOG.md` — left untouched; release-note wording is the maintainer's call.
  - Default behavior of `loadModelCatalog`: when `skipProviderPluginAugmentation` is omitted/false, the augmentation step still runs exactly as before, so `models list --all` (`appendCatalogSupplementRows`) and every other current `readOnly: true` caller keeps the same catalog contents.
  - `ensureOpenClawModelsJson`, `buildShouldSuppressBuiltInModel`, the manifest planner, and the model-catalog cache for the non-read-only slot: untouched.
  - `infer model run` (local + gateway), `infer model auth`, image/audio/tts/embedding subcommands: out of scope; they are write/run paths and do not go through the read-only catalog read.
  - No new exports, no plugin-SDK / public-surface contract changes, no `any` introduced.

### Cross-reference — already fixed upstream (no overlap with this PR)

Issue #74986 reported four hang commands. Three are addressed on `main` or by this PR via separate code paths; the fourth (`infer model run` via the gateway path) is tracked separately under "Out of scope". This PR has no textual conflict with any of the upstream fixes:

| Command | Status | Files / functions touched |
|---|---|---|
| `agents list` | Fixed on `main` by `8fe449c8`, `d5eae0d9` (2026-04-26) | `src/commands/agents.commands.list.ts`, `src/commands/agents.providers.ts`, `src/commands/health-format.ts`, `src/commands/message-format.ts` |
| `infer model run --local` | Fixed on `main` by `12ee7f69` (2026-04-29) | `src/agents/pi-embedded-runner/model.ts`, `src/agents/simple-completion-runtime.ts`, `src/cli/capability-cli.ts:656` (one-line `cfg,` add inside `runModelRun`, far from this PR's `buildModelProviders` / `registerCapabilityCli` call sites) |
| `infer model list / inspect / providers` | **Fixed by this PR** | `src/agents/model-catalog.ts`, `src/cli/capability-cli.ts` (`buildModelProviders`, `model.command("list"\|"inspect"\|"providers")`) |
| `infer model run` (gateway path) | **Not yet fixed** | Tracked under "Out of scope" — needs a focused follow-up issue with profile evidence |

### Reproduction

On 2026.4.27 (or current `main` before this PR), with a `~/.openclaw/config.yaml` similar to the reporter's:

```yaml
agents:
  defaults:
    llm: { idleTimeoutSeconds: 600 }
    model: { primary: ollama/qwen3.5:397b-cloud }
models:
  providers:
    ollama:
      baseUrl: http://winhost:11434
      apiKey: ollama-local
      api: ollama
```

```bash
openclaw gateway status                                  # works
openclaw infer model list                                # before fix: hangs at 100% CPU until timeout
                                                          # after fix: returns the catalog and exits
openclaw infer model inspect --model openai/gpt-5.4      # same
openclaw infer model providers --json                    # same
```

The hung process can be confirmed with `ps -o pcpu,etimes,wchan,comm -p <pid>` (CPU pegged at ~100, no progress) and `lsof -p <pid>` (only the std{out,err} pipes, zero TCP — i.e. work is happening before any provider network probe).

### Risk / Mitigation

- **Risk 1 — different output for catalog list**: Skipping `augmentModelCatalogWithProviderPlugins` means `infer model list / inspect / providers` no longer surface dynamic plugin-discovered models (e.g. live Ollama models from `/api/tags`). The output is now: PI SDK static rows + manifest-declared rows + `cfg.models.providers` configured rows.
  - **Mitigation**: For inspection commands this is the right trade-off — the user wants "what does the catalog know about" to return promptly, not "what does the live Ollama daemon currently expose"; the latter is what `models scan` / `models list --all` are for, both of which still go through the dynamic path (their `loadModelCatalog({ readOnly: true })` call site does **not** pass the new flag). The hang the reporter sees is a strictly worse failure mode than slightly-less-fresh output. The new flag is opt-in, so no other call site changes. The updated command `--description` strings point users to `models list --all` for live discovery.
- **Risk 2 — test coverage**: Need to lock the new metadata-only contract so a future refactor doesn't silently regress.
  - **Mitigation**: Three CLI tests assert the flag combination per command; five model-catalog tests verify (a) augmentation is genuinely not called when the flag is set, (b) the with-augmentation read-only cache is reused on repeat calls, (c) a metadata-only result is not served to a later non-skip caller, (d) `useCache: false` paired with `readOnly: true` invalidates the read-only slot, and (e) `useCache: false` *without* `readOnly` (the write-path direction used by `src/commands/auth-choice.model-check.ts`) also invalidates the read-only slot — locking the symmetric cross-slot freshness contract so a future revert of the guard relaxation cannot silently leave a stale read-only cache visible to inspection callers.
- **Risk 3 — typing/security**: No `any` introduced; only an existing optional parameter is added (`skipProviderPluginAugmentation?: boolean`) and consulted via a strict `=== true` check. No change to data flow, secrets handling, plugin trust boundary, or external surface.

### Out of scope (tracked separately)

This PR intentionally does **not** address:

- **`loadOpenClawPlugins` synchronous hot-path cost** — the `safeFileSignature` (per-plugin `fs.statSync`) + `hashJson(...)` cache-key build introduced by `b7a1bfd2`. This is the underlying engine that any non-skip catalog refresh still hits, and it has separate user-visible symptoms beyond the catalog inspection commands. Tracked in #75512 (per-turn re-evaluation, BLOCKER), #75069 (synchronous mirror walk blocking gateway main thread), and #75513 (ARM64 redundant calls on every request).
- **`infer model run` hang via the gateway path** (`prepareSimpleCompletionModelForAgent` → `resolveModelAsync` → `prepareProviderRuntimeAuth`). The `--local` variant is already fixed on `main` by `12ee7f69`; the gateway variant warrants a focused issue with profile evidence.

### Change Type (select all)

- [x] Bug fix

### Scope (select all touched areas)

- [x] CLI
- [x] Agents/models
- [x] Tests

### Linked Issue/PR

Refs #74986. Of the four hang commands reported in that issue:

- `agents list` — already fixed on `main` by `8fe449c8` / `d5eae0d9` (2026-04-26).
- `infer model run --local` — already fixed on `main` by `12ee7f69` (2026-04-29).
- `infer model list` — fixed by this PR. The same fix is preventively extended to `infer model inspect` and `infer model providers`, which share the read-only catalog code path but were not individually exercised by the reporter.
- `infer model run` via the gateway path — **still open**, intentionally out of scope here (see "Out of scope" section); needs a focused follow-up issue with profile evidence before it can be closed.

This PR therefore does not by itself fully address #74986; the issue should remain open until the gateway-run path is tracked and a separate fix lands.