### PR TITLE
fix(uninstall): preserve workspace-inside-state when only state scope selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,7 +99,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- CLI/uninstall: refuse to prune workspace-inside-state paths when the resolved state directory is an unsafe root (home or filesystem root), so `OPENCLAW_STATE_DIR=$HOME` overrides with a nested workspace cannot enumerate and delete home directory children. Fixes #75052. Thanks @hclsys.
+- CLI/uninstall: preserve configured workspaces nested inside the state directory when state-only uninstall is selected without workspace removal, so state cleanup no longer recursively deletes active workspace data; also refuse to prune workspace-inside-state paths when the state directory is an unsafe root (home or filesystem root). Fixes #75052. Thanks @hclsys.
 - Security/outbound: strip re-formed HTML tags during plain-text sanitization so nested tag fragments cannot leave a CodeQL-detected `<script>` sequence behind. Thanks @vincentkoc.
 - Security/secrets: compare credential bytes with padded timing-safe buffers instead of hashing candidate passwords before equality checks. Thanks @vincentkoc.
 - Security/QQBot: sanitize debug log arguments before writing to `console.*`, so gateway payload fields cannot forge extra log lines when debug logging is enabled. Thanks @vincentkoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- CLI/uninstall: refuse to prune workspace-inside-state paths when the resolved state directory is an unsafe root (home or filesystem root), so `OPENCLAW_STATE_DIR=$HOME` overrides with a nested workspace cannot enumerate and delete home directory children. Fixes #75052. Thanks @hclsys.
 - Security/outbound: strip re-formed HTML tags during plain-text sanitization so nested tag fragments cannot leave a CodeQL-detected `<script>` sequence behind. Thanks @vincentkoc.
 - Security/secrets: compare credential bytes with padded timing-safe buffers instead of hashing candidate passwords before equality checks. Thanks @vincentkoc.
 - Security/QQBot: sanitize debug log arguments before writing to `console.*`, so gateway payload fields cannot forge extra log lines when debug logging is enabled. Thanks @vincentkoc.

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, test, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
@@ -101,30 +103,42 @@ describe("cleanup path removals", () => {
     expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-2");
   });
 
-  it("skips state dir removal when a workspace inside it is not selected for deletion", async () => {
+  it("prunes state dir contents around a preserved workspace, keeping other state data removed", async () => {
     // Regression for openclaw/openclaw#75052: uninstalling with state scope but not workspace
-    // scope must not delete a workspace directory stored inside the state dir.
+    // scope must remove state data (config, credentials) while preserving the workspace subtree.
     const runtime = createRuntimeMock();
-    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "openclaw-cleanup");
-    const stateDir = path.join(tmpRoot, "state");
-    const workspaceInsideState = path.join(stateDir, "workspaces", "main");
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-75052-"));
+    try {
+      const stateDir = path.join(tmpDir, "state");
+      const workspaceInsideState = path.join(stateDir, "workspaces", "main");
+      // Populate state dir with config, credentials, and workspace
+      await fs.mkdir(path.join(stateDir, "workspaces", "main"), { recursive: true });
+      await fs.mkdir(path.join(stateDir, "credentials"), { recursive: true });
+      await fs.writeFile(path.join(stateDir, "openclaw.json"), "{}\n", "utf8");
+      await fs.writeFile(path.join(stateDir, "credentials", "token.json"), "{}\n", "utf8");
+      await fs.writeFile(path.join(workspaceInsideState, "agent.jsonl"), "{}\n", "utf8");
 
-    await removeStateAndLinkedPaths(
-      {
-        stateDir,
-        configPath: path.join(stateDir, "openclaw.json"),
-        oauthDir: path.join(tmpRoot, "oauth"),
-        configInsideState: true,
-        oauthInsideState: false,
-      },
-      runtime,
-      { dryRun: true, workspaceDirsToPreserve: [workspaceInsideState] },
-    );
+      await removeStateAndLinkedPaths(
+        {
+          stateDir,
+          configPath: path.join(stateDir, "openclaw.json"),
+          oauthDir: path.join(tmpDir, "oauth"),
+          configInsideState: true,
+          oauthInsideState: false,
+        },
+        runtime,
+        { dryRun: false, workspaceDirsToPreserve: [workspaceInsideState] },
+      );
 
-    const joinedLogs = runtime.log.mock.calls
-      .map(([line]) => line.replaceAll("\\", "/"))
-      .join("\n");
-    expect(joinedLogs).toContain("Skipping state dir removal");
-    expect(joinedLogs).not.toContain(`[dry-run] remove /tmp/openclaw-cleanup/state`);
+      // State-level items removed: config and credentials
+      await expect(fs.access(path.join(stateDir, "openclaw.json"))).rejects.toThrow();
+      await expect(fs.access(path.join(stateDir, "credentials"))).rejects.toThrow();
+      // Workspace preserved
+      await expect(
+        fs.access(path.join(workspaceInsideState, "agent.jsonl")),
+      ).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -131,6 +131,44 @@ describe("cleanup path removals", () => {
     await expect(fs.access(homeDir)).resolves.toBeUndefined();
   });
 
+  it("refuses to prune a symlinked state-dir root even when a workspace is inside it (#75052 security)", async () => {
+    // Regression: removeStateDirAroundWorkspaces must refuse when OPENCLAW_STATE_DIR is a symlink.
+    // Without this guard, fs.readdir follows the symlink and can enumerate/delete children of an
+    // unrelated target directory even though the apparent workspace-preservation path check passes.
+    const runtime = createRuntimeMock();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-75052-symlink-"));
+    try {
+      const realStateDir = path.join(tmpDir, "real-state");
+      const symlinkStateDir = path.join(tmpDir, "link-state");
+      const workspaceInsideSymlink = path.join(symlinkStateDir, "workspace");
+      await fs.mkdir(realStateDir, { recursive: true });
+      await fs.symlink(realStateDir, symlinkStateDir);
+      await fs.mkdir(path.join(realStateDir, "workspace"), { recursive: true });
+      await fs.writeFile(path.join(realStateDir, "token.json"), "{}\n", "utf8");
+
+      await removeStateAndLinkedPaths(
+        {
+          stateDir: symlinkStateDir,
+          configPath: path.join(symlinkStateDir, "openclaw.json"),
+          oauthDir: path.join(tmpDir, "oauth"),
+          configInsideState: true,
+          oauthInsideState: false,
+        },
+        runtime,
+        { dryRun: false, workspaceDirsToPreserve: [workspaceInsideSymlink] },
+      );
+
+      const errors = runtime.error.mock.calls.map(([line]: [string]) => line);
+      expect(errors.some((e: string) => e.includes("Refusing to prune symlinked state root"))).toBe(
+        true,
+      );
+      // Real state directory contents must be untouched.
+      await expect(fs.access(path.join(realStateDir, "token.json"))).resolves.toBeUndefined();
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("prunes state dir contents around a preserved workspace, keeping other state data removed", async () => {
     // Regression for openclaw/openclaw#75052: uninstalling with state scope but not workspace
     // scope must remove state data (config, credentials) while preserving the workspace subtree.

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -103,6 +103,34 @@ describe("cleanup path removals", () => {
     expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-2");
   });
 
+  it("refuses to prune an unsafe state-dir root even when a workspace is inside it (#75052 security)", async () => {
+    // Regression: removeStateDirAroundWorkspaces must apply the same unsafe-target guard as
+    // removePath. Without the guard, OPENCLAW_STATE_DIR=$HOME with a workspace below HOME
+    // would enumerate and delete home directory children instead of refusing.
+    const runtime = createRuntimeMock();
+    const homeDir = path.resolve(process.env["HOME"] ?? os.homedir());
+    // A synthetic workspace path that is inside $HOME — triggers the pruning branch.
+    const workspaceInsideHome = path.join(homeDir, ".openclaw", "workspaces", "main");
+
+    await removeStateAndLinkedPaths(
+      {
+        stateDir: homeDir,
+        configPath: path.join(homeDir, ".openclaw.json"),
+        oauthDir: path.join(homeDir, ".openclaw-oauth"),
+        configInsideState: false,
+        oauthInsideState: false,
+      },
+      runtime,
+      { dryRun: false, workspaceDirsToPreserve: [workspaceInsideHome] },
+    );
+
+    // Must have logged a refusal, never removed anything.
+    const errors = runtime.error.mock.calls.map(([line]: [string]) => line);
+    expect(errors.some((e: string) => e.includes("Refusing to remove unsafe path"))).toBe(true);
+    // Home directory itself must still exist.
+    await expect(fs.access(homeDir)).resolves.toBeUndefined();
+  });
+
   it("prunes state dir contents around a preserved workspace, keeping other state data removed", async () => {
     // Regression for openclaw/openclaw#75052: uninstalling with state scope but not workspace
     // scope must remove state data (config, credentials) while preserving the workspace subtree.

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -100,4 +100,31 @@ describe("cleanup path removals", () => {
     expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-1");
     expect(logs).toContain("[dry-run] remove /tmp/openclaw-workspace-2");
   });
+
+  it("skips state dir removal when a workspace inside it is not selected for deletion", async () => {
+    // Regression for openclaw/openclaw#75052: uninstalling with state scope but not workspace
+    // scope must not delete a workspace directory stored inside the state dir.
+    const runtime = createRuntimeMock();
+    const tmpRoot = path.join(path.parse(process.cwd()).root, "tmp", "openclaw-cleanup");
+    const stateDir = path.join(tmpRoot, "state");
+    const workspaceInsideState = path.join(stateDir, "workspaces", "main");
+
+    await removeStateAndLinkedPaths(
+      {
+        stateDir,
+        configPath: path.join(stateDir, "openclaw.json"),
+        oauthDir: path.join(tmpRoot, "oauth"),
+        configInsideState: true,
+        oauthInsideState: false,
+      },
+      runtime,
+      { dryRun: true, workspaceDirsToPreserve: [workspaceInsideState] },
+    );
+
+    const joinedLogs = runtime.log.mock.calls
+      .map(([line]) => line.replaceAll("\\", "/"))
+      .join("\n");
+    expect(joinedLogs).toContain("Skipping state dir removal");
+    expect(joinedLogs).not.toContain(`[dry-run] remove /tmp/openclaw-cleanup/state`);
+  });
 });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace.js";
@@ -142,7 +143,7 @@ async function removeStateDirAroundWorkspaces(
   runtime: RuntimeEnv,
   opts?: { dryRun?: boolean },
 ): Promise<void> {
-  let entries: fs.Dirent[];
+  let entries: Dirent[];
   try {
     entries = await fs.readdir(stateDir, { withFileTypes: true });
   } catch {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -151,6 +151,18 @@ async function removeStateDirAroundWorkspaces(
     return;
   }
 
+  // Refuse to enumerate through a symlinked state root — readdir follows symlinks,
+  // so a symlinked OPENCLAW_STATE_DIR could prune children of an unrelated directory.
+  try {
+    const stat = await fs.lstat(resolvedStateDir);
+    if (stat.isSymbolicLink()) {
+      runtime.error(`Refusing to prune symlinked state root: ${resolvedStateDir}`);
+      return;
+    }
+  } catch {
+    return;
+  }
+
   let entries: Dirent[];
   try {
     entries = await fs.readdir(resolvedStateDir, { withFileTypes: true });

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -109,19 +109,19 @@ export async function removeStateAndLinkedPaths(
   runtime: RuntimeEnv,
   opts?: { dryRun?: boolean; workspaceDirsToPreserve?: readonly string[] },
 ): Promise<void> {
-  const hasWorkspaceInsideState = opts?.workspaceDirsToPreserve?.some((dir) =>
-    isPathWithin(dir, cleanup.stateDir),
-  );
-  if (hasWorkspaceInsideState) {
-    runtime.log(
-      `Skipping state dir removal — workspace directories inside ${cleanup.stateDir} were not selected for deletion.`,
-    );
-  } else {
+  const preserveList = opts?.workspaceDirsToPreserve ?? [];
+  const workspacesInsideState = preserveList.filter((dir) => isPathWithin(dir, cleanup.stateDir));
+
+  if (workspacesInsideState.length === 0) {
     await removePath(cleanup.stateDir, runtime, {
       dryRun: opts?.dryRun,
       label: cleanup.stateDir,
     });
+  } else {
+    // Prune state dir contents, skipping only entries that contain (or are) a preserved workspace.
+    await removeStateDirAroundWorkspaces(cleanup.stateDir, workspacesInsideState, runtime, opts);
   }
+
   if (!cleanup.configInsideState) {
     await removePath(cleanup.configPath, runtime, {
       dryRun: opts?.dryRun,
@@ -133,6 +133,33 @@ export async function removeStateAndLinkedPaths(
       dryRun: opts?.dryRun,
       label: cleanup.oauthDir,
     });
+  }
+}
+
+async function removeStateDirAroundWorkspaces(
+  stateDir: string,
+  workspacesToPreserve: readonly string[],
+  runtime: RuntimeEnv,
+  opts?: { dryRun?: boolean },
+): Promise<void> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.readdir(stateDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const entryPath = path.join(stateDir, entry.name);
+    const isAncestorOfPreserved = workspacesToPreserve.some((w) => isPathWithin(w, entryPath));
+    const isPreservedItself = workspacesToPreserve.some((w) => isPathWithin(entryPath, w));
+    if (isAncestorOfPreserved) {
+      // Recurse into this directory to prune around the preserved workspace.
+      if (entry.isDirectory()) {
+        await removeStateDirAroundWorkspaces(entryPath, workspacesToPreserve, runtime, opts);
+      }
+    } else if (!isPreservedItself) {
+      await removePath(entryPath, runtime, { dryRun: opts?.dryRun, label: entryPath });
+    }
   }
 }
 

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -143,14 +143,22 @@ async function removeStateDirAroundWorkspaces(
   runtime: RuntimeEnv,
   opts?: { dryRun?: boolean },
 ): Promise<void> {
+  // Guard must mirror removePath: refuse to prune an unsafe root even when
+  // workspace-preservation skips the full removePath(stateDir) call.
+  const resolvedStateDir = path.resolve(stateDir);
+  if (isUnsafeRemovalTarget(resolvedStateDir)) {
+    runtime.error(`Refusing to remove unsafe path: ${resolvedStateDir}`);
+    return;
+  }
+
   let entries: Dirent[];
   try {
-    entries = await fs.readdir(stateDir, { withFileTypes: true });
+    entries = await fs.readdir(resolvedStateDir, { withFileTypes: true });
   } catch {
     return;
   }
   for (const entry of entries) {
-    const entryPath = path.join(stateDir, entry.name);
+    const entryPath = path.join(resolvedStateDir, entry.name);
     const isAncestorOfPreserved = workspacesToPreserve.some((w) => isPathWithin(w, entryPath));
     const isPreservedItself = workspacesToPreserve.some((w) => isPathWithin(entryPath, w));
     if (isAncestorOfPreserved) {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -107,12 +107,21 @@ export async function removePath(
 export async function removeStateAndLinkedPaths(
   cleanup: CleanupResolvedPaths,
   runtime: RuntimeEnv,
-  opts?: { dryRun?: boolean },
+  opts?: { dryRun?: boolean; workspaceDirsToPreserve?: readonly string[] },
 ): Promise<void> {
-  await removePath(cleanup.stateDir, runtime, {
-    dryRun: opts?.dryRun,
-    label: cleanup.stateDir,
-  });
+  const hasWorkspaceInsideState = opts?.workspaceDirsToPreserve?.some((dir) =>
+    isPathWithin(dir, cleanup.stateDir),
+  );
+  if (hasWorkspaceInsideState) {
+    runtime.log(
+      `Skipping state dir removal — workspace directories inside ${cleanup.stateDir} were not selected for deletion.`,
+    );
+  } else {
+    await removePath(cleanup.stateDir, runtime, {
+      dryRun: opts?.dryRun,
+      label: cleanup.stateDir,
+    });
+  }
   if (!cleanup.configInsideState) {
     await removePath(cleanup.configPath, runtime, {
       dryRun: opts?.dryRun,

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -176,7 +176,10 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
     await removeStateAndLinkedPaths(
       { stateDir, configPath, oauthDir, configInsideState, oauthInsideState },
       runtime,
-      { dryRun },
+      {
+        dryRun,
+        workspaceDirsToPreserve: scopes.has("workspace") ? undefined : workspaceDirs,
+      },
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes #75052.

When a user's workspace directory lives inside the state dir (e.g. `~/.openclaw/workspaces/main`) and they run `openclaw uninstall` selecting only the **State + config** scope (not **Workspace**), the entire state dir was deleted anyway — taking the workspace with it.

**Root cause:** `removeStateAndLinkedPaths` always called `removePath(stateDir)` unconditionally, even when a workspace-to-preserve was nested inside it.

**Fix:** Added `workspaceDirsToPreserve` option to `removeStateAndLinkedPaths`. Before deleting the state dir, the function checks whether any preserved workspace lives inside it. If so, it logs a warning and skips the state dir deletion. The `uninstall` command passes `workspaceDirs` as the preserve list when the workspace scope was NOT selected.

## Changes

- `src/commands/cleanup-utils.ts`: add `workspaceDirsToPreserve` opt + containment guard before `removePath(stateDir)`
- `src/commands/uninstall.ts`: pass `workspaceDirsToPreserve` when workspace scope not selected
- `src/commands/cleanup-utils.test.ts`: regression test for the skip path + dry-run assertion

## Test plan

- [x] `pnpm vitest run src/commands/cleanup-utils.test.ts` — 6/6 pass (including new regression)
- [x] Regression: `removeStateAndLinkedPaths` with `workspaceDirsToPreserve=[<path inside stateDir>]` logs "Skipping state dir removal" and does NOT emit `[dry-run] remove <stateDir>`
- [x] Existing tests unchanged (removes state normally when no preserve list, removes oauth when outside state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)