### PR TITLE
feat(memory-core): record terminal task outcomes for dreaming feedback

### DIFF
--- a/docs/.generated/plugin-sdk-api-baseline.sha256
+++ b/docs/.generated/plugin-sdk-api-baseline.sha256
@@ -1,2 +1,2 @@
-e94362ae9caa948c50ad0dc9a99c801750c9dd24ef687cdbc0e6996cdec1ad2b  plugin-sdk-api-baseline.json
-83f9fdc048267705b4a5cf5d68860b39bbb00985f3f01dd6d6ba28e12587b997  plugin-sdk-api-baseline.jsonl
+851a39b442a4a15e78d27d8a3e1ee66ff61a061356d412051e205f6c07f54c34  plugin-sdk-api-baseline.json
+d3106b731a3a13f7dddaa0b1916f223c1757fa8d1df3476914f70502c9532c2f  plugin-sdk-api-baseline.jsonl

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -12,6 +12,7 @@ import { registerBuiltInMemoryEmbeddingProviders } from "./src/memory/provider-a
 import { buildPromptSection } from "./src/prompt-section.js";
 import { listMemoryCorePublicArtifacts } from "./src/public-artifacts.js";
 import { memoryRuntime } from "./src/runtime-provider.js";
+import { registerTaskOutcomeRecorder } from "./src/task-outcome-recorder.js";
 import { createMemoryGetTool, createMemorySearchTool } from "./src/tools.js";
 export {
   buildMemoryFlushPlan,
@@ -30,6 +31,7 @@ export default definePluginEntry({
     registerBuiltInMemoryEmbeddingProviders(api);
     registerShortTermPromotionDreaming(api);
     registerDreamingCommand(api);
+    registerTaskOutcomeRecorder(api);
     api.registerMemoryCapability({
       promptBuilder: buildPromptSection,
       flushPlanResolver: buildMemoryFlushPlan,

--- a/extensions/memory-core/src/task-outcome-recorder.test.ts
+++ b/extensions/memory-core/src/task-outcome-recorder.test.ts
@@ -1,0 +1,125 @@
+import type { TaskRecord } from "openclaw/plugin-sdk/task-events";
+import { describe, expect, it } from "vitest";
+import { __testing } from "./task-outcome-recorder.js";
+
+const { buildOutcomeRecord, shouldRecord, summarizeOutcome } = __testing;
+
+function makeTask(overrides: Partial<TaskRecord>): TaskRecord {
+  return {
+    taskId: overrides.taskId ?? "task-1",
+    runtime: overrides.runtime ?? "subagent",
+    requesterSessionKey: overrides.requesterSessionKey ?? "session:default",
+    ownerKey: overrides.ownerKey ?? "owner:default",
+    scopeKind: overrides.scopeKind ?? "session",
+    task: overrides.task ?? "do thing",
+    status: overrides.status ?? "queued",
+    deliveryStatus: overrides.deliveryStatus ?? "pending",
+    notifyPolicy: overrides.notifyPolicy ?? "done_only",
+    createdAt: overrides.createdAt ?? 1_000,
+    ...overrides,
+  };
+}
+
+describe("task-outcome-recorder shouldRecord", () => {
+  it("emits on first transition into a terminal state", () => {
+    const event = {
+      kind: "upserted" as const,
+      task: makeTask({ status: "failed", error: "boom" }),
+      previous: makeTask({ status: "running" }),
+    };
+    const result = shouldRecord(event);
+    expect(result?.task.taskId).toBe("task-1");
+  });
+
+  it("ignores non-upserted events", () => {
+    expect(
+      shouldRecord({
+        kind: "deleted",
+        taskId: "task-1",
+        previous: makeTask({ status: "succeeded" }),
+      }),
+    ).toBeNull();
+    expect(shouldRecord({ kind: "restored", tasks: [makeTask({ status: "failed" })] })).toBeNull();
+  });
+
+  it("ignores upserts that stay in a non-terminal state", () => {
+    expect(
+      shouldRecord({
+        kind: "upserted",
+        task: makeTask({ status: "running" }),
+        previous: makeTask({ status: "queued" }),
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores re-emissions of an already-terminal task", () => {
+    expect(
+      shouldRecord({
+        kind: "upserted",
+        task: makeTask({ status: "failed" }),
+        previous: makeTask({ status: "failed" }),
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("task-outcome-recorder summarizeOutcome", () => {
+  it("uses label when present", () => {
+    expect(summarizeOutcome(makeTask({ status: "succeeded", label: "Build prod bundle" }))).toBe(
+      "Task succeeded: Build prod bundle",
+    );
+  });
+
+  it("falls back to first line of task body", () => {
+    expect(
+      summarizeOutcome(
+        makeTask({ status: "failed", task: "send slack message\n  to: #ops", error: "401" }),
+      ),
+    ).toBe("Task failed: send slack message — 401");
+  });
+
+  it("truncates oversized labels", () => {
+    const long = "x".repeat(500);
+    const out = summarizeOutcome(makeTask({ status: "succeeded", label: long }));
+    expect(out.length).toBeLessThan(300);
+    expect(out.startsWith("Task succeeded: ")).toBe(true);
+    expect(out.endsWith("…")).toBe(true);
+  });
+});
+
+describe("task-outcome-recorder buildOutcomeRecord", () => {
+  it("emits a JSON-serializable record with timestamp and durationMs", () => {
+    const task = makeTask({
+      taskId: "abc",
+      status: "succeeded",
+      runtime: "cli",
+      agentId: "main",
+      taskKind: "build",
+      label: "Build prod bundle",
+      startedAt: 1_000,
+      endedAt: 4_500,
+    });
+    const record = buildOutcomeRecord(task, 5_000);
+    expect(record).toMatchObject({
+      type: "task.outcome",
+      taskId: "abc",
+      status: "succeeded",
+      runtime: "cli",
+      agentId: "main",
+      taskKind: "build",
+      label: "Build prod bundle",
+      durationMs: 3_500,
+    });
+    expect(typeof record.timestamp).toBe("string");
+    expect(record.summary).toContain("Build prod bundle");
+  });
+
+  it("omits agentId/taskKind/label when missing", () => {
+    const task = makeTask({ status: "lost" });
+    const record = buildOutcomeRecord(task, 5_000);
+    expect(record.agentId).toBeUndefined();
+    expect(record.taskKind).toBeUndefined();
+    expect(record.label).toBeUndefined();
+    expect(record.durationMs).toBeUndefined();
+  });
+});

--- a/extensions/memory-core/src/task-outcome-recorder.ts
+++ b/extensions/memory-core/src/task-outcome-recorder.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  resolveAgentWorkspaceDir,
+  resolveDefaultAgentId,
+} from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  addTaskRegistryEventListener,
+  type TaskRecord,
+  type TaskRegistryObserverEvent,
+  type TaskStatus,
+} from "openclaw/plugin-sdk/task-events";
+
+const TASK_OUTCOME_LOG_RELATIVE_PATH = path.join("memory", ".dreams", "task-outcomes.jsonl");
+
+const TERMINAL_STATUSES = new Set<TaskStatus>([
+  "succeeded",
+  "failed",
+  "timed_out",
+  "cancelled",
+  "lost",
+]);
+
+type TaskOutcomeRecord = {
+  type: "task.outcome";
+  timestamp: string;
+  taskId: string;
+  status: TaskStatus;
+  runtime: TaskRecord["runtime"];
+  agentId?: string;
+  taskKind?: string;
+  label?: string;
+  summary: string;
+  durationMs?: number;
+  error?: string;
+};
+
+const MAX_LABEL_LENGTH = 240;
+const MAX_ERROR_LENGTH = 480;
+
+function shouldRecord(
+  event: TaskRegistryObserverEvent,
+): { task: TaskRecord; previous?: TaskRecord } | null {
+  if (event.kind !== "upserted") {
+    return null;
+  }
+  if (!TERMINAL_STATUSES.has(event.task.status)) {
+    return null;
+  }
+  // Only record state transitions; if the task was already terminal we have
+  // already logged the outcome on the original event.
+  if (event.previous && TERMINAL_STATUSES.has(event.previous.status)) {
+    return null;
+  }
+  return { task: event.task, previous: event.previous };
+}
+
+function truncate(value: string | undefined, max: number): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+function summarizeOutcome(task: TaskRecord): string {
+  const label =
+    truncate(task.label?.trim(), MAX_LABEL_LENGTH) ??
+    truncate(task.task.split("\n", 1)[0]?.trim(), MAX_LABEL_LENGTH) ??
+    task.taskId;
+  if (task.status === "succeeded") {
+    const trailing = task.terminalSummary ? ` — ${truncate(task.terminalSummary, 240)}` : "";
+    return `Task succeeded: ${label}${trailing}`;
+  }
+  const error = task.error ? ` — ${truncate(task.error, MAX_ERROR_LENGTH)}` : "";
+  return `Task ${task.status}: ${label}${error}`;
+}
+
+function buildOutcomeRecord(task: TaskRecord, nowMs: number): TaskOutcomeRecord {
+  return {
+    type: "task.outcome",
+    timestamp: new Date(nowMs).toISOString(),
+    taskId: task.taskId,
+    status: task.status,
+    runtime: task.runtime,
+    ...(task.agentId ? { agentId: task.agentId } : {}),
+    ...(task.taskKind ? { taskKind: task.taskKind } : {}),
+    ...(task.label ? { label: truncate(task.label, MAX_LABEL_LENGTH) } : {}),
+    summary: summarizeOutcome(task),
+    ...(task.startedAt && task.endedAt
+      ? { durationMs: Math.max(0, task.endedAt - task.startedAt) }
+      : {}),
+    ...(task.error ? { error: truncate(task.error, MAX_ERROR_LENGTH) } : {}),
+  };
+}
+
+async function appendTaskOutcomeRecord(
+  workspaceDir: string,
+  record: TaskOutcomeRecord,
+): Promise<void> {
+  const target = path.join(workspaceDir, TASK_OUTCOME_LOG_RELATIVE_PATH);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.appendFile(target, `${JSON.stringify(record)}\n`, "utf8");
+}
+
+/**
+ * Record terminal task outcomes (succeeded, failed, timed_out, cancelled, lost)
+ * to the agent's workspace as JSONL events. Downstream dreaming can read these
+ * to grow MEMORY entries about what worked and what didn't, closing the
+ * task → memory feedback loop.
+ *
+ * Returns an unsubscribe function so the listener can be cleaned up in tests
+ * or during plugin reloads.
+ */
+export function registerTaskOutcomeRecorder(api: OpenClawPluginApi): () => void {
+  const log = api.logger;
+  const unsubscribe = addTaskRegistryEventListener((event) => {
+    const recordable = shouldRecord(event);
+    if (!recordable) {
+      return;
+    }
+    const { task } = recordable;
+    const agentId = task.agentId ?? resolveDefaultAgentId(api.config);
+    if (!agentId) {
+      return;
+    }
+    let workspaceDir: string;
+    try {
+      workspaceDir = resolveAgentWorkspaceDir(api.config, agentId);
+    } catch (error) {
+      log.debug?.(
+        `task-outcome-recorder: workspace resolution failed for agent ${agentId}: ${String(error)}`,
+      );
+      return;
+    }
+    if (!workspaceDir) {
+      return;
+    }
+    const record = buildOutcomeRecord(task, Date.now());
+    void appendTaskOutcomeRecord(workspaceDir, record).catch((error: unknown) => {
+      log.debug?.(`task-outcome-recorder: append failed for ${task.taskId}: ${String(error)}`);
+    });
+  });
+  return unsubscribe;
+}
+
+export const __testing = {
+  buildOutcomeRecord,
+  shouldRecord,
+  summarizeOutcome,
+  TASK_OUTCOME_LOG_RELATIVE_PATH,
+};

--- a/package.json
+++ b/package.json
@@ -1206,6 +1206,10 @@
       "types": "./dist/plugin-sdk/text-autolink-runtime.d.ts",
       "default": "./dist/plugin-sdk/text-autolink-runtime.js"
     },
+    "./plugin-sdk/task-events": {
+      "types": "./dist/plugin-sdk/task-events.d.ts",
+      "default": "./dist/plugin-sdk/task-events.js"
+    },
     "./plugin-sdk/tool-payload": {
       "types": "./dist/plugin-sdk/tool-payload.d.ts",
       "default": "./dist/plugin-sdk/tool-payload.js"

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -284,6 +284,7 @@
   "telegram-account",
   "telegram-command-config",
   "text-autolink-runtime",
+  "task-events",
   "tool-payload",
   "tool-send",
   "webhook-ingress",

--- a/src/plugin-sdk/task-events.ts
+++ b/src/plugin-sdk/task-events.ts
@@ -1,0 +1,27 @@
+/**
+ * Plugin SDK seam for subscribing to task registry lifecycle events.
+ *
+ * Use `addTaskRegistryEventListener` to react to task transitions (queued,
+ * running, terminal). Listeners run inside the registry's emit path, so they
+ * must be quick and non-blocking — schedule any heavy work onto a microtask
+ * or background queue. Exceptions thrown from a listener are swallowed so
+ * one consumer cannot break the registry's notification path.
+ *
+ * The seam intentionally mirrors the internal observer event shape so that
+ * plugins do not need to keep up with the singleton observer wiring used by
+ * tests.
+ */
+export {
+  addTaskRegistryEventListener,
+  type TaskRegistryObserverEvent,
+} from "../tasks/task-registry.store.js";
+export type {
+  TaskDeliveryStatus,
+  TaskEventKind,
+  TaskNotifyPolicy,
+  TaskRecord,
+  TaskRuntime,
+  TaskScopeKind,
+  TaskStatus,
+  TaskTerminalOutcome,
+} from "../tasks/task-registry.types.js";

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -64,6 +64,7 @@ const defaultTaskRegistryStore: TaskRegistryStore = {
 
 let configuredTaskRegistryStore: TaskRegistryStore = defaultTaskRegistryStore;
 let configuredTaskRegistryObservers: TaskRegistryObservers | null = null;
+const additionalTaskRegistryEventListeners = new Set<(event: TaskRegistryObserverEvent) => void>();
 
 export function getTaskRegistryStore(): TaskRegistryStore {
   return configuredTaskRegistryStore;
@@ -71,6 +72,39 @@ export function getTaskRegistryStore(): TaskRegistryStore {
 
 export function getTaskRegistryObservers(): TaskRegistryObservers | null {
   return configuredTaskRegistryObservers;
+}
+
+export function hasAdditionalTaskRegistryEventListeners(): boolean {
+  return additionalTaskRegistryEventListeners.size > 0;
+}
+
+export function notifyAdditionalTaskRegistryEventListeners(event: TaskRegistryObserverEvent): void {
+  if (additionalTaskRegistryEventListeners.size === 0) {
+    return;
+  }
+  for (const listener of additionalTaskRegistryEventListeners) {
+    try {
+      listener(event);
+    } catch {
+      // Listeners are best-effort; one bad consumer must not block the others.
+    }
+  }
+}
+
+/**
+ * Register a plugin-side task-registry event listener.
+ *
+ * Unlike `configureTaskRegistryRuntime`, multiple listeners can subscribe in
+ * parallel. Returns an unsubscribe function. Listener exceptions are swallowed
+ * so that one consumer cannot break the registry's notification path.
+ */
+export function addTaskRegistryEventListener(
+  listener: (event: TaskRegistryObserverEvent) => void,
+): () => void {
+  additionalTaskRegistryEventListeners.add(listener);
+  return () => {
+    additionalTaskRegistryEventListeners.delete(listener);
+  };
 }
 
 export function configureTaskRegistryRuntime(params: {
@@ -89,4 +123,5 @@ export function resetTaskRegistryRuntimeForTests() {
   configuredTaskRegistryStore.close?.();
   configuredTaskRegistryStore = defaultTaskRegistryStore;
   configuredTaskRegistryObservers = null;
+  additionalTaskRegistryEventListeners.clear();
 }

--- a/src/tasks/task-registry.ts
+++ b/src/tasks/task-registry.ts
@@ -29,6 +29,8 @@ import type { TaskRegistryControlRuntime } from "./task-registry-control.types.j
 import {
   getTaskRegistryObservers,
   getTaskRegistryStore,
+  hasAdditionalTaskRegistryEventListeners,
+  notifyAdditionalTaskRegistryEventListeners,
   resetTaskRegistryRuntimeForTests,
   type TaskRegistryObserverEvent,
 } from "./task-registry.store.js";
@@ -239,16 +241,24 @@ function snapshotTaskRecords(source: ReadonlyMap<string, TaskRecord>): TaskRecor
 
 function emitTaskRegistryObserverEvent(createEvent: () => TaskRegistryObserverEvent): void {
   const observers = getTaskRegistryObservers();
-  if (!observers?.onEvent) {
+  const hasSingleton = Boolean(observers?.onEvent);
+  const hasAdditional = hasAdditionalTaskRegistryEventListeners();
+  if (!hasSingleton && !hasAdditional) {
     return;
   }
-  try {
-    observers.onEvent(createEvent());
-  } catch (error) {
-    log.warn("Task registry observer failed", {
-      event: "task-registry",
-      error,
-    });
+  const event = createEvent();
+  if (hasSingleton && observers?.onEvent) {
+    try {
+      observers.onEvent(event);
+    } catch (error) {
+      log.warn("Task registry observer failed", {
+        event: "task-registry",
+        error,
+      });
+    }
+  }
+  if (hasAdditional) {
+    notifyAdditionalTaskRegistryEventListeners(event);
   }
 }
 


### PR DESCRIPTION
## Summary

Adds a plugin-sdk seam (`openclaw/plugin-sdk/task-events`) that lets plugins subscribe to the task registry's lifecycle events without owning the singleton observer that tests rely on. Multiple listeners can register in parallel via `addTaskRegistryEventListener(listener)`, which returns an unsubscribe function. Listener exceptions are swallowed so one consumer cannot break the registry's notification path.

Wires memory-core to the seam: when a task transitions into a terminal state (`succeeded`, `failed`, `timed_out`, `cancelled`, `lost`), append a JSONL outcome record to `<workspace>/memory/.dreams/task-outcomes.jsonl` with status, runtime, agent, label, durationMs, and a short summary. Dreaming can pick these up later as candidate "what worked / what failed" entries, closing the missing task → memory feedback loop.

The `task-outcomes.jsonl` path keeps the new data isolated from the existing `MemoryHostEvent` log so the shared schema stays untouched.

### Files changed

- `src/tasks/task-registry.store.ts` — multi-listener registry helpers (\`addTaskRegistryEventListener\`, \`hasAdditionalTaskRegistryEventListeners\`, \`notifyAdditionalTaskRegistryEventListeners\`)
- `src/tasks/task-registry.ts` — emit path now also fans out to the additional listener set
- `src/plugin-sdk/task-events.ts` — new SDK facade (re-exports types and `addTaskRegistryEventListener`)
- `scripts/lib/plugin-sdk-entrypoints.json` + `package.json` + regenerated `docs/.generated/plugin-sdk-api-baseline.sha256` — register the new subpath
- `extensions/memory-core/src/task-outcome-recorder.ts` + tests — terminal-transition recorder writing JSONL events
- `extensions/memory-core/index.ts` — wire `registerTaskOutcomeRecorder` into the plugin's `register(api)` pass

## Test plan

- [x] `pnpm test extensions/memory-core/src/task-outcome-recorder.test.ts` — 9 tests covering shouldRecord, summarizeOutcome, buildOutcomeRecord, and JSON-serializable output
- [x] `pnpm check:changed` — typecheck (core + extensions) and tests green; lint shows only the unrelated pre-existing `doctor-state-integrity.ts:875` warning

## Notes for review

- I kept the singleton-observer pattern intact for tests. The new listener set is additive.
- `resolveAgentWorkspaceDir` is already exposed via `openclaw/plugin-sdk/memory-core-host-engine-foundation`, so memory-core can resolve a workspace from `task.agentId` without needing a new SDK seam.
- The recorder skips when no agentId resolves and falls back to `resolveDefaultAgentId(api.config)`. If neither is available, it silently does nothing (best-effort) rather than blocking the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)