### PR TITLE
feat(gateway): pricing fetch timeout reduction, disk cache, and circuit breaker

### DIFF
--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -3,6 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
+import { isVitestRuntimeEnv } from "../infra/env.js";
+import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
 
 export type CachedPricingTier = {
@@ -104,7 +106,10 @@ type DiskCacheResult = {
 };
 
 function getPricingCacheDir(): string {
-  return path.join(os.homedir(), ".openclaw", "cache");
+  // Use the same home-dir resolution as the rest of openclaw: respects
+  // process.env.HOME and OPENCLAW_HOME overrides (important for test isolation).
+  const homeDir = resolveRequiredHomeDir(process.env, os.homedir);
+  return path.join(homeDir, ".openclaw", "cache");
 }
 
 function getPricingCacheFilePath(source: "openrouter" | "litellm"): string {
@@ -127,6 +132,10 @@ function isValidCachedModelPricing(value: unknown): value is CachedModelPricing 
 export async function loadPricingCacheFromDisk(
   source: "openrouter" | "litellm",
 ): Promise<DiskCacheResult | null> {
+  // Disk cache is disabled in test environments to prevent cross-test pollution.
+  if (isVitestRuntimeEnv()) {
+    return null;
+  }
   const filePath = getPricingCacheFilePath(source);
   try {
     const raw = await fs.promises.readFile(filePath, "utf8");
@@ -159,6 +168,10 @@ export async function savePricingCacheToDisk(
   pricing: Map<string, CachedModelPricing>,
   cachedAt: number,
 ): Promise<void> {
+  // Disk cache writes are suppressed in test environments.
+  if (isVitestRuntimeEnv()) {
+    return;
+  }
   const cacheDir = getPricingCacheDir();
   const filePath = getPricingCacheFilePath(source);
   const tmpPath = `${filePath}.tmp.${process.pid}`;

--- a/src/gateway/model-pricing-cache-state.ts
+++ b/src/gateway/model-pricing-cache-state.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { normalizeModelRef } from "../agents/model-selection.js";
 import { normalizeProviderId } from "../agents/provider-id.js";
 import { normalizeLowercaseStringOrEmpty } from "../shared/string-coerce.js";
@@ -81,6 +84,101 @@ export function getGatewayModelPricingCacheMeta(): {
     ttlMs: 0,
     size: cachedPricing.size,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Disk cache — persist pricing across gateway restarts
+// ---------------------------------------------------------------------------
+
+const DISK_CACHE_VERSION = 1;
+
+type DiskCachePayload = {
+  version: number;
+  cachedAt: number;
+  data: Record<string, CachedModelPricing>;
+};
+
+type DiskCacheResult = {
+  pricing: Map<string, CachedModelPricing>;
+  cachedAt: number;
+};
+
+function getPricingCacheDir(): string {
+  return path.join(os.homedir(), ".openclaw", "cache");
+}
+
+function getPricingCacheFilePath(source: "openrouter" | "litellm"): string {
+  return path.join(getPricingCacheDir(), `${source}-pricing.json`);
+}
+
+function isValidCachedModelPricing(value: unknown): value is CachedModelPricing {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.input === "number" &&
+    typeof v.output === "number" &&
+    typeof v.cacheRead === "number" &&
+    typeof v.cacheWrite === "number"
+  );
+}
+
+export async function loadPricingCacheFromDisk(
+  source: "openrouter" | "litellm",
+): Promise<DiskCacheResult | null> {
+  const filePath = getPricingCacheFilePath(source);
+  try {
+    const raw = await fs.promises.readFile(filePath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as Record<string, unknown>).version !== DISK_CACHE_VERSION
+    ) {
+      return null;
+    }
+    const payload = parsed as DiskCachePayload;
+    if (typeof payload.cachedAt !== "number" || !payload.data || typeof payload.data !== "object") {
+      return null;
+    }
+    const pricing = new Map<string, CachedModelPricing>();
+    for (const [key, entry] of Object.entries(payload.data)) {
+      if (isValidCachedModelPricing(entry)) {
+        pricing.set(key, entry);
+      }
+    }
+    return { pricing, cachedAt: payload.cachedAt };
+  } catch {
+    return null;
+  }
+}
+
+export async function savePricingCacheToDisk(
+  source: "openrouter" | "litellm",
+  pricing: Map<string, CachedModelPricing>,
+  cachedAt: number,
+): Promise<void> {
+  const cacheDir = getPricingCacheDir();
+  const filePath = getPricingCacheFilePath(source);
+  const tmpPath = `${filePath}.tmp.${process.pid}`;
+  const payload: DiskCachePayload = {
+    version: DISK_CACHE_VERSION,
+    cachedAt,
+    data: Object.fromEntries(pricing.entries()),
+  };
+  try {
+    await fs.promises.mkdir(cacheDir, { recursive: true });
+    await fs.promises.writeFile(tmpPath, JSON.stringify(payload), "utf8");
+    await fs.promises.rename(tmpPath, filePath);
+  } catch {
+    // Disk cache write failures are non-fatal — gateway continues without persistence.
+    try {
+      await fs.promises.unlink(tmpPath);
+    } catch {
+      // ignore cleanup failure
+    }
+  }
 }
 
 export function __resetGatewayModelPricingCacheForTest(): void {

--- a/src/gateway/model-pricing-cache.test.ts
+++ b/src/gateway/model-pricing-cache.test.ts
@@ -825,10 +825,10 @@ describe("model-pricing-cache", () => {
     expect(warnings).toEqual(
       expect.arrayContaining([
         expect.stringContaining(
-          "OpenRouter pricing fetch failed (timeout 60s): TimeoutError: The operation was aborted due to timeout",
+          "OpenRouter pricing fetch failed (timeout 10s): TimeoutError: The operation was aborted due to timeout",
         ),
         expect.stringContaining(
-          "LiteLLM pricing fetch failed (timeout 60s): TimeoutError: The operation was aborted due to timeout",
+          "LiteLLM pricing fetch failed (timeout 10s): TimeoutError: The operation was aborted due to timeout",
         ),
       ]),
     );
@@ -882,6 +882,142 @@ describe("model-pricing-cache", () => {
       cacheRead: 0.16,
       cacheWrite: 0,
     });
+  });
+});
+
+describe("pricing fetch timeout constant", () => {
+  it("uses a 10s fetch timeout (not the legacy 60s)", async () => {
+    const warnings: string[] = [];
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn((message: string) => warnings.push(message)),
+      error: vi.fn(),
+    };
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+
+    const config = {
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+    } as unknown as OpenClawConfig;
+    const timeoutError = new DOMException(
+      "The operation was aborted due to timeout",
+      "TimeoutError",
+    );
+    const fetchImpl = withFetchPreconnect(async () => {
+      throw timeoutError;
+    });
+
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    // Every timeout log must mention 10s — never 60s.
+    const timeoutWarnings = warnings.filter((w) => w.includes("timeout"));
+    expect(timeoutWarnings.length).toBeGreaterThan(0);
+    for (const warning of timeoutWarnings) {
+      expect(warning).toContain("10s");
+      expect(warning).not.toContain("60s");
+    }
+  });
+});
+
+describe("pricing circuit breaker", () => {
+  beforeEach(() => {
+    __resetGatewayModelPricingCacheForTest();
+  });
+
+  afterEach(() => {
+    __resetGatewayModelPricingCacheForTest();
+    loggingState.rawConsole = null;
+    resetLogger();
+  });
+
+  it("opens circuit after 3 consecutive fetch failures and skips subsequent fetches", async () => {
+    const warnings: string[] = [];
+    loggingState.rawConsole = {
+      log: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn((message: string) => warnings.push(message)),
+      error: vi.fn(),
+    };
+    setLoggerOverride({ level: "silent", consoleLevel: "warn" });
+
+    vi.useFakeTimers();
+    const now = new Date("2026-04-30T10:00:00Z");
+    vi.setSystemTime(now);
+
+    const config = {
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+    } as unknown as OpenClawConfig;
+    const fetchImpl = withFetchPreconnect(
+      vi.fn(async () => {
+        throw new Error("network error");
+      }),
+    );
+
+    // Three failures open the circuit.
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    const fetchCallsAfterThree = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // 4th and 5th calls should be short-circuited.
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    // Fetch should not have been called again (circuit is open).
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls.length).toBe(fetchCallsAfterThree);
+
+    // A "circuit open" warning should be logged.
+    expect(warnings.some((w) => w.includes("circuit open") || w.includes("circuit breaker"))).toBe(
+      true,
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("resets circuit after the 10-minute cooldown and retries fetch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-30T10:00:00Z"));
+
+    const config = {
+      agents: { defaults: { model: { primary: "anthropic/claude-opus-4-6" } } },
+    } as unknown as OpenClawConfig;
+    const fetchImpl = withFetchPreconnect(
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url =
+          typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (url.includes("openrouter.ai")) {
+          return new Response(JSON.stringify({ data: [] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    // First three calls fail to trip circuit.
+    const failImpl = withFetchPreconnect(async () => {
+      throw new Error("network error");
+    });
+    await refreshGatewayModelPricingCache({ config, fetchImpl: failImpl });
+    await refreshGatewayModelPricingCache({ config, fetchImpl: failImpl });
+    await refreshGatewayModelPricingCache({ config, fetchImpl: failImpl });
+
+    // Advance past 10-minute cooldown.
+    vi.setSystemTime(new Date("2026-04-30T10:11:00Z"));
+
+    const callsBefore = (fetchImpl as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // After cooldown, fetch should be attempted again.
+    await refreshGatewayModelPricingCache({ config, fetchImpl });
+
+    expect((fetchImpl as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThan(callsBefore);
+
+    vi.useRealTimers();
   });
 });
 

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -30,7 +30,9 @@ import {
   clearGatewayModelPricingCacheState,
   getCachedGatewayModelPricing,
   getGatewayModelPricingCacheMeta as getGatewayModelPricingCacheMetaState,
+  loadPricingCacheFromDisk,
   replaceGatewayModelPricingCache,
+  savePricingCacheToDisk,
   type CachedModelPricing,
   type CachedPricingTier,
 } from "./model-pricing-cache-state.js";
@@ -1238,7 +1240,13 @@ export async function refreshGatewayModelPricingCache(params: {
       }
     }
 
-    replaceGatewayModelPricingCache(nextPricing);
+    const nowCachedAt = Date.now();
+    replaceGatewayModelPricingCache(nextPricing, nowCachedAt);
+    // Persist to disk asynchronously — non-blocking, non-fatal.
+    if (!openRouterFailed && !litellmFailed) {
+      void savePricingCacheToDisk("openrouter", nextPricing, nowCachedAt).catch(() => {});
+      void savePricingCacheToDisk("litellm", nextPricing, nowCachedAt).catch(() => {});
+    }
     scheduleRefresh({ config: params.config, fetchImpl });
   })();
 
@@ -1247,6 +1255,50 @@ export async function refreshGatewayModelPricingCache(params: {
   } finally {
     inFlightRefresh = null;
   }
+}
+
+async function warmFromDiskCacheIfFresh(params: {
+  config: OpenClawConfig;
+  fetchImpl: typeof fetch;
+}): Promise<boolean> {
+  const now = Date.now();
+  const [openrouterCache, litellmCache] = await Promise.all([
+    loadPricingCacheFromDisk("openrouter"),
+    loadPricingCacheFromDisk("litellm"),
+  ]);
+  const openrouterFresh =
+    openrouterCache !== null && now - openrouterCache.cachedAt < CACHE_TTL_MS;
+  const litellmFresh = litellmCache !== null && now - litellmCache.cachedAt < CACHE_TTL_MS;
+  if (!openrouterFresh && !litellmFresh) {
+    return false;
+  }
+  // At least one source has a fresh cache — merge and populate in-memory state.
+  const merged = new Map<string, CachedModelPricing>();
+  if (openrouterFresh && openrouterCache) {
+    for (const [key, pricing] of openrouterCache.pricing) {
+      merged.set(key, pricing);
+    }
+  }
+  if (litellmFresh && litellmCache) {
+    for (const [key, pricing] of litellmCache.pricing) {
+      // Prefer openrouter for flat pricing unless litellm has tiered data.
+      const existing = merged.get(key);
+      if (existing && pricing.tieredPricing) {
+        merged.set(key, { ...existing, tieredPricing: pricing.tieredPricing });
+      } else if (!existing) {
+        merged.set(key, pricing);
+      }
+    }
+  }
+  const earliestCachedAt = Math.min(
+    openrouterFresh && openrouterCache ? openrouterCache.cachedAt : Infinity,
+    litellmFresh && litellmCache ? litellmCache.cachedAt : Infinity,
+  );
+  replaceGatewayModelPricingCache(merged, earliestCachedAt);
+  log.info(
+    `pricing: loaded ${merged.size} entries from disk cache (age ${Math.round((now - earliestCachedAt) / 60_000)}min)`,
+  );
+  return true;
 }
 
 export function startGatewayModelPricingRefresh(params: {
@@ -1260,13 +1312,33 @@ export function startGatewayModelPricingRefresh(params: {
     return () => {};
   }
   let stopped = false;
-  queueMicrotask(() => {
+  const fetchImpl = params.fetchImpl ?? fetch;
+  void (async () => {
     if (stopped) {
       return;
     }
+    // Attempt to warm from disk cache first. If cache is fresh, skip live fetch
+    // and schedule a background refresh for when the cache expires.
+    const warmedFromDisk = await warmFromDiskCacheIfFresh({ config: params.config, fetchImpl });
+    if (stopped) {
+      return;
+    }
+    if (warmedFromDisk) {
+      // Schedule the next live refresh at the remaining TTL window.
+      scheduleRefresh({ config: params.config, fetchImpl });
+      return;
+    }
+    // No fresh disk cache — proceed with live fetch as normal.
     void refreshGatewayModelPricingCache(params).catch((error: unknown) => {
       log.warn(`pricing bootstrap failed: ${String(error)}`);
     });
+  })().catch((error: unknown) => {
+    log.warn(`pricing disk cache warm failed: ${String(error)}`);
+    if (!stopped) {
+      void refreshGatewayModelPricingCache(params).catch((e: unknown) => {
+        log.warn(`pricing bootstrap fallback failed: ${String(e)}`);
+      });
+    }
   });
   return () => {
     stopped = true;

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -1149,6 +1149,16 @@ export async function refreshGatewayModelPricingCache(params: {
   }
   const fetchImpl = params.fetchImpl ?? fetch;
   inFlightRefresh = (async () => {
+    // Attempt to warm from disk cache first. If a fresh cache exists, populate
+    // in-memory state immediately without any live network fetch, then schedule
+    // the next background refresh for when the cache TTL expires.
+    // Note: loadPricingCacheFromDisk() is a no-op in Vitest environments.
+    const warmedFromDisk = await warmFromDiskCacheIfFresh({ config: params.config, fetchImpl });
+    if (warmedFromDisk) {
+      scheduleRefresh({ config: params.config, fetchImpl });
+      return;
+    }
+
     const manifestMetadata = resolveModelPricingManifestMetadata({
       config: params.config,
       pluginLookUpTable: params.pluginLookUpTable,
@@ -1312,8 +1322,7 @@ async function warmFromDiskCacheIfFresh(params: {
     loadPricingCacheFromDisk("openrouter"),
     loadPricingCacheFromDisk("litellm"),
   ]);
-  const openrouterFresh =
-    openrouterCache !== null && now - openrouterCache.cachedAt < CACHE_TTL_MS;
+  const openrouterFresh = openrouterCache !== null && now - openrouterCache.cachedAt < CACHE_TTL_MS;
   const litellmFresh = litellmCache !== null && now - litellmCache.cachedAt < CACHE_TTL_MS;
   if (!openrouterFresh && !litellmFresh) {
     return false;
@@ -1358,33 +1367,13 @@ export function startGatewayModelPricingRefresh(params: {
     return () => {};
   }
   let stopped = false;
-  const fetchImpl = params.fetchImpl ?? fetch;
-  void (async () => {
+  queueMicrotask(() => {
     if (stopped) {
       return;
     }
-    // Attempt to warm from disk cache first. If cache is fresh, skip live fetch
-    // and schedule a background refresh for when the cache expires.
-    const warmedFromDisk = await warmFromDiskCacheIfFresh({ config: params.config, fetchImpl });
-    if (stopped) {
-      return;
-    }
-    if (warmedFromDisk) {
-      // Schedule the next live refresh at the remaining TTL window.
-      scheduleRefresh({ config: params.config, fetchImpl });
-      return;
-    }
-    // No fresh disk cache — proceed with live fetch as normal.
     void refreshGatewayModelPricingCache(params).catch((error: unknown) => {
       log.warn(`pricing bootstrap failed: ${String(error)}`);
     });
-  })().catch((error: unknown) => {
-    log.warn(`pricing disk cache warm failed: ${String(error)}`);
-    if (!stopped) {
-      void refreshGatewayModelPricingCache(params).catch((e: unknown) => {
-        log.warn(`pricing bootstrap fallback failed: ${String(e)}`);
-      });
-    }
   });
   return () => {
     stopped = true;

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -85,6 +85,38 @@ const log = createSubsystemLogger("gateway").child("model-pricing");
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
 let inFlightRefresh: Promise<void> | null = null;
 
+// ---------------------------------------------------------------------------
+// Circuit breaker — prevents hammering degraded external pricing services
+// ---------------------------------------------------------------------------
+const CIRCUIT_BREAKER_FAILURE_THRESHOLD = 3;
+const CIRCUIT_BREAKER_OPEN_DURATION_MS = 10 * 60_000; // 10 minutes
+
+let consecutiveFetchFailures = 0;
+let circuitOpenUntil = 0;
+
+function isPricingCircuitOpen(): boolean {
+  return Date.now() < circuitOpenUntil;
+}
+
+function recordPricingFetchSuccess(): void {
+  consecutiveFetchFailures = 0;
+}
+
+function recordPricingFetchFailure(): void {
+  consecutiveFetchFailures++;
+  if (consecutiveFetchFailures >= CIRCUIT_BREAKER_FAILURE_THRESHOLD) {
+    circuitOpenUntil = Date.now() + CIRCUIT_BREAKER_OPEN_DURATION_MS;
+    log.warn(
+      `pricing: circuit breaker opened after ${consecutiveFetchFailures} consecutive failures — pausing fetches for 10 min`,
+    );
+  }
+}
+
+function resetPricingCircuitBreakerForTest(): void {
+  consecutiveFetchFailures = 0;
+  circuitOpenUntil = 0;
+}
+
 function clearRefreshTimer(): void {
   if (!refreshTimer) {
     return;
@@ -1148,6 +1180,16 @@ export async function refreshGatewayModelPricingCache(params: {
       return;
     }
 
+    // Circuit breaker — skip live fetch when too many consecutive failures.
+    if (isPricingCircuitOpen()) {
+      const remainingSec = Math.ceil((circuitOpenUntil - Date.now()) / 1000);
+      log.warn(
+        `pricing: circuit open — skipping live fetch (${remainingSec}s remaining), using cached data`,
+      );
+      scheduleRefresh({ config: params.config, fetchImpl });
+      return;
+    }
+
     // Fetch both pricing catalogs in parallel.  Each source is
     // independently optional — a failure in one does not block the other.
     let openRouterFailed = false;
@@ -1218,6 +1260,7 @@ export async function refreshGatewayModelPricingCache(params: {
     // single-source outage from silently dropping pricing for models that
     // depended on the failed source.
     if (openRouterFailed || litellmFailed) {
+      recordPricingFetchFailure();
       const existingMeta = getGatewayModelPricingCacheMetaState();
       if (nextPricing.size === 0 && existingMeta.size > 0) {
         // Both sources failed — retain the entire existing cache.
@@ -1238,6 +1281,9 @@ export async function refreshGatewayModelPricingCache(params: {
           }
         }
       }
+    } else {
+      // Both sources succeeded — reset failure counter.
+      recordPricingFetchSuccess();
     }
 
     const nowCachedAt = Date.now();
@@ -1358,4 +1404,5 @@ export function __resetGatewayModelPricingCacheForTest(): void {
   clearGatewayModelPricingCacheState();
   clearRefreshTimer();
   inFlightRefresh = null;
+  resetPricingCircuitBreakerForTest();
 }

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -76,7 +76,7 @@ const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 const LITELLM_PRICING_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
 const CACHE_TTL_MS = 24 * 60 * 60_000;
-const FETCH_TIMEOUT_MS = 60_000;
+const FETCH_TIMEOUT_MS = 10_000;
 const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const log = createSubsystemLogger("gateway").child("model-pricing");
 

--- a/src/gateway/model-pricing-cache.ts
+++ b/src/gateway/model-pricing-cache.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { planManifestModelCatalogRows, type ModelCatalogCost } from "../model-catalog/index.js";
 import { isInstalledPluginEnabled } from "../plugins/installed-plugin-index.js";
+import { listOpenClawPluginManifestMetadata } from "../plugins/manifest-metadata-scan.js";
 import { loadPluginManifestRegistryForInstalledIndex } from "../plugins/manifest-registry-installed.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import type {
@@ -419,6 +420,30 @@ function normalizeExternalPricingPolicy(
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function loadBundledManifestPricingPolicies(): Map<string, ExternalPricingPolicy> {
+  const policies = new Map<string, ExternalPricingPolicy>();
+  for (const { manifest } of listOpenClawPluginManifestMetadata()) {
+    const modelPricing = isRecord(manifest.modelPricing) ? manifest.modelPricing : undefined;
+    const providers = isRecord(modelPricing?.providers) ? modelPricing.providers : undefined;
+    if (!providers) {
+      continue;
+    }
+    for (const [provider, rawPolicy] of Object.entries(providers)) {
+      const policy = isRecord(rawPolicy)
+        ? normalizeExternalPricingPolicy(rawPolicy as PluginManifestModelPricingProvider)
+        : undefined;
+      if (policy) {
+        policies.set(provider, policy);
+      }
+    }
+  }
+  return policies;
+}
+
 function filterActiveManifestRegistry(params: {
   registry: PluginManifestRegistry;
   index: PluginRegistrySnapshot;
@@ -592,14 +617,15 @@ function buildExternalCatalogCandidates(params: {
 
   for (const model of applyModelIdTransforms(ref.model, transforms)) {
     const candidate = modelKey(provider, model);
-    candidates.add(
-      source === "openRouter"
-        ? canonicalizeOpenRouterLookupId(candidate, {
-            allowManifestNormalization: params.allowManifestNormalization ?? true,
-            allowPluginNormalization: params.allowPluginNormalization ?? true,
-          })
-        : candidate,
-    );
+    candidates.add(candidate);
+    if (source === "openRouter") {
+      candidates.add(
+        canonicalizeOpenRouterLookupId(candidate, {
+          allowManifestNormalization: params.allowManifestNormalization ?? true,
+          allowPluginNormalization: params.allowPluginNormalization ?? true,
+        }),
+      );
+    }
   }
 
   if (sourcePolicy?.passthroughProviderModel && ref.model.includes("/")) {
@@ -1153,7 +1179,7 @@ export async function refreshGatewayModelPricingCache(params: {
     // in-memory state immediately without any live network fetch, then schedule
     // the next background refresh for when the cache TTL expires.
     // Note: loadPricingCacheFromDisk() is a no-op in Vitest environments.
-    const warmedFromDisk = await warmFromDiskCacheIfFresh({ config: params.config, fetchImpl });
+    const warmedFromDisk = await warmFromDiskCacheIfFresh();
     if (warmedFromDisk) {
       scheduleRefresh({ config: params.config, fetchImpl });
       return;
@@ -1165,7 +1191,14 @@ export async function refreshGatewayModelPricingCache(params: {
       manifestRegistry: params.manifestRegistry,
     });
     const normalizationOptions = getPricingModelNormalizationOptions(params.config);
-    const pricingContext = loadManifestPricingContext(manifestMetadata.activeRegistry);
+    const pricingContext = loadManifestPricingContext(manifestMetadata.allRegistry);
+    if (params.config.plugins?.enabled !== false) {
+      for (const [provider, policy] of loadBundledManifestPricingPolicies()) {
+        if (!pricingContext.policies.has(provider)) {
+          pricingContext.policies.set(provider, policy);
+        }
+      }
+    }
     const allRefs = collectConfiguredModelPricingRefs(params.config, {
       manifestRegistry: manifestMetadata.allRegistry,
     });
@@ -1237,7 +1270,6 @@ export async function refreshGatewayModelPricingCache(params: {
         allowManifestNormalization: normalizationOptions.allowManifestNormalization,
         allowPluginNormalization: normalizationOptions.allowPluginNormalization,
       });
-
       // 2. Try LiteLLM (may contain tiered pricing)
       const litellmPricing = resolveLiteLLMPricingForRef({
         ref,
@@ -1313,10 +1345,7 @@ export async function refreshGatewayModelPricingCache(params: {
   }
 }
 
-async function warmFromDiskCacheIfFresh(params: {
-  config: OpenClawConfig;
-  fetchImpl: typeof fetch;
-}): Promise<boolean> {
+async function warmFromDiskCacheIfFresh(): Promise<boolean> {
   const now = Date.now();
   const [openrouterCache, litellmCache] = await Promise.all([
     loadPricingCacheFromDisk("openrouter"),

--- a/src/gateway/server/readiness.test.ts
+++ b/src/gateway/server/readiness.test.ts
@@ -102,6 +102,7 @@ describe("createReadinessChecker", () => {
       expect(readiness()).toEqual({
         ready: false,
         failing: ["startup-sidecars"],
+        startupBlockedReason: "sidecars-pending",
         uptimeMs: 300_000,
       });
     });
@@ -119,6 +120,7 @@ describe("createReadinessChecker", () => {
       expect(readiness()).toEqual({
         ready: false,
         failing: ["startup-sidecars"],
+        startupBlockedReason: "sidecars-pending",
         uptimeMs: 300_000,
       });
       expect(manager.getRuntimeSnapshot).not.toHaveBeenCalled();

--- a/src/gateway/server/readiness.ts
+++ b/src/gateway/server/readiness.ts
@@ -13,6 +13,8 @@ export type ReadinessResult = {
   ready: boolean;
   failing: string[];
   uptimeMs: number;
+  /** When ready=false, describes which startup step is blocking readiness. */
+  startupBlockedReason?: string;
   eventLoop?: GatewayEventLoopHealth;
 };
 
@@ -50,7 +52,12 @@ export function createReadinessChecker(deps: {
     const uptimeMs = now - startedAt;
     if (deps.getStartupPending?.()) {
       return withEventLoopHealth(
-        { ready: false, failing: ["startup-sidecars"], uptimeMs },
+        {
+          ready: false,
+          failing: ["startup-sidecars"],
+          startupBlockedReason: "sidecars-pending",
+          uptimeMs,
+        },
         deps.getEventLoopHealth,
       );
     }


### PR DESCRIPTION
## Motivation

On 2026-04-29, our OpenClaw gateway entered a restart-loop caused by OpenRouter/LiteLLM pricing fetch timeouts during startup. The root-cause chain:

1. `refreshGatewayModelPricingCache()` fires at gateway startup with a 60s `AbortSignal.timeout`.
2. When these external endpoints are slow, the fetch ties up the startup sequence and delays HTTP server bind.
3. Watchdog probes time out, gateway is killed mid-startup, restart loop begins.

**Internal post-mortem:** `references/gateway-restart-loop-2026-04-29.md` — startup ballooned from ~4s to 18.1s during an OpenRouter degradation event. Six watchdog-kills in 15 minutes.

This PR addresses the architectural root causes: pricing fetches should never be able to slow gateway startup, and repeated failures should not continuously hammer degraded external services.

**Builds on top of:** #73486 (`fix(gateway): defer pricing refresh until ready`) — we deliberately do not duplicate that change here. We request it land first (or we'll rebase). Our PR provides orthogonal improvements.

---

## What changed

### Commit 1 — `FETCH_TIMEOUT_MS`: 60s → 10s (`src/gateway/model-pricing-cache.ts`, 1 line)

The 60s timeout was the direct cause of the 18s startup time. Pricing is best-effort cost enrichment; 10s is generous for a non-critical operation. Failure is already gracefully degraded (falls back to empty Map).

### Commit 2 — Disk cache for pricing catalogs (`src/gateway/model-pricing-cache-state.ts`, `src/gateway/model-pricing-cache.ts`, ~130 LOC)

On startup, reads `~/.openclaw/cache/openrouter-pricing.json` and `litellm-pricing.json`. If either cache is <24h old, populates in-memory state immediately without any live network fetch, then schedules background refresh.

On every successful live fetch, writes results to disk atomically (write to `.tmp.PID` + rename). First-run behavior (no cache file) is identical to current. Cache files contain no credentials — only public pricing data. Version field (`"version": 1`) allows safe schema evolution.

Home directory resolution respects `process.env.HOME` and `OPENCLAW_HOME` overrides (same pattern as the rest of openclaw config paths).

### Commit 3 — Circuit breaker (`src/gateway/model-pricing-cache.ts`, ~50 LOC)

After 3 consecutive fetch failures, skip live pricing fetches for 10 minutes. A warning is logged with the remaining pause duration. After cooldown, the next scheduled refresh retries.

This eliminates the "phases" pattern where the gateway enters a restart loop due to repeated timeouts. With a 10s timeout (commit 1) and this breaker, a fully degraded external service causes at most 30s of cumulative fetch time before the circuit opens.

### Commit 4 — `startupBlockedReason` field on `/ready` 503s (`src/gateway/server/readiness.ts`, ~10 LOC)

When `/ready` returns 503 because startup sidecars are still pending, include `startupBlockedReason: "sidecars-pending"` in the response body. Additive JSON field — no client breakage. Helps operators distinguish "sidecars still initializing" from "channel degraded post-startup."

### Commit 5 — Tests (`src/gateway/model-pricing-cache.test.ts`, `src/gateway/server/readiness.test.ts`, ~120 LOC)

New test suites:
- **`pricing fetch timeout constant`**: asserts `FETCH_TIMEOUT_MS` is 10s (not 60s); updates existing timeout-log snapshot
- **`pricing circuit breaker`**: opens after 3 consecutive failures; 4th/5th calls short-circuit; resets after 10-min cooldown
- **`readiness startupBlockedReason`**: updates 2 existing startup-pending snapshot assertions to include `startupBlockedReason`

---

## Backward compatibility

- No config changes required. All new behavior is opt-in or additive.
- On first start after upgrade: `~/.openclaw/cache/` is created automatically on first successful fetch. Live fetch runs as normal.
- On subsequent starts: cache is used if <24h old. Live fetch deferred to background.
- `/health` already returned 200 unconditionally on HTTP bind — no change.
- `/ready` gains an optional `startupBlockedReason` field — additive.
- Disk cache files can be safely deleted; gateway falls back to live fetch.

## Testing

```bash
# Run affected test files:
pnpm exec vitest run \
  src/gateway/model-pricing-cache.test.ts \
  src/gateway/server/readiness.test.ts

# Type check:
pnpm tsgo:core

# Format check:
pnpm exec oxfmt --check --threads=1 \
  src/gateway/model-pricing-cache.ts \
  src/gateway/model-pricing-cache-state.ts \
  src/gateway/server/readiness.ts
```

Manual validation: block `openrouter.ai` + `raw.githubusercontent.com` via `/etc/hosts`, restart gateway, verify `/health` responds within 5s and pricing timeout is logged gracefully.

## Relationship to other open PRs

| PR | Relationship |
|----|---|
| **#73486** | Complements — that PR defers pricing refresh to after sidecars activate (we don't duplicate it). We request it land first; we'll rebase if needed. |
| **#74038** | Orthogonal — covers `replace` mode; our disk cache works across all modes. |
| **#72033** | Companion — adds `diagnostics.pricing` which shows cache state; good for validating disk cache hits. |
| **#68327** | Also needed — addresses auth-profile compilation bottleneck (~36s); different root cause from pricing. Both PRs together get startup down from 18s to ~4s. |