### PR TITLE
fix(agents): preserve exact paths during compaction

### DIFF
--- a/src/agents/pi-hooks/compaction-safeguard.test.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.test.ts
@@ -47,6 +47,8 @@ const {
   capCompactionSummary,
   capCompactionSummaryPreservingSuffix,
   formatFileOperations,
+  collectExactPathLiterals,
+  formatExactPathLiterals,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
   readWorkspaceContextForSummary,
@@ -55,6 +57,7 @@ const {
   SAFETY_MARGIN,
   MAX_COMPACTION_SUMMARY_CHARS,
   MAX_FILE_OPS_SECTION_CHARS,
+  MAX_EXACT_PATH_LITERALS_SECTION_CHARS,
   SUMMARY_TRUNCATED_MARKER,
 } = __testing;
 
@@ -309,6 +312,65 @@ describe("compaction-safeguard summary budgets", () => {
     expect(section).toContain("<modified-files>");
     expect(section).toContain("...and ");
     expect(section.length).toBeLessThanOrEqual(MAX_FILE_OPS_SECTION_CHARS);
+  });
+
+  it("collects exact path literals from the full compaction input and file operations", () => {
+    const oldPath = "/root/workspace/skills/openclaw-cybersecurity-skills/CONVERSION_Rules.md";
+    const toolPath =
+      "/root/workspace/skills/Anthropic-Cybersecurity-Skills/skills/building-threat-hunt-hypothesis-framework/SKILL.md";
+    const windowsToolPath = "C:\\tmp\\openclaw\\skills\\SKILL.md";
+    const hiddenDetailsPath = "/private/diagnostics/raw-tool-result.json";
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: `Use ${oldPath} after compaction. API docs are at https://api.openai.com/v1/responses.`,
+        timestamp: 1,
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool-call",
+            toolName: "read",
+            toolCallId: "call-read",
+            input: { path: toolPath, windowsPath: windowsToolPath },
+          },
+        ],
+        timestamp: 2,
+      } as unknown as AgentMessage,
+      {
+        role: "toolResult",
+        toolCallId: "call-read",
+        toolName: "read",
+        content: [{ type: "text", text: "ok" }],
+        details: { rawPath: hiddenDetailsPath },
+        timestamp: 3,
+      } as unknown as AgentMessage,
+    ];
+
+    const paths = collectExactPathLiterals({
+      messages,
+      readFiles: ["docs/reference/compaction.md"],
+      modifiedFiles: ["src/agents/pi-hooks/compaction-safeguard.ts"],
+      previousSummary: "Previously inspected /tmp/openclaw/session-log.json.",
+    });
+    const section = formatExactPathLiterals(paths);
+
+    expect(paths).toContain(oldPath);
+    expect(paths).toContain(toolPath);
+    expect(paths).toContain(windowsToolPath);
+    expect(paths).toContain("/tmp/openclaw/session-log.json");
+    expect(paths).toContain("docs/reference/compaction.md");
+    expect(paths).toContain("src/agents/pi-hooks/compaction-safeguard.ts");
+    expect(paths).not.toContain("//api.openai.com/v1/responses");
+    expect(paths).not.toContain(hiddenDetailsPath);
+    expect(section).toContain("<exact-path-literals>");
+    expect(section).toContain(oldPath);
+    expect(section).toContain(toolPath);
+    expect(section).toContain(windowsToolPath);
+    expect(section).not.toContain("C:\\\\tmp\\\\openclaw\\\\skills\\\\SKILL.md");
+    expect(section).not.toContain(hiddenDetailsPath);
+    expect(section.length).toBeLessThanOrEqual(MAX_EXACT_PATH_LITERALS_SECTION_CHARS);
   });
 
   it("caps final compaction summary with a truncation marker", () => {
@@ -1847,6 +1909,59 @@ describe("compaction-safeguard recent-turn preservation", () => {
     expect(compaction.summary).toContain("## Recent turns preserved verbatim");
     expect(compaction.summary).toContain("latest ask status");
     expect(compaction.summary).toContain("latest assistant reply");
+  });
+
+  it("appends exact path literals so slash-separated paths survive provider compaction", async () => {
+    mockSummarizeInStages.mockReset();
+    registerCompactionProvider({
+      id: "path-provider",
+      label: "Path Provider",
+      summarize: vi.fn().mockResolvedValue("provider summary without paths"),
+    });
+
+    const exactPath = "/root/workspace/skills/openclaw-cybersecurity-skills/CONVERSION_Rules.md";
+    const corruptedPath =
+      "/root/workspace/ skills/ openclaw- cybersecurity- skills/ CONVERSION_ Rules. md";
+    const sessionManager = stubSessionManager();
+    setCompactionSafeguardRuntime(sessionManager, {
+      provider: "path-provider",
+    });
+
+    const event = {
+      preparation: {
+        messagesToSummarize: [
+          {
+            role: "user",
+            content: `Continue using ${exactPath} after compacting this long session.`,
+            timestamp: 1,
+          },
+        ],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-1",
+        tokensBefore: 1_500,
+        fileOps: {
+          read: [exactPath],
+          edited: [],
+          written: [],
+        },
+        settings: { reserveTokens: 4_000 },
+        previousSummary: undefined,
+        isSplitTurn: false,
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+
+    const { result } = await runCompactionScenario({
+      sessionManager,
+      event,
+      apiKey: null,
+    });
+
+    const compaction = expectCompactionResult(result);
+    expect(compaction.summary).toContain("<exact-path-literals>");
+    expect(compaction.summary).toContain(exactPath);
+    expect(compaction.summary).not.toContain(corruptedPath);
   });
 });
 

--- a/src/agents/pi-hooks/compaction-safeguard.ts
+++ b/src/agents/pi-hooks/compaction-safeguard.ts
@@ -62,6 +62,8 @@ const MAX_TOOL_FAILURE_CHARS = 240;
 const MAX_COMPACTION_SUMMARY_CHARS = 16_000;
 const MAX_FILE_OPS_SECTION_CHARS = 2_000;
 const MAX_FILE_OPS_LIST_CHARS = 900;
+const MAX_EXACT_PATH_LITERALS_SECTION_CHARS = 2_400;
+const MAX_PATH_EXTRACTION_DEPTH = 8;
 const SUMMARY_TRUNCATED_MARKER = "\n\n[Compaction summary truncated to fit budget]";
 const DEFAULT_RECENT_TURNS_PRESERVE = 3;
 const DEFAULT_QUALITY_GUARD_MAX_RETRIES = 1;
@@ -181,6 +183,7 @@ function assembleSuffix(parts: {
   preservedTurnsSection?: string;
   toolFailureSection?: string;
   fileOpsSummary?: string;
+  exactPathLiteralsSection?: string;
   workspaceContext?: string;
 }): string {
   let suffix = "";
@@ -188,6 +191,7 @@ function assembleSuffix(parts: {
   suffix = appendSummarySection(suffix, parts.preservedTurnsSection ?? "");
   suffix = appendSummarySection(suffix, parts.toolFailureSection ?? "");
   suffix = appendSummarySection(suffix, parts.fileOpsSummary ?? "");
+  suffix = appendSummarySection(suffix, parts.exactPathLiteralsSection ?? "");
   suffix = appendSummarySection(suffix, parts.workspaceContext ?? "");
   // Ensure leading separator so suffix does not merge with body (e.g. when body
   // ends without newline: "...## Exact identifiers## Tool Failures").
@@ -459,6 +463,117 @@ function formatFileOperations(readFiles: string[], modifiedFiles: string[]): str
   }
   const combined = `\n\n${sections.join("\n\n")}`;
   return capCompactionSummary(combined, MAX_FILE_OPS_SECTION_CHARS);
+}
+
+function sanitizePathLiteral(value: string): string {
+  return value
+    .trim()
+    .replace(/^[("'`[{<]+/, "")
+    .replace(/[)\]"'`,;:.!?<>]+$/, "");
+}
+
+function extractPathLiteralsFromText(text: string): string[] {
+  const posixMatches = text.match(/\/(?:[^\s"'`<>{}[\]|,;:()]+\/)+[^\s"'`<>{}[\]|,;:()]+/g) ?? [];
+  const windowsMatches =
+    text.match(/\b[A-Za-z]:\\(?:[^\s"'`<>{}[\]|,;()]+\\)+[^\s"'`<>{}[\]|,;()]+/g) ?? [];
+  return [...posixMatches, ...windowsMatches]
+    .map((value) => sanitizePathLiteral(value))
+    .filter((value) => value.length > 0 && !value.startsWith("//"));
+}
+
+function collectPathLiteralsFromAllowedValue(
+  value: unknown,
+  addPath: (pathLiteral: string) => void,
+  depth = 0,
+  seen = new WeakSet<object>(),
+): void {
+  if (depth > MAX_PATH_EXTRACTION_DEPTH || value === null || value === undefined) {
+    return;
+  }
+  if (typeof value === "string") {
+    for (const pathLiteral of extractPathLiteralsFromText(value)) {
+      addPath(pathLiteral);
+    }
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  if (seen.has(value)) {
+    return;
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectPathLiteralsFromAllowedValue(item, addPath, depth + 1, seen);
+    }
+    return;
+  }
+  for (const [key, nestedValue] of Object.entries(value)) {
+    if (key === "details") {
+      continue;
+    }
+    collectPathLiteralsFromAllowedValue(nestedValue, addPath, depth + 1, seen);
+  }
+}
+
+function collectExactPathLiterals(params: {
+  messages: AgentMessage[];
+  readFiles: string[];
+  modifiedFiles: string[];
+  previousSummary?: string;
+}): string[] {
+  const seen = new Set<string>();
+  const paths: string[] = [];
+  const addPath = (pathLiteral: string) => {
+    const normalized = sanitizePathLiteral(pathLiteral);
+    if (!normalized || seen.has(normalized)) {
+      return;
+    }
+    seen.add(normalized);
+    paths.push(normalized);
+  };
+
+  for (const pathLiteral of [...params.modifiedFiles, ...params.readFiles].toSorted()) {
+    addPath(pathLiteral);
+  }
+  if (params.previousSummary) {
+    for (const pathLiteral of extractPathLiteralsFromText(params.previousSummary)) {
+      addPath(pathLiteral);
+    }
+  }
+  for (const message of params.messages) {
+    collectPathLiteralsFromAllowedValue((message as { content?: unknown }).content, addPath);
+  }
+  return paths;
+}
+
+function formatExactPathLiterals(paths: string[]): string {
+  if (paths.length === 0) {
+    return "";
+  }
+  const openTag = "\n\n<exact-path-literals>\n";
+  const closeTag = "\n</exact-path-literals>";
+  const lines: string[] = [];
+  let usedChars = openTag.length + closeTag.length;
+
+  for (let i = 0; i < paths.length; i += 1) {
+    const line = `${paths[i]}\n`;
+    const remaining = paths.length - i - 1;
+    const overflowLine = remaining > 0 ? `...and ${remaining} more\n` : "";
+    const projected = usedChars + line.length + overflowLine.length;
+    if (projected > MAX_EXACT_PATH_LITERALS_SECTION_CHARS) {
+      const overflow = `...and ${paths.length - i} more\n`;
+      if (usedChars + overflow.length <= MAX_EXACT_PATH_LITERALS_SECTION_CHARS) {
+        lines.push(overflow);
+      }
+      break;
+    }
+    lines.push(line);
+    usedChars += line.length;
+  }
+
+  return lines.length > 0 ? `${openTag}${lines.join("")}${closeTag}` : "";
 }
 
 function capCompactionSummary(summary: string, maxChars = MAX_COMPACTION_SUMMARY_CHARS): string {
@@ -816,6 +931,13 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     }
     const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
+    const exactPathLiterals = collectExactPathLiterals({
+      messages: [...baseMessagesToSummarize, ...baseTurnPrefixMessages],
+      readFiles,
+      modifiedFiles,
+      previousSummary: preparation.previousSummary,
+    });
+    const exactPathLiteralsSection = formatExactPathLiterals(exactPathLiterals);
     const toolFailures = collectToolFailures([
       ...baseMessagesToSummarize,
       ...baseTurnPrefixMessages,
@@ -878,6 +1000,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
               preservedTurnsSection,
               toolFailureSection,
               fileOpsSummary,
+              exactPathLiteralsSection,
               workspaceContext,
             });
             const summary = capCompactionSummaryPreservingSuffix(providerResult, suffix);
@@ -1162,6 +1285,7 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
         preservedTurnsSection,
         toolFailureSection,
         fileOpsSummary,
+        exactPathLiteralsSection,
         workspaceContext,
       });
       const bodyToCap = lastHistorySummary || summary;
@@ -1209,6 +1333,8 @@ export const __testing = {
   capCompactionSummary,
   capCompactionSummaryPreservingSuffix,
   formatFileOperations,
+  collectExactPathLiterals,
+  formatExactPathLiterals,
   computeAdaptiveChunkRatio,
   isOversizedForSummary,
   readWorkspaceContextForSummary,
@@ -1220,5 +1346,6 @@ export const __testing = {
   MAX_COMPACTION_SUMMARY_CHARS,
   MAX_FILE_OPS_SECTION_CHARS,
   MAX_FILE_OPS_LIST_CHARS,
+  MAX_EXACT_PATH_LITERALS_SECTION_CHARS,
   SUMMARY_TRUNCATED_MARKER,
 } as const;


### PR DESCRIPTION
Fixes #75058.

## Summary
- Collect path-like literals from model-facing compaction input, previous summary, and file-operation metadata without serializing hidden tool-result details.
- Append a bounded deterministic `<exact-path-literals>` suffix so slash-separated paths survive provider and LLM compaction unchanged.
- Add regression coverage for URL exclusion, unescaped Windows paths, tool-result detail filtering, and provider compaction output preserving an exact absolute path.

## Validation
- `pnpm exec oxfmt --check --threads=1 src/agents/pi-hooks/compaction-safeguard.ts src/agents/pi-hooks/compaction-safeguard.test.ts src/agents/compaction.tool-result-details.test.ts`
- `pnpm test src/agents/pi-hooks/compaction-safeguard.test.ts src/agents/compaction.tool-result-details.test.ts -- --reporter=verbose`
- `pnpm check:changed`
- `git diff --check`

AI-assisted with OpenAI Codex.