### PR TITLE
fix(sessions): preserve activity for compaction metadata

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.runtime.ts
@@ -7,7 +7,7 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   observedCompactionCount: number;
   now?: number;
 }): Promise<number | undefined> {
-  const { sessionKey, agentId, configStore, observedCompactionCount, now = Date.now() } = params;
+  const { sessionKey, agentId, configStore, observedCompactionCount } = params;
   if (!sessionKey || observedCompactionCount <= 0) {
     return undefined;
   }
@@ -15,6 +15,7 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
   const nextEntry = await updateSessionStoreEntry({
     storePath,
     sessionKey,
+    preserveActivity: true,
     update: async (entry) => {
       const currentCount = Math.max(0, entry.compactionCount ?? 0);
       const nextCount = Math.max(currentCount, observedCompactionCount);
@@ -23,7 +24,6 @@ export async function reconcileSessionStoreCompactionCountAfterSuccess(params: {
       }
       return {
         compactionCount: nextCount,
-        updatedAt: Math.max(entry.updatedAt ?? 0, now),
       };
     },
   });

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.test.ts
@@ -73,10 +73,12 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-compaction-reconcile-"));
     const storePath = path.join(tmp, "sessions.json");
     const sessionKey = "main";
+    const updatedAt = Date.now() - 1_000;
     await seedSessionStore({
       storePath,
       sessionKey,
       compactionCount: 1,
+      updatedAt,
     });
 
     const nextCount = await reconcileSessionStoreCompactionCountAfterSuccess({
@@ -89,6 +91,11 @@ describe("reconcileSessionStoreCompactionCountAfterSuccess", () => {
 
     expect(nextCount).toBe(2);
     expect(await readCompactionCount(storePath, sessionKey)).toBe(2);
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      { updatedAt?: number }
+    >;
+    expect(store[sessionKey]?.updatedAt).toBe(updatedAt);
   });
 
   it("does not double count when the store is already at or above the observed value", async () => {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -924,6 +924,7 @@ export async function runMemoryFlushIfNeeded(params: {
         const updatedEntry = await memoryDeps.updateSessionStoreEntry({
           storePath: params.storePath,
           sessionKey: params.sessionKey,
+          preserveActivity: true,
           update: async () => ({
             memoryFlushAt: memoryDeps.now(),
             memoryFlushCompactionCount,

--- a/src/auto-reply/reply/reply-state.test.ts
+++ b/src/auto-reply/reply/reply-state.test.ts
@@ -432,6 +432,26 @@ describe("incrementCompactionCount", () => {
     expect(stored[sessionKey].compactionCount).toBe(3);
   });
 
+  it("preserves updatedAt when incrementing compaction count", async () => {
+    const updatedAt = Date.now() - 1_000;
+    const entry = { sessionId: "s1", updatedAt, compactionCount: 2 } as SessionEntry;
+    const { storePath, sessionKey, sessionStore } = await createCompactionSessionFixture(entry);
+
+    const count = await incrementCompactionCount({
+      sessionEntry: entry,
+      sessionStore,
+      sessionKey,
+      storePath,
+      now: Date.now(),
+    });
+    expect(count).toBe(3);
+    expect(sessionStore[sessionKey]?.updatedAt).toBe(updatedAt);
+
+    const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+    expect(stored[sessionKey].compactionCount).toBe(3);
+    expect(stored[sessionKey].updatedAt).toBe(updatedAt);
+  });
+
   it("updates totalTokens when tokensAfter is provided", async () => {
     const entry = {
       sessionId: "s1",

--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -234,7 +234,6 @@ export async function incrementCompactionCount(params: {
     sessionKey,
     storePath,
     cfg,
-    now = Date.now(),
     amount = 1,
     tokensAfter,
     newSessionId,
@@ -252,7 +251,6 @@ export async function incrementCompactionCount(params: {
   // Build update payload with compaction count and optionally updated token counts
   const updates: Partial<SessionEntry> = {
     compactionCount: nextCount,
-    updatedAt: now,
   };
   const explicitNewSessionFile = normalizeOptionalString(newSessionFile);
   const sessionIdChanged = Boolean(newSessionId && newSessionId !== entry.sessionId);
@@ -289,8 +287,9 @@ export async function incrementCompactionCount(params: {
   };
   if (storePath) {
     await updateSessionStore(storePath, (store) => {
+      const current = store[sessionKey] ?? entry;
       store[sessionKey] = {
-        ...store[sessionKey],
+        ...current,
         ...updates,
       };
     });

--- a/src/auto-reply/reply/session.compaction-daily-reset-race.test.ts
+++ b/src/auto-reply/reply/session.compaction-daily-reset-race.test.ts
@@ -1,0 +1,159 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  loadSessionStore,
+  saveSessionStore,
+  updateSessionStoreEntry,
+} from "../../config/sessions/store.js";
+import type { SessionEntry } from "../../config/sessions/types.js";
+import type { MsgContext } from "../templating.js";
+import { initSessionState } from "./session.js";
+
+vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
+  closeTrackedBrowserTabsForSessions: vi.fn(async () => 0),
+}));
+
+describe("initSessionState - compaction metadata preserves reset freshness", () => {
+  let tempDir: string;
+  let storePath: string;
+
+  const sessionKey = "main:user123";
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp("/tmp/openclaw-test-compaction-reset-");
+    storePath = path.join(tempDir, "sessions.json");
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const createConfig = (session: OpenClawConfig["session"]): OpenClawConfig => ({
+    agents: {
+      defaults: { workspace: tempDir },
+      list: [{ id: "main", workspace: tempDir }],
+    },
+    session: {
+      store: storePath,
+      ...session,
+    },
+    channels: {},
+    gateway: {
+      port: 18789,
+      mode: "local",
+      bind: "loopback",
+      auth: { mode: "token", token: "test" },
+    },
+    plugins: { entries: {} },
+  });
+
+  const createCtx = (overrides?: Partial<MsgContext>): MsgContext => ({
+    Body: "test message",
+    From: "user123",
+    To: "bot123",
+    SessionKey: sessionKey,
+    Provider: "quietchat",
+    Surface: "quietchat",
+    ChatType: "direct",
+    CommandAuthorized: true,
+    ...overrides,
+  });
+
+  const saveLegacySession = async (
+    sessionId: string,
+    updatedAt: number,
+    overrides: Partial<SessionEntry> = {},
+  ): Promise<void> => {
+    await saveSessionStore(storePath, {
+      [sessionKey]: {
+        sessionId,
+        updatedAt,
+        systemSent: true,
+        ...overrides,
+      },
+    });
+  };
+
+  const persistFlushMetadata = async (memoryFlushAt: number): Promise<void> => {
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      preserveActivity: true,
+      update: async () => ({
+        memoryFlushAt,
+        memoryFlushCompactionCount: 2,
+      }),
+    });
+  };
+
+  it("resets a legacy daily session after post-boundary compaction metadata", async () => {
+    const boundary = new Date(2026, 3, 28, 4, 0, 0, 0).getTime();
+    const lastRealActivity = boundary - 60 * 60_000;
+    const memoryFlushAt = boundary + 30 * 60_000;
+    await saveLegacySession("legacy-daily-session", lastRealActivity);
+    await persistFlushMetadata(memoryFlushAt);
+
+    const storeAfterFlush = loadSessionStore(storePath);
+    expect(storeAfterFlush[sessionKey]?.updatedAt).toBe(lastRealActivity);
+    expect(storeAfterFlush[sessionKey]?.memoryFlushAt).toBe(memoryFlushAt);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(boundary + 31 * 60_000);
+    const result = await initSessionState({
+      ctx: createCtx({ Body: "good morning" }),
+      cfg: createConfig({ reset: { mode: "daily", atHour: 4 } }),
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("legacy-daily-session");
+  });
+
+  it("resets a legacy idle session after recent compaction metadata", async () => {
+    const lastRealActivity = new Date(2026, 3, 28, 10, 0, 0, 0).getTime();
+    const memoryFlushAt = lastRealActivity + 9.5 * 60_000;
+    const now = lastRealActivity + 10 * 60_000;
+    await saveLegacySession("legacy-idle-session", lastRealActivity);
+    await persistFlushMetadata(memoryFlushAt);
+
+    const storeAfterFlush = loadSessionStore(storePath);
+    expect(storeAfterFlush[sessionKey]?.updatedAt).toBe(lastRealActivity);
+    expect(storeAfterFlush[sessionKey]?.memoryFlushAt).toBe(memoryFlushAt);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const result = await initSessionState({
+      ctx: createCtx({ Body: "hello again" }),
+      cfg: createConfig({ reset: { mode: "idle", idleMinutes: 5 } }),
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.sessionId).not.toBe("legacy-idle-session");
+  });
+
+  it("keeps a modern idle session fresh based on lastInteractionAt", async () => {
+    const lastRealActivity = new Date(2026, 3, 28, 10, 0, 0, 0).getTime();
+    const memoryFlushAt = lastRealActivity + 9.5 * 60_000;
+    const now = lastRealActivity + 10 * 60_000;
+    await saveLegacySession("modern-idle-session", lastRealActivity, {
+      sessionStartedAt: lastRealActivity - 60 * 60_000,
+      lastInteractionAt: memoryFlushAt,
+    });
+    await persistFlushMetadata(memoryFlushAt);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const result = await initSessionState({
+      ctx: createCtx({ Body: "hello again" }),
+      cfg: createConfig({ reset: { mode: "idle", idleMinutes: 5 } }),
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(false);
+    expect(result.sessionId).toBe("modern-idle-session");
+  });
+});

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -456,6 +456,53 @@ describe("sessions", () => {
     expect(store[sessionKey]?.reasoningLevel).toBe("on");
   });
 
+  it("updateSessionStoreEntry can preserve activity timestamps for metadata patches", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateSessionStoreEntry-preserve-activity",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+        },
+      },
+    });
+
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      preserveActivity: true,
+      update: async () => ({ memoryFlushAt: 200 }),
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.memoryFlushAt).toBe(200);
+    expect(store[sessionKey]?.updatedAt).toBe(100);
+  });
+
+  it("updateSessionStoreEntry refreshes activity timestamps by default", async () => {
+    const sessionKey = "agent:main:main";
+    const { storePath } = await createSessionStoreFixture({
+      prefix: "updateSessionStoreEntry-default-activity",
+      entries: {
+        [sessionKey]: {
+          sessionId: "sess-1",
+          updatedAt: 100,
+        },
+      },
+    });
+
+    await updateSessionStoreEntry({
+      storePath,
+      sessionKey,
+      update: async () => ({ memoryFlushAt: 200 }),
+    });
+
+    const store = loadSessionStore(storePath);
+    expect(store[sessionKey]?.memoryFlushAt).toBe(200);
+    expect(store[sessionKey]?.updatedAt).toBeGreaterThan(100);
+  });
+
   it("updateSessionStoreEntry returns null when session key does not exist", async () => {
     const { storePath } = await createSessionStoreFixture({
       prefix: "updateSessionStoreEntry-missing",

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -672,6 +672,7 @@ export async function updateSessionStoreEntry(params: {
   storePath: string;
   sessionKey: string;
   update: (entry: SessionEntry) => Promise<Partial<SessionEntry> | null>;
+  preserveActivity?: boolean;
 }): Promise<SessionEntry | null> {
   const { storePath, sessionKey, update } = params;
   return await withSessionStoreLock(storePath, async () => {
@@ -685,7 +686,10 @@ export async function updateSessionStoreEntry(params: {
     if (!patch) {
       return existing;
     }
-    const next = mergeSessionEntry(existing, patch);
+    const next =
+      params.preserveActivity === true
+        ? mergeSessionEntryPreserveActivity(existing, patch)
+        : mergeSessionEntry(existing, patch);
     return await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

If this PR fixes a plugin beta-release blocker, title it `fix(<plugin-id>): beta blocker - <summary>` and link the matching `Beta blocker: <plugin-name> - <summary>` issue labeled `beta-blocker`. Contributors cannot label PRs, so the title is the PR-side signal for maintainers and automation.

  - Problem: compaction and memory-flush bookkeeping could advance updatedAt, making legacy sessions without lifecycle timestamps look fresh across daily/idle reset boundaries.
  - Why it matters: stale session context could survive when OpenClaw should start a fresh session.
  - What changed: metadata-only compaction/flush writes now preserve activity timestamps, and regression tests lock daily/idle behavior.
  - What did NOT change (scope boundary): no reset policy rewrite, no store migration, no config/schema changes, no docs/changelog changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75037
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

For bug fixes or regressions, explain why this happened, not just what changed. Otherwise write `N/A`. If the cause is unclear, write `Unknown`.

  - Root cause: internal compaction/flush metadata writes used the normal session merge path, or explicitly set updatedAt, even though these writes are bookkeeping and not user activity.
  - Missing detection / guardrail: there was no regression coverage for legacy rows missing sessionStartedAt /
    lastInteractionAt after metadata-only writes.
  - Contributing context (if known): updatedAt is still a legacy fallback for reset freshness when explicit lifecycle timestamps cannot be recovered.

## Regression Test Plan (if applicable)

For bug fixes or regressions, name the smallest reliable test coverage that should catch this. Otherwise write `N/A`.

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
  - Target test or file: src/config/sessions.test.ts, src/auto-reply/reply/reply-state.test.ts, src/auto-reply/ reply/session.compaction-daily-reset-race.test.ts, src/agents/pi-embedded- subscribe.handlers.compaction.test.ts
  - Scenario the test should lock in: metadata-only compaction/flush writes preserve updatedAt, and legacy daily/idle sessions still reset after their boundary.
  - Why this is the smallest reliable guardrail: it tests the store merge seam plus the session reset decision without broad runner/e2e setup.
  - Existing test that already covers this (if any): existing reset and heartbeat tests covered related behavior, but not compaction/flush metadata writes against legacy rows.
  - If no new test is added, why not: N/A

## User-visible / Behavior Changes

  Legacy sessions that should expire by daily or idle reset will now expire even if compaction or memory-flush metadata was written shortly before the next user message.

## Diagram (if applicable)

For UI changes or non-trivial logic flows, include a small ASCII diagram reviewers can scan quickly. Otherwise write `N/A`.

```text
  Before:
  [compaction/flush metadata] -> updatedAt refreshed -> legacy reset fallback sees fresh session

  After:
  [compaction/flush metadata] -> updatedAt preserved -> legacy reset fallback sees stale session -> reset
```

## Security Impact (required)

  - New permissions/capabilities? (No)
  - Secrets/tokens handling changed? (No)
  - New/changed network calls? (No)
  - Command/tool execution surface changed? (No)
  - Data access scope changed? (No)
  - If any Yes, explain risk + mitigation: N/A

## Repro + Verification

### Environment

  - OS: macOS
  - Runtime/container: local repo, Node/pnpm via repo scripts
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): session.reset daily or idle mode

### Steps

  1. Create a legacy session row missing sessionStartedAt; for idle, also missing lastInteractionAt.
  2. Persist compaction or memory-flush metadata after a reset boundary or inside the idle window.
  3. Send the next real user message through session initialization.

### Expected

  - The legacy session resets when daily or idle policy says it is stale.

### Actual

  - Before this fix, metadata writes could refresh updatedAt, causing stale legacy sessions to be treated as fresh.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

  - Verified scenarios: targeted session store, compaction bookkeeping, memory flush metadata, heartbeat reset guard, and legacy daily/idle reset regression tests.
  - Edge cases checked: default updateSessionStoreEntry still refreshes activity; preserve-activity path only applies to selected metadata callers; modern idle rows use lastInteractionAt.
  - What you did not verify: Testbox pnpm check:changed, because blacksmith CLI was not installed locally.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

  - Backward compatible? (Yes)
  - Config/env changes? (No)
  - Migration needed? (No)
  - If yes, exact upgrade steps: N/A

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

  - Risk: a metadata caller that should represent real activity could accidentally use preserve-activity.
      - Mitigation: default merge behavior remains unchanged; only compaction/flush bookkeeping callers opt in,
        with focused tests.

### Built with Codex