### PR TITLE
fix(backup): use resolvePreferredOpenClawTmpDir for temp archive dir (#75007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Infra/backup: resolve a safe staging temp root outside all backup source paths before creating the manifest staging directory, falling back from the preferred OpenClaw temp dir to `os.tmpdir()` and throwing when both are inside the backup payload, so macOS LaunchAgent `openclaw backup create` runs no longer stage a duplicate `manifest.json` inside the archive. Fixes #75007. Thanks @hclsys.
 - Agents/pi-embedded-runner: extract the `abortable` provider-call wrapper from `runEmbeddedAttempt` to module scope so its promise handlers no longer close over the run lexical context, releasing transcripts, tool buffers, and subscription callbacks when a provider call hangs past abort. (#74182) Thanks @cjboy007.
 - Docker: restore `python3` in the gateway runtime image after the slim-runtime switch. Fixes #75041.
 - CLI/Voice Call: scope `voicecall` command activation to the Voice Call plugin so setup and smoke checks no longer broad-load unrelated plugin runtimes or hang after printing JSON. Thanks @vincentkoc.

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -13,7 +13,9 @@ import {
 } from "./backup-create.js";
 
 const tmpDirMocks = vi.hoisted(() => ({
-  resolvePreferredOpenClawTmpDir: vi.fn<() => string>(),
+  resolvePreferredOpenClawTmpDir: vi.fn<() => string>(() =>
+    process.platform === "win32" ? "C:\\openclaw-test-tmp" : "/tmp/openclaw-test",
+  ),
 }));
 vi.mock("./tmp-openclaw-dir.js", () => ({
   resolvePreferredOpenClawTmpDir: tmpDirMocks.resolvePreferredOpenClawTmpDir,

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -195,4 +195,40 @@ describe("createBackupArchive", () => {
       },
     );
   });
+
+  it("does not include duplicate manifest.json when TMPDIR is inside the state directory", async () => {
+    // Regression for openclaw/openclaw#75007: when the LaunchAgent sets TMPDIR=~/.openclaw/tmp
+    // (which is inside the state dir), backup-create used os.tmpdir() for the temp dir, causing
+    // tar to pick up the temp manifest.json as part of the payload AND as an explicit entry.
+    // Fix: use resolvePreferredOpenClawTmpDir() which always returns a path outside the payload.
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-backup-tmpdir-", scenario: "minimal" },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+
+        // Simulate TMPDIR pointing inside the state dir — the bug scenario.
+        const fakeInternalTmpDir = state.path("tmp");
+        await fs.mkdir(fakeInternalTmpDir, { recursive: true });
+        const origTmpdir = process.env["TMPDIR"];
+        process.env["TMPDIR"] = fakeInternalTmpDir;
+        try {
+          const result = await createBackupArchive({
+            output: outputDir,
+            includeWorkspace: false,
+            nowMs: Date.UTC(2026, 3, 30, 12, 0, 0),
+          });
+          const entries = await listArchiveEntries(result.archivePath);
+          const manifestEntries = entries.filter((e) => e.endsWith("manifest.json"));
+          expect(manifestEntries).toHaveLength(1);
+        } finally {
+          if (origTmpdir === undefined) {
+            delete process.env["TMPDIR"];
+          } else {
+            process.env["TMPDIR"] = origTmpdir;
+          }
+        }
+      },
+    );
+  });
 });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { backupVerifyCommand } from "../commands/backup-verify.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -9,6 +9,7 @@ import {
   buildExtensionsNodeModulesFilter,
   createBackupArchive,
   formatBackupCreateSummary,
+  resolveSafeBackupTempRoot,
   type BackupCreateResult,
 } from "./backup-create.js";
 
@@ -140,6 +141,10 @@ describe("buildExtensionsNodeModulesFilter", () => {
 });
 
 describe("createBackupArchive", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   beforeEach(async () => {
     // Default: resolve to the real preferred tmp dir so non-containment tests work normally.
     const real =
@@ -226,7 +231,7 @@ describe("createBackupArchive", () => {
         await fs.mkdir(outputDir, { recursive: true });
 
         // Force resolvePreferredOpenClawTmpDir to return a path inside the state dir payload.
-        const fakeInternalTmpDir = state.path("tmp");
+        const fakeInternalTmpDir = path.join(state.stateDir, "tmp");
         await fs.mkdir(fakeInternalTmpDir, { recursive: true });
         tmpDirMocks.resolvePreferredOpenClawTmpDir.mockReturnValue(fakeInternalTmpDir);
 
@@ -238,6 +243,33 @@ describe("createBackupArchive", () => {
         const entries = await listArchiveEntries(result.archivePath);
         const manifestEntries = entries.filter((e) => e.endsWith("manifest.json"));
         expect(manifestEntries).toHaveLength(1);
+      },
+    );
+  });
+
+  it("fails before archiving when preferred and fallback temp roots are inside the state directory", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "openclaw-backup-tmpdir-fallback-", scenario: "minimal" },
+      async (state) => {
+        const outputDir = state.path("backups");
+        await fs.mkdir(outputDir, { recursive: true });
+
+        const fakeInternalTmpDir = path.join(state.stateDir, "tmp");
+        await fs.mkdir(fakeInternalTmpDir, { recursive: true });
+        tmpDirMocks.resolvePreferredOpenClawTmpDir.mockReturnValue(fakeInternalTmpDir);
+        expect(() =>
+          resolveSafeBackupTempRoot(
+            [
+              {
+                kind: "state",
+                sourcePath: state.stateDir,
+                archivePath: "state",
+                displayPath: state.stateDir,
+              },
+            ],
+            fakeInternalTmpDir,
+          ),
+        ).toThrow(/temporary directory is inside a path selected for backup/i);
       },
     );
   });

--- a/src/infra/backup-create.test.ts
+++ b/src/infra/backup-create.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import * as tar from "tar";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { backupVerifyCommand } from "../commands/backup-verify.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -11,6 +11,13 @@ import {
   formatBackupCreateSummary,
   type BackupCreateResult,
 } from "./backup-create.js";
+
+const tmpDirMocks = vi.hoisted(() => ({
+  resolvePreferredOpenClawTmpDir: vi.fn<() => string>(),
+}));
+vi.mock("./tmp-openclaw-dir.js", () => ({
+  resolvePreferredOpenClawTmpDir: tmpDirMocks.resolvePreferredOpenClawTmpDir,
+}));
 
 function makeResult(overrides: Partial<BackupCreateResult> = {}): BackupCreateResult {
   return {
@@ -131,6 +138,15 @@ describe("buildExtensionsNodeModulesFilter", () => {
 });
 
 describe("createBackupArchive", () => {
+  beforeEach(async () => {
+    // Default: resolve to the real preferred tmp dir so non-containment tests work normally.
+    const real =
+      await vi.importActual<typeof import("./tmp-openclaw-dir.js")>("./tmp-openclaw-dir.js");
+    tmpDirMocks.resolvePreferredOpenClawTmpDir.mockImplementation(
+      real.resolvePreferredOpenClawTmpDir,
+    );
+  });
+
   it("omits installed plugin node_modules from the real archive while keeping plugin files", async () => {
     await withOpenClawTestState(
       {
@@ -196,38 +212,30 @@ describe("createBackupArchive", () => {
     );
   });
 
-  it("does not include duplicate manifest.json when TMPDIR is inside the state directory", async () => {
-    // Regression for openclaw/openclaw#75007: when the LaunchAgent sets TMPDIR=~/.openclaw/tmp
-    // (which is inside the state dir), backup-create used os.tmpdir() for the temp dir, causing
-    // tar to pick up the temp manifest.json as part of the payload AND as an explicit entry.
-    // Fix: use resolvePreferredOpenClawTmpDir() which always returns a path outside the payload.
+  it("does not include duplicate manifest.json when preferred temp root is inside the state directory", async () => {
+    // Regression for openclaw/openclaw#75007: when resolvePreferredOpenClawTmpDir() returns a
+    // path inside the backup payload (e.g. its fallback resolves under ~/.openclaw/tmp due to
+    // TMPDIR env), the containment guard must switch to os.tmpdir() so the staging dir stays
+    // outside the archived sources and manifest.json is not packed twice.
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-backup-tmpdir-", scenario: "minimal" },
       async (state) => {
         const outputDir = state.path("backups");
         await fs.mkdir(outputDir, { recursive: true });
 
-        // Simulate TMPDIR pointing inside the state dir — the bug scenario.
+        // Force resolvePreferredOpenClawTmpDir to return a path inside the state dir payload.
         const fakeInternalTmpDir = state.path("tmp");
         await fs.mkdir(fakeInternalTmpDir, { recursive: true });
-        const origTmpdir = process.env["TMPDIR"];
-        process.env["TMPDIR"] = fakeInternalTmpDir;
-        try {
-          const result = await createBackupArchive({
-            output: outputDir,
-            includeWorkspace: false,
-            nowMs: Date.UTC(2026, 3, 30, 12, 0, 0),
-          });
-          const entries = await listArchiveEntries(result.archivePath);
-          const manifestEntries = entries.filter((e) => e.endsWith("manifest.json"));
-          expect(manifestEntries).toHaveLength(1);
-        } finally {
-          if (origTmpdir === undefined) {
-            delete process.env["TMPDIR"];
-          } else {
-            process.env["TMPDIR"] = origTmpdir;
-          }
-        }
+        tmpDirMocks.resolvePreferredOpenClawTmpDir.mockReturnValue(fakeInternalTmpDir);
+
+        const result = await createBackupArchive({
+          output: outputDir,
+          includeWorkspace: false,
+          nowMs: Date.UTC(2026, 3, 30, 12, 0, 0),
+        });
+        const entries = await listArchiveEntries(result.archivePath);
+        const manifestEntries = entries.filter((e) => e.endsWith("manifest.json"));
+        expect(manifestEntries).toHaveLength(1);
       },
     );
   });

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import {
   buildBackupArchiveBasename,
@@ -295,6 +296,17 @@ export function buildExtensionsNodeModulesFilter(stateDir: string): (filePath: s
   };
 }
 
+function resolveSafeBackupTempRoot(assets: readonly BackupAsset[]): string {
+  const preferred = resolvePreferredOpenClawTmpDir();
+  const insidePayload = assets.some((asset) => isPathWithin(preferred, asset.sourcePath));
+  if (!insidePayload) {
+    return preferred;
+  }
+  // Fallback: preferred temp root is inside a backup source (e.g. TMPDIR=~/.openclaw/tmp).
+  // Use the system temp dir directly to keep staging outside the archived payload.
+  return os.tmpdir();
+}
+
 export async function createBackupArchive(
   opts: BackupCreateOptions = {},
 ): Promise<BackupCreateResult> {
@@ -350,7 +362,8 @@ export async function createBackupArchive(
   }
 
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
-  const tempDir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-backup-"));
+  const tempRoot = resolveSafeBackupTempRoot(result.assets);
+  const tempDir = await fs.mkdtemp(path.join(tempRoot, "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
   try {

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
+import { tmpdir as getOsTmpDir } from "node:os";
 import path from "node:path";
 import {
   buildBackupArchiveBasename,
@@ -296,15 +296,23 @@ export function buildExtensionsNodeModulesFilter(stateDir: string): (filePath: s
   };
 }
 
-function resolveSafeBackupTempRoot(assets: readonly BackupAsset[]): string {
+export function resolveSafeBackupTempRoot(
+  assets: readonly BackupAsset[],
+  fallbackTempRoot: string = getOsTmpDir(),
+): string {
   const preferred = resolvePreferredOpenClawTmpDir();
-  const insidePayload = assets.some((asset) => isPathWithin(preferred, asset.sourcePath));
-  if (!insidePayload) {
+  const isInsidePayload = (candidate: string): boolean =>
+    assets.some((asset) => isPathWithin(candidate, asset.sourcePath));
+
+  if (!isInsidePayload(preferred)) {
     return preferred;
   }
-  // Fallback: preferred temp root is inside a backup source (e.g. TMPDIR=~/.openclaw/tmp).
-  // Use the system temp dir directly to keep staging outside the archived payload.
-  return os.tmpdir();
+  if (!isInsidePayload(fallbackTempRoot)) {
+    return fallbackTempRoot;
+  }
+  throw new Error(
+    "Backup temporary directory is inside a path selected for backup; set TMPDIR outside OpenClaw state and retry.",
+  );
 }
 
 export async function createBackupArchive(

--- a/src/infra/backup-create.ts
+++ b/src/infra/backup-create.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import {
   buildBackupArchiveBasename,
@@ -13,6 +12,7 @@ import {
 import { isPathWithin } from "../commands/cleanup-utils.js";
 import { resolveHomeDir, resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
+import { resolvePreferredOpenClawTmpDir } from "./tmp-openclaw-dir.js";
 
 type TarRuntime = typeof import("tar");
 
@@ -350,7 +350,7 @@ export async function createBackupArchive(
   }
 
   await fs.mkdir(path.dirname(outputPath), { recursive: true });
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-"));
+  const tempDir = await fs.mkdtemp(path.join(resolvePreferredOpenClawTmpDir(), "openclaw-backup-"));
   const manifestPath = path.join(tempDir, "manifest.json");
   const tempArchivePath = buildTempArchivePath(outputPath);
   try {


### PR DESCRIPTION
## Problem

Fixes #75007.

When the macOS LaunchAgent sets `TMPDIR=~/.openclaw/tmp` (which OpenClaw does to solve SQLite temp file issues), `backup create` called `os.tmpdir()` to create its working temp directory. This placed the temp dir **inside** the state directory payload, causing tar to pack `manifest.json` twice:

1. Once as an explicit first entry (correct)
2. Once recursively when tar packs the state dir and walks into the tmp subdir

Result: the final archive contains two identical `manifest.json` entries.

## Fix

Replace the `os.tmpdir()` call in `createBackupArchive` with `resolvePreferredOpenClawTmpDir()`, which already exists in `infra/tmp-openclaw-dir.ts` and is used across the codebase (helpers, monitor, status.gather, restart). It always returns a path outside the state payload (`/tmp/openclaw` on POSIX, or a user-scoped fallback), ignoring the `TMPDIR` environment variable.

Remove the now-unused `os` import.

## Test

Added regression test: set `TMPDIR` to point inside the test state dir (the bug scenario), create a backup, verify the archive contains exactly **one** `manifest.json` entry.

All 6 `backup-create.test.ts` tests pass.