### PR TITLE
fix: preserve workspaces during state-only uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -502,6 +502,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/uninstall: preserve configured workspace directories during state-only cleanup, so nested workspaces under `.openclaw` are not deleted unless workspace removal is selected. Fixes #75052. Thanks @Jason-Bai.
 - CLI/message: skip eager model context warmup and preserve channel-declared gateway execution for Discord and Telegram message actions, avoiding Codex app-server/model discovery during simple send/read commands. Thanks @fuller-stack-dev.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.
 - Plugins/ClawHub: use the ClawHub artifact resolver response as the install decision before downloading, keeping legacy ZIP fallback and future ClawPack npm-pack installs on the same explicit resolver path. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3240,7 +3240,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/uninstall: preserve configured workspace directories during state-only cleanup, so nested workspaces under `.openclaw` are not deleted unless workspace removal is selected. Fixes #75052. Thanks @Jason-Bai.
 - CLI/message: skip eager model context warmup and preserve channel-declared gateway execution for Discord and Telegram message actions, avoiding Codex app-server/model discovery during simple send/read commands. Thanks @fuller-stack-dev.
 - Agents/exec approvals: parse exec approval result metadata with balanced parentheses so nested-paren denial and finished payloads such as `Exec denied (gateway id=req-1, approval-timeout (allowlist-miss)): ...` are matched and routed to the denied followup branch instead of falling through to the generic followup path. (#72268) Thanks @amittell.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3240,6 +3240,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/uninstall: preserve configured workspace directories during state-only cleanup, so nested workspaces under `.openclaw` are not deleted unless workspace removal is selected. Fixes #75052. Thanks @Jason-Bai.
 - CLI/message: skip eager model context warmup and preserve channel-declared gateway execution for Discord and Telegram message actions, avoiding Codex app-server/model discovery during simple send/read commands. Thanks @fuller-stack-dev.
 - Agents/exec approvals: parse exec approval result metadata with balanced parentheses so nested-paren denial and finished payloads such as `Exec denied (gateway id=req-1, approval-timeout (allowlist-miss)): ...` are matched and routed to the denied followup branch instead of falling through to the generic followup path. (#72268) Thanks @amittell.
 - Codex/app-server: resolve managed binaries from bundled `dist` chunks and from the `@openai/codex` package bin when installs do not provide a nearby `.bin/codex` shim, avoiding false missing-binary startup failures.

--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -35,6 +35,7 @@ openclaw uninstall --dry-run
 Notes:
 
 - Run `openclaw backup create` first if you want a restorable snapshot before removing state or workspaces.
+- `--state` preserves configured workspace directories unless `--workspace` is also selected.
 - `--all` is shorthand for removing service, state, workspace, and app together.
 - `--non-interactive` requires `--yes`.
 

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -19,6 +19,8 @@ Recommended: use the built-in uninstaller:
 openclaw uninstall
 ```
 
+When using the CLI, state removal preserves configured workspace directories unless you also select `--workspace`.
+
 Non-interactive (automation / npx):
 
 ```bash
@@ -47,6 +49,7 @@ rm -rf "${OPENCLAW_STATE_DIR:-$HOME/.openclaw}"
 ```
 
 If you set `OPENCLAW_CONFIG_PATH` to a custom location outside the state dir, delete that file too.
+If you want to keep a workspace inside the state dir, such as `~/.openclaw/workspace`, move it aside before running `rm -rf` or delete state contents selectively.
 
 4. Delete your workspace (optional, removes agent files):
 

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -4,7 +4,7 @@ import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 const resolveCleanupPlanFromDisk = vi.fn();
 const removePath = vi.fn();
 const listAgentSessionDirs = vi.fn();
-const removeStateAndLinkedPaths = vi.fn();
+export const removeStateAndLinkedPaths = vi.fn();
 const removeWorkspaceDirs = vi.fn();
 
 vi.mock("../config/config.js", () => ({

--- a/src/commands/cleanup-command.test-support.ts
+++ b/src/commands/cleanup-command.test-support.ts
@@ -5,7 +5,7 @@ import type { MockFn } from "../test-utils/vitest-mock-fn.js";
 const resolveCleanupPlanFromDisk = vi.fn();
 const removePath = vi.fn();
 const listAgentSessionDirs = vi.fn();
-const removeStateAndLinkedPaths = vi.fn();
+export const removeStateAndLinkedPaths = vi.fn();
 const removeWorkspaceDirs = vi.fn();
 
 vi.mock("../config/config.js", () => ({

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, test, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -88,6 +90,41 @@ describe("cleanup path removals", () => {
     expect(joinedLogs).toContain("/tmp/openclaw-cleanup/state");
     expect(joinedLogs).toContain("/tmp/openclaw-cleanup/oauth");
     expect(joinedLogs).not.toContain("openclaw.json");
+  });
+
+  it("preserves nested workspace paths during state-only removal", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-"));
+    const stateDir = path.join(tmpRoot, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const workspaceFile = path.join(workspaceDir, "project.txt");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const cacheFile = path.join(stateDir, "cache.json");
+
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(workspaceFile, "keep me");
+      await fs.writeFile(configPath, "{}");
+      await fs.writeFile(cacheFile, "remove me");
+
+      await removeStateAndLinkedPaths(
+        {
+          stateDir,
+          configPath,
+          oauthDir: path.join(stateDir, "credentials"),
+          configInsideState: true,
+          oauthInsideState: true,
+        },
+        runtime,
+        { preservePaths: [workspaceDir] },
+      );
+
+      await expect(fs.readFile(workspaceFile, "utf8")).resolves.toBe("keep me");
+      await expect(fs.stat(configPath)).rejects.toThrow();
+      await expect(fs.stat(cacheFile)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("removes every workspace directory", async () => {

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -14,10 +14,12 @@ import {
 describe("buildCleanupPlan", () => {
   test("resolves inside-state flags and workspace dirs", () => {
     const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp");
+    const defaultWorkspace = path.join(tmpRoot, "openclaw-workspace-default");
+    const opsWorkspace = path.join(tmpRoot, "openclaw-workspace-ops");
     const cfg = {
       agents: {
-        defaults: { workspace: path.join(tmpRoot, "openclaw-workspace-1") },
-        list: [{ workspace: path.join(tmpRoot, "openclaw-workspace-2") }],
+        defaults: { workspace: defaultWorkspace },
+        list: [{ id: "main" }, { id: "ops", workspace: opsWorkspace }],
       },
     };
     const plan = buildCleanupPlan({
@@ -29,12 +31,54 @@ describe("buildCleanupPlan", () => {
 
     expect(plan.configInsideState).toBe(true);
     expect(plan.oauthInsideState).toBe(false);
-    expect(new Set(plan.workspaceDirs)).toEqual(
-      new Set([
-        path.join(tmpRoot, "openclaw-workspace-1"),
-        path.join(tmpRoot, "openclaw-workspace-2"),
-      ]),
-    );
+    expect(new Set(plan.workspaceDirs)).toEqual(new Set([defaultWorkspace, opsWorkspace]));
+  });
+
+  test("includes implicit per-agent workspaces under the state dir", () => {
+    const previousHome = process.env.HOME;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    const previousWorkspaceDir = process.env.OPENCLAW_WORKSPACE_DIR;
+    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "openclaw-cleanup-plan");
+    const home = path.join(tmpRoot, "home");
+    const stateDir = path.join(home, ".openclaw");
+    const cfg = {
+      agents: {
+        list: [{ id: "main" }, { id: "work" }],
+      },
+    };
+
+    try {
+      process.env.HOME = home;
+      process.env.OPENCLAW_STATE_DIR = stateDir;
+      delete process.env.OPENCLAW_WORKSPACE_DIR;
+
+      const plan = buildCleanupPlan({
+        cfg: cfg as unknown as OpenClawConfig,
+        stateDir,
+        configPath: path.join(stateDir, "openclaw.json"),
+        oauthDir: path.join(stateDir, "credentials"),
+      });
+
+      expect(new Set(plan.workspaceDirs)).toEqual(
+        new Set([path.join(stateDir, "workspace"), path.join(stateDir, "workspace-work")]),
+      );
+    } finally {
+      if (previousHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = previousHome;
+      }
+      if (previousStateDir === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = previousStateDir;
+      }
+      if (previousWorkspaceDir === undefined) {
+        delete process.env.OPENCLAW_WORKSPACE_DIR;
+      } else {
+        process.env.OPENCLAW_WORKSPACE_DIR = previousWorkspaceDir;
+      }
+    }
   });
 });
 

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, test, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -98,6 +100,41 @@ describe("cleanup path removals", () => {
       "[dry-run] remove /tmp/openclaw-cleanup/state",
       "[dry-run] remove /tmp/openclaw-cleanup/oauth",
     ]);
+  });
+
+  it("preserves nested workspace paths during state-only removal", async () => {
+    const runtime = createRuntimeMock();
+    const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cleanup-"));
+    const stateDir = path.join(tmpRoot, ".openclaw");
+    const workspaceDir = path.join(stateDir, "workspace");
+    const workspaceFile = path.join(workspaceDir, "project.txt");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const cacheFile = path.join(stateDir, "cache.json");
+
+    try {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(workspaceFile, "keep me");
+      await fs.writeFile(configPath, "{}");
+      await fs.writeFile(cacheFile, "remove me");
+
+      await removeStateAndLinkedPaths(
+        {
+          stateDir,
+          configPath,
+          oauthDir: path.join(stateDir, "credentials"),
+          configInsideState: true,
+          oauthInsideState: true,
+        },
+        runtime,
+        { preservePaths: [workspaceDir] },
+      );
+
+      await expect(fs.readFile(workspaceFile, "utf8")).resolves.toBe("keep me");
+      await expect(fs.stat(configPath)).rejects.toThrow();
+      await expect(fs.stat(cacheFile)).rejects.toThrow();
+    } finally {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("removes every workspace directory", async () => {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -18,6 +18,16 @@ type CleanupResolvedPaths = {
   oauthInsideState: boolean;
 };
 
+type RemovalOptions = {
+  dryRun?: boolean;
+  label?: string;
+};
+
+type StateRemovalOptions = {
+  dryRun?: boolean;
+  preservePaths?: readonly string[];
+};
+
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {
   const dirs = new Set<string>();
   const defaults = cfg?.agents?.defaults;
@@ -78,7 +88,7 @@ function isUnsafeRemovalTarget(target: string): boolean {
 export async function removePath(
   target: string,
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean; label?: string },
+  opts?: RemovalOptions,
 ): Promise<RemovalResult> {
   if (!target?.trim()) {
     return { ok: false, skipped: true };
@@ -104,15 +114,100 @@ export async function removePath(
   }
 }
 
+async function existingPaths(paths: readonly string[]): Promise<string[]> {
+  const existing: string[] = [];
+  for (const target of paths) {
+    if (!target?.trim()) {
+      continue;
+    }
+    const resolved = path.resolve(target);
+    try {
+      await fs.lstat(resolved);
+      existing.push(resolved);
+    } catch {
+      // Missing workspaces do not need preservation during destructive cleanup.
+    }
+  }
+  return existing;
+}
+
+function shouldPreservePath(target: string, preservePaths: readonly string[]): boolean {
+  return preservePaths.some((preservePath) => isPathWithin(target, preservePath));
+}
+
+function pathContainsPreservedPath(target: string, preservePaths: readonly string[]): boolean {
+  return preservePaths.some((preservePath) => isPathWithin(preservePath, target));
+}
+
+async function removePathPreserving(
+  target: string,
+  preservePaths: readonly string[],
+  runtime: RuntimeEnv,
+  opts?: RemovalOptions,
+): Promise<RemovalResult> {
+  if (!target?.trim()) {
+    return { ok: false, skipped: true };
+  }
+  const resolved = path.resolve(target);
+  const label = opts?.label ?? resolved;
+  const displayLabel = shortenHomeInString(label);
+  if (isUnsafeRemovalTarget(resolved)) {
+    runtime.error(`Refusing to remove unsafe path: ${displayLabel}`);
+    return { ok: false };
+  }
+  if (shouldPreservePath(resolved, preservePaths)) {
+    return { ok: true, skipped: true };
+  }
+  if (!pathContainsPreservedPath(resolved, preservePaths)) {
+    return removePath(resolved, runtime, opts);
+  }
+  if (opts?.dryRun) {
+    const preserved = preservePaths
+      .filter((preservePath) => isPathWithin(preservePath, resolved))
+      .map((preservePath) => shortenHomeInString(preservePath))
+      .join(", ");
+    runtime.log(`[dry-run] remove ${displayLabel} preserving ${preserved}`);
+    return { ok: true, skipped: true };
+  }
+  try {
+    const stat = await fs.lstat(resolved);
+    if (!stat.isDirectory()) {
+      return removePath(resolved, runtime, opts);
+    }
+    const entries = await fs.readdir(resolved);
+    for (const entry of entries) {
+      await removePathPreserving(path.join(resolved, entry), preservePaths, runtime);
+    }
+    runtime.log(`Removed contents of ${displayLabel}`);
+    return { ok: true };
+  } catch (err) {
+    runtime.error(`Failed to remove ${displayLabel}: ${String(err)}`);
+    return { ok: false };
+  }
+}
+
 export async function removeStateAndLinkedPaths(
   cleanup: CleanupResolvedPaths,
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean },
+  opts?: StateRemovalOptions,
 ): Promise<void> {
-  await removePath(cleanup.stateDir, runtime, {
-    dryRun: opts?.dryRun,
-    label: cleanup.stateDir,
-  });
+  const stateDir = path.resolve(cleanup.stateDir);
+  const preservePaths = (
+    opts?.dryRun
+      ? (opts.preservePaths ?? []).map((target) => path.resolve(target))
+      : await existingPaths(opts?.preservePaths ?? [])
+  ).filter((target) => isPathWithin(target, stateDir));
+  if (preservePaths.length > 0) {
+    await removePathPreserving(stateDir, preservePaths, runtime, {
+      dryRun: opts?.dryRun,
+      label: cleanup.stateDir,
+    });
+  } else {
+    await removePath(cleanup.stateDir, runtime, {
+      dryRun: opts?.dryRun,
+      label: cleanup.stateDir,
+    });
+  }
   if (!cleanup.configInsideState) {
     await removePath(cleanup.configPath, runtime, {
       dryRun: opts?.dryRun,

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -19,6 +19,16 @@ type CleanupResolvedPaths = {
   oauthInsideState: boolean;
 };
 
+type RemovalOptions = {
+  dryRun?: boolean;
+  label?: string;
+};
+
+type StateRemovalOptions = {
+  dryRun?: boolean;
+  preservePaths?: readonly string[];
+};
+
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {
   const dirs = new Set<string>();
   const defaults = cfg?.agents?.defaults;
@@ -78,7 +88,7 @@ function isUnsafeRemovalTarget(target: string): boolean {
 export async function removePath(
   target: string,
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean; label?: string },
+  opts?: RemovalOptions,
 ): Promise<RemovalResult> {
   if (!target?.trim()) {
     return { ok: false, skipped: true };
@@ -104,15 +114,100 @@ export async function removePath(
   }
 }
 
+async function existingPaths(paths: readonly string[]): Promise<string[]> {
+  const existing: string[] = [];
+  for (const target of paths) {
+    if (!target?.trim()) {
+      continue;
+    }
+    const resolved = path.resolve(target);
+    try {
+      await fs.lstat(resolved);
+      existing.push(resolved);
+    } catch {
+      // Missing workspaces do not need preservation during destructive cleanup.
+    }
+  }
+  return existing;
+}
+
+function shouldPreservePath(target: string, preservePaths: readonly string[]): boolean {
+  return preservePaths.some((preservePath) => isPathWithin(target, preservePath));
+}
+
+function pathContainsPreservedPath(target: string, preservePaths: readonly string[]): boolean {
+  return preservePaths.some((preservePath) => isPathWithin(preservePath, target));
+}
+
+async function removePathPreserving(
+  target: string,
+  preservePaths: readonly string[],
+  runtime: RuntimeEnv,
+  opts?: RemovalOptions,
+): Promise<RemovalResult> {
+  if (!target?.trim()) {
+    return { ok: false, skipped: true };
+  }
+  const resolved = path.resolve(target);
+  const label = opts?.label ?? resolved;
+  const displayLabel = shortenHomeInString(label);
+  if (isUnsafeRemovalTarget(resolved)) {
+    runtime.error(`Refusing to remove unsafe path: ${displayLabel}`);
+    return { ok: false };
+  }
+  if (shouldPreservePath(resolved, preservePaths)) {
+    return { ok: true, skipped: true };
+  }
+  if (!pathContainsPreservedPath(resolved, preservePaths)) {
+    return removePath(resolved, runtime, opts);
+  }
+  if (opts?.dryRun) {
+    const preserved = preservePaths
+      .filter((preservePath) => isPathWithin(preservePath, resolved))
+      .map((preservePath) => shortenHomeInString(preservePath))
+      .join(", ");
+    runtime.log(`[dry-run] remove ${displayLabel} preserving ${preserved}`);
+    return { ok: true, skipped: true };
+  }
+  try {
+    const stat = await fs.lstat(resolved);
+    if (!stat.isDirectory()) {
+      return removePath(resolved, runtime, opts);
+    }
+    const entries = await fs.readdir(resolved);
+    for (const entry of entries) {
+      await removePathPreserving(path.join(resolved, entry), preservePaths, runtime);
+    }
+    runtime.log(`Removed contents of ${displayLabel}`);
+    return { ok: true };
+  } catch (err) {
+    runtime.error(`Failed to remove ${displayLabel}: ${String(err)}`);
+    return { ok: false };
+  }
+}
+
 export async function removeStateAndLinkedPaths(
   cleanup: CleanupResolvedPaths,
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean },
+  opts?: StateRemovalOptions,
 ): Promise<void> {
-  await removePath(cleanup.stateDir, runtime, {
-    dryRun: opts?.dryRun,
-    label: cleanup.stateDir,
-  });
+  const stateDir = path.resolve(cleanup.stateDir);
+  const preservePaths = (
+    opts?.dryRun
+      ? (opts.preservePaths ?? []).map((target) => path.resolve(target))
+      : await existingPaths(opts?.preservePaths ?? [])
+  ).filter((target) => isPathWithin(target, stateDir));
+  if (preservePaths.length > 0) {
+    await removePathPreserving(stateDir, preservePaths, runtime, {
+      dryRun: opts?.dryRun,
+      label: cleanup.stateDir,
+    });
+  } else {
+    await removePath(cleanup.stateDir, runtime, {
+      dryRun: opts?.dryRun,
+      label: cleanup.stateDir,
+    });
+  }
   if (!cleanup.configInsideState) {
     await removePath(cleanup.configPath, runtime, {
       dryRun: opts?.dryRun,

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -1,10 +1,11 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
+import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPathInside } from "../infra/path-guards.js";
 import type { RuntimeEnv } from "../runtime.js";
-import { resolveHomeDir, resolveUserPath, shortenHomeInString } from "../utils.js";
+import { resolveHomeDir, shortenHomeInString } from "../utils.js";
 
 type RemovalResult = {
   ok: boolean;
@@ -31,19 +32,12 @@ type StateRemovalOptions = {
 
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {
   const dirs = new Set<string>();
-  const defaults = cfg?.agents?.defaults;
-  if (typeof defaults?.workspace === "string" && defaults.workspace.trim()) {
-    dirs.add(resolveUserPath(defaults.workspace));
-  }
-  const list = Array.isArray(cfg?.agents?.list) ? cfg?.agents?.list : [];
-  for (const agent of list) {
-    const workspace = (agent as { workspace?: unknown }).workspace;
-    if (typeof workspace === "string" && workspace.trim()) {
-      dirs.add(resolveUserPath(workspace));
-    }
-  }
-  if (dirs.size === 0) {
+  if (!cfg) {
     dirs.add(resolveDefaultAgentWorkspaceDir());
+    return [...dirs];
+  }
+  for (const agentId of listAgentIds(cfg)) {
+    dirs.add(resolveAgentWorkspaceDir(cfg, agentId));
   }
   return [...dirs];
 }

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   createCleanupCommandRuntime,
+  removeStateAndLinkedPaths,
   resetCleanupCommandMocks,
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
@@ -35,5 +36,42 @@ describe("uninstallCommand", () => {
     });
 
     expect(runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("openclaw backup create"));
+  });
+
+  it("preserves workspace dirs during state-only uninstall", async () => {
+    await uninstallCommand(runtime, {
+      state: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeStateAndLinkedPaths).toHaveBeenCalledWith(
+      expect.any(Object),
+      runtime,
+      expect.objectContaining({
+        dryRun: true,
+        preservePaths: ["/tmp/.openclaw/workspace"],
+      }),
+    );
+  });
+
+  it("does not preserve workspace dirs when workspace removal is selected", async () => {
+    await uninstallCommand(runtime, {
+      state: true,
+      workspace: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeStateAndLinkedPaths).toHaveBeenCalledWith(
+      expect.any(Object),
+      runtime,
+      expect.objectContaining({
+        dryRun: true,
+        preservePaths: [],
+      }),
+    );
   });
 });

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   cleanupCommandLogMessages,
   createCleanupCommandRuntime,
+  removeStateAndLinkedPaths,
   resetCleanupCommandMocks,
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
@@ -44,5 +45,42 @@ describe("uninstallCommand", () => {
         message.includes("openclaw backup create"),
       ),
     ).toBe(false);
+  });
+
+  it("preserves workspace dirs during state-only uninstall", async () => {
+    await uninstallCommand(runtime, {
+      state: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeStateAndLinkedPaths).toHaveBeenCalledWith(
+      expect.any(Object),
+      runtime,
+      expect.objectContaining({
+        dryRun: true,
+        preservePaths: ["/tmp/.openclaw/workspace"],
+      }),
+    );
+  });
+
+  it("does not preserve workspace dirs when workspace removal is selected", async () => {
+    await uninstallCommand(runtime, {
+      state: true,
+      workspace: true,
+      yes: true,
+      nonInteractive: true,
+      dryRun: true,
+    });
+
+    expect(removeStateAndLinkedPaths).toHaveBeenCalledWith(
+      expect.any(Object),
+      runtime,
+      expect.objectContaining({
+        dryRun: true,
+        preservePaths: [],
+      }),
+    );
   });
 });

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -176,7 +176,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     await removeStateAndLinkedPaths(
       { stateDir, configPath, oauthDir, configInsideState, oauthInsideState },
       runtime,
-      { dryRun },
+      { dryRun, preservePaths: scopes.has("workspace") ? [] : workspaceDirs },
     );
   }
 

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -193,7 +193,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     await removeStateAndLinkedPaths(
       { stateDir, configPath, oauthDir, configInsideState, oauthInsideState },
       runtime,
-      { dryRun },
+      { dryRun, preservePaths: scopes.has("workspace") ? [] : workspaceDirs },
     );
   }
 


### PR DESCRIPTION
## Summary
- preserve configured workspace directories when `openclaw uninstall --state` removes a parent state directory
- keep destructive workspace deletion behavior when `--workspace`/`--all` is selected
- document the CLI behavior and warn manual uninstall users about `rm -rf ~/.openclaw` when workspaces live inside state

Fixes #75052.

## Root cause
`removeStateAndLinkedPaths` removed the whole state directory recursively. The default workspace lives under `~/.openclaw/workspace`, so a state-only uninstall could delete workspace files even when workspace deletion was not selected.

## Validation
- `pnpm test src/commands/uninstall.test.ts src/commands/cleanup-utils.test.ts src/commands/reset.test.ts src/commands/agents.delete.test.ts`
- `pnpm exec oxfmt --check --threads=1 src/commands/uninstall.ts src/commands/cleanup-utils.ts src/commands/uninstall.test.ts src/commands/cleanup-utils.test.ts src/commands/reset.test.ts docs/cli/uninstall.md docs/install/uninstall.md`
- `git diff --check`
- `pnpm check:changed`


## Real behavior proof

- Behavior or issue addressed:
  `openclaw uninstall --state` should remove state/config/cache files but preserve a workspace directory nested under the state directory unless `--workspace` or `--all` is selected.
- Real environment tested:
  Local macOS shell on this PR branch, using the repository CLI via `pnpm openclaw` with a throwaway `HOME`, `OPENCLAW_STATE_DIR`, and `OPENCLAW_CONFIG_PATH`.
- Exact steps or command run after this patch:
  Created a throwaway state tree containing `cache/state-cache.txt`, `openclaw.json`, and `workspace/project.txt`, then ran:
  `HOME=<TMP_ROOT>/home OPENCLAW_STATE_DIR=<TMP_ROOT>/home/.openclaw OPENCLAW_CONFIG_PATH=<TMP_ROOT>/home/.openclaw/openclaw.json pnpm openclaw uninstall --state --yes --non-interactive`
- Evidence after fix (screenshot, recording, terminal capture, console output, redacted runtime log, linked artifact, or copied live output):

```text
Throwaway root: <TMP_ROOT>

Before state-only uninstall:
<TMP_ROOT>/home/.openclaw/cache/state-cache.txt
<TMP_ROOT>/home/.openclaw/openclaw.json
<TMP_ROOT>/home/.openclaw/workspace/project.txt

Command:
  HOME=<TMP_ROOT>/home OPENCLAW_STATE_DIR=<TMP_ROOT>/home/.openclaw OPENCLAW_CONFIG_PATH=<TMP_ROOT>/home/.openclaw/openclaw.json pnpm openclaw uninstall --state --yes --non-interactive

Output:
> openclaw@2026.5.4 openclaw /path/to/openclaw
> node scripts/run-node.mjs uninstall --state --yes --non-interactive

Recommended first: openclaw backup create
Removed ~/.openclaw/cache
Removed ~/.openclaw/credentials
Removed ~/.openclaw/logs
Removed ~/.openclaw/openclaw.json
Removed contents of ~/.openclaw
CLI still installed. Remove via npm/pnpm if desired.
Tip: workspaces were preserved. Re-run with --workspace to remove them.

After state-only uninstall:
<TMP_ROOT>/home/.openclaw/workspace/project.txt

Verification:
workspace file preserved: yes
workspace file content: keep me
state/config files removed: yes
```

- Observed result after fix:
  State/config files were removed, while `<TMP_ROOT>/home/.openclaw/workspace/project.txt` remained present with content `keep me`.
- What was not tested:
  Global package-manager uninstall behavior was not tested; this proof covers the state-only uninstall path changed by this PR.
