### PR TITLE
docs(github): clarify restart after gh setup

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -63,6 +63,23 @@ gh auth login
 gh auth status
 ```
 
+### After installing or authenticating `gh`
+
+OpenClaw detects skill requirements when the gateway and agent sessions start. If you installed the GitHub CLI or ran `gh auth login` while OpenClaw was already running, start a fresh session or restart the gateway before assuming the skill is broken.
+
+```bash
+# Restart the gateway/service so OpenClaw re-checks available skill binaries
+openclaw gateway restart
+
+# Confirm the gateway came back cleanly
+openclaw gateway status
+
+# Confirm GitHub CLI auth is still visible to the service user
+gh auth status
+```
+
+On Linux/systemd installs, `openclaw gateway status` also shows the service command and environment. If `gh` works in your shell but the skill still appears unavailable, make sure the gateway service user can find the same `gh` binary on `PATH`.
+
 ## Common Commands
 
 ### Pull Requests

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -63,6 +63,29 @@ gh auth login
 gh auth status
 ```
 
+### After installing `gh` or changing `PATH`
+
+OpenClaw checks skill binary requirements from the running gateway process. If
+you install the GitHub CLI or change `PATH` while OpenClaw is already running,
+restart the gateway so it re-checks available skill binaries before assuming the
+skill is broken.
+
+```bash
+# Restart the gateway/service so OpenClaw re-checks available skill binaries
+openclaw gateway restart
+
+# Confirm the gateway came back cleanly
+openclaw gateway status
+
+# Confirm GitHub CLI auth is still visible to the service user
+gh auth status
+```
+
+On Linux/systemd installs, `openclaw gateway status` also shows the service
+command and environment. If `gh` works in your shell but the skill still appears
+unavailable, make sure the gateway service user can find the same `gh` binary on
+`PATH`.
+
 ### When the gateway HOME differs from the operator HOME
 
 OpenClaw agent shells often run with a different `HOME` than the user that ran
@@ -150,13 +173,17 @@ gh api repos/owner/repo --jq '{stars: .stargazers_count, forks: .forks_count}'
 Most commands support `--json` for structured output with `--jq` filtering:
 
 ```bash
-gh issue list --repo owner/repo --json number,title --jq '.[] | "\(.number): \(.title)"'
-gh pr list --json number,title,state,mergeable --jq '.[] | select(.mergeable == "MERGEABLE")'
+gh issue list --repo owner/repo --json number,title \
+  --jq '.[] | "\(.number): \(.title)"'
+gh pr list --json number,title,state,mergeable \
+  --jq '.[] | select(.mergeable == "MERGEABLE")'
 ```
 
 ## Templates
 
 ### PR Review Summary
+
+<!-- markdownlint-disable MD013 -->
 
 ```bash
 # Get PR overview for review
@@ -167,13 +194,19 @@ gh pr view $PR --repo $REPO --json title,body,author,additions,deletions,changed
 gh pr checks $PR --repo $REPO
 ```
 
+<!-- markdownlint-enable MD013 -->
+
 ### Issue Triage
+
+<!-- markdownlint-disable MD013 -->
 
 ```bash
 # Quick issue triage view
 gh issue list --repo owner/repo --state open --json number,title,labels,createdAt \
   --jq '.[] | "[\(.number)] \(.title) - \([.labels[].name] | join(", ")) (\(.createdAt[:10]))"'
 ```
+
+<!-- markdownlint-enable MD013 -->
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- make the post-install/PATH restart requirement prominent in the GitHub skill setup docs
- add concrete openclaw gateway restart / openclaw gateway status commands
- mention PATH/service-user checks when gh works in the shell but the skill still appears unavailable
- preserve the existing GH_CONFIG_DIR/HOME mismatch troubleshooting from main

Fixes #65958

## Real behavior proof

- **Behavior or issue addressed:** GitHub skill setup docs now distinguish install/PATH changes from auth/HOME troubleshooting. Installing `gh` or changing `PATH` while the gateway is already running requires `openclaw gateway restart`; fresh-session wording is no longer used for the binary-cache case.
- **Real environment tested:** Live OpenClaw setup on Linux `clankerpoo`, running gateway service via systemd user service, PR branch `paul/docs-github-restart-guidance` at `dad534fbce498dfcb3a332fcfe25530bc05bc07b` after rebase onto `origin/main`.
- **Exact steps or command run after this patch:**

  ```bash
  openclaw gateway status
  gh auth status
  grep -n "After installing \`gh\` or changing \`PATH\`\|openclaw gateway restart\|GH_CONFIG_DIR" skills/github/SKILL.md
  node --input-type=module <<'NODE'
  import fs from 'node:fs';
  import os from 'node:os';
  import path from 'node:path';
  import { hasBinary } from './src/shared/config-eval.ts';
  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'hasBinary-gh-'));
  const oldPath = process.env.PATH;
  process.env.PATH = dir;
  console.log('initial missing:', hasBinary('gh'));
  const gh = path.join(dir, 'gh');
  fs.writeFileSync(gh, '#!/bin/sh\necho fake-gh\n');
  fs.chmodSync(gh, 0o755);
  console.log('after install same PATH:', hasBinary('gh'));
  process.env.PATH = `${dir}${path.delimiter}${oldPath ?? ''}`;
  console.log('after PATH string changes:', hasBinary('gh'));
  NODE
  ```

- **Evidence after fix:** Copied live terminal output from the OpenClaw setup:

  ```text
  Service: systemd user (enabled)
  Command: /usr/bin/node /usr/lib/node_modules/openclaw/dist/index.js gateway --port 18789
  Service file: ~/.config/systemd/user/openclaw-gateway.service
  Service env: OPENCLAW_GATEWAY_PORT=18789
  Runtime: running (pid 1150531, state active, sub running, last exit 0, reason 0)
  Connectivity probe: ok
  Capability: admin-capable
  --- gh auth status ---
  github.com
    ✓ Logged in to github.com account pfrederiksen (/root/.config/gh/hosts.yml)
    - Active account: true
    - Git operations protocol: https
    - Token: gho_************************************
    - Token scopes: 'gist', 'read:org', 'repo', 'workflow'
  --- proof text grep ---
  66:### After installing `gh` or changing `PATH`
  75:openclaw gateway restart
  93:looks up its config under `$GH_CONFIG_DIR`, then `$XDG_CONFIG_HOME/gh`, then
  97:To point the gateway at the canonical `gh` config, set `GH_CONFIG_DIR` on the
  102:GH_CONFIG_DIR=/path/to/operator/.config/gh
  initial missing: false
  after install same PATH: false
  after PATH string changes: true
  ```

- **Observed result after fix:** The patched docs show the required gateway restart command for install/PATH changes, preserve the GH_CONFIG_DIR/HOME troubleshooting section from current main, and the live cache probe shows why restart is necessary: adding `gh` without changing the running process `PATH` keeps `hasBinary('gh')` false until the process environment changes or the gateway restarts.
- **What was not tested:** I did not actually uninstall/reinstall `gh` or restart the production gateway; the live proof uses a temporary executable and the real `hasBinary` implementation to avoid disrupting the running OpenClaw service.

## Verification
- `pnpm dlx markdownlint-cli2 skills/github/SKILL.md`
  - `Summary: 0 error(s)`
- `git diff --check`
- Rebased onto current `origin/main`; PR is now mergeable.
