### PR TITLE
fix: guard session reset prompts against fabricated data

### DIFF
--- a/src/auto-reply/reply/session-reset-prompt.test.ts
+++ b/src/auto-reply/reply/session-reset-prompt.test.ts
@@ -15,6 +15,8 @@ describe("buildBareSessionResetPrompt", () => {
     expect(prompt).toContain("read the required files before responding to the user");
     expect(prompt).toContain("If BOOTSTRAP.md exists in the provided Project Context");
     expect(prompt).toContain("read it and follow its instructions first");
+    expect(prompt).toContain("Do not invent or present calendar events");
+    expect(prompt).toContain("verify real data with tools before acting on it");
     expect(prompt).not.toContain(
       "If runtime-provided startup context is included for this first turn",
     );
@@ -30,6 +32,7 @@ describe("buildBareSessionResetPrompt", () => {
     expect(prompt).toContain("offer the simplest next step");
     expect(prompt).toContain("Do not pretend bootstrap is complete when it is not.");
     expect(prompt).toContain("Your first user-visible reply must follow BOOTSTRAP.md");
+    expect(prompt).toContain("Do not invent or present calendar events");
     expect(prompt).not.toContain("Then greet the user in your configured persona");
   });
 
@@ -40,6 +43,7 @@ describe("buildBareSessionResetPrompt", () => {
     expect(prompt).toContain("Do not claim bootstrap is complete");
     expect(prompt).toContain("do not use a generic first greeting");
     expect(prompt).toContain("switching to a primary interactive run with normal workspace access");
+    expect(prompt).toContain("Do not invent or present calendar events");
     expect(prompt).not.toContain("Please read BOOTSTRAP.md from the workspace now");
   });
 

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -8,8 +8,20 @@ import { resolveEffectiveToolInventory } from "../../agents/tools-effective-inve
 import { isWorkspaceBootstrapPending } from "../../agents/workspace.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
-const BARE_SESSION_RESET_PROMPT_BASE =
-  "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. If BOOTSTRAP.md exists in the provided Project Context, read it and follow its instructions first. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
+const SESSION_RESET_FACT_GUARDRAIL =
+  "Do not invent or present calendar events, emails, JSON, files, messages, memories, or other data as if the user provided it; verify real data with tools before acting on it.";
+
+const BARE_SESSION_RESET_PROMPT_BASE = [
+  "A new session was started via /new or /reset.",
+  "Execute your Session Startup sequence now - read the required files before responding to the user.",
+  "If BOOTSTRAP.md exists in the provided Project Context, read it and follow its instructions first.",
+  SESSION_RESET_FACT_GUARDRAIL,
+  "Then greet the user in your configured persona, if one is provided.",
+  "Be yourself - use your defined voice, mannerisms, and mood.",
+  "Keep it to 1-3 sentences and ask what they want to do.",
+  "If the runtime model differs from default_model in the system prompt, mention the default model.",
+  "Do not mention internal steps, files, tools, or reasoning.",
+].join(" ");
 
 const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_PENDING = [
   "A new session was started via /new or /reset while bootstrap is still pending for this workspace.",
@@ -19,6 +31,7 @@ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_PENDING = [
     firstReplyLine:
       "Your first user-visible reply must follow BOOTSTRAP.md, not a generic greeting.",
   }),
+  SESSION_RESET_FACT_GUARDRAIL,
   "If the runtime model differs from default_model in the system prompt, mention the default model only after handling BOOTSTRAP.md.",
   "Do not mention internal steps, files, tools, or reasoning.",
 ].join(" ");
@@ -31,6 +44,7 @@ const BARE_SESSION_RESET_PROMPT_BOOTSTRAP_LIMITED = [
     nextStepLine:
       "Typical next steps include switching to a primary interactive run with normal workspace access or having the user complete the canonical BOOTSTRAP.md deletion afterward.",
   }).slice(1),
+  SESSION_RESET_FACT_GUARDRAIL,
   "If the runtime model differs from default_model in the system prompt, mention the default model only after you have handled this limitation.",
   "Do not mention internal steps, files, tools, or reasoning.",
 ].join(" ");


### PR DESCRIPTION
## Summary

- Problem: Bare `/new` and `/reset` startup prompts did not explicitly prevent models from presenting invented data as user-provided context.
- Why it matters: On session reset, a model can fabricate realistic calendar/email/JSON-style data and act on it before verification.
- What changed: Added a shared reset-startup guardrail that tells the model not to invent user data and to verify real data with tools before acting.
- What did NOT change (scope boundary): No runtime behavior, tool permissions, model routing, bootstrap flow, or config defaults changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #75070
- Related #
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: The bare session reset prompt guided startup/greeting behavior but did not explicitly forbid fabricating contextual data during the first reset response.
- Missing detection / guardrail: Existing prompt tests checked startup and bootstrap wording, but not the anti-fabrication instruction.
- Contributing context (if known): The issue report showed reset responses could present invented calendar/API-style data as real.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [ ] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/auto-reply/reply/session-reset-prompt.test.ts`
- Scenario the test should lock in: Bare reset prompts, bootstrap-pending reset prompts, and limited-bootstrap reset prompts all include the anti-fabrication guardrail.
- Why this is the smallest reliable guardrail: The bug is in reset prompt construction, so direct prompt assertions catch regressions without model/provider variability.
- Existing test that already covers this (if any): Existing reset prompt tests covered startup/bootstrap wording; this PR extends them.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

Bare `/new` and `/reset` startup prompts now explicitly instruct the model not to invent user data and to verify real data with tools before acting.

## Diagram (if applicable)

```text
Before:
[/new or /reset] -> [startup prompt] -> [model may fill gaps with fabricated data]

After:
[/new or /reset] -> [startup prompt + anti-fabrication guardrail] -> [model must not present invented data as real]
```

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A, prompt-construction unit coverage
- Integration/channel (if any): Session reset prompt path
- Relevant config (redacted): N/A

### Steps

1. Trigger a bare `/new` or `/reset` session startup.
2. Inspect the generated reset startup prompt.
3. Verify the prompt includes the anti-fabrication guardrail.

### Expected

- Reset startup prompt tells the model not to invent user data and to verify real data with tools before acting.

### Actual

- Previous prompt did not explicitly include that guardrail.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Normal bare reset prompt includes the anti-fabrication guardrail.
  - Bootstrap-pending reset prompt includes the guardrail.
  - Limited-bootstrap reset prompt includes the guardrail.
- Edge cases checked:
  - Current-time prompt behavior remains covered by existing tests.
  - Bootstrap wording remains distinct from normal greeting wording.
- What you did **not** verify:
  - Live model behavior across providers.
  - Full repo lint, because `lint:core` currently fails on unrelated existing files.

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: Prompt wording could become too broad and discourage legitimate startup reads.
  - Mitigation: The guardrail only forbids inventing or presenting unverified data as real; it still allows tool verification before acting.
