### PR TITLE
fix(plugin-sdk): compare lock owner pid + start time

### DIFF
--- a/src/plugin-sdk/file-lock.test.ts
+++ b/src/plugin-sdk/file-lock.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getProcessStartTime } from "../shared/pid-alive.js";
 import {
   acquireFileLock,
   drainFileLockStateForTest,
@@ -22,6 +23,7 @@ describe("acquireFileLock", () => {
     if (tempDir) {
       await fs.rm(tempDir, { recursive: true, force: true });
     }
+    vi.restoreAllMocks();
   });
 
   it("respects the configured retry budget even when stale windows are much larger", async () => {
@@ -79,4 +81,125 @@ describe("acquireFileLock", () => {
 
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it.skipIf(process.platform !== "linux")(
+    "persists the current process starttime when acquiring a lock on Linux",
+    async () => {
+      const filePath = path.join(tempDir, "starttime-write");
+      const handle = await acquireFileLock(filePath, {
+        retries: { retries: 0, factor: 1, minTimeout: 1, maxTimeout: 1 },
+        stale: 1_000,
+      });
+      try {
+        const raw = await fs.readFile(handle.lockPath, "utf8");
+        const parsed = JSON.parse(raw) as {
+          pid?: number;
+          starttime?: number;
+          createdAt?: string;
+        };
+        expect(parsed.pid).toBe(process.pid);
+        expect(typeof parsed.starttime).toBe("number");
+        expect(parsed.starttime).toBe(getProcessStartTime(process.pid));
+        expect(typeof parsed.createdAt).toBe("string");
+      } finally {
+        await handle.release();
+      }
+    },
+  );
+
+  it.skipIf(process.platform !== "linux")(
+    "treats a lock as stale when the persisted starttime mismatches the live process",
+    async () => {
+      const filePath = path.join(tempDir, "starttime-mismatch");
+      const lockPath = `${filePath}.lock`;
+      const liveStarttime = getProcessStartTime(process.pid);
+      expect(typeof liveStarttime).toBe("number");
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify(
+          {
+            pid: process.pid,
+            starttime: (liveStarttime as number) + 1,
+            createdAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const handle = await acquireFileLock(filePath, {
+        retries: { retries: 1, factor: 1, minTimeout: 1, maxTimeout: 1 },
+        stale: 60_000,
+      });
+      try {
+        expect(handle.lockPath).toBe(lockPath);
+      } finally {
+        await handle.release();
+      }
+    },
+  );
+
+  it("falls back to createdAt age when the lock payload omits starttime", async () => {
+    const filePath = path.join(tempDir, "legacy-payload");
+    const lockPath = `${filePath}.lock`;
+    const oldCreatedAt = new Date(Date.now() - 60_000).toISOString();
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ pid: process.pid, createdAt: oldCreatedAt }, null, 2),
+      "utf8",
+    );
+
+    const handle = await acquireFileLock(filePath, {
+      retries: { retries: 1, factor: 1, minTimeout: 1, maxTimeout: 1 },
+      stale: 100,
+    });
+    try {
+      expect(handle.lockPath).toMatch(/legacy-payload\.lock$/);
+    } finally {
+      await handle.release();
+    }
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "removes a starttime-mismatched lock and replaces it with a fresh owner payload",
+    async () => {
+      const filePath = path.join(tempDir, "starttime-recovery");
+      const lockPath = `${filePath}.lock`;
+      const liveStarttime = getProcessStartTime(process.pid);
+      expect(typeof liveStarttime).toBe("number");
+      const previousCreatedAt = new Date(Date.now() - 5_000).toISOString();
+      await fs.writeFile(
+        lockPath,
+        JSON.stringify(
+          {
+            pid: process.pid,
+            starttime: (liveStarttime as number) + 1,
+            createdAt: previousCreatedAt,
+          },
+          null,
+          2,
+        ),
+        "utf8",
+      );
+
+      const handle = await acquireFileLock(filePath, {
+        retries: { retries: 1, factor: 1, minTimeout: 1, maxTimeout: 1 },
+        stale: 60_000,
+      });
+      try {
+        const raw = await fs.readFile(handle.lockPath, "utf8");
+        const parsed = JSON.parse(raw) as {
+          pid?: number;
+          starttime?: number;
+          createdAt?: string;
+        };
+        expect(parsed.pid).toBe(process.pid);
+        expect(parsed.starttime).toBe(liveStarttime);
+        expect(parsed.createdAt).not.toBe(previousCreatedAt);
+      } finally {
+        await handle.release();
+      }
+    },
+  );
 });

--- a/src/plugin-sdk/file-lock.ts
+++ b/src/plugin-sdk/file-lock.ts
@@ -1,8 +1,10 @@
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { isPidAlive } from "../shared/pid-alive.js";
+import { getProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
 import { resolveProcessScopedMap } from "../shared/process-scoped-map.js";
+
+const CURRENT_PROCESS_STARTTIME = getProcessStartTime(process.pid);
 
 export type FileLockOptions = {
   retries: {
@@ -17,6 +19,7 @@ export type FileLockOptions = {
 
 type LockFilePayload = {
   pid: number;
+  starttime?: number;
   createdAt: string;
 };
 
@@ -81,7 +84,11 @@ async function readLockPayload(lockPath: string): Promise<LockFilePayload | null
     if (typeof parsed.pid !== "number" || typeof parsed.createdAt !== "string") {
       return null;
     }
-    return { pid: parsed.pid, createdAt: parsed.createdAt };
+    return {
+      pid: parsed.pid,
+      ...(typeof parsed.starttime === "number" ? { starttime: parsed.starttime } : {}),
+      createdAt: parsed.createdAt,
+    };
   } catch {
     return null;
   }
@@ -103,6 +110,12 @@ async function isStaleLock(lockPath: string, staleMs: number): Promise<boolean> 
   const payload = await readLockPayload(lockPath);
   if (payload?.pid && !isPidAlive(payload.pid)) {
     return true;
+  }
+  if (payload?.pid && typeof payload.starttime === "number") {
+    const liveStarttime = getProcessStartTime(payload.pid);
+    if (liveStarttime !== null && liveStarttime !== payload.starttime) {
+      return true;
+    }
   }
   if (payload?.createdAt) {
     const createdAt = Date.parse(payload.createdAt);
@@ -185,7 +198,17 @@ export async function acquireFileLock(
       const handle = await fs.open(lockPath, "wx");
       try {
         await handle.writeFile(
-          JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }, null, 2),
+          JSON.stringify(
+            {
+              pid: process.pid,
+              ...(typeof CURRENT_PROCESS_STARTTIME === "number"
+                ? { starttime: CURRENT_PROCESS_STARTTIME }
+                : {}),
+              createdAt: new Date().toISOString(),
+            },
+            null,
+            2,
+          ),
           "utf8",
         );
       } catch (writeError) {


### PR DESCRIPTION
## Summary

- Problem: `isStaleLock` in `src/plugin-sdk/file-lock.ts` only checks whether the recorded lock owner pid is alive. In a container PID 1 environment where the same pid can be re-spawned in a short window (container restart, supervisor respawn, OOM), the helper can mistake a previous incarnation's lock for its own and exhaust the retry budget with `file_lock_timeout`.
- Why it matters: The same root cause class is already hardened in three of the four file-lock helpers — `src/plugins/bundled-runtime-deps-lock.ts` (#74361 and follow-ups), `src/agents/session-write-lock.ts`, and `src/infra/gateway-lock.ts`. `src/plugin-sdk/file-lock.ts` was the remaining helper without the same start-time guard.
- What changed: `LockFilePayload` gains an optional `starttime?: number` field. On Linux, the writer persists `getProcessStartTime` alongside `pid`. `isStaleLock` now compares the persisted `starttime` against the live process between the existing pid-alive check and the `createdAt` age fallback. Four new unit tests cover writer persistence, mismatch detection, legacy fallback, and acquire recovery. `afterEach` is extended with `vi.restoreAllMocks()` so spies installed by earlier tests do not leak into later ones under `vitest --isolate=false`.
- What did NOT change (scope boundary): SDK public API signatures are unchanged (`LockFilePayload` is module-internal and unexported). The `createdAt: string` schema is preserved (an epoch-ms migration is out of scope). The four lock helpers are not unified into a shared utility. On non-Linux hosts the writer omits `starttime` and produces legacy-compatible payloads. Independent of #74522 (which proposes writer-level tests for `bundled-runtime-deps-lock`); this PR's scope is `plugin-sdk/file-lock` cross-file parity with the existing hardening, not the bundled helper.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #74361
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: In container PID 1 environments, a long-running parent process can be re-spawned with the same pid in a short window. `isStaleLock` only verified that the recorded `pid` was alive, so a leftover payload from a previous incarnation was treated as the live owner's own lock. `acquireFileLock` then exhausted its retry budget and returned `file_lock_timeout`. The hardening in `src/plugins/bundled-runtime-deps-lock.ts` (PR #74361) and the parallel work in `src/agents/session-write-lock.ts` and `src/infra/gateway-lock.ts` already mitigated the same class via process start-time disambiguation; `src/plugin-sdk/file-lock.ts` was the remaining helper without the same start-time guard.
- Missing detection / guardrail: Existing tests covered the local timeout behavior, but did not assert parity with the start-time disambiguation used by the other lock helpers.
- Contributing context (if known): The gap surfaced during a separate investigation that grepped all four helpers for the same root cause class. `file-lock.ts` was the only helper without start-time disambiguation.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/plugin-sdk/file-lock.test.ts`
- Scenario the test should lock in:
  - Writer persists `starttime` when acquiring a lock on Linux.
  - Predicate returns stale when the persisted `starttime` differs from the live pid's start time.
  - Predicate falls back to the existing `createdAt` age check when the payload omits `starttime` (legacy shape).
  - Retry recovery removes a start-time-mismatched lock and writes a fresh owner payload.
- Why this is the smallest reliable guardrail: `file-lock.ts` is a single helper inside `plugin-sdk/`. The acquire path, the predicate, and the writer all live in the same module, so unit tests can lock the contract without spinning up real lock contention.
- Existing test that already covers this (if any): None (cross-file parity was not asserted before).
- If no new test is added, why not: N/A (four new tests added).

## User-visible / Behavior Changes

On the normal acquire and release path, there is no observable change. When a lock file from a previous incarnation is left on disk and a new process happens to start with the same pid, the new code recognizes the start-time mismatch and reclaims the lock immediately, instead of waiting for the `createdAt` age fallback to expire. The caller-facing API and configuration are unchanged.

## Diagram (if applicable)

N/A (the change is an internal type extension and a single new branch in the staleness predicate; there is no UI surface or non-trivial flow change).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`) — on Linux, the staleness check may read `/proc/<pid>/stat` to compare process start time. This is local process metadata only and matches the design already used by the other lock helpers (`bundled-runtime-deps-lock.ts` / `session-write-lock.ts` / `gateway-lock.ts`).

## Repro + Verification

### Environment

- OS: Linux container with the gateway as PID 1
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Start OpenClaw inside a container so the long-running parent process is PID 1.
2. Acquire a lock through `acquireFileLock`, then trigger a fast restart (container restart, kill -9, OOM) so the new process starts with the same pid.
3. The leftover lock file (`pid` + `createdAt`, with no `starttime` or with the previous incarnation's `starttime`) is still on disk when the new process calls `acquireFileLock`.

### Expected

- `isStaleLock` detects the start-time mismatch, removes the leftover lock, and the retry recovery succeeds.

### Actual (before this change)

- `isStaleLock` only checks `isPidAlive`. If `createdAt` is still inside the `staleMs` window, the predicate returns false and `acquireFileLock` exhausts its retry budget with `file_lock_timeout`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

The four new unit tests in `src/plugin-sdk/file-lock.test.ts` (three Linux-only and one cross-platform) all pass under `vitest test/vitest/vitest.plugin-sdk.config.ts` (`Test Files 1 passed (1)`, `Tests 6 passed (6)`). Without this change the four new tests fail by design — they encode the predicate, writer, and retry-recovery contracts the change establishes.

## Human Verification (required)

- Verified scenarios:
  - `pnpm check:changed --base upstream/main` passes end-to-end on the changed-file lane (typecheck core / coreTests / extensions / extensionTests; lint core 0 warn 0 err; lint extensions 0 warn 0 err; import-cycles 0 cycles; runtime-sidecar-loaders; webhook auth body order; pairing-store-group; pairing-account-scope; etc.).
  - `vitest test/vitest/vitest.plugin-sdk.config.ts` reports `Test Files 1 passed (1)` / `Tests 6 passed (6)` (four new + two pre-existing).
  - `codex review --base upstream/main` reports no actionable regressions on the diff.
  - `pnpm plugin-sdk:api:check` reports no SDK API baseline drift (`LockFilePayload` is module-internal and unexported).
- Edge cases checked:
  - Non-Linux hosts (`getProcessStartTime` returns `null`): the writer omits `starttime` and the predicate falls back to the existing `createdAt` age check (covered by `it.skipIf(process.platform !== "linux")` for three Linux-only tests plus one cross-platform legacy fallback test).
  - Legacy lock payloads (no `starttime`): treated identically to today's behavior via the age fallback.
  - Cross-test spy leakage: `afterEach` now calls `vi.restoreAllMocks()` so a `vi.spyOn(fs, "open")` installed in the writer-failure test does not bleed into later tests under `vitest --isolate=false`.
  - The same-name local function in `src/pairing/pairing-store.ts:107` (named import aliased as `withFileLock as withPathLock`) does not depend on `LockFilePayload` directly; the internal type extension does not affect it.
- What you did **not** verify:
  - Hands-on repro inside a real container PID 1 environment (the unit tests pin the behavior contract; live verification was not performed in this PR).
  - Hands-on testing on macOS or Windows hosts (one cross-platform unit test exercises the legacy fallback path; live hands-on was not performed).

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

(No bot review has been received at PR-open time; these will be updated as conversations are addressed.)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

`LockFilePayload` is module-internal to `src/plugin-sdk/file-lock.ts` and unexported, so adding the optional `starttime?: number` field is a strictly-additive internal change. Legacy lock payloads (no `starttime`) are read as-is and routed through the existing `createdAt` age fallback. On non-Linux hosts the writer omits `starttime`, producing legacy-compatible payloads. The public SDK signatures (`acquireFileLock`, `withFileLock`, `FileLockOptions`, `FileLockHandle`, `FILE_LOCK_TIMEOUT_ERROR_CODE`, `FileLockTimeoutError`, `resetFileLockStateForTest`, `drainFileLockStateForTest`) are unchanged.

## Risks and Mitigations

- Risk: Adding a `getProcessStartTime` call inside the staleness predicate introduces an extra `/proc/<pid>/stat` read per acquire when a lock file is contended.
  - Mitigation: The writer caches `CURRENT_PROCESS_STARTTIME` once at module load (the current process's own start time is immutable for its lifetime). The predicate reads `/proc` only when judging a leftover payload, mirroring the pattern already in production via `src/plugins/bundled-runtime-deps-lock.ts`.
- Risk: Non-Linux hosts skip the start-time comparison and fall back to the age check, which can leave a leftover same-pid lock in place slightly longer when re-spawned within the age window.
  - Mitigation: This matches the pre-change behavior exactly (no regression). `src/plugins/bundled-runtime-deps-lock.ts` uses the same fallback on non-Linux hosts, preserving cross-helper design parity.
- Risk: Reordering `isStaleLock` to add a step between pid-alive and `createdAt` could surprise callers that depended on the previous evaluation order.
  - Mitigation: The new order is (1) pid alive → (2) start-time match (Linux-only, skipped when `starttime` is absent) → (3) `createdAt` age → (4) mtime fallback. When pid is alive and start-time matches (or is absent), the predicate proceeds to the existing age check, identical to the prior path. Stale judgment via the new branch only triggers when pid is alive and the start-time disagrees — exactly the case this PR fixes.
