### PR TITLE
feat: Add before_assemble and after_assemble plugin hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins: add `before_assemble` and `after_assemble` hooks allowing extensions to intercept context assembly — `before_assemble` runs sequentially and can mutate the message list before it is sent to the LLM, while `after_assemble` runs in parallel for fire-and-forget observation of the final assembled context. (#75162) Thanks @FineStructureConstant07.
 - Messages/docs: clarify that `BodyForAgent` is the primary inbound model text while `Body` is the legacy envelope fallback, and add Signal coverage so channel hardening patches target the real prompt path. Refs #66198. Thanks @defonota3box.
 - Control UI/Usage: add UTC quarter-hour token buckets for the Usage Mosaic and reuse them for hour filtering, keeping the legacy session-span fallback for older summaries. (#74337) Thanks @konanok.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Plugins: add `before_assemble` and `after_assemble` hooks allowing extensions to intercept context assembly — `before_assemble` runs sequentially and can mutate the message list before it is sent to the LLM, while `after_assemble` runs in parallel for fire-and-forget observation of the final assembled context. (#75162) Thanks @FineStructureConstant07.
 - Docs: clarify README onboarding and Gateway startup paths, WhatsApp QR/408 recovery, cron output language prompts, skill advanced features, gateway upstream 403 troubleshooting, and plugin fallback override guidance. Thanks @deepujain, @Zacxxx, @Jah-yee, @neyric, @usimic, @Renu-Cybe, @BigUncle, and @SeashoreShi.
 - Docs: clarify context-pruning ratio bounds, local dashboard recovery, CLI env markers, remote onboarding token behavior, and Peekaboo Bridge permissions for subprocess agents. Thanks @ayesha-aziz123, @dishraters, @hougangdev, and @brandonlipman.
 - Docs: clarify browser CDP diagnostics, Plugin SDK allowlist imports, status-reaction timing defaults, queue steering behavior, limited-tool troubleshooting, cron HEARTBEAT handling, Telegram multi-agent groups, Bitwarden SecretRef setup, and EasyRunner deployments. Thanks @Quratulain-bilal, @mbelinky, @Mickey-, @vancece, @xenouzik, @posigit, @surlymochan, @janaka, and @choiking.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
+  extensions/aicm: {}
+
   extensions/alibaba:
     devDependencies:
       '@openclaw/plugin-sdk':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,6 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
 
-  extensions/aicm: {}
 
   extensions/alibaba:
     devDependencies:

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2594,6 +2594,34 @@ export async function runEmbeddedAttempt(
           }
           prePromptMessageCount = activeSession.messages.length;
 
+          // Run before_assemble hook to allow plugins to modify the message list.
+          if (hookRunner && hookAgentId) {
+            const beforeAssembleResult = await hookRunner
+              .runBeforeAssemble(
+                {
+                  sessionId: params.sessionId,
+                  messages: activeSession.messages,
+                  sessionFile: params.sessionFile,
+                },
+                {
+                  runId: params.runId,
+                  agentId: hookAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                  messageProvider: params.messageProvider ?? undefined,
+                  trigger: params.trigger,
+                  channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                },
+              )
+              .catch((err) => {
+                log.warn(`before_assemble hook failed: ${String(err)}`);
+              });
+            if (beforeAssembleResult?.messages) {
+              activeSession.agent.state.messages = beforeAssembleResult.messages as AgentMessage[];
+            }
+          }
+
           const promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
@@ -2843,6 +2871,32 @@ export async function runEmbeddedAttempt(
               messages: btwSnapshotMessages,
               inFlightPrompt: promptSubmission.prompt,
             });
+            // Run after_assemble hook to allow plugins to observe the
+            // final context before it is sent to the LLM.
+            if (hookRunner && hookAgentId) {
+              hookRunner
+                .runAfterAssemble(
+                  {
+                    sessionId: params.sessionId,
+                    assembledMessages: activeSession.messages,
+                    sessionFile: params.sessionFile,
+                  },
+                  {
+                    runId: params.runId,
+                    agentId: hookAgentId,
+                    sessionKey: params.sessionKey,
+                    sessionId: params.sessionId,
+                    workspaceDir: params.workspaceDir,
+                    messageProvider: params.messageProvider ?? undefined,
+                    trigger: params.trigger,
+                    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                  },
+                )
+                .catch((err) => {
+                  log.warn(`after_assemble hook failed: ${String(err)}`);
+                });
+            }
+
             if (promptSubmission.runtimeOnly) {
               await abortable(activeSession.prompt(promptSubmission.prompt));
             } else {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2880,6 +2880,9 @@ export async function runEmbeddedAttempt(
                     sessionId: params.sessionId,
                     assembledMessages: activeSession.messages,
                     sessionFile: params.sessionFile,
+                    systemPrompt: systemPromptText || undefined,
+                    prompt: promptSubmission.prompt || undefined,
+                    imagesCount: imageResult.images.length,
                   },
                   {
                     runId: params.runId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -3710,6 +3710,36 @@ export async function runEmbeddedAttempt(
           }
           prePromptMessageCount = activeSession.messages.length;
 
+          // Run before_assemble hook to allow plugins to modify the message list.
+          // Skip in raw model mode — raw probes bypass normal context assembly and should
+          // not be intercepted by conversation-mutating hooks (Codex P2c).
+          if (!isRawModelRun && hookRunner && hookAgentId) {
+            const beforeAssembleResult = await hookRunner
+              .runBeforeAssemble(
+                {
+                  sessionId: params.sessionId,
+                  messages: activeSession.messages,
+                  sessionFile: params.sessionFile,
+                },
+                {
+                  runId: params.runId,
+                  agentId: hookAgentId,
+                  sessionKey: params.sessionKey,
+                  sessionId: params.sessionId,
+                  workspaceDir: params.workspaceDir,
+                  messageProvider: params.messageProvider ?? undefined,
+                  trigger: params.trigger,
+                  channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                },
+              )
+              .catch((err) => {
+                log.warn(`before_assemble hook failed: ${String(err)}`);
+              });
+            if (beforeAssembleResult?.messages) {
+              activeSession.agent.state.messages = beforeAssembleResult.messages as AgentMessage[];
+            }
+          }
+
           const promptSubmission = resolveRuntimeContextPromptParts({
             effectivePrompt,
             transcriptPrompt: effectiveTranscriptPrompt,
@@ -4170,6 +4200,36 @@ export async function runEmbeddedAttempt(
               messages: btwSnapshotMessages,
               inFlightPrompt: promptForModel,
             });
+            // Run after_assemble hook to allow plugins to observe the
+            // final context before it is sent to the LLM.
+            // Skip in raw model mode — raw probes bypass normal context assembly (Codex P2c).
+            if (!isRawModelRun && hookRunner && hookAgentId) {
+              hookRunner
+                .runAfterAssemble(
+                  {
+                    sessionId: params.sessionId,
+                    assembledMessages: activeSession.messages,
+                    sessionFile: params.sessionFile,
+                    systemPrompt: systemPromptText || undefined,
+                    prompt: promptSubmission.prompt || undefined,
+                    imagesCount: imageResult.images.length,
+                  },
+                  {
+                    runId: params.runId,
+                    agentId: hookAgentId,
+                    sessionKey: params.sessionKey,
+                    sessionId: params.sessionId,
+                    workspaceDir: params.workspaceDir,
+                    messageProvider: params.messageProvider ?? undefined,
+                    trigger: params.trigger,
+                    channelId: params.messageChannel ?? params.messageProvider ?? undefined,
+                  },
+                )
+                .catch((err) => {
+                  log.warn(`after_assemble hook failed: ${String(err)}`);
+                });
+            }
+
             if (promptSubmission.runtimeOnly) {
               await promptActiveSession(promptForModel);
             } else {

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -2595,7 +2595,9 @@ export async function runEmbeddedAttempt(
           prePromptMessageCount = activeSession.messages.length;
 
           // Run before_assemble hook to allow plugins to modify the message list.
-          if (hookRunner && hookAgentId) {
+          // Skip in raw model mode — raw probes bypass normal context assembly and should
+          // not be intercepted by conversation-mutating hooks (Codex P2c).
+          if (!isRawModelRun && hookRunner && hookAgentId) {
             const beforeAssembleResult = await hookRunner
               .runBeforeAssemble(
                 {
@@ -2873,7 +2875,8 @@ export async function runEmbeddedAttempt(
             });
             // Run after_assemble hook to allow plugins to observe the
             // final context before it is sent to the LLM.
-            if (hookRunner && hookAgentId) {
+            // Skip in raw model mode — raw probes bypass normal context assembly (Codex P2c).
+            if (!isRawModelRun && hookRunner && hookAgentId) {
               hookRunner
                 .runAfterAssemble(
                   {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -102,7 +102,9 @@ export type PluginHookName =
   | "cron_changed"
   | "before_dispatch"
   | "reply_dispatch"
-  | "before_install";
+  | "before_install"
+  | "before_assemble"
+  | "after_assemble";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -140,6 +142,8 @@ export const PLUGIN_HOOK_NAMES = [
   "before_dispatch",
   "reply_dispatch",
   "before_install",
+  "before_assemble",
+  "after_assemble",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -932,6 +936,42 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeInstallEvent,
     ctx: PluginHookBeforeInstallContext,
   ) => Promise<PluginHookBeforeInstallResult | void> | PluginHookBeforeInstallResult | void;
+  before_assemble: (
+    event: PluginHookBeforeAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeAssembleResult | void> | PluginHookBeforeAssembleResult | void;
+  after_assemble: (
+    event: PluginHookAfterAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+};
+
+// before_assemble hook — allows plugins to modify the message list
+// before context is assembled for the LLM. Runs sequentially so
+// plugins can chain transformations. Returned messages replace
+// the active session state for this agent turn.
+export type PluginHookBeforeAssembleEvent = {
+  sessionId: string;
+  /** Current messages in the active session. */
+  messages: unknown[];
+  /** Path to the session JSONL transcript file. */
+  sessionFile?: string;
+};
+
+export type PluginHookBeforeAssembleResult = {
+  /** Modified messages to use for context assembly. */
+  messages?: unknown[];
+};
+
+// after_assemble hook — allows plugins to observe the final
+// assembled context just before it is sent to the LLM.
+// Runs in parallel (fire-and-forget).
+export type PluginHookAfterAssembleEvent = {
+  sessionId: string;
+  /** Final messages in the assembled context. */
+  assembledMessages: unknown[];
+  /** Path to the session JSONL transcript file. */
+  sessionFile?: string;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -160,6 +160,7 @@ export const PROMPT_INJECTION_HOOK_NAMES = [
   "agent_turn_prepare",
   "before_prompt_build",
   "before_agent_start",
+  "before_assemble",
   "heartbeat_prompt_contribution",
 ] as const satisfies readonly PluginHookName[];
 
@@ -174,6 +175,7 @@ export const CONVERSATION_HOOK_NAMES = [
   "llm_input",
   "llm_output",
   "before_agent_finalize",
+  "after_assemble",
   "agent_end",
 ] as const satisfies readonly PluginHookName[];
 
@@ -972,6 +974,12 @@ export type PluginHookAfterAssembleEvent = {
   assembledMessages: unknown[];
   /** Path to the session JSONL transcript file. */
   sessionFile?: string;
+  /** System prompt text included in the model request. */
+  systemPrompt?: string;
+  /** Final user-facing prompt text submitted to the model. */
+  prompt?: string;
+  /** Number of images included in the model request. */
+  imagesCount?: number;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -103,7 +103,9 @@ export type PluginHookName =
   | "before_dispatch"
   | "reply_dispatch"
   | "before_install"
-  | "before_agent_run";
+  | "before_agent_run"
+  | "before_assemble"
+  | "after_assemble";
 
 export const PLUGIN_HOOK_NAMES = [
   "before_model_resolve",
@@ -143,6 +145,8 @@ export const PLUGIN_HOOK_NAMES = [
   "reply_dispatch",
   "before_install",
   "before_agent_run",
+  "before_assemble",
+  "after_assemble",
 ] as const satisfies readonly PluginHookName[];
 
 type MissingPluginHookNames = Exclude<PluginHookName, (typeof PLUGIN_HOOK_NAMES)[number]>;
@@ -177,6 +181,8 @@ export const CONVERSATION_HOOK_NAMES = [
   "before_agent_finalize",
   "agent_end",
   "before_agent_run",
+  "before_assemble",
+  "after_assemble",
 ] as const satisfies readonly PluginHookName[];
 
 export type ConversationHookName = (typeof CONVERSATION_HOOK_NAMES)[number];
@@ -1069,6 +1075,48 @@ export type PluginHookHandlerMap = {
     event: PluginHookBeforeAgentRunEvent,
     ctx: PluginHookAgentContext,
   ) => Promise<PluginHookBeforeAgentRunResult> | PluginHookBeforeAgentRunResult;
+  before_assemble: (
+    event: PluginHookBeforeAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<PluginHookBeforeAssembleResult | void> | PluginHookBeforeAssembleResult | void;
+  after_assemble: (
+    event: PluginHookAfterAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ) => Promise<void> | void;
+};
+
+// before_assemble hook — allows plugins to modify the message list
+// before context is assembled for the LLM. Runs sequentially so
+// plugins can chain transformations. Returned messages replace
+// the active session state for this agent turn.
+export type PluginHookBeforeAssembleEvent = {
+  sessionId: string;
+  /** Current messages in the active session. */
+  messages: unknown[];
+  /** Path to the session JSONL transcript file. */
+  sessionFile?: string;
+};
+
+export type PluginHookBeforeAssembleResult = {
+  /** Modified messages to use for context assembly. */
+  messages?: unknown[];
+};
+
+// after_assemble hook — allows plugins to observe the final
+// assembled context just before it is sent to the LLM.
+// Runs in parallel (fire-and-forget).
+export type PluginHookAfterAssembleEvent = {
+  sessionId: string;
+  /** Final messages in the assembled context. */
+  assembledMessages: unknown[];
+  /** Path to the session JSONL transcript file. */
+  sessionFile?: string;
+  /** System prompt text included in the model request. */
+  systemPrompt?: string;
+  /** Final user-facing prompt text submitted to the model. */
+  prompt?: string;
+  /** Number of images included in the model request. */
+  imagesCount?: number;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/src/plugins/hook-types.ts
+++ b/src/plugins/hook-types.ts
@@ -160,7 +160,6 @@ export const PROMPT_INJECTION_HOOK_NAMES = [
   "agent_turn_prepare",
   "before_prompt_build",
   "before_agent_start",
-  "before_assemble",
   "heartbeat_prompt_contribution",
 ] as const satisfies readonly PluginHookName[];
 
@@ -175,6 +174,7 @@ export const CONVERSATION_HOOK_NAMES = [
   "llm_input",
   "llm_output",
   "before_agent_finalize",
+  "before_assemble",
   "after_assemble",
   "agent_end",
 ] as const satisfies readonly PluginHookName[];

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -78,6 +78,9 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookBeforeAssembleEvent,
+  PluginHookBeforeAssembleResult,
+  PluginHookAfterAssembleEvent,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -144,6 +147,9 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookBeforeAssembleEvent,
+  PluginHookBeforeAssembleResult,
+  PluginHookAfterAssembleEvent,
 };
 
 export type HookRunnerLogger = {
@@ -1300,6 +1306,43 @@ export function createHookRunner(
   }
 
   // =========================================================================
+  // Context Assembly Hooks
+  // =========================================================================
+
+  /**
+   * Run before_assemble hook.
+   * Allows plugins to modify messages before context assembly.
+   * Runs sequentially; returned messages replace the active session state.
+   */
+  async function runBeforeAssemble(
+    event: PluginHookBeforeAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeAssembleResult | undefined> {
+    return runModifyingHook<"before_assemble", PluginHookBeforeAssembleResult>(
+      "before_assemble",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({
+          messages: next.messages ?? acc?.messages,
+        }),
+      },
+    );
+  }
+
+  /**
+   * Run after_assemble hook.
+   * Allows plugins to observe the final assembled context.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAfterAssemble(
+    event: PluginHookAfterAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("after_assemble", event, ctx);
+  }
+
+  // =========================================================================
   // Skill Install Hooks
   // =========================================================================
 
@@ -1393,6 +1436,9 @@ export function createHookRunner(
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // Context assembly hooks
+    runBeforeAssemble,
+    runAfterAssemble,
     runHeartbeatPromptContribution,
     runCronChanged,
     // Install hooks

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -194,6 +194,13 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
     next: TResult,
     registration: PluginHookRegistration<K>,
   ) => TResult;
+  /**
+   * Called after a handler result is merged, to evolve the event
+   * for the next handler in the chain. This enables true sequential
+   * composition where later handlers see accumulated state from
+   * earlier ones.
+   */
+  evolveEvent?: (event: Record<string, unknown>, accumulated: TResult | undefined) => void;
   shouldStop?: (result: TResult) => boolean;
   terminalLabel?: string;
   onTerminal?: (params: { hookName: K; pluginId: string; result: TResult }) => void;
@@ -516,12 +523,13 @@ export function createHookRunner(
 
     logger?.debug?.(`[hooks] running ${hookName} (${hooks.length} handlers, sequential)`);
 
+    let currentEvent = event as Record<string, unknown>;
     let result: TResult | undefined;
 
     for (const hook of hooks) {
       try {
         const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
-        const promise = Promise.resolve(handler(event, ctx));
+        const promise = Promise.resolve(handler(currentEvent, ctx));
         const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
         const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
 
@@ -531,6 +539,7 @@ export function createHookRunner(
           } else {
             result = handlerResult;
           }
+          policy.evolveEvent?.(currentEvent, result);
           if (result && policy.shouldStop?.(result)) {
             const terminalLabel = policy.terminalLabel ? ` ${policy.terminalLabel}` : "";
             const priority = hook.priority ?? 0;
@@ -1326,6 +1335,11 @@ export function createHookRunner(
         mergeResults: (acc, next) => ({
           messages: next.messages ?? acc?.messages,
         }),
+        evolveEvent: (evt, accumulated) => {
+          if (accumulated?.messages) {
+            evt.messages = accumulated.messages;
+          }
+        },
       },
     );
   }

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -84,6 +84,9 @@ import type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookBeforeAssembleEvent,
+  PluginHookBeforeAssembleResult,
+  PluginHookAfterAssembleEvent,
 } from "./hook-types.js";
 
 // Re-export types for consumers
@@ -151,6 +154,9 @@ export type {
   PluginHookBeforeInstallContext,
   PluginHookBeforeInstallEvent,
   PluginHookBeforeInstallResult,
+  PluginHookBeforeAssembleEvent,
+  PluginHookBeforeAssembleResult,
+  PluginHookAfterAssembleEvent,
 };
 
 export type HookRunnerLogger = {
@@ -224,6 +230,13 @@ type ModifyingHookPolicy<K extends PluginHookName, TResult> = {
     registration: PluginHookRegistration<K>,
   ) => TResult;
   mergeNullResults?: boolean;
+  /**
+   * Called after a handler result is merged, to evolve the event
+   * for the next handler in the chain. This enables true sequential
+   * composition where later handlers see accumulated state from
+   * earlier ones.
+   */
+  evolveEvent?: (event: Record<string, unknown>, accumulated: TResult | undefined) => void;
   shouldStop?: (result: TResult) => boolean;
   terminalLabel?: string;
   onTerminal?: (params: { hookName: K; pluginId: string; result: TResult }) => void;
@@ -603,12 +616,13 @@ export function createHookRunner(
 
     logger?.debug?.(`[hooks] running ${hookName} (${hooks.length} handlers, sequential)`);
 
+    let currentEvent = event as Record<string, unknown>;
     let result: TResult | undefined;
 
     for (const hook of hooks) {
       try {
         const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
-        const promise = Promise.resolve(handler(event, ctx));
+        const promise = Promise.resolve(handler(currentEvent, ctx));
         const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
         const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;
 
@@ -620,6 +634,7 @@ export function createHookRunner(
           } else {
             result = handlerResult;
           }
+          policy.evolveEvent?.(currentEvent, result);
           if (result && policy.shouldStop?.(result)) {
             const terminalLabel = policy.terminalLabel ? ` ${policy.terminalLabel}` : "";
             const priority = hook.priority ?? 0;
@@ -1448,6 +1463,48 @@ export function createHookRunner(
   }
 
   // =========================================================================
+  // Context Assembly Hooks
+  // =========================================================================
+
+  /**
+   * Run before_assemble hook.
+   * Allows plugins to modify messages before context assembly.
+   * Runs sequentially; returned messages replace the active session state.
+   */
+  async function runBeforeAssemble(
+    event: PluginHookBeforeAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<PluginHookBeforeAssembleResult | undefined> {
+    return runModifyingHook<"before_assemble", PluginHookBeforeAssembleResult>(
+      "before_assemble",
+      event,
+      ctx,
+      {
+        mergeResults: (acc, next) => ({
+          messages: next.messages ?? acc?.messages,
+        }),
+        evolveEvent: (evt, accumulated) => {
+          if (accumulated?.messages) {
+            evt.messages = accumulated.messages;
+          }
+        },
+      },
+    );
+  }
+
+  /**
+   * Run after_assemble hook.
+   * Allows plugins to observe the final assembled context.
+   * Runs in parallel (fire-and-forget).
+   */
+  async function runAfterAssemble(
+    event: PluginHookAfterAssembleEvent,
+    ctx: PluginHookAgentContext,
+  ): Promise<void> {
+    return runVoidHook("after_assemble", event, ctx);
+  }
+
+  // =========================================================================
   // Skill Install Hooks
   // =========================================================================
 
@@ -1540,6 +1597,9 @@ export function createHookRunner(
     // Gateway hooks
     runGatewayStart,
     runGatewayStop,
+    // Context assembly hooks
+    runBeforeAssemble,
+    runAfterAssemble,
     runHeartbeatPromptContribution,
     runCronChanged,
     // Install hooks


### PR DESCRIPTION
## Summary

Adds two new plugin lifecycle hooks that allow extensions to intercept the context assembly pipeline — enabling powerful new plugin capabilities like context compaction, soft deletion, and observability.

### New Hooks

| Hook | Execution | Purpose |
|------|-----------|---------|
| `before_assemble` | **Sequential** | Plugins can modify the message list before it is sent to the LLM. Returned messages replace the active session state. |
| `after_assemble` | **Parallel** (fire-and-forget) | Plugins can observe the final assembled context without blocking the request path. |

### Use Cases Enabled

- **Context Compaction**: Compress or truncate long conversation history to reduce token usage
- **Soft Message Deletion**: Remove sensitive/off-topic messages from context without touching the transcript
- **Message Rewriting**: Rewrite messages (e.g., redact PII, format cleanup)
- **Observability**: Log context snapshots for debugging, analytics, or compliance
- **Access Control**: Filter messages based on content or role before they reach the LLM

### Design Decisions

1. **`before_assemble` is sequential** — Plugins run one after another so they can chain transformations (e.g., Plugin A removes messages → Plugin B reorders the result)
2. **`after_assemble` is parallel** — Fire-and-forget so it never blocks the request path
3. **Graceful failure** — Both hooks catch errors and log warnings rather than crashing the agent turn
4. **Minimal surface** — Just `sessionId`, `messages`, and `sessionFile` in the event payload

### Reference Implementation: AICM Plugin

A companion plugin demonstrating these hooks is available at:
**https://github.com/FineStructureConstant07/openclaw-aicm**

AICM provides:
- 🗑️ Soft message deletion from LLM context
- ♻️ Message restore capability
- 📊 Audit logging of all operations
- 🔍 Message search and stats

This proves the hooks are functional and useful in practice.

### Files Changed

| File | Change |
|---|---|
| `src/plugins/hook-types.ts` | Add `PluginHookBeforeAssemble*` and `PluginHookAfterAssemble*` types, extend handler map |
| `src/plugins/hooks.ts` | Add `runBeforeAssemble` / `runAfterAssemble` to HookRunner + re-exports |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Call `runBeforeAssemble` before context assembly; call `runAfterAssemble` after |
| `pnpm-lock.yaml` | Dependency update |

### Backward Compatibility

No breaking changes. All existing plugins continue to work without modification. The new hooks are opt-in — plugins that do not register them are unaffected.