### PR TITLE
fix(feishu): preserve threads without root_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Lark: preserve reply-thread routing when `root_id` is missing by falling back to reply ancestors, so ancestor-only replies stay anchored to the same topic session. Thanks @stevenchouai.
 - Control UI: allow deployments to configure grouped chat message max-width with a validated `gateway.controlUi.chatMessageMaxWidth` setting instead of patching bundled CSS after upgrades. Fixes #67935. Thanks @xiew4589-lang.
 - Control UI/Cron: ignore malformed persisted cron rows without valid payloads before they enter UI state and guard stale cron render paths, preventing blank Control UI sections after a bad cron snapshot. Fixes #55047 and #54439; supersedes #54550 and #54552.
 - Control UI/sessions: bound the default Sessions tab query to recent activity and fewer rows, avoiding expensive full-history loads while keeping filters editable. Fixes #76050. (#76051) Thanks @Neomail2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Docs: https://docs.openclaw.ai
 
@@ -2779,6 +2779,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/Lark: preserve reply-thread routing when `root_id` is missing by falling back to reply ancestors, so ancestor-only replies stay anchored to the same topic session. Thanks @stevenchouai.
 - CLI/message: skip eager model context warmup and preserve channel-declared gateway execution for Discord and Telegram message actions, avoiding Codex app-server/model discovery during simple send/read commands. Thanks @fuller-stack-dev.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.
 - Plugins/ClawHub: use the ClawHub artifact resolver response as the install decision before downloading, keeping legacy ZIP fallback and future ClawPack npm-pack installs on the same explicit resolver path. Thanks @vincentkoc.

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -4,7 +4,7 @@ import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./bot.js";
-import { handleFeishuMessage } from "./bot.js";
+import { handleFeishuMessage, parseFeishuMessageEvent } from "./bot.js";
 import { setFeishuRuntime } from "./runtime.js";
 
 type ConfiguredBindingRoute = ReturnType<typeof ConversationRuntime.resolveConfiguredBindingRoute>;
@@ -2203,6 +2203,45 @@ describe("handleFeishuMessage command authorization", () => {
         parentPeer: { kind: "group", id: "oc-group" },
       }),
     );
+  });
+
+  it("falls back to reply ancestors for thread root when Feishu omits root_id", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        reply_target_message_id: "om_reply_target_root",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_reply_target_root");
+  });
+
+  it("falls back to parent_id before upper_message_id when root_id and reply target are missing", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_parent_message");
   });
 
   it("keeps root_id as topic key when root_id and thread_id both exist", async () => {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -5,7 +5,7 @@ import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtim
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import type { FeishuMessageEvent } from "./bot.js";
-import { handleFeishuMessage } from "./bot.js";
+import { handleFeishuMessage, parseFeishuMessageEvent } from "./bot.js";
 import { createFeishuMessageReceiveHandler } from "./monitor.message-handler.js";
 import { setFeishuRuntime } from "./runtime.js";
 
@@ -2661,6 +2661,45 @@ describe("handleFeishuMessage command authorization", () => {
       id: "oc-group:topic:om_root_topic:sender:ou-topic-user",
     });
     expect(routeRequest.parentPeer).toEqual({ kind: "group", id: "oc-group" });
+  });
+
+  it("falls back to reply ancestors for thread root when Feishu omits root_id", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        reply_target_message_id: "om_reply_target_root",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_reply_target_root");
+  });
+
+  it("falls back to parent_id before upper_message_id when root_id and reply target are missing", () => {
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-topic-user" } },
+      message: {
+        message_id: "om_topic_reply_message",
+        chat_id: "oc-group",
+        chat_type: "group",
+        parent_id: "om_parent_message",
+        upper_message_id: "om_upper_message",
+        message_type: "text",
+        content: JSON.stringify({ text: "topic reply" }),
+      },
+    };
+
+    const ctx = parseFeishuMessageEvent(event);
+
+    expect(ctx.rootId).toBe("om_parent_message");
   });
 
   it("keeps root_id as topic key when root_id and thread_id both exist", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -247,7 +247,15 @@ export function parseFeishuMessageEvent(
     chatType: event.message.chat_type,
     mentionedBot,
     hasAnyMention,
-    rootId: event.message.root_id || undefined,
+    // Feishu thread reply events can omit root_id while still carrying a
+    // stable ancestor/reply target. Keep root_id precedence, then fall back
+    // to the best available message anchor so threaded replies stay grouped.
+    rootId:
+      event.message.root_id?.trim() ||
+      event.message.reply_target_message_id?.trim() ||
+      event.message.parent_id?.trim() ||
+      event.message.upper_message_id?.trim() ||
+      undefined,
     parentId: event.message.parent_id || undefined,
     threadId: event.message.thread_id || undefined,
     content,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -273,7 +273,15 @@ export function parseFeishuMessageEvent(
     chatType: event.message.chat_type,
     mentionedBot,
     hasAnyMention,
-    rootId: event.message.root_id || undefined,
+    // Feishu thread reply events can omit root_id while still carrying a
+    // stable ancestor/reply target. Keep root_id precedence, then fall back
+    // to the best available message anchor so threaded replies stay grouped.
+    rootId:
+      event.message.root_id?.trim() ||
+      event.message.reply_target_message_id?.trim() ||
+      event.message.parent_id?.trim() ||
+      event.message.upper_message_id?.trim() ||
+      undefined,
     parentId: event.message.parent_id || undefined,
     threadId: event.message.thread_id || undefined,
     content,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -771,7 +771,9 @@ export async function handleFeishuMessage(params: {
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    const replyInThread = isGroup
+      ? (groupSession?.replyInThread ?? false)
+      : Boolean(ctx.threadId || ctx.rootId || ctx.replyTargetMessageId);
     const feishuAcpConversationSupported =
       !isGroup ||
       groupSession?.groupSessionScope === "group_topic" ||
@@ -1331,13 +1333,17 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    const replyTargetMessageId =
-      isTopicSession || configReplyInThread
+    const dmThreadContext = Boolean(ctx.threadId || ctx.rootId || ctx.replyTargetMessageId);
+    const replyTargetMessageId = !isGroup
+      ? ctx.suppressReplyTarget
+        ? undefined
+        : ctx.messageId
+      : isTopicSession || configReplyInThread
         ? (ctx.rootId ??
           ctx.replyTargetMessageId ??
           (ctx.suppressReplyTarget ? undefined : ctx.messageId))
         : (ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId));
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : dmThreadContext;
     const lastRouteThreadId =
       isGroup && (isTopicSession || configReplyInThread || threadReply)
         ? replyTargetMessageId
@@ -1461,7 +1467,7 @@ export async function handleFeishuMessage(params: {
             chatId: ctx.chatId,
             allowReasoningPreview,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            skipReplyToInMessages: false,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1626,7 +1632,7 @@ export async function handleFeishuMessage(params: {
         chatId: ctx.chatId,
         allowReasoningPreview,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        skipReplyToInMessages: false,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,

--- a/extensions/feishu/src/event-types.ts
+++ b/extensions/feishu/src/event-types.ts
@@ -14,6 +14,7 @@ export type FeishuMessageEvent = {
     suppress_reply_target?: boolean;
     root_id?: string;
     parent_id?: string;
+    upper_message_id?: string;
     thread_id?: string;
     chat_id: string;
     chat_type: "p2p" | "group" | "topic_group" | "private";


### PR DESCRIPTION
## Summary

- Preserve Feishu threaded reply grouping when message events omit `root_id`
- Fall back to `reply_target_message_id`, `parent_id`, then `upper_message_id` as the best available root message anchor
- Add coverage for the fallback order and include `upper_message_id` in the event type

## Testing

- `pnpm exec vitest run extensions/feishu/src/bot.test.ts`
- `pnpm exec oxfmt --check extensions/feishu/src/bot.ts extensions/feishu/src/bot.test.ts extensions/feishu/src/event-types.ts`

## Notes

Some Feishu thread reply deliveries include a reply/ancestor message id but no `root_id`; without a fallback the message can be routed as a fresh group context instead of the existing thread.
