### PR TITLE
fix(gateway): allow memory slot tool plugin invokes

### DIFF
--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -19,6 +19,7 @@ const hookMocks = vi.hoisted(() => ({
 
 let cfg: Record<string, unknown> = {};
 let lastCreateOpenClawToolsContext: Record<string, unknown> | undefined;
+let createOpenClawToolsContexts: Array<Record<string, unknown>> = [];
 
 // Perf: keep this suite pure unit. Mock heavyweight config/session modules.
 vi.mock("../config/config.js", () => ({
@@ -91,6 +92,16 @@ vi.mock("../agents/openclaw-tools.js", () => {
       name: "agents_list",
       parameters: { type: "object", properties: { action: { type: "string" } } },
       execute: async () => ({ ok: true, result: [] }),
+    },
+    {
+      name: "memory_search",
+      parameters: { type: "object", properties: { query: { type: "string" } } },
+      execute: async () => ({ ok: true, results: [] }),
+    },
+    {
+      name: "memory_get",
+      parameters: { type: "object", properties: { path: { type: "string" } } },
+      execute: async () => ({ ok: true, content: "" }),
     },
     {
       name: "sessions_spawn",
@@ -190,7 +201,10 @@ vi.mock("../agents/openclaw-tools.js", () => {
   return {
     createOpenClawTools: (ctx: Record<string, unknown>) => {
       lastCreateOpenClawToolsContext = ctx;
-      return ctx.disablePluginTools ? tools.filter((tool) => tool.name !== "browser") : tools;
+      createOpenClawToolsContexts.push(ctx);
+      return ctx.disablePluginTools
+        ? tools.filter((tool) => tool.name !== "browser" && !tool.name.startsWith("memory_"))
+        : tools;
     },
   };
 });
@@ -258,6 +272,7 @@ beforeEach(() => {
   pluginHttpHandlers = [];
   cfg = {};
   lastCreateOpenClawToolsContext = undefined;
+  createOpenClawToolsContexts = [];
   hookMocks.resolveToolLoopDetectionConfig.mockClear();
   hookMocks.resolveToolLoopDetectionConfig.mockImplementation(() => ({ warnAt: 3 }));
   hookMocks.runBeforeToolCallHook.mockClear();
@@ -445,6 +460,30 @@ describe("POST /tools/invoke", () => {
 
     expect(res.status).toBe(200);
     expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
+  });
+
+  it("keeps plugin tools enabled for memory slot tool invokes", async () => {
+    setMainAllowedTools({ allow: ["memory_search"] });
+
+    const res = await invokeToolAuthed({
+      tool: "memory_search",
+      args: { query: "probe" },
+      sessionKey: "main",
+    });
+
+    const body = await expectOkInvokeResponse(res);
+    expect(body.result).toEqual({ ok: true, results: [] });
+    expect(createOpenClawToolsContexts.map((ctx) => ctx.disablePluginTools)).toEqual([true, false]);
+    expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(false);
+  });
+
+  it("keeps plugin tools disabled for ordinary known core tool invokes", async () => {
+    allowAgentsListForMain();
+
+    const res = await invokeAgentsListAuthed({ sessionKey: "main" });
+
+    expect(res.status).toBe(200);
+    expect(lastCreateOpenClawToolsContext?.disablePluginTools).toBe(true);
   });
 
   it("blocks tool execution when before_tool_call rejects the invoke", async () => {


### PR DESCRIPTION
## Summary
- add regression coverage for Gateway HTTP `/tools/invoke` fallback to plugin-backed memory slot tools
- verify memory slot tool ids resolve successfully when they are cataloged core ids but only available through the configured plugin slot
- verify ordinary known core tool invokes still keep plugin tools disabled

## Why
`/tools/invoke` needs to support memory slot tools such as `memory_search` / `memory_get` when memory is provided through the configured plugin slot. Upstream `main` now contains the generalized production fallback behavior: first resolve known core tools with plugin tools disabled, then fall back to plugin-enabled resolution if that requested known core tool is absent.

This PR keeps that production implementation and adds targeted tests to lock the behavior so memory slot tools do not regress.

## Verification
Executed from a clean local worktree on branch `fix/p0b-memory-tools-invoke-20260430` after rebasing onto current upstream `main`:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.gateway.config.ts src/gateway/tools-invoke-http.test.ts` — PASS, 27/27
- `pnpm tsgo:core:test` — PASS
- `pnpm tsgo:core` — PASS
- `git diff --check` — PASS
- `pnpm exec oxfmt --check src/gateway/tools-invoke-http.test.ts` — PASS

## Notes
- Current head: `b167c63bb52458bca863b46f33c78ad324ae431c`
- Stable patch-id after rebase: `35635d4cfe2d909e8ba6e5236602eadfc170d58b`
- GitHub currently reports the PR as mergeable; CI/review still needs to complete.
