### PR TITLE
fix(heartbeat): ignore docs related scaffold links

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -211,6 +211,30 @@ Keep this file empty unless you want a tiny checklist. Keep it small.
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
   });
 
+  it("returns true for the current fenced heartbeat template body with docs Related links", () => {
+    const content = `\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+
+## Related
+
+- [Heartbeat config](/gateway/config-agents)
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+
+  it("does not ignore non-docs tasks under a Related heading", () => {
+    const content = `# HEARTBEAT.md
+
+## Related
+
+- Check email
+`;
+    expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(false);
+  });
+
   it("returns false when fenced heartbeat content includes a real task", () => {
     const content = `\`\`\`markdown
 # Keep this file empty when you want to skip.

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -26,10 +26,39 @@ export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
  * - Markdown ATX headers (`#`, `##`, ...)
  * - Markdown fence markers such as ``` or ```markdown
  * - Empty list item stubs (`- `, `- [ ]`, `* `, `+ `)
+ * - A trailing docs-only `## Related` section with local documentation links
  *
  * Note: A missing file returns false (not effectively empty) so the LLM can still
  * decide what to do. This function is only for when the file exists but has no content.
  */
+function stripTrailingDocsRelatedSection(content: string): string {
+  const lines = content.split("\n");
+  let relatedHeaderIndex = -1;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const trimmed = lines[i]?.trim() ?? "";
+    if (/^##\s+Related\s*$/i.test(trimmed)) {
+      relatedHeaderIndex = i;
+    }
+  }
+
+  if (relatedHeaderIndex < 0) {
+    return content;
+  }
+
+  const docsLocalLinkListItem = /^[-*+]\s+\[[^\]]+\]\(\/[A-Za-z0-9_./#?=-]+\)\s*$/;
+  const trailingLines = lines.slice(relatedHeaderIndex + 1);
+  const nonEmptyTrailingLines = trailingLines.map((line) => line.trim()).filter(Boolean);
+  if (nonEmptyTrailingLines.length === 0) {
+    return content;
+  }
+  if (!nonEmptyTrailingLines.every((line) => docsLocalLinkListItem.test(line))) {
+    return content;
+  }
+
+  return lines.slice(0, relatedHeaderIndex).join("\n");
+}
+
 export function isHeartbeatContentEffectivelyEmpty(content: string | undefined | null): boolean {
   if (content === undefined || content === null) {
     return false;
@@ -38,7 +67,7 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
     return false;
   }
 
-  const lines = content.split("\n");
+  const lines = stripTrailingDocsRelatedSection(content).split("\n");
   for (const line of lines) {
     const trimmed = line.trim();
     // Skip empty lines

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -1284,6 +1284,7 @@ describe("runHeartbeatOnce", () => {
     | "actionable"
     | "legacy-comment-only"
     | "fenced-empty"
+    | "fenced-empty-with-related"
     | "fenced-actionable"
     | "missing"
     | "read-error";
@@ -1326,6 +1327,21 @@ describe("runHeartbeatOnce", () => {
 
 # Add tasks below when you want the agent to check something periodically.
 \`\`\`
+`,
+        "utf-8",
+      );
+    } else if (params.fileState === "fenced-empty-with-related") {
+      await fs.writeFile(
+        path.join(workspaceDir, "HEARTBEAT.md"),
+        `\`\`\`markdown
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+
+# Add tasks below when you want the agent to check something periodically.
+\`\`\`
+
+## Related
+
+- [Heartbeat config](/gateway/config-agents)
 `,
         "utf-8",
       );
@@ -1592,6 +1608,14 @@ tasks:
       {
         name: "fenced empty template + interval skips",
         fileState: "fenced-empty",
+        expectedStatus: "skipped",
+        expectedSkipReason: "empty-heartbeat-file",
+        expectedSendCalls: 0,
+        expectedReplyCalls: 0,
+      },
+      {
+        name: "fenced empty template with docs Related links + interval skips",
+        fileState: "fenced-empty-with-related",
         expectedStatus: "skipped",
         expectedSkipReason: "empty-heartbeat-file",
         expectedSendCalls: 0,


### PR DESCRIPTION
## Summary

- Fixes a regression where the docs-only `## Related` section copied into default `HEARTBEAT.md` makes scaffold-only heartbeat files look actionable.
- Treats a trailing docs `Related` link section as non-actionable for heartbeat empty-file detection.
- Adds regression coverage for the current `docs/reference/templates/HEARTBEAT.md` shape at helper and runner levels.

## Root cause

`docs/reference/templates/HEARTBEAT.md` is both a docs page and the runtime workspace seed template. Commit `2fb9c7e3e586` added docs `## Related` sections to reference templates, including `HEARTBEAT.md`. Runtime `loadTemplate()` strips frontmatter but not docs-only trailing sections, so new workspaces receive:

```md
## Related

- [Heartbeat config](/gateway/config-agents)
```

`isHeartbeatContentEffectivelyEmpty()` ignores headers and fence markers, but not real markdown link bullets, so the heartbeat runner no longer returns `empty-heartbeat-file` for the default scaffold and can invoke the LLM every heartbeat interval.

## Testing

- [x] `pnpm test src/auto-reply/heartbeat.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- [x] `pnpm test src/agents/workspace.test.ts`
- [x] `pnpm format:check src/auto-reply/heartbeat.ts src/auto-reply/heartbeat.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts`
- [x] `pnpm exec oxlint src/auto-reply/heartbeat.ts src/auto-reply/heartbeat.test.ts src/infra/heartbeat-runner.returns-default-unset.test.ts` — reported 0 warnings / 0 errors before the wrapper process was killed after completion
- [ ] `pnpm check:changed` — attempted; targeted checks passed until `lint:core`, which stalled/was killed in this local environment after full sparse checkout expansion

## AI assistance

AI-assisted. I understand the change and verified the behavior locally against the installed package/current source.

Related: #61690, #63434
