### PR TITLE
fix(gateway): silence mcp loopback conflict warn for typed unions

### DIFF
--- a/src/gateway/mcp-http.schema.test.ts
+++ b/src/gateway/mcp-http.schema.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildMcpToolSchema, type McpLoopbackTool } from "./mcp-http.schema.js";
+
+const { logWarnMock } = vi.hoisted(() => ({
+  logWarnMock: vi.fn(),
+}));
+
+vi.mock("../logger.js", () => ({
+  logWarn: logWarnMock,
+}));
+
+function tool(parameters: Record<string, unknown>): McpLoopbackTool {
+  return {
+    name: "demo",
+    label: "demo",
+    description: "demo tool",
+    parameters,
+    execute: async () => "ok",
+  } as unknown as McpLoopbackTool;
+}
+
+describe("buildMcpToolSchema", () => {
+  it("flattens union tool parameters without warning on repeated non-mergeable fields", () => {
+    const schema = buildMcpToolSchema([
+      tool({
+        anyOf: [
+          {
+            type: "object",
+            properties: {
+              action: { const: "create" },
+              doc_token: { type: "string", description: "Document token" },
+            },
+            required: ["action", "doc_token"],
+          },
+          {
+            type: "object",
+            properties: {
+              action: { const: "update" },
+              doc_token: { type: "string", description: "Existing document token" },
+              block_id: { type: "string" },
+            },
+            required: ["action", "doc_token", "block_id"],
+          },
+        ],
+      }),
+    ]);
+
+    expect(schema).toEqual([
+      {
+        name: "demo",
+        description: "demo tool",
+        inputSchema: {
+          type: "object",
+          properties: {
+            action: { enum: ["create", "update"] },
+            doc_token: { type: "string", description: "Document token" },
+            block_id: { type: "string" },
+          },
+          required: ["action", "doc_token"],
+        },
+      },
+    ]);
+    expect(logWarnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/mcp-http.schema.ts
+++ b/src/gateway/mcp-http.schema.ts
@@ -1,4 +1,3 @@
-import { logWarn } from "../logger.js";
 import { resolveGatewayScopedTools } from "./tool-resolution.js";
 
 export type McpLoopbackTool = ReturnType<typeof resolveGatewayScopedTools>["tools"][number];
@@ -42,9 +41,10 @@ function flattenUnionSchema(raw: Record<string, unknown>): Record<string, unknow
           mergedProps[key] = merged;
           continue;
         }
-        logWarn(
-          `mcp loopback: conflicting schema definitions for "${key}", keeping the first variant`,
-        );
+        // The MCP loopback exposes one schema per tool. Some local tools use
+        // TypeBox unions where repeated field names carry different labels or
+        // descriptions across variants. Keeping the first non-mergeable shape is
+        // the least surprising fallback, and avoids log spam during tool listing.
       }
     }
     requiredSets.push(


### PR DESCRIPTION
## Summary

The MCP loopback flattens TypeBox union schemas into a single object so each tool publishes one parameter shape. When two variants declare the same field with different labels or descriptions, the flattener kept the first shape and emitted a warn. With many local tools using `Type.Union([Type.Object(...)])`, that warn fired on every tool listing and drowned real diagnostics.

The "first shape wins" fallback is the least surprising behavior here, so this PR promotes it to the documented contract instead of warning. Adds a regression test to lock the silent behavior in.

## Test plan

- [x] `pnpm test src/gateway/mcp-http.schema.test.ts` — 1/1 passes; `logWarn` not called for typed-union conflicts
- [x] `pnpm check:changed` — typecheck and lint green for the changed files
- [x] Manual: ran `openclaw gateway run` and listed tools; no spurious "conflicting schema definitions" lines in the gateway log

🤖 Generated with [Claude Code](https://claude.com/claude-code)