### PR TITLE
fix(auth): explain masked oauth profiles

### DIFF
--- a/src/agents/auth-profiles/persisted.ts
+++ b/src/agents/auth-profiles/persisted.ts
@@ -115,6 +115,54 @@ function normalizeCommonCredentialFields(entry: Record<string, unknown>): Record
   return normalized;
 }
 
+function normalizeStringFieldAlias(
+  entry: Record<string, unknown>,
+  canonicalField: string,
+  aliases: readonly string[],
+): void {
+  if (canonicalField in entry) {
+    return;
+  }
+  for (const alias of aliases) {
+    const value = entry[alias];
+    if (typeof value === "string") {
+      entry[canonicalField] = value;
+      return;
+    }
+  }
+}
+
+function normalizeNumberFieldAlias(
+  entry: Record<string, unknown>,
+  canonicalField: string,
+  aliases: readonly string[],
+): void {
+  if (canonicalField in entry) {
+    return;
+  }
+  for (const alias of aliases) {
+    const value = entry[alias];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      entry[canonicalField] = value;
+      return;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+      const parsed = Number(value);
+      if (Number.isFinite(parsed)) {
+        entry[canonicalField] = parsed;
+        return;
+      }
+    }
+  }
+}
+
+function normalizeLegacyOpenAiCodexOAuthAliases(entry: Record<string, unknown>): void {
+  normalizeStringFieldAlias(entry, "access", ["access_token", "accessToken"]);
+  normalizeStringFieldAlias(entry, "refresh", ["refresh_token", "refreshToken"]);
+  normalizeNumberFieldAlias(entry, "expires", ["expires_at", "expiresAt"]);
+  normalizeStringFieldAlias(entry, "accountId", ["account_id", "accountID"]);
+}
+
 function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<AuthProfileCredential> {
   const entry = { ...raw } as Record<string, unknown>;
   if (!("type" in entry) && typeof entry["mode"] === "string") {
@@ -132,6 +180,13 @@ function normalizeRawCredentialEntry(raw: Record<string, unknown>): Partial<Auth
   }
   normalizeSecretBackedField({ entry, valueField: "key", refField: "keyRef" });
   normalizeSecretBackedField({ entry, valueField: "token", refField: "tokenRef" });
+  if (
+    entry.type === "oauth" &&
+    typeof entry.provider === "string" &&
+    normalizeProviderId(entry.provider) === "openai-codex"
+  ) {
+    normalizeLegacyOpenAiCodexOAuthAliases(entry);
+  }
   if (entry.type === "api_key") {
     const normalized: Record<string, unknown> = {
       type: "api_key",

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -192,6 +192,39 @@ describe("promoteAuthProfileInOrder", () => {
     });
   });
 
+  it("normalizes legacy OpenAI Codex OAuth field aliases on load", async () => {
+    await withAuthProfileTestState("openclaw-auth-codex-legacy-aliases-", ({ agentDir }) => {
+      fs.mkdirSync(agentDir, { recursive: true });
+      const expires = Date.now() + 60_000;
+      fs.writeFileSync(
+        path.join(agentDir, "auth-profiles.json"),
+        JSON.stringify({
+          version: AUTH_STORE_VERSION,
+          profiles: {
+            "openai-codex:default": {
+              type: "oauth",
+              provider: "openai-codex",
+              access_token: "legacy-access-token",
+              refreshToken: "legacy-refresh-token",
+              expires_at: String(expires),
+              account_id: "acct_legacy",
+            },
+          },
+        }),
+      );
+
+      const credential = loadPersistedAuthProfileStore(agentDir)?.profiles["openai-codex:default"];
+
+      expectOAuthCredentialFields(credential, {
+        provider: "openai-codex",
+        access: "legacy-access-token",
+        refresh: "legacy-refresh-token",
+        expires,
+        accountId: "acct_legacy",
+      });
+    });
+  });
+
   it("preserves access-only openai oauth credentials inline", async () => {
     await withAuthProfileTestState("openclaw-auth-profile-access-only-", ({ agentDir }) => {
       fs.mkdirSync(agentDir, { recursive: true });

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -12,7 +12,7 @@ import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-d
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
-import { loadPersistedAuthProfileStore } from "./persisted.js";
+import { coercePersistedAuthProfileStore, loadPersistedAuthProfileStore } from "./persisted.js";
 import {
   clearLastGoodProfileWithLock,
   promoteAuthProfileInOrder,
@@ -193,35 +193,27 @@ describe("promoteAuthProfileInOrder", () => {
   });
 
   it("normalizes legacy OpenAI Codex OAuth field aliases on load", async () => {
-    await withAuthProfileTestState("openclaw-auth-codex-legacy-aliases-", ({ agentDir }) => {
-      fs.mkdirSync(agentDir, { recursive: true });
-      const expires = Date.now() + 60_000;
-      fs.writeFileSync(
-        path.join(agentDir, "auth-profiles.json"),
-        JSON.stringify({
-          version: AUTH_STORE_VERSION,
-          profiles: {
-            "openai-codex:default": {
-              type: "oauth",
-              provider: "openai-codex",
-              access_token: "legacy-access-token",
-              refreshToken: "legacy-refresh-token",
-              expires_at: String(expires),
-              account_id: "acct_legacy",
-            },
-          },
-        }),
-      );
+    const expires = Date.now() + 60_000;
+    const credential = coercePersistedAuthProfileStore({
+      version: AUTH_STORE_VERSION,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access_token: "legacy-access-token",
+          refreshToken: "legacy-refresh-token",
+          expires_at: String(expires),
+          account_id: "acct_legacy",
+        },
+      },
+    })?.profiles["openai-codex:default"];
 
-      const credential = loadPersistedAuthProfileStore(agentDir)?.profiles["openai-codex:default"];
-
-      expectOAuthCredentialFields(credential, {
-        provider: "openai-codex",
-        access: "legacy-access-token",
-        refresh: "legacy-refresh-token",
-        expires,
-        accountId: "acct_legacy",
-      });
+    expectOAuthCredentialFields(credential, {
+      provider: "openai-codex",
+      access: "legacy-access-token",
+      refresh: "legacy-refresh-token",
+      expires,
+      accountId: "acct_legacy",
     });
   });
 

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -513,6 +513,52 @@ describe("getApiKeyForModel", () => {
     ).rejects.toThrow(/requires an OpenAI API key profile/);
   });
 
+  it("explains when stale config mode masks a stored Codex OAuth profile", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          ...oauthFixture,
+        },
+      },
+    };
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "openai-codex",
+            mode: "api_key",
+          },
+        },
+      },
+    };
+
+    let error: unknown = null;
+    try {
+      await resolveApiKeyForProvider({
+        provider: "openai-codex",
+        cfg,
+        store,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    const message = String(error);
+    expect(message).toContain('No API key found for provider "openai-codex".');
+    expect(message).toContain(
+      'Auth profile "openai-codex:default" for provider "openai-codex" exists as oauth',
+    );
+    expect(message).toContain(
+      'auth.profiles.openai-codex:default.mode is "api_key", so it is skipped',
+    );
+    expect(message).toContain('Update that config mode to "oauth"');
+    expect(message).not.toContain(oauthFixture.access);
+    expect(message).not.toContain(oauthFixture.refresh);
+  });
+
   it("uses the config default agent dir when resolving provider profiles", async () => {
     await withOpenClawTestState(
       {

--- a/src/agents/model-auth.profiles.test.ts
+++ b/src/agents/model-auth.profiles.test.ts
@@ -109,6 +109,9 @@ vi.mock("./provider-auth-aliases.js", () => ({
     if (normalized === "bedrock" || normalized === "aws-bedrock") {
       return "amazon-bedrock";
     }
+    if (normalized === "codex-cli") {
+      return "openai-codex";
+    }
     return normalized;
   },
 }));
@@ -645,6 +648,51 @@ describe("getApiKeyForModel", () => {
         );
       },
     );
+  });
+
+  it("uses provider auth aliases when explaining stale config mode mismatches", async () => {
+    const store = {
+      version: 1 as const,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth" as const,
+          provider: "openai-codex",
+          ...oauthFixture,
+        },
+      },
+    };
+    const cfg: OpenClawConfig = {
+      auth: {
+        profiles: {
+          "openai-codex:default": {
+            provider: "codex-cli",
+            mode: "api_key",
+          },
+        },
+      },
+    };
+
+    let error: unknown = null;
+    try {
+      await resolveApiKeyForProvider({
+        provider: "codex-cli",
+        cfg,
+        store,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    const message = String(error);
+    expect(message).toContain('No API key found for provider "codex-cli".');
+    expect(message).toContain(
+      'Auth profile "openai-codex:default" for provider "codex-cli" exists as oauth',
+    );
+    expect(message).toContain(
+      'auth.profiles.openai-codex:default.mode is "api_key", so it is skipped',
+    );
+    expect(message).not.toContain(oauthFixture.access);
+    expect(message).not.toContain(oauthFixture.refresh);
   });
 
   it("uses OpenAI OAuth when it is configured for the provider", async () => {

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -54,7 +54,8 @@ import {
   NON_ENV_SECRETREF_MARKER,
 } from "./model-auth-markers.js";
 import { ProviderAuthError, type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
-import { normalizeProviderId, normalizeProviderIdForAuth } from "./model-selection.js";
+import { normalizeProviderId } from "./model-selection.js";
+import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 export {
   ensureAuthProfileStore,
@@ -395,13 +396,18 @@ function buildAuthProfileModeMismatchHint(params: {
   if (!profiles) {
     return null;
   }
-  const providerAuthKey = normalizeProviderIdForAuth(params.provider);
+  const providerAuthKey = resolveProviderIdForAuth(params.provider, { config: params.cfg });
   for (const [profileId, profileConfig] of Object.entries(profiles)) {
-    if (normalizeProviderIdForAuth(profileConfig.provider) !== providerAuthKey) {
+    if (
+      resolveProviderIdForAuth(profileConfig.provider, { config: params.cfg }) !== providerAuthKey
+    ) {
       continue;
     }
     const credential = params.store.profiles[profileId];
-    if (!credential || normalizeProviderIdForAuth(credential.provider) !== providerAuthKey) {
+    if (
+      !credential ||
+      resolveProviderIdForAuth(credential.provider, { config: params.cfg }) !== providerAuthKey
+    ) {
       continue;
     }
     if (

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -54,7 +54,7 @@ import {
   NON_ENV_SECRETREF_MARKER,
 } from "./model-auth-markers.js";
 import { ProviderAuthError, type ResolvedProviderAuth } from "./model-auth-runtime-shared.js";
-import { normalizeProviderId } from "./model-selection.js";
+import { normalizeProviderId, normalizeProviderIdForAuth } from "./model-selection.js";
 
 export {
   ensureAuthProfileStore,
@@ -371,6 +371,54 @@ function resolveProviderAuthOverride(
     return auth;
   }
   return undefined;
+}
+
+function isConfigProfileModeCompatible(params: {
+  configuredMode: string | undefined;
+  storedType: string | undefined;
+}): boolean {
+  if (!params.configuredMode || !params.storedType) {
+    return true;
+  }
+  if (params.configuredMode === params.storedType) {
+    return true;
+  }
+  return params.configuredMode === "oauth" && params.storedType === "token";
+}
+
+function buildAuthProfileModeMismatchHint(params: {
+  cfg: OpenClawConfig | undefined;
+  store: AuthProfileStore;
+  provider: string;
+}): string | null {
+  const profiles = params.cfg?.auth?.profiles;
+  if (!profiles) {
+    return null;
+  }
+  const providerAuthKey = normalizeProviderIdForAuth(params.provider);
+  for (const [profileId, profileConfig] of Object.entries(profiles)) {
+    if (normalizeProviderIdForAuth(profileConfig.provider) !== providerAuthKey) {
+      continue;
+    }
+    const credential = params.store.profiles[profileId];
+    if (!credential || normalizeProviderIdForAuth(credential.provider) !== providerAuthKey) {
+      continue;
+    }
+    if (
+      isConfigProfileModeCompatible({
+        configuredMode: profileConfig.mode,
+        storedType: credential.type,
+      })
+    ) {
+      continue;
+    }
+    return [
+      `Auth profile "${profileId}" for provider "${params.provider}" exists as ${credential.type}`,
+      `but auth.profiles.${profileId}.mode is "${profileConfig.mode}", so it is skipped.`,
+      `Update that config mode to "${credential.type}" or remove the stale auth.profiles override.`,
+    ].join(" ");
+  }
+  return null;
 }
 
 function shouldUseImplicitAwsSdkAuth(params: {
@@ -1285,14 +1333,22 @@ export async function resolveApiKeyForProvider(params: {
 
   const authStorePath = resolveAuthStorePathForDisplay(agentDir);
   const resolvedAgentDir = path.dirname(authStorePath);
+  const authProfileModeMismatchHint = buildAuthProfileModeMismatchHint({
+    cfg,
+    store,
+    provider,
+  });
   throw new ProviderAuthError(
     "missing-provider-auth",
     provider,
     [
       `No API key found for provider "${provider}".`,
+      authProfileModeMismatchHint,
       `Auth store: ${authStorePath} (agentDir: ${resolvedAgentDir}).`,
       `Configure auth for this agent (${formatCliCommand("openclaw agents add <id>")}) or copy only portable static auth profiles from the main agentDir.`,
-    ].join(" "),
+    ]
+      .filter(Boolean)
+      .join(" "),
   );
 }
 


### PR DESCRIPTION
## Summary

- Normalize legacy `openai-codex` OAuth auth-profile aliases on load so older stored profiles remain usable.
- Add a targeted diagnostic when a stored auth profile exists for a provider but is skipped because `auth.profiles.<id>.mode` does not match the stored credential type.
- This now covers both #47964 failure modes: alias-shaped OAuth credentials and stale `mode=api_key` masking a valid OAuth profile.

## Linked Issue/PR

- Fixes #47964
- [x] This PR fixes a bug or regression

## Root Cause

There were two adjacent present-but-unusable OpenAI Codex OAuth paths:

- Older `auth-profiles.json` entries could contain legacy OAuth aliases such as `access_token`, `refreshToken`, `expires_at`, or `account_id`. The loader preserved those fields, but downstream PI credential conversion only reads canonical `access`, `refresh`, and finite `expires`, so the profile was ignored.
- A stale config override could set `auth.profiles.<id>.mode` to `api_key` while the stored credential was OAuth. Auth profile ordering skipped the stored OAuth credential, then the final error only reported a missing API key.

## What Changed

- Normalize known legacy OpenAI Codex OAuth aliases to canonical fields during persisted profile parsing.
- Keep canonical stored fields authoritative if both canonical and alias fields exist.
- Detect config/store auth-profile mode mismatches before throwing the final missing-auth error.
- Include a secret-free hint naming only profile/provider/mode metadata.
- Add regression coverage for both the legacy alias profile and the stale `api_key` mode conflict.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? Only compatibility normalization on read for known OpenAI Codex OAuth aliases
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

Diagnostics deliberately report only profile/provider/mode metadata. Regression coverage asserts OAuth access and refresh token values are not included in the diagnostic.

## Verification

- Rebased onto upstream/main `751cd0c9b8`.
- `node scripts/test-projects.mjs src/agents/model-auth.profiles.test.ts src/agents/auth-profiles.ensureauthprofilestore.test.ts --reporter verbose` passed, 86 tests.
- `./node_modules/.bin/oxfmt --check src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts src/agents/auth-profiles/persisted.ts src/agents/auth-profiles.ensureauthprofilestore.test.ts` passed, 4 files.
- `git diff --check upstream/main...HEAD` passed.

Earlier verification:

- `corepack pnpm test src/agents/auth-profiles.ensureauthprofilestore.test.ts`
- `corepack pnpm test src/agents/model-auth.profiles.test.ts src/agents/pi-model-discovery.auth.test.ts extensions/openai/openai-codex-device-code.test.ts extensions/openai/openai-codex-provider.test.ts`
- `corepack pnpm exec oxfmt --check --threads=1 src/agents/auth-profiles/persisted.ts src/agents/auth-profiles.ensureauthprofilestore.test.ts src/agents/model-auth.ts src/agents/model-auth.profiles.test.ts`
- `node scripts/run-tsgo.mjs -p tsconfig.core.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.test.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions-test.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo`
- `node scripts/run-tsgo.mjs -p tsconfig.extensions.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/extensions.tsbuildinfo`
- `git diff --check`

## Real behavior proof

- Behavior or issue addressed: Verified the auth-profile surface after this patch still exposes a real OpenAI Codex OAuth profile as an OAuth profile instead of masking it as missing API-key auth.
- Real environment tested: Local macOS OpenClaw install with a running LaunchAgent gateway on `127.0.0.1:18789`; real user auth-profile store under `~/.openclaw/agents/main/agent`.
- Exact steps or command run after this patch: `openclaw gateway status`; `openclaw models auth list --json`.
- Evidence after fix: Redacted terminal output from the real setup:

```text
$ openclaw gateway status
Service: LaunchAgent (loaded)
Gateway: bind=custom (127.0.0.1), port=18789 (service args)
Runtime: running (pid redacted, state active)
Connectivity probe: ok
Capability: admin-capable

$ openclaw models auth list --json
{
  "agentId": "main",
  "provider": null,
  "profiles": [
    {
      "id": "openai-codex:default",
      "provider": "openai-codex",
      "type": "oauth",
      "label": "openai-codex:default",
      "expiresAt": "2026-05-02T08:28:49.000Z"
    }
  ]
}
```

- Observed result after fix: The real gateway was reachable and the auth listing completed without exposing secrets; the OpenAI Codex profile was surfaced as `type: "oauth"` in the live profile list rather than being treated as an API-key-only missing-auth case.
- What was not tested: I did not perform a fresh OpenAI Codex OAuth browser/device-code login during this verification. The focused regression tests cover legacy alias normalization and stale mode mismatch diagnostics.
