### PR TITLE
fix(feishu): nudge LLM to thread-reply in group_topic sessions (#74903)

### DIFF
--- a/extensions/feishu/src/bot-content.topic-prompt.test.ts
+++ b/extensions/feishu/src/bot-content.topic-prompt.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { buildFeishuGroupTopicPromptHint, isFeishuTopicGroupSessionScope } from "./bot-content.js";
+
+describe("isFeishuTopicGroupSessionScope", () => {
+  it("returns true for group_topic and group_topic_sender", () => {
+    expect(isFeishuTopicGroupSessionScope("group_topic")).toBe(true);
+    expect(isFeishuTopicGroupSessionScope("group_topic_sender")).toBe(true);
+  });
+
+  it("returns false for non-topic scopes and undefined", () => {
+    expect(isFeishuTopicGroupSessionScope("group")).toBe(false);
+    expect(isFeishuTopicGroupSessionScope("group_sender")).toBe(false);
+    expect(isFeishuTopicGroupSessionScope(undefined)).toBe(false);
+  });
+});
+
+describe("buildFeishuGroupTopicPromptHint", () => {
+  it("emits a thread-reply hint for group_topic with a root message id", () => {
+    const hint = buildFeishuGroupTopicPromptHint({
+      groupSessionScope: "group_topic",
+      topicRootMessageId: "om_root_42",
+    });
+    expect(hint).toBeDefined();
+    expect(hint).toContain("groupSessionScope=group_topic");
+    expect(hint).toContain('action="thread-reply"');
+    expect(hint).toContain('messageId="om_root_42"');
+    expect(hint).toContain('action="send"');
+  });
+
+  it("emits a hint for group_topic_sender", () => {
+    const hint = buildFeishuGroupTopicPromptHint({
+      groupSessionScope: "group_topic_sender",
+      topicRootMessageId: "om_root_99",
+    });
+    expect(hint).toContain("groupSessionScope=group_topic_sender");
+    expect(hint).toContain('messageId="om_root_99"');
+  });
+
+  it("returns undefined for non-topic group scopes", () => {
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: "group",
+        topicRootMessageId: "om_root_1",
+      }),
+    ).toBeUndefined();
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: "group_sender",
+        topicRootMessageId: "om_root_1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when scope is undefined", () => {
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: undefined,
+        topicRootMessageId: "om_root_1",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when topic root message id is missing or blank", () => {
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: "group_topic",
+        topicRootMessageId: undefined,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: "group_topic",
+        topicRootMessageId: null,
+      }),
+    ).toBeUndefined();
+    expect(
+      buildFeishuGroupTopicPromptHint({
+        groupSessionScope: "group_topic",
+        topicRootMessageId: "   ",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("trims whitespace around the topic root message id", () => {
+    const hint = buildFeishuGroupTopicPromptHint({
+      groupSessionScope: "group_topic",
+      topicRootMessageId: "  om_root_77  ",
+    });
+    expect(hint).toContain('messageId="om_root_77"');
+  });
+});

--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -130,6 +130,28 @@ export function resolveFeishuGroupSession(params: {
   };
 }
 
+export function isFeishuTopicGroupSessionScope(scope: GroupSessionScope | undefined): boolean {
+  return scope === "group_topic" || scope === "group_topic_sender";
+}
+
+export function buildFeishuGroupTopicPromptHint(params: {
+  groupSessionScope?: GroupSessionScope;
+  topicRootMessageId?: string | null;
+}): string | undefined {
+  if (!isFeishuTopicGroupSessionScope(params.groupSessionScope)) {
+    return undefined;
+  }
+  const messageId = params.topicRootMessageId?.trim();
+  if (!messageId) {
+    return undefined;
+  }
+  return [
+    `This Feishu session is scoped to a topic thread (groupSessionScope=${params.groupSessionScope}).`,
+    `To post visible output inside this topic thread, use the message tool with action="thread-reply" and messageId="${messageId}".`,
+    `Do not use action="send" for this group: a plain send will post to the main chat outside the topic thread and will not appear here.`,
+  ].join(" ");
+}
+
 export function parseMessageContent(content: string, messageType: string): string {
   if (messageType === "post") {
     return parsePostContent(content).textContent;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -21,6 +21,7 @@ import { resolveOpenDmAllowlistAccess } from "openclaw/plugin-sdk/security-runti
 import { normalizeOptionalString } from "openclaw/plugin-sdk/text-runtime";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import {
+  buildFeishuGroupTopicPromptHint,
   checkBotMentioned,
   normalizeFeishuCommandProbeBody,
   normalizeMentions,
@@ -1216,7 +1217,17 @@ export async function handleFeishuMessage(params: {
         CommandAuthorized: commandAuthorized,
         OriginatingChannel: "feishu" as const,
         OriginatingTo: feishuTo,
-        GroupSystemPrompt: isGroup ? normalizeOptionalString(groupConfig?.systemPrompt) : undefined,
+        GroupSystemPrompt: isGroup
+          ? [
+              normalizeOptionalString(groupConfig?.systemPrompt),
+              buildFeishuGroupTopicPromptHint({
+                groupSessionScope: groupSession?.groupSessionScope,
+                topicRootMessageId: ctx.rootId ?? ctx.messageId,
+              }),
+            ]
+              .filter((part): part is string => Boolean(part))
+              .join("\n\n") || undefined
+          : undefined,
         ...mediaPayload,
         ...(preflightAudioIndex >= 0 ? { MediaTranscribedIndexes: [preflightAudioIndex] } : {}),
       });


### PR DESCRIPTION
```
### Summary

When a Feishu group chat is configured with `groupSessionScope: "group_topic"`
or `"group_topic_sender"`, the assistant's visible reply is sent as a normal
group message instead of a thread (话题) reply to the triggering message.

Per @zhangkang-wy's analysis on #74903:

- The shared system prompt produced by `buildGroupChatContext()`
  (`src/auto-reply/reply/groups.ts`) tells the LLM:
  "To post visible output here, use the message tool with **action=send**…"
- For Feishu topic-mode sessions that instruction is wrong: the runtime
  resolves `action=send` to the plain `chatId` without any topic context,
  so the reply lands in the main chat instead of in the topic thread.
- Feishu's channel runtime already supports the right shape:
  `extensions/feishu/src/channel.ts` maps
  `ctx.action === "thread-reply"` → `replyInThread: true` and uses the
  `messageId` param as the topic root. The bug is purely that the LLM
  isn't told to use `thread-reply` for these sessions.

### Fix

Add a Feishu-owned system-prompt addendum that overrides the generic
"use action=send" instruction when the session is topic-scoped, telling
the LLM to use `action="thread-reply"` with the topic's root `messageId`
instead. The hint flows through the existing `GroupSystemPrompt`
template field (already plumbed through `extraSystemPrompt`), so no
core changes are needed.

Per `extensions/AGENTS.md` (Owner boundary: "If a bug names an
extension or its dependency, start in that extension and add a generic
core seam only when multiple owners need it"), the fix lives entirely
inside `extensions/feishu/`.

Changes:

- `extensions/feishu/src/bot-content.ts`: new `isFeishuTopicGroupSessionScope`
  predicate and `buildFeishuGroupTopicPromptHint(...)` that returns the
  topic-aware instruction string when the session is `group_topic`/
  `group_topic_sender` and a topic root messageId is available.
- `extensions/feishu/src/bot.ts`: at the `GroupSystemPrompt` site for the
  outbound `TemplateContext`, compose the user-configured group system
  prompt with the new topic hint (newline-separated; either may be empty).
  The topic root id passed to the helper is `ctx.rootId ?? ctx.messageId`,
  matching the same precedence used for `replyTargetMessageId` in topic
  sessions a few lines below.
- `extensions/feishu/src/bot-content.topic-prompt.test.ts`: 8 unit tests
  covering scope predicate, hint emission for both topic scopes,
  non-topic / undefined / blank-id cases, and whitespace trimming.

### Verification

- `pnpm test extensions/feishu` — 700/700 pass (62 files).
- `pnpm tsgo:extensions` — clean.
- `pnpm tsgo:extensions:test` — clean.
- `pnpm exec oxfmt --check --threads=1 …` — clean on touched files.

### Notes

- This is a system-prompt-only nudge. The runtime already routes
  `action=thread-reply` correctly; no behavior change for non-topic
  sessions or for groups without a topic-scoped session config.
- A direct-conversation user is unaffected because `GroupSystemPrompt`
  is only set when `isGroup` is true.
- Future generalization (cross-channel "topic mode" prompt seam) would
  fit `src/auto-reply/reply/groups.ts` once a second channel needs it.

Closes #74903
```