### PR TITLE
fix(ui): use catalog display names for agent models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2015,6 +2015,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/agents: use catalog display names for configured and raw agent model options while preserving intentional custom aliases. Fixes #67988. (#75157) Thanks @liaoandi.
 - Agents: honor `OPENCLAW_WORKSPACE_DIR` when resolving the default agent workspace, preserving explicit config precedence while keeping env-backed deployments out of the system prompt fallback path. Fixes #66786.
 - Doctor/Codex: stop warning that the message tool is unavailable for source-reply paths where OpenClaw grants `message` at runtime, keeping update and doctor output aligned with the OpenAI happy path. Thanks @pashpashpash.
 - Channels/Weixin: bump the external Weixin catalog entry to `@tencent-weixin/openclaw-weixin@2.4.3` with the matching package integrity. (#81730) Thanks @scotthuang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@ Docs: https://docs.openclaw.ai
 - Native commands: handle slash commands before workspace and agent-reply bootstrap so Telegram `/status` and other command-only native replies do not wait behind full agent turn setup.
 - Plugins/Nix: allow externally configured plugin roots under `/nix/store` to load in `OPENCLAW_NIX_MODE=1` while keeping normal external plugin hardlink rejection unchanged. Thanks @joshp123.
 - Nextcloud Talk: include the required bot `response` feature in setup, explain missing `--feature response` on rejected sends, and surface missing response capability in doctor/status checks. Fixes #78935. (#79657) Thanks @joshavant.
+- Control UI/agents: use catalog display names for configured and raw agent model options while preserving intentional custom aliases. Fixes #67988. (#75157) Thanks @liaoandi.
 - fix(discord): gate user allowlist name resolution [AI]. (#79002) Thanks @pgondhi987.
 - fix(msteams): gate startup user allowlist resolution [AI]. (#79003) Thanks @pgondhi987.
 - Infra/fetch-timeout: pass `operation` and `url` context to `buildTimeoutAbortSignal` from the music-generate reference fetch and the Matrix guarded redirect transport, so the `fetch timeout reached; aborting operation` warning carries actionable structured fields instead of a bare line. Fixes #79195. Thanks @pandadev66.

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -6,7 +6,11 @@ import {
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
 import { DEFAULT_ASSISTANT_AVATAR } from "../assistant-identity.ts";
-import { buildQualifiedChatModelValue } from "../chat-model-ref.ts";
+import {
+  buildCatalogDisplayLookup,
+  buildQualifiedChatModelValue,
+  formatCatalogEntryDisplay,
+} from "../chat-model-ref.ts";
 import { controlUiPublicAssetPath } from "../public-assets.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 import type {
@@ -641,13 +645,44 @@ type ConfiguredModelOption = {
   label: string;
 };
 
+function buildQualifiedModelValue(entry: ModelCatalogEntry): string {
+  return buildQualifiedChatModelValue(entry.id, entry.provider);
+}
+
+function isAliasCoveredByCatalogLabel(
+  alias: string,
+  value: string,
+  entry: ModelCatalogEntry,
+  catalogLabel: string,
+) {
+  const normalizedAlias = normalizeLowercaseStringOrEmpty(alias);
+  if (!normalizedAlias) {
+    return true;
+  }
+  if (
+    normalizedAlias === normalizeLowercaseStringOrEmpty(value) ||
+    normalizedAlias === normalizeLowercaseStringOrEmpty(entry.id) ||
+    normalizedAlias === normalizeLowercaseStringOrEmpty(entry.alias ?? "")
+  ) {
+    return true;
+  }
+  const labelWords = new Set(catalogLabel.toLowerCase().split(/[^a-z0-9.]+/));
+  return labelWords.has(normalizedAlias);
+}
+
 function resolveConfiguredModels(
   configForm: Record<string, unknown> | null,
+  catalog?: ModelCatalogEntry[],
 ): ConfiguredModelOption[] {
   const cfg = configForm as ConfigSnapshot | null;
   const models = cfg?.agents?.defaults?.models;
   if (!models || typeof models !== "object") {
     return [];
+  }
+  const displayLookup = buildCatalogDisplayLookup(catalog ?? []);
+  const catalogByValue = new Map<string, ModelCatalogEntry>();
+  for (const entry of catalog ?? []) {
+    catalogByValue.set(normalizeLowercaseStringOrEmpty(buildQualifiedModelValue(entry)), entry);
   }
   const options: ConfiguredModelOption[] = [];
   for (const [modelId, modelRaw] of Object.entries(models)) {
@@ -661,7 +696,17 @@ function resolveConfiguredModels(
           ? (modelRaw as { alias?: string }).alias?.trim()
           : undefined
         : undefined;
-    const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    const catalogEntry = catalogByValue.get(normalizeLowercaseStringOrEmpty(trimmed));
+    let label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    if (catalogEntry) {
+      const catalogLabel = formatCatalogEntryDisplay(catalogEntry, displayLookup);
+      label =
+        alias &&
+        alias !== trimmed &&
+        !isAliasCoveredByCatalogLabel(alias, trimmed, catalogEntry, catalogLabel)
+          ? `${alias} (${catalogLabel})`
+          : catalogLabel;
+    }
     options.push({ value: trimmed, label });
   }
   return options;
@@ -685,16 +730,14 @@ export function buildModelOptions(
     options.push({ value, label });
   };
 
-  for (const opt of resolveConfiguredModels(configForm)) {
+  for (const opt of resolveConfiguredModels(configForm, catalog)) {
     addOption(opt.value, opt.label);
   }
 
   if (catalog) {
+    const displayLookup = buildCatalogDisplayLookup(catalog);
     for (const entry of catalog) {
-      const provider = entry.provider?.trim();
-      const value = buildQualifiedChatModelValue(entry.id, provider);
-      const label = provider ? `${entry.id} · ${provider}` : entry.id;
-      addOption(value, label);
+      addOption(buildQualifiedModelValue(entry), formatCatalogEntryDisplay(entry, displayLookup));
     }
   }
 

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -5,7 +5,11 @@ import {
   resolveToolProfilePolicy,
 } from "../../../../src/agents/tool-policy-shared.js";
 import { DEFAULT_ASSISTANT_AVATAR } from "../assistant-identity.ts";
-import { buildQualifiedChatModelValue } from "../chat-model-ref.ts";
+import {
+  buildCatalogDisplayLookup,
+  buildQualifiedChatModelValue,
+  formatCatalogEntryDisplay,
+} from "../chat-model-ref.ts";
 import { normalizeLowercaseStringOrEmpty, normalizeOptionalString } from "../string-coerce.ts";
 import type {
   AgentIdentityResult,
@@ -641,13 +645,55 @@ type ConfiguredModelOption = {
   label: string;
 };
 
+function buildQualifiedModelValue(entry: ModelCatalogEntry): string {
+  return buildQualifiedChatModelValue(entry.id, entry.provider);
+}
+
+function isAliasCoveredByCatalogLabel(
+  alias: string,
+  value: string,
+  entry: ModelCatalogEntry,
+  catalogLabel: string,
+) {
+  const normalizedAlias = normalizeLowercaseStringOrEmpty(alias);
+  if (!normalizedAlias) {
+    return true;
+  }
+  if (
+    normalizedAlias === normalizeLowercaseStringOrEmpty(value) ||
+    normalizedAlias === normalizeLowercaseStringOrEmpty(entry.id)
+  ) {
+    return true;
+  }
+  const labelWords = new Set(catalogLabel.toLowerCase().split(/[^a-z0-9.]+/));
+  return labelWords.has(normalizedAlias);
+}
+
+function toNameFirstCatalogEntry(entry: ModelCatalogEntry): ModelCatalogEntry {
+  return {
+    id: entry.id,
+    name: entry.name,
+    provider: entry.provider,
+    contextWindow: entry.contextWindow,
+    reasoning: entry.reasoning,
+    input: entry.input,
+  };
+}
+
 function resolveConfiguredModels(
   configForm: Record<string, unknown> | null,
+  catalog?: ModelCatalogEntry[],
 ): ConfiguredModelOption[] {
   const cfg = configForm as ConfigSnapshot | null;
   const models = cfg?.agents?.defaults?.models;
   if (!models || typeof models !== "object") {
     return [];
+  }
+  const nameFirstCatalog = (catalog ?? []).map(toNameFirstCatalogEntry);
+  const displayLookup = buildCatalogDisplayLookup(nameFirstCatalog);
+  const catalogByValue = new Map<string, ModelCatalogEntry>();
+  for (const entry of catalog ?? []) {
+    catalogByValue.set(normalizeLowercaseStringOrEmpty(buildQualifiedModelValue(entry)), entry);
   }
   const options: ConfiguredModelOption[] = [];
   for (const [modelId, modelRaw] of Object.entries(models)) {
@@ -661,7 +707,17 @@ function resolveConfiguredModels(
           ? (modelRaw as { alias?: string }).alias?.trim()
           : undefined
         : undefined;
-    const label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    const catalogEntry = catalogByValue.get(normalizeLowercaseStringOrEmpty(trimmed));
+    let label = alias && alias !== trimmed ? `${alias} (${trimmed})` : trimmed;
+    if (catalogEntry) {
+      const catalogLabel = formatCatalogEntryDisplay(catalogEntry, displayLookup);
+      label =
+        alias &&
+        alias !== trimmed &&
+        !isAliasCoveredByCatalogLabel(alias, trimmed, catalogEntry, catalogLabel)
+          ? `${alias} (${catalogLabel})`
+          : catalogLabel;
+    }
     options.push({ value: trimmed, label });
   }
   return options;
@@ -685,16 +741,14 @@ export function buildModelOptions(
     options.push({ value, label });
   };
 
-  for (const opt of resolveConfiguredModels(configForm)) {
+  for (const opt of resolveConfiguredModels(configForm, catalog)) {
     addOption(opt.value, opt.label);
   }
 
   if (catalog) {
+    const displayLookup = buildCatalogDisplayLookup(catalog);
     for (const entry of catalog) {
-      const provider = entry.provider?.trim();
-      const value = buildQualifiedChatModelValue(entry.id, provider);
-      const label = provider ? `${entry.id} · ${provider}` : entry.id;
-      addOption(value, label);
+      addOption(buildQualifiedModelValue(entry), formatCatalogEntryDisplay(entry, displayLookup));
     }
   }
 

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -206,6 +206,147 @@ describe("renderAgents", () => {
     );
   });
 
+  it("uses catalog display names for configured model aliases", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-opus-4-7": { alias: "opus" },
+                    "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+            { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const labelsByValue = new Map(
+      Array.from(select?.options ?? []).map((option) => [option.value, option.textContent?.trim()]),
+    );
+
+    expect(labelsByValue.get("anthropic/claude-opus-4-7")).toBe("Claude Opus 4.7");
+    expect(labelsByValue.get("anthropic/claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
+  });
+
+  it("keeps custom configured aliases while replacing raw model ids with catalog names", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-sonnet-4-6": { alias: "daily-driver" },
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const option = Array.from(select?.options ?? []).find(
+      (candidate) => candidate.value === "anthropic/claude-sonnet-4-6",
+    );
+
+    expect(option?.textContent?.trim()).toBe("daily-driver (Claude Sonnet 4.6)");
+  });
+
+  it("disambiguates duplicate catalog display names by provider", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+                    "openrouter/anthropic/claude-sonnet-4-6": {},
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+            {
+              provider: "openrouter",
+              id: "anthropic/claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const labelsByValue = new Map(
+      Array.from(select?.options ?? []).map((option) => [option.value, option.textContent?.trim()]),
+    );
+
+    expect(labelsByValue.get("anthropic/claude-sonnet-4-6")).toBe("Claude Sonnet 4.6 · anthropic");
+    expect(labelsByValue.get("openrouter/anthropic/claude-sonnet-4-6")).toBe(
+      "Claude Sonnet 4.6 · openrouter",
+    );
+  });
+
   it("remounts overview model controls when switching selected agents", async () => {
     const container = document.createElement("div");
     const configForm = {

--- a/ui/src/ui/views/agents.test.ts
+++ b/ui/src/ui/views/agents.test.ts
@@ -187,6 +187,162 @@ describe("renderAgents", () => {
     );
   });
 
+  it("uses catalog display names for configured model aliases", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-opus-4-7": { alias: "opus" },
+                    "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            {
+              provider: "anthropic",
+              id: "claude-opus-4-7",
+              name: "Claude Opus 4.7",
+              alias: "opus",
+            },
+            {
+              provider: "anthropic",
+              id: "claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+              alias: "sonnet",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const labelsByValue = new Map(
+      Array.from(select?.options ?? []).map((option) => [option.value, option.textContent?.trim()]),
+    );
+
+    expect(labelsByValue.get("anthropic/claude-opus-4-7")).toBe("Claude Opus 4.7");
+    expect(labelsByValue.get("anthropic/claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
+  });
+
+  it("keeps custom configured aliases while replacing raw model ids with catalog names", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-sonnet-4-6": { alias: "daily-driver" },
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            {
+              provider: "anthropic",
+              id: "claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+              alias: "daily-driver",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const option = Array.from(select?.options ?? []).find(
+      (candidate) => candidate.value === "anthropic/claude-sonnet-4-6",
+    );
+
+    expect(option?.textContent?.trim()).toBe("daily-driver (Claude Sonnet 4.6)");
+  });
+
+  it("disambiguates duplicate catalog display names by provider", async () => {
+    const container = document.createElement("div");
+
+    render(
+      renderAgents(
+        createProps({
+          selectedAgentId: "alpha",
+          config: {
+            form: {
+              agents: {
+                defaults: {
+                  model: { primary: "anthropic/claude-sonnet-4-6" },
+                  models: {
+                    "anthropic/claude-sonnet-4-6": { alias: "sonnet" },
+                    "openrouter/anthropic/claude-sonnet-4-6": {},
+                  },
+                },
+                list: [{ id: "alpha" }],
+              },
+            },
+            loading: false,
+            saving: false,
+            dirty: false,
+          },
+          modelCatalog: [
+            { provider: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+            {
+              provider: "openrouter",
+              id: "anthropic/claude-sonnet-4-6",
+              name: "Claude Sonnet 4.6",
+            },
+          ],
+        }),
+      ),
+      container,
+    );
+
+    const select = await vi.waitFor(() => {
+      const element = container.querySelector<HTMLSelectElement>(".agent-model-fields select");
+      expect(element).toBeTruthy();
+      return element;
+    });
+    const labelsByValue = new Map(
+      Array.from(select?.options ?? []).map((option) => [option.value, option.textContent?.trim()]),
+    );
+
+    expect(labelsByValue.get("anthropic/claude-sonnet-4-6")).toBe("Claude Sonnet 4.6 · anthropic");
+    expect(labelsByValue.get("openrouter/anthropic/claude-sonnet-4-6")).toBe(
+      "Claude Sonnet 4.6 · openrouter",
+    );
+  });
+
   it("remounts overview model controls when switching selected agents", async () => {
     const container = document.createElement("div");
     const configForm = {


### PR DESCRIPTION
## Summary

- Prefer catalog display names for configured Agents/Control UI model options when the configured provider/model exists in the gateway model catalog.
- Keep intentional custom aliases visible by rendering them as `alias (Catalog Name)`.
- Avoid duplicating aliases that already match the full catalog display name.
- Use catalog names for raw catalog options too, instead of falling back to `id · provider`.
- Keep release-note context in the PR body only; this branch does not edit `CHANGELOG.md`.

Closes #67988.

## Real behavior proof

- **Behavior or issue addressed:** The Agents panel model selector should show catalog display names such as `Claude Opus 4.7` and `Claude Sonnet 4.6` instead of raw configured model ids like `anthropic/claude-opus-4-7`, while still preserving intentional custom aliases and avoiding duplicated labels such as `Claude Sonnet 4.6 (Claude Sonnet 4.6)`.
- **Real environment tested:** Local OpenClaw checkout on macOS, current PR head `42889570dad4dbb8c6968f5a8bafc8a6e4e4d2a2`, running the actual Agents model-option builder with gateway-model-catalog-shaped entries.
- **Exact steps or command run after this patch:** Rebased the PR branch onto current `upstream/main`, ran the focused UI regression suite, then ran a local `node --import tsx` probe against `buildModelOptions()` with configured Anthropic/OpenRouter catalog rows, default aliases, a custom alias, a full-label alias, and duplicate catalog display names.
- **Evidence after fix:** Terminal capture from the current-head local probe:

```text
default alias:
  anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · anthropic
  openrouter/anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · openrouter
custom alias:
  anthropic/claude-sonnet-4-6 => daily-driver (Claude Sonnet 4.6 · anthropic)
  openrouter/anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · openrouter
full label alias:
  anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · anthropic
  openrouter/anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · openrouter
duplicate catalog:
  anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · anthropic
  openrouter/anthropic/claude-sonnet-4-6 => Claude Sonnet 4.6 · openrouter
```

Focused tests on current head:

```console
$ node scripts/run-vitest.mjs ui/src/ui/views/agents.test.ts ui/src/ui/views/agents-utils.test.ts ui/src/ui/chat-model-ref.test.ts ui/src/ui/chat-model-select-state.test.ts

 RUN  v4.1.6 /Users/antonio/projects/openclaw_worktrees/pr75157_clean

 Test Files  4 passed (4)
      Tests  64 passed (64)
   Start at  16:38:20
   Duration  1.17s (transform 82ms, setup 47ms, import 117ms, tests 123ms, environment 1.51s)
```

Format check on current head:

```console
$ ./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/views/agents-utils.ts ui/src/ui/views/agents.test.ts
Checking formatting...
All matched files use the correct format.
Finished in 131ms on 2 files using 1 threads.
```

Whitespace check on current head:

```console
$ git diff --check upstream/main...HEAD
(no output)
```

- **Observed result after fix:** The rendered/model-option path uses catalog labels for configured options, preserves an intentional custom `daily-driver` alias, avoids duplicating an alias that already matches the catalog display name, and disambiguates duplicate catalog display names with provider suffixes.
- **What was not tested:** No additional gaps.

## Test plan

- [x] `node scripts/run-vitest.mjs ui/src/ui/views/agents.test.ts ui/src/ui/views/agents-utils.test.ts ui/src/ui/chat-model-ref.test.ts ui/src/ui/chat-model-select-state.test.ts`
- [x] `./node_modules/.bin/oxfmt --check --threads=1 ui/src/ui/views/agents-utils.ts ui/src/ui/views/agents.test.ts`
- [x] `git diff --check upstream/main...HEAD`
- [x] Current-head `node --import tsx` model-option probe above.
