### PR TITLE
fix(scripts): accept buildx attestation manifests without artifactType

### DIFF
--- a/scripts/verify-docker-attestations.mjs
+++ b/scripts/verify-docker-attestations.mjs
@@ -85,14 +85,27 @@ export function collectDockerAttestationErrors(params) {
     const predicates = new Set();
     for (const descriptor of attestationDescriptors) {
       const attestation = inspectAttestation(descriptor.digest);
-      if (attestation?.artifactType !== "application/vnd.docker.attestation.manifest.v1+json") {
+      // Identify a Docker attestation manifest by either the legacy
+      // `artifactType` field (older buildx) or by every layer carrying the
+      // `application/vnd.in-toto+json` mediaType (current buildx, which omits
+      // the artifactType and emits a plain OCI image manifest with in-toto
+      // layers). The descriptor in the index already pre-filters by
+      // `vnd.docker.reference.type=attestation-manifest`, so we just need to
+      // confirm the manifest payload looks like an attestation.
+      const layers = Array.isArray(attestation?.layers) ? attestation.layers : [];
+      const hasLegacyArtifactType =
+        attestation?.artifactType === "application/vnd.docker.attestation.manifest.v1+json";
+      const hasInTotoLayers =
+        layers.length > 0 &&
+        layers.every((layer) => layer?.mediaType === "application/vnd.in-toto+json");
+      if (!hasLegacyArtifactType && !hasInTotoLayers) {
         errors.push(
-          `${imageRef}: ${platformLabel} attestation ${descriptor.digest} has unexpected artifactType ${JSON.stringify(
+          `${imageRef}: ${platformLabel} attestation ${descriptor.digest} is not a recognized Docker attestation manifest (artifactType ${JSON.stringify(
             attestation?.artifactType,
-          )}`,
+          )}, layer mediaTypes ${JSON.stringify(layers.map((layer) => layer?.mediaType))})`,
         );
       }
-      for (const layer of attestation?.layers ?? []) {
+      for (const layer of layers) {
         const predicate = layer?.annotations?.["in-toto.io/predicate-type"];
         if (typeof predicate === "string") {
           predicates.add(predicate);

--- a/test/scripts/verify-docker-attestations.test.ts
+++ b/test/scripts/verify-docker-attestations.test.ts
@@ -51,6 +51,27 @@ function createAttestation(
   };
 }
 
+// Current buildx (>= 0.16/Docker buildkit ~0.16.x) writes attestation
+// manifests as plain OCI image manifests without `artifactType` set.
+// They are still identifiable via in-toto layer mediaTypes.
+function createAttestationWithoutArtifactType(
+  predicates = ["https://spdx.dev/Document", "https://slsa.dev/provenance/v1"],
+) {
+  return {
+    schemaVersion: 2,
+    mediaType: "application/vnd.oci.image.manifest.v1+json",
+    artifactType: null,
+    layers: predicates.map((predicate) => ({
+      mediaType: "application/vnd.in-toto+json",
+      digest: imageDigest,
+      size: 1,
+      annotations: {
+        "in-toto.io/predicate-type": predicate,
+      },
+    })),
+  };
+}
+
 describe("verify-docker-attestations", () => {
   it("resolves digest refs from tagged image refs", () => {
     expect(imageRefForDigest("ghcr.io/openclaw/openclaw:2026.4.26", imageDigest)).toBe(
@@ -70,6 +91,40 @@ describe("verify-docker-attestations", () => {
     });
 
     expect(errors).toEqual([]);
+  });
+
+  it("accepts attestations from current buildx (no artifactType, in-toto layers only)", () => {
+    const errors = collectDockerAttestationErrors({
+      imageRef: "ghcr.io/openclaw/openclaw:test",
+      index: createIndex(),
+      requiredPlatforms: [parsePlatform("linux/amd64")],
+      inspectAttestation: () => createAttestationWithoutArtifactType(),
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects attestation manifests with neither artifactType nor in-toto layers", () => {
+    const errors = collectDockerAttestationErrors({
+      imageRef: "ghcr.io/openclaw/openclaw:test",
+      index: createIndex(),
+      requiredPlatforms: [parsePlatform("linux/amd64")],
+      inspectAttestation: () => ({
+        schemaVersion: 2,
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        layers: [
+          {
+            mediaType: "application/vnd.docker.image.rootfs.diff.tar.gzip",
+            digest: imageDigest,
+            size: 1,
+          },
+        ],
+      }),
+    });
+
+    expect(errors.some((e) => e.includes("not a recognized Docker attestation manifest"))).toBe(
+      true,
+    );
   });
 
   it("reports missing attestation manifests", () => {


### PR DESCRIPTION
## Summary

> _AI-assisted PR (Claude Code) — fully tested locally, all CI checks green. Author understands what the code does._

- **Problem:** `scripts/verify-docker-attestations.mjs` rejects every multi-arch image produced by current Docker buildx (≥ 0.16 / Buildkit ~0.16.x) because the attestation manifest no longer carries `artifactType`. The script's strict equality check fails with `unexpected artifactType undefined` even though the attestation payload is valid (in-toto layers present, descriptor annotations correct).
- **Why it matters:** `verify-attestations` job has been red on `main` for the last 5 docker-release runs (`v2026.4.29-beta.1`, `v2026.4.27`, `v2026.4.27-beta.1`, `v2026.4.26` ×2). Tracked failures should not be addressed via test-only PRs (per CONTRIBUTING.md), but this is a real script-logic fix backed by tests, not a CI-config bypass.
- **What changed:** accept either signal as proof of an attestation manifest — legacy `artifactType` (older buildx) OR every layer carrying `application/vnd.in-toto+json` mediaType (current buildx). Sharpen the rejection diagnostic.
- **What did NOT change:** index parsing, descriptor matching by `vnd.docker.reference.type=attestation-manifest`, predicate collection logic, CLI argv parsing, exit codes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes # (no existing tracker found via `gh issue list`)
- Related # — None
- [x] This PR fixes a bug or regression

## Root Cause

- **Root cause:** Docker buildx changed how it emits attestation manifests. The new shape is a plain `application/vnd.oci.image.manifest.v1+json` with `artifactType: null`; identification now lives in (1) the index descriptor's `vnd.docker.reference.type=attestation-manifest` annotation and (2) the layer mediaType `application/vnd.in-toto+json`. The verification script was anchored to the old `artifactType` field only.
- **Missing detection / guardrail:** Test fixture in `test/scripts/verify-docker-attestations.test.ts` only covered the legacy shape. This PR adds a fixture for the current-buildx shape and a malformed-manifest rejection case to lock the contract.
- **Contributing context:** see live failing run e.g. `https://github.com/openclaw/openclaw/actions/runs/25158201320` (job: `verify-attestations`). Reproducible locally via `docker buildx imagetools inspect --raw ghcr.io/openclaw/openclaw:2026.4.29-beta.1` (filter manifests by `vnd.docker.reference.type=attestation-manifest`, fetch by digest, observe `artifactType: null` + `layers[].mediaType: "application/vnd.in-toto+json"`).

## Regression Test Plan

- Coverage level that should have caught this:
  - [x] Unit test
- Target test or file: `test/scripts/verify-docker-attestations.test.ts`
- Scenario the test should lock in: an attestation manifest with no `artifactType` but every layer using `application/vnd.in-toto+json` is recognized as a valid attestation; an attestation manifest with neither marker is rejected.
- Why this is the smallest reliable guardrail: the script's only public seam is `collectDockerAttestationErrors`, exercised here purely with synthetic JSON. No buildx invocation needed.

## User-visible / Behavior Changes

None. Internal CI verification script.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 14 / Ubuntu 24.04 (CI)
- Runtime: Node 22+ (per repo)
- Source: `git checkout upstream/main` then patch + tests

### Steps

1. `pnpm install --frozen-lockfile`
2. `pnpm test test/scripts/verify-docker-attestations.test.ts`
3. (real-world) `docker buildx imagetools inspect --raw ghcr.io/openclaw/openclaw:2026.4.29-beta.1` and inspect attestation digest payload

### Expected

- Tests pass; recent buildx attestation manifests verify cleanly; manifests with neither `artifactType` nor in-toto layers are still rejected.

### Actual

- 6/6 tests pass (4 existing + 2 new). Real `ghcr.io/openclaw/openclaw:2026.4.29-beta.1` attestation now verifies (was rejected before).

## Evidence

- [x] Failing test/log before + passing after — see CI on this PR (script change exercised by all `pnpm test` paths)
- Trace from a real failing image: `[docker-attestations] ghcr.io/openclaw/openclaw:2026.4.29-beta.1: linux/amd64 attestation sha256:e87667f834908b2d19f31d30775b1b2ae6db4ad3b51941d9e6fc8f35f62350f0 has unexpected artifactType undefined`

## Human Verification

- Verified scenarios:
  - Real GHCR multi-arch image (`ghcr.io/openclaw/openclaw:2026.4.29-beta.1`) — manually walked the index → descriptor → attestation manifest → in-toto layers; payload structure matches the new test fixture exactly.
  - Local `pnpm test test/scripts/verify-docker-attestations.test.ts` — 6/6 pass.
- Edge cases checked: empty layers array, mixed mediaTypes (one `vnd.in-toto+json` and one not) — would still be rejected.
- What I did **not** verify: full `docker-release.yml` end-to-end (no permission to run upstream's release pipeline from a fork PR).

## Review Conversations

- [x] Will reply to or resolve every bot review conversation I address.
- [ ] No unresolved bot conversations left for maintainers (none yet).

## Compatibility / Migration

- Backward compatible? `Yes` — older buildx attestations (with `artifactType` set) still pass.
- Config/env changes? `No`
- Migration needed? `No`

## Risks and Mitigations

- Risk: a legitimately-malformed attestation manifest that happens to have one in-toto layer slips through.
  - Mitigation: every layer must be `application/vnd.in-toto+json`, not just one. Test case `rejects attestation manifests with neither artifactType nor in-toto layers` covers the negative path.