### PR TITLE
fix(daemon): load <stateDir>/gateway.env into runtime env

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -145,6 +145,31 @@ describe("loadDotEnv", () => {
     });
   });
 
+  it("loads ~/.openclaw/gateway.env so service-install commands inherit user-defined keys", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ base, cwdDir }) => {
+        process.env.HOME = base;
+        const defaultStateDir = path.join(base, ".openclaw");
+        process.env.OPENCLAW_STATE_DIR = defaultStateDir;
+        await writeEnvFile(path.join(defaultStateDir, ".env"), "ALPHA=from-state-env\n");
+        await writeEnvFile(
+          path.join(defaultStateDir, "gateway.env"),
+          ["GATEWAY_AUTH_TOKEN=from-state-gateway", "ALPHA=from-state-gateway"].join("\n"),
+        );
+
+        vi.spyOn(process, "cwd").mockReturnValue(cwdDir);
+        delete process.env.GATEWAY_AUTH_TOKEN;
+        delete process.env.ALPHA;
+        loggerMocks.warn.mockClear();
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.GATEWAY_AUTH_TOKEN).toBe("from-state-gateway");
+        expect(process.env.ALPHA).toBe("from-state-env");
+      });
+    });
+  });
+
   it("loads the Ubuntu gateway.env compatibility fallback after ~/.openclaw/.env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ base, cwdDir }) => {

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -258,9 +258,15 @@ export function loadGlobalRuntimeDotEnvFiles(opts?: { quiet?: boolean; stateEnvP
   const hasExplicitNonDefaultStateDir =
     process.env.OPENCLAW_STATE_DIR?.trim() !== undefined &&
     path.resolve(stateEnvPath) !== path.resolve(defaultStateEnvPath);
+  const stateGatewayEnvPath = path.join(path.dirname(stateEnvPath), "gateway.env");
   const parsedFiles = [
     readDotEnvFile({
       filePath: stateEnvPath,
+      shouldBlockKey: shouldBlockRuntimeDotEnvKey,
+      quiet,
+    }),
+    readDotEnvFile({
+      filePath: stateGatewayEnvPath,
       shouldBlockKey: shouldBlockRuntimeDotEnvKey,
       quiet,
     }),


### PR DESCRIPTION
## Summary

`loadGlobalRuntimeDotEnvFiles` was reading `<stateDir>/.env` and (as a fallback) `~/.config/openclaw/gateway.env`, but never `<stateDir>/gateway.env`. That left a real-world gap: many users keep API keys and `GATEWAY_AUTH_TOKEN` in `~/.openclaw/gateway.env` because the on-disk service-env wrapper file lives next to it. When `openclaw doctor --fix` regenerates `service-env/<label>.env`, it pulls secret refs (e.g. `gateway.auth.token = ${GATEWAY_AUTH_TOKEN}`) from `process.env`. With `~/.openclaw/gateway.env` never sourced, the key is missing in `process.env`, the regenerated service-env drops it, and the LaunchAgent crash-loops with `SecretRefResolutionError`.

This PR adds `<stateDir>/gateway.env` to the dotenv loader chain, alongside the existing `<stateDir>/.env` and the XDG `~/.config/openclaw/gateway.env` compat path. Conflict-resolution semantics keep `<stateDir>/.env` winning for shared keys.

Reproduction:
1. Put `GATEWAY_AUTH_TOKEN=...` in `~/.openclaw/gateway.env` only (not in shell).
2. Run `openclaw doctor --fix`.
3. Observe `~/.openclaw/logs/gateway.err.log` — repeated `SecretRefResolutionError: Environment variable "GATEWAY_AUTH_TOKEN" is missing or empty` entries.

After this PR the regenerated service-env keeps the user key.

## Test plan

- [x] `pnpm test src/infra/dotenv.test.ts` — 29 tests pass, including the new "loads ~/.openclaw/gateway.env so service-install commands inherit user-defined keys" case
- [x] `pnpm check:changed` — typecheck and tests green; only failure is the unrelated pre-existing `doctor-state-integrity.ts:875` lint warning from commit 0f120c09ba
- [x] Manual: regenerated service-env locally and confirmed gateway came back up after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)