### PR TITLE
fix(memory-core): drop dreaming theme echoes from promotion candidates

### DIFF
--- a/extensions/memory-core/src/short-term-promotion.test.ts
+++ b/extensions/memory-core/src/short-term-promotion.test.ts
@@ -1101,6 +1101,19 @@ describe("short-term promotion", () => {
     ).toBe(false);
   });
 
+  it("treats Light Sleep theme echoes as contaminated even without status/recalls", () => {
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "Candidate: Reflections: Theme: `memory/2026-04-13.md` kept surfacing across 271 memories.; confidence: 1.00; evidence: memory/2026-04-13.md:73-76, memory/2026-04-13.md:53-56; note: reflection",
+      ),
+    ).toBe(true);
+    expect(
+      __testing.isContaminatedDreamingSnippet(
+        "Reflections: Theme: `kept` kept surfacing across 64 memories.",
+      ),
+    ).toBe(true);
+  });
+
   it("treats transcript-style dreaming prompt echoes as contaminated", () => {
     expect(
       __testing.isContaminatedDreamingSnippet(

--- a/extensions/memory-core/src/short-term-promotion.ts
+++ b/extensions/memory-core/src/short-term-promotion.ts
@@ -40,6 +40,13 @@ const PHASE_SIGNAL_HALF_LIFE_DAYS = 14;
 const DREAMING_TRANSCRIPT_PROMPT_LINE_RE =
   /\[[^\]]*dreaming-narrative[^\]]*]\s*(?:User|Assistant):\s*Write a dream diary entry from these memory fragments:?/i;
 const DREAMING_DIFF_PREFIX_RE = /@@\s*-\d+(?:,\d+)?\s+[-*+]\s+/iy;
+// Light Sleep and Deep Sleep phases write `- Theme: \`X\` kept surfacing across
+// N memories.` lines into daily notes. Without filtering, the next dreaming
+// cycle re-ingests those rows as fresh candidates and promotes them again,
+// growing a self-referential feedback loop in MEMORY.md. Match the unique
+// "kept surfacing across N memories" signature so we can drop them even when
+// the snippet does not yet carry a status:staged or recalls field.
+const DREAMING_THEME_SIGNATURE_RE = /\bkept surfacing across\s+\d+\s+memor(?:y|ies)\b/i;
 const inProcessShortTermLocks = new Map<string, Promise<void>>();
 const ensuredShortTermDirs = new Map<string, Promise<void>>();
 
@@ -285,6 +292,9 @@ function isContaminatedDreamingSnippet(raw: string): boolean {
   }
 
   const hasNarrativeLead = hasDreamingNarrativeLead(snippet);
+  if (hasNarrativeLead && DREAMING_THEME_SIGNATURE_RE.test(snippet)) {
+    return true;
+  }
   const hasConfidence = /\bconfidence:\s*\d/i.test(snippet);
   const hasEvidence = /\bevidence:\s*(?:memory\/\.dreams\/session-corpus\/|memory\/)/i.test(
     snippet,


### PR DESCRIPTION
## Summary

Light Sleep / Deep Sleep phases write
\`\`\`
- Theme: \`X\` kept surfacing across N memories.
\`\`\`
into daily notes. The next dreaming cycle re-ingests the first line as a fresh candidate before the indented \`status: staged\` and \`recalls: 0\` rows land. The 5-field contamination check (\`hasNarrativeLead && hasConfidence && hasEvidence && hasStatus && hasRecalls\`) then misses the snippet, so the theme echo gets promoted into MEMORY.md and the cycle keeps recursing. Real workspaces accumulate dozens of these per agent (verified by inspection of multiple `~/.openclaw/workspace-*/memory/2026-04-*.md` files).

This PR adds a separate guard: when a snippet has a narrative lead AND matches the unique \`kept surfacing across N memories\` signature, mark it as contaminated even without status/recalls. The original 5-field check stays as additional safety.

## Test plan

- [x] `pnpm test extensions/memory-core/src/short-term-promotion.test.ts` — 45 tests pass, including the new "treats Light Sleep theme echoes as contaminated even without status/recalls" case
- [x] `pnpm check:changed` — typecheck and tests green for extension lanes
- [x] Existing "does not treat ordinary candidate notes with daily-memory evidence as contaminated" still passes (regular candidates without the theme signature stay through)

🤖 Generated with [Claude Code](https://claude.com/claude-code)