### PR TITLE
fix(media): strip trailing serialized JSON from MEDIA directive local paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/config: include rejected validation paths in foreground and service last-known-good recovery logs plus main-agent notices, so unsupported direct edits explain which key caused restore instead of looking like silent reversion. Fixes #75060. Thanks @amknight.
 - Plugins/runtime-deps: hash the OS-canonical `packageRoot` via `fs.realpathSync.native` (with `path.resolve` fallback) when computing the bundled runtime-deps stage key, so loader and channel `bundled-root` callers no longer derive divergent stage directories under `~/.openclaw/plugin-runtime-deps/openclaw-<version>-<hash>/` and bundled channels stop failing with `ENOENT` on shared dist chunks under Windows npm symlinks, junctions, or PM2 multi-instance worker layouts. Fixes #74963. (#75048) Thanks @openperf and @vincentkoc.
 - fix(logging): add redaction patterns for Tencent Cloud, Alibaba Cloud, HuggingFace and Replicate API keys (#58162). Thanks @gavyngong
+- Agents/media: strip trailing serialised-JSON suffixes (e.g. `","width":…`) from MEDIA directive local paths so the media parser no longer discards valid file extensions when the upstream agent serialises attachment metadata as a JSON fragment appended to the path string. Fixes #75182. Thanks @hclsys.
 - Pairing: surface unexpected allowlist filesystem stat errors instead of treating the allowlist as missing, so permission and I/O failures are visible during pairing authorization checks. (#63324) Thanks @franciscomaestre.
 
 ## 2026.4.29

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -59,6 +59,8 @@ describe("splitMediaFromOutput", () => {
       "/path/to/image.png",
       'MEDIA:/path/to/image.png"}],"details":{"provider":"openai","model":"gpt-image-2"}',
     ],
+    // Commas and pipes in a path must NOT be stripped (they can appear in valid paths).
+    ["/tmp/render,final.png", "MEDIA:/tmp/render,final.png"],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -54,6 +54,11 @@ describe("splitMediaFromOutput", () => {
     ["C:\\Users\\pete\\Pictures\\snap.png", "MEDIA:C:\\Users\\pete\\Pictures\\snap.png"],
     ["/tmp/tts-fAJy8C/voice-1770246885083.opus", "MEDIA:/tmp/tts-fAJy8C/voice-1770246885083.opus"],
     ["image.png", "MEDIA:image.png"],
+    // Regression #75182: trailing serialized JSON after a local path must be stripped.
+    [
+      "/path/to/image.png",
+      'MEDIA:/path/to/image.png"}],"details":{"provider":"openai","model":"gpt-image-2"}',
+    ],
   ] as const)("accepts supported media path variant: %s", (expectedPath, input) => {
     expectAcceptedMediaPathCase(expectedPath, input);
   });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -34,8 +34,14 @@ export function normalizeMediaSource(src: string) {
   return src.startsWith("file://") ? src.replace("file://", "") : src;
 }
 
+// Matches a file-extension boundary followed by non-path serialized JSON noise
+// (e.g. `.png"}],"details":...`). Captures the path up to and including the ext.
+const TRAILING_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})["'}\]|,].*$/s;
+
 function cleanCandidate(raw: string) {
-  return raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");
+  const stripped = raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");
+  const jsonMatch = TRAILING_JSON_AFTER_EXT_RE.exec(stripped);
+  return jsonMatch?.[1] ?? stripped;
 }
 
 const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -34,9 +34,10 @@ export function normalizeMediaSource(src: string) {
   return src.startsWith("file://") ? src.replace("file://", "") : src;
 }
 
-// Matches a file-extension boundary followed by non-path serialized JSON noise
-// (e.g. `.png"}],"details":...`). Captures the path up to and including the ext.
-const TRAILING_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})["'}\]|,].*$/s;
+// Matches a file-extension boundary followed by a double-quote — the opening
+// delimiter of serialized JSON noise (e.g. `.png"}],"details":...`). Commas,
+// pipes, and single-quotes are excluded: they can appear in valid media paths.
+const TRAILING_JSON_AFTER_EXT_RE = /^(.*\.\w{1,10})".*$/s;
 
 function cleanCandidate(raw: string) {
   const stripped = raw.replace(/^[`"'[{(]+/, "").replace(/[`"'\\})\],]+$/, "");


### PR DESCRIPTION
## Summary

When image generation appends tool-result JSON on the same line as a `MEDIA:` directive (e.g. `MEDIA:/path/to/image.png"}],"details":{"provider":"openai","model":"gpt-image-2"}`), `MEDIA_TOKEN_RE` absorbs the full line and `cleanCandidate`'s trailing-char strip does not remove the embedded JSON noise, producing an ENOENT-causing polluted path.

**Root cause:** `cleanCandidate` strips outer punctuation chars from start/end, but `"` appears *inside* the path after the extension — `cleanCandidate` never reaches it.

**Fix:** Add `TRAILING_JSON_AFTER_EXT_RE` as a second pass in `cleanCandidate`: after the standard strip, if a file extension is followed by any JSON boundary character (`"'{}[]|,`), truncate at the extension boundary.

**Test:** Added regression case in the accepted-path table:
```
MEDIA:/path/to/image.png"}],"details":{"provider":"openai","model":"gpt-image-2"}
→ /path/to/image.png  ✓
```

53/53 tests pass.

Fixes #75182.