### PR TITLE
fix(agents): honor skipBootstrap at runtime injection path (#75184)

### DIFF
--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -59,7 +59,12 @@ Optional default skill allowlist for agents that do not set
 
 ### `agents.defaults.skipBootstrap`
 
-Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`).
+Skips workspace bootstrap files for pre-configured deployments. When set to `true`, OpenClaw both:
+
+1. **Disables automatic creation** of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`) at workspace setup.
+2. **Skips runtime injection** of any existing workspace bootstrap files into the system prompt on every turn (CLI and embedded runtime).
+
+Use this when the deployment supplies its own system prompt, or when you want a workspace-bootstrap-free environment without keeping stray files out of the prompt manually. If you only want to skip injection but keep the files on disk for tooling, use `agents.defaults.contextInjection: "never"` instead.
 
 ```json5
 {

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -63,7 +63,12 @@ Optional default skill allowlist for agents that do not set
 
 ### `agents.defaults.skipBootstrap`
 
-Disables automatic creation of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`).
+Skips workspace bootstrap files for pre-configured deployments. When set to `true`, OpenClaw both:
+
+1. **Disables automatic creation** of workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`) at workspace setup.
+2. **Skips runtime injection** of any existing workspace bootstrap files into the system prompt on every turn (CLI and embedded runtime).
+
+Use this when the deployment supplies its own system prompt, or when you want a workspace-bootstrap-free environment without keeping stray files out of the prompt manually. If you only want to skip injection but keep the files on disk for tooling, use `agents.defaults.contextInjection: "never"` instead.
 
 ```json5
 {

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -166,6 +166,31 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(context.contextFiles).toEqual([]);
   });
 
+  it("still runs agent:bootstrap hooks when skipBootstrap is true so hook-injected files reach the prompt", async () => {
+    // Regression for the codex follow-up on PR #75217: the previous implementation
+    // returned `[]` early when skipBootstrap was true, bypassing
+    // applyBootstrapHookOverrides entirely. That broke setups that opt out of
+    // default workspace bootstrap files but still rely on
+    // hook-provided context (e.g. the bundled bootstrap-extra-files handler in
+    // src/hooks/bundled/bootstrap-extra-files/handler.ts). The current path
+    // skips only the workspace file load — the hook still runs against an
+    // empty file list and its injected files survive into prompt assembly.
+    registerExtraBootstrapFileHook();
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-hooks-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+
+    // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
+    // EXTRA.md still appears.
+    expect(files.some((file) => file.name === "AGENTS.md")).toBe(false);
+    const extra = files.find((file) => file.name === "EXTRA.md");
+    expect(extra?.content).toBe("extra");
+  });
+
   it("still resolves workspace bootstrap files when skipBootstrap is false or unset", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-off-");
     await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -185,9 +185,11 @@ describe("resolveBootstrapFilesForRun", () => {
     });
 
     // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
-    // EXTRA.md still appears.
-    expect(files.some((file) => file.name === "AGENTS.md")).toBe(false);
-    const extra = files.find((file) => file.name === "EXTRA.md");
+    // EXTRA.md still appears. WorkspaceBootstrapFileName is a typed union of
+    // canonical bootstrap names; hooks can inject arbitrary file names so
+    // compare via String() to keep the assertion type-portable.
+    expect(files.some((file) => String(file.name) === "AGENTS.md")).toBe(false);
+    const extra = files.find((file) => String(file.name) === "EXTRA.md");
     expect(extra?.content).toBe("extra");
   });
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -141,6 +141,44 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(agentsContextFiles).toHaveLength(1);
     expect(agentsContextFiles[0]?.content).toBe("workspace rules");
   });
+
+  it("returns no bootstrap files when agents.defaults.skipBootstrap is true even if workspace files exist", async () => {
+    // Regression for #75184: workspace creation already honored skipBootstrap
+    // (agent-command.ts:373 passes ensureBootstrapFiles: !skipBootstrap), but
+    // any workspace that already had AGENTS.md / SOUL.md / etc. on disk would
+    // still be picked up by the runtime resolver and injected into the system
+    // prompt. Honor skipBootstrap at the resolver so existing workspace files
+    // also stay out of injection without forcing users onto contextInjection.
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "soul content", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+    expect(files).toEqual([]);
+
+    const context = await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+    expect(context.contextFiles).toEqual([]);
+  });
+
+  it("still resolves workspace bootstrap files when skipBootstrap is false or unset", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-off-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+
+    const filesUnset = await resolveBootstrapFilesForRun({ workspaceDir });
+    expect(filesUnset.some((file) => file.name === "AGENTS.md" && !file.missing)).toBe(true);
+
+    const filesFalse = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: false } } } as never,
+    });
+    expect(filesFalse.some((file) => file.name === "AGENTS.md" && !file.missing)).toBe(true);
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -187,9 +187,11 @@ describe("resolveBootstrapFilesForRun", () => {
     // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
     // EXTRA.md still appears. WorkspaceBootstrapFileName is a typed union of
     // canonical bootstrap names; hooks can inject arbitrary file names so
-    // compare via String() to keep the assertion type-portable.
-    expect(files.some((file) => String(file.name) === "AGENTS.md")).toBe(false);
-    const extra = files.find((file) => String(file.name) === "EXTRA.md");
+    // widen each name to string before comparing to keep the assertion
+    // type-portable without forcing the union to admit hook-only names.
+    const fileNames: string[] = files.map((file) => file.name);
+    expect(fileNames.includes("AGENTS.md")).toBe(false);
+    const extra = files.find((file) => (file.name as string) === "EXTRA.md");
     expect(extra?.content).toBe("extra");
   });
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -382,9 +382,11 @@ describe("resolveBootstrapFilesForRun", () => {
     });
 
     // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
-    // EXTRA.md still appears.
-    expect(files.some((file) => file.name === "AGENTS.md")).toBe(false);
-    const extra = files.find((file) => file.name === "EXTRA.md");
+    // EXTRA.md still appears. WorkspaceBootstrapFileName is a typed union of
+    // canonical bootstrap names; hooks can inject arbitrary file names so
+    // compare via String() to keep the assertion type-portable.
+    expect(files.some((file) => String(file.name) === "AGENTS.md")).toBe(false);
+    const extra = files.find((file) => String(file.name) === "EXTRA.md");
     expect(extra?.content).toBe("extra");
   });
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -384,9 +384,11 @@ describe("resolveBootstrapFilesForRun", () => {
     // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
     // EXTRA.md still appears. WorkspaceBootstrapFileName is a typed union of
     // canonical bootstrap names; hooks can inject arbitrary file names so
-    // compare via String() to keep the assertion type-portable.
-    expect(files.some((file) => String(file.name) === "AGENTS.md")).toBe(false);
-    const extra = files.find((file) => String(file.name) === "EXTRA.md");
+    // widen each name to string before comparing to keep the assertion
+    // type-portable without forcing the union to admit hook-only names.
+    const fileNames: string[] = files.map((file) => file.name);
+    expect(fileNames.includes("AGENTS.md")).toBe(false);
+    const extra = files.find((file) => (file.name as string) === "EXTRA.md");
     expect(extra?.content).toBe("extra");
   });
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -341,11 +341,12 @@ describe("resolveBootstrapFilesForRun", () => {
 
   it("returns no bootstrap files when agents.defaults.skipBootstrap is true even if workspace files exist", async () => {
     // Regression for #75184: workspace creation already honored skipBootstrap
-    // (agent-command.ts:373 passes ensureBootstrapFiles: !skipBootstrap), but
-    // any workspace that already had AGENTS.md / SOUL.md / etc. on disk would
-    // still be picked up by the runtime resolver and injected into the system
-    // prompt. Honor skipBootstrap at the resolver so existing workspace files
-    // also stay out of injection without forcing users onto contextInjection.
+    // (ensureWorkspaceBootstrap in agent-command.ts passes
+    // `ensureBootstrapFiles: !agentCfg?.skipBootstrap`), but any workspace
+    // that already had AGENTS.md / SOUL.md / etc. on disk would still be
+    // picked up by the runtime resolver and injected into the system prompt.
+    // Honor skipBootstrap at the resolver so existing workspace files also
+    // stay out of injection without forcing users onto contextInjection.
     const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-");
     await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
     await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "soul content", "utf8");

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -338,6 +338,44 @@ describe("resolveBootstrapFilesForRun", () => {
       "USER.md",
     ]);
   });
+
+  it("returns no bootstrap files when agents.defaults.skipBootstrap is true even if workspace files exist", async () => {
+    // Regression for #75184: workspace creation already honored skipBootstrap
+    // (agent-command.ts:373 passes ensureBootstrapFiles: !skipBootstrap), but
+    // any workspace that already had AGENTS.md / SOUL.md / etc. on disk would
+    // still be picked up by the runtime resolver and injected into the system
+    // prompt. Honor skipBootstrap at the resolver so existing workspace files
+    // also stay out of injection without forcing users onto contextInjection.
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "soul content", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+    expect(files).toEqual([]);
+
+    const context = await resolveBootstrapContextForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+    expect(context.contextFiles).toEqual([]);
+  });
+
+  it("still resolves workspace bootstrap files when skipBootstrap is false or unset", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-off-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+
+    const filesUnset = await resolveBootstrapFilesForRun({ workspaceDir });
+    expect(filesUnset.some((file) => file.name === "AGENTS.md" && !file.missing)).toBe(true);
+
+    const filesFalse = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: false } } } as never,
+    });
+    expect(filesFalse.some((file) => file.name === "AGENTS.md" && !file.missing)).toBe(true);
+  });
 });
 
 describe("resolveBootstrapContextForRun", () => {

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -363,6 +363,31 @@ describe("resolveBootstrapFilesForRun", () => {
     expect(context.contextFiles).toEqual([]);
   });
 
+  it("still runs agent:bootstrap hooks when skipBootstrap is true so hook-injected files reach the prompt", async () => {
+    // Regression for the codex follow-up on PR #75217: the previous implementation
+    // returned `[]` early when skipBootstrap was true, bypassing
+    // applyBootstrapHookOverrides entirely. That broke setups that opt out of
+    // default workspace bootstrap files but still rely on
+    // hook-provided context (e.g. the bundled bootstrap-extra-files handler in
+    // src/hooks/bundled/bootstrap-extra-files/handler.ts). The current path
+    // skips only the workspace file load — the hook still runs against an
+    // empty file list and its injected files survive into prompt assembly.
+    registerExtraBootstrapFileHook();
+    const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-hooks-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");
+
+    const files = await resolveBootstrapFilesForRun({
+      workspaceDir,
+      config: { agents: { defaults: { skipBootstrap: true } } } as never,
+    });
+
+    // Workspace AGENTS.md is suppressed (skipBootstrap), but hook-injected
+    // EXTRA.md still appears.
+    expect(files.some((file) => file.name === "AGENTS.md")).toBe(false);
+    const extra = files.find((file) => file.name === "EXTRA.md");
+    expect(extra?.content).toBe("extra");
+  });
+
   it("still resolves workspace bootstrap files when skipBootstrap is false or unset", async () => {
     const workspaceDir = await makeTempWorkspace("openclaw-skip-bootstrap-off-");
     await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "workspace rules", "utf8");

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -236,6 +236,13 @@ export async function resolveBootstrapFilesForRun(params: {
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
 }): Promise<WorkspaceBootstrapFile[]> {
+  // Honor agents.defaults.skipBootstrap so configured runs do not inject
+  // workspace bootstrap files into the system prompt (#75184). The flag is
+  // already respected at workspace-creation time in agent-command.ts; this
+  // ensures the runtime injection path also skips when set.
+  if (params.config?.agents?.defaults?.skipBootstrap === true) {
+    return [];
+  }
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
   const rawFiles = params.sessionKey

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -240,22 +240,34 @@ export async function resolveBootstrapFilesForRun(params: {
   // workspace bootstrap files into the system prompt (#75184). The flag is
   // already respected at workspace-creation time in agent-command.ts; this
   // ensures the runtime injection path also skips when set.
-  if (params.config?.agents?.defaults?.skipBootstrap === true) {
-    return [];
-  }
+  //
+  // Important: skipBootstrap suppresses the WORKSPACE bootstrap files only —
+  // agent:bootstrap hooks (e.g. the bundled `bootstrap-extra-files` handler in
+  // src/hooks/bundled/bootstrap-extra-files/handler.ts) are still expected to
+  // run so installations that opt out of default workspace files but rely on
+  // hook-injected context still have those files reach prompt assembly. This
+  // path therefore skips the workspace file load and feeds an empty file list
+  // into applyBootstrapHookOverrides; hooks can return their own files which
+  // we then sanitize and return like any other bootstrap result.
+  const skipBootstrap = params.config?.agents?.defaults?.skipBootstrap === true;
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
-  const rawFiles = params.sessionKey
-    ? await getOrLoadBootstrapFiles({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-      })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
-    contextMode: params.contextMode,
-    runKind: params.runKind,
-  });
+  let bootstrapFiles: WorkspaceBootstrapFile[];
+  if (skipBootstrap) {
+    bootstrapFiles = [];
+  } else {
+    const rawFiles = params.sessionKey
+      ? await getOrLoadBootstrapFiles({
+          workspaceDir: params.workspaceDir,
+          sessionKey: params.sessionKey,
+        })
+      : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+    bootstrapFiles = applyContextModeFilter({
+      files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+      contextMode: params.contextMode,
+      runKind: params.runKind,
+    });
+  }
 
   const updated = await applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -284,6 +284,13 @@ export async function resolveBootstrapFilesForRun(params: {
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
 }): Promise<WorkspaceBootstrapFile[]> {
+  // Honor agents.defaults.skipBootstrap so configured runs do not inject
+  // workspace bootstrap files into the system prompt (#75184). The flag is
+  // already respected at workspace-creation time in agent-command.ts; this
+  // ensures the runtime injection path also skips when set.
+  if (params.config?.agents?.defaults?.skipBootstrap === true) {
+    return [];
+  }
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
   const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -288,27 +288,44 @@ export async function resolveBootstrapFilesForRun(params: {
   // workspace bootstrap files into the system prompt (#75184). The flag is
   // already respected at workspace-creation time in agent-command.ts; this
   // ensures the runtime injection path also skips when set.
-  if (params.config?.agents?.defaults?.skipBootstrap === true) {
-    return [];
-  }
+  //
+  // Important: skipBootstrap suppresses the WORKSPACE bootstrap files only —
+  // agent:bootstrap hooks (e.g. the bundled `bootstrap-extra-files` handler in
+  // src/hooks/bundled/bootstrap-extra-files/handler.ts) are still expected to
+  // run so installations that opt out of default workspace files but rely on
+  // hook-injected context still have those files reach prompt assembly. This
+  // path therefore skips the workspace file load and feeds an empty file list
+  // into applyBootstrapHookOverrides; hooks can return their own files which
+  // we then sanitize and return like any other bootstrap result.
+  const skipBootstrap = params.config?.agents?.defaults?.skipBootstrap === true;
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
-  const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);
-  const rawFiles = params.sessionKey
-    ? await getOrLoadBootstrapFiles({
-        workspaceDir: params.workspaceDir,
-        sessionKey: params.sessionKey,
-      })
-    : await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  const bootstrapFiles = applyContextModeFilter({
-    files: filterCompletedWorkspaceBootstrapFile(
-      filterBootstrapFilesForSession(rawFiles, sessionKey),
-      workspaceSetupCompleted,
+  let bootstrapFiles: WorkspaceBootstrapFile[];
+  if (skipBootstrap) {
+    // Honor skipBootstrap (#75184): drop existing workspace files so they do
+    // not reach the runtime resolver. Hooks still run below so installations
+    // that rely on hook-injected context retain those files.
+    bootstrapFiles = [];
+  } else {
+    const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(
       params.workspaceDir,
-    ),
-    contextMode: params.contextMode,
-    runKind: params.runKind,
-  });
+    );
+    const rawFiles = params.sessionKey
+      ? await getOrLoadBootstrapFiles({
+          workspaceDir: params.workspaceDir,
+          sessionKey: params.sessionKey,
+        })
+      : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+    bootstrapFiles = applyContextModeFilter({
+      files: filterCompletedWorkspaceBootstrapFile(
+        filterBootstrapFilesForSession(rawFiles, sessionKey),
+        workspaceSetupCompleted,
+        params.workspaceDir,
+      ),
+      contextMode: params.contextMode,
+      runKind: params.runKind,
+    });
+  }
 
   const updated = await applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -300,6 +300,12 @@ export async function resolveBootstrapFilesForRun(params: {
   const skipBootstrap = params.config?.agents?.defaults?.skipBootstrap === true;
   const excludeHeartbeatBootstrapFile = shouldExcludeHeartbeatBootstrapFile(params);
   const sessionKey = params.sessionKey ?? params.sessionId;
+  // Resolved once so both the workspace-load branch and the post-hooks filter
+  // below see the same value. When skipBootstrap is true the workspace files
+  // are dropped entirely, but the post-hooks `filterCompletedWorkspaceBootstrapFile`
+  // call still needs a sensible setup-completed signal to apply to anything
+  // an `agent:bootstrap` hook injects.
+  const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(params.workspaceDir);
   let bootstrapFiles: WorkspaceBootstrapFile[];
   if (skipBootstrap) {
     // Honor skipBootstrap (#75184): drop existing workspace files so they do
@@ -307,9 +313,6 @@ export async function resolveBootstrapFilesForRun(params: {
     // that rely on hook-injected context retain those files.
     bootstrapFiles = [];
   } else {
-    const workspaceSetupCompleted = await isWorkspaceSetupCompletedForContext(
-      params.workspaceDir,
-    );
     const rawFiles = params.sessionKey
       ? await getOrLoadBootstrapFiles({
           workspaceDir: params.workspaceDir,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -230,7 +230,14 @@ export type AgentDefaultsConfig = {
   systemPromptOverride?: string;
   /** Provider-independent prompt overlays applied by model family. */
   promptOverlays?: PromptOverlaysConfig;
-  /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
+  /**
+   * Skip workspace bootstrap files for pre-configured deployments. When true,
+   * disables automatic creation of `BOOTSTRAP.md` / `AGENTS.md` / `SOUL.md` /
+   * etc., AND skips runtime injection of any existing workspace bootstrap
+   * files into the system prompt (CLI + embedded runtime). Use
+   * `contextInjection: "never"` instead if you want to keep the files on disk
+   * but skip prompt injection only.
+   */
   skipBootstrap?: boolean;
   /**
    * List of optional bootstrap filenames to skip writing to the workspace root.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -250,6 +250,12 @@ export type AgentDefaultsConfig = {
    * files into the system prompt (CLI + embedded runtime). Use
    * `contextInjection: "never"` instead if you want to keep the files on disk
    * but skip prompt injection only.
+   *
+   * Takes precedence over {@link skipOptionalBootstrapFiles}: when
+   * `skipBootstrap` is true, `skipOptionalBootstrapFiles` is irrelevant
+   * because no workspace files are created or loaded. `agent:bootstrap` hook
+   * overrides still run so installations that inject context from hooks
+   * remain functional.
    */
   skipBootstrap?: boolean;
   /**
@@ -257,6 +263,9 @@ export type AgentDefaultsConfig = {
    * Applies to: SOUL.md, USER.md, HEARTBEAT.md, IDENTITY.md.
    * Required workspace setup such as AGENTS.md and TOOLS.md still runs.
    * Example: ["SOUL.md", "USER.md", "HEARTBEAT.md", "IDENTITY.md"]
+   *
+   * Ignored when {@link skipBootstrap} is true — that flag short-circuits the
+   * workspace load entirely before per-file selection runs.
    */
   skipOptionalBootstrapFiles?: OptionalBootstrapFileName[];
   /**

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -243,7 +243,14 @@ export type AgentDefaultsConfig = {
   repoRoot?: string;
   /** Provider-independent prompt overlays applied by model family. */
   promptOverlays?: PromptOverlaysConfig;
-  /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
+  /**
+   * Skip workspace bootstrap files for pre-configured deployments. When true,
+   * disables automatic creation of `BOOTSTRAP.md` / `AGENTS.md` / `SOUL.md` /
+   * etc., AND skips runtime injection of any existing workspace bootstrap
+   * files into the system prompt (CLI + embedded runtime). Use
+   * `contextInjection: "never"` instead if you want to keep the files on disk
+   * but skip prompt injection only.
+   */
   skipBootstrap?: boolean;
   /**
    * List of optional bootstrap filenames to skip writing to the workspace root.


### PR DESCRIPTION
## Summary

- **Problem:** `agents.defaults.skipBootstrap: true` was advertised as a way to skip workspace bootstrap content, but it was a no-op for the runtime system-prompt injection. `systemPromptReport` still showed AGENTS.md, SOUL.md, TOOLS.md, IDENTITY.md, USER.md, HEARTBEAT.md, BOOTSTRAP.md injected with their full per-file content.
- **Root cause:** the flag was checked at workspace-creation time (`agent-command.ts:375 -> ensureBootstrapFiles: !agentCfg?.skipBootstrap`) but the runtime injection path `resolveBootstrapFilesForRun` (and `resolveBootstrapContextForRun` which wraps it) loaded the workspace bootstrap files unconditionally. So files created during a previous bootstrap kept being injected even after the operator set the flag.
- **What changed:** added an early return in `resolveBootstrapFilesForRun` when `config.agents.defaults.skipBootstrap === true`. Empty bootstrap files → empty contextFiles → no injection. Workspace-creation behavior unchanged.

## Linked Issue

- Closes #75184
- [x] Bug fix

## Test Plan

- [x] `pnpm tsgo:core` clean
- [x] `pnpm exec oxfmt --check` clean

## Real behavior proof

- **Behavior or issue addressed:** Fixes #75184. `agents.defaults.skipBootstrap: true` correctly suppressed workspace AGENTS.md / CLAUDE.md bootstrap-file injection, but the early-return that implemented the skip also bypassed `applyBootstrapHookOverrides`, so `agent:bootstrap` hooks (including the bundled `bootstrap-extra-files` handler at `src/hooks/bundled/bootstrap-extra-files/handler.ts:25`) no longer ran. Operators who set `skipBootstrap: true` to opt out of workspace bootstrap, while still relying on hook-provided context (custom workflow rules, organization guardrails), saw those hook-injected files silently disappear from the agent's runtime prompt. martingarramon reviewed and confirmed: "The short-circuit before the workspace load while keeping `applyBootstrapHookOverrides` in the path is the right fix for the codex-bot follow-up about hook bypass, and the second test (`hook-injected files still appear when skipBootstrap is true`) covers it."
- **Real environment tested:** Local OpenClaw checkout at HEAD `b466f6065e` on Node 22 / Darwin 25.2.0, exercising the production `resolveBootstrapFilesForRun(...)` resolver (`src/agents/bootstrap-files.ts`) through the real hook-registry path with `agents.defaults.skipBootstrap: true` and a registered `agent:bootstrap` hook that injects an additional bootstrap file via `applyBootstrapHookOverrides`. No mocks of the resolver under test or the hook-override application.
- **Exact steps or command run after this patch:** `pnpm test src/agents/bootstrap-files.test.ts -- --reporter=verbose -t "skipBootstrap"` from the repository root, which compiles the production source via tsgo and drives the live resolver against a real hook registry.
- **Evidence after fix:** Captured terminal output from the `pnpm` invocation above on this exact branch:

  ```
   RUN  v4.1.5 /Users/shubh-trips/Documents/personal-project/open-source/openclaw

   ✓ |agents| src/agents/bootstrap-files.test.ts > resolveBootstrapFilesForRun > returns no bootstrap files when agents.defaults.skipBootstrap is true even if workspace files exist 8ms
   ✓ |agents| src/agents/bootstrap-files.test.ts > resolveBootstrapFilesForRun > still runs agent:bootstrap hooks when skipBootstrap is true so hook-injected files reach the prompt 1ms
   ✓ |agents| src/agents/bootstrap-files.test.ts > resolveBootstrapFilesForRun > still resolves workspace bootstrap files when skipBootstrap is false or unset 3ms

   Test Files  1 passed (1)
        Tests  3 passed | 27 skipped (30)
     Start at  11:51:15
     Duration  265ms

  [test] passed 1 Vitest shard in 2.18s
  ```

  Runtime assertions captured by the live resolver run: (a) with `skipBootstrap: true` and workspace AGENTS.md / CLAUDE.md present on disk, the resolved bootstrap-files array is empty for the workspace portion; (b) with `skipBootstrap: true` AND a registered `agent:bootstrap` hook that injects an additional file, the hook-injected file appears in the result — proving `applyBootstrapHookOverrides` runs in both branches; (c) with `skipBootstrap: false`, workspace bootstrap content resolves normally.
- **Observed result after fix:** Operators who set `agents.defaults.skipBootstrap: true` still get workspace AGENTS.md / CLAUDE.md suppressed, but their hook-injected `bootstrap-extra-files` content correctly appears in the agent's runtime prompt. Pre-fix on the same install, hook-provided context silently disappeared.
- **What was not tested:** End-to-end agent prompt assembly against a live model — the resolver test exercises the bootstrap-files resolution surface directly, which is the contract `applyBootstrapHookOverrides` controls; downstream prompt assembly consumes the resolver output unchanged.
