### PR TITLE
docs(feishu): add mixed proxy troubleshooting

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -213,6 +213,51 @@ Feishu/Lark does not support native slash-command menus, so send these as plain 
 5. Ensure the gateway is running: `openclaw gateway status`
 6. Check logs: `openclaw logs --follow`
 
+### Bot stops responding when a system proxy is configured
+
+Feishu/Lark traffic uses the same process environment as the gateway. If your
+model provider needs an outbound proxy but Feishu/Lark official endpoints must
+go direct in your network, configure a `NO_PROXY` bypass for the Feishu/Lark
+domains instead of clearing `HTTP_PROXY` / `HTTPS_PROXY` globally.
+
+Typical symptoms:
+
+- token requests fail even though `appId` and `appSecret` are correct
+- the WebSocket connection never becomes ready
+- logs show TLS/proxy errors while provider requests still need the proxy
+
+PowerShell example for Feishu China:
+
+```powershell
+$env:HTTPS_PROXY = "http://127.0.0.1:7890"
+$env:HTTP_PROXY = "http://127.0.0.1:7890"
+$env:NO_PROXY = "open.feishu.cn,*.feishu.cn"
+openclaw gateway restart
+```
+
+PowerShell example for Lark global:
+
+```powershell
+$env:HTTPS_PROXY = "http://127.0.0.1:7890"
+$env:HTTP_PROXY = "http://127.0.0.1:7890"
+$env:NO_PROXY = "open.larksuite.com,*.larksuite.com"
+openclaw gateway restart
+```
+
+If you use a custom Feishu/Lark domain, add that hostname to `NO_PROXY` as
+well. `NO_PROXY` entries can be comma- or whitespace-separated, and wildcard
+suffixes such as `*.example.com` are supported by OpenClaw's proxy matching.
+
+To verify the boundary:
+
+1. Restart the gateway after setting the environment variables
+2. Run `openclaw gateway status`
+3. Send a DM or @mention the bot
+4. Watch logs with `openclaw logs --follow`
+
+Avoid posting real `appId`, `appSecret`, tokens, webhook URLs, proxy
+credentials, or full local logs when asking for help.
+
 ### App Secret leaked
 
 1. Reset the App Secret in Feishu Open Platform / Lark Developer

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -226,13 +226,17 @@ Typical symptoms:
 - the WebSocket connection never becomes ready
 - logs show TLS/proxy errors while provider requests still need the proxy
 
+For a one-off foreground gateway, set the proxy environment in the same shell
+that starts `openclaw gateway`. This makes the gateway process inherit the
+values directly.
+
 PowerShell example for Feishu China:
 
 ```powershell
 $env:HTTPS_PROXY = "http://127.0.0.1:7890"
 $env:HTTP_PROXY = "http://127.0.0.1:7890"
 $env:NO_PROXY = "open.feishu.cn,*.feishu.cn"
-openclaw gateway restart
+openclaw gateway
 ```
 
 PowerShell example for Lark global:
@@ -241,8 +245,15 @@ PowerShell example for Lark global:
 $env:HTTPS_PROXY = "http://127.0.0.1:7890"
 $env:HTTP_PROXY = "http://127.0.0.1:7890"
 $env:NO_PROXY = "open.larksuite.com,*.larksuite.com"
-openclaw gateway restart
+openclaw gateway
 ```
+
+For an installed or managed gateway service, a new terminal's `$env:*` values
+do not automatically update the background service environment. Put the proxy
+variables in the service launcher or wrapper environment, reinstall or refresh
+that service environment if needed, and then restart the managed gateway. Do not
+expect `openclaw gateway restart` by itself to inject transient shell variables
+into an already-installed service.
 
 If you use a custom Feishu/Lark domain, add that hostname to `NO_PROXY` as
 well. `NO_PROXY` entries can be comma- or whitespace-separated, and wildcard
@@ -250,7 +261,8 @@ suffixes such as `*.example.com` are supported by OpenClaw's proxy matching.
 
 To verify the boundary:
 
-1. Restart the gateway after setting the environment variables
+1. Confirm the gateway was launched from the environment that contains the
+   proxy variables
 2. Run `openclaw gateway status`
 3. Send a DM or @mention the bot
 4. Watch logs with `openclaw logs --follow`


### PR DESCRIPTION
## Summary

- Adds Feishu/Lark troubleshooting guidance for mixed proxy environments.
- Documents the case where model-provider traffic needs `HTTP_PROXY` / `HTTPS_PROXY`, but Feishu/Lark official endpoints should go direct via `NO_PROXY`.
- Includes PowerShell examples for Feishu China and Lark global domains.
- Adds verification steps and a reminder not to share app secrets, tokens, proxy credentials, or full local logs.

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #72595
- [ ] This PR fixes a bug or regression

## Root Cause (if applicable)

N/A. This is a docs-only troubleshooting update.

## Regression Test Plan (if applicable)

N/A. No runtime behavior changed.

## User-visible / Behavior Changes

None. Documentation only.

## Diagram (if applicable)

```text
Provider requests -> use env proxy when configured
Feishu/Lark API + WebSocket -> bypass via NO_PROXY when the local network requires direct access
```

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows docs example, docs-only change
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel: Feishu/Lark
- Relevant config (redacted): proxy env examples only, no real credentials

### Steps

1. Reviewed `docs/channels/feishu.md` troubleshooting flow.
2. Added a mixed proxy section after the existing "Bot does not receive messages" checks.
3. Verified the docs page parses as MDX.

### Expected

- Users with mixed proxy setups can keep model-provider proxy env vars while bypassing Feishu/Lark official endpoints through `NO_PROXY`.

### Actual

- Documentation now includes symptoms, PowerShell examples, verification steps, and sensitive-log guidance.

## Evidence

- [x] Trace/log snippets

Verification run locally:

```text
pnpm docs:check-mdx -- docs\channels\feishu.md
Docs MDX check passed (484 files, 1991ms).

git diff --check -- docs\channels\feishu.md
passed
```

Note: `pnpm format:docs:check` currently fails before checking this file with `TypeError: Cannot read properties of undefined (reading 'trim')` in `scripts/format-docs.mjs`. A targeted `markdownlint-cli2 docs\channels\feishu.md` invocation also expands to the repo docs globs and reports an unrelated pre-existing `docs/CLAUDE.md` trailing-newline issue.

## Human Verification (required)

- Verified scenarios: docs-only MDX parsing and whitespace check.
- Edge cases checked: Feishu China domain, Lark global domain, custom domain note, sensitive credential redaction note.
- What you did **not** verify: live Feishu/Lark connectivity from this branch, because no runtime behavior changed.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Users may copy examples without adapting them to their own proxy/domain setup.
  - Mitigation: The docs explicitly call out Feishu China, Lark global, and custom-domain variants, and keep the examples credential-free.