### PR TITLE
fix(telegram): preserve forwarded context in agent body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,6 +598,7 @@ Docs: https://docs.openclaw.ai
 - Cron: preserve legacy top-level array `jobs.json` stores when loading or adding scheduled jobs so old cron jobs are no longer treated as an empty store during upgrade. Fixes #60799. (#84433) Thanks @IWhatsskill.
 - Gateway/agents: use an agent's `identity.name` in Gateway agent summaries when `agents.list[].name` is unset, so configured agent labels remain visible in clients. (#84355; refs #57835) Thanks @luoyanglang.
 - Channels/replies: keep normal `/verbose` failed-tool progress compact in message-tool replies and prevent late text-only tool output from appearing after the final answer. (#84303) Thanks @VACInc.
+- Telegram: preserve per-item forwarded-message attribution for coalesced forward bursts while keeping prompt body text clean. (#75121) Thanks @Komzpa.
 - Plugins/hooks: apply a default 30-second timeout to `before_compaction` and `after_compaction` hooks so a hung plugin handler no longer blocks compaction completion. (#84153)
 - Discord: preserve reusable presentation buttons through portable conversion and Discord component registration. (#84187) Thanks @100menotu001.
 - Discord: preserve disabled presentation buttons when adapting and rendering Discord message controls. (#84188) Thanks @100menotu001.

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -336,7 +336,26 @@ export const registerTelegramHandlers = ({
     text: string;
     date?: number;
     from?: Message["from"];
+    stripForwardMetadata?: boolean;
   }): Message => {
+    const baseMessage = params.base as Message & {
+      forward_origin?: unknown;
+      forward_from?: unknown;
+      forward_from_chat?: unknown;
+      forward_sender_name?: unknown;
+      forward_date?: unknown;
+    };
+    if (!params.stripForwardMetadata) {
+      return {
+        ...baseMessage,
+        ...(params.from ? { from: params.from } : {}),
+        text: params.text,
+        caption: undefined,
+        caption_entities: undefined,
+        entities: undefined,
+        ...(params.date != null ? { date: params.date } : {}),
+      };
+    }
     const {
       forward_origin: _forwardOrigin,
       forward_from: _forwardFrom,
@@ -344,12 +363,7 @@ export const registerTelegramHandlers = ({
       forward_sender_name: _forwardSenderName,
       forward_date: _forwardDate,
       ...baseWithoutForwardMetadata
-    } = params.base as Message & {
-      forward_from?: unknown;
-      forward_from_chat?: unknown;
-      forward_sender_name?: unknown;
-      forward_date?: unknown;
-    };
+    } = baseMessage;
     return {
       ...baseWithoutForwardMetadata,
       ...(params.from ? { from: params.from } : {}),
@@ -605,6 +619,7 @@ export const registerTelegramHandlers = ({
         base: first.msg,
         text: combinedText,
         date: last.msg.date ?? first.msg.date,
+        stripForwardMetadata: true,
       });
       const messageIdOverride = last.msg.message_id ? String(last.msg.message_id) : undefined;
       const syntheticCtx = buildSyntheticContext(baseCtx, syntheticMessage);

--- a/extensions/telegram/src/bot-handlers.runtime.ts
+++ b/extensions/telegram/src/bot-handlers.runtime.ts
@@ -65,7 +65,10 @@ import {
   isRecoverableMediaGroupError,
   resolveInboundMediaFileId,
 } from "./bot-handlers.media.js";
-import type { TelegramMediaRef } from "./bot-message-context.js";
+import type {
+  TelegramForwardedBatchContextEntry,
+  TelegramMediaRef,
+} from "./bot-message-context.js";
 import type {
   TelegramMessageContextOptions,
   TelegramPromptContextEntry,
@@ -84,6 +87,7 @@ import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
   isTelegramCommandsAllowFromConfigured,
+  normalizeForwardedContext,
   resolveTelegramCommandAuthorization,
   resolveTelegramForumFlag,
   resolveTelegramForumThreadId,
@@ -332,15 +336,63 @@ export const registerTelegramHandlers = ({
     text: string;
     date?: number;
     from?: Message["from"];
-  }): Message => ({
-    ...params.base,
-    ...(params.from ? { from: params.from } : {}),
-    text: params.text,
-    caption: undefined,
-    caption_entities: undefined,
-    entities: undefined,
-    ...(params.date != null ? { date: params.date } : {}),
-  });
+  }): Message => {
+    const {
+      forward_origin: _forwardOrigin,
+      forward_from: _forwardFrom,
+      forward_from_chat: _forwardFromChat,
+      forward_sender_name: _forwardSenderName,
+      forward_date: _forwardDate,
+      ...baseWithoutForwardMetadata
+    } = params.base as Message & {
+      forward_from?: unknown;
+      forward_from_chat?: unknown;
+      forward_sender_name?: unknown;
+      forward_date?: unknown;
+    };
+    return {
+      ...baseWithoutForwardMetadata,
+      ...(params.from ? { from: params.from } : {}),
+      text: params.text,
+      caption: undefined,
+      caption_entities: undefined,
+      entities: undefined,
+      ...(params.date != null ? { date: params.date } : {}),
+    };
+  };
+  const buildForwardedBatchContextEntry = (
+    entry: TelegramDebounceEntry,
+    index: number,
+    bodyLine?: number,
+  ): TelegramForwardedBatchContextEntry | null => {
+    const forwardOrigin = normalizeForwardedContext(entry.msg);
+    if (!forwardOrigin) {
+      return null;
+    }
+    return {
+      senderId: forwardOrigin.fromId,
+      senderUsername: forwardOrigin.fromUsername,
+      context: {
+        label: "Telegram forwarded batch item",
+        source: "telegram",
+        type: "forwarded_message",
+        payload: {
+          item_index: index + 1,
+          message_id: entry.msg.message_id,
+          ...(bodyLine !== undefined ? { body_line: bodyLine } : {}),
+          from: forwardOrigin.from,
+          from_type: forwardOrigin.fromType,
+          from_id: forwardOrigin.fromId,
+          username: forwardOrigin.fromUsername,
+          title: forwardOrigin.fromTitle,
+          signature: forwardOrigin.fromSignature,
+          chat_type: forwardOrigin.fromChatType,
+          forwarded_message_id: forwardOrigin.fromMessageId,
+          date_ms: forwardOrigin.date ? forwardOrigin.date * 1000 : undefined,
+        },
+      },
+    };
+  };
   const buildSyntheticContext = (
     ctx: Pick<TelegramContext, "me"> & { getFile?: unknown },
     message: Message,
@@ -522,10 +574,24 @@ export const registerTelegramHandlers = ({
         });
         return;
       }
-      const combinedText = entries
-        .map((entry) => getTelegramTextParts(entry.msg).text)
-        .filter(Boolean)
-        .join("\n");
+      const textEntries = entries.map((entry, index) => ({
+        entry,
+        index,
+        text: getTelegramTextParts(entry.msg).text,
+      }));
+      const emittedTextEntries = textEntries.filter((entry) => entry.text.trim() !== "");
+      const combinedText = emittedTextEntries.map((entry) => entry.text).join("\n");
+      let nextBodyLine = 1;
+      const bodyLineByEntryIndex = new Map<number, number>();
+      for (const entry of emittedTextEntries) {
+        bodyLineByEntryIndex.set(entry.index, nextBodyLine);
+        nextBodyLine += entry.text.split("\n").length;
+      }
+      const forwardedBatchContext = textEntries
+        .map(({ entry, index }) =>
+          buildForwardedBatchContextEntry(entry, index, bodyLineByEntryIndex.get(index)),
+        )
+        .filter((entry): entry is NonNullable<typeof entry> => entry !== null);
       const combinedMedia = entries.flatMap((entry) => entry.allMedia);
       if (!combinedText.trim() && combinedMedia.length === 0) {
         return;
@@ -552,6 +618,7 @@ export const registerTelegramHandlers = ({
           receivedAtMs: first.receivedAtMs,
           ingressBuffer: "inbound-debounce",
           ...promptContextBoundaryOptions(promptContextMinTimestampMs),
+          ...(forwardedBatchContext.length > 0 ? { forwardedBatchContext } : {}),
         },
         dispatchDedupeKeys: mergeDispatchDedupeKeys(
           ...entries.map((entry) => entry.dispatchDedupeKeys),

--- a/extensions/telegram/src/bot-message-context.forwarded.test.ts
+++ b/extensions/telegram/src/bot-message-context.forwarded.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext forwarded metadata", () => {
+  it("keeps typed forwarded origin when the sender forwarded their own message", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 42,
+        chat: { id: 999, type: "private" },
+        from: {
+          id: 999,
+          first_name: "Bob",
+          last_name: "Smith",
+          username: "bobsmith",
+          is_bot: false,
+        },
+        text: "This is from an earlier chat",
+        date: 1736380800,
+        forward_origin: {
+          type: "user",
+          sender_user: {
+            id: 999,
+            first_name: "Bob",
+            last_name: "Smith",
+            username: "bobsmith",
+            is_bot: false,
+          },
+          date: 500,
+        },
+      },
+    });
+
+    expect(context).not.toBeNull();
+    const payload = context?.ctxPayload;
+    expect(payload?.SenderId).toBe("999");
+    expect(payload?.ForwardedFromId).toBe("999");
+    expect(payload?.BodyForAgent).toBe("This is from an earlier chat");
+    expect(payload?.RawBody).toBe("This is from an earlier chat");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -331,6 +331,20 @@ export async function buildTelegramInboundContextPayload(params: {
     return [includeForwarded ? visibleEntry : stripReplyChainForwarded(visibleEntry)];
   });
   const visibleForwardOrigin = includeForwardOrigin ? forwardOrigin : null;
+  const visibleForwardedBatchContext = (options?.forwardedBatchContext ?? [])
+    .filter((entry) =>
+      shouldIncludeGroupSupplementalContext({
+        kind: "forwarded",
+        senderId: entry.senderId,
+        senderUsername: entry.senderUsername,
+      }),
+    )
+    .map((entry) => entry.context);
+  const untrustedStructuredContext = [
+    ...promptContext,
+    ...(options?.untrustedStructuredContext ?? []),
+    ...visibleForwardedBatchContext,
+  ];
   const replySuffix =
     visibleReplyChain.length > 0
       ? `\n\n[Reply chain - nearest first]\n${visibleReplyChain
@@ -529,7 +543,8 @@ export async function buildTelegramInboundContextPayload(params: {
           }
         : undefined,
       groupSystemPrompt: isGroup || (!isGroup && groupConfig) ? groupSystemPrompt : undefined,
-      untrustedContext: promptContext.length > 0 ? promptContext : undefined,
+      untrustedContext:
+        untrustedStructuredContext.length > 0 ? untrustedStructuredContext : undefined,
     },
     contextVisibility: contextVisibilityMode,
     extra: {

--- a/extensions/telegram/src/bot-message-context.ts
+++ b/extensions/telegram/src/bot-message-context.ts
@@ -56,7 +56,10 @@ import { getTopicName, resolveTopicNameCacheScope, updateTopicName } from "./top
 
 export type {
   BuildTelegramMessageContextParams,
+  TelegramForwardedBatchContextEntry,
+  TelegramMessageContextOptions,
   TelegramMediaRef,
+  TelegramUntrustedStructuredContextEntry,
 } from "./bot-message-context.types.js";
 
 type TelegramMessageContextRuntime = typeof import("./bot-message-context.runtime.js");

--- a/extensions/telegram/src/bot-message-context.types.ts
+++ b/extensions/telegram/src/bot-message-context.types.ts
@@ -17,6 +17,19 @@ export type TelegramMediaRef = {
   stickerMetadata?: StickerMetadata;
 };
 
+export type TelegramUntrustedStructuredContextEntry = {
+  label: string;
+  source?: string;
+  type?: string;
+  payload: unknown;
+};
+
+export type TelegramForwardedBatchContextEntry = {
+  context: TelegramUntrustedStructuredContextEntry;
+  senderId?: string;
+  senderUsername?: string;
+};
+
 export type TelegramMessageContextOptions = {
   commandSource?: "text" | "native";
   forceWasMentioned?: boolean;
@@ -24,6 +37,8 @@ export type TelegramMessageContextOptions = {
   receivedAtMs?: number;
   ingressBuffer?: "inbound-debounce" | "text-fragment";
   promptContextMinTimestampMs?: number;
+  untrustedStructuredContext?: TelegramUntrustedStructuredContextEntry[];
+  forwardedBatchContext?: TelegramForwardedBatchContextEntry[];
 };
 
 export type TelegramPromptContextEntry = NonNullable<

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -1117,6 +1117,81 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("preserves forwarded attribution when flushing long text fragments", async () => {
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    replySpy.mockImplementation(async () => ({ text: "ok" }));
+
+    try {
+      createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+      const longForwardedText = `${"forwarded long text ".repeat(210)}tail`;
+
+      await handler({
+        message: {
+          chat: { id: 42, type: "private" },
+          text: longForwardedText,
+          date: 1736380800,
+          message_id: 401,
+          from: { id: 777, first_name: "N" },
+          forward_origin: {
+            type: "user",
+            date: 500,
+            sender_user: {
+              id: 999,
+              first_name: "Bob",
+              last_name: "Smith",
+              username: "bobsmith",
+              is_bot: false,
+            },
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      expect(replySpy).not.toHaveBeenCalled();
+
+      const textFragmentFlushCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === TELEGRAM_TEST_TIMINGS.textFragmentGapMs,
+      );
+      expect(textFragmentFlushCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[textFragmentFlushCallIndex]?.value as ReturnType<
+          typeof setTimeout
+        >,
+      );
+      const flushTextFragment = setTimeoutSpy.mock.calls[textFragmentFlushCallIndex]?.[0] as
+        | (() => Promise<void>)
+        | undefined;
+
+      await flushTextFragment?.();
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0]?.[0];
+      expect(payload.BodyForAgent).toBe(longForwardedText);
+      expect(payload.RawBody).toBe(longForwardedText);
+      expect(payload.ForwardedFrom).toBe("Bob Smith (@bobsmith)");
+      expect(payload.ForwardedFromType).toBe("user");
+      expect(payload.ForwardedFromId).toBe("999");
+      expect(payload.ForwardedFromUsername).toBe("bobsmith");
+      expect(payload.ForwardedDate).toBe(500000);
+      expect(payload.Body).toContain("[Forwarded from Bob Smith (@bobsmith)");
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("redacts forwarded batch attribution blocked by group context visibility", async () => {
     loadConfig.mockReturnValue({
       agents: {

--- a/extensions/telegram/src/bot.create-telegram-bot.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.test.ts
@@ -143,25 +143,20 @@ function mockTelegramConfigWrites() {
   return vi.spyOn(configMutation, "mutateConfigFile").mockResolvedValue({} as never);
 }
 
-async function withEnvAsync(env: Record<string, string | undefined>, fn: () => Promise<void>) {
-  const previous = new Map<string, string | undefined>();
-  for (const [key, value] of Object.entries(env)) {
-    previous.set(key, process.env[key]);
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
+async function withTimezoneEnvAsync(timezone: string | undefined, fn: () => Promise<void>) {
+  const previousTimezone = process.env.TZ;
+  if (timezone === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = timezone;
   }
   try {
     await fn();
   } finally {
-    for (const [key, value] of previous) {
-      if (value === undefined) {
-        delete process.env[key];
-      } else {
-        process.env[key] = value;
-      }
+    if (previousTimezone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previousTimezone;
     }
   }
 }
@@ -1018,6 +1013,215 @@ describe("createTelegramBot", () => {
     }
   });
 
+  it("coalesces forwarded text bursts with per-message attribution", async () => {
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    replySpy.mockImplementation(async () => ({ text: "ok" }));
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: 42, type: "private" },
+          text: "first forwarded note\ncontinued forwarded note",
+          date: 1736380800,
+          message_id: 201,
+          from: { id: 777, first_name: "N" },
+          forward_origin: {
+            type: "hidden_user",
+            date: 500,
+            sender_user_name: "Original A",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      await handler({
+        message: {
+          chat: { id: 42, type: "private" },
+          text: "second forwarded note",
+          date: 1736380801,
+          message_id: 202,
+          from: { id: 777, first_name: "N" },
+          forward_origin: {
+            type: "hidden_user",
+            date: 600,
+            sender_user_name: "Original B",
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      const forwardDebounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === 80,
+      );
+      expect(forwardDebounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[forwardDebounceCallIndex]?.value as ReturnType<
+          typeof setTimeout
+        >,
+      );
+      const flushForwardBurst = setTimeoutSpy.mock.calls[forwardDebounceCallIndex]?.[0] as
+        | (() => Promise<void>)
+        | undefined;
+
+      await flushForwardBurst?.();
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0]?.[0];
+      expect(payload.BodyForAgent).toBe(
+        ["first forwarded note\ncontinued forwarded note", "second forwarded note"].join("\n"),
+      );
+      expect(payload.Body).not.toContain("[Forwarded from");
+      expect(payload.ForwardedFrom).toBeUndefined();
+      expect(payload.UntrustedStructuredContext).toEqual([
+        expect.objectContaining({
+          label: "Telegram forwarded batch item",
+          source: "telegram",
+          type: "forwarded_message",
+          payload: expect.objectContaining({
+            item_index: 1,
+            body_line: 1,
+            from: "Original A",
+            date_ms: 500000,
+          }),
+        }),
+        expect.objectContaining({
+          label: "Telegram forwarded batch item",
+          source: "telegram",
+          type: "forwarded_message",
+          payload: expect.objectContaining({
+            item_index: 2,
+            body_line: 3,
+            from: "Original B",
+            date_ms: 600000,
+          }),
+        }),
+      ]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("redacts forwarded batch attribution blocked by group context visibility", async () => {
+    loadConfig.mockReturnValue({
+      agents: {
+        defaults: {
+          envelopeTimezone: "utc",
+        },
+      },
+      channels: {
+        telegram: {
+          groupPolicy: "allowlist",
+          contextVisibility: "allowlist",
+          groups: {
+            "-1007": {
+              requireMention: false,
+              allowFrom: ["1"],
+            },
+          },
+        },
+      },
+    });
+
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    replySpy.mockImplementation(async () => ({ text: "ok" }));
+
+    try {
+      createTelegramBot({ token: "tok" });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      await handler({
+        message: {
+          chat: { id: -1007, type: "group", title: "Ops" },
+          text: "first forwarded note",
+          date: 1736380800,
+          message_id: 301,
+          from: { id: 1, first_name: "Ada", username: "ada", is_bot: false },
+          forward_origin: {
+            type: "user",
+            date: 500,
+            sender_user: {
+              id: 999,
+              first_name: "Bob",
+              last_name: "Smith",
+              username: "bobsmith",
+              is_bot: false,
+            },
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      await handler({
+        message: {
+          chat: { id: -1007, type: "group", title: "Ops" },
+          text: "second forwarded note",
+          date: 1736380801,
+          message_id: 302,
+          from: { id: 1, first_name: "Ada", username: "ada", is_bot: false },
+          forward_origin: {
+            type: "user",
+            date: 600,
+            sender_user: {
+              id: 999,
+              first_name: "Bob",
+              last_name: "Smith",
+              username: "bobsmith",
+              is_bot: false,
+            },
+          },
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      const forwardDebounceCallIndex = setTimeoutSpy.mock.calls.findLastIndex(
+        (call) => call[1] === 80,
+      );
+      expect(forwardDebounceCallIndex).toBeGreaterThanOrEqual(0);
+      clearTimeout(
+        setTimeoutSpy.mock.results[forwardDebounceCallIndex]?.value as ReturnType<
+          typeof setTimeout
+        >,
+      );
+      const flushForwardBurst = setTimeoutSpy.mock.calls[forwardDebounceCallIndex]?.[0] as
+        | (() => Promise<void>)
+        | undefined;
+
+      await flushForwardBurst?.();
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0]?.[0];
+      expect(payload.BodyForAgent).toBe(
+        ["first forwarded note", "second forwarded note"].join("\n"),
+      );
+      expect(payload.Body).not.toContain("[Forwarded from");
+      expect(payload.ForwardedFrom).toBeUndefined();
+      const forwardedBatchContext = (
+        payload.UntrustedStructuredContext as Array<{ label?: unknown }> | undefined
+      )?.filter((entry) => entry.label === "Telegram forwarded batch item");
+      expect(forwardedBatchContext ?? []).toEqual([]);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = requireValue(
@@ -1247,7 +1451,7 @@ describe("createTelegramBot", () => {
     expect(buildModelsProviderDataMock.mock.calls.at(-1)?.[1]).toBe("agent-b");
   });
   it("wraps inbound message with Telegram envelope", async () => {
-    await withEnvAsync({ TZ: "Europe/Vienna" }, async () => {
+    await withTimezoneEnvAsync("Europe/Vienna", async () => {
       createTelegramBot({ token: "tok" });
       const messageRegistration = onSpy.mock.calls.find(([event]) => event === "message");
       expect(messageRegistration?.[1]).toBeTypeOf("function");

--- a/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
+++ b/extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts
@@ -647,7 +647,22 @@ describe("telegram forwarded bursts", () => {
         expect(runtimeError).not.toHaveBeenCalled();
         const payload = replyPayload(replySpy);
         expect(payload.Body).toContain("Look at this");
+        expect(payload.BodyForAgent).toBe("Look at this");
         expect(payload.MediaPaths).toHaveLength(1);
+        expect(payload.UntrustedStructuredContext).toEqual([
+          expect.objectContaining({
+            payload: expect.objectContaining({
+              item_index: 1,
+              body_line: 1,
+              from: "A",
+            }),
+          }),
+          expect.objectContaining({
+            payload: expect.not.objectContaining({
+              body_line: expect.any(Number),
+            }),
+          }),
+        ]);
       } finally {
         fetchSpy.mockRestore();
       }

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2530,6 +2530,47 @@ describe("createTelegramBot", () => {
     );
   });
 
+  it("keeps BodyForAgent clean while carrying typed forwarded origin for direct messages", async () => {
+    onSpy.mockReset();
+    sendMessageSpy.mockReset();
+    replySpy.mockReset();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 7, type: "private" },
+        text: "Can I borrow a drill?",
+        date: 1736380800,
+        forward_origin: {
+          type: "user",
+          sender_user: {
+            id: 999,
+            first_name: "Bob",
+            last_name: "Smith",
+            username: "bobsmith",
+            is_bot: false,
+          },
+          date: 500,
+        },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    const forwardedPrefix = "[Forwarded from Bob Smith (@bobsmith) at 1970-01-01T00:08:20.000Z]";
+    expect(payload.ForwardedFrom).toBe("Bob Smith (@bobsmith)");
+    expect(payload.ForwardedFromType).toBe("user");
+    expect(payload.ForwardedDate).toBe(500000);
+    expect(payload.Body).toContain(forwardedPrefix);
+    expect(payload.BodyForAgent).toBe("Can I borrow a drill?");
+    expect(payload.RawBody).toBe("Can I borrow a drill?");
+    expect(payload.CommandBody).toBe("Can I borrow a drill?");
+  });
+
   it("redacts forwarded origin inside reply targets when context visibility is allowlist", async () => {
     onSpy.mockReset();
     sendMessageSpy.mockReset();

--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -913,6 +913,59 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).not.toContain("Chat history since last reply");
   });
 
+  it("renders Telegram forwarded context for direct and batched forwards", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "telegram",
+      ForwardedFrom: "Bob Smith (@bobsmith)",
+      ForwardedFromType: "user",
+      ForwardedFromId: "999",
+      ForwardedDate: 500000,
+      UntrustedStructuredContext: [
+        {
+          label: "Telegram forwarded batch item",
+          source: "telegram",
+          type: "forwarded_message",
+          payload: {
+            item_index: 2,
+            body_line: 2,
+            from: "Original B",
+            date_ms: 600000,
+          },
+        },
+      ],
+    } as TemplateContext);
+
+    const directForward = parseUntrustedJsonBlock(
+      text,
+      "Forwarded message context (untrusted metadata):",
+    ) as Record<string, unknown>;
+    expect(directForward).toEqual(
+      expect.objectContaining({
+        from: "Bob Smith (@bobsmith)",
+        type: "user",
+        date_ms: 500000,
+      }),
+    );
+
+    const batchForward = parseUntrustedJsonBlock(
+      text,
+      "Telegram forwarded batch item (untrusted metadata):",
+    ) as Record<string, unknown>;
+    expect(batchForward).toEqual(
+      expect.objectContaining({
+        source: "telegram",
+        type: "forwarded_message",
+        payload: expect.objectContaining({
+          item_index: 2,
+          body_line: 2,
+          from: "Original B",
+          date_ms: 600000,
+        }),
+      }),
+    );
+  });
+
   it("omits forwarded metadata blocks unless ForwardedFrom is present", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "group",


### PR DESCRIPTION
## Summary

- keep Telegram forwarded-message bodies clean in `BodyForAgent`
- rely on typed `ForwardedFrom*` fields for single forwarded messages so prompt assembly renders the existing structured forwarded context block
- preserve per-message forwarded attribution when Telegram forwards arrive as one debounced burst by passing typed `UntrustedStructuredContext` entries
- add regression tests for direct forwarded Telegram messages, self-forwards, mixed media/text burst coalescing, and prompt-visible forwarded context rendering

## Real behavior proof (required for external PRs)

- **Behavior or issue addressed:** Telegram forwarded messages keep the user-visible text clean for the agent while preserving forwarded attribution as typed untrusted metadata in the prompt context. This covers the direct-forward path fixed by this PR and the same prompt renderer used by forwarded batch context.
- **Real environment tested:** Local OpenClaw checkout `/home/kom/proj/openclaw-pr75121` at head `724d658ebc68a869bb14e9f7e576f4732fc8f893` on Linux, Node `v24.15.0`, pnpm `11.2.2`, with the Telegram extension and auto-reply prompt code loaded from this branch.
- **Exact steps or command run after this patch:**

```bash
node --import tsx --eval "const {buildTelegramMessageContextForTest}=await import('./extensions/telegram/src/bot-message-context.test-harness.ts'); const {buildInboundUserContextPrefix}=await import('./src/auto-reply/reply/inbound-meta.ts'); const c=await buildTelegramMessageContextForTest({message:{message_id:42,chat:{id:999,type:'private'},from:{id:777,first_name:'N',is_bot:false},text:'Can I borrow a drill?',date:1736380800,forward_origin:{type:'user',sender_user:{id:999,first_name:'Bob',last_name:'Smith',username:'bobsmith',is_bot:false},date:500}}}); console.log(JSON.stringify({bodyForAgent:c?.ctxPayload.BodyForAgent,raw:c?.ctxPayload.RawBody,forwardedFrom:c?.ctxPayload.ForwardedFrom,forwardedType:c?.ctxPayload.ForwardedFromType,forwardedDate:c?.ctxPayload.ForwardedDate,prefix:buildInboundUserContextPrefix(c?.ctxPayload ?? {})},null,2));"
```

- **Evidence after fix:** Terminal output copied from the command above:

```json
{
  "bodyForAgent": "Can I borrow a drill?",
  "raw": "Can I borrow a drill?",
  "forwardedFrom": "Bob Smith (@bobsmith)",
  "forwardedType": "user",
  "forwardedDate": 500000,
  "prefix": "Conversation info (untrusted metadata):\n```json\n{\n  \"chat_id\": \"telegram:999\",\n  \"message_id\": \"42\",\n  \"sender_id\": \"777\",\n  \"sender\": \"N\",\n  \"timestamp\": \"Thu 2025-01-09 04:00:00 GMT+4\",\n  \"inbound_event_kind\": \"user_request\",\n  \"has_forwarded_context\": true\n}\n```\n\nSender (untrusted metadata):\n```json\n{\n  \"label\": \"N (777)\",\n  \"id\": \"777\",\n  \"name\": \"N\"\n}\n```\n\nForwarded message context (untrusted metadata):\n```json\n{\n  \"from\": \"Bob Smith (@bobsmith)\",\n  \"type\": \"user\",\n  \"username\": \"bobsmith\",\n  \"title\": \"Bob Smith\",\n  \"date_ms\": 500000\n}\n```"
}
```

- **Observed result after fix:** The live output shows the forwarded text remains exactly `Can I borrow a drill?` in `BodyForAgent`/`RawBody`; the agent-visible prefix separately contains `Forwarded message context (untrusted metadata)` with the original sender, username, type, title, and forwarded date. There is no plaintext `[Forwarded from ...]` envelope in `BodyForAgent`.
- **What was not tested:** No known gaps for the local OpenClaw context-builder and prompt-renderer proof; a real Telegram Desktop/Mantis account capture was not exercised in this local run.

## Why

Telegram already parses `forward_origin` and populates `ForwardedFrom*` fields. Normal prompt assembly renders those fields through `buildInboundUserContextPrefix(...)`, so `BodyForAgent` must stay clean to avoid duplicate plaintext attribution in `BodyStripped`.

A self-forward keeps the same typed attribution too: even when `ForwardedFromId` equals `SenderId`, the message is still forwarded context, not a fresh direct instruction to the agent.

When multiple forwarded Telegram updates arrive together, the forward burst debounce path now builds one model-visible turn with clean joined body text plus a typed `UntrustedStructuredContext` entry for each forwarded item. The synthetic message strips inherited Telegram forward fields so the batch is not represented as if every item came from only the first origin.

For mixed media/text bursts, `body_line` is assigned only to entries that actually contribute non-empty text to the joined `BodyForAgent`; media-only forwarded entries keep `item_index`/`message_id` without a misleading line reference.

## Scenario coverage

- Direct forward: clean `BodyForAgent`, typed `ForwardedFrom*`, prompt-visible `Forwarded message context` block.
- Self-forward: `SenderId == ForwardedFromId` still keeps typed forwarded context.
- Burst/batch forward: one turn, clean joined body, per-item prompt-visible `Telegram forwarded batch item` metadata.
- Mixed text + media-only forward burst: media-only item does not claim a nonexistent `body_line`.

## Review feedback addressed

- Addressed ClawSweeper P2: `BodyForAgent` remains clean; forwarded context is carried as typed metadata / structured context.
- Addressed ClawSweeper P2: forwarded batch `body_line` now tracks actual joined body lines and is omitted for media-only entries.

## Test Plan

- `node scripts/run-vitest.mjs extensions/telegram/src/bot.create-telegram-bot.test.ts extensions/telegram/src/bot.test.ts extensions/telegram/src/bot-message-context.forwarded.test.ts extensions/telegram/src/bot.media.downloads-media-file-path-no-file-download.e2e.test.ts src/auto-reply/reply/inbound-meta.test.ts`
- `git diff --check origin/main..HEAD`
- `node scripts/check-no-conflict-markers.mjs`
- local dependency guard preflight: no dependency graph files/fields changed across the 10 PR files



