### PR TITLE
fix(agent): keep cleanup hooks isolated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Memory: close temp SQLite handles before failed atomic reindex cleanup and retry Windows EBUSY/EPERM/EACCES temp file removals, so `memory index --force` does not abort or leave temp sidecars on locked filesystems. Fixes #79708. Thanks @LobsterFarmerAmp and @hclsys.
+- Agents/CLI: keep bundle MCP cleanup running even when live-session cleanup fails after one-shot CLI runs, so later run-end cleanup hooks are not skipped. Thanks @HemantSudarshan.
 - Agents/CLI: add an explicit `reseedFromRawTranscriptWhenUncompacted` backend opt-in so safe invalidated CLI sessions can reseed from a bounded raw OpenClaw transcript tail before compaction while auth-boundary resets remain no-raw. Fixes #79713. (#79764) Thanks @hclsys.
 - Agents/CLI: handle resumed CLI JSONL output and bound supervisor output buffering so resumed runs stay readable without letting noisy child output grow unbounded.
 - Codex app-server: honor per-call `timeoutMs`, configured `image_generate` timeouts, and media image-understanding timeouts for dynamic tool calls, capped at 600000 ms, so slow image generation and image analysis no longer fail at the 30s bridge default. Fixes #79810. Thanks @omarshahine.

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -200,4 +200,21 @@ describe("runCliAgent cron before_agent_reply seam", () => {
     expect(executePreparedCliRunMock).toHaveBeenCalledTimes(1);
     expect(closeMcpLoopbackServerMock).toHaveBeenCalledTimes(1);
   });
+
+  it("runs remaining cleanup when one cleanup hook fails", async () => {
+    const { runCliAgent } = await import("./cli-runner.js");
+    executePreparedCliRunMock.mockResolvedValue({ text: "real reply" });
+    closeClaudeLiveSessionForContextMock.mockRejectedValueOnce(new Error("live cleanup failed"));
+
+    await expect(
+      runCliAgent({
+        ...baseRunParams,
+        cleanupCliLiveSessionOnRunEnd: true,
+        cleanupBundleMcpOnRunEnd: true,
+      }),
+    ).resolves.toMatchObject({ payloads: [{ text: "real reply" }] });
+
+    expect(closeClaudeLiveSessionForContextMock).toHaveBeenCalledTimes(1);
+    expect(closeMcpLoopbackServerMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -117,13 +117,21 @@ export async function runCliAgent(params: RunCliAgentParams): Promise<EmbeddedPi
     return await runPreparedCliAgent(context);
   } finally {
     if (params.cleanupCliLiveSessionOnRunEnd === true) {
-      const { closeClaudeLiveSessionForContext } =
-        await import("./cli-runner/claude-live-session.js");
-      await closeClaudeLiveSessionForContext(context);
+      try {
+        const { closeClaudeLiveSessionForContext } =
+          await import("./cli-runner/claude-live-session.js");
+        await closeClaudeLiveSessionForContext(context);
+      } catch (err) {
+        log.warn(`CLI live session cleanup failed after run: ${formatErrorMessage(err)}`);
+      }
     }
     if (params.cleanupBundleMcpOnRunEnd === true) {
-      const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
-      await closeMcpLoopbackServer();
+      try {
+        const { closeMcpLoopbackServer } = await import("../gateway/mcp-http.js");
+        await closeMcpLoopbackServer();
+      } catch (err) {
+        log.warn(`bundle MCP loopback cleanup failed after run: ${formatErrorMessage(err)}`);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Problem: PR #74543 fixed timeout fallback session keys, but CLI run cleanup still had a shared `finally` path where one failing cleanup hook could skip later cleanup.
- Why it matters: timeout fallback now avoids the surfaced session-lock issue, but skipped cleanup can still leak bundle MCP resources or other run-scoped state.
- What changed: isolate the CLI live-session and bundle MCP cleanup hooks in separate best-effort guards and log each cleanup failure independently.
- What did NOT change (scope boundary): no gateway fallback routing, session-key, provider, or lock semantics changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor required for the fix
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #74543
- [x] This PR fixes a bug or regression

## Root Cause (if applicable)

- Root cause: `runCliAgent` awaited multiple cleanup hooks sequentially in one `finally` block, so a rejection from `closeClaudeLiveSessionForContext` prevented `closeMcpLoopbackServer` from running.
- Missing detection / guardrail: existing tests covered each cleanup hook firing on success, but not the case where one cleanup hook fails and the later cleanup still must run.
- Contributing context (if known): #74543 surfaced this class through gateway timeout fallback/session locks, but the cleanup path is broader than session locks.

## Regression Test Plan (if applicable)

- Coverage level that should have caught this:
  - [x] Unit test
  - [x] Seam / integration test
  - [ ] End-to-end test
  - [ ] Existing coverage already sufficient
- Target test or file: `src/agents/cli-runner.before-agent-reply-cron.test.ts`
- Scenario the test should lock in: when live-session cleanup rejects, bundle MCP cleanup still runs and the CLI agent result still resolves.
- Why this is the smallest reliable guardrail: it exercises the exact `runCliAgent` cleanup seam with mocked cleanup hooks and no full gateway process.
- Existing test that already covers this (if any): none for cleanup failure continuation.
- If no new test is added, why not: N/A

## User-visible / Behavior Changes

None.

## Diagram (if applicable)

```text
Before:
run finishes -> live session cleanup rejects -> bundle MCP cleanup skipped

After:
run finishes -> live session cleanup guarded -> bundle MCP cleanup guarded -> result preserved
```

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A


## Real behavior proof
- **Behavior or issue addressed:** `runCliAgent` cleanup should remain best-effort per cleanup hook. If live-session cleanup rejects after a one-shot run, bundle MCP loopback cleanup must still run and the agent result must still resolve.
- **Real environment tested:** Local Windows checkout of this branch at `1a502191b6`, Node v22.15.0 via repo scripts, after rebasing onto `upstream/main` at `ca39429a28`.
- **Exact steps or command run after this patch:** Ran `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/cli-runner.before-agent-reply-cron.test.ts -- --reporter=verbose` from the repo root. The regression case exercises the real `runCliAgent` cleanup path with both cleanup hooks enabled and one cleanup hook forced to reject.
- **Evidence after fix:** Copied terminal output from the focused run:
```text
✓ |agents| src/agents/cli-runner.before-agent-reply-cron.test.ts > runCliAgent cron before_agent_reply seam > can close temporary CLI live sessions after a run
✓ |agents| src/agents/cli-runner.before-agent-reply-cron.test.ts > runCliAgent cron before_agent_reply seam > can close temporary bundle MCP loopback resources after a run
✓ |agents| src/agents/cli-runner.before-agent-reply-cron.test.ts > runCliAgent cron before_agent_reply seam > runs remaining cleanup when one cleanup hook fails

Test Files  1 passed (1)
Tests       8 passed (8)
```
- **Observed result after fix:** The cleanup-failure regression passes: the later bundle MCP cleanup still runs even when live-session cleanup rejects, and the CLI agent result resolves instead of allowing one cleanup failure to skip the remaining cleanup.
- **What was not tested:** No full live Gateway process was started for this proof; the failure condition is a cleanup-failure seam that is deterministic in the focused `runCliAgent` test. Broader gateway timeout fallback tests were already covered by the PR body verification list.
## Repro + Verification

### Environment

- OS: Windows
- Runtime/container: Node 22 via repo scripts
- Model/provider: N/A
- Integration/channel (if any): gateway agent CLI fallback cleanup path
- Relevant config (redacted): N/A

### Steps

1. Trigger `runCliAgent` with both cleanup flags enabled.
2. Make `closeClaudeLiveSessionForContext` reject.
3. Verify `closeMcpLoopbackServer` still runs and the run result resolves.

### Expected

- Cleanup failures are isolated and later cleanup hooks still run.

### Actual

- Before this patch, a rejected live-session cleanup skipped bundle MCP cleanup.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm exec oxfmt --check --threads=1 src/agents/cli-runner.ts src/agents/cli-runner.before-agent-reply-cron.test.ts`
  - `git diff --check`
  - `pnpm check:changed`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/commands/agent-via-gateway.test.ts src/commands/agent.session.test.ts src/commands/agent/session.test.ts src/gateway/call.test.ts src/agents/run-wait.test.ts src/agents/cli-runner.before-agent-reply-cron.test.ts -- --reporter=verbose`
  - `OPENCLAW_VITEST_MAX_WORKERS=1 OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=180000 OPENCLAW_VITEST_NO_OUTPUT_RETRY=0 pnpm test src/gateway/server.agent.gateway-server-agent-b.test.ts -- --reporter=verbose --testNamePattern "agent dedupe|agent events stream"`
- Edge cases checked: one cleanup hook rejecting while another must still run; #74543 timeout fallback/session routing tests stayed green.
- What you did **not** verify: full `src/gateway/server.agent.gateway-server-agent-b.test.ts`; it exposes a separate pre-existing teardown/order-dependency issue where the full shard can pass assertions but not exit, and the isolated ack/final-response case can time out.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Risks and Mitigations

- Risk: cleanup failures are now logged instead of failing the overall CLI agent call during `finally`.
  - Mitigation: these cleanup paths are already best-effort run-end cleanup; isolating them prevents one leak source from suppressing another cleanup hook while preserving diagnostics.
## 2026-05-09 Refresh

- Rebased onto current `upstream/main` at `ca39429a28` and refreshed the PR branch at `1a502191b6f50613163efd73e577956af8e83ba7`.
- Added the requested active-version `CHANGELOG.md` entry under `2026.5.9` / `### Fixes` with human contributor credit.
- Focused regression proof: `OPENCLAW_VITEST_MAX_WORKERS=1 pnpm test src/agents/cli-runner.before-agent-reply-cron.test.ts -- --reporter=verbose` passed 8/8 tests, including the cleanup-failure continuation case.
- Formatting/changed proof: `pnpm exec oxfmt --check --threads=1 CHANGELOG.md src/agents/cli-runner.ts src/agents/cli-runner.before-agent-reply-cron.test.ts`, `git diff --check`, `git diff --check upstream/main..HEAD`, and `pnpm check:changed --base upstream/main` all passed.