### PR TITLE
fix(agents): preserve compaction summary extra params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -367,6 +367,7 @@ Docs: https://docs.openclaw.ai
 - Installer/Linux: warn before switching an unwritable npm global prefix to `~/.npm-global`, then tell users to run future global updates with `npm i -g openclaw@latest` without `sudo` so npm keeps using the redirected user prefix. Fixes #44365; carries forward #50479. Thanks @Sayeem3051.
 - Gateway/plugins: enable the native `require()` fast path on Windows for bundled plugin modules so plugin loading uses `require()` instead of Jiti's transform pipeline, reducing startup from ~39s to ~2s on typical 6-plugin setups. Fixes #68656. (#74173) Thanks @galiniliev.
 - macOS app: detect stale Gateway TLS certificate pins, automatically repair trusted Tailscale Serve rotations, and surface paired-but-disconnected Mac companion nodes so partial Gateway connections no longer look healthy. Thanks @guti.
+- Agents/compaction: preserve configured OpenAI-compatible extra payload params such as `chat_template_kwargs` during safeguard summary generation, so vLLM Qwen compaction can keep thinking disabled. Thanks @jax-yu.
 
 ## 2026.4.27
 

--- a/package.json
+++ b/package.json
@@ -1733,7 +1733,8 @@
     },
     "patchedDependencies": {
       "@whiskeysockets/baileys@7.0.0-rc.9": "patches/@whiskeysockets__baileys@7.0.0-rc.9.patch",
-      "@agentclientprotocol/claude-agent-acp@0.31.1": "patches/@agentclientprotocol__claude-agent-acp@0.31.1.patch"
+      "@agentclientprotocol/claude-agent-acp@0.31.1": "patches/@agentclientprotocol__claude-agent-acp@0.31.1.patch",
+      "@mariozechner/pi-coding-agent@0.70.6": "patches/@mariozechner__pi-coding-agent@0.70.6.patch"
     }
   },
   "openclaw": {

--- a/patches/@mariozechner__pi-coding-agent@0.70.6.patch
+++ b/patches/@mariozechner__pi-coding-agent@0.70.6.patch
@@ -1,0 +1,47 @@
+diff --git a/dist/core/compaction/compaction.d.ts b/dist/core/compaction/compaction.d.ts
+index 1c73f386d0e5a0a699fa2311ea95f8ee29381f43..807b7593b94035f764f71b55e36a4652986fad57 100644
+--- a/dist/core/compaction/compaction.d.ts
++++ b/dist/core/compaction/compaction.d.ts
+@@ -5,7 +5,7 @@
+  * and after compaction the session is reloaded.
+  */
+ import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
+-import type { Model, Usage } from "@mariozechner/pi-ai";
++import type { Model, SimpleStreamOptions, Usage } from "@mariozechner/pi-ai";
+ import { type SessionEntry } from "../session-manager.js";
+ import { type FileOperations } from "./utils.js";
+ /** Details stored in CompactionEntry.details for file tracking */
+@@ -91,7 +91,7 @@ export declare function findCutPoint(entries: SessionEntry[], startIndex: number
+  * Generate a summary of the conversation using the LLM.
+  * If previousSummary is provided, uses the update prompt to merge.
+  */
+-export declare function generateSummary(currentMessages: AgentMessage[], model: Model<any>, reserveTokens: number, apiKey: string, headers?: Record<string, string>, signal?: AbortSignal, customInstructions?: string, previousSummary?: string, thinkingLevel?: ThinkingLevel): Promise<string>;
++export declare function generateSummary(currentMessages: AgentMessage[], model: Model<any>, reserveTokens: number, apiKey: string, headers?: Record<string, string>, signal?: AbortSignal, customInstructions?: string, previousSummary?: string, thinkingLevel?: ThinkingLevel, summaryOptions?: Pick<SimpleStreamOptions, "onPayload">): Promise<string>;
+ export interface CompactionPreparation {
+     /** UUID of first entry to keep */
+     firstKeptEntryId: string;
+diff --git a/dist/core/compaction/compaction.js b/dist/core/compaction/compaction.js
+index 0658cb737dd13f5606ea9b5ebb98443c547a922d..c301c6ef7fa5d9dce74b564069a2117e68dabbbc 100644
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -429,7 +429,7 @@ Keep each section concise. Preserve exact file paths, function names, and error
+  * Generate a summary of the conversation using the LLM.
+  * If previousSummary is provided, uses the update prompt to merge.
+  */
+-export async function generateSummary(currentMessages, model, reserveTokens, apiKey, headers, signal, customInstructions, previousSummary, thinkingLevel) {
++export async function generateSummary(currentMessages, model, reserveTokens, apiKey, headers, signal, customInstructions, previousSummary, thinkingLevel, summaryOptions) {
+     const maxTokens = Math.floor(0.8 * reserveTokens);
+     // Use update prompt if we have a previous summary, otherwise initial prompt
+     let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
+@@ -456,7 +456,10 @@ export async function generateSummary(currentMessages, model, reserveTokens, api
+     const completionOptions = model.reasoning && thinkingLevel && thinkingLevel !== "off"
+         ? { maxTokens, signal, apiKey, headers, reasoning: thinkingLevel }
+         : { maxTokens, signal, apiKey, headers };
+-    const response = await completeSimple(model, { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages }, completionOptions);
++    const response = await completeSimple(model, { systemPrompt: SUMMARIZATION_SYSTEM_PROMPT, messages: summarizationMessages }, {
++        ...completionOptions,
++        ...(summaryOptions?.onPayload ? { onPayload: summaryOptions.onPayload } : {}),
++    });
+     if (response.stopReason === "error") {
+         throw new Error(`Summarization failed: ${response.errorMessage || "Unknown error"}`);
+     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ patchedDependencies:
   '@agentclientprotocol/claude-agent-acp@0.31.1':
     hash: e8b472d71289ac8de9813c57d79abac524889ca96f279f6f3ad08043434f6615
     path: patches/@agentclientprotocol__claude-agent-acp@0.31.1.patch
+  '@mariozechner/pi-coding-agent@0.70.6':
+    hash: 888ae4119f46aed51e6763efe8cb23a11ce468d7d8f0e5a974c12d9c5cfd2b08
+    path: patches/@mariozechner__pi-coding-agent@0.70.6.patch
   '@whiskeysockets/baileys@7.0.0-rc.9':
     hash: 23ec8efe1484afa57c51b96955ba331d1467521a8e676a18c2690da7e70a6201
     path: patches/@whiskeysockets__baileys@7.0.0-rc.9.patch
@@ -59,7 +62,7 @@ importers:
         version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.70.6
-        version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.70.6(patch_hash=888ae4119f46aed51e6763efe8cb23a11ce468d7d8f0e5a974c12d9c5cfd2b08)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
         specifier: 0.70.6
         version: 0.70.6
@@ -392,7 +395,7 @@ importers:
     dependencies:
       '@mariozechner/pi-coding-agent':
         specifier: 0.70.6
-        version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+        version: 0.70.6(patch_hash=888ae4119f46aed51e6763efe8cb23a11ce468d7d8f0e5a974c12d9c5cfd2b08)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
       '@openai/codex':
         specifier: 0.125.0
         version: 0.125.0
@@ -9552,7 +9555,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.70.6(patch_hash=888ae4119f46aed51e6763efe8cb23a11ce468d7d8f0e5a974c12d9c5cfd2b08)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -100,4 +100,51 @@ describe("summarizeWithFallback", () => {
     // Full attempt plus distinct partial transcript; timeout-classed failures do not retry.
     expect(piCodingAgentMocks.generateSummary.mock.calls.length).toBe(2);
   });
+
+  it("passes completion payload hooks to summary generation", async () => {
+    piCodingAgentMocks.generateSummary.mockResolvedValue("summary");
+    const onPayload = vi.fn((payload: unknown) => {
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        (payload as Record<string, unknown>).chat_template_kwargs = {
+          enable_thinking: false,
+          preserve_thinking: true,
+        };
+      }
+    });
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: "hello",
+        timestamp: 1,
+      } satisfies UserMessage,
+    ];
+
+    await summarizeWithFallback({
+      messages,
+      model: testModel,
+      apiKey: "test-key", // pragma: allowlist secret
+      signal: new AbortController().signal,
+      reserveTokens: 1000,
+      maxChunkTokens: 50_000,
+      contextWindow: 200_000,
+      thinkingLevel: "off",
+      completionOptions: { onPayload },
+    });
+
+    expect(piCodingAgentMocks.generateSummary.mock.calls[0]?.[8]).toBe("off");
+
+    const completionOptions = piCodingAgentMocks.generateSummary.mock.calls[0]?.[9] as
+      | { onPayload?: typeof onPayload }
+      | undefined;
+    expect(completionOptions?.onPayload).toBe(onPayload);
+
+    const payload: Record<string, unknown> = {};
+    completionOptions?.onPayload?.(payload);
+    expect(payload).toEqual({
+      chat_template_kwargs: {
+        enable_thinking: false,
+        preserve_thinking: true,
+      },
+    });
+  });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -1,9 +1,11 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
   estimateTokens,
   generateSummary as piGenerateSummary,
 } from "@mariozechner/pi-coding-agent";
+import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { retryAsync } from "../infra/retry.js";
@@ -45,6 +47,8 @@ export type CompactionSummarizationInstructions = {
   identifierInstructions?: string;
 };
 
+export type CompactionSummaryCompletionOptions = Pick<SimpleStreamOptions, "onPayload">;
+
 type GenerateSummaryCompat = {
   (
     currentMessages: AgentMessage[],
@@ -54,6 +58,8 @@ type GenerateSummaryCompat = {
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string,
+    thinkingLevel?: ThinkLevel,
+    completionOptions?: CompactionSummaryCompletionOptions,
   ): Promise<string>;
   (
     currentMessages: AgentMessage[],
@@ -64,6 +70,8 @@ type GenerateSummaryCompat = {
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string,
+    thinkingLevel?: ThinkLevel,
+    completionOptions?: CompactionSummaryCompletionOptions,
   ): Promise<string>;
 };
 
@@ -301,6 +309,8 @@ async function summarizeChunks(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  thinkingLevel?: ThinkLevel;
+  completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   if (params.messages.length === 0) {
     return params.previousSummary ?? DEFAULT_SUMMARY_FALLBACK;
@@ -326,6 +336,8 @@ async function summarizeChunks(params: {
           params.signal,
           effectiveInstructions,
           summary,
+          params.thinkingLevel,
+          params.completionOptions,
         ),
       {
         attempts: 3,
@@ -350,8 +362,10 @@ function generateSummary(
   signal: AbortSignal,
   customInstructions?: string,
   previousSummary?: string,
+  thinkingLevel?: ThinkLevel,
+  completionOptions?: CompactionSummaryCompletionOptions,
 ): Promise<string> {
-  if (piGenerateSummary.length >= 8) {
+  if (piGenerateSummary.length >= 8 || thinkingLevel || completionOptions) {
     return generateSummaryCompat(
       currentMessages,
       model,
@@ -361,6 +375,8 @@ function generateSummary(
       signal,
       customInstructions,
       previousSummary,
+      thinkingLevel,
+      completionOptions,
     );
   }
   return generateSummaryCompat(
@@ -390,6 +406,8 @@ export async function summarizeWithFallback(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  thinkingLevel?: ThinkLevel;
+  completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   const { messages, contextWindow } = params;
 
@@ -454,8 +472,10 @@ export async function summarizeInStages(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
+  thinkingLevel?: ThinkLevel;
   parts?: number;
   minMessagesForSplit?: number;
+  completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   const { messages } = params;
   if (messages.length === 0) {

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -1,11 +1,10 @@
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { SimpleStreamOptions } from "@mariozechner/pi-ai";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import {
   estimateTokens,
   generateSummary as piGenerateSummary,
 } from "@mariozechner/pi-coding-agent";
-import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { AgentCompactionIdentifierPolicy } from "../config/types.agent-defaults.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { retryAsync } from "../infra/retry.js";
@@ -58,7 +57,7 @@ type GenerateSummaryCompat = {
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string,
-    thinkingLevel?: ThinkLevel,
+    thinkingLevel?: ThinkingLevel,
     completionOptions?: CompactionSummaryCompletionOptions,
   ): Promise<string>;
   (
@@ -70,7 +69,7 @@ type GenerateSummaryCompat = {
     signal?: AbortSignal,
     customInstructions?: string,
     previousSummary?: string,
-    thinkingLevel?: ThinkLevel,
+    thinkingLevel?: ThinkingLevel,
     completionOptions?: CompactionSummaryCompletionOptions,
   ): Promise<string>;
 };
@@ -309,7 +308,7 @@ async function summarizeChunks(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: ThinkingLevel;
   completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   if (params.messages.length === 0) {
@@ -362,7 +361,7 @@ function generateSummary(
   signal: AbortSignal,
   customInstructions?: string,
   previousSummary?: string,
-  thinkingLevel?: ThinkLevel,
+  thinkingLevel?: ThinkingLevel,
   completionOptions?: CompactionSummaryCompletionOptions,
 ): Promise<string> {
   if (piGenerateSummary.length >= 8 || thinkingLevel || completionOptions) {
@@ -406,7 +405,7 @@ export async function summarizeWithFallback(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: ThinkingLevel;
   completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   const { messages, contextWindow } = params;
@@ -472,7 +471,7 @@ export async function summarizeInStages(params: {
   customInstructions?: string;
   summarizationInstructions?: CompactionSummarizationInstructions;
   previousSummary?: string;
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: ThinkingLevel;
   parts?: number;
   minMessagesForSplit?: number;
   completionOptions?: CompactionSummaryCompletionOptions;

--- a/src/agents/openai-completions-extra-params.ts
+++ b/src/agents/openai-completions-extra-params.ts
@@ -1,0 +1,129 @@
+type PayloadPatchLogger = {
+  warn(message: string): void;
+};
+
+export type OpenAICompletionsPayloadPatch = (payload: Record<string, unknown>) => void;
+
+function sanitizeExtraParamsRecord(
+  value: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      ([key]) => key !== "__proto__" && key !== "prototype" && key !== "constructor",
+    ),
+  );
+}
+
+function sanitizeExtraBodyRecord(value: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(sanitizeExtraParamsRecord(value) ?? {}).filter(
+      ([, entry]) => entry !== undefined,
+    ),
+  );
+}
+
+function resolveAliasedParamValue(
+  sources: Array<Record<string, unknown> | undefined>,
+  snakeCaseKey: string,
+  camelCaseKey: string,
+): unknown {
+  let resolved: unknown = undefined;
+  let seen = false;
+  for (const source of sources) {
+    if (!source) {
+      continue;
+    }
+    const hasSnakeCaseKey = Object.hasOwn(source, snakeCaseKey);
+    const hasCamelCaseKey = Object.hasOwn(source, camelCaseKey);
+    if (!hasSnakeCaseKey && !hasCamelCaseKey) {
+      continue;
+    }
+    resolved = hasSnakeCaseKey ? source[snakeCaseKey] : source[camelCaseKey];
+    seen = true;
+  }
+  return seen ? resolved : undefined;
+}
+
+function resolveExtraBodyParam(
+  rawExtraBody: unknown,
+  logger?: PayloadPatchLogger,
+): Record<string, unknown> | undefined {
+  if (rawExtraBody === undefined || rawExtraBody === null) {
+    return undefined;
+  }
+  if (typeof rawExtraBody !== "object" || Array.isArray(rawExtraBody)) {
+    const summary = typeof rawExtraBody === "string" ? rawExtraBody : typeof rawExtraBody;
+    logger?.warn(`ignoring invalid extra_body param: ${summary}`);
+    return undefined;
+  }
+  const extraBody = sanitizeExtraBodyRecord(rawExtraBody as Record<string, unknown>);
+  return Object.keys(extraBody).length > 0 ? extraBody : undefined;
+}
+
+function resolveChatTemplateKwargsParam(
+  rawChatTemplateKwargs: unknown,
+  logger?: PayloadPatchLogger,
+): Record<string, unknown> | undefined {
+  if (rawChatTemplateKwargs === undefined || rawChatTemplateKwargs === null) {
+    return undefined;
+  }
+  if (typeof rawChatTemplateKwargs !== "object" || Array.isArray(rawChatTemplateKwargs)) {
+    const summary =
+      typeof rawChatTemplateKwargs === "string"
+        ? rawChatTemplateKwargs
+        : typeof rawChatTemplateKwargs;
+    logger?.warn(`ignoring invalid chat_template_kwargs param: ${summary}`);
+    return undefined;
+  }
+  const chatTemplateKwargs = sanitizeExtraBodyRecord(
+    rawChatTemplateKwargs as Record<string, unknown>,
+  );
+  return Object.keys(chatTemplateKwargs).length > 0 ? chatTemplateKwargs : undefined;
+}
+
+export function createOpenAICompletionsExtraParamsPayloadPatch(params: {
+  sources: Array<Record<string, unknown> | undefined>;
+  logger?: PayloadPatchLogger;
+}): OpenAICompletionsPayloadPatch | undefined {
+  const rawChatTemplateKwargs = resolveAliasedParamValue(
+    params.sources,
+    "chat_template_kwargs",
+    "chatTemplateKwargs",
+  );
+  const configuredChatTemplateKwargs = resolveChatTemplateKwargsParam(
+    rawChatTemplateKwargs,
+    params.logger,
+  );
+  const rawExtraBody = resolveAliasedParamValue(params.sources, "extra_body", "extraBody");
+  const extraBody = resolveExtraBodyParam(rawExtraBody, params.logger);
+  if (!configuredChatTemplateKwargs && !extraBody) {
+    return undefined;
+  }
+
+  return (payloadObj) => {
+    if (configuredChatTemplateKwargs) {
+      const existing = payloadObj.chat_template_kwargs;
+      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
+        payloadObj.chat_template_kwargs = {
+          ...(existing as Record<string, unknown>),
+          ...configuredChatTemplateKwargs,
+        };
+      } else {
+        payloadObj.chat_template_kwargs = configuredChatTemplateKwargs;
+      }
+    }
+
+    if (extraBody) {
+      const collisions = Object.keys(extraBody).filter((key) => Object.hasOwn(payloadObj, key));
+      if (collisions.length > 0) {
+        params.logger?.warn(
+          `extra_body overwriting request payload keys: ${collisions.join(", ")}`,
+        );
+      }
+      Object.assign(payloadObj, extraBody);
+    }
+  };
+}

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -983,6 +983,39 @@ describe("applyExtraParamsToAgent", () => {
     });
   });
 
+  it("continues to pass global chat_template_kwargs through normal openai-completions streams", () => {
+    const payload = runResponsesPayloadMutationCase({
+      applyProvider: "vllm",
+      applyModelId: "Qwen/Qwen3-8B",
+      cfg: {
+        agents: {
+          defaults: {
+            params: {
+              chat_template_kwargs: {
+                enable_thinking: false,
+                preserve_thinking: true,
+              },
+            },
+          },
+        },
+      },
+      model: {
+        api: "openai-completions",
+        provider: "vllm",
+        id: "Qwen/Qwen3-8B",
+        baseUrl: "http://127.0.0.1:8000/v1",
+      } as Model<"openai-completions">,
+      payload: {
+        messages: [],
+      },
+    });
+
+    expect(payload.chat_template_kwargs).toEqual({
+      enable_thinking: false,
+      preserve_thinking: true,
+    });
+  });
+
   it("warns and skips invalid chat_template_kwargs params", () => {
     const warnSpy = vi.spyOn(log, "warn").mockImplementation(() => {});
     try {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -843,6 +843,7 @@ export async function compactEmbeddedPiSessionDirect(
         modelId,
         model,
         thinkingLevel: thinkLevel,
+        agentId: sessionAgentId,
         workspaceDir: effectiveWorkspace,
         agentDir,
       });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -842,6 +842,9 @@ export async function compactEmbeddedPiSessionDirect(
         provider,
         modelId,
         model,
+        thinkingLevel: thinkLevel,
+        workspaceDir: effectiveWorkspace,
+        agentDir,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,

--- a/src/agents/pi-embedded-runner/extensions.test.ts
+++ b/src/agents/pi-embedded-runner/extensions.test.ts
@@ -13,7 +13,10 @@ vi.mock("../../plugins/provider-runtime.js", () => ({
 }));
 
 vi.mock("../../plugins/provider-hook-runtime.js", () => ({
+  prepareProviderExtraParams: () => undefined,
+  resolveProviderExtraParamsForTransport: () => undefined,
   resolveProviderRuntimePlugin: () => undefined,
+  wrapProviderStreamFn: () => undefined,
 }));
 
 function buildSafeguardFactories(cfg: OpenClawConfig) {

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { ExtensionFactory, SessionManager } from "@mariozechner/pi-coding-agent";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { resolveContextWindowInfo } from "../context-window-guard.js";
@@ -15,6 +16,7 @@ import { makeToolPrunablePredicate } from "../pi-hooks/context-pruning/tools.js"
 import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
+import { resolvePreparedExtraParams } from "./extra-params.js";
 
 type PiToolResultEvent = {
   threadId?: string;
@@ -138,6 +140,9 @@ export function buildEmbeddedExtensionFactories(params: {
   provider: string;
   modelId: string;
   model: ProviderRuntimeModel | undefined;
+  thinkingLevel?: ThinkLevel;
+  workspaceDir?: string;
+  agentDir?: string;
 }): ExtensionFactory[] {
   const factories: ExtensionFactory[] = [];
   if (resolveCompactionMode(params.cfg) === "safeguard") {
@@ -160,6 +165,16 @@ export function buildEmbeddedExtensionFactories(params: {
       qualityGuardEnabled: qualityGuardCfg?.enabled ?? true,
       qualityGuardMaxRetries: qualityGuardCfg?.maxRetries,
       model: params.model,
+      thinkingLevel: params.thinkingLevel,
+      extraParams: resolvePreparedExtraParams({
+        cfg: params.cfg,
+        provider: params.provider,
+        modelId: params.modelId,
+        thinkingLevel: params.thinkingLevel,
+        workspaceDir: params.workspaceDir,
+        agentDir: params.agentDir,
+        model: params.model,
+      }),
       recentTurnsPreserve: compactionCfg?.recentTurnsPreserve,
       provider: compactionCfg?.provider,
     });

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -17,6 +17,7 @@ import { ensurePiCompactionReserveTokens } from "../pi-settings.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import { isCacheTtlEligibleProvider, readLastCacheTtlTimestamp } from "./cache-ttl.js";
 import { resolvePreparedExtraParams } from "./extra-params.js";
+import { mapThinkingLevel } from "./utils.js";
 
 type PiToolResultEvent = {
   threadId?: string;
@@ -141,6 +142,7 @@ export function buildEmbeddedExtensionFactories(params: {
   modelId: string;
   model: ProviderRuntimeModel | undefined;
   thinkingLevel?: ThinkLevel;
+  agentId?: string;
   workspaceDir?: string;
   agentDir?: string;
 }): ExtensionFactory[] {
@@ -165,11 +167,12 @@ export function buildEmbeddedExtensionFactories(params: {
       qualityGuardEnabled: qualityGuardCfg?.enabled ?? true,
       qualityGuardMaxRetries: qualityGuardCfg?.maxRetries,
       model: params.model,
-      thinkingLevel: params.thinkingLevel,
+      thinkingLevel: mapThinkingLevel(params.thinkingLevel),
       extraParams: resolvePreparedExtraParams({
         cfg: params.cfg,
         provider: params.provider,
         modelId: params.modelId,
+        agentId: params.agentId,
         thinkingLevel: params.thinkingLevel,
         workspaceDir: params.workspaceDir,
         agentDir: params.agentDir,

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -11,6 +11,10 @@ import {
 } from "../../plugins/provider-hook-runtime.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { legacyModelKey, modelKey } from "../model-selection-normalize.js";
+import {
+  createOpenAICompletionsExtraParamsPayloadPatch,
+  type OpenAICompletionsPayloadPatch,
+} from "../openai-completions-extra-params.js";
 import { supportsGptParallelToolCallsPayload } from "../provider-api-families.js";
 import { resolveProviderRequestPolicyConfig } from "../provider-request-config.js";
 import { createGoogleThinkingPayloadWrapper } from "./google-stream-wrappers.js";
@@ -425,86 +429,16 @@ function createOpenAICompletionsStoreCompatWrapper(baseStreamFn: StreamFn | unde
   };
 }
 
-function sanitizeExtraBodyRecord(value: Record<string, unknown>): Record<string, unknown> {
-  return Object.fromEntries(
-    Object.entries(sanitizeExtraParamsRecord(value) ?? {}).filter(
-      ([, entry]) => entry !== undefined,
-    ),
-  );
-}
-
-function resolveExtraBodyParam(rawExtraBody: unknown): Record<string, unknown> | undefined {
-  if (rawExtraBody === undefined || rawExtraBody === null) {
-    return undefined;
-  }
-  if (typeof rawExtraBody !== "object" || Array.isArray(rawExtraBody)) {
-    const summary = typeof rawExtraBody === "string" ? rawExtraBody : typeof rawExtraBody;
-    log.warn(`ignoring invalid extra_body param: ${summary}`);
-    return undefined;
-  }
-  const extraBody = sanitizeExtraBodyRecord(rawExtraBody as Record<string, unknown>);
-  return Object.keys(extraBody).length > 0 ? extraBody : undefined;
-}
-
-function resolveChatTemplateKwargsParam(
-  rawChatTemplateKwargs: unknown,
-): Record<string, unknown> | undefined {
-  if (rawChatTemplateKwargs === undefined || rawChatTemplateKwargs === null) {
-    return undefined;
-  }
-  if (typeof rawChatTemplateKwargs !== "object" || Array.isArray(rawChatTemplateKwargs)) {
-    const summary =
-      typeof rawChatTemplateKwargs === "string"
-        ? rawChatTemplateKwargs
-        : typeof rawChatTemplateKwargs;
-    log.warn(`ignoring invalid chat_template_kwargs param: ${summary}`);
-    return undefined;
-  }
-  const chatTemplateKwargs = sanitizeExtraBodyRecord(
-    rawChatTemplateKwargs as Record<string, unknown>,
-  );
-  return Object.keys(chatTemplateKwargs).length > 0 ? chatTemplateKwargs : undefined;
-}
-
-function createOpenAICompletionsChatTemplateKwargsWrapper(params: {
+function createOpenAICompletionsExtraParamsPayloadWrapper(params: {
   baseStreamFn: StreamFn | undefined;
-  configured: Record<string, unknown>;
+  patchPayload: OpenAICompletionsPayloadPatch;
 }): StreamFn {
   const underlying = params.baseStreamFn ?? streamSimple;
   return (model, context, options) => {
     if (model.api !== "openai-completions") {
       return underlying(model, context, options);
     }
-    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      const existing = payloadObj.chat_template_kwargs;
-      if (existing && typeof existing === "object" && !Array.isArray(existing)) {
-        payloadObj.chat_template_kwargs = {
-          ...(existing as Record<string, unknown>),
-          ...params.configured,
-        };
-        return;
-      }
-      payloadObj.chat_template_kwargs = params.configured;
-    });
-  };
-}
-
-function createOpenAICompletionsExtraBodyWrapper(
-  baseStreamFn: StreamFn | undefined,
-  extraBody: Record<string, unknown>,
-): StreamFn {
-  const underlying = baseStreamFn ?? streamSimple;
-  return (model, context, options) => {
-    if (model.api !== "openai-completions") {
-      return underlying(model, context, options);
-    }
-    return streamWithPayloadPatch(underlying, model, context, options, (payloadObj) => {
-      const collisions = Object.keys(extraBody).filter((key) => Object.hasOwn(payloadObj, key));
-      if (collisions.length > 0) {
-        log.warn(`extra_body overwriting request payload keys: ${collisions.join(", ")}`);
-      }
-      Object.assign(payloadObj, extraBody);
-    });
+    return streamWithPayloadPatch(underlying, model, context, options, params.patchPayload);
   };
 }
 
@@ -574,27 +508,15 @@ function applyPostPluginStreamWrappers(
   // blocks. Disable thinking unless an earlier wrapper already set it.
   ctx.agent.streamFn = createMinimaxThinkingDisabledWrapper(ctx.agent.streamFn);
 
-  const rawChatTemplateKwargs = resolveAliasedParamValue(
-    [ctx.effectiveExtraParams, ctx.override],
-    "chat_template_kwargs",
-    "chatTemplateKwargs",
-  );
-  const configuredChatTemplateKwargs = resolveChatTemplateKwargsParam(rawChatTemplateKwargs);
-  if (configuredChatTemplateKwargs) {
-    ctx.agent.streamFn = createOpenAICompletionsChatTemplateKwargsWrapper({
+  const extraParamsPayloadPatch = createOpenAICompletionsExtraParamsPayloadPatch({
+    sources: [ctx.effectiveExtraParams, ctx.override],
+    logger: log,
+  });
+  if (extraParamsPayloadPatch) {
+    ctx.agent.streamFn = createOpenAICompletionsExtraParamsPayloadWrapper({
       baseStreamFn: ctx.agent.streamFn,
-      configured: configuredChatTemplateKwargs,
+      patchPayload: extraParamsPayloadPatch,
     });
-  }
-
-  const rawExtraBody = resolveAliasedParamValue(
-    [ctx.effectiveExtraParams, ctx.override],
-    "extra_body",
-    "extraBody",
-  );
-  const extraBody = resolveExtraBodyParam(rawExtraBody);
-  if (extraBody) {
-    ctx.agent.streamFn = createOpenAICompletionsExtraBodyWrapper(ctx.agent.streamFn, extraBody);
   }
   ctx.agent.streamFn = createOpenAICompletionsStoreCompatWrapper(ctx.agent.streamFn);
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1391,6 +1391,9 @@ export async function runEmbeddedAttempt(
         provider: params.provider,
         modelId: params.modelId,
         model: params.model,
+        thinkingLevel: params.thinkLevel,
+        workspaceDir: effectiveWorkspace,
+        agentDir,
       });
       const resourceLoader = new DefaultResourceLoader({
         cwd: resolvedWorkspace,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1392,6 +1392,7 @@ export async function runEmbeddedAttempt(
         modelId: params.modelId,
         model: params.model,
         thinkingLevel: params.thinkLevel,
+        agentId: sessionAgentId,
         workspaceDir: effectiveWorkspace,
         agentDir,
       });

--- a/src/agents/pi-hooks/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-hooks/compaction-safeguard-runtime.ts
@@ -1,4 +1,5 @@
 import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { AgentCompactionIdentifierPolicy } from "../../config/types.agent-defaults.js";
 import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-registry.js";
 
@@ -14,6 +15,10 @@ export type CompactionSafeguardRuntimeValue = {
    * (extensionRunner.initialize() is never called in that path).
    */
   model?: Model<Api>;
+  /** Resolved agent/provider params to apply to built-in LLM summary requests. */
+  extraParams?: Record<string, unknown>;
+  /** Resolved thinking level to use for built-in LLM summary requests. */
+  thinkingLevel?: ThinkLevel;
   recentTurnsPreserve?: number;
   qualityGuardEnabled?: boolean;
   qualityGuardMaxRetries?: number;

--- a/src/agents/pi-hooks/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-hooks/compaction-safeguard-runtime.ts
@@ -1,5 +1,5 @@
+import type { ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { Api, Model } from "@mariozechner/pi-ai";
-import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import type { AgentCompactionIdentifierPolicy } from "../../config/types.agent-defaults.js";
 import { createSessionManagerRuntimeRegistry } from "./session-manager-runtime-registry.js";
 
@@ -18,7 +18,7 @@ export type CompactionSafeguardRuntimeValue = {
   /** Resolved agent/provider params to apply to built-in LLM summary requests. */
   extraParams?: Record<string, unknown>;
   /** Resolved thinking level to use for built-in LLM summary requests. */
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: ThinkingLevel;
   recentTurnsPreserve?: number;
   qualityGuardEnabled?: boolean;
   qualityGuardMaxRetries?: number;

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -622,17 +622,45 @@ describe("compaction-safeguard runtime registry", () => {
         defaults: {
           params: {
             chat_template_kwargs: {
-              enable_thinking: false,
-              preserve_thinking: true,
+              enable_thinking: true,
+              source: "default",
             },
             extra_body: {
-              top_k: 20,
+              top_k: 10,
+            },
+          },
+          models: {
+            "vllm/Qwen/Qwen3-8B": {
+              params: {
+                chat_template_kwargs: {
+                  enable_thinking: true,
+                  source: "model",
+                },
+                extra_body: {
+                  top_k: 20,
+                },
+              },
             },
           },
           compaction: {
             mode: "safeguard",
           },
         },
+        list: [
+          {
+            id: "research",
+            params: {
+              chat_template_kwargs: {
+                enable_thinking: false,
+                preserve_thinking: true,
+                source: "agent",
+              },
+              extra_body: {
+                top_k: 30,
+              },
+            },
+          },
+        ],
       },
     } as OpenClawConfig;
 
@@ -641,6 +669,7 @@ describe("compaction-safeguard runtime registry", () => {
       sessionManager,
       provider: "vllm",
       modelId: "Qwen/Qwen3-8B",
+      agentId: "research",
       model: {
         api: "openai-completions",
         provider: "vllm",
@@ -658,11 +687,47 @@ describe("compaction-safeguard runtime registry", () => {
       chat_template_kwargs: {
         enable_thinking: false,
         preserve_thinking: true,
+        source: "agent",
       },
       extra_body: {
-        top_k: 20,
+        top_k: 30,
       },
     });
+  });
+
+  it("maps OpenClaw thinking levels before storing compaction summary runtime", () => {
+    for (const [thinkingLevel, expected] of [
+      ["max", "xhigh"],
+      ["adaptive", "medium"],
+    ] as const) {
+      const sessionManager = {} as unknown as Parameters<
+        typeof buildEmbeddedExtensionFactories
+      >[0]["sessionManager"];
+
+      buildEmbeddedExtensionFactories({
+        cfg: {
+          agents: {
+            defaults: {
+              compaction: {
+                mode: "safeguard",
+              },
+            },
+          },
+        } as OpenClawConfig,
+        sessionManager,
+        provider: "vllm",
+        modelId: "Qwen/Qwen3-8B",
+        thinkingLevel,
+        model: {
+          api: "openai-completions",
+          provider: "vllm",
+          id: "Qwen/Qwen3-8B",
+          contextWindow: 200_000,
+        } as Parameters<typeof buildEmbeddedExtensionFactories>[0]["model"],
+      });
+
+      expect(getCompactionSafeguardRuntime(sessionManager)?.thinkingLevel).toBe(expected);
+    }
   });
 });
 

--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -612,6 +612,58 @@ describe("compaction-safeguard runtime registry", () => {
     expect(resolveQualityGuardMaxRetries(runtime?.qualityGuardMaxRetries)).toBe(3);
     expect(resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve)).toBe(12);
   });
+
+  it("wires resolved provider params into compaction safeguard runtime", () => {
+    const sessionManager = {} as unknown as Parameters<
+      typeof buildEmbeddedExtensionFactories
+    >[0]["sessionManager"];
+    const cfg = {
+      agents: {
+        defaults: {
+          params: {
+            chat_template_kwargs: {
+              enable_thinking: false,
+              preserve_thinking: true,
+            },
+            extra_body: {
+              top_k: 20,
+            },
+          },
+          compaction: {
+            mode: "safeguard",
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    buildEmbeddedExtensionFactories({
+      cfg,
+      sessionManager,
+      provider: "vllm",
+      modelId: "Qwen/Qwen3-8B",
+      model: {
+        api: "openai-completions",
+        provider: "vllm",
+        id: "Qwen/Qwen3-8B",
+        contextWindow: 200_000,
+      } as Parameters<typeof buildEmbeddedExtensionFactories>[0]["model"],
+    });
+
+    const runtime = getCompactionSafeguardRuntime(sessionManager) as
+      | (NonNullable<ReturnType<typeof getCompactionSafeguardRuntime>> & {
+          extraParams?: Record<string, unknown>;
+        })
+      | null;
+    expect(runtime?.extraParams).toMatchObject({
+      chat_template_kwargs: {
+        enable_thinking: false,
+        preserve_thinking: true,
+      },
+      extra_body: {
+        top_k: 20,
+      },
+    });
+  });
 });
 
 describe("compaction-safeguard recent-turn preservation", () => {
@@ -1344,6 +1396,64 @@ describe("compaction-safeguard recent-turn preservation", () => {
       "User-Agent": "GitHubCopilotChat/0.26.7",
       "X-Test": "1",
       "x-initiator": "user",
+    });
+  });
+
+  it("passes vLLM extra payload params to built-in compaction summarization", async () => {
+    mockSummarizeInStages.mockReset();
+    mockSummarizeInStages.mockResolvedValue("mock summary");
+
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture({
+      id: "Qwen/Qwen3-8B",
+      name: "Qwen3 8B",
+      provider: "vllm",
+      api: "openai-completions" as const,
+      baseUrl: "http://127.0.0.1:8000/v1",
+      reasoning: true,
+    });
+    setCompactionSafeguardRuntime(sessionManager, {
+      model,
+      recentTurnsPreserve: 0,
+      qualityGuardEnabled: false,
+      thinkingLevel: "off",
+      extraParams: {
+        chat_template_kwargs: {
+          enable_thinking: false,
+          preserve_thinking: true,
+        },
+      },
+    });
+
+    const getApiKeyAndHeadersMock = vi.fn().mockResolvedValue({
+      ok: true,
+      apiKey: "vllm-token",
+    });
+    const mockContext = createCompactionContext({
+      sessionManager,
+      getApiKeyAndHeadersMock,
+    });
+    const compactionHandler = createCompactionHandler();
+    const event = createCompactionEvent({
+      messageText: "summarize me",
+      tokensBefore: 1000,
+    });
+    (event.preparation as { settings?: { reserveTokens: number } }).settings = {
+      reserveTokens: 4000,
+    };
+
+    const result = (await compactionHandler(event, mockContext)) as { cancel?: boolean };
+
+    expect(result.cancel).not.toBe(true);
+    const summaryCall = mockSummarizeInStages.mock.calls.at(-1)?.[0];
+    expect(summaryCall?.thinkingLevel).toBe("off");
+    const payload: Record<string, unknown> = {};
+    summaryCall?.completionOptions?.onPayload?.(payload, model);
+    expect(payload).toEqual({
+      chat_template_kwargs: {
+        enable_thinking: false,
+        preserve_thinking: true,
+      },
     });
   });
 

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, FileOperations } from "@mariozechner/pi-coding-agent";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAbortError } from "../../infra/unhandled-rejections.js";
@@ -20,6 +21,7 @@ import {
   MIN_CHUNK_RATIO,
   SAFETY_MARGIN,
   SUMMARIZATION_OVERHEAD_TOKENS,
+  type CompactionSummaryCompletionOptions,
   computeAdaptiveChunkRatio,
   estimateMessagesTokens,
   isOversizedForSummary,
@@ -31,6 +33,7 @@ import { collectTextContentBlocks } from "../content-blocks.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "../copilot-dynamic-headers.js";
 import { isTimeoutError } from "../failover-error.js";
 import { stripRuntimeContextCustomMessages } from "../internal-runtime-context.js";
+import { createOpenAICompletionsExtraParamsPayloadPatch } from "../openai-completions-extra-params.js";
 import { repairToolUseResultPairing } from "../session-transcript-repair.js";
 import { extractToolCallsFromAssistant, extractToolResultId } from "../tool-call-id.js";
 import {
@@ -74,6 +77,29 @@ const PREVIOUS_SUMMARY_REDISTILL_PREFIX =
 const compactionSafeguardDeps = {
   summarizeInStages,
 };
+
+function buildSummaryCompletionOptions(
+  extraParams: Record<string, unknown> | undefined,
+): CompactionSummaryCompletionOptions | undefined {
+  const payloadPatch = createOpenAICompletionsExtraParamsPayloadPatch({
+    sources: [extraParams],
+    logger: log,
+  });
+  if (!payloadPatch) {
+    return undefined;
+  }
+  return {
+    onPayload: (payload, model) => {
+      if (model.api !== "openai-completions") {
+        return undefined;
+      }
+      if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+        payloadPatch(payload as Record<string, unknown>);
+      }
+      return undefined;
+    },
+  };
+}
 
 function buildPreviousSummaryMessage(previousSummary: string): AgentMessage {
   return {
@@ -152,6 +178,8 @@ async function summarizeViaLLM(params: {
   customInstructions?: string;
   summarizationInstructions?: Parameters<typeof summarizeInStages>[0]["summarizationInstructions"];
   previousSummary?: string;
+  thinkingLevel?: ThinkLevel;
+  completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   const messages = prependPreviousSummaryForRedistill({
     messages: params.messages,
@@ -169,6 +197,8 @@ async function summarizeViaLLM(params: {
     customInstructions: params.customInstructions,
     summarizationInstructions: params.summarizationInstructions,
     previousSummary: undefined,
+    thinkingLevel: params.thinkingLevel,
+    completionOptions: params.completionOptions,
   });
 }
 
@@ -835,6 +865,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     };
     const identifierPolicy = runtime?.identifierPolicy ?? "strict";
     const providerId = runtime?.provider;
+    const completionOptions = buildSummaryCompletionOptions(runtime?.extraParams);
+    const thinkingLevel = runtime?.thinkingLevel;
     const turnPrefixMessages = baseTurnPrefixMessages;
     const recentTurnsPreserve = resolveRecentTurnsPreserve(runtime?.recentTurnsPreserve);
     const { preservedMessages: providerPreservedMessages } = splitPreservedRecentTurns({
@@ -1006,6 +1038,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: structuredInstructions,
                   summarizationInstructions,
                   previousSummary: preparation.previousSummary,
+                  thinkingLevel,
+                  completionOptions,
                 });
               } catch (droppedError) {
                 log.warn(
@@ -1078,6 +1112,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
                   customInstructions: currentInstructions,
                   summarizationInstructions,
                   previousSummary: effectivePreviousSummary,
+                  thinkingLevel,
+                  completionOptions,
                 })
               : buildStructuredFallbackSummary(effectivePreviousSummary, summarizationInstructions);
 
@@ -1098,6 +1134,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               ),
               summarizationInstructions,
               previousSummary: undefined,
+              thinkingLevel,
+              completionOptions,
             });
             splitTurnSection = `**Turn Context (split turn):**\n\n${prefixSummary}`;
             summaryWithoutPreservedTurns = historySummary.trim()

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -1,9 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { AgentMessage, ThinkingLevel } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, ExtensionContext, FileOperations } from "@mariozechner/pi-coding-agent";
 import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
-import type { ThinkLevel } from "../../auto-reply/thinking.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { isAbortError } from "../../infra/unhandled-rejections.js";
@@ -178,7 +177,7 @@ async function summarizeViaLLM(params: {
   customInstructions?: string;
   summarizationInstructions?: Parameters<typeof summarizeInStages>[0]["summarizationInstructions"];
   previousSummary?: string;
-  thinkingLevel?: ThinkLevel;
+  thinkingLevel?: ThinkingLevel;
   completionOptions?: CompactionSummaryCompletionOptions;
 }): Promise<string> {
   const messages = prependPreviousSummaryForRedistill({


### PR DESCRIPTION
## Summary

- Preserve configured OpenAI-compatible extra payload params, including `chat_template_kwargs` and supported `extra_body` fields, when safeguard compaction generates built-in LLM summaries.
- Thread resolved provider params and the active thinking level into compaction safeguard runtime so summary calls inherit the same vLLM/Qwen thinking behavior as normal assistant turns.
- Add a small `@mariozechner/pi-coding-agent` patch so `generateSummary()` can receive an optional `onPayload` hook without changing default behavior.

## Root Cause

The normal assistant stream path already patched OpenAI-compatible request bodies, but the compaction summary fallback called `generateSummary()` directly. That dependency function forced summary completion setup internally and exposed no request payload hook, so vLLM params such as:

```json
{
  "chat_template_kwargs": {
    "enable_thinking": false,
    "preserve_thinking": true
  }
}
```

never reached summary requests during compaction.

## Tests

- `pnpm test src/agents/compaction.summarize-fallback.test.ts`
- `pnpm test src/agents/pi-hooks/compaction-safeguard.test.ts`
- `pnpm test src/agents/pi-embedded-runner-extraparams.test.ts`
- `pnpm check`
- `pnpm build`
