### PR TITLE
fix(memory): bound `memory status --deep` embedding probe with 8s budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/CLI: bound the `memory status --deep` embedding probe with an 8 s diagnostic budget so a slow or warming local provider can no longer inherit the 600 s batch-embedding timeout and stall the command, and wire a `log` progress fallback so non-TTY callers (CI logs, pipes, the ClawNanny diagnostic runner) still see "Probing vector..." / "Probing embeddings..." labels. When the budget is exceeded, the probe returns a parseable `timedOut: true` result and the rendered status reads `Embeddings: timeout` &mdash; distinct from the existing `unavailable` failure state &mdash; while indexing continues to use the longer batch budget. Fixes #74544.
 - Agents/subagents: bound automatic orphan recovery with persisted recovery attempts and a wedged-session tombstone, and teach task maintenance/doctor to reconcile those sessions so restart loops no longer require manual `sessions.json` surgery. Fixes #74864. Thanks @solosage1.
 - Gateway/startup: skip pre-bind web-fetch provider discovery for credential-free `tools.web.fetch` config, so Docker/Kubernetes gateways bind even when optional fetch limits are present. Fixes #74896. Thanks @KoykL.
 - Slack: require bot-authored room messages with `allowBots=true` to come from an explicitly channel-allowlisted bot or from a room where an explicit Slack owner is present, so broad bot relays cannot run unattended. Fixes #59284. Thanks @andrewhong-translucent.

--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -51,7 +51,7 @@ openclaw memory index --agent main --verbose
 
 `memory status`:
 
-- `--deep`: probe vector + embedding availability. Plain `memory status` stays fast and does not run a live embedding ping. QMD lexical `searchMode: "search"` skips semantic vector probes and embedding maintenance even with `--deep`.
+- `--deep`: probe vector + embedding availability. Plain `memory status` stays fast and does not run a live embedding ping. QMD lexical `searchMode: "search"` skips semantic vector probes and embedding maintenance even with `--deep`. The embedding probe is bounded by an 8 s diagnostic budget so a slow or warming local provider cannot inherit the longer batch-embedding timeout; if the budget is hit, the embeddings line renders as `timeout` (distinct from `unavailable`) and the JSON output sets `embeddingProbe.timedOut = true`. Indexing (`--index`) keeps the full batch timeout.
 - `--index`: run a reindex if the store is dirty (implies `--deep`).
 - `--fix`: repair stale recall locks and normalize promotion metadata.
 - `--json`: print JSON output.

--- a/extensions/memory-core/src/cli.probe-budget.test.ts
+++ b/extensions/memory-core/src/cli.probe-budget.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeEmbeddingWithBudget } from "./cli.runtime.js";
+
+// Verifies that `memory status --deep` cannot inherit the local-provider
+// batch timeout (600 s default) by checking the call-site budget in
+// cli.runtime.ts.  When the underlying probe blocks, we must surface a
+// parseable `timedOut: true` result so the rendered banner says "timeout"
+// rather than "unavailable" and the JSON output stays distinguishable from
+// a hard provider failure.
+describe("probeEmbeddingWithBudget", () => {
+  it("resolves with the manager probe result when it returns within the budget", async () => {
+    const manager = {
+      probeEmbeddingAvailability: vi.fn(async () => ({ ok: true })),
+    };
+    const result = await probeEmbeddingWithBudget(manager, 5_000);
+    expect(result).toEqual({ ok: true });
+    expect(manager.probeEmbeddingAvailability).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards a manager-side failure result without flagging it as a timeout", async () => {
+    const manager = {
+      probeEmbeddingAvailability: vi.fn(async () => ({
+        ok: false,
+        error: "provider unreachable",
+      })),
+    };
+    const result = await probeEmbeddingWithBudget(manager, 5_000);
+    expect(result).toEqual({ ok: false, error: "provider unreachable" });
+    expect(result.timedOut).toBeUndefined();
+  });
+
+  it("returns a timed-out result when the manager probe exceeds the budget", async () => {
+    const manager = {
+      // Never resolves — the budget race is what must complete the call.
+      probeEmbeddingAvailability: vi.fn(() => new Promise<{ ok: boolean }>(() => {})),
+    };
+    const start = Date.now();
+    const result = await probeEmbeddingWithBudget(manager, 50);
+    const elapsed = Date.now() - start;
+    expect(result.ok).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.error).toMatch(/Embedding probe exceeded 50ms diagnostic budget/);
+    // The race must not extend much beyond the budget.  Generous ceiling to
+    // tolerate slow CI runners while still catching obvious regressions.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});

--- a/extensions/memory-core/src/cli.runtime.ts
+++ b/extensions/memory-core/src/cli.runtime.ts
@@ -84,6 +84,49 @@ type LoadedMemoryCommandConfig = {
   diagnostics: string[];
 };
 
+/**
+ * Diagnostic budget for `memory status --deep` embedding probe.  The
+ * underlying provider call (`embedBatchWithRetry(["ping"])`) can otherwise
+ * inherit the local-provider batch timeout of 10 minutes, which makes the
+ * status command unusable as a health check when the provider is slow to
+ * initialize.  Eight seconds is long enough for warm hosted providers and a
+ * ready local provider, while keeping the worst-case `memory status --deep`
+ * runtime bounded.  Indexing keeps the longer batch budget unchanged.
+ */
+const MEMORY_STATUS_DEEP_PROBE_BUDGET_MS = 8_000;
+
+/**
+ * Exported for unit testing — race a manager probe against a wall-clock
+ * budget.  See {@link MEMORY_STATUS_DEEP_PROBE_BUDGET_MS} for the production
+ * default and the rationale for bounding this call.
+ */
+export async function probeEmbeddingWithBudget(
+  manager: { probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> },
+  budgetMs: number,
+): Promise<MemoryEmbeddingProbeResult> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<MemoryEmbeddingProbeResult>((resolve) => {
+    timer = setTimeout(() => {
+      resolve({
+        ok: false,
+        timedOut: true,
+        error: `Embedding probe exceeded ${budgetMs}ms diagnostic budget — provider may be initializing or unreachable`,
+      });
+    }, budgetMs);
+    // Don't keep the event loop alive solely for this timeout.
+    if (typeof timer.unref === "function") {
+      timer.unref();
+    }
+  });
+  try {
+    return await Promise.race([manager.probeEmbeddingAvailability(), timeoutPromise]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
 function getMemoryCommandSecretTargetIds(): Set<string> {
   return new Set([
     "agents.defaults.memorySearch.remote.apiKey",
@@ -676,14 +719,41 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
         let indexError: string | undefined;
         const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
         if (deep) {
-          await withProgress({ label: "Checking memory…", total: 2 }, async (progress) => {
-            progress.setLabel("Probing vector…");
-            await manager.probeVectorAvailability();
-            progress.tick();
-            progress.setLabel("Probing embeddings…");
-            embeddingProbe = await manager.probeEmbeddingAvailability();
-            progress.tick();
-          });
+          await withProgress(
+            {
+              label: "Checking memory…",
+              total: 2,
+              // Without a non-spinner fallback, non-TTY callers (CI logs,
+              // pipes, the ClawNanny diagnostic runner) get a no-op reporter
+              // and therefore see no progress at all while a slow probe
+              // hangs.  Use "line" when --verbose is set (matches the
+              // indexing block below); otherwise fall back to "log" so each
+              // label change still shows up in non-TTY logs.
+              fallback: opts.verbose ? "line" : "log",
+            },
+            async (progress) => {
+              progress.setLabel("Probing vector…");
+              await manager.probeVectorAvailability();
+              progress.tick();
+              progress.setLabel("Probing embeddings…");
+              // Bound the embedding probe with a diagnostic budget shorter
+              // than the local-provider batch timeout (which defaults to
+              // 600s in manager-embedding-ops.ts).  When the cache misses
+              // and the provider is initializing, the underlying
+              // embedBatchWithRetry(["ping"]) call can otherwise block this
+              // command for the full batch window, which is unusable as a
+              // status check.  On timeout we surface a parseable
+              // `timedOut: true` result so the JSON output and the rendered
+              // "Embeddings: timeout" line stay distinguishable from a hard
+              // "unavailable" failure, and indexing keeps the longer
+              // batch-timeout budget for actual embedding work.
+              embeddingProbe = await probeEmbeddingWithBudget(
+                manager,
+                MEMORY_STATUS_DEEP_PROBE_BUDGET_MS,
+              );
+              progress.tick();
+            },
+          );
           if (opts.index && syncFn) {
             await withProgressTotals(
               {
@@ -834,7 +904,21 @@ export async function runMemoryStatus(opts: MemoryCommandOptions) {
       `${label("Dreaming")} ${info(formatDreamingSummary(cfg))}`,
     ].filter(Boolean) as string[];
     if (embeddingProbe) {
-      const state = embeddingProbe.ok ? "ready" : "unavailable";
+      // Three rendered states:
+      //   ok       -> "ready"        (success color)
+      //   timedOut -> "timeout"      (warn color, distinct from "unavailable")
+      //   else     -> "unavailable"  (warn color)
+      // The timeout case is intentionally separated so users can tell a
+      // diagnostic-budget hit ("provider warming up; retry") apart from a
+      // hard provider failure ("misconfigured / unreachable").
+      let state: string;
+      if (embeddingProbe.ok) {
+        state = "ready";
+      } else if (embeddingProbe.timedOut) {
+        state = "timeout";
+      } else {
+        state = "unavailable";
+      }
       const stateColor = embeddingProbe.ok ? theme.success : theme.warn;
       lines.push(`${label("Embeddings")} ${colorize(rich, stateColor, state)}`);
       if (embeddingProbe.error) {

--- a/packages/memory-host-sdk/src/host/types.ts
+++ b/packages/memory-host-sdk/src/host/types.ts
@@ -19,6 +19,14 @@ export type MemoryEmbeddingProbeResult = {
   cached?: boolean;
   checkedAtMs?: number;
   cacheExpiresAtMs?: number;
+  /**
+   * True when the probe was bounded by a diagnostic budget at the call site
+   * and did not complete in time. Distinct from a hard provider failure: a
+   * timed-out probe means the embedding backend may still be initializing or
+   * is unreachable, but indexing/search may succeed once the provider warms
+   * up. CLI surfaces should render this as "timeout" rather than "unavailable".
+   */
+  timedOut?: boolean;
 };
 
 export type MemorySyncProgressUpdate = {

--- a/src/plugin-sdk/memory-core-host-engine-storage.ts
+++ b/src/plugin-sdk/memory-core-host-engine-storage.ts
@@ -46,6 +46,14 @@ export type MemoryEmbeddingProbeResult = {
   cached?: boolean;
   checkedAtMs?: number;
   cacheExpiresAtMs?: number;
+  /**
+   * True when the probe was bounded by a diagnostic budget at the call site
+   * and did not complete in time. Distinct from a hard provider failure: a
+   * timed-out probe means the embedding backend may still be initializing or
+   * is unreachable, but indexing/search may succeed once the provider warms
+   * up. CLI surfaces should render this as "timeout" rather than "unavailable".
+   */
+  timedOut?: boolean;
 };
 
 export type {


### PR DESCRIPTION
## Summary

- `memory status --deep` could block for the full local-provider batch timeout (default 600s) because `probeEmbeddingAvailability()`'s cache-miss path calls `embedBatchWithRetry(["ping"])`, which inherits `EMBEDDING_BATCH_TIMEOUT_LOCAL_MS` from `manager-embedding-ops.ts`. That makes the command unusable as a diagnostic check when a local provider is slow to initialize.
- The deep block also called `withProgress` with no non-spinner `fallback`, so non-TTY callers (CI logs, pipes, programmatic diagnostic runners) got the no-op reporter and saw nothing while the probe hung.

This patch bounds the deep probe with an 8-second wall-clock budget, surfaces a parseable `timedOut` result distinct from `unavailable`, and wires `fallback: "log"` (or `"line"` under `--verbose`) so non-TTY callers still see the `Probing vector...` / `Probing embeddings...` labels.

Fixes #74544.

## Implementation notes

- New helper `probeEmbeddingWithBudget(manager, budgetMs)` in `extensions/memory-core/src/cli.runtime.ts` races `manager.probeEmbeddingAvailability()` against a `setTimeout` with `unref()` so the budget timer does not keep the event loop alive.
- New constant `MEMORY_STATUS_DEEP_PROBE_BUDGET_MS = 8_000` is documented inline. 8s is long enough for warm hosted providers and a ready local provider, while keeping the worst-case `memory status --deep` runtime bounded; indexing (`--index`) keeps the existing longer batch budget so embedding work itself is not cut off.
- `MemoryEmbeddingProbeResult` gains an optional `timedOut?: boolean` field in both the SDK type (`packages/memory-host-sdk/src/host/types.ts`) and the in-tree mirror (`src/plugin-sdk/memory-core-host-engine-storage.ts`), with a JSDoc comment explaining the semantic distinction from a hard `unavailable` failure.
- The status renderer now emits three states for the embeddings line: `ready` (success color), `timeout` (warn color, new), and `unavailable` (warn color). JSON output (`--json`) gets the new `embeddingProbe.timedOut` flag automatically.
- `withProgress` is called with `fallback: opts.verbose ? "line" : "log"` &mdash; matching the indexing block immediately below it &mdash; so non-TTY callers see each label change as a printed line.

## Test plan

- [x] New `extensions/memory-core/src/cli.probe-budget.test.ts` covers three cases against the helper directly: (1) probe resolves within budget, (2) manager-side failure forwarded without flagging timeout, (3) probe exceeds a 50ms budget and returns `timedOut: true` with a parseable error message. All three pass.
- [x] Existing `extensions/memory-core/src/cli.test.ts` (48 tests) still passes; output now visibly shows `Probing vector...` / `Probing embeddings...` lines confirming the `log` fallback is wired.
- [x] `extensions/memory-core/src/memory/manager-embedding-timeout.test.ts` (9 tests) still passes &mdash; the underlying timeout helper is untouched.
- [x] `pnpm exec oxfmt --check` clean for all files in this PR.
- [x] `pnpm lint -- extensions/memory-core/src/cli.runtime.ts extensions/memory-core/src/cli.probe-budget.test.ts` clean.
- [x] `pnpm check:changed` clean.

## Files changed

- `extensions/memory-core/src/cli.runtime.ts` &mdash; new helper, exported for testing; deep block uses budget + `fallback`; renderer adds `timeout` state.
- `extensions/memory-core/src/cli.probe-budget.test.ts` &mdash; new (3 tests).
- `packages/memory-host-sdk/src/host/types.ts` &mdash; add `timedOut?` to `MemoryEmbeddingProbeResult`.
- `src/plugin-sdk/memory-core-host-engine-storage.ts` &mdash; mirror the new field in the in-tree type.
- `docs/cli/memory.md` &mdash; document the budget, the `timeout` rendered state, and the JSON field.
- `CHANGELOG.md` &mdash; Unreleased fix entry.